### PR TITLE
[codex] Add Ivan Briukhovetskyi BIO dossier

### DIFF
--- a/docs/research/bio/ivan-briukhovetskyi.md
+++ b/docs/research/bio/ivan-briukhovetskyi.md
@@ -1,0 +1,230 @@
+# Іван Мартинович Брюховецький — Research Dossier
+
+**Slug:** `ivan-briukhovetskyi`
+**Block:** G (politically charged Ruin-era Hetmanate figure; Black Council, populism, Moscow leverage, Moscow Articles, and collapse)
+**Tier:** 1a
+**Issue:** #4215 (BIO full Cossack coverage epic — P0 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕІУ, IEU, ЕІУ Chorna Rada, ЕІУ Left-Bank uprising, IEU Moscow/Baturyn Articles, NBUV/Ukrainica pointer)
+- [x] Source-tier checkboxes included and lower-tier sources kept non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: Moscow-backed electoral engineering, Moscow Articles, voivode/garrison/fiscal incorporation, Andrusovo shock, 1668 revolt/death)
+- [x] §4 includes 1 corpus-verified chronicle excerpt plus 2 document excerpts with verification caveats
+- [x] Black Council and popular politics are framed without blaming "the people" or flattening Briukhovetskyi into a one-word collaborator
+- [x] Cross-track links: every "Existing" plan path verified with `test -e`/`rg --files` on 2026-07-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+- [x] **T1 baseline:** ЕІУ and Internet Encyclopedia of Ukraine anchor core facts, dates, offices, Black Council sequence, Moscow Articles, and 1668 rebellion/death.
+- [x] **T2/T4 scholarship:** Horobets's 2019 Institute-hosted monograph page/PDF and NBUV/Ukrainica pointer frame interpretation and bibliography.
+- [x] **T3/T5 caution:** Wikipedia, textbook/web хрестоматія, and general web are navigation or primary-text-transcription aids only; they are not load-bearing for interpretation.
+- [x] **Primary/doc excerpts:** short excerpts are explicitly marked by corpus/document status; source editions should be rechecked before classroom quotation.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Іван Мартинович Брюховецький. [T1: ЕІУ; T1: IEU]
+- **Pseudonyms / aliases:** Іван Брюховецький; кошовий отаман / кошовий гетьман in the Sich phase; Ivan Briukhovetskyi; Ivan Briukhovetsky; Brjuxovec'kyj in IEU transliteration. Forbidden body-text forms: Иван Брюховецкий; "малоросійський гетьман" as a normalized identity; "московський агент" or "зрадник" as a total explanation rather than an analyzed political frame.
+- **Born:** approximately **1623**; birthplace uncertain. ЕІУ says he was probably born into a noble family but does not anchor a place; lower-tier summaries sometimes attach him to Dykanka/Poltava region. Use "ca. 1623, place uncertain" unless a module directly verifies a place-source. [T1: ЕІУ; T3]
+- **Died:** **17 June 1668 O.S.**; IEU gives **18 June 1668**; some modern summaries render **17/27 June 1668**. The stable classroom formulation is "June 1668, during the Left-Bank/Right-Bank encounter with Petro Doroshenko's forces." [T1: ЕІУ; T1: IEU; T3]
+- **Death place / burial:** ЕІУ places his death near Dykanka during the joint general council; IEU says the village of Budyshchi near Opishnia. ЕІУ says Doroshenko ordered the body taken to Hadiach and buried with hetman honors. Treat exact death-place wording as source-sensitive. [T1: ЕІУ; T1: IEU]
+- **Family / education key facts:** served at Bohdan Khmelnytskyy's court as a senior servant/attendant and was connected with the upbringing of Yurii Khmelnytskyi; performed diplomatic errands, including a 1656 Transylvanian mission and a 1658 Warsaw mission for Ivan Vyhovskyi. [T1: ЕІУ]
+- **Office / role:** Zaporozhian Sich leader / kish otaman in the early 1660s; hetman of Left-Bank Ukraine, **1663-1668**. His biography is central to the Black Council, the social legitimacy crisis of the Ruin, and the shift from protectorate bargaining to Moscow-directed incorporation. [T1: ЕІУ; T1: IEU; T4: Horobets]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Birthplace:** do not present Dykanka as fact. It is plausible in lower-tier memory, but the Tier 1 ЕІУ entry only gives a probable social origin.
+2. **Sich office dates:** IEU gives otaman **1661-1663**; ЕІУ says he was elected kish otaman in autumn 1659 and in 1661 accepted the title of kish hetman. Use "Sich leader in the early 1660s" unless teaching the office chronology directly.
+3. **Black Council date:** ЕІУ gives **27-28 June 1663 N.S. / 17-18 June O.S.** near Nizhyn. IEU gives 17-18 June without unpacking calendar style. Use both forms when precision matters.
+4. **Death date/place:** 17 June O.S., 18 June, and 17/27 June forms circulate. The stable fact is violent death in June 1668 during the collapse of his Left-Bank authority.
+5. **Moscow Articles date:** IEU gives **11 October 1665**; source transcriptions often give **22 October 1665** in new-style rendering. Avoid mixing calendar systems silently.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Briukhovetskyi rose by combining Sich legitimacy, social-populist rhetoric against starshyna privilege, and Moscow support. The result was not popular sovereignty. The 1663 Black Council was held under Russian tsarist instruction and with tsarist military presence; ЕІУ stresses that the election outcome was effectively pre-shaped by Moscow's decision to secure Briukhovetskyi's victory. Afterward, his rivals Yakym Somko and Vasyl Zolotarenko were eliminated, and his government moved toward deeper dependence on Moscow. [T1: ЕІУ Chorna Rada; T1: IEU]
+
+**By whom:** Moscow/tsarist power in the election-management, garrison, voivode, fiscal, diplomatic, and church-control layers; Briukhovetskyi and his circle in the local agency layer; parts of the Left-Bank starshyna and Sich milieu in the coalition layer. The dossier must not erase any side's agency.
+
+**Document references:** the **Baturyn Articles (1663)**, the **Moscow Articles (1665)**, the **Andrusovo Truce (1667)**, and the 1668 Left-Bank anti-Moscow uprising. The Moscow Articles are the load-bearing document for the incorporation mechanism: Hetmanate foreign relations were restricted, Muscovite garrisons and voivodes expanded, taxes on non-Cossacks were redirected to the tsar's treasury, and the Kyivan church question was drawn toward Moscow. [T1: IEU Moscow Articles; T1: ЕІУ; T5/primary transcription]
+
+**Mechanism specifics:** the imperial simplification is to make Briukhovetskyi a useful "loyal Little Russian" until he is no longer useful. The opposite simplification is to make him only a venal collaborator. A decolonized BIO reading has to show how Moscow exploited internal Hetmanate conflicts, social grievance, and the language of protection; how Briukhovetskyi used Moscow leverage against rival elites; and how the 1665 agreement then narrowed the political space of the Hetmanate itself. [T1: ЕІУ; T1: IEU; T4: Horobets]
+
+**What survived / what was distorted:** the Black Council survived in literature and public memory through Kulish, but that memory can over-moralize the "chern" and blame mass politics alone. The distortion to avoid is "the people caused the Ruin." The structural lesson is harder: starshyna privilege, Sich autonomy, Moscow intervention, Polish-Muscovite partition diplomacy, and Briukhovetskyi's own opportunism all interacted.
+
+## 3. Major works / legacy
+
+- `1650s` — served at Bohdan Khmelnytskyy's court and performed diplomatic/household-political tasks, including care connected with Yurii Khmelnytskyi. [T1: ЕІУ]
+- `1656` — visited Transylvania to normalize relations and explore a military-political alliance. [T1: ЕІУ]
+- `1657-1658` — accompanied Yurii Khmelnytskyi to Kyiv-Mohyla College; visited Warsaw on Vyhovskyi's assignment. [T1: ЕІУ]
+- `1659-1661` — moved into Sich politics, led anti-hetman agitation, and became a Sich authority figure; date/title details vary by source. [T1: ЕІУ; T1: IEU]
+- `1661-1663` — built a campaign for the Left-Bank mace through Moscow contacts, anti-starshyna rhetoric, and support from Zaporozhian and lower-estate constituencies. [T1: ЕІУ Chorna Rada; T4: Horobets]
+- `27-28 June 1663 N.S. / 17-18 June O.S.` — Black Council near Nizhyn; elected Left-Bank hetman in a process shaped by Moscow support and social conflict. [T1: ЕІУ Chorna Rada; T1: IEU]
+- `1663` — Baturyn Articles confirmed the earlier protectorate framework and added obligations including provisioning Russian troops in Ukraine; a precursor to the more severe 1665 settlement. [T1: IEU Baturyn Articles]
+- `1663` — eliminated principal rivals Yakym Somko and Vasyl Zolotarenko; this consolidated power but deepened the legitimacy crisis. [T1: ЕІУ; T1: IEU]
+- `1663-1665` — attempted to strengthen hetman authority, discipline opposition, manage finances, subordinate city communities, and reduce Sich influence in Left-Bank politics. [T1: ЕІУ]
+- `11/22 October 1665` — signed the Moscow Articles, the most consequential institutional concession of his rule. IEU describes the terms as essentially obliterating Hetman-state sovereignty except for Cossack estate autonomy. [T1: IEU Moscow Articles; T5/primary transcription]
+- `1665` — received the title of boyar, lands, and marriage into the Dolgoruky family; this personal elevation made his identification with Moscow power politically explosive at home. [T1: IEU; T4: Horobets]
+- `1666` — implementation of Moscow Articles, including fiscal/garrison measures and the census context, generated wider dissatisfaction. [T1: IEU Moscow Articles; T1: ЕІУ Left-Bank uprising]
+- `1667` — Andrusovo confirmed the partition of Ukrainian lands between Moscow and the Commonwealth without Ukrainian consent; Briukhovetskyi's position became untenable. [T1: ЕІУ Left-Bank uprising]
+- `19 January 1668` — secret Hadyach starshyna council: Briukhovetskyi announced a break with Moscow and the plan to expel Russian troops from the Left Bank. [T1: ЕІУ Left-Bank uprising]
+- `February-March 1668` — Left-Bank uprising cleared much of the region of Russian presence, though key garrisons held out. [T1: ЕІУ Left-Bank uprising]
+- `June 1668` — during the convergence with Petro Doroshenko's forces and a joint council, Left-Bank Cossacks rejected Briukhovetskyi and killed him; Doroshenko was proclaimed hetman of united Ukraine, though that unity quickly proved unstable. [T1: ЕІУ; T1: ЕІУ Left-Bank uprising; T1: IEU]
+
+## 4. Primary-source quotes (≥2 required)
+
+> **Honest tool note (#M-4):** administrative documents such as the Moscow Articles are outside the literary `verify_quote` corpus, so the Moscow Articles excerpts below correctly return 0.0. They are document-source excerpts from the cited хрестоматія transcription, not corpus-verified literary quotations. Recheck a source edition before classroom quotation.
+
+**Excerpt 1 — Velychko on the Ruin's moral-political corruption:**
+
+> "задля золота та срібла"
+
+Context: this is not a Briukhovetskyi personal quote; it is a corpus-verified chronicle fragment for the Ruin's political atmosphere. `verify_quote(author="Величко")` on the longer line beginning "задля золота та срібла не тільки..." returned **matched: true, best_confidence: 1.0**, works `wave12-velychko-litopys` and `wave2-velychko`, year 1720. Use it to introduce the chronicle's moral register, not as factual proof of a specific Briukhovetskyi act.
+
+**Excerpt 2 — Moscow Articles on foreign relations:**
+
+> "без государския воли до чужих окрестных земель"
+
+Context: this clause captures the foreign-policy restriction: the hetman was not to send envoys to neighboring powers without the tsar's will. `verify_quote(author="Московські статті")` returned **matched: false, best_confidence: 0.0**, expected because the document is outside the literary corpus. [T5/primary transcription]
+
+**Excerpt 3 — Moscow Articles on hetman regalia:**
+
+> "булаву и знамя большое присылать ... к Москве"
+
+Context: this phrase shows how even symbols of hetman authority were pulled into Moscow confirmation. `verify_quote(author="Московські статті")` returned **matched: false, best_confidence: 0.0**, expected because the document is outside the literary corpus. [T5/primary transcription]
+
+## 5. Language register and learner-use notes
+
+- **Register:** Cossack-chancery, treaty, chronicle, and modern historiographic language; high density of political and institutional terms.
+- **CEFR readiness for full reading:** B2-C1 for adapted biography; C1-C2 for Moscow Articles excerpts, chronicle prose, and source criticism around the Black Council.
+- **Lexicon notes:** `Чорна рада`, `чернь`, `кошовий отаман`, `кошовий гетьман`, `булава`, `клейноди`, `воєвода`, `залога`, `Московські статті`, `Батуринські статті`, `Андрусівське перемир'я`, `інкорпорація`, `поспільство`, `старшина`, `універсал`, `місцеблюститель`, `демагогія`, `популізм`, `протекція`.
+- **Learner-use notes:** this dossier supports a C1 seminar on how `популізм`, `соціальна справедливість`, and imperial leverage can overlap without being identical. It also works for practicing careful causal language: "contributed to," "made possible," "exploited," "accelerated," not only "caused."
+- **Stylistic features:** contrast short document clauses with later narrative judgment. Learners should notice how legal formulas can sound orderly while transferring real power.
+- **Sensitive framing:** do not ask learners to decide whether "the people" were guilty. Better prompt: "Which grievances were real, and how were they converted into a political outcome that weakened Hetmanate autonomy?"
+
+## 6. Contested points
+
+- **Populist legitimacy or demagogy?** Both terms matter. Briukhovetskyi spoke to real resentment against elite accumulation and starshyna domination, especially among the Sich, rank-and-file Cossacks, townspeople, and poorer groups. He also used those grievances to win power under Moscow patronage. Treat the social base seriously without romanticizing it.
+- **Was Moscow the only cause of the Black Council?** No. Moscow support was decisive in the political engineering, but internal Hetmanate conflict, rival starshyna clans, Sich aspirations, and economic-social grievances made the intervention effective. Avoid both imperial denial and Ukrainian self-blame.
+- **Somko and Zolotarenko:** they were not democratic martyrs in a simple morality play; they represented elite and regional projects that also had limits. Their execution after the Black Council is still a major legitimacy rupture.
+- **Moscow Articles responsibility:** do not hide Briukhovetskyi's agency by saying Moscow simply imposed everything. Also do not pretend the negotiation was equal: IEU explicitly emphasizes unfavorable conditions and dependence on Muscovy.
+- **Boyar title and marriage:** personal reward mattered politically, but reducing the Moscow visit to greed misses the institutional bargain and the problem of status politics in early-modern diplomacy.
+- **1668 break with Moscow:** this was not a clean patriotic conversion. It was a response to collapsing authority, popular anger at the Moscow Articles, Andrusovo's partition, and fear that Moscow might bargain with Doroshenko over the Left Bank. That does not make the anti-Moscow uprising meaningless.
+- **Death and Doroshenko's role:** sources differ in detail and later narratives dramatize the scene. The stable point is that Left-Bank Cossacks killed Briukhovetskyi during the Doroshenko convergence; Doroshenko then ordered a hetman-honors burial. Do not overclaim intent unless a source edition is being read directly.
+- **"The people caused the Ruin":** this is the pedagogical danger. The Black Council shows how mass participation can be manipulated, but it also shows how elite failure and foreign intervention create the conditions for manipulation.
+- **Image authenticity:** portraits are later/posthumous unless file metadata proves otherwise. Do not imply a life portrait.
+- **Modern disinformation:** Russian narratives can use Briukhovetskyi as proof that "reasonable Ukrainians chose Moscow," while anti-Moscow shorthand can use him as a one-word traitor. The dossier should teach how both flatten the record.
+
+## 7. Cross-track links
+
+> Every curriculum plan path under **Existing** below was verified locally on 2026-07-03. `docs/research/bio/petro-doroshenko.md` is a verified dossier file, not an existing BIO plan path in this tree.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — court service and the post-Khmelnytsky succession crisis.
+  - `curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml` — early missions, anti-hetman agitation, and Ruin-era legitimacy struggles.
+  - `curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml` — Sich politics and later anti-Moscow/anti-Ottoman frontier choices.
+  - `curriculum/l2-uk-en/plans/bio/yuriy-nemyrych.yaml` — Hadiach/statehood alternatives that frame the post-Khmelnytsky fragmentation.
+  - `curriculum/l2-uk-en/plans/bio/ivan-mazepa.yaml` — later comparison for "traitor" framing, Moscow leverage, and risky statecraft.
+  - `curriculum/l2-uk-en/plans/bio/pylyp-orlyk.yaml` — later legal language of Cossack rights after autonomy collapses.
+  - `curriculum/l2-uk-en/plans/bio/danylo-apostol.yaml`, `curriculum/l2-uk-en/plans/bio/pavlo-polubotok.yaml` — later autonomy-under-imperial-pressure cases.
+  - `curriculum/l2-uk-en/plans/bio/kost-hordiyenko.yaml` — Sich autonomy versus hetman centralization in later statehood gambles.
+- **Existing BIO dossiers (VERIFIED present; not curriculum plan paths):**
+  - `docs/research/bio/petro-doroshenko.md` — immediate 1668 counterpart; Doroshenko's brief all-Ukraine proclamation after Briukhovetskyi's death.
+  - `docs/research/bio/ivan-vyhovskyi.md`, `docs/research/bio/ivan-sirko.md`, `docs/research/bio/yuriy-nemyrych.md`, `docs/research/bio/ivan-mazepa.md`, `docs/research/bio/pylyp-orlyk.md`, `docs/research/bio/danylo-apostol.md`, `docs/research/bio/pavlo-polubotok.md`, `docs/research/bio/kost-hordiyenko.md` — verified related Cossack/Hetmanate dossiers.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/ruina-i.yaml` — first Ruin phase, including the path to the Black Council.
+  - `curriculum/l2-uk-en/plans/hist/ruina-ii.yaml` — Doroshenko/Right-Bank and post-1663 continuation.
+  - `curriculum/l2-uk-en/plans/hist/andrusivske-peremyrya.yaml` — partition context behind the 1668 anti-Moscow turn.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — institutional baseline for what the Moscow Articles narrowed.
+  - `curriculum/l2-uk-en/plans/hist/pereyaslavska-uhoda.yaml` — earlier protectorate vocabulary and later distortions.
+- **Existing LIT/RUTH plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/black-council-history.yaml`, `curriculum/l2-uk-en/plans/lit/black-council-plot.yaml` — Kulish's literary memory of the event.
+  - `curriculum/l2-uk-en/plans/lit-hist-fic/kulish-black-council-revisit.yaml` — historical fiction/source comparison.
+  - `curriculum/l2-uk-en/plans/ruth/black-council.yaml` — older-language and political vocabulary around the Black Council.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `nizhynska-chorna-rada-1663` — source-critical module on election mechanics and social grievance.
+  - `moskovski-statti-1665` — treaty/source-reading module on incorporation language.
+  - `livoberezhne-povstannia-1668` — anti-Moscow uprising and failed reunification case study.
+  - `yakym-somko` / `vasyl-zolotarenko` — candidate BIO support files if the Black Council cluster expands.
+- **Potential LIT additions surfaced by this research:**
+  - A comparison of Kulish's Briukhovetskyi with Horobets/ЕІУ and chronicle sources, centered on how fiction turns political causality into character drama.
+
+## 8. Naming-canonical
+
+- **Slug:** `ivan-briukhovetskyi`
+- **EN canonical (project spelling):** Ivan Briukhovetskyi
+- **UA canonical (with patronymic):** Іван Мартинович Брюховецький
+- **Aliases (track these for `aliases:` YAML field):** Іван Брюховецький; гетьман Іван Брюховецький; кошовий отаман Іван Брюховецький; Ivan Briukhovetskyi; Ivan Briukhovetsky; Brjuxovec'kyj; Bryukhovetskyj.
+- **Forbidden forms (Russian-imperial / flattening forms to flag in body text):** Иван Брюховецкий; "малороссийский гетман"; "царський боярин" as an identity label without explanation; "зрадник" as fact; "народ винен" as causal shorthand.
+- **Term warning:** `чернь` is a period/source term. Use it with explanation; do not normalize it as the narrator's contempt for common people.
+- **Name collision warning:** do not confuse this Ivan Briukhovetskyi with later surname bearers or with Pavlo Skoropadskyi / the 1918 Hetmanate, which is out of scope for this BIO Cossack dossier.
+
+## 9. Image candidates
+
+- **Best likely portrait candidate:** Wikimedia Commons / encyclopedia-linked portrait of Ivan Briukhovetskyi, often described as a later portrait after the Velychko tradition or a 19th-century rendering. Verify the individual file page, not a thumbnail, before reuse.
+- **Backup candidates:** rights-clear image of Nizhyn/Black Council context; Hadiach burial/context site; Liutenka/Poltava-region memorial/bust image if the license is explicit.
+- **Document/context image:** a facsimile of the Moscow Articles or a rights-clear page from a source edition would be more pedagogically precise than a dubious portrait.
+- **Authenticity caveat:** no life portrait should be implied unless the file metadata proves it. Many hetman portraits are later political-memory artifacts.
+- **Avoid:** generic "angry crowd" art that visually blames common people; Russian-imperial costume imagery; unrelated Cossack stock art; images that make Moscow patronage look like natural legitimacy.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- [T1] Горобець В. М. "Брюховецький Іван Мартинович" // *Енциклопедія історії України*, т. 1. URL: https://www.history.org.ua/?termin=Bryukhovetskyj_I_M | resolved HTTP 200, accessed 2026-07-03. Core facts: ca. 1623-17(07).06.1668; Khmelnytsky court service; Sich phase; Black Council rise; Moscow Articles; January 1668 break; death and Hadiach burial.
+- [T1] "Briukhovetsky, Ivan" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CB%5CR%5CBriukhovetskyIvan.htm | resolved HTTP 200, accessed 2026-07-03. Core facts: registered Cossack/courier, otaman 1661-1663, Chorna rada, Moscow Articles, boyar/marriage reward, Andrusovo response, death at Budyshchi near Opishnia.
+- [T1] Горобець В. М. "Чорна рада 1663" // *Енциклопедія історії України*, т. 10. URL: https://www.history.org.ua/?termin=Chorna_rada_1663 | resolved HTTP 200, accessed 2026-07-03. Used for Black Council date, participants, Moscow military presence, social-political programs, and election mechanics.
+- [T1] Горобець В. М. "Повстання Лівобережне 1668" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=povstannja_livoberezhne_1668 | resolved HTTP 200, accessed 2026-07-03. Used for Moscow Articles implementation, Andrusovo catalyst, Hadyach council, anti-Moscow revolt, and death/proclamation sequence.
+- [T1] "Moscow Articles of 1665" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CM%5CO%5CMoscowArticlesof1665.htm | resolved HTTP 200, accessed 2026-07-03. Used for institutional effects of the treaty.
+- [T1] "Baturyn Articles" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CB%5CA%5CBaturynArticles.htm | resolved HTTP 200, accessed 2026-07-03. Used for the 1663 agreement baseline.
+- [T1] "Chorna rada" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CC%5CH%5CChornaradaIT.htm | resolved HTTP 200, accessed 2026-07-03. Used for English-language baseline and Kulish memory link.
+
+**Tier 2 (institutional / bibliographic):**
+- [T2] Національна бібліотека України імені В. І. Вернадського, Електронна бібліотека "Україніка", "Брюховецький Іван Мартинович." URL: https://irbis-nbuv.gov.ua/ulib/item/REF0003158 | resolved HTTP 200, accessed 2026-07-03. Used as institutional authority/name-category pointer to ЕІУ.
+
+**Tier 3 (encyclopedic — navigation only):**
+- [T3] "Іван Брюховецький" // Ukrainian Wikipedia. URL: https://uk.wikipedia.org/wiki/Іван_Брюховецький | accessed 2026-07-03. Used only for date/place/image navigation and cross-checks; not load-bearing.
+- [T3] "Ivan Briukhovetsky" // English Wikipedia. URL: https://en.wikipedia.org/wiki/Ivan_Briukhovetsky | accessed 2026-07-03. Used only for English aliases and image discovery.
+
+**Tier 4 (modern scholarly post-1991 / academic):**
+- [T4] Горобець В. *Гетьман Брюховецький. Життя у славі, владі та ганьбі.* Київ: Парламентське видавництво, 2019. Institute of History resource page: https://resource.history.org.ua/item/0014851 | PDF resolved and text-extracted locally, accessed 2026-07-03. Used for interpretive framing, not for unsupported classroom quotation.
+- [T4] Горобець В. М. *Від союзу до інкорпорації: українсько-російські відносини другої половини XVII - першої чверті XVIII ст.* Київ, 1995. Bibliographic anchor via ЕІУ.
+- [T4] Горобець В. *"Чорна рада" 1663 року: Передумови, результати, наслідки.* Київ, 2013. Bibliographic anchor via ЕІУ Chorna Rada entry.
+- [T4] Яковлева Т. *Руїна Гетьманщини: Від Переяславської ради-2 до Андрусівської угоди (1659-1667 рр.).* Київ, 2003. Bibliographic anchor via ЕІУ Chorna Rada / Horobets.
+- [T4] Смолій В. А., Степанков В. С. *Українська національна революція XVII ст. (1648-1676 рр.).* Київ, 1999. Bibliographic anchor via ЕІУ Chorna Rada / Left-Bank uprising entries.
+
+**Tier 5 (general web / transcription — not load-bearing):**
+- [T5/primary transcription] В. А. Смолій хрестоматія page, "Московські статті, прийняті гетьманом Іваном Брюховецьким..." URL: https://uahistory.co/book/xrestomatia/239.php | resolved HTTP 200 via local `curl`, accessed 2026-07-03. Used only for short document excerpts in §4; source edition should be rechecked before lesson publication.
+
+**Primary-source documents accessed / verification notes:**
+- Velychko chronicle fragment: `verify_quote(author="Величко")` matched true, confidence 1.0, but it is contextual rather than Briukhovetskyi-specific.
+- Moscow Articles foreign-relations excerpt: `verify_quote(author="Московські статті")` returned matched false, confidence 0.0; expected because this administrative document is outside the literary corpus.
+- Moscow Articles regalia excerpt: `verify_quote(author="Московські статті")` returned matched false, confidence 0.0; expected because this administrative document is outside the literary corpus.
+
+**Honest gaps:** the dossier did not directly inspect archival copies of the Baturyn Articles, the full Moscow Articles source edition, or all chronicle variants of Briukhovetskyi's death scene. The Horobets 2019 PDF was downloaded to `/tmp` and text-extracted for targeted checking, but the dossier does not pretend to exhaust a 440-page monograph. For module writing, recheck exact death-scene wording, Black Council eyewitness detail, and Moscow Articles clauses against source editions.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Moscow is treated as a power intervening in Hetmanate politics, not as Ukraine's natural center.
+- [x] Briukhovetskyi is not flattened into a one-word collaborator; his social base, agency, opportunism, and constraints are all named.
+- [x] The Black Council is not used to blame "the people"; social grievance and elite failure are separated from imperial manipulation.
+- [x] No Russian-imperial transliterations in body text except forbidden forms in §8.
+- [x] Moscow Articles are treated as institutional incorporation, not merely personal moral failure.
+- [x] Andrusovo is named as an outside partition of Ukrainian lands without Ukrainian consent.
+- [x] Anti-imperial reading does not hide Briukhovetskyi's executions, coercion, opportunism, or responsibility for the 1665 concessions.
+- [x] No out-of-scope Pavlo Skoropadskyi / 1918 Hetmanate material added.
+- [x] Modern Ukrainian place/institution naming used with historical context: Ніжин, Гадяч, Лівобережжя, Правобережжя, Гетьманщина, Запорозька Січ.
+
+## Validation checklist
+
+- [x] Single owned file only: `docs/research/bio/ivan-briukhovetskyi.md`.
+- [x] Existing cross-track plan paths verified locally before citation.
+- [x] Lower-tier sources marked as non-load-bearing.
+- [x] No generated `status/`, `audit/`, `review/`, or telemetry artifacts referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans, module files, activities, vocabulary, resources, site MDX, or wiki files edited.


### PR DESCRIPTION
## Scope

Adds the BIO Cossack P0 research dossier for Ivan Briukhovetskyi under issue #4215.

This dossier covers Black Council context, populist legitimacy, Moscow leverage, the Baturyn/Moscow Articles, Andrusovo, the 1668 anti-Moscow turn, death during the Doroshenko convergence, memory politics, learner-use notes, aliases/transliteration, image-rights caveats, bibliography, and validation checklist.

## Changed Files

- `docs/research/bio/ivan-briukhovetskyi.md`

## Validation

- `npx markdownlint-cli2 docs/research/bio/ivan-briukhovetskyi.md` — passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/ivan-briukhovetskyi.md` — passed
- `git diff --check` — passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- Protected artifact/config guard — passed; only `docs/research/bio/ivan-briukhovetskyi.md` is changed

## Source And Decolonization Caveats

- Core facts are anchored in ЕІУ and Internet Encyclopedia of Ukraine, with Horobets's Institute-hosted 2019 monograph used as the main modern interpretive anchor.
- Primary/document excerpts are source-cautious: one Velychko chronicle fragment is corpus-verified; Moscow Articles snippets are marked as document-source excerpts outside the literary `verify_quote` corpus.
- The framing avoids both hagiography and imperial simplification: Briukhovetskyi is treated as a complex Ruin-era actor whose populism, Moscow patronage, institutional concessions, anti-Moscow reversal, and collapse must be taught together.
- The Black Council is not used to blame "the people"; the dossier separates real social grievance from elite failure and Moscow manipulation.

No independent review has been routed yet because the orchestrator handles that step.