### PR TITLE
[codex] Harden writer prompt tone

### DIFF
--- a/scripts/build/phases/linear-write-grok.md
+++ b/scripts/build/phases/linear-write-grok.md
@@ -228,8 +228,7 @@ one JSON block per structured artifact. Do not include trailing commas. Do
 not include comments. Do not mix YAML or prose into JSON blocks. The pipeline
 uses `json.loads` and fails the build on any parse error.
 
-**Wrap the `module.md` artifact in a 4-backtick OUTER fence**: ````markdown
-file=module.md` opens, ```` (four backticks, bare, on its own line) closes.
+**Wrap the `module.md` artifact in a 4-backtick OUTER fence**: the opening line is four backticks followed by `markdown file=module.md`; the closing line is four backticks, bare, on its own line.
 The 4-backtick wrapper lets you include 3-backtick code blocks INSIDE
 module.md for verb conjugation tables, code-style examples, or any prose
 that benefits from a fenced block — those inner 3-backtick fences will be
@@ -351,6 +350,8 @@ Words and grammar listed in **Cumulative vocabulary** / **Grammar already taught
 
 ## Tone and immersion (mandatory)
 
+Write restrained, concrete educational prose from the first draft. Reject decorative pathos, hagiography, elegiac/heroizing framing, symbolic abstractions, and thesis-sounding sentences that feel impressive but vague. Every sentence must do one concrete job: name a source-grounded fact, show a Ukrainian form in use, explain a language pattern, or direct a learner action. If it cannot, replace it with concrete content or cut it; never pad, and never drop below the contract word floor. For BIO and cultural modules, keep biography, reception, and context factual and natural; do not turn the person or topic into a legend or moral emblem, and do not reach for melodramatic Soviet/post-Soviet pathos. State repression, censorship, russification, institutional pressure, and decolonization facts plainly when the plan or sources require them.
+
 The prose of `module.md` is for a learner who is encountering Ukrainian, not
 for a teacher narrating their own lesson plan. Hold to this register:
 
@@ -382,11 +383,11 @@ for a teacher narrating their own lesson plan. Hold to this register:
 **Dialogue format (REQUIRED for gate counting).** All Ukrainian dialogue lines MUST be emitted as one of:
 
 - `<DialogueBox uk="..." en="..." />` JSX component (preferred for V7 rendering), or
-- `> `-prefixed Markdown blockquote (Markdown fallback)
+- `>`-prefixed Markdown blockquote (Markdown fallback)
 
-The `l2_exposure_floor` gate counts only these two forms. **Em-dash dialogue lines (e.g. `— Привіт, Насте!`) under a `## Діалоги` heading WITHOUT `<DialogueBox>` or `> ` wrapping are an anti-pattern** — the gate cannot count them and the module will fail the dialogue-line floor even when the dialogue is pedagogically present.
+The `l2_exposure_floor` gate counts only these two forms. **Em-dash dialogue lines (e.g. `— Привіт, Насте!`) under a `## Діалоги` heading WITHOUT `<DialogueBox>` or `>` wrapping are an anti-pattern** — the gate cannot count them and the module will fail the dialogue-line floor even when the dialogue is pedagogically present.
 
-Default to `<DialogueBox>` for new modules; `> ` blockquote acceptable when a multi-line dialogue is more naturally rendered as quoted prose.
+Default to `<DialogueBox>` for new modules; `>` blockquote acceptable when a multi-line dialogue is more naturally rendered as quoted prose.
 
 **Inline gloss for dialogue lines (REQUIRED to clear `long_uk_ceiling`).** Each Ukrainian dialogue line MUST have an inline English gloss within 8 tokens of proximity. Two valid shapes:
 

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -3,6 +3,8 @@
 This is the actionable subset of `docs/north-star.md` for the writer phase.
 
 <!-- rule_id: #R-VOICE-META -->
