### PR TITLE
docs(bio): add sofiia rusova dossier

### DIFF
--- a/docs/research/bio/sofiia-rusova.md
+++ b/docs/research/bio/sofiia-rusova.md
@@ -102,7 +102,9 @@
 ## 6. Risks / open questions
 
 - **Birth-date style:** EIU / IEU / UINP use 18 February 1856; UBE gives dual Julian / Gregorian notation. Low-context copy should use 18 February 1856, with dual style only in date-focused lessons.
+- **Calendar-parenthetical drift:** UBE prints `18.02(03.03).1856`, while most learner-safe sources use only 18 February. Recheck and source-label the parenthetical before any Julian / Gregorian conversion exercise surfaces it.
 - **Education year drift:** EIU says Kyiv gymnasium in 1871; UBE / UEEO say 1870. Use `Kyiv gymnasium graduate` or source-label exact year.
+- **Father / grandfather drift:** UINP frames Fedir Lindfors as her father, a retired imperial officer; some biographical summaries frame Fedir Fedorovych Lindfors as her grandfather, a Swedish general. Reconcile before learner-facing family-biography detail goes beyond `Lindfors family with Swedish ancestry`.
 - **Kindergarten year drift:** EIU says she opened the first Kyiv kindergarten soon after graduating; UINP gives 1 September 1871; some secondary sources say 1872. Use `early 1870s` unless citing UINP's exact date.
 - **Department title drift:** EIU says preschool and out-of-school education department, IEU says preschool and adult education, and UINP says preschool education department. For learner text, use `preschool and out-of-school / adult education department` unless the module needs source-level title comparison.
 - **Hetmanate simplification:** IEU's Hetman-government ministry note should not be treated as proof that she fully endorsed Hetmanate politics. It is an administrative context during unstable state-building.
@@ -168,7 +170,9 @@
 - `docs/research/bio/nataliya-kobrynska.md`
 - `docs/research/bio/milena-rudnytska.md`
 - `docs/research/bio/olena-pchilka.md`
+- `docs/research/bio/sofiya-okunevska.md`
 - `docs/research/bio/borys-hrinchenko.md`
+- `docs/research/bio/mariia-voiakovska.md`
 - `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`
 - `curriculum/l2-uk-en/hist/discovery/tsentralna-rada.yaml`
 - `curriculum/l2-uk-en/plans/istorio/zhinky-v-revoiuutsiiakh.yaml`

