### PR TITLE
docs(atlas): refresh lexicon tracker truth

### DIFF
--- a/docs/decisions/2026-06-25-lexicon-update-mechanics.md
+++ b/docs/decisions/2026-06-25-lexicon-update-mechanics.md
@@ -18,14 +18,53 @@
   self-hosted runner**. (~1 GB weekly download — acceptable on Actions.) This supersedes options
   (a)/(b)/(c) below with a fourth path: **(d) hosted runner hydrates the DBs from Release assets.**
 
+## Current tracker snapshot (2026-07-02)
+
+Current static Atlas counts:
+
+- Atlas manifest: 5,280 entries, including 336 `form_of` records.
+- Public search/browse: 5,270 entries, 61 search shards, 31 browse shards.
+- Daily Word: 300 entries.
+- Practice deck: 4,484 lexemes and 22 reviewed A1 cloze items.
+- Source-inventory seeds: 133 rows total: 80 textbook, 33 Ohoiko/ULP, and
+  20 curriculum sample rows.
+
+Closed tracker leaves that should not be treated as active backlog:
+
+- #3932 - shard search and browse before 25k entries.
+- #3796 - practice deck Release-asset hydration.
+- #3449 - open attributed dataset Release-asset export.
+- #3450 - inflected-form dedupe to canonical `form_of` cards.
+
+Merged recent delivery PRs:
+
+- #4074 - sharded lexicon search index.
+- #4075 - static lexicon API contract.
+- #4083 - Tatoeba cloze attribution preservation.
+- #4084 - third textbook source-decision ledger batch.
+
+Open board:
+
+- #3936 - tracker/reliability coordination.
+- Private teacher-lesson vocabulary intake - create or update a dedicated
+  issue before publishing rows; use privacy-safe source labels in committed
+  artifacts.
+- #3933 - Ohoiko/ULP source-safe intake.
+- #3934 - textbook/headword intake beyond the current 80-row seed.
+- #3797 - reviewed cloze expansion beyond the current 22 A1 items.
+
+Daily Word, Practice, and cloze remain separate admission decisions. Atlas
+browse/search growth must not automatically move rows into those learner
+surfaces.
+
 ## TL;DR — when does lexicon content update?
 
 There is no single continuous pipeline; it is a 3-layer system, and the heavy layer is **manual + local**
 because the dictionary DBs (`data/vesum.db` ~967 MB, `data/sources.db`) are gitignored and too big for CI.
 
 | Layer | What | Trigger today | Where |
