### PR TITLE
Add private teacher lesson source inventory seed

### DIFF
--- a/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+++ b/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
@@ -1,0 +1,211 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Private teacher lesson vocabulary - explicit table seed
+    locator: local-only explicit vocabulary table rows 1-38
+    notes: Derived headword metadata only; raw private lesson material is local-only and not committed. Daily Word, Practice, and cloze remain frozen without explicit surface_admission.
+    headwords:
+      - lemma: справедливий
+        pos: adjective
+        gloss: fair
+        locator: explicit vocabulary table row 1
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: справедливість
+        pos: noun
+        gloss: justice; fairness
+        locator: explicit vocabulary table row 2
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: справедливо
+        pos: adverb
+        gloss: fairly; justly
+        locator: explicit vocabulary table row 3
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: витирати
+        pos: verb
+        gloss: to wipe; imperfective
+        locator: explicit vocabulary table row 4
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: витерти
+        pos: verb
+        gloss: to wipe; perfective
+        locator: explicit vocabulary table row 5
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: випробування
+        pos: noun
+        gloss: challenge; trial
+        locator: explicit vocabulary table row 6
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: знецінення
+        pos: noun
+        gloss: devaluation; undervaluing
+        locator: explicit vocabulary table row 7
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: явно
+        pos: adverb
+        gloss: clearly; explicitly
+        locator: explicit vocabulary table row 8
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вийти з ладу
+        pos: phrase
+        gloss: to break down; to go out of order
+        locator: explicit vocabulary table row 9
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: підозрюваний
+        pos: noun
+        gloss: suspect
+        locator: explicit vocabulary table row 10
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: наближатися
+        pos: verb
+        gloss: to get closer; imperfective
+        locator: explicit vocabulary table row 11
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: наблизитися
+        pos: verb
+        gloss: to get closer; perfective
+        locator: explicit vocabulary table row 12
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: таємно
+        pos: adverb
+        gloss: secretly
+        locator: explicit vocabulary table row 13
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: чверть
+        pos: noun
+        gloss: quarter
+        locator: explicit vocabulary table row 14
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: підприємець
+        pos: noun
+        gloss: entrepreneur
+        locator: explicit vocabulary table row 15
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: не смій
+        pos: phrase
+        gloss: don't you dare
+        locator: explicit vocabulary table row 16
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вибухати
+        pos: verb
+        gloss: to explode; imperfective
+        locator: explicit vocabulary table row 17
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вибухнути
+        pos: verb
+        gloss: to explode; perfective
+        locator: explicit vocabulary table row 18
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: епілептичний напад
+        pos: noun
+        gloss: epileptic seizure
+        locator: explicit vocabulary table row 19
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: камера
+        pos: noun
+        gloss: prison cell
+        locator: explicit vocabulary table row 20
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вирубати
+        pos: verb
+        gloss: to knock out; to turn off
+        locator: explicit vocabulary table row 21
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вирубити
+        pos: verb
+        gloss: to knock out; to turn off
+        locator: explicit vocabulary table row 22
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: присягатися
+        pos: verb
+        gloss: to swear; imperfective
+        locator: explicit vocabulary table row 23
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: клястися
+        pos: verb
+        gloss: to swear; imperfective
+        locator: explicit vocabulary table row 23
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: присягнутися
+        pos: verb
+        gloss: to swear; perfective
+        locator: explicit vocabulary table row 24
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: поклястися
+        pos: verb
+        gloss: to swear; perfective
+        locator: explicit vocabulary table row 24
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: рогівка
+        pos: noun
+        gloss: cornea
+        locator: explicit vocabulary table row 25
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: заводитися
+        pos: verb
+        gloss: to start, as a car; imperfective
+        locator: explicit vocabulary table row 26
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: завестися
+        pos: verb
+        gloss: to start, as a car; perfective
+        locator: explicit vocabulary table row 27
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: тарган
+        pos: noun
+        gloss: cockroach
+        locator: explicit vocabulary table row 28
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: незадовільний
+        pos: adjective
+        gloss: unsatisfactory
+        locator: explicit vocabulary table row 29
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: взуватися
+        pos: verb
+        gloss: to put on shoes; imperfective
+        locator: explicit vocabulary table row 30
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: взутися
+        pos: verb
+        gloss: to put on shoes; perfective
+        locator: explicit vocabulary table row 31
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: роззуватися
+        pos: verb
+        gloss: to take off shoes; imperfective
+        locator: explicit vocabulary table row 32
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: роззутися
+        pos: verb
+        gloss: to take off shoes; perfective
+        locator: explicit vocabulary table row 33
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: безглуздий
+        pos: adjective
+        gloss: absurd; senseless
+        locator: explicit vocabulary table row 34
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: неоплачений
+        pos: adjective
+        gloss: unpaid
+        locator: explicit vocabulary table row 35
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: місцезнаходження
+        pos: noun
+        gloss: whereabouts; location
+        locator: explicit vocabulary table row 36
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: камера спостереження
+        pos: noun
+        gloss: surveillance camera
+        locator: explicit vocabulary table row 37
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: цілодобово
+        pos: adverb
+        gloss: around the clock; twenty-four seven
+        locator: explicit vocabulary table row 38
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.

