### PR TITLE
feat(qg): persist module LLM quality gates

### DIFF
--- a/docs/runbooks/module-quality-gates.md
+++ b/docs/runbooks/module-quality-gates.md
@@ -1,0 +1,177 @@
+# Module Quality Gates
+
+This runbook defines the audit stack for all `curriculum/l2-uk-en` modules:
+A1, A2, B1+, C-level core tracks, and seminar tracks.
+
+The rule is code first. Deterministic checks run for every module. LLM review is
+reserved for quality judgments that regexes, YAML schemas, VESUM, and source
+tools cannot make reliably.
+
+## Level Policy
+
+| Track family | English policy | Reviewer calibration |
+| --- | --- | --- |
+| A1 | English scaffolding is expected and often substantial. | Do not penalize English task support, grammar terminology, or line-level glosses when they support a Ukrainian-first teaching move. Hard-fail only AI/internal/path leakage and clear scaffolding replacement of Ukrainian anchors. |
+| A2 | Easy Ukrainian becomes the default body voice; English support decreases. | Warn on English-led prose. Do not demand B1-style Ukrainian-only explanations. Penalize English paragraphs that take over the lesson. |
+| B1+ core | Learner-facing prose should be Ukrainian-led. | English is exceptional and local. Naturalness, register, collocation, and grammar government are core review targets. |
+| Seminars | Advanced Ukrainian teaching voice. | English leakage, school-textbook simplification, weak source framing, and decolonization failures are high-risk. |
+
+## Code Gates
+
+Run these on every built module before LLM review:
+
+- Schema and structure: markdown/YAML parse, activity schema, component props,
+  inline/workbook split, required artifacts, MDX render.
+- Solvability: answer consistency, minimum correct options, fill-in answers,
+  translate/quiz explanations, known activity-type constraints.
+- Ukrainian surface validity: VESUM, known Russianisms/surzhyk/calques/paronyms,
+  bad-form heritage handling, stress/ULP gates where applicable.
+- Source and citation integrity: plan-reference match, source coverage,
+  quote fidelity, wiki coverage, resource URL checks.
+- Leakage and register surface gates:
+  - AI/persona/scratchpad leakage.
+  - Local path and internal artifact leakage.
+  - Level-aware English leakage.
+  - Pathos/gamified/register-warning phrases.
+
+The current implementation adds `surface_policy` to Python QG. It scans
+`module.md` with level-aware English policy, and scans YAML sidecars only for
+AI/path/internal leakage so normal YAML English keys, glosses, and metadata do
+not become false positives.
+
+For an all-module coverage pass, run:
+
+```bash
+.venv/bin/python scripts/audit/module_quality_audit.py --format summary
+```
+
+For machine-readable triage, use JSON and save it outside committed artifact
+paths unless a task explicitly asks for a report:
+
+```bash
+.venv/bin/python scripts/audit/module_quality_audit.py --format json --output /tmp/module-quality-audit.json
+```
+
+The report counts planned modules, built modules, surface-policy failures,
+current DB-backed LLM-QG records, file-only fallback records, stale records, and
+missing records. It also reports the same coverage by `a1`, `a2`, `b1_plus`,
+and `seminar` reviewer profiles. Each built-module row includes reviewer
+family/model, gate version, prompt hash, content hash, and whether a second
+cross-family review is recommended because the module is seminar, surface-gate
+flagged, or missing/stale LLM-QG.
+
+## LLM Gates
+
+Use LLM review only for residual judgment:
+
+- Native Ukrainian naturalness: grammar government, collocation, idiom, calqued
+  passives, unnatural nominalizations, anthropomorphic metalanguage, and
+  register shifts.
+- Pedagogy: sequence quality, example quality, whether the lesson actually
+  teaches the target, and whether an upstream plan frame is pedagogically
+  unsupported.
+- Tone: consistent teacher voice, correct register for the learner level, no
+  generic motivational prose.
+- Engagement: whether examples, callouts, and activities carry real teaching
+  value rather than filler.
+- Decolonization and seminar framing: historically accurate Ukrainian-centered
+  framing, source skepticism, and no Russian-imperial/Soviet default frame.
+
+The reviewer prompt must include the level policy above. A1/A2 English support
+is not a defect by itself. B1+ and seminars are held to a Ukrainian-led standard.
+Reviewer responses preserve `issue_ids` and `findings` in `llm_qg.json` and the
+SQLite store so known issue classes can be audited later instead of being lost
+inside prose evidence.
+
+## Persistence
+
+LLM-QG output is expensive and must not be lost.
+
+- Raw forensic files remain in the run archive.
+- Current queryable LLM-QG state is persisted to local SQLite at
+  `data/telemetry/llm_qg.db`.
+- The store is content-hash bound to `module.md`, `activities.yaml`,
+  `vocabulary.yaml`, and `resources.yaml`.
+- API readers prefer the current SQLite record and fall back to module-local
+  `llm_qg.json` only when the file is newer than all learner-facing content.
+- Corrupt local telemetry DBs degrade to missing QG rather than breaking the
+  Monitor API.
+- Generated QG artifacts and telemetry DBs stay out of PR diffs.
+- Standalone parity runs via `scripts/build/run_llm_qg_parity.py` also persist
+  to the SQLite store after writing `llm_qg.json`.
+
+## Team Roles
+
+Use five roles for implementation work on this system:
+
+| Role | Owner | Responsibility |
+| --- | --- | --- |
+| Integrator | Main Codex thread | Architecture, worktree hygiene, final merge shape, tests, and resolving reviewer findings. |
+| Deterministic-gates reviewer | Explorer or worker | Code-first checks, false-positive risk, level policy, activity solvability, and Python-QG integration. |
+| Persistence/API reviewer | Explorer or worker | Durable QG storage, stale-state prevention, Monitor API behavior, and artifact-policy compliance. |
+| Prompt/language reviewer | Language-focused reviewer | LLM prompt calibration for A1/A2/B1+/seminars and Ukrainian naturalness failure modes. |
+| Independent reviewer | Non-author route | Final read-only review of the diff and prompt behavior before PR/merge. Internal Codex self-review is not enough. |
+
+For broad sweeps, use one main integrator plus two or three parallel reviewers.
+Do not use five implementation workers on the same files; that increases
+merge risk without improving language quality.
+
+## LLM Review Cost Model
+
+Default production flow:
+
+1. Run deterministic gates for every module.
+2. Run one primary LLM-QG reviewer only after code gates pass or produce a
+   bounded warning set.
+3. Persist the LLM-QG result immediately.
+4. Run a second cross-family LLM reviewer only for:
+   - modules flagged by deterministic gates,
+   - modules where the primary LLM-QG score is near threshold,
+   - seminars and politically/factually sensitive tracks,
+   - prompt-version canaries,
+   - a random calibration sample.
+
+Do not run 2x LLM review on every module by default. Measure marginal recall
+first. If the second reviewer catches materially different issues on sampled
+modules, expand the sample. If it mostly duplicates the primary reviewer, keep
+it as a canary and escalation path.
+
+## Review Of The LLM Check
+
+The LLM check itself is reviewed in three layers:
+
+- Machine checks: JSON shape, required evidence quotes, exact dimensions, score
+  aggregation, persistence, and content-hash freshness.
+- Calibration checks: prompt canaries for known defects such as `застереження
+  каже`, bad passives, wrong government, bad lock/open/medicine collocations,
+  A1/A2 English scaffolding, and seminar decolonization framing.
+- Independent review: a non-author reviewer checks prompt changes and sampled
+  LLM-QG outputs against the actual module text.
+
+If the LLM gate misses a known seeded defect, treat that as a prompt/eval bug,
+not as a module-only bug.
+
+Run deterministic canary evaluation before paying for a large LLM batch:
+
+```bash
+.venv/bin/python scripts/audit/llm_qg_canaries.py --level b1 --list
+.venv/bin/python scripts/audit/llm_qg_canaries.py --level b1 /tmp/reviewer-canary-result.json
+```
+
+The canary set includes required-catch cases (`застосунок має бути відкритий`,
+`Застереження каже: ...`, AI leakage, path/internal leakage, B1/seminar English
+leakage, seminar pathos) and false-positive protection for allowed A1/A2
+English scaffolding.
+
+## Batch Rollout
+
+Run in phases:
+
+1. Calibrate on known bad and known good modules from A1, A2, B1, and at least
+   one seminar track.
+2. Run deterministic gates across all built modules and collect false positives.
+3. Run primary LLM-QG only on modules that pass deterministic hard gates or need
+   naturalness/pedagogy judgment.
+4. Run second-review sampling and compare recall/cost.
+5. Promote prompt and deterministic-gate changes only after sampled reviewers
+   agree that A1/A2 support is preserved and B1+/seminar issues are caught.

--- a/scripts/api/state_compute.py
+++ b/scripts/api/state_compute.py
@@ -17,6 +17,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from common.thresholds import REVIEW_PASS_FLOOR
 
+from scripts.audit.llm_qg_store import (
+    current_payload_for_module,
+    llm_qg_file_is_current_for_module,
+)
+
 try:
     from path_safety import safe_join  # scripts/ on sys.path (test sys.path-hack)
 except ImportError:
@@ -246,8 +251,14 @@ def _read_json_file(path: Path) -> dict | None:
 def read_llm_qg(track_dir: Path, slug: str) -> dict | None:
     """Read a module's LLM quality-gate artifact if present."""
     try:
-        path = safe_join(track_dir, slug, "llm_qg.json")
+        module_dir = safe_join(track_dir, slug)
+        current = current_payload_for_module(track_dir.name, slug, module_dir)
+        if current is not None:
+            return current
+        path = safe_join(module_dir, "llm_qg.json")
     except ValueError:
+        return None
+    if not llm_qg_file_is_current_for_module(module_dir, path):
         return None
     return _read_json_file(path)
 

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -37,6 +37,10 @@ from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
 from scripts.analytics.cost_report import CostRecord, load_cost_records
+from scripts.audit.llm_qg_store import (
+    current_payload_for_module,
+    llm_qg_file_is_current_for_module,
+)
 
 try:
     from path_safety import safe_join  # scripts/ on sys.path (test sys.path-hack)
