### PR TITLE
Add teacher lesson rows 139-158 approval ledger

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-03-eighth-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-03-eighth-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,299 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-eighth-approved-teacher-lesson-ledger-batch-2026-07-03
+batch_label: eighth-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-03'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4190
+  total_queue_rows: 175
+  approved_in_queue: 20
+  promotion_batch_size: 20
+production_outputs_updated: []
+decisions:
+- lemma: хвалити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to praise; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 488ede37db8d2eeb
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 139
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: похвалити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to praise; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 67038385043918f7
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 140
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: дозвіл
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: permission
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 30aeac68fdda1b60
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 141
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: облаштовуватися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to settle in; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 428f0b886cdb0f41
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 142
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags calque_warning; heritage_status flags russian_shadow
+- lemma: облаштуватися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to settle in; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: e835170f9fd7d4dd
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 143
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags calque_warning; heritage_status flags russian_shadow
+- lemma: пекарня
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: bakery
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 0bb973d1e2234b46
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 144
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags calque_warning; heritage_status flags russian_shadow
+- lemma: гірчиця
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: mustard
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 1aaa4544380ab020
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 145
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: випічка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: baked goods; pastry
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 58d100699fae82df
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 146
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: єнот
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: raccoon
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 9c39f93d140badf0
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 147
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: сказ
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: rabies
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 31cef5d446acf656
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 148
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: скажений
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: rabid; furious; uncontrolled
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: b1e3153253876d44
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 149
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: сліпий
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: blind
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 45f325df05b9cdb8
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 150
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: підписатися на
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to subscribe to; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 313fd53bf250e2bf
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 151
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: відписатися від
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to unsubscribe from; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 56c49f2d16bc3cdf
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 152
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: слідкувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to follow; to monitor; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 9b430c429d2c6c31
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 153
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: дотримуватися правила
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to follow a rule; to observe a rule; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: f79a0498023e0af9
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 154
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: помічати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to notice; to mark; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 3d319e750f2b72a0
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 155
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: помітити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to notice; to mark; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a3f0b04d226c9d66
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 156
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: пішохід
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: pedestrian
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 89e450b7e53f1dcb
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 157
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: публікувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to publish; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: da3979dc7c4d5f9c
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml
+    locator: explicit vocabulary table row 158
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-139-158
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -21,10 +21,10 @@ source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.
 
-Current approval-ledger coverage is 147 reviewed headwords from rows 1-138.
+Current approval-ledger coverage is 167 reviewed headwords from rows 1-158.
 Live Atlas browse/search coverage is 147 neutral `teacher_lesson` provenance
-entries from rows 1-138. Rows 139-158 are pending source-inventory rows and
-remain out of approval ledgers and live Atlas until later controlled PRs.
+entries from rows 1-138. Rows 139-158 are approved for later publish, but
+remain out of live Atlas until a later controlled PR updates browse/search.
 Missing `surface_admission` keeps Daily Word, Practice, and cloze frozen.
 
 ## Source Handling Rule

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -94,10 +94,11 @@ enrichment lacks a visible English translation.
 
 The private teacher-lesson seeds contribute 167 reviewed `teacher_lesson`
 headwords from an explicit local vocabulary table, with approval ledgers
-covering rows 1-138. Rows 139-158 are source-inventory only until a later
-decision ledger. Their committed rows are derived metadata only: no raw private
-lesson material, private document paths, or teacher-identifying labels should
-appear in the inventory.
+covering rows 1-158. Rows 139-158 are approved for later publish, but are not
+live Atlas output until a later controlled publish PR updates browse/search.
+Their committed rows are derived metadata only: no raw private lesson material,
+private document paths, or teacher-identifying labels should appear in the
+inventory.
 
 When a candidate is later promoted into a manifest entry,
 `promote_grow_candidates.manifest_entry_from_candidate()` copies

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -77,6 +77,11 @@ PRIVATE_TEACHER_SEVENTH_LEDGER = (
     / "data/lexicon/source-inventory-review-decisions/"
     "2026-07-03-seventh-approved-teacher-lesson-ledger-batch.yaml"
 )
+PRIVATE_TEACHER_EIGHTH_LEDGER = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory-review-decisions/"
+    "2026-07-03-eighth-approved-teacher-lesson-ledger-batch.yaml"
+)
 
 
 def test_private_teacher_inventory_is_privacy_safe_review_metadata() -> None:
@@ -483,6 +488,36 @@ def test_private_teacher_seventh_decision_ledger_stays_review_only() -> None:
     assert all("surface_admission" not in row for row in payload["decisions"])
 
 
