### PR TITLE
data(atlas): approve teacher lesson rows 179-198

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-03-tenth-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-03-tenth-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,312 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-tenth-approved-teacher-lesson-ledger-batch-2026-07-03
+batch_label: tenth-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-03'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4205
+  total_queue_rows: 198
+  approved_in_queue: 21
+  promotion_batch_size: 21
+production_outputs_updated: []
+decisions:
+- lemma: виставляти
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to make someone look like; imperfective; takes instrumental
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 0ebde1d4fc612c5e
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 179
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: голосувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to vote; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 7a5791f1d3062f52
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 180
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: проголосувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to vote; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: fb37ee3a03465f47
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 181
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: підкупляти
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to bribe; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 986a9fa61ea45a63
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 182
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: підкупити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to bribe; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 34c2e82dd0d2aa32
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 183
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: давати на лапу
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: to bribe; idiom
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 40cc8868b57169ba
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 184
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: невдалий
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: unsuccessful; unfortunate
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: faf99d17f2a02bfa
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 185
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: стегно
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: thigh
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: da991f129ef2bff4
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 186
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: набережна
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: waterfront; embankment
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 62237761a9b1cbf9
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 187
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags calque_warning; heritage_status flags russian_shadow
+- lemma: терпець урвався
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: patience ran out; takes dative experiencer
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: ed7dd64afc3c8109
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 188
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: терпець увірвався
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: patience ran out; takes dative experiencer
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 3a78b8fc30943341
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 188
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: гігієна
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: hygiene
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 3fc11c87fdd9e5d0
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 189
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: штрафувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to fine; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: e1305173836e5291
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 190
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: оштрафувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to fine; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: e381313208d9ff05
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 191
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: поводитися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to behave
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: c637edee9eae1ba0
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 192
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: корм
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: animal feed
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 70859a1bc99a8bea
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 193
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: значний
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: significant
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 576f1a9ba8e592e7
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 194
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: незначний
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: insignificant
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 383a3ede51f86915
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 195
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: мені пощастило
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: I was lucky; I got lucky
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: '5392254839162808'
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 196
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: щитовидка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: thyroid gland; colloquial
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 3c0055c9112a172a
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 197
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: кролик
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: rabbit
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: f9ad6f2cdee703af
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml
+    locator: explicit vocabulary table row 198
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-179-198
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -23,12 +23,12 @@ source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.
 
-Current approval-ledger coverage is 187 reviewed headwords from rows 1-178.
+Current approval-ledger coverage is 208 reviewed headwords from rows 1-198.
 Live Atlas manifest coverage is 187 neutral `teacher_lesson` provenance refs
 across 184 Atlas entries from rows 1-178; public browse/search is regenerated
-from that manifest. Rows 179-198 are committed as review-only source inventory;
-they are not approved or live Atlas output yet. Missing `surface_admission`
-keeps Daily Word, Practice, and cloze frozen.
+from that manifest. Rows 179-198 are approved for later controlled
+browse/search publish; they are not live Atlas output yet. Missing
+`surface_admission` keeps Daily Word, Practice, and cloze frozen.
 
 ## Source Handling Rule
 

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -96,12 +96,12 @@ are curated learner-facing English anchors for cases where dictionary
 enrichment lacks a visible English translation.
 
 The private teacher-lesson seeds contribute 208 `teacher_lesson` headwords from
-an explicit local vocabulary table, with approval ledgers and live Atlas
-provenance covering rows 1-178. Rows 179-198 are committed as review-only source
-inventory and still need a later approval ledger before any controlled
-browse/search publish. Their committed rows are derived metadata only: no raw
-private lesson material, private document paths, or teacher-identifying labels
-should appear in the inventory.
+an explicit local vocabulary table, with approval ledgers covering rows 1-198
+and live Atlas provenance covering rows 1-178. Rows 179-198 are approved for a
+later controlled browse/search publish; they are not live Atlas output yet.
+Their committed rows are derived metadata only: no raw private lesson material,
+private document paths, or teacher-identifying labels should appear in the
+inventory or ledger.
 
 When a candidate is later promoted into a manifest entry,
 `promote_grow_candidates.manifest_entry_from_candidate()` copies

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -97,6 +97,11 @@ PRIVATE_TEACHER_NINTH_LEDGER = (
     / "data/lexicon/source-inventory-review-decisions/"
     "2026-07-03-ninth-approved-teacher-lesson-ledger-batch.yaml"
 )
