### PR TITLE
Seed teacher lesson Atlas rows 99-118

### DIFF
--- a/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+++ b/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
@@ -1,0 +1,114 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Private teacher lesson vocabulary - explicit table rows 99-118
+    locator: local-only explicit vocabulary table rows 99-118
+    notes: >-
+      Derived headword metadata only; raw private lesson material is local-only
+      and not committed. Daily Word, Practice, and cloze remain frozen without
+      explicit surface_admission.
+    headwords:
+      - lemma: постукати
+        pos: verb
+        gloss: to knock; perfective
+        locator: explicit vocabulary table row 99
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: стукіт
+        pos: noun
+        gloss: knocking
+        locator: explicit vocabulary table row 100
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: свідок
+        pos: noun
+        gloss: witness
+        locator: explicit vocabulary table row 101
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: ЗМІ
+        pos: abbreviation
+        gloss: media; mass media
+        locator: explicit vocabulary table row 102
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: правдиво
+        pos: adverb
+        gloss: truthfully
+        locator: explicit vocabulary table row 103
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: неприємність
+        pos: noun
+        gloss: trouble; mishap; nuisance
+        locator: explicit vocabulary table row 104
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вбивство
+        pos: noun
+        gloss: murder
+        locator: explicit vocabulary table row 105
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: розслідування
+        pos: noun
+        gloss: investigation
+        locator: explicit vocabulary table row 106
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: прибулець
+        pos: noun
+        gloss: alien; newcomer
+        locator: explicit vocabulary table row 107
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: відбитки
+        pos: noun
+        gloss: imprints; fingerprints
+        locator: explicit vocabulary table row 108
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: кругом
+        pos: adverb
+        gloss: everywhere; all around
+        locator: explicit vocabulary table row 109
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: загублений
+        pos: adjective
+        gloss: lost
+        locator: explicit vocabulary table row 110
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: штраф
+        pos: noun
+        gloss: fine; penalty
+        locator: explicit vocabulary table row 111
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: негайно
+        pos: adverb
+        gloss: immediately
+        locator: explicit vocabulary table row 112
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: за рогом
+        pos: phrase
+        gloss: around the corner
+        locator: explicit vocabulary table row 113
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: нахабність
+        pos: noun
+        gloss: audacity; insolence
+        locator: explicit vocabulary table row 114
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: остогиднути
+        pos: verb
+        gloss: to become unbearable; to make someone fed up; perfective
+        locator: explicit vocabulary table row 115
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вони мені остогидли
+        pos: phrase
+        gloss: I am fed up with them; they have become unbearable to me
+        locator: explicit vocabulary table row 116
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: мисливець
+        pos: noun
+        gloss: hunter
+        locator: explicit vocabulary table row 117
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: втручатися
+        pos: verb
+        gloss: to intervene; imperfective
+        locator: explicit vocabulary table row 118
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.

--- a/docs/decisions/2026-06-25-lexicon-update-mechanics.md
+++ b/docs/decisions/2026-06-25-lexicon-update-mechanics.md
@@ -18,15 +18,15 @@
   self-hosted runner**. (~1 GB weekly download — acceptable on Actions.) This supersedes options
   (a)/(b)/(c) below with a fourth path: **(d) hosted runner hydrates the DBs from Release assets.**
 
-## Current tracker snapshot (2026-07-02)
+## Current tracker snapshot (2026-07-03)
 
 Current static Atlas counts:
 
-- Atlas manifest: 5,280 entries, including 336 `form_of` records.
-- Public search/browse: 5,270 entries, 61 search shards, 31 browse shards.
+- Atlas manifest: 5,374 entries, including 336 `form_of` records.
+- Public search/browse: 5,364 entries, 61 search shards, 31 browse shards.
 - Daily Word: 300 entries.
 - Practice deck: 4,484 lexemes and 22 reviewed A1 cloze items.
-- Source-inventory seeds: 173 rows total: 80 textbook, 40 private
+- Source-inventory seeds: 258 rows total: 80 textbook, 125 private
   teacher-lesson, 33 Ohoiko/ULP, and 20 curriculum sample rows.
 
 Closed tracker leaves that should not be treated as active backlog:
