### PR TITLE
Add fifth teacher lesson source approval ledger

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-03-fifth-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-03-fifth-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,310 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-fifth-approved-teacher-lesson-ledger-batch-2026-07-03
+batch_label: fifth-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-03'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4180
+  total_queue_rows: 142
+  approved_in_queue: 21
+  promotion_batch_size: 21
+production_outputs_updated: []
+decisions:
+- lemma: безпорадний
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: helpless
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 345ce21a2b8f7e70
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 79
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: обігрівач
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: heater
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 7f00041cd5f6701d
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 80
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: спішити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to hurry; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 7aae9b93934280c6
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 81
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: поспішити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to hurry; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: cc432cc849c9f6b5
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 82
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: вірити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to believe; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 174dd6a15a971c4b
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 83
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: повірити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to believe; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: fc315f33fc4efc14
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 84
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: висувати ультиматум
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: to give an ultimatum; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 6b4ce4a275982393
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 85
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: висунути ультиматум
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: to give an ultimatum; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 467034c364bd5767
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 85
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: нещасний випадок
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: accident
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: e0d2a35da4d16218
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 86
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: виходити на зв'язок
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: to get in touch; to make contact
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 030097c92a758806
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 87
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: як нова копійка
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: neat; well-dressed; clean
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 1849572fcc2153f9
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 88
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: збій
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: failure; breakdown; malfunction
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: b777363feeab9d74
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 89
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: глюк
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: glitch
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 83ff662c9af3f402
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 90
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags calque_warning; heritage_status flags russian_shadow
+- lemma: перевищення швидкості
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: speeding
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 0a5f96038ced9ca1
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 91
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: поза
+  decision: approve_for_publish
+  approved_pos: preposition
+  approved_gloss: outside; beyond
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: cbb547e2818d6ceb
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 92
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: виборча дільниця
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: polling station
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 49b968360477d9e4
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 93
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: стверджувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to claim; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 36199efb7e4cda3b
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 94
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: ствердити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to claim; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 777280f540bc0abd
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 95
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: помічник
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: helper
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: b7931a6b3e4fc255
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 96
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: бути в розпачі
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: to be devastated; to be in despair
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 1ddbf8c1ae88d6d5
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 97
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: стукати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to knock; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 162742c589371663
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml
+    locator: explicit vocabulary table row 98
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-79-98
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -18,6 +18,10 @@ source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.
 
+Current approval-ledger coverage is 105 reviewed headwords from rows 1-98.
+Live Atlas browse/search coverage still depends on a later controlled publish
+PR. Missing `surface_admission` keeps Daily Word, Practice, and cloze frozen.
+
 ## Source Handling Rule
 
 Use the ignored local lesson material only as private evidence for deriving

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -90,9 +90,10 @@ are curated learner-facing English anchors for cases where dictionary
 enrichment lacks a visible English translation.
 
 The private teacher-lesson seeds contribute 105 reviewed `teacher_lesson`
-headwords from an explicit local vocabulary table. Their committed rows are
-derived metadata only: no raw private lesson material, private document paths,
-or teacher-identifying labels should appear in the inventory.
+headwords from an explicit local vocabulary table, with approval ledgers now
+covering rows 1-98. Their committed rows are derived metadata only: no raw
+private lesson material, private document paths, or teacher-identifying labels
+should appear in the inventory.
 
 When a candidate is later promoted into a manifest entry,
 `promote_grow_candidates.manifest_entry_from_candidate()` copies

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -47,6 +47,11 @@ PRIVATE_TEACHER_FOURTH_LEDGER = (
     / "data/lexicon/source-inventory-review-decisions/"
     "2026-07-03-fourth-approved-teacher-lesson-ledger-batch.yaml"
 )
+PRIVATE_TEACHER_FIFTH_LEDGER = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory-review-decisions/"
+    "2026-07-03-fifth-approved-teacher-lesson-ledger-batch.yaml"
+)
 
 
 def test_private_teacher_inventory_is_privacy_safe_review_metadata() -> None:
