### PR TITLE
data(atlas): approve teacher lesson rows 119-138

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-03-seventh-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-03-seventh-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,301 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-seventh-approved-teacher-lesson-ledger-batch-2026-07-03
+batch_label: seventh-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-03'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4187
+  total_queue_rows: 164
+  approved_in_queue: 22
+  promotion_batch_size: 22
+production_outputs_updated: []
+decisions:
+- lemma: втрутитися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to intervene; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d372ae8ee4f2174b
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 119
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: обдурювати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to trick; to deceive; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: ac56ff930fd9e77a
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 120
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: обдурити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to trick; to deceive; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: b9d6d353b1220a40
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 121
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: обхитрити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to outwit; to trick; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 834d588f0d88892d
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 121
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: ніяково
+  decision: approve_for_publish
+  approved_pos: adverb
+  approved_gloss: awkwardly
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 73cdacf9e5db10d2
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 122
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: крісло колісне
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: wheelchair
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: eec331c0e843270f
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 123
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: очне навчання
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: full-time education; in-person study
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 94b8a18a9005cc19
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 124
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: заочне навчання
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: correspondence education; part-time study
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 05179216738f68cd
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 125
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: носій мови
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: native speaker
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 66894b8932cd893e
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 126
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: звинувачувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to accuse; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 8eedd809d8890f59
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 127
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: звинуватити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to accuse; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 262fb043a33cad98
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 128
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: заплутаний
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: confusing; tangled
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 8fc8f84a277a8e39
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 129
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: вбивця
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: killer; murderer
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 97037cff1c0e8133
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 130
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: протяг
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: draft; draught
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 1f2bcccbe577ec0c
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 131
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: ДТП
+  decision: approve_for_publish
+  approved_pos: abbreviation
+  approved_gloss: road traffic accident; car accident
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 26fd1a86f84beba1
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 132
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: дорожньо-транспортна пригода
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: road traffic accident; car accident
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 292ed9370125aabf
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 132
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: вичитувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to lecture; to scold; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: bad27d15e16a3929
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 133
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: вичитати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to lecture; to scold; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 0c1e7cb51be77e6d
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 134
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: засуджувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to sentence; to convict; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 3af6a78e861207d3
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 135
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: засудити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to sentence; to convict; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 66b992e7d7dfa712
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 136
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: перепади настрою
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: mood swings
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 987e8fec1c10cb9e
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 137
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: підозріло
+  decision: approve_for_publish
+  approved_pos: adverb
+  approved_gloss: suspiciously
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 87e41171cba92fa9
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml
+    locator: explicit vocabulary table row 138
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-119-138
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -20,10 +20,10 @@ source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.
 
-Current approval-ledger coverage is 125 reviewed headwords from rows 1-118.
+Current approval-ledger coverage is 147 reviewed headwords from rows 1-138.
 Live Atlas browse/search coverage is 125 neutral `teacher_lesson` provenance
-entries from rows 1-118. Rows 119-138 are seeded for later review, but remain
-out of approval ledgers and live Atlas until controlled follow-up PRs. Missing
+entries from rows 1-118. Rows 119-138 are approved for later Atlas publish, but
+remain out of live Atlas until a controlled publish PR. Missing
 `surface_admission` keeps Daily Word, Practice, and cloze frozen.
 
 ## Source Handling Rule

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -93,8 +93,7 @@ enrichment lacks a visible English translation.
 
 The private teacher-lesson seeds contribute 147 reviewed `teacher_lesson`
 headwords from an explicit local vocabulary table, with approval ledgers now
-covering rows 1-118. Rows 119-138 are seeded but not yet approved. Their
-committed rows are derived metadata only: no raw
+covering rows 1-138. Their committed rows are derived metadata only: no raw
 private lesson material, private document paths, or teacher-identifying labels
 should appear in the inventory.
 

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -67,6 +67,11 @@ PRIVATE_TEACHER_SIXTH_LEDGER = (
     / "data/lexicon/source-inventory-review-decisions/"
     "2026-07-03-sixth-approved-teacher-lesson-ledger-batch.yaml"
 )
+PRIVATE_TEACHER_SEVENTH_LEDGER = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory-review-decisions/"
+    "2026-07-03-seventh-approved-teacher-lesson-ledger-batch.yaml"
+)
 
 
 def test_private_teacher_inventory_is_privacy_safe_review_metadata() -> None:
