### PR TITLE
[codex] Keep B2 landing availability in sync

### DIFF
--- a/scripts/audit/check_locked_module_not_published.py
+++ b/scripts/audit/check_locked_module_not_published.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Block locked/todo/planned seminar modules from being served as live MDX."""
+"""Block locked/todo/planned landing modules from being served as live MDX."""
 
 from __future__ import annotations
 
@@ -12,7 +12,15 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DOCS_DIR = PROJECT_ROOT / "site" / "src" / "content" / "docs"
 
-SEMINAR_DOC_TRACKS = {
+LANDING_DOC_TRACKS = {
+    "a1",
+    "a2",
+    "b1",
+    "b2",
+    "b2-pro",
+    "c1",
+    "c1-pro",
+    "c2",
     "bio",
     "folk",
     "hist",
@@ -149,7 +157,7 @@ def check_scope(scope: CheckScope, *, docs_dir: Path = DOCS_DIR) -> list[Finding
     modules_by_track = {
         track: parse_landing_modules(docs_dir / track / "index.mdx", track)
         for track in tracks
-        if track in SEMINAR_DOC_TRACKS
+        if track in LANDING_DOC_TRACKS
     }
 
     for track in scope.tracks:
@@ -183,7 +191,7 @@ def affected_scope(paths: list[Path]) -> CheckScope:
             continue
 
         track = parts[4]
-        if track not in SEMINAR_DOC_TRACKS:
+        if track not in LANDING_DOC_TRACKS:
             continue
         if parts[5] == "index.mdx":
             tracks.add(track)
@@ -212,28 +220,40 @@ def get_local_changed_files(*, cached: bool = False) -> list[Path]:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Check locked/todo/planned seminar modules are not published.")
+    parser = argparse.ArgumentParser(description="Check locked/todo/planned landing modules are not published.")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--changed-vs-base", metavar="BASE", help="Compare against base branch, e.g. origin/main")
     group.add_argument("--files", nargs="+", type=Path, help="Scan explicit files, e.g. from pre-commit")
+    group.add_argument("--all", action="store_true", help="Scan every known landing track.")
     return parser
+
+
+def discover_scope(*, docs_dir: Path = DOCS_DIR) -> CheckScope:
+    tracks = frozenset(
+        path.parent.name
+        for path in docs_dir.glob("*/index.mdx")
+        if path.parent.name in LANDING_DOC_TRACKS
+    )
+    return CheckScope(tracks=tracks, modules=frozenset())
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
 
-    if args.changed_vs_base:
+    if args.all:
+        scope = discover_scope()
+    elif args.changed_vs_base:
         raw_paths = [
             *get_changed_files(args.changed_vs_base),
             *get_local_changed_files(),
             *get_local_changed_files(cached=True),
         ]
+        scope = affected_scope(raw_paths)
     else:
         raw_paths = args.files
-
-    scope = affected_scope(raw_paths)
+        scope = affected_scope(raw_paths)
     if not scope.tracks and not scope.modules:
-        print("0 findings: no changed seminar docs require locked-module publish check.")
+        print("0 findings: no landing docs require locked-module publish check.")
         return 0
 
     findings = check_scope(scope)

--- a/scripts/generate_landing_pages.py
+++ b/scripts/generate_landing_pages.py
@@ -6,6 +6,7 @@ accurate landing pages with correct slugs, titles, and build statuses.
 Usage:
     .venv/bin/python scripts/generate_landing_pages.py [--track a1]
     .venv/bin/python scripts/generate_landing_pages.py --all
+    .venv/bin/python scripts/generate_landing_pages.py --track b2 --check
 """
 
 from __future__ import annotations
@@ -403,6 +404,7 @@ def main():
     parser = argparse.ArgumentParser(description="Generate Site landing pages")
     parser.add_argument("--track", help="Generate for specific track (e.g., a1)")
     parser.add_argument("--all", action="store_true", help="Generate for all tracks")
+    parser.add_argument("--check", action="store_true", help="Fail if generated landing pages differ from disk")
     args = parser.parse_args()
 
     curriculum = yaml.safe_load((CURRICULUM_ROOT / "curriculum.yaml").read_text("utf-8"))
