### PR TITLE
docs(atlas): correct tracker closed issue state

### DIFF
--- a/docs/decisions/2026-06-25-lexicon-update-mechanics.md
+++ b/docs/decisions/2026-06-25-lexicon-update-mechanics.md
@@ -124,13 +124,10 @@ for source-inventory rows promoted to browse/search.
 - **#3450** — inflected-form dedupe is closed; manifest entries now include
   canonical `form_of` cards instead of publishing those rows as ordinary
   article pages.
-
-## Open backlog
-
-- **#3406** — ~24 ЕСУМ entries carry OCR mojibake bibliographic text (careful: a prior dirty regen was
-  discarded — fix the data, re-enrich only those entries).
-- **#3675** — auto-grow P1–P3 shipped; Gap 1 above is the remaining "make it actually run" piece, now
-  unblocked by the option-(d) decision (publish the DBs as Release assets → hosted cron hydrates them).
+- **#3406** — targeted ЕСУМ OCR/mojibake cleanup is closed.
+- **#3675** — stateless content/doc-import Atlas growth is closed. The Gap 1
+  release-asset mechanics remain documented here as decision history, not as
+  an active #3675 issue leaf.
 
 ## Current sequencing
 

--- a/docs/runbooks/word-atlas-static-api.md
+++ b/docs/runbooks/word-atlas-static-api.md
@@ -26,8 +26,8 @@ As of 2026-07-02, the static contract should expose this board state:
   20 curriculum sample rows.
 
 Open Atlas/Lexicon board items are #3936, private teacher-lesson vocabulary
-intake, #3933, #3934, #3797, #3406, and #3675. Closed items that should not
-reappear as active backlog are #3932, #3796, #3449, and #3450.
+intake, #3933, #3934, and #3797. Closed items that should not reappear as
+active backlog are #3932, #3796, #3449, #3450, #3406, and #3675.
 
 The status payload also points to existing static browse assets:
 


### PR DESCRIPTION
## Summary
- Corrects the tracker-truth docs from #4158 so #3406 and #3675 are classified as closed/history, not active board items.
- Keeps the active board to #3936, private teacher-lesson vocabulary intake, #3933, #3934, and #3797.

## Validation
- `npx --no-install markdownlint-cli2 docs/decisions/2026-06-25-lexicon-update-mechanics.md docs/runbooks/word-atlas-static-api.md`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Independent Agy/Gemini blocker review: `NO BLOCKERS`.

## Notes
- Docs-only correction; no generated Atlas outputs.
- Uses privacy-safe teacher-lesson wording only.