@@ -270,6 +275,34 @@ def test_private_teacher_fourth_decision_ledger_stays_review_only() -> None:
     assert ".docx" not in ledger_text
 
 
+def test_private_teacher_fifth_decision_ledger_stays_review_only() -> None:
+    summary = decisions.validate_committed_decision_files([PRIVATE_TEACHER_FIFTH_LEDGER])
+    payload = yaml.safe_load(PRIVATE_TEACHER_FIFTH_LEDGER.read_text(encoding="utf-8"))
+
+    assert summary == {
+        "files": 1,
+        "rows": 21,
+        "decision_counts": {"approve_for_publish": 21},
+    }
+    assert payload["source_queue"]["generated_from_pr"] == 4180
+    assert payload["source_queue"]["promotion_batch_size"] == 21
+    assert payload["production_outputs_updated"] == []
+    assert payload["decisions"][0]["lemma"] == "безпорадний"
+    assert payload["decisions"][-1]["lemma"] == "стукати"
+    assert all(
+        row["source_inventory"]["source_family"] == "teacher_lesson"
+        for row in payload["decisions"]
+    )
+    assert {
+        row["source_inventory"]["source_id"]
+        for row in payload["decisions"]
+    } == {"private-teacher-lesson-vocabulary-table-1-rows-79-98"}
+    assert all("surface_admission" not in row for row in payload["decisions"])
+
+    ledger_text = PRIVATE_TEACHER_FIFTH_LEDGER.read_text(encoding="utf-8")
+    assert ".docx" not in ledger_text
+
+
 def test_private_teacher_decision_ledgers_cover_seed_without_live_surfaces() -> None:
     records = read_source_inventory(PRIVATE_TEACHER_INVENTORY, project_root=PROJECT_ROOT)
     inventory_keys = {
@@ -336,6 +369,32 @@ def test_private_teacher_rows_39_58_decision_ledger_covers_pending_seed() -> Non
     }
 
     payload = yaml.safe_load(PRIVATE_TEACHER_THIRD_LEDGER.read_text(encoding="utf-8"))
+    ledger_keys = {
+        row["source_inventory"]["key"]
+        for row in payload["decisions"]
+    }
+
+    assert ledger_keys == inventory_keys
+
+
+def test_private_teacher_rows_79_98_decision_ledger_covers_pending_seed() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_79_98_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+    inventory_keys = {
+        decisions.source_inventory_key(
+            lemma=record.lemma,
+            inventory_path=(
+                "data/lexicon/source-inventory/"
+                "private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml"
+            ),
+            locator=record.source_locator,
+        )
+        for record in records
+    }
+
+    payload = yaml.safe_load(PRIVATE_TEACHER_FIFTH_LEDGER.read_text(encoding="utf-8"))
     ledger_keys = {
         row["source_inventory"]["key"]
         for row in payload["decisions"]


### PR DESCRIPTION
## Summary

- adds the fifth review-only `teacher_lesson` approval ledger for rows 79-98
- approves 21 committed private teacher-lesson source-inventory headwords for later Atlas publish planning
- updates tests/runbooks so rows 1-98 are covered by approval ledgers

## Boundaries

- no live Atlas manifest/search/browse output changes
- no manifest pointer or fingerprint changes
- no Daily Word, Practice, or cloze changes
- no `surface_admission` decisions
- no raw private lesson material, private file paths, or teacher-identifying labels

## Validation

- `../../../../.venv/bin/python -m scripts.audit.source_inventory_review_decisions`
- `../../../../.venv/bin/python -m pytest tests/test_source_inventory_review_decisions.py tests/test_private_teacher_lesson_source_inventory.py -q`
- `../../../../.venv/bin/ruff check tests/test_private_teacher_lesson_source_inventory.py`
- `git diff --check`
- `../../../../.venv/bin/python scripts/audit/lint_agent_trailer.py`

Helper agent `Hubble` ran a bounded read-only ledger-readiness review. It found the 21 seed entries structurally ledger-ready and flagged the idiomatic/multiword rows for manual caution; those rows are retained as explicit review-queue reasons where generated by the local candidate queue.
