### PR TITLE
docs(bio): add volodymyr chekhivskyi dossier

### DIFF
--- a/docs/research/bio/volodymyr-chekhivskyi.md
+++ b/docs/research/bio/volodymyr-chekhivskyi.md
@@ -62,7 +62,7 @@
 
 - **1897-1904 Ukrainian socialist formation:** Ukrainian social-democratic circles, RUP, and USDRP place him in the political generation that linked national rights, social justice, and education.
 - **1906 First State Duma / Vologda exile:** Duma election and punishment give a concrete pre-1917 state-repression anchor.
-- **1907-1917 Odesa Ukrainian civic work:** Teaching, Prosvita, hromada networks, `Українське слово`, and municipal politics show the Black Sea / Odesa dimension of Ukrainian Revolution history.
+- **1908-1917 Odesa Ukrainian civic work:** Teaching, Prosvita, hromada networks, `Українське слово`, and municipal politics show the Black Sea / Odesa dimension of Ukrainian Revolution history.
 - **1917 Central Rada and Kherson / Odesa leadership:** EIU records Central Rada membership, Odesa city-duma deputyship, and Kherson gubernial civic leadership. This links the BIO module to regional revolution infrastructure.
 - **1918 confessions administration:** Ministry-of-Confessions service under UPR / Ukrainian State connects him to church policy before his short premiership.
 - **December 1918 anti-Hetmanate transition:** ESU / EIU identify him among leaders of the anti-Hetmanate uprising and Ukrainian revolutionary committee, then head of government.
@@ -106,7 +106,7 @@
 - **Entente / Bolshevik policy:** His willingness to negotiate with Bolshevik Russia and opposition to Entente alignment should be framed as a contested wartime strategy, not proof that the Soviet charges were legitimate.
 - **Autocephaly overclaim:** He was central to the 1919 law and UAOC ideology, but not the sole founder of Ukrainian autocephaly. Pair him with Vasyl Lypkivskyi, Ivan Ohienko, and Oleksandr Lototskyi.
 - **SVU wording:** Never state "member of SVU" as fact. The safe language is `arrested / tried in the fabricated SVU case` or `defendant in the SVU show trial`.
-- **Ethnicity line in victim lists:** RFE/RL's Sandarmokh list labels him `поляк`. This may reflect Soviet file metadata and should not be turned into learner-facing identity without a dedicated source discussion.
+- **Victim-list metadata:** Nationality / ethnicity fields in repression lists may reflect Soviet file metadata and should not be turned into learner-facing identity without a dedicated source discussion.
 - **Image provenance:** `Volodymyr Chekhivsky.png` is marked PD-Ukraine but needs US public-domain scrutiny because the source is only "scan from book." `Chekhivski.jpg` has a stronger publication note from `Діло`, Lviv, April 1930, but still needs file-level check before production.
 
 ## 7. Cross-track links

