### PR TITLE
data(atlas): seed teacher lesson rows 119-138

### DIFF
--- a/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+++ b/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
@@ -1,0 +1,124 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Private teacher lesson vocabulary - explicit table rows 119-138
+    locator: local-only explicit vocabulary table rows 119-138
+    notes: >-
+      Derived headword metadata only; raw private lesson material is local-only
+      and not committed. Daily Word, Practice, and cloze remain frozen without
+      explicit surface_admission.
+    headwords:
+      - lemma: втрутитися
+        pos: verb
+        gloss: to intervene; perfective
+        locator: explicit vocabulary table row 119
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: обдурювати
+        pos: verb
+        gloss: to trick; to deceive; imperfective
+        locator: explicit vocabulary table row 120
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: обдурити
+        pos: verb
+        gloss: to trick; to deceive; perfective
+        locator: explicit vocabulary table row 121
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: обхитрити
+        pos: verb
+        gloss: to outwit; to trick; perfective
+        locator: explicit vocabulary table row 121
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: ніяково
+        pos: adverb
+        gloss: awkwardly
+        locator: explicit vocabulary table row 122
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: крісло колісне
+        pos: noun
+        gloss: wheelchair
+        locator: explicit vocabulary table row 123
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: очне навчання
+        pos: noun
+        gloss: full-time education; in-person study
+        locator: explicit vocabulary table row 124
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: заочне навчання
+        pos: noun
+        gloss: correspondence education; part-time study
+        locator: explicit vocabulary table row 125
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: носій мови
+        pos: noun
+        gloss: native speaker
+        locator: explicit vocabulary table row 126
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: звинувачувати
+        pos: verb
+        gloss: to accuse; imperfective
+        locator: explicit vocabulary table row 127
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: звинуватити
+        pos: verb
+        gloss: to accuse; perfective
+        locator: explicit vocabulary table row 128
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: заплутаний
+        pos: adjective
+        gloss: confusing; tangled
+        locator: explicit vocabulary table row 129
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вбивця
+        pos: noun
+        gloss: killer; murderer
+        locator: explicit vocabulary table row 130
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: протяг
+        pos: noun
+        gloss: draft; draught
+        locator: explicit vocabulary table row 131
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: ДТП
+        pos: abbreviation
+        gloss: road traffic accident; car accident
+        locator: explicit vocabulary table row 132
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: дорожньо-транспортна пригода
+        pos: noun
+        gloss: road traffic accident; car accident
+        locator: explicit vocabulary table row 132
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вичитувати
+        pos: verb
+        gloss: to lecture; to scold; imperfective
+        locator: explicit vocabulary table row 133
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вичитати
+        pos: verb
+        gloss: to lecture; to scold; perfective
+        locator: explicit vocabulary table row 134
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: засуджувати
+        pos: verb
+        gloss: to sentence; to convict; imperfective
+        locator: explicit vocabulary table row 135
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: засудити
+        pos: verb
+        gloss: to sentence; to convict; perfective
+        locator: explicit vocabulary table row 136
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: перепади настрою
+        pos: noun
+        gloss: mood swings
+        locator: explicit vocabulary table row 137
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: підозріло
+        pos: adverb
+        gloss: suspiciously
+        locator: explicit vocabulary table row 138
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.

--- a/docs/decisions/2026-06-25-lexicon-update-mechanics.md
+++ b/docs/decisions/2026-06-25-lexicon-update-mechanics.md
@@ -22,11 +22,11 @@
 
 Current static Atlas counts:
 
-- Atlas manifest: 5,374 entries, including 336 `form_of` records.
-- Public search/browse: 5,364 entries, 61 search shards, 31 browse shards.
+- Atlas manifest: 5,393 entries, including 336 `form_of` records.
+- Public search/browse: 5,383 entries, 61 search shards, 31 browse shards.
 - Daily Word: 300 entries.
 - Practice deck: 4,484 lexemes and 22 reviewed A1 cloze items.
-- Source-inventory seeds: 258 rows total: 80 textbook, 125 private
+- Source-inventory seeds: 280 rows total: 80 textbook, 147 private
   teacher-lesson, 33 Ohoiko/ULP, and 20 curriculum sample rows.
 
 Closed tracker leaves that should not be treated as active backlog:
