### PR TITLE
docs(bio): add dmytro vitovskyi dossier

### DIFF
--- a/docs/research/bio/dmytro-vitovskyi.md
+++ b/docs/research/bio/dmytro-vitovskyi.md
@@ -1,0 +1,176 @@
+# Дмитро Дмитрович Вітовський - Research Dossier
+
+**Slug:** `dmytro-vitovskyi`
+**Block:** +77 backfill - Ukrainian Sich Riflemen / ZUNR military affairs / November action / Ukrainian Galician Army / Paris delegation
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #319
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-02
+
+**Source acronym legend:** EIU = Encyclopedia History Ukraine / Institute History of Ukraine, NASU; ESU = Encyclopedia Modern Ukraine / NASU; IEU = Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies; UINP = Ukrainian Institute National Memory; BIO / HIST / ISTORIO / wiki = existing learn-ukrainian track materials; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, scholarly, primary-text, and image-rights sources cited
+- [x] Pressure mechanism framed Habsburg collapse, ZUNR state-building, November 1918 Lviv action, Polish-Ukrainian war, army-building, Paris diplomacy, death-date/source drift, and memory politics
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-02 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric periodization: frame Habsburg collapse, Ukrainian Revolution, ZUNR / Western Ukrainian statehood, and Polish-Ukrainian war, not generic "Russian Civil War."
+- [x] Ukrainian agency preserved: Vitovskyi is a ZUNR military organizer and political actor, not only an Austrian officer or Polish-Ukrainian war footnote.
+- [x] Polish-Ukrainian conflict taught as competing state projects, military organization, diplomacy, and civilian risk, not inherited ethnic inevitability.
+- [x] Soviet erasure named: Ukrainian Sich Riflemen, ZUNR statehood, and Galician army-building were marginalized or reframed in Soviet narratives.
+- [x] Anti-hagiography included: he is important without making him sole creator of ZUNR, sole author of November action, or long-term commander of all UHA campaigns.
+
+## 1. Identity / chronology
+
+- **Canonical UA:** `Дмитро Дмитрович Вітовський`.
+- **Canonical EN:** `Dmytro Vitovskyi`.
+- **Core identity:** Ukrainian military, political, and civic figure; sotnyk of the Ukrainian Sich Riflemen; organizer of the November 1918 Lviv action; first commander of Ukrainian forces / Ukrainian Galician Army in the opening Lviv fighting; State Secretary of Military Affairs of the Western Ukrainian People's Republic / ZUNR.
+- **Pseudonym:** ESU / EIU give `Гнат Буряк`.
+- **Birth:** ESU / EIU / IEU / UINP give 8 November 1887, Medukha, then Stanyslaviv region / Galicia, now Ivano-Frankivsk oblast.
+- **Education:** ESU / EIU say he finished gymnasium in Stanyslaviv in 1907, studied law at Lviv University, was expelled in 1910 after Ukrainian student anti-Polish protest activity, and completed legal studies at Krakow University.
+- **Prewar civic work:** From 1911, ESU / EIU place him in legal work in Stanyslaviv and in Ukrainian Radical Party, `Січ`, `Просвіта`, paramilitary, and educational organizing.
+- **First World War / USS:** ESU / EIU / UINP describe him as commander of a company and battalion of the Ukrainian Sich Riflemen; the sources connect him with Carpathian fighting, Makivka memory, and later cultural-political work.
+- **Kovel / Volhynia work:** ESU / EIU place him in Kovel in 1916-1917, supporting Ukrainian schooling and USS cultural-political work in Volhynia.
+- **1918 Right-Bank Ukraine:** EIU and UINP connect his 1918 work with Ukrainian affairs in Austrian military structures and USS-linked civic activity in Right-Bank / southern Ukraine contexts. Keep exact staff-title wording source-labeled.
+- **October-November 1918:** ESU says he headed the Ukrainian Military General Committee from 29 October 1918 and prepared the 1 November armed action in Lviv; IEU identifies him as chair of the Ukrainian Military Committee that staged the November Uprising in Lviv.
+- **ZUNR military office:** ESU / IEU identify him as commander of Ukrainian forces in Lviv from 1-5 November 1918, then State Secretary / minister of defense from 9 November 1918. IEU records service until 13 February 1919 and promotion from major to colonel on 1 January 1919.
+- **Paris Peace Conference:** ESU / EIU / IEU place him in the Western Ukrainian delegation or as a military adviser in spring 1919, arguing against Polish occupation of Western Ukrainian lands.
+- **Death:** ESU / EIU give 4 August 1919 near Ratibor, Germany, now Raciborz, Poland, in an air crash while returning to Ukraine. IEU's older English entry gives 8 July 1919; Hai-Nyzhnyk argues 2 August 1919. Use `1887-1919` in low-context learner copy unless exact date is part of source criticism.
+
+## 2. Political pressure mechanism
+
+- **Imperial-collapse pressure:** Vitovskyi's generation moved Habsburg schooling, Austrian military service, Sich societies, legal training, and Ukrainian party networks into state-building when imperial authority collapsed in 1918.
+- **Student civic mobilization:** Lviv University conflict, Radical Party work, `Січ`, `Просвіта`, and paramilitary organizing show how political education, legal training, and mass mobilization fed later military leadership.
+- **USS as military-political school:** Ukrainian Sich Riflemen were not only a battlefield formation; they also created print culture, schooling work, political networks, and disciplined cadres that ZUNR could mobilize quickly.
+- **November action pressure:** Ukrainian National Rada's October 1918 claim needed control of administrative and military sites in Lviv before Polish institutions consolidated power. Vitovskyi's role belongs inside that urgent timing.
+- **Polish-Ukrainian war pressure:** Ukrainian control in Lviv met Polish armed resistance and soon became war over Eastern Galicia. Teach state claims, demographics, military organization, and civilian risk separately.
+- **State-building under fire:** As State Secretary of Military Affairs, Vitovskyi had to turn revolutionary seizure, scattered formations, and Sich networks into army and military-administrative structures.
+- **UNR-ZUNR connection:** EIU credits him with support for UNR-ZUNR unification. This belongs beside Act Zluky and the later fragility of practical institutional unity.
+- **Paris pressure:** His Paris role shows ZUNR translating battlefield defeat and territorial claims into international-law argument while Great Power priorities increasingly favored Polish state security.
+- **Memory pressure:** Ukrainian memory often emphasizes heroic "Листопадовий зрив"; Polish memory may emphasize defense of Lwow / Lviv; Soviet memory minimized Ukrainian statehood and Galician military agency.
+
+## 3. Major events / historical footprint
+
+- **1907-1911 legal-political formation:** Gymnasium, Lviv University activism, expulsion, Krakow law studies, and Stanyslaviv legal work explain his later blend of political and military language.
+- **1914-1915 USS command:** First World War service connects the future ZUNR commander with Ukrainian Sich Riflemen, Carpathian fighting, and Makivka memory.
+- **1916-1917 Kovel / Volhynia:** Ukrainian schooling work in occupied Volhynia is a strong pedagogical bridge: army service could also mean education, language policy, and institution-building.
+- **1918 Central Military Committee:** Heading the Ukrainian Military Committee / General Committee in Lviv made him an operational planner of the November action.
+- **1 November 1918 Lviv action:** IEU's November Uprising entry describes Ukrainian soldiers occupying administrative, public-utility, and military objectives before Polish resistance consolidated. Vitovskyi becomes a practical state-formation figure, not only a symbolic speaker.
+- **1-5 November 1918 Ukrainian command:** ESU / IEU identify him as first commander of Ukrainian forces / Ukrainian Galician Army in the earliest Lviv fighting. His very short command tenure should remain visible.
+- **9 November 1918 military secretary:** State Secretary of Military Affairs made him responsible for army-building and military-administrative structures in ZUNR.
+- **1 January 1919 colonel promotion:** IEU records promotion from major to colonel; use as a rank-vocabulary anchor, but avoid overloading short biography with full UHA rank history.
+- **Spring 1919 Paris mission:** Delegation work shifts the biography from front-line organizing to diplomacy and international recognition.
+- **August 1919 air crash:** Death near Ratibor / Raciborz while returning to Ukraine makes the biography a case of interrupted state-building leadership. Exact day belongs in a source-comparison note.
+- **2002 Lychakiv reburial:** UINP notes reburial at Lychakiv cemetery. Use this as a memory-history anchor, not evidence for 1918 events.
+
+## 4. Pedagogical anchors
+
+- **Army and state anchor:** UINP's attributed slogan `Буде армія - буде державність` is useful as a source-critical teaching prompt: why did ZUNR military organizers tie statehood to army-building?
+- **One-night state action anchor:** The November action gives a concrete timeline: committee, night operation, flags and proclamations, Polish resistance, command crisis, transformation into wider war.
+- **USS-to-ZUNR continuity anchor:** Track how Ukrainian Sich Riflemen networks became a cadre source for Western Ukrainian statehood.
+- **Lawyer-soldier anchor:** Vitovskyi's legal education and military role help learners see Ukrainian Revolution actors as institution-builders, not only armed commanders.
+- **Lviv map anchor:** Medukha, Stanyslaviv / Ivano-Frankivsk, Lviv, Kovel, Oleksandrivsk / Zaporizhzhia, Halych, Makivka, Paris, Ratibor / Raciborz, Berlin, and Lychakiv cemetery.
+- **Conflict-language anchor:** Pair "Листопадовий зрив" with Polish "defense of Lwow / Lviv" framings to teach competing memory vocabularies without adopting either as neutral narrator language.
+- **Act Zluky anchor:** Vitovskyi sits before and after the January 1919 unity act: ZUNR military needs, UNR cooperation, and still-fragile institutional unity.
+- **Anti-hagiography anchor:** His importance does not require claiming he personally "created ZUNR." He organized key military machinery inside broader Rada, Sich, party, and social networks.
+- **Visual anchor:** Commons `File:Vitovsky Dmytro.jpg` is a portrait candidate; Commons `File:Сотник Дмитро Вітовський, 1915.jpg` anchors USS-era military identity if production confirms file-level rights.
+
+## 5. Language register
+
+- **Register:** military-political biography, Habsburg collapse, Western Ukrainian statehood, November action, army-building, diplomacy, memory politics.
+- **CEFR readiness:** B1+/B2 short biography map; B2/C1 November action sequence and ZUNR offices; C1/C2 competing Polish/Ukrainian memory and Paris diplomacy.
+- **Core vocabulary:** `Дмитро Вітовський`, `Гнат Буряк`, `Українські січові стрільці`, `УСС`, `ЗУНР`, `Українська Галицька Армія`, `УГА`, `Листопадовий зрив`, `Український військовий комітет`, `державний секретар військових справ`, `сотник`, `полковник`, `Паризька мирна конференція`, `Східна Галичина`.
+- **Place-name caution:** Use `Lviv / Львів`, `Stanyslaviv / Станиславів`, `Medukha / Медуха`, `Kovel / Ковель`, `Oleksandrivsk / Олександрівськ`, `Ratibor / Raciborz / Ратібор`, and `Lychakiv / Личаків` with source-sensitive historical names.
+- **Conflict-language caution:** Avoid "Polish occupiers" as the narrator's only frame in beginner text; source-label diplomatic claims and distinguish military action from later international recognition.
+- **Death-date caution:** Use 4 August 1919 when following ESU/EIU, but record IEU's older 8 July date and Hai-Nyzhnyk's 2 August reconstruction when learners compare sources.
+
+## 6. Risks / open questions
+
+- **Death-date discrepancy:** ESU / EIU give 4 August 1919; Hai-Nyzhnyk argues 2 August 1919 from crash-circumstance reconstruction; IEU's older English entry gives 8 July 1919. Use `1887-1919` unless an exact day is source-labeled.
+- **First commander wording:** ESU / IEU say first commander of Ukrainian forces / Ukrainian Galician Army, but the Lviv command was brief and changed during November fighting. Do not imply long command over all later UHA campaigns.
+- **November action agency:** Vitovskyi led military preparation, but action depended on Ukrainian National Rada decisions, garrison composition, Sich networks, and Austrian collapse. Avoid a single-person origin story.
+- **Polish-Ukrainian war framing:** Conflict over Lviv / Eastern Galicia involved statehood claims, urban demographics, armed youth formations, military command, and civilian danger. Do not flatten it into ethnic destiny.
+- **Paris diplomacy:** Sources identify delegation work, but module text should avoid inventing speeches or negotiations unless primary source checked.
+- **USS mythology:** Sich Riflemen memory can turn into clean heroic folklore. Preserve schooling, press, discipline, and political ideology beside battlefield memory.
+- **Austrian-service drift:** He served in Austrian military contexts during the First World War. Present this as Habsburg Ukrainian mobilization and later state transition, not contradiction of Ukrainian identity.
+- **Image identity:** Commons has usable-looking portraits, but file-level author/source fields may be weak on older transferred uploads. Use only after license and identity review; caption uncertainty where needed.
+
+## 7. Cross-track links
+
+- **Existing BIO plan / dossier anchors (VERIFIED `test -e` / `rg` 2026-07-02):** `site/src/content/docs/bio/index.mdx` lists BIO #319 `dmytro-vitovskyi`; `docs/research/bio/yevhen-petrushevych.md` supports ZUNR political leadership context; `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml`, `docs/research/bio/symon-petliura.md` support UNR-ZUNR / Act Zluky tension; `curriculum/l2-uk-en/plans/bio/andrii-chaikovskyi.yaml`, `docs/research/bio/andrii-chaikovskyi.md` support Galician civic ZUNR milieu; `curriculum/l2-uk-en/plans/bio/vasyl-stefanyk.yaml`, `docs/research/bio/vasyl-stefanyk.md` support Galician political-cultural context; `curriculum/l2-uk-en/plans/bio/oleksandr-hrekiv.yaml`, `docs/research/bio/oleksandr-hrekiv.md` support UHA / UNR military comparison.
+- **Existing HIST plan / discovery surfaces (VERIFIED `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/hist/zunr.yaml`, `curriculum/l2-uk-en/hist/discovery/zunr.yaml`; `curriculum/l2-uk-en/plans/hist/symon-petliura-revolution.yaml`, `curriculum/l2-uk-en/hist/discovery/symon-petliura-revolution.yaml`; `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml`, `curriculum/l2-uk-en/hist/discovery/dyrektoriia.yaml`; `curriculum/l2-uk-en/plans/hist/sichovi-striltsi.yaml`, `curriculum/l2-uk-en/hist/discovery/sichovi-striltsi.yaml`.
+- **Existing ISTORIO plan / discovery surfaces (VERIFIED `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/istorio/akt-zluki.yaml`, `curriculum/l2-uk-en/istorio/discovery/akt-zluki.yaml`; `curriculum/l2-uk-en/plans/istorio/halychyna-pid-avstriieyu.yaml`, `curriculum/l2-uk-en/istorio/discovery/halychyna-pid-avstriieyu.yaml`; `curriculum/l2-uk-en/plans/istorio/halychyna-natsionalnyi-rukh.yaml`, `curriculum/l2-uk-en/istorio/discovery/halychyna-natsionalnyi-rukh.yaml`; `curriculum/l2-uk-en/plans/istorio/sich-dokumenty.yaml`, `curriculum/l2-uk-en/istorio/discovery/sich-dokumenty.yaml`; `curriculum/l2-uk-en/plans/istorio/polskyi-pohliad.yaml`, `curriculum/l2-uk-en/istorio/discovery/polskyi-pohliad.yaml`.
+- **Existing wiki / context surfaces (VERIFIED `test -e` 2026-07-02):** `wiki/periods/zunr.md`, `wiki/periods/symon-petliura-revolution.md`, `wiki/academic/c1/halychyna.md`, `wiki/historiography/universaly-unr.md`, `wiki/figures/symon-petliura.md`, `wiki/figures/yevhen-konovalets.md`.
+- **Candidate / absent BIO #319 surfaces (VERIFIED absent `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/bio/dmytro-vitovskyi.yaml`, `curriculum/l2-uk-en/bio/discovery/dmytro-vitovskyi.yaml`, `wiki/figures/dmytro-vitovskyi.md`, `site/src/content/docs/bio/dmytro-vitovskyi.mdx`, `curriculum/l2-uk-en/bio/dmytro-vitovskyi/module.md`, `curriculum/l2-uk-en/bio/dmytro-vitovskyi/activities.yaml`, `curriculum/l2-uk-en/bio/dmytro-vitovskyi/vocabulary.yaml`, `curriculum/l2-uk-en/bio/dmytro-vitovskyi/resources.yaml`.
+- **Candidate / absent context surfaces (VERIFIED absent `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/hist/lystopadovyi-chyn.yaml`, `curriculum/l2-uk-en/hist/discovery/lystopadovyi-chyn.yaml`, `wiki/periods/ukrainian-revolution.md`, `wiki/periods/ukrainian-polish-war.md`.
+
+## 8. Name variants / search aliases
+
+- **Canonical UA:** `Дмитро Дмитрович Вітовський`.
+- **Canonical EN:** `Dmytro Vitovskyi`.
+- **Common UA search forms:** `Дмитро Вітовський`, `Вітовський Дмитро`, `Вітовський Дмитро Дмитрович`, `Д. Вітовський`, `Гнат Буряк`.
+- **Common EN / transliteration forms:** `Dmytro Vitovskyi`, `Dmytro Vitovsky`, `Dmytro Vitovskyj`, `Dmytro Vitovs'kyi`, `Dmytro Witowski`, `Dmytro Witowsky`, `Dmytro Witovsky`.
+- **Institution / office aliases:** `Ukrainian Sich Riflemen`, `Legion of Ukrainian Sich Riflemen`, `Ukrainian Military Committee`, `Ukrainian Military General Committee`, `State Secretary of Military Affairs`, `minister of defense of ZUNR`, `Ukrainian Galician Army`, `UHA`.
+- **Learner-facing display:** `Dmytro Vitovskyi (Дмитро Вітовський, 1887-1919)`.
+
+## 9. Image rights / visual material notes
+
+- **Primary portrait candidate:** Commons `File:Vitovsky Dmytro.jpg`; public-domain-marked older portrait. Use after file-level source / author / license check; useful for biography card.
+- **USS-era portrait candidate:** Commons `File:Сотник Дмитро Вітовський, 1915.jpg`; public-domain-marked military portrait. Useful for First World War / USS sections if identity and licensing are confirmed.
+- **Modern illustration candidate:** Commons `File:Vitovsky UINP.tif`; UINP / Diachenko 2018, CC BY-SA 4.0. Useful rights-clean modern illustration, not historical photograph.
+- **Context / group image caution:** Commons `File:Boberski Witowski Cehelski 1918.jpg` is public-domain-marked but has caption/name consistency risk. Do not use as a Vitovskyi-specific image unless identity is independently verified.
+- **Memorial candidate:** Commons `File:Pamjatnyk Vitovskomu.jpg`; public-domain-released photograph of Lychakiv tomb / monument. It can support memory and reburial lessons, but is a modern memory surface, not evidence for 1918.
+- **Avoid default:** YouTube thumbnails, social-media graphics, school-site hero images, AI colorizations, unattributed November action posters, and images that present Polish-Ukrainian conflict as meme rather than documented historical episode.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- "Вітовський Дмитро Дмитрович." Енциклопедія Сучасної України, НАН України / НТШ. https://esu.com.ua/article-34991. Accessed 2026-07-02.
+- Науменко К.Є. "Вітовський Дмитро." Енциклопедія історії України, Інститут історії України НАН України. https://www.history.org.ua/?termin=Vitovskyj_D. Accessed 2026-07-02.
+- "Vitovsky, Dmytro." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CV%5CI%5CVitovskyDmytro.htm. Accessed 2026-07-02.
+- UINP, "1887 - народився Дмитро Вітовський, сотник Легіону Українських січових стрільців." https://uinp.gov.ua/istorychnyy-kalendar/lystopad/8/1887-narodyvsya-dmytro-vitovskyy-sotnyk-legionu-ukrayinskyh-sichovyh-strilciv. Accessed 2026-07-02.
+- UINP UNR figures, "Вітовський Дмитро." https://unr.uinp.gov.ua/figures/vitovskiy-dmitro. Accessed 2026-07-02.
+- UINP, "1918 - у Львові розпочався Листопадовий чин." https://uinp.gov.ua/istorychnyy-kalendar/lystopad/1/1918-u-lvovi-rozpochavsya-lystopadovyy-chyn. Accessed 2026-07-02.
+- "November Uprising in Lviv, 1918." Internet Encyclopedia of Ukraine. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CN%5CO%5CNovemberUprisinginLviv1918.htm. Accessed 2026-07-02.
+- "Західноукраїнська Народна Республіка (ЗУНР)." Енциклопедія історії України, Інститут історії України НАН України. https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21FMT=eiu_all&S21P03=TRN%3D&S21STR=ZUNR. Accessed 2026-07-02.
+- "Українсько-польська війна 1918-1919." Енциклопедія історії України, Інститут історії України НАН України. https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21FMT=eiu_all&S21P03=TRN%3D&S21STR=Ukrainsko_polska_1918. Accessed 2026-07-02.
+- "Листопадова національно-демократична революція 1918." Енциклопедія Сучасної України. https://esu.com.ua/article-55016. Accessed 2026-07-02.
+- "Державний секретаріат ЗУНР." Енциклопедія історії України. https://www.history.org.ua/?termin=Derzh_sek_at_ZUNR. Accessed 2026-07-02.
+- "Українська Галицька армія." Енциклопедія історії України. https://history.org.ua/?termin=Ukrainska_Halytska. Accessed 2026-07-02.
+- "Ukrainian Galician Army." Internet Encyclopedia of Ukraine. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CU%5CK%5CUkrainianGalicianArmy.htm. Accessed 2026-07-02.
+- Гай-Нижник П. "Дмитро Вітовський: встановлення історичної дати та обставин загибелі." https://hai-nyzhnyk.in.ua/doc/247doc.php. Accessed 2026-07-02.
+
+**Tier 3 (learn-ukrainian cross-track sources checked 2026-07-02):**
+
+- `site/src/content/docs/bio/index.mdx`
+- `docs/research/bio/yevhen-petrushevych.md`
+- `docs/research/bio/symon-petliura.md`
+- `docs/research/bio/andrii-chaikovskyi.md`
+- `docs/research/bio/vasyl-stefanyk.md`
+- `docs/research/bio/oleksandr-hrekiv.md`
+- `curriculum/l2-uk-en/plans/hist/zunr.yaml`
+- `curriculum/l2-uk-en/hist/discovery/zunr.yaml`
+- `curriculum/l2-uk-en/plans/hist/sichovi-striltsi.yaml`
+- `curriculum/l2-uk-en/hist/discovery/sichovi-striltsi.yaml`
+- `curriculum/l2-uk-en/plans/istorio/akt-zluki.yaml`
+- `curriculum/l2-uk-en/istorio/discovery/akt-zluki.yaml`
+- `wiki/periods/zunr.md`
+- `wiki/academic/c1/halychyna.md`
+
+**Tier 4 (image-rights / media-rights sources):**
+
+- Commons `File:Vitovsky Dmytro.jpg`. https://commons.wikimedia.org/wiki/File:Vitovsky_Dmytro.jpg. Accessed 2026-07-02.
+- Commons `File:Сотник Дмитро Вітовський, 1915.jpg`. https://commons.wikimedia.org/wiki/File:%D0%A1%D0%BE%D1%82%D0%BD%D0%B8%D0%BA_%D0%94%D0%BC%D0%B8%D1%82%D1%80%D0%BE_%D0%92%D1%96%D1%82%D0%BE%D0%B2%D1%81%D1%8C%D0%BA%D0%B8%D0%B9,_1915.jpg. Accessed 2026-07-02.
+- Commons `Category:Dmytro Vitovskyi`. https://commons.wikimedia.org/wiki/Category:Dmytro_Vitovskyi. Accessed 2026-07-02.
+- Commons `File:Vitovsky UINP.tif`. https://commons.wikimedia.org/wiki/File:Vitovsky_UINP.tif. Accessed 2026-07-02.
+- Commons `File:Boberski Witowski Cehelski 1918.jpg`. https://commons.wikimedia.org/wiki/File:Boberski_Witowski_Cehelski_1918.jpg. Accessed 2026-07-02.
+- Commons `File:Pamjatnyk Vitovskomu.jpg`. https://commons.wikimedia.org/wiki/File:Pamjatnyk_Vitovskomu.jpg. Accessed 2026-07-02.

--- a/docs/research/bio/dmytro-vitovskyi.md
+++ b/docs/research/bio/dmytro-vitovskyi.md
@@ -41,7 +41,7 @@
 - **Kovel / Volhynia work:** ESU / EIU place him in Kovel in 1916-1917, supporting Ukrainian schooling and USS cultural-political work in Volhynia.
 - **1918 Right-Bank Ukraine:** EIU and UINP connect his 1918 work with Ukrainian affairs in Austrian military structures and USS-linked civic activity in Right-Bank / southern Ukraine contexts. Keep exact staff-title wording source-labeled.
 - **October-November 1918:** ESU says he headed the Ukrainian Military General Committee from 29 October 1918 and prepared the 1 November armed action in Lviv; IEU identifies him as chair of the Ukrainian Military Committee that staged the November Uprising in Lviv.
-- **ZUNR military office:** ESU / IEU identify him as commander of Ukrainian forces in Lviv from 1-5 November 1918, then State Secretary / minister of defense from 9 November 1918. IEU records service until 13 February 1919 and promotion from major to colonel on 1 January 1919.
+- **ZUNR military office:** ESU / IEU identify him as commander of Ukrainian forces in Lviv from 1-5 November 1918, then State Secretary / minister of defense from 9 November 1918. IEU records service until 13 February 1919 and a 1 January 1919 major-to-colonel promotion; treat 12/13 February and colonel chronology as source-sensitive at build time.
 - **Paris Peace Conference:** ESU / EIU / IEU place him in the Western Ukrainian delegation or as a military adviser in spring 1919, arguing against Polish occupation of Western Ukrainian lands.
 - **Death:** ESU / EIU give 4 August 1919 near Ratibor, Germany, now Raciborz, Poland, in an air crash while returning to Ukraine. IEU's older English entry gives 8 July 1919; Hai-Nyzhnyk argues 2 August 1919. Use `1887-1919` in low-context learner copy unless exact date is part of source criticism.
 
@@ -66,7 +66,7 @@
 - **1 November 1918 Lviv action:** IEU's November Uprising entry describes Ukrainian soldiers occupying administrative, public-utility, and military objectives before Polish resistance consolidated. Vitovskyi becomes a practical state-formation figure, not only a symbolic speaker.
 - **1-5 November 1918 Ukrainian command:** ESU / IEU identify him as first commander of Ukrainian forces / Ukrainian Galician Army in the earliest Lviv fighting. His very short command tenure should remain visible.
 - **9 November 1918 military secretary:** State Secretary of Military Affairs made him responsible for army-building and military-administrative structures in ZUNR.
-- **1 January 1919 colonel promotion:** IEU records promotion from major to colonel; use as a rank-vocabulary anchor, but avoid overloading short biography with full UHA rank history.
+- **Rank chronology source note:** IEU records a 1 January 1919 major-to-colonel promotion; later Ukrainian summaries place colonel status by the November 1918 State Secretariat appointment. Use source-labeled rank chronology rather than settled timeline.
 - **Spring 1919 Paris mission:** Delegation work shifts the biography from front-line organizing to diplomacy and international recognition.
 - **August 1919 air crash:** Death near Ratibor / Raciborz while returning to Ukraine makes the biography a case of interrupted state-building leadership. Exact day belongs in a source-comparison note.
 - **2002 Lychakiv reburial:** UINP notes reburial at Lychakiv cemetery. Use this as a memory-history anchor, not evidence for 1918 events.
@@ -94,7 +94,8 @@
 
 ## 6. Risks / open questions
 
-- **Death-date discrepancy:** ESU / EIU give 4 August 1919; Hai-Nyzhnyk argues 2 August 1919 from crash-circumstance reconstruction; IEU's older English entry gives 8 July 1919. Use `1887-1919` unless an exact day is source-labeled.
+- **Death-date discrepancy:** ESU / EIU give 4 August 1919; Hai-Nyzhnyk argues 2 August 1919 and treats 4 August as inaccurate; IEU's older English entry gives 8 July 1919. Use 2 August as scholarly preferred only when source-labeled; use `1887-1919` for low-context copy.
+- **Military office date / rank chronology:** IEU uses 13 February 1919 and a 1 January colonel promotion; later Ukrainian summaries use 12 February and imply colonel status by the 9 November 1918 State Secretariat appointment. Do not combine these into one unlabelled chronology.
 - **First commander wording:** ESU / IEU say first commander of Ukrainian forces / Ukrainian Galician Army, but the Lviv command was brief and changed during November fighting. Do not imply long command over all later UHA campaigns.
 - **November action agency:** Vitovskyi led military preparation, but action depended on Ukrainian National Rada decisions, garrison composition, Sich networks, and Austrian collapse. Avoid a single-person origin story.
 - **Polish-Ukrainian war framing:** Conflict over Lviv / Eastern Galicia involved statehood claims, urban demographics, armed youth formations, military command, and civilian danger. Do not flatten it into ethnic destiny.


### PR DESCRIPTION
## Summary

- Adds the BIO #319 `dmytro-vitovskyi` research dossier.
- Frames Vitovskyi through Ukrainian Sich Riflemen, ZUNR army-building, the November 1918 Lviv action, Paris diplomacy, and source-sensitive death-date drift.
- Keeps this as dossier-only prep: only `docs/research/bio/dmytro-vitovskyi.md` is changed.

## Validation

- `npx markdownlint-cli2 docs/research/bio/dmytro-vitovskyi.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/dmytro-vitovskyi.md`
- `git diff --check`
- `git diff --cached --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Independent Review

Pending required read-only non-Codex review before merge.