--- a/docs/research/bio/volodymyr-chekhivskyi.md
+++ b/docs/research/bio/volodymyr-chekhivskyi.md
@@ -1,0 +1,182 @@
+# Володимир Мусійович Чехівський - Research Dossier
+
+**Slug:** `volodymyr-chekhivskyi`
+**Block:** +77 backfill - UNR Directory government / foreign affairs / church autocephaly / Ukrainian socialism / SVU show trial / Sandarmokh
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #322
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-03
+
+**Source acronym legend:** EIU = Encyclopedia History Ukraine / Institute History of Ukraine, NASU; ESU = Encyclopedia Modern Ukraine / NASU; IEU = Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies; UINP = Ukrainian Institute National Memory; RFE/RL = Radio Free Europe / Radio Liberty Ukrainian service; NBUV = Vernadsky National Library of Ukraine; BIO / HIST / ISTORIO / wiki = existing learn-ukrainian track materials; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, archival, primary-text, and image-rights sources cited
+- [x] Repression mechanism names OGPU / GPU show-trial pathway, SVU case, Supreme Court of the Ukrainian SSR sentence, Solovky imprisonment, Leningrad oblast NKVD troika decision, Sandarmokh execution, and rehabilitation
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / explorer check on 2026-07-03 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric periodization: frame is Ukrainian Revolution, UPR Directory, Ukrainian church autocephaly, Soviet show-trial terror, and Sandarmokh, not generic "Russian civil war."
+- [x] Ukrainian agency preserved: Chekhivskyi is treated as teacher, organizer, premier, foreign minister, church intellectual, and Soviet-terror victim, not as a footnote to Vynnychenko, Petliura, or Moscow church politics.
+- [x] Church autocephaly presented as legal, social, and decolonial institution-building, not only a confessional dispute.
+- [x] Anti-hagiography included: his left-socialist / Christian-socialist program, attempted compromise with Bolshevik power, and opposition to Entente alignment are recorded as contested political choices under war pressure.
+- [x] Soviet accusation language is source-labeled as fabricated or prosecutorial where used; it is not adopted as fact.
+
+## 1. Identity / chronology
+
+- **Canonical UA:** `Володимир Мусійович Чехівський`.
+- **Canonical EN:** `Volodymyr Chekhivskyi`.
+- **Core identity:** Ukrainian civic, political, state, religious, pedagogical, and scholarly figure; Central Rada member; Odesa Ukrainian organizer; head of the Council of People's Ministers of the Ukrainian People's Republic under the Directory; Minister of Foreign Affairs; one of the key lay ideologues and organizers of Ukrainian Orthodox autocephaly; professor; defendant in the fabricated SVU show trial; executed in Sandarmokh during the Great Terror.
+- **Birth:** ESU, EIU, IEU, and UINP give 19 July 1876, Horokhuvatka / `Горохуватка`, Kyiv gubernia, now Kyiv oblast. ESU specifies historical Kyiv county / gubernia and current Obukhiv raion; EIU's older place note says then Kaharlyk raion. Use the modern administrative label only in source-sensitive contexts.
+- **Death:** ESU, EIU, UINP, and the RFE/RL Sandarmokh list give 3 November 1937, Sandarmokh, Karelia. IEU's older entry says Solovets Islands for death; teach the corrected Sandarmokh execution site when giving precise place.
+- **Family / education:** ESU / EIU say he came from a priest's family. ESU records Kyiv spiritual school in 1890, seminary in 1896, and Kyiv Theological Academy in 1900 with candidate of theology degree; IEU gives Kyiv Theological Academy and Doctor of Theology language. Use `Kyiv Theological Academy graduate` as the low-risk learner label.
+- **Early teaching and politics:** ESU and EIU place him in Podillia and Kyiv seminary work, then Cherkasy teaching. EIU says he joined Ukrainian social-democratic circles in 1897, was in the Revolutionary Ukrainian Party in 1902-1904, then in the Ukrainian Social Democratic Workers' Party until January 1919.
+- **Imperial policing:** EIU and ESU record election to the First State Duma of the Russian Empire in 1906, exile to Vologda after the Duma's dissolution, and later Odesa teaching under police surveillance. IEU summarizes a one-year Vologda exile and Odesa teaching / hromada / Prosvita activity.
+- **Odesa and Central Rada:** EIU / ESU place him in Odesa in 1917 as editor of `Українське слово`, Odesa city-duma deputy, head of the Odesa USDRP committee, member of the Ukrainian Central Rada, head of the Kherson gubernial council of united civic organizations, and head of the Odesa revolutionary committee in October-November 1917.
+- **UPR / Ukrainian State religious administration:** EIU and ESU state that from April 1918 he served as director of the confessions department in the UPR government and then in the Ministry of Confessions / church policy under the Ukrainian State.
+- **Directory government:** EIU / IEU give 26 December 1918-11 February 1919 as head of the Council of People's Ministers and foreign minister. ESU gives December 1918-February 1919 and says he effectively built a new foreign-ministry apparatus. UINP gives resignation on 13 February 1919; use source-labeled dates for the exact end.
+- **Autocephaly:** EIU calls him the initiator of the 1 January 1919 law on Ukrainian Orthodox Church autocephaly. IEU says the law on autocephalous status was adopted under his government leadership. UINP names him one of the founders of the Ukrainian Autocephalous Orthodox Church.
+- **Soviet Ukraine period:** ESU / EIU / UINP say he remained in Ukraine after Bolshevik occupation, became one of the leaders of the Ukrainian Communist Party (independentists), worked with Metropolitan Vasyl Lypkivskyi and the UAOC, and taught / worked in VUAN and Kyiv higher schools.
+- **Repression:** ESU / EIU / IEU agree that he was arrested on 29 July 1929 in the SVU case. ESU gives 19 April 1930 death sentence commuted to 10 years' imprisonment, Solovky special-purpose camp, Leningrad oblast NKVD troika decision on 9 October 1937, execution on 3 November 1937, and rehabilitation in 1989.
+
+## 2. Political pressure mechanism
+
+- **Imperial surveillance and exile:** Chekhivskyi's early path shows how Ukrainian teaching, student organizing, and Duma representation were policed before 1917. EIU / ESU support one-year Vologda exile after the First Duma and open police surveillance in Odesa.
+- **Teacher-organizer pressure:** His Odesa work joined school administration, Ukrainian-language press, Prosvita, city politics, and USDRP organizing. This is a useful alternative to a purely military account of 1917: local education and press networks fed state-building.
+- **Directory crisis government:** Chekhivskyi headed the UNR government during a compressed crisis: anti-Hetmanate transition, Kyiv, foreign policy, Bolshevik offensive, Entente negotiations, labor-congress politics, Zluky context, language law, autocephaly law, and land-law pressure.
+- **Foreign-policy split:** ESU and UINP record that he favored understanding with Bolshevik Russia and opposed an Entente course. Present this as a contested left-socialist strategy under military collapse, not as a morality shortcut.
+- **Church autocephaly as decolonization:** The 1 January 1919 autocephaly law and later UAOC work treated ecclesiastical dependence on Moscow as a political and spiritual problem. Chekhivskyi connected social justice, Ukrainian language, church self-government, and state independence.
+- **Soviet squeeze after 1920:** His decision to stay in Soviet Ukraine did not make him safe. UINP notes that he combined left ideology and religious work; ESU states that he was under OGPU surveillance because of religious convictions and UAOC activity.
+- **Fabricated SVU case:** UINP calls the case fabricated; IEU's SVU entry describes the "Union for the Liberation of Ukraine" as a fictitious GPU construction for a show trial against Ukrainian intelligentsia and Ukrainization. For learner text, never repeat the accusation as fact.
+- **Sentence and imprisonment:** ESU and RFE/RL's Sandarmokh list give specific legal pathway: arrest 29 July 1929, Supreme Court of the Ukrainian SSR sentence on 19 April 1930, 10 years after the death sentence was commuted, political-isolator / Solovky imprisonment, and an NKVD-troika death decision on 9 October 1937.
+- **Execution and memory:** Sandarmokh makes the biography part of the Great Terror against Ukrainian elites. He should be taught beside other executed cultural, church, and state figures, while preserving his specific state-church profile.
+- **Rehabilitation:** ESU records rehabilitation in 1989. Do not frame this as "closure"; rehabilitation corrected the legal status but did not undo execution, archive damage, or Soviet erasure.
+
+## 3. Major events / historical footprint
+
+- **1897-1904 Ukrainian socialist formation:** Ukrainian social-democratic circles, RUP, and USDRP place him in the political generation that linked national rights, social justice, and education.
+- **1906 First State Duma / Vologda exile:** Duma election and punishment give a concrete pre-1917 state-repression anchor.
+- **1907-1917 Odesa Ukrainian civic work:** Teaching, Prosvita, hromada networks, `Українське слово`, and municipal politics show the Black Sea / Odesa dimension of Ukrainian Revolution history.
+- **1917 Central Rada and Kherson / Odesa leadership:** EIU records Central Rada membership, Odesa city-duma deputyship, and Kherson gubernial civic leadership. This links the BIO module to regional revolution infrastructure.
+- **1918 confessions administration:** Ministry-of-Confessions service under UPR / Ukrainian State connects him to church policy before his short premiership.
+- **December 1918 anti-Hetmanate transition:** ESU / EIU identify him among leaders of the anti-Hetmanate uprising and Ukrainian revolutionary committee, then head of government.
+- **26 December 1918-11 February 1919 government leadership:** IEU gives exact premier / foreign minister dates. ESU emphasizes new foreign-ministry apparatus; UINP emphasizes laws passed under his premiership.
+- **1 January 1919 autocephaly law:** This is the strongest pedagogical hinge: language, church, and state law inside one month of Directory rule.
+- **January 1919 state-policy cluster:** UINP lists Zluky, Ukrainian language, church autocephaly, and land law as the policy cluster of his government. Treat these as collective Directory / government actions, not single-person authorship.
+- **1921 UAOC council and church work:** IEU places him in the All-Ukrainian Orthodox Church Council presidium and ideological commission. UINP says he participated in the first church sobor confirming UAOC autocephaly.
+- **1922 `За Церкву, Христову громаду, проти царства тьми`:** NBUV / Commons identify the work as a 1922 church-history / church-political pamphlet about Ukrainian church independence and the 1686 Kyiv-metropolia question.
+- **1927 Second All-Ukrainian UAOC Sobor:** ESU and UINP identify him as chair / leading figure. This gives a later church anchor after the UNR government period.
+- **1929-1930 SVU show trial:** Arrest and show-trial sentencing become the major Soviet repression anchor.
+- **1937 Sandarmokh execution:** RFE/RL's list gives the 9 October 1937 special-troika death decision and 3 November 1937 execution at Sandarmokh.
+- **2006 memory marker:** ESU notes a National Bank of Ukraine two-hryvnia coin with his portrait, useful as a post-Soviet memory / commemoration artifact, not as a primary historical source.
+
+## 4. Pedagogical anchors
+
+- **Premier for seven weeks:** Teach why a short premiership can still matter: laws, foreign policy, church policy, and collapse pressure were concentrated in weeks.
+- **State and church in one biography:** Chekhivskyi connects Ministry of Foreign Affairs, Council of People's Ministers, Ukrainian language law, autocephaly, and UAOC institution-building.
+- **Odesa as Ukrainian Revolution site:** His Odesa work helps avoid Kyiv-only history and links Black Sea urban politics to national institutions.
+- **Left politics without Soviet loyalty:** His Ukrainian socialism and later Ukrainian Communist Party (independentists) role must be distinguished from acceptance of Soviet imperial control.
+- **Show-trial literacy:** The SVU case is a model for teaching `справа`, `показовий процес`, `сфабриковане обвинувачення`, `вирок`, `трійка`, `реабілітація`.
+- **Sandarmokh map anchor:** Horokhuvatka / Kyiv region, Kyiv, Kamianets-Podilskyi, Cherkasy, Vologda, Odesa, Kherson, Kyiv again, Kharkiv trial context, Yaroslavl, Solovky, Sandarmokh.
+- **Comparison anchor:** Pair with Volodymyr Vynnychenko for left-socialist Directory politics; Symon Petliura for foreign-policy and military conflict; Borys Martos for later Directory government; Oleksandr Lototskyi, Ivan Ohienko, and Vasyl Lypkivskyi for church autocephaly; Serhii Yefremov for the SVU case.
+- **Anti-hagiography anchor:** He was a victim of fabricated Soviet terror, but his political choices before repression remain debatable. The dossier should hold both truths.
+
+## 5. Language register
+
+- **Register:** state-administrative, socialist political, church-law, theological, Soviet legal-repression, and memorial language.
+- **CEFR readiness:** B1+/B2 short biography and map; B2/C1 Directory offices, church autocephaly, and Odesa revolutionary vocabulary; C1/C2 SVU show-trial mechanics, church-law texts, and Christian-socialist argument.
+- **Core vocabulary:** `Володимир Чехівський`, `Горохуватка`, `Українська Центральна Рада`, `УСДРП`, `Директорія УНР`, `Рада народних міністрів`, `міністр закордонних справ`, `Міністерство віросповідань`, `автокефалія`, `УАПЦ`, `Василь Липківський`, `ВУАН`, `справа СВУ`, `ОГПУ`, `НКВС`, `особлива трійка`, `Соловки`, `Сандармох`, `реабілітація`.
+- **Office-title caution:** Use `head of the Council of People's Ministers of the UNR` or `premier of the UNR Directory government`; avoid implying a stable modern cabinet system.
+- **Date caution:** Use `1876-1937` in low-context copy. If exact office chronology appears, distinguish IEU / EIU `26 December 1918-11 February 1919` from UINP's 13 February resignation date.
+- **Death-place caution:** Use Sandarmokh for precise death place; mention IEU's older Solovets wording only as a source-history caution if learners are comparing references.
+- **Church-language caution:** Distinguish `autocephaly`, `UAOC`, `Ministry of Confessions`, `sobor`, `metropolitan`, and `Kyiv metropolia`. Avoid collapsing the 1919 state law, the 1921 UAOC sobor, and modern tomos history into one event.
+
+## 6. Risks / open questions
+
+- **Death-place source drift:** ESU / EIU / UINP / RFE/RL support Sandarmokh; IEU's older entry says Solovets Islands. Use Sandarmokh as corrected precise place and source-label the older form if cited.
+- **Office end date drift:** IEU / EIU give 11 February 1919; UINP says resignation on 13 February. Use `December 1918-February 1919` in low-context copy and exact dates only with source labels.
+- **Degree title drift:** ESU says candidate of theology; IEU says DTh. Use `Kyiv Theological Academy graduate / theologian` unless the module needs degree terminology.
+- **Party simplification:** He moved through RUP, USDRP, Ukrainian Communist Party (independentists), and church activism. Do not simplify this into either "Bolshevik" or "anti-Bolshevik"; the point is Ukrainian left autonomy and later Soviet repression.
+- **Entente / Bolshevik policy:** His willingness to negotiate with Bolshevik Russia and opposition to Entente alignment should be framed as a contested wartime strategy, not proof that the Soviet charges were legitimate.
+- **Autocephaly overclaim:** He was central to the 1919 law and UAOC ideology, but not the sole founder of Ukrainian autocephaly. Pair him with Vasyl Lypkivskyi, Ivan Ohienko, and Oleksandr Lototskyi.
+- **SVU wording:** Never state "member of SVU" as fact. The safe language is `arrested / tried in the fabricated SVU case` or `defendant in the SVU show trial`.
+- **Ethnicity line in victim lists:** RFE/RL's Sandarmokh list labels him `поляк`. This may reflect Soviet file metadata and should not be turned into learner-facing identity without a dedicated source discussion.
+- **Image provenance:** `Volodymyr Chekhivsky.png` is marked PD-Ukraine but needs US public-domain scrutiny because the source is only "scan from book." `Chekhivski.jpg` has a stronger publication note from `Діло`, Lviv, April 1930, but still needs file-level check before production.
+
+## 7. Cross-track links
+
+- **Existing BIO dossier anchors (VERIFIED present by explorer / `test -e` 2026-07-03):** `docs/research/bio/borys-martos.md`, `docs/research/bio/dmytro-vitovskyi.md`, `docs/research/bio/ivan-ohienko.md`, `docs/research/bio/marko-bezruchko.md`, `docs/research/bio/oleksandr-lototskyi.md`, `docs/research/bio/symon-petliura.md`, `docs/research/bio/vasyl-lypkivskyi.md`, `docs/research/bio/volodymyr-vynnychenko.md`, `docs/research/bio/yevhen-petrushevych.md`, `docs/research/bio/natalia-livytska-kholodna.md`.
+- **Existing wiki figure anchors (VERIFIED present by explorer 2026-07-03):** `wiki/figures/ivan-ohienko.md`, `wiki/figures/symon-petliura.md`.
+- **Existing HIST plan / discovery surfaces (VERIFIED `test -e` 2026-07-03):** `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml`, `curriculum/l2-uk-en/hist/discovery/dyrektoriia.yaml`, `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`, `curriculum/l2-uk-en/hist/discovery/tsentralna-rada.yaml`, `curriculum/l2-uk-en/plans/hist/tomos.yaml`, `curriculum/l2-uk-en/hist/discovery/tomos.yaml`.
+- **Existing ISTORIO plan / discovery surfaces (VERIFIED `test -e` 2026-07-03):** `curriculum/l2-uk-en/plans/istorio/akt-zluki.yaml`, `curriculum/l2-uk-en/istorio/discovery/akt-zluki.yaml`, `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`, `curriculum/l2-uk-en/istorio/discovery/universaly-unr.yaml`, `curriculum/l2-uk-en/plans/istorio/pravoslavna-identychnist.yaml`, `curriculum/l2-uk-en/istorio/discovery/pravoslavna-identychnist.yaml`, `curriculum/l2-uk-en/plans/istorio/syntez-relihiina-identychnist.yaml`, `curriculum/l2-uk-en/istorio/discovery/syntez-relihiina-identychnist.yaml`.
+- **Existing wiki / context surfaces (VERIFIED `test -e` / `rg` 2026-07-03):** `wiki/periods/dyrektoriia.md`, `wiki/periods/symon-petliura-revolution.md`, `wiki/periods/skoropadskyi.md`, `wiki/periods/tomos.md`, `wiki/periods/bilshovytsko-ukrainska-viyna.md`, `wiki/historiography/universaly-unr.md`.
+- **Candidate / absent BIO #322 surfaces (VERIFIED absent by explorer 2026-07-03):** `curriculum/l2-uk-en/plans/bio/volodymyr-chekhivskyi.yaml`, `curriculum/l2-uk-en/bio/discovery/volodymyr-chekhivskyi.yaml`, `wiki/figures/volodymyr-chekhivskyi.md`, `site/src/content/docs/bio/volodymyr-chekhivskyi.mdx`, `curriculum/l2-uk-en/bio/volodymyr-chekhivskyi/module.md`, `curriculum/l2-uk-en/bio/volodymyr-chekhivskyi/activities.yaml`, `curriculum/l2-uk-en/bio/volodymyr-chekhivskyi/vocabulary.yaml`, `curriculum/l2-uk-en/bio/volodymyr-chekhivskyi/resources.yaml`.
+- **Candidate cross-track additions:** future BIO / HIST planning can connect Chekhivskyi to the SVU show trial, Ukrainian church autocephaly before the modern tomos, Odesa Ukrainian Revolution networks, and Sandarmokh memorialization. These are research suggestions, not existing build artifacts.
+
+## 8. Name variants / search aliases
+
+- **Canonical UA:** `Володимир Мусійович Чехівський`.
+- **Canonical EN:** `Volodymyr Chekhivskyi`.
+- **Common UA search forms:** `Володимир Чехівський`, `Чехівський Володимир`, `Чехівський Володимир Мусійович`, `В. Чехівський`, `В. М. Чехівський`.
+- **Common EN / transliteration forms:** `Volodymyr Chekhivskyi`, `Volodymyr Chekhivsky`, `Volodymyr Chekhivskij`, `Volodymyr Čechivs'kyj`, `Vladimir Chekhivsky`.
+- **Patronymic / variant forms:** `Мусійович`; occasional derivative or older forms may show `Мойсейович`. Do not treat them as separate people without source evidence.
+- **Institution / office aliases:** `head of the Council of People's Ministers`, `premier of the UNR`, `Minister of Foreign Affairs`, `Ministry of Confessions`, `Ukrainian Autocephalous Orthodox Church`, `UAOC`, `SVU trial`, `Union for the Liberation of Ukraine trial`, `Sandarmokh`.
+- **Russified / imperial-search forms:** `Владимир Чеховский`, `Владимир Моисеевич Чеховский`, `Vladimir Chekhovsky`, `Kiev Theological Academy`, `Solovki`. Keep these for source discovery only, not learner display.
+- **Learner-facing display:** `Volodymyr Chekhivskyi (Володимир Чехівський, 1876-1937)`.
+
+## 9. Image rights / visual material notes
+
+- **Primary portrait candidate:** Commons `File:Chekhivski.jpg`; described as Volodymyr Chekhivskyi, source `Діло`, Lviv, April 1930, author unknown-anonymous, date before 1919, and public-domain-marked with Ukrainian / Polish / US rationale. This is likely the cleanest portrait candidate if production rechecks file-level metadata.
+- **Alternate portrait candidate:** Commons `File:Volodymyr Chekhivsky.png`; photo of Chekhivskyi, circa 1929, author unknown, source listed as scan from book, public-domain-marked under PD-Ukraine. Strong identity candidate, but weaker provenance note than `Chekhivski.jpg`.
+- **Derivative caution:** Commons `File:Chekhivski cropped (3x4).jpg` is a derivative of `Chekhivski.jpg`. Prefer the original file for production rights review.
+- **Primary-text visual candidate:** Commons `File:Чехівський В. За Церкву (1922).pdf`; his 1922 pamphlet, sourced to NBUV / IRBIS and marked `PD/expired|1937`. Useful for document-context visuals, church-language excerpts, or source-study activities.
+- **Commemorative artifact candidate:** Commons / NBU sources around the 2006 National Bank of Ukraine coin may be useful for memory-history context, but do not use coin imagery as evidence for historical claims about his role.
+- **Avoid default:** unattributed web portraits, AI colorizations, screenshots from social-media posts, and portraits labeled only through Wikipedia mirrors without file-level rights checks.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- Веденєєв Д. В. "Чехівський Володимир Мусійович." Енциклопедія Сучасної України, НАН України / НТШ. https://esu.com.ua/article-886288. Accessed 2026-07-03.
+- Гриценко А. П. "Чехівський Володимир Мусійович." Енциклопедія історії України, Інститут історії України НАН України. https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Chekhivskyj_V. Accessed 2026-07-03.
+- "Chekhivsky, Volodymyr." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CC%5CH%5CChekhivskyVolodymyr.htm. Accessed 2026-07-03.
+- UINP, "1876 - народився Володимир Чехівський, політик." https://uinp.gov.ua/istorychnyy-kalendar/lypen/19/1876-narodyvsya-volodymyr-chehivskyy-polityk. Accessed 2026-07-03.
+
+**Tier 2 / 3 (source-rich, memorial, primary-text, and archival references):**
+
+- RFE/RL Ukrainian Service, "Список розстріляних у Сандармоху українців і вихідців з України." https://www.radiosvoboda.org/a/24477308.html. Accessed 2026-07-03.
+- NBUV / IRBIS, "Чехівський В. М. За Церкву, Христову громаду, проти царства тьми." https://irbis-nbuv.gov.ua/ulib/item/ukr0000024538. Accessed 2026-07-03.
+- Commons `File:Чехівський В. За Церкву (1922).pdf`, source metadata pointing to NBUV / IRBIS. https://commons.wikimedia.org/wiki/File:%D0%A7%D0%B5%D1%85%D1%96%D0%B2%D1%81%D1%8C%D0%BA%D0%B8%D0%B9_%D0%92._%D0%97%D0%B0_%D0%A6%D0%B5%D1%80%D0%BA%D0%B2%D1%83_%281922%29.pdf. Accessed 2026-07-03.
+- Local History / Sandarmoh project, "Володимир Чехівський. 'Свята по вдачі людина'." https://sandarmoh.localhistory.org.ua/chekhivskii. Accessed 2026-07-03.
+- Пристайко В., Шаповал Ю. `Справа "Спілки визволення України"`; cited by ESU as recommended literature. Use for Phase 2 if deeper show-trial case-file work is needed.
+
+**Tier 4 (learn-ukrainian cross-track sources checked 2026-07-03):**
+
+- `curriculum/l2-uk-en/curriculum.yaml`
+- `docs/research/bio/borys-martos.md`
+- `docs/research/bio/ivan-ohienko.md`
+- `docs/research/bio/oleksandr-lototskyi.md`
+- `docs/research/bio/symon-petliura.md`
+- `docs/research/bio/vasyl-lypkivskyi.md`
+- `docs/research/bio/volodymyr-vynnychenko.md`
+- `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml`
+- `curriculum/l2-uk-en/hist/discovery/dyrektoriia.yaml`
+- `curriculum/l2-uk-en/plans/hist/tomos.yaml`
+- `curriculum/l2-uk-en/hist/discovery/tomos.yaml`
+- `curriculum/l2-uk-en/plans/istorio/akt-zluki.yaml`
+- `curriculum/l2-uk-en/istorio/discovery/akt-zluki.yaml`
+- `curriculum/l2-uk-en/plans/istorio/pravoslavna-identychnist.yaml`
+- `wiki/periods/dyrektoriia.md`
+- `wiki/periods/tomos.md`
+
+**Tier 5 (image-rights / media-rights sources):**
+
+- Commons `File:Chekhivski.jpg`. https://commons.wikimedia.org/wiki/File:Chekhivski.jpg. Accessed 2026-07-03.
+- Commons `File:Volodymyr Chekhivsky.png`. https://commons.wikimedia.org/wiki/File:Volodymyr_Chekhivsky.png. Accessed 2026-07-03.
+- Commons `File:Chekhivski cropped (3x4).jpg`. https://commons.wikimedia.org/wiki/File:Chekhivski_cropped_(3%C3%974).jpg. Accessed 2026-07-03.