-|---|---|---|---|
-| **1. Manifest (SSOT)** | `lexicon-manifest.json` (4575 entries) — the Atlas word data | **manual `make atlas`** when content/sources change | local only (needs the DBs) |
+| --- | --- | --- | --- |
+| **1. Manifest (SSOT)** | `lexicon-manifest.json` Release asset (5,280 entries in the current pointer) — the Atlas word data | **manual `make atlas`** when content/sources change | local only (needs the DBs) |
 | **2. Auto-grow** | find NEW lemmas in modules/readings → enrich → gated PR (#3675) | cron **Mon 07:23** + `workflow_dispatch` | `atlas-grow.yml` — **no-op on hosted runners** |
 | **3. Derived artifacts** | search-index, daily-pool, open-dataset | part of `make atlas` | local |
 
@@ -37,12 +76,14 @@ CI gate + `check_atlas_manifest_enrichment` guard staleness/thin-manifest.
 ## The two gaps
 
 ### Gap 1 — the auto-grow cron is dormant (no-op on GitHub-hosted runners)
+
 `atlas-grow.yml` needs `data/vesum.db` + `data/sources.db` on the runner; hosted runners don't have them,
 so the weekly run skips with a `::notice::`. So **content→lexicon growth only happens via a local manual
 run** (or a self-hosted runner). Net: the lexicon does not actually auto-update from new content today.
 **RESOLVED (user, 2026-06-25) → option (d):** publish `vesum.db` + `sources.db` as Release assets; the
 existing hosted `atlas-grow` cron downloads (hydrates) them at the start of the run, then grows + opens a
 gated PR — no self-hosted runner. The options below are recorded for context but (d) is the chosen path.
+
 - (a) **Self-hosted runner** with the DBs → the Monday cron actually grows + opens a gated PR. Most
   automated; needs a machine + the DBs maintained on it. *(Not chosen — a self-hosted machine is a
   maintenance liability the project wants to avoid.)*
@@ -54,16 +95,17 @@ gated PR — no self-hosted runner. The options below are recorded for context b
   the heavy enrich stays local. Lowest-maintenance signal without a self-hosted runner. *(Not chosen —
   (d) gives the full grow, not just a detection signal.)*
 
-### Gap 2 — the practice deck is NOT wired into the regen → it drifts (open; sequence after #3796)
-`generate_practice_deck.py` (shipped #3795) is not in `make atlas` nor any freshness gate, so when the
-manifest updates the deck (`site/public/lexicon/practice-*.json`) silently goes stale vs the Atlas.
-**Fix:** (1) add the deck regen to `make atlas`; (2) a CI **deck-freshness gate** — the deck's
-`deckVersion` already embeds `_manifest_fingerprint(entries)`, so CI (which hydrates the manifest for the
-Frontend build) can recompute the fingerprint and fail if it ≠ the committed deck's `deckVersion`. This is
-the load-bearing guard so the deck can't drift. **Sequence after #3796**: the freshness check differs for a
-committed deck vs a Release-asset-hydrated deck, so build it once the deck-hosting decision lands.
+### Gap 2 — practice deck freshness after Release-asset hydration
+
+`generate_practice_deck.py` (shipped #3795) is no longer a committed-shard
+problem: #3796 moved the practice deck to Release-asset hydration, and the
+current pointer records 4,484 lexemes plus 22 A1 cloze items across the
+per-level deck files. The remaining guardrail is policy, not storage: Daily
+Word, Practice, and cloze admission must stay explicit and reviewed, especially
+for source-inventory rows promoted to browse/search.
 
 ## Proposed cadence (recommendation)
+
 1. **On content milestones** (a batch of modules/readings shipped): local `make atlas` → auto-grow → gated
    PR → review + self-merge. This is the real "update lexicon content" trigger.
 2. **On dictionary-source updates** (rare — a VESUM/ЕСУМ bump): local `make atlas` full regen.
@@ -72,24 +114,33 @@ committed deck vs a Release-asset-hydrated deck, so build it once the deck-hosti
 4. **Weekly auto-grow** becomes the live safety net once option (d) lands — the hosted cron hydrates the
    DBs from Release assets, grows, and opens a gated PR.
 
-## Open backlog (the "rest of the lexicon stuff")
-- **#3796** — migrate the committed ~2.9 MB practice deck → Release-asset hydration (before it churns).
-- **#3449** — open dataset is **already published in git** (`data/lexicon-dataset/`, 36 files / 1.6 MB,
-  committed in #3633). BUT re-running `export_open_dataset.py` on today's manifest produces **31 MB** (the
-  enrichment grew since #3633) — so the committed-dataset approach **bloats on every regen**. This is the
-  same derived-artifact-hosting problem as the manifest (#3659) and the deck (#3796): **migrate the dataset
-  to a Release asset** (and `git rm` the committed copy) so regen doesn't grow git history.
-- **#3450** — inflected-form dedupe → canonical "form of «lemma»" cards (filter drops them at consumers via
-  `lexeme_filter`; the manifest-level canonicalization is the remaining piece).
+## Resolved backlog moved out of active work
+
+- **#3796** — practice deck Release-asset hydration is closed. The current
+  pointer is `site/src/data/lexicon-practice-deck.pointer.json`.
+- **#3449** — the open attributed dataset is closed and pinned as the
+  `atlas-open-dataset` Release asset. The current pointer is
+  `data/lexicon-dataset.pointer.json`.
+- **#3450** — inflected-form dedupe is closed; manifest entries now include
+  canonical `form_of` cards instead of publishing those rows as ordinary
+  article pages.
+
+## Open backlog
+
 - **#3406** — ~24 ЕСУМ entries carry OCR mojibake bibliographic text (careful: a prior dirty regen was
   discarded — fix the data, re-enrich only those entries).
 - **#3675** — auto-grow P1–P3 shipped; Gap 1 above is the remaining "make it actually run" piece, now
   unblocked by the option-(d) decision (publish the DBs as Release assets → hosted cron hydrates them).
 
-## Sequencing (the order the Release-asset migrations land)
-1. **#3796 — practice deck → Release asset** (named-first, "before it churns"; establishes the
-   deck-hydration pattern these others reuse).
-2. **DBs (`vesum.db`, `sources.db`) → Release assets + atlas-grow cron hydration** (Gap 1 / #3675-(d)).
-3. **#3449 — open dataset → Release asset** (`git rm` the committed 1.6 MB copy that re-exports to 31 MB).
-4. **Gap 2 — deck-freshness gate** (after #3796, once the deck is hydrated, so the freshness check targets
-   the pointer rather than committed shards).
+## Current sequencing
+
+1. Keep #3936 accurate as the delivery board; update it when leaves close.
+2. Add a dedicated private teacher-lesson vocabulary source-inventory lane
+   before more broad textbook/Ohoiko growth, using privacy-safe committed
+   labels and tracked source locators.
+3. Continue #3933 with source-safe Ohoiko/ULP rows only.
+4. Continue #3934 with reviewed textbook/headword rows beyond the current
+   80-row seed.
+5. Continue #3797 for reviewed cloze expansion and Tatoeba go-live policy.
+6. Admit rows to Daily Word, Practice, or cloze only through explicit
+   `surface_admission` decisions.

--- a/docs/runbooks/word-atlas-static-api.md
+++ b/docs/runbooks/word-atlas-static-api.md
@@ -14,6 +14,21 @@ as static JSON, not as a live backend service.
 - `/api/lexicon/practice-lexemes.{level}.json` — per-level Practice lexeme deck.
 - `/api/lexicon/practice-cloze.{level}.json` — per-level reviewed cloze deck.
 
+## Current Snapshot
+
+As of 2026-07-02, the static contract should expose this board state:
+
+- Atlas manifest: 5,280 entries, including 336 `form_of` records.
+- Public search/browse: 5,270 entries, 61 search shards, 31 browse shards.
+- Daily Word: 300 entries.
+- Practice deck: 4,484 lexemes and 22 reviewed A1 cloze items.
+- Source-inventory seeds: 133 rows total: 80 textbook, 33 Ohoiko/ULP, and
+  20 curriculum sample rows.
+
+Open Atlas/Lexicon board items are #3936, private teacher-lesson vocabulary
+intake, #3933, #3934, #3797, #3406, and #3675. Closed items that should not
+reappear as active backlog are #3932, #3796, #3449, and #3450.
+
 The status payload also points to existing static browse assets:
 
 - `/lexicon/browse/{letter}.json`


### PR DESCRIPTION
## Summary
- Refreshes the Lexicon/Word Atlas update mechanics decision with the current tracker snapshot.
- Moves #3796, #3449, and #3450 out of active backlog now that they are closed.
- Records the current serial order, including a privacy-safe private teacher-lesson vocabulary intake lane before broader Ohoiko/textbook expansion.
- Adds the same current board snapshot to the static API runbook.

## Validation
- `npx --no-install markdownlint-cli2 docs/decisions/2026-06-25-lexicon-update-mechanics.md docs/runbooks/word-atlas-static-api.md`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Independent non-Codex review via Agy/Gemini: initial blockers fixed; final pass returned `NO BLOCKERS`.

## Notes
- Docs-only; no Atlas manifest/search/browse/Daily/Practice/cloze assets regenerated.
- Uses privacy-safe committed labels and does not name private teachers.