@@ -740,12 +744,18 @@ def _read_llm_qg_scores(module_dir: Path) -> dict[str, Any]:
     generically, so a newly-added dim (e.g. ``beauty`` once Phase A lands) is
     surfaced automatically with no change here.
     """
+    level = module_dir.parent.name
+    slug = module_dir.name
+    data = current_payload_for_module(level, slug, module_dir)
     path = module_dir / "llm_qg.json"
-    if not path.exists():
-        return {"aggregate": None, "dimensions": {}}
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError, ValueError):
+    if data is None:
+        if not llm_qg_file_is_current_for_module(module_dir, path):
+            return {"aggregate": None, "dimensions": {}}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError, ValueError):
+            return {"aggregate": None, "dimensions": {}}
+    if not isinstance(data, dict):
         return {"aggregate": None, "dimensions": {}}
 
     raw_agg = data.get("aggregate") if isinstance(data, dict) else None

--- a/scripts/audit/content_surface_gates.py
+++ b/scripts/audit/content_surface_gates.py
@@ -1,0 +1,365 @@
+"""Level-aware deterministic surface checks for learner-facing module text.
+
+This module catches cheap, high-precision failures before an LLM reviewer is
+asked to make judgment calls. It deliberately does not try to prove native
+Ukrainian style; collocation, idiom, register, and grammar-naturalness remain
+LLM/native-review dimensions.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+SEMINAR_LEVELS = {
+    "bio",
+    "folk",
+    "hist",
+    "istorio",
+    "lit",
+    "lit-drama",
+    "lit-essay",
+    "lit-fantastika",
+    "lit-hist-fic",
+    "lit-humor",
+    "lit-war",
+    "lit-youth",
+    "oes",
+    "ruth",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class SurfacePolicy:
+    """Deterministic surface policy for one level family."""
+
+    family: str
+    english_policy: str
+    english_led_severity: str
+    english_led_min_latin_words: int
+    english_ratio_warn: float | None
+    english_ratio_fail: float | None
+    ai_leak_severity: str = "critical"
+    path_leak_severity: str = "critical"
+    pathos_severity: str = "warning"
+
+
+_A1_POLICY = SurfacePolicy(
+    family="a1",
+    english_policy="English scaffolding is expected; only internal/AI/path leaks are blocking.",
+    english_led_severity="info",
+    english_led_min_latin_words=9999,
+    english_ratio_warn=None,
+    english_ratio_fail=None,
+)
+_A2_POLICY = SurfacePolicy(
+    family="a2",
+    english_policy="English support is receding; English-led prose is a warning, not an automatic failure.",
+    english_led_severity="warning",
+    english_led_min_latin_words=12,
+    english_ratio_warn=0.45,
+    english_ratio_fail=None,
+)
+_B1_PLUS_POLICY = SurfacePolicy(
+    family="b1_plus",
+    english_policy="B1+ learner-facing lesson prose should be Ukrainian-led.",
+    english_led_severity="critical",
+    english_led_min_latin_words=8,
+    english_ratio_warn=0.08,
+    english_ratio_fail=0.18,
+)
+_SEMINAR_POLICY = SurfacePolicy(
+    family="seminar",
+    english_policy="Seminar learner-facing prose should be Ukrainian-led; English is only incidental metadata.",
+    english_led_severity="critical",
+    english_led_min_latin_words=8,
+    english_ratio_warn=0.05,
+    english_ratio_fail=0.12,
+)
+
+_LATIN_WORD_RE = re.compile(r"\b[A-Za-z][A-Za-z'-]*\b")
+_CYRILLIC_WORD_RE = re.compile(r"[\u0400-\u04ff][\u0400-\u04ff'ʼ-]*")
+_FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_TAG_RE = re.compile(r"<[^>\n]{2,160}>")
+_FRONTMATTER_RE = re.compile(r"\A---\n.*?\n---\n", re.DOTALL)
+
+AI_LEAK_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = tuple(
+    (re.compile(pattern, re.IGNORECASE), label)
+    for pattern, label in (
+        (r"\bAs an AI\b", "AI persona disclaimer"),
+        (r"\bI (?:cannot|can't) (?:assist|help|comply)\b", "AI refusal text"),
+        (r"\b(?:apologies|sorry),?\s+(?:but\s+)?I\b", "AI apology text"),
+        (r"\bNote to self\b", "model scratchpad text"),
+        (r"\bWait,\s+(?:actually|no)\b", "model self-correction text"),
+        (r"\bCorrection:\s+", "model correction label"),
+        (r"\bDraft:\s+", "model draft label"),
+        (r"\bRewrite this\b", "model editing instruction"),
+        (r"<(?:implementation_map|activity_split|plan_reasoning)_audit\b", "writer audit line"),
+        (r"\b(?:Generated Content|artifact fence|reviewer-fix anchor)\b", "build/reviewer scaffolding"),
+    )
+)
+
+PATH_LEAK_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = tuple(
+    (re.compile(pattern), label)
+    for pattern, label in (
+        (r"/Users/[^\s)]+", "local user path"),
+        (r"/tmp/[^\s)]+", "temporary filesystem path"),
+        (r"\bcurriculum/l2-uk-en/[^\s)]+", "curriculum source path"),
+        (r"\bscripts/(?:build|audit|api|sync)/[^\s)]+", "internal script path"),
+        (r"\bstarlight/src/[^\s)]+", "site source path"),
+        (r"\b(?:llm_qg|python_qg|wiki_coverage_gate)\.json\b", "internal QG artifact"),
+    )
+)
+
+PATHOS_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = tuple(
+    (re.compile(pattern, re.IGNORECASE), label)
+    for pattern, label in (
+        (r"\bGreat job!\b", "generic praise"),
+        (r"\bYou have unlocked\b", "gamified progress language"),
+        (r"\bLet's dive in\b", "LLM-style opener"),
+        (r"\bWelcome to (?:A1|A2|B1|B2|C1|C2)\b", "course-level marketing opener"),
+        (r"пориньмо\s+у\s+захоплив", "inflated journey metaphor"),
+        (r"неймовірн[а-яіїєґ]*\s+подорож", "inflated journey metaphor"),
+        (r"ти\s+справжн[ійяє]\s+геро", "overheated learner praise"),
+    )
+)
+
+
+def policy_for_level(level: str | None) -> SurfacePolicy:
+    """Return deterministic surface policy for a level/track code."""
+    clean = str(level or "").strip().lower()
+    if clean in SEMINAR_LEVELS:
+        return _SEMINAR_POLICY
+    if clean.startswith("a1"):
+        return _A1_POLICY
+    if clean.startswith("a2"):
+        return _A2_POLICY
+    return _B1_PLUS_POLICY
+
+
+def _line_no(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _mask_match(match: re.Match[str]) -> str:
+    return "".join("\n" if ch == "\n" else " " for ch in match.group(0))
+
+
+def _mask_ignored_regions(text: str) -> str:
+    """Mask comments/code/frontmatter while preserving line numbers."""
+    masked = _FRONTMATTER_RE.sub(_mask_match, text)
+    masked = _FENCE_RE.sub(_mask_match, masked)
+    return _HTML_COMMENT_RE.sub(_mask_match, masked)
+
+
+def _mask_tags(text: str) -> str:
+    return _TAG_RE.sub(_mask_match, text)
+
+
+def _is_ignored_line(line: str) -> bool:
+    stripped = line.strip()
+    return (
+        not stripped
+        or stripped.startswith("|")
+        or stripped.startswith("#")
+        or stripped.startswith(">")
+        or stripped.startswith("---")
+    )
+
+
+def _finding(
+    *,
+    kind: str,
+    severity: str,
+    line: int,
+    text: str,
+    message: str,
+    source: str,
+) -> dict[str, Any]:
+    return {
+        "type": kind,
+        "severity": severity,
+        "line": line,
+        "text": text[:160],
+        "message": message,
+        "source": source,
+    }
+
+
+def _english_led_findings(masked: str, *, policy: SurfacePolicy, source: str) -> list[dict[str, Any]]:
+    if policy.english_led_severity == "info":
+        return []
+    findings: list[dict[str, Any]] = []
+    for line_no, line in enumerate(masked.splitlines(), 1):
+        if _is_ignored_line(line):
+            continue
+        latin_words = _LATIN_WORD_RE.findall(line)
+        if len(latin_words) < policy.english_led_min_latin_words:
+            continue
+        if _CYRILLIC_WORD_RE.search(line):
+            continue
+        findings.append(
+            _finding(
+                kind="english_led_line",
+                severity=policy.english_led_severity,
+                line=line_no,
+                text=line.strip(),
+                message=policy.english_policy,
+                source=source,
+            )
+        )
+    return findings
+
+
+def _english_ratio_finding(masked: str, *, policy: SurfacePolicy, source: str) -> dict[str, Any] | None:
+    latin_count = 0
+    cyrillic_count = 0
+    for line in masked.splitlines():
+        if _is_ignored_line(line):
+            continue
+        latin_count += len(_LATIN_WORD_RE.findall(line))
+        cyrillic_count += len(_CYRILLIC_WORD_RE.findall(line))
+    total = latin_count + cyrillic_count
+    if total == 0:
+        return None
+    ratio = latin_count / total
+    severity: str | None = None
+    if policy.english_ratio_fail is not None and ratio > policy.english_ratio_fail:
+        severity = "critical"
+    elif policy.english_ratio_warn is not None and ratio > policy.english_ratio_warn:
+        severity = "warning"
+    if severity is None:
+        return None
+    return _finding(
+        kind="english_ratio",
+        severity=severity,
+        line=0,
+        text=f"latin_words={latin_count} cyrillic_words={cyrillic_count} ratio={ratio:.2f}",
+        message=policy.english_policy,
+        source=source,
+    )
+
+
+def _pattern_findings(
+    text: str,
+    *,
+    patterns: tuple[tuple[re.Pattern[str], str], ...],
+    kind: str,
+    severity: str,
+    source: str,
+) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    for pattern, label in patterns:
+        for match in pattern.finditer(text):
+            findings.append(
+                _finding(
+                    kind=kind,
+                    severity=severity,
+                    line=_line_no(text, match.start()),
+                    text=match.group(0),
+                    message=label,
+                    source=source,
+                )
+            )
+    return findings
+
+
+def scan_surface_text(
+    text: str,
+    *,
+    level: str | None,
+    source: str = "module.md",
+    include_language_policy: bool = True,
+) -> dict[str, Any]:
+    """Run level-aware deterministic checks over one learner-facing text blob."""
+    policy = policy_for_level(level)
+    masked = _mask_ignored_regions(text)
+    language_masked = _mask_tags(masked)
+    findings: list[dict[str, Any]] = []
+    findings.extend(
+        _pattern_findings(
+            masked,
+            patterns=AI_LEAK_PATTERNS,
+            kind="ai_leakage",
+            severity=policy.ai_leak_severity,
+            source=source,
+        )
+    )
+    findings.extend(
+        _pattern_findings(
+            masked,
+            patterns=PATH_LEAK_PATTERNS,
+            kind="path_leakage",
+            severity=policy.path_leak_severity,
+            source=source,
+        )
+    )
+    if include_language_policy:
+        findings.extend(_english_led_findings(language_masked, policy=policy, source=source))
+        ratio_finding = _english_ratio_finding(language_masked, policy=policy, source=source)
+        if ratio_finding is not None:
+            findings.append(ratio_finding)
+    findings.extend(
+        _pattern_findings(
+            masked,
+            patterns=PATHOS_PATTERNS,
+            kind="pathos_or_register",
+            severity=policy.pathos_severity,
+            source=source,
+        )
+    )
+
+    critical = [item for item in findings if item.get("severity") == "critical"]
+    warnings = [item for item in findings if item.get("severity") == "warning"]
+    verdict = "FAIL" if critical else "WARN" if warnings else "PASS"
+    return {
+        "passed": not critical,
+        "verdict": verdict,
+        "level_policy": asdict(policy),
+        "findings": findings,
+        "counts": {
+            "critical": len(critical),
+            "warning": len(warnings),
+            "total": len(findings),
+        },
+    }
+
+
+def scan_module_surface(module_dir: Path, *, level: str | None = None) -> dict[str, Any]:
+    """Run deterministic surface checks for the learner-facing files in a module."""
+    sources = [
+        ("module.md", module_dir / "module.md"),
+        ("activities.yaml", module_dir / "activities.yaml"),
+        ("vocabulary.yaml", module_dir / "vocabulary.yaml"),
+        ("resources.yaml", module_dir / "resources.yaml"),
+    ]
+    reports: dict[str, Any] = {}
+    findings: list[dict[str, Any]] = []
+    for source, path in sources:
+        if not path.exists():
+            continue
+        report = scan_surface_text(
+            path.read_text(encoding="utf-8"),
+            level=level,
+            source=source,
+            include_language_policy=source == "module.md",
+        )
+        reports[source] = report
+        findings.extend(report["findings"])
+    critical = [item for item in findings if item.get("severity") == "critical"]
+    warnings = [item for item in findings if item.get("severity") == "warning"]
+    return {
+        "passed": not critical,
+        "verdict": "FAIL" if critical else "WARN" if warnings else "PASS",
+        "level": level,
+        "files": reports,
+        "findings": findings,
+        "counts": {
+            "critical": len(critical),
+            "warning": len(warnings),
+            "total": len(findings),
+        },
+    }

--- a/scripts/audit/llm_qg_canaries.py
+++ b/scripts/audit/llm_qg_canaries.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Deterministic LLM-QG canary definitions and pure evaluators."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.api.config import SEMINAR_TRACK_IDS
+
+_NORMALIZE_RE = re.compile(r"[^A-Z0-9_]")
+
+
+@dataclass(frozen=True, slots=True)
+class LLMQGCanary:
+    """One deterministic canary rule used by LLM-QG calibration tests."""
+
+    canary_id: str
+    level: str
+    snippet: str
+    required_issue_ids: frozenset[str]
+    issue_family: str
+    rationale: str
+    forbidden_issue_ids: frozenset[str] = frozenset()
+
+
+CANARIES: tuple[LLMQGCanary, ...] = (
+    LLMQGCanary(
+        canary_id="a1-english-scaffold-allowed",
+        level="a1",
+        snippet="Read the dialogue. **Я тут.** - I am here.",
+        required_issue_ids=frozenset(),
+        issue_family="policy",
+        rationale="A1 can use concise English task support and glosses without being marked as English leakage.",
+        forbidden_issue_ids=frozenset({"ENGLISH_LEAKAGE"}),
+    ),
+    LLMQGCanary(
+        canary_id="a2-english-gloss-allowed",
+        level="a2",
+        snippet="Прочитайте: **прокидаюся** - I wake up. Повторіть речення українською.",
+        required_issue_ids=frozenset(),
+        issue_family="policy",
+        rationale="A2 can still use concise English glosses while the default prose remains easy Ukrainian.",
+        forbidden_issue_ids=frozenset({"ENGLISH_LEAKAGE"}),
+    ),
+    LLMQGCanary(
+        canary_id="b1-passive-result-state",
+        level="b1",
+        snippet="застосунок має бути відкритий",
+        required_issue_ids=frozenset({"AWKWARD_PASSIVE_RESULT_STATE"}),
+        issue_family="grammar_register",
+        rationale="Awkward passive/result-state phrasing should be flagged as grammar/register defect.",
+    ),
+    LLMQGCanary(
+        canary_id="b1-anthropomorphic-pathos",
+        level="b1",
+        snippet="Застереження каже: будь обережний, щоб небажаний результат не стався.",
+        required_issue_ids=frozenset({"UNNATURAL_ANTHROPOMORPHISM"}),
+        issue_family="grammar_register",
+        rationale=(
+            "Metatranslated or anthropomorphic register should be flagged in B1 naturalness review."
+        ),
+    ),
+    LLMQGCanary(
+        canary_id="surface-ai-leakage",
+        level="any",
+        snippet="I will now think step-by-step and produce a corrected draft.",
+        required_issue_ids=frozenset({"AI_LEAKAGE"}),
+        issue_family="surface",
+        rationale=(
+            "LLM chain-of-thought / scratchpad wording should be blocked by the reviewer."
+        ),
+    ),
+    LLMQGCanary(
+        canary_id="policy-b1-english-led",
+        level="b1",
+        snippet="In this lesson we will cover the grammar before you can follow the Ukrainian meaning.",
+        required_issue_ids=frozenset({"ENGLISH_LEAKAGE"}),
+        issue_family="policy",
+        rationale=(
+            "B1 learner-facing prose should be Ukrainian-led; English-led narration should be flagged."
+        ),
+    ),
+    LLMQGCanary(
+        canary_id="policy-seminar-english-led",
+        level="seminar",
+        snippet="Students must understand this unit to improve English output in Ukrainian literature.",
+        required_issue_ids=frozenset({"ENGLISH_LEAKAGE"}),
+        issue_family="policy",
+        rationale="Seminar prose should keep Ukrainian teaching voice; English scaffolding only."
+    ),
+    LLMQGCanary(
+        canary_id="surface-path-leakage",
+        level="any",
+        snippet="Use /tmp/course-output/material.md for the next example before publishing.",
+        required_issue_ids=frozenset({"PATH_LEAKAGE"}),
+        issue_family="surface",
+        rationale="Filesystem paths should not leak into learner-facing text.",
+    ),
+    LLMQGCanary(
+        canary_id="surface-internal-leakage",
+        level="any",
+        snippet="See internal artifact: scripts/audit/llm_qg.json before final publish.",
+        required_issue_ids=frozenset({"INTERNAL_LEAKAGE"}),
+        issue_family="surface",
+        rationale="Internal file names and debug artifacts should not leak into outputs.",
+    ),
+    LLMQGCanary(
+        canary_id="seminar-register-pathos",
+        level="seminar",
+        snippet=(
+            "Розповідь має надихнути учасників, пробудити гордість і об'єднати спільноту "
+            "навколо правильної позиції наприкінці модуля."
+        ),
+        required_issue_ids=frozenset({"SEMINAR_REGISTER_PATHOS"}),
+        issue_family="register_pathos",
+        rationale="Seminar reviews should reject oversold motivational framing and pathos-heavy register.",
+    ),
+)
+
+
+def _canonical_level(level: str | None) -> str | None:
+    if level is None:
+        return None
+    wanted = level.strip().lower()
+    if not wanted:
+        return None
+    if wanted in SEMINAR_TRACK_IDS:
+        return "seminar"
+    if wanted.startswith("b1"):
+        return "b1"
+    return wanted
+
+
+def _selected_canary_ids(result: Any) -> frozenset[str] | None:
+    if not isinstance(result, Mapping):
+        return None
+    raw = result.get("canary_id")
+    if raw is None:
+        raw = result.get("canary_ids")
+    if isinstance(raw, str):
+        return frozenset({raw})
+    if isinstance(raw, list):
+        return frozenset(item for item in raw if isinstance(item, str))
+    return None
+
+
+def list_canaries(
+    level: str | None = None,
+    *,
+    canary_ids: frozenset[str] | None = None,
+) -> tuple[LLMQGCanary, ...]:
+    """Return canaries applicable to the requested level.
+
+    ``level=None`` returns all canaries.
+    """
+
+    wanted = _canonical_level(level)
+    if wanted is None:
+        return CANARIES
+    canaries = tuple(canary for canary in CANARIES if canary.level in {"any", wanted})
+    if canary_ids is not None:
+        canaries = tuple(canary for canary in canaries if canary.canary_id in canary_ids)
+    return canaries
+
+
+def required_issue_ids(
+    level: str,
+    *,
+    canary_ids: frozenset[str] | None = None,
+) -> frozenset[str]:
+    """Return issue IDs required for this level's canaries."""
+
+    return frozenset(
+        issue_id
+        for canary in list_canaries(level, canary_ids=canary_ids)
+        for issue_id in canary.required_issue_ids
+    )
+
+
+def forbidden_issue_ids(
+    level: str,
+    *,
+    canary_ids: frozenset[str] | None = None,
+) -> frozenset[str]:
+    """Return issue IDs forbidden for this level's allow-list canaries."""
+
+    return frozenset(
+        issue_id
+        for canary in list_canaries(level, canary_ids=canary_ids)
+        for issue_id in canary.forbidden_issue_ids
+    )
+
+
+def normalize_issue_id(raw: Any) -> str | None:
+    """Normalize a raw issue identifier to canonical uppercase underscore form."""
+
+    if not isinstance(raw, str):
+        return None
+    normalized = _NORMALIZE_RE.sub("_", raw.strip().upper())
+    normalized = re.sub(r"_+", "_", normalized).strip("_")
+    return normalized or None
+
+
+def _yield_issue_values(obj: Mapping[str, Any]) -> list[str]:
+    fields = (
+        "issue_id",
+        "issue_ids",
+        "issue_type",
+        "issue_types",
+        "type",
+        "kind",
+        "tag",
+        "error_class",
+        "issue",
+        "flags",
+        "flags_raised",
+    )
+    issue_values: list[str] = []
+    for field in fields:
+        value = obj.get(field)
+        if isinstance(value, str):
+            issue_values.append(value)
+        elif isinstance(value, list):
+            issue_values.extend(item for item in value if isinstance(item, str))
+    return issue_values
+
+
+def extract_issue_ids(result: Any) -> frozenset[str]:
+    """Extract canonical issue IDs from a JSON-ish LLM result."""
+
+    if not isinstance(result, Mapping):
+        return frozenset()
+
+    ids: set[str] = set()
+    payload = dict(result)
+
+    def add_values(value: Any) -> None:
+        if isinstance(value, str):
+            normalized = normalize_issue_id(value)
+            if normalized:
+                ids.add(normalized)
+        elif isinstance(value, list):
+            for item in value:
+                add_values(item)
+        elif isinstance(value, Mapping):
+            for raw in _yield_issue_values(value):
+                normalized = normalize_issue_id(raw)
+                if normalized:
+                    ids.add(normalized)
+
+    def add_from_findings(value: Any) -> None:
+        if not isinstance(value, list):
+            return
+        for finding in value:
+            if isinstance(finding, (Mapping, str)):
+                add_values(finding)
+
+    add_values(payload.get("issue_ids"))
+    add_values(payload.get("flags"))
+    add_values(payload.get("flags_raised"))
+    add_from_findings(payload.get("findings"))
+
+    aggregate = payload.get("aggregate")
+    if isinstance(aggregate, Mapping):
+        add_values(aggregate.get("issue_ids"))
+        add_values(aggregate.get("flags"))
+        add_values(aggregate.get("flags_raised"))
+        add_from_findings(aggregate.get("findings"))
+
+    dimensions = payload.get("dimensions")
+    if isinstance(dimensions, Mapping):
+        for entry in dimensions.values():
+            if isinstance(entry, Mapping):
+                add_values(entry.get("issue_ids"))
+                add_values(entry.get("flags"))
+                add_values(entry.get("flags_raised"))
+                add_from_findings(entry.get("findings"))
+
+    return frozenset(ids)
+
+
+def evaluate_canaries(result: Any, level: str) -> dict[str, Any]:
+    """Match a JSON-ish LLM result to required issue IDs for one level."""
+
+    selected_ids = _selected_canary_ids(result)
+    applicable_canaries = list_canaries(level, canary_ids=selected_ids)
+    required = required_issue_ids(level, canary_ids=selected_ids)
+    forbidden = forbidden_issue_ids(level, canary_ids=selected_ids)
+    found = extract_issue_ids(result)
+    missing = required - found
+    forbidden_found = forbidden & found
+
+    matched_canaries: list[str] = []
+    missed_canaries: list[str] = []
+    for canary in applicable_canaries:
+        required_pass = canary.required_issue_ids.issubset(found)
+        forbidden_pass = not (canary.forbidden_issue_ids & found)
+        if required_pass and forbidden_pass:
+            matched_canaries.append(canary.canary_id)
+        else:
+            missed_canaries.append(canary.canary_id)
+
+    return {
+        "level": _canonical_level(level) or "",
+        "canary_ids": tuple(sorted(canary.canary_id for canary in applicable_canaries)),
+        "passed": len(missed_canaries) == 0,
+        "required_issue_ids": tuple(sorted(required)),
+        "forbidden_issue_ids": tuple(sorted(forbidden)),
+        "found_issue_ids": tuple(sorted(found)),
+        "missing_issue_ids": tuple(sorted(missing)),
+        "forbidden_issue_ids_found": tuple(sorted(forbidden_found)),
+        "matched_canaries": tuple(sorted(matched_canaries)),
+        "missed_canaries": tuple(sorted(missed_canaries)),
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("result", nargs="?", type=Path, help="Optional JSON reviewer result to evaluate.")
+    parser.add_argument("--level", default="b1", help="Level/profile to evaluate, e.g. a1, a2, b1, seminar.")
+    parser.add_argument("--list", action="store_true", help="Print applicable canaries instead of evaluating a result.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.list:
+        payload = [asdict(canary) for canary in list_canaries(args.level)]
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True, default=sorted))
+        return 0
+    if args.result is None:
+        raise SystemExit("error: result file is required unless --list is set")
+    result = json.loads(args.result.read_text(encoding="utf-8"))
+    report = evaluate_canaries(result, args.level)
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/llm_qg_store.py
+++ b/scripts/audit/llm_qg_store.py
@@ -1,0 +1,391 @@
+"""Persistent storage for LLM quality-gate results.
+
+The pipeline may still emit ``llm_qg.json`` artifacts for debugging or
+promotion workflows, but durable gate state belongs in a local SQLite store.
+This keeps generated QG files out of PR diffs while still giving the Monitor
+API and certification code a queryable source of truth.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from scripts.api.config import PROJECT_ROOT
+from scripts.api.resilience import connect_sqlite
+
+DEFAULT_DB_PATH = PROJECT_ROOT / "data" / "telemetry" / "llm_qg.db"
+DB_ENV_VAR = "LEARN_UKRAINIAN_LLM_QG_DB"
+CONTENT_FILES = ("module.md", "activities.yaml", "vocabulary.yaml", "resources.yaml")
+
+
+@dataclass(frozen=True, slots=True)
+class StoredQG:
+    """One persisted LLM-QG run."""
+
+    run_id: str
+    level: str
+    slug: str
+    content_sha: str
+    gate_version: str
+    prompt_hash: str | None
+    reviewer_model: str | None
+    reviewer_family: str | None
+    source: str
+    payload: dict[str, Any]
+    created_at: str
+
+    def is_current_for(self, module_dir: Path) -> bool:
+        return self.content_sha == content_sha_for_module(module_dir)
+
+
+def db_path(path: Path | None = None) -> Path:
+    """Return the configured QG database path."""
+    if path is not None:
+        return path
+    return Path(os.environ.get(DB_ENV_VAR, str(DEFAULT_DB_PATH)))
+
+
+def _now_z() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def content_sha_for_module(module_dir: Path) -> str:
+    """Hash the learner-facing source artifacts for one module directory."""
+    h = hashlib.sha256()
+    for name in CONTENT_FILES:
+        path = module_dir / name
+        if not path.exists():
+            continue
+        h.update(name.encode("utf-8"))
+        h.update(b"\0")
+        h.update(path.read_bytes())
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+def llm_qg_file_is_current_for_module(module_dir: Path, path: Path | None = None) -> bool:
+    """Return True when a module-local QG artifact is not older than content.
+
+    File artifacts do not carry a content hash. Treat them as a fallback only
+    when their mtime is at least as new as every learner-facing source file.
+    """
+    qg_path = path or module_dir / "llm_qg.json"
+    try:
+        artifact_mtime_ns = qg_path.stat().st_mtime_ns
+    except OSError:
+        return False
+
+    for name in CONTENT_FILES:
+        content_path = module_dir / name
+        if not content_path.exists():
+            continue
+        try:
+            if content_path.stat().st_mtime_ns > artifact_mtime_ns:
+                return False
+        except OSError:
+            return False
+    return True
+
+
+def prompt_hash_for_text(prompt: str | None) -> str | None:
+    """Return a stable hash for a prompt body, if present."""
+    if prompt is None:
+        return None
+    return _sha256_bytes(prompt.encode("utf-8"))
+
+
+def init_db(path: Path | None = None) -> Path:
+    """Create the LLM-QG persistence schema if needed."""
+    resolved = db_path(path)
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    with closing(connect_sqlite(str(resolved))) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS llm_qg_runs (
+                run_id          TEXT PRIMARY KEY,
+                created_at      TEXT NOT NULL,
+                level           TEXT NOT NULL,
+                slug            TEXT NOT NULL,
+                content_sha     TEXT NOT NULL,
+                gate_version    TEXT NOT NULL,
+                prompt_hash     TEXT,
+                reviewer_model  TEXT,
+                reviewer_family TEXT,
+                source          TEXT NOT NULL,
+                verdict         TEXT,
+                terminal_verdict TEXT,
+                min_score       REAL,
+                min_dim         TEXT,
+                payload_json    TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_llm_qg_level_slug_created
+                ON llm_qg_runs(level, slug, created_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_llm_qg_level_slug_content
+                ON llm_qg_runs(level, slug, content_sha, created_at DESC);
+
+            CREATE TABLE IF NOT EXISTS llm_qg_findings (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_id          TEXT NOT NULL,
+                category        TEXT,
+                severity        TEXT,
+                file            TEXT,
+                quote           TEXT,
+                replacement     TEXT,
+                payload_json    TEXT NOT NULL,
+                FOREIGN KEY(run_id) REFERENCES llm_qg_runs(run_id)
+                    ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_llm_qg_findings_run
+                ON llm_qg_findings(run_id, id);
+            CREATE INDEX IF NOT EXISTS idx_llm_qg_findings_category
+                ON llm_qg_findings(category, severity);
+            """
+        )
+        conn.commit()
+    return resolved
+
+
+def _aggregate(payload: dict[str, Any]) -> dict[str, Any]:
+    aggregate = payload.get("aggregate")
+    return aggregate if isinstance(aggregate, dict) else {}
+
+
+def _iter_findings(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    findings = payload.get("findings")
+    if isinstance(findings, list):
+        return [item for item in findings if isinstance(item, dict)]
+    dimensions = payload.get("dimensions")
+    if not isinstance(dimensions, dict):
+        return []
+    out: list[dict[str, Any]] = []
+    for dim, entry in dimensions.items():
+        if not isinstance(entry, dict):
+            continue
+        dim_findings = entry.get("findings")
+        if isinstance(dim_findings, list):
+            for item in dim_findings:
+                if isinstance(item, dict):
+                    out.append({"dimension": dim, **item})
+    return out
+
+
+def _finding_category(item: dict[str, Any]) -> Any:
+    return (
+        item.get("category")
+        or item.get("issue_id")
+        or item.get("issue_type")
+        or item.get("type")
+        or item.get("kind")
+    )
+
+
+def record_llm_qg(
+    *,
+    level: str,
+    slug: str,
+    module_dir: Path,
+    payload: dict[str, Any],
+    gate_version: str,
+    prompt_hash: str | None = None,
+    reviewer_model: str | None = None,
+    reviewer_family: str | None = None,
+    source: str = "pipeline",
+    run_id: str | None = None,
+    path: Path | None = None,
+) -> StoredQG:
+    """Persist one LLM-QG run and return the stored record."""
+    resolved = init_db(path)
+    clean_level = level.strip().lower()
+    clean_slug = slug.strip()
+    clean_run_id = run_id or f"llm-qg-{uuid4().hex}"
+    created_at = _now_z()
+    content_sha = content_sha_for_module(module_dir)
+    aggregate = _aggregate(payload)
+    findings = _iter_findings(payload)
+
+    with closing(connect_sqlite(str(resolved))) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.execute(
+            """
+            INSERT INTO llm_qg_runs (
+                run_id, created_at, level, slug, content_sha, gate_version,
+                prompt_hash, reviewer_model, reviewer_family, source, verdict,
+                terminal_verdict, min_score, min_dim, payload_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(run_id) DO UPDATE SET
+                created_at = excluded.created_at,
+                level = excluded.level,
+                slug = excluded.slug,
+                content_sha = excluded.content_sha,
+                gate_version = excluded.gate_version,
+                prompt_hash = excluded.prompt_hash,
+                reviewer_model = excluded.reviewer_model,
+                reviewer_family = excluded.reviewer_family,
+                source = excluded.source,
+                verdict = excluded.verdict,
+                terminal_verdict = excluded.terminal_verdict,
+                min_score = excluded.min_score,
+                min_dim = excluded.min_dim,
+                payload_json = excluded.payload_json
+            """,
+            (
+                clean_run_id,
+                created_at,
+                clean_level,
+                clean_slug,
+                content_sha,
+                gate_version,
+                prompt_hash,
+                reviewer_model,
+                reviewer_family,
+                source,
+                aggregate.get("verdict"),
+                aggregate.get("terminal_verdict"),
+                aggregate.get("min_score"),
+                aggregate.get("min_dim"),
+                _json_dumps(payload),
+            ),
+        )
+        conn.execute("DELETE FROM llm_qg_findings WHERE run_id = ?", (clean_run_id,))
+        conn.executemany(
+            """
+            INSERT INTO llm_qg_findings (
+                run_id, category, severity, file, quote, replacement, payload_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    clean_run_id,
+                    _finding_category(item),
+                    item.get("severity"),
+                    item.get("file"),
+                    item.get("quote"),
+                    item.get("replacement"),
+                    _json_dumps(item),
+                )
+                for item in findings
+            ],
+        )
+        conn.commit()
+
+    return StoredQG(
+        run_id=clean_run_id,
+        level=clean_level,
+        slug=clean_slug,
+        content_sha=content_sha,
+        gate_version=gate_version,
+        prompt_hash=prompt_hash,
+        reviewer_model=reviewer_model,
+        reviewer_family=reviewer_family,
+        source=source,
+        payload=payload,
+        created_at=created_at,
+    )
+
+
+def _row_to_record(row: sqlite3.Row) -> StoredQG:
+    return StoredQG(
+        run_id=str(row["run_id"]),
+        level=str(row["level"]),
+        slug=str(row["slug"]),
+        content_sha=str(row["content_sha"]),
+        gate_version=str(row["gate_version"]),
+        prompt_hash=row["prompt_hash"],
+        reviewer_model=row["reviewer_model"],
+        reviewer_family=row["reviewer_family"],
+        source=str(row["source"]),
+        payload=json.loads(str(row["payload_json"])),
+        created_at=str(row["created_at"]),
+    )
+
+
+def latest_llm_qg(
+    level: str,
+    slug: str,
+    *,
+    content_sha: str | None = None,
+    path: Path | None = None,
+) -> StoredQG | None:
+    """Return the newest persisted QG run for a module, optionally hash-bound."""
+    resolved = db_path(path)
+    if not resolved.exists():
+        return None
+    params: list[Any] = [level.strip().lower(), slug.strip()]
+    where = "level = ? AND slug = ?"
+    if content_sha is not None:
+        where += " AND content_sha = ?"
+        params.append(content_sha)
+    try:
+        with closing(connect_sqlite(str(resolved))) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                f"""
+                SELECT *
+                FROM llm_qg_runs
+                WHERE {where}
+                ORDER BY created_at DESC, run_id DESC
+                LIMIT 1
+                """,
+                params,
+            ).fetchone()
+        return _row_to_record(row) if row else None
+    except (json.JSONDecodeError, OSError, sqlite3.DatabaseError, ValueError):
+        return None
+
+
+def current_llm_qg_for_module(
+    level: str,
+    slug: str,
+    module_dir: Path,
+    *,
+    path: Path | None = None,
+) -> StoredQG | None:
+    """Return the newest QG run whose content hash matches current artifacts."""
+    return latest_llm_qg(
+        level,
+        slug,
+        content_sha=content_sha_for_module(module_dir),
+        path=path,
+    )
+
+
+def current_payload_for_module(
+    level: str,
+    slug: str,
+    module_dir: Path,
+    *,
+    path: Path | None = None,
+) -> dict[str, Any] | None:
+    """Return the current QG payload for a module, or ``None`` if missing/stale."""
+    record = current_llm_qg_for_module(level, slug, module_dir, path=path)
+    if record is None:
+        return None
+    return {
+        **record.payload,
+        "_store": {
+            "run_id": record.run_id,
+            "created_at": record.created_at,
+            "content_sha": record.content_sha,
+            "gate_version": record.gate_version,
+            "source": record.source,
+        },
+    }

--- a/scripts/audit/module_quality_audit.py
+++ b/scripts/audit/module_quality_audit.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+"""Audit module quality-gate coverage across planned curriculum modules.
+
+This is the cheap, deterministic pass to run before spending reviewer tokens.
+It scans built module artifacts for surface-policy failures and reports whether
+each built module has a current persisted LLM quality-gate result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+AUDIT_DIR = Path(__file__).resolve().parent
+if str(AUDIT_DIR) not in sys.path:
+    sys.path.insert(0, str(AUDIT_DIR))
+
+from content_surface_gates import scan_module_surface
+from llm_qg_canaries import evaluate_canaries
+from llm_qg_store import (
+    current_llm_qg_for_module,
+    latest_llm_qg,
+    llm_qg_file_is_current_for_module,
+)
+
+from scripts.api.config import CURRICULUM_ROOT, LEVELS, SEMINAR_TRACK_IDS
+
+_YAML_LOADER = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+_CURRENT_LLM_STATUSES = {"current_db", "current_file_only"}
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedModule:
+    """One module from the curriculum manifest or plan fallback."""
+
+    num: int
+    level: str
+    slug: str
+    profile: str
+
+
+@dataclass(frozen=True, slots=True)
+class ModuleQualityAudit:
+    """Quality-gate coverage for one planned module."""
+
+    num: int
+    level: str
+    slug: str
+    profile: str
+    built: bool
+    module_dir: str | None
+    surface_verdict: str
+    surface_counts: dict[str, int]
+    surface_findings: list[dict[str, Any]]
+    llm_qg_status: str
+    llm_qg_source: str | None
+    llm_qg_run_id: str | None
+    llm_qg_gate_version: str | None
+    llm_qg_prompt_hash: str | None
+    llm_qg_content_sha: str | None
+    llm_qg_reviewer_family: str | None
+    llm_qg_reviewer_model: str | None
+    needs_llm_qg: bool
+    needs_db_persistence: bool
+    second_review_recommended: bool
+    second_review_reason: str | None
+
+
+def planned_modules(
+    *,
+    curriculum_root: Path = CURRICULUM_ROOT,
+    level_ids: list[str] | None = None,
+) -> list[PlannedModule]:
+    """Return planned modules for selected levels/tracks."""
+    levels = _selected_level_ids(level_ids)
+    manifest = _load_manifest(curriculum_root / "curriculum.yaml")
+    modules: list[PlannedModule] = []
+
+    for level in levels:
+        slugs = _manifest_slugs(manifest, level)
+        if not slugs:
+            slugs = _plan_dir_slugs(curriculum_root / "plans" / level)
+        profile = profile_for_level(level)
+        modules.extend(
+            PlannedModule(num=index, level=level, slug=slug, profile=profile)
+            for index, slug in enumerate(slugs, 1)
+        )
+    return modules
+
+
+def audit_modules(
+    *,
+    curriculum_root: Path = CURRICULUM_ROOT,
+    level_ids: list[str] | None = None,
+    db_path: Path | None = None,
+    include_findings: bool = True,
+    canary_results: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Audit planned modules and return a JSON-serializable report."""
+    rows = [
+        audit_one_module(
+            module,
+            curriculum_root=curriculum_root,
+            db_path=db_path,
+            include_findings=include_findings,
+        )
+        for module in planned_modules(curriculum_root=curriculum_root, level_ids=level_ids)
+    ]
+    row_dicts = [asdict(row) for row in rows]
+    return {
+        "summary": summarize(row_dicts),
+        "canaries": canary_results or {},
+        "modules": row_dicts,
+    }
+
+
+def audit_one_module(
+    module: PlannedModule,
+    *,
+    curriculum_root: Path = CURRICULUM_ROOT,
+    db_path: Path | None = None,
+    include_findings: bool = True,
+) -> ModuleQualityAudit:
+    """Audit one planned module."""
+    module_dir = curriculum_root / module.level / module.slug
+    built = (module_dir / "module.md").exists()
+    if not built:
+        return ModuleQualityAudit(
+            num=module.num,
+            level=module.level,
+            slug=module.slug,
+            profile=module.profile,
+            built=False,
+            module_dir=None,
+            surface_verdict="NOT_BUILT",
+            surface_counts={"critical": 0, "warning": 0, "total": 0},
+            surface_findings=[],
+            llm_qg_status="not_built",
+            llm_qg_source=None,
+            llm_qg_run_id=None,
+            llm_qg_gate_version=None,
+            llm_qg_prompt_hash=None,
+            llm_qg_content_sha=None,
+            llm_qg_reviewer_family=None,
+            llm_qg_reviewer_model=None,
+            needs_llm_qg=False,
+            needs_db_persistence=False,
+            second_review_recommended=False,
+            second_review_reason=None,
+        )
+
+    surface = scan_module_surface(module_dir, level=module.level)
+    llm_status = llm_qg_status_for_module(
+        level=module.level,
+        slug=module.slug,
+        module_dir=module_dir,
+        db_path=db_path,
+    )
+    second_review_reason = second_review_reason_for_module(
+        profile=module.profile,
+        surface_verdict=str(surface["verdict"]),
+        llm_qg_status=str(llm_status["status"]),
+    )
+    return ModuleQualityAudit(
+        num=module.num,
+        level=module.level,
+        slug=module.slug,
+        profile=module.profile,
+        built=True,
+        module_dir=str(module_dir),
+        surface_verdict=str(surface["verdict"]),
+        surface_counts=dict(surface["counts"]),
+        surface_findings=list(surface["findings"]) if include_findings else [],
+        llm_qg_status=str(llm_status["status"]),
+        llm_qg_source=llm_status["source"],
+        llm_qg_run_id=llm_status["run_id"],
+        llm_qg_gate_version=llm_status["gate_version"],
+        llm_qg_prompt_hash=llm_status["prompt_hash"],
+        llm_qg_content_sha=llm_status["content_sha"],
+        llm_qg_reviewer_family=llm_status["reviewer_family"],
+        llm_qg_reviewer_model=llm_status["reviewer_model"],
+        needs_llm_qg=llm_status["status"] not in _CURRENT_LLM_STATUSES,
+        needs_db_persistence=llm_status["status"] != "current_db",
+        second_review_recommended=second_review_reason is not None,
+        second_review_reason=second_review_reason,
+    )
+
+
+def llm_qg_status_for_module(
+    *,
+    level: str,
+    slug: str,
+    module_dir: Path,
+    db_path: Path | None = None,
+) -> dict[str, Any]:
+    """Return LLM-QG persistence status and reviewer metadata."""
+    current = current_llm_qg_for_module(level, slug, module_dir, path=db_path)
+    if current is not None:
+        return _record_status("current_db", current)
+
+    latest = latest_llm_qg(level, slug, path=db_path)
+    file_path = module_dir / "llm_qg.json"
+    file_exists = file_path.exists()
+    if file_exists and llm_qg_file_is_current_for_module(module_dir, file_path):
+        return _empty_status("current_file_only", source="llm_qg.json")
+    if latest is not None:
+        return _record_status("stale_db", latest)
+    if file_exists:
+        return _empty_status("stale_file", source="llm_qg.json")
+    return _empty_status("missing")
+
+
+def _record_status(status: str, record: Any) -> dict[str, Any]:
+    return {
+        "status": status,
+        "source": record.source,
+        "run_id": record.run_id,
+        "gate_version": record.gate_version,
+        "prompt_hash": record.prompt_hash,
+        "content_sha": record.content_sha,
+        "reviewer_family": record.reviewer_family,
+        "reviewer_model": record.reviewer_model,
+    }
+
+
+def _empty_status(status: str, *, source: str | None = None) -> dict[str, Any]:
+    return {
+        "status": status,
+        "source": source,
+        "run_id": None,
+        "gate_version": None,
+        "prompt_hash": None,
+        "content_sha": None,
+        "reviewer_family": None,
+        "reviewer_model": None,
+    }
+
+
+def second_review_reason_for_module(
+    *,
+    profile: str,
+    surface_verdict: str,
+    llm_qg_status: str,
+) -> str | None:
+    """Return why a module should receive a second cross-family review."""
+    if profile == "seminar":
+        return "seminar_high_risk"
+    if surface_verdict in {"FAIL", "WARN"}:
+        return f"surface_{surface_verdict.lower()}"
+    if llm_qg_status not in _CURRENT_LLM_STATUSES:
+        return "missing_or_stale_llm_qg"
+    return None
+
+
+def summarize(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize per-module audit rows."""
+    planned = len(rows)
+    built_rows = [row for row in rows if row["built"]]
+    built = len(built_rows)
+    surface_fail = [row for row in built_rows if row["surface_verdict"] == "FAIL"]
+    surface_warn = [row for row in built_rows if row["surface_verdict"] == "WARN"]
+    current_db = [row for row in built_rows if row["llm_qg_status"] == "current_db"]
+    current_file = [row for row in built_rows if row["llm_qg_status"] == "current_file_only"]
+    stale = [row for row in built_rows if row["llm_qg_status"] in {"stale_db", "stale_file"}]
+    missing = [row for row in built_rows if row["llm_qg_status"] == "missing"]
+    return {
+        "planned_modules": planned,
+        "built_modules": built,
+        "unbuilt_modules": planned - built,
+        "surface_fail_modules": len(surface_fail),
+        "surface_warn_modules": len(surface_warn),
+        "current_db_llm_qg_modules": len(current_db),
+        "current_file_only_llm_qg_modules": len(current_file),
+        "stale_llm_qg_modules": len(stale),
+        "missing_llm_qg_modules": len(missing),
+        "modules_without_current_db_llm_qg": built - len(current_db),
+        "modules_without_current_any_llm_qg": built - len(current_db) - len(current_file),
+        "modules_needing_llm_review": sum(1 for row in built_rows if row["needs_llm_qg"]),
+        "modules_needing_db_persistence": sum(1 for row in built_rows if row["needs_db_persistence"]),
+        "modules_recommended_for_second_review": sum(
+            1 for row in built_rows if row["second_review_recommended"]
+        ),
+        "by_level": _summary_by(rows, "level"),
+        "by_profile": _summary_by(rows, "profile"),
+    }
+
+
+def profile_for_level(level: str) -> str:
+    """Return reviewer calibration profile for a level or seminar track."""
+    clean = level.strip().lower()
+    if clean in SEMINAR_TRACK_IDS:
+        return "seminar"
+    if clean.startswith("a1"):
+        return "a1"
+    if clean.startswith("a2"):
+        return "a2"
+    return "b1_plus"
+
+
+def _selected_level_ids(level_ids: list[str] | None) -> list[str]:
+    known = [str(item["id"]) for item in LEVELS]
+    if level_ids is None:
+        return known
+    requested = [level.strip().lower() for level in level_ids if level.strip()]
+    unknown = sorted(set(requested) - set(known))
+    if unknown:
+        raise ValueError(f"unknown level/track: {', '.join(unknown)}")
+    return requested
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return yaml.load(path.read_text(encoding="utf-8"), Loader=_YAML_LOADER) or {}
+
+
+def _manifest_slugs(manifest: dict[str, Any], level: str) -> list[str]:
+    raw = manifest.get("levels", {}).get(level, {}).get("modules", [])
+    if not isinstance(raw, list):
+        return []
+    slugs = []
+    for entry in raw:
+        slug = str(entry).split("#", 1)[0].strip()
+        if slug:
+            slugs.append(_to_bare_slug(slug))
+    return slugs
+
+
+def _plan_dir_slugs(plan_dir: Path) -> list[str]:
+    if not plan_dir.is_dir():
+        return []
+    return [
+        path.stem
+        for path in sorted(plan_dir.glob("*.yaml"))
+        if path.name != ".gitkeep"
+    ]
+
+
+def _to_bare_slug(entry: str) -> str:
+    head, sep, tail = entry.partition("-")
+    if sep and head.isdigit():
+        return tail
+    return entry
+
+
+def _summary_by(rows: list[dict[str, Any]], key: str) -> dict[str, Any]:
+    out: dict[str, dict[str, int]] = {}
+    for row in rows:
+        label = str(row[key])
+        bucket = out.setdefault(
+            label,
+            {
+                "planned": 0,
+                "built": 0,
+                "surface_fail": 0,
+                "surface_warn": 0,
+                "current_db_llm_qg": 0,
+                "current_file_only_llm_qg": 0,
+                "missing_or_stale_llm_qg": 0,
+                "needs_db_persistence": 0,
+                "second_review_recommended": 0,
+            },
+        )
+        bucket["planned"] += 1
+        if row["built"]:
+            bucket["built"] += 1
+        if row["surface_verdict"] == "FAIL":
+            bucket["surface_fail"] += 1
+        if row["surface_verdict"] == "WARN":
+            bucket["surface_warn"] += 1
+        if row["llm_qg_status"] == "current_db":
+            bucket["current_db_llm_qg"] += 1
+        if row["llm_qg_status"] == "current_file_only":
+            bucket["current_file_only_llm_qg"] += 1
+        if row["llm_qg_status"] in {"missing", "stale_db", "stale_file"}:
+            bucket["missing_or_stale_llm_qg"] += 1
+        if row["needs_db_persistence"]:
+            bucket["needs_db_persistence"] += 1
+        if row["second_review_recommended"]:
+            bucket["second_review_recommended"] += 1
+    return out
+
+
+def load_canary_results(specs: list[str] | None) -> dict[str, Any]:
+    """Load LEVEL=PATH specs and evaluate reviewer canary outputs."""
+    if not specs:
+        return {}
+    out: dict[str, Any] = {}
+    for spec in specs:
+        level, sep, raw_path = spec.partition("=")
+        if not sep or not level.strip() or not raw_path.strip():
+            raise ValueError("--canary-result must use LEVEL=/path/to/result.json")
+        path = Path(raw_path)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        out[level.strip().lower()] = {
+            "path": str(path),
+            **evaluate_canaries(payload, level),
+        }
+    return out
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--level",
+        action="append",
+        dest="levels",
+        help="Level/track id to audit. Repeat for multiple levels. Defaults to all configured levels.",
+    )
+    parser.add_argument(
+        "--curriculum-root",
+        type=Path,
+        default=CURRICULUM_ROOT,
+        help="Curriculum root containing curriculum.yaml and level directories.",
+    )
+    parser.add_argument(
+        "--llm-qg-db",
+        type=Path,
+        default=None,
+        help="Optional LLM-QG SQLite path. Defaults to LEARN_UKRAINIAN_LLM_QG_DB or data/telemetry/llm_qg.db.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "summary"),
+        default="summary",
+        help="Output format. JSON includes per-module rows.",
+    )
+    parser.add_argument(
+        "--include-findings",
+        action="store_true",
+        help="Include full surface finding rows in JSON output.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional output file. Defaults to stdout.",
+    )
+    parser.add_argument(
+        "--canary-result",
+        action="append",
+        dest="canary_results",
+        help="Evaluate a saved LLM canary result as LEVEL=/path/result.json and include it in the report.",
+    )
+    parser.add_argument(
+        "--fail-on-canary-failure",
+        action="store_true",
+        help="Return exit code 1 if any supplied canary result fails.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        canary_results = load_canary_results(args.canary_results)
+        report = audit_modules(
+            curriculum_root=args.curriculum_root,
+            level_ids=args.levels,
+            db_path=args.llm_qg_db,
+            include_findings=args.include_findings,
+            canary_results=canary_results,
+        )
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        output = json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True)
+    else:
+        output = _format_summary(report["summary"])
+
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(output + "\n", encoding="utf-8")
+    else:
+        print(output)
+    if args.fail_on_canary_failure and any(
+        not result.get("passed") for result in report.get("canaries", {}).values()
+    ):
+        return 1
+    return 0
+
+
+def _format_summary(summary: dict[str, Any]) -> str:
+    lines = [
+        "Module Quality Gate Audit",
+        f"Planned modules: {summary['planned_modules']}",
+        f"Built modules: {summary['built_modules']}",
+        f"Unbuilt modules: {summary['unbuilt_modules']}",
+        f"Surface FAIL/WARN: {summary['surface_fail_modules']}/{summary['surface_warn_modules']}",
+        f"Current DB LLM-QG: {summary['current_db_llm_qg_modules']}",
+        f"Current file-only LLM-QG: {summary['current_file_only_llm_qg_modules']}",
+        f"Stale LLM-QG: {summary['stale_llm_qg_modules']}",
+        f"Missing LLM-QG: {summary['missing_llm_qg_modules']}",
+        f"Built modules without current DB LLM-QG: {summary['modules_without_current_db_llm_qg']}",
+        f"Built modules without current DB/file LLM-QG: {summary['modules_without_current_any_llm_qg']}",
+        f"Modules needing LLM review: {summary['modules_needing_llm_review']}",
+        f"Modules needing DB persistence: {summary['modules_needing_db_persistence']}",
+        f"Modules recommended for second review: {summary['modules_recommended_for_second_review']}",
+        "",
+        "By profile:",
+    ]
+    for profile, bucket in sorted(summary["by_profile"].items()):
+        lines.append(
+            "  "
+            f"{profile}: planned={bucket['planned']} built={bucket['built']} "
+            f"surface_fail={bucket['surface_fail']} surface_warn={bucket['surface_warn']} "
+            f"current_db={bucket['current_db_llm_qg']} "
+            f"missing_or_stale={bucket['missing_or_stale_llm_qg']}"
+        )
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -46,6 +46,7 @@ PRIMARY_TEXT_SOURCES_PATH = PROJECT_ROOT / "data" / "primary_text_sources.yaml"
 CLAUDE_WRITER_AGENT_SOURCE = PROJECT_ROOT / "agents_extensions/shared" / "agents" / "curriculum-writer.md"
 CLAUDE_WRITER_AGENT_TARGET = PROJECT_ROOT / ".claude" / "agents" / "curriculum-writer.md"
 
+from scripts.audit.content_surface_gates import scan_module_surface, scan_surface_text
 from scripts.audit.failure_classes import FailureClass, FailureRecord
 from scripts.audit.wiki_completeness_gate import SEMINAR_LEVELS
 from scripts.build.citation_matcher import (
@@ -193,6 +194,7 @@ PYTHON_QG_GATE_ORDER = (
     "inject_activity_ids",
     "activity_types",
     "ai_slop_clean",
+    "surface_policy",
     "russianisms_strict",
     "register_consistency",
     "engagement_floor",
@@ -5369,6 +5371,12 @@ def parse_review_response(
         raw_flags = [raw_flags]
     if isinstance(raw_flags, list) and raw_flags:
         entry["flags"] = [_clean_telemetry_text(flag, 120) for flag in raw_flags if str(flag).strip()]
+    issue_ids = _llm_qg_issue_ids_from_payload(payload)
+    if issue_ids:
+        entry["issue_ids"] = issue_ids
+    findings = _llm_qg_findings_from_payload(payload)
+    if findings:
+        entry["findings"] = findings
     validate_llm_review_report({**_placeholder_review_report(), dim: entry})
     if verdict not in {"PASS", "REVISE", "REJECT"}:
         raise LinearPipelineError(f"LLM QG response for {dim} has invalid verdict")
@@ -5517,6 +5525,70 @@ def parse_wiki_coverage_review_response(response: str) -> dict[str, Any]:
 
 
 _LLM_QG_QUOTE_MARKERS = ('"', "“", "”", "«", "»")
+_LLM_QG_ISSUE_ID_RE = re.compile(r"[^A-Z0-9_]")
+
+
+def _normalize_llm_qg_issue_id(raw: Any) -> str | None:
+    if not isinstance(raw, str):
+        return None
+    normalized = _LLM_QG_ISSUE_ID_RE.sub("_", raw.strip().upper())
+    normalized = re.sub(r"_+", "_", normalized).strip("_")
+    return normalized or None
+
+
+def _llm_qg_issue_ids_from_payload(payload: Mapping[str, Any]) -> list[str]:
+    ids: set[str] = set()
+
+    def add(value: Any) -> None:
+        if isinstance(value, str):
+            normalized = _normalize_llm_qg_issue_id(value)
+            if normalized:
+                ids.add(normalized)
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+            for item in value:
+                add(item)
+
+    add(payload.get("issue_ids"))
+    findings = payload.get("findings")
+    if isinstance(findings, Sequence) and not isinstance(findings, (str, bytes, bytearray)):
+        for finding in findings:
+            if isinstance(finding, Mapping):
+                for key in ("issue_id", "issue_type", "type", "kind", "tag", "error_class", "issue"):
+                    add(finding.get(key))
+            else:
+                add(finding)
+    return sorted(ids)
+
+
+def _llm_qg_findings_from_payload(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    raw_findings = payload.get("findings")
+    if not isinstance(raw_findings, Sequence) or isinstance(raw_findings, (str, bytes, bytearray)):
+        return []
+
+    findings: list[dict[str, Any]] = []
+    for raw in raw_findings[:50]:
+        if isinstance(raw, str):
+            issue_id = _normalize_llm_qg_issue_id(raw)
+            if issue_id:
+                findings.append({"issue_id": issue_id})
+            continue
+        if not isinstance(raw, Mapping):
+            continue
+        item: dict[str, Any] = {}
+        issue_id = None
+        for key in ("issue_id", "issue_type", "type", "kind", "tag", "error_class", "issue"):
+            issue_id = _normalize_llm_qg_issue_id(raw.get(key))
+            if issue_id:
+                break
+        if issue_id:
+            item["issue_id"] = issue_id
+        for key in ("severity", "quote", "replacement", "explanation", "dimension"):
+            value = raw.get(key)
+            if isinstance(value, str) and value.strip():
+                item[key] = _clean_telemetry_text(value, 500)
+        if item:
+            findings.append(item)
+    return findings
 
 
 def _evidence_passes_quote_contract(entry: Mapping[str, Any]) -> bool:
@@ -8612,6 +8684,10 @@ def run_python_qg(
         ),
     )
     record("ai_slop_clean", _ai_slop_gate(prose_text))
+    record(
+        "surface_policy",
+        scan_module_surface(module_dir, level=str(plan["level"])),
+    )
     record("russianisms_strict", _russianisms_strict_gate(text_for_quality))
     record("register_consistency", _register_consistency_gate(module_text, plan))
     record("engagement_floor", _engagement_floor_gate(module_text, plan))

--- a/scripts/build/phases/linear-review-dim.md
+++ b/scripts/build/phases/linear-review-dim.md
@@ -26,6 +26,27 @@ schema + types + props, formatting standards, `forbidden_words`
 META_NARRATION zero-tolerance ban).
 
 Your job in this LLM dim is the residual judgment that regex cannot make.
+
+## Level Calibration — do not mis-score intended scaffolding
+
+Apply the level contract before scoring any dimension:
+
+- A1: English scaffolding is expected and often substantial. Do NOT penalize
+  English task support, English grammar terminology, or line-level glosses when
+  they support a Ukrainian-first teaching move. Penalize only English-led
+  lecture prose that replaces the Ukrainian anchor, or internal writer/reviewer
+  scaffolding that leaked into learner-facing content.
+- A2: easy Ukrainian should be the default body voice, with decreasing English
+  support for first-introduction grammar, safety clarifications, and concise
+  glosses. Do not demand B1-style Ukrainian-only prose, but flag English
+  paragraphs that take over the lesson.
+- B1/B2/C1/C2: learner-facing prose should be Ukrainian-led. English support is
+  exceptional, local, and justified; English-led sections are evidence against
+  tone, naturalness, and pedagogy.
+- Seminars: use advanced Ukrainian teaching voice. English leakage, generic
+  inspirational language, or school-textbook simplification is evidence against
+  tone/naturalness unless the plan explicitly requires a bilingual artifact.
+
 For `{DIM}` specifically:
 
 - `engagement`: does the prose actually *hold attention*? The gate already
@@ -82,7 +103,26 @@ For `{DIM}` specifically:
     two-column unless a third column adds essential teaching value (e.g.,
     stress mark, IPA).
 - `naturalness`: does Ukrainian read as native? The gate confirmed VESUM +
-  russianism shadow; you assess flow, register, idiom.
+  russianism shadow; you assess flow, register, idiom, grammar government, and
+  collocation. This is a linguistic-quality review, not a vibes review.
+  Actively search for:
+  - calqued or evasive passives where native Ukrainian would use an active,
+    impersonal, or result-state construction;
+  - wrong government/prepositions (for example, prefer `чекати на когось/щось`
+    where a bare English-style object such as `чекайте номер` sounds calqued);
+  - wrong verb choice for ordinary Ukrainian collocations (`відчинити/зачинити`
+    for doors/windows, `відімкнути/замкнути` for lock/unlock actions,
+    `прийняти препарат/ліки` rather than drinking medicine, etc.);
+  - anthropomorphic or model-translated metalanguage (`форма просить`,
+    `застереження каже`, `правило хоче`) unless quoted as a deliberate learner
+    mnemonic;
+  - unnatural nominalizations, bureaucratic phrasing, literal English/Russian
+    sentence architecture, or register shifts that a Ukrainian editor would
+    rewrite even if every surface form passes VESUM.
+  If you find two or more concrete native-style Ukrainian defects in generated
+  Ukrainian prose, score naturalness below PASS even when deterministic gates
+  passed. Name the defect type in `rubric_mapping` and quote the exact offending
+  phrase.
 - `decolonization`: is the lesson teaching Ukrainian **on its own terms**?
   The gate confirmed forbidden_words.
 
@@ -217,6 +257,27 @@ trace to verbatim quotes from the content is invalid by definition.
    REJECT.
 
 The JSON response MUST include `evidence_quotes` with 3 verbatim quotes from step 1 and `rubric_mapping` explaining how each quote maps to `{DIM}` before the score. The `evidence` field MUST be one of those verbatim quotes, wrapped in escaped quotes. A summary or paraphrase in any evidence field is a reviewer-protocol failure.
+
+If you find concrete defects, emit structured `findings` entries and canonical
+`issue_ids`. Use these issue IDs when they apply:
+
+- `AWKWARD_PASSIVE_RESULT_STATE`: calqued/evasive passive or result-state
+  wording such as `застосунок має бути відкритий` where a native Ukrainian
+  editor would use an active, impersonal, or clearer state construction.
+- `UNNATURAL_ANTHROPOMORPHISM`: model-translated metalanguage such as
+  `форма просить`, `застереження каже`, or `правило хоче`.
+- `ENGLISH_LEAKAGE`: English-led learner-facing prose that violates the level
+  calibration above. Do not use this for allowed A1/A2 glosses or scaffolding.
+- `AI_LEAKAGE`: model persona, scratchpad, refusal, draft, or self-correction
+  text leaked into learner-facing content.
+- `PATH_LEAKAGE` / `INTERNAL_LEAKAGE`: filesystem paths, source paths,
+  internal gate names, or debug artifacts leaked into learner-facing content.
+- `SEMINAR_REGISTER_PATHOS`: seminar prose that drifts into motivational,
+  generic, propagandistic, or wrong-register pathos instead of advanced
+  Ukrainian teaching voice.
+
+For each finding, include at minimum `issue_id`, `quote`, `severity`, and
+`explanation`. Leave `issue_ids` empty when no concrete defect applies.
 
 ## Tier-1 verification audit (do this DURING evidence search — #1661)
 
@@ -377,7 +438,7 @@ broken content (the writer is lying to its own audit).
 Return only JSON:
 
 ```json
-{"score": 0.0, "evidence_quotes": ["verbatim quote 1", "verbatim quote 2", "verbatim quote 3"], "rubric_mapping": "Quote 1: ...; Quote 2: ...; Quote 3: ...", "evidence": "\"verbatim quote from evidence_quotes\"", "flags": ["activity_split_audit_missing", "out_of_level_literary", "..."], "verdict": "REVISE"}
+{"score": 0.0, "evidence_quotes": ["verbatim quote 1", "verbatim quote 2", "verbatim quote 3"], "rubric_mapping": "Quote 1: ...; Quote 2: ...; Quote 3: ...", "evidence": "\"verbatim quote from evidence_quotes\"", "issue_ids": ["AWKWARD_PASSIVE_RESULT_STATE"], "findings": [{"issue_id": "AWKWARD_PASSIVE_RESULT_STATE", "quote": "verbatim offending phrase", "severity": "high", "explanation": "why this fails the assigned dimension"}], "flags": ["activity_split_audit_missing", "out_of_level_literary", "..."], "verdict": "REVISE"}
 ```
 
 The `flags` array MUST contain any FLAG strings raised during audits A-J that

--- a/scripts/build/run_llm_qg_parity.py
+++ b/scripts/build/run_llm_qg_parity.py
@@ -2,7 +2,8 @@
 """Standalone LLM-QG parity runner.
 
 Re-runs the V7 per-dimension LLM review on an already-built module and persists
-``llm_qg.json``, with a reviewer override. Replicates ``v7_build._run_llm_qg``
+``llm_qg.json`` plus the SQLite LLM-QG store, with a reviewer override.
+Replicates ``v7_build._run_llm_qg``
 (the handoff-prescribed mechanism) so folk modules that shipped python_qg-green
 *without* an ``llm_qg.json`` can reach e2e-proper parity with kalendarna.
 
@@ -19,8 +20,8 @@ The shared QG runner resumes dimensions whose prompt/raw-response artifacts
 already parse cleanly, and retries a dimension when the backend returns an empty
 or malformed response.
 
-Outputs ``<module_dir>/llm_qg.json`` and prints the aggregate verdict line. Exit
-code 0 on success, 1 on missing plan/module.
+Outputs ``<module_dir>/llm_qg.json``, persists the current DB record, and prints
+the aggregate verdict line. Exit code 0 on success, 1 on missing plan/module.
 """
 
 from __future__ import annotations
@@ -66,6 +67,14 @@ def run_parity(level: str, slug: str, *, writer: str, reviewer: str, out: str | 
         profile=profile,
     )
     linear_pipeline.write_json(module_dir / "llm_qg.json", llm_qg)
+    v7_build._persist_llm_qg_result(
+        level=level,
+        slug=slug,
+        module_dir=module_dir,
+        llm_qg=llm_qg,
+        reviewer=v7_build._reviewer_for_writer(writer, reviewer),
+        source="run_llm_qg_parity",
+    )
     agg = llm_qg["aggregate"]
     print(
         f"[parity] DONE {slug} in {round(time.monotonic() - started)}s :: "
@@ -75,6 +84,7 @@ def run_parity(level: str, slug: str, *, writer: str, reviewer: str, out: str | 
         flush=True,
     )
     print(f"LLM_QG_JSON_WRITTEN {module_dir / 'llm_qg.json'}", flush=True)
+    print("LLM_QG_DB_PERSISTED true", flush=True)
     return 0
 
 

--- a/scripts/build/v7_build.py
+++ b/scripts/build/v7_build.py
@@ -21,6 +21,12 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from scripts.agent_runtime.errors import AgentStalledError
+from scripts.audit.llm_qg_store import (
+    current_payload_for_module,
+    llm_qg_file_is_current_for_module,
+    prompt_hash_for_text,
+    record_llm_qg,
+)
 from scripts.audit.wiki_completeness_gate import SEMINAR_LEVELS
 from scripts.build import linear_pipeline, run_archive
 from scripts.build.phases.implementation_map import (
@@ -1149,6 +1155,44 @@ def _run_llm_qg(
     )
 
 
+def _persist_llm_qg_result(
+    *,
+    level: str,
+    slug: str,
+    module_dir: Path,
+    llm_qg: dict[str, Any],
+    reviewer: str,
+    source: str,
+) -> None:
+    defaults = linear_pipeline.REVIEWER_DEFAULTS.get(reviewer, {})
+    try:
+        record_llm_qg(
+            level=level,
+            slug=slug,
+            module_dir=module_dir,
+            payload=llm_qg,
+            gate_version="v7.llm_qg.1",
+            prompt_hash=_combined_llm_qg_prompt_hash(module_dir),
+            reviewer_model=defaults.get("model"),
+            reviewer_family=reviewer,
+            source=source,
+        )
+    except Exception as exc:
+        raise linear_pipeline.LinearPipelineError(
+            f"LLM QG completed but result persistence failed: {exc}"
+        ) from exc
+
+
+def _combined_llm_qg_prompt_hash(module_dir: Path) -> str | None:
+    prompt_parts: list[str] = []
+    for dim in QG_DIMS:
+        prompt_path = module_dir / f"llm-qg-{dim}-prompt.md"
+        if not prompt_path.exists():
+            return None
+        prompt_parts.append(f"## {dim}\n{prompt_path.read_text(encoding='utf-8')}")
+    return prompt_hash_for_text("\n\n".join(prompt_parts))
+
+
 def _run_wiki_coverage_review(
     *,
     plan: Mapping[str, Any],
@@ -1467,15 +1511,28 @@ def _phase_artifact_passes(module_dir: Path, phase: str) -> bool:
             and str(data.get("overall_verdict", "")).upper() == "PASS"
         )
     if phase == "llm_qg":
-        data = _read_json(module_dir / "llm_qg.json")
-        if not isinstance(data, Mapping):
-            return False
-        aggregate = data.get("aggregate")
-        if not isinstance(aggregate, Mapping):
-            return False
-        terminal_verdict = aggregate.get("terminal_verdict", aggregate.get("verdict", ""))
-        return str(terminal_verdict).upper() == "PASS"
+        return _current_db_llm_qg_passes(module_dir)
     return False
+
+
+def _llm_qg_payload_passes(payload: Mapping[str, Any] | None) -> bool:
+    if not isinstance(payload, Mapping):
+        return False
+    aggregate = payload.get("aggregate")
+    if not isinstance(aggregate, Mapping):
+        return False
+    terminal_verdict = aggregate.get("terminal_verdict", aggregate.get("verdict", ""))
+    return str(terminal_verdict).upper() == "PASS"
+
+
+def _current_db_llm_qg_payload(module_dir: Path) -> dict[str, Any] | None:
+    level = module_dir.parent.name
+    slug = module_dir.name
+    return current_payload_for_module(level, slug, module_dir)
+
+
+def _current_db_llm_qg_passes(module_dir: Path) -> bool:
+    return _llm_qg_payload_passes(_current_db_llm_qg_payload(module_dir))
 
 
 def _run_stress_annotation_for_level(module_dir: Path, level: str) -> dict[str, Any]:
@@ -1962,12 +2019,14 @@ def _run(args: argparse.Namespace) -> int:
         llm_qg_reviewer_samples = linear_pipeline.llm_qg_reviewer_samples_for_level(level)
         timeout_agent = _reviewer_for_writer(writer, llm_qg_reviewer_override)
         started_at = time.monotonic()
+        resumed_llm_qg = _current_db_llm_qg_payload(module_dir)
         if (
             resume_enabled
             and not force_rerun
-            and _phase_artifact_passes(module_dir, "llm_qg")
+            and _llm_qg_payload_passes(resumed_llm_qg)
         ):
-            llm_qg = _read_json(module_dir / "llm_qg.json")
+            llm_qg = resumed_llm_qg
+            llm_qg_source = "v7_build:resumed-db"
             tracker.emit("phase_resumed", phase=phase, level=level, slug=slug)
         else:
             if resume_enabled:
@@ -2008,6 +2067,15 @@ def _run(args: argparse.Namespace) -> int:
                     reviewer_samples=llm_qg_reviewer_samples,
                 )
             linear_pipeline.write_json(module_dir / "llm_qg.json", llm_qg)
+            llm_qg_source = "v7_build"
+        _persist_llm_qg_result(
+            level=level,
+            slug=slug,
+            module_dir=module_dir,
+            llm_qg=llm_qg,
+            reviewer=_reviewer_for_writer(writer, llm_qg_reviewer_override),
+            source=llm_qg_source,
+        )
         aggregate = llm_qg["aggregate"]
         tracker.emit(
             "review_score",

--- a/tests/audit/test_content_surface_gates.py
+++ b/tests/audit/test_content_surface_gates.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from scripts.audit.content_surface_gates import scan_module_surface, scan_surface_text
+
+
+def test_a1_english_scaffolding_is_allowed() -> None:
+    text = """
+Read the dialogue and notice the verb.
+
+**Я чекаю на автобус.** — I am waiting for the bus.
+"""
+    report = scan_surface_text(text, level="a1")
+
+    assert report["passed"] is True
+    assert report["counts"]["critical"] == 0
+
+
+def test_a2_english_led_prose_warns_without_failing() -> None:
+    text = """
+This paragraph explains the whole grammar point in English before any Ukrainian anchor appears.
+
+**Я чекаю на автобус.**
+"""
+    report = scan_surface_text(text, level="a2")
+
+    assert report["passed"] is True
+    assert report["verdict"] == "WARN"
+    assert any(finding["type"] == "english_led_line" for finding in report["findings"])
+
+
+def test_b1_plus_english_led_prose_fails() -> None:
+    text = """
+This paragraph explains the whole grammar point in English before any Ukrainian anchor appears.
+
+**Я чекаю на автобус.**
+"""
+    report = scan_surface_text(text, level="b1")
+
+    assert report["passed"] is False
+    assert report["verdict"] == "FAIL"
+    assert any(
+        finding["type"] == "english_led_line" and finding["severity"] == "critical"
+        for finding in report["findings"]
+    )
+
+
+def test_ai_and_path_leaks_are_blocking_even_at_a1() -> None:
+    text = """
+As an AI, I cannot assist with this request.
+
+<activity_split_audit>level=B1 inline_n=1 workbook_n=2</activity_split_audit>
+
+Read /Users/person/project/curriculum/l2-uk-en/a1/foo/module.md.
+"""
+    report = scan_surface_text(text, level="a1")
+
+    assert report["passed"] is False
+    assert {finding["type"] for finding in report["findings"]} >= {"ai_leakage", "path_leakage"}
+
+
+def test_html_verify_comments_do_not_count_as_path_leaks() -> None:
+    text = """
+<!-- VERIFY: source="curriculum/l2-uk-en/plans/a1/foo.yaml" -->
+
+**Я чекаю на автобус.**
+"""
+    report = scan_surface_text(text, level="b1")
+
+    assert report["passed"] is True
+    assert report["findings"] == []
+
+
+def test_sidecar_scan_catches_ai_leak_without_english_ratio_false_positive(tmp_path) -> None:
+    module_dir = tmp_path / "b1" / "sidecar"
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text("## Урок\n\n**Я чекаю на автобус.**\n", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text(
+        "- type: quiz\n"
+        "  prompt: This YAML activity prompt is intentionally English but allowed as data.\n"
+        "  note: As an AI, I cannot assist with this request.\n",
+        encoding="utf-8",
+    )
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+
+    report = scan_module_surface(module_dir, level="b1")
+
+    assert report["passed"] is False
+    assert any(
+        finding["type"] == "ai_leakage" and finding["source"] == "activities.yaml"
+        for finding in report["findings"]
+    )
+    assert not any(
+        finding["type"] == "english_led_line" and finding["source"] == "activities.yaml"
+        for finding in report["findings"]
+    )

--- a/tests/audit/test_llm_qg_store.py
+++ b/tests/audit/test_llm_qg_store.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from scripts.audit.llm_qg_store import (
+    current_payload_for_module,
+    latest_llm_qg,
+    record_llm_qg,
+)
+
+
+def _module(tmp_path: Path) -> Path:
+    module_dir = tmp_path / "b1" / "aspect-in-imperatives"
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text("## Тест\n\nЧекайте на номер.\n", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    return module_dir
+
+
+def _payload(score: float = 7.5) -> dict:
+    return {
+        "aggregate": {
+            "verdict": "REVISE",
+            "terminal_verdict": "PASS",
+            "min_score": score,
+            "min_dim": "naturalness",
+            "failing_dims": ["naturalness"],
+            "warning_dims": ["naturalness"],
+        },
+        "dimensions": {
+            "naturalness": {
+                "score": score,
+                "verdict": "REVISE",
+                "evidence": '"Чекайте номер"',
+                "findings": [
+                    {
+                        "category": "government",
+                        "severity": "warning",
+                        "quote": "Чекайте номер",
+                        "replacement": "Чекайте на номер",
+                    }
+                ],
+            }
+        },
+    }
+
+
+def test_record_and_read_current_llm_qg(tmp_path: Path) -> None:
+    module_dir = _module(tmp_path)
+    db_path = tmp_path / "qg.db"
+
+    stored = record_llm_qg(
+        level="B1",
+        slug="aspect-in-imperatives",
+        module_dir=module_dir,
+        payload=_payload(),
+        gate_version="test.v1",
+        reviewer_model="review-model",
+        reviewer_family="reviewer-tools",
+        source="test",
+        path=db_path,
+    )
+    current = current_payload_for_module("b1", "aspect-in-imperatives", module_dir, path=db_path)
+
+    assert stored.level == "b1"
+    assert current is not None
+    assert current["aggregate"]["min_dim"] == "naturalness"
+    assert current["_store"]["gate_version"] == "test.v1"
+
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute("SELECT count(*) FROM llm_qg_findings").fetchone()[0]
+    assert count == 1
+
+
+def test_findings_index_uses_issue_id_when_category_is_absent(tmp_path: Path) -> None:
+    module_dir = _module(tmp_path)
+    db_path = tmp_path / "qg.db"
+    payload = _payload()
+    payload["dimensions"]["naturalness"]["findings"] = [
+        {
+            "issue_id": "UNNATURAL_ANTHROPOMORPHISM",
+            "severity": "high",
+            "quote": "Застереження каже",
+        }
+    ]
+
+    record_llm_qg(
+        level="b1",
+        slug="aspect-in-imperatives",
+        module_dir=module_dir,
+        payload=payload,
+        gate_version="test.v1",
+        path=db_path,
+    )
+
+    with sqlite3.connect(db_path) as conn:
+        category = conn.execute("SELECT category FROM llm_qg_findings").fetchone()[0]
+    assert category == "UNNATURAL_ANTHROPOMORPHISM"
+
+
+def test_current_llm_qg_is_hash_bound_to_module_content(tmp_path: Path) -> None:
+    module_dir = _module(tmp_path)
+    db_path = tmp_path / "qg.db"
+
+    record_llm_qg(
+        level="b1",
+        slug="aspect-in-imperatives",
+        module_dir=module_dir,
+        payload=_payload(),
+        gate_version="test.v1",
+        path=db_path,
+    )
+    (module_dir / "module.md").write_text("## Тест\n\nЧекайте на свій номер.\n", encoding="utf-8")
+
+    assert current_payload_for_module("b1", "aspect-in-imperatives", module_dir, path=db_path) is None
+    assert latest_llm_qg("b1", "aspect-in-imperatives", path=db_path) is not None

--- a/tests/audit/test_module_quality_audit.py
+++ b/tests/audit/test_module_quality_audit.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.audit.llm_qg_canaries import (
+    evaluate_canaries,
+    extract_issue_ids,
+    list_canaries,
+)
+from scripts.audit.llm_qg_store import record_llm_qg
+from scripts.audit.module_quality_audit import audit_modules, main, planned_modules
+
+
+def _write_module(root: Path, level: str, slug: str, body: str) -> Path:
+    module_dir = root / level / slug
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text(body, encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    return module_dir
+
+
+def _write_manifest(root: Path) -> None:
+    (root / "plans").mkdir(parents=True)
+    manifest = {
+        "levels": {
+            "a1": {"modules": ["01-intro"]},
+            "b1": {"modules": ["27-bad-style", "28-not-built"]},
+            "hist": {"modules": ["01-seminar"]},
+        }
+    }
+    (root / "curriculum.yaml").write_text(
+        yaml.safe_dump(manifest, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _payload() -> dict:
+    return {
+        "aggregate": {
+            "verdict": "PASS",
+            "terminal_verdict": "PASS",
+            "min_score": 8.5,
+            "min_dim": "naturalness",
+        },
+        "findings": [],
+    }
+
+
+def test_planned_modules_use_manifest_order_and_profiles(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+
+    modules = planned_modules(curriculum_root=tmp_path, level_ids=["a1", "b1", "hist"])
+
+    assert [(item.num, item.level, item.slug, item.profile) for item in modules] == [
+        (1, "a1", "intro", "a1"),
+        (1, "b1", "bad-style", "b1_plus"),
+        (2, "b1", "not-built", "b1_plus"),
+        (1, "hist", "seminar", "seminar"),
+    ]
+
+
+def test_audit_modules_reports_surface_and_llm_qg_coverage(tmp_path: Path) -> None:
+    _write_manifest(tmp_path)
+    a1_dir = _write_module(
+        tmp_path,
+        "a1",
+        "intro",
+        "Read the short dialogue.\n\n**Я тут.** - I am here.\n",
+    )
+    b1_dir = _write_module(
+        tmp_path,
+        "b1",
+        "bad-style",
+        "This paragraph explains the whole grammar point in English before Ukrainian appears.\n",
+    )
+    qg_artifact = b1_dir / "llm_qg.json"
+    qg_artifact.write_text(json.dumps(_payload()), encoding="utf-8")
+    (b1_dir / "module.md").write_text(
+        "This paragraph explains the whole grammar point in English before Ukrainian appears.\n\n"
+        "**Я тут.**\n",
+        encoding="utf-8",
+    )
+    db_path = tmp_path / "llm_qg.db"
+    record_llm_qg(
+        level="a1",
+        slug="intro",
+        module_dir=a1_dir,
+        payload=_payload(),
+        gate_version="test.v1",
+        prompt_hash="prompt-sha",
+        reviewer_model="review-model",
+        reviewer_family="reviewer-family",
+        source="test",
+        path=db_path,
+    )
+
+    report = audit_modules(
+        curriculum_root=tmp_path,
+        level_ids=["a1", "b1"],
+        db_path=db_path,
+        include_findings=False,
+    )
+
+    assert report["summary"]["planned_modules"] == 3
+    assert report["summary"]["built_modules"] == 2
+    assert report["summary"]["unbuilt_modules"] == 1
+    assert report["summary"]["surface_fail_modules"] == 1
+    assert report["summary"]["current_db_llm_qg_modules"] == 1
+    assert report["summary"]["stale_llm_qg_modules"] == 1
+    assert report["summary"]["modules_without_current_db_llm_qg"] == 1
+    assert report["summary"]["modules_needing_llm_review"] == 1
+    assert report["summary"]["modules_recommended_for_second_review"] == 1
+
+    rows = {(row["level"], row["slug"]): row for row in report["modules"]}
+    assert rows[("a1", "intro")]["llm_qg_status"] == "current_db"
+    assert rows[("a1", "intro")]["llm_qg_gate_version"] == "test.v1"
+    assert rows[("a1", "intro")]["llm_qg_prompt_hash"] == "prompt-sha"
+    assert rows[("a1", "intro")]["llm_qg_reviewer_family"] == "reviewer-family"
+    assert rows[("a1", "intro")]["llm_qg_reviewer_model"] == "review-model"
+    assert rows[("b1", "bad-style")]["llm_qg_status"] == "stale_file"
+    assert rows[("b1", "bad-style")]["surface_verdict"] == "FAIL"
+    assert rows[("b1", "bad-style")]["second_review_reason"] == "surface_fail"
+    assert rows[("b1", "not-built")]["llm_qg_status"] == "not_built"
+
+
+def test_cli_json_output(tmp_path: Path, capsys) -> None:
+    _write_manifest(tmp_path)
+    _write_module(tmp_path, "a1", "intro", "**Я тут.**\n")
+
+    code = main(
+        [
+            "--curriculum-root",
+            str(tmp_path),
+            "--level",
+            "a1",
+            "--llm-qg-db",
+            str(tmp_path / "missing.db"),
+            "--format",
+            "json",
+        ]
+    )
+
+    assert code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["summary"]["planned_modules"] == 1
+    assert output["summary"]["missing_llm_qg_modules"] == 1
+
+
+def test_cli_includes_canary_results_and_can_fail_on_canary_failure(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    _write_manifest(tmp_path)
+    _write_module(tmp_path, "b1", "bad-style", "**Я тут.**\n")
+    canary_path = tmp_path / "canary.json"
+    canary_path.write_text(
+        json.dumps({"findings": [{"issue_id": "AI_LEAKAGE"}]}),
+        encoding="utf-8",
+    )
+
+    code = main(
+        [
+            "--curriculum-root",
+            str(tmp_path),
+            "--level",
+            "b1",
+            "--format",
+            "json",
+            "--canary-result",
+            f"b1={canary_path}",
+            "--fail-on-canary-failure",
+        ]
+    )
+
+    assert code == 1
+    output = json.loads(capsys.readouterr().out)
+    assert output["canaries"]["b1"]["passed"] is False
+    assert "AWKWARD_PASSIVE_RESULT_STATE" in output["canaries"]["b1"]["missing_issue_ids"]
+
+
+def test_b1_canary_snippets_include_required_examples() -> None:
+    b1_snippets = [item.snippet for item in list_canaries("b1")]
+
+    assert any("застосунок має бути відкритий" in snippet for snippet in b1_snippets)
+    assert any(
+        "Застереження каже: будь обережний, щоб небажаний результат не стався."
+        in snippet
+        for snippet in b1_snippets
+    )
+
+
+def test_extract_issue_ids_reads_top_level_and_dimensional_findings() -> None:
+    result = {
+        "issue_ids": ["internal_leakage"],
+        "flags": ["awkward passive result state"],
+        "aggregate": {
+            "findings": [{"type": "ai_leakage"}, {"issue_type": "path_leakage"}],
+        },
+        "dimensions": {
+            "register": {
+                "findings": [
+                    {"kind": "seminar_register_pathos"},
+                    {"type": "ENGLISH_LEAKAGE"},
+                ],
+                "flags_raised": ["unnatural anthropomorphism"],
+            },
+        },
+        "other": "must be ignored",
+    }
+
+    assert set(extract_issue_ids(result)) == {
+        "AI_LEAKAGE",
+        "PATH_LEAKAGE",
+        "SEMINAR_REGISTER_PATHOS",
+        "ENGLISH_LEAKAGE",
+        "INTERNAL_LEAKAGE",
+        "AWKWARD_PASSIVE_RESULT_STATE",
+        "UNNATURAL_ANTHROPOMORPHISM",
+    }
+
+
+def test_evaluator_fails_when_required_issue_ids_are_missing_for_level() -> None:
+    result = {
+        "findings": [
+            {"issue_type": "AI_LEAKAGE"},
+            {"issue_type": "PATH_LEAKAGE"},
+            {"issue_type": "INTERNAL_LEAKAGE"},
+            {"issue_type": "AWKWARD_PASSIVE_RESULT_STATE"},
+        ],
+    }
+
+    report = evaluate_canaries(result, "b1")
+    assert not report["passed"]
+    assert report["level"] == "b1"
+    assert "UNNATURAL_ANTHROPOMORPHISM" in report["missing_issue_ids"]
+    assert "ENGLISH_LEAKAGE" in report["missing_issue_ids"]
+
+
+def test_evaluator_can_score_one_named_canary() -> None:
+    result = {
+        "canary_id": "b1-passive-result-state",
+        "findings": [{"issue_id": "AWKWARD_PASSIVE_RESULT_STATE"}],
+    }
+
+    report = evaluate_canaries(result, "b1")
+
+    assert report["passed"]
+    assert report["canary_ids"] == ("b1-passive-result-state",)
+    assert report["missing_issue_ids"] == ()
+
+
+def test_evaluator_marks_pass_when_all_required_issue_ids_present() -> None:
+    level = "seminar"
+    required = set()
+    for canary in list_canaries(level):
+        required.update(canary.required_issue_ids)
+
+    result = {"findings": [{"type": issue_id} for issue_id in sorted(required)]}
+    report = evaluate_canaries(result, level)
+
+    assert report["passed"]
+    assert report["missing_issue_ids"] == ()
+    assert set(report["matched_canaries"]) == {
+        canary.canary_id for canary in list_canaries(level)
+    }
+
+
+def test_evaluator_fails_when_allow_list_canary_is_false_positive() -> None:
+    result = {
+        "findings": [{"issue_id": "AI_LEAKAGE"}],
+        "dimensions": {"tone": {"flags": ["ENGLISH_LEAKAGE"]}},
+    }
+
+    report = evaluate_canaries(result, "a1")
+
+    assert not report["passed"]
+    assert "ENGLISH_LEAKAGE" in report["forbidden_issue_ids"]
+    assert "ENGLISH_LEAKAGE" in report["forbidden_issue_ids_found"]
+    assert "a1-english-scaffold-allowed" in report["missed_canaries"]
+
+
+@pytest.mark.parametrize("level", ["a1", "a2", "b1", "seminar", "any"])
+def test_list_canaries_includes_global_and_level_specific_rules(level: str) -> None:
+    ids = {canary.canary_id for canary in list_canaries(level)}
+
+    assert "surface-ai-leakage" in ids
+    assert "surface-path-leakage" in ids
+    assert "surface-internal-leakage" in ids
+
+    if level == "a1":
+        assert "a1-english-scaffold-allowed" in ids
+        return
+
+    if level == "a2":
+        assert "a2-english-gloss-allowed" in ids
+        return
+
+    if level == "b1":
+        assert "b1-passive-result-state" in ids
+        assert "b1-anthropomorphic-pathos" in ids
+        assert "policy-b1-english-led" in ids
+        return
+
+    if level == "seminar":
+        assert "policy-seminar-english-led" in ids
+        assert "seminar-register-pathos" in ids
+        return
+
+    assert level == "any"
+    required = set(
+        issue
+        for canary in list_canaries(level)
+        for issue in canary.required_issue_ids
+    )
+    assert "AI_LEAKAGE" in required
+
+
+def test_seminar_track_ids_use_seminar_canaries() -> None:
+    ids = {canary.canary_id for canary in list_canaries("hist")}
+
+    assert "policy-seminar-english-led" in ids
+    assert "seminar-register-pathos" in ids

--- a/tests/test_api_state_scores.py
+++ b/tests/test_api_state_scores.py
@@ -9,6 +9,7 @@ status cache, and must degrade gracefully when a module has not been scored.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -16,8 +17,13 @@ from fastapi.testclient import TestClient
 import scripts.api.main as api_main
 import scripts.api.state_router as state_router
 from scripts.api.state_router import _read_llm_qg_scores
+from scripts.audit.llm_qg_store import DB_ENV_VAR, record_llm_qg
 
 client = TestClient(api_main.app, raise_server_exceptions=False)
+
+
+def _set_mtime_ns(path: Path, value: int) -> None:
+    os.utime(path, ns=(value, value))
 
 
 def _write_llm_qg(module_dir: Path, *, dims: dict[str, float], aggregate: dict) -> None:
@@ -64,6 +70,74 @@ def test_read_scores_malformed_json_degrades(tmp_path: Path) -> None:
     (tmp_path / "llm_qg.json").write_text("{ not json", encoding="utf-8")
     out = _read_llm_qg_scores(tmp_path)
     assert out == {"aggregate": None, "dimensions": {}}
+
+
+def test_read_scores_ignores_stale_file_fallback(tmp_path: Path) -> None:
+    module_dir = tmp_path / "b1" / "stale-mod"
+    _write_llm_qg(
+        module_dir,
+        dims={"naturalness": 8.0},
+        aggregate={
+            "verdict": "PASS",
+            "terminal_verdict": "PASS",
+            "min_score": 8.0,
+            "min_dim": "naturalness",
+            "failing_dims": [],
+            "warning_dims": [],
+        },
+    )
+    (module_dir / "module.md").write_text("## Changed\n\nНовий текст.\n", encoding="utf-8")
+    _set_mtime_ns(module_dir / "llm_qg.json", 1_000_000_000)
+    _set_mtime_ns(module_dir / "module.md", 2_000_000_000)
+
+    out = _read_llm_qg_scores(module_dir)
+
+    assert out == {"aggregate": None, "dimensions": {}}
+
+
+def test_read_scores_corrupt_db_degrades(tmp_path: Path, monkeypatch) -> None:
+    bad_db = tmp_path / "bad.db"
+    bad_db.write_text("not sqlite", encoding="utf-8")
+    monkeypatch.setenv(DB_ENV_VAR, str(bad_db))
+    module_dir = tmp_path / "b1" / "unscored"
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text("## Тест\n\nЧекайте на номер.\n", encoding="utf-8")
+
+    out = _read_llm_qg_scores(module_dir)
+
+    assert out == {"aggregate": None, "dimensions": {}}
+
+
+def test_read_scores_uses_persisted_current_qg_without_file(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv(DB_ENV_VAR, str(tmp_path / "llm_qg.db"))
+    module_dir = tmp_path / "b1" / "stored-mod"
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text("## Тест\n\nЧекайте на номер.\n", encoding="utf-8")
+    record_llm_qg(
+        level="b1",
+        slug="stored-mod",
+        module_dir=module_dir,
+        payload={
+            "dimensions": {"naturalness": {"score": 6.5, "verdict": "REVISE"}},
+            "aggregate": {
+                "verdict": "REVISE",
+                "terminal_verdict": "PASS",
+                "min_score": 6.5,
+                "min_dim": "naturalness",
+                "failing_dims": ["naturalness"],
+                "warning_dims": ["naturalness"],
+            },
+        },
+        gate_version="test.v1",
+    )
+
+    out = _read_llm_qg_scores(module_dir)
+
+    assert out["dimensions"] == {"naturalness": 6.5}
+    assert out["aggregate"]["min_dim"] == "naturalness"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_linear_pipeline_telemetry.py
+++ b/tests/test_linear_pipeline_telemetry.py
@@ -379,6 +379,36 @@ def test_writer_rule_fired_event_emitted_on_known_failure_class(tmp_path: Path) 
     )
 
 
+def test_python_qg_surface_policy_scans_yaml_sidecars(tmp_path: Path) -> None:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text("## Урок\n\n**Я чекаю на автобус.**\n", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text(
+        "- type: quiz\n"
+        "  prompt: Обери відповідь.\n"
+        "  note: As an AI, I cannot assist with this request.\n",
+        encoding="utf-8",
+    )
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "resources.yaml").write_text("[]\n", encoding="utf-8")
+
+    def verify_words(words: list[str]) -> dict[str, list[dict[str, str]]]:
+        return {word: [{"lemma": word}] for word in words}
+
+    report = linear_pipeline.run_python_qg(
+        module_dir,
+        linear_pipeline.plan_path_for("a1", "my-morning"),
+        verify_words_fn=verify_words,
+    )
+
+    surface_policy = report["gates"]["surface_policy"]
+    assert surface_policy["passed"] is False
+    assert any(
+        finding["type"] == "ai_leakage" and finding["source"] == "activities.yaml"
+        for finding in surface_policy["findings"]
+    )
+
+
 def test_mcp_tools_writer_runtime_gate_still_fires_for_empty_tool_calls() -> None:
     with pytest.raises(
         linear_pipeline.LinearPipelineError,

--- a/tests/test_python_qg_correction_loop.py
+++ b/tests/test_python_qg_correction_loop.py
@@ -244,6 +244,21 @@ def test_python_qg_frontier_does_not_rank_unmapped_failure_as_pass() -> None:
     assert linear_pipeline._python_qg_frontier_gate(report) == "future_unmapped_gate"
 
 
+def test_surface_policy_is_ranked_in_python_qg_frontier() -> None:
+    report = _qg_report_from_gates(
+        {
+            "ai_slop_clean": {"passed": True, "violations": []},
+            "surface_policy": {"passed": False, "findings": [{"type": "ai_leakage"}]},
+        }
+    )
+
+    assert "surface_policy" in linear_pipeline.PYTHON_QG_GATE_ORDER
+    assert linear_pipeline._python_qg_frontier(report) == linear_pipeline.PYTHON_QG_GATE_ORDER.index(
+        "surface_policy"
+    )
+    assert linear_pipeline._python_qg_frontier_gate(report) == "surface_policy"
+
+
 def test_previous_regression_scans_actual_gate_key_union() -> None:
     before = _qg_report_from_gates(
         {

--- a/tests/test_reviewer_prompt_v7_register_rules.py
+++ b/tests/test_reviewer_prompt_v7_register_rules.py
@@ -94,3 +94,33 @@ def test_reviewer_prompt_flags_unsupported_grammar_taxonomies() -> None:
     )
     for anchor in anchors:
         assert _normalize(anchor) in normalized
+
+
+def test_reviewer_prompt_has_level_calibration_for_english_scaffolding() -> None:
+    normalized = _normalize(_prompt())
+
+    anchors = (
+        "Level Calibration — do not mis-score intended scaffolding",
+        "A1: English scaffolding is expected and often substantial",
+        "A2: easy Ukrainian should be the default body voice",
+        "B1/B2/C1/C2: learner-facing prose should be Ukrainian-led",
+        "Seminars: use advanced Ukrainian teaching voice",
+    )
+    for anchor in anchors:
+        assert _normalize(anchor) in normalized
+
+
+def test_reviewer_prompt_naturalness_requires_native_style_defects() -> None:
+    normalized = _normalize(_prompt())
+
+    anchors = (
+        "This is a linguistic-quality review, not a vibes review",
+        "calqued or evasive passives where native Ukrainian would use an active, impersonal, or result-state construction",
+        "wrong government/prepositions (for example, prefer `чекати на когось/щось`",
+        "wrong verb choice for ordinary Ukrainian collocations",
+        "`відімкнути/замкнути` for lock/unlock actions",
+        "`форма просить`, `застереження каже`, `правило хоче`",
+        "score naturalness below PASS even when deterministic gates passed",
+    )
+    for anchor in anchors:
+        assert _normalize(anchor) in normalized

--- a/tests/test_v7_build_reviewer_assert.py
+++ b/tests/test_v7_build_reviewer_assert.py
@@ -1,12 +1,18 @@
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
-from scripts.build import linear_pipeline, v7_build
+from scripts.audit.llm_qg_store import latest_llm_qg, record_llm_qg
+from scripts.build import linear_pipeline, run_llm_qg_parity, v7_build
 from scripts.common.thresholds import QG_DIMS
+
+
+def _set_mtime_ns(path: Path, value: int) -> None:
+    os.utime(path, ns=(value, value))
 
 
 def test_reviewer_override_normalizes_alias():
@@ -15,6 +21,69 @@ def test_reviewer_override_normalizes_alias():
     )
 
     assert v7_build._reviewer_for_writer(args.writer, args.reviewer) == "cursor-tools"
+
+
+def test_llm_qg_phase_artifact_does_not_resume_stale_file(tmp_path: Path) -> None:
+    (tmp_path / "module.md").write_text("## Original\n\nТекст.\n", encoding="utf-8")
+    (tmp_path / "activities.yaml").write_text("[]\n", encoding="utf-8")
+    (tmp_path / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    (tmp_path / "llm_qg.json").write_text(
+        json.dumps(
+            {
+                "aggregate": {
+                    "verdict": "PASS",
+                    "terminal_verdict": "PASS",
+                    "min_score": 8.0,
+                    "min_dim": "naturalness",
+                },
+                "dimensions": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    _set_mtime_ns(tmp_path / "llm_qg.json", 1_000_000_000)
+    _set_mtime_ns(tmp_path / "module.md", 2_000_000_000)
+
+    assert v7_build._phase_artifact_passes(tmp_path, "llm_qg") is False
+
+
+def test_llm_qg_phase_artifact_requires_current_db_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "llm_qg.db"
+    monkeypatch.setenv("LEARN_UKRAINIAN_LLM_QG_DB", str(db_path))
+    module_dir = tmp_path / "b1" / "target"
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text("## Тест\n\nТекст.\n", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "llm_qg.json").write_text(
+        json.dumps(
+            {
+                "aggregate": {
+                    "verdict": "PASS",
+                    "terminal_verdict": "PASS",
+                    "min_score": 8.0,
+                    "min_dim": "naturalness",
+                },
+                "dimensions": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert v7_build._phase_artifact_passes(module_dir, "llm_qg") is False
+
+    record_llm_qg(
+        level="b1",
+        slug="target",
+        module_dir=module_dir,
+        payload=json.loads((module_dir / "llm_qg.json").read_text(encoding="utf-8")),
+        gate_version="test.v1",
+    )
+
+    assert v7_build._phase_artifact_passes(module_dir, "llm_qg") is True
 
 
 def test_seminar_llm_qg_routes_away_from_gemini_reviewer():
@@ -172,6 +241,47 @@ def _llm_qg_response(dim: str) -> str:
     )
 
 
+def test_llm_qg_parse_preserves_structured_issue_findings() -> None:
+    response = json.dumps(
+        {
+            "score": 6.5,
+            "evidence_quotes": [
+                "застосунок має бути відкритий",
+                "Застереження каже: будь обережний",
+                "Чекайте номер біля входу",
+            ],
+            "rubric_mapping": "Quote 1: passive; Quote 2: anthropomorphism; Quote 3: government.",
+            "evidence": '"застосунок має бути відкритий"',
+            "issue_ids": ["awkward passive result state"],
+            "findings": [
+                {
+                    "issue_id": "unnatural anthropomorphism",
+                    "quote": "Застереження каже",
+                    "severity": "high",
+                    "explanation": "Anthropomorphic metatext.",
+                }
+            ],
+            "flags": ["чекати government"],
+            "verdict": "REVISE",
+        }
+    )
+
+    entry = linear_pipeline.parse_review_response(response, "naturalness")
+
+    assert entry["issue_ids"] == [
+        "AWKWARD_PASSIVE_RESULT_STATE",
+        "UNNATURAL_ANTHROPOMORPHISM",
+    ]
+    assert entry["findings"] == [
+        {
+            "issue_id": "UNNATURAL_ANTHROPOMORPHISM",
+            "quote": "Застереження каже",
+            "severity": "high",
+            "explanation": "Anthropomorphic metatext.",
+        }
+    ]
+
+
 def _patch_llm_qg_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         v7_build.linear_pipeline,
@@ -278,3 +388,93 @@ def test_llm_qg_reports_malformed_dimension_response_clearly(
     assert f"LLM QG {QG_DIMS[0]} failed after" in message
     assert "malformed backend response" in message
     assert "response.raw.md" in message
+
+
+def test_run_llm_qg_parity_persists_sqlite_record(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text("level: b1\nslug: target\n", encoding="utf-8")
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text("## Модуль\n", encoding="utf-8")
+    llm_qg = {
+        "aggregate": {
+            "verdict": "PASS",
+            "terminal_verdict": "PASS",
+            "min_score": 8.5,
+            "min_dim": "naturalness",
+        },
+        "dimensions": {},
+    }
+    persisted: dict[str, object] = {}
+
+    monkeypatch.setattr(run_llm_qg_parity.linear_pipeline, "plan_path_for", lambda *_args: plan_path)
+    monkeypatch.setattr(run_llm_qg_parity.linear_pipeline, "load_plan", lambda _path: {"level": "b1", "slug": "target"})
+    monkeypatch.setattr(run_llm_qg_parity.linear_pipeline, "validate_plan", lambda _plan: None)
+    monkeypatch.setattr(run_llm_qg_parity.linear_pipeline, "curriculum_profile_for_level", lambda _level: "core")
+    monkeypatch.setattr(run_llm_qg_parity.v7_build, "_resolve_output_dir", lambda *_args: module_dir)
+    monkeypatch.setattr(run_llm_qg_parity.v7_build, "_run_llm_qg", lambda **_kwargs: llm_qg)
+    monkeypatch.setattr(
+        run_llm_qg_parity.v7_build,
+        "_persist_llm_qg_result",
+        lambda **kwargs: persisted.update(kwargs),
+    )
+
+    assert (
+        run_llm_qg_parity.run_parity(
+            "b1",
+            "target",
+            writer="claude-tools",
+            reviewer="codex-tools",
+            out=None,
+        )
+        == 0
+    )
+
+    assert (module_dir / "llm_qg.json").exists()
+    assert persisted["level"] == "b1"
+    assert persisted["slug"] == "target"
+    assert persisted["module_dir"] == module_dir
+    assert persisted["reviewer"] == "codex-tools"
+    assert persisted["source"] == "run_llm_qg_parity"
+
+
+def test_persist_llm_qg_records_combined_prompt_hash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "llm_qg.db"
+    monkeypatch.setenv("LEARN_UKRAINIAN_LLM_QG_DB", str(db_path))
+    module_dir = tmp_path / "b1" / "target"
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text("## Тест\n", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    for dim in QG_DIMS:
+        (module_dir / f"llm-qg-{dim}-prompt.md").write_text(
+            f"prompt for {dim}\n",
+            encoding="utf-8",
+        )
+
+    v7_build._persist_llm_qg_result(
+        level="b1",
+        slug="target",
+        module_dir=module_dir,
+        llm_qg={
+            "aggregate": {
+                "verdict": "PASS",
+                "terminal_verdict": "PASS",
+                "min_score": 8.5,
+                "min_dim": "naturalness",
+            },
+            "dimensions": {},
+        },
+        reviewer="codex-tools",
+        source="test",
+    )
+
+    stored = latest_llm_qg("b1", "target")
+    assert stored is not None
+    assert stored.prompt_hash is not None


### PR DESCRIPTION
## Summary

Closes #4216.

Implements the module quality-gate infrastructure for the B1/native-Ukrainian-style failure class and the missing LLM-QG persistence problem:

- adds a level-aware deterministic `surface_policy` gate for AI leakage, path/internal leakage, English leakage, and pathos/register surface issues;
- adds durable SQLite LLM-QG persistence with content-hash freshness over `module.md`, `activities.yaml`, `vocabulary.yaml`, and `resources.yaml`;
- updates API readers to prefer current DB records and reject stale fallback `llm_qg.json`;
- hardens the LLM reviewer prompt for A1/A2/B1+/seminar calibration and native Ukrainian naturalness issues (`застосунок має бути відкритий`, `Застереження каже`, collocations, government, register);
- preserves structured reviewer `issue_ids` / `findings`, indexes `issue_id` in the findings table, and stores prompt hashes;
- adds canary calibration tooling for known bad and allowed-good cases;
- adds all-module audit CLI with reviewer metadata and second-review recommendations;
- changes LLM-QG resume to trust only DB-current records, not mtime-fresh `llm_qg.json`;
- documents the runbook and cost-controlled second-review policy.

This does **not** claim the existing corpus is clean. The full corpus remediation batch is tracked separately in #4218.

## Audit Evidence

Real all-module audit run:

```text
Planned modules: 1934
Built modules: 319
Unbuilt modules: 1615
Surface FAIL/WARN: 238/1
Current DB LLM-QG: 0
Current file-only LLM-QG: 0
Stale LLM-QG: 0
Missing LLM-QG: 319
Built modules without current DB LLM-QG: 319
Built modules without current DB/file LLM-QG: 319
Modules needing LLM review: 319
Modules needing DB persistence: 319
Modules recommended for second review: 319
```

Live B1 canary calibration via Agy/Gemini caught all expected issue IDs:

- `AWKWARD_PASSIVE_RESULT_STATE`
- `UNNATURAL_ANTHROPOMORPHISM`
- `ENGLISH_LEAKAGE`
- `AI_LEAKAGE`
- `PATH_LEAKAGE`
- `INTERNAL_LEAKAGE`

Live local DB smoke wrote a temp LLM-QG record, verified prompt hash persistence, DB-backed current readback, and `issue_id` indexing.

## External Review

- Codex subagents reviewed persistence/API, deterministic gates, and prompt/language calibration.
- Agy/Gemini live canary review passed.
- Cursor external implementation review found blockers; all were fixed:
  - DB-only LLM-QG resume;
  - per-canary evaluator semantics;
  - seminar track canary mapping;
  - prompt hash persistence;
  - `issue_id` indexing in `llm_qg_findings`.
- Hermes/DeepSeek route was attempted but unavailable: `HTTP 401: token expired or incorrect`.

## Verification

```text
.venv/bin/python -m pytest tests/test_llm_qg_api.py tests/test_v7_build_reviewer_assert.py tests/test_v7_build_persist_guard.py tests/test_prompt_cot_tier1_scaffolding.py tests/test_python_qg_correction_loop.py tests/test_linear_pipeline_telemetry.py::test_python_qg_surface_policy_scans_yaml_sidecars tests/audit/test_content_surface_gates.py tests/audit/test_llm_qg_store.py tests/audit/test_module_quality_audit.py tests/test_api_state_scores.py tests/test_reviewer_prompt_v7_register_rules.py
# 166 passed

.venv/bin/ruff check scripts/audit/content_surface_gates.py scripts/audit/llm_qg_store.py scripts/audit/llm_qg_canaries.py scripts/audit/module_quality_audit.py scripts/build/linear_pipeline.py scripts/build/v7_build.py scripts/build/run_llm_qg_parity.py tests/audit/test_content_surface_gates.py tests/audit/test_llm_qg_store.py tests/audit/test_module_quality_audit.py tests/test_api_state_scores.py tests/test_linear_pipeline_telemetry.py tests/test_python_qg_correction_loop.py tests/test_reviewer_prompt_v7_register_rules.py tests/test_v7_build_reviewer_assert.py
# All checks passed

.venv/bin/python scripts/audit/lint_agent_trailer.py
# PASS

git diff --check
# clean
```

Pre-commit on commit also ran Ruff, gitleaks, affected pytest (`79 passed`), and repository guardrails.