--- a/docs/decisions/2026-06-25-lexicon-update-mechanics.md
+++ b/docs/decisions/2026-06-25-lexicon-update-mechanics.md
@@ -26,8 +26,8 @@ Current static Atlas counts:
 - Public search/browse: 5,270 entries, 61 search shards, 31 browse shards.
 - Daily Word: 300 entries.
 - Practice deck: 4,484 lexemes and 22 reviewed A1 cloze items.
-- Source-inventory seeds: 133 rows total: 80 textbook, 33 Ohoiko/ULP, and
-  20 curriculum sample rows.
+- Source-inventory seeds: 173 rows total: 80 textbook, 40 private
+  teacher-lesson, 33 Ohoiko/ULP, and 20 curriculum sample rows.
 
 Closed tracker leaves that should not be treated as active backlog:
 
@@ -46,9 +46,8 @@ Merged recent delivery PRs:
 Open board:
 
 - #3936 - tracker/reliability coordination.
-- Private teacher-lesson vocabulary intake - create or update a dedicated
-  issue before publishing rows; use privacy-safe source labels in committed
-  artifacts.
+- #4160 - private teacher-lesson vocabulary intake; use privacy-safe source
+  labels in committed artifacts.
 - #3933 - Ohoiko/ULP source-safe intake.
 - #3934 - textbook/headword intake beyond the current 80-row seed.
 - #3797 - reviewed cloze expansion beyond the current 22 A1 items.
@@ -132,9 +131,8 @@ for source-inventory rows promoted to browse/search.
 ## Current sequencing
 
 1. Keep #3936 accurate as the delivery board; update it when leaves close.
