### PR TITLE
[codex] Approve teacher lesson rows 199-218

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-03-eleventh-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-03-eleventh-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,301 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-eleventh-approved-teacher-lesson-ledger-batch-2026-07-03
+batch_label: eleventh-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-03'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  generated_from_pr: 4209
+  total_queue_rows: 218
+  approved_in_queue: 20
+  promotion_batch_size: 20
+production_outputs_updated: []
+decisions:
+- lemma: злива
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: downpour
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 7e555a3c9a4893c1
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 199
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: з'ясовувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to figure out; to find out; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 20573937e4f172a6
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 200
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: з'ясувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to figure out; to find out; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 4fb05359891cac56
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 201
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: лампочка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: light bulb
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: f3f9a32f51543e12
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 202
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: щасливої дороги
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: safe travels; have a good trip
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 33313d5f86234a03
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 203
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: випускати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to release; to let out; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 4ec88606f07011f1
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 204
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: випустити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to release; to let out; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 319ff6cbac9730ec
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 205
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: схил
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: slope
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 13c8456746f2a64f
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 206
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: зі злості
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: out of anger
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: fd38dc97daecaac0
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 207
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: приватність
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: privacy
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a5b4357cfa293396
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 208
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: квашений
+  decision: approve_for_publish
+  approved_pos: adjective
+  approved_gloss: fermented; pickled
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: feb7a7ceec924c1d
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 209
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags calque_warning; heritage_status flags russian_shadow
+- lemma: по імені
+  decision: approve_for_publish
+  approved_pos: phrase
+  approved_gloss: by name
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: ffaf99a96eb5e88c
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 210
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition
+- lemma: зраджувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to betray; to cheat on; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: bcdd71c1a203d3aa
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 211
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: зрадити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to betray; to cheat on; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a2ffd1092ba9e7a2
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 212
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: довіра
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: trust
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 58a14e858cfe157d
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 213
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: діставатися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to get to; to arrive; to make it; imperfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 2d0c919b8a084cde
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 214
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: дістатися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to get to; to arrive; to make it; perfective
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 91db36d17d1a22c6
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 215
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: пил
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: dust
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a3c703bc04ca17a3
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 216
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: яма
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: pit; hole in the ground
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 765517df323ff3dc
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 217
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:heritage_status flags russian_shadow
+- lemma: чайний сервіз
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: tea set
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a73ed69332ebb77f
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml
+    locator: explicit vocabulary table row 218
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-199-218
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+  review_queue_reasons:
+  - grow_needs_review:missing dictionary definition

--- a/docs/runbooks/word-atlas-private-teacher-source-scope.md
+++ b/docs/runbooks/word-atlas-private-teacher-source-scope.md
@@ -24,11 +24,11 @@ source titles, source ids, locators, and context are intentionally privacy-safe.
 The inventories do not commit raw notes, transcripts, prompts, document paths,
 or teacher-identifying names.
 
-Current approval-ledger coverage is 208 reviewed headwords from rows 1-198.
+Current approval-ledger coverage is 228 reviewed headwords from rows 1-218.
 After PR #4208, live Atlas manifest coverage is 208 neutral `teacher_lesson`
 provenance refs across 204 Atlas entries from rows 1-198; public browse/search
-is regenerated from that manifest. Rows 199-218 are committed as review-only
-source inventory; they are not approved or live Atlas output yet. Missing
+is regenerated from that manifest. Rows 199-218 are approved for later
+controlled browse/search publish; they are not live Atlas output yet. Missing
 `surface_admission` keeps Daily Word, Practice, and cloze frozen.
 
 ## Source Handling Rule

--- a/docs/runbooks/word-atlas-source-inventory-review-candidates.md
+++ b/docs/runbooks/word-atlas-source-inventory-review-candidates.md
@@ -97,12 +97,12 @@ are curated learner-facing English anchors for cases where dictionary
 enrichment lacks a visible English translation.
 
 The private teacher-lesson seeds contribute 228 `teacher_lesson` headwords from
-an explicit local vocabulary table. Approval ledgers cover rows 1-198; after PR
+an explicit local vocabulary table. Approval ledgers cover rows 1-218; after PR
 `#4208`, live Atlas provenance also covers rows 1-198. Rows 199-218 are
-committed as review-only source inventory and still need a later approval ledger
-before any controlled browse/search publish. Their committed rows are derived
-metadata only: no raw private lesson material, private document paths, or
-teacher-identifying labels should appear in the inventory or ledger.
+approved for later controlled browse/search publish; they are not live Atlas
+output yet. Their committed rows are derived metadata only: no raw private
+lesson material, private document paths, or teacher-identifying labels should
+appear in the inventory or ledger.
 
 When a candidate is later promoted into a manifest entry,
 `promote_grow_candidates.manifest_entry_from_candidate()` copies

--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -107,6 +107,11 @@ PRIVATE_TEACHER_TENTH_LEDGER = (
     / "data/lexicon/source-inventory-review-decisions/"
     "2026-07-03-tenth-approved-teacher-lesson-ledger-batch.yaml"
 )
