### PR TITLE
data(atlas): approve remaining Ohoiko abetka rows

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-03-second-approved-ohoiko-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-03-second-approved-ohoiko-ledger-batch.yaml
@@ -1,0 +1,314 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: ohoiko-abetka-second-approved-ledger-batch-2026-07-03
+batch_label: second-approved-ohoiko-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-03'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4021
+  total_queue_rows: 36
+  approved_in_queue: 23
+  promotion_batch_size: 23
+production_outputs_updated: []
+decisions:
+- lemma: морква
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: carrot
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 74c55d29f878db79
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[М].key_word
+    source_id: ohoiko-abetka-1-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: літак
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: airplane
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 71ec5d9f5cca994d
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Л].key_word
+    source_id: ohoiko-abetka-1-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: Україна
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: Ukraine
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: f96b805806966f44
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[У].key_word
+    source_id: ohoiko-abetka-1-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: ножиці
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: scissors
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 7da2ef7637019654
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Н].key_word
+    source_id: ohoiko-abetka-1-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: сумка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: bag; handbag
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 7c5994117b26596e
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[С].key_word
+    source_id: ohoiko-abetka-1-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: риба
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: fish
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 1e4cc44f00cde009
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[И].key_word
+    source_id: ohoiko-abetka-2-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: ракета
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: rocket; missile
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 9a1ed75431370793
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Р].key_word
+    source_id: ohoiko-abetka-2-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: вовк
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: wolf
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: e11e5d05b0e85fe7
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[В].key_word
+    source_id: ohoiko-abetka-2-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: індик
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: turkey
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 21ea9299ebdeb5f9
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[І].key_word
+    source_id: ohoiko-abetka-2-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: павук
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: spider
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 323dedb3d07bd5b6
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[П].key_word
+    source_id: ohoiko-abetka-3-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: ґанок
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: porch
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 0e104c98fcf04fd8
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Ґ].key_word
+    source_id: ohoiko-abetka-3-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: екран
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: screen
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 92174367a9319045
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Е].key_word
+    source_id: ohoiko-abetka-3-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: шапка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: hat; cap
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: f6de7815ae70b6c1
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Ш].key_word
+    source_id: ohoiko-abetka-3-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: хліб
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: bread
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: a0d2d5c19eb2abd7
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Х].key_word
+    source_id: ohoiko-abetka-3-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: йогурт
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: yogurt
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: d8d6d25efd4b2832
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Й].key_word
+    source_id: ohoiko-abetka-4-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: щітка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: brush
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 0c5c0f28bd906050
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Щ].key_word
+    source_id: ohoiko-abetka-4-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: яблуко
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: apple
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: dad1f0e64266d4ae
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Я].key_word
+    source_id: ohoiko-abetka-4-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: юнак
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: young man
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 7b1812e4db44aa34
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Ю].key_word
+    source_id: ohoiko-abetka-4-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: єнот
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: raccoon
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: ee96b22412f6a457
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Є].key_word
+    source_id: ohoiko-abetka-4-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: сіль
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: salt
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 3f0e6b310a74f67d
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Ь].key_word
+    source_id: ohoiko-abetka-4-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: їжак
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: hedgehog
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: c7fc850fbd90372e
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Ї].key_word
+    source_id: ohoiko-abetka-4-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: цибуля
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: onion
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 56cf596d2e29b7ec
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Ц].key_word
+    source_id: ohoiko-abetka-4-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary
+- lemma: фламінго
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: flamingo
+  sense_note: Ohoiko + dictionary
+  source_inventory:
+    key: 877d270182699d48
+    path: data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml
+    locator: letters[Ф].key_word
+    source_id: ohoiko-abetka-4-keywords
+    source_family: ohoiko
+  evidence_refs:
+  - Ohoiko + dictionary

--- a/docs/runbooks/word-atlas-ohoiko-ulp-source-scope.md
+++ b/docs/runbooks/word-atlas-ohoiko-ulp-source-scope.md
@@ -22,6 +22,10 @@ Those modules contain public YouTube pronunciation-video metadata and explicit
 Current committed coverage is complete for that source: 4 abetka modules, 33
 `key_word` rows, and 33 Ohoiko source-inventory headwords.
 
+Current review-ledger coverage is also complete for that source: 33 of 33
+Ohoiko source-inventory rows have `approve_for_publish` decisions. This does
+not by itself admit rows to Daily Word, Practice, or cloze surfaces.
+
 ## Link-Only Sources
 
 The Ukrainian Lessons resource indexes are useful for curriculum alignment and
@@ -56,8 +60,8 @@ A safe follow-up PR may do one of these:
 
 - add a manually reviewed Ohoiko/ULP headword inventory where every row cites a
   public, non-premium source locator and includes review notes
