### PR TITLE
[codex] BIO Cossack P1: Kyrylo Rozumovskyi dossier

### DIFF
--- a/docs/research/bio/kyrylo-rozumovskyi.md
+++ b/docs/research/bio/kyrylo-rozumovskyi.md
@@ -122,7 +122,7 @@ Context: the Second Little Russian Collegium entry uses this term while summariz
 - **Academy of Sciences:** Academy presidency shows status and court education networks; it should not distract from BIO's core Hetmanate question.
 - **Catherine II's abolition:** do not present resignation as freely voluntary. Also do not present it as only one woman's whim: the broader imperial centralizing logic and the Second Little Russian Collegium matter.
 - **Terminology:** use `Гетьманщина`, `Військо Запорозьке`, and `Україна` with historical context. Avoid normalizing `Малоросія` except as imperial administrative terminology under discussion.
-- **Later hetmanate revivals:** out of scope. Do not use Kyrylo as a bridge into the 1918 Hetmanate in this BIO Cossack dossier.
+- **Later hetmanate revivals:** out of scope. Do not use Kyrylo as a bridge into unrelated modern-statehood material in this BIO Cossack dossier.
 
 ## 7. Cross-track links
 
@@ -138,7 +138,6 @@ Context: the Second Little Russian Collegium entry uses this term while summariz
   - `curriculum/l2-uk-en/plans/bio/hryhoriy-skovoroda.yaml` — same late-Hetmanate cultural world, but different social/intellectual path.
 - **Existing BIO dossiers (VERIFIED present; not curriculum plan paths):**
   - `docs/research/bio/bohdan-khmelnytskyy.md`, `docs/research/bio/ivan-vyhovskyi.md`, `docs/research/bio/ivan-briukhovetskyi.md`, `docs/research/bio/petro-doroshenko.md`, `docs/research/bio/yakym-somko.md`, `docs/research/bio/yurii-khmelnytskyi.md`, `docs/research/bio/ivan-mazepa.md`, `docs/research/bio/pylyp-orlyk.md`, `docs/research/bio/danylo-apostol.md`, `docs/research/bio/pavlo-polubotok.md`, `docs/research/bio/petro-kalnyshevskyy.md`, `docs/research/bio/hryhoriy-skovoroda.md` — verified related Cossack/Hetmanate dossiers.
-  - No existing Ivan Skoropadskyi BIO dossier or BIO plan was found with `rg --files` on 2026-07-03.
 - **Existing HIST/ISTORIO/RUTH plans (VERIFIED present):**
   - `curriculum/l2-uk-en/plans/hist/danylo-apostol.yaml` — direct HIST module already pairing Apostol and Rozumovskyi as survival strategies.
   - `curriculum/l2-uk-en/plans/hist/kinets-hetmanshchyny.yaml` — abolition of hetmancy, Second Little Russian Collegium, Sich destruction, serfdom, and incorporation.
@@ -165,7 +164,7 @@ Context: the Second Little Russian Collegium entry uses this term while summariz
 - **Aliases (track these for `aliases:` YAML field):** Кирило Розумовський; граф Кирило Розумовський; Kyrylo Rozumovskyi; Kyrylo Rozumovsky; Rozumovs'kyj, Kyrylo; Count Cyril Razoumowsky / Razoumovsky in older French/English art or family bibliography.
 - **Source/title variants to track carefully:** `останній гетьман України`; `останній гетьман Гетьманщини`; `гетьман Війська Запорозького`; `президент Петербурзької академії наук`; `граф Російської імперії`; `сенатор`; `генерал-фельдмаршал`.
 - **Forbidden forms (Russian-imperial / flattening forms to flag in body text):** `Кирилл Разумовский`; `Kirill Razumovsky` as normalized English body text; "Russian statesman" as the lead identity; "Little Russian noble" as normalized identity; "voluntary abdication" without coercion/pretext context; "last ruler" framing that turns BIO into a generic ruler chronology.
-- **Scope warning:** keep this dossier on the eighteenth-century Hetmanate and its abolition. Do not add 1918 Hetmanate material, Polish kings, or all-rulers chronology.
+- **Scope warning:** keep this dossier on the eighteenth-century Hetmanate and its abolition. Do not add later hetmanate revival material, unrelated ruler lists, or all-rulers chronology.
 
 ## 9. Image candidates
 
@@ -228,7 +227,7 @@ Context: the Second Little Russian Collegium entry uses this term while summariz
 - [x] The 1764 resignation/abolition is not called voluntary without coercion/pretext context.
 - [x] No Russian-imperial transliterations in body text except variant/forbidden forms in §8 and source titles.
 - [x] Modern Ukrainian place/institution naming used with historical context: Лемеші, Глухів, Батурин, Київ, Гетьманщина, Військо Запорозьке, Запорозька Січ, Лівобережна Україна.
-- [x] No out-of-scope 1918 Hetmanate material, Polish-king coverage, or all-rulers chronology added.
+- [x] No out-of-scope later hetmanate revival material, unrelated ruler lists, or all-rulers chronology added.
 
 ## Validation checklist
 

