### PR TITLE
Add teacher lesson rows 139-158 seed

### DIFF
--- a/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+++ b/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
@@ -1,0 +1,114 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Private teacher lesson vocabulary - explicit table rows 139-158
+    locator: local-only explicit vocabulary table rows 139-158
+    notes: >-
+      Derived headword metadata only; raw private lesson material is local-only
+      and not committed. Daily Word, Practice, and cloze remain frozen without
+      explicit surface_admission.
+    headwords:
+      - lemma: хвалити
+        pos: verb
+        gloss: to praise; imperfective
+        locator: explicit vocabulary table row 139
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: похвалити
+        pos: verb
+        gloss: to praise; perfective
+        locator: explicit vocabulary table row 140
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: дозвіл
+        pos: noun
+        gloss: permission
+        locator: explicit vocabulary table row 141
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: облаштовуватися
+        pos: verb
+        gloss: to settle in; imperfective
+        locator: explicit vocabulary table row 142
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: облаштуватися
+        pos: verb
+        gloss: to settle in; perfective
+        locator: explicit vocabulary table row 143
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: пекарня
+        pos: noun
+        gloss: bakery
+        locator: explicit vocabulary table row 144
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: гірчиця
+        pos: noun
+        gloss: mustard
+        locator: explicit vocabulary table row 145
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: випічка
+        pos: noun
+        gloss: baked goods; pastry
+        locator: explicit vocabulary table row 146
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: єнот
+        pos: noun
+        gloss: raccoon
+        locator: explicit vocabulary table row 147
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: сказ
+        pos: noun
+        gloss: rabies
+        locator: explicit vocabulary table row 148
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: скажений
+        pos: adjective
+        gloss: rabid; furious; uncontrolled
+        locator: explicit vocabulary table row 149
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: сліпий
+        pos: adjective
+        gloss: blind
+        locator: explicit vocabulary table row 150
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: підписатися на
+        pos: verb
+        gloss: to subscribe to; perfective
+        locator: explicit vocabulary table row 151
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: відписатися від
+        pos: verb
+        gloss: to unsubscribe from; perfective
+        locator: explicit vocabulary table row 152
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: слідкувати
+        pos: verb
+        gloss: to follow; to monitor; imperfective
+        locator: explicit vocabulary table row 153
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: дотримуватися правила
+        pos: verb
+        gloss: to follow a rule; to observe a rule; imperfective
+        locator: explicit vocabulary table row 154
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: помічати
+        pos: verb
+        gloss: to notice; to mark; imperfective
+        locator: explicit vocabulary table row 155
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: помітити
+        pos: verb
+        gloss: to notice; to mark; perfective
+        locator: explicit vocabulary table row 156
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: пішохід
+        pos: noun
+        gloss: pedestrian
+        locator: explicit vocabulary table row 157
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: публікувати
+        pos: verb
+        gloss: to publish; imperfective
+        locator: explicit vocabulary table row 158
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -13,18 +13,19 @@ The committed inventory seeds are:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml`
 
-Current committed coverage is 147 reviewed headwords from explicit local
-vocabulary table rows 1-138. The source family is `teacher_lesson`, and the
+Current committed coverage is 167 reviewed headwords from explicit local
+vocabulary table rows 1-158. The source family is `teacher_lesson`, and the
 source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.
 
 Current approval-ledger coverage is 147 reviewed headwords from rows 1-138.
-Live Atlas browse/search coverage is 125 neutral `teacher_lesson` provenance
-entries from rows 1-118. Rows 119-138 are approved for later Atlas publish, but
-remain out of live Atlas until a controlled publish PR. Missing
-`surface_admission` keeps Daily Word, Practice, and cloze frozen.
+Live Atlas browse/search coverage is 147 neutral `teacher_lesson` provenance
+entries from rows 1-138. Rows 139-158 are pending source-inventory rows and
+remain out of approval ledgers and live Atlas until later controlled PRs.
+Missing `surface_admission` keeps Daily Word, Practice, and cloze frozen.
 
 ## Source Handling Rule
 

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -22,6 +22,7 @@ The committed source inventory input is:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml`
 - `data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml`
 
 The candidate JSON follows the existing grow-candidate shape: `counts`,
@@ -91,11 +92,12 @@ conjunction, particle, and interjection. Optional per-headword `gloss` values
 are curated learner-facing English anchors for cases where dictionary
 enrichment lacks a visible English translation.
 
-The private teacher-lesson seeds contribute 147 reviewed `teacher_lesson`
-headwords from an explicit local vocabulary table, with approval ledgers now
-covering rows 1-138. Their committed rows are derived metadata only: no raw
-private lesson material, private document paths, or teacher-identifying labels
-should appear in the inventory.
+The private teacher-lesson seeds contribute 167 reviewed `teacher_lesson`
+headwords from an explicit local vocabulary table, with approval ledgers
+covering rows 1-138. Rows 139-158 are source-inventory only until a later
+decision ledger. Their committed rows are derived metadata only: no raw private
+lesson material, private document paths, or teacher-identifying labels should
+appear in the inventory.
 
 When a candidate is later promoted into a manifest entry,
 `promote_grow_candidates.manifest_entry_from_candidate()` copies