-- add reviewed decision-ledger rows for already-generated Ohoiko candidates
-- publish an already-approved Ohoiko batch to Atlas browse/search only
+- publish approved Ohoiko rows to Atlas browse/search only
+- add reviewed decision-ledger rows for any newly added Ohoiko/ULP inventory
 
 Daily Word, Practice, and cloze admission must remain separate
 `surface_admission` decisions. Missing `surface_admission` means Atlas

--- a/tests/test_ohoiko_source_inventory_scope.py
+++ b/tests/test_ohoiko_source_inventory_scope.py
@@ -6,11 +6,16 @@ from pathlib import Path
 
 import yaml
 
+from scripts.audit import source_inventory_review_decisions as decisions
 from scripts.audit.source_inventory_intake import read_source_inventory
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 ABETKA_DIR = PROJECT_ROOT / "curriculum/l2-uk-direct/a1"
 OHOIKO_INVENTORY = PROJECT_ROOT / "data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml"
+DECISION_DIR = PROJECT_ROOT / "data/lexicon/source-inventory-review-decisions"
+OHOIKO_DECISION_BATCH = (
+    DECISION_DIR / "2026-07-03-second-approved-ohoiko-ledger-batch.yaml"
+)
 ULP_SCHEMA = PROJECT_ROOT / "docs/resources/EXTERNAL_RESOURCES_SCHEMA.md"
 ULP_BLOG_DB = PROJECT_ROOT / "docs/resources/ukrainianlessons/blog_db.json"
 
@@ -36,6 +41,37 @@ def test_ohoiko_abetka_inventory_covers_all_committed_key_words() -> None:
 
     assert _abetka_key_words() == ohoiko_rows
     assert sum(ohoiko_rows.values()) == 33
+
+
+def test_ohoiko_abetka_inventory_has_review_decisions_for_all_rows() -> None:
+    records = read_source_inventory(OHOIKO_INVENTORY, project_root=PROJECT_ROOT)
+    inventory_rows = Counter(
+        (record.source_id, record.lemma)
+        for record in records
+        if record.source_family == "ohoiko"
+    )
+    approved_rows: Counter[tuple[str, str]] = Counter()
+    for path in sorted(DECISION_DIR.glob("*.yaml")):
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for row in payload.get("decisions", []):
+            source_inventory = row.get("source_inventory", {})
+            if (
+                row.get("decision") == "approve_for_publish"
+                and source_inventory.get("source_family") == "ohoiko"
+                and source_inventory.get("path")
+                == "data/lexicon/source-inventory/ohoiko-abetka-keywords.yaml"
+            ):
+                approved_rows[(source_inventory["source_id"], row["lemma"])] += 1
+
+    assert inventory_rows == approved_rows
+    assert sum(approved_rows.values()) == 33
+
+    summary = decisions.validate_committed_decision_files([OHOIKO_DECISION_BATCH])
+    assert summary == {
+        "files": 1,
+        "rows": 23,
+        "decision_counts": {"approve_for_publish": 23},
+    }
 
 
 def test_ulp_resource_policy_remains_link_only_for_lexicon_scope() -> None:


### PR DESCRIPTION
## Summary
- Add a second Ohoiko review-only source-inventory ledger batch for the 23 remaining abetka key-word rows.
- Tighten the Ohoiko scope test so the committed 33-row Ohoiko inventory must have matching `approve_for_publish` decisions.
- Update the Ohoiko/ULP scope runbook to record full 33/33 ledger coverage and clarify that learner surfaces still require separate admission.

## Atlas / learner-surface effect
- No live Atlas manifest/search/browse output changes.
- No Daily Word changes.
- No Practice changes.
- No cloze changes.
- Promotion planner for this ledger: 23 approved, 23 matched, 11 proposed additions, 12 skipped existing, 0 missing.

## Validation
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.audit.source_inventory_review_decisions`
  - `files=12 rows=250 decisions={'approve_for_publish': 250}`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_ohoiko_source_inventory_scope.py tests/test_source_inventory_review_decisions.py -q`
  - 16 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check tests/test_ohoiko_source_inventory_scope.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/yamllint data/lexicon/source-inventory-review-decisions/2026-07-03-second-approved-ohoiko-ledger-batch.yaml`
- `npx --yes markdownlint-cli2 docs/runbooks/word-atlas-ohoiko-ulp-source-scope.md`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/check_static_practice_assets.py --format json`
  - Daily 300, Practice 4,484, cloze 22, ok true
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
  - pass

## Independent review
- AGY/Gemini `review-3933-ohoiko-ledger-diff`: NO BLOCKERS.
