### PR TITLE
Approve first teacher lesson inventory ledger batch

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-02-first-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-02-first-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,297 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-first-approved-teacher-lesson-ledger-batch-2026-07-02
+batch_label: first-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-02'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4162
+  total_queue_rows: 110
+  approved_in_queue: 20
+  promotion_batch_size: 20
+production_outputs_updated: []
+decisions:
+- lemma: справедливий
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: fair
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: e6ad793fbaeee5ee
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 1
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: справедливість
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: justice; fairness
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 305bc00e29fb712a
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 2
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: справедливо
+  decision: approve_for_publish
+  approved_pos: adverb
+  approved_gloss: fairly; justly
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 3403360d70c9a5ad
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 3
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: витирати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to wipe; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d4201c579c1c8640
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 4
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: витерти
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to wipe; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 9bcfbd3704903ba3
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 5
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: випробування
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: challenge; trial
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 388aeec18b66eccf
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 6
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: знецінення
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: devaluation; undervaluing
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: b4c31dc045a8e57a
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 7
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: явно
+  decision: approve_for_publish
+  approved_pos: adverb
+  approved_gloss: clearly; explicitly
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 4c35de10df6fba73
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 8
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: вийти з ладу
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: to break down; to go out of order
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 5db7b54cdaa34a63
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 9
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: підозрюваний
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: suspect
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 2bb173228e72443b
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 10
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: наближатися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to get closer; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 3576d5481e124703
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 11
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: наблизитися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to get closer; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: fd3b42c917e58c91
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 12
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: таємно
+  decision: approve_for_publish
+  approved_pos: adverb
+  approved_gloss: secretly
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 08098e1aaa8737d9
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 13
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: чверть
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: quarter
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: ea65b432bee773cf
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 14
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: підприємець
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: entrepreneur
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 3dcbb14ca94d9f39
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 15
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: не смій
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: don't you dare
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d068b8bbc0e2ca54
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 16
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: вибухати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to explode; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 174ab9330b4b6ba9
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 17
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: вибухнути
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to explode; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: f49b9bcdf9d25316
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 18
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: епілептичний напад
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: epileptic seizure
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 2fcaea1f6c579419
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 19
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: камера
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: prison cell
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 8fa85a7c5fd2c8a7
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 20
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -2,12 +2,20 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
+from scripts.audit import source_inventory_review_decisions as decisions
 from scripts.audit.source_inventory_intake import read_source_inventory
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 PRIVATE_TEACHER_INVENTORY = (
     PROJECT_ROOT
     / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml"
+)
+PRIVATE_TEACHER_FIRST_LEDGER = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory-review-decisions/"
+    "2026-07-02-first-approved-teacher-lesson-ledger-batch.yaml"
 )
 
 
@@ -39,3 +47,24 @@ def test_private_teacher_inventory_uses_clean_headwords_not_raw_table_cells() ->
     assert all("/" not in record.lemma for record in records)
     assert "тарган" in {record.lemma for record in records}
     assert "вийти з ладу" in {record.lemma for record in records}
+
+
+def test_private_teacher_first_decision_ledger_stays_review_only() -> None:
+    summary = decisions.validate_committed_decision_files([PRIVATE_TEACHER_FIRST_LEDGER])
+    payload = yaml.safe_load(PRIVATE_TEACHER_FIRST_LEDGER.read_text(encoding="utf-8"))
+
+    assert summary == {
+        "files": 1,
+        "rows": 20,
+        "decision_counts": {"approve_for_publish": 20},
+    }
+    assert payload["source_queue"]["promotion_batch_size"] == 20
+    assert payload["production_outputs_updated"] == []
+    assert all(
+        row["source_inventory"]["source_family"] == "teacher_lesson"
+        for row in payload["decisions"]
+    )
+    assert all("surface_admission" not in row for row in payload["decisions"])
+
+    ledger_text = PRIVATE_TEACHER_FIRST_LEDGER.read_text(encoding="utf-8")
+    assert ".docx" not in ledger_text


### PR DESCRIPTION
## Summary

- add the first approved `teacher_lesson` source-inventory decision ledger batch: 20 rows
- keep the batch review-only with `production_outputs_updated: []` and no `surface_admission`
- extend the private teacher-lesson tests to guard ledger shape, privacy, and no Daily/Practice/Cloze admission

This PR does not update live Atlas manifest/search/browse output, Daily Word, Practice, cloze, manifest pointer, or fingerprint.

## Boundary check

Promotion-plan dry run against the hydrated current manifest:

- approved decisions: 20
- matched candidates: 20
- proposed additions: 18
- skipped existing: 2 (`справедливий`, `чверть`)
- missing candidates: 0
- production outputs updated: []

## Validation

- `.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_review_decisions.py tests/test_source_inventory_promotion_plan.py -q`
- `.venv/bin/python -m scripts.audit.source_inventory_review_decisions`
- `.venv/bin/python -m scripts.audit.plan_source_inventory_promotion --candidates /tmp/atlas-source-inventory-review-candidates-4160-publish-boundary.json --decision-file data/lexicon/source-inventory-review-decisions/2026-07-02-first-approved-teacher-lesson-ledger-batch.yaml --manifest site/src/data/lexicon-manifest.json --out /tmp/atlas-teacher-lesson-approved-promotion-plan.json --report-out /tmp/atlas-teacher-lesson-approved-promotion-plan.md --report`
- `.venv/bin/ruff check tests/test_private_teacher_lesson_source_inventory.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

Independent non-Codex review: AGY/Gemini returned `NO BLOCKERS`.

Refs #4160
Refs #3936