### PR TITLE
docs(bio): add serhii yefremov dossier

### DIFF
--- a/docs/research/bio/serhii-yefremov.md
+++ b/docs/research/bio/serhii-yefremov.md
@@ -1,0 +1,187 @@
+# Сергій Олександрович Єфремов - Research Dossier
+
+**Slug:** `serhii-yefremov`
+**Block:** +77 backfill - literary criticism / Central Rada / Ukrainian Academy of Sciences / SVU show-trial repression
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #326
+**Researcher:** Codex orchestrator (GPT-5)
+**Completed:** 2026-07-03
+
+**Source acronym legend:** EIU = Encyclopedia History Ukraine / Institute History of Ukraine, NASU; ESU = Encyclopedia Modern Ukraine / NASU; IEU = Internet Encyclopedia Ukraine / Canadian Institute of Ukrainian Studies; UINP = Ukrainian Institute National Memory; NBUV = Vernadsky National Library of Ukraine; KNU = Taras Shevchenko National University of Kyiv; BIO / HIST / ISTORIO / LIT / wiki = existing learn-ukrainian track materials; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, scholarly, primary-text, and image-rights sources cited
+- [x] Pressure mechanism framed imperial censorship, name Russification metadata, Central Rada state-building, VUAN administrative pressure, the fabricated SVU process, prison death, and post-Soviet rehabilitation
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-03 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric periodization: frame is Ukrainian public culture, Ukrainian political organization, Central Rada state-building, VUAN institution-building, and Soviet anti-Ukrainian repression, not generic "Russian liberalism."
+- [x] Ukrainian agency preserved: Yefremov is treated as a literary historian, publisher, journalist, Central Rada official, party organizer, academic administrator, and witness of Ukrainian Revolution-era politics.
+- [x] Imperial pressure named: the `Yefremov / Efremov` name trail, imperial censorship of Ukrainian-language print, tsarist arrests, and later Soviet prosecution are treated as pressure mechanisms, not neutral biographical color.
+- [x] SVU show trial decolonized: `Спілка визволення України` in 1929-1930 is identified as a fabricated case / show trial, not as a proven underground organization.
+- [x] `СВУ` abbreviation disambiguated: do not confuse the 1930 `Спілка визволення України` case with the 1914 `Союз визволення України` wartime organization.
+- [x] Anti-hagiography included: Yefremov's narodnyk / neopopulist literary method, anti-modernist judgments, political factionalism, and source conflicts are kept visible.
+
+## 1. Identity / chronology
+
+- **Canonical UA:** `Сергій Олександрович Єфремов`.
+- **Canonical EN:** `Serhii Yefremov`.
+- **Core identity:** Ukrainian literary critic, historian of literature, publicist, publisher, public and political figure, Central Rada deputy head, first General Secretariat official for interethnic / nationalities affairs, Ukrainian Party of Socialists-Federalists leader, academician and vice-president of VUAN, and chief defendant in the fabricated 1930 SVU show trial.
+- **Birth:** EIU gives 6 October 1876 old style; ESU and IEU give 6 / 18 October 1876, Palchyk, Zvenyhorodka county, Kyiv gubernia, now Cherkasy region. Use `18 October 1876, Palchyk` in learner copy when exact new-style dating is needed.
+- **Death:** ESU and IEU give 31 March 1939 in Vladimir / Vladimir prison; EIU gives the same date but says he died in Yaroslavl prison. Commons creator metadata also exposes date / place drift. Use `1876-1939` or source-labeled exact death metadata in low-context copy.
+- **Family / name trail:** ESU identifies him as brother of Petro and Fedir Yefremov; NBUV lists `Охріменко Сергій Олександрович` as a variant. KNU states `Охріменко` was the original surname. Treat `Охріменко` as a meaningful de-Russification / search alias, but source-label any causal claim about why the family name changed.
+- **Education:** EIU / ESU say he studied at Kyiv Theological Seminary in 1891-1896 and graduated from the law faculty of Kyiv University / University of St Volodymyr in 1901.
+- **Publishing and journalism:** EIU / ESU identify him as one of the founders / leaders of `Вік` publishing house, active in `Киевская старина`, `Громадська думка`, `Рада`, `Нова рада`, `Літературно-науковий вістник`, `Україна`, and other journals / newspapers.
+- **Political organization before 1917:** EIU places him in the General Ukrainian Non-Party Democratic Organization from 1897, the Ukrainian Democratic Party and Ukrainian Radical Party cluster in 1904-1905, the Ukrainian Democratic-Radical Party, and the Society of Ukrainian Progressives from 1908.
+- **1917 Central Rada:** EIU / ESU / IEU identify him as one of the initiators of the Ukrainian Central Rada, deputy head of the UCR, member of the Little Rada, and General Secretariat official for interethnic / nationalities affairs in the first Ukrainian government. IEU renders the office as "international affairs"; keep the Ukrainian office wording visible.
+- **UPSF:** EIU and ESU say he headed the Ukrainian Party of Socialists-Federalists, the successor / transformation path of the TUP milieu, in 1917.
+- **1919-1928 Academy work:** EIU says he worked in UAN in 1919, was amnestied in 1921 at VUAN's request, became vice-president of VUAN in 1922-1928, and effectively handled much of the Academy's daily administration. ESU also identifies him as secretary of the historical-philological department.
+- **1929-1930 repression:** ESU says he was arrested 21 July 1929 and in 1930 sentenced to execution, later commuted to 10 years; EIU says he was sentenced in April 1930 in the SVU case to 10 years imprisonment. Use source-labeled chronology when sentence details matter.
+- **1989 rehabilitation:** UINP states that participants in the so-called SVU case were rehabilitated on 11 August 1989 because the court found no corpus delicti.
+
+## 2. Political pressure mechanism
+
+- **Imperial print constraint:** Yefremov's career began in a system where Ukrainian print, education, and public organization were restricted or policed. His defense of Ukrainian-language writing and journalism belongs to the same civic infrastructure as `Вік`, `Громадська думка`, `Рада`, and the wider press network around Yevhen Chykalenko.
+- **Name and catalog pressure:** `Єфремов`, `Efremov`, and `Охріменко` should be handled as a pressure-sensitive name trail. The learner-facing label stays `Serhii Yefremov`, while `Ohrimenko / Okhrimenko` and Russified forms are search metadata.
+- **Tsarist policing:** ESU notes arrests by tsarist gendarmerie for publicistic and political activity. This gives a concrete bridge between literary criticism and political repression before 1917.
+- **Party organization under empire:** His path through UDP / URP / UDRP / TUP / UPSF shows the moderate federalist-autonomist strand of Ukrainian politics, not a single stable party label from youth to 1930.
+- **Nationalities office in 1917:** As General Secretary for interethnic / nationalities affairs, he worked at the point where Ukrainian state-building had to address non-Ukrainian communities, empire-wide legal uncertainty, and the Provisional Government. Do not flatten this into a modern foreign-minister title without explanation.
+- **Academy as fragile sovereignty infrastructure:** In the 1920s, VUAN was not only a research body; it was an institutional shelter for Ukrainian-language scholarship, bibliography, historical-philological work, terminology, and cultural memory. That made its administrators visible targets.
+- **Soviet administrative strangulation:** EIU says he was pushed out of Academy posts in 1928 after sustained party pressure. This is the prelude to the criminal case, not a separate scholarly dispute.
+- **SVU as staged decapitation:** EIU's SVU article defines the 1929-1930 `Спілка визволення України` as a mythical counterrevolutionary organization alleged by Soviet authorities. It documents the 9 March-19 April 1930 show trial, the role assigned to Yefremov, and the use of testimonies to construct the case.
+- **Repression scale:** UINP describes the SVU process as a fabricated case against leading Ukrainian scientific, cultural, and church intelligentsia; EIU notes 45 main defendants and broader arrests / exile waves. Use this to teach mechanism, not melodrama.
+- **Rehabilitation as evidence, not repair:** The 1989 rehabilitation confirms the criminal accusations lacked legal substance, but it did not restore the destroyed lives, lost institutions, or suppressed scholarship.
+
+## 3. Major events / historical footprint
+
+- **1895-1918 `Вік` publishing house:** EIU / ESU identify Yefremov as a founder / leader. The publishing house and its anthology work make him useful for lessons on how a canon is built materially through editing, selection, print runs, and distribution.
+- **1904-1905 party formation:** With Borys Hrinchenko and Fedir Matushevskyi, he participated in the Ukrainian Democratic / Radical / Democratic-Radical party cluster. This anchors moderate Ukrainian liberal-federalist politics in the late imperial period.
+- **1901-1910s literary publicist:** His work in Ukrainian and Russian-language periodicals introduced Ukrainian literature to broader readers while defending Ukrainian public speech under censorship.
+- **1911 `Історія українського письменства`:** ESU identifies this as the fullest statement of his historical-literary method. It is the central title anchor for BIO, LIT, and LIT-ESSAY integration.
+- **Monographs on nineteenth-century writers:** ESU lists major works on Marko Vovchok, Taras Shevchenko, Ivan Franko, Mykhailo Kotsiubynskyi, Ivan Nechui-Levytskyi, Karpenko-Karyi, and Panas Myrnyi. Use this to show how a critic can define a school curriculum before official curriculum does.
+- **1917 Central Rada office:** His deputy-chair and General Secretariat roles place him near Hrushevskyi, Vynnychenko, Petliura, Lototskyi, Steshenko, Martos, and Shulhyn in the first-government cluster.
+- **`Нова рада` during 1917-1919:** EIU says more than 900 of his pieces appeared there in those years. This is a strong source for daily political language, not merely biography.
+- **1919-1928 UAN / VUAN administration:** His academy work included historical-philological administration, publication of classics, bibliography, and daily institutional governance. Pair with Ahatanhel Krymskyi, Volodymyr Vernadskyi, Mykola Vasylenko, and Liudmyla Starytska-Cherniakhivska.
+- **1927-1929 editions and diaries:** ESU mentions editing Shevchenko's diary / correspondence and other classic editions; IEU and scholarship foreground his diaries as a major witness to Sovietization of Ukrainian culture.
+- **1929-1930 SVU case:** Arrest, staged trial, death sentence commuted to imprisonment, and prison death form the repression arc. Do not make the fabricated charge the identity label.
+- **1989 rehabilitation:** UINP and EIU place rehabilitation in August 1989, useful for lessons on late-Soviet memory, legal language, and posthumous justice.
+
+## 4. Pedagogical anchors
+
+- **Canon-building as action:** Yefremov lets learners see a canon as edited, argued, printed, defended, and contested, not simply inherited.
+- **Critic versus creator:** He is not primarily a poet or novelist; his power came through publicism, literary history, publishing, editing, and institutional administration.
+- **Central Rada language:** His office supports vocabulary for `заступник голови`, `Мала Рада`, `Генеральний секретаріат`, `міжнаціональні справи`, `делегація`, `автономія`, and `федералізм`.
+- **LIT-ESSAY bridge:** Existing `yefremov-literary-criticism` materials frame him as an architect of the Ukrainian canon and a target for later critique by aesthetic / formalist approaches. BIO can supply the life-and-pressure spine behind that seminar.
+- **Anti-modernist debate:** His narodnyk / neopopulist criteria make him a strong comparison point for Kobylianska, Lesia Ukrainka, Kotsiubynskyi, Khvylovyi, Semenko, Zerov, Chyzhevskyi, and Hrabovych.
+- **Show-trial literacy:** The SVU case lets learners distinguish indictment language, forced testimony, propaganda spectacle, rehabilitation, and historical evidence.
+- **Abbreviation trap:** `СВУ` can mean the 1914 `Союз визволення України` or the 1930 `Спілка визволення України` case. The dossier should train students to expand acronyms before interpreting them.
+- **Map anchor:** Palchyk, Kyiv, St Petersburg / imperial print networks, Kharkiv Opera House, Yaroslavl prison, Vladimir prison, and post-1989 Kyiv memory sites.
+- **Textbook echo:** Local history and language textbooks mention Yefremov as Central Rada deputy head, publicist, literary scholar, and SVU defendant; use textbooks as curricular echo, not as final authority.
+
+## 5. Language register
+
+- **Register:** high literary-critical, publicistic, party-political, Central Rada administrative, Academy / bibliography, legal-repressive, and memory-politics language.
+- **CEFR readiness:** B1 short biography / map; B2 Central Rada and Academy vocabulary; C1 literary-canon debate; C1/C2 SVU source criticism, diary excerpts, and historiographic comparison.
+- **Core vocabulary:** `Сергій Єфремов`, `літературний критик`, `історик літератури`, `публіцист`, `видавництво`, `канон`, `народництво`, `неонародництво`, `позитивізм`, `письменство`, `громадське служіння`, `Українська Центральна Рада`, `Мала Рада`, `Генеральний секретаріат`, `міжнаціональні справи`, `Українська партія соціалістів-федералістів`, `Всеукраїнська академія наук`, `віце-президент ВУАН`, `показовий процес`, `сфабрикована справа`, `вирок`, `ув'язнення`, `реабілітація`.
+- **Office-title caution:** Use `генеральний секретар міжнаціональних справ` / `General Secretary for interethnic or nationalities affairs`. If using `international affairs`, source-label it as IEU's rendering; if using `foreign minister`, mark it as a learner gloss, not a title.
+- **Death metadata caution:** Use `1876-1939` unless the exact place / date is source-labeled, because EIU, ESU, IEU, NBUV, and Commons metadata do not fully align.
+- **Name caution:** `Охріменко`, `Okhrimenko`, `Ohrimenko`, `Yefremov`, `Iefremov`, `Jefremov`, `Efremov` belong in search / metadata. Learner display should not switch to Russified `Sergey Efremov`.
+- **SVU caution:** Write `сфабрикована справа "Спілки визволення України"`, not `член СВУ`, unless quoting or analyzing indictment language.
+
+## 6. Risks / open questions
+
+- **Death place conflict:** ESU and IEU say Vladimir / Vladimir prison; EIU's article says he died in Yaroslavl prison; Commons creator metadata currently shows Yaroslavl and also date drift. Low-context copy should not assert a single prison without source label.
+- **Death date drift:** Major encyclopedia entries used here converge on 31 March 1939, but Commons / Wikidata-derived surfaces expose 10 March / 31 March drift. Avoid exact-date quizzes unless the source is named.
+- **Office translation drift:** `міжнаціональних справ` can be mistranslated as generic international or foreign affairs. Preserve the Ukrainian title and explain the 1917 context of nationalities policy.
+- **`Father of UNR` / first-use claim:** KNU says he first used the name `Українська Народна Республіка`; this is a useful hook but should remain source-labeled and not become a headline claim without primary verification.
+- **Original surname causality:** NBUV and KNU support `Охріменко` as a variant / original surname trail. The stronger explanation that church administration pressured the name change needs a direct source before production copy treats it as settled.
+- **Literary method overcorrection:** Do not rehabilitate him by erasing his limits. His critique of modernists and preference for public-service criteria are pedagogically useful precisely because later scholars disputed them.
+- **SVU indictment language:** Avoid saying he "headed SVU" as fact. Use `Soviet authorities alleged / cast him as head` or `chief defendant in the fabricated SVU process`.
+- **Antisemitism / national worldview:** Tarnawsky's essay notes both national-centered thinking and passages critical of antisemitism. If diary excerpts are used, handle ethnic jokes / polemics with source criticism, not sanitization or sensationalism.
+- **Textbook OCR errors:** Local textbook extracts contain OCR noise and one line says he died in 1938. Do not use textbook OCR for exact biographical metadata.
+- **Image-rights drift:** Some Commons files are cleanly labeled public domain; others lack full US public-domain tags or have weak source chains. Production should choose file-level metadata, not the general existence of a portrait.
+
+## 7. Cross-track links
+
+- **Existing BIO dossier anchors (VERIFIED `test -e` / `rg` 2026-07-03):** `site/src/content/docs/bio/index.mdx` lists BIO #326 `serhii-yefremov`; `docs/research/bio/mykhailo-hrushevskyi.md` and `docs/research/bio/volodymyr-vynnychenko.md` support Central Rada leadership; `docs/research/bio/oleksandr-lototskyi.md`, `docs/research/bio/borys-hrinchenko.md`, and `docs/research/bio/dmytro-dontsov.md` support pre-1917 party / publicist comparisons; `docs/research/bio/ahatanhel-krymskyi.md`, `docs/research/bio/volodymyr-vernadskyi.md`, and `docs/research/bio/mykola-vasylenko.md` support UAN / VUAN institution-building; `docs/research/bio/liudmyla-starytska.md` supports the SVU show-trial victim cluster; `docs/research/bio/mykola-zerov.md` supports literary-method debate and later repression.
+- **Existing LIT / LIT-ESSAY surfaces (VERIFIED `test -e` / `rg` 2026-07-03):** `curriculum/l2-uk-en/plans/lit-essay/yefremov-literary-criticism.yaml`, `curriculum/l2-uk-en/lit-essay/discovery/yefremov-literary-criticism.yaml`, `site/src/content/docs/lit-essay/index.mdx`, `wiki/literature/works/yefremov-literary-criticism.md`, and `wiki/literature/works/yefremov-literary-criticism.sources.yaml`.
+- **Existing literature plan echo (VERIFIED `rg` 2026-07-03):** Yefremov appears as critic / source in plans for Hlibov, Kotliarevskyi, Nechui-Levytskyi, Franko, Lesia Ukrainka, Kotsiubynskyi, Stefanyk, Oles, Tychyna, Starytskyi, and others. Use selective links later rather than dumping every occurrence into BIO learner copy.
+- **Existing HIST / ISTORIO repression surfaces (VERIFIED `rg` 2026-07-03):** `curriculum/l2-uk-en/plans/istorio/rozstriliane-kontekst.yaml`, `curriculum/l2-uk-en/plans/istorio/mekhanizm-znyshchennia.yaml`, `curriculum/l2-uk-en/plans/hist/syntez-trahedii.yaml`, and BIO plans for `liudmyla-starytska`, `valentyna-radzymovska`, `mykola-vasylenko`, `mykola-zerov`, and `oleksa-slisarenko` all carry SVU / repression context.
+- **Existing wiki / period surfaces (VERIFIED `rg` 2026-07-03):** `wiki/periods/destalinizatsiia.md`, `wiki/periods/drahomanov.md`, `wiki/periods/franko-lesia-hrinchenko.md`, `wiki/historiography/1918-1920-viina-i-soiuz.md`, and `wiki/literature/works/chyzhevsky-baroque-history.md` contain usable Yefremov-adjacent discussion.
+- **Textbook echo (VERIFIED `rg` / `sed` 2026-07-03):** `docs/references/textbooks-txt/10-klas-history.txt` mentions Yefremov as Central Rada deputy head / nationalities secretary and as fabricated SVU defendant; `docs/references/textbooks-txt/11-klas-ukrajinska-mova-voron-2019.txt` mentions him as publicist and political thinker; `docs/references/textbooks-txt/9-klas-history.txt` places him in the URP / UDRP party cluster.
+- **Candidate / absent BIO #326 surfaces (VERIFIED absent `test -e` 2026-07-03):** `curriculum/l2-uk-en/plans/bio/serhii-yefremov.yaml`, `curriculum/l2-uk-en/bio/discovery/serhii-yefremov.yaml`, `wiki/figures/serhii-yefremov.md`, `site/src/content/docs/bio/serhii-yefremov.mdx`, `curriculum/l2-uk-en/bio/serhii-yefremov/module.md`, `curriculum/l2-uk-en/bio/serhii-yefremov/activities.yaml`, `curriculum/l2-uk-en/bio/serhii-yefremov/vocabulary.yaml`, `curriculum/l2-uk-en/bio/serhii-yefremov/resources.yaml`.
+
+## 8. Name variants / search aliases
+
+- **Canonical UA:** `Сергій Олександрович Єфремов`.
+- **Original / variant UA trail:** `Охріменко Сергій Олександрович`; `Сергій Охріменко`.
+- **Canonical EN:** `Serhii Yefremov`.
+- **Common EN / transliteration forms:** `Serhiy Yefremov`, `Sergiy Yefremov`, `Serhii Oleksandrovych Yefremov`, `Serhiy Oleksandrovych Yefremov`, `Iefremov`, `Jefremov`.
+- **Russified / imperial-search forms:** `Sergey Efremov`, `Sergei Efremov`, `Sergey Aleksandrovich Efremov`, `Сергей Александрович Ефремов`, `Сергей Ефремов`. Keep these for source discovery only, not learner display.
+- **Pseudonyms / cryptonyms surfaced by ESU / EIU:** `С. Є.`, `Ромул`, `Spectator`, `С. Охріменко`, `С. Ярошенко`, `Р. Дніпровенко`, `С. Ситковецький`, `Липовчанин`, `Земець`, `С. Александрович`, `Киянин`, `Волосар` / `Волосожар`, `Гр. Лановий`, `П. Устяк`.
+- **Institution / office aliases:** `Central Rada deputy head`, `Little Rada`, `General Secretariat`, `General Secretary of Nationalities Affairs`, `General Secretary of interethnic affairs`, `Ukrainian Party of Socialists-Federalists`, `VUAN vice-president`, `SVU trial`, `Union for the Liberation of Ukraine show trial`.
+- **Learner-facing display:** `Serhii Yefremov (Сергій Єфремов, 1876-1939)`.
+
+## 9. Image rights / visual material notes
+
+- **Primary portrait candidate:** Commons `File:Serhiy Yefremov.jpg`; 1900 or slightly earlier portrait by Franciszek de Mezer, source chain to Lviv museum digital object, author died 1922, Commons public-domain marking. Strong candidate if production accepts Commons file metadata and caption preserves the autograph-to-Konyskyi context.
+- **Alternate portrait candidate:** Commons / Ukrainian Wikipedia `File:Yefremov-Serhiy.jpg`; source listed as `Єфремов Сергій. Щоденники, 1923-1929`, Kyiv 1997; unknown author and public-domain marking. Useful but weaker source chain than the de Mezer portrait.
+- **Lower-resolution fallback:** Commons `File:Єфремов С2.jpg`; source to a Prosvita library image with unknown author and Ukrainian public-domain tag. Use only after checking whether the US public-domain condition is adequately satisfied.
+- **SVU context image:** UINP uses / cites a courtroom image of defendants in the SVU process; Commons / archive rights need file-level verification before production. It is a strong context image but should not replace the individual portrait.
+- **IEU images:** IEU displays Yefremov portraits and first General Secretariat group images, but the picture page carries CIUS copyright text. Treat IEU images as reference / identification unless rights are separately cleared.
+- **Primary-text visual candidates:** Title pages / scans of `Історія українського письменства`, `Щоденники 1923-1929`, and `Вік` anthology materials can support LIT-ESSAY and source-study lessons. Check scan license and edition date separately.
+- **Avoid default:** modern blog portraits without provenance, AI-restored images, screenshots from videos, and courtroom images with only a secondary news credit.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- "Єфремов Сергій Олександрович." Енциклопедія історії України, Інститут історії України НАН України. https://history.org.ua/?termin=Efremov_S_O. Accessed 2026-07-03.
+- "Єфремов Сергій Олександрович." Енциклопедія Сучасної України, НАН України / НТШ. https://esu.com.ua/article-20235. Accessed 2026-07-03.
+- "Yefremov, Serhii." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CY%5CE%5CYefremovSerhii.htm. Accessed 2026-07-03.
+- "Спілка визволення України (СВУ)." Енциклопедія історії України / Інститут історії України НАН України. https://history.org.ua/?termin=Spilka_vyzvolennia. Accessed 2026-07-03.
+- UINP, "1989 - реабілітовано учасників так званої Спілки визволення України." https://uinp.gov.ua/istorychnyy-kalendar/serpen/11/1989-reabilitovano-uchasnykiv-tak-zvanoyi-spilky-vyzvolennya-ukrayiny. Accessed 2026-07-03.
+- NBUV, "Єфремов Сергій Олександрович." https://irbis-nbuv.gov.ua/ulib/item/REF0002483. Accessed 2026-07-03.
+- KNU, "Єфремов Сергій Олександрович (1876-1939)." https://knu.ua/ua/geninf/osobystosti/efremov/. Accessed 2026-07-03.
+
+**Tier 2 / 3 (scholarly, biographical, and primary-text references):**
+
+- Tarnawsky, Maxim. "Serhii Yefremov: Epitome of the Ukrainian Revolution." Kyiv-Mohyla Humanities Journal 4 (2017): 1-10. https://philarchive.org/archive/TARSYE. Accessed 2026-07-03.
+- Yefremov, Serhii. `Історія українського письменства` (primary title anchor; editions listed by ESU / IEU and local LIT-ESSAY plan).
+- Yefremov, Serhii. `Щоденники, 1923-1929` (primary diary anchor; EIU / NBUV / local source pack identify it as a core witness text).
+- `docs/references/textbooks-txt/10-klas-history.txt`, `11-klas-ukrajinska-mova-voron-2019.txt`, and `9-klas-history.txt`, local textbook extractions mentioning Yefremov, Central Rada, publicism, party organization, and the SVU process. Checked 2026-07-03.
+
+**Tier 4 (learn-ukrainian cross-track sources checked 2026-07-03):**
+
+- `site/src/content/docs/bio/index.mdx`
+- `curriculum/l2-uk-en/plans/lit-essay/yefremov-literary-criticism.yaml`
+- `curriculum/l2-uk-en/lit-essay/discovery/yefremov-literary-criticism.yaml`
+- `wiki/literature/works/yefremov-literary-criticism.md`
+- `wiki/literature/works/yefremov-literary-criticism.sources.yaml`
+- `docs/research/bio/mykhailo-hrushevskyi.md`
+- `docs/research/bio/volodymyr-vynnychenko.md`
+- `docs/research/bio/oleksandr-lototskyi.md`
+- `docs/research/bio/borys-hrinchenko.md`
+- `docs/research/bio/dmytro-dontsov.md`
+- `docs/research/bio/ahatanhel-krymskyi.md`
+- `docs/research/bio/volodymyr-vernadskyi.md`
+- `docs/research/bio/mykola-vasylenko.md`
+- `docs/research/bio/liudmyla-starytska.md`
+- `docs/research/bio/mykola-zerov.md`
+- `curriculum/l2-uk-en/plans/istorio/rozstriliane-kontekst.yaml`
+- `curriculum/l2-uk-en/plans/istorio/mekhanizm-znyshchennia.yaml`
+- `curriculum/l2-uk-en/plans/hist/syntez-trahedii.yaml`
+
+**Tier 5 (image-rights / media-rights sources):**
+
+- Commons `File:Serhiy Yefremov.jpg`. https://commons.wikimedia.org/wiki/File:Serhiy_Yefremov.jpg. Accessed 2026-07-03.
+- Commons `File:Єфремов С2.jpg`. https://commons.wikimedia.org/wiki/File:%D0%84%D1%84%D1%80%D0%B5%D0%BC%D0%BE%D0%B2_%D0%A12.jpg. Accessed 2026-07-03.
+- Ukrainian Wikipedia / Commons file metadata, `File:Yefremov-Serhiy.jpg`. https://uk.wikipedia.org/wiki/%D0%A4%D0%B0%D0%B9%D0%BB:Yefremov-Serhiy.jpg. Accessed 2026-07-03.
+- Commons `Creator:Serhiy Yefremov`. https://commons.wikimedia.org/wiki/Creator:Serhiy_Yefremov. Accessed 2026-07-03.


### PR DESCRIPTION
## Summary
- Add BIO #326 research dossier for Serhii Yefremov.
- Frame Central Rada, VUAN, literary-canon work, and the fabricated SVU show-trial repression arc.
- Preserve source conflicts around death place/date and office-title translation.

## Fleet / helper lanes
- AGY read-only source pack: bio-326-serhii-yefremov-source-pack.
- Codex read-only path/media helper: bio-326-serhii-yefremov-path-media.
- Hermes adversarial bridge attempted, but no retrievable review text was produced; not counted as a gate.

## Validation
- npx markdownlint-cli2 docs/research/bio/serhii-yefremov.md
- .venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/serhii-yefremov.md
- git diff --check
- .venv/bin/python scripts/audit/lint_agent_trailer.py

## Scope
- Dossier-only PR: docs/research/bio/serhii-yefremov.md