### PR TITLE
docs(bio): add yevhen petrushevych dossier

### DIFF
--- a/docs/research/bio/yevhen-petrushevych.md
+++ b/docs/research/bio/yevhen-petrushevych.md
@@ -1,0 +1,182 @@
+# Євген Омелянович Петрушевич - Research Dossier
+
+**Slug:** `yevhen-petrushevych`
+**Block:** +77 backfill - ZUNR statehood / Ukrainian National Rada / wartime dictatorship / exile diplomacy
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #317
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-02
+**Source acronym legend:** EIU = Encyclopedia of History of Ukraine / Institute of History of Ukraine, NASU; ESU = Encyclopedia of Modern Ukraine / NASU; IEU = Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies; UIJ = Ukrainian Historical Journal / Institute of History of Ukraine, NASU; UINP = Ukrainian Institute of National Memory; BIO / HIST / ISTORIO / wiki = existing learn-ukrainian track materials; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, scholarly, document, and image-rights sources cited
+- [x] Pressure mechanism framed Habsburg collapse, Polish-Ukrainian war over Eastern Galicia, Entente realpolitik, UNR-ZUNR conflict, Soviet erasure, and exile diplomacy; no simple hero-or-failure story
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-02 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric periodization: the frame is Ukrainian Revolution / ZUNR / UNR-ZUNR statehood, not generic "Russian Civil War."
+- [x] Polish state and military pressure named as historical actors without turning the Polish population into a collective villain.
+- [x] Soviet erasure and later Soviet tactical contacts are kept distinct: Petrushevych's anti-Polish diplomatic gambit is not treated as ideological Bolshevism.
+- [x] The title `dictator` is explained as an extraordinary wartime constitutional role in ZUNR politics, not imported from twentieth-century fascist vocabulary.
+- [x] Anti-hagiography preserved: emergency powers, the Petliura conflict, exile miscalculations, and contested late diplomacy remain visible.
+
+## 1. Identity / chronology
+
+- **Canonical UA:** `Євген Омелянович Петрушевич`.
+- **Canonical EN:** `Yevhen Petrushevych`.
+- **Core identity:** Ukrainian Galician lawyer, parliamentarian, president of the Ukrainian National Rada, head of the Western Ukrainian People's Republic / Western Oblast of the Ukrainian People's Republic, and wartime `dictator` of ZUNR in 1919.
+- **Birth:** ESU and EIU give 3 June 1863, Busk, now Lviv oblast, in a priestly family.
+- **Education:** ESU / EIU place him at the Lviv Academic Gymnasium and the Faculty of Law of Lviv University; he was active in Ukrainian student civic life.
+- **Legal and civic work:** ESU / EIU describe legal practice and Ukrainian civic work in Sokal, then Skole, with `Просвіта`, cooperative, credit, and reading-room activity.
+- **Parliamentarian:** EIU / ESU identify him as deputy to the Austrian parliament / Reichsrat from 1907 to 1918 and a Galician Sejm deputy in the prewar period. Treat exact Sejm date ranges as source-sensitive if a module needs precision.
+- **1918 statehood turn:** On 18 October 1918 Ukrainian representatives in Lviv formed the Ukrainian National Rada; Petrushevych was elected its president. He was initially in Vienna, then became the key civil-political head of the West-Ukrainian state.
+- **1919 unification / conflict:** Petrushevych participated in the UPR-ZUNR unification process and, after the Act of Zluky, represented the Galician side in all-Ukrainian state structures. His relations with Symon Petliura and the Directory deteriorated sharply over military strategy, Galicia, and the Polish alliance.
+- **Emergency powers:** On 9 June 1919 the Ukrainian National Rada gave Petrushevych extraordinary powers as `диктатор` of ZUNR during the Polish-Ukrainian war crisis.
+- **Exile:** From 1919-1923 he led the ZUNR government-in-exile / diplomatic campaign, especially from Vienna, before the Entente decision in March 1923 made that governmental line untenable. He later lived in Berlin.
+- **Death:** ESU / EIU give 29 August 1940, Berlin. His remains were later reburied in Lviv in 2002.
+
+## 2. Political pressure mechanism
+
+- **Imperial-collapse opening:** Petrushevych's biography is not a story of sudden nationalism after 1918. His prewar parliamentary and civic work grew inside Habsburg Galicia, where Ukrainians built legal, cooperative, educational, and electoral institutions under unequal conditions.
+- **Self-determination vs state succession:** The Ukrainian National Rada claimed Ukrainian lands of Austria-Hungary through Wilsonian self-determination and local representative authority. Polish political actors claimed much of the same territory through historical-state, demographic, and strategic arguments.
+- **Polish-Ukrainian war over Eastern Galicia:** The ZUNR state project immediately faced military conflict over Lviv and Galicia. This must be taught as state conflict and competing national projects, not ethnic hatred as a default explanation.
+- **Entente realpolitik:** ZUNR's diplomacy depended on Paris, London, Geneva, and League of Nations channels, but the Great Powers ultimately privileged regional security and Polish state-building over West-Ukrainian sovereignty.
+- **UNR-ZUNR asymmetry:** The Act of Zluky created a powerful symbol of unity, but institutions, armies, diplomatic priorities, and territorial pressures remained divided. Petrushevych's conflict with Petliura is a core mechanism, not a personality anecdote.
+- **Emergency authority:** The `dictator` title arose from military collapse and executive centralization, especially after the Chortkiv offensive and pressure on the Ukrainian Galician Army. It carries a legitimacy question for learners: war emergency, constitutional improvisation, or authoritarian drift?
+- **Exile-state pressure:** After loss of territory, Petrushevych had to convert statehood into memoranda, delegations, legal arguments, and international lobbying. That work failed politically in 1923 but preserved documentary and diplomatic traces.
+- **Soviet / anti-Polish tactical temptation:** Some sources note Petrushevych's later contacts or tactical hopes toward Soviet Ukraine in the 1920s. Teach this as exile desperation and anti-Polish strategy, not as a simple conversion to Bolshevism.
+- **Memory pressure:** Soviet narratives marginalized ZUNR statehood as "bourgeois-nationalist" separatism, while simplified diaspora and local memory can flatten Petrushevych into a clean statehood icon. Both lose the institutional and political complexity.
+
+## 3. Major events / historical footprint
+
+- **Student and lawyer formation:** Lviv University and Galician civic life made Petrushevych a legal-parliamentary type of national leader, unlike military insurgent or underground revolutionary figures.
+- **Austrian parliament / Galician Sejm:** His prewar politics linked Ukrainian representation, language rights, electoral reform, and local institution-building in Galicia.
+- **18-19 October 1918:** Ukrainian representatives created the Ukrainian National Rada and proclaimed the political claim to Ukrainian lands of Austria-Hungary. Petrushevych was chosen president of the Rada.
+- **1 November 1918 / Lviv:** The November uprising made the Ukrainian claim concrete in Lviv. Petrushevych was not the military organizer of the night action, but his Rada presidency gave the state project civil-political authority.
+- **ZUNR institution-building:** The Rada and State Secretariat built legal, administrative, educational, military, and diplomatic structures while fighting for territory. This is the main reason Petrushevych belongs in a BIO statehood cluster.
+- **22 January 1919 Act of Zluky:** The unification act connected ZUNR and UNR symbolically and legally, while leaving major practical conflicts unresolved.
+- **9 June 1919 dictatorship:** Extraordinary authority over ZUNR is the central hard-to-teach event. It belongs beside the military collapse, Chortkiv offensive, UHA retreat, and split with the Directory.
+- **Petliura conflict / Warsaw line:** Petrushevych opposed Petliura's readiness to trade claims over Galicia for Polish support against Bolshevik Russia. This is a strong cross-track anchor to `symon-petliura` and `akt-zluki`.
+- **Vienna and League diplomacy:** In exile he tried to keep the Galician question alive through international law, conferences, memoranda, and foreign offices.
+- **March 1923 diplomatic defeat:** The Council of Ambassadors' recognition of Polish sovereignty over Eastern Galicia ended the practical international opening for the ZUNR government-in-exile.
+- **Berlin years and death:** Late Berlin exile, declining political influence, and 1940 death show the end of a statehood generation whose public life had begun in Habsburg parliamentary politics.
+
+## 4. Pedagogical anchors
+
+- **President / dictator contrast:** Petrushevych is ideal for teaching how one person can be both parliamentary legalist and wartime emergency ruler.
+- **ZUNR as state, not episode:** Use him to show laws, Rada procedures, diplomacy, army, and administration, not only a short-lived uprising in Lviv.
+- **Act Zluky tension:** Pair the public rhetoric of unity with practical conflict over army command, diplomatic recognition, and Galicia.
+- **Petliura comparison:** Petliura faced Bolshevik pressure from the east and made the Warsaw alliance; Petrushevych read that as a betrayal of Galician claims. Both arguments can be reconstructed without making either figure a cartoon.
+- **International-law anchor:** Paris Peace Conference, League of Nations, Geneva, Genoa, memoranda, and Council of Ambassadors let learners practice the vocabulary of recognition and non-recognition.
+- **Terminology anchor:** `ЗУНР`, `УНРада`, `Державний секретаріат`, `диктатор`, `Східна Галичина`, `Акт Злуки`, `УГА`, and `еміграційний уряд` should be taught as institutional vocabulary.
+- **Map anchor:** Busk, Lviv, Sokal, Skole, Stanislaviv / Ivano-Frankivsk, Zbruch, Kamianets-Podilskyi, Vienna, Geneva, Berlin.
+- **Visual anchor:** Commons 1918 / 1919 government photographs can show ZUNR as an institutional cabinet and Rada milieu, not merely a portrait of a single man.
+- **Anti-hagiography anchor:** Ask learners whether preserving a lost state's legal claim can become politically counterproductive after military defeat.
+- **Decolonization anchor:** Compare Ukrainian `Західноукраїнська Народна Республіка` with external framings such as "Eastern Galicia," "Małopolska Wschodnia," and Soviet "bourgeois nationalism."
+
+## 5. Language register
+
+- **Register:** legal-political biography, parliamentary history, military emergency, diplomatic memoranda, exile-state memory.
+- **CEFR readiness:** B1+/B2 for short biography and map chronology; B2/C1 for ZUNR institutions and Act Zluky; C1/C2 for the Petliura conflict, international recognition, and the `dictator` debate.
+- **Core vocabulary:** `Євген Петрушевич`, `ЗУНР`, `Західноукраїнська Народна Республіка`, `Українська Національна Рада`, `УНРада`, `президент`, `диктатор`, `Державний секретаріат`, `УГА`, `Східна Галичина`, `Львів`, `Станиславів`, `Акт Злуки`, `УНР`, `Директорія`, `Симон Петлюра`, `Варшавський договір`, `Антанта`, `Паризька мирна конференція`, `Ліга Націй`, `екзильний уряд`, `еміграція`, `Берлін`.
+- **Register caution:** Do not let `диктатор` become a false cognate for modern totalitarian dictator without explanation.
+- **Name caution:** `Yevhen Petrushevych` is the project-facing English form; source titles may also use `Eugene`, `Evhen`, `Jewhen`, `Jevhen`, or Polish / German variants.
+- **Place-name caution:** Historical source language may use `Stanislaviv`, `Stanisławów`, `Lemberg`, `Lwów`, or `Lviv`; learner-facing prose should explain the period rather than silently switch names.
+- **Conflict-language caution:** Use `Polish-Ukrainian war`, `Eastern Galicia`, `ZUNR`, and `Ukrainian Galician Army` precisely. Avoid slogans such as "Poles stole Galicia" or "Galicians betrayed unity."
+
+## 6. Risks / open questions
+
+- **Exact date variants:** Some sources differ on prewar Sejm dates, return from Vienna to Galicia, and exact dates of entry into all-Ukrainian structures after the Act of Zluky. Use source-labeled dates when the module needs precision.
+- **`Dictator` mistranslation:** This is the largest learner-risk. It was an extraordinary office in ZUNR's wartime constitutional crisis. A module should contrast the historical office with modern usage rather than avoiding the word.
+- **ZUNR vs ZO UNR:** After the Act of Zluky, the formal language may shift toward `Western Oblast of the Ukrainian People's Republic`; learner-facing text can say ZUNR first, then note the legal name change.
+- **Petliura reduction:** The Petrushevych-Petliura conflict should not be reduced to rivalry or regional jealousy. It involved Galicia's fate, military collapse, anti-Bolshevik strategy, and international recognition.
+- **Polish-Ukrainian conflict drift:** The war over Eastern Galicia must not turn into collective ethnic blame. State projects, armed formations, international diplomacy, and civilian suffering need separate vocabulary.
+- **Sovietophile overclaim:** Some accounts of Petrushevych's later exile tactics mention orientation toward Soviet Ukraine. This should be handled as a controversial tactical move after diplomatic failure, not as proof he ceased to be a Ukrainian statehood figure.
+- **Memorandum-to-Germany sensitivity:** Late exile contacts with German authorities before / during the Second World War appear in some summaries. If used, they require careful dating and source wording, not insinuation.
+- **Over-symbolizing Act Zluky:** Petrushevych is a corrective to purely celebratory unity narratives: the public act mattered, but institutional unity remained fragile.
+- **Image identity:** Portraits and group photographs on Commons are useful, but captions should specify whether the image is a portrait, ZUNR government group, or later memorial, and file-level licensing must be checked before production use.
+
+## 7. Cross-track links
+
+- **Existing BIO plan / dossier anchors (VERIFIED `test -e` / `rg` 2026-07-02):** `site/src/content/docs/bio/index.mdx` lists BIO #317 `yevhen-petrushevych`; `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml`, `docs/research/bio/symon-petliura.md` support the Petliura comparison and Warsaw-alliance conflict; `curriculum/l2-uk-en/plans/bio/yevhen-konovalets.yaml`, `docs/research/bio/yevhen-konovalets.md` support Sich Riflemen / post-1919 statehood continuity; `curriculum/l2-uk-en/plans/bio/andrii-chaikovskyi.yaml`, `docs/research/bio/andrii-chaikovskyi.md` support ZUNR legal / civic circles; `curriculum/l2-uk-en/plans/bio/vasyl-stefanyk.yaml`, `docs/research/bio/vasyl-stefanyk.md` support the ZUNR delegation / Act Zluky bridge; `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml`, `docs/research/bio/mykhailo-hrushevskyi.md` support Central Rada / all-Ukrainian constitutional comparison.
+- **Existing HIST plan / discovery surfaces (VERIFIED `test -e` / `rg` 2026-07-02):** `curriculum/l2-uk-en/plans/hist/zunr.yaml`, `curriculum/l2-uk-en/hist/discovery/zunr.yaml`; `curriculum/l2-uk-en/plans/hist/symon-petliura-revolution.yaml`, `curriculum/l2-uk-en/hist/discovery/symon-petliura-revolution.yaml`; `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`; `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml`; `curriculum/l2-uk-en/plans/hist/syntez-revoliutsiia.yaml`, `curriculum/l2-uk-en/hist/discovery/syntez-revoliutsiia.yaml`.
+- **Existing ISTORIO plan / discovery surfaces (VERIFIED `test -e` / `rg` 2026-07-02):** `curriculum/l2-uk-en/plans/istorio/akt-zluki.yaml`, `curriculum/l2-uk-en/istorio/discovery/akt-zluki.yaml`; `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`; `curriculum/l2-uk-en/plans/istorio/halychyna-pid-avstriieyu.yaml`, `curriculum/l2-uk-en/istorio/discovery/halychyna-pid-avstriieyu.yaml`.
+- **Existing wiki / context surfaces (VERIFIED `test -e` / `rg` 2026-07-02):** `wiki/periods/zunr.md`, `wiki/periods/symon-petliura-revolution.md`, `wiki/academic/c1/halychyna.md`.
+- **Candidate / absent BIO #317 production surfaces (VERIFIED absent `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/bio/yevhen-petrushevych.yaml`, `curriculum/l2-uk-en/bio/discovery/yevhen-petrushevych.yaml`, `wiki/figures/yevhen-petrushevych.md`, `site/src/content/docs/bio/yevhen-petrushevych.mdx`, `curriculum/l2-uk-en/bio/yevhen-petrushevych/module.md`, `curriculum/l2-uk-en/bio/yevhen-petrushevych/activities.yaml`, `curriculum/l2-uk-en/bio/yevhen-petrushevych/vocabulary.yaml`, `curriculum/l2-uk-en/bio/yevhen-petrushevych/resources.yaml`.
+- **Candidate / absent wiki targets referenced by existing plans (VERIFIED absent `test -e` 2026-07-02):** `wiki/hist/zunr-akt-zluky.md`, `wiki/hist/symon-petliura-revolution.md`, `wiki/hist/revoliutsiia-1917-1921.md`, `wiki/istorio/habsburg-vs-romanov.md`.
+
+## 8. Name variants / search aliases
+
+- **Canonical UA:** `Євген Омелянович Петрушевич`.
+- **Canonical EN:** `Yevhen Petrushevych`.
+- **Common UA search forms:** `Євген Петрушевич`, `Петрушевич Євген Омелянович`, `Є. Петрушевич`, `Євген Омелянович Петрушевич`.
+- **Common EN / transliteration forms:** `Yevhen Petrushevych`, `Evhen Petrushevych`, `Eugene Petrushevych`, `Jewhen Petruszewycz`, `Jevhen Petrushevych`, `Petrushevych Yevhen`.
+- **Polish / German source variants:** `Eugeniusz Petruszewycz`, `Jewhen Petruszewycz`, `Eugen Petruschewitsch`, `Petruszewycz`.
+- **Institutional aliases:** `president of the Ukrainian National Rada`, `head of ZUNR`, `dictator of ZUNR`, `president of the Western Ukrainian National Republic`, `Ukrainian Galician leader`.
+- **Search pairings:** `Євген Петрушевич ЗУНР`, `Петрушевич диктатор ЗУНР`, `Petrushevych ZUNR government`, `Petrushevych Ukrainian National Council`, `Petrushevych Petliura Warsaw alliance`, `Petrushevych League of Nations`, `Петрушевич еміграційний уряд`.
+- **Learner-facing pairing:** `Євген Петрушевич (Yevhen Petrushevych), president of the Ukrainian National Rada and wartime dictator of ZUNR, 1863-1940`.
+
+## 9. Image rights / media candidates
+
+- **Default portrait candidate:** Commons `File:Petrushevych Yevhen.jpg`; public domain in Canada and the United States, with Commons caution that it may not be public domain in every jurisdiction. Use only after file-level rights review for the publication target.
+- **Alternate portrait candidate:** Commons `File:Петрушевич Євген Омелянович.jpg`; public-domain / public-domain-marked historical portrait, sourced through an Istpravda page. Good learner-facing portrait if file-level provenance is accepted.
+- **ZUNR government group candidate:** Commons `File:Pic P E Petrushevych Yevhen and ZUNR government (1918).jpg`; public-domain group image with strong ZUNR institutional context.
+- **Government context candidate:** Commons `File:Уряд ЗУНР 1919.jpg`; public-domain / PD-Ukraine context image for cabinet / government lessons.
+- **Military-state context candidate:** Commons `File:Петрушевич зі старшинами та помічниками, 1919.jpg`; public-domain / PD-Ukraine image useful for connecting civil leadership with UHA officers.
+- **UHA context candidate:** Commons `File:1-ша бригада УСС УГА, 1919.jpg`; public-domain contextual image for Ukrainian Galician Army material, not a Petrushevych portrait.
+- **Memorial candidates:** Commons `Category:Yevhen Petrushevych` includes grave and Chortkiv plaque subcategories. These need file-level license confirmation before production use.
+- **Avoid default:** unsourced internet portraits, colorized restorations, school-site images, modern monument photos without explicit reusable licensing, and images that make Petrushevych look like a military commander detached from institutions.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- "Петрушевич Євген Омелянович." Енциклопедія Сучасної України, НАН України. https://esu.com.ua/article-879937. Accessed 2026-07-02.
+- "Петрушевич Євген Омелянович." Енциклопедія історії України, Інститут історії України НАН України. https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21FMT=eiu_all&S21P03=TRN%3D&S21STR=Petrushevych_Y. Accessed 2026-07-02.
+- "Українська національна рада ЗУНР." Енциклопедія історії України, Інститут історії України НАН України. https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21FMT=eiu_all&S21P03=TRN%3D&S21STR=Ukrainska_ZUNR. Accessed 2026-07-02.
+- "Західноукраїнська Народна Республіка (ЗУНР)." Енциклопедія історії України, Інститут історії України НАН України. https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21FMT=eiu_all&S21P03=TRN%3D&S21STR=ZUNR. Accessed 2026-07-02.
+- "Українсько-польська війна 1918-1919." Енциклопедія історії України, Інститут історії України НАН України. https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21FMT=eiu_all&S21P03=TRN%3D&S21STR=Ukrainsko_polska_1918. Accessed 2026-07-02.
+- "Акт злуки УНР і ЗУНР." Енциклопедія Сучасної України, НАН України. https://esu.com.ua/article-43521. Accessed 2026-07-02.
+
+**Tier 2 (scholarly / documentary / memory context):**
+
+- Тимченко Р. "Євген Петрушевич - лідер Західноукраїнської Народної Республіки." Український історичний журнал, 2013, no. 5. https://history.org.ua/JournALL/journal/2013/5/11.pdf. Accessed 2026-07-02.
+- Дацків І. "Дипломатія ЗУНР на Паризькій мирній конференції 1919 р." Український історичний журнал, 2008, no. 5. https://history.org.ua/JournALL/journal/2008/5/9.pdf. Accessed 2026-07-02.
+- Малюта О. "Органи влади ЗУНР та УНР в екзилі у 20-40-і рр. ХХ ст." https://history.org.ua/JournALL/xxx/12/19.pdf. Accessed 2026-07-02.
+- `Західно-Українська народна республіка 1918-1923: Документи і матеріали`, т. 3, кн. 2. https://resource.history.org.ua/item/0014704. Accessed 2026-07-02.
+- `Західно-Українська народна республіка 1918-1923: Документи і матеріали`, т. 5, кн. 3. https://resource.history.org.ua/item/0014714. Accessed 2026-07-02.
+- UINP, "Інформаційні матеріали до 100-річчя проголошення Акта Злуки." https://uinp.gov.ua/pres-centr/novyny/informaciyni-materialy-do-100-richchya-progoloshennya-akta-zluky. Accessed 2026-07-02.
+
+**Tier 3 (learn-ukrainian cross-track sources, verified locally 2026-07-02):**
+
+- `site/src/content/docs/bio/index.mdx`
+- `docs/research/bio/symon-petliura.md`
+- `docs/research/bio/yevhen-konovalets.md`
+- `docs/research/bio/andrii-chaikovskyi.md`
+- `docs/research/bio/vasyl-stefanyk.md`
+- `docs/research/bio/mykhailo-hrushevskyi.md`
+- `curriculum/l2-uk-en/plans/hist/zunr.yaml`
+- `curriculum/l2-uk-en/hist/discovery/zunr.yaml`
+- `curriculum/l2-uk-en/plans/hist/symon-petliura-revolution.yaml`
+- `curriculum/l2-uk-en/hist/discovery/symon-petliura-revolution.yaml`
+- `curriculum/l2-uk-en/plans/istorio/akt-zluki.yaml`
+- `curriculum/l2-uk-en/istorio/discovery/akt-zluki.yaml`
+- `wiki/periods/zunr.md`
+- `wiki/periods/symon-petliura-revolution.md`
+- `wiki/academic/c1/halychyna.md`
+
+**Tier 4 (image-rights / media-rights sources):**
+
+- Commons `File:Petrushevych Yevhen.jpg`. https://commons.wikimedia.org/wiki/File:Petrushevych_Yevhen.jpg. Accessed 2026-07-02.
+- Commons `File:Петрушевич Євген Омелянович.jpg`. https://commons.wikimedia.org/wiki/File:%D0%9F%D0%B5%D1%82%D1%80%D1%83%D1%88%D0%B5%D0%B2%D0%B8%D1%87_%D0%84%D0%B2%D0%B3%D0%B5%D0%BD_%D0%9E%D0%BC%D0%B5%D0%BB%D1%8F%D0%BD%D0%BE%D0%B2%D0%B8%D1%87.jpg. Accessed 2026-07-02.
+- Commons `File:Pic P E Petrushevych Yevhen and ZUNR government (1918).jpg`. https://commons.wikimedia.org/wiki/File:Pic_P_E_Petrushevych_Yevhen_and_ZUNR_government_%281918%29.jpg. Accessed 2026-07-02.
+- Commons `File:Уряд ЗУНР 1919.jpg`. https://commons.wikimedia.org/wiki/File:%D0%A3%D1%80%D1%8F%D0%B4_%D0%97%D0%A3%D0%9D%D0%A0_1919.jpg. Accessed 2026-07-02.
+- Commons `File:Петрушевич зі старшинами та помічниками, 1919.jpg`. https://commons.wikimedia.org/wiki/File:%D0%9F%D0%B5%D1%82%D1%80%D1%83%D1%88%D0%B5%D0%B2%D0%B8%D1%87_%D0%B7%D1%96_%D1%81%D1%82%D0%B0%D1%80%D1%88%D0%B8%D0%BD%D0%B0%D0%BC%D0%B8_%D1%82%D0%B0_%D0%BF%D0%BE%D0%BC%D1%96%D1%87%D0%BD%D0%B8%D0%BA%D0%B0%D0%BC%D0%B8%2C_1919.jpg. Accessed 2026-07-02.
+- Commons `File:1-ша бригада УСС УГА, 1919.jpg`. https://commons.wikimedia.org/wiki/File:1-%D1%88%D0%B0_%D0%B1%D1%80%D0%B8%D0%B3%D0%B0%D0%B4%D0%B0_%D0%A3%D0%A1%D0%A1_%D0%A3%D0%93%D0%90%2C_1919.jpg. Accessed 2026-07-02.

