### PR TITLE
data(atlas): add teacher lesson rows 179-198 seed

### DIFF
--- a/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+++ b/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
@@ -1,0 +1,119 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Private teacher lesson vocabulary - explicit table rows 179-198
+    locator: local-only explicit vocabulary table rows 179-198
+    notes: >-
+      Derived headword metadata only; raw private lesson material is local-only
+      and not committed. Daily Word, Practice, and cloze remain frozen without
+      explicit surface_admission.
+    headwords:
+      - lemma: виставляти
+        pos: verb
+        gloss: to make someone look like; imperfective; takes instrumental
+        locator: explicit vocabulary table row 179
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: голосувати
+        pos: verb
+        gloss: to vote; imperfective
+        locator: explicit vocabulary table row 180
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: проголосувати
+        pos: verb
+        gloss: to vote; perfective
+        locator: explicit vocabulary table row 181
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: підкупляти
+        pos: verb
+        gloss: to bribe; imperfective
+        locator: explicit vocabulary table row 182
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: підкупити
+        pos: verb
+        gloss: to bribe; perfective
+        locator: explicit vocabulary table row 183
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: давати на лапу
+        pos: phrase
+        gloss: to bribe; idiom
+        locator: explicit vocabulary table row 184
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: невдалий
+        pos: adjective
+        gloss: unsuccessful; unfortunate
+        locator: explicit vocabulary table row 185
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: стегно
+        pos: noun
+        gloss: thigh
+        locator: explicit vocabulary table row 186
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: набережна
+        pos: noun
+        gloss: waterfront; embankment
+        locator: explicit vocabulary table row 187
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: терпець урвався
+        pos: phrase
+        gloss: patience ran out; takes dative experiencer
+        locator: explicit vocabulary table row 188
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: терпець увірвався
+        pos: phrase
+        gloss: patience ran out; takes dative experiencer
+        locator: explicit vocabulary table row 188
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: гігієна
+        pos: noun
+        gloss: hygiene
+        locator: explicit vocabulary table row 189
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: штрафувати
+        pos: verb
+        gloss: to fine; imperfective
+        locator: explicit vocabulary table row 190
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: оштрафувати
+        pos: verb
+        gloss: to fine; perfective
+        locator: explicit vocabulary table row 191
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: поводитися
+        pos: verb
+        gloss: to behave
+        locator: explicit vocabulary table row 192
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: корм
+        pos: noun
+        gloss: animal feed
+        locator: explicit vocabulary table row 193
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: значний
+        pos: adjective
+        gloss: significant
+        locator: explicit vocabulary table row 194
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: незначний
+        pos: adjective
+        gloss: insignificant
+        locator: explicit vocabulary table row 195
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: мені пощастило
+        pos: phrase
+        gloss: I was lucky; I got lucky
+        locator: explicit vocabulary table row 196
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: щитовидка
+        pos: noun
+        gloss: thyroid gland; colloquial
+        locator: explicit vocabulary table row 197
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: кролик
+        pos: noun
+        gloss: rabbit
+        locator: explicit vocabulary table row 198
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -15,19 +15,20 @@ The committed inventory seeds are:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml`
 
-Current committed coverage is 187 source-inventory headwords from explicit
-local vocabulary table rows 1-178. The source family is `teacher_lesson`, and the
+Current committed coverage is 208 source-inventory headwords from explicit
+local vocabulary table rows 1-198. The source family is `teacher_lesson`, and the
 source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.
 
 Current approval-ledger coverage is 187 reviewed headwords from rows 1-178.
-Live Atlas manifest coverage is 167 neutral `teacher_lesson` provenance refs
-across 166 Atlas entries from rows 1-158; public browse/search is regenerated
-from that manifest. Rows 159-178 are approved for later publish, but remain out
-of live Atlas until a later controlled publish PR updates browse/search.
-Missing `surface_admission` keeps Daily Word, Practice, and cloze frozen.
+Live Atlas manifest coverage is 187 neutral `teacher_lesson` provenance refs
+across 184 Atlas entries from rows 1-178; public browse/search is regenerated
+from that manifest. Rows 179-198 are committed as review-only source inventory;
+they are not approved or live Atlas output yet. Missing `surface_admission`
+keeps Daily Word, Practice, and cloze frozen.
 
 ## Source Handling Rule
 
@@ -45,7 +46,9 @@ prompt dumps, screenshots, or teacher-identifying labels.
 
 ## Current Boundary
 
-This lane is source-inventory only. It does not update:
+New private teacher-lesson inventory and ledger PRs are review-only until a
+separate controlled publish PR updates Atlas browse/search. A review-only seed
+or ledger PR does not update:
 
 - live Atlas manifest, search, or browse output
 - Daily Word

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -24,6 +24,7 @@ The committed source inventory input is:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml`
 - `data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml`
 - `data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml`
 
@@ -94,12 +95,13 @@ conjunction, particle, and interjection. Optional per-headword `gloss` values
 are curated learner-facing English anchors for cases where dictionary
 enrichment lacks a visible English translation.
 