@@ -63,7 +63,7 @@ because the dictionary DBs (`data/vesum.db` ~967 MB, `data/sources.db`) are giti
 
 | Layer | What | Trigger today | Where |
 | --- | --- | --- | --- |
-| **1. Manifest (SSOT)** | `lexicon-manifest.json` Release asset (5,374 entries in the current pointer) — the Atlas word data | **manual `make atlas`** when content/sources change | local only (needs the DBs) |
+| **1. Manifest (SSOT)** | `lexicon-manifest.json` Release asset (5,393 entries in the current pointer) — the Atlas word data | **manual `make atlas`** when content/sources change | local only (needs the DBs) |
 | **2. Auto-grow** | find NEW lemmas in modules/readings → enrich → gated PR (#3675) | cron **Mon 07:23** + `workflow_dispatch` | `atlas-grow.yml` — **no-op on hosted runners** |
 | **3. Derived artifacts** | search-index, daily-pool, open-dataset | part of `make atlas` | local |
 

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -12,17 +12,18 @@ The committed inventory seeds are:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml`
 
-Current committed coverage is 125 reviewed headwords from explicit local
-vocabulary table rows 1-118. The source family is `teacher_lesson`, and the
+Current committed coverage is 147 reviewed headwords from explicit local
+vocabulary table rows 1-138. The source family is `teacher_lesson`, and the
 source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.
 
 Current approval-ledger coverage is 125 reviewed headwords from rows 1-118.
-Live Atlas browse/search coverage is 105 neutral `teacher_lesson` provenance
-entries from rows 1-98. Rows 99-118 are approved for later Atlas publish, but
-remain out of live Atlas until a controlled publish PR. Missing
+Live Atlas browse/search coverage is 125 neutral `teacher_lesson` provenance
+entries from rows 1-118. Rows 119-138 are seeded for later review, but remain
+out of approval ledgers and live Atlas until controlled follow-up PRs. Missing
 `surface_admission` keeps Daily Word, Practice, and cloze frozen.
 
 ## Source Handling Rule

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -21,6 +21,7 @@ The committed source inventory input is:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml`
 - `data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml`
 
 The candidate JSON follows the existing grow-candidate shape: `counts`,
@@ -90,9 +91,10 @@ conjunction, particle, and interjection. Optional per-headword `gloss` values
 are curated learner-facing English anchors for cases where dictionary
 enrichment lacks a visible English translation.
 
-The private teacher-lesson seeds contribute 125 reviewed `teacher_lesson`
+The private teacher-lesson seeds contribute 147 reviewed `teacher_lesson`
 headwords from an explicit local vocabulary table, with approval ledgers now
-covering rows 1-118. Their committed rows are derived metadata only: no raw
+covering rows 1-118. Rows 119-138 are seeded but not yet approved. Their
+committed rows are derived metadata only: no raw
 private lesson material, private document paths, or teacher-identifying labels
 should appear in the inventory.
 

--- a/docs/runbooks/word-atlas-static-api.md
+++ b/docs/runbooks/word-atlas-static-api.md
@@ -18,11 +18,11 @@ as static JSON, not as a live backend service.
 
 As of 2026-07-03, the static contract should expose this board state:
 
-- Atlas manifest: 5,374 entries, including 336 `form_of` records.
-- Public search/browse: 5,364 entries, 61 search shards, 31 browse shards.
+- Atlas manifest: 5,393 entries, including 336 `form_of` records.
+- Public search/browse: 5,383 entries, 61 search shards, 31 browse shards.
 - Daily Word: 300 entries.
 - Practice deck: 4,484 lexemes and 22 reviewed A1 cloze items.
-- Source-inventory seeds: 258 rows total: 80 textbook, 125 private
+- Source-inventory seeds: 280 rows total: 80 textbook, 147 private
   teacher-lesson, 33 Ohoiko/ULP, and 20 curriculum sample rows.
 
 Open Atlas/Lexicon board items are #3936, #4160, #3933, #3934, and #3797.

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -24,6 +24,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-59-78.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )
 

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -32,6 +32,11 @@ PRIVATE_TEACHER_ROWS_99_118_INVENTORY = (
     / "data/lexicon/source-inventory/"
     "private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml"
 )