+def test_private_teacher_eighth_decision_ledger_stays_review_only() -> None:
+    summary = decisions.validate_committed_decision_files([PRIVATE_TEACHER_EIGHTH_LEDGER])
+    payload = yaml.safe_load(PRIVATE_TEACHER_EIGHTH_LEDGER.read_text(encoding="utf-8"))
+
+    assert summary == {
+        "files": 1,
+        "rows": 20,
+        "decision_counts": {"approve_for_publish": 20},
+    }
+    assert payload["source_queue"]["generated_from_pr"] == 4190
+    assert payload["source_queue"]["promotion_batch_size"] == 20
+    assert payload["production_outputs_updated"] == []
+    assert payload["decisions"][0]["lemma"] == "хвалити"
+    assert payload["decisions"][-1]["lemma"] == "публікувати"
+    assert all(
+        row["source_inventory"]["source_family"] == "teacher_lesson"
+        for row in payload["decisions"]
+    )
+    assert {
+        row["source_inventory"]["source_id"]
+        for row in payload["decisions"]
+    } == {"private-teacher-lesson-vocabulary-table-1-rows-139-158"}
+    assert all("surface_admission" not in row for row in payload["decisions"])
+
+    ledger_text = PRIVATE_TEACHER_EIGHTH_LEDGER.read_text(encoding="utf-8")
+    assert ".docx" not in ledger_text
+    assert "alona" not in ledger_text.lower()
+    assert "native-reviewer-lessons" not in ledger_text
+
+
 def test_private_teacher_decision_ledgers_cover_seed_without_live_surfaces() -> None:
     records = read_source_inventory(PRIVATE_TEACHER_INVENTORY, project_root=PROJECT_ROOT)
     inventory_keys = {
@@ -627,6 +662,32 @@ def test_private_teacher_rows_119_138_decision_ledger_covers_pending_seed() -> N
     }
 
     payload = yaml.safe_load(PRIVATE_TEACHER_SEVENTH_LEDGER.read_text(encoding="utf-8"))
+    ledger_keys = {
+        row["source_inventory"]["key"]
+        for row in payload["decisions"]
+    }
+
+    assert ledger_keys == inventory_keys
+
+
+def test_private_teacher_rows_139_158_decision_ledger_covers_pending_seed() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_139_158_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+    inventory_keys = {
+        decisions.source_inventory_key(
+            lemma=record.lemma,
+            inventory_path=(
+                "data/lexicon/source-inventory/"
+                "private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml"
+            ),
+            locator=record.source_locator,
+        )
+        for record in records
+    }
+
+    payload = yaml.safe_load(PRIVATE_TEACHER_EIGHTH_LEDGER.read_text(encoding="utf-8"))
     ledger_keys = {
         row["source_inventory"]["key"]
         for row in payload["decisions"]


### PR DESCRIPTION
## Summary

- Adds the eighth private teacher-lesson approval ledger for source-inventory rows 139-158.
- Updates private teacher/source-inventory runbooks from rows 1-138 approval coverage to rows 1-158.
- Extends private-teacher tests to validate the new ledger, stable source keys, privacy markers, and frozen learner-surface admission.

## Scope Boundary

- Review ledger only.
- No live Atlas manifest/search/browse/pointer/fingerprint changes.
- No Daily Word, Practice, or cloze changes.
- No raw private lesson material, private document paths, transcripts, or teacher-identifying labels.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.audit.source_inventory_review_decisions`
  - `files=11 rows=227 decisions={'approve_for_publish': 227}`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_review_decisions.py tests/test_source_inventory_review_candidates.py tests/test_source_inventory_promotion_plan.py -q`
  - `74 passed`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.audit.generate_source_inventory_review_candidates --report`
  - `processed=288`, `publish_ready=113`, `needs_publish_review=175`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.audit.plan_source_inventory_promotion --generate-candidates --out /tmp/atlas-source-inventory-approved-promotion-plan-139-158.json --report-out /tmp/atlas-source-inventory-approved-promotion-plan-139-158.md --report`
  - `approved_decisions=227`, `matched_candidates=227`, `proposed_additions=227`, `missing_candidates=0`, `production_outputs_updated=[]`
- Ruff, markdownlint, yamllint, `git diff --check`
- `node site/scripts/hydrate-manifest.mjs`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/check_static_practice_assets.py --format json`
  - `ok=true`, Daily `300`, Practice `4484`, cloze `22`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Independent Review

AGY/Gemini review completed. Initial `generated_from_pr` concern was resolved as a false positive because this field follows the existing convention of pointing to the seed PR; rows 139-158 were seeded by PR #4190. Follow-up result: `NO BLOCKERS`.

Fixes part of #4160.
