### PR TITLE
docs(bio): add oleksandr lototskyi dossier

### DIFF
--- a/docs/research/bio/oleksandr-lototskyi.md
+++ b/docs/research/bio/oleksandr-lototskyi.md
@@ -7,7 +7,7 @@
 **Researcher:** Codex orchestrator (GPT-5)
 **Completed:** 2026-07-02
 
-**Source acronym legend:** EIU = Encyclopedia History Ukraine / Institute History of Ukraine, NASU; ESU = Encyclopedia Modern Ukraine / NASU; IEU = Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies; UINP = Ukrainian Institute National Memory; CDIAK = Central State Historical Archive of Ukraine in Kyiv; NBVU = Vernadsky National Library of Ukraine; Diasporiana = Ukrainian diaspora digital library; BIO / HIST / ISTORIO / wiki = existing learn-ukrainian track materials; Commons = Wikimedia Commons.
+**Source acronym legend:** EIU = Encyclopedia History Ukraine / Institute History of Ukraine, NASU; ESU = Encyclopedia Modern Ukraine / NASU; IEU = Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies; UINP = Ukrainian Institute National Memory; CDIAK = Central State Historical Archive of Ukraine in Kyiv; NBUV = Vernadsky National Library of Ukraine; Diasporiana = Ukrainian diaspora digital library; BIO / HIST / ISTORIO / wiki = existing learn-ukrainian track materials; Commons = Wikimedia Commons.
 
 **Acceptance self-check:**
 
@@ -34,7 +34,7 @@
 - **Canonical EN:** `Oleksandr Lototskyi` for project display; source aliases include `Oleksander Lototsky`, `Oleksander Lototskyi`, and older `Lotoc'kyj`.
 - **Core identity:** Ukrainian civic and political figure, writer, publicist, scholar of church history and canon law, diplomat, General Chancellor of the General Secretariat, State Controller of the UPR, Minister of Confessions / Religious Affairs, UPR envoy to Turkey, and later emigration-state official and academic.
 - **Pseudonyms / cryptonyms:** ESU and EIU list many forms, including `Білоусенко О.`, `О. І. Подоляк`, `О. Липовецький`, `Лотоцці`, `Spektator`, `А. Б.`, and `А. Л.`. Use only the best-attested forms in learner-facing materials.
-- **Birth:** ESU and EIU give old/new style 9(21) March 1870, Bronnytsia / Bronnitsia, now Mohyliv-Podilskyi district, Vinnytsia oblast. UINP calendar uses 21 March 1870.
+- **Birth:** ESU and EIU give old/new style 9(21) March 1870, Bronytsia, now Mohyliv-Podilskyi district, Vinnytsia oblast. UINP calendar uses 21 March 1870.
 - **Death and reburial:** ESU / EIU give 22 October 1939, Warsaw; ESU / EIU / UINP note 1971 reburial at St Andrew Cemetery, Bound Brook / South Bound Brook, New Jersey, USA.
 - **Education:** ESU / EIU trace Podillian, Tiflis, and Kyiv seminary education; he earned a candidate of theology degree at Kyiv Theological Academy in 1896. UINP notes guidance by Volodymyr Antonovych and Mykhailo Hrushevskyi and a blocked academy career because of "unreliable Ukrainophile" reputation.
 - **Publishing / civic formation:** ESU / EIU identify him as co-founder of the publishing house `Вік` in 1894 and active in Ukrainian scholarly, periodical, charitable, and St Petersburg civic networks. UINP emphasizes his role in defending Ukrainian-language publication against imperial censorship.
@@ -77,7 +77,7 @@
 - **Autocephaly as law and diplomacy:** Pair 1 January 1919 law with the Constantinople mission to show that church independence needed documents, offices, and international recognition.
 - **Civil servant as activist:** Lototskyi lets learners see how administrative skill, not only battlefield command, built Ukrainian state capacity.
 - **Censorship-resistance anchor:** `Вік`, Ukrainian-language publication, and anti-Valuev/Ems-era memory connect BIO to language-rights history.
