### PR TITLE
data(atlas): approve third teacher lesson ledger batch

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-03-third-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-03-third-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,320 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-third-approved-teacher-lesson-ledger-batch-2026-07-03
+batch_label: third-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-03'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4172
+  total_queue_rows: 133
+  approved_in_queue: 23
+  promotion_batch_size: 23
+production_outputs_updated: []
+decisions:
+- lemma: правила дорожнього руху
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: traffic rules
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 91005988cced2c30
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 39
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: гнучкий
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: flexible
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 300b29b01fc27db8
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 40
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: притулок
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: shelter
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: b60733f26b6d02ed
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 41
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: потворний
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: ugly
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 06e2db3b59cb5594
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 42
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: орендодавець
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: landlord; lessor
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: ab3b472bb24f2784
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 43
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: повідомляти
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to let someone know; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: ebfe8456f7a78364
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 44
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: давати знати
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: to let someone know; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a736f93f13ea1fee
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 44
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: повідомити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to let someone know; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a767579a7c9e34ad
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 45
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: дати знати
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: to let someone know; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: ea2f8fbbf32375a2
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 45
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: кролик
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: rabbit
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: ff830ab8977a624a
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 46
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: гальмувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to brake; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: aab2b484f7fe8b56
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 47
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: загальмувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to brake; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 6284fa92a38f4cf4
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 48
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: багажник
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: car trunk; boot
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 7930226b7fcadb54
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 49
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: страховка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: insurance
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 216c7dbbda4e6c04
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 50
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: страхування
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: insurance
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: e88fb27336236004
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 50
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: затримувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to delay; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 4112f28c96d85a88
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 51
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: затримати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to delay; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 774037998ea01029
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 52
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: ділитися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to share; to divide into; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: f98ba1149af64424
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 53
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: поділитися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to share; to divide into; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 600f84a822610b46
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 54
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: займати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to reserve; to occupy; to take time; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: b26066211a4a0917
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 55
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: зайняти
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to reserve; to occupy; to take time; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 1b546ef5de6a0c3f
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 56
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: витримувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to endure; to withstand; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 7ee07a12f840cd16
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 57
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: витримати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to endure; to withstand; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: bb8eef90793d8aee
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml
+    locator: explicit vocabulary table row 58
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-39-58
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -27,6 +27,11 @@ PRIVATE_TEACHER_SECOND_LEDGER = (
     / "data/lexicon/source-inventory-review-decisions/"
     "2026-07-03-second-approved-teacher-lesson-ledger-batch.yaml"
 )
+PRIVATE_TEACHER_THIRD_LEDGER = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory-review-decisions/"
+    "2026-07-03-third-approved-teacher-lesson-ledger-batch.yaml"
+)
 
 
 def test_private_teacher_inventory_is_privacy_safe_review_metadata() -> None:
@@ -132,6 +137,34 @@ def test_private_teacher_second_decision_ledger_stays_review_only() -> None:
     assert ".docx" not in ledger_text
 
 
+def test_private_teacher_third_decision_ledger_stays_review_only() -> None:
+    summary = decisions.validate_committed_decision_files([PRIVATE_TEACHER_THIRD_LEDGER])
+    payload = yaml.safe_load(PRIVATE_TEACHER_THIRD_LEDGER.read_text(encoding="utf-8"))
+
+    assert summary == {
+        "files": 1,
+        "rows": 23,
+        "decision_counts": {"approve_for_publish": 23},
+    }
+    assert payload["source_queue"]["generated_from_pr"] == 4172
+    assert payload["source_queue"]["promotion_batch_size"] == 23
+    assert payload["production_outputs_updated"] == []
+    assert payload["decisions"][0]["lemma"] == "правила дорожнього руху"
+    assert payload["decisions"][-1]["lemma"] == "витримати"
+    assert all(
+        row["source_inventory"]["source_family"] == "teacher_lesson"
+        for row in payload["decisions"]
+    )
+    assert {
+        row["source_inventory"]["source_id"]
+        for row in payload["decisions"]
+    } == {"private-teacher-lesson-vocabulary-table-1-rows-39-58"}
+    assert all("surface_admission" not in row for row in payload["decisions"])
+
+    ledger_text = PRIVATE_TEACHER_THIRD_LEDGER.read_text(encoding="utf-8")
+    assert ".docx" not in ledger_text
+
+
 def test_private_teacher_decision_ledgers_cover_seed_without_live_surfaces() -> None:
     records = read_source_inventory(PRIVATE_TEACHER_INVENTORY, project_root=PROJECT_ROOT)
     inventory_keys = {
@@ -150,5 +183,31 @@ def test_private_teacher_decision_ledgers_cover_seed_without_live_surfaces() -> 
             row["source_inventory"]["key"]
             for row in payload["decisions"]
         )
+
+    assert ledger_keys == inventory_keys
+
+
+def test_private_teacher_rows_39_58_decision_ledger_covers_pending_seed() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_39_58_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+    inventory_keys = {
+        decisions.source_inventory_key(
+            lemma=record.lemma,
+            inventory_path=(
+                "data/lexicon/source-inventory/"
+                "private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml"
+            ),
+            locator=record.source_locator,
+        )
+        for record in records
+    }
+
+    payload = yaml.safe_load(PRIVATE_TEACHER_THIRD_LEDGER.read_text(encoding="utf-8"))
+    ledger_keys = {
+        row["source_inventory"]["key"]
+        for row in payload["decisions"]
+    }
 
     assert ledger_keys == inventory_keys


### PR DESCRIPTION
## Summary

- Adds the third private teacher-lesson source-inventory decision ledger batch for rows 39-58 from #4172.
- Approves 23 privacy-safe headword metadata rows for a later controlled Atlas publish PR.
- Keeps live Atlas/search/browse outputs, Daily Word, Practice, and cloze frozen: `production_outputs_updated: []`, no `surface_admission`.
- Extends teacher-lesson source-inventory tests so the new ledger validates and covers the pending 23-row seed.

## Publish-plan facts

Generated from the current source-inventory candidate payload and current Atlas manifest:

- approved decisions: 23
- matched candidates: 23
- proposed future Atlas additions: 19
- skipped existing Atlas entries / future provenance overlays: 4
- missing candidates: 0
- production outputs updated: none

## Validation

- `../../../../.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_review_decisions.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_candidates.py -q` -> 56 passed
- `../../../../.venv/bin/python -m scripts.audit.source_inventory_review_decisions data/lexicon/source-inventory-review-decisions/2026-07-03-third-approved-teacher-lesson-ledger-batch.yaml` -> 1 file / 23 rows valid
- `../../../../.venv/bin/ruff check tests/test_private_teacher_lesson_source_inventory.py scripts/audit/source_inventory_review_decisions.py` -> passed
- `git diff --cached --check` -> passed before commit
- `../../../../.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed
- Independent AGY/Gemini review: `NO BLOCKERS.`

Refs #4160
Refs #3936