+PRIVATE_TEACHER_TENTH_LEDGER = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory-review-decisions/"
+    "2026-07-03-tenth-approved-teacher-lesson-ledger-batch.yaml"
+)
 
 
 def test_private_teacher_inventory_is_privacy_safe_review_metadata() -> None:
@@ -636,6 +641,36 @@ def test_private_teacher_ninth_decision_ledger_stays_review_only() -> None:
     assert "native-reviewer-lessons" not in ledger_text
 
 
+def test_private_teacher_tenth_decision_ledger_stays_review_only() -> None:
+    summary = decisions.validate_committed_decision_files([PRIVATE_TEACHER_TENTH_LEDGER])
+    payload = yaml.safe_load(PRIVATE_TEACHER_TENTH_LEDGER.read_text(encoding="utf-8"))
+
+    assert summary == {
+        "files": 1,
+        "rows": 21,
+        "decision_counts": {"approve_for_publish": 21},
+    }
+    assert payload["source_queue"]["generated_from_pr"] == 4205
+    assert payload["source_queue"]["promotion_batch_size"] == 21
+    assert payload["production_outputs_updated"] == []
+    assert payload["decisions"][0]["lemma"] == "виставляти"
+    assert payload["decisions"][-1]["lemma"] == "кролик"
+    assert all(
+        row["source_inventory"]["source_family"] == "teacher_lesson"
+        for row in payload["decisions"]
+    )
+    assert {
+        row["source_inventory"]["source_id"]
+        for row in payload["decisions"]
+    } == {"private-teacher-lesson-vocabulary-table-1-rows-179-198"}
+    assert all("surface_admission" not in row for row in payload["decisions"])
+
+    ledger_text = PRIVATE_TEACHER_TENTH_LEDGER.read_text(encoding="utf-8")
+    assert ".docx" not in ledger_text
+    assert "alona" not in ledger_text.lower()
+    assert "native-reviewer-lessons" not in ledger_text
+
+
 def test_private_teacher_decision_ledgers_cover_seed_without_live_surfaces() -> None:
     records = read_source_inventory(PRIVATE_TEACHER_INVENTORY, project_root=PROJECT_ROOT)
     inventory_keys = {
@@ -832,6 +867,32 @@ def test_private_teacher_rows_159_178_decision_ledger_covers_pending_seed() -> N
     }
 
     payload = yaml.safe_load(PRIVATE_TEACHER_NINTH_LEDGER.read_text(encoding="utf-8"))
+    ledger_keys = {
+        row["source_inventory"]["key"]
+        for row in payload["decisions"]
+    }
+
+    assert ledger_keys == inventory_keys
+
+
+def test_private_teacher_rows_179_198_decision_ledger_covers_pending_seed() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_179_198_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+    inventory_keys = {
+        decisions.source_inventory_key(
+            lemma=record.lemma,
+            inventory_path=(
+                "data/lexicon/source-inventory/"
+                "private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml"
+            ),
+            locator=record.source_locator,
+        )
+        for record in records
+    }
+
+    payload = yaml.safe_load(PRIVATE_TEACHER_TENTH_LEDGER.read_text(encoding="utf-8"))
     ledger_keys = {
         row["source_inventory"]["key"]
         for row in payload["decisions"]


### PR DESCRIPTION
## Summary

- Adds the tenth review-only source-inventory decision ledger for private teacher-lesson rows 179-198.
- Approves 21 derived headwords for a later controlled Atlas browse/search publish.
- Updates runbooks/tests to state rows 179-198 are approved for later publish, while live Atlas output still covers rows 1-178 only.

## Boundaries

- No live Atlas manifest/search/browse changes.
- No Daily Word, Practice, or cloze admission.
- No `surface_admission` entries in the new ledger.
- No raw private lesson material, private file paths, or teacher-identifying labels in the production docs/ledger.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_review_decisions.py tests/test_source_inventory_intake.py -q` -> 50 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.audit.source_inventory_review_decisions` -> files=16 rows=362 decisions={'approve_for_publish': 362}
- `plan_source_inventory_promotion` for the new ledger -> approved_decisions=21, matched_candidates=21, proposed_additions=17, skipped_existing=4, missing_candidates=0, production_outputs_updated=[]
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/check_static_practice_assets.py --format json` -> Daily 300, Practice 4484, Cloze 22
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check tests/test_private_teacher_lesson_source_inventory.py`
- `npx markdownlint-cli2 docs/runbooks/word-atlas-private-teacher-source-scope.md docs/runbooks/word-atlas-source-inventory-review-candidates.md`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Independent review

AGY/Gemini review task `review-4160-teacher-179-198-ledger`: no blockers.