--- a/docs/research/bio/yevhen-petrushevych.md
+++ b/docs/research/bio/yevhen-petrushevych.md
@@ -119,7 +119,7 @@
 - **Common UA search forms:** `Євген Петрушевич`, `Петрушевич Євген Омелянович`, `Є. Петрушевич`, `Євген Омелянович Петрушевич`.
 - **Common EN / transliteration forms:** `Yevhen Petrushevych`, `Evhen Petrushevych`, `Eugene Petrushevych`, `Jewhen Petruszewycz`, `Jevhen Petrushevych`, `Petrushevych Yevhen`.
 - **Polish / German source variants:** `Eugeniusz Petruszewycz`, `Jewhen Petruszewycz`, `Eugen Petruschewitsch`, `Petruszewycz`.
-- **Institutional aliases:** `president of the Ukrainian National Rada`, `head of ZUNR`, `dictator of ZUNR`, `president of the Western Ukrainian National Republic`, `Ukrainian Galician leader`.
+- **Institutional aliases:** `president of the Ukrainian National Rada`, `head of ZUNR`, `dictator of ZUNR`, `president of the Western Ukrainian People's Republic`, `Ukrainian Galician leader`.
 - **Search pairings:** `Євген Петрушевич ЗУНР`, `Петрушевич диктатор ЗУНР`, `Petrushevych ZUNR government`, `Petrushevych Ukrainian National Council`, `Petrushevych Petliura Warsaw alliance`, `Petrushevych League of Nations`, `Петрушевич еміграційний уряд`.
 - **Learner-facing pairing:** `Євген Петрушевич (Yevhen Petrushevych), president of the Ukrainian National Rada and wartime dictator of ZUNR, 1863-1940`.
 


### PR DESCRIPTION
## Summary
- Adds the BIO #317 research dossier for `yevhen-petrushevych`.
- Covers ZUNR statehood, Ukrainian National Rada leadership, wartime dictatorship, the Petliura conflict, exile diplomacy, cross-track links, and image-rights candidates.

## Scope
- Dossier-only change: `docs/research/bio/yevhen-petrushevych.md`.
- No plan YAML, module content, activities, vocabulary, resources, MDX, wiki packets, status/audit/review artifacts, telemetry files, package files, or linter configs changed.

## Validation
- `npx markdownlint-cli2 docs/research/bio/yevhen-petrushevych.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/yevhen-petrushevych.md`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Review
- Draft until independent non-Codex review completes and any findings are resolved.
