### PR TITLE
[codex] docs(bio): add Pavlo Teteria dossier

### DIFF
--- a/docs/research/bio/pavlo-teteria.md
+++ b/docs/research/bio/pavlo-teteria.md
@@ -1,0 +1,689 @@
+# Павло Іванович Тетеря — Research Dossier
+
+**Slug:** `pavlo-teteria`
+**Block:** G (politically charged Ruin-era / Right-Bank Hetmanate figure;
+Commonwealth alignment, Chudniv/Slobodyshche settlement politics, failed
+all-bank campaign, Right-Bank civil conflict, repression, exile, and contested
+collaboration memory)
+**Tier:** 1a
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ Teteria, IEU Teteria, ЕІУ
+  Chudniv campaign, IEU Slobodyshche Treaty, ЕІУ Hadiach Treaty, ЕІУ
+  Pavoloch uprising, ЕІУ Right-Bank uprising, ЕІУ Bila Tserkva battle, ЕІУ
+  Stavyshche defense, Institute-hosted Gazin monograph page)
+- [x] Source-tier checkboxes included and lower-tier sources kept
+  non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: treaty bargaining,
+  Warsaw-court alignment, 1663-1664 Left-Bank campaign, Right-Bank
+  restoration politics, uprising/repression, seizure of regalia/archive,
+  banishment/exile, and later "failed collaborator" memory)
+- [x] §4 includes 3 short document/source-language anchors with verification
+  caveats
+- [x] Teteria is framed as complex: educated diplomat, starshyna negotiator,
+  Commonwealth-aligned Right-Bank hetman, coercive civil-war actor, church and
+  property patron, exile, and later compromised-memory figure
+- [x] Cross-track links: every "Existing" plan path verified locally with
+  `rg --files` on 2026-07-04
+- [x] Naming-canonical applied
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+
+- [x] **T1 baseline:** ЕІУ and Internet Encyclopedia of Ukraine anchor core
+  facts, names, offices, diplomatic roles, Right-Bank hetmancy, 1663-1665
+  crisis, exile, and death variants.
+- [x] **T1 event context:** ЕІУ entries on the Chudniv campaign, Hadiach
+  Treaty, Pavoloch uprising, Right-Bank uprising, Bila Tserkva battle, and
+  Stavyshche defense are used to keep campaign, treaty, and violence claims
+  event-specific.
+- [x] **T2/T4 scholarship:** Gazin's Institute-hosted monograph page, the NBUV
+  entry for *Volodari hetmanskoi bulavy*, Dashkevych, Chukhlib, Horobets,
+  Krykun, Smolii/Stepankov, and Wojcik are used as scholarly/bibliographic
+  anchors for follow-up, not as unsupported fact dumps.
+- [x] **T3/T5 caution:** Wikipedia, Commons, popular summaries, and school
+  pages are navigation or image-rights aids only; they are not load-bearing for
+  interpretation.
+- [x] **Primary/doc excerpts:** short excerpts are explicitly marked as
+  document/source-language anchors; recheck source editions before classroom
+  quotation.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Павло Іванович Тетеря. ЕІУ gives
+  `Тетеря (Моржковський, Мошковський) Павло Іванович`; IEU gives
+  `Teteria, Pavlo (Morzhkovsky)`. [T1: ЕІУ; T1: IEU]
+- **Pseudonyms / aliases:** Павло Тетеря; Павло Іванович Тетеря;
+  Павло Моржковський-Тетеря; Моржковський; Мошковський; Pavlo Teteria;
+  Pavlo Teterya; Pawel Tetera / Tetera in Polish-language scholarship;
+  Teterja and Morzhkovsky in IEU transliteration.
+- **Born:** unknown. IEU gives birth-place as Pereiaslav, while ЕІУ does not
+  anchor a birthplace and instead states unknown birth year and Volhynian noble
+  Morzhkovsky background. Use "born at an unknown date; origin and birthplace
+  source-sensitive" unless a module verifies a specialist source. [T1: ЕІУ;
+  T1: IEU]
+- **Origin / education:** ЕІУ presents him as from the Volhynian noble
+  Morzhkovsky family of the Radwan coat of arms; he studied at a Uniate school
+  near Minsk and at the Kyiv Collegium. IEU also notes Kyivan Mohyla College
+  education. [T1: ЕІУ; T1: IEU]
+- **Pre-1648 office:** ЕІУ says he was a chancery clerk of the grod court in
+  Lutsk before 1648; IEU says city-court secretary of Volodymyr-Volynskyi.
+  Treat the court-office layer as secure, the exact town as source-sensitive.
+  [T1: ЕІУ; T1: IEU]
+- **Cossack offices:** military scribe / chancellor of the Pereiaslav regiment
+  from 1649; Pereiaslav colonel in **1653-1658**; general scribe in Yurii
+  Khmelnytskyi's government in **1662**; hetman of Right-Bank Ukraine in
+  **1663-1665**. [T1: ЕІУ; T1: IEU]
+- **Diplomatic profile:** active in Chyhyryn diplomacy and missions to
+  Commonwealth, Muscovite, Moldavian, and Transylvanian actors; ЕІУ names him
+  as one of the authors of the 1654 Pereiaslav-Moscow settlement, the 1658
+  Hadiach Treaty, and the 1660 Chudniv/Slobodyshche settlement. [T1: ЕІУ;
+  T1: IEU Pereiaslav; T1: ЕІУ Hadiach; T1: ЕІУ Chudniv; T1: IEU Slobodyshche]
+- **Family / patronage:** married first to Ivan Vyhovskyi's sister and later,
+  in 1660, to Olena / Kateryna Khmelnytska, Bohdan Khmelnytskyy's daughter.
+  ЕІУ also records estate holdings in Kyiv, Bratslav, Volhynia, and Podlasie,
+  a Warsaw house, 1667 membership in the Lviv Dormition Brotherhood, and
+  monastery donations in 1669. [T1: ЕІУ; T1: IEU]
+- **Death / exile:** source-sensitive. ЕІУ gives death in April **1671** and
+  says he was poisoned by a Commonwealth-side agent in Istanbul, with likely
+  burial in an Orthodox church in Edirne. IEU gives death ca. **1670** in
+  Adrianopolis / Edirne. Use "died in Ottoman exile around 1670-1671" unless
+  teaching the death-tradition problem itself. [T1: ЕІУ; T1: IEU]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Birth and birthplace:** do not present 1620 or Pereiaslav as Tier 1
+   settled fact. ЕІУ's safer formulation is unknown birth year plus noble
+   Morzhkovsky origin.
+2. **Name form:** `Тетеря` may be the better project canonical public form,
+   while `Моржковський` / `Мошковський` should be tracked for aliases and
+   source search.
+3. **Court office town:** Lutsk and Volodymyr-Volynskyi appear in Tier 1
+   references; use "grod/city-court chancery experience in Volhynian legal
+   administration" when precision is not needed.
+4. **Confessional status:** IEU says he converted to Catholicism after leaving
+   the hetmancy, while ЕІУ records later Orthodox brotherhood membership,
+   monastery donations, and a wish to become a Kyiv-Pechersk monk. Do not turn
+   this into a simple conversion story without direct source work.
+5. **Hadiach role:** ЕІУ presents him as a Ukrainian negotiator before the
+   treaty; IEU says he later tried to strip the Grand Principality of Rus' idea
+   from the settlement. Treat that as a debated interpretive claim requiring
+   source-edition follow-up.
+6. **Responsibility for executions:** IEU links him to the deaths of Ivan
+   Vyhovskyi and Ivan Bohun; ЕІУ event entries show Teteria and allied
+   commanders involved in interrogations and repression during the 1664
+   uprising. Phrase responsibility cautiously unless a module verifies the
+   relevant correspondence and trial records.
+7. **Office end:** ЕІУ says his forces were defeated in June 1665, after which
+   he renounced the mace and left for Warsaw with regalia and archive
+   documents. Some summaries smooth this into a simple abdication; the dossier
+   should keep the defeat, flight, and archive/regalia issue visible.
+8. **Death site/date:** Istanbul, Edirne/Adrianopolis, 1670, and 1671 appear in
+   reference traditions. Present the uncertainty directly.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Teteria's career shows a Cossack-diplomatic elite trying to
+survive after the Khmelnytsky-era state fractured. He moved through three
+settlement languages: the 1654 Pereiaslav-Moscow framework, the 1658 Hadiach
+federal project, and the 1660 Chudniv/Slobodyshche return to formal
+Commonwealth ties after military defeat. By 1663 he was Right-Bank hetman and
+attempted to reunite both Dnipro banks through a Commonwealth-backed military
+campaign. That strategy intensified civil-war violence, provoked Right-Bank
+resistance, and collapsed under revolt and loss of military capacity. [T1:
+ЕІУ; T1: IEU; T1: IEU Slobodyshche]
+
+**By whom:** Commonwealth institutions and commanders in the Warsaw-court,
+campaign, restoration, and repression layers; Muscovite power in the post-1654
+intervention and Left-Bank opposition layer; Zaporozhian and Left-Bank actors
+in the anti-Teteria resistance layer; Crimean forces in campaign and yasir
+contexts; Teteria and his starshyna network in the local agency layer. The
+point is not to excuse him by naming constraints, but to show the mechanism
+that made compromise, coercion, and factional survival inseparable.
+
+**Document references:** the **Pereiaslav-Moscow treaty / March Articles
+1654**; the **Hadiach Treaty 1658**; the **Chudniv/Slobodyshche settlement
+1660**; the 1663-1664 Right-Bank/Left-Bank campaign; the **Pavoloch uprising
+1663**; the **Right-Bank uprising 1664-1665**; the **Bila Tserkva battle
+1664**; the **Stavyshche defense 1664**; Teteria's 1664 Warsaw-sejm reform
+project; and banishment/exile records after 1670. [T1: ЕІУ; T1 event entries]
+
+**Mechanism specifics:** imperial simplification can turn Teteria into proof
+that Ukrainian politics required outside management; nationalist shorthand can
+turn him into nothing but a collaborator. Both are too easy. Teteria had real
+agency: he negotiated treaties, chose Commonwealth alignment, backed a
+campaign into the Left Bank, repressed opponents, and left with state regalia
+and archive material. He also operated in a field where rival powers used
+recognition, offices, religion, landed rights, and military support to
+reconfigure Ukrainian autonomy after every defeat.
+
+**What survived / what was distorted:** what survived is a record of high
+education, diplomatic skill, legal-office experience, and institutional
+ambition. What was distorted is the moral frame. Later memory often makes him
+only a failed hetman or "foreign-aligned" villain. A decolonized BIO lesson
+should teach why his line looked plausible to some starshyna after
+Slobodyshche and why it became disastrous for Right-Bank society.
+
+## 3. Major works / legacy
+
+Teteria left no literary corpus; "works" means offices, treaties, policy
+projects, campaign decisions, church/property acts, and memory.
+
+- `late 1630s-1640s` — served in a magnate-court environment and gained
+  Volhynian court-chancery experience before joining the Cossack state. ЕІУ
+  also notes European travel and possible time in Italy, but this should remain
+  background unless a module checks a specialist source. [T1: ЕІУ; T1: IEU]
+- `1649` — became military scribe / chancellor of the Pereiaslav regiment,
+  entering the administrative layer of the Cossack state. [T1: ЕІУ; T1: IEU]
+- `1653-1658` — Pereiaslav colonel; this gives him a stable regimental and
+  starshyna base before the Ruin. [T1: ЕІУ; T1: IEU]
+- `January-April 1654` — participated in the Pereiaslav-Moscow negotiations;
+  IEU's Pereiaslav Treaty entry names him and Samiilo Bohdanovych-Zarudny in
+  the April Moscow phase. Use this to teach treaty labor and diplomatic
+  drafting, not a simple loyalty label. [T1: IEU Pereiaslav; T1: ЕІУ]
+- `1650s` — took part in Chyhyryn negotiations and missions to Commonwealth,
+  Muscovite, Moldavian, and Transylvanian counterparts. [T1: ЕІУ]
+- `1658` — represented the Ukrainian side in early Hadiach negotiations
+  according to ЕІУ; the treaty's later ratified form narrowed key Ukrainian
+  demands, which makes Teteria useful for teaching how negotiators and ratifiers
+  could diverge. [T1: ЕІУ Hadiach]
+- `1658-1662` — moved into Warsaw-court service and Commonwealth offices while
+  remaining tied to Cossack politics; this is the transition that later memory
+  often flattens into a single alignment label. [T1: ЕІУ]
+- `1660` — connected with the Chudniv/Slobodyshche settlement, which followed
+  the military crisis around Yurii Khmelnytskyi and formally renewed ties with
+  the Commonwealth while failing to secure a broad all-bank consensus. [T1:
+  ЕІУ Chudniv; T1: IEU Slobodyshche]
+- `1662` — served as general scribe in Yurii Khmelnytskyi's government, then
+  became the main Right-Bank successor after Yurii's withdrawal from the mace.
+  [T1: ЕІУ; T1: IEU]
+- `1663` — elected Right-Bank hetman at a Chyhyryn general council and
+  recognized the authority of the Commonwealth ruler Jan II Casimir. [T1: ЕІУ;
+  T1: IEU]
+- `May-June 1663` — Pavoloch uprising against his policy: ЕІУ connects the
+  revolt to restored Commonwealth-side landholding practices, abuses by
+  leaseholders and merchants, and a plan to replace Teteria with Yakym Somko's
+  authority. The revolt was suppressed and leaders executed after torture. [T1:
+  ЕІУ Pavoloch uprising]
+- `late 1663-early 1664` — supported the Commonwealth campaign into Left-Bank
+  Ukraine, hoping to reunite both banks under his authority; the campaign failed
+  and fed deeper Right-Bank resistance. [T1: ЕІУ; T1: IEU; T1: ЕІУ
+  Right-Bank uprising]
+- `March 1664` — Bila Tserkva battle: insurgent forces were defeated by
+  Commonwealth-side troops, Teteria's units, and Crimean forces; ЕІУ records
+  destruction, plunder, and the execution of about 1,500 prisoners, followed by
+  the death sentence against Ivan Vyhovskyi after interrogation. [T1: ЕІУ
+  Bila Tserkva battle]
+- `1664` — Teteria submitted or sponsored a Warsaw-sejm project to reform
+  Ukraine's internal political order. ЕІУ mentions the project but does not
+  supply full text; use it as a source lead, not a classroom quotation. [T1:
+  ЕІУ]
+- `July-October 1664` — Stavyshche defense: town residents and rebel Cossacks
+  defended the city against the combined forces of Teteria, Stefan Czarniecki,
+  and Crimean Khan Mehmed-Girei IV. ЕІУ describes repeated assaults,
+  bombardment, capitulation terms, renewed revolt, massacre, and total
+  devastation of the town and surrounding villages. [T1: ЕІУ Stavyshche
+  defense]
+- `1664-1665` — Right-Bank uprising spread through Kyiv and Bratslav regions,
+  with Zaporozhian and Left-Bank support. ЕІУ explicitly links the revolt to
+  Teteria's orientation and social policy, restoration of landholding rights,
+  campaign failure, and repression. [T1: ЕІУ Right-Bank uprising]
+- `June 1665` — after defeat by rebels, renounced the mace and left for Warsaw,
+  taking hetman regalia and key archive documents with him. This should be
+  taught as a state-institutional loss, not just a biographical exit. [T1:
+  ЕІУ; T1: IEU]
+- `1667-1669` — church/property layer: ЕІУ records his Lviv Brotherhood
+  membership, relic donation, village transfers to the Mezhyhiria and
+  Kyiv-Pechersk monasteries, and a wish to become a Kyiv-Pechersk monk. Treat
+  this alongside, not instead of, the conflict and property-restoration
+  controversies of his rule. [T1: ЕІУ]
+- `June 1670-April 1671` — after banishment, moved through Moldavia into
+  Ottoman territory; ЕІУ says he was considered as a possible hetman candidate
+  and then poisoned in Istanbul in April 1671. IEU gives ca. 1670 death in
+  Adrianopolis/Edirne. [T1: ЕІУ; T1: IEU]
+- `later memory` — remembered as a compromised or failed Right-Bank hetman.
+  His case is valuable precisely because it resists clean categories:
+  capable diplomat, factional tactician, coercive ruler, failed unifier,
+  archive/removal actor, and exile. [T1/T4]
+
+## 4. Primary-source quotes (>=2 required)
+
+> **Honest tool note (#M-4):** no project `verify_quote` tool was run in this
+> pass. The excerpts below are short document/source-language anchors from
+> cited encyclopedia entries and document traditions, not corpus-certified
+> classroom quotations. Recheck source editions before using longer primary
+> text in a module.
+
+**Anchor 1 — office label:**
+
+> "гетьман Правобережної України"
+
+Context: ЕІУ uses this office label in the Teteria headnote for his 1663-1665
+rule. Use it to teach that his office was Right-Bank specific, not stable
+control over all Ukraine. [T1: ЕІУ Teteria]
+
+**Anchor 2 — treaty label:**
+
+> "Чуднівський договір 1660"
+
+Context: ЕІУ names Teteria among the authors of the Chudniv settlement; IEU
+calls the Slobodyshche pact a treaty that abolished the 1659 Pereiaslav
+Articles and restored formal ties with the Commonwealth. Use the label to
+teach treaty-switch vocabulary after military defeat. [T1: ЕІУ Teteria; T1:
+IEU Slobodyshche]
+
+**Anchor 3 — revolt label:**
+
+> "Правобережне повстання 1664-1665"
+
+Context: ЕІУ uses this event title for the revolt against Teteria's government
+and Commonwealth-restoration policy. Use it as a social-political event label,
+not as proof that all resistance had one command or one ideology. [T1: ЕІУ
+Right-Bank uprising]
+
+## 5. Language register and learner-use notes
+
+- **Register:** Cossack-chancery, treaty, court, military-campaign,
+  church-property, and modern historiographic language.
+- **CEFR readiness for full reading:** B2-C1 for adapted biography; C1-C2 for
+  treaty/source discussion, Hadiach/Slobodyshche vocabulary, and Right-Bank
+  uprising narratives.
+- **Lexicon notes:** `гетьман`, `генеральний писар`, `переяславський
+  полковник`, `булава`, `клейноди`, `державний архів`, `Гадяцький договір`,
+  `Чуднівський договір`, `Слободищенський трактат`, `старшина`, `сейм`,
+  `повстання`, `реституція`, `шляхта`, `орендар`, `ясир`, `баніція`,
+  `братство`, `монастирські маєтності`.
+- **Learner-use notes:** this dossier supports a B2-C1 lesson on cautious
+  alignment verbs: "recognized," "sought support from," "relied on,"
+  "negotiated with," "was accused of," "is said by one source to have." It is
+  also useful for practicing contrast clauses around compromise and coercion.
+- **Stylistic features:** pair legal and diplomatic vocabulary with words for
+  social consequence: `проєкт реформи` beside `повстання`, `репресії`,
+  `спустошення`, `ясир`, `зречення`, and `еміграція`.
+- **Sensitive framing:** do not ask learners whether Teteria was simply
+  "foreign-controlled" or "a traitor." Better prompt: "Which goals did he
+  pursue, which allies made those goals possible, and what costs did those
+  choices impose on Right-Bank communities?"
+
+## 6. Contested points
+
+- **Collaborator label:** Teteria's Commonwealth alignment is central, but a
+  flat label hides the political question: he tried to make that alignment a
+  path to reunifying the Cossack polity, then used coercive means when the
+  social base rejected it.
+- **Hadiach inheritance:** he belonged to the Hadiach diplomatic world, but the
+  ratified Hadiach text, Slobodyshche, and his later Right-Bank policy were not
+  identical. Teach the sequence rather than saying he simply continued one
+  program.
+- **Court office and social origin:** noble origin, legal-chancery experience,
+  and Pereiaslav regimental office all matter. They explain why he was a
+  negotiator and administrator, not just a battlefield rival.
+- **Right-Bank unrest:** Pavoloch and the larger 1664-1665 uprising should not
+  be reduced to disorder. Sources identify material grievances, restoration of
+  landholding rights, abuses, campaign failure, Zaporozhian and Left-Bank
+  support, and weak coordination among rebels.
+- **Violence and responsibility:** Bila Tserkva, Vyhovskyi's execution,
+  Stavyshche, mass executions, town destruction, and yasir belong in the
+  biography. Avoid blaming only outside forces or only Teteria; the point is
+  the coalition of command, repression, and civil war.
+- **Bohun death:** IEU attributes a role to Teteria in Ivan Bohun's execution.
+  Existing Bohun research correctly treats precise responsibility as
+  source-sensitive. Do not make Teteria personally responsible as a classroom
+  fact without checking specialist work and execution records.
+- **Church/property profile:** monastery donations and Orthodox brotherhood
+  membership do not cancel the social anger around property restoration during
+  his rule. Conversely, the uprising record does not prove that every church
+  and property act was cynical. Keep both layers.
+- **Regalia/archive removal:** leaving with state regalia and archive documents
+  is institutionally important. It marks the collapse of a government, not just
+  a dramatic personal flight.
+- **Exile and death:** 1670/1671, Istanbul/Edirne, poison, and burial details
+  remain source-sensitive. Do not stage the death scene as settled fact unless
+  the module verifies the death tradition directly.
+- **Memory:** Teteria is easy to use as a foil for Doroshenko or Bohun. A
+  stronger lesson teaches him as an example of failed compromise under the
+  Ruin: skilled, ambitious, coercive, and politically defeated.
+- **Image authenticity:** available portraits are posthumous and often derived
+  from later copying traditions. Caption as later visual memory unless metadata
+  proves otherwise.
+
+## 7. Cross-track links
+
+> Every curriculum plan path under **Existing** below was verified locally on
+> 2026-07-04. `docs/research/bio/*` entries are verified dossier files, not
+> existing BIO plan paths in this tree.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — diplomatic
+    state baseline, Pereiaslav negotiations, and Khmelnytsky family connection.
+  - `curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml` — Hadiach diplomacy,
+    post-Bohdan factional legitimacy, and execution/responsibility caution.
+  - `curriculum/l2-uk-en/plans/bio/yuriy-nemyrych.yaml` — Hadiach federal
+    project and the Grand Principality of Rus' problem.
+  - `curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml` — Zaporozhian opposition
+    to Teteria-era and Doroshenko-era Commonwealth/Ottoman alignments.
+  - `curriculum/l2-uk-en/plans/bio/ivan-mazepa.yaml` — later comparison for
+    constrained autonomy, archive/statecraft, and accusation vocabulary.
+  - `curriculum/l2-uk-en/plans/bio/pylyp-orlyk.yaml` — later legal-memory and
+    exile-statehood vocabulary after the Ruin.
+  - `curriculum/l2-uk-en/plans/bio/danylo-apostol.yaml`,
+    `curriculum/l2-uk-en/plans/bio/pavlo-polubotok.yaml` — later constrained
+    autonomy cases after the Cossack statehood corridor narrowed.
+- **Existing BIO dossiers (VERIFIED present; not curriculum plan paths):**
+  - `docs/research/bio/bohdan-khmelnytskyy.md`,
+    `docs/research/bio/ivan-vyhovskyi.md`,
+    `docs/research/bio/petro-doroshenko.md`,
+    `docs/research/bio/ivan-briukhovetskyi.md`,
+    `docs/research/bio/yakym-somko.md`,
+    `docs/research/bio/yurii-khmelnytskyi.md`,
+    `docs/research/bio/ivan-samoilovych.md`,
+    `docs/research/bio/ivan-bohun.md`,
+    `docs/research/bio/ivan-sirko.md`,
+    `docs/research/bio/ivan-mazepa.md`,
+    `docs/research/bio/yuriy-nemyrych.md`,
+    `docs/research/bio/pylyp-orlyk.md`,
+    `docs/research/bio/danylo-apostol.md`,
+    `docs/research/bio/pavlo-polubotok.md`,
+    `docs/research/bio/kyrylo-rozumovskyi.md` — verified related
+    Cossack/Hetmanate dossiers.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/bohdan-khmelnytskyi.yaml`,
+    `curriculum/l2-uk-en/plans/hist/khmelnychchyna-prychyny.yaml`,
+    `curriculum/l2-uk-en/plans/hist/syntez-khmelnychchyna.yaml` — origin
+    frame for the state Teteria served as diplomat and later tried to reunify.
+  - `curriculum/l2-uk-en/plans/hist/zborivska-bila-tserkva.yaml` — treaty and
+    battlefield baseline before the later Right-Bank collapse.
+  - `curriculum/l2-uk-en/plans/hist/pereyaslavska-uhoda.yaml` — earlier
+    treaty vocabulary and later reinterpretation of the 1654 settlement.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — office,
+    regiment, council, starshyna, and archive/regalia vocabulary.
+  - `curriculum/l2-uk-en/plans/hist/ruina-i.yaml`,
+    `curriculum/l2-uk-en/plans/hist/ruina-ii.yaml`,
+    `curriculum/l2-uk-en/plans/hist/andrusivske-peremyrya.yaml` — direct
+    Ruin, partition, Doroshenko, and post-Teteria context.
+  - `curriculum/l2-uk-en/plans/hist/ivan-sirko.yaml`,
+    `curriculum/l2-uk-en/plans/hist/ivan-mazepa-derzhavnyk.yaml`,
+    `curriculum/l2-uk-en/plans/hist/ivan-mazepa-kultura.yaml`,
+    `curriculum/l2-uk-en/plans/hist/pylyp-orlyk-konstytutsiia.yaml`,
+    `curriculum/l2-uk-en/plans/hist/danylo-apostol.yaml`,
+    `curriculum/l2-uk-en/plans/hist/pavlo-polubotok.yaml`,
+    `curriculum/l2-uk-en/plans/hist/kinets-hetmanshchyny.yaml` — comparative
+    autonomy and incorporation arc.
+- **Existing ISTORIO/RUTH/LIT/FOLK plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/istorio/pereiaslav-tsykl.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/pereiaslav-alternatyvy.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/pereyaslavski-statti.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/universaly-khmelnytkoho.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/kozatski-litopysy-ohliad.yaml` —
+    treaty, universal, and chronicle-source vocabulary.
+  - `curriculum/l2-uk-en/plans/ruth/the-ruin.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/cossack-hierarchy.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/diplomatic-language.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/document-types.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/treason.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/eyewitness-samovydets.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/velychko-ruin-baroque-2.yaml` — older
+    office, document, accusation, and chronicle registers.
+  - `curriculum/l2-uk-en/plans/lit/black-council-history.yaml`,
+    `curriculum/l2-uk-en/plans/lit/black-council-plot.yaml`,
+    `curriculum/l2-uk-en/plans/lit-hist-fic/kulish-black-council-revisit.yaml`
+    — literary memory of the split and civil-war causality.
+  - `curriculum/l2-uk-en/plans/folk/istorychni-pisni.yaml`,
+    `curriculum/l2-uk-en/plans/folk/dumy-nevilnytski-lytsarski.yaml` —
+    historical-song/duma memory where Teteria is mentioned by ЕІУ as later
+    memory material.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `pavlo-teteria` — future BIO plan/module if this dossier is promoted into
+    curriculum.
+  - `pavolotske-povstannia-1663` — local revolt, property restoration, and
+    Somko legitimacy case.
+  - `pohid-1663-1664-na-livoberezhzhia` — failed all-bank campaign and
+    coalition warfare.
+  - `pravoberezhne-povstannia-1664-1665` — social policy, repression,
+    Zaporozhian/Left-Bank intervention, and civilian harm.
+  - `stavyschanska-oborona-1664` — siege, negotiated surrender, massacre, and
+    memory of town devastation.
+  - `hetmanski-kleinody-i-arkhiv` — regalia/archive as state-institutional
+    continuity problem.
+- **Potential LIT/FOLK additions surfaced by this research:**
+  - A memory-history unit on how historical songs, chronicles, portraits, and
+    school prose turn compromised Ruin-era hetmans into moral shorthand.
+
+## 8. Naming-canonical
+
+- **Slug:** `pavlo-teteria`
+- **EN canonical (project spelling):** Pavlo Teteria
+- **UA canonical (with patronymic):** Павло Іванович Тетеря
+- **Aliases (track these for `aliases:` YAML field):** Павло Тетеря; Павло
+  Іванович Тетеря; Павло Моржковський-Тетеря; Моржковський; Мошковський;
+  Pavlo Teteria; Pavlo Teterya; Teterja; Morzhkovsky; Pawel Tetera; Pawel
+  Teteria; Pawel Morzkowski.
+- **Source/title variants to track carefully:** `гетьман Правобережної
+  України`; `переяславський полковник`; `військовий писар Переяславського
+  полку`; `генеральний писар`; `староста брацлавський`; `староста
+  чигиринський`; `полоцький стольник`; `мельницький підчаший`.
+- **Forbidden forms (Russian-imperial / flattening forms to flag in body
+  text):** Russian-only name forms as normalized Ukrainian/English body text;
+  "puppet" as fact; "traitor" as fact; "failed ruler" as a complete
+  biography; "foreign-controlled hetman" without agency/constraint analysis.
+- **Term warning:** `баніція` is a legal banishment term; explain it as a
+  sentence/exile mechanism, not simply "emigration."
+- **Scope warning:** keep this BIO dossier on seventeenth-century Right-Bank
+  Cossack politics and memory afterlife. Do not turn it into an all-rulers
+  chronology or unrelated modern-statehood material.
+
+## 9. Image candidates
+
+- **Best likely portrait candidate:** Wikimedia Commons `File:Pavlo
+  Teterya.jpg` / related file `Pavlo Teterya (Historical figures of
+  Southwestern Russia in biographies and portraits. Portrait 14).jpg`.
+  Metadata describes a 19th-century portrait/copy based on a Havrylo Vasko
+  portrait and the Samiilo Velychko chronicle miniature tradition. Verify the
+  individual file page and license before reuse. [T5: Commons]
+- **Alternate engraved portrait:** Commons `File:Pavlo Teterya (Engraved
+  portrait, 19th century, Stanislaw Maslowski)-cropped.jpg`; useful only if the
+  license and source chain are checked. [T5: Commons]
+- **Coat-of-arms candidate:** Commons `File:Alex K Pavlo Teteria.svg` is a
+  Radwan/coat-of-arms style lead, not a likeness; it may be better for a
+  heraldry/name-origin sidebar than as the primary BIO image. [T5: Commons]
+- **Signature/document candidate:** Commons files for Teteria's signature can
+  support a document-literacy lesson if license and provenance are verified.
+  A signature is not a portrait.
+- **Context candidates:** rights-clear images of Chyhyryn, Pereiaslav, Bila
+  Tserkva, Stavyshche, or a map of Right-Bank/Left-Bank Ukraine may be more
+  pedagogically precise than a posthumous portrait.
+- **Authenticity caveat:** available portraits are later visual-memory
+  artifacts. Caption as posthumous representation unless metadata proves a
+  life-era likeness.
+- **Avoid:** generic Cossack stock art, images that visually naturalize
+  Commonwealth or Muscovite control, romanticized battlefield scenes unrelated
+  to the 1663-1665 events, or unlicensed modern illustrations.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- [T1] Чухліб Т. В. "Тетеря Павло Іванович" // *Енциклопедія історії України*.
+  URL: https://www.history.org.ua/?termin=Teteria_P | resolved HTTP 200,
+  accessed 2026-07-04. Core facts: unknown birth year, Morzhkovsky/Moshkovsky
+  aliases, noble origin, education, Pereiaslav scribe/colonel, Chyhyryn
+  diplomacy, role in 1654/1658/1660 settlements, Warsaw-court service,
+  general scribe, Right-Bank hetmancy, 1663-1664 campaign, uprising, 1665
+  abdication/flight with regalia/archive, banishment, Ottoman exile, death,
+  church/property notes, memory in songs and dumas.
+- [T1] Zhukovsky A. "Teteria, Pavlo" // *Internet Encyclopedia of Ukraine*.
+  URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CT%5CE%5CTeteriaPavlo.htm
+  | resolved HTTP 200, accessed 2026-07-04. Core facts: education, marriages,
+  Pereiaslav regiment, Pereiaslav Treaty mission, Vyhovskyi/Hadiach period,
+  Right-Bank hetmancy, 1663-1664 campaign, uprising, 1665 resignation, archive
+  and regalia removal, exile, death; used carefully where interpretive claims
+  require cross-checking.
+- [T1] "Pereiaslav Treaty of 1654" // *Internet Encyclopedia of Ukraine*.
+  URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CP%5CE%5CPereiaslavTreatyof1654.htm
+  | resolved HTTP 200, accessed 2026-07-04. Used for Teteria and Samiilo
+  Bohdanovych-Zarudny in the April Moscow phase, treaty limits, and later
+  reinterpretation risks.
+- [T1] Горобець В. М. "Гадяцький договір 1658" // *Енциклопедія історії
+  України*. URL: https://www.history.org.ua/?termin=Gadjackij_dogovir |
+  resolved HTTP 200, accessed 2026-07-04. Used for Teteria's negotiation role,
+  Grand Principality of Rus' framework, ratification changes, and later reuse
+  of Hadiach provisions.
+- [T1] Галушка А. А. "Чуднівська кампанія 1660" // *Енциклопедія історії
+  України*. URL: https://www.history.org.ua/?termin=Chudnivskyj_dohovir_1660 |
+  resolved HTTP 200, accessed 2026-07-04. Used for the Chudniv/Slobodyshche
+  military crisis and settlement background.
+- [T1] "Slobodyshche, Treaty of" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CL%5CSlobodyshcheTreatyof.htm
+  | resolved HTTP 200, accessed 2026-07-04. Used for the 27 October 1660 pact,
+  abolition of the 1659 Pereiaslav Articles, limited autonomy, and the
+  Left-Bank split under Somko/Zolotarenko.
+- [T1] Степанков В. С. "Паволоцьке повстання 1663" // *Енциклопедія історії
+  України*. URL: https://www.history.org.ua/?termin=Pavolotske_povstannia_1663
+  | resolved HTTP 200, accessed 2026-07-04. Used for causes, Ivan Popovych,
+  Somko alignment, suppression, torture, and executions.
+- [T1] Горобець В. М. "Правобережне повстання 1664-1665" // *Енциклопедія
+  історії України*. URL:
+  https://www.history.org.ua/?termin=Pravoberezhne_povstannia_1664 |
+  resolved HTTP 200, accessed 2026-07-04. Used for causes, participants,
+  Sirko/Left-Bank/Zaporozhian support, repression, yasir, and Teteria's fall.
+- [T1] Станіславський В. В. "Білоцерківська битва 1664 р." // *Енциклопедія
+  історії України*. URL: https://www.history.org.ua/?termin=Bilotserkivska_bytva_1664
+  | resolved HTTP 200, accessed 2026-07-04. Used for insurgent forces,
+  Teteria/Machowski/Crimean-side response, prisoner executions, destruction,
+  and the Vyhovskyi execution sequence.
+- [T1] Чухліб Т. В. "Ставищанська оборона 1664" // *Енциклопедія історії
+  України*. URL: https://www.history.org.ua/?termin=Stavyschanska_oborona_1664
+  | resolved HTTP 200, accessed 2026-07-04. Used for siege duration, combined
+  attackers, rebel defenders, assaults, surrender terms, renewed uprising,
+  massacre, and town devastation.
+
+**Tier 2 (institutional / bibliographic):**
+
+- [T2/T4] Газін В. В. *Гетьман Павло Тетеря: соціально-політичний портрет*.
+  Кам'янець-Подільський: Аксіома, 2007. Institute of History resource page:
+  https://resource.history.org.ua/item/0009791 | accessed 2026-07-04. Used as
+  institutional monograph pointer, table-of-contents guide, and bibliography
+  anchor; direct PDF not exhaustively annotated in this pass.
+- [T2/T4] *Володарі гетьманської булави: історичні портрети*. NBUV Ukrainica
+  record. URL: https://irbis-nbuv.gov.ua/ulib/item/ukr0000021787 | accessed
+  2026-07-04. Used for Dashkevych's "Павло Тетеря" chapter pointer.
+- [T2] Кам'янець-Подільський національний університет, faculty profile for
+  В. В. Газін. URL: https://histua.kpnu.edu.ua/volodymyr-volodymyrovych-hazin/
+  | accessed 2026-07-04. Used only to corroborate Gazin bibliography; not
+  load-bearing against ЕІУ/IEU.
+
+**Tier 3 (encyclopedic — navigation only):**
+
+- [T3] "Павло Тетеря" // Ukrainian Wikipedia. URL:
+  https://uk.wikipedia.org/wiki/Павло_Тетеря | accessed 2026-07-04. Used only
+  for alias/image/date navigation; cross-checked against T1.
+- [T3] "Pavlo Teteria" // English Wikipedia. URL:
+  https://en.wikipedia.org/wiki/Pavlo_Teteria | accessed 2026-07-04. Used only
+  for English alias/image navigation; not load-bearing.
+
+**Tier 4 (modern scholarly post-1991 / academic anchors):**
+
+- [T4] Дашкевич Я. "Павло Тетеря." In *Володарі гетьманської булави:
+  історичні портрети*. Київ: Варта, 1994/1995, pp. 253-283. Bibliographic
+  anchor via ЕІУ and NBUV; direct chapter not fully inspected in this pass.
+- [T4] Чухліб Т. В. *Гетьмани Правобережної України в історії
+  Центрально-Східної Європи (1663-1713 рр.)*. Київ, 2004. Bibliographic anchor
+  via ЕІУ.
+- [T4] Горобець В. М. *Еліта козацької України у пошуках політичної
+  легітимації: стосунки з Москвою та Варшавою, 1654-1665*. Київ, 2001.
+  Bibliographic anchor via ЕІУ.
+- [T4] Крикун М. *Між війною та радою: Козацтво Правобережної України в другій
+  половині XVII - на початку XVIII століття*. Київ: Критика, 2006.
+  Bibliographic anchor via ЕІУ.
+- [T4] Смолій В. А., Степанков В. С. *Українська національна революція
+  XVII ст. (1648-1676 рр.)*. Київ, 1999. Bibliographic anchor via ЕІУ event
+  entries.
+- [T4] Wojcik Z. "The early period of P. Teterja's Hetmancy in the Right-Bank
+  Ukraine (1661-1663)." *Harvard Ukrainian Studies*, 1979/80, vol. 3-4.
+  Bibliographic anchor via ЕІУ.
+- [T4] Jurkow E. *Pawel Tetera, hetman Ukrainy prawobrzezny w ll. 1662-1665
+  (rola polityczna)*. Lviv, 1928 dissertation. Bibliographic anchor via ЕІУ;
+  archival dissertation not inspected.
+
+**Tier 5 (general web / image metadata — not load-bearing):**
+
+- [T5/image metadata] Wikimedia Commons, `Category:Pavlo Teterya`. URL:
+  https://commons.wikimedia.org/wiki/Category:Pavlo_Teterya | accessed
+  2026-07-04. Used for image-rights leads only.
+- [T5/image metadata] Wikimedia Commons, `File:Pavlo Teterya.jpg` and related
+  portrait files, accessed 2026-07-04. Used for image candidates and
+  authenticity caveat; individual file pages must be checked before reuse.
+- [T5/image metadata] IEU picture page for "Pavlo Teteria." URL:
+  https://www.encyclopediaofukraine.com/picturedisplay.asp?id=16147&key=%3CStyle+type%3D%22text%2Fcss%22%3E+a+%7B+text-decoration%3A+none+%21important%3B+text-align%3A+right%3B+%7D+%3C%2FStyle%3E+Teteria%2C+Pavlo%2C+%D0%A2%D0%B5%D1%82%D0%B5%D1%80%D1%8F%2C+%D0%9F%D0%B0%D0%B2%D0%BB%D0%BE%3B+Teterja%2C+Morzhkovsky&linkpath=pic%5CT%5CE%5CTeteria+Pavlo+%28portrait%29.jpg&page=pages%5CT%5CE%5CTeteriaPavlo.htm&pid=15420&tyt=Teteria%2C+Pavlo
+  | accessed 2026-07-04. Used as a portrait lead only; verify rights elsewhere
+  before publication.
+
+**Primary-source documents accessed / verification notes:**
+
+- Pereiaslav-Moscow settlement / March Articles 1654: Teteria participation and
+  treaty character verified through IEU and ЕІУ; original article copies not
+  directly inspected.
+- Hadiach Treaty 1658: negotiation sequence, core provisions, and ratification
+  narrowing verified through ЕІУ; source editions not directly inspected.
+- Chudniv/Slobodyshche settlement 1660: military crisis and settlement effects
+  verified through ЕІУ and IEU; original treaty text not directly inspected.
+- Right-Bank uprising 1664-1665: event sequence verified through ЕІУ event
+  entries; full court, military, and correspondence packets not directly
+  inspected.
+- Teteria's 1664 Warsaw-sejm project: identified through ЕІУ; full text not
+  directly inspected.
+
+**Honest gaps:** this dossier did not inspect archival originals, full
+Commonwealth-court records, Teteria's correspondence, complete monastery
+property acts, complete trial/execution records for Ivan Vyhovskyi or Ivan
+Bohun, or the full Gazin/Dashkevych monograph chapters. For module writing,
+recheck direct wording around Hadiach revisions, the 1664 reform project,
+Pavoloch and Stavyshche violence, regalia/archive removal, confessional status,
+and death/exile traditions against source editions.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Muscovy is treated as an intervening power, not
+  Ukraine's natural arbiter.
+- [x] Commonwealth alignment is named directly without turning Teteria into a
+  one-label villain or sanitized statesman.
+- [x] Teteria's agency is visible: treaty work, office seeking, campaign
+  support, repression, flight with regalia/archive, and exile choices.
+- [x] Constraints are visible: post-Bohdan succession crisis, Chudniv defeat,
+  Hadiach/Slobodyshche narrowing, Left-Bank opposition, Zaporozhian politics,
+  Right-Bank social conflict, and neighboring-power pressure.
+- [x] Campaign violence, executions, yasir, Stavyshche devastation, and civilian
+  vulnerability are not hidden.
+- [x] Church/property material is not used to wash the biography, and social
+  conflict is not used to erase his patronage/religious-network record.
+- [x] No Russian-imperial transliterations in body text except variant/forbidden
+  forms in §8.
+- [x] No out-of-scope all-rulers chronology or unrelated modern-statehood
+  material added.
+- [x] Modern Ukrainian place/institution naming used with historical context:
+  Луцьк, Володимир-Волинський, Переяслав, Чигирин, Гадяч, Слободище, Паволоч,
+  Біла Церква, Ставище, Брацлавщина, Київщина, Лівобережжя, Правобережжя,
+  Гетьманщина, Запорозька Січ, Варшава, Ясси, Стамбул, Едірне.
+
+## Validation checklist
+
+- [x] Single owned file only: `docs/research/bio/pavlo-teteria.md`.
+- [x] Existing cross-track plan paths verified locally before citation.
+- [x] Lower-tier sources marked non-load-bearing.
+- [x] Guard terms for unrelated modern-statehood, all-rulers, and
+  out-of-scope ruler-line material avoided.
+- [x] No generated `status/`, `audit/`, `review/`, or telemetry artifacts
+  referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans,
+  module files, activities, vocabulary, resources, site MDX, or wiki files
+  edited.


### PR DESCRIPTION
## Scope

Adds the BIO Cossack P1 research dossier for Pavlo Teteria only.

## Changed files

- `docs/research/bio/pavlo-teteria.md`

## Validation

- `npx markdownlint-cli2 docs/research/bio/pavlo-teteria.md` — passed, 0 errors
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/pavlo-teteria.md` — passed, no fabricated Existing cross-track plan paths
- `git diff --check` — passed
- Guard for out-of-scope names/terms in `docs/research/bio/pavlo-teteria.md` — passed, no matches
- Protected artifact/config guard — passed; only the dossier file is changed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed for 1 commit

## Source and decolonization caveats

- Core claims are anchored in ЕІУ / Internet Encyclopedia of Ukraine and event-specific ЕІУ entries for Chudniv, Hadiach, Pavoloch, Right-Bank uprising, Bila Tserkva, and Stavyshche.
- Wikipedia, Commons, popular web, and image metadata are explicitly non-load-bearing.
- The dossier flags disputed emphasis around birth/origin, court-office town, confessional status, Hadiach role, responsibility for Vyhovskyi/Bohun executions, office end, and death/exile details.
- Teteria is framed as a constrained but responsible political actor: not a flat collaboration label, not a sanitized statesman.

## Review gate

No independent review has been routed yet; the orchestrator handles that gate.