### PR TITLE
data(atlas): seed textbook family numerals

### DIFF
--- a/data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+++ b/data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
@@ -1,0 +1,190 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: vashulenko-grade3-2020-family-vocabulary
+    source_family: textbook
+    extraction_mode: headword_inventory
+    title: Вашуленко М.С. Українська мова та читання. 3 клас. Частина 1, 2020
+    path: docs/l2-uk-direct/textbook-map.yaml
+    locator: topic_index.vocabulary_family
+    notes: Seed uses only tracked textbook-map word lists; source PDF is not committed.
+    headwords:
+      - lemma: мама
+        pos: noun
+        gloss: mother
+        locator: topic_index.vocabulary_family.words[0]
+        context: "Grade 3 family vocabulary word list includes мама."
+      - lemma: тато
+        pos: noun
+        gloss: father; dad
+        locator: topic_index.vocabulary_family.words[1]
+        context: "Grade 3 family vocabulary word list includes тато."
+      - lemma: баба
+        pos: noun
+        gloss: grandmother; older woman
+        locator: topic_index.vocabulary_family.words[2]
+        context: "Grade 3 family vocabulary word list includes баба."
+      - lemma: дід
+        pos: noun
+        gloss: grandfather; old man
+        locator: topic_index.vocabulary_family.words[3]
+        context: "Grade 3 family vocabulary word list includes дід."
+      - lemma: сестра
+        pos: noun
+        gloss: sister
+        locator: topic_index.vocabulary_family.words[4]
+        context: "Grade 3 family vocabulary word list includes сестра."
+      - lemma: брат
+        pos: noun
+        gloss: brother
+        locator: topic_index.vocabulary_family.words[5]
+        context: "Grade 3 family vocabulary word list includes брат."
+      - lemma: дитина
+        pos: noun
+        gloss: child
+        locator: topic_index.vocabulary_family.words[6]
+        context: "Grade 3 family vocabulary word list includes дитина."
+      - lemma: дружина
+        pos: noun
+        gloss: wife
+        locator: topic_index.vocabulary_family.words[7]
+        context: "Grade 3 family vocabulary word list includes дружина."
+      - lemma: чоловік
+        pos: noun
+        gloss: husband; man
+        locator: topic_index.vocabulary_family.words[8]
+        context: "Grade 3 family vocabulary word list includes чоловік."
+  - id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+    extraction_mode: headword_inventory
+    title: Вашуленко М.С. Українська мова та читання. 3 клас. Частина 1, 2020
+    path: docs/l2-uk-direct/textbook-map.yaml
+    locator: topic_index.vocabulary_numerals
+    notes: Seed uses only tracked textbook-map word lists; source PDF is not committed.
+    headwords:
+      - lemma: один
+        pos: numeral
+        gloss: one
+        locator: topic_index.vocabulary_numerals.words_1_20[0]
+        context: "Grade 3 pp138-143 numeral word list includes один."
+      - lemma: два
+        pos: numeral
+        gloss: two
+        locator: topic_index.vocabulary_numerals.words_1_20[1]
+        context: "Grade 3 pp138-143 numeral word list includes два."
+      - lemma: три
+        pos: numeral
+        gloss: three
+        locator: topic_index.vocabulary_numerals.words_1_20[2]
+        context: "Grade 3 pp138-143 numeral word list includes три."
+      - lemma: чотири
+        pos: numeral
+        gloss: four
+        locator: topic_index.vocabulary_numerals.words_1_20[3]
+        context: "Grade 3 pp138-143 numeral word list includes чотири."
+      - lemma: п'ять
+        pos: numeral
+        gloss: five
+        locator: topic_index.vocabulary_numerals.words_1_20[4]
+        context: "Grade 3 pp138-143 numeral word list includes п'ять."
+      - lemma: шість
+        pos: numeral
+        gloss: six
+        locator: topic_index.vocabulary_numerals.words_1_20[5]
+        context: "Grade 3 pp138-143 numeral word list includes шість."
+      - lemma: сім
+        pos: numeral
+        gloss: seven
+        locator: topic_index.vocabulary_numerals.words_1_20[6]
+        context: "Grade 3 pp138-143 numeral word list includes сім."
+      - lemma: вісім
+        pos: numeral
+        gloss: eight
+        locator: topic_index.vocabulary_numerals.words_1_20[7]
+        context: "Grade 3 pp138-143 numeral word list includes вісім."
+      - lemma: дев'ять
+        pos: numeral
+        gloss: nine
+        locator: topic_index.vocabulary_numerals.words_1_20[8]
+        context: "Grade 3 pp138-143 numeral word list includes дев'ять."
+      - lemma: десять
+        pos: numeral
+        gloss: ten
+        locator: topic_index.vocabulary_numerals.words_1_20[9]
+        context: "Grade 3 pp138-143 numeral word list includes десять."
+      - lemma: одинадцять
+        pos: numeral
+        gloss: eleven
+        locator: topic_index.vocabulary_numerals.words_1_20[10]
+        context: "Grade 3 pp138-143 numeral word list includes одинадцять."
+      - lemma: дванадцять
+        pos: numeral
+        gloss: twelve
+        locator: topic_index.vocabulary_numerals.words_1_20[11]
+        context: "Grade 3 pp138-143 numeral word list includes дванадцять."
+      - lemma: тринадцять
+        pos: numeral
+        gloss: thirteen
+        locator: topic_index.vocabulary_numerals.words_1_20[12]
+        context: "Grade 3 pp138-143 numeral word list includes тринадцять."
+      - lemma: чотирнадцять
+        pos: numeral
+        gloss: fourteen
+        locator: topic_index.vocabulary_numerals.words_1_20[13]
+        context: "Grade 3 pp138-143 numeral word list includes чотирнадцять."
+      - lemma: п'ятнадцять
+        pos: numeral
+        gloss: fifteen
+        locator: topic_index.vocabulary_numerals.words_1_20[14]
+        context: "Grade 3 pp138-143 numeral word list includes п'ятнадцять."
+      - lemma: шістнадцять
+        pos: numeral
+        gloss: sixteen
+        locator: topic_index.vocabulary_numerals.words_1_20[15]
+        context: "Grade 3 pp138-143 numeral word list includes шістнадцять."
+      - lemma: сімнадцять
+        pos: numeral
+        gloss: seventeen
+        locator: topic_index.vocabulary_numerals.words_1_20[16]
+        context: "Grade 3 pp138-143 numeral word list includes сімнадцять."
+      - lemma: вісімнадцять
+        pos: numeral
+        gloss: eighteen
+        locator: topic_index.vocabulary_numerals.words_1_20[17]
+        context: "Grade 3 pp138-143 numeral word list includes вісімнадцять."
+      - lemma: дев'ятнадцять
+        pos: numeral
+        gloss: nineteen
+        locator: topic_index.vocabulary_numerals.words_1_20[18]
+        context: "Grade 3 pp138-143 numeral word list includes дев'ятнадцять."
+      - lemma: двадцять
+        pos: numeral
+        gloss: twenty
+        locator: topic_index.vocabulary_numerals.words_1_20[19]
+        context: "Grade 3 pp138-143 numeral word list includes двадцять."
+      - lemma: тридцять
+        pos: numeral
+        gloss: thirty
+        locator: topic_index.vocabulary_numerals.words_tens[0]
+        context: "Grade 3 pp138-143 tens numeral word list includes тридцять."
+      - lemma: п'ятдесят
+        pos: numeral
+        gloss: fifty
+        locator: topic_index.vocabulary_numerals.words_tens[1]
+        context: "Grade 3 pp138-143 tens numeral word list includes п'ятдесят."
+      - lemma: шістдесят
+        pos: numeral
+        gloss: sixty
+        locator: topic_index.vocabulary_numerals.words_tens[2]
+        context: "Grade 3 pp138-143 tens numeral word list includes шістдесят."
+      - lemma: сімдесят
+        pos: numeral
+        gloss: seventy
+        locator: topic_index.vocabulary_numerals.words_tens[3]
+        context: "Grade 3 pp138-143 tens numeral word list includes сімдесят."
+      - lemma: вісімдесят
+        pos: numeral
+        gloss: eighty
+        locator: topic_index.vocabulary_numerals.words_tens[4]
+        context: "Grade 3 pp138-143 tens numeral word list includes вісімдесят."

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -24,6 +24,7 @@ The committed source inventory input is:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml`
+- `data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml`
 - `data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml`
 
 The candidate JSON follows the existing grow-candidate shape: `counts`,

--- a/docs/runbooks/word-atlas-textbook-source-scope.md
+++ b/docs/runbooks/word-atlas-textbook-source-scope.md
@@ -6,7 +6,7 @@ before broader textbook ingestion can be treated as resolved.
 
 ## Current Textbook Inventories
 
-The committed textbook source-inventory lane currently has 80 rows:
+The committed textbook source-inventory lane currently has 114 rows:
 
 - `data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml`
   - 40 headwords
@@ -14,6 +14,9 @@ The committed textbook source-inventory lane currently has 80 rows:
     `docs/l2-uk-direct/textbook-reading-notes/bolshakova-bukvar-mapping.md`
 - `data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml`
   - 40 headwords
+  - source map: `docs/l2-uk-direct/textbook-map.yaml`
+- `data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml`
+  - 34 headwords
   - source map: `docs/l2-uk-direct/textbook-map.yaml`
 
 These inventory rows cite tracked notes/maps, not untracked source PDFs. The
@@ -28,6 +31,8 @@ The Vashulenko Grade 3 inventory is deliberately topic-bounded:
 - interior vocabulary: 17 rows
 - marine vocabulary: 6 rows
 - bird vocabulary: 10 rows
+- family vocabulary: 9 rows
+- numerals: 25 rows
 
 The row locators point into `docs/l2-uk-direct/textbook-map.yaml`, for example
 `topic_index.vocabulary_school.words[0]`. Tests resolve those locators back to
@@ -36,7 +41,7 @@ the tracked source map.
 
 ## Not Yet Done
 
-Issue #3934 remains open because the current 80 rows are only a reviewed seed, not a
+Issue #3934 remains open because the current 114 rows are only a reviewed seed, not a
 complete textbook corpus. The missing work is:
 
 - add more reviewed textbook/headword inventories with tracked source locators

--- a/scripts/audit/apply_source_inventory_provenance.py
+++ b/scripts/audit/apply_source_inventory_provenance.py
@@ -73,7 +73,7 @@ def apply_existing_provenance_overlay(
             missing_manifest_entries.append({**base_row, "reason": "approved lemma missing from manifest"})
             continue
 
-        candidate_provenance = _source_provenance(match.entry)
+        candidate_provenance = plan._approved_source_provenance(decision, match.entry)
         if not candidate_provenance:
             missing_candidates.append({**base_row, "reason": "matched candidate lacks source_provenance"})
             continue
@@ -146,13 +146,6 @@ def format_report(result: Mapping[str, Any]) -> str:
             for row in result["missing_manifest_entries"]
         )
     return "\n".join(lines)
-
-
-def _source_provenance(entry: Mapping[str, Any]) -> list[dict[str, Any]]:
-    provenance = entry.get("source_provenance")
-    if not isinstance(provenance, list):
-        return []
-    return [dict(item) for item in provenance if isinstance(item, Mapping)]
 
 
 def _append_missing_provenance(entry: dict[str, Any], provenance: Sequence[Mapping[str, Any]]) -> int:

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -27,6 +27,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )
 

--- a/scripts/audit/plan_source_inventory_promotion.py
+++ b/scripts/audit/plan_source_inventory_promotion.py
@@ -197,6 +197,7 @@ def resolve_ephemeral_plan_output_path(out: Path) -> Path:
 
 def _planned_addition(decision: ApprovedDecision, match: CandidateMatch) -> dict[str, Any]:
     candidate = copy.deepcopy(dict(match.entry))
+    candidate["source_provenance"] = _approved_source_provenance(decision, match.entry)
     candidate["pos"] = decision.approved_pos
     candidate["gloss"] = decision.approved_gloss
     candidate.pop("surface_admission", None)
@@ -224,6 +225,37 @@ def _planned_addition(decision: ApprovedDecision, match: CandidateMatch) -> dict
         "decision_file": decision.decision_file,
         "manifest_entry": manifest_entry,
     }
+
+
+def _approved_source_provenance(
+    decision: ApprovedDecision,
+    entry: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Return only the candidate provenance row approved by ``decision``."""
+    provenance = entry.get("source_provenance")
+    if not isinstance(provenance, list):
+        return []
+    approved: list[dict[str, Any]] = []
+    lemma = strip_acute_stress(_clean_text(entry.get("lemma"))) or decision.lemma
+    for item in provenance:
+        if not isinstance(item, Mapping):
+            continue
+        inventory_path = _clean_text(item.get("inventory_path"))
+        locator = _clean_text(item.get("source_locator"))
+        if not inventory_path or not locator:
+            continue
+        source_key = decisions.source_inventory_key(
+            lemma=lemma,
+            inventory_path=inventory_path,
+            locator=locator,
+        )
+        if source_key == decision.source_key:
+            approved.append(dict(item))
+    if not approved:
+        raise SourceInventoryError(
+            f"{decision.lemma}: approved source key {decision.source_key!r} missing from matched candidate"
+        )
+    return approved
 
 
 def _candidate_index(payload: Mapping[str, Any]) -> dict[str, CandidateMatch]:

--- a/tests/test_apply_source_inventory_promotion.py
+++ b/tests/test_apply_source_inventory_promotion.py
@@ -97,7 +97,7 @@ def test_apply_existing_provenance_overlay_updates_existing_entries() -> None:
         expected_additions=0,
         expected_skipped_existing=1,
     )
-    decision = _approved_decision("чверть", key="key-чверть")
+    decision = _approved_decision("чверть")
     candidate_index = {
         decision.source_key: planner.CandidateMatch(
             entry={"source_provenance": [_provenance(locator="explicit vocabulary table row 14")]},
@@ -254,16 +254,22 @@ def _provenance(*, locator: str = "explicit vocabulary table row 1") -> dict[str
     }
 
 
-def _approved_decision(lemma: str, *, key: str) -> planner.ApprovedDecision:
+def _approved_decision(lemma: str) -> planner.ApprovedDecision:
+    inventory_path = "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml"
+    locator = "explicit vocabulary table row 14"
     return planner.ApprovedDecision(
         lemma=lemma,
         approved_pos="noun",
         approved_gloss=lemma,
         sense_note="fixture",
         source_inventory={
-            "key": key,
-            "path": "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-seed.yaml",
-            "locator": "explicit vocabulary table row 14",
+            "key": planner.decisions.source_inventory_key(
+                lemma=lemma,
+                inventory_path=inventory_path,
+                locator=locator,
+            ),
+            "path": inventory_path,
+            "locator": locator,
             "source_id": "private-teacher-lesson-vocabulary-table-1-seed",
             "source_family": "teacher_lesson",
         },

--- a/tests/test_apply_source_inventory_provenance.py
+++ b/tests/test_apply_source_inventory_provenance.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from scripts.audit.apply_source_inventory_provenance import apply_existing_provenance_overlay
 from scripts.audit.plan_source_inventory_promotion import ApprovedDecision, CandidateMatch
+from scripts.audit.source_inventory_review_decisions import source_inventory_key
+
+SOURCE_LOCATOR = "letters[А].key_word"
 
 
 def decision(lemma: str, family: str = "ohoiko") -> ApprovedDecision:
@@ -11,9 +14,13 @@ def decision(lemma: str, family: str = "ohoiko") -> ApprovedDecision:
         approved_gloss="test gloss",
         sense_note="reviewed",
         source_inventory={
-            "key": f"{family}-{lemma}",
+            "key": source_inventory_key(
+                lemma=lemma,
+                inventory_path=f"data/lexicon/source-inventory/{family}.yaml",
+                locator=SOURCE_LOCATOR,
+            ),
             "path": f"data/lexicon/source-inventory/{family}.yaml",
-            "locator": "sources[0].headwords[0]",
+            "locator": SOURCE_LOCATOR,
             "source_id": f"{family}-source",
             "source_family": family,
         },
@@ -34,7 +41,7 @@ def match(lemma: str, family: str = "ohoiko") -> CandidateMatch:
                 {
                     "source_family": family,
                     "source_id": f"{family}-source",
-                    "source_locator": "letters[А].key_word",
+                    "source_locator": SOURCE_LOCATOR,
                     "inventory_path": f"data/lexicon/source-inventory/{family}.yaml",
                     "inventory_locator": "sources[0].headwords[0]",
                 }
@@ -47,10 +54,11 @@ def match(lemma: str, family: str = "ohoiko") -> CandidateMatch:
 
 def test_overlay_adds_source_provenance_to_existing_manifest_entry() -> None:
     manifest = {"entries": [{"lemma": "ананас", "primary_source": "built_vocabulary"}]}
+    approved = decision("ананас")
     result = apply_existing_provenance_overlay(
         manifest,
-        {"ohoiko-ананас": match("ананас")},
-        [decision("ананас")],
+        {approved.source_key: match("ананас")},
+        [approved],
         source_family="ohoiko",
     )
 
@@ -69,6 +77,7 @@ def test_overlay_adds_source_provenance_to_existing_manifest_entry() -> None:
 
 def test_overlay_is_idempotent_for_existing_provenance() -> None:
     provenance = match("ананас").entry["source_provenance"]
+    approved = decision("ананас")
     manifest = {
         "entries": [
             {
@@ -81,8 +90,8 @@ def test_overlay_is_idempotent_for_existing_provenance() -> None:
 
     result = apply_existing_provenance_overlay(
         manifest,
-        {"ohoiko-ананас": match("ананас")},
-        [decision("ананас")],
+        {approved.source_key: match("ананас")},
+        [approved],
         source_family="ohoiko",
     )
 
@@ -92,6 +101,8 @@ def test_overlay_is_idempotent_for_existing_provenance() -> None:
 
 
 def test_overlay_source_family_filter_keeps_other_lanes_untouched() -> None:
+    ohoiko_decision = decision("ананас", "ohoiko")
+    textbook_decision = decision("дошка", "textbook")
     manifest = {
         "entries": [
             {"lemma": "ананас", "primary_source": "built_vocabulary"},
@@ -102,10 +113,10 @@ def test_overlay_source_family_filter_keeps_other_lanes_untouched() -> None:
     result = apply_existing_provenance_overlay(
         manifest,
         {
-            "ohoiko-ананас": match("ананас", "ohoiko"),
-            "textbook-дошка": match("дошка", "textbook"),
+            ohoiko_decision.source_key: match("ананас", "ohoiko"),
+            textbook_decision.source_key: match("дошка", "textbook"),
         },
-        [decision("ананас", "ohoiko"), decision("дошка", "textbook")],
+        [ohoiko_decision, textbook_decision],
         source_family="ohoiko",
     )
 
@@ -114,3 +125,28 @@ def test_overlay_source_family_filter_keeps_other_lanes_untouched() -> None:
     assert result["counts"]["updated_entries"] == 1
     assert manifest["entries"][0]["source_provenance"][0]["source_family"] == "ohoiko"
     assert "source_provenance" not in manifest["entries"][1]
+
+
+def test_overlay_only_adds_approved_duplicate_source_ref() -> None:
+    approved = decision("ананас", "ohoiko")
+    candidate = match("ананас", "ohoiko")
+    candidate.entry["source_provenance"].append(
+        {
+            "source_family": "textbook",
+            "source_id": "textbook-source",
+            "source_locator": "topic_index.fixture.words[0]",
+            "inventory_path": "data/lexicon/source-inventory/textbook.yaml",
+            "inventory_locator": "sources[0].headwords[0]",
+        }
+    )
+    manifest = {"entries": [{"lemma": "ананас", "primary_source": "built_vocabulary"}]}
+
+    result = apply_existing_provenance_overlay(
+        manifest,
+        {approved.source_key: candidate},
+        [approved],
+        source_family="ohoiko",
+    )
+
+    assert result["counts"]["added_provenance_refs"] == 1
+    assert manifest["entries"][0]["source_provenance"] == [candidate.entry["source_provenance"][0]]

--- a/tests/test_source_inventory_promotion_plan.py
+++ b/tests/test_source_inventory_promotion_plan.py
@@ -64,7 +64,17 @@ def _write_json(path: Path, payload: object) -> None:
 def test_plan_maps_approved_decision_to_manifest_addition(tmp_path: Path) -> None:
     decision = _first_decision()
     candidates = tmp_path / "candidates.json"
-    _write_json(candidates, _candidate_payload_for(decision))
+    payload = _candidate_payload_for(decision)
+    payload["needs_review"][0]["entry"]["source_provenance"].append(
+        {
+            "source_family": "textbook",
+            "inventory_path": "data/lexicon/source-inventory/other.yaml",
+            "source_locator": "topic_index.other.words[0]",
+            "source_id": "unapproved-duplicate-source",
+            "context": "fixture duplicate context",
+        }
+    )
+    _write_json(candidates, payload)
 
     plan = planner.build_promotion_plan(
         candidates_path=candidates,
@@ -86,6 +96,7 @@ def test_plan_maps_approved_decision_to_manifest_addition(tmp_path: Path) -> Non
     assert addition["manifest_entry"]["gloss"] == decision["approved_gloss"]
     assert addition["manifest_entry"]["primary_source"] == "source_inventory_grow"
     assert addition["manifest_entry"]["course_usage"] == []
+    assert len(addition["manifest_entry"]["source_provenance"]) == 1
     assert addition["manifest_entry"]["source_provenance"][0]["source_id"] == (
         decision["source_inventory"]["source_id"]
     )

--- a/tests/test_textbook_source_inventory_scope.py
+++ b/tests/test_textbook_source_inventory_scope.py
@@ -16,17 +16,25 @@ BOLSHAKOVA_INVENTORY = (
 VASHULENKO_INVENTORY = (
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml"
 )
+VASHULENKO_FAMILY_NUMERALS_INVENTORY = (
+    PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml"
+)
 VASHULENKO_MAP = PROJECT_ROOT / "docs/l2-uk-direct/textbook-map.yaml"
 BOLSHAKOVA_NOTES = (
     PROJECT_ROOT / "docs/l2-uk-direct/textbook-reading-notes/bolshakova-bukvar-mapping.md"
 )
+TEXTBOOK_INVENTORIES = [
+    BOLSHAKOVA_INVENTORY,
+    VASHULENKO_INVENTORY,
+    VASHULENKO_FAMILY_NUMERALS_INVENTORY,
+]
 
 LOCATOR_PART_RE = re.compile(r"^([A-Za-z0-9_]+)(?:\[(\d+)\])?$")
 
 
 def _records() -> list:
     records = []
-    for path in [BOLSHAKOVA_INVENTORY, VASHULENKO_INVENTORY]:
+    for path in TEXTBOOK_INVENTORIES:
         records.extend(read_source_inventory(path, project_root=PROJECT_ROOT))
     return records
 
@@ -46,13 +54,15 @@ def test_textbook_inventory_counts_and_source_paths_are_stable() -> None:
     records = _records()
     counts = Counter(record.source_id for record in records)
 
-    assert len(records) == 80
+    assert len(records) == 114
     assert counts == {
         "bolshakova-bukvar-2025-part1-keywords": 40,
+        "vashulenko-grade3-2020-family-vocabulary": 9,
         "vashulenko-grade3-2020-school-vocabulary": 7,
         "vashulenko-grade3-2020-interior-vocabulary": 17,
         "vashulenko-grade3-2020-marine-vocabulary": 6,
         "vashulenko-grade3-2020-birds-vocabulary": 10,
+        "vashulenko-grade3-2020-numerals-vocabulary": 25,
     }
     for record in records:
         assert record.source_family == "textbook"
@@ -64,7 +74,9 @@ def test_textbook_inventory_counts_and_source_paths_are_stable() -> None:
 
 def test_vashulenko_inventory_locators_resolve_to_tracked_source_map() -> None:
     textbook_map = yaml.safe_load(VASHULENKO_MAP.read_text(encoding="utf-8"))
-    records = read_source_inventory(VASHULENKO_INVENTORY, project_root=PROJECT_ROOT)
+    records = []
+    for path in [VASHULENKO_INVENTORY, VASHULENKO_FAMILY_NUMERALS_INVENTORY]:
+        records.extend(read_source_inventory(path, project_root=PROJECT_ROOT))
 
     for record in records:
         assert record.source_path == str(VASHULENKO_MAP.relative_to(PROJECT_ROOT))


### PR DESCRIPTION
## Summary

Adds the next review-only textbook/source-inventory seed for #3934 from tracked Vashulenko Grade 3 textbook-map rows.

What changed:
- Added `data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml`.
- Seeded 34 tracked-map textbook rows:
  - 9 family vocabulary rows.
  - 25 numeral rows.
- Registered the new inventory in `generate_source_inventory_review_candidates.py`.
- Updated textbook scope/runbook counts: textbook inventory is now 114 rows; total source inventory is now 354 rows.
- Added a provenance safety guard so future approval/promotion of one deduped source row carries only that approved source provenance, not every duplicate provenance ref attached to the candidate lemma.

Boundary:
- Review-only seed and safety guard.
- No approval ledger added.
- No live Atlas manifest/search/browse/pointer/fingerprint updates.
- No Daily Word, Practice, or Cloze changes.
- No generated status/audit/review/telemetry artifacts.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_textbook_source_inventory_scope.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_candidates.py tests/test_source_inventory_promotion_plan.py tests/test_apply_source_inventory_provenance.py tests/test_apply_source_inventory_promotion.py -q` -> 65 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/audit/generate_source_inventory_review_candidates.py scripts/audit/plan_source_inventory_promotion.py scripts/audit/apply_source_inventory_provenance.py tests/test_textbook_source_inventory_scope.py tests/test_source_inventory_promotion_plan.py tests/test_apply_source_inventory_provenance.py tests/test_apply_source_inventory_promotion.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.audit.source_inventory_review_decisions` -> 14 files / 307 approved rows
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` -> Daily 300, Practice 4,484, Cloze 22
- candidate generation with root `data/sources.db`: total_delta 337, auto_merge 134, needs_review 203, production_outputs_updated []
- real planner run over all existing ledgers: 307 matched, 0 missing; every planned manifest addition had exactly one source provenance ref
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

Independent review:
- AGY/Gemini `review-3934-textbook-family-numerals-seed`: NO BLOCKERS.

#3934 remains open for review decisions and later controlled publish of this new textbook batch.
