### PR TITLE
docs(bio): add Ivan Steshenko dossier

### DIFF
--- a/docs/research/bio/ivan-steshenko.md
+++ b/docs/research/bio/ivan-steshenko.md
@@ -1,0 +1,191 @@
+# Іван Матвійович Стешенко - Research Dossier
+
+**Slug:** `ivan-steshenko`
+**Block:** +77 backfill - Central Rada education / school Ukrainization / literary scholarship / Ukrainian State Academy of Arts / political assassination
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #327
+**Researcher:** Codex worker (GPT-5)
+**Completed:** 2026-07-03
+
+**Source acronym legend:** EIU = Encyclopedia History Ukraine / Institute History of Ukraine, NASU; IEU = Internet Encyclopedia Ukraine / Canadian Institute Ukrainian Studies; UINP = Ukrainian Institute National Memory; DNPB = V. O. Sukhomlynskyi State Scientific and Pedagogical Library of Ukraine, NAES of Ukraine; NBUV = Vernadsky National Library of Ukraine; NLU = Yaroslav Mudryi National Library of Ukraine; BIO / HIST / ISTORIO / wiki = existing learn-ukrainian track materials; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, encyclopedia, pedagogical, primary-text, and image-rights sources cited
+- [x] Pressure mechanism framed tsarist arrest / exile / teaching ban, imperial education-language control, Central Rada school Ukrainization, revolutionary-period assassination, and later Soviet-family repression cautions
+- [x] At least 2 title / source / visual anchors supplied
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-03 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric periodization: frame is Ukrainian public culture, Ukrainian Revolution-era state-building, and Ukrainian-language schooling, not generic "Russian Civil War" or "Russian education reform."
+- [x] Ukrainian agency preserved: Steshenko is treated as a pedagogue, literary scholar, translator, education secretary / minister, Society of School Education organizer, and Ukrainian institutional builder.
+- [x] Imperial constraints named: the Russian Empire's policing of student politics, Ukrainian public organization, teaching licenses, and school-language policy are explicit mechanisms, not background scenery.
+- [x] Assassination language is concrete but source-safe: use "assassinated / murdered by gunmen" as the stable fact; source-label claims that the Zinkiv county Bolshevik organization ordered the killing.
+- [x] Russian-language titles and catalog forms are treated as publication / search metadata, not identity labels.
+- [x] Anti-hagiography included: short office tenure, partial implementation of school reform, source conflicts, and contested assassination evidence are kept visible.
+
+## 1. Identity / chronology
+
+- **Canonical UA:** `Іван Матвійович Стешенко`.
+- **Canonical EN:** `Ivan Matviiovych Steshenko`.
+- **Core identity:** Ukrainian civic and political figure, pedagogue, literary scholar, poet, writer, translator, member of the Ukrainian Central Rada, General Secretary / Minister of Education in the UNR state-building moment, organizer of the Society of School Education, and one of the institutional founders connected with the Ukrainian State Academy of Arts. [T1: EIU - Стешенко Іван Матвійович] [T1: IEU - Steshenko, Ivan M.] [T2: DNPB - Біографія І. М. Стешенка]
+- **Birth:** Use `24 June 1873, Poltava` in low-context learner copy, with a source note that this corresponds to the source-pack target `12 June old style / 24 June new style`. UINP and DNPB give 24 June 1873 in Poltava; Ukrainian tertiary pages give `12 [24] June`; EIU's online display says `24.07.1873`; IEU says `24 June 1874`. Treat EIU / IEU as date-drift here, not as final production metadata until checked against print / archive copies.
+- **Death:** Use `30 July 1918, Poltava, assassinated` in low-context copy. EIU gives 30 July 1918; UINP narrates the attack during the night from 29 to 30 July; IEU says he died 1 August 1918. Do not build exact-date quizzes without source labels.
+- **Family:** His father Matvii Steshenko is described by DNPB / UINP as a retired non-commissioned officer from a large Poltava family that invested in children's education. In 1897 Ivan married Oksana Starytska / Steshenko; through that family he is linked to Mykhailo Starytskyi, Liudmyla Starytska-Cherniakhivska, Iryna Steshenko, and Yaroslav Steshenko. [T1: IEU - Steshenko, Ivan M.] [T2: DNPB - Біографія]
+- **Education:** Poltava Classical Gymnasium, then the historical-philological faculty of Kyiv University / University of St Volodymyr, completed in 1896. EIU notes a silver medal for work on Serbo-Croatian literature. [T1: EIU] [T2: DNPB]
+- **Literary circle:** As a student he worked in the `Плеяда` / Kyiv literary Hromada milieu, published in Lviv periodicals, translated European literature into Ukrainian, and wrote poetry and drama. [T1: IEU] [T2: DNPB]
+- **Political formation:** In 1896 he helped found the Ukrainian social-democratic circle with Lesia Ukrainka, Mykhailo Kotsiubynskyi, Pavlo Tulub, Pavlo Tuchapskyi, and Mykola Kovalevskyi. Later affiliations include Stara Hromada, USDRP, the Society of Ukrainian Progressives, the Ukrainian Scientific Society in Kyiv, and the Shevchenko Scientific Society from 1917. [T1: EIU] [T1: IEU]
+- **Teaching career:** He taught at Kyiv women's and commercial schools, the Froebel Institute, higher women's courses, and the Mykola Lysenko Music and Drama School; DNPB notes that he was the first there to teach history of drama in Ukrainian. [T1: IEU] [T2: DNPB]
+- **1917-1918 education office:** He headed the Society of School Education, entered the Ukrainian Central Rada, became General Secretary of Education in June 1917, and served as Minister of People's Education in early 1918. [T1: EIU] [T1: IEU] [T2: DNPB]
+
+## 2. Political pressure mechanism
+
+- **Tsarist arrest and professional punishment:** After student protest activity in 1897, Steshenko was imprisoned, expelled from Kyiv, and barred from teaching. IEU gives four months in prison plus three years of exile from Kyiv; UINP narrates a five-month wait and the `вовчий білет` / black-marked status; DNPB explains that his later return to commercial-school teaching was possible partly because commercial schools were under the Ministry of Finance, not the more politically rigid imperial Ministry of Education. Use this as a concrete repression mechanism, not a vague "had difficulties." [T1: IEU] [T2: DNPB] [T2: UINP]
+- **Imperial education-language regime:** Steshenko's public work developed under a state that treated Ukrainian-language schooling, publishing, and civic organization as suspect. His teaching bans, the need for Ukrainian cultural work in tolerated spaces, and the slow creation of Ukrainian terminology and textbooks belong together.
+- **School Ukrainization as state-building:** In 1917 the Society of School Education and the General Secretariat of Education made Ukrainian-language schooling a sovereignty project. DNPB records work on teacher preparation, Ukrainian terminology, orthography, textbooks, local school commissioners, teacher unions, `Просвіти`, and new programs.
+- **Circular / legal instrument anchor:** DNPB cites a circular signed by Steshenko requiring Ukrainian studies subjects in all schools, Ukrainian-language extracurricular study of literature and history, libraries of Ukrainian literature, Ukrainian school performances, national student unions, and historical excursions. This should be a primary policy-text anchor for production, with the DNPB / source-edition citation kept visible rather than paraphrased into a generic "he promoted Ukrainian."
+- **Decentralization anchor:** DNPB notes the Central Rada law abolishing school districts as centralized bureaucratic intermediaries between the education secretariat and local self-government. This is a useful low-drama way to show how anti-imperial education reform worked administratively.
+- **War and resource limits:** His program was ambitious but only partly implemented because of teacher shortages, war, state fragility, and shifting regimes. UINP explicitly notes unrealized plans such as peasant gymnasia.
+- **Assassination:** EIU states that a Bolshevik organization in Zinkiv county sentenced him to death and that he was killed in Poltava. UINP gives a detailed narrative of two gunmen and quotes later testimony / diary evidence pointing to local Bolshevik responsibility. For learner-facing copy, the stable wording should be: "Steshenko was assassinated in Poltava in July 1918; Ukrainian sources attribute the killing to a local Bolshevik organization, but the operational details should stay source-labeled."
+- **Later Soviet-family pressure:** The 1941 arrest materials around Oksana Steshenko and Liudmyla Starytska-Cherniakhivska are relevant context but not proof by themselves for every detail of the 1918 murder. Use them as evidence of Soviet treatment of the family and memory trail, not as the only basis for the assassination narrative.
+
+## 3. Major events / historical footprint
+
+- **1892-1896 Kyiv University and `Плеяда`:** Student literary work, translation, and Ukrainian publicism connect him to Lesia Ukrainka, the Starytskyi family, and Kyiv's Ukrainian literary infrastructure.
+- **1893 Ovid translation:** `Овідій-Назон. Метаморфози`, translated as Ivan Serdeshnyi / Ivan Steshenko, gives a strong primary-text anchor for Ukrainian translation of classical literature before the 1917 state-building period. Commons hosts a 1893 scan with Steshenko as translator and public-domain status.
+- **1896 Ukrainian social-democratic circle:** The group around Steshenko, Lesia Ukrainka, Kotsiubynskyi, and others translated / issued social-democratic materials in Galicia. This places him in a Ukrainian political and print network rather than only a school-reform story. [T1: EIU]
+- **1897 arrest, prison, exile, teaching ban:** The repression mechanism shaped both his family life with Oksana Starytska and his turn to writing, scholarship, translation, and dictionary work.
+- **1898 Kotliarevskyi study:** `Поэзия И. П. Котляревского` / `Поезія І. П. Котляревського` became a key title anchor; EIU says he received a Petersburg Academy award for it. Keep the Russian title form as publication metadata, not as narrator language.
+- **1899-1901 poetry collections:** `Хуторні сонети` and `Степові мотиви` are useful for showing him as a writer, not only a minister.
+- **1905 `Шершень` and `Ґедзь`:** With Lesia Ukrainka, Liudmyla Starytska, Maksym Slavinskyi, and others, he used the brief post-1905 opening to publish satirical Ukrainian periodicals before renewed restriction. [T1: EIU] [T2: DNPB]
+- **1908 `Історія української драми`:** A major literary-historical work and a clean LIT / theatre bridge. NBUV / Commons provide a 1908 scan published in Kyiv and marked public domain.
+- **1912 `Про українську літературну мову`:** A concise language-policy / literary-language source, valuable for advanced learners studying standardization debates. Commons hosts the 1912 NLU scan and marks it public domain.
+- **1915-1917 Tetyanivska gymnasium:** EIU says he headed a gymnasium for Galician refugee children forcibly taken to Kyiv during Russian army occupation of Galicia. This is an important wartime education and imperial-violence anchor.
+- **1917 Society of School Education and General Secretariat:** His brief ministry joined teacher preparation, textbooks, terminology, minority education rights, Ukrainian studies, Ukrainian school theatre, and local self-government in one program.
+- **1917 Ukrainian State Academy of Arts connection:** IEU and UINP identify him among the founders / institutional builders; Commons has a 1917 founders image with him seated among Hrushevskyi, Narbut, Krychevsky, Boichuk, Murashko, Manevich, and Burachek.
+- **July 1918 assassination and funeral:** His murder in Poltava and burial in Kyiv's Baikove Cemetery make him an early martyr figure in the Ukrainian Revolution's cultural / education state-building cluster. Use martyr framing sparingly and keep the political mechanism factual.
+
+## 4. Pedagogical anchors
+
+- **Education as sovereignty:** Steshenko lets learners see why schools, teacher training, textbooks, terminology, and local school governance were state-building, not secondary cultural work.
+- **Ukrainianization without caricature:** Teach `українізація освіти` as building Ukrainian-language public capacity while also guaranteeing minority communities' right to national development, as DNPB summarizes his position.
+- **Administrative vocabulary:** `Генеральний секретаріат`, `генеральний секретар освіти`, `міністр народної освіти`, `Товариство шкільної освіти`, `шкільні округи`, `комісар`, `учительська спілка`, `підручник`, `правопис`, `термінологія`, `українознавство`.
+- **Literary scholarship bridge:** His Kotliarevskyi, drama-history, Shevchenko, and literary-language works connect BIO to LIT, LIT-ESSAY, theatre history, and Ukrainian language standardization debates.
+- **Translation bridge:** Ovid, Schiller, Byron, Béranger, and other translations show the Pleiada-era goal of making world literature available in Ukrainian.
+- **Central Rada cluster:** Pair him with Hrushevskyi, Vynnychenko, Yefremov, Petliura, Lototskyi, Tuhan-Baranovskyi, Martos, Chekhivskyi, and Rusova to show how education, finance, diplomacy, publishing, and social policy intersected in 1917.
+- **Map anchor:** Poltava, Kyiv, Lviv / Galicia print routes, Chernechyi Yar / Zinkiv county, Baikove Cemetery, and wartime Galicia-to-Kyiv refugee schooling.
+- **Source criticism exercise:** Ask learners to compare `assassinated by unknown assailants`, `local Bolshevik organization ordered the killing`, and later Soviet-file wording. The lesson is not uncertainty theater; it is how historians keep mechanism, evidence type, and source status distinct.
+- **Anti-hagiography anchor:** His education program was foundational but not fully realized; his office was brief; and some sources drift on dates. Teach institutional effort and limits together.
+
+## 5. Language register
+
+- **Register:** literary-historical, pedagogical, Central Rada administrative, language-standardization, translation, publicist, and repression / assassination vocabulary.
+- **CEFR readiness:** A2/B1 short biography around school, city, family, and work; B1/B2 Central Rada education vocabulary; B2/C1 literary-language and drama-history texts; C1/C2 source comparison around assassination evidence and imperial school policy.
+- **Core vocabulary:** `Іван Стешенко`, `педагог`, `літературознавець`, `перекладач`, `поет`, `Плеяда`, `Полтавська гімназія`, `Київський університет`, `Українська Центральна Рада`, `Генеральний секретаріат освіти`, `Товариство шкільної освіти`, `українізація школи`, `українознавство`, `підручник`, `правопис`, `термінологія`, `Українська державна академія мистецтв`, `замах`, `вбивство`, `поховання`.
+- **Title-language caution:** Preserve original title forms when citing editions: `Поэзия И. П. Котляревского`, `Історія української драми`, `Про українську лїтературну мову`, `Життя і твори Тараса Шевченка`. In learner voice, explain that Russian-title publications reflect imperial publishing contexts.
+- **Office-title caution:** Use `General Secretary of Education` / `Minister of People's Education` when translating the 1917-1918 offices. Do not flatten him into a long-serving modern education minister.
+- **Date caution:** Use `1873-1918` for most low-context displays. If exact dates appear, name the source and note the birth / death drift.
+- **Assassination caution:** Avoid passive "lost his life." Use `was assassinated / murdered in Poltava`; source-label claims about who ordered it.
+- **Name caution:** `Steshenko`, not Polish / Russian-derived `Steszenko` or Russian patronymic forms, in learner display.
+
+## 6. Risks / open questions
+
+- **Birth date conflict:** UINP and DNPB support 24 June 1873; the source-pack target gives 12 June O.S. / 24 June N.S.; EIU's online entry displays 24 July 1873; IEU displays 24 June 1874; Commons creator metadata also treats 24 June as Julian, likely compounding confusion. Production should use `1873-1918` or `24 June 1873` with a source note until a print encyclopedia / archival record settles the old-style notation.
+- **Death date conflict:** EIU and Commons metadata support 30 July 1918; UINP describes the attack on the night of 29-30 July; IEU gives 1 August 1918. Low-context copy should not use 1 August without naming IEU.
+- **Assassination attribution:** EIU states local Bolshevik responsibility; UINP quotes Yefremov's diary trail and a 1941 Soviet arrest document. These are serious Ukrainian sources, but production should distinguish the confirmed assassination from the reconstructed perpetrator chain.
+- **"First political murder" wording:** UINP / secondary summaries call it one of the first political murders in Ukraine. Use this only as a source-labeled formulation, not as a quiz fact.
+- **Dictionary anecdote:** The dictionary-work thread after the 1897 arrest is well attested, but any colorful "dictionary-burning" anecdote should be treated as family / literary legend unless a direct source is found.
+- **IEU identity metadata drift:** IEU is valuable for English cross-checking but has date drift; Commons creator pages also contain metadata such as "Russian translator, writer and politician." Treat such labels as catalog artifacts, not identity claims.
+- **Russian-title overreading:** Several major works and periodicals have Russian titles because of the publishing environment. Do not use those titles to narrate Steshenko as Russian.
+- **Office chronology:** Sources vary in exact month spans for General Secretary / Minister of Education. Use `June 1917 to early 1918` unless the exact office dates are required and sourced.
+- **Academy of Arts role:** IEU / UINP / Commons support the institutional connection. Later production should avoid implying he was a visual artist; his role is founding / education / state-building context.
+- **Family conflation:** Do not confuse Ivan Matviiovych Steshenko with singer Ivan Nykyforovych Steshenko, wife Oksana Steshenko, son Yaroslav, or daughter Iryna. Commons contains similarly named files that are not this subject.
+
+## 7. Cross-track links
+
+- **Current BIO #327 inventory state (VERIFIED `test -e` / index scan 2026-07-03):** `site/src/content/docs/bio/index.mdx` lists BIO #327 `ivan-steshenko`; this dossier creates `docs/research/bio/ivan-steshenko.md`. The following production surfaces were absent before this dossier: `curriculum/l2-uk-en/plans/bio/ivan-steshenko.yaml`, `curriculum/l2-uk-en/bio/discovery/ivan-steshenko.yaml`, `wiki/figures/ivan-steshenko.md`, `wiki/figures/ivan-steshenko.sources.yaml`, `site/src/content/docs/bio/ivan-steshenko.mdx`, `curriculum/l2-uk-en/bio/ivan-steshenko/module.md`, `curriculum/l2-uk-en/bio/ivan-steshenko/activities.yaml`, `curriculum/l2-uk-en/bio/ivan-steshenko/vocabulary.yaml`, and `curriculum/l2-uk-en/bio/ivan-steshenko/resources.yaml`.
+- **Existing BIO dossier anchors (VERIFIED `test -e` 2026-07-03):** `docs/research/bio/serhii-yefremov.md`, `docs/research/bio/mykhailo-hrushevskyi.md`, `docs/research/bio/volodymyr-vynnychenko.md`, `docs/research/bio/symon-petliura.md`, `docs/research/bio/borys-martos.md`, `docs/research/bio/oleksandr-lototskyi.md`, `docs/research/bio/sofiia-rusova.md`, `docs/research/bio/borys-hrinchenko.md`, `docs/research/bio/ivan-kotliarevskyi.md`, and `docs/research/bio/liudmyla-starytska.md`.
+- **Absent BIO family / literary-risk anchors (VERIFIED absent `test -e` 2026-07-03):** `docs/research/bio/lesia-ukrainka.md`, `docs/research/bio/mykhailo-starytskyi.md`, and `docs/research/bio/oksana-steshenko.md`. If added later, cross-link carefully because they are central to the Pleiada / Starytskyi / Steshenko family network.
+- **Existing HIST / ISTORIO plan and discovery surfaces (VERIFIED `test -e` 2026-07-03):** `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`, `curriculum/l2-uk-en/hist/discovery/tsentralna-rada.yaml`, `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`, `curriculum/l2-uk-en/istorio/discovery/universaly-unr.yaml`, `curriculum/l2-uk-en/plans/hist/rosiiska-imperiia-ukraina.yaml`, `curriculum/l2-uk-en/hist/discovery/rosiiska-imperiia-ukraina.yaml`, `curriculum/l2-uk-en/plans/hist/hromady.yaml`, `curriculum/l2-uk-en/hist/discovery/hromady.yaml`, `curriculum/l2-uk-en/plans/istorio/emskyi-ukaz-tekst.yaml`, and `curriculum/l2-uk-en/istorio/discovery/emskyi-ukaz-tekst.yaml`.
+- **Existing wiki / context surfaces (VERIFIED `test -e` / `rg` 2026-07-03):** `wiki/periods/tsentralna-rada.md`, `wiki/historiography/universaly-unr.md`, `wiki/periods/movna-polityka.md`, `wiki/periods/hromady.md`, `wiki/historiography/emskyi-ukaz-tekst.md`, `wiki/linguistics/ruthenian/vertep-ukrainskyi-teatr.md`, `wiki/linguistics/ruthenian/intermedii-xvii-xviii.md`, and `wiki/literature/works/lesia-in-the-catacombs.md`.
+- **Local textbook echo (VERIFIED `rg` / `sed` 2026-07-03):** `docs/references/textbooks-txt/10-klas-history.txt` mentions Ivan Steshenko in the Ukrainian Democratic Party leader cluster and as head of the Ukrainian Society of School Education in the school-Ukrainization section. Treat the textbook as curricular echo, not the metadata authority.
+- **Candidate cross-track additions:** future BIO / HIST / ISTORIO / LIT planning can connect Steshenko to Ukrainian school reform, teacher education, Ukrainian-language curriculum, Pleiada translation work, Kotliarevskyi studies, Ukrainian drama history, Central Rada administration, and political assassination during the Ukrainian Revolution.
+
+## 8. Name variants / search aliases
+
+- **Canonical UA:** `Іван Матвійович Стешенко`.
+- **Canonical EN:** `Ivan Matviiovych Steshenko`.
+- **Common UA search forms:** `Іван Стешенко`, `Стешенко Іван`, `Стешенко Іван Матвійович`, `І. М. Стешенко`, `Ів. Стешенко`.
+- **Pseudonyms / signatures:** `Іван Сердешний`, `Ів. Сердешний`, `Ів. Січовик`, `Світленко`, `Ів. Сепура`, `Ів. Степура`.
+- **Common EN / transliteration forms:** `Ivan Steshenko`, `Ivan M. Steshenko`, `Ivan Matviyovych Steshenko`, `Ivan Matviiovych Steshenko`, `I. Serdeshny`, `I. Sichovyk`, `I. Svitlenko`, `I. Stepura`.
+- **Russified / imperial-search forms:** `Иван Матвеевич Стешенко`, `Иван Стешенко`, `Ivan Matveevich Steshenko`, `Iwan Steszenko`, `Stešenko`, `Kievskaia starina`, `Kiev`. Keep these for source discovery and catalog reconciliation only, not learner display.
+- **Institution / topic aliases:** `General Secretary of Education`, `Minister of People's Education`, `Society of School Education`, `Ukrainian Central Rada`, `Ukrainian State Academy of Arts`, `Ukrainian Pedagogical Academy`, `Історія української драми`, `Про українську літературну мову`, `Поезія Котляревського`, `Плеяда`.
+- **Learner-facing display:** `Ivan Steshenko (Іван Стешенко, 1873-1918)`.
+
+## 9. Image rights / visual material notes
+
+- **Primary portrait candidate:** Commons `File:Стешенко Іван.jpg`; 1890s Kyiv portrait of Ivan Steshenko, source listed as `mvduk.kiev.ua`, author Mykola Uzemskyi (1892-1914), public-domain marking with a note that a US public-domain tag is still needed. Strong candidate after production resolves the US tag gap.
+- **Alternate portrait candidate:** Commons `File:Стешенко І.jpg`; identifies Ivan Matviiovych Steshenko (1873-1918), source `primetour.ua`, unknown author, public-domain Ukraine / Ukrainian SSR work tag. Useful but weaker provenance than the named-author portrait.
+- **Wrong-person caution:** Commons `File:Ivan Steshenko.jpg` is singer Ivan Nykyforovych Steshenko, not this subject. Do not use it for BIO #327.
+- **General Secretariat context image:** Commons `File:General Secretariat of Ukraine. Генеральний секретаріат УНР.jpg`; first General Secretariat group in Kyiv, 5 July 1917, with Steshenko seated. File has public-domain / PD-Ukraine markings and a useful caption, but production should check file-level source and US status.
+- **Academy of Arts context image:** Commons `File:Founders of the Ukrainian academy of arts.jpg`; 1917 academy-founder image including Steshenko. Commons page marks PD-Ukraine / unknown author; use as context, not as portrait.
+- **Primary-text visual candidates:** Commons / NBUV / NLU scans of `Історія української драми` (1908), `Про українську лїтературну мову` (1912), and `Життя і твори Тараса Шевченка` (1918) are strong PD title-page or source-study visuals.
+- **Avoid default:** Russian Wikipedia mirrors, unsourced blog portraits, AI colorizations, files for Ivan Nykyforovych Steshenko, and any image whose caption cannot separate Ivan Matviiovych from other Steshenko family members.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- Янковська О. В. "Стешенко Іван Матвійович." Енциклопедія історії України, Інститут історії України НАН України. https://www.history.org.ua/?termin=Steshenko_I. Accessed 2026-07-03.
+- Senkus, Roman. "Steshenko, Ivan M." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CT%5CSteshenkoIvanM.htm. Accessed 2026-07-03.
+- UINP, "1873 - народився Іван Стешенко, перший міністр освіти УНР." https://uinp.gov.ua/istorychnyy-kalendar/cherven/24/1873-narodyvsya-ivan-steshenko-pershyy-ministr-osvity-unr. Accessed 2026-07-03.
+- DNPB, "Біографія І. М. Стешенка." https://dnpb.gov.ua/informatsiyno-bibliohrafichni-resursy/vydatni-pedahohy/steshenko-i-m/biohrafiya/. Accessed 2026-07-03.
+- NBUV, "СТЕШЕНКО Іван Матвійович (1873-1918). Фонд № 207." https://www.irbis-nbuv.gov.ua/catalogi/0207/P9.html. Accessed 2026-07-03.
+
+**Tier 2 / 3 (pedagogical, source-rich, and primary-text references):**
+
+- Самоплавська Т. О. "Стешенко Іван Матвійович (1873-1918)," in `Українська педагогіка в персоналіях`, cited by DNPB biography page. Checked 2026-07-03.
+- Commons / NBUV, `Стешенко І. Історія української драми. Т. 1` (Kyiv, 1908). https://commons.wikimedia.org/wiki/File:%D0%A1%D1%82%D0%B5%D1%88%D0%B5%D0%BD%D0%BA%D0%BE_%D0%86._%D0%86%D1%81%D1%82%D0%BE%D1%80%D1%96%D1%8F_%D1%83%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D1%81%D1%8C%D0%BA%D0%BE%D1%97_%D0%B4%D1%80%D0%B0%D0%BC%D0%B8._%D0%A2._1_(1908).pdf. Accessed 2026-07-03.
+- Commons / NLU, `Стешенко І. Про українську лїтературну мову` (Kyiv, 1912). https://commons.wikimedia.org/wiki/File:%D0%A1%D1%82%D0%B5%D1%88%D0%B5%D0%BD%D0%BA%D0%BE_%D0%86._%D0%9F%D1%80%D0%BE_%D1%83%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D1%81%D1%8C%D0%BA%D1%83_%D0%BB%D1%97%D1%82%D0%B5%D1%80%D0%B0%D1%82%D1%83%D1%80%D0%BD%D1%83_%D0%BC%D0%BE%D0%B2%D1%83_(1912).djvu. Accessed 2026-07-03.
+- Commons / NLU, `Стешенко І. Життя і твори Тараса Шевченка` (Lviv, 1918). https://commons.wikimedia.org/wiki/File:%D0%A1%D1%82%D0%B5%D1%88%D0%B5%D0%BD%D0%BA%D0%BE_%D0%86._%D0%96%D0%B8%D1%82%D1%82%D1%8F_%D1%96_%D1%82%D0%B2%D0%BE%D1%80%D0%B8_%D0%A2%D0%B0%D1%80%D0%B0%D1%81%D0%B0_%D0%A8%D0%B5%D0%B2%D1%87%D0%B5%D0%BD%D0%BA%D0%B0_(1918).djvu. Accessed 2026-07-03.
+- Commons / Chtyvo, `Овідій-Назон. Метаморфози`, Ukrainian translation by Ivan Serdeshnyi / Ivan Steshenko (Lviv, 1893). https://commons.wikimedia.org/wiki/File:%D0%9E%D0%B2%D1%96%D0%B4%D1%96%D0%B9%E2%80%91%D0%9D%D0%B0%D0%B7%D0%BE%D0%BD._%D0%9C%D0%B5%D1%82%D0%B0%D0%BC%D0%BE%D1%80%D1%84%D0%BE%D0%B7%D0%B8_(1893).pdf. Accessed 2026-07-03.
+- `docs/references/textbooks-txt/10-klas-history.txt`, local textbook extraction mentioning Steshenko, Ukrainian Democratic Party, Society of School Education, and school Ukrainization. Checked 2026-07-03.
+
+**Tier 4 (learn-ukrainian cross-track sources checked 2026-07-03):**
+
+- `curriculum/l2-uk-en/curriculum.yaml`
+- `site/src/content/docs/bio/index.mdx`
+- `docs/research/bio/serhii-yefremov.md`
+- `docs/research/bio/mykhailo-hrushevskyi.md`
+- `docs/research/bio/volodymyr-vynnychenko.md`
+- `docs/research/bio/symon-petliura.md`
+- `docs/research/bio/borys-martos.md`
+- `docs/research/bio/oleksandr-lototskyi.md`
+- `docs/research/bio/sofiia-rusova.md`
+- `docs/research/bio/borys-hrinchenko.md`
+- `docs/research/bio/ivan-kotliarevskyi.md`
+- `docs/research/bio/liudmyla-starytska.md`
+- `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`
+- `curriculum/l2-uk-en/hist/discovery/tsentralna-rada.yaml`
+- `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml`
+- `curriculum/l2-uk-en/istorio/discovery/universaly-unr.yaml`
+- `curriculum/l2-uk-en/plans/hist/rosiiska-imperiia-ukraina.yaml`
+- `curriculum/l2-uk-en/hist/discovery/rosiiska-imperiia-ukraina.yaml`
+- `curriculum/l2-uk-en/plans/hist/hromady.yaml`
+- `curriculum/l2-uk-en/hist/discovery/hromady.yaml`
+- `curriculum/l2-uk-en/plans/istorio/emskyi-ukaz-tekst.yaml`
+- `curriculum/l2-uk-en/istorio/discovery/emskyi-ukaz-tekst.yaml`
+
+**Tier 5 (image-rights / media-rights sources):**
+
+- Commons `Category:Ivan Steshenko`. https://commons.wikimedia.org/wiki/Category:Ivan_Steshenko. Accessed 2026-07-03.
+- Commons `File:Стешенко Іван.jpg`. https://commons.wikimedia.org/wiki/File:%D0%A1%D1%82%D0%B5%D1%88%D0%B5%D0%BD%D0%BA%D0%BE_%D0%86%D0%B2%D0%B0%D0%BD.jpg. Accessed 2026-07-03.
+- Commons `File:Стешенко І.jpg`. https://commons.wikimedia.org/wiki/File:%D0%A1%D1%82%D0%B5%D1%88%D0%B5%D0%BD%D0%BA%D0%BE_%D0%86.jpg. Accessed 2026-07-03.
+- Commons `File:Ivan Steshenko.jpg` (wrong-person caution: Ivan Nykyforovych Steshenko). https://commons.wikimedia.org/wiki/File:Ivan_Steshenko.jpg. Accessed 2026-07-03.
+- Commons `File:General Secretariat of Ukraine. Генеральний секретаріат УНР.jpg`. https://commons.wikimedia.org/wiki/File:General_Secretariat_of_Ukraine._%D0%93%D0%B5%D0%BD%D0%B5%D1%80%D0%B0%D0%BB%D1%8C%D0%BD%D0%B8%D0%B9_%D1%81%D0%B5%D0%BA%D1%80%D0%B5%D1%82%D0%B0%D1%80%D1%96%D0%B0%D1%82_%D0%A3%D0%9D%D0%A0.jpg. Accessed 2026-07-03.
+- Commons `File:Founders of the Ukrainian academy of arts.jpg`. https://commons.wikimedia.org/wiki/File:Founders_of_the_Ukrainian_academy_of_arts.jpg. Accessed 2026-07-03.


