### PR TITLE
data(atlas): approve second teacher lesson ledger batch

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-03-second-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-03-second-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,281 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-second-approved-teacher-lesson-ledger-batch-2026-07-03
+batch_label: second-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-03'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4162
+  total_queue_rows: 110
+  approved_in_queue: 20
+  promotion_batch_size: 20
+production_outputs_updated: []
+decisions:
+- lemma: вирубати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to knock out; to turn off
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 4c324c91b790de8a
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 21
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: вирубити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to knock out; to turn off
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 32bb21e024b9ce10
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 22
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: присягатися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to swear; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: db723503be6cf683
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 23
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: клястися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to swear; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 1a9e98e0a4bdeb49
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 23
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: присягнутися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to swear; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: cecae3fcf52df9a3
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 24
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: поклястися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to swear; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 39756c76d548432c
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 24
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: рогівка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: cornea
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 5d16a7aca4341d2c
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 25
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: заводитися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to start, as a car; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: b7d1d39e28d0d32e
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 26
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: завестися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to start, as a car; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: fb9c7c0c4be40123
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 27
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: тарган
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: cockroach
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a7e275b344dc7513
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 28
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: незадовільний
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: unsatisfactory
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: b46d3b65eada0f67
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 29
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: взуватися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to put on shoes; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 88db5c259559fd8b
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 30
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: взутися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to put on shoes; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 2b7ad2484e2844ca
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 31
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: роззуватися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to take off shoes; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 0adf97de235b275c
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 32
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: роззутися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to take off shoes; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: c00db345006e2cd0
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 33
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: безглуздий
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: absurd; senseless
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 326669ce64b0e8f1
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 34
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: неоплачений
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: unpaid
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: ccc3e8c4022cc32c
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 35
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: місцезнаходження
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: whereabouts; location
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 8d4a59243da38e40
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 36
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: камера спостереження
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: surveillance camera
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a175d43525f093e9
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 37
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: цілодобово
+  decision: approve_for_publish
+  approved_pos: adverb
+  approved_gloss: around the clock; twenty-four seven
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 76af8b3b919dfad2
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml
+    locator: explicit vocabulary table row 38
+    source_id: private-teacher-lesson-vocabulary-table-1-seed
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -17,6 +17,11 @@ PRIVATE_TEACHER_FIRST_LEDGER = (
     / "data/lexicon/source-inventory-review-decisions/"
     "2026-07-02-first-approved-teacher-lesson-ledger-batch.yaml"
 )
+PRIVATE_TEACHER_SECOND_LEDGER = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory-review-decisions/"
+    "2026-07-03-second-approved-teacher-lesson-ledger-batch.yaml"
+)
 
 
 def test_private_teacher_inventory_is_privacy_safe_review_metadata() -> None:
@@ -68,3 +73,48 @@ def test_private_teacher_first_decision_ledger_stays_review_only() -> None:
 
     ledger_text = PRIVATE_TEACHER_FIRST_LEDGER.read_text(encoding="utf-8")
     assert ".docx" not in ledger_text
+
+
+def test_private_teacher_second_decision_ledger_stays_review_only() -> None:
+    summary = decisions.validate_committed_decision_files([PRIVATE_TEACHER_SECOND_LEDGER])
+    payload = yaml.safe_load(PRIVATE_TEACHER_SECOND_LEDGER.read_text(encoding="utf-8"))
+
+    assert summary == {
+        "files": 1,
+        "rows": 20,
+        "decision_counts": {"approve_for_publish": 20},
+    }
+    assert payload["source_queue"]["promotion_batch_size"] == 20
+    assert payload["production_outputs_updated"] == []
+    assert payload["decisions"][0]["lemma"] == "вирубати"
+    assert payload["decisions"][-1]["lemma"] == "цілодобово"
+    assert all(
+        row["source_inventory"]["source_family"] == "teacher_lesson"
+        for row in payload["decisions"]
+    )
+    assert all("surface_admission" not in row for row in payload["decisions"])
+
+    ledger_text = PRIVATE_TEACHER_SECOND_LEDGER.read_text(encoding="utf-8")
+    assert ".docx" not in ledger_text
+
+
+def test_private_teacher_decision_ledgers_cover_seed_without_live_surfaces() -> None:
+    records = read_source_inventory(PRIVATE_TEACHER_INVENTORY, project_root=PROJECT_ROOT)
+    inventory_keys = {
+        decisions.source_inventory_key(
+            lemma=record.lemma,
+            inventory_path="data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml",
+            locator=record.source_locator,
+        )
+        for record in records
+    }
+
+    ledger_keys = set()
+    for ledger in (PRIVATE_TEACHER_FIRST_LEDGER, PRIVATE_TEACHER_SECOND_LEDGER):
+        payload = yaml.safe_load(ledger.read_text(encoding="utf-8"))
+        ledger_keys.update(
+            row["source_inventory"]["key"]
+            for row in payload["decisions"]
+        )
+
+    assert ledger_keys == inventory_keys


### PR DESCRIPTION
## Summary

- Add the second private teacher-lesson source-inventory decision ledger batch for rows 21-40.
- Approve 20 more privacy-safe teacher-lesson rows for future controlled Atlas promotion.
- Update teacher source-inventory tests so both teacher ledgers cover the current 40-row committed seed and stay review-only.

## Scope Boundaries

- Review-only ledger PR; no live Atlas manifest/search/browse output changes.
- No Daily Word, Practice, or cloze admission changes.
- No raw private lesson docs, local private paths, or teacher-identifying source names.

## Promotion Plan Evidence

Using the current hydrated Atlas manifest and generated review candidates:

- approved_decisions: 20
- matched_candidates: 20
- proposed future Atlas additions: 19
- skipped existing: 1 (`взуватися`)
- missing_candidates: 0
- production_outputs_updated: []

## Validation

- `../../../../.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_review_decisions.py tests/test_source_inventory_promotion_plan.py -q` -> 29 passed
- `../../../../.venv/bin/python -m scripts.audit.source_inventory_review_decisions` -> 5 files / 100 approved rows
- `node site/scripts/hydrate-manifest.mjs`
- `../../../../.venv/bin/python -m scripts.audit.plan_source_inventory_promotion --candidates /tmp/atlas-teacher-next-candidates.json --decision-file data/lexicon/source-inventory-review-decisions/2026-07-03-second-approved-teacher-lesson-ledger-batch.yaml --manifest site/src/data/lexicon-manifest.json --out /tmp/atlas-teacher-second-approved-promotion-plan.json --report-out /tmp/atlas-teacher-second-approved-promotion-plan.md --report`
- `../../../../.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` -> Daily 300, Practice 4,484, cloze 22
- `../../../../.venv/bin/ruff check --fix tests/test_private_teacher_lesson_source_inventory.py` -> clean
- `git diff --check`
- `../../../../.venv/bin/python scripts/audit/lint_agent_trailer.py` -> pass

## Independent Review

AGY/Gemini review on staged diff: `NO BLOCKERS`.

Fixes #4160 for the current committed 40-row teacher-lesson seed. Follow-up after merge: controlled live publish of this second approved teacher-lesson batch.