### PR TITLE
data(atlas): add next teacher lesson inventory seed

### DIFF
--- a/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+++ b/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
@@ -1,0 +1,116 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Private teacher lesson vocabulary - explicit table rows 59-78
+    locator: local-only explicit vocabulary table rows 59-78
+    notes: Derived headword metadata only; raw private lesson material is local-only and not committed. Daily Word, Practice, and cloze remain frozen without explicit surface_admission.
+    headwords:
+      - lemma: мікрохвильова піч
+        pos: noun
+        gloss: microwave oven
+        locator: explicit vocabulary table row 59
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: мікрохвильовка
+        pos: noun
+        gloss: microwave oven
+        locator: explicit vocabulary table row 59
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: виснажений
+        pos: adjective
+        gloss: exhausted
+        locator: explicit vocabulary table row 60
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: палити
+        pos: verb
+        gloss: to burn; imperfective
+        locator: explicit vocabulary table row 61
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: спалити
+        pos: verb
+        gloss: to burn; perfective
+        locator: explicit vocabulary table row 62
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: дотла
+        pos: adverb
+        gloss: to ashes; completely
+        locator: explicit vocabulary table row 63
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: платіж
+        pos: noun
+        gloss: payment
+        locator: explicit vocabulary table row 64
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: відповідач
+        pos: noun
+        gloss: defendant
+        locator: explicit vocabulary table row 65
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: позивач
+        pos: noun
+        gloss: plaintiff
+        locator: explicit vocabulary table row 66
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: суддя
+        pos: noun
+        gloss: judge
+        locator: explicit vocabulary table row 67
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: годинами
+        pos: adverb
+        gloss: for hours
+        locator: explicit vocabulary table row 68
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: мужність
+        pos: noun
+        gloss: courage
+        locator: explicit vocabulary table row 69
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: зв'язок
+        pos: noun
+        gloss: connection
+        locator: explicit vocabulary table row 70
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: новонароджений
+        pos: adjective
+        gloss: newborn
+        locator: explicit vocabulary table row 71
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: заплутатися
+        pos: verb
+        gloss: to get confused; to get lost; to get tangled; perfective
+        locator: explicit vocabulary table row 72
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: густий
+        pos: adjective
+        gloss: thick; dense
+        locator: explicit vocabulary table row 73
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: рідкий
+        pos: adjective
+        gloss: liquid; thin
+        locator: explicit vocabulary table row 74
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: підписаний на
+        pos: phrase
+        gloss: subscribed to
+        locator: explicit vocabulary table row 75
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: сліпий
+        pos: adjective
+        gloss: blind
+        locator: explicit vocabulary table row 76
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: глухий
+        pos: adjective
+        gloss: deaf
+        locator: explicit vocabulary table row 77
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: німий
+        pos: adjective
+        gloss: mute
+        locator: explicit vocabulary table row 78
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -9,9 +9,10 @@ The committed inventory seeds are:
 
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml`
 
-Current committed coverage is 63 reviewed headwords from explicit local
-vocabulary table rows 1-58. The source family is `teacher_lesson`, and the
+Current committed coverage is 84 reviewed headwords from explicit local
+vocabulary table rows 1-78. The source family is `teacher_lesson`, and the
 source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -17,6 +17,8 @@ The committed source inventory input is:
 - `data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml`
 - `data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml`
 - `data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml`
 
 The candidate JSON follows the existing grow-candidate shape: `counts`,
@@ -86,8 +88,8 @@ conjunction, particle, and interjection. Optional per-headword `gloss` values
 are curated learner-facing English anchors for cases where dictionary
 enrichment lacks a visible English translation.
 
-The private teacher-lesson seed contributes 40 reviewed `teacher_lesson`
-headwords from an explicit local vocabulary table. Its committed rows are
+The private teacher-lesson seeds contribute 84 reviewed `teacher_lesson`
+headwords from an explicit local vocabulary table. Their committed rows are
 derived metadata only: no raw private lesson material, private document paths,
 or teacher-identifying labels should appear in the inventory.
 

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -21,6 +21,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/pos-balanced-grammar-sample.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )
 

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -17,6 +17,11 @@ PRIVATE_TEACHER_ROWS_39_58_INVENTORY = (
     / "data/lexicon/source-inventory/"
     "private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml"
 )
+PRIVATE_TEACHER_ROWS_59_78_INVENTORY = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory/"
+    "private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml"
+)
 PRIVATE_TEACHER_FIRST_LEDGER = (
     PROJECT_ROOT
     / "data/lexicon/source-inventory-review-decisions/"
@@ -90,6 +95,36 @@ def test_private_teacher_rows_39_58_inventory_is_pending_review_metadata() -> No
     assert all("(" not in record.lemma and ")" not in record.lemma for record in records)
 
     inventory_text = PRIVATE_TEACHER_ROWS_39_58_INVENTORY.read_text(encoding="utf-8")
+    assert ".docx" not in inventory_text
+
+
+def test_private_teacher_rows_59_78_inventory_is_pending_review_metadata() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_59_78_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+
+    assert len(records) == 21
+    assert {record.source_family for record in records} == {"teacher_lesson"}
+    assert {record.extraction_mode for record in records} == {"curated_headword"}
+    assert {record.source_id for record in records} == {
+        "private-teacher-lesson-vocabulary-table-1-rows-59-78"
+    }
+    assert all(record.source_path is None for record in records)
+    assert all(record.source_url is None for record in records)
+    assert all(record.source_title for record in records)
+    assert all(record.source_locator for record in records)
+    assert all(record.context for record in records)
+    assert all(record.pos for record in records)
+    assert all(record.gloss for record in records)
+    assert "мікрохвильова піч" in {record.lemma for record in records}
+    assert "мікрохвильовка" in {record.lemma for record in records}
+    assert "німий" in {record.lemma for record in records}
+    assert all("," not in record.lemma for record in records)
+    assert all("/" not in record.lemma for record in records)
+    assert all("(" not in record.lemma and ")" not in record.lemma for record in records)
+
+    inventory_text = PRIVATE_TEACHER_ROWS_59_78_INVENTORY.read_text(encoding="utf-8")
     assert ".docx" not in inventory_text
 
 


### PR DESCRIPTION
## Summary
- Add the fourth private teacher-lesson source-inventory seed for explicit vocabulary table rows 59-78.
- Register the new inventory in the source-inventory review candidate generator.
- Update the private teacher source runbooks and tests to reflect 84 committed teacher-lesson seed headwords.

## Scope
Review-only. This PR does not change live Atlas manifest/search/browse outputs, manifest pointers, Daily Word, Practice, or cloze content.

## Validation
- `../../../../.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_candidates.py -q`
- `../../../../.venv/bin/ruff check tests/test_private_teacher_lesson_source_inventory.py scripts/audit/generate_source_inventory_review_candidates.py`
- `git diff --check`
- `ln -s /Users/krisztiankoos/projects/learn-ukrainian/data/sources.db data/sources.db && ../../../../.venv/bin/python -m scripts.audit.generate_source_inventory_review_candidates --out /tmp/atlas-source-inventory-review-candidates-4160-fourth-seed.json --report; rm -f data/sources.db`
- `../../../../.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Commit hook affected-file pytest: `tests/test_private_teacher_lesson_source_inventory.py` (9 passed)

## Review
- Internal helper review: no blockers.
- Independent AGY/Gemini review: `NO BLOCKERS`.