@@ -63,7 +63,7 @@ because the dictionary DBs (`data/vesum.db` ~967 MB, `data/sources.db`) are giti
 
 | Layer | What | Trigger today | Where |
 | --- | --- | --- | --- |
-| **1. Manifest (SSOT)** | `lexicon-manifest.json` Release asset (5,280 entries in the current pointer) — the Atlas word data | **manual `make atlas`** when content/sources change | local only (needs the DBs) |
+| **1. Manifest (SSOT)** | `lexicon-manifest.json` Release asset (5,374 entries in the current pointer) — the Atlas word data | **manual `make atlas`** when content/sources change | local only (needs the DBs) |
 | **2. Auto-grow** | find NEW lemmas in modules/readings → enrich → gated PR (#3675) | cron **Mon 07:23** + `workflow_dispatch` | `atlas-grow.yml` — **no-op on hosted runners** |
 | **3. Derived artifacts** | search-index, daily-pool, open-dataset | part of `make atlas` | local |
 

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -11,16 +11,19 @@ The committed inventory seeds are:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml`
 
-Current committed coverage is 105 reviewed headwords from explicit local
-vocabulary table rows 1-98. The source family is `teacher_lesson`, and the
+Current committed coverage is 125 reviewed headwords from explicit local
+vocabulary table rows 1-118. The source family is `teacher_lesson`, and the
 source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.
 
 Current approval-ledger coverage is 105 reviewed headwords from rows 1-98.
-Live Atlas browse/search coverage still depends on a later controlled publish
-PR. Missing `surface_admission` keeps Daily Word, Practice, and cloze frozen.
+Live Atlas browse/search coverage is 105 neutral `teacher_lesson` provenance
+entries from rows 1-98. Rows 99-118 remain seed-only until a later approval
+ledger and controlled publish PR. Missing `surface_admission` keeps Daily Word,
+Practice, and cloze frozen.
 
 ## Source Handling Rule
 

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -20,6 +20,7 @@ The committed source inventory input is:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml`
 - `data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml`
 
 The candidate JSON follows the existing grow-candidate shape: `counts`,
@@ -89,7 +90,7 @@ conjunction, particle, and interjection. Optional per-headword `gloss` values
 are curated learner-facing English anchors for cases where dictionary
 enrichment lacks a visible English translation.
 
-The private teacher-lesson seeds contribute 105 reviewed `teacher_lesson`
+The private teacher-lesson seeds contribute 125 reviewed `teacher_lesson`
 headwords from an explicit local vocabulary table, with approval ledgers now
 covering rows 1-98. Their committed rows are derived metadata only: no raw
 private lesson material, private document paths, or teacher-identifying labels

--- a/docs/runbooks/word-atlas-static-api.md
+++ b/docs/runbooks/word-atlas-static-api.md
@@ -16,13 +16,13 @@ as static JSON, not as a live backend service.
 
 ## Current Snapshot
 
-As of 2026-07-02, the static contract should expose this board state:
+As of 2026-07-03, the static contract should expose this board state:
 
-- Atlas manifest: 5,280 entries, including 336 `form_of` records.
-- Public search/browse: 5,270 entries, 61 search shards, 31 browse shards.
+- Atlas manifest: 5,374 entries, including 336 `form_of` records.
+- Public search/browse: 5,364 entries, 61 search shards, 31 browse shards.
 - Daily Word: 300 entries.
 - Practice deck: 4,484 lexemes and 22 reviewed A1 cloze items.
-- Source-inventory seeds: 173 rows total: 80 textbook, 40 private
+- Source-inventory seeds: 258 rows total: 80 textbook, 125 private
   teacher-lesson, 33 Ohoiko/ULP, and 20 curriculum sample rows.
 
 Open Atlas/Lexicon board items are #3936, #4160, #3933, #3934, and #3797.

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -23,6 +23,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-39-58.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )
 

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -27,6 +27,11 @@ PRIVATE_TEACHER_ROWS_79_98_INVENTORY = (
     / "data/lexicon/source-inventory/"
     "private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml"
 )
