### PR TITLE
data(atlas): approve textbook family numerals

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-03-fifth-approved-textbook-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-03-fifth-approved-textbook-ledger-batch.yaml
@@ -1,0 +1,456 @@
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: textbook-fifth-approved-ledger-batch-2026-07-03
+batch_label: fifth-approved-textbook-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-03'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4202
+  total_queue_rows: 34
+  approved_in_queue: 34
+  promotion_batch_size: 34
+production_outputs_updated: []
+decisions:
+- lemma: мама
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: mother
+  sense_note: Vashulenko family vocabulary
+  source_inventory:
+    key: 8da9ccd28a2230db
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_family.words[0]
+    source_id: vashulenko-grade3-2020-family-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko family vocabulary + dictionary
+- lemma: тато
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: father; dad
+  sense_note: Vashulenko family vocabulary
+  source_inventory:
+    key: 62a6083102e94078
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_family.words[1]
+    source_id: vashulenko-grade3-2020-family-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko family vocabulary + dictionary
+- lemma: баба
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: grandmother; older woman
+  sense_note: Vashulenko family vocabulary
+  source_inventory:
+    key: 5d295d951a3eca4b
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_family.words[2]
+    source_id: vashulenko-grade3-2020-family-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko family vocabulary + dictionary
+- lemma: дід
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: grandfather; old man
+  sense_note: Vashulenko family vocabulary
+  source_inventory:
+    key: 6550dd19b4130f94
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_family.words[3]
+    source_id: vashulenko-grade3-2020-family-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko family vocabulary + dictionary
+- lemma: сестра
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: sister
+  sense_note: Vashulenko family vocabulary
+  source_inventory:
+    key: 4b6a65f37b268078
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_family.words[4]
+    source_id: vashulenko-grade3-2020-family-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko family vocabulary + dictionary
+- lemma: брат
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: brother
+  sense_note: Vashulenko family vocabulary
+  source_inventory:
+    key: 712855a7b30d6f0c
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_family.words[5]
+    source_id: vashulenko-grade3-2020-family-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko family vocabulary + dictionary
+- lemma: дитина
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: child
+  sense_note: Vashulenko family vocabulary
+  source_inventory:
+    key: 36afd0faeb590f15
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_family.words[6]
+    source_id: vashulenko-grade3-2020-family-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko family vocabulary + dictionary
+- lemma: дружина
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: wife
+  sense_note: Vashulenko family vocabulary
+  source_inventory:
+    key: 9982fc0dc03c277b
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_family.words[7]
+    source_id: vashulenko-grade3-2020-family-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko family vocabulary + dictionary
+- lemma: чоловік
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: husband; man
+  sense_note: Vashulenko family vocabulary
+  source_inventory:
+    key: 9619eaf966da5c2e
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_family.words[8]
+    source_id: vashulenko-grade3-2020-family-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko family vocabulary + dictionary
+- lemma: один
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: one
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 769cf73ae794971f
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[0]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: два
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: two
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 1196cfa63db84394
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[1]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: три
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: three
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: c5f069c296d34174
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[2]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: чотири
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: four
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 9ae2eae1a447a213
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[3]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: п'ять
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: five
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 5635bd1edf3591f6
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[4]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: шість
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: six
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: b26094e67eeb76fd
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[5]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: сім
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: seven
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 5bf622fcf7b17b07
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[6]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: вісім
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: eight
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 4b835f17902150d8
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[7]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: дев'ять
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: nine
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: e3835ff847a7d135
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[8]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: десять
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: ten
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 95a7c6993ec9fd19
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[9]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: одинадцять
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: eleven
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 2166c558e27a7a22
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[10]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: дванадцять
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: twelve
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 80a9b8fe380895e8
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[11]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: тринадцять
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: thirteen
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 916442452bc23c97
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[12]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: чотирнадцять
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: fourteen
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 7329cdce76d2bd2a
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[13]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: п'ятнадцять
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: fifteen
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: bbf37922ea8bb5d6
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[14]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: шістнадцять
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: sixteen
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 71cc33f23ca52148
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[15]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: сімнадцять
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: seventeen
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 60b8d1e86075f171
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[16]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: вісімнадцять
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: eighteen
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: bfd4650e6269119b
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[17]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: дев'ятнадцять
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: nineteen
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 5d05660de09748ef
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[18]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: двадцять
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: twenty
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: e31c7f1e900d1141
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_1_20[19]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: тридцять
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: thirty
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: af675c82f655447e
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_tens[0]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: п'ятдесят
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: fifty
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 85bcb851baedcbc7
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_tens[1]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: шістдесят
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: sixty
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 87839b266b4f7026
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_tens[2]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: сімдесят
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: seventy
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: a658a98e0e4c1908
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_tens[3]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary
+- lemma: вісімдесят
+  decision: approve_for_publish
+  approved_pos: numeral
+  approved_gloss: eighty
+  sense_note: Vashulenko numeral vocabulary
+  source_inventory:
+    key: 8e48f9a5ffabcc1a
+    path: data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml
+    locator: topic_index.vocabulary_numerals.words_tens[4]
+    source_id: vashulenko-grade3-2020-numerals-vocabulary
+    source_family: textbook
+  evidence_refs:
+  - Vashulenko numeral vocabulary + dictionary