-- **Map anchor:** Bronnytsia / Mohyliv-Podilskyi, Kamianets-Podilskyi, Tiflis / Tbilisi, Kyiv, Saint Petersburg / Petrograd, Bukovyna, Pokuttia, Constantinople / Istanbul, Vienna, Prague, Warsaw, Bound Brook / South Bound Brook.
+- **Map anchor:** Bronytsia / Mohyliv-Podilskyi, Kamianets-Podilskyi, Tiflis / Tbilisi, Kyiv, Saint Petersburg / Petrograd, Bukovyna, Pokuttia, Constantinople / Istanbul, Vienna, Prague, Warsaw, Bound Brook / South Bound Brook.
 - **Regime-change anchor:** Central Rada, UPR, Ukrainian State, Directory, and UPR government-in-exile can be taught as institutional layers rather than a confusing list of names.
 - **Scholar-diplomat anchor:** His books on church law and autocephaly explain why a diplomat could also be a historian and canon-law scholar.
 - **Anti-hagiography anchor:** The 1919 mission did not win immediate patriarchal recognition. Failure under pressure can still be historically central.
@@ -88,7 +88,7 @@
 - **Register:** civic-political biography, administrative state-building, church-law vocabulary, diplomacy, emigration scholarship, censorship and publishing history.
 - **CEFR readiness:** B1+/B2 short biography and map; B2/C1 Central Rada / Hetmanate / Directory offices; C1/C2 church autocephaly, canon-law argument, and emigration institutions.
 - **Core vocabulary:** `Олександр Лотоцький`, `Білоусенко`, `Вік`, `Просвіта`, `Українська Центральна Рада`, `Генеральний Секретаріат`, `генеральний писар`, `державний контролер`, `міністр віросповідань`, `автокефалія`, `Вселенський патріархат`, `Царгород`, `Стамбул`, `Український вільний університет`, `Український науковий інститут у Варшаві`, `Державний центр УНР в екзилі`.
-- **Place-name caution:** Use `Saint Petersburg / Petrograd`, `Constantinople / Istanbul`, `Tiflis / Tbilisi`, `Bound Brook / South Bound Brook`, and `Bronnytsia / Bronytsi` with source-sensitive historical names.
+- **Place-name caution:** Use `Saint Petersburg / Petrograd`, `Constantinople / Istanbul`, `Tiflis / Tbilisi`, `Bound Brook / South Bound Brook`, and `Bronytsia / Брониця` with source-sensitive historical names.
 - **Church-language caution:** Distinguish `autocephaly`, `autonomy`, `church sobor`, `Ecumenical Patriarchate`, and `Moscow Patriarchate` claims. Avoid teaching "Tomos" as a generic synonym for every autocephaly effort.
 - **Office-title caution:** `Minister of Confessions`, `Minister of Religious Affairs`, and `міністр віросповідань` refer to overlapping source translations. Use source labels if precise title/dates matter.
 
@@ -142,7 +142,7 @@
 - UINP, "1870 - народився Олександр Лотоцький, письменник і публіцист." https://uinp.gov.ua/istorychnyy-kalendar/berezen/21/1870-narodyvsya-oleksandr-lotockyy-pysmennyk-i-publicyst. Accessed 2026-07-02.
 - UINP UNR figures, "Лотоцький Олександр." https://unr.uinp.gov.ua/figures/lototskiy-oleksandr. Accessed 2026-07-02.
 - CDIAK, "До 150-річчя від дня народження Олександра Гнатовича Лотоцького..." https://cdiak.archives.gov.ua/v_do_150_narodzhennia_Lotockoho.php. Accessed 2026-07-02.
-- NBVU, "Поборник української соборності - Олександр Гнатович Лотоцький." https://www.nbuv.gov.ua/node/5180. Accessed 2026-07-02.
+- NBUV, "Поборник української соборності - Олександр Гнатович Лотоцький." https://www.nbuv.gov.ua/node/5180. Accessed 2026-07-02.
 
 **Tier 2 / 3 (scholarly, primary-text, and source-rich references):**
 