### PR DESCRIPTION
## Summary
- Add BIO #322 `volodymyr-chekhivskyi` research dossier only.
- Frame Chekhivskyi through UNR Directory government, foreign affairs, Ukrainian church autocephaly, the fabricated SVU show trial, Solovky imprisonment, and Sandarmokh execution.
- Record source conflicts/cautions: Sandarmokh vs older Solovky wording, 11/13 February 1919 office-end dates, degree-title drift, and SVU accusation language.

## Scope
- Dossier-only PR: `docs/research/bio/volodymyr-chekhivskyi.md`.
- No plan YAML, module markdown, activities, vocabulary, resources, MDX, wiki packet, package, telemetry, status, audit, or linter-config files.

## Fleet routing
- AGY read-only source-pack helper: `bio-322-volodymyr-chekhivskyi-source-pack`.
- Codex read-only path/media explorer: `019f24ec-80e3-7263-b95c-12cbb073dc5e`.
- Main Codex owned drafting, validation, PR, and review routing.

## Validation
- `npx markdownlint-cli2 docs/research/bio/volodymyr-chekhivskyi.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/volodymyr-chekhivskyi.md`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Explicit `test -e` sweep for all 32 paths named as existing in §7

## Independent review
- Pending required non-Codex read-only review before merge.