--- a/docs/runbooks/word-atlas-textbook-source-scope.md
+++ b/docs/runbooks/word-atlas-textbook-source-scope.md
@@ -6,7 +6,9 @@ before broader textbook ingestion can be treated as resolved.
 
 ## Current Textbook Inventories
 
-The committed textbook source-inventory lane currently has 114 rows:
+The committed textbook source-inventory lane currently has 114 rows. All 114
+now have approved source-decision ledger rows; live Atlas provenance is a
+separate publish step.
 
 - `data/lexicon/source-inventory/bolshakova-bukvar-keywords.yaml`
   - 40 headwords
@@ -18,6 +20,8 @@ The committed textbook source-inventory lane currently has 114 rows:
 - `data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml`
   - 34 headwords
   - source map: `docs/l2-uk-direct/textbook-map.yaml`
+  - approved by
+    `data/lexicon/source-inventory-review-decisions/2026-07-03-fifth-approved-textbook-ledger-batch.yaml`
 
 These inventory rows cite tracked notes/maps, not untracked source PDFs. The
 source PDFs are not committed, so the reviewable repository evidence is the
@@ -41,12 +45,12 @@ the tracked source map.
 
 ## Not Yet Done
 
-Issue #3934 remains open because the current 114 rows are only a reviewed seed, not a
-complete textbook corpus. The missing work is:
+Issue #3934 remains open because the current 114 approved rows are only a
+reviewed seed, not a complete textbook corpus. The missing work is:
 
 - add more reviewed textbook/headword inventories with tracked source locators
-- review held rows before publishing
-- publish approved browse/search batches separately from source review
+- publish the 34 family/numeral approvals separately from source review
+- review held rows before publishing future batches
 - make separate `surface_admission` decisions for Daily Word, Practice, and
   cloze
 

--- a/tests/test_textbook_source_inventory_scope.py
+++ b/tests/test_textbook_source_inventory_scope.py
@@ -8,6 +8,7 @@ from typing import Any
 import yaml
 
 from scripts.audit.source_inventory_intake import read_source_inventory
+from scripts.audit.source_inventory_review_decisions import source_inventory_key
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 BOLSHAKOVA_INVENTORY = (
@@ -20,6 +21,10 @@ VASHULENKO_FAMILY_NUMERALS_INVENTORY = (
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml"
 )
 VASHULENKO_MAP = PROJECT_ROOT / "docs/l2-uk-direct/textbook-map.yaml"
+VASHULENKO_FAMILY_NUMERALS_LEDGER = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory-review-decisions/2026-07-03-fifth-approved-textbook-ledger-batch.yaml"
+)
 BOLSHAKOVA_NOTES = (
     PROJECT_ROOT / "docs/l2-uk-direct/textbook-reading-notes/bolshakova-bukvar-mapping.md"
 )
