### PR TITLE
data(atlas): approve teacher lesson rows 159-178

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-03-ninth-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-03-ninth-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,297 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-ninth-approved-teacher-lesson-ledger-batch-2026-07-03
+batch_label: ninth-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-03'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4199
+  total_queue_rows: 186
+  approved_in_queue: 20
+  promotion_batch_size: 20
+production_outputs_updated: []
+decisions:
+- lemma: опублікувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to publish; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a52150b0ef634985
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 159
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: свекруха
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: mother-in-law; husband's mother
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 7ed83f76b63cbb19
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 160
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: теща
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: mother-in-law; wife's mother
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d1e010400d3bb431
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 161
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: свекор
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: father-in-law; husband's father
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 128365260d26f53c
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 162
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: тесть
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: father-in-law; wife's father
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 263f257dd3f1fe5c
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 163
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: знущатися над
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to bully; to abuse; imperfective; takes над + instrumental
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 4cc676a3d37f5c69
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 164
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: швабра
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: mop
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 05ab2695510c60f9
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 165
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: липкий
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: sticky
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: e1bae6115bc59629
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 166
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: слизький
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: slippery
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 63d3c02e5cee9cb5
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 167
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: сварка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: argument; quarrel
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 426a218bd60c5327
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 168
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: затримувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to delay; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: f9883b588bf54654
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 169
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: затримати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to delay; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a1322d25fd06d29f
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 170
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: штора
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: curtain
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 4121b2eb84a50c59
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 171
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: в'язниця
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: prison
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: f1b15fd4aaa021ed
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 172
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: шахрайство
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: fraud
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 03308a0a685e1196
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 173
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: у шоці з
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: shocked by; takes genitive
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: b756160cb8e3a6a1
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 174
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: похід
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: hike; trip
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: c11d7070e07fea40
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 175
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: чаклун
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: sorcerer
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: ac0959be9ccc084e
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 176
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: переїзд
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: moving; relocation
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 42b16128869e024a
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 177
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: виставити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to make someone look like; perfective; takes instrumental
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d57d661173be7005
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml
+    locator: explicit vocabulary table row 178
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-159-178
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -22,11 +22,11 @@ source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.
 
-Current approval-ledger coverage is 167 reviewed headwords from rows 1-158.
+Current approval-ledger coverage is 187 reviewed headwords from rows 1-178.
 Live Atlas manifest coverage is 167 neutral `teacher_lesson` provenance refs
 across 166 Atlas entries from rows 1-158; public browse/search is regenerated
-from that manifest. Rows 159-178 are source-inventory only until a later
-approval ledger and controlled publish PR updates browse/search.
+from that manifest. Rows 159-178 are approved for later publish, but remain out
+of live Atlas until a later controlled publish PR updates browse/search.
 Missing `surface_admission` keeps Daily Word, Practice, and cloze frozen.
 
 ## Source Handling Rule

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -94,11 +94,11 @@ are curated learner-facing English anchors for cases where dictionary
 enrichment lacks a visible English translation.
 
 The private teacher-lesson seeds contribute 187 `teacher_lesson` headwords from
-an explicit local vocabulary table, with approval ledgers covering rows 1-158.
-Rows 159-178 are source-inventory only until a later approval ledger and
-controlled publish PR updates browse/search. Their committed rows are derived
-metadata only: no raw private lesson material, private document paths, or
-teacher-identifying labels should appear in the inventory.
+an explicit local vocabulary table, with approval ledgers covering rows 1-178.
+Rows 159-178 are approved for later publish, but are not live Atlas output until
+a later controlled publish PR updates browse/search. Their committed rows are
+derived metadata only: no raw private lesson material, private document paths,
+or teacher-identifying labels should appear in the inventory.
 
 When a candidate is later promoted into a manifest entry,
 `promote_grow_candidates.manifest_entry_from_candidate()` copies

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -87,6 +87,11 @@ PRIVATE_TEACHER_EIGHTH_LEDGER = (
     / "data/lexicon/source-inventory-review-decisions/"
     "2026-07-03-eighth-approved-teacher-lesson-ledger-batch.yaml"
 )
+PRIVATE_TEACHER_NINTH_LEDGER = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory-review-decisions/"
+    "2026-07-03-ninth-approved-teacher-lesson-ledger-batch.yaml"
+)
 
 
 def test_private_teacher_inventory_is_privacy_safe_review_metadata() -> None:
@@ -558,6 +563,36 @@ def test_private_teacher_eighth_decision_ledger_stays_review_only() -> None:
     assert "native-reviewer-lessons" not in ledger_text
 
 
