### PR TITLE
data(atlas): seed next teacher lesson source rows

### DIFF
--- a/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+++ b/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
@@ -1,0 +1,116 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Private teacher lesson vocabulary - explicit table rows 79-98
+    locator: local-only explicit vocabulary table rows 79-98
+    notes: Derived headword metadata only; raw private lesson material is local-only and not committed. Daily Word, Practice, and cloze remain frozen without explicit surface_admission.
+    headwords:
+      - lemma: безпорадний
+        pos: adjective
+        gloss: helpless
+        locator: explicit vocabulary table row 79
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: обігрівач
+        pos: noun
+        gloss: heater
+        locator: explicit vocabulary table row 80
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: спішити
+        pos: verb
+        gloss: to hurry; imperfective
+        locator: explicit vocabulary table row 81
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: поспішити
+        pos: verb
+        gloss: to hurry; perfective
+        locator: explicit vocabulary table row 82
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вірити
+        pos: verb
+        gloss: to believe; imperfective
+        locator: explicit vocabulary table row 83
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: повірити
+        pos: verb
+        gloss: to believe; perfective
+        locator: explicit vocabulary table row 84
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: висувати ультиматум
+        pos: phrase
+        gloss: to give an ultimatum; imperfective
+        locator: explicit vocabulary table row 85
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: висунути ультиматум
+        pos: phrase
+        gloss: to give an ultimatum; perfective
+        locator: explicit vocabulary table row 85
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: нещасний випадок
+        pos: noun
+        gloss: accident
+        locator: explicit vocabulary table row 86
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: виходити на зв'язок
+        pos: phrase
+        gloss: to get in touch; to make contact
+        locator: explicit vocabulary table row 87
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: як нова копійка
+        pos: phrase
+        gloss: neat; well-dressed; clean
+        locator: explicit vocabulary table row 88
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: збій
+        pos: noun
+        gloss: failure; breakdown; malfunction
+        locator: explicit vocabulary table row 89
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: глюк
+        pos: noun
+        gloss: glitch
+        locator: explicit vocabulary table row 90
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: перевищення швидкості
+        pos: noun
+        gloss: speeding
+        locator: explicit vocabulary table row 91
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: поза
+        pos: preposition
+        gloss: outside; beyond
+        locator: explicit vocabulary table row 92
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: виборча дільниця
+        pos: noun
+        gloss: polling station
+        locator: explicit vocabulary table row 93
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: стверджувати
+        pos: verb
+        gloss: to claim; imperfective
+        locator: explicit vocabulary table row 94
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: ствердити
+        pos: verb
+        gloss: to claim; perfective
+        locator: explicit vocabulary table row 95
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: помічник
+        pos: noun
+        gloss: helper
+        locator: explicit vocabulary table row 96
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: бути в розпачі
+        pos: phrase
+        gloss: to be devastated; to be in despair
+        locator: explicit vocabulary table row 97
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: стукати
+        pos: verb
+        gloss: to knock; imperfective
+        locator: explicit vocabulary table row 98
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -10,9 +10,10 @@ The committed inventory seeds are:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml`
 
-Current committed coverage is 84 reviewed headwords from explicit local
-vocabulary table rows 1-78. The source family is `teacher_lesson`, and the
+Current committed coverage is 105 reviewed headwords from explicit local
+vocabulary table rows 1-98. The source family is `teacher_lesson`, and the
 source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -19,6 +19,7 @@ The committed source inventory input is:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml`
 - `data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml`
 
 The candidate JSON follows the existing grow-candidate shape: `counts`,
@@ -88,7 +89,7 @@ conjunction, particle, and interjection. Optional per-headword `gloss` values
 are curated learner-facing English anchors for cases where dictionary
 enrichment lacks a visible English translation.
 