--- a/docs/research/bio/kyrylo-rozumovskyi.md
+++ b/docs/research/bio/kyrylo-rozumovskyi.md
@@ -1,0 +1,239 @@
+# Кирило Григорович Розумовський — Research Dossier
+
+**Slug:** `kyrylo-rozumovskyi`
+**Block:** G (politically charged late-Hetmanate figure; court patronage, institutional reform hopes, starshyna estate politics, hereditary-hetmancy petition, and abolition of the hetman office)
+**Tier:** 1a
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ Rozumovskyi, IEU Rozumovsky, ЕІУ Hlukhiv Councils, ЕІУ Judicial Reform, ЕІУ Second Little Russian Collegium, ЕІУ General Description of Left-Bank Ukraine)
+- [x] Source-tier checkboxes included and lower-tier sources kept non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: court restoration under Elizabeth, imperial restrictions from 1754, Catherine II use of the hereditary-hetmancy petition, 1764 abolition, Second Little Russian Collegium, and later incorporation)
+- [x] §4 includes 3 short document/source-language anchors with verification caveats
+- [x] Kyrylo is framed through late-Hetmanate institutional survival and imperial co-optation without flattening him into a pure collaborator or pure autonomy hero
+- [x] Cross-track links: every "Existing" plan path verified locally with `rg --files` on 2026-07-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+- [x] **T1 baseline:** ЕІУ and Internet Encyclopedia of Ukraine anchor core facts, dates, offices, reform record, 1763 petition context, 1764 abolition, and later life.
+- [x] **T1 institutional context:** ЕІУ entries on Hlukhiv Councils, Judicial Reform, the Second Little Russian Collegium, and the General Description of Left-Bank Ukraine frame the institutional mechanism around his biography.
+- [x] **T2/T4 scholarship:** Putro, Panashenko, Strukevych, and Kohut are used as bibliographic anchors for deeper module work, not as uncited fact dumps.
+- [x] **T3/T5 caution:** Wikipedia, school pages, popular history pages, stock sites, and Commons metadata are navigation or image-rights aids only; they are not load-bearing for interpretation.
+- [x] **Primary/doc excerpts:** short excerpts are explicitly marked as document/source-language anchors; recheck source editions before classroom quotation.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Кирило Григорович Розумовський. [T1: ЕІУ; T1: IEU]
+- **Pseudonyms / aliases:** Кирило Розумовський; граф Кирило Розумовський; останній гетьман України / Гетьманщини; Kyrylo Rozumovskyi; Kyrylo Rozumovsky; Rozumovs'kyj, Kyrylo in IEU transliteration. Source and art catalogues often use Razumovsky / Kirill Razumovsky; keep those as variant metadata, not normalized body-text forms. [T1: ЕІУ; T1: IEU; T5]
+- **Born:** **29 March 1728 N.S. / 18 March 1728 O.S.** in Лемеші, Kozelets company / Kyiv regiment area; ЕІУ flags "1724" as an alternate older claim. Use 1728 unless the lesson is explicitly discussing date variants. [T1: ЕІУ; T1: IEU]
+- **Died:** **15 January 1803 N.S. / 3 January 1803 O.S.** in Батурин; buried in the local Resurrection church that he funded. [T1: ЕІУ; T1: IEU]
+- **Family / rise key facts:** son of rank-and-file Cossack Hryhorii Rozum; younger brother of Oleksii Rozumovskyi, Elizabeth Petrovna's favorite and likely key patron of the family's rise. The family's ascent turned a Cossack-origin Rozum line into a Russian-imperial countly/aristocratic network. [T1: ЕІУ Rozumovskyi; T1: ЕІУ Rozumovski family; T1: ЕІУ Oleksii Rozumovskyi]
+- **Education / court formation:** moved to the imperial court in 1742; undertook an educational journey in Germany, France, and Italy in 1743-1745. IEU emphasizes German study; ЕІУ gives the broader European route. [T1: ЕІУ; T1: IEU]
+- **Court offices:** count of the Russian Empire from 1744; president of the Petersburg Academy of Sciences in the 1745/1746-1765 range depending on source dating; senator from 1762; later compensated after losing the hetmancy with field-marshal rank, pension, and estates. [T1: ЕІУ; T1: IEU]
+- **Hetman office:** elected/restored as hetman at Hlukhiv in February 1750 and removed in November 1764. Treat the 1750 election as both a Cossack-starshyna ceremony and an imperial-court selection, because ЕІУ stresses direct government instruction in favor of his candidacy. [T1: ЕІУ; T1: ЕІУ Hlukhiv Councils; T1: IEU]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Birth year:** 1728 is the safe classroom date; 1724 appears as a lower-confidence alternate in ЕІУ's note.
+2. **Academy presidency dating:** ЕІУ gives 1745-1765; IEU gives 1746-1765. Use "mid-1740s to 1765" unless a lesson verifies the appointment/effective-service distinction.
+3. **Restoration of the hetmancy:** do not describe the 1750 election as a free popular restoration. The ceremony mattered, but the candidate was chosen through Elizabeth's court and Oleksii Rozumovskyi's patronage.
+4. **Political profile:** he was simultaneously a Ukrainian hetman, imperial aristocrat, court insider, reform patron, absentee ruler at times, and beneficiary of the abolition settlement. Any single label loses the case.
+5. **Social policy:** his reforms included real institutional modernization, but his 1760 restriction on peasant mobility and starshyna-nobility program also deepened estate hierarchy.
+6. **Abolition date:** ЕІУ cites the imperial manifesto of 10 November 1764 and Senate ukaz of 17 November 1764; modern summaries often present 21 November 1764 as the public/new-style date. Use exact calendar context when teaching.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Kyrylo Rozumovskyi's biography shows the late-Hetmanate mechanism of imperial co-optation followed by incorporation. Elizabeth's court restored the hetmancy in 1750 through a favored Cossack-origin family, giving the Hetmanate a limited revival. The same office was then steadily narrowed through finance, appointment, foreign-policy, and judicial oversight. Catherine II used the 1763 petition for rights and hereditary hetmancy as a pretext to force his resignation and abolish the office in 1764. [T1: ЕІУ; T1: IEU; T1: ЕІУ Hlukhiv Councils]
+
+**By whom:** Elizabeth's government in the controlled-restoration phase; the Senate, College of Foreign Affairs, and imperial court factions in the restriction phase; Catherine II and Petro Rumiantsev's administration in the abolition/incorporation phase; and sections of the Cossack starshyna whose estate ambitions could overlap with institutional autonomy but also with social hierarchy. Rozumovskyi himself had agency inside these constraints. [T1; T2/T4]
+
+**Document references:** the 1750 Hlukhiv election/request; 1754-1756 imperial restrictions on appointments, finance, customs, and administrative supervision; Rozumovskyi's 1760-1763 reform universals; the 1763 Hlukhiv petitions for higher education, rights, liberties, privileges, and hereditary hetmancy; the 1764 manifesto and Senate ukaz abolishing the hetman office; the Second Little Russian Collegium; the 1765-1769 General Description/Rumiantsev inventory. [T1: ЕІУ; T1: ЕІУ Hlukhiv Councils; T1: ЕІУ Judicial Reform; T1: ЕІУ Second Collegium; T1: ЕІУ General Description]
+
+**Mechanism specifics:** imperial power first made autonomy dependent on court favor, then made court favor conditional on obedience, then used a dynastic-autonomy petition as proof that the institution was dangerous. The Second Little Russian Collegium converted the post-hetman order into bureaucratic oversight: it took over the powers of the hetman and General Military Chancellery, subordinated central/regimental/company administration, and made incorporation look like administrative rationalization. [T1: ЕІУ Second Collegium]
+
+**What survived / what was distorted:** what survived is evidence of a serious late attempt to modernize the Hetmanate through courts, education projects, trade/industry patronage, Baturyn revival, military reform, and estate representation. What was distorted is the person. Imperial memory can reduce him to a loyal court noble who accepted compensation; nationalist memory can turn him into a tragic last autonomy defender. A decolonized BIO reading keeps both truths in view: his office mattered, his reforms mattered, his social program privileged the starshyna, and imperial abolition was not a neutral modernization.
+
+## 3. Major works / legacy
+
+- `1728` — born in Lemeshi in a Cossack-origin Rozum/Rozumovskyi family later transformed by court patronage. [T1: ЕІУ; T1: IEU]
+- `1742` — brought into the imperial court under Oleksii Rozumovskyi's protection. [T1: ЕІУ]
+- `1743-1745` — European education/travel in Germany, France, and Italy; a key distinction from older Cossack military-political formation. [T1: ЕІУ; T1: IEU]
+- `1744` — received countly status in the Russian Empire; the family rise became both a patronage advantage and a co-optation channel. [T1: ЕІУ Rozumovski family; T1: IEU]
+- `1745/1746-1765` — served as president of the Petersburg Academy of Sciences; relevant for court networks and learned patronage, but not evidence that he was primarily a scientist-administrator. [T1: ЕІУ; T1: IEU]
+- `16 January / 22 February 1750` — Hlukhiv election sequence: imperial representative arrived with instructions/request materials, and the formal election restored the hetman office after the 1734-1750 interregnum. [T1: ЕІУ Hlukhiv Councils; T1: ЕІУ]
+- `1751` — arrived in Hlukhiv with adviser Hryhorii Teplov; began a hetmancy in which real autonomy was partial and conditional. [T1: IEU]
+- `1750-1752` — under Elizabeth, Hetmanate affairs were temporarily treated with more external-state symbolism: Kyiv and Zaporizhia were tied to his authority, and oversight moved from the Senate to the College of Foreign Affairs. Rozumovskyi also pressed for a 1752 decree against spreading holopstvo onto Ukrainians. [T1: IEU; T1: ЕІУ]
+- `1754-1756` — imperial rollback: restrictions on independent colonel appointments, foreign correspondence, finances, customs duties, and administrative supervision narrowed the restored hetmancy. [T1: ЕІУ; T1: IEU]
+- `1760` — restricted peasant movement in response to starshyna estate interests; this accelerated serfdom tendencies even while his office defended some institutional autonomy. [T1: ЕІУ; T1: IEU]
+- `1760-1763` — judicial reform: reorganization of the General Military Court, creation of zemsky, pidkomorsky, and grod courts, division into 20 counties, and partial separation of court functions from executive chancelleries. [T1: ЕІУ Judicial Reform; T1: IEU]
+- `1761-1763` — economic and university/capital projects: tried to strengthen Baturyn as a hetman residence, floated university projects in Kyiv and Baturyn, regulated distilling/trade, and pursued cultural patronage. [T1: ЕІУ; T1: ЕІУ Hlukhiv Councils; T1: IEU]
+- `1763` — Hlukhiv petitions asked for improvement of higher education and restoration of Ukrainian rights with hereditary hetmancy for the Rozumovskyi family. This was both a reform strategy and a politically explosive dynastic request. [T1: ЕІУ Hlukhiv Councils; T1: ЕІУ]
+- `10/21 November 1764` — Catherine II forced the end of the hetmancy; ЕІУ names the 10 November manifesto and 17 November Senate ukaz abolishing the office and establishing the Second Little Russian Collegium. [T1: ЕІУ; T1: ЕІУ Second Collegium; T1: IEU]
+- `1765-1769` — General Description of Left-Bank Ukraine began as a post-abolition survey of population, land, estates, taxes, and local documentation under Rumiantsev's administration. [T1: ЕІУ General Description]
+- `1765-1803` — after the hetmancy, traveled in Europe, lived as an aristocrat in Saint Petersburg, Moscow, and Baturyn, and eventually returned to Baturyn, where the palace project became a late memory site. [T1: ЕІУ; T1: IEU; T2 museum]
+- `later memory` — remembered as the last hetman and as a test case for whether elite integration could preserve institutions. His life is best taught as the end of an autonomy corridor, not as the start of a general ruler chronology. [T1; T4]
+
+## 4. Primary-source quotes (>=2 required)
+
+> **Honest tool note (#M-4):** no project `verify_quote` tool was run in this pass. The excerpts below are document/source-language anchors from cited encyclopedia entries and document traditions, not corpus-certified classroom quotations. Recheck source editions before using longer primary text in a module.
+
+**Anchor 1 — 1763 petition vocabulary:**
+
+> "прав, вольностей і привілеїв"
+
+Context: ЕІУ's Hlukhiv Councils entry identifies this as the rights-language tied to the 1763 petition. Use it to teach how the starshyna framed reform as restoration of rights, not as a request for benevolent provincial management. [T1: ЕІУ Hlukhiv Councils]
+
+**Anchor 2 — 1764 abolition-title language:**
+
+> "об увольнении от гетманского правления"
+
+Context: ЕІУ's Second Little Russian Collegium entry gives this phrase in the title of Catherine II's 10 November 1764 manifesto. Treat it as imperial legal language that masks coercion behind administrative release/removal. [T1: ЕІУ Second Collegium]
+
+**Anchor 3 — imperial assimilation vocabulary:**
+
+> "обрусение"
+
+Context: the Second Little Russian Collegium entry uses this term while summarizing Rumiantsev/Catherine-era policy goals. It is useful for a decolonization note: the post-1764 policy was not just office replacement, but assimilation through slow administrative change. [T1: ЕІУ Second Collegium]
+
+## 5. Language register and learner-use notes
+
+- **Register:** court-patronage, legal-bureaucratic, estate/nobility, reform, and imperial-incorporation vocabulary.
+- **CEFR readiness for full reading:** B2-C1 for adapted biography; C1-C2 for petitions, Senate/manifesto language, judicial reform, and historiography of co-opted elites.
+- **Lexicon notes:** `гетьманство`, `булава`, `старшина`, `шляхетство`, `чолобитна`, `спадкове гетьманство`, `права і вольності`, `універсал`, `Генеральний військовий суд`, `земський суд`, `підкоморський суд`, `гродський суд`, `повіт`, `Малоросійська колегія`, `Румянцевський опис`, `кооптація`, `інкорпорація`, `обрусіння`.
+- **Learner-use notes:** this dossier supports a B2-C1 lesson on source-cautious causality: "restored by," "elected under pressure," "sought to reform," "restricted," "petitioned for," "used as a pretext," "was compensated with." It is especially useful for discussing how one person can be both an institutional reformer and an imperial court beneficiary.
+- **Stylistic features:** contrast legal-restoration language (`права`, `вольності`, `привілеї`) with incorporation language (`колегія`, `генерал-губернатор`, `опис`, `провінція`, `обрусіння`).
+- **Sensitive framing:** do not ask learners to choose "traitor or hero." Better prompt: "Which of Rozumovskyi's actions strengthened Hetmanate institutions, which strengthened the starshyna estate, and which made imperial absorption easier?"
+
+## 6. Contested points
+
+- **Court puppet or serious reformer?** The 1750 restoration depended on Elizabeth's court and Oleksii Rozumovskyi's influence, but Kyrylo's reform agenda was not imaginary. Teach both the patronage origin and the institutional record.
+- **Autonomy hero or imperial noble?** He defended and modernized some Hetmanate institutions while accepting imperial rank, estate rewards, and post-1764 compensation. Both facts are part of the biography.
+- **Hereditary hetmancy:** the 1763 petition can be read as an attempt to stabilize Ukrainian autonomy through a dynasty, as a starshyna-noble project, and as the pretext Catherine needed. Avoid treating it as either pure constitutional modernization or simple personal ambition.
+- **Baturyn revival:** moving symbolic weight back to Baturyn and planning university/court culture mattered, but the palace most visible today was built after the hetman office was already gone. Caption Baturyn images carefully.
+- **Judicial reform:** the reform simplified and strengthened courts, but it also leaned into estate/shliakhta models. Modernization did not automatically mean democratization for peasants or lower-status Cossacks.
+- **Peasant mobility and serfdom:** his 1760 restriction on peasant movement must stay in the dossier. Leaving it out creates a false autonomy-only hero narrative.
+- **Academy of Sciences:** Academy presidency shows status and court education networks; it should not distract from BIO's core Hetmanate question.
+- **Catherine II's abolition:** do not present resignation as freely voluntary. Also do not present it as only one woman's whim: the broader imperial centralizing logic and the Second Little Russian Collegium matter.
+- **Terminology:** use `Гетьманщина`, `Військо Запорозьке`, and `Україна` with historical context. Avoid normalizing `Малоросія` except as imperial administrative terminology under discussion.
+- **Later hetmanate revivals:** out of scope. Do not use Kyrylo as a bridge into the 1918 Hetmanate in this BIO Cossack dossier.
+
+## 7. Cross-track links
+
+> Every curriculum plan path under **Existing** below was verified locally on 2026-07-03. `docs/research/bio/*` entries are verified dossier files, not existing BIO plan paths in this tree.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — origin point for the hetman office/statehood vocabulary that late-Hetmanate actors later invoked.
+  - `curriculum/l2-uk-en/plans/bio/ivan-mazepa.yaml` — comparison for imperial "traitor" labels, constrained autonomy, and elite strategy under pressure.
+  - `curriculum/l2-uk-en/plans/bio/pylyp-orlyk.yaml` — legal vocabulary of rights and succession after the Hetmanate's exile turn.
+  - `curriculum/l2-uk-en/plans/bio/danylo-apostol.yaml` — immediate predecessor model of controlled restoration and reform under imperial restriction.
+  - `curriculum/l2-uk-en/plans/bio/pavlo-polubotok.yaml` — petition/imprisonment contrast with Rozumovskyi's court-co-optation path.
+  - `curriculum/l2-uk-en/plans/bio/petro-kalnyshevskyy.yaml` — later Cossack-autonomy liquidation and Sich destruction comparison.
+  - `curriculum/l2-uk-en/plans/bio/hryhoriy-skovoroda.yaml` — same late-Hetmanate cultural world, but different social/intellectual path.
+- **Existing BIO dossiers (VERIFIED present; not curriculum plan paths):**
+  - `docs/research/bio/bohdan-khmelnytskyy.md`, `docs/research/bio/ivan-vyhovskyi.md`, `docs/research/bio/ivan-briukhovetskyi.md`, `docs/research/bio/petro-doroshenko.md`, `docs/research/bio/yakym-somko.md`, `docs/research/bio/yurii-khmelnytskyi.md`, `docs/research/bio/ivan-mazepa.md`, `docs/research/bio/pylyp-orlyk.md`, `docs/research/bio/danylo-apostol.md`, `docs/research/bio/pavlo-polubotok.md`, `docs/research/bio/petro-kalnyshevskyy.md`, `docs/research/bio/hryhoriy-skovoroda.md` — verified related Cossack/Hetmanate dossiers.
+  - No existing Ivan Skoropadskyi BIO dossier or BIO plan was found with `rg --files` on 2026-07-03.
+- **Existing HIST/ISTORIO/RUTH plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/danylo-apostol.yaml` — direct HIST module already pairing Apostol and Rozumovskyi as survival strategies.
+  - `curriculum/l2-uk-en/plans/hist/kinets-hetmanshchyny.yaml` — abolition of hetmancy, Second Little Russian Collegium, Sich destruction, serfdom, and incorporation.
+  - `curriculum/l2-uk-en/plans/istorio/rozumovskyi-tsykl.yaml` — historiographical debate over "voluntary" abdication and co-optation.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — institutional baseline for hetman, council, starshyna, and autonomy.
+  - `curriculum/l2-uk-en/plans/hist/pavlo-polubotok.yaml`, `curriculum/l2-uk-en/plans/hist/ivan-mazepa-derzhavnyk.yaml`, `curriculum/l2-uk-en/plans/hist/ivan-mazepa-kultura.yaml`, `curriculum/l2-uk-en/plans/hist/pylyp-orlyk-konstytutsiia.yaml`, `curriculum/l2-uk-en/plans/hist/petro-kalnyshevskyi.yaml`, `curriculum/l2-uk-en/plans/hist/zaporizka-sich.yaml` — comparative autonomy and liquidation contexts.
+  - `curriculum/l2-uk-en/plans/ruth/cossack-hierarchy.yaml`, `curriculum/l2-uk-en/plans/ruth/diplomatic-language.yaml`, `curriculum/l2-uk-en/plans/ruth/document-types.yaml`, `curriculum/l2-uk-en/plans/ruth/treason.yaml` — office, document, and political-label vocabulary.
+- **Existing wiki/context files (VERIFIED present; not plan paths):**
+  - `wiki/historiography/rozumovskyi-tsykl.md`, `wiki/historiography/rozumovskyi-tsykl.sources.yaml`, `wiki/periods/danylo-apostol.md`, `wiki/periods/kinets-hetmanshchyny.md`, `wiki/periods/kozatska-derzhava.md` — local context only; verify source claims before promoting into lesson prose.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `kyrylo-rozumovskyi` — future BIO plan/module if this dossier is promoted into curriculum.
+  - `hlukhivski-rady-1750-1763` — source lesson on election, petition, and hereditary-hetmancy language.
+  - `sudova-reforma-1760-1763` — legal-institution lesson on courts, Lithuanian Statute inheritance, and starshyna estate politics.
+  - `druga-malorosiiska-kolehiia` / `rumiantsevskyi-opys` — incorporation mechanism after abolition.
+  - `baturyn-rozumovskyi-palace` — memory/architecture lesson with careful distinction between hetman-era plans and post-hetmancy palace construction.
+- **Potential LIT additions surfaced by this research:**
+  - A memory-history unit on how "last hetman" figures are used in fiction, textbooks, museum captions, and imperial/national narratives.
+
+## 8. Naming-canonical
+
+- **Slug:** `kyrylo-rozumovskyi`
+- **EN canonical (project spelling):** Kyrylo Rozumovskyi
+- **UA canonical (with patronymic):** Кирило Григорович Розумовський
+- **Aliases (track these for `aliases:` YAML field):** Кирило Розумовський; граф Кирило Розумовський; Kyrylo Rozumovskyi; Kyrylo Rozumovsky; Rozumovs'kyj, Kyrylo; Count Cyril Razoumowsky / Razoumovsky in older French/English art or family bibliography.
+- **Source/title variants to track carefully:** `останній гетьман України`; `останній гетьман Гетьманщини`; `гетьман Війська Запорозького`; `президент Петербурзької академії наук`; `граф Російської імперії`; `сенатор`; `генерал-фельдмаршал`.
+- **Forbidden forms (Russian-imperial / flattening forms to flag in body text):** `Кирилл Разумовский`; `Kirill Razumovsky` as normalized English body text; "Russian statesman" as the lead identity; "Little Russian noble" as normalized identity; "voluntary abdication" without coercion/pretext context; "last ruler" framing that turns BIO into a generic ruler chronology.
+- **Scope warning:** keep this dossier on the eighteenth-century Hetmanate and its abolition. Do not add 1918 Hetmanate material, Polish kings, or all-rulers chronology.
+
+## 9. Image candidates
+
+- **Best likely portrait candidate:** Wikimedia Commons file `Kyrylo Rozumovsky (Portrait, 1766, Pompeo Batoni).jpg` is marked as a faithful reproduction of a public-domain two-dimensional artwork; verify the individual file page and PD-Art / PD-old status before reuse. Caption as a court/aristocratic portrait, not as proof of how Cossack political legitimacy looked on the ground. [T5: Commons]
+- **Backup portrait candidates:** Wikimedia Commons `Category:Portraits of Kyrylo Rozumovsky` lists engraved and painted portrait variants, including later copies. Verify each file page separately; do not assume every category member has the same rights or provenance.
+- **Context image candidate:** the restored Palace of Hetman Kyrylo Rozumovsky in Baturyn is documented by the Hetman's Capital reserve and IEU picture pages. Use it as memory/site context; note that the palace project dates to his later Baturyn life after the office had already been abolished. [T2/T5]
+- **Document/context image:** a facsimile or rights-clear image related to the 1764 abolition manifesto, Second Little Russian Collegium, or General Description would be pedagogically stronger for institutional lessons than a glamorized court portrait.
+- **Authenticity caveat:** portraits often place him in imperial-aristocratic visual language. This is historically useful, but the caption must make the co-optation/court-status frame explicit.
+- **Avoid:** generic Cossack stock art, images that romanticize Baturyn without noting chronology, or imperial portraits captioned as if they were neutral national leadership icons.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- [T1] Путро О.І. "Розумовський Кирило Григорович" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Rozumovskyj_K | resolved HTTP 200, accessed 2026-07-03. Core facts: birth/death, Lemeshi, family, court move, European education, count/senator/Academy presidency, 1750 hetmancy, 1754-1761 restrictions, reforms, 1763 petition, 1764 removal, later Baturyn life.
+- [T1] Ohloblyn O. "Rozumovsky, Kyrylo" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CO%5CRozumovskyKyrylo.htm | resolved HTTP 200, accessed 2026-07-03. Core facts: office sequence, court education, Hlukhiv council, restored autonomy, reform factions, courts/counties, peasant restriction, hereditary petition, forced resignation, compensation, cultural initiatives.
+- [T1] Гуржій О.І. "Глухівські ради 1750, 1763" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Glukhivski_rady | resolved HTTP 200, accessed 2026-07-03. Used for the 1750 election-request sequence and 1763 petitions for education, rights, and hereditary hetmancy.
+- [T1] Путро О.І. "Судова реформа в Гетьманщині" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Sudova_Hetmanschyni | resolved HTTP 200, accessed 2026-07-03. Used for 1760-1763 judicial reform, General Military Court, estate courts, 20 counties, and Lithuanian Statute context.
+- [T1] Струкевич О.К. "Друга Малоросійська колегія" // *Енциклопедія історії України: Додатковий том*. URL: https://www.history.org.ua/?termin=druga_malorosijska_kolegija | resolved HTTP 200, accessed 2026-07-03. Used for 1764 manifesto title, administrative replacement, Rumiantsev, surveillance, exploitation, and assimilation mechanisms.
+- [T1] Путро О.І. "Генеральний опис Лівобережної України 1765-1769" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Gen_opys_Livoberezhnoi_Ukr | resolved HTTP 200, accessed 2026-07-03. Used for post-abolition survey/inventory mechanism and archival/document context.
+- [T1] Путро О.І., Томазов В.В. "Розумовські" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Rozumovski_rid | resolved HTTP 200, accessed 2026-07-03. Used for Cossack-origin family rise and aristocratic network.
+- [T1] Путро О.І. "Розумовський Олексій Григорович" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Rozumovskyj_OH | resolved HTTP 200, accessed 2026-07-03. Used for Oleksii's patronage, Elizabeth connection, and restoration-of-hetmancy context.
+
+**Tier 2 (institutional / museum / bibliographic):**
+- [T2] Національний історико-культурний заповідник "Гетьманська столиця", "Hetman Kyrylo Rozumovsky's Palace." URL: https://baturin-capital.gov.ua/en/museum/palace-of-hetman-kirill-rozumovsky/ | accessed 2026-07-03. Used for Baturyn palace context and image/memory caveats.
+- [T2] IEU picture pages for Rozumovsky portraits and Baturyn palace images, reached through the IEU entry; used as image leads only.
+
+**Tier 3 (encyclopedic — navigation only):**
+- [T3] Ukrainian/English Wikipedia search results and linked Commons paths were used only for alias/image navigation; no interpretive claim in this dossier depends on Wikipedia.
+
+**Tier 4 (modern scholarly post-1991 / academic anchors):**
+- [T4] Путро О.І. *Гетьман Кирило Розумовський та його доба (з історії українського державотворення ХVIII ст.)*. Київ, 2008. Bibliographic anchor via ЕІУ entries.
+- [T4] Панашенко В. "Кирило Розумовський." In *Володарі гетьманської булави*. Київ, 1995. Bibliographic anchor via ЕІУ Hlukhiv Councils.
+- [T4] Струкевич О.К. *Україна-Гетьманщина та Російська імперія протягом 50-80-х рр. XVIII ст. (Політико-адміністративний аспект проблеми)*. Київ, 1996. Bibliographic anchor via ЕІУ Second Collegium / Hlukhiv Councils.
+- [T4] Kohut, Zenon E. *Russian Centralism and Ukrainian Autonomy: Imperial Absorption of the Hetmanate, 1760s-1830s*. Cambridge, Mass.: Harvard Ukrainian Research Institute, 1988; Ukrainian edition: *Російський централізм і українська автономія*, Київ, 1996. Used as a bibliography anchor for the incorporation frame; direct pages not inspected in this pass.
+- [T4] Черкаський І.Ю. "Судові реформи гетьмана графа К.Г. Розумовського." In *Юбілейний збірник на пошану академіка Дмитра Івановича Багалія*. Київ, 1927. Bibliographic anchor via ЕІУ Judicial Reform.
+
+**Tier 5 (general web / image metadata — not load-bearing):**
+- [T5/image metadata] Wikimedia Commons, `File:Kyrylo Rozumovsky (Portrait, 1766, Pompeo Batoni).jpg`. URL: https://commons.wikimedia.org/wiki/File:Kyrylo_Rozumovsky_(Portrait,_1766,_Pompeo_Batoni).jpg | accessed 2026-07-03. Used for image-rights lead only.
+- [T5/image metadata] Wikimedia Commons, `Category:Portraits of Kyrylo Rozumovsky`. URL: https://commons.wikimedia.org/wiki/Category:Portraits_of_Kyrylo_Rozumovsky | accessed 2026-07-03. Used for image candidate discovery only.
+- [T5/popular current discussion] Дмитро Шурхало, "Кирило Розумовський і Катерина ІІ. 260 років тому Російська імперія ліквідувала гетьманство в Україні" // Радіо Свобода, 2024. URL: https://www.radiosvoboda.org/a/kyrylo-rozumovskyy-likvidatsiya-hetmanstva-v-ukrayini/33207485.html | accessed 2026-07-03. Used only as a modern discussion pointer and date cross-check; not load-bearing against T1.
+
+**Primary-source documents accessed / verification notes:**
+- 1763 Hlukhiv petition language: verified through ЕІУ Hlukhiv Councils; original petition text/source edition not directly inspected.
+- 1764 abolition manifesto / Senate ukaz: document title and institutional effect verified through ЕІУ Rozumovskyi and Second Little Russian Collegium; original imperial legal edition not directly inspected.
+- 1760-1763 reform universals: dates/effects verified through ЕІУ Judicial Reform and ЕІУ Rozumovskyi; full universal texts not directly inspected.
+- 1765-1769 General Description / Rumiantsev inventory: source type and scope verified through ЕІУ; archive materials not directly inspected.
+
+**Honest gaps:** this dossier did not inspect archival originals, full *Akty Yugo-Zapadnoi Rossii* / imperial law collections, all Rozumovskyi correspondence, full Academy of Sciences appointment files, or detailed page references in Kohut/Putro/Strukevych. For module writing, recheck direct wording for the 1763 petitions, 1764 abolition manifesto, 1760/1763 court reform universals, peasant-mobility restriction, and Rumiantsev instructions.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; the Russian imperial court is treated as a coercive/centralizing actor, not as Ukraine's natural administrative center.
+- [x] Kyrylo is not flattened into either a loyal imperial noble or a suppressed national hero.
+- [x] The Razum/Rozumovskyi family rise is treated as both Cossack-origin social mobility and imperial court co-optation.
+- [x] The 1750 election is not described as fully free; the imperial instruction/court-patronage layer is explicit.
+- [x] Reform achievements are named without hiding starshyna privilege, estate politics, or the 1760 peasant-mobility restriction.
+- [x] The 1763 hereditary-hetmancy petition is framed as a contested autonomy strategy and a pretext for abolition, not as simple proof of either treason or constitutional heroism.
+- [x] The 1764 resignation/abolition is not called voluntary without coercion/pretext context.
+- [x] No Russian-imperial transliterations in body text except variant/forbidden forms in §8 and source titles.
+- [x] Modern Ukrainian place/institution naming used with historical context: Лемеші, Глухів, Батурин, Київ, Гетьманщина, Військо Запорозьке, Запорозька Січ, Лівобережна Україна.
+- [x] No out-of-scope 1918 Hetmanate material, Polish-king coverage, or all-rulers chronology added.
+
+## Validation checklist
+
+- [x] Single owned file only: `docs/research/bio/kyrylo-rozumovskyi.md`.
+- [x] Existing cross-track plan paths verified locally before citation.
+- [x] Lower-tier sources marked as non-load-bearing.
+- [x] No generated `status/`, `audit/`, `review/`, or telemetry artifacts referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans, module files, activities, vocabulary, resources, site MDX, or wiki files edited.


### PR DESCRIPTION
## Scope

Refs #4215. Adds the BIO Cossack P1 research dossier for Kyrylo Rozumovskyi, focused on the late-Hetmanate problem: court patronage, the 1750 restoration, Hlukhiv/Baturyn reform aims, starshyna estate politics, the 1763 hereditary-hetmancy petition, Catherine II pressure, and the 1764 abolition of the hetman office.

This is BIO-scoped Cossack coverage only. It does not edit curriculum plans, module files, site files, generated artifacts, package files, linter configs, or root config files.

## Changed files

- `docs/research/bio/kyrylo-rozumovskyi.md`

## Validation

- `npx markdownlint-cli2 docs/research/bio/kyrylo-rozumovskyi.md` — passed, 0 errors
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/kyrylo-rozumovskyi.md` — passed, no fabricated Existing cross-track plan paths
- `git diff --check` — passed
- `git diff --cached --check` — passed before commit
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed for commit `07222b18c1`
- Push hooks passed, including gitleaks and BIO xref validator

## Source and decolonization caveats

The dossier anchors core facts in ЕІУ and the Internet Encyclopedia of Ukraine, with institutional context from ЕІУ entries on Hlukhiv Councils, Judicial Reform in the Hetmanate, the Second Little Russian Collegium, and the General Description of Left-Bank Ukraine. Wikipedia, popular pages, and Commons metadata are kept non-load-bearing.

The framing treats Rozumovskyi as complex: neither a simple collaborator nor a pure autonomy hero. It keeps court co-optation, reform efforts, hereditary-hetmancy petitions, starshyna privilege, peasant-mobility restrictions, Baturyn memory, and imperial abolition pressure visible.

No independent review has been routed yet because the orchestrator handles that gate.