### PR TITLE
[codex] Add Petro Doroshenko BIO dossier

### DIFF
--- a/docs/research/bio/petro-doroshenko.md
+++ b/docs/research/bio/petro-doroshenko.md
@@ -1,0 +1,214 @@
+# Петро Дорофійович Дорошенко — Research Dossier
+
+**Slug:** `petro-doroshenko`
+**Block:** G (politically charged Cossack-statehood figure; Ottoman-protectorate caricature and Ruina-era statecraft)
+**Tier:** 1a
+**Issue:** #4215 (BIO full Cossack coverage epic — P0 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕІУ, IEU, Chukhlib academic article/PDF; Cambridge/Grygorieva bibliographic cross-check)
+- [x] Source-tier checkboxes included and lower-tier sources kept non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: Andrusovo partition, "Turkish vassal" smear, forced Moscow surrender/exile, Right-Bank devastation)
+- [x] §4 includes 3 primary/document excerpts with verification caveats
+- [x] Ottoman protectorate is framed as catastrophic-condition statecraft, not as a smear; coercion and devastation are not sanitized
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-07-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+- [x] **T1 baseline:** ЕІУ and Internet Encyclopedia of Ukraine anchor core facts, dates, offices, and political sequence.
+- [x] **T2/T4 scholarship:** Chukhlib, Doroshenko/Rypka, Grygorieva, Ostapchuk, Krykun, and Chukhlib's Right-Bank Hetmanate work frame Ottoman-protectorate interpretation.
+- [x] **T3/T5 caution:** Wikipedia and general web are suitable only for navigation or low-risk cross-checks; do not use them as load-bearing evidence.
+- [x] **Primary/doc excerpts:** use short excerpts only with document-source caveats; verify against source editions before classroom quotation.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Петро Дорофійович Дорошенко. [T1: ЕІУ; T1: IEU]
+- **Pseudonyms / aliases:** Петро Дорошенко; Petro Doroshenko; Piotr Doroszenko in Polish-language scholarship. Forbidden body-text forms: Пётр Дорошенко; "турецький зрадник" or "султанський васал" as factual labels rather than polemical frames.
+- **Born:** **1627** | **Чигирин**, Kyiv Voivodeship / Cossack Ukraine context. Ukrainian Wikipedia gives **14/24 May 1627**, but Tier 1 references used here state the year and place without relying on the day. [T1: ЕІУ; T1: IEU; T3]
+- **Died:** **9/19 November 1698** | **Ярополче / Ярополець** near Volokolamsk/Moscow; buried near the church of St Paraskeva in the village. ЕІУ gives 09.11.1698; IEU gives 19 November 1698. Use both calendar forms when precision matters. [T1: ЕІУ; T1: IEU]
+- **Family / education key facts:** grandson of hetman Mykhailo Doroshenko; son of Dorofii Doroshenko; probably educated at the Kyiv-Mohyla College; knew Latin and Polish. [T1: ЕІУ; T1: IEU]
+- **Office / role:** hetman of Right-Bank Ukraine, 1665/1666-1676; briefly proclaimed hetman of all Ukraine on **8 June 1668** after the Left-Bank revolt and Ivan Briukhovetsky's death. His durable project was not "pro-Ottomanism" as identity, but reunification of both banks of the Dnipro under a Cossack polity. [T1: ЕІУ; T1: IEU]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Hetman election chronology:** ЕІУ emphasizes his rise to the hetmancy in August 1665 and consolidation by the end of 1665; IEU distinguishes an October 1665 acting-hetman election in Chyhyryn and a January 1666 Right-Bank hetmancy. Teach the sequence, not a single flattened date.
+2. **Ottoman-protectorate date:** IEU gives the Korsun general military council as **10-12 March 1669** and the sultan's proclamation as **1 May 1669**. Some popular summaries blur 1668/1669 or O.S./N.S. forms; use the Tier 1 / scholarly 1669 sequence unless a source edition is being read directly.
+3. **Abdication/surrender:** IEU gives Doroshenko's surrender to Ivan Samoilovych as **19 September 1676**. Chukhlib notes the handover of the mace in mid-September, and modern summaries may render this as 19/29 September. Keep "September 1676" if the lesson does not teach calendar conversion.
+4. **Death place naming:** Ярополче is the early-modern/ЕІУ form; Ярополець/Yaropolets is the modern place name. Avoid implying he died in Moscow city.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Doroshenko's statecraft was formed by the **Andrusovo partition of 1667**, in which Muscovy and the Polish-Lithuanian Commonwealth divided Ukrainian lands without Ukrainian consent. His turn toward the Ottoman Empire and the Crimean Khanate was a search for a third-power guarantee against that partition. It failed under the combined pressure of hostile neighbors, unreliable allies, Right-Bank devastation, internal opposition, and loss of popular support. [T1: IEU; T1: ЕІУ; T4: Chukhlib]
+
+**By whom:** Muscovy and the Commonwealth in the partition-and-containment layer; the Ottoman and Crimean allies in the coercive-devastation layer; later Russian imperial power in the surrender, Moscow detention, Viatka voivodeship, and Yaropolcha exile layer. The dossier must tell the truth in every direction.
+
+**Document references:** the **Andrusovo Truce (1667)**; the Chyhyryn senior-officer decision of January 1668; the **Korsun council (1669)**; the Ottoman berat/proclamation of 1669; the **Buchach Peace Treaty (1672)**. These are statecraft documents, not personality quirks. [T1: IEU; T4: Chukhlib; T4: Grygorieva/Ostapchuk bibliography]
+
+**Mechanism specifics:** the imperial/Soviet memory move is to reduce Doroshenko to a "Turkish vassal" or "anti-Christian traitor." A decolonized reading starts elsewhere: after Andrusovo, Moscow and Warsaw had shown that Ukrainian statehood could be partitioned by outsiders, so Doroshenko sought an alternative protectorate with conditions meant to preserve the Hetmanate's autonomy, elected hetmancy, diplomacy, and territorial unity. But the correction is not hagiography. Ottoman-Crimean intervention helped him militarily and also devastated Right-Bank society, intensified fears among Orthodox communities, and made his rule increasingly unsustainable. [T1: IEU; T1: ЕІУ; T4: Chukhlib]
+
+**What survived / what was distorted:** the image "Сонце Руїни" survived as a tragic statehood memory; the distorted version turns a desperate international strategy into ethnic/religious betrayal. The opposite distortion romanticizes him as a flawless sovereign. Neither is good enough for BIO: teach him as a skilled but failing state-builder whose options were narrow and whose choices carried catastrophic costs.
+
+## 3. Major works / legacy
+
+- `1647-1649` — joined Bohdan Khmelnytskyy's movement; served in Chyhyryn military-administrative roles and became artillery secretary of the Chyhyryn regiment. [T1: ЕІУ; T1: IEU]
+- `1657-1659` — Pryluky colonel; supported Ivan Vyhovskyi, signed the Hadiach Treaty, fought Muscovite forces in 1659, and then shifted to Yurii Khmelnytskyy while trying to limit civil-war escalation. [T1: ЕІУ; T1: IEU]
+- `1660` — signed the Slobodyshche/Chudniv settlement with the Commonwealth side after the crisis of Yurii Khmelnytskyy's policy. [T1: ЕІУ; T1: IEU]
+- `1663-1665` — general osaul under Pavlo Teteria, then Cherkasy colonel; involved in the failed 1663-1664 Right-Bank push onto the Left Bank. [T1: ЕІУ; T1: IEU]
+- `1665-1666` — rose to the Right-Bank hetmancy; restored a measure of administrative order on the Right Bank and built personal military capacity, including hired **serdiuk** regiments. [T1: ЕІУ; T3]
+- `9 December 1666` — victory over Polish forces at Brailiv after concluding that Warsaw and Moscow were moving toward partition. [T1: ЕІУ]
+- `1667` — Andrusovo made Doroshenko's unification program urgent: if Moscow and Warsaw could partition Ukraine, a different security architecture was needed. [T1: IEU; T4: Chukhlib]
+- `8 June 1668` — proclaimed hetman of all Ukraine after the Left-Bank revolt and Briukhovetsky's death; the high point of his reunification project. [T1: IEU; T4: Chukhlib]
+- `10-12 March 1669` — Korsun council approved the Ottoman alliance/protectorate; the sultan proclaimed it on 1 May 1669. [T1: IEU; T4: Grygorieva bibliography]
+- `1670` — Ostroh Commission attempt to reach a Hadiach-like understanding with the Commonwealth failed; Poland backed Mykhailo Khanenko instead. [T1: IEU]
+- `18/8 July 1672` — victory at Batozka / near Batih-Chetvertynivka against Khanenko's and Polish-aligned forces, followed by the Ottoman campaign against Kamianets-Podilskyi. [T1: ЕІУ — Батоцька битва 1672]
+- `1672` — Buchach Peace: Podilia went to the Ottoman Empire; Cossack Ukraine under Doroshenko was recognized in protectorate terms, but the campaign's devastation undercut his legitimacy. [T1: IEU]
+- `1674-1675` — Left-Bank/Russian pressure, Ottoman-Crimean intervention, and devastation of the Right Bank eroded his support. [T1: ЕІУ; T1: IEU]
+- `September 1676` — surrendered Chyhyryn and the mace to Samoilovych/Romodanovsky; the Doroshenko statehood project collapsed. [T1: IEU; T1: ЕІУ]
+- `1677-1682` — Moscow detention/honorary exile, then Viatka voivodeship; later residence at Yaropolcha until death in 1698. [T1: ЕІУ; T1: IEU]
+
+## 4. Primary-source quotes (≥2 required)
+
+> **Honest tool note (#M-4):** no project `verify_quote` run was available for Doroshenko's own letters in this pass. The excerpts below are document-language anchors drawn from cited source editions or scholarly quotation. Use them as research leads unless a classroom module verifies the source edition directly.
+
+**Excerpt 1 — Chyhyryn senior-officer decision after Andrusovo, January 1668:**
+
+> "з обох сторін Дніпра жителям бути в з'єднанні"
+
+Context: the point is unity of both banks, not a simple religious betrayal narrative. Chukhlib cites this from *Akty Yugo-Zapadnoi Rossii*, vol. 7, pp. 30-31. `verify_quote(author="Дорошенко")` was **not run**; source-edition verification is still required before using as a primary quote in lessons. [T4: Chukhlib]
+
+**Excerpt 2 — proposed Ottoman-protectorate diplomacy condition:**
+
+> "без відомості і згоди нашого Гетьмана"
+
+Context: Chukhlib cites this as a demand that the sultan not make alliances with Poland or Muscovy without the hetman and Host's knowledge and consent. This is the strongest short excerpt for teaching "protectorate was negotiated as statecraft." `verify_quote(author="Дорошенко")` was **not run**. [T4: Chukhlib]
+
+**Excerpt 3 — Doroshenko after the June 1668 Left-Bank success:**
+
+> "Усе Військо вкупі"
+
+Context: in a letter to Jan Sobieski, Doroshenko described both Trans-Dnipro sides as coming under one command. Use as a unification-program excerpt, not proof that his authority was stable. `verify_quote(author="Дорошенко")` was **not run**. [T4: Chukhlib]
+
+## 5. Language register and learner-use notes
+
+- **Register:** Cossack chancery, diplomatic, and treaty vocabulary; high-density political nouns and sovereignty formulas.
+- **CEFR readiness for full reading:** B2-C1 for an adapted biography; C1-C2 for source excerpts from treaties, council decisions, and diplomatic correspondence.
+- **Lexicon notes:** `протекторат`, `сюзеренітет`, `булава`, `сердюки`, `клейноди`, `старшинська рада`, `генеральна рада`, `Андрусівське перемир'я`, `Бучацький мир`, `соборність`, `Руїна`, `ясир`, `військові вольності`.
+- **Learner-use notes:** this dossier supports a C1 seminar on the difference between `протекторат`, `васалітет`, `союз`, and `підданство`; it also works for practicing concessive argument ("although the protectorate was a statecraft move, it produced...").
+- **Stylistic features:** teach through paired contrasts: `державотворення / руйнація`, `зовнішній союз / внутрішня легітимність`, `соборність / Руїна`, `право / сила`.
+- **Sensitive framing:** learners should not be asked to choose between "hero" and "traitor" as the only options. A better prompt: "What problem was Doroshenko trying to solve, and why did his solution destroy the support he needed?"
+
+## 6. Contested points
+
+- **State-builder or "Turkish vassal"?** The decolonized answer is not to deny the Ottoman protectorate. It is to ask what alternatives remained after Andrusovo and how Doroshenko tried to write Ukrainian autonomy into a protectorate relationship. The anti-hagiographic answer is that this strategy became inseparable from coercion, devastation, and religious-political fear.
+- **Protectorate or vassalage?** Source language can include `підданство`, Ottoman legal hierarchy, tribute language, and Ukrainian autonomy conditions. Teach this as a contested early-modern vocabulary problem rather than forcing a modern sovereignty category onto it.
+- **Korsun 1669:** the council is a critical pivot, but date forms vary in lower-tier summaries. Use IEU's 10-12 March 1669 unless working from the primary text.
+- **Buchach 1672:** useful for teaching international recognition of Cossack Ukraine, but do not let the recognition point hide the price: Podilia became an Ottoman province, the military campaign devastated communities, and Doroshenko's support eroded.
+- **Doroshenko versus Ivan Sirko:** avoid turning Sirko into "pure patriot" and Doroshenko into "traitor," or the reverse. Sirko's Zaporizhian opposition mattered; it also destabilized Doroshenko's centralizing project. This is a conflict of political models under impossible pressure.
+- **Internal violence and social base:** Doroshenko suppressed opponents, relied on hired formations and allied forces, and could not consolidate starshyna, rank-and-file Cossacks, and common people around independence. Chukhlib's conclusion explicitly treats his failure to consolidate these groups as part of the collapse.
+- **Moscow exile:** he was not tortured to death. He was detained, used as Viatka voivode, and given an estate at Yaropolcha. This does not make the surrender benign; it shows how imperial incorporation could combine coercion, prestige management, and removal from Ukrainian politics.
+- **Russian disinformation / imperial framing:** the durable smear is that any Ukrainian search for non-Moscow protection equals betrayal. Doroshenko's case helps learners see how empires turn a smaller polity's alliance strategy into a moral crime.
+- **Ukrainian romantic memory:** "Сонце Руїни" is powerful, but it can obscure practical failure. Keep tragedy and agency together.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-07-03 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — Doroshenko began in Khmelnytskyy's military-diplomatic environment and pursued the later unity of the state Khmelnytsky founded.
+  - `curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml` — Doroshenko supported Vyhovskyi and signed Hadiach; both are anti-Moscow statehood figures distorted by "traitor" frames.
+  - `curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml` — Zaporizhian opposition to Doroshenko's Ottoman line is essential to teach without caricature.
+  - `curriculum/l2-uk-en/plans/bio/yuriy-nemyrych.yaml` — Hadiach-style federation thinking is the intellectual/diplomatic context for Doroshenko's later failed search for guarantees.
+  - `curriculum/l2-uk-en/plans/bio/ivan-mazepa.yaml` — a later statehood gamble against Moscow; useful comparison for "traitor" propaganda and risky alliance strategy.
+  - `curriculum/l2-uk-en/plans/bio/pylyp-orlyk.yaml` — exile-statehood and treaty language after the collapse of earlier Hetmanate autonomy projects.
+  - `curriculum/l2-uk-en/plans/bio/danylo-apostol.yaml`, `curriculum/l2-uk-en/plans/bio/pavlo-polubotok.yaml` — later constrained-autonomy cases after the Cossack statehood corridor narrowed.
+  - `curriculum/l2-uk-en/plans/bio/kost-hordiyenko.yaml` — later Sich leadership and the problem of Zaporozhian autonomy versus centralized hetman power.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/ruina-i.yaml` — immediate post-Khmelnytskyy fragmentation.
+  - `curriculum/l2-uk-en/plans/hist/ruina-ii.yaml` — the dedicated Doroshenko/Hope HIST module this BIO dossier can support.
+  - `curriculum/l2-uk-en/plans/hist/andrusivske-peremyrya.yaml` — the partition that made Doroshenko's Ottoman turn intelligible.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — institutional baseline for what Doroshenko was trying to preserve/reunify.
+  - `curriculum/l2-uk-en/plans/hist/pereyaslavska-uhoda.yaml` — background for protectorate language and the earlier Muscovite alliance framework.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `korsunska-rada-1669` — council-source lesson on negotiated Ottoman protectorate conditions.
+  - `buchatskyi-myr-1672` — international-law and treaty-language lesson on Podilia, Cossack Ukraine, and the cost of recognition.
+  - `chyhyrynski-pokhody-1677-1678` — post-Doroshenko military aftermath and symbolic destruction of Chyhyryn.
+- **Potential LIT additions surfaced by this research:**
+  - A LIT/memory module on Vasyl Pachovskyi's drama *Сонце Руїни* and how literary memory shaped the tragic-Doroshenko image.
+
+## 8. Naming-canonical
+
+- **Slug:** `petro-doroshenko`
+- **EN canonical (BGN/PCGN-style project spelling):** Petro Doroshenko
+- **UA canonical (with patronymic):** Петро Дорофійович Дорошенко
+- **Aliases (track these for `aliases:` YAML field):** Петро Дорошенко; гетьман Петро Дорошенко; Petro Doroshenko; Piotr Doroszenko; Dorošenko in older scholarly transliteration.
+- **Forbidden forms (Russian-imperial transliterations to flag in body text):** Пётр Дорошенко; Петр Дорошенко as normalized Russian form; "малороссийский гетман"; "турецкий вассал" as an unexamined identity label.
+- **Name collision warning:** do not confuse him with historian **Dmytro Doroshenko** (1882-1951), a descendant and major biographer; cite the historian as an author only, never as the BIO subject.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons / IEU-linked engraving or portrait of Petro Doroshenko; verify the individual file page and provenance before selecting. IEU displays an engraving and a Narbut-designed coat of arms, but the lesson should verify reuse rights from the actual image file, not from the article thumbnail.
+- **Backup candidates:** Chyhyryn context image; Kamianets-Podilskyi / Podilia context after the 1672 campaign; a facsimile/scan of a council or treaty source if rights-clear.
+- **If no secure PD/CC portrait exists:** use a rights-clear Chyhyryn or Kamianets context image and caption it as context, not as a likeness.
+- **Authenticity caveat:** many Cossack-hetman portraits are later/posthumous. Do not imply a life portrait unless the file metadata supports that claim.
+- **Avoid:** generic Cossack stock art, Ottoman battle imagery unrelated to Doroshenko, or images that visually frame the protectorate as exotic betrayal.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- [T1] Степанков В. С. "Дорошенко Петро Дорофійович" // *Енциклопедія історії України*, т. 2. URL: https://www.history.org.ua/?termin=Doroshenko_P | resolved HTTP 200, accessed 2026-07-03. Core facts: 1627-09.11.1698; Chyhyryn birth; likely Kyiv-Mohyla education; offices; 1665-1676 hetmancy; Andrusovo response; 1676 abdication; Moscow/Viatka/Yaropolcha afterlife.
+- [T1] "Doroshenko, Petro" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CD%5CO%5CDoroshenkoPetro.htm | resolved HTTP 200, accessed 2026-07-03. Core facts: birth/death, office sequence, 1668 proclamation, Ottoman protectorate wording, Buchach, surrender and exile.
+- [T1] Степанков В. С. "Батоцька битва 1672 р." // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Batozka_bytva_1672 | resolved HTTP 200, accessed 2026-07-03. Used for the 1672 battle chronology.
+
+**Tier 2 (institutional / reference context):**
+- [T2] М. Грушевський reference portal, "Дорошенко Петро Дорофійович (1627-1698)." URL: https://hrushevsky.history.org.ua/item/0009281 | resolved HTTP 200, accessed 2026-07-03. Used as a pointer, not load-bearing evidence.
+
+**Tier 3 (encyclopedic — navigation only):**
+- [T3] "Петро Дорошенко" // Ukrainian Wikipedia. URL: https://uk.wikipedia.org/wiki/Петро_Дорошенко | accessed 2026-07-03. Used only for date-form navigation and image/link discovery; cross-checked against T1.
+
+**Tier 4 (modern scholarly post-1991 / academic):**
+- [T4] Чухліб Т. "Перші спроби П. Дорошенка встановити контакти зі Стамбулом." PDF hosted by Інститут історії України. URL: https://history.org.ua/LiberUA/978-966-355-041-1/11.pdf | resolved HTTP 200, accessed 2026-07-03.
+- [T4] Чухліб Т. "Гетьман Петро Дорошенко та його політика умиротворення Московського царства." URL: https://www.myslenedrevo.com.ua/uk/Sci/History/Doroshenko/Articles/Chuxlib.html | resolved HTTP 200, accessed 2026-07-03. Used for Chyhyryn decision excerpts, Andrusovo response, and Doroshenko's unity program.
+- [T4] Doroshenko D. *Гетьман Петро Дорошенко: огляд його життя і політичної діяльности.* New York, 1985. Standard monograph repeatedly cited by T1/T4 sources.
+- [T4] Grygorieva T. "Ottoman Protection of Cossack Ukraine under Hetman Petro Doroshenko: Between Legal Aspects and Actual Practice," in *Tributaries and Peripheries of the Ottoman Empire*, ed. Gabor Karman. Leiden/Boston: Brill, 2020, pp. 240-263. Used bibliographically via Cambridge/Brill references; direct text not fully read in this pass.
+- [T4] Ostapchuk V. "Cossack Ukraine in and out of Ottoman Orbit, 1648-1681," in *The European Tributary States of the Ottoman Empire in the Sixteenth and Seventeenth Centuries*. Brill, 2013, pp. 123-152. Bibliographic anchor for Ottoman orbit context.
+- [T4] Krykun M. *Між війною і радою: Козацтво Правобережної України в другій половині XVII - на початку XVIII століття.* Kyiv: Krytyka, 2006. Bibliographic anchor from Cambridge article.
+- [T4] Chukhlib T. *Гетьмани Правобережної України в історії Центрально-Східної Європи (1663-1713).* Kyiv: Kyievo-Mohylianska Akademiia, 2004. Bibliographic anchor from Cambridge article.
+- [T4] Michels G. "Replacing Tsar, King, and Emperor with the Sultan: Ukrainians, Hungarians, and the Ottomans (1660-1680)." *Central European History*. URL: https://www.cambridge.org/core/journals/central-european-history/article/replacing-tsar-king-and-emperor-with-the-sultan-ukrainians-hungarians-and-the-ottomans-16601680/E550156396C99C79BA423206E087A827 | accessed 2026-07-03. Used mainly for bibliography and comparative caution, not as Doroshenko core narrative.
+
+**Tier 5 (general web — not load-bearing):**
+- [T5] АрміяInform, "Османська Україна Петра Дорошенка." URL: https://armyinform.com.ua/2021/11/09/osmanska-ukrayina-petra-doroshenka/ | accessed 2026-07-03. Useful popular synthesis; cross-check only because it includes date forms that should be verified against T1/T4 before classroom use.
+
+**Primary-source documents accessed / verification notes:**
+- Chyhyryn senior-officer decision excerpts via Chukhlib / *Akty Yugo-Zapadnoi Rossii*: `verify_quote` not run.
+- Doroshenko letter-to-Sobieski excerpt via Chukhlib: `verify_quote` not run.
+- Ottoman-protectorate clause excerpts via Chukhlib / source-edition references: `verify_quote` not run.
+
+**Honest gaps:** the dossier did not directly inspect the Ottoman berat, full Buchach treaty text, or *Akty Yugo-Zapadnoi Rossii* volumes. For module writing, verify those primary texts before quoting beyond the short excerpts above. The "Panstwo Ukrainskie" discussion should be checked against the treaty text before becoming a load-bearing classroom claim.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Moscow and Warsaw are treated as powers that partitioned Ukrainian lands, not as natural arbiters of Ukraine.
+- [x] Ottoman protectorate is treated as statecraft under catastrophic conditions, not as an identity smear.
+- [x] No sanitized story: Ottoman-Crimean devastation, coerced populations, civil-war violence, internal opposition, and loss of support are named directly.
+- [x] No Russian-imperial transliterations in body text except forbidden forms in §8.
+- [x] No "traitor" label used as fact; smear vocabulary is identified as propaganda or polemic.
+- [x] No out-of-scope all-rulers or 20th-century Hetmanate material added.
+- [x] Modern Ukrainian place/institution naming used with historical context where needed: Чигирин, Правобережжя, Лівобережжя, Гетьманщина, Ярополче/Ярополець.
+- [x] The anti-imperial reading does not hide Polish, Ottoman, Crimean, Cossack, or Muscovite violence.
+
+## Validation checklist
+
+- [x] Single owned file only: `docs/research/bio/petro-doroshenko.md`.
+- [x] Existing cross-track paths verified locally before citation.
+- [x] Lower-tier sources marked as non-load-bearing.
+- [x] No generated `status/`, `audit/`, `review/`, or telemetry artifacts referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans, module files, activities, vocabulary, resources, site MDX, or wiki files edited.


### PR DESCRIPTION
## Scope

Adds the BIO Cossack P0 research dossier for Petro Doroshenko as a complex Ruina-era statehood figure. The dossier keeps the Ottoman protectorate framed as catastrophic-condition statecraft while also naming coercion, devastation, civil-war violence, factional failure, and limits of support.

## Changed files

- `docs/research/bio/petro-doroshenko.md`

## Validation

- `npx markdownlint-cli2 docs/research/bio/petro-doroshenko.md` — passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/petro-doroshenko.md` — passed
- `git diff --check` — passed
- `git diff --cached --check` — passed before commit
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- Protected artifact/config guard — passed; only `docs/research/bio/petro-doroshenko.md` is changed in `origin/main..HEAD`

## Source and decolonization caveats

- Tier 1 baseline uses ЕІУ and Internet Encyclopedia of Ukraine; Chukhlib and academic Ottoman-protectorate scholarship are used for interpretation and source leads.
- Wikipedia/general web are marked as non-load-bearing navigation/cross-check sources.
- Primary/document excerpts are kept short and explicitly caveated: full source-edition verification is still needed before classroom quotation.
- The dossier avoids a simple pro-Ottoman/anti-Polish/anti-Moscow caricature and does not sanitize the destructive consequences of Doroshenko's strategy.

## Review note

No independent review has been routed by this worker. The orchestrator handles independent review routing for this epic.