-The private teacher-lesson seeds contribute 84 reviewed `teacher_lesson`
+The private teacher-lesson seeds contribute 105 reviewed `teacher_lesson`
 headwords from an explicit local vocabulary table. Their committed rows are
 derived metadata only: no raw private lesson material, private document paths,
 or teacher-identifying labels should appear in the inventory.

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -22,6 +22,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )
 

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -22,6 +22,11 @@ PRIVATE_TEACHER_ROWS_59_78_INVENTORY = (
     / "data/lexicon/source-inventory/"
     "private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml"
 )
+PRIVATE_TEACHER_ROWS_79_98_INVENTORY = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory/"
+    "private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml"
+)
 PRIVATE_TEACHER_FIRST_LEDGER = (
     PROJECT_ROOT
     / "data/lexicon/source-inventory-review-decisions/"
@@ -130,6 +135,38 @@ def test_private_teacher_rows_59_78_inventory_is_pending_review_metadata() -> No
     assert all("(" not in record.lemma and ")" not in record.lemma for record in records)
 
     inventory_text = PRIVATE_TEACHER_ROWS_59_78_INVENTORY.read_text(encoding="utf-8")
+    assert ".docx" not in inventory_text
+
+
+def test_private_teacher_rows_79_98_inventory_is_pending_review_metadata() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_79_98_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+
+    assert len(records) == 21
+    assert {record.source_family for record in records} == {"teacher_lesson"}
+    assert {record.extraction_mode for record in records} == {"curated_headword"}
+    assert {record.source_id for record in records} == {
+        "private-teacher-lesson-vocabulary-table-1-rows-79-98"
+    }
+    assert all(record.source_path is None for record in records)
+    assert all(record.source_url is None for record in records)
+    assert all(record.source_title for record in records)
+    assert all(record.source_locator for record in records)
+    assert all(record.context for record in records)
+    assert all(record.pos for record in records)
+    assert all(record.gloss for record in records)
+    assert "безпорадний" in {record.lemma for record in records}
+    assert "висувати ультиматум" in {record.lemma for record in records}
+    assert "висунути ультиматум" in {record.lemma for record in records}
+    assert "стукати" in {record.lemma for record in records}
+    assert all("," not in record.lemma for record in records)
+    assert all("/" not in record.lemma for record in records)
+    assert all("(" not in record.lemma and ")" not in record.lemma for record in records)
+    assert all("surface_admission" not in record.provenance_payload() for record in records)
+
+    inventory_text = PRIVATE_TEACHER_ROWS_79_98_INVENTORY.read_text(encoding="utf-8")
     assert ".docx" not in inventory_text
 
 


### PR DESCRIPTION
## Summary

- Add the next privacy-safe private teacher-lesson source-inventory seed: explicit local vocabulary table rows 79-98.
- Add 21 neutral derived headword metadata rows under `teacher_lesson`; row 85 is split into imperfective/perfective phrase headwords.
- Update the committed source-inventory list, focused tests, and runbook counts from 84 to 105 teacher-lesson headwords.
- Keep this PR review-only: no live Atlas manifest/search/browse/pointer/fingerprint changes, no Daily Word, no Practice, and no Cloze changes.

## New Seed

- File: `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml`
- Source rows: 79-98
- Headwords: 21
- Candidate generator classification for this new seed: 10 auto-merge candidates, 11 needs publish review
- `surface_admission`: absent by design

## Validation

- `.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_review_candidates.py -q` (39 passed)
- `.venv/bin/python -m scripts.audit.source_inventory_review_decisions`
- `.venv/bin/python -m scripts.audit.generate_source_inventory_review_candidates --out /tmp/atlas-source-inventory-review-candidates-4160-next-seed.json --report`
- `.venv/bin/ruff check scripts/audit/generate_source_inventory_review_candidates.py tests/test_private_teacher_lesson_source_inventory.py`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Reviews

- Low-cost helper review: no blockers.
- Independent AGY/Gemini review: no blockers; privacy boundary and review-only scope confirmed.

Refs #4160
