### PR TITLE
data(atlas): add next teacher lesson inventory seed

### DIFF
--- a/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+++ b/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
@@ -1,0 +1,126 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Private teacher lesson vocabulary - explicit table rows 39-58
+    locator: local-only explicit vocabulary table rows 39-58
+    notes: Derived headword metadata only; raw private lesson material is local-only and not committed. Daily Word, Practice, and cloze remain frozen without explicit surface_admission.
+    headwords:
+      - lemma: правила дорожнього руху
+        pos: noun
+        gloss: traffic rules
+        locator: explicit vocabulary table row 39
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: гнучкий
+        pos: adjective
+        gloss: flexible
+        locator: explicit vocabulary table row 40
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: притулок
+        pos: noun
+        gloss: shelter
+        locator: explicit vocabulary table row 41
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: потворний
+        pos: adjective
+        gloss: ugly
+        locator: explicit vocabulary table row 42
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: орендодавець
+        pos: noun
+        gloss: landlord; lessor
+        locator: explicit vocabulary table row 43
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: повідомляти
+        pos: verb
+        gloss: to let someone know; imperfective
+        locator: explicit vocabulary table row 44
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: давати знати
+        pos: phrase
+        gloss: to let someone know; imperfective
+        locator: explicit vocabulary table row 44
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: повідомити
+        pos: verb
+        gloss: to let someone know; perfective
+        locator: explicit vocabulary table row 45
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: дати знати
+        pos: phrase
+        gloss: to let someone know; perfective
+        locator: explicit vocabulary table row 45
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: кролик
+        pos: noun
+        gloss: rabbit
+        locator: explicit vocabulary table row 46
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: гальмувати
+        pos: verb
+        gloss: to brake; imperfective
+        locator: explicit vocabulary table row 47
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: загальмувати
+        pos: verb
+        gloss: to brake; perfective
+        locator: explicit vocabulary table row 48
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: багажник
+        pos: noun
+        gloss: car trunk; boot
+        locator: explicit vocabulary table row 49
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: страховка
+        pos: noun
+        gloss: insurance
+        locator: explicit vocabulary table row 50
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: страхування
+        pos: noun
+        gloss: insurance
+        locator: explicit vocabulary table row 50
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: затримувати
+        pos: verb
+        gloss: to delay; imperfective
+        locator: explicit vocabulary table row 51
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: затримати
+        pos: verb
+        gloss: to delay; perfective
+        locator: explicit vocabulary table row 52
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: ділитися
+        pos: verb
+        gloss: to share; to divide into; imperfective
+        locator: explicit vocabulary table row 53
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: поділитися
+        pos: verb
+        gloss: to share; to divide into; perfective
+        locator: explicit vocabulary table row 54
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: займати
+        pos: verb
+        gloss: to reserve; to occupy; to take time; imperfective
+        locator: explicit vocabulary table row 55
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: зайняти
+        pos: verb
+        gloss: to reserve; to occupy; to take time; perfective
+        locator: explicit vocabulary table row 56
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: витримувати
+        pos: verb
+        gloss: to endure; to withstand; imperfective
+        locator: explicit vocabulary table row 57
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: витримати
+        pos: verb
+        gloss: to endure; to withstand; perfective
+        locator: explicit vocabulary table row 58
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -5,15 +5,16 @@ Atlas source-inventory lane without publishing private lesson material.
 
 ## Current Safe Source
 
-The committed inventory seed is:
+The committed inventory seeds are:
 
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml`
 
-Current committed coverage is 40 reviewed headwords from an explicit local
-vocabulary table. The source family is `teacher_lesson`, and the source title,
-source id, locators, and context are intentionally privacy-safe. The inventory
-does not commit raw notes, transcripts, prompts, document paths, or teacher
-identifying names.
+Current committed coverage is 63 reviewed headwords from explicit local
+vocabulary table rows 1-58. The source family is `teacher_lesson`, and the
+source titles, source ids, locators, and context are intentionally privacy-safe.
+The inventories do not commit raw notes, transcripts, prompts, document paths,
+or teacher-identifying names.
 
 ## Source Handling Rule
 

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -20,6 +20,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )
 

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -12,6 +12,11 @@ PRIVATE_TEACHER_INVENTORY = (
     PROJECT_ROOT
     / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml"
 )
+PRIVATE_TEACHER_ROWS_39_58_INVENTORY = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory/"
+    "private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml"
+)
 PRIVATE_TEACHER_FIRST_LEDGER = (
     PROJECT_ROOT
     / "data/lexicon/source-inventory-review-decisions/"
@@ -52,6 +57,35 @@ def test_private_teacher_inventory_uses_clean_headwords_not_raw_table_cells() ->
     assert all("/" not in record.lemma for record in records)
     assert "тарган" in {record.lemma for record in records}
     assert "вийти з ладу" in {record.lemma for record in records}
+
+
+def test_private_teacher_rows_39_58_inventory_is_pending_review_metadata() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_39_58_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+
+    assert len(records) == 23
+    assert {record.source_family for record in records} == {"teacher_lesson"}
+    assert {record.extraction_mode for record in records} == {"curated_headword"}
+    assert {record.source_id for record in records} == {
+        "private-teacher-lesson-vocabulary-table-1-rows-39-58"
+    }
+    assert all(record.source_path is None for record in records)
+    assert all(record.source_url is None for record in records)
+    assert all(record.source_title for record in records)
+    assert all(record.source_locator for record in records)
+    assert all(record.context for record in records)
+    assert all(record.pos for record in records)
+    assert all(record.gloss for record in records)
+    assert "правила дорожнього руху" in {record.lemma for record in records}
+    assert "витримати" in {record.lemma for record in records}
+    assert all("," not in record.lemma for record in records)
+    assert all("/" not in record.lemma for record in records)
+    assert all("(" not in record.lemma and ")" not in record.lemma for record in records)
+
+    inventory_text = PRIVATE_TEACHER_ROWS_39_58_INVENTORY.read_text(encoding="utf-8")
+    assert ".docx" not in inventory_text
 
 
 def test_private_teacher_first_decision_ledger_stays_review_only() -> None:


### PR DESCRIPTION
## Summary

- Add the next privacy-safe private teacher-lesson source inventory seed for explicit table rows 39-58.
- Register the new seed in the review-candidate generator.
- Update the private teacher source-scope runbook and tests for the new pending batch.

## Scope Boundaries

- Review-only source inventory expansion.
- No live Atlas manifest/search/browse output changes.
- No Daily Word, Practice, or cloze admission changes.
- No raw private lesson docs, local private paths, or teacher-identifying source names.

## Counts

- New pending inventory rows: 23 headwords.
- Total committed source inventory records: 196.
- Total committed teacher_lesson inventory records: 63.
- Existing approved decision ledgers remain 5 files / 100 approved rows.
- Current live Atlas counts remain unchanged from #4170: manifest 5,317; search/browse 5,307; Daily 300; Practice 4,484; cloze 22.

## Validation

- `../../../../.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_candidates.py -q` -> 42 passed
- `../../../../.venv/bin/python -m scripts.audit.source_inventory_review_decisions` -> 5 files / 100 approved rows
- `../../../../.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` -> Daily 300, Practice 4,484, cloze 22
- `../../../../.venv/bin/ruff check --fix scripts/audit/generate_source_inventory_review_candidates.py tests/test_private_teacher_lesson_source_inventory.py` -> clean
- `git diff --check`
- `../../../../.venv/bin/python scripts/audit/lint_agent_trailer.py` -> pass

## Independent Review

AGY/Gemini review on staged diff: `NO BLOCKERS`.

Refs #4160 and #3936.