### PR TITLE
docs(bio): add Mykhailo Tuhan-Baranovskyi dossier

### DIFF
--- a/docs/research/bio/mykhailo-tuhan-baranovskyi.md
+++ b/docs/research/bio/mykhailo-tuhan-baranovskyi.md
@@ -1,0 +1,198 @@
+# Михайло Іванович Туган-Барановський - Research Dossier
+
+**Slug:** `mykhailo-tuhan-baranovskyi`
+**Block:** +77 backfill - political economy / cooperative movement / Central Rada finance / Ukrainian Academy of Sciences / monetary theory
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #325
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-03
+
+**Source acronym legend:** EIU = Encyclopedia History Ukraine / Institute History of Ukraine, NASU; ESU = Encyclopedia Modern Ukraine / NASU; IEU = Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies; UINP = Ukrainian Institute National Memory; NBUV = Vernadsky National Library of Ukraine; NAS Library = National Academy of Sciences of Ukraine library authority data; BIO / HIST / ISTORIO / C1 / C2 / wiki = existing learn-ukrainian track materials; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, scholarly, primary-text, and image-rights sources cited
+- [x] Pressure mechanism framed imperial academic constraint, legal Marxism debates, cooperative economics, fiscal sovereignty, Central Rada finance work, Ukrainian Academy of Sciences institution-building, and later cataloging politics
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-03 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric periodization: frame is Ukrainian political economy, Central Rada state-building, cooperative self-organization, UAN institution-building, and Ukrainian-language economic education, not generic "Russian economic thought."
+- [x] Ukrainian agency preserved: Tuhan-Baranovskyi is treated as an economist, cooperative theorist, General Secretary of Finance, UAN founder, and Ukrainian public figure, not only as a St Petersburg professor.
+- [x] Imperial-language constraints named: many major works appeared in Russian or German because those were the available academic and publishing markets, not because Ukrainian economic vocabulary was irrelevant.
+- [x] Cooperative economics distinguished from later Soviet collectivization: `кооперація` means member-owned credit, consumer, production, and educational self-organization in this context.
+- [x] Anti-hagiography included: his office tenure was short, his early legal-Marxist reputation and later anti-Marxist revisionism need explanation, and source conflicts over dates / places are not hidden.
+
+## 1. Identity / chronology
+
+- **Canonical UA:** `Михайло Іванович Туган-Барановський`; some sources and older publications preserve the fuller family form `Туган-Мірза-Барановський`.
+- **Canonical EN:** `Mykhailo Tuhan-Baranovskyi`.
+- **Core identity:** Ukrainian economist, sociologist, historian of economic development, public figure, cooperative-movement theorist, critic and reviser of Marxism, General Secretary of Finance in the Ukrainian Central Rada / UNR government, founder / academician of the Ukrainian Academy of Sciences, and organizer of Ukrainian economic research institutions.
+- **Birth:** EIU and ESU give 8 January old style / 20 January new style 1865, `Соляниківка` / Solianykivka in Kupiansk county, Kharkiv gubernia; ESU notes that the settlement is now removed from the register. IEU gives `Solone`, UINP uses `Солонім`, and NAS Library authority data gives `Старовірівка`. Treat these as nested / adjacent historical-place metadata around the now-defunct Solianykivka area, not as four separate birth stories. Use `20 January 1865, Solianykivka area, Kharkiv region` in low-context copy and preserve the source-drift note for exact place work.
+- **Death / burial:** EIU, ESU, IEU, and UINP converge on 21 January 1919, near the Zatyshshia / Zatyshok railway-station area while he was traveling as an adviser to a Ukrainian diplomatic mission to France; ESU specifies burial in Odesa. NBUV / NAS authority data show 22 January in some records. Use `1865-1919` or source-labeled exact dates in learner copy.
+- **Family / ancestry:** UINP and source-rich references describe a paternal line of Lithuanian Tatar / `murza` origin and a maternal Ukrainian gentry / Poltava-region line. Do not use ancestry to dilute his Ukrainian public identification or his service to Ukrainian institutions.
+- **Education:** EIU / ESU / NBUV record gymnasium study in Kharkiv, Kyiv, and Moscow contexts, Kharkiv University physical-mathematical studies completed in 1888, and law studies completed in 1890.
+- **Academic degrees and early career:** EIU / ESU record a 1894 master's thesis on industrial crises in modern England and a doctorate connected to `Русская фабрика в прошлом и настоящем`; source trails vary between 1898 for the work / defense and 1899 for degree metadata. From 1895 to 1917 he worked around St Petersburg / Petrograd academic institutions; EIU / ESU identify the St Petersburg University professorship / chair in 1913, while some derivative records foreground earlier institute professorships after 1905. Use venue-labeled dates.
+- **Imperial policing:** Source trails distinguish his dismissal from St Petersburg University around 1899 for free-thinking / political unreliability from his 1901-1905 Poltava-province period. This becomes the bridge from imperial academic career to Ukrainian civic and cooperative work.
+- **Economic thought:** EIU / ESU / IEU identify him as a major theorist of industrial cycles, monetary theory, cooperation, and critiques of Marxism. ESU says his crisis theory influenced later cycle theory; IEU notes his synthesis of labor-value and marginal-utility discussion and his later rejection of several Marxist doctrines.
+- **1917 Central Rada:** EIU / IEU / UINP identify him as General Secretary of Finance in the General Secretariat of the Ukrainian Central Rada / UNR government. Sources vary between August-November and September-December 1917; use source-labeled dates for exact office chronology.
+- **1918 Ukrainian Academy of Sciences:** EIU / ESU / NBUV record him as an initiator / founder of the Ukrainian Academy of Sciences, full academician in 1918, head of the socio-economic department, director / founder of economic-conjuncture work, and organizer of demographic and cooperative institutes.
+- **Cooperative institutions:** EIU / ESU / UINP place him in the Ukrainian Society of Economists, Central Cooperative Ukrainian Committee, `Українська кооперація`, cooperative institutes, and the broader Ukrainian cooperative movement.
+- **Final mission:** EIU / ESU / IEU say he was appointed an adviser to the Ukrainian diplomatic mission to France and died en route to the Paris Peace Conference.
+
+## 2. Political pressure mechanism
+
+- **Imperial academic marketplace:** His early career moved through Kharkiv, Moscow, and St Petersburg / Petrograd institutions because the empire controlled universities, degree recognition, and publication networks. This explains the Russian-language title record without making him simply a "Russian economist."
+- **Political unreliability and exile:** The 1899 dismissal and 1901-1905 Poltava period show how even a scholar using imperial academic channels could be pushed out when socialist and Ukrainian civic activity became visible.
+- **Legal Marxism and revision:** He was associated with legal Marxist debates, but later criticized Marxist crisis theory, breakdown theory, and class-struggle simplifications. Teach this as an intellectual trajectory, not a stable party label.
+- **Cooperation as sovereignty infrastructure:** For late-imperial Ukraine, cooperatives were member-owned economic networks that trained accountants, organizers, editors, teachers, and future administrators. Tuhan-Baranovskyi's cooperative theory made economics a social and national infrastructure question.
+- **Fiscal sovereignty:** His Central Rada finance office belongs to the same state-building cluster as taxation, currency, banking, credit, and budget vocabulary. Political autonomy without fiscal tools remained fragile.
+- **Ukrainian-language economic education:** UINP and NBUV emphasize his late Ukrainian-language lectures / textbooks and his effort to work in Ukrainian. This is not cosmetic; it is part of building a usable Ukrainian academic register for political economy.
+- **UAN as state-building:** The 1918 Academy work connects science policy to sovereignty. Economic conjuncture, demography, cooperation, and university teaching were meant to make Ukrainian state and society measurable, teachable, and administrable.
+- **Cataloging pressure:** Commons, English catalogs, and older scholarship often label him `Russian economist` or index him as `Mikhail Tugan-Baranovsky`. Use those aliases for search, but learner-facing narration should source-label the imperial venue rather than adopt the imperial-national label.
+- **Soviet / later simplification risk:** Soviet narratives could fold him into Russian Marxism or pre-revolutionary economics, while Ukrainian memorial narratives can overstate his direct policy results. The useful frame is an internationally known economist who tried to turn expertise into Ukrainian institutions.
+
+## 3. Major events / historical footprint
+
+- **1890 marginal utility / labor-value article:** IEU notes his early attempt to synthesize labor theory and marginal utility. This is a high-level economics anchor for C1/C2 learners.
+- **1894 `Промышленные кризисы в современной Англии...`:** EIU / ESU identify this master's thesis as the work that made his business-cycle theory internationally visible. It lets learners connect `криза`, `кон'юнктура`, `інвестиції`, and `заощадження`.
+- **1898 `Русская фабрика в прошлом и настоящем`:** His doctorate is a strong source-study anchor for industrialization, factory labor, capitalism, and empire-wide economic history. Do not make the title a nationality label for him.
+- **1899 dismissal / 1901-1905 Poltava period:** Political policing forced a shift from university career into broader Ukrainian civic, cooperative, and publishing work.
+- **Editing and economic journalism:** EIU / ESU identify `Вестник кооперации`, `Новые идеи в экономике`, `Украинский народ в его прошлом и настоящем`, and later `Українська кооперація` as publication anchors.
+- **1916 `Социальные основы кооперации`:** A major cooperative-theory text. Pair with Ukrainian cooperative vocabulary and Borys Martos to show how theory and practice met.
+- **1917 `Бумажные деньги и металл`:** Monetary theory anchor for paper money, credit, inflation, and currency sovereignty. In Ukrainian learner materials, use `паперові гроші`, not Russian-derived false-friend wording.
+- **1917 General Secretary of Finance:** His short office tenure grounds the biography in Central Rada state-building: budget, money, tax, and banking were immediate problems of autonomy.
+- **1905 Shevchenko-monument initiative:** NBUV / UINP record his Poltava fundraising / civic initiative around a Shevchenko monument. Use this as a source-labeled Ukrainian public-agency anchor, not as the main achievement.
+- **1918 Ukrainian Academy of Sciences founding:** UAN socio-economic department, economic-conjuncture institute, demographic institute, cooperative institute, and the Ukrainian Society of Economists make this a science-and-state institution lesson. The demographic-institute initiative is especially useful for showing that Academy work meant concrete Ukrainian research infrastructure, not only honorary titles.
+- **1919 Ukrainian economic textbooks / cooperative publications:** NBUV notes Ukrainian-language economic work in 1919, including `Кооперація, її природа та мета` and `Політична економія: курс популярний`; useful for language-register teaching.
+- **January 1919 death en route to Paris:** His final mission connects economic expertise to UNR diplomacy and the Paris Peace Conference moment. UINP describes sudden heart failure / aggravated angina near the Zatyshok station, with burial in Odesa.
+
+## 4. Pedagogical anchors
+
+- **Economist as state-builder:** Learners can see why a finance secretary matters even when his tenure is short: fiscal vocabulary is sovereignty vocabulary.
+- **Cooperative movement beyond "business":** `кооперація`, `спілка`, `пай`, `кредит`, `ощадність`, `банк`, `контора`, `ревізія`, and `статут` connect economy, civil society, and national organization.
+- **Business-cycle theory:** For C1/C2, his crises work supports causal language: disproportionality, investment, savings, consumer goods, capital goods, and market cycles.
+- **Paper money / metal money:** Pair with OES currency and C1 / C2 economics surfaces. The historical problem makes modern money words less abstract.
+- **Language-switching anchor:** He wrote major works in Russian / German but moved into Ukrainian state and academic work. This supports a lesson on language, power, and academic registers without shaming multilingual source trails.
+- **Academy-building anchor:** Pair him with Ahatanhel Krymskyi, Volodymyr Vernadskyi, Mykola Vasylenko, and other UAN founders to show that science institutions were part of Ukrainian state-building.
+- **Map anchor:** Solianykivka / Starovirivka area, Kharkiv, Moscow, St Petersburg / Petrograd, Poltava, Kyiv, Zatyshshia / Odesa, and Paris as the destination of the final mission.
+- **Comparison anchor:** Pair with Borys Martos for cooperative economics and finance; Oleksandr Lototskyi for state administration and diplomacy; Mykhailo Hrushevskyi and Volodymyr Vynnychenko for Central Rada context; Sofiia Rusova for Ukrainian-language education and institutional building.
+- **Anti-hagiography anchor:** He was globally respected, but he did not single-handedly create Ukrainian finance, the Academy, or cooperative practice. Teach shared institutional work and source limits.
+
+## 5. Language register
+
+- **Register:** political economy, economic theory, cooperative movement, Central Rada administration, fiscal policy, monetary theory, academy / university administration, and source-cataloging language.
+- **CEFR readiness:** B1+/B2 short biography and map; B2/C1 Central Rada finance, cooperation, and UAN vocabulary; C1/C2 industrial-crisis theory, monetary theory, and Marxism / marginal utility debates.
+- **Core vocabulary:** `Михайло Туган-Барановський`, `політична економія`, `економіст`, `соціолог`, `кооперація`, `кооперативний рух`, `кредит`, `заощадження`, `інвестиції`, `промислова криза`, `економічна кон'юнктура`, `паперові гроші`, `метал`, `Генеральний Секретаріат`, `генеральний секретар фінансів`, `Українська Центральна Рада`, `Українська академія наук`, `академік`, `демографічний інститут`, `Інститут економічної кон'юнктури`.
+- **Office-title caution:** Use `General Secretary of Finance` / `генеральний секретар фінансів`, not a flat modern `finance minister` unless glossing for learners. If `minister` appears, source-label it as simplified comparison.
+- **Date caution:** Use `1865-1919` in low-context copy. If exact dates appear, distinguish old/new style birth date and source drift around 21 / 22 January 1919 death records.
+- **Place-name caution:** Use `Solianykivka / Соляниківка` with a note that sources also show `Solone`, `Solonim`, and `Starovirivka`; avoid pretending every catalog uses the same settlement name.
+- **False-friend caution:** For `paper money`, use Ukrainian `паперові гроші`; do not import Russian `бумажні гроші` into learner-facing Ukrainian.
+- **Identity-language caution:** Keep `Tugan-Baranovsky`, `Mikhail`, and `Russian economist` as catalog / search metadata, not as the main learner label.
+
+## 6. Risks / open questions
+
+- **Birthplace drift:** EIU / ESU support `Соляниківка`; IEU says `Solone`; UINP uses `Солонім`; NAS authority data says `Старовірівка`. The safest framing is a now-defunct Solianykivka / Solone-area settlement near Starovirivka in historical Kupiansk county. Low-context copy should avoid over-precise modern administrative claims unless it source-labels them.
+- **Birth date drift:** Institutional sources generally support 8(20) January 1865, while NBUV's display line appears to scramble old/new style notation. Use old/new style carefully.
+- **Death date drift:** EIU / ESU / IEU / UINP support 21 January 1919; NBUV / NAS authority records show 22 January in some places. Do not silently mix them.
+- **Degree-year drift:** ESU / EIU connect the doctorate to the 1898 `Русская фабрика...` work; some later profiles display 1899 for doctorate metadata. Use `1898/1899` only in source-comparison contexts.
+- **Professorship venue drift:** EIU / ESU foreground the 1913 St Petersburg University professorship / chair; some derivative summaries identify earlier professorships in commercial / polytechnic institutes after 1905. Do not collapse all venues into one date.
+- **Office chronology drift:** Sources vary between August-November and September-December 1917 for his finance-secretary role. Use `1917` or `late 1917` unless exact dates are source-labeled.
+- **Title-language problem:** Major works have Russian titles because of publication history. Dossier / lesson prose can gloss them in English or Ukrainian, but should not invent original Ukrainian titles as if they were the first editions.
+- **"Father of" overclaim:** He was a major business-cycle, monetary, and cooperative theorist, but do not present him as sole inventor of Keynesianism, Ukrainian finance, or cooperative economics.
+- **Marxism simplification:** He is useful precisely because he moved through legal-Marxist debate, critique of Marxist economic doctrine, cooperative social justice, and Ukrainian state work. One label will mislead.
+- **Cataloging decolonization:** Commons and library records may say `Russian economist`; production should source-label that as imperial / cataloging metadata, not repeat it as narrative fact.
+- **Image-rights uncertainty:** Commons portrait and bust files need file-level source, author, publication-date, and US public-domain checks before production use. Avoid modern web portraits and restorations unless the exact file license is clean.
+
+## 7. Cross-track links
+
+- **Existing BIO dossier anchors (VERIFIED `test -e` / `rg` 2026-07-03):** `site/src/content/docs/bio/index.mdx` lists BIO #325 `mykhailo-tuhan-baranovskyi`; `docs/research/bio/borys-martos.md` supports cooperative economics and finance comparison; `docs/research/bio/oleksandr-lototskyi.md` supports UPR administration / diplomacy context; `docs/research/bio/volodymyr-chekhivskyi.md` supports Directory / government office comparison; `docs/research/bio/sofiia-rusova.md` supports education and Ukrainian institutional building; `docs/research/bio/mykhailo-hrushevskyi.md`, `docs/research/bio/volodymyr-vynnychenko.md`, and `docs/research/bio/symon-petliura.md` support Central Rada / UNR state context; `docs/research/bio/yevhen-chykalenko.md` supports pre-1917 civic networks; `docs/research/bio/mykola-vasylenko.md`, `docs/research/bio/volodymyr-vernadskyi.md`, and `docs/research/bio/ahatanhel-krymskyi.md` support Ukrainian Academy of Sciences institution-building; `docs/research/bio/mykhailo-drahomanov.md`, `docs/research/bio/ivan-franko.md`, `docs/research/bio/yulian-bachynskyi.md`, and `docs/research/bio/viacheslav-lypynskyi.md` support political-economy / social-theory comparisons.
+- **Existing HIST plan / discovery surfaces (VERIFIED `test -e` / `rg` 2026-07-03):** `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`, `curriculum/l2-uk-en/hist/discovery/tsentralna-rada.yaml`, `wiki/periods/tsentralna-rada.md`; `curriculum/l2-uk-en/plans/hist/drahomanov.yaml` supports cooperation / ethical socialism comparisons; `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml`, `curriculum/l2-uk-en/hist/discovery/dyrektoriia.yaml`, `curriculum/l2-uk-en/plans/hist/symon-petliura-revolution.yaml`, and `wiki/periods/syntez-revoliutsiia.md` support UNR / revolutionary-state context.
+- **Existing ISTORIO plan / discovery surfaces (VERIFIED `test -e` / `rg` 2026-07-03):** `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`, `curriculum/l2-uk-en/istorio/discovery/universaly-unr.yaml`, `curriculum/l2-uk-en/plans/istorio/unr-vybory.yaml`, `curriculum/l2-uk-en/istorio/discovery/unr-vybory.yaml`, `wiki/historiography/universaly-unr.md`, `wiki/historiography/unr-vybory.md`, and `curriculum/l2-uk-en/plans/lit-essay/franko-some-words.yaml` for "small deeds" / cooperation as nation-building vocabulary.
+- **Existing economics / currency surfaces (VERIFIED `test -e` / `rg` 2026-07-03):** `curriculum/l2-uk-en/plans/c1/economics-vocabulary-c1.yaml`, `curriculum/l2-uk-en/c1/discovery/economics-vocabulary-c1.yaml`, `wiki/academic/c1/economics-vocabulary-c1.md`, `curriculum/l2-uk-en/plans/c2/ekonomika-i-dobrobut.yaml`, `wiki/mastery/c2/ekonomika-i-dobrobut.md`, `curriculum/l2-uk-en/plans/oes/numbers-currency.yaml`, `site/src/content/docs/oes/index.mdx`, and `wiki/linguistics/oes/numbers-currency.md`.
+- **Existing wiki / context surfaces (VERIFIED `test -e` / `rg` 2026-07-03):** `wiki/periods/hrushevskyi.md`, `wiki/periods/syntez-revoliutsiia.md`, `wiki/periods/voienna-ekonomika.md`, `wiki/periods/nezalezhnist-1991.md`, `wiki/academic/c1/business-etiquette.md`, and `wiki/academic/c1/case-studies.md`.
+- **Textbook mention (VERIFIED `rg` 2026-07-03):** `docs/references/textbooks-txt/10-klas-history.txt` mentions `Михайло Туган-Барановський` and Ukrainian cooperation. Use the textbook only as a curricular-echo source, not as the factual authority.
+- **Candidate / absent BIO #325 surfaces (VERIFIED absent `test -e` 2026-07-03):** `curriculum/l2-uk-en/plans/bio/mykhailo-tuhan-baranovskyi.yaml`, `curriculum/l2-uk-en/bio/discovery/mykhailo-tuhan-baranovskyi.yaml`, `wiki/figures/mykhailo-tuhan-baranovskyi.md`, `site/src/content/docs/bio/mykhailo-tuhan-baranovskyi.mdx`, `curriculum/l2-uk-en/bio/mykhailo-tuhan-baranovskyi/module.md`, `curriculum/l2-uk-en/bio/mykhailo-tuhan-baranovskyi/activities.yaml`, `curriculum/l2-uk-en/bio/mykhailo-tuhan-baranovskyi/vocabulary.yaml`, `curriculum/l2-uk-en/bio/mykhailo-tuhan-baranovskyi/resources.yaml`.
+
+## 8. Name variants / search aliases
+
+- **Canonical UA:** `Михайло Іванович Туган-Барановський`.
+- **Fuller family / historical UA form:** `Михайло Іванович Туган-Мірза-Барановський`.
+- **Canonical EN:** `Mykhailo Tuhan-Baranovskyi`.
+- **Common UA search forms:** `Михайло Туган-Барановський`, `Туган-Барановський Михайло`, `Туган-Барановський Михайло Іванович`, `М. І. Туган-Барановський`, `М. Туган-Барановський`.
+- **Common EN / transliteration forms:** `Mykhailo Tuhan-Baranovsky`, `Mykhailo Tuhan-Baranovs'kyi`, `Mykhailo Tugan-Baranovsky`, `Mikhail Tugan-Baranovsky`, `Mikhail Ivanovich Tugan-Baranovsky`, `Mikhail Ivanovich Tugan-Baranovskij`, `Tuhan-Baranovsky`, `Tugan-Baranovsky`.
+- **Russified / imperial-search forms:** `Михаил Иванович Туган-Барановский`, `М. И. Туган-Барановский`, `Михаил Туган-Барановский`. Keep these for source discovery only, not learner display.
+- **Institution / office aliases:** `General Secretary of Finance`, `finance secretary`, `Ukrainian Central Rada`, `Ukrainian People's Republic`, `Ukrainian Academy of Sciences`, `UAN`, `economic conjuncture`, `cooperative movement`, `Ukrainian Society of Economists`, `Central Cooperative Ukrainian Committee`.
+- **Learner-facing display:** `Mykhailo Tuhan-Baranovskyi (Михайло Туган-Барановський, 1865-1919)`.
+
+## 9. Image rights / visual material notes
+
+- **Primary portrait candidate:** Commons `File:Mikhail Ivanovich Tugan-Baranovskij.jpg`; described as an early-20th-century portrait with unknown author and public-domain claims. The file's source chain points to a later book while the license includes uploader public-domain language, so production should recheck original publication / author / US public-domain status rather than rely on uploader PD alone. Metadata labels him in Russian-imperial terms, so production should separate file identification from narrative identity.
+- **Alternate portrait / bust candidate:** Commons `File:Myhaylo Tuhan-Baranovsky.jpg`; appears to show a modern photograph of a Donetsk bust / monument rather than a clean historical headshot. Use as memorial material only if the file-level license, source, and freedom-of-panorama questions are cleared.
+- **Commons category:** `Category:Myhaylo Tuhan-Baranovsky` contains portraits, scans, and memorial files but also category metadata such as `Russian economist`; treat this as a cataloging caution.
+- **Primary-text visual candidates:** Commons and digital-library scans of `Geschichte der russischen Fabrik`, `Теоретические основы марксизма`, and related works can support source-study visuals, but title pages need separate file-level rights checks. The `Geschichte der russischen Fabrik` scan is a strong industrialization / economics context visual, but Commons metadata may still need a US public-domain tag check.
+- **Avoid default:** unsourced web portraits, AI restorations, cropped social-media images, modern bust photos without clear license, and any file whose source says only "from book" without publication / author evidence.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- "Туган-Барановський Михайло Іванович." Енциклопедія історії України, Інститут історії України НАН України. https://history.org.ua/?termin=Tuhan_Baranovskyj_M. Accessed 2026-07-03.
+- "Туган-Барановський Михайло Іванович." Енциклопедія Сучасної України, НАН України / НТШ. https://esu.com.ua/article-889470. Accessed 2026-07-03.
+- "Tuhan-Baranovsky, Mykhailo." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CT%5CU%5CTuhanBaranovskyMykhailo.htm. Accessed 2026-07-03.
+- UINP, "1865 - народився Михайло Туган-Барановський, економіст, міністр фінансів Центральної Ради." https://uinp.gov.ua/istorychnyy-kalendar/sichen/20/1865-narodyvsya-myhaylo-tugan-baranovskyy-ekonomist-ministr-finansiv-centralnoyi-rady. Accessed 2026-07-03.
+- NBUV, "Михайло Іванович Туган-Барановський." https://nbuv.gov.ua/node/1913. Accessed 2026-07-03.
+- NAS Library authority profile, "Туган-Барановський Михайло Іванович." http://libnas.nbuv.gov.ua/person/IDP000000404990. Accessed 2026-07-03.
+
+**Tier 2 / 3 (scholarly, biographical, and primary-text references):**
+
+- Kachor, Andrii. `М. І. Туган-Барановський на службі науки й свого народу`. Diasporiana. https://diasporiana.org.ua/biografiyi/946-kachor-a-m-i-tugan-baranovskiy-na-sluzhbi-nauki-y-svogo-narodu/. Accessed 2026-07-03.
+- Tuhan-Baranovskyi, Mykhailo. `Політична економія`. Diasporiana. https://diasporiana.org.ua/ideologiya/7504-tugan-baranovskiy-m-politichna-ekonomiya/. Accessed 2026-07-03.
+- `docs/references/textbooks-txt/10-klas-history.txt`, local textbook extraction mentioning Mykhailo Tuhan-Baranovskyi and Ukrainian cooperation. Checked 2026-07-03.
+
+**Tier 4 (learn-ukrainian cross-track sources checked 2026-07-03):**
+
+- `site/src/content/docs/bio/index.mdx`
+- `docs/research/bio/borys-martos.md`
+- `docs/research/bio/oleksandr-lototskyi.md`
+- `docs/research/bio/volodymyr-chekhivskyi.md`
+- `docs/research/bio/sofiia-rusova.md`
+- `docs/research/bio/mykhailo-hrushevskyi.md`
+- `docs/research/bio/volodymyr-vynnychenko.md`
+- `docs/research/bio/symon-petliura.md`
+- `docs/research/bio/yevhen-chykalenko.md`
+- `docs/research/bio/mykola-vasylenko.md`
+- `docs/research/bio/volodymyr-vernadskyi.md`
+- `docs/research/bio/ahatanhel-krymskyi.md`
+- `docs/research/bio/mykhailo-drahomanov.md`
+- `docs/research/bio/ivan-franko.md`
+- `docs/research/bio/yulian-bachynskyi.md`
+- `docs/research/bio/viacheslav-lypynskyi.md`
+- `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`
+- `curriculum/l2-uk-en/hist/discovery/tsentralna-rada.yaml`
+- `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml`
+- `curriculum/l2-uk-en/hist/discovery/dyrektoriia.yaml`
+- `curriculum/l2-uk-en/plans/hist/symon-petliura-revolution.yaml`
+- `curriculum/l2-uk-en/plans/hist/drahomanov.yaml`
+- `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`
+- `curriculum/l2-uk-en/istorio/discovery/universaly-unr.yaml`
+- `curriculum/l2-uk-en/plans/lit-essay/franko-some-words.yaml`
+- `curriculum/l2-uk-en/plans/c1/economics-vocabulary-c1.yaml`
+- `curriculum/l2-uk-en/c1/discovery/economics-vocabulary-c1.yaml`
+- `wiki/academic/c1/economics-vocabulary-c1.md`
+- `curriculum/l2-uk-en/plans/c2/ekonomika-i-dobrobut.yaml`
+- `wiki/mastery/c2/ekonomika-i-dobrobut.md`
+- `curriculum/l2-uk-en/plans/oes/numbers-currency.yaml`
+- `wiki/linguistics/oes/numbers-currency.md`
+- `wiki/periods/tsentralna-rada.md`
+
+**Tier 5 (image-rights / media-rights sources):**
+
+- Commons `Category:Myhaylo Tuhan-Baranovsky`. https://commons.wikimedia.org/wiki/Category:Myhaylo_Tuhan-Baranovsky. Accessed 2026-07-03.
+- Commons `File:Mikhail Ivanovich Tugan-Baranovskij.jpg`. https://commons.wikimedia.org/wiki/File:Mikhail_Ivanovich_Tugan-Baranovskij.jpg. Accessed 2026-07-03.
+- Commons `File:Myhaylo Tuhan-Baranovsky.jpg`. https://commons.wikimedia.org/wiki/File:Myhaylo_Tuhan-Baranovsky.jpg. Accessed 2026-07-03.


### PR DESCRIPTION
## Summary
- Adds BIO #325 research dossier for Mykhailo Tuhan-Baranovskyi.
- Frames political economy, cooperative movement, Central Rada finance work, UAN institution-building, and cataloging/decolonization risks.
- Keeps scope dossier-only: docs/research/bio/mykhailo-tuhan-baranovskyi.md.

## Fleet / helper lanes
- AGY read-only source-pack helper: bio-325-mykhailo-tuhan-baranovskyi-source-pack.
- Codex read-only path/media helper: bio-325-mykhailo-tuhan-baranovskyi-path-media.
- Independent Claude review will be requested before ready/merge.

## Validation
- npx markdownlint-cli2 docs/research/bio/mykhailo-tuhan-baranovskyi.md
- .venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/mykhailo-tuhan-baranovskyi.md
- git diff --check
- .venv/bin/python scripts/audit/lint_agent_trailer.py
