### PR TITLE
docs(bio): add Nestor Makhno dossier

### DIFF
--- a/docs/research/bio/nestor-makhno.md
+++ b/docs/research/bio/nestor-makhno.md
@@ -1,0 +1,194 @@
+# Нестор Іванович Махно - Research Dossier
+
+**Slug:** `nestor-makhno`
+**Block:** +77 backfill - anarchist peasant insurgency / Ukrainian Revolution / contested violence memory
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #316
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-02
+
+**Source acronym legend:** EIU = Encyclopedia of the History of Ukraine / Institute of History of Ukraine, NASU; ESU = Encyclopedia of Modern Ukraine / NASU; IEU = Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies; 1914-1918 Online = International Encyclopedia of the First World War; CUH = Center for Urban History of East Central Europe; KSL = Kate Sharpley Library; MIA = Marxists Internet Archive; YIVO = YIVO Institute for Jewish Research; BIO / HIST / LIT / wiki = existing learn-ukrainian track materials; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, scholarly, primary-text, and image-rights sources cited
+- [x] Pressure mechanism framed peasant land war, occupation, civil-war state violence, Bolshevik centralization, White restoration politics, pogrom-era antisemitism, and anarchist mythology; no simple bandit-or-saint frame
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-02 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric framing: Makhno is not reduced to a Russian Civil War side character or to the Soviet `bandit` category.
+- [x] Ukrainian rural agency central: Huliaipole, peasant self-organization, local councils, land politics, and the Revolutionary Insurgent Army of Ukraine remain central.
+- [x] Anti-hagiography present: anarchist self-defense texts, Makhnovist memory, Soviet demonization, pogrom-era catastrophe, and civilian violence are kept in tension.
+- [x] UNR / Directory, White, and Bolshevik forces are not collapsed into a single opponent; the dossier preserves shifting civil-war alignments.
+
+## 1. Identity / chronology
+
+- **Canonical UA:** `Нестор Іванович Махно`; EIU / ESU title form `Махно (Міхненко) Нестор Іванович`.
+- **Canonical EN:** `Nestor Makhno`.
+- **Core identity:** Ukrainian anarcho-communist and commander of a peasant insurgent movement in southern Ukraine during 1918-1921, associated with Makhnovshchyna and the Revolutionary Insurgent Army of Ukraine.
+- **Birth:** EIU / ESU give `26 October (OS) / 7 November (NS) 1888`, Huliaipole, Oleksandrivsk county, Katerynoslav gubernia, now Zaporizhzhia oblast.
+- **Family / early life:** EIU / ESU describe a poor large peasant family, early loss of his father, childhood hired labor, primary education, and work from 1903 at Kerner's iron foundry in Huliaipole.
+- **1905-1917 formation:** EIU / ESU say Makhno entered political activity under the influence of the 1905 revolutionary events, joined anarchist circles, was arrested, sentenced, and spent years in prison before the 1917 amnesty.
+- **1917 return:** After the February Revolution he returned to Huliaipole and became active in local soviets, peasant committees, land redistribution, and revolutionary self-organization.
+- **1918-1921 insurgency:** EIU / IEU frame him as leader of a peasant insurgent movement in southern Ukraine; IEU emphasizes guerrilla war against German / Austro-Hungarian occupation, raids on estates, and shifting conflicts with Bolsheviks, Whites, and Ukrainian national forces.
+- **Exile:** EIU / ESU describe defeat and flight abroad in 1921, with later stays in Romania, Poland, Germany, and France.
+- **Death:** EIU / ESU give 25 July 1934 in Paris. Learner-facing chronology can use `1888-1934`, with the old-style / new-style birth-date note where relevant.
+
+## 2. Political pressure mechanism
+
+- **Peasant land war:** Makhno's movement grows from village-level land redistribution, estate conflict, and armed defense after imperial collapse. It should not be taught only as abstract ideology.
+- **Occupation / Hetmanate pressure:** IEU and civil-war scholarship connect early insurgency with resistance to German / Austro-Hungarian occupation, estate restoration, and the Hetmanate-era order after the 1918 Treaty of Brest-Litovsk.
+- **Civil-war multi-front pressure:** 1914-1918 Online describes Makhno's forces fighting Bolsheviks, Whites, and Ukrainian nationalists in the southeast. Teach the fluid civil-war environment, not a single-front rebellion.
+- **Bolshevik centralization:** Conflict with the Bolsheviks was not only tactical; Makhnovist commitments to local peasant control and free soviets clashed with party-state centralization and Red Army discipline.
+- **White restoration threat:** Makhnovists fought White forces that threatened landlord restoration and anti-revolutionary repression. This does not erase coercion and violence on the insurgent side.
+- **UNR / Directory tension:** Existing HIST `dyrektoriia` and `symon-petliura-revolution` materials help situate Makhno beside, not inside, UNR state-building. Avoid collapsing all anti-Bolshevik actors into one camp.
+- **Pogrom-era catastrophe:** YIVO and Quest scholarship show 1918-1921 Ukraine as a site of mass anti-Jewish violence by multiple armed actors. Makhno's own anti-antisemitism statements and later anarchist defenses must be read against this wider catastrophe, not used to erase it.
+- **Soviet label pressure:** Soviet narratives often made `махновщина` mean banditry / chaos; anarchist counter-memory often makes libertarian heroism. Both can flatten rural history.
+
+## 3. Major events / historical footprint
+
+- **1905-1910 anarchist initiation / repression:** EIU / ESU place Makhno's political formation in the 1905 revolutionary wave, underground anarchist activism, arrest, and prison.
+- **1917 Huliaipole:** Return after amnesty made Huliaipole a local experiment in peasant self-organization, land committees, and armed defense. IEU's Huliaipole entry names the town as the center of Makhno's activity in 1917-1921.
+- **1918 anti-occupation insurgency:** IEU says Makhno led popular insurrection against German occupying forces while raiding local estates.
+- **Makhnovist army:** IEU emphasizes mobile tactics, disciplined voluntary forces, cavalry, and tachanky. Learner modules can connect `тачанка` to military innovation without turning it into folklore alone.
+- **Alliance / rupture cycles:** IEU's partisan-movement context helps sequence uneasy Bolshevik cooperation, anti-White fighting, and later ruptures. The movement should be taught as a shifting civil-war actor, not as a stable ally.
+- **Free-soviet / anarchist program:** IEU's Anarchists entry and CUH primary-source gateway help distinguish Makhno's political self-presentation from anarchism in general and from later internet slogan culture.
+- **Anti-pogrom controversy:** Makhno's 1927 texts `To the Jews of All Countries` and `The Makhnovshchina and Anti-Semitism` are primary-source defenses asking for evidence and denying organized pogrom policy. They are valuable evidence in the accusation / defense field, not independent exoneration.
+- **Defeat / exile:** EIU / ESU place defeat in 1921 and exile through Romania, Poland, Germany, and France. Paris exile links him to transnational anarchist memory and polemics.
+- **Death in Paris:** 25 July 1934 closes the biography as a shift from rural insurgent command to impoverished exile, memoir, and polemic.
+- **Cultural afterlife:** Makhno appears in history plans, Revolution-era literary memory, Soviet villainy, post-Soviet Huliaipole memory, and global anarchist reception. Keep these layers separate.
+
+## 4. Pedagogical anchors
+
+- **Huliaipole anchor:** Huliaipole gives a concrete place for peasant politics, land committees, local armed power, and museum memory, not just a name attached to cavalry myths.
+- **Anarchism vs chaos anchor:** Use `анархізм`, `анархо-комунізм`, `вільні ради`, and `махновщина` to distinguish political doctrine, movement, and polemical label.
+- **Tachanka anchor:** IEU's mobile-warfare note lets lessons teach military vocabulary and material culture while avoiding comic-book bandit imagery.
+- **Alliance map anchor:** Makhno is ideal for a map of shifting relations among occupation forces, the Hetmanate, Bolsheviks, Whites, UNR / Directory, local peasants, Mennonite colonies, and Jewish communities.
+- **Pogrom-discussion anchor:** Pair Makhno with Petliura materials and YIVO / Quest context to show why "who committed pogroms?" is a serious historical question, not a propaganda shortcut.
+- **Anti-hagiography anchor:** Ask whether a movement can be anti-state and locally participatory while still coercive, violent, and vulnerable to myth-making. This is the central seminar question.
+- **Literary bridge:** Existing `yurii-yanovskyi` research notes how `Вершники` maps brothers across Denikin, Petliura, Makhno, and Bolshevik factions. This is a strong LIT bridge for civil-war fragmentation memory.
+- **Lost-poem bridge:** Existing `volodymyr-sosiura` research and the RAG literary catalog preserve the trace of Sosiura's lost poem `Махно`, useful for memory / censorship discussion.
+- **Exile-memory anchor:** Paris death and Père-Lachaise grave media support diaspora / anarchist memory lessons rather than battlefield-only biography.
+- **Visual anchor:** Commons `File:Makhno-1919.jpg` is a public-domain historical portrait candidate; caption with file-page provenance, not internet-circulated certainty.
+- **Grave-memory anchor:** Commons `File:Nestor Makhno tombe.jpg` is a 2024 CC0 photo of the Père-Lachaise grave; useful for exile commemoration lessons.
+
+## 5. Language register
+
+- **Register:** revolutionary biography, peasant insurgency, anarchist political vocabulary, civil-war alliance mapping, pogrom memory, exile memoir polemic.
+- **CEFR readiness:** B1+/B2 can handle short chronology and place vocabulary; B2/C1 can compare `анархія`, `анархізм`, `махновщина`; C1/C2 can debate pogrom evidence, free soviets, wartime coercion, and memory politics.
+- **Core vocabulary:** `Нестор Махно`, `Махно (Міхненко)`, `Батько Махно`, `Гуляйполе`, `анархізм`, `анархо-комунізм`, `махновщина`, `махновці`, `повстанський рух`, `селянський рух`, `Революційна повстанська армія України`, `вільні ради`, `самоврядування`, `окупаційні війська`, `гетьманат`, `більшовики`, `білі`, `Директорія`, `тачанка`, `партизанська війна`, `реквізиція`, `погром`, `антисемітизм`, `еміграція`, `Париж`.
+- **Register caution:** `бандит`, `отаманщина`, `анархічна маса`, `визволитель`, `народний месник`, and `махновщина` can be polemical. Label who is using the term and why.
+- **Pogrom-language caution:** Avoid "proving innocence" or "proving guilt" by slogan. Separate documented pogrom catastrophe, allegations about Makhnovists, Makhno's anti-pogrom claims, and later historiography.
+- **Ideology-language caution:** `Anarchism` is not a synonym for disorder in learner-facing prose; `анархія` as chaos should be identified as polemical usage.
+
+## 6. Risks / open questions
+
+- **Birth-date calendar:** Use `26 October (OS) / 7 November (NS) 1888` or simply `1888` depending on level. Do not mix styles without labels.
+- **Surname variant:** EIU / ESU title form includes `Міхненко`; use as variant / birth-family form, not a second learner-facing identity.
+- **"Batko" title:** `Батько Махно` is famous, but it can mythologize patriarchal charisma. Use as a term of address / memory marker, not the main canonical name.
+- **1918-1921 compression:** Do not reduce the movement to one alliance. Cooperation and conflict with Bolsheviks, anti-White operations, and conflict with Ukrainian national forces need sequencing.
+- **Pogrom evidence:** Quest and YIVO context require caution. Do not use Makhno's 1927 defenses as final adjudication; do not use broad pogrom catastrophe to assign unsupported command responsibility.
+- **Mennonite / local civilian memory:** Patterson's memory study is valuable for competing narratives. Future modules should not treat anarchist memoirs as the only memory archive.
+- **UNR comparison:** Petliura-command responsibility debates and Makhno anti-pogrom claims are different evidence problems. Pair them carefully, not as simple equivalence.
+- **White-movement conflict:** Anti-White struggle matters, but it is not a moral ledger that resolves Makhnovist coercion or civilian violence.
+- **Modern internet romance:** Makhno is popular in online anarchist culture; do not let memes, flags, slogans, or restored portraits supply factual detail.
+- **Image identity:** Many Makhno portraits circulate without file-level provenance. Use Commons file pages and caption uncertainty.
+
+## 7. Cross-track links
+
+- **Existing BIO anchors (VERIFIED `test -e` / `rg` 2026-07-02):** `site/src/content/docs/bio/index.mdx` lists BIO #316 `nestor-makhno`; `docs/research/bio/symon-petliura.md` supports UNR / pogrom-command-responsibility comparison; `docs/research/bio/ivan-gonta.md`, `docs/research/bio/maksym-zalizniak.md`, `docs/research/bio/oleksa-dovbush.md`, and `docs/research/bio/ustym-karmaliuk.md` support contested social-resistance memory comparisons.
+- **Existing HIST plan / discovery surfaces (VERIFIED `test -e` / `rg` 2026-07-02):** `curriculum/l2-uk-en/plans/hist/bilshovytsko-ukrainska-viyna.yaml`, `curriculum/l2-uk-en/hist/discovery/bilshovytsko-ukrainska-viyna.yaml`, `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml`, `curriculum/l2-uk-en/hist/discovery/dyrektoriia.yaml`, `curriculum/l2-uk-en/plans/hist/symon-petliura-revolution.yaml`, `curriculum/l2-uk-en/hist/discovery/symon-petliura-revolution.yaml`, `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`, `curriculum/l2-uk-en/hist/discovery/tsentralna-rada.yaml`, `curriculum/l2-uk-en/plans/hist/zunr.yaml`, `curriculum/l2-uk-en/hist/discovery/zunr.yaml`, `curriculum/l2-uk-en/plans/hist/kholodnyi-yar.yaml`, `curriculum/l2-uk-en/plans/hist/syntez-revoliutsiia.yaml`.
+- **Existing ISTORIO source-criticism surfaces (VERIFIED `test -e` / `rg` 2026-07-02):** `curriculum/l2-uk-en/plans/istorio/unr-vybory.yaml`, `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`.
+- **Existing LIT / literary memory surfaces (VERIFIED `test -e` / `rg` 2026-07-02):** `docs/research/bio/yurii-yanovskyi.md`, `docs/research/bio/volodymyr-sosiura.md`, `docs/archive/RAG-LITERARY-CATALOG.md`, `curriculum/l2-uk-en/plans/lit/vynnychenko-honesty.yaml`, `curriculum/l2-uk-en/plans/lit/vynnychenko-black-panther.yaml`, `curriculum/l2-uk-en/plans/lit/vynnychenko-solar-machine.yaml`.
+- **Existing wiki anchors (VERIFIED `test -e` / `rg` 2026-07-02):** `wiki/figures/symon-petliura.md`, `wiki/periods/symon-petliura-revolution.md`, `wiki/historiography/hranitna-revoliutsiia.md`, `wiki/grammar/b1/traveling-ukraine.md`.
+- **Absent BIO surfaces (VERIFIED absent `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/bio/nestor-makhno.yaml`, `curriculum/l2-uk-en/bio/discovery/nestor-makhno.yaml`, `wiki/figures/nestor-makhno.md`, `site/src/content/docs/bio/nestor-makhno.mdx`, `curriculum/l2-uk-en/bio/nestor-makhno/module.md`, `curriculum/l2-uk-en/bio/nestor-makhno/activities.yaml`, `curriculum/l2-uk-en/bio/nestor-makhno/vocabulary.yaml`, `curriculum/l2-uk-en/bio/nestor-makhno/resources.yaml`.
+- **Absent candidate period wiki surfaces (VERIFIED absent `test -e` 2026-07-02):** `wiki/periods/ukrainian-revolution.md`, `wiki/periods/dyrektoriia-unr.md`, `wiki/periods/bolsheviks-and-ukraine.md`, `wiki/periods/white-movement.md`.
+
+## 8. Name variants / search aliases
+
+- **Canonical UA:** `Нестор Іванович Махно`.
+- **Canonical EN:** `Nestor Makhno`.
+- **Source title / family variant:** `Махно (Міхненко) Нестор Іванович`, `Нестор Міхненко`.
+- **Movement / nickname forms:** `Батько Махно`, `Batko Makhno`, `батя Махно`, `махновщина`, `махновці`.
+- **English / transliteration variants:** `Nestor Ivanovych Makhno`, `Nestor Ivanovich Makhno`, `Nestor Machno`, `Nestor Machnoe`, `Makhno, Nestor`.
+- **Russian / imperial source variants:** `Нестор Иванович Махно`, `Махно Нестор Иванович`, `Нестор Махно`. Use only for source search or caption provenance, not as primary learner-facing form.
+- **Search variants:** `Нестор Махно`, `Махно Нестор`, `Нестор Іванович Махно`, `Makhno Nestor`, `Nestor Makhno anarchism`, `Makhnovshchyna`, `Махновщина`, `Революційна повстанська армія України`, `Revolutionary Insurgent Army of Ukraine`, `Huliaipole`, `Гуляйполе`, `free soviets`, `вільні ради`, `tachanka`, `тачанка`, `Makhno antisemitism`, `Makhnovists pogroms`.
+- **Learner-facing pairing:** `Нестор Махно (Nestor Makhno), Ukrainian anarchist peasant-insurgent leader, 1888-1934`.
+- **Index caution:** Do not confuse with `Нестор Літописець` / `nestor-litopysets`, which is a separate BIO entry.
+
+## 9. Image rights / media candidates
+
+- **Default portrait candidate:** Commons `File:Makhno-1919.jpg`; public-domain in the United States and Ukraine, dated 1919 / published 1924. Use as the cleanest portrait default after file-page verification.
+- **Group-photo candidate:** Commons `File:Nestor Makhno and his Lieutenants, Berdyansk, 1919.jpg`; public-domain in the United States and Ukraine. Strong for Makhnovshchyna army / command context.
+- **Exile portrait candidate:** Commons `File:1921. Нестор Махно в лагере для перемещенных лиц в Румынии.jpg`; public-domain in the United States and Ukraine. Strong for defeat / displaced-person / exile framing.
+- **Grave / exile-memory candidate:** Commons `File:Nestor Makhno tombe.jpg`; 2024 Père-Lachaise grave photo, CC0. Strong for exile / memory lessons.
+- **Secondary portrait caution:** Commons has additional cropped portraits derived from historical photographs; use only after file-level identity and license review because portraits circulate with weak provenance.
+- **Movement-symbol candidate:** Commons images of Makhnovist flags / banners may be useful for ideology lessons but are high-risk for slogan simplification and must be checked file by file.
+- **Avoid default:** unsourced internet portraits, AI restorations/colorizations, modern statue photos without reusable licensing, YouTube thumbnails, meme flags, and partisan/anarchist graphics without explicit rights.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- "Махно (Міхненко) Нестор Іванович." Енциклопедія історії України, Інститут історії України НАН України. https://history.org.ua/?termin=Makhno_N_I. Accessed 2026-07-02.
+- "Махно Нестор Іванович." Енциклопедія Сучасної України, НАН України. https://esu.com.ua/article-67136. Accessed 2026-07-02.
+- "Makhno, Nestor." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CM%5CA%5CMakhnoNestor.htm. Accessed 2026-07-02.
+- "Huliaipole." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CH%5CU%5CHuliaipole.htm. Accessed 2026-07-02.
+- "Partisan movement in Ukraine, 1918-22." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CP%5CA%5CPartisanmovementinUkraine1918hD722.htm. Accessed 2026-07-02.
+- "Anarchists." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CA%5CN%5CAnarchists.htm. Accessed 2026-07-02.
+- "Jews." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CJ%5CE%5CJews.htm. Accessed 2026-07-02.
+- "Makhno Nestor Ivanovich." 1914-1918 Online: International Encyclopedia of the First World War. https://encyclopedia.1914-1918-online.net/article/makhno-nestor-ivanovich/. Accessed 2026-07-02.
+- "Makhno Nestor Ivanovych." NBUV Ukrainian National Bibliographic / reference record. https://irbis-nbuv.gov.ua/ulib/item/REF0000441. Accessed 2026-07-02.
+- CUH / REESOURCES, "Nestor Makhno on Ukraine in late 1910-1920s." https://edu.lvivcenter.org/en/documents/nestor-makhno-on-ukraine-in-late-1910-1920s/. Accessed 2026-07-02.
+
+**Tier 2 (scholarly / specialist):**
+
+- Palij, Michael. `The Anarchism of Nestor Makhno, 1918-1921: An Aspect of the Ukrainian Revolution`. University of Washington Press, 1976.
+- Malet, Michael. `Nestor Makhno in the Russian Civil War`. Macmillan, 1982.
+- Darch, Colin. `Nestor Makhno and Rural Anarchism in Ukraine, 1917-1921`. Pluto Press, 2020.
+- Patterson, Sean. `Makhno and Memory: Anarchist and Mennonite Narratives of Ukraine's Civil War, 1917-1921`. University of Manitoba Press, 2020.
+- Bemporad, Elissa. "Red Antisemitism: Anti-Jewish Violence and Revolutionary Politics in Ukraine, 1919." `QUEST. Issues in Contemporary Jewish History`. https://www.quest-cdecjournal.it/red-antisemitism-anti-jewish-violence-and-revolutionary-politics-in-ukraine-1919/. Accessed 2026-07-02.
+- YIVO, "They Never Taught Us About This: The Pogroms of 1917-1921." https://www.yivo.org/They-never-taught-us-about-this. Accessed 2026-07-02.
+- Bemporad / YIVO event page, "Jewish Resistance during Pogroms in Ukraine in 1918-1921." https://www.yivo.org/YCLS2024-Bemporad. Accessed 2026-07-02.
+
+**Tier 3 (primary / movement texts / reception; source-sensitive):**
+
+- Makhno, Nestor. "To the Jews of All Countries." 1927; accessible via Libcom PDF / anarchist archives. Use as primary self-defense text, not neutral adjudication.
+- Makhno, Nestor. "The Makhnovshchina and Anti-Semitism." 1927; MIA mirror. https://www.marxists.org/reference/archive/makhno-nestor/works/1927/11/anti-semitism.htm. Use as primary polemic, not neutral adjudication.
+- KSL, "Makhnovist movement articles." http://www.katesharpleylibrary.net/gqnkxw. Use for movement / reception bibliography with caution.
+- WorldCat / OCLC record, `Under the blows of the counterrevolution, April-June 1918`. https://search.worldcat.org/title/Under-the-blows-of-the-counterrevolution-April-June-1918/oclc/428868531. Accessed 2026-07-02.
+
+**Tier 4 (learn-ukrainian cross-track materials):**
+
+- `site/src/content/docs/bio/index.mdx`
+- `docs/research/bio/symon-petliura.md`
+- `docs/research/bio/ivan-gonta.md`
+- `docs/research/bio/maksym-zalizniak.md`
+- `docs/research/bio/oleksa-dovbush.md`
+- `docs/research/bio/ustym-karmaliuk.md`
+- `docs/research/bio/yurii-yanovskyi.md`
+- `curriculum/l2-uk-en/plans/hist/bilshovytsko-ukrainska-viyna.yaml`
+- `curriculum/l2-uk-en/hist/discovery/bilshovytsko-ukrainska-viyna.yaml`
+- `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml`
+- `curriculum/l2-uk-en/hist/discovery/dyrektoriia.yaml`
+- `curriculum/l2-uk-en/plans/hist/symon-petliura-revolution.yaml`
+- `curriculum/l2-uk-en/hist/discovery/symon-petliura-revolution.yaml`
+- `curriculum/l2-uk-en/plans/hist/syntez-revoliutsiia.yaml`
+- `curriculum/l2-uk-en/plans/istorio/unr-vybory.yaml`
+- `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`
+- `wiki/periods/symon-petliura-revolution.md`
+- `docs/research/bio/volodymyr-sosiura.md`
+- `docs/archive/RAG-LITERARY-CATALOG.md`
+
+**Tier 5 (image-rights / media-rights checks):**
+
+- Commons `File:Makhno-1919.jpg`. https://commons.wikimedia.org/wiki/File:Makhno-1919.jpg. Public-domain in the United States and Ukraine; verify file page at use time.
+- Commons `File:Nestor Makhno and his Lieutenants, Berdyansk, 1919.jpg`. https://commons.wikimedia.org/wiki/File:Nestor_Makhno_and_his_Lieutenants%2C_Berdyansk%2C_1919.jpg. Public-domain in the United States and Ukraine; verify file page at use time.
+- Commons `File:1921. Нестор Махно в лагере для перемещенных лиц в Румынии.jpg`. https://commons.wikimedia.org/wiki/File:1921._%D0%9D%D0%B5%D1%81%D1%82%D0%BE%D1%80_%D0%9C%D0%B0%D1%85%D0%BD%D0%BE_%D0%B2_%D0%BB%D0%B0%D0%B3%D0%B5%D1%80%D0%B5_%D0%B4%D0%BB%D1%8F_%D0%BF%D0%B5%D1%80%D0%B5%D0%BC%D0%B5%D1%89%D0%B5%D0%BD%D0%BD%D1%8B%D1%85_%D0%BB%D0%B8%D1%86_%D0%B2_%D0%A0%D1%83%D0%BC%D1%8B%D0%BD%D0%B8%D0%B8.jpg. Public-domain in the United States and Ukraine; verify file page at use time.
+- Commons `File:Nestor Makhno tombe.jpg`. https://commons.wikimedia.org/wiki/File:Nestor_Makhno_tombe.jpg. CC0 1.0 own-work grave photo; verify file page at use time.


### PR DESCRIPTION
## Summary

- Adds the BIO #316 `nestor-makhno` research dossier.
- Frames Makhno through Ukrainian peasant insurgency, anarchism, civil-war alliance shifts, pogrom-era evidence cautions, and anti-hagiographic memory.
- Includes cross-track anchors and media-rights candidates for later BIO build work.

## Scope

- Dossier-only PR: `docs/research/bio/nestor-makhno.md`.
- Does not modify plans, modules, activities, vocabulary, resources, site MDX, wiki packets, package files, status/audit/review artifacts, telemetry, or linter configs.

## Validation

- `npx markdownlint-cli2 docs/research/bio/nestor-makhno.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/nestor-makhno.md`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Review Gate

Independent read-only BIO dossier review still required before ready/merge.
