### PR TITLE
[codex] Add teacher lesson rows 199-218 seed

### DIFF
--- a/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+++ b/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
@@ -1,0 +1,114 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Private teacher lesson vocabulary - explicit table rows 199-218
+    locator: local-only explicit vocabulary table rows 199-218
+    notes: >-
+      Derived headword metadata only; raw private lesson material is local-only
+      and not committed. Daily Word, Practice, and cloze remain frozen without
+      explicit surface_admission.
+    headwords:
+      - lemma: злива
+        pos: noun
+        gloss: downpour
+        locator: explicit vocabulary table row 199
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: з'ясовувати
+        pos: verb
+        gloss: to figure out; to find out; imperfective
+        locator: explicit vocabulary table row 200
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: з'ясувати
+        pos: verb
+        gloss: to figure out; to find out; perfective
+        locator: explicit vocabulary table row 201
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: лампочка
+        pos: noun
+        gloss: light bulb
+        locator: explicit vocabulary table row 202
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: щасливої дороги
+        pos: phrase
+        gloss: safe travels; have a good trip
+        locator: explicit vocabulary table row 203
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: випускати
+        pos: verb
+        gloss: to release; to let out; imperfective
+        locator: explicit vocabulary table row 204
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: випустити
+        pos: verb
+        gloss: to release; to let out; perfective
+        locator: explicit vocabulary table row 205
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: схил
+        pos: noun
+        gloss: slope
+        locator: explicit vocabulary table row 206
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: зі злості
+        pos: phrase
+        gloss: out of anger
+        locator: explicit vocabulary table row 207
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: приватність
+        pos: noun
+        gloss: privacy
+        locator: explicit vocabulary table row 208
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: квашений
+        pos: adjective
+        gloss: fermented; pickled
+        locator: explicit vocabulary table row 209
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: по імені
+        pos: phrase
+        gloss: by name
+        locator: explicit vocabulary table row 210
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: зраджувати
+        pos: verb
+        gloss: to betray; to cheat on; imperfective
+        locator: explicit vocabulary table row 211
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: зрадити
+        pos: verb
+        gloss: to betray; to cheat on; perfective
+        locator: explicit vocabulary table row 212
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: довіра
+        pos: noun
+        gloss: trust
+        locator: explicit vocabulary table row 213
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: діставатися
+        pos: verb
+        gloss: to get to; to arrive; to make it; imperfective
+        locator: explicit vocabulary table row 214
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: дістатися
+        pos: verb
+        gloss: to get to; to arrive; to make it; perfective
+        locator: explicit vocabulary table row 215
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: пил
+        pos: noun
+        gloss: dust
+        locator: explicit vocabulary table row 216
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: яма
+        pos: noun
+        gloss: pit; hole in the ground
+        locator: explicit vocabulary table row 217
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: чайний сервіз
+        pos: noun
+        gloss: tea set
+        locator: explicit vocabulary table row 218
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -16,18 +16,19 @@ The committed inventory seeds are:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml`
 
-Current committed coverage is 208 source-inventory headwords from explicit
-local vocabulary table rows 1-198. The source family is `teacher_lesson`, and the
+Current committed coverage is 228 source-inventory headwords from explicit
+local vocabulary table rows 1-218. The source family is `teacher_lesson`, and the
 source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.
 
 Current approval-ledger coverage is 208 reviewed headwords from rows 1-198.
-Live Atlas manifest coverage is 187 neutral `teacher_lesson` provenance refs
-across 184 Atlas entries from rows 1-178; public browse/search is regenerated
-from that manifest. Rows 179-198 are approved for later controlled
-browse/search publish; they are not live Atlas output yet. Missing
+After PR #4208, live Atlas manifest coverage is 208 neutral `teacher_lesson`
+provenance refs across 204 Atlas entries from rows 1-198; public browse/search
+is regenerated from that manifest. Rows 199-218 are committed as review-only
+source inventory; they are not approved or live Atlas output yet. Missing
 `surface_admission` keeps Daily Word, Practice, and cloze frozen.
 
 ## Source Handling Rule

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -25,6 +25,7 @@ The committed source inventory input is:
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml`
 - `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml`
+- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml`
 - `data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml`
 - `data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml`
 
@@ -95,13 +96,13 @@ conjunction, particle, and interjection. Optional per-headword `gloss` values
 are curated learner-facing English anchors for cases where dictionary
 enrichment lacks a visible English translation.
 
-The private teacher-lesson seeds contribute 208 `teacher_lesson` headwords from
-an explicit local vocabulary table, with approval ledgers covering rows 1-198
-and live Atlas provenance covering rows 1-178. Rows 179-198 are approved for a
-later controlled browse/search publish; they are not live Atlas output yet.
-Their committed rows are derived metadata only: no raw private lesson material,
-private document paths, or teacher-identifying labels should appear in the
-inventory or ledger.
+The private teacher-lesson seeds contribute 228 `teacher_lesson` headwords from
+an explicit local vocabulary table. Approval ledgers cover rows 1-198; after PR
+`#4208`, live Atlas provenance also covers rows 1-198. Rows 199-218 are
+committed as review-only source inventory and still need a later approval ledger
+before any controlled browse/search publish. Their committed rows are derived
+metadata only: no raw private lesson material, private document paths, or
+teacher-identifying labels should appear in the inventory or ledger.
 
 When a candidate is later promoted into a manifest entry,
 `promote_grow_candidates.manifest_entry_from_candidate()` copies

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -28,6 +28,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-139-158.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -52,6 +52,11 @@ PRIVATE_TEACHER_ROWS_179_198_INVENTORY = (
     / "data/lexicon/source-inventory/"
     "private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml"
 )
+PRIVATE_TEACHER_ROWS_199_218_INVENTORY = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory/"
+    "private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml"
+)
 PRIVATE_TEACHER_FIRST_LEDGER = (
     PROJECT_ROOT
     / "data/lexicon/source-inventory-review-decisions/"
@@ -391,6 +396,45 @@ def test_private_teacher_rows_179_198_inventory_is_pending_review_metadata() -> 
     assert all("surface_admission" not in record.provenance_payload() for record in records)
 
     inventory_text = PRIVATE_TEACHER_ROWS_179_198_INVENTORY.read_text(
+        encoding="utf-8"
+    )
+    assert ".docx" not in inventory_text
+    assert "alona" not in inventory_text.lower()
+    assert "native-reviewer-lessons" not in inventory_text
+
+
+def test_private_teacher_rows_199_218_inventory_is_pending_review_metadata() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_199_218_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+
+    assert len(records) == 20
+    assert {record.source_family for record in records} == {"teacher_lesson"}
+    assert {record.extraction_mode for record in records} == {"curated_headword"}
+    assert {record.source_id for record in records} == {
+        "private-teacher-lesson-vocabulary-table-1-rows-199-218"
+    }
+    assert all(record.source_path is None for record in records)
+    assert all(record.source_url is None for record in records)
+    assert all(record.source_title for record in records)
+    assert all(record.source_locator for record in records)
+    assert all(record.context for record in records)
+    assert all(record.pos for record in records)
+    assert all(record.gloss for record in records)
+    assert "злива" in {record.lemma for record in records}
+    assert "з'ясовувати" in {record.lemma for record in records}
+    assert "з'ясувати" in {record.lemma for record in records}
+    assert "щасливої дороги" in {record.lemma for record in records}
+    assert "випустити" in {record.lemma for record in records}
+    assert "чайний сервіз" in {record.lemma for record in records}
+    assert "випустути" not in {record.lemma for record in records}
+    assert all("," not in record.lemma for record in records)
+    assert all("/" not in record.lemma for record in records)
+    assert all("(" not in record.lemma and ")" not in record.lemma for record in records)
+    assert all("surface_admission" not in record.provenance_payload() for record in records)
+
+    inventory_text = PRIVATE_TEACHER_ROWS_199_218_INVENTORY.read_text(
         encoding="utf-8"
     )
     assert ".docx" not in inventory_text


### PR DESCRIPTION
## Summary

- Adds a review-only source-inventory seed for private teacher lesson table rows 199-218: 20 normalized headwords with privacy-safe metadata.
- Wires the new inventory into the review-candidate generator and adds focused test coverage.
- Updates Atlas source-intake runbooks: committed teacher coverage is now 228 rows, rows 1-198 are approved/live after PR #4208, and rows 199-218 remain unapproved/non-live.

This PR does not update live Atlas manifest/search/browse output and does not admit anything into Daily Word, Practice, or cloze.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_decisions.py tests/test_source_inventory_review_candidates.py -q` -> 78 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.audit.source_inventory_review_decisions` -> files=16 rows=362 approvals
- `grow_lexicon_from_sources` on the new batch -> total_delta=20 processed=20 auto_merge=7 needs_review=13
- `generate_source_inventory_review_candidates --report` -> total_delta=377 publish_ready=148 needs_publish_review=229
- `check_static_practice_assets.py --format json` -> Daily=300, Practice=4484, Cloze=22
- `ruff check --fix` on changed Python files -> clean
- `markdownlint-cli2` on changed docs -> clean
- `git diff --check` -> clean
- privacy scan for private names/paths/docx in production files -> clean
- `scripts/audit/lint_agent_trailer.py` -> pass

## Review

- Read-only helper review with `gpt-5.4-mini` found no blockers.
- Independent AGY/Gemini review initially flagged stale-state/privacy wording concerns. Privacy wording was restored to cover inventory or ledger, live-state docs were clarified as post-#4208, and AGY follow-up withdrew both blockers.