### PR TITLE
data(atlas): approve teacher lesson rows 99-118

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-03-sixth-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-03-sixth-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,295 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-sixth-approved-teacher-lesson-ledger-batch-2026-07-03
+batch_label: sixth-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-03'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4184
+  total_queue_rows: 152
+  approved_in_queue: 20
+  promotion_batch_size: 20
+production_outputs_updated: []
+decisions:
+- lemma: постукати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to knock; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: c470a7a31ef9f9e2
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 99
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: стукіт
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: knocking
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 7b5ca04c643de713
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 100
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: свідок
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: witness
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 55ef80446e2b8802
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 101
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: ЗМІ
+  decision: approve_for_publish
+  approved_pos: abbreviation
+  approved_gloss: media; mass media
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 11dcbf836a4234b0
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 102
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags calque_warning; heritage_status flags russian_shadow
+- lemma: правдиво
+  decision: approve_for_publish
+  approved_pos: adverb
+  approved_gloss: truthfully
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: c6fb4f04c6e0e5e1
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 103
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: неприємність
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: trouble; mishap; nuisance
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 51400cf909257351
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 104
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: вбивство
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: murder
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 660fcd017ef17836
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 105
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: розслідування
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: investigation
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: cbc91acdbd546908
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 106
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: прибулець
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: alien; newcomer
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 8e1db0b5fcf3504a
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 107
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: відбитки
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: imprints; fingerprints
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: b0c5d77422b5a2ed
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 108
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: кругом
+  decision: approve_for_publish
+  approved_pos: adverb
+  approved_gloss: everywhere; all around
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 2a6ecdb5ad4b604d
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 109
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: загублений
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: lost
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: f6bb6f029bcf2189
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 110
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: штраф
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: fine; penalty
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 6d7d99036e42de8d
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 111
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: негайно
+  decision: approve_for_publish
+  approved_pos: adverb
+  approved_gloss: immediately
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: f53ad350e026db6e
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 112
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: за рогом
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: around the corner
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: b9a12302ff8af0c6
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 113
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: нахабність
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: audacity; insolence
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: eb886c699c64a0e8
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 114
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: остогиднути
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to become unbearable; to make someone fed up; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: f08cef61905524c4
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 115
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: вони мені остогидли
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: I am fed up with them; they have become unbearable to me
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: c6bbd0d5e1abe9b0
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 116
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: мисливець
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: hunter
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 15cd12ea40d9052d
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 117
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: втручатися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to intervene; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 34189f986a33a03b
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml
+    locator: explicit vocabulary table row 118
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-99-118
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -19,11 +19,11 @@ source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.
 
-Current approval-ledger coverage is 105 reviewed headwords from rows 1-98.
+Current approval-ledger coverage is 125 reviewed headwords from rows 1-118.
 Live Atlas browse/search coverage is 105 neutral `teacher_lesson` provenance
-entries from rows 1-98. Rows 99-118 remain seed-only until a later approval
-ledger and controlled publish PR. Missing `surface_admission` keeps Daily Word,
-Practice, and cloze frozen.
+entries from rows 1-98. Rows 99-118 are approved for later Atlas publish, but
+remain out of live Atlas until a controlled publish PR. Missing
+`surface_admission` keeps Daily Word, Practice, and cloze frozen.
 
 ## Source Handling Rule
 

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -92,7 +92,7 @@ enrichment lacks a visible English translation.
 
 The private teacher-lesson seeds contribute 125 reviewed `teacher_lesson`
 headwords from an explicit local vocabulary table, with approval ledgers now
-covering rows 1-98. Their committed rows are derived metadata only: no raw
+covering rows 1-118. Their committed rows are derived metadata only: no raw
 private lesson material, private document paths, or teacher-identifying labels
 should appear in the inventory.
 

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -57,6 +57,11 @@ PRIVATE_TEACHER_FIFTH_LEDGER = (
     / "data/lexicon/source-inventory-review-decisions/"
     "2026-07-03-fifth-approved-teacher-lesson-ledger-batch.yaml"
 )
+PRIVATE_TEACHER_SIXTH_LEDGER = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory-review-decisions/"
+    "2026-07-03-sixth-approved-teacher-lesson-ledger-batch.yaml"
+)
 
 
 def test_private_teacher_inventory_is_privacy_safe_review_metadata() -> None:
@@ -342,6 +347,36 @@ def test_private_teacher_fifth_decision_ledger_stays_review_only() -> None:
     assert ".docx" not in ledger_text
 
 