-2. Add a dedicated private teacher-lesson vocabulary source-inventory lane
-   before more broad textbook/Ohoiko growth, using privacy-safe committed
-   labels and tracked source locators.
+2. Continue #4160 before more broad textbook/Ohoiko growth, using
+   privacy-safe committed labels and neutral source locators.
 3. Continue #3933 with source-safe Ohoiko/ULP rows only.
 4. Continue #3934 with reviewed textbook/headword rows beyond the current
    80-row seed.

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -1,0 +1,57 @@
+# Word Atlas Private Teacher-Lesson Source Scope
+
+This note defines how private teacher-lesson vocabulary can enter the Word
+Atlas source-inventory lane without publishing private lesson material.
+
+## Current Safe Source
+
+The committed inventory seed is:
+
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml`
+
+Current committed coverage is 40 reviewed headwords from an explicit local
+vocabulary table. The source family is `teacher_lesson`, and the source title,
+source id, locators, and context are intentionally privacy-safe. The inventory
+does not commit raw notes, transcripts, prompts, document paths, or teacher
+identifying names.
+
+## Source Handling Rule
+
+Use the ignored local lesson material only as private evidence for deriving
+reviewed headword metadata. Committed rows may contain:
+
+- a normalized Ukrainian headword or phrase
+- a POS tag
+- a short learner-facing English gloss
+- a neutral source id and locator such as `explicit vocabulary table row 12`
+- a generic context sentence that does not quote private lesson prose
+
+Do not commit raw private source files, private file paths, lesson transcripts,
+prompt dumps, screenshots, or teacher-identifying labels.
+
+## Current Boundary
+
+This lane is source-inventory only. It does not update:
+
+- live Atlas manifest, search, or browse output
+- Daily Word
+- Practice decks
+- cloze decks
+- manifest pointer or fingerprint
+
+Daily Word, Practice, and cloze admission must remain separate
+`surface_admission` decisions. Missing `surface_admission` means Atlas
+browse/search only after a later publish PR, and no learner-facing activity
+admission.
+
+## Next Valid #4160 PR Shapes
+
+A safe follow-up PR may do one of these:
+
+- add the next bounded reviewed private teacher-lesson inventory batch
+- add reviewed decision-ledger rows for already committed teacher-lesson
+  candidates
+- publish an already-approved teacher-lesson batch to Atlas browse/search only
+
+Do not mix private-source intake, live Atlas publish, and Daily/Practice/cloze
+admission in one PR.

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -16,6 +16,7 @@ The committed source inventory input is:
 - `data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml`
 - `data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml`
 - `data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml`
 - `data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml`
 
 The candidate JSON follows the existing grow-candidate shape: `counts`,
@@ -84,6 +85,11 @@ each for noun, adjective, numeral, pronoun, verb, adverb, preposition,
 conjunction, particle, and interjection. Optional per-headword `gloss` values
 are curated learner-facing English anchors for cases where dictionary
 enrichment lacks a visible English translation.
+
+The private teacher-lesson seed contributes 40 reviewed `teacher_lesson`
+headwords from an explicit local vocabulary table. Its committed rows are
+derived metadata only: no raw private lesson material, private document paths,
+or teacher-identifying labels should appear in the inventory.
 
 When a candidate is later promoted into a manifest entry,
 `promote_grow_candidates.manifest_entry_from_candidate()` copies

--- a/docs/runbooks/word-atlas-static-api.md
+++ b/docs/runbooks/word-atlas-static-api.md
@@ -22,11 +22,11 @@ As of 2026-07-02, the static contract should expose this board state:
 - Public search/browse: 5,270 entries, 61 search shards, 31 browse shards.
 - Daily Word: 300 entries.
 - Practice deck: 4,484 lexemes and 22 reviewed A1 cloze items.
-- Source-inventory seeds: 133 rows total: 80 textbook, 33 Ohoiko/ULP, and
-  20 curriculum sample rows.
+- Source-inventory seeds: 173 rows total: 80 textbook, 40 private
+  teacher-lesson, 33 Ohoiko/ULP, and 20 curriculum sample rows.
 
-Open Atlas/Lexicon board items are #3936, private teacher-lesson vocabulary
-intake, #3933, #3934, and #3797. Closed items that should not reappear as
+Open Atlas/Lexicon board items are #3936, #4160, #3933, #3934, and #3797.
+Closed items that should not reappear as
 active backlog are #3932, #3796, #3449, #3450, #3406, and #3675.
 
 The status payload also points to existing static browse assets:

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -19,6 +19,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )
 

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.audit.source_inventory_intake import read_source_inventory
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+PRIVATE_TEACHER_INVENTORY = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml"
+)
+
+
+def test_private_teacher_inventory_is_privacy_safe_review_metadata() -> None:
+    records = read_source_inventory(PRIVATE_TEACHER_INVENTORY, project_root=PROJECT_ROOT)
+
+    assert len(records) == 40
+    assert {record.source_family for record in records} == {"teacher_lesson"}
+    assert {record.extraction_mode for record in records} == {"curated_headword"}
+    assert {record.source_id for record in records} == {
+        "private-teacher-lesson-vocabulary-table-1-seed"
+    }
+    assert all(record.source_path is None for record in records)
+    assert all(record.source_url is None for record in records)
+    assert all(record.source_title for record in records)
+    assert all(record.source_locator for record in records)
+    assert all(record.context for record in records)
+    assert all(record.pos for record in records)
+    assert all(record.gloss for record in records)
+
+    inventory_text = PRIVATE_TEACHER_INVENTORY.read_text(encoding="utf-8")
+    assert ".docx" not in inventory_text
+
+
+def test_private_teacher_inventory_uses_clean_headwords_not_raw_table_cells() -> None:
+    records = read_source_inventory(PRIVATE_TEACHER_INVENTORY, project_root=PROJECT_ROOT)
+
+    assert all("," not in record.lemma for record in records)
+    assert all("/" not in record.lemma for record in records)
+    assert "тарган" in {record.lemma for record in records}
+    assert "вийти з ладу" in {record.lemma for record in records}

--- a/tests/test_source_inventory_intake.py
+++ b/tests/test_source_inventory_intake.py
@@ -202,7 +202,7 @@ def test_committed_source_inventory_files_are_valid() -> None:
     assert candidates
     assert len(records) >= 100
     assert len(candidates) >= 100
-    assert {"curriculum", "ohoiko", "textbook"} <= {
+    assert {"curriculum", "ohoiko", "teacher_lesson", "textbook"} <= {
         record.source_family for record in records
     }
 

--- a/tests/test_source_inventory_review_candidates.py
+++ b/tests/test_source_inventory_review_candidates.py
@@ -27,7 +27,12 @@ POS_BALANCED_POS = {
     "particle",
     "interjection",
 }
-REQUIRED_REVIEW_SOURCE_FAMILIES = {"curriculum", "ohoiko", "textbook"}
+REQUIRED_REVIEW_SOURCE_FAMILIES = {
+    "curriculum",
+    "ohoiko",
+    "teacher_lesson",
+    "textbook",
+}
 
 
 def test_review_candidates_use_committed_inventories_and_keep_provenance(


### PR DESCRIPTION
## Summary

- add a privacy-safe `teacher_lesson` Word Atlas source-inventory seed with 40 reviewed headwords from explicit local lesson vocabulary rows
- wire the new inventory into the review-candidate generator defaults and update tracker/runbook counts from 133 to 173 source rows
- add guard tests so committed teacher-lesson metadata does not point at raw local source files and does not preserve raw slash/comma table cells

This is source-inventory only. It does not update live Atlas manifest/search/browse output, Daily Word, Practice, cloze, manifest pointers, or fingerprints.

## Validation

- `.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_candidates.py -q`
- `.venv/bin/ruff check scripts/audit/generate_source_inventory_review_candidates.py tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_candidates.py`
- `npx --no-install markdownlint-cli2 docs/runbooks/word-atlas-private-teacher-source-scope.md docs/runbooks/word-atlas-source-inventory-review-candidates.md docs/runbooks/word-atlas-static-api.md docs/decisions/2026-06-25-lexicon-update-mechanics.md`
- `.venv/bin/python -m scripts.audit.source_inventory_review_decisions`
- `.venv/bin/python -m scripts.audit.generate_source_inventory_review_candidates --report --out /tmp/atlas-source-inventory-review-candidates-4160-postfix.json`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

Independent non-Codex review: AGY/Gemini found one locator range mismatch; fixed. Follow-up review returned `NO BLOCKERS`.

Refs #4160
Refs #3936