+PRIVATE_TEACHER_ELEVENTH_LEDGER = (
+    PROJECT_ROOT
+    / "data/lexicon/source-inventory-review-decisions/"
+    "2026-07-03-eleventh-approved-teacher-lesson-ledger-batch.yaml"
+)
 
 
 def test_private_teacher_inventory_is_privacy_safe_review_metadata() -> None:
@@ -715,6 +720,37 @@ def test_private_teacher_tenth_decision_ledger_stays_review_only() -> None:
     assert "native-reviewer-lessons" not in ledger_text
 
 
+def test_private_teacher_eleventh_decision_ledger_stays_review_only() -> None:
+    summary = decisions.validate_committed_decision_files([PRIVATE_TEACHER_ELEVENTH_LEDGER])
+    payload = yaml.safe_load(PRIVATE_TEACHER_ELEVENTH_LEDGER.read_text(encoding="utf-8"))
+
+    assert summary == {
+        "files": 1,
+        "rows": 20,
+        "decision_counts": {"approve_for_publish": 20},
+    }
+    assert payload["source_queue"]["generated_from_pr"] == 4209
+    assert payload["source_queue"]["total_queue_rows"] == 218
+    assert payload["source_queue"]["promotion_batch_size"] == 20
+    assert payload["production_outputs_updated"] == []
+    assert payload["decisions"][0]["lemma"] == "злива"
+    assert payload["decisions"][-1]["lemma"] == "чайний сервіз"
+    assert all(
+        row["source_inventory"]["source_family"] == "teacher_lesson"
+        for row in payload["decisions"]
+    )
+    assert {
+        row["source_inventory"]["source_id"]
+        for row in payload["decisions"]
+    } == {"private-teacher-lesson-vocabulary-table-1-rows-199-218"}
+    assert all("surface_admission" not in row for row in payload["decisions"])
+
+    ledger_text = PRIVATE_TEACHER_ELEVENTH_LEDGER.read_text(encoding="utf-8")
+    assert ".docx" not in ledger_text
+    assert "alona" not in ledger_text.lower()
+    assert "native-reviewer-lessons" not in ledger_text
+
+
 def test_private_teacher_decision_ledgers_cover_seed_without_live_surfaces() -> None:
     records = read_source_inventory(PRIVATE_TEACHER_INVENTORY, project_root=PROJECT_ROOT)
     inventory_keys = {
@@ -937,6 +973,32 @@ def test_private_teacher_rows_179_198_decision_ledger_covers_pending_seed() -> N
     }
 
     payload = yaml.safe_load(PRIVATE_TEACHER_TENTH_LEDGER.read_text(encoding="utf-8"))
+    ledger_keys = {
+        row["source_inventory"]["key"]
+        for row in payload["decisions"]
+    }
+
+    assert ledger_keys == inventory_keys
+
+
+def test_private_teacher_rows_199_218_decision_ledger_covers_pending_seed() -> None:
+    records = read_source_inventory(
+        PRIVATE_TEACHER_ROWS_199_218_INVENTORY,
+        project_root=PROJECT_ROOT,
+    )
+    inventory_keys = {
+        decisions.source_inventory_key(
+            lemma=record.lemma,
+            inventory_path=(
+                "data/lexicon/source-inventory/"
+                "private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml"
+            ),
+            locator=record.source_locator,
+        )
+        for record in records
+    }
+
+    payload = yaml.safe_load(PRIVATE_TEACHER_ELEVENTH_LEDGER.read_text(encoding="utf-8"))
     ledger_keys = {
         row["source_inventory"]["key"]
         for row in payload["decisions"]


### PR DESCRIPTION
## Summary

- Adds the eleventh review-only decision ledger for private teacher lesson rows 199-218.
- Approves 20 seeded headwords for later controlled Atlas browse/search publish.
- Updates tests and runbooks so rows 199-218 are now approved but not live; rows 1-198 remain the current live teacher provenance boundary after #4208.

This PR does not update live Atlas manifest/search/browse output and does not admit anything into Daily Word, Practice, or cloze.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_private_teacher_lesson_source_inventory.py tests/test_source_inventory_review_decisions.py tests/test_source_inventory_review_candidates.py -q` -> 71 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m scripts.audit.source_inventory_review_decisions` -> files=17 rows=382 approvals
- Targeted promotion plan for the new ledger -> approved_decisions=20, matched_candidates=20, proposed_additions=17, skipped_existing=3, missing_candidates=0, production_outputs_updated=[]
- `check_static_practice_assets.py --format json` -> Daily=300, Practice=4484, Cloze=22
- `ruff check --fix` on changed test file -> clean
- `markdownlint-cli2` on changed docs -> clean
- `git diff --check` -> clean
- privacy scan for private names/paths/docx in production files -> clean
- `scripts/audit/lint_agent_trailer.py` -> pass

## Review

- Read-only helper review with `gpt-5.4-mini` found no blockers and verified row/key/path/locator alignment.
- Independent AGY/Gemini review initially questioned `total_queue_rows`; follow-up evidence showed existing teacher ledgers use that field as the cumulative review queue cursor. The blocker was withdrawn and AGY reported no remaining blockers.