### PR TITLE
docs(bio): add marko bezruchko dossier

### DIFF
--- a/docs/research/bio/marko-bezruchko.md
+++ b/docs/research/bio/marko-bezruchko.md
@@ -1,0 +1,196 @@
+# Марко Данилович Безручко - Research Dossier
+
+**Slug:** `marko-bezruchko`
+**Block:** +77 backfill - UNR Army / 6th Sich Rifle Division / Zamość defense / Polish-Ukrainian alliance / military exile
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #318
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-02
+
+**Source acronym legend:** EIU = Encyclopedia History Ukraine / Institute History of Ukraine, NASU; ESU = Encyclopedia Modern Ukraine / NASU; IEU = Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies; UINP = Ukrainian Institute National Memory; IPN = Institute National Remembrance, Poland; Gov.pl = official Polish government portal; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, primary-text, or image-rights sources cited
+- [x] Pressure mechanism framed imperial officer training, UNR army-building, Polish-Ukrainian alliance, Zamość / Battle of Warsaw, Riga, internment, exile-state military work, and memory politics
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-02 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric periodization: frame is Ukrainian Revolution / UNR Army / Bolshevik-Ukrainian and Polish-Soviet war context, not generic "Russian Civil War."
+- [x] Ukrainian agency preserved: Bezruchko is not only a Polish ally or auxiliary; he commanded UNR formations with Ukrainian military goals.
+- [x] Polish alliance framed double-sided: 1920 battlefield cooperation is taught beside the Riga settlement, internment, and post-defeat exile.
+- [x] Anti-Bolshevik language is precise: name Bolshevik Russia / Red Army pressure without turning every conflict into a simple civilizational slogan.
+- [x] Anti-hagiography applied: "saved Poland / Europe" appears only as commemorative memory language, not neutral single-cause military analysis.
+- [x] Soviet erasure named: UNR officers, Polish-allied anti-Bolshevik command, and exile military history were incompatible with Soviet public memory.
+
+## 1. Identity / chronology
+
+- **Canonical UA:** `Марко Данилович Безручко`.
+- **Canonical EN:** `Marko Bezruchko`.
+- **Core identity:** Ukrainian military officer, General Staff officer, general-khorunzhyi of the Army of the Ukrainian People's Republic, commander of the 6th Sich Rifle Division, and a central Ukrainian commander in the 1920 defense of Zamość.
+- **Birth:** ESU gives `31 October (12 November) 1883`, Velykyi Tokmak, Tavriia gubernia, now Tokmak, Zaporizhzhia oblast. EIU and UINP use 31 October 1883. IEU's older English entry gives 31 October 1886, so use 1883 as the canonical project date and keep the discrepancy for source-criticism notes.
+- **Education:** ESU / EIU record Odessa infantry junker school in 1908 and Imperial Military Academy / General Staff Academy in Saint Petersburg in 1914. UINP and IPN also emphasize his professional officer preparation before Ukrainian service.
+- **First World War:** ESU / EIU place him in the imperial Russian army during the First World War; EIU identifies him as lieutenant colonel and chief of staff of the 30th artillery corps on the Southwestern Front.
+- **1917-1918 Ukrainian army formation:** EIU says he participated in Ukrainization of front units and Ukrainian army-building. UINP places him in the personnel department of the UNR / Ukrainian State General Staff from 8 March 1918; other staff-office summaries use operational-department language, so exact department/date wording should stay source-labeled in learner materials.
+- **1919 Sich Riflemen staff role:** UINP and EIU place him as chief of staff of UNR formations in 1919, including the Corps of Sich Riflemen.
+- **1920 6th Sich Rifle Division:** UINP says he headed the 1st Division from 8 February 1920, renamed the 6th Sich Division from 21 March 1920. ESU / IEU confirm command of the 6th Sich Riflemen / Sich Division.
+- **Kyiv campaign:** ESU / EIU / Gov.pl place the division in the spring 1920 Polish-Ukrainian campaign; ESU says the division was among the first to enter Kyiv.
+- **Zamość / Battle of Warsaw:** UINP, Gov.pl, IPN, EIU, IEU, and ESU all identify Zamość as his signature military episode, with his division resisting Budyonny's 1st Cavalry Army during the wider Battle of Warsaw campaign.
+- **Internment and exile:** ESU / EIU describe UNR internment in Polish camps and Bezruchko's later Warsaw exile, military-government work, and Ukrainian Military History Society leadership.
+- **Death:** ESU / EIU give 10 February 1944, Warsaw.
+
+## 2. Political pressure mechanism
+
+- **Russian imperial military pipeline:** Bezruchko was trained inside the imperial Russian officer system, then redirected professional military expertise into Ukrainian state service. This is a useful case for teaching continuity and rupture in officer cadres.
+- **Army-building under collapse:** UNR military structures had to form while fronts disintegrated, Bolshevik forces advanced, the Hetmanate rose and fell, and Ukrainian command institutions repeatedly reorganized.
+- **Bolshevik military pressure:** The 1920 Polish-Ukrainian alliance aimed at Bolshevik Russia. Avoid Soviet-style wording that turns the Ukrainian side into a passive object of "Polish intervention."
+- **Polish-Ukrainian alliance pressure:** Bezruchko's 6th Sich Division fought alongside Polish forces after the Piłsudski-Petliura agreement. The alliance was a real anti-Bolshevik framework, but it also exposed Ukrainian dependence on Polish strategic choices.
+- **Zamość as operational memory node:** Holding Zamość helped disrupt Budyonny's cavalry pressure during the wider Battle of Warsaw. Later memory often turns this into "he saved Poland / Europe"; curriculum should teach operational fact and memory phrase separately.
+- **Riga / internment pressure:** After the 1920 campaign, Polish-Soviet negotiations and armistice logic left the UNR army isolated. UINP and Gov.pl both note that Ukrainian soldiers were later interned in Poland.
+- **Exile-state military continuity:** Bezruchko's Warsaw work in UNR military-government circles, the Supreme Military Council milieu, and the Ukrainian Military History Society preserved military memory after battlefield defeat.
+- **Soviet erasure pressure:** A Polish-allied UNR general who fought the Red Army did not fit Soviet narratives of legitimate revolutionary victory or "fraternal" Ukrainian-Russian history.
+- **Modern memory pressure:** Streets, commemorations, and the 2022 naming of Ukraine's 110th Mechanized Brigade connect Bezruchko to present-day anti-imperial military memory, but current commemorations must not become primary sources for 1920 battlefield facts.
+
+## 3. Major events / historical footprint
+
+- **1908 / 1914 officer education:** Odessa infantry school and General Staff academy credentials explain why Bezruchko appears as organizer and staff officer, not only field commander.
+- **1917 Ukrainization:** EIU records his participation in Ukrainization of Russian-front units, making him useful for teaching how empire-trained personnel entered Ukrainian institutions.
+- **1918 General Staff role:** UINP places him as assistant chief in the personnel department of the General Staff of the UNR Army / Ukrainian State structures from 8 March 1918. Treat exact department/date as source-sensitive if module prose needs precision.
+- **March-April 1919 staff appointments:** UINP identifies him as chief of staff of the Separate Zaporizhian Brigade named after Symon Petliura, then chief of staff of the Corps of Sich Riflemen.
+- **February-March 1920 division formation:** UINP's sequence helps avoid generic "he led a Ukrainian unit" wording: 1st Division from February, renamed 6th Sich Division from March.
+- **April-May 1920 Kyiv offensive:** The 6th Sich Division joined the Polish-Ukrainian campaign; this is the strongest bridge to Petliura, the Warsaw agreement, and the Kyiv offensive.
+- **August 1920 Zamość:** Bezruchko's defense of Zamość against Budyonny's 1st Cavalry Army is the dossier's signature event. Use IPN / Gov.pl for source-labeled operational context and avoid unsourced force-ratio claims.
+- **Komarów / Vistula context:** Gov.pl ties Bezruchko's fighting near Zamość and Komarów to the broader defeat of the Red Army's westward campaign.
+- **September-November 1920 UNR command:** EIU says he commanded the Central Group of the UNR Army in September-November 1920 and later led military mission / army staff work in Warsaw.
+- **1920-1924 exile-government work:** EIU / IEU place him in defense-ministry, deputy-ministry, or Supreme Military Council roles in the UNR government-in-exile. Use source labels because English / Ukrainian title wording varies.
+- **1931-1935 military-history leadership:** EIU / IEU identify him as head of the Ukrainian Military History Society in Warsaw; writings and editorial milieu belong in military-memory pedagogy.
+- **2022 honorary naming:** Presidential Decree 606/2022 assigned the honorary name "імені генерал-хорунжого Марка Безручка" to Ukraine's 110th Separate Mechanized Brigade. Use this only as modern memory evidence.
+
+## 4. Pedagogical anchors
+
+- **Staff officer anchor:** Bezruchko teaches that army-building depends on staff work, personnel, logistics, and division formation, not only battlefield charisma.
+- **Alliance paradox anchor:** In 1918-1919 Polish and Ukrainian forces fought over Galicia; in 1920 Polish and Ukrainian forces fought together against Bolshevik Russia. Pair him with `1918-1920: Війна і союз одночасно`.
+- **Zamość map anchor:** Use Zamość, Warsaw, Komarów, Kyiv, Brest-Litovsk, Aleksandrów Kujawski, Kalisz / Szczypiorno, Tokmak, and the Zbruch line to make alliance, retreat, internment, and exile visible.
+- **Memory phrase anchor:** "Miracle on the Vistula" and "saved Europe" are source-criticism phrases: who uses them, when, and for what politics of memory?
+- **Riga realpolitik anchor:** After alliance came internment. Learners can compare treaty promise, military convention, battlefield cooperation, armistice, and the loss of effective UNR military options.
+- **Primary-text anchor:** Wikisource author and `За Державність` pages provide Bezruchko-attributed Sich Riflemen military-history texts. Verify exact article / book title before learner-facing reuse, and treat them as authored testimony rather than neutral omniscient narration.
+- **Modern-war memory anchor:** The 110th Mechanized Brigade naming links UNR military memory to present-day Ukrainian defense without making the modern brigade a source for 1920 facts.
+- **Anti-hagiography anchor:** A disciplined commander can be commemorated without implying that the 1920 alliance solved Ukrainian statehood or that every Polish policy toward Ukrainians was friendly.
+- **Visual anchor:** Commons `File:Marko Bezruczko.jpg` gives a file-level public-domain portrait candidate; `File:Petlura Bezruczko 1920.jpg` can anchor UNR officer and Petliura context if the production use confirms file-level rights.
+
+## 5. Language register
+
+- **Register:** military biography, staff chronology, campaign narrative, Polish-Ukrainian alliance, exile-state memory, military historiography.
+- **CEFR readiness:** B1+/B2 short biography maps; B2/C1 Kyiv offensive and Zamość chronology; C1/C2 alliance, Riga, internment, and memory-politics comparison.
+- **Core vocabulary:** `Марко Безручко`, `генерал-хорунжий`, `Армія УНР`, `6-та Січова стрілецька дивізія`, `Січові стрільці`, `Генеральний штаб`, `українізація війська`, `польсько-український союз`, `Варшавська угода`, `Замостя`, `Диво на Віслі`, `Будьонний`, `1-ша Кінна армія`, `інтернування`, `Александрів-Куявський`, `Каліш`, `Щипйорно`, `еміграційний уряд`, `Українське воєнно-історичне товариство`, `За Державність`.
+- **Term caution:** `генерал-хорунжий` is a UNR rank. Do not flatten it into generic "general" when Ukrainian military vocabulary is a teaching point.
+- **Alliance-language caution:** Avoid simple "Polish-Ukrainian brotherhood" conclusions. The alliance coexisted with the earlier war over Galicia and the later Polish-Soviet settlement.
+- **Memory-language caution:** "Saved Europe" should appear inside source-analysis tasks, not as the narrator's voice.
+- **Place-name caution:** Use `Zamość / Замостя`, `Warsaw / Варшава`, `Aleksandrów Kujawski / Александрів-Куявський`, `Kalisz / Каліш`, `Szczypiorno / Щипйорно`; preserve diacritics where source titles use them.
+- **Source-language caution:** Polish sources use `URL` for `Ukraińska Republika Ludowa`; learner-facing English should stay with project usage `UNR / Ukrainian People's Republic`.
+
+## 6. Risks / open questions
+
+- **Birth-year discrepancy:** ESU / EIU / UINP support 1883; IEU's older English entry gives 1886. Use 1883 in learner-facing text and mention the discrepancy only where source criticism is relevant.
+- **Old-style / new-style date:** ESU gives 31 October / 12 November 1883. EIU / UINP often use 31 October. A module can use `1883-1944` unless calendar precision matters.
+- **Command wording at Zamość:** Sources alternate among "organized," "commanded," "led," and "distinguished himself." Use IPN / Gov.pl / UINP wording when narrating mixed Polish-Ukrainian operational detail.
+- **"Saved Europe" inflation:** Commemorative sources may claim Zamość / Warsaw saved Europe from Bolshevism. Teach this as geopolitical memory, not single-cause military history.
+- **Polish institutional memory:** Gov.pl / IPN sources are valuable but also represent Polish state memory. Pair them with Ukrainian institutional sources and treaty / convention texts.
+- **Treaty vs battlefield:** The Warsaw agreement and military convention created an allied framework, but Polish-Soviet negotiations later abandoned the UNR military position. Do not teach only alliance.
+- **Internment phrasing:** Polish camps held former allies after the 1920 campaign. Explain armistice and border politics without turning the episode into a simple ethnic morality play.
+- **Modern brigade naming:** The 2022 honorary name is current memory in the context of Russian aggression. It should not backfill 1920 facts.
+- **Late-life politics:** EIU / ESU mention later support for OUN and Second World War-era views. If used, date and source carefully; this dossier's BIO build can focus on UNR command and exile military history.
+- **Image rights:** Commons portrait and 1920 group-photo candidates are public-domain-marked, but production use still needs file-level confirmation of source, publication date, and Commons warning text.
+
+## 7. Cross-track links
+
+- **Existing BIO plan / dossier anchors (VERIFIED `test -e` / `rg` 2026-07-02):** `site/src/content/docs/bio/index.mdx` lists BIO #318 `marko-bezruchko`; `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml`, `docs/research/bio/symon-petliura.md` support Warsaw alliance / UNR command; `curriculum/l2-uk-en/plans/bio/yevhen-konovalets.yaml`, `docs/research/bio/yevhen-konovalets.md` support Sich Riflemen continuity; `curriculum/l2-uk-en/plans/bio/petro-bolbochan.yaml`, `docs/research/bio/petro-bolbochan.md` support UNR officer-cadre comparison; `curriculum/l2-uk-en/plans/bio/oleksandr-hrekiv.yaml`, `docs/research/bio/oleksandr-hrekiv.md` support UNR / ZUNR military elite comparisons; `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml`, `docs/research/bio/mykhailo-hrushevskyi.md` support all-Ukrainian statehood context.
+- **Existing HIST plan / discovery surfaces (VERIFIED `test -e` / `rg` 2026-07-02):** `curriculum/l2-uk-en/plans/hist/symon-petliura-revolution.yaml`, `curriculum/l2-uk-en/hist/discovery/symon-petliura-revolution.yaml`; `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml`, `curriculum/l2-uk-en/hist/discovery/dyrektoriia.yaml`; `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`, `curriculum/l2-uk-en/hist/discovery/tsentralna-rada.yaml`; `curriculum/l2-uk-en/plans/hist/bilshovytsko-ukrainska-viyna.yaml`, `curriculum/l2-uk-en/hist/discovery/bilshovytsko-ukrainska-viyna.yaml`; `curriculum/l2-uk-en/plans/hist/sichovi-striltsi.yaml`, `curriculum/l2-uk-en/hist/discovery/sichovi-striltsi.yaml`; `curriculum/l2-uk-en/plans/hist/zunr.yaml`, `curriculum/l2-uk-en/hist/discovery/zunr.yaml`.
+- **Existing ISTORIO plan / discovery surfaces (VERIFIED `test -e` / `rg` 2026-07-02):** `curriculum/l2-uk-en/plans/istorio/1918-1920-viina-i-soiuz.yaml`, `curriculum/l2-uk-en/istorio/discovery/1918-1920-viina-i-soiuz.yaml`; `curriculum/l2-uk-en/plans/istorio/akt-zluki.yaml`, `curriculum/l2-uk-en/istorio/discovery/akt-zluki.yaml`; `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`, `curriculum/l2-uk-en/istorio/discovery/universaly-unr.yaml`.
+- **Existing wiki / context surfaces (VERIFIED `test -e` 2026-07-02):** `wiki/periods/symon-petliura-revolution.md`, `wiki/periods/dyrektoriia.md`, `wiki/periods/zunr.md`, `wiki/figures/symon-petliura.md`, `wiki/figures/yevhen-konovalets.md`, `wiki/historiography/universaly-unr.md`.
+- **Candidate / absent BIO #318 surfaces (VERIFIED absent `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/bio/marko-bezruchko.yaml`, `curriculum/l2-uk-en/bio/discovery/marko-bezruchko.yaml`, `wiki/figures/marko-bezruchko.md`, `site/src/content/docs/bio/marko-bezruchko.mdx`, `curriculum/l2-uk-en/bio/marko-bezruchko/module.md`, `curriculum/l2-uk-en/bio/marko-bezruchko/activities.yaml`, `curriculum/l2-uk-en/bio/marko-bezruchko/vocabulary.yaml`, `curriculum/l2-uk-en/bio/marko-bezruchko/resources.yaml`.
+- **Candidate / absent context surfaces (VERIFIED absent `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/hist/polish-soviet-war.yaml`, `curriculum/l2-uk-en/hist/discovery/polish-soviet-war.yaml`, `curriculum/l2-uk-en/plans/hist/zamosc.yaml`, `curriculum/l2-uk-en/hist/discovery/zamosc.yaml`, `wiki/periods/dyrektoriia-unr.md`, `wiki/periods/ukrainian-revolution.md`.
+
+## 8. Name variants / search aliases
+
+- **Canonical UA:** `Марко Данилович Безручко`.
+- **Canonical EN:** `Marko Bezruchko`.
+- **Common UA search forms:** `Марко Безручко`, `Безручко Марко Данилович`, `М. Безручко`, `генерал Марко Безручко`, `генерал-хорунжий Марко Безручко`.
+- **Common EN / transliteration forms:** `Marko Bezruchko`, `Marko Bezručko`, `Marko Bezruczko`, `Mark Bezruchko`, `Bezruchko Marko`, `Bezruczko Marko`.
+- **Polish source variants:** `Marko Bezruczko`, `gen. Marko Bezruczko`, `płk Marko Bezruczko`.
+- **Institutional aliases:** `general-khorunzhyi of the Army of the Ukrainian People's Republic`, `commander of the 6th Sich Rifle Division`, `defender of Zamość`, `UNR general`, `Ukrainian commander in the Battle of Warsaw`.
+- **Search pairings:** `Марко Безручко Замостя`, `Марко Безручко Диво на Віслі`, `Безручко 6 Січова дивізія`, `Bezruchko Zamość`, `Bezruczko Zamość`, `Marko Bezruchko 6th Sich Division`, `Bezruchko Budyonny`, `Bezruchko Petliura`, `Безручко Варшавська угода`, `Безручко УНР еміграція`.
+- **Learner-facing pairing:** `Марко Безручко (Marko Bezruchko), general-khorunzhyi of the UNR Army and commander of the 6th Sich Division at Zamość, 1883-1944`.
+
+## 9. Image rights / media candidates
+
+- **Default portrait candidate:** Commons `File:Marko Bezruczko.jpg`; source `За Державність`, z. 3, Warszawa 1933; author unknown-anonymous; public-domain-marked under Polish and Ukrainian public-domain templates. Strong portrait candidate, but confirm file-level warning text before production.
+- **Later portrait candidate:** Commons `File:Marko Bezruczko 1934.jpg`; source `За Державність`, z. 5, Warszawa 1935; author unknown-anonymous; useful for exile / military-history context.
+- **UNR officer context candidate:** Commons `File:Petlura Bezruczko 1920.jpg`; source Centralne Archiwum Wojskowe; author unknown-anonymous; shows UNR officers with Bezruchko and Symon Petliura during the Polish-Soviet War; public-domain-marked.
+- **Kyiv offensive context candidate:** Commons `File:Listowski i Petlura1920.jpg`; source points to NAC / Audiovis; public-domain-marked in Poland / US; useful for Polish-Ukrainian command context, not a Bezruchko portrait.
+- **UNR / Kyiv parade context candidate:** Commons `File:Petlura defilada 6 dywizji URL Kijów 23.05.1920.jpg`; Centralne Archiwum Wojskowe source; useful for 6th Division / Kyiv offensive context if file-level licensing is confirmed.
+- **Grave / memorial candidate:** Commons `File:Marek bezruczko grób cmentarz prawosławny na woli.JPG`; own work, CC BY-SA 4.0 plus GFDL; useful for Warsaw exile-memory lessons, not battle depiction.
+- **Risky / avoid by default:** YouTube thumbnails, social-media portraits without reusable rights, AI colorizations, school-site hero graphics, unsourced "saved Europe" posters, and modern Polish/Ukrainian patriotic memes.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- "Безручко Марко Данилович." Енциклопедія Сучасної України, НАН України. https://esu.com.ua/article-41587. Accessed 2026-07-02.
+- Бойко О.Д. "Безручко Марко Данилович." Енциклопедія історії України, Інститут історії України НАН України. https://www.history.org.ua/?termin=Bezruchko_M. Accessed 2026-07-02.
+- "Bezruchko, Marko." Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CB%5CE%5CBezruchkoMarko.htm. Accessed 2026-07-02.
+- UINP, "Безручко Марко." https://unr.uinp.gov.ua/figures/bezruchko-marko. Accessed 2026-07-02.
+- UINP, "1883 - народився Марко Безручко, генерал-хорунжий Армії УНР." https://www.uinp.gov.ua/istorychnyy-kalendar/zhovten/31/1883-narodyvsya-marko-bezruchko-general-horunzhyy-armiyi-unr. Accessed 2026-07-02.
+- UINP, "1920 - завершення Варшавської битви, названої 'Диво на Віслі'." https://uinp.gov.ua/istorychnyy-kalendar/serpen/25/1920-zavershennya-varshavskoyi-bytvy. Accessed 2026-07-02.
+- UINP, "Вулиця Генерала Безручка." https://unr.uinp.gov.ua/memory-places/vulitsya-generala-bezruchka. Accessed 2026-07-02.
+- Президент України, Указ N 606/2022. https://www.president.gov.ua/documents/6062022-43757. Accessed 2026-07-02.
+
+**Tier 2 (scholarly / institutional context):**
+
+- Mirosław Szumiło, "Sojusz polsko-ukraiński w 1920 roku," IPN / Biuletyn IPN 2020, no. 1-2. https://archiwum.ipn.gov.pl/download/1/449792/BiuletynIPN2020nr1-2Szumilo.pdf. Accessed 2026-07-02.
+- Gov.pl, "Wsparcie Ukrainy dla Polski w wojnie polsko-bolszewickiej." https://www.gov.pl/web/ukraina/wsparcie-ukrainy-dla-polski-w-wojnie-polsko-bolszewickiej. Accessed 2026-07-02.
+- IPN, "Polecamy: Sojusz polsko-ukraiński w 1920 roku." https://ipn.gov.pl/pl/historia-z-ipn/95808%2CPolecamy-Sojusz-polsko-ukrainski-w-1920-roku.html. Accessed 2026-07-02.
+- IPN, `Bolszewika bij! Lubelszczyzna 1920 r.` https://archiwum.ipn.gov.pl/download/1/449585/BolszewikabijLubelszczyzna1920r.pdf. Accessed 2026-07-02.
+
+**Tier 3 (primary / near-primary texts; use source-critically):**
+
+- Wikisource, "Автор:Марко Безручко." https://uk.wikisource.org/wiki/Автор:Марко_Безручко. Accessed 2026-07-02.
+- Wikisource, Bezruchko-attributed Sich Riflemen text in `За Державність`, vol. 2. https://uk.wikisource.org/wiki/За_Державність/2/Січові_стрільці_в_боротьбі_за_державність. Accessed 2026-07-02.
+- Wikisource, Bezruchko-attributed Sich Riflemen text in `За Державність`, vol. 3. https://uk.wikisource.org/wiki/За_Державність/3/Січові_стрільці_в_боротьбі_за_державність. Accessed 2026-07-02.
+- Polish Wikisource, Warsaw political agreement of 21 April 1920. https://pl.wikisource.org/wiki/Umowa_między_rządem_Rzeczypospolitej_Polskiej_a_rządem_Ukraińskiej_Republiki_Ludowej_21_kwietnia_1920. Accessed 2026-07-02.
+- Polish Wikisource, Military convention between Poland and the Ukrainian People's Republic, 1920. https://pl.wikisource.org/wiki/Konwencja_wojskowa_między_Rzecząpospolitą_Polską_a_Ukraińską_Republiką_Ludową_(1920). Accessed 2026-07-02.
+
+**Tier 4 (learn-ukrainian cross-track sources checked 2026-07-02):**
+
+- `site/src/content/docs/bio/index.mdx`
+- `docs/research/bio/symon-petliura.md`
+- `docs/research/bio/yevhen-konovalets.md`
+- `docs/research/bio/petro-bolbochan.md`
+- `docs/research/bio/oleksandr-hrekiv.md`
+- `docs/research/bio/mykhailo-hrushevskyi.md`
+- `curriculum/l2-uk-en/plans/hist/symon-petliura-revolution.yaml`
+- `curriculum/l2-uk-en/hist/discovery/symon-petliura-revolution.yaml`
+- `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml`
+- `curriculum/l2-uk-en/hist/discovery/dyrektoriia.yaml`
+- `curriculum/l2-uk-en/plans/hist/bilshovytsko-ukrainska-viyna.yaml`
+- `curriculum/l2-uk-en/hist/discovery/bilshovytsko-ukrainska-viyna.yaml`
+- `curriculum/l2-uk-en/plans/hist/sichovi-striltsi.yaml`
+- `curriculum/l2-uk-en/hist/discovery/sichovi-striltsi.yaml`
+- `curriculum/l2-uk-en/plans/istorio/1918-1920-viina-i-soiuz.yaml`
+- `curriculum/l2-uk-en/istorio/discovery/1918-1920-viina-i-soiuz.yaml`
+
+**Tier 5 (image-rights / media-rights sources):**
+
+- Commons `File:Marko Bezruczko.jpg`. https://commons.wikimedia.org/wiki/File:Marko_Bezruczko.jpg. Accessed 2026-07-02.
+- Commons `Category:Marko Bezruchko`. https://commons.wikimedia.org/wiki/Category:Marko_Bezruchko. Accessed 2026-07-02.
+- Commons `File:Marko Bezruczko 1934.jpg`. https://commons.wikimedia.org/wiki/File:Marko_Bezruczko_1934.jpg. Accessed 2026-07-02.
+- Commons `File:Petlura Bezruczko 1920.jpg`. https://commons.wikimedia.org/wiki/File:Petlura_Bezruczko_1920.jpg. Accessed 2026-07-02.
+- Commons `File:Listowski i Petlura1920.jpg`. https://commons.wikimedia.org/wiki/File:Listowski_i_Petlura1920.jpg. Accessed 2026-07-02.
+- Commons `File:Petlura defilada 6 dywizji URL Kijów 23.05.1920.jpg`. https://commons.wikimedia.org/wiki/File:Petlura_defilada_6_dywizji_URL_KIj%C3%B3w_23.05.1920.jpg. Accessed 2026-07-02.
+- Commons `File:Marek bezruczko grób cmentarz prawosławny na woli.JPG`. https://commons.wikimedia.org/wiki/File:Marek_bezruczko_gr%C3%B3b_cmentarz_prawos%C5%82awny_na_woli.JPG. Accessed 2026-07-02.


### PR DESCRIPTION
## Summary
- add BIO #318 Marko Bezruchko research dossier
- cover UNR Army command, 6th Sich Division, Zamość / Battle of Warsaw, Polish-Ukrainian alliance, internment, exile military history, and image-rights candidates

## Scope
- dossier-only: docs/research/bio/marko-bezruchko.md
- no plan YAML, module content, activities, vocabulary, resources, site MDX, wiki packets, telemetry, package files, or unrelated files

## Validation
- npx markdownlint-cli2 docs/research/bio/marko-bezruchko.md
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/marko-bezruchko.md
- git diff --check
- git diff --cached --check
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py

## Review
- Independent read-only review required before merge.