### PR TITLE
docs(bio): add Ivan Samoilovych dossier

### DIFF
--- a/docs/research/bio/ivan-samoilovych.md
+++ b/docs/research/bio/ivan-samoilovych.md
@@ -1,0 +1,259 @@
+# Іван Самійлович Самойлович — Research Dossier
+
+**Slug:** `ivan-samoilovych`
+**Block:** G (politically charged Ruin-era / Left-Bank Hetmanate figure; consolidation after Doroshenko, Moscow pressure, starshyna politics, Right-Bank devastation, and 1687 Kolomak fall)
+**Tier:** 1a
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-03
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ Samoilovych, IEU Samoilovych, ЕІУ Konotop Articles, ЕІУ 1674 Right-Bank campaign, ЕІУ Chyhyryn defenses, ЕІУ Great Expulsion, ЕІУ Crimean campaigns, IEU Kolomak Articles)
+- [x] Source-tier checkboxes included and lower-tier sources kept non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: constrained election, Konotop Articles, Moscow/Right-Bank policy pressure, church subordination, 1686 Eternal Peace, 1687 Crimean-campaign blame, Kolomak arrest/exile)
+- [x] §4 includes 3 short document/source-language anchors with verification caveats
+- [x] Samoilovych is framed as complex: consolidator, autonomy defender in some contexts, coercive Right-Bank actor, starshyna patron, and Moscow-constrained ruler
+- [x] Cross-track links: every "Existing" plan path verified locally with `test -e` / `rg --files` on 2026-07-03
+- [x] Naming-canonical applied
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+- [x] **T1 baseline:** ЕІУ and Internet Encyclopedia of Ukraine anchor core facts, dates, offices, Left-Bank hetmancy, Doroshenko/Right-Bank sequence, church and Moscow-pressure context, fall, and exile.
+- [x] **T1 institutional context:** ЕІУ entries on Konotop Articles, Samoilovych/Romodanovsky's 1674 Right-Bank campaign, Chyhyryn defenses, Great Expulsion, Crimean campaigns, and IEU Kolomak Articles frame the mechanism around the biography.
+- [x] **T2/T4 scholarship:** Chukhlib, Hurzhii/Chukhlib, Horobets, Panashenko, Stanislavskyi, Luzhanov, and Davies are used as scholarly/bibliographic anchors for module follow-up, not as unsupported fact dumps.
+- [x] **T3/T5 caution:** Wikipedia, Commons, and general web are navigation or image-rights aids only; they are not load-bearing for interpretation.
+- [x] **Primary/doc excerpts:** short excerpts are explicitly marked as document/source-language anchors; recheck source editions before classroom quotation.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Іван Самійлович Самойлович. [T1: ЕІУ; T1: IEU]
+- **Pseudonyms / aliases:** Іван Самойлович; Самойлович-Попович / Popovych in some reference contexts; Ivan Samoilovych; Ivan Samoylovych; Samojlovyč in IEU transliteration. Forbidden body-text forms: normalized Russian-only forms; "Moscow client" or "autonomy hero" as total explanations; "Little Russian ruler" as normalized identity.
+- **Born:** year uncertain. ЕІУ gives unknown birth year; IEU gives unknown birth year; lower-tier summaries often use **1630** or **1630s**. Use "born in the 1630s or at an unknown date" unless a module verifies a stronger source. [T1: ЕІУ; T1: IEU; T3]
+- **Birthplace / origin:** **Ходорків** in the Skvyra / modern Zhytomyr-region context; ЕІУ says he was born in a priest's family. IEU gives Khodorkiv and notes the Popovych name variant. [T1: ЕІУ; T1: IEU]
+- **Died:** **1690** in **Тобольськ**, Siberian exile, after his 1687 removal. [T1: ЕІУ; T1: IEU]
+- **Education / early career:** studied at the Kyiv Collegium / Kyivan Mohyla College; served as scribe of the Krasnokoliadyn company of the Chernihiv regiment, later as sotnyk of the Vepryk company of the Hadiach regiment, then held posts in the Poltava and Chernihiv regimental worlds. [T1: ЕІУ; T1: IEU]
+- **Offices before hetmancy:** Chernihiv colonel in the late 1660s according to IEU; general judge under Demian Mnohohrishny, **1669-1672**. [T1: ЕІУ; T1: IEU]
+- **Hetman office:** elected hetman of Left-Bank Ukraine at a council near Konotop / Kozatska Dibrova in June 1672 and ruled until his removal in July 1687. [T1: ЕІУ; T1: IEU; T1: ЕІУ Konotop Articles]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Birth date:** do not present 1630 as a Tier 1 fact. The safest formulation is "born at an unknown date, often placed in the 1630s."
+2. **Name form:** `Самійлович` is the patronymic; `Самойлович` is the surname. The project slug should stay `ivan-samoilovych` while aliases should track `Ivan Samoylovych` because that spelling is common in English web sources.
+3. **Election date:** ЕІУ gives 27/17 June 1672 at Kozatska Dibrova near Konotop; IEU says June 1672 near Konotop. Use both calendar forms when precision matters.
+4. **"Both banks" status:** he was recognized in 1674 by part of Right-Bank senior officers and after Doroshenko's 1676 surrender could claim broader authority, but his de facto control over the Right Bank was unstable, war-shaped, and contested.
+5. **Right-Bank policy:** unification aims and coercive depopulation both belong in the record. The Great Expulsion was not a benign resettlement program, and it was not only foreign violence.
+6. **1687 fall:** the accusation of secret contacts with the Crimean Khanate should be treated as a politically useful charge after the failed campaign, not as a settled finding.
+7. **Church policy:** Samoilovych's patronage of Orthodox institutions and the 1686 subordination of the Kyiv metropolitanate to Moscow can coexist in the same biography. Do not smooth this into either piety-only or betrayal-only.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Samoilovych came to power after the deposition of Demian Mnohohrishny and under a treaty regime that preserved parts of the Hetmanate's order while narrowing the field of autonomous action. His rule then tried to stabilize the Left Bank after the Ruin, extend authority over the Right Bank, and keep the Hetmanate from being reduced to a provincial appendage. Those efforts operated inside Moscow military pressure, Commonwealth-Ottoman-Crimean war, starshyna estate interests, Zaporozhian autonomy, and the destructive politics of the Dnipro partition. [T1: ЕІУ; T1: IEU; T1: ЕІУ Konotop Articles]
+
+**By whom:** Moscow/tsarist power in the treaty, military, foreign-policy, church, and removal layers; Ottoman and Crimean forces in the Chyhyryn and Right-Bank war layer; Commonwealth diplomacy in the partition-and-recognition layer; Samoilovych and his starshyna coalition in the coercive consolidation layer; Zaporozhian and Right-Bank actors in the competing-legitimacy layer. No side should be erased.
+
+**Document references:** the **Konotop Articles of 1672**; the **Pereiaslav Articles of 1674** around Right-Bank submission; the Chyhyryn campaign correspondence and military orders; the **Bakhchysarai Peace of 1681**; the **Eternal Peace of 1686**; the 1687 Crimean-campaign accusations; and the **Kolomak Articles** that accompanied his removal and Mazepa's election. [T1: ЕІУ; T1: IEU Kolomak Articles]
+
+**Mechanism specifics:** the imperial simplification is to make Samoilovych either a loyal administrator of Moscow's interests or a failed local despot whose removal was natural. The record is sharper. He opposed arrangements that formalized Ukraine's partition, sought to attach Slobidska Ukraine more closely to the Hetmanate, and resisted a Muscovite-Commonwealth framework that treated Ukrainian territory as negotiable. At the same time, he built a more authoritarian hetman office, enriched and promoted his family and clients, depended on Moscow military power, and used forced migration and settlement destruction on the Right Bank. [T1: IEU; T1: ЕІУ Great Expulsion]
+
+**What survived / what was distorted:** what survived is the evidence of Left-Bank institutional recovery, Baturyn-centered governance, church and cultural patronage, and a more stable starshyna order after the worst phase of the Ruin. What was distorted is the person and the period. Russian-imperial framing can turn him into a local manager within a natural imperial order; nationalist shorthand can turn him into a pure autonomy defender. A decolonized BIO reading keeps the constraints, agency, coercion, and institutional survival together.
+
+## 3. Major works / legacy
+
+- `before 1648 / 1650s` — studied at the Kyiv Collegium / Kyivan Mohyla College according to standard reference tradition; use as education background, not as a fully documented intellectual biography. [T1: ЕІУ; T1: IEU]
+- `1660s` — moved through company, regimental, and general-office posts in the Left-Bank Hetmanate; this administrative career matters because he was not simply an imported appointee. [T1: ЕІУ]
+- `1668-1669` — served in the Chernihiv regimental command according to IEU; then became general judge under Demian Mnohohrishny. [T1: IEU; T1: ЕІУ]
+- `1672` — participated in the political move against Mnohohrishny and was elected hetman near Konotop / Kozatska Dibrova; the Konotop Articles broadly repeated earlier Moscow-Hetmanate arrangements while adding limits favorable to starshyna interests and to Moscow's control of expansion and diplomacy. [T1: ЕІУ; T1: ЕІУ Konotop Articles]
+- `1672-1674` — consolidated the Left Bank after the Ruin and pursued a program of uniting the two Dnipro banks under his authority. [T1: ЕІУ; T1: IEU]
+- `1674` — Samoilovych and Romodanovsky's Right-Bank campaign attacked Doroshenko's forces, captured several towns, failed to take Chyhyryn, and produced the Pereiaslav council recognition of Samoilovych as hetman of both sides of the Dnipro by part of the Right-Bank elite. [T1: ЕІУ Right-Bank campaign]
+- `1674-1676` — the Doroshenko endgame remained contested by Ottoman, Crimean, Moscow, Commonwealth, Zaporozhian, and Right-Bank forces; Doroshenko's 1675 oath in Sirko's presence was not accepted by Moscow, and the September 1676 surrender to Samoilovych/Romodanovsky was the decisive transfer. [T1: ЕІУ Right-Bank campaign; T1: IEU]
+- `1676-1681` — participated as a major Cossack commander in the Russian-Ottoman war zone around Chyhyryn and the Right Bank; sources credit him with active military leadership, but responsibility for destruction and displacement must be kept visible. [T1: ЕІУ; T1: ЕІУ Chyhyryn defenses; T1: IEU Chyhyryn]
+- `1677` — Chyhyryn was defended against Ottoman assault by Cossack and Russian forces; Samoilovych's forces operated with Romodanovsky in the relief of the fortress. [T1: ЕІУ Chyhyryn defenses; T1: IEU Chyhyryn]
+- `1678` — the second Chyhyryn campaign ended with Chyhyryn destroyed and abandoned; Sirko's attacks and the Samoilovych/Romodanovsky army are part of the military context, but the result for Right-Bank civilians was devastation. [T1: ЕІУ Chyhyryn defenses; T1: IEU Sirko]
+- `1678-1679` — the **Great Expulsion** moved people from the Right Bank to the Left Bank and destroyed settlements to deny opponents a support base; ЕІУ identifies Samoilovych as organizer and names both strategic intent and coercive methods. [T1: ЕІУ Great Expulsion]
+- `1681` — objected to the Bakhchysarai settlement because it left much of the Right Bank outside effective Cossack-Hetmanate control and fixed a depopulated border zone. [T1: ЕІУ; T1: ЕІУ Great Expulsion]
+- `1680s` — fostered Left-Bank economic recovery, trade, cultural life, church building, and starshyna consolidation; also pursued hereditary and family-centered power, giving offices and estates to his sons. [T1: IEU; T1: ЕІУ]
+- `1686` — opposed the Eternal Peace because it legalized the partition of Ukrainian lands; the same year, the Kyiv metropolitanate was subordinated to the Moscow patriarchate, a major church-autonomy loss during his rule. [T1: ЕІУ; T1: IEU]
+- `1687` — led roughly 50,000 Cossacks in the first Crimean campaign alongside Vasilii Golitsyn's army; after supply failure and retreat, Russian commanders and Cossack starshyna placed blame on Samoilovych and accused him of contacts with Tatars. [T1: ЕІУ Crimean campaigns]
+- `22/25 July 1687 sequence` — arrested in the Kolomak camp, removed from the hetmancy, sent first toward Moscow and then into Siberian exile; a narrow starshyna council elected Ivan Mazepa under Golitsyn's support. [T1: ЕІУ Crimean campaigns; T1: IEU Kolomak Articles; T1: IEU Mazepa]
+- `1690` — died in Tobolsk; his fall shows how starshyna interests and Moscow intervention could converge when a hetman became politically vulnerable. [T1: ЕІУ; T1: IEU]
+
+## 4. Primary-source quotes (>=2 required)
+
+> **Honest tool note (#M-4):** no project `verify_quote` tool was run in this pass. The excerpts below are short document/source-language anchors from cited encyclopedia entries and document traditions, not corpus-certified classroom quotations. Recheck source editions before using longer primary text in a module.
+
+**Anchor 1 — 1672 treaty label:**
+
+> "Конотопські статті 1672"
+
+Context: use the document title to introduce Samoilovych's accession framework. ЕІУ stresses that the agreement regulated relations with the tsar, largely supplemented earlier arrangements, limited hetman power in favor of the starshyna, and narrowed autonomy in specific areas. [T1: ЕІУ Konotop Articles]
+
+**Anchor 2 — 1674 Right-Bank claim language:**
+
+> "гетьманом обох боків Дніпра"
+
+Context: ЕІУ uses this formula for the Pereiaslav council recognition during the Samoilovych/Romodanovsky campaign. Use it as a contested claim of authority, not as proof of stable control over both banks. [T1: ЕІУ Right-Bank campaign]
+
+**Anchor 3 — 1687 accusation formula:**
+
+> "таємні зв'язки з татарами"
+
+Context: ЕІУ's Crimean-campaign entry presents this as the charge used after the failed campaign. It is useful for teaching how military failure, starshyna conflict, and Moscow pressure could become a treason accusation. Treat the phrase as accusation language, not verified fact. [T1: ЕІУ Crimean campaigns]
+
+## 5. Language register and learner-use notes
+
+- **Register:** Cossack-chancery, treaty, military-campaign, church, and modern historiographic language; dense with office titles and dependency vocabulary.
+- **CEFR readiness for full reading:** B2-C1 for adapted biography; C1-C2 for Konotop/Pereiaslav/Kolomak article language, campaign narratives, and church-jurisdiction discussion.
+- **Lexicon notes:** `гетьман`, `генеральний суддя`, `старшина`, `старшинська рада`, `Конотопські статті`, `Переяславські статті 1674`, `Коломацькі статті`, `булава`, `клейноди`, `Лівобережжя`, `Правобережжя`, `Чигиринські оборони`, `Великий згін`, `Бахчисарайський мир`, `Вічний мир`, `митрополія`, `підпорядкування`, `заслання`.
+- **Learner-use notes:** this dossier supports a C1 lesson on constrained agency: "sought to unite," "was recognized by," "could not control," "was forced to operate with," "was accused of," "was deposed under pressure." It is useful for practicing contrast clauses that do not collapse a historical actor into one moral label.
+- **Stylistic features:** pair treaty vocabulary with war and displacement vocabulary. `Права і вольності` language should be taught beside `переселення`, `знищення поселень`, and `заслання`.
+- **Sensitive framing:** do not ask learners whether Samoilovych was simply "pro-Moscow" or "anti-Moscow." Better prompt: "Which choices preserved Hetmanate institutions, which choices harmed communities, and which pressures made both true at once?"
+
+## 6. Contested points
+
+- **Moscow client or autonomy defender?** Both labels are too flat. Samoilovych was elected and operated inside Moscow's military-diplomatic order, but he also opposed arrangements that partitioned Ukraine and tried to expand the Hetmanate's reach. Teach the mechanism, not a verdict.
+- **Authoritarian rule:** IEU emphasizes his desire for an authoritarian and even hereditary model of hetman power. This matters. His consolidation strengthened institutions but also concentrated offices, estates, and influence around family and favored starshyna.
+- **Starshyna interests:** the Konotop Articles limited hetman power in ways favorable to senior officers; later, senior officers helped remove him. The starshyna were not just victims of empire or pure patriots. They were political actors with estate interests.
+- **Doroshenko and Right-Bank policy:** Samoilovych's campaign against Doroshenko should not be told as simple national reunification. It included Moscow strategic goals, Right-Bank coercion, Ottoman-Crimean intervention, and the collapse of Doroshenko's support.
+- **Great Expulsion:** do not soften it into voluntary migration. ЕІУ explicitly identifies forced relocation and destruction of settlements. At the same time, some voluntary movements occurred in the period; keep both categories separate.
+- **Sirko relationship:** Sirko's role is source-sensitive. He was a shifting Zaporozhian actor, not simply Samoilovych's subordinate. Use firm claims only where sources anchor them: Sirko appears in the Doroshenko 1675 oath context, in Mazepa's 1674 capture/transfer context, and in anti-Ottoman actions during the Chyhyryn campaigns.
+- **Mazepa relationship:** Mazepa entered Samoilovych's service after Sirko captured him on a mission and handed him over; he gained Samoilovych's confidence, served on missions, participated in Chyhyryn campaigns, became general osaul, and then was elected after Samoilovych's fall. This should be taught as patronage, service, and succession politics, not as a single betrayal story. [T1: IEU Mazepa]
+- **Church patronage and church loss:** Samoilovych funded churches and monasteries, but the Kyiv metropolitanate's 1686 subordination to Moscow happened during his rule. The lesson should hold patronage and institutional loss together.
+- **Chyhyryn responsibility:** do not assign the entire Chyhyryn catastrophe to one person. Ottoman strategy, Moscow command, Cossack defense, Romodanovsky's decisions, Sirko's raids, and the Right-Bank civilian disaster all belong in the account.
+- **1687 fall:** the failed Crimean campaign exposed a coalition against Samoilovych. Accusations of secret contacts with the Crimean side should be framed as politically charged and source-sensitive.
+- **Image authenticity:** most available portraits are later/posthumous, often 19th-century works. Do not imply a life portrait unless file metadata proves it.
+- **Modern memory:** commemoration in Khodorkiv/Baturyn can recover an overlooked hetman, but it can also slide into heroic smoothing. The dossier should teach institutional survival without hiding coercion.
+
+## 7. Cross-track links
+
+> Every curriculum plan path under **Existing** below was verified locally on 2026-07-03. `docs/research/bio/*` entries are verified dossier files, not existing BIO plan paths in this tree.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — origin point for the Cossack state whose post-Ruin institutions Samoilovych tried to stabilize.
+  - `curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml` — earlier autonomy/diplomacy comparison before the Left-Bank consolidation corridor.
+  - `curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml` — Zaporozhian autonomy, Doroshenko/Mazepa/Samoilovych intersections, and Chyhyryn-era anti-Ottoman action.
+  - `curriculum/l2-uk-en/plans/bio/ivan-mazepa.yaml` — direct successor and former client; Kolomak and post-1687 autonomy comparison.
+  - `curriculum/l2-uk-en/plans/bio/pylyp-orlyk.yaml` — later legal-memory and exile-statehood vocabulary after the autonomy corridor narrows.
+  - `curriculum/l2-uk-en/plans/bio/danylo-apostol.yaml`, `curriculum/l2-uk-en/plans/bio/pavlo-polubotok.yaml` — later constrained-autonomy cases under imperial pressure.
+- **Existing BIO dossiers (VERIFIED present; not curriculum plan paths):**
+  - `docs/research/bio/bohdan-khmelnytskyy.md`, `docs/research/bio/ivan-vyhovskyi.md`, `docs/research/bio/petro-doroshenko.md`, `docs/research/bio/ivan-briukhovetskyi.md`, `docs/research/bio/yakym-somko.md`, `docs/research/bio/yurii-khmelnytskyi.md`, `docs/research/bio/ivan-sirko.md`, `docs/research/bio/ivan-mazepa.md`, `docs/research/bio/pylyp-orlyk.md`, `docs/research/bio/danylo-apostol.md`, `docs/research/bio/pavlo-polubotok.md`, `docs/research/bio/kyrylo-rozumovskyi.md` — verified related Cossack/Hetmanate dossiers.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/bohdan-khmelnytskyi.yaml` — revolution/state-formation baseline.
+  - `curriculum/l2-uk-en/plans/hist/ruina-i.yaml`, `curriculum/l2-uk-en/plans/hist/ruina-ii.yaml` — direct Ruin and post-Doroshenko frame.
+  - `curriculum/l2-uk-en/plans/hist/andrusivske-peremyrya.yaml` — partition context behind Right-Bank policy and anti-partition diplomacy.
+  - `curriculum/l2-uk-en/plans/hist/pereyaslavska-uhoda.yaml` — protectorate vocabulary and treaty-distortion background.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — institutional baseline for hetman, council, starshyna, regiments, and autonomy claims.
+  - `curriculum/l2-uk-en/plans/hist/ivan-sirko.yaml`, `curriculum/l2-uk-en/plans/hist/ivan-mazepa-derzhavnyk.yaml`, `curriculum/l2-uk-en/plans/hist/ivan-mazepa-kultura.yaml`, `curriculum/l2-uk-en/plans/hist/ivan-mazepa-poltava.yaml`, `curriculum/l2-uk-en/plans/hist/pylyp-orlyk-konstytutsiia.yaml`, `curriculum/l2-uk-en/plans/hist/danylo-apostol.yaml`, `curriculum/l2-uk-en/plans/hist/pavlo-polubotok.yaml`, `curriculum/l2-uk-en/plans/hist/kinets-hetmanshchyny.yaml` — comparative autonomy, culture, and incorporation arc.
+- **Existing ISTORIO/RUTH/LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/istorio/pereiaslav-tsykl.yaml`, `curriculum/l2-uk-en/plans/istorio/pereiaslav-alternatyvy.yaml`, `curriculum/l2-uk-en/plans/istorio/pereyaslavski-statti.yaml` — treaty-source cycle and protectorate vocabulary.
+  - `curriculum/l2-uk-en/plans/ruth/the-ruin.yaml`, `curriculum/l2-uk-en/plans/ruth/cossack-hierarchy.yaml`, `curriculum/l2-uk-en/plans/ruth/diplomatic-language.yaml`, `curriculum/l2-uk-en/plans/ruth/document-types.yaml`, `curriculum/l2-uk-en/plans/ruth/treason.yaml` — older-language and legal-political vocabulary around councils, offices, documents, and accusation language.
+  - `curriculum/l2-uk-en/plans/lit-hist-fic/lepkyi-mazepa.yaml`, `curriculum/l2-uk-en/plans/lit/lepkyi-mazepa-trilogy.yaml` — later literary-memory comparison around Mazepa and the late-17th-century political world.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `ivan-samoilovych` — future BIO plan/module if this dossier is promoted into curriculum.
+  - `konotopski-statti-1672` — source lesson on accession, starshyna interests, and constrained autonomy.
+  - `chyhyrynski-oborony-1677-1678` — military/source-critical lesson on Ottoman, Moscow, Cossack, and civilian perspectives.
+  - `velykyi-zghin-1678-1679` — forced-migration and Right-Bank devastation lesson.
+  - `kolomatska-rada-1687` / `kolomatski-statti` — accusation, removal, Mazepa succession, and treaty erosion lesson.
+- **Potential LIT additions surfaced by this research:**
+  - A memory-history unit on how overlooked hetmans are restored in monuments, stamps, museum captions, and popular videos, and how commemoration can correct erasure without turning biography into hagiography.
+
+## 8. Naming-canonical
+
+- **Slug:** `ivan-samoilovych`
+- **EN canonical (project spelling):** Ivan Samoilovych
+- **UA canonical (with patronymic):** Іван Самійлович Самойлович
+- **Aliases (track these for `aliases:` YAML field):** Іван Самойлович; Самойлович-Попович; Ivan Samoilovych; Ivan Samoylovych; Samojlovyč; Popovych.
+- **Source/title variants to track carefully:** `гетьман Лівобережної України`; `гетьман обох боків Дніпра` / `гетьман обох сторін Дніпра`; `генеральний суддя`; `чернігівський полковник`; `правитель у Батурині`.
+- **Forbidden forms (Russian-imperial / flattening forms to flag in body text):** Russian-only name forms as normalized Ukrainian/English body text; "Moscow puppet" without agency/constraint analysis; "absolute ruler" without explaining source framing; "traitor" as factual label; "Little Russian ruler" as identity rather than imperial terminology under analysis.
+- **Term warning:** `Великий згін` names a forced relocation/destruction operation. Do not translate it as neutral "resettlement" without coercion.
+- **Scope warning:** keep this BIO dossier on seventeenth-century Left-Bank consolidation and the post-Ruin Hetmanate. Do not turn it into an all-rulers chronology or unrelated later revival material.
+
+## 9. Image candidates
+
+- **Best likely portrait candidates:** Wikimedia Commons category `Portraits of Ivan Samoylovych` includes several 19th-century portrait files, including `Ivan Samoylovych (Portrait №1, 19th century, Skarzhynska collection).jpg`, `Ivan Samoylovych (Portrait №2, 19th century, Skarzhynska collection).jpg`, and `Ivan Samoylovych (Portrait, 19th century).jpg`. Verify each file page before reuse. [T5: Commons]
+- **IEU image candidate:** IEU links a portrait of Ivan Samoilovych from the article. Use it as an image lead only; verify rights on the image page or a reuse-safe repository before publication. [T1/T5: IEU image lead]
+- **Context image candidates:** rights-clear image of Baturyn, a Chyhyryn context image, a facsimile of the Konotop/Kolomak article tradition, or a map of Left-Bank/Right-Bank Ukraine may be more pedagogically precise than a later portrait.
+- **Commemoration candidates:** Khodorkiv monument, Baturyn monument group, or Ukrainian stamp imagery can support a memory-history lesson, but only with explicit license verification and a caption that distinguishes modern commemoration from early-modern likeness.
+- **Authenticity caveat:** most portraits are later/posthumous, often 19th-century works. Caption as later portrait tradition unless metadata proves life-era provenance.
+- **Avoid:** generic Cossack stock art, images that naturalize Moscow authority, exoticized Ottoman imagery, or battlefield images unrelated to Chyhyryn/Right-Bank contexts.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- [T1] Чухліб Т. В. "Самойлович Іван Самійлович" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Samojlovych_I | resolved HTTP 200, accessed 2026-07-03. Core facts: unknown birth year, Khodorkiv priest-family origin, education, early offices, general judge, 1672-1687 hetmancy, Right-Bank policy, Chyhyryn/Ottoman war role, Great Expulsion, Bakhchysarai/Eternal Peace objections, church subordination, 1687 fall, exile, patronage.
+- [T1] Ohloblyn O. "Samoilovych, Ivan" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CA%5CSamoilovychIvan.htm | resolved HTTP 200, accessed 2026-07-03. Core facts: Khodorkiv/Tobolsk, education, Chernihiv colonel/general judge, Konotop election, Right-Bank recognition and Doroshenko abdication, Slobidska Ukraine aim, Chyhyryn/Eternal Peace, authoritarian/hereditary program, economy/culture, church, 1687 deposition.
+- [T1] Горобець В. М. "Конотопські статті 1672" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Konotopski_Statti_1672 | resolved HTTP 200, accessed 2026-07-03. Used for accession treaty, starshyna limits on hetman power, Moscow-Hetmanate restrictions, and autonomy narrowing.
+- [T1] Станіславський В. В. "Самойловича І. та Ромодановського Г. Правобережна кампанія 1674" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Samojlovycha_Y | resolved HTTP 200, accessed 2026-07-03. Used for Doroshenko negotiations, Moscow refusal of conditions, 1674 campaign, Pereiaslav recognition, Ottoman pressure, Doroshenko's 1675/1676 surrender sequence.
+- [T1] Галушка А. А. "Чигиринські оборони 1677 і 1678" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=chygyrynski_oborony | resolved HTTP 200, accessed 2026-07-03. Used for Chyhyryn military context, Samoilovych/Romodanovsky forces, fortress defense, 1678 destruction, and source-cautious responsibility.
+- [T1] "Chyhyryn campaigns, 1677-8" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CC%5CH%5CChyhyryncampaigns1677hD78.htm | resolved HTTP 200, accessed 2026-07-03. Used for English-language military baseline, Ottoman plan, Samoilovych and Sirko context.
+- [T1] Лужанов І. В. "Великий згін 1678-1679" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=velykyj_zgin_1678_1679 | resolved HTTP 200, accessed 2026-07-03. Used for forced relocation/destruction mechanism and Bakhchysarai neutral-zone context.
+- [T1] Панашенко В. В. "Кримські походи 1687 і 1689" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Krimski_Pohodi_1687_1689 | resolved HTTP 200, accessed 2026-07-03. Used for 1687 campaign, supply failure, blame against Samoilovych, Kolomak arrest, and Mazepa election.
+- [T1] "Kolomak Articles" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CO%5CKolomakArticles.htm | resolved HTTP 200, accessed 2026-07-03. Used for Kolomak council coercion, Samoilovych deposition, Mazepa election, and treaty restrictions.
+- [T1] "Mazepa, Ivan" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CM%5CA%5CMazepaIvan.htm | resolved HTTP 200, accessed 2026-07-03. Used for Mazepa's capture by Sirko, service under Samoilovych, missions, Chyhyryn participation, general-osaul appointment, and 1687 succession.
+- [T1] Горобець В. М. "Сірко Іван" // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Sirko_I | resolved HTTP 200, accessed 2026-07-03. Used for Sirko's shifting political orientation and source-sensitive Zaporozhian context.
+- [T1] "Sirko, Ivan" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CI%5CSirkoIvan.htm | resolved HTTP 200, accessed 2026-07-03. Used for Chyhyryn/Samoilovych/Sirko military context and caution around legend.
+
+**Tier 2 (institutional / reference / bibliographic):**
+
+- [T2] *Велика українська енциклопедія*, "Самойлович, Іван Самійлович." URL: https://vue.gov.ua/Самойлович,_Іван_Самійлович | accessed through search result 2026-07-03. Used as a supplemental institutional reference lead, not load-bearing against ЕІУ/IEU.
+- [T2] Чернігівська обласна універсальна наукова бібліотека / educational bibliography page, "Іван Самойлович — гетьман Війська Запорозького." URL: https://library.chnpu.edu.ua/iva-n-samojlo-vich-getman-vijska-zaporozkogo/ | accessed 2026-07-03. Used as a pointer to ЕІУ and bibliography, not load-bearing interpretation.
+
+**Tier 3 (encyclopedic — navigation only):**
+
+- [T3] "Іван Самойлович" // Ukrainian Wikipedia. URL: https://uk.wikipedia.org/wiki/Іван_Самойлович | accessed 2026-07-03. Used only for alias/image/date navigation; cross-checked against T1.
+- [T3] "Ivan Samoylovych" // English Wikipedia. URL: https://en.wikipedia.org/wiki/Ivan_Samoylovych | accessed 2026-07-03. Used only for English alias/image navigation; not load-bearing.
+
+**Tier 4 (modern scholarly post-1991 / academic anchors):**
+
+- [T4] Чухліб Т. В. "Особливості зовнішньої політики І. Самойловича та проблема міжнародного становища Українського гетьманату в 1672-1686 рр." *Український історичний журнал*, 2005, no. 2. Bibliographic anchor via ЕІУ.
+- [T4] Чухліб Т. *Козаки і монархи: Міжнародні відносини ранньомодерної Української держави 1648-1721 рр.* Київ, 2009. Bibliographic anchor via ЕІУ.
+- [T4] Гуржій О., Чухліб Т. *Гетьманська Україна.* Київ, 1999. Bibliographic anchor via ЕІУ.
+- [T4] Чухліб Т. "Іван Самойлович." In *Історія України в особах: Козаччина*. Київ, 2000. Bibliographic anchor via ЕІУ.
+- [T4] Сергієнко Г. "Самойлович Іван." In *Володарі гетьманської булави*. Київ, 1994. Bibliographic anchor via ЕІУ.
+- [T4] Горобець В. М. *Від союзу до інкорпорації: українсько-російські відносини другої половини XVII - першої чверті XVIII ст.* Київ, 1995. Bibliographic anchor via ЕІУ Konotop Articles.
+- [T4] Davies B. "The Second Chigirin Campaign (1678): Late Muscovite Power in Transition," in *The Military and Society in Russia, 1450-1917*, ed. E. Lohr and M. Poe. Leiden, 2002. Bibliographic anchor via IEU Chyhyryn campaigns; direct pages not inspected in this pass.
+- [T4] *Історія українського козацтва*, vol. 1. Київ, 2006. Bibliographic anchor via ЕІУ Crimean campaigns; direct pages not inspected in this pass.
+
+**Tier 5 (general web / image metadata — not load-bearing):**
+
+- [T5/image metadata] Wikimedia Commons, `Category:Portraits of Ivan Samoylovych`. URL: https://commons.wikimedia.org/wiki/Category:Portraits_of_Ivan_Samoylovych | accessed 2026-07-03. Used for image-rights leads only.
+- [T5/image metadata] Wikimedia Commons, `File:Ivan Samoylovych (Portrait №1, 19th century, Skarzhynska collection).jpg`. URL: https://commons.wikimedia.org/wiki/File:Ivan_Samoylovych_(Portrait_%E2%84%961,_19th_century,_Skarzhynska_collection).jpg | accessed 2026-07-03. Used for image candidate and authenticity caveat.
+- [T5/popular web] Poltava regional/history popular articles and museum pages surfaced in search. Used only as commemoration/image leads; not load-bearing against T1/T4.
+
+**Primary-source documents accessed / verification notes:**
+
+- Konotop Articles 1672: title and effects verified through ЕІУ; original source edition not directly inspected.
+- Pereiaslav 1674 / Right-Bank council recognition: phrase and context verified through ЕІУ Right-Bank campaign; original council/treaty text not directly inspected.
+- Great Expulsion orders/reports: mechanism verified through ЕІУ Great Expulsion; full correspondence/source editions not directly inspected.
+- 1687 Crimean campaign accusation language: verified through ЕІУ Crimean campaigns; investigative or denunciation documents not directly inspected.
+- Kolomak Articles 1687: treaty context verified through IEU; original source edition not directly inspected.
+
+**Honest gaps:** this dossier did not inspect archival originals, full *Akty Yugo-Zapadnoi Rossii* volumes, Samoilovych correspondence, church-jurisdiction source editions, or all Right-Bank migration documents. For module writing, recheck direct wording for Konotop/Pereiaslav/Kolomak article clauses, Great Expulsion orders, Chyhyryn command decisions, the Kyiv metropolitanate subordination, and the 1687 denunciation packet against source editions.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Moscow is treated as an intervening and centralizing power, not as Ukraine's natural administrative center.
+- [x] Samoilovych is not flattened into a Moscow client, pure collaborator, or spotless autonomy hero.
+- [x] The dossier names his institutional achievements and his coercive Right-Bank policy.
+- [x] Starshyna agency is visible; senior officers are neither erased nor romanticized.
+- [x] Doroshenko/Samoilovych/Mazepa/Sirko relations are kept source-cautious and not turned into a morality play.
+- [x] Great Expulsion language preserves coercion and civilian harm.
+- [x] Church patronage is not used to hide the 1686 church-autonomy loss.
+- [x] No Russian-imperial transliterations in body text except variant/forbidden forms in §8 and source-title contexts.
+- [x] No out-of-scope later revival material, unrelated ruler lists, or all-rulers chronology added.
+- [x] Modern Ukrainian place/institution naming used with historical context: Ходорків, Конотоп, Батурин, Чигирин, Переяслав, Тобольськ, Лівобережжя, Правобережжя, Гетьманщина, Запорозька Січ.
+
+## Validation checklist
+
+- [x] Single owned file only: `docs/research/bio/ivan-samoilovych.md`.
+- [x] Existing cross-track plan paths verified locally before citation.
+- [x] Lower-tier sources marked non-load-bearing.
+- [x] Guard terms for unrelated later-Hetmanate, modern-statehood, and all-rulers scope avoided.
+- [x] No generated `status/`, `audit/`, `review/`, or telemetry artifacts referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans, module files, activities, vocabulary, resources, site MDX, or wiki files edited.


### PR DESCRIPTION
## Scope

Adds the BIO Cossack P1 research dossier for Ivan Samoilovych, focused on Left-Bank consolidation after the Ruin, Right-Bank policy, Chyhyryn campaigns, starshyna/court politics, Moscow pressure, church-autonomy loss, and the 1687 Kolomak/Crimean-campaign fall.

## Changed files

- `docs/research/bio/ivan-samoilovych.md`

## Validation

- `npx markdownlint-cli2 docs/research/bio/ivan-samoilovych.md` — passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/ivan-samoilovych.md` — passed
- `git diff --check` — passed
- `rg -n "Skoropadskyi|Скоропад|1918|Polish king|Polish kings|Польськ.*корол|польськ.*корол" docs/research/bio/ivan-samoilovych.md` — no matches
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- Protected-file/artifact guard — only `docs/research/bio/ivan-samoilovych.md` changed; no generated status/audit/review/telemetry files; no linter configs or `.python-version`

## Source and decolonization caveats

- Core facts and framing are anchored in ЕІУ / Internet Encyclopedia of Ukraine and related ЕІУ institutional entries for Konotop Articles, the 1674 Right-Bank campaign, Chyhyryn defenses, Great Expulsion, Crimean campaigns, and Kolomak context.
- Lower-tier sources are explicitly marked as navigation or image-rights aids only.
- Primary/source-language anchors are marked as document/source-language leads, not corpus-certified classroom quotations; source editions should be rechecked before module quotation.
- The dossier avoids flattening Samoilovych into either a Moscow client or a pure autonomy hero, keeping coercion, limited agency, starshyna interests, Right-Bank civilian harm, church-autonomy loss, and imperial pressure visible.

## Review gate

No independent review has been routed yet because the orchestrator handles that gate.