@@ -416,6 +418,7 @@ def main():
     else:
         tracks = [k for k in levels if levels[k].get("modules")]
 
+    stale_paths: list[Path] = []
     for level in tracks:
         if level not in levels:
             print(f"⚠️  Track {level} not in curriculum.yaml, skipping")
@@ -429,9 +432,25 @@ def main():
         out_dir = SITE_DOCS / level
         out_dir.mkdir(parents=True, exist_ok=True)
         out_path = out_dir / "index.mdx"
+        if args.check:
+            if not out_path.exists() or out_path.read_text("utf-8") != mdx:
+                stale_paths.append(out_path)
+                print(f"  STALE {out_path}")
+            else:
+                print(f"  OK {out_path}")
+            continue
+
         out_path.write_text(mdx, "utf-8")
         print(f"  ✅ {out_path}")
 
+    if stale_paths:
+        print("\nLanding page drift detected. Regenerate with:")
+        for path in stale_paths:
+            level = path.parent.name
+            print(f"  .venv/bin/python scripts/generate_landing_pages.py --track {level}")
+        return 1
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/site/src/content/docs/b2/index.mdx
+++ b/site/src/content/docs/b2/index.mdx
@@ -10,9 +10,9 @@ import LevelLanding from '@site/src/components/LevelLanding';
   client:load
   level="B2"
   title="Впевнено"
-  subtitle="Upper-intermediate Ukrainian course — 68 learner pages available · 93 modules"
+  subtitle="Upper-intermediate Ukrainian course — 82 learner pages available · 93 modules"
   progressTitle="B2 Build Status"
-  progressDescription="68 available · 68 reviewed · 25 planned"
+  progressDescription="82 available · 0 reviewed · 11 planned"
   moduleCount={93}
   wordTarget={4000}
   color="var(--lu-id-b2)"
@@ -118,25 +118,25 @@ import LevelLanding from '@site/src/components/LevelLanding';
         { num: 66, slug: "checkpoint-morphology", title: "Контрольна точка: Морфологія", sub: "Підсумковий контроль: морфологія", status: "active" },
         { num: 67, slug: "synonymy-types-and-rows", title: "Типи синонімів та синонімічні ряди", sub: "Синонімія: типи та ряди", status: "active" },
         { num: 68, slug: "synonymy-in-registers", title: "Синонімія у різних реєстрах", sub: "Синонімія в регістрами", status: "active" },
