### PR TITLE
feat(atlas): add intake registry and gate foundation

### DIFF
--- a/scripts/audit/atlas_intake_census.py
+++ b/scripts/audit/atlas_intake_census.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Safe source-family census for full-corpus Atlas intake."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = Path(__file__).resolve().parent
+if sys.path and Path(sys.path[0]).resolve() == SCRIPT_DIR:
+    sys.path.pop(0)
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.audit.atlas_intake_gate import (
+    classification_counts,
+    classify_candidates,
+)
+from scripts.audit.atlas_intake_registry import (
+    REQUIRED_SOURCE_FAMILIES,
+    is_registered_source_family,
+    registered_source_families,
+    registry_payload,
+)
+from scripts.audit.source_inventory_intake import (
+    SourceInventoryError,
+    SourceInventoryRecord,
+    read_source_inventories,
+    source_inventory_candidates,
+)
+
+SUPPORTED_INVENTORY_SUFFIXES = {".csv", ".tsv", ".jsonl", ".json", ".yaml", ".yml"}
+DEFAULT_INVENTORY_DIR = PROJECT_ROOT / "data/lexicon/source-inventory"
+WORKFLOW_ID = "atlas_intake_census.v1"
+OMITTED_RAW_FIELDS = ("lemma", "headword", "word", "context", "gloss", "notes", "raw_text")
+
+
+def discover_inventory_paths(
+    inventory_dir: Path = DEFAULT_INVENTORY_DIR,
+) -> tuple[Path, ...]:
+    """Return supported source-inventory files in deterministic order."""
+    return tuple(
+        sorted(
+            path
+            for path in inventory_dir.iterdir()
+            if path.is_file() and path.suffix.lower() in SUPPORTED_INVENTORY_SUFFIXES
+        )
+    )
+
+
+def build_census(
+    inventory_paths: Sequence[Path],
+    *,
+    project_root: Path = PROJECT_ROOT,
+) -> dict[str, Any]:
+    """Build a safe derived census without raw source text or candidate lemmas."""
+    records = read_source_inventories(inventory_paths, project_root=project_root)
+    candidates = source_inventory_candidates(records)
+    gate_results = classify_candidates(candidates)
+    by_family = _family_rows(records)
+    registered = set(registered_source_families())
+    seen_families = set(by_family)
+    unknown_families = sorted(family for family in seen_families if family not in registered)
+    missing_required = sorted(set(REQUIRED_SOURCE_FAMILIES) - seen_families)
+
+    inventory_rows = _inventory_rows(records, inventory_paths, project_root)
+    return {
+        "workflow": WORKFLOW_ID,
+        "source_registry": {
+            **registry_payload(),
+            "missing_required_source_families": missing_required,
+            "unknown_source_families": unknown_families,
+        },
+        "counts": {
+            "inventory_files": len(inventory_paths),
+            "source_units": _source_unit_count(records),
+            "source_rows": len(records),
+            "deduped_candidates": len(candidates),
+            "registered_source_rows": sum(
+                1 for record in records if is_registered_source_family(record.source_family)
+            ),
+            "unknown_source_rows": sum(
+                1 for record in records if not is_registered_source_family(record.source_family)
+            ),
+        },
+        "gate": {
+            "workflow": "atlas_intake_gate.v1",
+            "classification_counts": classification_counts(gate_results),
+        },
+        "by_family": {
+            family: _family_payload(rows, registered=family in registered)
+            for family, rows in sorted(by_family.items())
+        },
+        "inventory_files": inventory_rows,
+        "safety": {
+            "raw_text_included": False,
+            "omitted_fields": list(OMITTED_RAW_FIELDS),
+            "public_boundary": (
+                "Census output is derived metadata only: counts, source ids, paths, "
+                "and locators. It omits lemmas, contexts, glosses, and raw source text."
+            ),
+        },
+    }
+
+
+def format_markdown_census(census: Mapping[str, Any]) -> str:
+    """Format a compact human-readable census report."""
+    counts = census["counts"]
+    lines = [
+        "# Atlas Intake Source Census",
+        "",
+        f"- workflow: `{census['workflow']}`",
+        f"- inventory_files: {counts['inventory_files']}",
+        f"- source_units: {counts['source_units']}",
+        f"- source_rows: {counts['source_rows']}",
+        f"- deduped_candidates: {counts['deduped_candidates']}",
+        "- raw_text_included: false",
+        "",
+        "## Gate Counts",
+        "",
+    ]
+    gate_counts = census["gate"]["classification_counts"]
+    lines.extend(f"- `{key}`: {gate_counts[key]}" for key in sorted(gate_counts))
+    lines.extend(["", "## Source Families", ""])
+    for family, row in census["by_family"].items():
+        lines.append(
+            f"- `{family}`: rows={row['source_rows']} units={row['source_units']} "
+            f"candidates={row['deduped_candidates']} frequency={row['frequency']}"
+        )
+    return "\n".join(lines)
+
+
+def _family_rows(records: Sequence[SourceInventoryRecord]) -> dict[str, list[SourceInventoryRecord]]:
+    rows: dict[str, list[SourceInventoryRecord]] = defaultdict(list)
+    for record in records:
+        rows[record.source_family].append(record)
+    return rows
+
+
+def _family_payload(rows: Sequence[SourceInventoryRecord], *, registered: bool) -> dict[str, Any]:
+    candidates = source_inventory_candidates(rows)
+    source_units = _source_units(rows)
+    extraction_modes = sorted({record.extraction_mode for record in rows})
+    inventory_paths = sorted({record.inventory_path for record in rows})
+    return {
+        "registered": registered,
+        "source_rows": len(rows),
+        "source_units": len(source_units),
+        "deduped_candidates": len(candidates),
+        "frequency": sum(record.count for record in rows),
+        "inventory_files": len(inventory_paths),
+        "inventory_paths": inventory_paths,
+        "extraction_modes": extraction_modes,
+        "safe_locators": [_source_unit_payload(unit_rows) for unit_rows in source_units],
+    }
+
+
+def _source_units(
+    records: Sequence[SourceInventoryRecord],
+) -> list[list[SourceInventoryRecord]]:
+    grouped: dict[tuple[str, str, str], list[SourceInventoryRecord]] = defaultdict(list)
+    for record in records:
+        key = (
+            record.source_family,
+            record.source_id or "<missing-source-id>",
+            record.inventory_path,
+        )
+        grouped[key].append(record)
+    return [grouped[key] for key in sorted(grouped)]
+
+
+def _source_unit_count(records: Sequence[SourceInventoryRecord]) -> int:
+    return len(_source_units(records))
+
+
+def _source_unit_payload(rows: Sequence[SourceInventoryRecord]) -> dict[str, Any]:
+    first = rows[0]
+    locators = sorted({record.source_locator for record in rows if record.source_locator})
+    source_paths = sorted({record.source_path for record in rows if record.source_path})
+    return {
+        "inventory_path": first.inventory_path,
+        "source_id": first.source_id,
+        "source_path": source_paths[0] if len(source_paths) == 1 else None,
+        "source_locator": locators[0] if len(locators) == 1 else None,
+        "source_locator_count": len(locators),
+        "headword_rows": len(rows),
+        "frequency": sum(record.count for record in rows),
+    }
+
+
+def _inventory_rows(
+    records: Sequence[SourceInventoryRecord],
+    inventory_paths: Sequence[Path],
+    project_root: Path,
+) -> list[dict[str, Any]]:
+    by_path: dict[str, list[SourceInventoryRecord]] = defaultdict(list)
+    for record in records:
+        by_path[record.inventory_path].append(record)
+    rows: list[dict[str, Any]] = []
+    for path in inventory_paths:
+        display_path = _display_path(path, project_root)
+        path_records = by_path.get(display_path, [])
+        rows.append(
+            {
+                "path": display_path,
+                "source_families": sorted({record.source_family for record in path_records}),
+                "source_units": _source_unit_count(path_records),
+                "source_rows": len(path_records),
+                "frequency": sum(record.count for record in path_records),
+            }
+        )
+    return rows
+
+
+def _display_path(path: Path, project_root: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(project_root.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--inventory",
+        dest="inventory_paths",
+        action="append",
+        type=Path,
+        help="Source inventory file to include; defaults to all committed source-inventory files.",
+    )
+    parser.add_argument("--format", choices=("json", "markdown"), default="json")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    inventory_paths = tuple(args.inventory_paths or discover_inventory_paths())
+    if not inventory_paths:
+        print("error: no source inventory files found", file=sys.stderr)
+        return 2
+    try:
+        census = build_census(inventory_paths)
+    except (FileNotFoundError, SourceInventoryError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    if args.format == "markdown":
+        print(format_markdown_census(census))
+    else:
+        print(json.dumps(census, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/atlas_intake_gate.py
+++ b/scripts/audit/atlas_intake_gate.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Deterministic candidate gate for Atlas intake foundation runs."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+from scripts.audit.atlas_intake_registry import is_registered_source_family
+from scripts.audit.source_inventory_intake import SourceInventoryCandidate
+
+CLASSIFICATION_AUTO_APPROVE = "auto_approve"
+CLASSIFICATION_REVIEW_QUEUE = "review_queue"
+CLASSIFICATION_REJECT = "reject"
+
+AtlasGateClassification = Literal["auto_approve", "review_queue", "reject"]
+
+CLASSIFICATIONS: tuple[AtlasGateClassification, ...] = (
+    CLASSIFICATION_AUTO_APPROVE,
+    CLASSIFICATION_REVIEW_QUEUE,
+    CLASSIFICATION_REJECT,
+)
+
+
+@dataclass(frozen=True)
+class AtlasIntakeGateResult:
+    """One deterministic gate decision for a source-inventory candidate."""
+
+    lemma: str
+    classification: AtlasGateClassification
+    gate_evidence: dict[str, object]
+
+    def candidate_payload(self) -> dict[str, object]:
+        """Return the safe derived candidate schema for review/status output."""
+        source_families = list(self.gate_evidence["source_families"])
+        return {
+            "lemma": self.lemma,
+            "headword": self.lemma,
+            "source_family": source_families[0] if len(source_families) == 1 else "multiple",
+            "source_families": source_families,
+            "source_ids": list(self.gate_evidence["source_ids"]),
+            "locators": list(self.gate_evidence["locators"]),
+            "count": self.gate_evidence["source_count"],
+            "frequency": self.gate_evidence["frequency"],
+            "classification": self.classification,
+            "gate_evidence": self.gate_evidence,
+        }
+
+
+def classify_candidate(candidate: SourceInventoryCandidate) -> AtlasIntakeGateResult:
+    """Classify one source-inventory candidate without mutating Atlas outputs."""
+    source_families = _source_families(candidate.source_provenance)
+    source_ids = _source_ids(candidate.source_provenance)
+    locators = _locators(candidate.source_provenance)
+
+    reject_reasons: list[str] = []
+    review_reasons: list[str] = []
+
+    if not _has_text(candidate.lemma):
+        reject_reasons.append("missing_lemma")
+    if not candidate.source_provenance:
+        reject_reasons.append("missing_source_provenance")
+    unknown_families = [family for family in source_families if not is_registered_source_family(family)]
+    reject_reasons.extend(f"unknown_source_family:{family}" for family in unknown_families)
+    if not source_families:
+        reject_reasons.append("missing_source_family")
+    if not source_ids:
+        review_reasons.append("missing_source_id")
+    if not locators:
+        review_reasons.append("missing_locator")
+    if not _has_text(candidate.pos):
+        review_reasons.append("missing_pos")
+    if not _has_text(candidate.gloss):
+        review_reasons.append("missing_english_anchor")
+
+    if reject_reasons:
+        classification: AtlasGateClassification = CLASSIFICATION_REJECT
+        reasons = reject_reasons + review_reasons
+    elif review_reasons:
+        classification = CLASSIFICATION_REVIEW_QUEUE
+        reasons = review_reasons
+    else:
+        classification = CLASSIFICATION_AUTO_APPROVE
+        reasons = ["deterministic_contract_satisfied"]
+
+    source_count = candidate.source_count or len(candidate.source_provenance)
+    frequency = candidate.frequency or _frequency(candidate.source_provenance) or source_count
+    return AtlasIntakeGateResult(
+        lemma=candidate.lemma,
+        classification=classification,
+        gate_evidence={
+            "workflow": "atlas_intake_gate.v1",
+            "source_families": source_families,
+            "source_ids": source_ids,
+            "locators": locators,
+            "source_count": source_count,
+            "frequency": frequency,
+            "has_pos": _has_text(candidate.pos),
+            "has_english_anchor": _has_text(candidate.gloss),
+            "reasons": reasons,
+        },
+    )
+
+
+def classify_candidates(
+    candidates: Sequence[SourceInventoryCandidate],
+) -> list[AtlasIntakeGateResult]:
+    """Classify candidates in deterministic order."""
+    return sorted(
+        (classify_candidate(candidate) for candidate in candidates),
+        key=lambda result: result.lemma.casefold(),
+    )
+
+
+def classification_counts(results: Sequence[AtlasIntakeGateResult]) -> dict[str, int]:
+    """Return stable counts for all supported gate classifications."""
+    counts = Counter(result.classification for result in results)
+    return {classification: counts.get(classification, 0) for classification in CLASSIFICATIONS}
+
+
+def _source_families(provenance: Sequence[Mapping[str, object]]) -> list[str]:
+    families = {_clean_text(row.get("source_family")) for row in provenance}
+    return sorted(family for family in families if family)
+
+
+def _source_ids(provenance: Sequence[Mapping[str, object]]) -> list[str]:
+    ids = {_clean_text(row.get("source_id")) for row in provenance}
+    return sorted(source_id for source_id in ids if source_id)
+
+
+def _locators(provenance: Sequence[Mapping[str, object]]) -> list[str]:
+    locators = {
+        _clean_text(row.get("source_locator")) or _clean_text(row.get("inventory_locator"))
+        for row in provenance
+    }
+    return sorted(locator for locator in locators if locator)
+
+
+def _frequency(provenance: Sequence[Mapping[str, object]]) -> int:
+    total = 0
+    for row in provenance:
+        count = row.get("count", 1)
+        if isinstance(count, int) and count > 0:
+            total += count
+        else:
+            total += 1
+    return total
+
+
+def _clean_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _has_text(value: object) -> bool:
+    return _clean_text(value) is not None

--- a/scripts/audit/atlas_intake_registry.py
+++ b/scripts/audit/atlas_intake_registry.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Shared source-family registry for full-corpus Atlas intake."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+SOURCE_FAMILY_CURRICULUM = "curriculum"
+SOURCE_FAMILY_TEACHER_LESSON = "teacher_lesson"
+SOURCE_FAMILY_TEXTBOOK = "textbook"
+SOURCE_FAMILY_OHOIKO = "ohoiko"
+
+SourceFamilyId = Literal["curriculum", "teacher_lesson", "textbook", "ohoiko"]
+
+REQUIRED_SOURCE_FAMILIES: tuple[SourceFamilyId, ...] = (
+    SOURCE_FAMILY_CURRICULUM,
+    SOURCE_FAMILY_TEACHER_LESSON,
+    SOURCE_FAMILY_TEXTBOOK,
+    SOURCE_FAMILY_OHOIKO,
+)
+
+
+@dataclass(frozen=True)
+class SourceFamilyDefinition:
+    """Policy for one safe Atlas-intake source family."""
+
+    id: SourceFamilyId
+    label: str
+    raw_text_policy: str
+    safe_locator_policy: str
+    default_extraction_modes: tuple[str, ...]
+    atlas_publish_policy: str
+    surface_admission_policy: str
+
+
+SOURCE_FAMILY_REGISTRY: dict[str, SourceFamilyDefinition] = {
+    SOURCE_FAMILY_CURRICULUM: SourceFamilyDefinition(
+        id=SOURCE_FAMILY_CURRICULUM,
+        label="Owned curriculum/module content",
+        raw_text_policy="owned source text may be inspected; intake census still emits derived metadata only",
+        safe_locator_policy="repository-relative path plus section/key locator",
+        default_extraction_modes=(
+            "grammar_vocabulary_item",
+            "module_markdown_token",
+            "activity_token",
+            "vocabulary_yaml_item",
+        ),
+        atlas_publish_policy="deterministic gate, review queue for ambiguous candidates, controlled Atlas publish",
+        surface_admission_policy="Daily Word, Practice, and Cloze require explicit surface_admission",
+    ),
+    SOURCE_FAMILY_TEACHER_LESSON: SourceFamilyDefinition(
+        id=SOURCE_FAMILY_TEACHER_LESSON,
+        label="Private teacher lessons",
+        raw_text_policy="never commit raw private lesson text, filenames, or private infrastructure details",
+        safe_locator_policy="neutral lesson slug/source id plus table/paragraph locator",
+        default_extraction_modes=(
+            "curated_headword",
+            "private_document_token",
+        ),
+        atlas_publish_policy="derived metadata only; external/non-Codex review before publish batches",
+        surface_admission_policy="no learner-surface admission without explicit surface_admission policy",
+    ),
+    SOURCE_FAMILY_TEXTBOOK: SourceFamilyDefinition(
+        id=SOURCE_FAMILY_TEXTBOOK,
+        label="Ukrainian textbook corpus",
+        raw_text_policy="never commit raw copyrighted textbook text or OCR chunks",
+        safe_locator_policy="public/source slug plus page/chunk/row locator where rights-safe",
+        default_extraction_modes=(
+            "curated_headword",
+            "headword_inventory",
+            "ocr_candidate",
+        ),
+        atlas_publish_policy="strong noise/OCR filters plus review for source-thin candidates",
+        surface_admission_policy="no learner-surface admission without explicit surface_admission policy",
+    ),
+    SOURCE_FAMILY_OHOIKO: SourceFamilyDefinition(
+        id=SOURCE_FAMILY_OHOIKO,
+        label="Anna Ohoiko corpus",
+        raw_text_policy="never commit raw copyrighted book/content text",
+        safe_locator_policy="corpus/source slug plus section/page/item locator",
+        default_extraction_modes=(
+            "curated_headword",
+            "book_candidate",
+            "content_token",
+        ),
+        atlas_publish_policy="dedupe against Atlas/ledgers, review queue for ambiguous candidates",
+        surface_admission_policy="no learner-surface admission without explicit surface_admission policy",
+    ),
+}
+
+
+def registered_source_families() -> tuple[str, ...]:
+    """Return registered source-family identifiers in deterministic order."""
+    return tuple(SOURCE_FAMILY_REGISTRY)
+
+
+def is_registered_source_family(source_family: object) -> bool:
+    """Return true when a source-family value is in the registry."""
+    return isinstance(source_family, str) and source_family.casefold() in SOURCE_FAMILY_REGISTRY
+
+
+def source_family_definition(source_family: str) -> SourceFamilyDefinition:
+    """Return the registry definition for a source family."""
+    family = source_family.casefold()
+    try:
+        return SOURCE_FAMILY_REGISTRY[family]
+    except KeyError as exc:
+        raise KeyError(f"unregistered Atlas source family: {source_family}") from exc
+
+
+def registry_payload() -> dict[str, object]:
+    """Return a JSON-ready registry summary safe for public reports."""
+    return {
+        "workflow": "atlas_intake_source_registry.v1",
+        "required_source_families": list(REQUIRED_SOURCE_FAMILIES),
+        "families": [
+            {
+                "id": definition.id,
+                "label": definition.label,
+                "raw_text_policy": definition.raw_text_policy,
+                "safe_locator_policy": definition.safe_locator_policy,
+                "default_extraction_modes": list(definition.default_extraction_modes),
+                "atlas_publish_policy": definition.atlas_publish_policy,
+                "surface_admission_policy": definition.surface_admission_policy,
+            }
+            for definition in SOURCE_FAMILY_REGISTRY.values()
+        ],
+    }

--- a/scripts/audit/check_atlas_intake_freeze.py
+++ b/scripts/audit/check_atlas_intake_freeze.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Before/after freeze check for Atlas-intake-only runs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+WORKFLOW_ID = "atlas_intake_surface_freeze.v1"
+DAILY_POOL = Path("site/src/data/lexicon-daily-pool.json")
+PRACTICE_DECK_POINTER = Path("site/src/data/lexicon-practice-deck.pointer.json")
+PRACTICE_REVIEWED_SOURCES = Path("site/src/data/lexicon-practice-reviewed-sources.json")
+CLOZE_SOURCES = Path("site/src/data/lexicon-practice-cloze-sources.json")
+HYDRATED_PRACTICE_GLOB = "site/public/lexicon/practice-*.json"
+
+
+def build_surface_snapshot(project_root: Path = PROJECT_ROOT) -> dict[str, Any]:
+    """Return hashes and derived counts for frozen learner-facing surfaces."""
+    files = _surface_files(project_root)
+    file_hashes = {
+        _display_path(path, project_root): _file_fingerprint(path) for path in files
+    }
+    daily_pool = _read_json(project_root / DAILY_POOL)
+    practice_pointer = _read_json(project_root / PRACTICE_DECK_POINTER)
+    reviewed_sources = _read_json(project_root / PRACTICE_REVIEWED_SOURCES)
+    cloze_sources = _read_json(project_root / CLOZE_SOURCES)
+    return {
+        "workflow": WORKFLOW_ID,
+        "surfaces": {
+            "daily": {
+                "count": len(daily_pool) if isinstance(daily_pool, list) else 0,
+                "files": [str(DAILY_POOL)],
+            },
+            "practice": _practice_surface(practice_pointer),
+            "cloze": {
+                "source_count": len(cloze_sources) if isinstance(cloze_sources, list) else 0,
+                "deck_cloze_count": _practice_cloze_count(practice_pointer),
+                "reviewed_source_count": _reviewed_source_count(reviewed_sources),
+                "files": [
+                    str(PRACTICE_DECK_POINTER),
+                    str(PRACTICE_REVIEWED_SOURCES),
+                    str(CLOZE_SOURCES),
+                ],
+            },
+        },
+        "files": file_hashes,
+    }
+
+
+def compare_snapshots(
+    before: Mapping[str, Any],
+    after: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Compare two freeze snapshots."""
+    surface_diffs = _mapping_diffs(before.get("surfaces"), after.get("surfaces"), prefix="surfaces")
+    file_diffs = _mapping_diffs(before.get("files"), after.get("files"), prefix="files")
+    diffs = surface_diffs + file_diffs
+    return {
+        "workflow": WORKFLOW_ID,
+        "ok": not diffs,
+        "diffs": diffs,
+        "before_surfaces": before.get("surfaces"),
+        "after_surfaces": after.get("surfaces"),
+    }
+
+
+def _surface_files(project_root: Path) -> list[Path]:
+    tracked = [
+        project_root / DAILY_POOL,
+        project_root / PRACTICE_DECK_POINTER,
+        project_root / PRACTICE_REVIEWED_SOURCES,
+        project_root / CLOZE_SOURCES,
+    ]
+    hydrated = sorted(project_root.glob(HYDRATED_PRACTICE_GLOB))
+    return [path for path in [*tracked, *hydrated] if path.exists()]
+
+
+def _practice_surface(pointer_payload: object) -> dict[str, Any]:
+    files = [str(PRACTICE_DECK_POINTER)]
+    if not isinstance(pointer_payload, Mapping):
+        return {
+            "lexeme_count": 0,
+            "cloze_count": 0,
+            "deck_version": None,
+            "package_sha256": None,
+            "file_count": 0,
+            "files": files,
+        }
+    pointer_files = pointer_payload.get("files")
+    package_files = pointer_files if isinstance(pointer_files, list) else []
+    return {
+        "lexeme_count": _practice_lexeme_count(pointer_payload),
+        "cloze_count": _practice_cloze_count(pointer_payload),
+        "deck_version": pointer_payload.get("deck_version"),
+        "package_sha256": pointer_payload.get("package_sha256"),
+        "file_count": pointer_payload.get("file_count"),
+        "files": files,
+        "package_files": len(package_files),
+    }
+
+
+def _practice_lexeme_count(pointer_payload: object) -> int:
+    return _practice_count(pointer_payload, "lexemes")
+
+
+def _practice_cloze_count(pointer_payload: object) -> int:
+    return _practice_count(pointer_payload, "cloze")
+
+
+def _practice_count(pointer_payload: object, key: str) -> int:
+    if not isinstance(pointer_payload, Mapping):
+        return 0
+    files = pointer_payload.get("files")
+    if not isinstance(files, list):
+        return 0
+    total = 0
+    for row in files:
+        if not isinstance(row, Mapping):
+            continue
+        counts = row.get("counts")
+        if isinstance(counts, Mapping) and isinstance(counts.get(key), int):
+            total += counts[key]
+    return total
+
+
+def _reviewed_source_count(payload: object) -> int:
+    if isinstance(payload, Mapping):
+        reviewed = payload.get("reviewed")
+        return len(reviewed) if isinstance(reviewed, list) else 0
+    if isinstance(payload, list):
+        return len(payload)
+    return 0
+
+
+def _file_fingerprint(path: Path) -> dict[str, object]:
+    data = path.read_bytes()
+    return {
+        "bytes": len(data),
+        "sha256": hashlib.sha256(data).hexdigest(),
+    }
+
+
+def _read_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _mapping_diffs(before: object, after: object, *, prefix: str) -> list[str]:
+    if before == after:
+        return []
+    if not isinstance(before, Mapping) or not isinstance(after, Mapping):
+        return [prefix]
+    diffs: list[str] = []
+    for key in sorted(set(before) | set(after)):
+        path = f"{prefix}.{key}"
+        if key not in before:
+            diffs.append(f"{path}: added")
+        elif key not in after:
+            diffs.append(f"{path}: removed")
+        elif before[key] != after[key]:
+            if isinstance(before[key], Mapping) and isinstance(after[key], Mapping):
+                diffs.extend(_mapping_diffs(before[key], after[key], prefix=path))
+            else:
+                diffs.append(f"{path}: changed")
+    return diffs
+
+
+def _display_path(path: Path, project_root: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(project_root.resolve()))
+    except ValueError:
+        return str(path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshot-out", type=Path, help="Write the current snapshot to JSON.")
+    parser.add_argument("--compare-to", type=Path, help="Compare current snapshot to a previous snapshot JSON.")
+    parser.add_argument("--format", choices=("summary", "json"), default="summary")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    current = build_surface_snapshot()
+    result: dict[str, Any] = current
+    status = 0
+    if args.compare_to:
+        before = json.loads(args.compare_to.read_text(encoding="utf-8"))
+        result = compare_snapshots(before, current)
+        status = 0 if result["ok"] else 1
+    if args.snapshot_out:
+        args.snapshot_out.parent.mkdir(parents=True, exist_ok=True)
+        args.snapshot_out.write_text(
+            json.dumps(current, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.format == "json":
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    elif args.compare_to:
+        if result["ok"]:
+            print("Atlas intake freeze OK: Daily/Practice/Cloze surfaces unchanged.")
+        else:
+            print("Atlas intake freeze failed:")
+            for diff in result["diffs"]:
+                print(f"- {diff}")
+    else:
+        surfaces = current["surfaces"]
+        print(
+            "Atlas intake freeze snapshot: "
+            f"{surfaces['daily']['count']} daily words, "
+            f"{surfaces['practice']['lexeme_count']} practice lexemes, "
+            f"{surfaces['cloze']['source_count']} cloze source rows."
+        )
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/source_inventory_intake.py
+++ b/scripts/audit/source_inventory_intake.py
@@ -34,7 +34,18 @@ _SOURCE_FIELDS = {
     "notes",
     "headwords",
 }
-_HEADWORD_FIELDS = {"lemma", "headword", "word", "pos", "gloss", "locator", "context", "notes"}
+_HEADWORD_FIELDS = {
+    "lemma",
+    "headword",
+    "word",
+    "pos",
+    "gloss",
+    "locator",
+    "context",
+    "notes",
+    "count",
+    "frequency",
+}
 _FLAT_FIELDS = {
     "lemma",
     "source_family",
@@ -48,6 +59,8 @@ _FLAT_FIELDS = {
     "pos",
     "gloss",
     "notes",
+    "count",
+    "frequency",
 }
 _FLAT_ALIASES = {
     "headword": "lemma",
@@ -90,6 +103,7 @@ class SourceInventoryRecord:
     pos: str | None = None
     gloss: str | None = None
     notes: str | None = None
+    count: int = 1
 
     def provenance_payload(self) -> dict[str, Any]:
         """Return JSON-ready provenance for a candidate entry."""
@@ -107,6 +121,7 @@ class SourceInventoryRecord:
             "source_locator": self.source_locator,
             "context": self.context,
             "notes": self.notes,
+            "count": self.count if self.count != 1 else None,
         }
         payload.update({key: value for key, value in optional.items() if value})
         return payload
@@ -120,6 +135,8 @@ class SourceInventoryCandidate:
     pos: str | None
     gloss: str | None
     source_provenance: tuple[dict[str, Any], ...]
+    source_count: int = 0
+    frequency: int = 0
 
 
 def read_source_inventories(
@@ -180,6 +197,7 @@ def source_inventory_candidates(
                 "pos": record.pos,
                 "gloss": record.gloss,
                 "source_provenance": [],
+                "frequency": 0,
             },
         )
         existing_pos = group["pos"]
@@ -197,6 +215,7 @@ def source_inventory_candidates(
         if record.gloss and not existing_gloss:
             group["gloss"] = record.gloss
         group["source_provenance"].append(record.provenance_payload())
+        group["frequency"] += record.count
 
     candidates = [
             SourceInventoryCandidate(
@@ -204,6 +223,8 @@ def source_inventory_candidates(
                 pos=group["pos"],
                 gloss=group["gloss"],
                 source_provenance=tuple(group["source_provenance"]),
+                source_count=len(group["source_provenance"]),
+                frequency=int(group["frequency"]),
             )
         for group in grouped.values()
     ]
@@ -334,6 +355,12 @@ def _record_from_structured_headword(
         pos=_optional_slug(row.get("pos"), "pos", inventory_path, inventory_locator),
         gloss=_optional_text(row.get("gloss")),
         notes=_optional_text(row.get("notes")) or _optional_text(source.get("notes")),
+        count=_positive_int(
+            _first_present(row, ("count", "frequency")),
+            "count",
+            inventory_path,
+            inventory_locator,
+        ),
     )
 
 
@@ -361,6 +388,12 @@ def _record_from_flat_row(
         pos=_optional_slug(normalized.get("pos"), "pos", inventory_path, locator),
         gloss=_optional_text(normalized.get("gloss")),
         notes=_optional_text(normalized.get("notes")),
+        count=_positive_int(
+            _first_present(normalized, ("count", "frequency")),
+            "count",
+            inventory_path,
+            locator,
+        ),
     )
 
 
@@ -428,6 +461,22 @@ def _optional_text(value: object) -> str | None:
         return None
     text = str(value).strip()
     return text or None
+
+
+def _positive_int(value: object, field: str, inventory_path: str, locator: str) -> int:
+    if value is None:
+        return 1
+    try:
+        count = int(str(value).strip())
+    except (TypeError, ValueError) as exc:
+        raise SourceInventoryError(
+            f"{inventory_path}: {locator}: {field} must be a positive integer"
+        ) from exc
+    if count < 1:
+        raise SourceInventoryError(
+            f"{inventory_path}: {locator}: {field} must be a positive integer"
+        )
+    return count
 
 
 def _first_present(row: Mapping[str, object], keys: Sequence[str]) -> object | None:

--- a/tests/test_atlas_intake_foundation.py
+++ b/tests/test_atlas_intake_foundation.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.audit.atlas_intake_census import build_census
+from scripts.audit.atlas_intake_gate import (
+    CLASSIFICATION_AUTO_APPROVE,
+    CLASSIFICATION_REJECT,
+    CLASSIFICATION_REVIEW_QUEUE,
+    classification_counts,
+    classify_candidate,
+    classify_candidates,
+)
+from scripts.audit.atlas_intake_registry import (
+    REQUIRED_SOURCE_FAMILIES,
+    registry_payload,
+    source_family_definition,
+)
+from scripts.audit.check_atlas_intake_freeze import (
+    build_surface_snapshot,
+    compare_snapshots,
+)
+from scripts.audit.source_inventory_intake import (
+    SourceInventoryCandidate,
+    read_source_inventory,
+    source_inventory_candidates,
+)
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+def _write_minimal_freeze_surface(root: Path) -> None:
+    _write_json(
+        root / "site/src/data/lexicon-daily-pool.json",
+        [{"lemma": "дім", "slug": "дім", "gloss": "house", "k": "vyv", "cefr": "A1"}],
+    )
+    _write_json(
+        root / "site/src/data/lexicon-practice-deck.pointer.json",
+        {
+            "deck_version": "atlas-practice-v1-fixture",
+            "package_sha256": "fixture",
+            "file_count": 3,
+            "files": [
+                {
+                    "path": "practice-index.A1.json",
+                    "kind": "index",
+                    "counts": {"lexemes": 2, "cloze": 1},
+                }
+            ],
+        },
+    )
+    _write_json(
+        root / "site/src/data/lexicon-practice-reviewed-sources.json",
+        {"reviewed": [{"status": "reviewed", "path": "fixture"}]},
+    )
+    _write_json(
+        root / "site/src/data/lexicon-practice-cloze-sources.json",
+        [{"lemma": "дім", "sentence": "Я у ___."}],
+    )
+
+
+def test_registry_declares_required_source_families() -> None:
+    payload = registry_payload()
+
+    assert tuple(payload["required_source_families"]) == REQUIRED_SOURCE_FAMILIES
+    assert {family["id"] for family in payload["families"]} == set(REQUIRED_SOURCE_FAMILIES)
+    for family in REQUIRED_SOURCE_FAMILIES:
+        definition = source_family_definition(family)
+        assert definition.default_extraction_modes
+        assert "surface_admission" in definition.surface_admission_policy
+
+
+def test_inventory_candidates_carry_count_and_frequency(tmp_path: Path) -> None:
+    inventory = tmp_path / "sources.yaml"
+    inventory.write_text(
+        """
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: curriculum-fixture-a
+    source_family: curriculum
+    extraction_mode: vocabulary_yaml_item
+    title: Fixture A
+    headwords:
+      - lemma: авто
+        pos: noun
+        gloss: car
+        locator: vocabulary[0]
+        count: 3
+  - id: curriculum-fixture-b
+    source_family: curriculum
+    extraction_mode: vocabulary_yaml_item
+    title: Fixture B
+    headwords:
+      - lemma: авто́
+        pos: noun
+        gloss: car
+        locator: vocabulary[1]
+        frequency: 2
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    records = read_source_inventory(inventory, project_root=tmp_path)
+    candidates = source_inventory_candidates(records)
+
+    assert [record.count for record in records] == [3, 2]
+    assert len(candidates) == 1
+    assert candidates[0].lemma == "авто"
+    assert candidates[0].source_count == 2
+    assert candidates[0].frequency == 5
+    assert [row["count"] for row in candidates[0].source_provenance] == [3, 2]
+
+
+def test_gate_contract_emits_three_classifications(tmp_path: Path) -> None:
+    inventory = tmp_path / "sources.yaml"
+    inventory.write_text(
+        """
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: curriculum-ok
+    source_family: curriculum
+    extraction_mode: vocabulary_yaml_item
+    title: Fixture
+    headwords:
+      - lemma: авто
+        pos: noun
+        gloss: car
+        locator: vocabulary[0]
+      - lemma: безглос
+        pos: noun
+        locator: vocabulary[1]
+  - id: unknown-family
+    source_family: ulp
+    extraction_mode: curated_headword
+    title: Fixture
+    headwords:
+      - lemma: ревю
+        pos: noun
+        gloss: revue
+        locator: row 1
+""".lstrip(),
+        encoding="utf-8",
+    )
+    candidates = source_inventory_candidates(read_source_inventory(inventory, project_root=tmp_path))
+
+    results = classify_candidates(candidates)
+    by_lemma = {result.lemma: result for result in results}
+
+    assert classification_counts(results) == {
+        CLASSIFICATION_AUTO_APPROVE: 1,
+        CLASSIFICATION_REVIEW_QUEUE: 1,
+        CLASSIFICATION_REJECT: 1,
+    }
+    auto_payload = by_lemma["авто"].candidate_payload()
+    assert auto_payload["classification"] == CLASSIFICATION_AUTO_APPROVE
+    assert auto_payload["source_family"] == "curriculum"
+    assert auto_payload["source_ids"] == ["curriculum-ok"]
+    assert auto_payload["locators"] == ["vocabulary[0]"]
+    assert auto_payload["count"] == 1
+    assert auto_payload["frequency"] == 1
+    assert by_lemma["безглос"].classification == CLASSIFICATION_REVIEW_QUEUE
+    assert by_lemma["безглос"].gate_evidence["reasons"] == ["missing_english_anchor"]
+    assert by_lemma["ревю"].classification == CLASSIFICATION_REJECT
+    assert by_lemma["ревю"].gate_evidence["reasons"] == ["unknown_source_family:ulp"]
+
+
+def test_gate_frequency_fallback_counts_missing_count_as_one() -> None:
+    candidate = SourceInventoryCandidate(
+        lemma="частота",
+        pos="noun",
+        gloss="frequency",
+        source_provenance=(
+            {
+                "source_family": "curriculum",
+                "source_id": "source-a",
+                "source_locator": "row 1",
+            },
+            {
+                "source_family": "curriculum",
+                "source_id": "source-b",
+                "source_locator": "row 2",
+                "count": 3,
+            },
+        ),
+        source_count=2,
+        frequency=0,
+    )
+
+    result = classify_candidate(candidate)
+
+    assert result.candidate_payload()["frequency"] == 4
+
+
+def test_census_reports_safe_counts_without_raw_text(tmp_path: Path) -> None:
+    inventory = tmp_path / "sources.yaml"
+    inventory.write_text(
+        """
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: curriculum-fixture
+    source_family: curriculum
+    extraction_mode: vocabulary_yaml_item
+    title: Fixture Curriculum
+    locator: vocabulary
+    headwords:
+      - lemma: секретне-слово
+        pos: noun
+        gloss: secret fixture gloss
+        locator: vocabulary[0]
+        context: PRIVATE RAW CONTEXT
+  - id: teacher-fixture
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Neutral Teacher Fixture
+    locator: table 1
+    headwords:
+      - lemma: учительське
+        pos: adjective
+        gloss: teacher fixture
+        locator: row 1
+  - id: textbook-fixture
+    source_family: textbook
+    extraction_mode: headword_inventory
+    title: Textbook Fixture
+    locator: page 1
+    headwords:
+      - lemma: підручник
+        pos: noun
+        gloss: textbook
+        locator: page 1
+  - id: ohoiko-fixture
+    source_family: ohoiko
+    extraction_mode: curated_headword
+    title: Ohoiko Fixture
+    locator: unit 1
+    headwords:
+      - lemma: абетка
+        pos: noun
+        gloss: alphabet
+        locator: unit 1
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    census = build_census([inventory], project_root=tmp_path)
+    serialized = json.dumps(census, ensure_ascii=False)
+
+    assert census["counts"]["inventory_files"] == 1
+    assert census["counts"]["source_units"] == 4
+    assert census["counts"]["source_rows"] == 4
+    assert set(census["by_family"]) == set(REQUIRED_SOURCE_FAMILIES)
+    assert census["safety"]["raw_text_included"] is False
+    assert "секретне-слово" not in serialized
+    assert "secret fixture gloss" not in serialized
+    assert "PRIVATE RAW CONTEXT" not in serialized
+
+
+def test_freeze_snapshot_compares_daily_practice_and_cloze_surfaces(tmp_path: Path) -> None:
+    _write_minimal_freeze_surface(tmp_path)
+    before = build_surface_snapshot(tmp_path)
+    after = build_surface_snapshot(tmp_path)
+
+    assert before["surfaces"]["daily"]["count"] == 1
+    assert before["surfaces"]["practice"]["lexeme_count"] == 2
+    assert before["surfaces"]["cloze"]["source_count"] == 1
+    assert compare_snapshots(before, after)["ok"] is True
+
+    _write_json(
+        tmp_path / "site/src/data/lexicon-daily-pool.json",
+        [
+            {"lemma": "дім", "slug": "дім", "gloss": "house", "k": "vyv", "cefr": "A1"},
+            {"lemma": "сад", "slug": "сад", "gloss": "garden", "k": "vyv", "cefr": "A1"},
+        ],
+    )
+    changed = compare_snapshots(before, build_surface_snapshot(tmp_path))
+
+    assert changed["ok"] is False
+    assert any(diff.startswith("surfaces.daily") for diff in changed["diffs"])


### PR DESCRIPTION
## Summary

Closes #4221.

Adds the #4221 foundation for full-corpus Word Atlas intake without publishing live Atlas entries or moving learner surfaces:

- shared source-family registry for `curriculum`, `teacher_lesson`, `textbook`, and `ohoiko`
- deterministic intake gate contract with `auto_approve`, `review_queue`, and `reject`
- safe census CLI that reports derived counts/locators only, omitting raw text, lemmas, contexts, and glosses
- before/after freeze checker for Daily Word, Practice, and Cloze surfaces
- optional count/frequency metadata in source inventory records and candidates

## Current Census

`atlas_intake_census.py --format markdown` reports:

- inventory files: 15
- source rows: 395
- deduped candidates: 377
- gate counts: 260 `auto_approve`, 117 `review_queue`, 0 `reject`
- family rows: curriculum 20, Ohoiko 33, teacher lesson 228, textbook 114

No live Atlas publish is included. Daily Word, Practice, and Cloze remain frozen.

## Review

Independent non-Codex review route: AGY / `gemini-3.1-pro-high` via `scripts/ai_agent_bridge/__main__.py ask-agy --review`.

AGY found one major fallback-frequency bug: missing provenance `count` implied one occurrence but the fallback counted it as zero. Fixed in `atlas_intake_gate._frequency()` and covered by `test_gate_frequency_fallback_counts_missing_count_as_one`.

## Verification

- `.venv/bin/ruff check scripts/audit/atlas_intake_registry.py scripts/audit/atlas_intake_gate.py scripts/audit/atlas_intake_census.py scripts/audit/check_atlas_intake_freeze.py scripts/audit/source_inventory_intake.py tests/test_atlas_intake_foundation.py`
- `.venv/bin/python -m pytest tests/test_atlas_intake_foundation.py tests/test_source_inventory_intake.py tests/test_source_inventory_review_candidates.py tests/test_grow_lexicon_from_sources.py tests/test_check_static_practice_assets.py` — 52 passed
- `.venv/bin/python scripts/audit/atlas_intake_census.py --format markdown`
- `.venv/bin/python scripts/audit/check_atlas_intake_freeze.py --snapshot-out /tmp/...`; census run; `.venv/bin/python scripts/audit/check_atlas_intake_freeze.py --compare-to /tmp/...` — Daily/Practice/Cloze unchanged
- `git diff --cached --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
