### PR TITLE
data(atlas): seed teacher lesson rows 159-178

### DIFF
--- a/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+++ b/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
@@ -1,0 +1,114 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Private teacher lesson vocabulary - explicit table rows 159-178
+    locator: local-only explicit vocabulary table rows 159-178
+    notes: >-
+      Derived headword metadata only; raw private lesson material is local-only
+      and not committed. Daily Word, Practice, and cloze remain frozen without
+      explicit surface_admission.
+    headwords:
+      - lemma: опублікувати
+        pos: verb
+        gloss: to publish; perfective
+        locator: explicit vocabulary table row 159
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: свекруха
+        pos: noun
+        gloss: mother-in-law; husband's mother
+        locator: explicit vocabulary table row 160
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: теща
+        pos: noun
+        gloss: mother-in-law; wife's mother
+        locator: explicit vocabulary table row 161
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: свекор
+        pos: noun
+        gloss: father-in-law; husband's father
+        locator: explicit vocabulary table row 162
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: тесть
+        pos: noun
+        gloss: father-in-law; wife's father
+        locator: explicit vocabulary table row 163
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: знущатися над
+        pos: verb
+        gloss: to bully; to abuse; imperfective; takes над + instrumental
+        locator: explicit vocabulary table row 164
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: швабра
+        pos: noun
+        gloss: mop
+        locator: explicit vocabulary table row 165
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: липкий
+        pos: adjective
+        gloss: sticky
+        locator: explicit vocabulary table row 166
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: слизький
+        pos: adjective
+        gloss: slippery
+        locator: explicit vocabulary table row 167
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: сварка
+        pos: noun
+        gloss: argument; quarrel
+        locator: explicit vocabulary table row 168
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: затримувати
+        pos: verb
+        gloss: to delay; imperfective
+        locator: explicit vocabulary table row 169
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: затримати
+        pos: verb
+        gloss: to delay; perfective
+        locator: explicit vocabulary table row 170
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: штора
+        pos: noun
+        gloss: curtain
+        locator: explicit vocabulary table row 171
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: в'язниця
+        pos: noun
+        gloss: prison
+        locator: explicit vocabulary table row 172
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: шахрайство
+        pos: noun
+        gloss: fraud
+        locator: explicit vocabulary table row 173
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: у шоці з
+        pos: phrase
+        gloss: shocked by; takes genitive
+        locator: explicit vocabulary table row 174
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: похід
+        pos: noun
+        gloss: hike; trip
+        locator: explicit vocabulary table row 175
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: чаклун
+        pos: noun
+        gloss: sorcerer
+        locator: explicit vocabulary table row 176
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: переїзд
+        pos: noun
+        gloss: moving; relocation
+        locator: explicit vocabulary table row 177
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: виставити
+        pos: verb
+        gloss: to make someone look like; perfective; takes instrumental
+        locator: explicit vocabulary table row 178
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -14,17 +14,19 @@ The committed inventory seeds are:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml`
 
-Current committed coverage is 167 reviewed headwords from explicit local
-vocabulary table rows 1-158. The source family is `teacher_lesson`, and the
+Current committed coverage is 187 source-inventory headwords from explicit
+local vocabulary table rows 1-178. The source family is `teacher_lesson`, and the
 source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.
 
 Current approval-ledger coverage is 167 reviewed headwords from rows 1-158.
-Live Atlas browse/search coverage is 147 neutral `teacher_lesson` provenance
-entries from rows 1-138. Rows 139-158 are approved for later publish, but
-remain out of live Atlas until a later controlled PR updates browse/search.
+Live Atlas manifest coverage is 167 neutral `teacher_lesson` provenance refs
+across 166 Atlas entries from rows 1-158; public browse/search is regenerated
+from that manifest. Rows 159-178 are source-inventory only until a later
+approval ledger and controlled publish PR updates browse/search.
 Missing `surface_admission` keeps Daily Word, Practice, and cloze frozen.
 
 ## Source Handling Rule

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -23,6 +23,7 @@ The committed source inventory input is:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml`
 - `data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml`
 
 The candidate JSON follows the existing grow-candidate shape: `counts`,
@@ -92,13 +93,12 @@ conjunction, particle, and interjection. Optional per-headword `gloss` values
 are curated learner-facing English anchors for cases where dictionary
 enrichment lacks a visible English translation.
 