+PRIVATE_TEACHER_ROWS_119_138_INVENTORY = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory/"
+    "private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml"
+)
 PRIVATE_TEACHER_FIRST_LEDGER = (
     PROJECT_ROOT
     / "data/lexicon/source-inventory-review-decisions/"
@@ -217,6 +222,37 @@ def test_private_teacher_rows_99_118_inventory_is_pending_review_metadata() -> N
     assert ".docx" not in inventory_text
     assert "alona" not in inventory_text.lower()
     assert "native-reviewer-lessons" not in inventory_text
+
+
+def test_private_teacher_rows_119_138_inventory_is_pending_review_metadata() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_119_138_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+
+    assert len(records) == 22
+    assert {record.source_family for record in records} == {"teacher_lesson"}
+    assert {record.extraction_mode for record in records} == {"curated_headword"}
+    assert {record.source_id for record in records} == {
+        "private-teacher-lesson-vocabulary-table-1-rows-119-138"
+    }
+    assert all(record.source_path is None for record in records)
+    assert all(record.source_url is None for record in records)
+    assert all(record.source_title for record in records)
+    assert all(record.source_locator for record in records)
+    assert all(record.context for record in records)
+    assert all(record.pos for record in records)
+    assert all(record.gloss for record in records)
+    assert "втрутитися" in {record.lemma for record in records}
+    assert "обдурити" in {record.lemma for record in records}
+    assert "обхитрити" in {record.lemma for record in records}
+    assert "ДТП" in {record.lemma for record in records}
+    assert "дорожньо-транспортна пригода" in {record.lemma for record in records}
+    assert "підозріло" in {record.lemma for record in records}
+    assert all("," not in record.lemma for record in records)
+    assert all("/" not in record.lemma for record in records)
+    assert all("(" not in record.lemma and ")" not in record.lemma for record in records)
+    assert all("surface_admission" not in record.provenance_payload() for record in records)
 
 
 def test_private_teacher_first_decision_ledger_stays_review_only() -> None:


### PR DESCRIPTION
## Summary
- Add the next privacy-safe private teacher-lesson source-inventory seed for explicit vocabulary table rows 119-138.
- Registers the new seed in the source-inventory review candidate generator.
- Updates tests and runbooks/decision snapshot for the new committed coverage.

## Scope
- Adds 22 normalized `teacher_lesson` headwords derived from 20 explicit table rows.
- Keeps this PR review-only: no live Atlas manifest/search/browse output changes.
- Keeps Daily Word, Practice, and cloze frozen.
- Does not commit raw private source paths, teacher/person names, transcripts, or private prose.

## Counts
- Source-inventory records: 280 total.
- Teacher-lesson committed seed coverage: 147 headwords from rows 1-138.
- Teacher-lesson approval-ledger coverage remains 125 headwords from rows 1-118.
- Teacher-lesson live Atlas coverage remains 125 entries from rows 1-118.
- Atlas live counts remain manifest 5,393 and public search/browse 5,383.
- Daily Word 300, Practice lexemes 4,484, cloze items 22.

## Validation
- `.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_candidates.py -q`
- `.venv/bin/python -m scripts.audit.generate_source_inventory_review_candidates --out /tmp/atlas-source-inventory-review-candidates-4160-rows-119-138-seed.json --report`
- `.venv/bin/python -m scripts.audit.source_inventory_review_decisions`
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json`
- `.venv/bin/yamllint data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml`
- `npx --no-install markdownlint-cli2 docs/runbooks/word-atlas-private-teacher-source-scope.md docs/runbooks/word-atlas-source-inventory-review-candidates.md docs/runbooks/word-atlas-static-api.md docs/decisions/2026-06-25-lexicon-update-mechanics.md`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Independent Review
- AGY/Gemini read-only review `review-4160-teacher-rows-119-138-seed`: PASS, no blockers.