+Write restrained, concrete educational prose from the first draft. Reject decorative pathos, hagiography, elegiac/heroizing framing, symbolic abstractions, and thesis-sounding sentences that feel impressive but vague. Every sentence must do one concrete job: name a source-grounded fact, show a Ukrainian form in use, explain a language pattern, or direct a learner action. If it cannot, replace it with concrete content or cut it; never pad, and never drop below the contract word floor. For BIO and cultural modules, keep biography, reception, and context factual and natural; do not turn the person or topic into a legend or moral emblem, and do not reach for melodramatic Soviet/post-Soviet pathos. State repression, censorship, russification, institutional pressure, and decolonization facts plainly when the plan or sources require them.
+
 Adult peer voice only. No English meta-narration or teacherly transitions in `module.md`. Forbidden patterns include "Welcome to...", "In this section...", "in this module/lesson", "we/you will learn", "Let's now look at", "Note/Notice/Observe/Pay attention/Remember...", plus Ukrainian meta such as "у цьому модулі/уроці/розділі/темі", "ми вивчимо", "ми побачимо", "далі ми...". Speak TO the learner about the LANGUAGE; never narrate ABOUT the module. Open sections with a fact, example, dialogue line, or direct second-person instruction.
 
 <!-- rule_id: #R-VOICE-META -->

--- a/scripts/build/universal_rules/R-VOICE-META.md
+++ b/scripts/build/universal_rules/R-VOICE-META.md
@@ -1,6 +1,6 @@
 ---
 id: R-VOICE-META
-description: Adult peer voice; no English meta-narration or teacherly transitions in module.md.
+description: Adult peer voice; restrained concrete prose; no English meta-narration or teacherly transitions in module.md.
 applies_to:
   levels: [all]
   tracks: [all]
@@ -8,6 +8,8 @@ applies_to:
 slot: shared.contract
 depends_on: []
 ---
+
+Write restrained, concrete educational prose from the first draft. Reject decorative pathos, hagiography, elegiac/heroizing framing, symbolic abstractions, and thesis-sounding sentences that feel impressive but vague. Every sentence must do one concrete job: name a source-grounded fact, show a Ukrainian form in use, explain a language pattern, or direct a learner action. If it cannot, replace it with concrete content or cut it; never pad, and never drop below the contract word floor. For BIO and cultural modules, keep biography, reception, and context factual and natural; do not turn the person or topic into a legend or moral emblem, and do not reach for melodramatic Soviet/post-Soviet pathos. State repression, censorship, russification, institutional pressure, and decolonization facts plainly when the plan or sources require them.
 
 Adult peer voice only. No English meta-narration or teacherly transitions in `module.md`. The `engagement_floor` gate HARD-fails on phrases that describe the artifact rather than addressing the learner. Forbidden patterns (English): "Welcome to the start of our journey", "In this section we will learn", "this section teaches", "in this module", "in this lesson", "this module covers", "this lesson covers", "learners will", "students will", "the activity asks", "the exercise asks", "we will learn", "you will learn" (in the meta sense, not a real plan), "Now that you have seen these verbs", "Let's now look at", "Before we move on", "Note that…", "Notice that…", "Observe that…", "Pay attention to…", "Remember that…", "It is important to…". Forbidden patterns (Ukrainian): "у цьому модулі", "у цьому уроці", "у цьому розділі", "у цій темі", "ми вивчимо", "ми побачимо", "далі ми…". Rule of thumb: speak TO the learner in second person about the LANGUAGE; never narrate ABOUT the module, section, activity, or learner cohort. Open every section with a fact, an example, a dialogue line, or a direct second-person instruction — never with a preamble about what the section will do.
 


### PR DESCRIPTION
## Summary
- add a compact write-time guardrail for restrained, concrete prose in the universal voice rule
- mirror the same guardrail into the default legacy writer prompt and Grok writer prompt
- clarify that BIO/cultural modules should avoid melodramatic pathos while still stating repression, censorship, russification, institutional pressure, and decolonization facts plainly
- clean pre-existing Markdown code-span formatting in the touched Grok prompt so markdownlint passes

## Review
- Claude review via ai_agent_bridge task `review-strengthen-writer-prompt`: no blockers
- Applied Claude's minor wording suggestion to avoid weakening decolonization/repression coverage

## Validation
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python - <<'PY' ...` registry/render check for `R-VOICE-META`
- `npx markdownlint-cli2 scripts/build/universal_rules/R-VOICE-META.md scripts/build/phases/linear-write.md scripts/build/phases/linear-write-grok.md`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`