### PR TITLE
data(atlas): approve fourth teacher lesson ledger batch

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-03-fourth-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-03-fourth-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,312 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-fourth-approved-teacher-lesson-ledger-batch-2026-07-03
+batch_label: fourth-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-03'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4176
+  total_queue_rows: 131
+  approved_in_queue: 21
+  promotion_batch_size: 21
+production_outputs_updated: []
+decisions:
+- lemma: мікрохвильова піч
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: microwave oven
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 55782c898f097bd8
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 59
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: мікрохвильовка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: microwave oven
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 2fbf60c81a48cc96
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 59
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags calque_warning; heritage_status flags russian_shadow
+- lemma: виснажений
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: exhausted
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 7b6a0303ce99ccc2
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 60
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: палити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to burn; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 9ece608311391d71
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 61
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: спалити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to burn; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 7b938981df6fd79d
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 62
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: дотла
+  decision: approve_for_publish
+  approved_pos: adverb
+  approved_gloss: to ashes; completely
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 4b3d3ccb35678e61
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 63
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: платіж
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: payment
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a2a515e787da26ba
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 64
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: відповідач
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: defendant
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: dffa57fdc774b006
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 65
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: позивач
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: plaintiff
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: bf30891a80b81c1b
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 66
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: суддя
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: judge
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: fa59c34f17476d9a
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 67
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: годинами
+  decision: approve_for_publish
+  approved_pos: adverb
+  approved_gloss: for hours
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 9d52712cfa16299d
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 68
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition; heritage_status flags calque_warning; heritage_status flags russian_shadow
+- lemma: мужність
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: courage
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: f13a464243f3c491
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 69
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: зв'язок
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: connection
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: be62e84e9585dfd3
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 70
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags calque_warning; heritage_status flags russian_shadow
+- lemma: новонароджений
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: newborn
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: b691d37b78c1b562
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 71
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: заплутатися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to get confused; to get lost; to get tangled; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 7a532b3fba795db1
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 72
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: густий
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: thick; dense
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 43ced25b7541b1e5
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 73
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: рідкий
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: liquid; thin
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d82fd5b60ccdefe0
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 74
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: підписаний на
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: subscribed to
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a4d4cadd367a9151
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 75
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: сліпий
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: blind
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 70727fa93c62f959
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 76
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: глухий
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: deaf
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: cf7ba2b6a2bc12cf
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 77
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: німий
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: mute
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: e2475bb78973dff1
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml
+    locator: explicit vocabulary table row 78
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-59-78
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -37,6 +37,11 @@ PRIVATE_TEACHER_THIRD_LEDGER = (
     / "data/lexicon/source-inventory-review-decisions/"
     "2026-07-03-third-approved-teacher-lesson-ledger-batch.yaml"
 )
+PRIVATE_TEACHER_FOURTH_LEDGER = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory-review-decisions/"
+    "2026-07-03-fourth-approved-teacher-lesson-ledger-batch.yaml"
+)
 
 
 def test_private_teacher_inventory_is_privacy_safe_review_metadata() -> None:
@@ -200,6 +205,34 @@ def test_private_teacher_third_decision_ledger_stays_review_only() -> None:
     assert ".docx" not in ledger_text
 
 