-        { num: 69, slug: "synonymy-practice-precision", title: "Практикум із синонімії: Точність слововживання", sub: "Практика синонімії: точність", status: "locked" },
-        { num: 70, slug: "proverbs-work-wisdom-character", title: "Прислів'я та приказки: Праця, мудрість, характер", sub: "Прислів'я: праця, мудрість, характер", status: "locked" },
-        { num: 71, slug: "proverbs-nature-time-caution", title: "Прислів'я та приказки: Природа, час, обережність", sub: "Прислів'я: природа, час, обережність", status: "locked" },
-        { num: 72, slug: "set-expressions-combined", title: "Сталі словосполучення: Комбінований огляд", sub: "Стійкі вислови: загальний огляд", status: "locked" },
-        { num: 73, slug: "checkpoint-lexicology-i", title: "Контрольний модуль: Лексикологія I (синонімія та пареміологія)", sub: "Підсумковий контроль: синонімія, прислів'я та сталі вирази", status: "locked" },
+        { num: 69, slug: "synonymy-practice-precision", title: "Практикум із синонімії: Точність слововживання", sub: "Практика синонімії: точність", status: "active" },
+        { num: 70, slug: "proverbs-work-wisdom-character", title: "Прислів'я та приказки: Праця, мудрість, характер", sub: "Прислів'я: праця, мудрість, характер", status: "active" },
+        { num: 71, slug: "proverbs-nature-time-caution", title: "Прислів'я та приказки: Природа, час, обережність", sub: "Прислів'я: природа, час, обережність", status: "active" },
+        { num: 72, slug: "set-expressions-combined", title: "Сталі словосполучення: Комбінований огляд", sub: "Стійкі вислови: загальний огляд", status: "active" },
+        { num: 73, slug: "checkpoint-lexicology-i", title: "Контрольний модуль: Лексикологія I (синонімія та пареміологія)", sub: "Підсумковий контроль: синонімія, прислів'я та сталі вирази", status: "active" },
       ]
     },
     {
       unit: "B2.7 [Idioms, Neologisms & Professional Communication]",
       items: [
-        { num: 74, slug: "idioms-somatic", title: "Соматична фразеологія: Тіло та емоції", sub: "Соматичні фразеологізми: тіло та емоції", status: "locked" },
-        { num: 75, slug: "idioms-animals", title: "Зооморфні ідіоми: Тваринний світ у мові", sub: "Зооморфні фразеологізми: тваринний світ у мові", status: "locked" },
-        { num: 76, slug: "idioms-nature", title: "Природничі ідіоми: Стихії та ландшафти", sub: "Фразеологізми про природу: стихії та пейзажі", status: "locked" },
-        { num: 77, slug: "neologisms-borrowings", title: "Неологізми та запозичення: Динаміка мовного оновлення", sub: "Неологізми та запозичення: динаміка оновлення мови", status: "locked" },
-        { num: 78, slug: "checkpoint-lexicology-ii", title: "Контрольний модуль: Лексикологія II (ідіоми, неологізми та динаміка)", sub: "Підсумковий контроль: ідіоми, неологізми та лексична динаміка", status: "locked" },
-        { num: 79, slug: "professional-email-basics", title: "Ділова переписка: Основи електронного листування", sub: "Професійний email: основи електронного листування", status: "locked" },
-        { num: 80, slug: "professional-email-advanced", title: "Ділова переписка: Поглиблені аспекти та складні ситуації", sub: "Професійний е-мейл: просунуті аспекти та складні ситуації", status: "locked" },
-        { num: 81, slug: "professional-reports", title: "Професійні звіти: від основ до стратегії", sub: "Професійні звіти: від основ до стратегії", status: "locked" },
-        { num: 82, slug: "academic-writing", title: "Академічне письмо та науковий стиль", sub: "Академічне письмо та науковий стиль", status: "locked" },
+        { num: 74, slug: "idioms-somatic", title: "Соматична фразеологія: Тіло та емоції", sub: "Соматичні фразеологізми: тіло та емоції", status: "active" },
+        { num: 75, slug: "idioms-animals", title: "Зооморфні ідіоми: Тваринний світ у мові", sub: "Зооморфні фразеологізми: тваринний світ у мові", status: "active" },
+        { num: 76, slug: "idioms-nature", title: "Природничі ідіоми: Стихії та ландшафти", sub: "Фразеологізми про природу: стихії та пейзажі", status: "active" },
+        { num: 77, slug: "neologisms-borrowings", title: "Неологізми та запозичення: Динаміка мовного оновлення", sub: "Неологізми та запозичення: динаміка оновлення мови", status: "active" },
+        { num: 78, slug: "checkpoint-lexicology-ii", title: "Контрольний модуль: Лексикологія II (ідіоми, неологізми та динаміка)", sub: "Підсумковий контроль: ідіоми, неологізми та лексична динаміка", status: "active" },
+        { num: 79, slug: "professional-email-basics", title: "Ділова переписка: Основи електронного листування", sub: "Професійний email: основи електронного листування", status: "active" },
+        { num: 80, slug: "professional-email-advanced", title: "Ділова переписка: Поглиблені аспекти та складні ситуації", sub: "Професійний е-мейл: просунуті аспекти та складні ситуації", status: "active" },
+        { num: 81, slug: "professional-reports", title: "Професійні звіти: від основ до стратегії", sub: "Професійні звіти: від основ до стратегії", status: "active" },
+        { num: 82, slug: "academic-writing", title: "Академічне письмо та науковий стиль", sub: "Академічне письмо та науковий стиль", status: "active" },
         { num: 83, slug: "text-analysis", title: "Аналіз тексту: Підтекст, стиль та цільова аудиторія", sub: "Аналіз тексту: підтекст, стиль та цільова аудиторія", status: "locked" },
         { num: 84, slug: "news-analysis", title: "Аналіз новин: від структури до критичного мислення", sub: "Аналіз новин: від структури до критичного мислення", status: "locked" },
       ]

--- a/tests/test_check_locked_module_not_published.py
+++ b/tests/test_check_locked_module_not_published.py
@@ -68,4 +68,22 @@ def test_affected_scope_checks_index_tracks_and_module_pages() -> None:
     scope = check_locked_module_not_published.affected_scope(paths)
 
     assert scope.tracks == frozenset({"folk"})
-    assert scope.modules == frozenset({check_locked_module_not_published.ModuleTarget("folk", "locked-module")})
+    assert scope.modules == frozenset({
+        check_locked_module_not_published.ModuleTarget("a1", "core-module"),
+        check_locked_module_not_published.ModuleTarget("folk", "locked-module"),
+    })
+
+
+def test_discover_scope_includes_core_landing_tracks(tmp_path: Path) -> None:
+    docs_dir = tmp_path / "docs"
+    (docs_dir / "b2").mkdir(parents=True)
+    (docs_dir / "b2" / "index.mdx").write_text("", encoding="utf-8")
+    (docs_dir / "folk").mkdir(parents=True)
+    (docs_dir / "folk" / "index.mdx").write_text("", encoding="utf-8")
+    (docs_dir / "not-a-track").mkdir(parents=True)
+    (docs_dir / "not-a-track" / "index.mdx").write_text("", encoding="utf-8")
+
+    scope = check_locked_module_not_published.discover_scope(docs_dir=docs_dir)
+
+    assert scope.tracks == frozenset({"b2", "folk"})
+    assert scope.modules == frozenset()

--- a/tests/test_landings_use_levellanding.py
+++ b/tests/test_landings_use_levellanding.py
@@ -2,6 +2,9 @@ import re
 from pathlib import Path
 
 import pytest
+import yaml
+
+from scripts import generate_landing_pages
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 DOCS_ROOT = PROJECT_ROOT / "site" / "src" / "content" / "docs"
@@ -86,3 +89,11 @@ def test_content_collection_loads_track_index_mdx_files() -> None:
 
     missing = sorted(track for track in tracks if track not in text)
     assert not missing, f"content loader does not include track indexes: {', '.join(missing)}"
+
+
+def test_b2_landing_matches_generated_curriculum_state() -> None:
+    curriculum = yaml.safe_load((PROJECT_ROOT / "curriculum" / "l2-uk-en" / "curriculum.yaml").read_text("utf-8"))
+    expected = generate_landing_pages.generate_landing_page("b2", curriculum)
+    actual = (DOCS_ROOT / "b2" / "index.mdx").read_text(encoding="utf-8")
+
+    assert actual == expected, "Run `.venv/bin/python scripts/generate_landing_pages.py --track b2`."


### PR DESCRIPTION
## Summary

Fixes the stale B2 landing page availability state and adds guardrails so this drift is caught next time.

## Root cause

The B2 rebuild workers generated module pages, but the B2 landing page is a static MDX file. The existing landing generator was not part of the merge gate, and the locked/published audit only covered seminar tracks, so B2 cards could remain `locked` even after the MDX routes existed.

## Changes

- Regenerated `site/src/content/docs/b2/index.mdx` from `scripts/generate_landing_pages.py` so M69-M82 are active and the count is 82 available / 11 planned.
- Added `--check` mode to `scripts/generate_landing_pages.py` for CI or orchestration gates.
- Extended `check_locked_module_not_published.py` to cover core landing tracks and added `--all` scan mode.
- Added focused tests for B2 landing freshness and core-track locked/published scope discovery.

## Validation

- `.venv/bin/python scripts/generate_landing_pages.py --track b2 --check`
- `.venv/bin/python scripts/audit/check_locked_module_not_published.py --all`
- `.venv/bin/python -m pytest tests/test_landings_use_levellanding.py tests/test_check_locked_module_not_published.py -q`
- `.venv/bin/ruff check scripts/generate_landing_pages.py scripts/audit/check_locked_module_not_published.py tests/test_landings_use_levellanding.py tests/test_check_locked_module_not_published.py`
- `git diff --check`
- `npm --prefix site ci`
- `npm --prefix site run build`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