+def test_private_teacher_sixth_decision_ledger_stays_review_only() -> None:
+    summary = decisions.validate_committed_decision_files([PRIVATE_TEACHER_SIXTH_LEDGER])
+    payload = yaml.safe_load(PRIVATE_TEACHER_SIXTH_LEDGER.read_text(encoding="utf-8"))
+
+    assert summary == {
+        "files": 1,
+        "rows": 20,
+        "decision_counts": {"approve_for_publish": 20},
+    }
+    assert payload["source_queue"]["generated_from_pr"] == 4184
+    assert payload["source_queue"]["promotion_batch_size"] == 20
+    assert payload["production_outputs_updated"] == []
+    assert payload["decisions"][0]["lemma"] == "постукати"
+    assert payload["decisions"][-1]["lemma"] == "втручатися"
+    assert all(
+        row["source_inventory"]["source_family"] == "teacher_lesson"
+        for row in payload["decisions"]
+    )
+    assert {
+        row["source_inventory"]["source_id"]
+        for row in payload["decisions"]
+    } == {"private-teacher-lesson-vocabulary-table-1-rows-99-118"}
+    assert all("surface_admission" not in row for row in payload["decisions"])
+
+    ledger_text = PRIVATE_TEACHER_SIXTH_LEDGER.read_text(encoding="utf-8")
+    assert ".docx" not in ledger_text
+    assert "alona" not in ledger_text.lower()
+    assert "native-reviewer-lessons" not in ledger_text
+
+
 def test_private_teacher_decision_ledgers_cover_seed_without_live_surfaces() -> None:
     records = read_source_inventory(PRIVATE_TEACHER_INVENTORY, project_root=PROJECT_ROOT)
     inventory_keys = {
@@ -434,6 +469,32 @@ def test_private_teacher_rows_79_98_decision_ledger_covers_pending_seed() -> Non
     }
 
     payload = yaml.safe_load(PRIVATE_TEACHER_FIFTH_LEDGER.read_text(encoding="utf-8"))
+    ledger_keys = {
+        row["source_inventory"]["key"]
+        for row in payload["decisions"]
+    }
+
+    assert ledger_keys == inventory_keys
+
+
+def test_private_teacher_rows_99_118_decision_ledger_covers_pending_seed() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_99_118_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+    inventory_keys = {
+        decisions.source_inventory_key(
+            lemma=record.lemma,
+            inventory_path=(
+                "data/lexicon/source-inventory/"
+                "private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml"
+            ),
+            locator=record.source_locator,
+        )
+        for record in records
+    }
+
+    payload = yaml.safe_load(PRIVATE_TEACHER_SIXTH_LEDGER.read_text(encoding="utf-8"))
     ledger_keys = {
         row["source_inventory"]["key"]
         for row in payload["decisions"]


### PR DESCRIPTION
## Summary

- add the sixth review-only teacher-lesson approval ledger for rows 99-118
- approve 20 neutral `teacher_lesson` source-inventory rows for a later Atlas publish PR
- update the teacher-lesson runbooks and tests to reflect approval coverage through rows 1-118

## Boundary

- no live Atlas manifest/search/browse output changes
- no manifest pointer/fingerprint changes
- no Daily Word, Practice, or Cloze admission changes
- no `surface_admission`
- no raw private lesson material, private paths, or teacher-identifying labels

## Validation

- `.venv/bin/python -m scripts.audit.source_inventory_review_decisions data/lexicon/source-inventory-review-decisions/2026-07-03-sixth-approved-teacher-lesson-ledger-batch.yaml`
- `.venv/bin/python -m scripts.audit.source_inventory_review_decisions` -> 9 files / 185 approved rows
- `.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_review_decisions.py tests/test_source_inventory_review_candidates.py tests/test_source_inventory_intake.py -q` -> 65 passed
- `.venv/bin/yamllint data/lexicon/source-inventory-review-decisions/2026-07-03-sixth-approved-teacher-lesson-ledger-batch.yaml`
- `.venv/bin/ruff check tests/test_private_teacher_lesson_source_inventory.py`
- `npx --no-install markdownlint-cli2 docs/runbooks/word-atlas-private-teacher-source-scope.md docs/runbooks/word-atlas-source-inventory-review-candidates.md`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- AGY/Gemini read-only review: no blockers, no non-blocking concerns, merge recommended
