### PR TITLE
fix(qg): ignore YAML correction keys in surface gate

### DIFF
--- a/scripts/audit/content_surface_gates.py
+++ b/scripts/audit/content_surface_gates.py
@@ -85,6 +85,7 @@ _FENCE_RE = re.compile(r"```.*?```", re.DOTALL)
 _HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 _TAG_RE = re.compile(r"<[^>\n]{2,160}>")
 _FRONTMATTER_RE = re.compile(r"\A---\n.*?\n---\n", re.DOTALL)
+_YAML_KEY_RE = re.compile(r"(?m)^(\s*(?:-\s*)?)[A-Za-z_][A-Za-z0-9_-]*:(?=\s|$)")
 
 AI_LEAK_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = tuple(
     (re.compile(pattern, re.IGNORECASE), label)
@@ -157,6 +158,18 @@ def _mask_ignored_regions(text: str) -> str:
 
 def _mask_tags(text: str) -> str:
     return _TAG_RE.sub(_mask_match, text)
+
+
+def _mask_yaml_keys(text: str) -> str:
+    """Mask YAML mapping keys while preserving line numbers and scalar values."""
+    return _YAML_KEY_RE.sub(
+        lambda match: match.group(1) + " " * (len(match.group(0)) - len(match.group(1))),
+        text,
+    )
+
+
+def _is_yaml_source(source: str) -> bool:
+    return source.endswith((".yaml", ".yml"))
 
 
 def _is_ignored_line(line: str) -> bool:
@@ -277,11 +290,12 @@ def scan_surface_text(
     """Run level-aware deterministic checks over one learner-facing text blob."""
     policy = policy_for_level(level)
     masked = _mask_ignored_regions(text)
-    language_masked = _mask_tags(masked)
+    prose_masked = _mask_yaml_keys(masked) if _is_yaml_source(source) else masked
+    language_masked = _mask_tags(prose_masked)
     findings: list[dict[str, Any]] = []
     findings.extend(
         _pattern_findings(
-            masked,
+            prose_masked,
             patterns=AI_LEAK_PATTERNS,
             kind="ai_leakage",
             severity=policy.ai_leak_severity,
@@ -290,7 +304,7 @@ def scan_surface_text(
     )
     findings.extend(
         _pattern_findings(
-            masked,
+            prose_masked,
             patterns=PATH_LEAK_PATTERNS,
             kind="path_leakage",
             severity=policy.path_leak_severity,
@@ -304,7 +318,7 @@ def scan_surface_text(
             findings.append(ratio_finding)
     findings.extend(
         _pattern_findings(
-            masked,
+            prose_masked,
             patterns=PATHOS_PATTERNS,
             kind="pathos_or_register",
             severity=policy.pathos_severity,

--- a/tests/audit/test_content_surface_gates.py
+++ b/tests/audit/test_content_surface_gates.py
@@ -93,3 +93,59 @@ def test_sidecar_scan_catches_ai_leak_without_english_ratio_false_positive(tmp_p
         finding["type"] == "english_led_line" and finding["source"] == "activities.yaml"
         for finding in report["findings"]
     )
+
+
+def test_yaml_activity_correction_keys_are_not_ai_leaks(tmp_path) -> None:
+    module_dir = tmp_path / "b1" / "sidecar"
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text("## Урок\n\n**Не відкривайте файл.**\n", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text(
+        "- type: error-correction\n"
+        "  prompt: Виправте речення.\n"
+        "  items:\n"
+        "    - incorrect: Не відкрийте файл.\n"
+        "      correction: Не відкривайте файл.\n"
+        "      explanation: Це заборона контрольованої дії.\n",
+        encoding="utf-8",
+    )
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+
+    report = scan_module_surface(module_dir, level="b1")
+
+    assert report["passed"] is True
+    assert not any(
+        finding["type"] == "ai_leakage" and finding["source"] == "activities.yaml"
+        for finding in report["findings"]
+    )
+
+
+def test_yaml_activity_correction_label_in_value_still_fails(tmp_path) -> None:
+    module_dir = tmp_path / "b1" / "sidecar"
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text("## Урок\n\n**Не відкривайте файл.**\n", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text(
+        "- type: quiz\n"
+        "  prompt: 'Correction: rewrite the learner-facing line before publishing.'\n",
+        encoding="utf-8",
+    )
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+
+    report = scan_module_surface(module_dir, level="b1")
+
+    assert report["passed"] is False
+    assert any(
+        finding["type"] == "ai_leakage" and finding["source"] == "activities.yaml"
+        for finding in report["findings"]
+    )
+
+
+def test_markdown_correction_label_still_fails() -> None:
+    text = """
+Correction: rewrite this draft before publishing.
+
+**Не відкривайте файл.**
+"""
+    report = scan_surface_text(text, level="b1", source="module.md")
+
+    assert report["passed"] is False
+    assert any(finding["type"] == "ai_leakage" for finding in report["findings"])


### PR DESCRIPTION
## Summary

Fixes a deterministic surface-gate false positive found during B1-27 calibration: YAML mapping keys such as `correction:` in `activities.yaml` were being flagged as AI leakage because the prose regex saw the key name.

The scanner now masks YAML mapping keys before applying leakage/pathos/path regexes while still scanning YAML scalar values and markdown prose.

## Verification

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/audit/test_content_surface_gates.py tests/audit/test_module_quality_audit.py` — 25 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/audit/content_surface_gates.py tests/audit/test_content_surface_gates.py` — passed
- `git diff --check` — passed
- `scripts/audit/lint_agent_trailer.py` — passed
- External Agy/Gemini review `review-qg-yaml-correction-full` — no blocking findings

## Notes

This keeps `Correction:` detection active in `module.md` prose and YAML scalar values; only YAML key names are masked.