+def test_private_teacher_ninth_decision_ledger_stays_review_only() -> None:
+    summary = decisions.validate_committed_decision_files([PRIVATE_TEACHER_NINTH_LEDGER])
+    payload = yaml.safe_load(PRIVATE_TEACHER_NINTH_LEDGER.read_text(encoding="utf-8"))
+
+    assert summary == {
+        "files": 1,
+        "rows": 20,
+        "decision_counts": {"approve_for_publish": 20},
+    }
+    assert payload["source_queue"]["generated_from_pr"] == 4199
+    assert payload["source_queue"]["promotion_batch_size"] == 20
+    assert payload["production_outputs_updated"] == []
+    assert payload["decisions"][0]["lemma"] == "опублікувати"
+    assert payload["decisions"][-1]["lemma"] == "виставити"
+    assert all(
+        row["source_inventory"]["source_family"] == "teacher_lesson"
+        for row in payload["decisions"]
+    )
+    assert {
+        row["source_inventory"]["source_id"]
+        for row in payload["decisions"]
+    } == {"private-teacher-lesson-vocabulary-table-1-rows-159-178"}
+    assert all("surface_admission" not in row for row in payload["decisions"])
+
+    ledger_text = PRIVATE_TEACHER_NINTH_LEDGER.read_text(encoding="utf-8")
+    assert ".docx" not in ledger_text
+    assert "alona" not in ledger_text.lower()
+    assert "native-reviewer-lessons" not in ledger_text
+
+
 def test_private_teacher_decision_ledgers_cover_seed_without_live_surfaces() -> None:
     records = read_source_inventory(PRIVATE_TEACHER_INVENTORY, project_root=PROJECT_ROOT)
     inventory_keys = {
@@ -728,6 +763,32 @@ def test_private_teacher_rows_139_158_decision_ledger_covers_pending_seed() -> N
     }
 
     payload = yaml.safe_load(PRIVATE_TEACHER_EIGHTH_LEDGER.read_text(encoding="utf-8"))
+    ledger_keys = {
+        row["source_inventory"]["key"]
+        for row in payload["decisions"]
+    }
+
+    assert ledger_keys == inventory_keys
+
+
+def test_private_teacher_rows_159_178_decision_ledger_covers_pending_seed() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_159_178_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+    inventory_keys = {
+        decisions.source_inventory_key(
+            lemma=record.lemma,
+            inventory_path=(
+                "data/lexicon/source-inventory/"
+                "private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml"
+            ),
+            locator=record.source_locator,
+        )
+        for record in records
+    }
+
+    payload = yaml.safe_load(PRIVATE_TEACHER_NINTH_LEDGER.read_text(encoding="utf-8"))
     ledger_keys = {
         row["source_inventory"]["key"]
         for row in payload["decisions"]


### PR DESCRIPTION
## Summary
- Add the ninth review-only approval ledger for private teacher-lesson rows 159-178.
- Approve 20 queued `teacher_lesson` headwords for a later controlled Atlas publish.
- Update focused tests and runbooks for approval coverage through rows 1-178.

## Boundary
- Review-only approval data.
- No live Atlas manifest/search/browse output changes.
- No manifest pointer/fingerprint changes.
- No Daily Word, Practice, or cloze admission changes.
- No raw private lesson material, private document paths, transcripts, or teacher-identifying labels.

## Counts
- Source decision ledgers after this PR: 14 files / 307 approved rows.
- Teacher-lesson approval coverage after this PR: rows 1-178 / 187 headwords.
- Planner for the later publish PR: 20 approved, 20 matched, 13 proposed additions, 7 skipped existing/provenance cases, 0 missing candidates.

## Validation
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_review_decisions.py tests/test_source_inventory_promotion_plan.py -q` -> 50 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.audit.source_inventory_review_decisions` -> 14 files / 307 approved rows
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` -> ok; Daily 300, Practice 4,484, Cloze 22
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check tests/test_private_teacher_lesson_source_inventory.py`
- `node site/scripts/hydrate-manifest.mjs`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.audit.plan_source_inventory_promotion --candidates /tmp/atlas-source-inventory-review-candidates-4160-159-178.json --decision-file data/lexicon/source-inventory-review-decisions/2026-07-03-ninth-approved-teacher-lesson-ledger-batch.yaml --manifest site/src/data/lexicon-manifest.json --out /tmp/atlas-teacher-159-178-ledger-plan.json --report-out /tmp/atlas-teacher-159-178-ledger-plan.md --report`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --check`

## Independent review
- AGY/Gemini review final verdict: `NO BLOCKERS`.
- AGY noted `generated_from_pr: 4199` as non-blocking; this is intentionally the seed PR number, matching the existing ledger convention (`generated_from_pr` records the source seed PR, not the GitHub issue number).