@@ -413,6 +418,31 @@ def test_private_teacher_sixth_decision_ledger_stays_review_only() -> None:
     assert "native-reviewer-lessons" not in ledger_text
 
 
+def test_private_teacher_seventh_decision_ledger_stays_review_only() -> None:
+    summary = decisions.validate_committed_decision_files([PRIVATE_TEACHER_SEVENTH_LEDGER])
+    payload = yaml.safe_load(PRIVATE_TEACHER_SEVENTH_LEDGER.read_text(encoding="utf-8"))
+
+    assert summary == {
+        "files": 1,
+        "rows": 22,
+        "decision_counts": {"approve_for_publish": 22},
+    }
+    assert payload["source_queue"]["generated_from_pr"] == 4187
+    assert payload["source_queue"]["promotion_batch_size"] == 22
+    assert payload["production_outputs_updated"] == []
+    assert payload["decisions"][0]["lemma"] == "втрутитися"
+    assert payload["decisions"][-1]["lemma"] == "підозріло"
+    assert all(
+        row["source_inventory"]["source_family"] == "teacher_lesson"
+        for row in payload["decisions"]
+    )
+    assert {
+        row["source_inventory"]["source_id"]
+        for row in payload["decisions"]
+    } == {"private-teacher-lesson-vocabulary-table-1-rows-119-138"}
+    assert all("surface_admission" not in row for row in payload["decisions"])
+
+
 def test_private_teacher_decision_ledgers_cover_seed_without_live_surfaces() -> None:
     records = read_source_inventory(PRIVATE_TEACHER_INVENTORY, project_root=PROJECT_ROOT)
     inventory_keys = {
@@ -531,6 +561,32 @@ def test_private_teacher_rows_99_118_decision_ledger_covers_pending_seed() -> No
     }
 
     payload = yaml.safe_load(PRIVATE_TEACHER_SIXTH_LEDGER.read_text(encoding="utf-8"))
+    ledger_keys = {
+        row["source_inventory"]["key"]
+        for row in payload["decisions"]
+    }
+
+    assert ledger_keys == inventory_keys
+
+
+def test_private_teacher_rows_119_138_decision_ledger_covers_pending_seed() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_119_138_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+    inventory_keys = {
+        decisions.source_inventory_key(
+            lemma=record.lemma,
+            inventory_path=(
+                "data/lexicon/source-inventory/"
+                "private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml"
+            ),
+            locator=record.source_locator,
+        )
+        for record in records
+    }
+
+    payload = yaml.safe_load(PRIVATE_TEACHER_SEVENTH_LEDGER.read_text(encoding="utf-8"))
     ledger_keys = {
         row["source_inventory"]["key"]
         for row in payload["decisions"]


### PR DESCRIPTION
## Summary

- Add the seventh review-only Atlas source-inventory decision ledger for private teacher-lesson rows 119-138.
- Approve 22 queued headwords for a later controlled Atlas publish path with no surface admission.
- Update focused tests and runbooks so approval-ledger coverage is now rows 1-138 / 147 reviewed teacher-lesson headwords.

## Scope Control

- No live Atlas manifest/search/browse output updates.
- No Daily Word, Practice, or cloze changes.
- No raw private lesson material, private document paths, teacher/person names, transcripts, or private prose.
- `production_outputs_updated` stays empty and every decision omits `surface_admission`.

## Validation

- `.venv/bin/python -m scripts.audit.source_inventory_review_decisions` -> `files=10 rows=207 decisions={'approve_for_publish': 207}`
- `.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_review_decisions.py tests/test_source_inventory_promotion_plan.py -q` -> 44 passed
- `.venv/bin/yamllint data/lexicon/source-inventory-review-decisions/2026-07-03-seventh-approved-teacher-lesson-ledger-batch.yaml`
- `npx --no-install markdownlint-cli2 docs/runbooks/word-atlas-private-teacher-source-scope.md docs/runbooks/word-atlas-source-inventory-review-candidates.md` -> 0 errors
- `git diff --check`
- Added-line privacy scan -> no matches
- Path-scope scan for daily/practice/cloze/static output/generated artifacts/config files -> no matches
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Independent AGY/Gemini review `review-4160-teacher-rows-119-138-ledger` -> no blockers, acceptable to PR/merge

Refs #4160
Refs #3936