+def test_private_teacher_fourth_decision_ledger_stays_review_only() -> None:
+    summary = decisions.validate_committed_decision_files([PRIVATE_TEACHER_FOURTH_LEDGER])
+    payload = yaml.safe_load(PRIVATE_TEACHER_FOURTH_LEDGER.read_text(encoding="utf-8"))
+
+    assert summary == {
+        "files": 1,
+        "rows": 21,
+        "decision_counts": {"approve_for_publish": 21},
+    }
+    assert payload["source_queue"]["generated_from_pr"] == 4176
+    assert payload["source_queue"]["promotion_batch_size"] == 21
+    assert payload["production_outputs_updated"] == []
+    assert payload["decisions"][0]["lemma"] == "мікрохвильова піч"
+    assert payload["decisions"][-1]["lemma"] == "німий"
+    assert all(
+        row["source_inventory"]["source_family"] == "teacher_lesson"
+        for row in payload["decisions"]
+    )
+    assert {
+        row["source_inventory"]["source_id"]
+        for row in payload["decisions"]
+    } == {"private-teacher-lesson-vocabulary-table-1-rows-59-78"}
+    assert all("surface_admission" not in row for row in payload["decisions"])
+
+    ledger_text = PRIVATE_TEACHER_FOURTH_LEDGER.read_text(encoding="utf-8")
+    assert ".docx" not in ledger_text
+
+
 def test_private_teacher_decision_ledgers_cover_seed_without_live_surfaces() -> None:
     records = read_source_inventory(PRIVATE_TEACHER_INVENTORY, project_root=PROJECT_ROOT)
     inventory_keys = {
@@ -218,6 +251,32 @@ def test_private_teacher_decision_ledgers_cover_seed_without_live_surfaces() -> 
             row["source_inventory"]["key"]
             for row in payload["decisions"]
         )
+
+    assert ledger_keys == inventory_keys
+
+
+def test_private_teacher_rows_59_78_decision_ledger_covers_pending_seed() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_59_78_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+    inventory_keys = {
+        decisions.source_inventory_key(
+            lemma=record.lemma,
+            inventory_path=(
+                "data/lexicon/source-inventory/"
+                "private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml"
+            ),
+            locator=record.source_locator,
+        )
+        for record in records
+    }
+
+    payload = yaml.safe_load(PRIVATE_TEACHER_FOURTH_LEDGER.read_text(encoding="utf-8"))
+    ledger_keys = {
+        row["source_inventory"]["key"]
+        for row in payload["decisions"]
+    }
 
     assert ledger_keys == inventory_keys
 


### PR DESCRIPTION
## Summary
- Add the fourth review-only teacher-lesson source-inventory decision ledger for rows 59-78.
- Approve 21 pending teacher_lesson headwords for a later controlled Atlas publish path.
- Extend private teacher source tests to prove the ledger is review-only and covers the rows 59-78 seed keys.

## Scope
Review-only. This PR does not change live Atlas manifest/search/browse outputs, manifest pointers, Daily Word, Practice, or cloze content.

Dry promotion plan from the current candidate queue:
- 21 matched approved candidates
- 19 proposed Atlas additions
- 2 existing Atlas entries for later provenance overlay: `зв'язок`, `глухий`
- 0 missing candidates

## Validation
- `../../../../.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_review_decisions.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_candidates.py -q`
- `../../../../.venv/bin/ruff check tests/test_private_teacher_lesson_source_inventory.py`
- `../../../../.venv/bin/python -m scripts.audit.source_inventory_review_decisions data/lexicon/source-inventory-review-decisions/2026-07-03-fourth-approved-teacher-lesson-ledger-batch.yaml`
- `git diff --check`
- `node site/scripts/hydrate-manifest.mjs`
- `../../../../.venv/bin/python -m scripts.audit.plan_source_inventory_promotion --candidates /tmp/atlas-source-inventory-review-candidates-4160-fourth-ledger.json --decision-file data/lexicon/source-inventory-review-decisions/2026-07-03-fourth-approved-teacher-lesson-ledger-batch.yaml --manifest site/src/data/lexicon-manifest.json --out /tmp/atlas-source-inventory-promotion-plan-4160-fourth-ledger.json --report-out /tmp/atlas-source-inventory-promotion-plan-4160-fourth-ledger.md --report`
- `../../../../.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Commit hook affected-file pytest: `tests/test_private_teacher_lesson_source_inventory.py` (11 passed)

## Review
- Internal helper review: no blockers.
- Independent AGY/Gemini review: `NO BLOCKERS`.