--- a/docs/research/bio/oleksandr-lototskyi.md
+++ b/docs/research/bio/oleksandr-lototskyi.md
@@ -1,0 +1,175 @@
+# Олександр Гнатович Лотоцький - Research Dossier
+
+**Slug:** `oleksandr-lototskyi`
+**Block:** +77 backfill - Central Rada / Ukrainian State church policy / UPR diplomacy / Constantinople autocephaly mission / emigration scholarship
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #320
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-02
+
+**Source acronym legend:** EIU = Encyclopedia History Ukraine / Institute History of Ukraine, NASU; ESU = Encyclopedia Modern Ukraine / NASU; IEU = Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies; UINP = Ukrainian Institute National Memory; CDIAK = Central State Historical Archive of Ukraine in Kyiv; NBVU = Vernadsky National Library of Ukraine; Diasporiana = Ukrainian diaspora digital library; BIO / HIST / ISTORIO / wiki = existing learn-ukrainian track materials; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, scholarly, primary-text, and image-rights sources cited
+- [x] Pressure mechanism framed imperial censorship, Ukrainian civic publishing, Central Rada / Hetmanate / Directory state service, church autocephaly, Constantinople diplomacy, emigration scholarship, and memory politics
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-02 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric periodization: frame is Ukrainian civic self-organization, Ukrainian Revolution, UPR diplomacy, and church autocephaly, not "Russian liberal reform" or generic imperial administration.
+- [x] Ukrainian agency preserved: Lototskyi is not only an imperial civil servant; he used state-control expertise, publishing networks, and church-law scholarship for Ukrainian institution-building.
+- [x] Church autocephaly presented as a legal, diplomatic, and decolonial issue involving Kyiv, Constantinople, Ukrainian state authorities, and Moscow-imperial church control.
+- [x] Exile work treated as institutional continuity, not a failed afterlife: Ukrainian Free University, Warsaw University, Ukrainian Scientific Institute in Warsaw, and UPR state center in exile remain part of the biography.
+- [x] Anti-hagiography included: he advanced Ukrainian autocephaly and diplomacy but did not single-handedly create a church; the 1919 Constantinople mission was constrained by war, Entente occupation, and state collapse.
+
+## 1. Identity / chronology
+
+- **Canonical UA:** `Олександр Гнатович Лотоцький`.
+- **Canonical EN:** `Oleksandr Lototskyi` for project display; source aliases include `Oleksander Lototsky`, `Oleksander Lototskyi`, and older `Lotoc'kyj`.
+- **Core identity:** Ukrainian civic and political figure, writer, publicist, scholar of church history and canon law, diplomat, General Chancellor of the General Secretariat, State Controller of the UPR, Minister of Confessions / Religious Affairs, UPR envoy to Turkey, and later emigration-state official and academic.
+- **Pseudonyms / cryptonyms:** ESU and EIU list many forms, including `Білоусенко О.`, `О. І. Подоляк`, `О. Липовецький`, `Лотоцці`, `Spektator`, `А. Б.`, and `А. Л.`. Use only the best-attested forms in learner-facing materials.
+- **Birth:** ESU and EIU give old/new style 9(21) March 1870, Bronnytsia / Bronnitsia, now Mohyliv-Podilskyi district, Vinnytsia oblast. UINP calendar uses 21 March 1870.
+- **Death and reburial:** ESU / EIU give 22 October 1939, Warsaw; ESU / EIU / UINP note 1971 reburial at St Andrew Cemetery, Bound Brook / South Bound Brook, New Jersey, USA.
+- **Education:** ESU / EIU trace Podillian, Tiflis, and Kyiv seminary education; he earned a candidate of theology degree at Kyiv Theological Academy in 1896. UINP notes guidance by Volodymyr Antonovych and Mykhailo Hrushevskyi and a blocked academy career because of "unreliable Ukrainophile" reputation.
+- **Publishing / civic formation:** ESU / EIU identify him as co-founder of the publishing house `Вік` in 1894 and active in Ukrainian scholarly, periodical, charitable, and St Petersburg civic networks. UINP emphasizes his role in defending Ukrainian-language publication against imperial censorship.
+- **Imperial civil-service period:** ESU / IEU place him in state-control service in Kyiv and Saint Petersburg, where he gained administrative expertise while supporting Ukrainian Duma clubs, press, and cultural institutions.
+- **1917 revolution:** ESU / EIU / IEU identify him as head of the Ukrainian National Council in Petrograd, a Central Rada figure, Kyiv `Просвіта` leader, gubernial commissioner for Bukovyna and Pokuttia, and General Chancellor / General Secretary in the General Secretariat.
+- **1918 state offices:** ESU / EIU / IEU place him as State Controller of the UPR in spring 1918 and Minister of Confessions / Religious Affairs under the Ukrainian State in October-November 1918.
+- **Autocephaly policy:** ESU says he initiated the Directory's 1 January 1919 law on supreme authority in the Ukrainian autocephalous Orthodox church; IEU says he was instrumental in the 1 January 1919 declaration of autocephaly.
+- **Constantinople mission:** ESU / IEU / UINP place him as UPR diplomatic mission head / minister plenipotentiary in Constantinople / Istanbul from 1919 into 1920, seeking Ecumenical Patriarchate recognition of Ukrainian autocephaly.
+- **Exile / academic work:** ESU / IEU place him in Vienna, Prague, and Warsaw; professor / docent of canon law at the Ukrainian Free University, professor of Orthodox church history at Warsaw University, and founder-director of the Ukrainian Scientific Institute in Warsaw from 1930 to 1939.
+- **UPR state center in exile:** IEU and ESU identify him as deputy premier and minister of internal affairs in the UPR government-in-exile / State Center in 1927-1930; IEU-linked emigration context also supports Supreme Emigration Council ties.
+
+## 2. Political pressure mechanism
+
+- **Imperial censorship pressure:** Lototskyi's state-control career coexisted with Ukrainian publishing work. UINP's censorship anecdote makes him a useful case for how Ukrainian activists used administrative literacy inside hostile imperial systems.
+- **Publishing as infrastructure:** `Вік`, Duma Ukrainian clubs, Ukrainian periodicals, and St Petersburg `Громада` show that national politics depended on books, journals, networks, and legal work before open statehood.
+- **Revolutionary administration pressure:** In 1917-1918 Ukrainian institutions needed people who could run offices, correspondence, control, finance, and law. Lototskyi's bureaucratic skill made him a state-builder rather than only a writer.
+- **Central Rada to Hetmanate continuity:** He served across Central Rada, UPR, Ukrainian State, and Directory settings. This complicates simple party labels and lets learners track institutional continuity through regime change.
+- **Church decolonization pressure:** Autocephaly required more than a slogan: law, canon-law argument, Ukrainian state authority, Constantinople diplomacy, and challenge to Moscow-centered church claims.
+- **Diplomacy under collapse:** The Istanbul / Constantinople mission tried to secure church recognition and broader UPR diplomatic legitimacy while the state lost territory and the Ottoman / Turkish context was unstable under Entente and Greek-Turkish pressures.
+- **Emigration institution-building:** Prague and Warsaw work kept Ukrainian scholarship, church history, and UPR state memory alive after battlefield defeat. This belongs beside Petliura-era exile politics, not outside Ukrainian state history.
+- **Memory pressure:** Soviet and imperial narratives could reduce church autocephaly to "separatism" or foreign intrigue; diaspora narratives can over-clean the difficulty of failed diplomacy. Teach legal-diplomatic struggle and failed outcomes together.
+
+## 3. Major events / historical footprint
+
+- **1894 `Вік` publishing house:** Co-founding `Вік` anchors Ukrainian-language publishing under restriction and connects Lototskyi to literary-cultural nation-building.
+- **1900-1917 St Petersburg work:** State-control service, Ukrainian community leadership, Duma Ukrainian caucus support, and censorship advocacy connect bureaucracy and cultural activism.
+- **1917 Ukrainian National Council in Petrograd:** He becomes a bridge between imperial capital Ukrainian networks and Kyiv state institutions.
+- **September-November 1917 General Chancellor:** General Secretariat service gives a concrete administrative vocabulary anchor: `генеральний писар`, `секретаріат`, `діловодство`, `державний контроль`.
+- **Spring 1918 State Controller:** UPR state control work provides a non-military model of statehood: budgets, audit, accountability, paperwork, and office discipline.
+- **October-November 1918 Minister of Confessions:** Ukrainian State church ministry role is the hinge between religious policy and national sovereignty.
+- **1 January 1919 autocephaly law / declaration:** The strongest pedagogical moment: Ukrainian state authority formally tied church self-government to statehood and decolonization from Moscow ecclesiastical control.
+- **1919-1920 Constantinople mission:** Lototskyi's diplomacy toward the Ecumenical Patriarchate shifts the biography from Kyiv law to international church recognition.
+- **1922-1929 Ukrainian Free University:** Prague academic work extends the story into emigration education and canon-law scholarship.
+- **1930-1939 Ukrainian Scientific Institute in Warsaw:** Founder-director role shows how Warsaw became a site of Ukrainian scholarship, editions, and political memory.
+- **`Українські джерела церковного права`, `Автокефалія`, and memoirs:** These works make him a source-maker for later church-history and Ukrainian Revolution research, not only a subject.
+- **1939 Warsaw death / 1971 Bound Brook reburial:** Death during the opening of the Second World War and later diaspora reburial connect exile, archive loss risk, and community memory.
+
+## 4. Pedagogical anchors
+
+- **Autocephaly as law and diplomacy:** Pair 1 January 1919 law with the Constantinople mission to show that church independence needed documents, offices, and international recognition.
+- **Civil servant as activist:** Lototskyi lets learners see how administrative skill, not only battlefield command, built Ukrainian state capacity.
+- **Censorship-resistance anchor:** `Вік`, Ukrainian-language publication, and anti-Valuev/Ems-era memory connect BIO to language-rights history.
+- **Map anchor:** Bronnytsia / Mohyliv-Podilskyi, Kamianets-Podilskyi, Tiflis / Tbilisi, Kyiv, Saint Petersburg / Petrograd, Bukovyna, Pokuttia, Constantinople / Istanbul, Vienna, Prague, Warsaw, Bound Brook / South Bound Brook.
+- **Regime-change anchor:** Central Rada, UPR, Ukrainian State, Directory, and UPR government-in-exile can be taught as institutional layers rather than a confusing list of names.
+- **Scholar-diplomat anchor:** His books on church law and autocephaly explain why a diplomat could also be a historian and canon-law scholar.
+- **Anti-hagiography anchor:** The 1919 mission did not win immediate patriarchal recognition. Failure under pressure can still be historically central.
+- **Visual anchor:** Commons `File:Олександр Лотоцький.png` and `File:Alexander Ign. Lototsky.jpeg` are portrait candidates if production confirms file-level public-domain status and identity.
+
+## 5. Language register
+
+- **Register:** civic-political biography, administrative state-building, church-law vocabulary, diplomacy, emigration scholarship, censorship and publishing history.
+- **CEFR readiness:** B1+/B2 short biography and map; B2/C1 Central Rada / Hetmanate / Directory offices; C1/C2 church autocephaly, canon-law argument, and emigration institutions.
+- **Core vocabulary:** `Олександр Лотоцький`, `Білоусенко`, `Вік`, `Просвіта`, `Українська Центральна Рада`, `Генеральний Секретаріат`, `генеральний писар`, `державний контролер`, `міністр віросповідань`, `автокефалія`, `Вселенський патріархат`, `Царгород`, `Стамбул`, `Український вільний університет`, `Український науковий інститут у Варшаві`, `Державний центр УНР в екзилі`.
+- **Place-name caution:** Use `Saint Petersburg / Petrograd`, `Constantinople / Istanbul`, `Tiflis / Tbilisi`, `Bound Brook / South Bound Brook`, and `Bronnytsia / Bronytsi` with source-sensitive historical names.
+- **Church-language caution:** Distinguish `autocephaly`, `autonomy`, `church sobor`, `Ecumenical Patriarchate`, and `Moscow Patriarchate` claims. Avoid teaching "Tomos" as a generic synonym for every autocephaly effort.
+- **Office-title caution:** `Minister of Confessions`, `Minister of Religious Affairs`, and `міністр віросповідань` refer to overlapping source translations. Use source labels if precise title/dates matter.
+
+## 6. Risks / open questions
+
+- **Birth-date style:** ESU / EIU use old/new style `9(21) March 1870`; UINP and learner-facing summaries often use 21 March 1870. Use `1870-1939` or 21 March unless calendar style is being taught.
+- **Name romanization:** IEU uses `Oleksander Lototsky`; project slug uses `oleksandr-lototskyi`; Commons files also use `Alexander Ign. Lototsky`. Keep `Oleksandr Lototskyi` as learner display but preserve aliases for search.
+- **Patronymic / family forms:** Ukrainian sources use `Гнатович`; some forms appear with `Ігнатович` or "Ign." in transliteration. Do not treat these as separate people.
+- **Office-title drift:** Sources compress secretary-general / general chancellor / general scribe, state controller, minister of confessions, and acting minister roles differently. Modules should avoid overprecise day-level office chronology unless sourced.
+- **Autocephaly overclaim:** He was instrumental in state church policy and Constantinople diplomacy, but the Ukrainian Autocephalous Orthodox Church was not consolidated by him alone. Do not imply the 1919 mission secured immediate recognition.
+- **Constantinople mission context:** UINP notes the Ecumenical Patriarchate faced Greek-Turkish conflict and postwar pressure. This matters when explaining why negotiations failed or stalled.
+- **Emigration simplification:** Prague and Warsaw scholarship should not be presented as passive exile; it produced institutions, publications, and state-memory work.
+- **Archive / memoir source use:** `Сторінки минулого` and `В Царгороді` are valuable primary/memoir sources but are not neutral omniscient narration. Use them as testimony with context.
+- **Image identity:** Commons has several portrait-looking files plus group images. Use clear portrait files first; avoid group photos or family-name matches without independent identity verification.
+
+## 7. Cross-track links
+
+- **Existing BIO plan / dossier anchors (VERIFIED `test -e` / `rg` 2026-07-02):** `site/src/content/docs/bio/index.mdx` lists BIO #320 `oleksandr-lototskyi`; `curriculum/l2-uk-en/plans/bio/ivan-ohienko.yaml`, `curriculum/l2-uk-en/bio/discovery/ivan-ohienko.yaml`, and `docs/research/bio/ivan-ohienko.md` support church autocephaly / Bible / ministry comparison; `curriculum/l2-uk-en/plans/bio/vasyl-lypkivskyi.yaml` and `docs/research/bio/vasyl-lypkivskyi.md` support Ukrainian autocephaly and church repression; `curriculum/l2-uk-en/plans/bio/iov-boretskyi.yaml`, `curriculum/l2-uk-en/bio/discovery/iov-boretskyi.yaml`, and `docs/research/bio/iov-boretskyi.md` support earlier Kyiv-metropolia church autonomy context; `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml`, `docs/research/bio/mykhailo-hrushevskyi.md` support scholarly / Central Rada networks; `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml`, `docs/research/bio/symon-petliura.md` support UPR exile-state and diplomacy; `curriculum/l2-uk-en/plans/bio/volodymyr-vynnychenko.yaml`, `docs/research/bio/volodymyr-vynnychenko.md` support General Secretariat / Central Rada comparison; `curriculum/l2-uk-en/plans/bio/yevhen-chykalenko.yaml`, `docs/research/bio/yevhen-chykalenko.md` support pre-1917 civic-publishing networks.
+- **Existing HIST plan / discovery surfaces (VERIFIED `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`, `curriculum/l2-uk-en/hist/discovery/tsentralna-rada.yaml`; `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml`, `curriculum/l2-uk-en/hist/discovery/dyrektoriia.yaml`; `curriculum/l2-uk-en/plans/hist/symon-petliura-revolution.yaml`, `curriculum/l2-uk-en/hist/discovery/symon-petliura-revolution.yaml`; `curriculum/l2-uk-en/plans/hist/tomos.yaml`, `curriculum/l2-uk-en/hist/discovery/tomos.yaml`.
+- **Existing ISTORIO plan / discovery surfaces (VERIFIED `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`, `curriculum/l2-uk-en/istorio/discovery/universaly-unr.yaml`; `curriculum/l2-uk-en/plans/istorio/pravoslavna-identychnist.yaml`, `curriculum/l2-uk-en/istorio/discovery/pravoslavna-identychnist.yaml`; `curriculum/l2-uk-en/plans/istorio/syntez-relihiina-identychnist.yaml`, `curriculum/l2-uk-en/istorio/discovery/syntez-relihiina-identychnist.yaml`.
+- **Existing wiki / context surfaces (VERIFIED `test -e` / `rg` 2026-07-02):** `wiki/periods/hrushevskyi.md`, `wiki/periods/syntez-revoliutsiia.md`, `wiki/periods/tomos.md`, `wiki/literature/works/oles-oleksandr-liryka.md`, `wiki/figures/symon-petliura.md`, `wiki/historiography/universaly-unr.md`.
+- **Candidate / absent BIO #320 surfaces (VERIFIED absent `test -e` 2026-07-02):** `curriculum/l2-uk-en/plans/bio/oleksandr-lototskyi.yaml`, `curriculum/l2-uk-en/bio/discovery/oleksandr-lototskyi.yaml`, `wiki/figures/oleksandr-lototskyi.md`, `site/src/content/docs/bio/oleksandr-lototskyi.mdx`, `curriculum/l2-uk-en/bio/oleksandr-lototskyi/module.md`, `curriculum/l2-uk-en/bio/oleksandr-lototskyi/activities.yaml`, `curriculum/l2-uk-en/bio/oleksandr-lototskyi/vocabulary.yaml`, `curriculum/l2-uk-en/bio/oleksandr-lototskyi/resources.yaml`.
+- **Candidate / absent context surfaces (VERIFIED absent `test -e` 2026-07-02):** `wiki/figures/oleksandr-lototskyi.md`, `curriculum/l2-uk-en/plans/hist/ukrainian-autocephaly.yaml`, `curriculum/l2-uk-en/hist/discovery/ukrainian-autocephaly.yaml`.
+
+## 8. Name variants / search aliases
+
+- **Canonical UA:** `Олександр Гнатович Лотоцький`.
+- **Canonical EN:** `Oleksandr Lototskyi`.
+- **Common UA search forms:** `Олександр Лотоцький`, `Лотоцький Олександр`, `Лотоцький Олександр Гнатович`, `О. Лотоцький`, `Олександер Лотоцький`, `Олександр Ігнатович Лотоцький`.
+- **Common EN / transliteration forms:** `Oleksandr Lototskyi`, `Oleksander Lototsky`, `Oleksander Lototskyi`, `Oleksandr Lototsky`, `Oleksander Lotoc'kyj`, `Alexander Ign. Lototsky`.
+- **Pseudonyms / cryptonyms:** `Білоусенко О.`, `О. І. Подоляк`, `О. Липовецький`, `О. Любенький`, `О. Лобанський`, `П. Краєвський`, `П. Сухоцький`, `Spektator`, `А. Б.`, `А. Л.`.
+- **Office / institution aliases:** `General Chancellor`, `генеральний писар`, `State Controller`, `Minister of Confessions`, `Minister of Religious Affairs`, `UPR envoy to Turkey`, `Ukrainian Scientific Institute in Warsaw`, `Ukrainian Free University`.
+- **Learner-facing display:** `Oleksandr Lototskyi (Олександр Лотоцький, 1870-1939)`.
+
+## 9. Image rights / visual material notes
+
+- **Primary portrait candidate:** Commons `File:Олександр Лотоцький.png`; public-domain-marked and sourced to NBUV. Best lead-image candidate if file-level source and identity remain clear in production review.
+- **Alternate portrait candidate:** Commons `File:Alexander Ign. Lototsky.jpeg`; public-domain-marked and sourced to an NBUV / IRBIS catalog page; description identifies him as minister of confessions. Use with transliteration caution.
+- **Fallback portrait candidate:** Commons `File:Лотоцький О.jpg`; PD-Art / public-domain faithful reproduction, NBUV catalog source, likely correct identity. Slightly weaker than direct portrait files.
+- **Contextual group-photo caution:** Commons `File:Група професорів Українського Вільного Університету, 1926.jpg` is CC BY-SA 3.0 but is a group image and structured data may emphasize another person. Use only for Ukrainian Free University context, not as a headshot.
+- **Avoid default:** Commons book/page scans in the Oleksander Lototskyi category, `Гурт "віківців" cropped.jpg`, family-name matches such as Antin Lototskyi, unattributed web portraits, social-media graphics, and AI colorizations.
+- **Caption caution:** If using Warsaw / Prague academic images, caption as emigration scholarship context, not as proof of specific 1919 church negotiations.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- "Лотоцький Олександр Гнатович." Енциклопедія Сучасної України, НАН України / НТШ. https://esu.com.ua/article-56538. Accessed 2026-07-02.
+- Швидкий В.П. "Лотоцький Олександр Гнатович." Енциклопедія історії України, Інститут історії України НАН України. https://history.org.ua/?termin=Lototsky_O_G. Accessed 2026-07-02.
+- "Lototsky, Oleksander." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CL%5CO%5CLototskyOleksander.htm. Accessed 2026-07-02.
+- UINP, "1870 - народився Олександр Лотоцький, письменник і публіцист." https://uinp.gov.ua/istorychnyy-kalendar/berezen/21/1870-narodyvsya-oleksandr-lotockyy-pysmennyk-i-publicyst. Accessed 2026-07-02.
+- UINP UNR figures, "Лотоцький Олександр." https://unr.uinp.gov.ua/figures/lototskiy-oleksandr. Accessed 2026-07-02.
+- CDIAK, "До 150-річчя від дня народження Олександра Гнатовича Лотоцького..." https://cdiak.archives.gov.ua/v_do_150_narodzhennia_Lotockoho.php. Accessed 2026-07-02.
+- NBVU, "Поборник української соборності - Олександр Гнатович Лотоцький." https://www.nbuv.gov.ua/node/5180. Accessed 2026-07-02.
+
+**Tier 2 / 3 (scholarly, primary-text, and source-rich references):**
+
+- Partykevich, Andre. `Between Kyiv and Constantinople: Oleksander Lototsky and the Quest for Ukrainian Autocephaly`. CIUS Press, 1998. https://diasporiana.org.ua/wp-content/uploads/books/24945/file.pdf. Accessed 2026-07-02.
+- Diasporiana, "Лотоцький О. Сторінки минулого." https://diasporiana.org.ua/memuari/lotoczkyj-o-storinky-mynulogo/. Accessed 2026-07-02.
+- Захарченко П. "Автокефалія Української церкви: політико-правова доктрина О. Лотоцького за доби Української революції." https://chtyvo.org.ua/authors/Zakharchenko_Petro/Avtokefaliia_Ukrainskoi_tserkvy_polityko-pravova_doktryna_O_Lototskoho_za_doby_Ukrainskoi_revoliutsi.pdf. Accessed 2026-07-02.
+
+**Tier 4 (learn-ukrainian cross-track sources checked 2026-07-02):**
+
+- `site/src/content/docs/bio/index.mdx`
+- `docs/research/bio/ivan-ohienko.md`
+- `docs/research/bio/vasyl-lypkivskyi.md`
+- `docs/research/bio/iov-boretskyi.md`
+- `docs/research/bio/mykhailo-hrushevskyi.md`
+- `docs/research/bio/symon-petliura.md`
+- `docs/research/bio/volodymyr-vynnychenko.md`
+- `docs/research/bio/yevhen-chykalenko.md`
+- `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`
+- `curriculum/l2-uk-en/hist/discovery/tsentralna-rada.yaml`
+- `curriculum/l2-uk-en/plans/hist/tomos.yaml`
+- `curriculum/l2-uk-en/hist/discovery/tomos.yaml`
+- `wiki/periods/tomos.md`
+- `wiki/periods/syntez-revoliutsiia.md`
+
+**Tier 5 (image-rights / media-rights sources):**
+
+- Commons `File:Олександр Лотоцький.png`. https://commons.wikimedia.org/wiki/File:%D0%9E%D0%BB%D0%B5%D0%BA%D1%81%D0%B0%D0%BD%D0%B4%D1%80_%D0%9B%D0%BE%D1%82%D0%BE%D1%86%D1%8C%D0%BA%D0%B8%D0%B9.png. Accessed 2026-07-02.
+- Commons `File:Alexander Ign. Lototsky.jpeg`. https://commons.wikimedia.org/wiki/File:Alexander_Ign._Lototsky.jpeg. Accessed 2026-07-02.
+- Commons `File:Лотоцький О.jpg`. https://commons.wikimedia.org/wiki/File:%D0%9B%D0%BE%D1%82%D0%BE%D1%86%D1%8C%D0%BA%D0%B8%D0%B9_%D0%9E.jpg. Accessed 2026-07-02.
+- Commons `File:Група професорів Українського Вільного Університету, 1926.jpg`. https://commons.wikimedia.org/wiki/File:%D0%93%D1%80%D1%83%D0%BF%D0%B0_%D0%BF%D1%80%D0%BE%D1%84%D0%B5%D1%81%D0%BE%D1%80%D1%96%D0%B2_%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D1%81%D1%8C%D0%BA%D0%BE%D0%B3%D0%BE_%D0%92%D1%96%D0%BB%D1%8C%D0%BD%D0%BE%D0%B3%D0%BE_%D0%A3%D0%BD%D1%96%D0%B2%D0%B5%D1%80%D1%81%D0%B8%D1%82%D0%B5%D1%82%D1%83%2C_1926.jpg. Accessed 2026-07-02.


### PR DESCRIPTION
## Summary

- Adds the BIO #320 `oleksandr-lototskyi` research dossier.
- Frames Lototskyi through Ukrainian civic publishing, Central Rada / UPR administration, church autocephaly, Constantinople diplomacy, and emigration scholarship.
- Keeps this as dossier-only prep: only `docs/research/bio/oleksandr-lototskyi.md` is changed.

## Validation

- `npx markdownlint-cli2 docs/research/bio/oleksandr-lototskyi.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/oleksandr-lototskyi.md`
- `git diff --check -- docs/research/bio/oleksandr-lototskyi.md`
- `git diff --cached --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Independent Review

Pending required read-only non-Codex review before merge.
