### PR TITLE
[codex] add Yurii Khmelnytskyi BIO dossier

### DIFF
--- a/docs/research/bio/yurii-khmelnytskyi.md
+++ b/docs/research/bio/yurii-khmelnytskyi.md
@@ -1,0 +1,237 @@
+# Юрій Богданович Хмельницький — Research Dossier
+
+**Slug:** `yurii-khmelnytskyi`
+**Block:** G (politically charged Ruin-era Hetmanate figure; inherited Khmelnytsky legitimacy, coerced treaties, monastic withdrawal, Ottoman-backed Right-Bank episode, and contested memory)
+**Tier:** 1a
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] ≥3 Tier 1/Tier 2 sources cited (ЕІУ Yurii Khmelnytskyi, IEU Yurii Khmelnytsky, ЕІУ Pereiaslav Articles 1659, ЕІУ political-processes entry, IEU Slobodyshche Treaty, IEU Chyhyryn campaigns, Savchuk/NBUV institutional pointer)
+- [x] Source-tier checkboxes included and lower-tier sources kept non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: hereditary succession pressure, Trubetskoi/Pereiaslav coercion, Slobodyshche split, Polish imprisonment, Crimean/Ottoman captivity, Ottoman title-use, and later "weak son/puppet" flattening)
+- [x] §4 includes 3 short document/source-language anchors with verification caveats
+- [x] Yurii is framed through succession, factional pressure, and the Ruin without hagiography or a simplistic "failed son" biography
+- [x] Cross-track links: every "Existing" plan path verified locally with `rg --files` on 2026-07-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+- [x] **T1 baseline:** ЕІУ and Internet Encyclopedia of Ukraine anchor core facts, dates, offices, Pereiaslav/Slobodyshche sequence, monastic turn, Ottoman-backed episode, and death/disappearance variants.
+- [x] **T2/T4 scholarship:** Savchuk's institutional/NBUV-listed monograph, Mytsyk's BIO-focused works, Luniak's Ukrainian Historical Journal article, and recent Ottoman-war scholarship frame interpretation and bibliography.
+- [x] **T3/T5 caution:** Wikipedia, mirrors, school pages, stock-image sites, and Commons/PICRYL metadata are navigation or image-rights aids only; they are not load-bearing for interpretation.
+- [x] **Primary/doc excerpts:** short excerpts are explicitly marked as document/source-language anchors; recheck source editions before classroom quotation.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Юрій Богданович Хмельницький. [T1: ЕІУ; T1: IEU]
+- **Pseudonyms / aliases:** Юрій Хмельницький; Юрась Хмельницький; Хмельниченко; у чернецтві — Гедеон; Yurii Khmelnytskyi; Yurii Khmelnytsky; Yury Khmelnytsky; Yuras; Xmel'nyc'kyj, Jurij in IEU transliteration. Ottoman-backed titulature can appear as `Юрій Гедеон Венжик Хмельницький`, `князь України`, `князь Сарматії`, `руський монарх`; keep these as title claims, not stable constitutional facts. [T1: ЕІУ; T1: IEU]
+- **Born:** **1640 or 1641**; ЕІУ gives 1640 or 1641 and either Subotiv or Chyhyryn; IEU gives 1641. Use "1640/1641, Subotiv/Chyhyryn area" unless a module verifies a source edition for a narrower claim. [T1: ЕІУ; T1: IEU]
+- **Died:** disputed. ЕІУ's headnote gives **1681**, then lists several traditions: execution at Kamianets-Podilskyi, removal to Istanbul and lifelong imprisonment, or a later monastic end after long imprisonment. IEU gives **1685** and execution at Kamianets-Podilskyi after renewed title claims. The safest classroom formulation is "deposed in 1681; death/execution tradition disputed, often given as 1681 or 1685." [T1: ЕІУ; T1: IEU; T4]
+- **Family / education key facts:** younger son of Bohdan Khmelnytskyi and Hanna Somko; after Tymish Khmelnytskyi's death in 1653 he became the dynastic focus of Bohdan's succession plans. He received home education, spent time at the Kyiv College, and knew Church Slavonic, Polish, Latin, and Greek according to ЕІУ. [T1: ЕІУ; T1: IEU]
+- **Health / capacity caution:** ЕІУ names chronic illness and epilepsy; IEU uses a strongly negative personality judgment. Use health information only to explain why contemporaries doubted his military-political capacity. Do not make illness the whole causal explanation for the Ruin. [T1: ЕІУ; T1: IEU]
+- **Office / role:** designated or nominal heir in 1657; hetman of the Zaporozhian Host/Ukraine in **1659-1663**; monk and archimandrite as Гедеон after abdication; Ottoman-backed Right-Bank title-holder/ruler in the **1677-1681** Chyhyryn/Nemyriv sequence. [T1: ЕІУ; T1: IEU; T1: IEU Chyhyryn]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Birth date/place:** 1640/1641 and Subotiv/Chyhyryn circulate in Tier 1 sources. Avoid a false precision such as one exact birthday.
+2. **First hetmancy:** 1657 should be treated as dynastic designation or brief nominal choice under Bohdan's plan, not stable personal rule.
+3. **Pereiaslav 1659:** ЕІУ stresses Trubetskoi's military advantage, rejection of the Ukrainian project, and imposition of restrictive/falsified article sets. Do not call the agreement a free renewal of 1654.
+4. **Slobodyshche/Chudniv 1660:** this was not a simple patriotic correction or simple betrayal. It broke with Moscow after military defeat and restored formal ties with the Commonwealth, but without a secure Grand Duchy of Rus framework and with strong Left-Bank opposition.
+5. **Monastic names:** `Гедеон` is the stable monastic name; expanded forms such as `Юрій Гедеон Венжик Хмельницький` belong to the Ottoman-backed title phase.
+6. **Death:** 1681 and 1685 traditions remain live in standard references. Do not narrate the execution scene as settled fact unless a lesson verifies a specific source edition.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Yurii's biography exposes a failed succession mechanism after Bohdan Khmelnytskyi. A teenage/young heir carried symbolic legitimacy but lacked durable command over a fractured Cossack elite, a militarized society, and neighboring powers that had learned to use recognition as leverage. Moscow, Warsaw/Commonwealth actors, Crimea, and the Ottoman Porte all treated his name as a tool for their own war aims at different moments. [T1: ЕІУ; T1: IEU; T1: ЕІУ political-processes entry]
+
+**By whom:** Moscow/tsarist power in the Pereiaslav 1659 coercion, voivode/garrison expansion, and Left-Bank opposition layer; Commonwealth/Polish authorities in the Slobodyshche settlement and later Malbork/Warsaw imprisonment layer; Crimean and Ottoman power in the captivity and title-use layer; local Cossack starshyna, Zaporozhian leaders, and rival hetmans in the factional layer. Yurii himself also had agency, including failed military choices, shifting alliances, and coercive Right-Bank rule in the Nemyriv period. [T1; T2/T4]
+
+**Document references:** the April 1657 succession decision; the 1659 Pereiaslav Articles / "New Articles"; the 1660 Chudniv/Slobodyshche settlement; the 1663 monastic abdication and Pavlo Teteria succession; the Chyhyryn campaigns of 1677-1678; the 1681 Bakhchysarai peace and related Ottoman-Muscovite settlement context. [T1: ЕІУ; T1: IEU Slobodyshche; T1: IEU Chyhyryn]
+
+**Mechanism specifics:** the imperial simplification is to present Moscow as the necessary order-bringer after an incompetent Ukrainian heir. The Polish/Commonwealth simplification is to treat Slobodyshche as a restored order without asking why Ukrainian autonomy and elite consent failed. The Ottoman simplification is to treat the Khmelnytsky name as a ready-made Right-Bank legitimacy device after Doroshenko. The Ukrainian romantic simplification is to explain Yurii only as tragedy next to Bohdan. A decolonized BIO reading has to keep all these layers visible: inherited legitimacy was real, coercion was real, factional agency was real, and Yurii's own rule could be violent and politically destructive.
+
+**What survived / what was distorted:** what survived is a cautionary memory of the Ruin: a famous surname could not substitute for institutions, consensus, or military capacity. What was distorted is the person. He is often reduced to "weak son," "puppet," or "mad tyrant." Those labels may echo source judgments, but they are not a sufficient biography. The stronger lesson is about how empires and local factions convert a person's symbolic capital into a mechanism of control.
+
+## 3. Major works / legacy
+
+- `1653` — after Tymish Khmelnytskyi's death, Bohdan Khmelnytskyi began treating Yurii as the dynastic heir to the mace. [T1: ЕІУ; T1: IEU]
+- `April 1657` — council decision under Bohdan's authority designated Yurii as successor; he remained under the practical care and military tutelage of senior colonels. [T1: ЕІУ]
+- `August 1657` — after Bohdan's death, the Cossack council chose Ivan Vyhovskyi rather than leaving state command to the teenage heir. [T1: IEU; T1: ЕІУ political-processes entry]
+- `September 1659` — after Vyhovskyi's fall, Yurii was proclaimed/elected hetman at the moment when the Cossack state was already militarily and socially fractured. [T1: ЕІУ; T1: ЕІУ political-processes entry]
+- `27/17 October 1659` — Pereiaslav Articles imposed under Trubetskoi's military leverage; Ukrainian sovereignty was sharply narrowed through restrictions on foreign policy, hetman authority, starshyna appointments, and Moscow voivode/garrison presence. [T1: ЕІУ Pereiaslav Articles]
+- `1660` — participated in the failed Muscovite-Cossack campaign against the Commonwealth; the defeat around Chudniv/Slobodyshche forced a turn toward a Commonwealth settlement. [T1: ЕІУ; T1: ЕІУ political-processes entry; T1: IEU Slobodyshche]
+- `17/27 October 1660` — Slobodyshche/Chudniv Treaty abolished the Pereiaslav Articles and formally renewed ties with Poland/Commonwealth, but Left-Bank regiments under Yakym Somko and Vasyl Zolotarenko, and Zaporozhian forces around Ivan Briukhovetskyi, rejected the settlement. [T1: IEU Slobodyshche; T1: ЕІУ]
+- `1661-1662` — attempts to restore authority over the Left Bank failed; ЕІУ names the heavy defeat by Somko and Romodanovsky and the politically disastrous Crimean alliance/yasir context near Kaniv. [T1: ЕІУ; T1: ЕІУ political-processes entry]
+- `autumn 1662-beginning 1663` — at Korsun and then in the succession sequence, Yurii gave up the mace; Pavlo Teteria became hetman, and Yurii entered monastic life as Гедеон near Korsun. [T1: ЕІУ; T1: IEU]
+- `1663-1667` — after welcoming the Commonwealth campaign in Bila Tserkva, he was accused of involvement with anti-Polish unrest, imprisoned at Malbork, later transferred to Warsaw, and escaped/returned after the Andrusovo context. [T1: ЕІУ]
+- `1669-1670` — left monastic affairs and joined Right-Bank factional politics against Petro Doroshenko; captured near Uman by the Bilhorod Horde, imprisoned at Akkerman/Yedikule/Akkerman in the Ottoman orbit. [T1: ЕІУ; T1: IEU]
+- `1676-1677` — after Doroshenko's fall, the Ottoman Porte released or elevated Yurii for the Chyhyryn campaigns, hoping his name would attract Ukrainian support. [T1: ЕІУ; T1: IEU Chyhyryn]
+- `1677-1678` — Ottoman campaigns aimed at Chyhyryn and the Right Bank; IEU describes the Porte's plan to install Yurii as vassal with titles of hetman and Prince of Sarmatia/Ukraine. [T1: IEU Chyhyryn; T4]
+- `1678-1681` — Nemyriv-centered Right-Bank episode: Yurii controlled parts of Kyiv, Cherkasy, and Vinnytsia regions under Ottoman military backing, collected taxes, judged cases, and violently repressed opposition. [T1: ЕІУ; T1: IEU]
+- `1681/1685 traditions` — deposed after Ottoman-Muscovite peace calculations; death traditions include hanging at Kamianets-Podilskyi, removal to Istanbul, or later monastic death. [T1: ЕІУ; T1: IEU; T4]
+- `later memory` — remembered as Bohdan's ill-fated son and as a symbol of the Ruin; modern teaching should use him to explain succession, coercive protectorates, and the collapse of all-Ukraine legitimacy rather than to assign a simple moral label. [T1; T4]
+
+## 4. Primary-source quotes (≥2 required)
+
+> **Honest tool note (#M-4):** no project `verify_quote` tool was run in this pass. The excerpts below are document/source-language anchors from cited encyclopedia entries and document traditions, not corpus-certified classroom quotations. Recheck source editions before using longer primary text in a module.
+
+**Anchor 1 — Pereiaslav 1659 as coerced article language:**
+
+> "Переяславські статті 1659"
+
+Context: use the title with ЕІУ's warning that Trubetskoi rejected the Ukrainian project and imposed restrictive "old" and "new" articles. It is a treaty label, not proof of consensual renewal. [T1: ЕІУ Pereiaslav Articles]
+
+**Anchor 2 — Slobodyshche/Chudniv as a competing treaty label:**
+
+> "Slobodyshche, Treaty of (aka Treaty of Chudniv)"
+
+Context: IEU uses the paired name and dates the pact to 27 October 1660. It marks a switch away from the Pereiaslav framework, but it also helps teach why the Left Bank and Zaporozhian opposition rejected Yurii's authority. [T1: IEU Slobodyshche]
+
+**Anchor 3 — Ottoman-backed title vocabulary:**
+
+> "князь України"
+
+Context: ЕІУ lists this among title formulas attached to Yurii after the Ottoman Porte released and promoted him for the Chyhyryn campaigns. Use it as a contested title claim and propaganda mechanism, not as a stable state title. [T1: ЕІУ]
+
+## 5. Language register and learner-use notes
+
+- **Register:** Cossack council, treaty, chronicle, monastic, and diplomatic vocabulary; heavy use of legitimacy and dependency terms.
+- **CEFR readiness for full reading:** B2-C1 for adapted biography; C1-C2 for Pereiaslav/Slobodyshche treaty language, Chyhyryn campaign source criticism, and early-modern title formulas.
+- **Lexicon notes:** `гетьманич`, `булава`, `спадкове гетьманство`, `старшинська рада`, `генеральна рада`, `Переяславські статті`, `Чуднівський договір`, `Слободищенський трактат`, `наказний гетьман`, `архімандрит`, `ясир`, `протекторат`, `васал`, `князь України`, `руський монарх`, `Руїна`.
+- **Learner-use notes:** this dossier supports a B2-C1 lesson on legitimacy verbs and modal language: "was designated," "was forced to accept," "was recognized by," "was opposed by," "claimed the title," "was used by." It is especially useful for practicing source-cautious clauses instead of verdict labels.
+- **Stylistic features:** contrast treaty/legal formulas with biographical judgments. The same person can be a `гетьманич`, `гетьман`, `чернець`, `архімандрит`, `в'язень`, `князь`, and `маріонетка` depending on the source and moment.
+- **Sensitive framing:** do not ask learners whether Yurii was simply "weak" or "a traitor." Better prompt: "Which institutions failed around him, which powers used him, and where did he still make damaging choices?"
+
+## 6. Contested points
+
+- **Inherited rule or elected hetmancy?** Bohdan's plan gave Yurii dynastic legitimacy, but Cossack political culture still depended on council recognition, starshyna support, and military capacity. The dossier should teach that tension, not resolve it into one modern category.
+- **Youth and illness:** sources repeatedly cite youth, inexperience, and illness. Those facts matter, but they should not become an ableist explanation that hides the structural crisis after 1657.
+- **Pereiaslav 1659:** do not call it a voluntary "reunification" renewal. ЕІУ explicitly frames the process through Trubetskoi's military advantage and the rejection of the Ukrainian draft.
+- **Slobodyshche 1660:** do not call Yurii simply pro-Polish. The treaty followed military defeat and tried to escape the Pereiaslav 1659 constraint, but its limited autonomy and lack of all-bank consensus deepened the split.
+- **Somko/Briukhovetskyi context:** Yakym Somko, Vasyl Zolotarenko, and Ivan Briukhovetskyi were not merely disobedient subordinates. They represented competing Left-Bank, Sich, and Moscow-oriented legitimacy claims after Yurii's turn.
+- **Crimean alliance and yasir:** ЕІУ's figure around Kaniv is morally and politically central, but do not narrate it as a timeless ethnic stereotype. It belongs to a specific military alliance and captive-taking system under Ruin conditions.
+- **Monastic withdrawal:** entering monastic life was not a simple spiritual happy ending. It was also a political exit from failed rule, followed by repeated forced returns into factional and imperial politics.
+- **Ottoman-backed title:** `князь України` and `князь Сарматії` are important title formulas, but the Porte's military backing and the weak local support must be taught with them.
+- **Death/execution:** 1681 and 1685 traditions differ; do not stage the Kamianets hanging as settled unless teaching the death-tradition problem itself.
+- **Modern memory:** Russian-imperial memory can use Yurii to prove Ukrainian incapacity without Moscow; Ukrainian popular memory can use him only as the tragic contrast to Bohdan. Both moves flatten the biography.
+
+## 7. Cross-track links
+
+> Every curriculum plan path under **Existing** below was verified locally on 2026-07-03. `docs/research/bio/ivan-briukhovetskyi.md`, `docs/research/bio/petro-doroshenko.md`, and `docs/research/bio/yakym-somko.md` are verified dossier files, not existing BIO plan paths in this tree.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — father, dynastic succession plan, and the state whose institutions failed after 1657.
+  - `curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml` — regency/succession alternative, Hadiach background, and the 1659 transfer of power.
+  - `curriculum/l2-uk-en/plans/bio/yuriy-nemyrych.yaml` — Hadiach/federal alternative and the post-Pereiaslav legitimacy crisis.
+  - `curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml` — Zaporozhian politics and anti-Ottoman/anti-Doroshenko context around the later Ruin.
+  - `curriculum/l2-uk-en/plans/bio/ivan-mazepa.yaml` — later comparison for constrained autonomy and "traitor" vocabulary under imperial pressure.
+  - `curriculum/l2-uk-en/plans/bio/pylyp-orlyk.yaml` — later legal language of Cossack rights after the Ruin.
+  - `curriculum/l2-uk-en/plans/bio/danylo-apostol.yaml`, `curriculum/l2-uk-en/plans/bio/pavlo-polubotok.yaml` — later constrained-autonomy cases after the Cossack statehood corridor narrowed.
+- **Existing BIO dossiers (VERIFIED present; not curriculum plan paths):**
+  - `docs/research/bio/bohdan-khmelnytskyy.md`, `docs/research/bio/ivan-vyhovskyi.md`, `docs/research/bio/ivan-briukhovetskyi.md`, `docs/research/bio/petro-doroshenko.md`, `docs/research/bio/yakym-somko.md`, `docs/research/bio/ivan-sirko.md`, `docs/research/bio/yuriy-nemyrych.md`, `docs/research/bio/ivan-mazepa.md`, `docs/research/bio/pylyp-orlyk.md`, `docs/research/bio/danylo-apostol.md`, `docs/research/bio/pavlo-polubotok.md` — verified related Cossack/Hetmanate dossiers.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/bohdan-khmelnytskyi.yaml` — revolution/state-formation baseline.
+  - `curriculum/l2-uk-en/plans/hist/khmelnychchyna-prychyny.yaml`, `curriculum/l2-uk-en/plans/hist/syntez-khmelnychchyna.yaml` — why Bohdan's state could not be reduced to one successor.
+  - `curriculum/l2-uk-en/plans/hist/ruina-i.yaml`, `curriculum/l2-uk-en/plans/hist/ruina-ii.yaml` — the direct political frame for Yurii's career.
+  - `curriculum/l2-uk-en/plans/hist/pereyaslavska-uhoda.yaml` — earlier protectorate vocabulary and later 1659 distortions.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — institutional baseline for office, council, starshyna, and autonomy claims.
+  - `curriculum/l2-uk-en/plans/hist/andrusivske-peremyrya.yaml` — later partition context and Yurii's post-1667 return/captivity sequence.
+  - `curriculum/l2-uk-en/plans/hist/yurii-nemyrych.yaml`, `curriculum/l2-uk-en/plans/hist/ivan-sirko.yaml`, `curriculum/l2-uk-en/plans/hist/ivan-mazepa-derzhavnyk.yaml`, `curriculum/l2-uk-en/plans/hist/pylyp-orlyk-konstytutsiia.yaml` — comparative statehood and source-language anchors.
+- **Existing ISTORIO/RUTH/LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/istorio/pereyaslavski-statti.yaml`, `curriculum/l2-uk-en/plans/istorio/pereiaslav-alternatyvy.yaml`, `curriculum/l2-uk-en/plans/istorio/pereiaslav-tsykl.yaml` — treaty and source-cycle context.
+  - `curriculum/l2-uk-en/plans/istorio/universaly-khmelnytkoho.yaml`, `curriculum/l2-uk-en/plans/istorio/sich-dokumenty.yaml`, `curriculum/l2-uk-en/plans/istorio/litopys-samovidtsia.yaml`, `curriculum/l2-uk-en/plans/istorio/litopys-velychka.yaml` — documentary/chronicle registers for future source work.
+  - `curriculum/l2-uk-en/plans/ruth/cossack-hierarchy.yaml`, `curriculum/l2-uk-en/plans/ruth/diplomatic-language.yaml`, `curriculum/l2-uk-en/plans/ruth/document-types.yaml`, `curriculum/l2-uk-en/plans/ruth/the-ruin.yaml`, `curriculum/l2-uk-en/plans/ruth/treason.yaml` — older-language and legal-political vocabulary.
+  - `curriculum/l2-uk-en/plans/lit/black-council-history.yaml`, `curriculum/l2-uk-en/plans/lit/black-council-plot.yaml`, `curriculum/l2-uk-en/plans/lit-hist-fic/kulish-black-council-revisit.yaml` — literary memory of the split that followed Yurii's Slobodyshche turn.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `yurii-khmelnytskyi` — future BIO plan/module if this dossier is promoted into curriculum.
+  - `chudnivska-uhoda-1660` / `slobodyshchenskyi-traktat` — treaty/source-reading module on the 1660 switch and the beginning of the bank split.
+  - `pereiaslavski-statti-1659` as a BIO-linked source lesson if ISTORIO scope expands beyond existing plan coverage.
+  - `chyhyrynski-pokhody-1677-1678` — Ottoman-backed title, Chyhyryn destruction, and Nemyriv rule.
+  - `pavlo-teteria`, `mykhailo-khanenko`, `ivan-samoilovych`, `vasyl-zolotarenko` — future Ruin support cluster.
+- **Potential LIT additions surfaced by this research:**
+  - A close-reading unit on how chronicles, historical fiction, and textbook prose turn Yurii into a moral contrast figure rather than a source-critical succession case.
+
+## 8. Naming-canonical
+
+- **Slug:** `yurii-khmelnytskyi`
+- **EN canonical (project spelling):** Yurii Khmelnytskyi
+- **UA canonical (with patronymic):** Юрій Богданович Хмельницький
+- **Aliases (track these for `aliases:` YAML field):** Юрій Хмельницький; Юрась Хмельницький; Хмельниченко; Гедеон; Yurii Khmelnytskyi; Yurii Khmelnytsky; Yury Khmelnytsky; Yuras; Khmelnychenko; Xmel'nyc'kyj, Jurij; Jurij Chmielnicki; Jerzy Chmielnicki in Polish contexts.
+- **Title/office variants to track carefully:** `гетьманич`, `гетьман України`, `архімандрит Гедеон`, `князь України`, `князь Сарматії`, `руський монарх`, `Юрій Гедеон Венжик Хмельницький`.
+- **Forbidden forms (Russian-imperial / flattening forms to flag in body text):** "weak son" as total explanation; "Ottoman puppet" without title/constraint context; "natural Moscow correction"; "Polish traitor" or "Turkish traitor" as factual labels; Russian-only forms such as `Юрий Хмельницкий` in normalized Ukrainian/English body text.
+- **Scope warning:** keep this BIO Cossack dossier on seventeenth-century succession/Ruin politics. Do not turn it into a general ruler chronology or a route to later Hetmanate projects outside this epic.
+
+## 9. Image candidates
+
+- **Best likely portrait candidates:** Wikimedia Commons category `Portraits of Yurii Khmelnytsky` includes several public-domain or PD-Art portrait files, including `Yuriy Khmelnytsky - Google Art Project.jpg`, `Yurii Khmelnytsky (Historical figures of Southwestern Russia in biographies and portraits. Portrait 10).jpg`, and `Юрась Хмельницький.jpg`. Verify the individual file page and license before reuse.
+- **IEU image candidate:** IEU displays a "Yurii Khmelnytsky (17th century engraving)" and other portrait images. Verify reuse rights from the image page and source metadata, not from the article thumbnail alone.
+- **Museum/context candidate:** the Ivan Honchar Museum / Google Arts & Culture portrait is attributed to an unknown creator and dated early 1800s-early 1840s; rights are museum-controlled, so do not assume open reuse without checking.
+- **Document/context image:** a rights-clear facsimile of the 1659 Pereiaslav Articles, a treaty/source page, or a Chyhyryn/Nemyriv context map may be more pedagogically honest than a posthumous portrait.
+- **Authenticity caveat:** most Yurii portraits are later portrait traditions or engravings. Caption as later representation unless file metadata proves life-era provenance.
+- **Avoid:** generic Cossack stock art, images that visually naturalize Moscow arbitration, Ottoman "exotic" imagery used as betrayal shorthand, or portraits copied from commercial stock sites without license clarity.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- [T1] Мицик Ю. А. "Хмельницький Юрій" // *Енциклопедія історії України*, т. 10. URL: https://www.history.org.ua/?termin=Khmelnytskyj_Y | resolved HTTP 200, accessed 2026-07-03. Core facts: 1640/1641, Subotiv/Chyhyryn, education, health, succession, 1659 Pereiaslav, 1660 Chudniv/Slobodyshche, Somko split, monastic turn, captivity, Ottoman-backed titles, Nemyriv rule, death variants.
+- [T1] "Khmelnytsky, Yurii" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CH%5CKhmelnytskyYurii.htm | resolved HTTP 200, accessed 2026-07-03. Core facts: office sequence, 1657/1659-1663, Pereiaslav restrictions, Slobodyshche, Ruin split, monastic name, Ottoman-backed Right-Bank episode, 1685 execution tradition.
+- [T1] Горобець В. М. "Переяславські статті 1659" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Pereiaslavski_statti_1659 | resolved HTTP 200, accessed 2026-07-03. Used for Trubetskoi coercion, rejected Ukrainian draft, forged/old article issue, foreign-policy restrictions, voivodes, and autonomy narrowing.
+- [T1] Галушко К. Ю., упорядник. "Політичні процеси в Козацькій державі у 1657-1663" // *Енциклопедія історії України: Україна-Українці*, кн. 2. URL: https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=2.11.+1&Z21ID= | accessed 2026-07-03. Used for post-Bohdan succession, 1659-1663 field of maneuver, Chudniv, Somko/Briukhovetskyi opposition, and split into two hetmanates.
+- [T1] "Slobodyshche, Treaty of" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CL%5CSlobodyshcheTreatyof.htm | resolved HTTP 200, accessed 2026-07-03. Used for 27 October 1660 treaty naming, Pereiaslav abolition, limited autonomy, and Left-Bank opposition.
+- [T1] "Chyhyryn campaigns, 1677-8" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CC%5CH%5CChyhyryncampaigns1677hD78.htm | resolved HTTP 200, accessed 2026-07-03. Used for the Ottoman Porte's plan to install Yurii as vassal/title-holder and for Chyhyryn campaign context.
+
+**Tier 2 (institutional / bibliographic):**
+- [T2] Національна бібліотека України імені В. І. Вернадського, Електронна бібліотека "Україніка", "Савчук Н. О. Українська держава за гетьманування Ю. Хмельницького (1659-поч. 1663 рр.)." URL: https://irbis-nbuv.gov.ua/ulib/item/ukr0000013024 | accessed 2026-07-03. Used as institutional pointer and bibliography anchor for the 1659-1663 government.
+- [T2] Хмельницький університет управління та права repository, Савчук Н. О. *Українська держава за гетьманування Ю. Хмельницького (1659-поч. 1663 рр.)* PDF page. URL: https://irlykhuml.univer.km.ua/handle/123456789/1327 | accessed 2026-07-03. Used for abstract-level framing of internal/geopolitical causes; full PDF not exhaustively annotated in this pass.
+- [T2] Національна бібліотека України імені В. І. Вернадського, "Мицик Ю. Тиміш та Юрій Хмельницькі." URL: https://irbis-nbuv.gov.ua/ulib/item/ukr0000027622 | accessed 2026-07-03. Used as institutional bibliographic pointer.
+
+**Tier 3 (encyclopedic — navigation only):**
+- [T3] "Юрій Хмельницький" // Ukrainian Wikipedia. URL: https://uk.wikipedia.org/wiki/Юрій_Хмельницький | accessed 2026-07-03. Used only for alias/image/date navigation; cross-checked against T1.
+- [T3] "Yurii Khmelnytsky" // English Wikipedia. URL: https://en.wikipedia.org/wiki/Yurii_Khmelnytsky | accessed 2026-07-03. Used only for English aliases and lower-tier warning about 1685/death-place claims.
+
+**Tier 4 (modern scholarly post-1991 / academic):**
+- [T4] Мицик Ю. А. "Юрій Хмельницький." In *Володарі гетьманської булави*. Київ, 1994/1995, pp. 237-251. Bibliographic anchor via ЕІУ/NBUV; direct text not fully inspected in this pass.
+- [T4] Мицик Ю. *Тиміш та Юрій Хмельницькі*. Харків: Фоліо, 2010. Bibliographic anchor via ЕІУ/NBUV.
+- [T4] Савчук Н. О. *Українська держава за гетьманування Ю. Хмельницького (1659-поч. 1663 рр.)*. Кам'янець-Подільський: Каліграф, 2001. Institutional PDF page consulted; used for bibliography and high-level framing, not for unverified page quotations.
+- [T4] Луняк Є. М. "Юрій Хмельницький у французьких дипломатів другої половини XVII ст." *Український історичний журнал* 2012, no. 1. PDF URL: https://jnas.nbuv.gov.ua/j-pdf/UIJ_2012_1_11.pdf | accessed 2026-07-03 through search/open attempts and bibliographic snippet; use for French-diplomatic memory leads, not load-bearing details in this dossier.
+- [T4] Michels G. "A Breathing Space for Vienna? The 1677 Ottoman Invasion of Ukraine and its Impact on Hungary and the Habsburg Empire." *Austrian History Yearbook* 2025/2026 online article page. URL: https://www.cambridge.org/core/journals/austrian-history-yearbook/article/breathing-space-for-vienna-the-1677-ottoman-invasion-of-ukraine-and-its-impact-on-hungary-and-the-habsburg-empire/4A14A6C4EA42AF0B30D5CCFC8895A26B | accessed 2026-07-03. Used for comparative Ottoman-war context and for the caution that Yurii's 1677 role is under-studied.
+- [T4] Kochegarov K. A. "The Last Days of Yurii Kchmelnitsky." *Slavic Almanac* 2025, no. 1-2, pp. 12-46. DOI: https://doi.org/10.31168/2073-5731.2025.1-2.01 | article page accessed 2026-07-03. Used only as a recent specialist lead on the 1680-1681 endgame; interpret with decolonization caution because it is a Russian institutional publication and uses non-project transliteration.
+
+**Tier 5 (general web / image metadata — not load-bearing):**
+- [T5/image metadata] Wikimedia Commons, `Category:Portraits of Yurii Khmelnytsky`. URL: https://commons.wikimedia.org/wiki/Category:Portraits_of_Yurii_Khmelnytsky | accessed 2026-07-03. Used for image-rights leads only.
+- [T5/image metadata] IEU picture page, "Yurii Khmelnytsky (17th century engraving)." URL: https://www.encyclopediaofukraine.com/picturedisplay.asp?id=5666&key=Khmelnytsky%2C+Yurii%2C+Xmel%E2%80%99nyc%E2%80%99kyj%2C+Jurij%2C+aka+Khmelnychenko%2C+Yuras&linkpath=pic%5CK%5CH%5CKhmelnytsky+Yurii+%28engraving%29.jpg&page=pages%5CK%5CH%5CKhmelnytskyYurii.htm&pid=3585&tyt=Khmelnytsky%2C+Yurii | accessed 2026-07-03. Used for portrait lead only.
+
+**Primary-source documents accessed / verification notes:**
+- Pereiaslav Articles 1659: document title and clause effects verified through ЕІУ; original source edition not directly inspected.
+- Slobodyshche/Chudniv Treaty 1660: document title and treaty effects verified through IEU/ЕІУ; original source edition not directly inspected.
+- Ottoman-backed title formulas: verified through ЕІУ's Yurii entry; Ottoman chancery/source edition not directly inspected.
+
+**Honest gaps:** this dossier did not inspect archival originals, complete *Akty Yugo-Zapadnoi Rossii* volumes, Ottoman chancery material, or every chronicle/death-tradition variant. For module writing, recheck direct document wording for Pereiaslav 1659, Slobodyshche 1660, Yurii's late-1670s titulature, and the 1681/1685 death traditions against source editions.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Moscow is treated as an intervening power with coercive leverage, not as Ukraine's natural arbiter.
+- [x] Yurii is not flattened into either a helpless weak son or a simple foreign puppet.
+- [x] Polish/Commonwealth, Crimean, Ottoman, Moscow, and Cossack-factional pressures are all named without turning any one into the whole explanation.
+- [x] No Russian-imperial transliterations in body text except variant/forbidden forms in §8.
+- [x] Inherited legitimacy is treated as real political capital but not as a substitute for institutions or consent.
+- [x] Illness/youth are handled cautiously and not used as a moral diagnosis.
+- [x] Ottoman-backed title claims are taught as constrained statecraft/propaganda, not as exotic betrayal shorthand.
+- [x] No out-of-scope all-rulers chronology, Polish-king coverage, or later Hetmanate material added.
+- [x] Modern Ukrainian place/institution naming used with historical context: Суботів, Чигирин, Переяслав, Слободище, Корсунь, Умань, Аккерман/Білгород-Дністровський, Немирів, Кам'янець-Подільський, Лівобережжя, Правобережжя, Гетьманщина, Запорозька Січ.
+
+## Validation checklist
+
+- [x] Single owned file only: `docs/research/bio/yurii-khmelnytskyi.md`.
+- [x] Existing cross-track plan paths verified locally before citation.
+- [x] Lower-tier sources marked as non-load-bearing.
+- [x] No generated `status/`, `audit/`, `review/`, or telemetry artifacts referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans, module files, activities, vocabulary, resources, site MDX, or wiki files edited.


### PR DESCRIPTION
## Scope

Adds the P1 BIO Cossack research dossier for Yurii Khmelnytskyi, scoped to the succession/Ruin problem after Bohdan Khmelnytskyi: inherited legitimacy, Pereiaslav 1659, Chudniv/Slobodyshche, Left-Bank opposition, monastic withdrawal, Ottoman-backed Right-Bank title/rule, disputed death traditions, and later memory.

This is BIO-scoped dossier work only. No curriculum plans, lesson modules, activities, vocabulary, site files, generated artifacts, linter configs, package files, or telemetry files are changed.

## Changed files

- `docs/research/bio/yurii-khmelnytskyi.md`

## Validation

- `npx markdownlint-cli2 docs/research/bio/yurii-khmelnytskyi.md` — passed, 0 errors
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/yurii-khmelnytskyi.md` — passed, no fabricated Existing cross-track plan paths
- `git diff --check` — passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed, 1 commit with required `X-Agent` trailer
- Protected artifact/config guard — confirmed only `docs/research/bio/yurii-khmelnytskyi.md` is changed

## Source and decolonization caveats

- Tier 1 facts are anchored in ЕІУ, Internet Encyclopedia of Ukraine, ЕІУ Pereiaslav Articles 1659, ЕІУ 1657-1663 political-processes entry, IEU Slobodyshche Treaty, and IEU Chyhyryn campaigns.
- Lower-tier sources are kept as navigation or image-rights aids only.
- Death/execution traditions, office/titulature, monastic names, and Ottoman-backed title claims are flagged as source-sensitive rather than smoothed into a single certainty.
- The dossier avoids reducing Yurii to either a weak son or a simple foreign puppet, while still naming his agency and the coercive role of Moscow/Commonwealth/Crimean/Ottoman pressures.

## Review gate

No independent review has been routed yet because the orchestrator handles that gate.