+PRIVATE_TEACHER_ROWS_99_118_INVENTORY = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory/"
+    "private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml"
+)
 PRIVATE_TEACHER_FIRST_LEDGER = (
     PROJECT_ROOT
     / "data/lexicon/source-inventory-review-decisions/"
@@ -173,6 +178,40 @@ def test_private_teacher_rows_79_98_inventory_is_pending_review_metadata() -> No
 
     inventory_text = PRIVATE_TEACHER_ROWS_79_98_INVENTORY.read_text(encoding="utf-8")
     assert ".docx" not in inventory_text
+
+
+def test_private_teacher_rows_99_118_inventory_is_pending_review_metadata() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_99_118_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+
+    assert len(records) == 20
+    assert {record.source_family for record in records} == {"teacher_lesson"}
+    assert {record.extraction_mode for record in records} == {"curated_headword"}
+    assert {record.source_id for record in records} == {
+        "private-teacher-lesson-vocabulary-table-1-rows-99-118"
+    }
+    assert all(record.source_path is None for record in records)
+    assert all(record.source_url is None for record in records)
+    assert all(record.source_title for record in records)
+    assert all(record.source_locator for record in records)
+    assert all(record.context for record in records)
+    assert all(record.pos for record in records)
+    assert all(record.gloss for record in records)
+    assert "постукати" in {record.lemma for record in records}
+    assert "ЗМІ" in {record.lemma for record in records}
+    assert "вони мені остогидли" in {record.lemma for record in records}
+    assert "втручатися" in {record.lemma for record in records}
+    assert all("," not in record.lemma for record in records)
+    assert all("/" not in record.lemma for record in records)
+    assert all("(" not in record.lemma and ")" not in record.lemma for record in records)
+    assert all("surface_admission" not in record.provenance_payload() for record in records)
+
+    inventory_text = PRIVATE_TEACHER_ROWS_99_118_INVENTORY.read_text(encoding="utf-8")
+    assert ".docx" not in inventory_text
+    assert "alona" not in inventory_text.lower()
+    assert "native-reviewer-lessons" not in inventory_text
 
 
 def test_private_teacher_first_decision_ledger_stays_review_only() -> None:


### PR DESCRIPTION
## Summary
- Add the next privacy-safe private teacher-lesson source-inventory seed: explicit local vocabulary table rows 99-118.
- Add 20 neutral derived `teacher_lesson` headword metadata rows.
- Register the new inventory in the review-candidate generator defaults.
- Update runbook/tracker snapshots from 105 to 125 teacher-lesson source rows and from 173 to 258 total source-inventory rows.

## Boundary
- Review-only source inventory seed.
- No live Atlas manifest/search/browse/pointer/fingerprint changes.
- No Daily Word, Practice, or Cloze changes.
- No raw private lesson material, private file paths, teacher names, transcripts, or document references.
- `surface_admission` remains absent by design.

## New seed
- File: `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml`
- Source rows: 99-118
- Headwords: 20
- Candidate generator classification for this new seed: 10 auto-merge candidates, 10 needs publish review

## Validation
- `.venv/bin/yamllint data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml`
- `.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_review_candidates.py tests/test_source_inventory_intake.py -q` (51 passed)
- `.venv/bin/python -m scripts.audit.generate_source_inventory_review_candidates --out /tmp/atlas-source-inventory-review-candidates-4160-rows-99-118.json --report`
- `.venv/bin/python -m scripts.audit.source_inventory_review_decisions`
- `.venv/bin/ruff check scripts/audit/generate_source_inventory_review_candidates.py tests/test_private_teacher_lesson_source_inventory.py`
- `npx --no-install markdownlint-cli2 docs/runbooks/word-atlas-private-teacher-source-scope.md docs/runbooks/word-atlas-source-inventory-review-candidates.md docs/runbooks/word-atlas-static-api.md docs/decisions/2026-06-25-lexicon-update-mechanics.md`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

Refs #4160
Refs #3936