-The private teacher-lesson seeds contribute 187 `teacher_lesson` headwords from
-an explicit local vocabulary table, with approval ledgers covering rows 1-178.
-Rows 159-178 are approved for later publish, but are not live Atlas output until
-a later controlled publish PR updates browse/search. Their committed rows are
-derived metadata only: no raw private lesson material, private document paths,
-or teacher-identifying labels should appear in the inventory.
+The private teacher-lesson seeds contribute 208 `teacher_lesson` headwords from
+an explicit local vocabulary table, with approval ledgers and live Atlas
+provenance covering rows 1-178. Rows 179-198 are committed as review-only source
+inventory and still need a later approval ledger before any controlled
+browse/search publish. Their committed rows are derived metadata only: no raw
+private lesson material, private document paths, or teacher-identifying labels
+should appear in the inventory.
 
 When a candidate is later promoted into a manifest entry,
 `promote_grow_candidates.manifest_entry_from_candidate()` copies

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -27,6 +27,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-119-138.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -47,6 +47,11 @@ PRIVATE_TEACHER_ROWS_159_178_INVENTORY = (
     / "data/lexicon/source-inventory/"
     "private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml"
 )
+PRIVATE_TEACHER_ROWS_179_198_INVENTORY = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory/"
+    "private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml"
+)
 PRIVATE_TEACHER_FIRST_LEDGER = (
     PROJECT_ROOT
     / "data/lexicon/source-inventory-review-decisions/"
@@ -345,6 +350,44 @@ def test_private_teacher_rows_159_178_inventory_is_pending_review_metadata() -> 
     assert all("surface_admission" not in record.provenance_payload() for record in records)
 
     inventory_text = PRIVATE_TEACHER_ROWS_159_178_INVENTORY.read_text(encoding="utf-8")
+    assert ".docx" not in inventory_text
+    assert "alona" not in inventory_text.lower()
+    assert "native-reviewer-lessons" not in inventory_text
+
+
+def test_private_teacher_rows_179_198_inventory_is_pending_review_metadata() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_179_198_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+
+    assert len(records) == 21
+    assert {record.source_family for record in records} == {"teacher_lesson"}
+    assert {record.extraction_mode for record in records} == {"curated_headword"}
+    assert {record.source_id for record in records} == {
+        "private-teacher-lesson-vocabulary-table-1-rows-179-198"
+    }
+    assert all(record.source_path is None for record in records)
+    assert all(record.source_url is None for record in records)
+    assert all(record.source_title for record in records)
+    assert all(record.source_locator for record in records)
+    assert all(record.context for record in records)
+    assert all(record.pos for record in records)
+    assert all(record.gloss for record in records)
+    assert "виставляти" in {record.lemma for record in records}
+    assert "давати на лапу" in {record.lemma for record in records}
+    assert "терпець урвався" in {record.lemma for record in records}
+    assert "терпець увірвався" in {record.lemma for record in records}
+    assert "щитовидка" in {record.lemma for record in records}
+    assert "кролик" in {record.lemma for record in records}
+    assert all("," not in record.lemma for record in records)
+    assert all("/" not in record.lemma for record in records)
+    assert all("(" not in record.lemma and ")" not in record.lemma for record in records)
+    assert all("surface_admission" not in record.provenance_payload() for record in records)
+
+    inventory_text = PRIVATE_TEACHER_ROWS_179_198_INVENTORY.read_text(
+        encoding="utf-8"
+    )
     assert ".docx" not in inventory_text
     assert "alona" not in inventory_text.lower()
     assert "native-reviewer-lessons" not in inventory_text


### PR DESCRIPTION
## Summary

- Add the next privacy-safe private teacher-lesson source-inventory seed for explicit vocabulary table rows 179-198.
- Register the new seed in the source-inventory review-candidate workflow.
- Update the private teacher/source-inventory runbooks and tests for the new counts.

## Scope boundary

This is review-only source inventory. It does not approve rows, publish Atlas manifest/search/browse output, or admit anything to Daily Word, Practice, or Cloze.

The committed seed contains only derived metadata: normalized headword, POS, short learner gloss, neutral row locator, and generic context. It does not include raw private lesson material, private file paths, the ignored source document name, or teacher-identifying source labels.

## Counts

- Source inventory: 354 -> 375 total rows.
- `teacher_lesson` inventory: 187 -> 208 rows.
- New rows: 21 derived headwords from explicit table rows 179-198.
- Approval ledgers unchanged: 341 approved rows total, including 187 `teacher_lesson` rows.
- Live Atlas unchanged: 5,485 manifest entries; 187 teacher-lesson provenance refs across 184 entries.
- Daily / Practice / Cloze unchanged: 300 / 4,484 / 22.

## Validation

- `ruff check scripts/audit/generate_source_inventory_review_candidates.py tests/test_private_teacher_lesson_source_inventory.py`
- `.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_decisions.py -q` -> 48 passed
- `.venv/bin/python -m scripts.audit.grow_lexicon_from_sources --inventory data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml --out /tmp/4160-teacher-rows-179-198-grow-candidates.json --report` -> `total_delta=21`, `processed=21`, `auto_merge=9`, `needs_review=12`
- `.venv/bin/python -m scripts.audit.source_inventory_review_decisions` -> 15 files / 341 approved rows
- `npx --no-install markdownlint-cli2 docs/runbooks/word-atlas-private-teacher-source-scope.md docs/runbooks/word-atlas-source-inventory-review-candidates.md` -> 0 errors
- `.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` -> ok, Daily 300, Practice 4,484, Cloze 22
- privacy scan on new inventory/docs/script: no private path/docx/name leaks
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Independent AGY/Gemini review: `NO BLOCKERS`

## Note

The full all-inventory `generate_source_inventory_review_candidates --report` run was interrupted after hanging inside an existing enrichment idiom lookup. The new-file-only candidate generation passed and exercises the new seed directly.