--- a/docs/runbooks/word-atlas-static-api.md
+++ b/docs/runbooks/word-atlas-static-api.md
@@ -18,11 +18,11 @@ as static JSON, not as a live backend service.
 
 As of 2026-07-03, the static contract should expose this board state:
 
-- Atlas manifest: 5,393 entries, including 336 `form_of` records.
-- Public search/browse: 5,383 entries, 61 search shards, 31 browse shards.
+- Atlas manifest: 5,415 entries, including 336 `form_of` records.
+- Public search/browse: 5,405 entries, 61 search shards, 31 browse shards.
 - Daily Word: 300 entries.
 - Practice deck: 4,484 lexemes and 22 reviewed A1 cloze items.
-- Source-inventory seeds: 280 rows total: 80 textbook, 147 private
+- Source-inventory seeds: 300 rows total: 80 textbook, 167 private
   teacher-lesson, 33 Ohoiko/ULP, and 20 curriculum sample rows.
 
 Open Atlas/Lexicon board items are #3936, #4160, #3933, #3934, and #3797.

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -25,6 +25,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-79-98.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )
 

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -37,6 +37,11 @@ PRIVATE_TEACHER_ROWS_119_138_INVENTORY = (
     / "data/lexicon/source-inventory/"
     "private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml"
 )
+PRIVATE_TEACHER_ROWS_139_158_INVENTORY = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory/"
+    "private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml"
+)
 PRIVATE_TEACHER_FIRST_LEDGER = (
     PROJECT_ROOT
     / "data/lexicon/source-inventory-review-decisions/"
@@ -258,6 +263,41 @@ def test_private_teacher_rows_119_138_inventory_is_pending_review_metadata() -> 
     assert all("/" not in record.lemma for record in records)
     assert all("(" not in record.lemma and ")" not in record.lemma for record in records)
     assert all("surface_admission" not in record.provenance_payload() for record in records)
+
+
+def test_private_teacher_rows_139_158_inventory_is_pending_review_metadata() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_139_158_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+
+    assert len(records) == 20
+    assert {record.source_family for record in records} == {"teacher_lesson"}
+    assert {record.extraction_mode for record in records} == {"curated_headword"}
+    assert {record.source_id for record in records} == {
+        "private-teacher-lesson-vocabulary-table-1-rows-139-158"
+    }
+    assert all(record.source_path is None for record in records)
+    assert all(record.source_url is None for record in records)
+    assert all(record.source_title for record in records)
+    assert all(record.source_locator for record in records)
+    assert all(record.context for record in records)
+    assert all(record.pos for record in records)
+    assert all(record.gloss for record in records)
+    assert "хвалити" in {record.lemma for record in records}
+    assert "облаштуватися" in {record.lemma for record in records}
+    assert "підписатися на" in {record.lemma for record in records}
+    assert "дотримуватися правила" in {record.lemma for record in records}
+    assert "публікувати" in {record.lemma for record in records}
+    assert all("," not in record.lemma for record in records)
+    assert all("/" not in record.lemma for record in records)
+    assert all("(" not in record.lemma and ")" not in record.lemma for record in records)
+    assert all("surface_admission" not in record.provenance_payload() for record in records)
+
+    inventory_text = PRIVATE_TEACHER_ROWS_139_158_INVENTORY.read_text(encoding="utf-8")
+    assert ".docx" not in inventory_text
+    assert "alona" not in inventory_text.lower()
+    assert "native-reviewer-lessons" not in inventory_text
 
 
 def test_private_teacher_first_decision_ledger_stays_review_only() -> None:


### PR DESCRIPTION
## Summary

- Add the next privacy-safe `teacher_lesson` source-inventory seed: explicit vocabulary table rows 139-158.
- Register the new seed in the source-inventory review candidate generator.
- Extend focused tests and runbooks so committed teacher-lesson source coverage is 167 headwords from rows 1-158.

## Boundary

- Review-only source inventory seed.
- No live Atlas manifest/search/browse output changes.
- No manifest pointer/fingerprint changes.
- No Daily Word, Practice, or cloze admission changes.
- No raw private lesson material, private paths, transcripts, or teacher-identifying labels.

## Validation

- `pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_review_candidates.py tests/test_source_inventory_intake.py -q` -> 57 passed.
- `source_inventory_review_decisions` -> 10 files / 207 approved rows.
- Candidate generation -> total_delta 288, processed 288, auto_merge 115, needs_review 173, publish_ready 113, needs_publish_review 175.
- Rows 139-158 contribution -> 8 auto_merge / 12 needs_review.
- Source inventory count -> 300 total (`teacher_lesson` 167, `textbook` 80, `ohoiko` 33, `curriculum` 20).
- Static practice check -> Daily 300, Practice 4,484, cloze 22 unchanged.
- markdownlint, yamllint, ruff, `git diff --check`, pre-commit, trailer audit passed.
- Independent AGY/Gemini review final verdict: `NO BLOCKERS`.

Refs #4160
Refs #3936