@@ -81,6 +86,50 @@ def test_vashulenko_inventory_locators_resolve_to_tracked_source_map() -> None:
     for record in records:
         assert record.source_path == str(VASHULENKO_MAP.relative_to(PROJECT_ROOT))
         assert _resolve_locator(textbook_map, record.source_locator) == record.lemma
+
+
+def test_vashulenko_family_numerals_approval_ledger_matches_inventory() -> None:
+    records = {
+        (record.lemma, record.source_locator): record
+        for record in read_source_inventory(
+            VASHULENKO_FAMILY_NUMERALS_INVENTORY,
+            project_root=PROJECT_ROOT,
+        )
+    }
+    ledger = yaml.safe_load(VASHULENKO_FAMILY_NUMERALS_LEDGER.read_text(encoding="utf-8"))
+    rows = ledger["decisions"]
+
+    assert ledger["production_outputs_updated"] == []
+    assert ledger["source_queue"] == {
+        "workflow": "source_inventory_publish_review_queue.v1",
+        "generated_from_pr": 4202,
+        "total_queue_rows": 34,
+        "approved_in_queue": 34,
+        "promotion_batch_size": 34,
+    }
+    assert len(rows) == 34
+    assert Counter(row["source_inventory"]["source_id"] for row in rows) == {
+        "vashulenko-grade3-2020-family-vocabulary": 9,
+        "vashulenko-grade3-2020-numerals-vocabulary": 25,
+    }
+
+    for row in rows:
+        source_inventory = row["source_inventory"]
+        record = records[(row["lemma"], source_inventory["locator"])]
+
+        assert row["decision"] == "approve_for_publish"
+        assert row["approved_pos"] == record.pos
+        assert row["approved_gloss"] == record.gloss
+        assert source_inventory["path"] == str(
+            VASHULENKO_FAMILY_NUMERALS_INVENTORY.relative_to(PROJECT_ROOT)
+        )
+        assert source_inventory["source_family"] == "textbook"
+        assert source_inventory["source_id"] == record.source_id
+        assert source_inventory["key"] == source_inventory_key(
+            lemma=row["lemma"],
+            inventory_path=source_inventory["path"],
+            locator=source_inventory["locator"],
+        )
 
 
 def test_bolshakova_inventory_rows_are_backed_by_tracked_notes() -> None:


### PR DESCRIPTION
## Summary

Adds the fifth textbook source-inventory approval ledger batch for #3934:

- approves all 34 Vashulenko Grade 3 family/numeral source-inventory rows from #4202
- documents that the 114 textbook inventory rows now have approval ledgers, while live Atlas provenance remains a separate publish step
- adds a focused test that checks the new ledger rows against the committed source inventory, stable source keys, source ids, and batch counts

This is review-only. It does not update live Atlas manifest/search/browse/pointer/fingerprint output, Daily Word, Practice, or Cloze.

## Planner boundary

A real promotion-plan check against the current manifest reported:

- approved decisions: 34
- matched candidates: 34
- proposed future additions: 2 (`баба`, `дід`)
- skipped existing: 32
- missing candidates: 0
- production outputs updated: []

## Validation

- `source_inventory_review_decisions`: 15 files / 341 approved rows
- `pytest tests/test_source_inventory_intake.py tests/test_source_inventory_review_candidates.py tests/test_source_inventory_promotion_plan.py tests/test_apply_source_inventory_provenance.py tests/test_apply_source_inventory_promotion.py tests/test_textbook_source_inventory_scope.py tests/test_source_inventory_review_decisions.py -q` -> 78 passed
- `pytest tests/test_textbook_source_inventory_scope.py tests/test_source_inventory_review_decisions.py tests/test_source_inventory_promotion_plan.py -q` -> 28 passed after doc edit
- `ruff check tests/test_textbook_source_inventory_scope.py` -> passed
- `check_static_practice_assets` -> Daily 300, Practice 4,484, Cloze 22
- `git diff --check` -> passed
- `lint_agent_trailer.py` -> passed
- Independent AGY/Gemini review: NO BLOCKERS

Refs #3934.
Refs #3936.