### PR DESCRIPTION
## Scope

Creates exactly one file:

- `docs/research/bio/ivan-steshenko.md`

No plans, discovery packets, wiki files, module files, generated artifacts, linter configs, telemetry, or package files were edited.

## Gates run

- `npx markdownlint-cli2 docs/research/bio/ivan-steshenko.md` - passed
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/ivan-steshenko.md` - passed using the repository venv interpreter because this Codex worktree has no local `.venv`
- `git diff --check` - passed
- `git diff --name-only` - confirmed exactly `docs/research/bio/ivan-steshenko.md`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` - passed using the repository venv interpreter after commit

Commit hooks also passed during commit/push, including the BIO dossier xref validator and X-Agent trailer warning.

## Source conflicts / risks for orchestrator

- Birth metadata conflicts: UINP/DNPB support 24 June 1873; source-pack target gives 12 June O.S. / 24 June N.S.; EIU online displays 24.07.1873; IEU displays 24 June 1874.
- Death metadata conflicts: EIU supports 30 July 1918; UINP narrates the night of 29-30 July; IEU gives 1 August 1918.
- Assassination attribution should stay source-labeled: confirmed assassination in Poltava, with Ukrainian sources attributing the order/execution to a local Bolshevik organization.
- Image production should avoid wrong-person Commons `File:Ivan Steshenko.jpg` and recheck US public-domain tags for the best portrait/context candidates.