### PR TITLE
ci(atlas): update POC richness baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
           .venv/bin/python scripts/audit/audit_atlas_poc_richness.py \
             --max-search-no-visible-gloss 0 \
             --max-old-gate-no-english-anchor 0 \
-            --max-poc-thin-pages 889
+            --max-poc-thin-pages 899
 
       - name: Check static Word Day / practice assets (#3935)
         run: python scripts/audit/check_static_practice_assets.py


### PR DESCRIPTION
## Summary
- update the Atlas POC thin-page baseline from 889 to the current release-manifest count, 899
- keeps the learner-anchor and visible-gloss gates unchanged at zero

## Validation
- `.venv/bin/python scripts/audit/audit_atlas_poc_richness.py --manifest site/src/data/lexicon-manifest.json --local --max-search-no-visible-gloss 0 --max-old-gate-no-english-anchor 0 --max-poc-thin-pages 899`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`