--- a/docs/research/bio/sofiia-rusova.md
+++ b/docs/research/bio/sofiia-rusova.md
@@ -1,0 +1,185 @@
+# Софія Федорівна Русова - Research Dossier
+
+**Slug:** `sofiia-rusova`
+**Block:** +77 backfill - Ukrainian pedagogy / preschool and adult education / Central Rada / women's movement / emigration / national school
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #323
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-03
+
+**Source acronym legend:** EIU = Encyclopedia History Ukraine / Institute History of Ukraine, NASU; IEU = Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies; UINP = Ukrainian Institute National Memory; UBE = Ukrainian Library Encyclopedia / Yaroslav Mudryi National Library of Ukraine; UEEO = Ukrainian Electronic Encyclopedia of Education / NAES education resource; NBUV = Vernadsky National Library of Ukraine; Lviv Center = Center for Urban History educational primary-source portal; BIO / HIST / ISTORIO / wiki = existing learn-ukrainian track materials; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, archival, primary-text, and image-rights sources cited
+- [x] Political pressure mechanism names imperial censorship / police searches and arrests, bans on Ukrainian-language schooling, revolutionary education ministry work, emigration, interwar international advocacy, and Holodomor-era relief / protest context
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / explorer check on 2026-07-03 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric periodization: frame is Ukrainian national education, Hromada networks, Ukrainian Revolution, UNR education policy, emigration institutions, and Ukrainian women's international advocacy, not generic "Russian liberal pedagogy."
+- [x] Ukrainian agency preserved: Rusova is treated as an education theorist, organizer, Central Rada member, ministry official, publisher, women's-movement leader, and exile advocate, not only as Oleksandr Rusov's wife or a "Russian Empire educator."
+- [x] Family origin handled without ethnic reduction: her Swedish-French / Lindfors-Gervais background is relevant, but the learner-facing identity is the Ukrainian civic and pedagogical project she chose and built.
+- [x] Women's movement is not decorative: it is a political infrastructure for Ukrainian representation, refugee care, school reform, international lobbying, and memory work.
+- [x] Anti-hagiography included: her left-democratic and Ukrainian Socialist-Revolutionary politics, elite family background, exile leadership, and programmatic claims about national schooling are presented as historically situated choices, not saintly inevitability.
+
+## 1. Identity / chronology
+
+- **Canonical UA:** `Софія Федорівна Русова`; birth name `Софія Федорівна Ліндфорс`.
+- **Canonical EN:** `Sofiia Rusova` or `Sofia Rusova`; use `Sofiia Rusova` for Ukrainian transliteration consistency in internal notes, while source titles may use `Sofia`.
+- **Core identity:** Ukrainian pedagogue, writer, editor, public and political activist, Central Rada member, education-ministry organizer for preschool / adult / out-of-school education, one of the organizers of the Ukrainian women's movement, Prague exile professor, memoirist, and international advocate for Ukrainian issues.
+- **Birth:** EIU, IEU, UINP, UBE, and UEEO give 18 February 1856, Oleshnia / `Олешня`, Chernihiv gubernia, now Chernihiv oblast. UBE gives the Julian / Gregorian notation `18.02(03.03).1856`; use 18 February in low-context copy unless calendar style is being taught.
+- **Death:** EIU, IEU, UBE, and UINP give 5 February 1940, Prague. UINP says she was buried at Olshany Cemetery / `Ольшанське кладовище`.
+- **Family background:** EIU and UBE record that she was born into the Lindfors family with Swedish and French ancestry; UINP names her father Fedir Lindfors, a retired officer in the Russian imperial army, and mother Anna / Hanna Gervais, a French aristocrat. Teach this as a multilingual imperial-border upbringing that did not predetermine her later Ukrainian identity.
+- **Education:** EIU says she finished gymnasium in Kyiv in 1871; UBE says Fundukleivska women's gymnasium in 1870 with a gold medal. Use `Kyiv gymnasium graduate / self-educated pedagogue` unless the module needs exact graduation-year comparison.
+- **First kindergarten:** EIU records that soon after gymnasium she and sister Mariia opened Kyiv's first kindergarten and the second in the Russian Empire. UINP gives a more specific 1 September 1871 opening and stresses its Ukrainian-language / child-centered character.
+- **Hromada and Shevchenko publishing:** UINP and UEEO connect the Lindfors / Rusov circles to Stara Hromada, Mykhailo Starytsky, Mykola Lysenko, and the Prague preparation of an uncensored `Kobzar` edition in 1876 with Fedir Vovk.
+- **Imperial pressure:** EIU records repeated searches and arrests; UINP gives the memorable but source-sensitive summary of 15 searches and five imprisonments. The safe learner wording is `repeated police searches and arrests for Ukrainian civic and publishing work`.
+- **Pedagogy and publishing before 1917:** EIU, UINP, UBE, and UEEO identify her as author of pedagogical, literary, historical, geographic, and popular-education works; editor / co-worker of `Світло` (1910-1914); and advocate of nationalizing school and out-of-school education.
+- **Central Rada / ministry work:** EIU states that she was elected to the Ukrainian Central Rada at the 1917 All-Ukrainian National Congress and served as founder / director of the preschool and out-of-school education department of the General Secretariat / Ministry of Education from 6 August 1917 to March 1919. IEU says she headed the Department of Preschool and Adult Education in the Ministry of Education under the Hetman government.
+- **Teachers' movement:** EIU and IEU identify her as one of the organizers and leaders of the All-Ukrainian Teachers' Association / `Всеукраїнська учительська спілка`.
+- **Kamianets-Podilskyi and university work:** EIU and UBE place her in Kamianets-Podilskyi in 1919-1920, teaching pedagogy and supporting Ukrainian educational institutions.
+- **Emigration:** EIU says she emigrated in 1922, worked first in Poland and from 1923 in Prague; IEU says she escaped Soviet Ukraine in 1922 and taught at the Ukrainian Higher Pedagogical Institute in Prague between 1924 and 1939.
+- **Women's movement and international advocacy:** IEU names her a founding member and first president of the National Council of Ukrainian Women; UINP notes international congress activity in Rome, Paris, Copenhagen, and Grenoble and relief / protest work during the 1933 famine.
+
+## 2. Political pressure mechanism
+
+- **Empire as school-language regime:** Rusova's biography should show how the Russian imperial order restricted Ukrainian print, Ukrainian-language schooling, and civic organization. The pressure mechanism is not only police violence; it is the denial of Ukrainian as a legitimate school language.
+- **Police searches and arrests:** EIU's compact formulation and UINP's detailed narrative support repeated searches, arrests, and prison experiences. Use source labels for exact counts because memorial articles sometimes compress a long series of episodes into symbolic numbers.
+- **Publishing under censorship:** The 1876 Prague `Kobzar` work is a strong pressure anchor: it ties Rusova to Ukrainian literature under the Ems Ukaz censorship environment without making her a literary figure only.
+- **National school as political project:** Her call for Ukrainian-language schooling belongs in the same political field as state-building. UBE describes her work in the UNR government as support for Prosvita congresses, public libraries, out-of-school education, and reading infrastructure.
+- **Central Rada to Hetmanate continuity / tension:** IEU's note that she headed a department under the Hetman government should not be read as ideological alignment with all Hetmanate policy. It shows that education-building crossed the unstable 1917-1919 government changes and needs source-sensitive framing.
+- **Women's representation:** The National Council of Ukrainian Women and international congress work moved Ukrainian claims into women's networks, refugee / orphan aid, and League-of-Nations style advocacy. Avoid reducing it to "charity."
+- **Exile as institution-building:** Prague was not only refuge. It was where she taught at the Drahomanov Higher Pedagogical Institute, wrote pedagogical works, represented Ukrainian women abroad, and preserved UNR-era memory in `Мої спомини`.
+- **Holodomor-era advocacy:** UINP states that in 1933, at her initiative, the Union of Ukrainian Women in Czechoslovakia created a temporary committee to help the starving in Ukraine. Treat this as a documented exile response to famine, not as a full Holodomor dossier.
+- **Soviet / imperial naming risk:** Do not describe her as simply "Russian-born" or "Russian educator" because the birthplace was in imperial administrative space. The learner-facing contrast is imperial subjecthood versus Ukrainian civic-political identification.
+
+## 3. Major events / historical footprint
+
+- **1856 Oleshnia birth and multilingual family:** Establish the Swedish-French / Ukrainian-Chernihiv setting without making ethnicity the explanatory key.
+- **1870 / 1871 Kyiv education:** Use the graduation-year drift as a source-label issue; both EIU and UBE agree on Kyiv gymnasium formation.
+- **1871 Kyiv kindergarten:** Kyiv's first kindergarten is the best B1/B2 anchor: child, school, language, and civic initiative in one scene.
+- **1874 marriage to Oleksandr Rusov:** The marriage placed her inside Hromada and statistical / ethnographic networks, but she should not be presented as his appendix.
+- **1876 uncensored `Kobzar` edition:** Prague printing and return to Ukraine give a vivid censorship / literary-civic bridge.
+- **1870s-1900s mobile civic work:** UINP lists Chernihiv region, Odesa, Kherson, Kharkiv, and Poltava as sites where the Rusovs moved under pressure and where she opened or supported kindergartens, Sunday schools, public readings, and popular books.
+- **1910-1914 `Світло`:** EIU and UINP identify her as a founder / editor / major contributor to a Ukrainian pedagogical journal. This is a clean source for education-register vocabulary.
+- **1905-1906 teachers' organizing:** UEEO describes her work with teacher associations and Ukrainian educational demands in the broader empire-wide teacher movement.
+- **1917 Central Rada election:** EIU explicitly places her election at the All-Ukrainian National Congress. This connects her to `tsentralna-rada` surfaces and to women in the revolution.
+- **1917-1919 education ministry department:** Preschool, out-of-school, adult education, Prosvita libraries, textbooks, and teacher training make her an education-infrastructure figure rather than a symbolic "woman in politics."
+- **1919-1920 Kamianets-Podilskyi:** The university and UNR-government relocation context connect her to late revolutionary state-building after Kyiv.
+- **1922-1923 emigration and Prague:** EIU / IEU support the move abroad; UEEO and IEU support the Drahomanov Institute teaching period.
+- **1934 women's memory work:** IEU lists `Наші визначні жінки` (1934), useful for a module on canon formation and women's biographies.
+- **1937 `Мої спомини`:** NBUV describes the memoirs as important for Ukrainian intelligentsia and public-political life from the late 19th to early 20th century; Lviv Center provides an educational excerpt on the UNR period.
+- **1940 death in Prague:** End with exile memory, not with a narrative of "disappearance." Her texts, institutions, and later library / school naming give posthumous continuity.
+
+## 4. Pedagogical anchors
+
+- **A kindergarten as national politics:** Learners can understand that a preschool is not "small history" when the language of school is politically controlled.
+- **Education ladder:** Kindergarten, Sunday schools, adult reading, libraries, teacher unions, ministry department, university teaching, and exile institute form a sequence across CEFR levels.
+- **Women's movement as diplomacy:** Pair National Council of Ukrainian Women with international congresses so learners see how non-state networks carried Ukrainian claims abroad.
+- **Censorship through a book:** The uncensored `Kobzar` edition makes abstract imperial censorship concrete.
+- **Central Rada vocabulary:** `Українська Центральна Рада`, `Генеральний секретаріат`, `міністерство освіти`, `департамент`, `позашкільна освіта`, `українізація освіти`.
+- **Map anchor:** Oleshnia / Chernihiv region, Kyiv, Prague, Odesa, Kherson, Kharkiv, Poltava, Kamianets-Podilskyi, Prague again.
+- **Comparison anchor:** Pair with Nataliya Kobrynska for women's organizing, Milena Rudnytska for international advocacy, Olena Pchilka for women / language / publishing, Borys Hrinchenko for education and language work, Mykhailo Hrushevskyi for Central Rada, and Mykola Vasylenko for education-policy contrast under the Hetmanate.
+- **Anti-hagiography anchor:** Rusova's program was expansive and often idealistic; modules should ask how national education, social education, and political representation worked under war, exile, and censorship rather than treating every slogan as already implemented.
+
+## 5. Language register
+
+- **Register:** pedagogy, preschool education, adult / out-of-school education, public libraries, Ukrainian Revolution administration, women's organizations, exile institutions, memoir / source-study language.
+- **CEFR readiness:** A2/B1 profile for family, school, kindergarten, and city map; B1/B2 education vocabulary and Central Rada offices; B2/C1 source-study on censorship, women's international organizations, exile, and memoirs; C1/C2 historiography of national schooling and diaspora institution-building.
+- **Core vocabulary:** `Софія Русова`, `Софія Ліндфорс`, `Олешня`, `Фундуклеївська гімназія`, `дитячий садок`, `дошкільна освіта`, `позашкільна освіта`, `народні читання`, `громадська бібліотека`, `Стара громада`, `Кобзар`, `Світло`, `Українська Центральна Рада`, `Всеукраїнська учительська спілка`, `Генеральний секретаріат освіти`, `Національна рада українських жінок`, `еміграція`, `Прага`, `Мої спомини`.
+- **Name caution:** Use `Sofiia Rusova` / `Софія Русова` for Ukrainian transliteration. Source titles may use `Sofia Rusova`, `Sofija Rusowa`, or `Rusova, Sofiia`; do not create duplicate people.
+- **Calendar caution:** UBE's `18.02(03.03).1856` requires explanation only when learners are studying Julian / Gregorian dates. Otherwise use 18 February 1856.
+- **Office caution:** Distinguish the General Secretariat / Ministry of Education, the Hetman-period ministry context, and later Prague educational institutions. Avoid saying she was a cabinet minister unless a source explicitly says so.
+- **Women's-organization caution:** `National Council of Ukrainian Women`, `Union of Ukrainian Women`, and `World Union of Ukrainian Women` are different organizations. Use source labels if exact office titles matter.
+- **Ethnicity caution:** `Swedish-French background` is a family-origin fact, not a reason to deny or exoticize her Ukrainian political identity.
+
+## 6. Risks / open questions
+
+- **Birth-date style:** EIU / IEU / UINP use 18 February 1856; UBE gives dual Julian / Gregorian notation. Low-context copy should use 18 February 1856, with dual style only in date-focused lessons.
+- **Education year drift:** EIU says Kyiv gymnasium in 1871; UBE / UEEO say 1870. Use `Kyiv gymnasium graduate` or source-label exact year.
+- **Kindergarten year drift:** EIU says she opened the first Kyiv kindergarten soon after graduating; UINP gives 1 September 1871; some secondary sources say 1872. Use `early 1870s` unless citing UINP's exact date.
+- **Department title drift:** EIU says preschool and out-of-school education department, IEU says preschool and adult education, and UINP says preschool education department. For learner text, use `preschool and out-of-school / adult education department` unless the module needs source-level title comparison.
+- **Hetmanate simplification:** IEU's Hetman-government ministry note should not be treated as proof that she fully endorsed Hetmanate politics. It is an administrative context during unstable state-building.
+- **Arrest-count precision:** UINP's 15 searches / five prisons is useful but should be source-labeled. Use `repeated searches and arrests` in simpler copy.
+- **Doctorate / formal credential drift:** UEEO says she received a doctoral degree in 1908, while the core encyclopedia entries foreground her pedagogical work rather than using that as the main credential. Avoid degree claims unless a module specifically verifies the credential pathway.
+- **Women's movement chronology:** She appears across several organizations and congresses; do not collapse Ukrainian, Galician, Prague, and world-level organizations into one body.
+- **Holodomor relief scope:** UINP's note on 1933 relief is important, but this dossier should not turn into a full Holodomor module. Use it as exile advocacy context.
+- **Image provenance:** Commons has multiple portraits and scans; production must recheck file-level author, publication, and US public-domain status before using any portrait.
+
+## 7. Cross-track links
+
+- **Existing BIO dossier anchors (VERIFIED `test -e` 2026-07-03):** `docs/research/bio/mykhailo-hrushevskyi.md`, `docs/research/bio/volodymyr-vynnychenko.md`, `docs/research/bio/mykola-vasylenko.md`, `docs/research/bio/liudmyla-starytska.md`, `docs/research/bio/nataliya-kobrynska.md`, `docs/research/bio/milena-rudnytska.md`, `docs/research/bio/olena-pchilka.md`, `docs/research/bio/sofiya-okunevska.md`, `docs/research/bio/borys-hrinchenko.md`, `docs/research/bio/mariia-voiakovska.md`.
+- **Existing HIST / ISTORIO plan and discovery surfaces (VERIFIED `test -e` 2026-07-03):** `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`, `curriculum/l2-uk-en/hist/discovery/tsentralna-rada.yaml`, `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml`, `curriculum/l2-uk-en/hist/discovery/dyrektoriia.yaml`, `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`, `curriculum/l2-uk-en/istorio/discovery/universaly-unr.yaml`, `curriculum/l2-uk-en/plans/istorio/zhinky-v-revoiuutsiiakh.yaml`, `curriculum/l2-uk-en/istorio/discovery/zhinky-v-revoiuutsiiakh.yaml`.
+- **Existing language / civil-society context surfaces (VERIFIED `test -e` 2026-07-03):** `curriculum/l2-uk-en/plans/hist/hromady.yaml`, `curriculum/l2-uk-en/hist/discovery/hromady.yaml`, `curriculum/l2-uk-en/plans/hist/shevchenko-awakening.yaml`, `curriculum/l2-uk-en/hist/discovery/shevchenko-awakening.yaml`, `wiki/periods/movna-polityka.md`, `wiki/historiography/zhinky-v-revoiuutsiiakh.md`, `wiki/literature/works/kobrynska-pershyi-vinok.md`.
+- **Existing wiki figure anchors (VERIFIED `test -e` 2026-07-03):** `wiki/figures/nataliya-kobrynska.md`, `wiki/figures/milena-rudnytska.md`, `wiki/figures/olena-pchilka.md`, `wiki/figures/mykhailo-hrushevskyi.md`, `wiki/figures/mykhailo-starytsky.md`.
+- **Candidate / absent BIO #323 surfaces (VERIFIED absent 2026-07-03):** `curriculum/l2-uk-en/plans/bio/sofiia-rusova.yaml`, `curriculum/l2-uk-en/bio/discovery/sofiia-rusova.yaml`, `wiki/figures/sofiia-rusova.md`, `site/src/content/docs/bio/sofiia-rusova.mdx`, `curriculum/l2-uk-en/bio/sofiia-rusova/module.md`, `curriculum/l2-uk-en/bio/sofiia-rusova/activities.yaml`, `curriculum/l2-uk-en/bio/sofiia-rusova/vocabulary.yaml`, `curriculum/l2-uk-en/bio/sofiia-rusova/resources.yaml`.
+- **Candidate cross-track additions:** future BIO / HIST / ISTORIO planning can connect Rusova to Ukrainian-language schooling, the Central Rada education apparatus, women in revolutions, Prosvita library infrastructure, exile Prague, and memoir-based source work.
+
+## 8. Name variants / search aliases
+
+- **Canonical UA:** `Софія Федорівна Русова`.
+- **Birth name:** `Софія Федорівна Ліндфорс`; English `Sofiia / Sofia Lindfors`.
+- **Canonical EN:** `Sofiia Rusova`; common source form `Sofia Rusova`.
+- **Common UA search forms:** `Софія Русова`, `Русова Софія`, `Русова Софія Федорівна`, `С. Русова`, `С. Ф. Русова`, `Софія Ліндфорс`.
+- **Common EN / transliteration forms:** `Sofiia Rusova`, `Sofia Rusova`, `Sofija Rusowa`, `Sofiya Rusova`, `Rusova, Sofiia`, `Rusova, Sofia`, `Sofia Lindfors-Rusova`.
+- **Institution / topic aliases:** `National Council of Ukrainian Women`, `All-Ukrainian Teachers' Association`, `Department of Preschool and Adult Education`, `Department of Preschool and Out-of-School Education`, `Ukrainian Higher Pedagogical Institute in Prague`, `Drahomanov Higher Pedagogical Institute`, `Svitlo`, `Moi spomyny`.
+- **Russified / imperial-search forms:** `София Русова`, `София Федоровна Русова`, `София Линдфорс`, `Sofiya Fedorovna Rusova`, `Kiev kindergarten`. Keep these for source discovery only, not learner display.
+- **Learner-facing display:** `Sofiia Rusova (Софія Русова, 1856-1940)`.
+
+## 9. Image rights / visual material notes
+
+- **Primary portrait candidate:** Commons `File:Sofija Rusowa.jpg`; metadata identifies an 1874 portrait, source as an archived anniversary page, author unknown. Useful for a young-Rusova visual if file-level PD status and US status pass production review.
+- **Later portrait candidate:** Commons `File:Софія Русова (1934).jpg`; likely valuable for exile / women's-movement context, but production must recheck publication source and licensing.
+- **Archive-photo candidate:** Commons `File:Фотографія С. Русової.jpg`; metadata points to a 1893 CDIAK archive photo, author unknown, with PD-Ukraine style rationale and a US-status caveat. Strong documentary candidate after file-level verification.
+- **General category:** Commons `Category:Sofia Rusova` lists portraits, badges, and book-cover / document files. Use the category for discovery, not as a rights decision.
+- **Primary-text visual candidates:** Commons / NBUV files for `Мої спомини` (1937), `Позашкільна освіта` (1918), `Теорія і практика дошкільного виховання` (1924), and `Дидактика` (1925) can support source-study activities if file metadata confirms public-domain status in Ukraine and the United States.
+- **NBUV / Lviv Center text anchors:** NBUV's `Мої спомини` item and the Lviv Center educational excerpt are preferable to unsourced portrait reposts for documentary context.
+- **Avoid default:** unattributed social-media portraits, school commemorative posters without file-level rights, AI colorizations, and English-language mirrors that do not expose original publication metadata.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- Осташко Т. С., Кізченко В. І. "Русова Софія Федорівна." Енциклопедія історії України, Інститут історії України НАН України. https://www.history.org.ua/?termin=Rusova_S. Accessed 2026-07-03.
+- Bohachevsky-Chomiak, Marta. "Rusova, Sofiia." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CU%5CRusovaSofiia.htm. Accessed 2026-07-03.
+- UINP, "1856, народилася Софія Русова, педагогиня." https://uinp.gov.ua/istorychnyy-kalendar/lyutyy/18/1856-narodylasya-sofiya-rusova. Accessed 2026-07-03.
+- "Русова Софія Федорівна." Українська бібліотечна енциклопедія / Національна бібліотека України імені Ярослава Мудрого. https://ube.nlu.org.ua/article/%D0%A0%D1%83%D1%81%D0%BE%D0%B2%D0%B0%20%D0%A1%D0%BE%D1%84%D1%96%D1%8F%20%D0%A4%D0%B5%D0%B4%D0%BE%D1%80%D1%96%D0%B2%D0%BD%D0%B0. Accessed 2026-07-03.
+
+**Tier 2 / 3 (education, primary-text, and archival references):**
+
+- "Русова Софія Федорівна." Українська електронна енциклопедія освіти. https://eduglos.iitta.gov.ua/index.php/%D0%A0%D1%83%D1%81%D0%BE%D0%B2%D0%B0_%D0%A1%D0%BE%D1%84%D1%96%D1%8F_%D0%A4%D0%B5%D0%B4%D0%BE%D1%80%D1%96%D0%B2%D0%BD%D0%B0. Accessed 2026-07-03.
+- NBUV / IRBIS, "Русова С. Мої спомини (1937)." https://irbis-nbuv.gov.ua/ulib/item/ukr0000021777. Accessed 2026-07-03.
+- Lviv Center / REESOURCES, "Sofia Rusova's Memories on Ukrainian People's Republic." https://edu.lvivcenter.org/en/documents/sofia-rusovas-memories-ukrainian-peoples-republic/. Accessed 2026-07-03.
+- IEU, "National Council of Ukrainian Women." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CN%5CA%5CNationalCouncilofUkrainianWomen.htm. Accessed 2026-07-03.
+
+**Tier 4 (learn-ukrainian cross-track sources checked 2026-07-03):**
+
+- `curriculum/l2-uk-en/curriculum.yaml`
+- `docs/research/bio/mykhailo-hrushevskyi.md`
+- `docs/research/bio/volodymyr-vynnychenko.md`
+- `docs/research/bio/mykola-vasylenko.md`
+- `docs/research/bio/liudmyla-starytska.md`
+- `docs/research/bio/nataliya-kobrynska.md`
+- `docs/research/bio/milena-rudnytska.md`
+- `docs/research/bio/olena-pchilka.md`
+- `docs/research/bio/borys-hrinchenko.md`
+- `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`
+- `curriculum/l2-uk-en/hist/discovery/tsentralna-rada.yaml`
+- `curriculum/l2-uk-en/plans/istorio/zhinky-v-revoiuutsiiakh.yaml`
+- `curriculum/l2-uk-en/istorio/discovery/zhinky-v-revoiuutsiiakh.yaml`
+- `wiki/historiography/zhinky-v-revoiuutsiiakh.md`
+- `wiki/periods/movna-polityka.md`
+
+**Tier 5 (image-rights / media-rights sources):**
+
+- Commons `Category:Sofia Rusova`. https://commons.wikimedia.org/wiki/Category:Sofia_Rusova. Accessed 2026-07-03.
+- Commons `File:Sofija Rusowa.jpg`. https://commons.wikimedia.org/wiki/File:Sofija_Rusowa.jpg. Accessed 2026-07-03.
+- Commons `File:Софія Русова (1934).jpg`. https://commons.wikimedia.org/wiki/File:%D0%A1%D0%BE%D1%84%D1%96%D1%8F_%D0%A0%D1%83%D1%81%D0%BE%D0%B2%D0%B0_(1934).jpg. Accessed 2026-07-03.
+- Commons `File:Фотографія С. Русової.jpg`. https://commons.wikimedia.org/wiki/File:%D0%A4%D0%BE%D1%82%D0%BE%D0%B3%D1%80%D0%B0%D1%84%D1%96%D1%8F_%D0%A1._%D0%A0%D1%83%D1%81%D0%BE%D0%B2%D0%BE%D1%97.jpg. Accessed 2026-07-03.
+- Commons `File:Софія Русова. Мої спомини. 1937.pdf`. https://commons.wikimedia.org/wiki/File:%D0%A1%D0%BE%D1%84%D1%96%D1%8F_%D0%A0%D1%83%D1%81%D0%BE%D0%B2%D0%B0._%D0%9C%D0%BE%D1%97_%D1%81%D0%BF%D0%BE%D0%BC%D0%B8%D0%BD%D0%B8._1937.pdf. Accessed 2026-07-03.


### PR DESCRIPTION
## Summary
- Add BIO #323 research dossier for `sofiia-rusova`.
- Cover Ukrainian pedagogy, preschool/adult education, Central Rada ministry work, women’s movement, Prague exile, source risks, cross-track anchors, and image-rights notes.
- Dossier-only scope: `docs/research/bio/sofiia-rusova.md`.

## Fleet lanes
- AGY read-only source pack: `bio-323-sofiia-rusova-source-pack`.
- Codex read-only path/media surface check: `bio-323-sofiia-rusova-path-media`.
- Main Codex integrated, validated, committed, and opened PR.

## Validation
- `npx markdownlint-cli2 docs/research/bio/sofiia-rusova.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/sofiia-rusova.md`
- `git diff --check`
- `git diff --cached --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Review gate
- Independent read-only review still required before merge.