-The private teacher-lesson seeds contribute 167 reviewed `teacher_lesson`
-headwords from an explicit local vocabulary table, with approval ledgers
-covering rows 1-158. Rows 139-158 are approved for later publish, but are not
-live Atlas output until a later controlled publish PR updates browse/search.
-Their committed rows are derived metadata only: no raw private lesson material,
-private document paths, or teacher-identifying labels should appear in the
-inventory.
+The private teacher-lesson seeds contribute 187 `teacher_lesson` headwords from
+an explicit local vocabulary table, with approval ledgers covering rows 1-158.
+Rows 159-178 are source-inventory only until a later approval ledger and
+controlled publish PR updates browse/search. Their committed rows are derived
+metadata only: no raw private lesson material, private document paths, or
+teacher-identifying labels should appear in the inventory.
 
 When a candidate is later promoted into a manifest entry,
 `promote_grow_candidates.manifest_entry_from_candidate()` copies

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -26,6 +26,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-99-118.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )
 

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -42,6 +42,11 @@ PRIVATE_TEACHER_ROWS_139_158_INVENTORY = (
     / "data/lexicon/source-inventory/"
     "private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml"
 )
+PRIVATE_TEACHER_ROWS_159_178_INVENTORY = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory/"
+    "private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml"
+)
 PRIVATE_TEACHER_FIRST_LEDGER = (
     PROJECT_ROOT
     / "data/lexicon/source-inventory-review-decisions/"
@@ -300,6 +305,41 @@ def test_private_teacher_rows_139_158_inventory_is_pending_review_metadata() -> 
     assert all("surface_admission" not in record.provenance_payload() for record in records)
 
     inventory_text = PRIVATE_TEACHER_ROWS_139_158_INVENTORY.read_text(encoding="utf-8")
+    assert ".docx" not in inventory_text
+    assert "alona" not in inventory_text.lower()
+    assert "native-reviewer-lessons" not in inventory_text
+
+
+def test_private_teacher_rows_159_178_inventory_is_pending_review_metadata() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_159_178_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+
+    assert len(records) == 20
+    assert {record.source_family for record in records} == {"teacher_lesson"}
+    assert {record.extraction_mode for record in records} == {"curated_headword"}
+    assert {record.source_id for record in records} == {
+        "private-teacher-lesson-vocabulary-table-1-rows-159-178"
+    }
+    assert all(record.source_path is None for record in records)
+    assert all(record.source_url is None for record in records)
+    assert all(record.source_title for record in records)
+    assert all(record.source_locator for record in records)
+    assert all(record.context for record in records)
+    assert all(record.pos for record in records)
+    assert all(record.gloss for record in records)
+    assert "опублікувати" in {record.lemma for record in records}
+    assert "знущатися над" in {record.lemma for record in records}
+    assert "в'язниця" in {record.lemma for record in records}
+    assert "у шоці з" in {record.lemma for record in records}
+    assert "виставити" in {record.lemma for record in records}
+    assert all("," not in record.lemma for record in records)
+    assert all("/" not in record.lemma for record in records)
+    assert all("(" not in record.lemma and ")" not in record.lemma for record in records)
+    assert all("surface_admission" not in record.provenance_payload() for record in records)
+
+    inventory_text = PRIVATE_TEACHER_ROWS_159_178_INVENTORY.read_text(encoding="utf-8")
     assert ".docx" not in inventory_text
     assert "alona" not in inventory_text.lower()
     assert "native-reviewer-lessons" not in inventory_text


### PR DESCRIPTION
## Summary
- Add the next privacy-safe private teacher-lesson source-inventory seed for explicit vocabulary table rows 159-178.
- Register the new seed in the source-inventory review candidate generator.
- Extend focused tests and refresh runbook counts/status for the current teacher-lesson lane.

## Boundary
- Review-only source inventory seed.
- No live Atlas manifest/search/browse output changes.
- No manifest pointer/fingerprint changes.
- No Daily Word, Practice, or cloze admission changes.
- No raw private lesson material, private document paths, transcripts, or teacher-identifying labels.

## Counts
- Source inventory after this PR: 320 total rows.
- `teacher_lesson` source inventory after this PR: 187 rows.
- Existing approval-ledger coverage remains rows 1-158 / 167 `teacher_lesson` headwords.
- New rows 159-178 are source-inventory only until a later approval ledger and controlled publish PR.
- Candidate generation sees 20 new row provenance refs from `private-teacher-lesson-vocabulary-table-1-rows-159-178`, split 9 auto-merge / 11 needs-review.

## Validation
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_candidates.py -q` -> 60 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.audit.source_inventory_review_decisions` -> 13 files / 287 approved rows
- `generate_source_inventory_review_candidates` via worktree code with root `data/sources.db` -> total_delta 306, processed 306, auto_merge 122, needs_review 184; publish_ready 120, needs_publish_review 186
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/audit/generate_source_inventory_review_candidates.py tests/test_private_teacher_lesson_source_inventory.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` -> ok; Daily 300, Practice 4,484, Cloze 22
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --check`

## Independent review
- AGY/Gemini review: `NO BLOCKERS`.
