### PR TITLE
docs(bio): add Ivan Skoropadskyi dossier

### DIFF
--- a/docs/research/bio/ivan-skoropadskyi.md
+++ b/docs/research/bio/ivan-skoropadskyi.md
@@ -1,0 +1,643 @@
+# Іван Ілліч Скоропадський — Research Dossier
+
+**Slug:** `ivan-skoropadskyi`
+**Block:** G (politically charged post-Mazepa Hetmanate figure; Hlukhiv
+election under Peter I, constrained institutional defense, Reshetylivka
+petition, military occupation, resident oversight, and the 1722 Little Russian
+Collegium)
+**Tier:** 1a
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (IEU Skoropadsky, IEU Reshetylivka
+  Articles, IEU Little Russian Collegium, IEU Poltava battle, IEU Mazepa,
+  Institute-published Reshetylivka dictionary entry, Kyiv-Mohyla institutional
+  note, NBUV monograph page)
+- [x] Source-tier checkboxes included and lower-tier sources kept
+  non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: coerced Hlukhiv
+  election, Baturyn/Poltava terror context, refusal to ratify the
+  Reshetylivka petition as a treaty guarantee, resident oversight, troop
+  quartering, command/fiscal restrictions, printing and academy pressure, and
+  the 1722 Collegium)
+- [x] §4 includes 3 short document/source-language anchors with verification
+  caveats
+- [x] Skoropadskyi is framed as complex: Mazepa-era administrator, Starodub
+  colonel, constrained hetman, autonomy petitioner, estate-building starshyna,
+  patron, and ruler under shrinking room for action
+- [x] Cross-track links: every "Existing" plan path verified locally with
+  `rg --files` on 2026-07-04
+- [x] Naming-canonical applied
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+
+- [x] **T1 baseline:** Internet Encyclopedia of Ukraine anchors core facts,
+  dates, offices, election, post-Poltava restrictions, protests, death, and
+  burial.
+- [x] **T1 institutional context:** IEU entries on the Reshetylivka Articles,
+  Little Russian Collegium, Poltava battle, and Mazepa frame the institutional
+  mechanism around the biography.
+- [x] **T2 institutional / bibliographic context:** Kyiv-Mohyla Academy's
+  virtual museum note, NBUV's page for Hurzhii's monograph, and the
+  Institute-published Reshetylivka dictionary entry provide education,
+  patronage, and bibliography leads.
+- [x] **T4 scholarship:** Hurzhii's *Ukrainian Historical Journal* article
+  and monograph page are used for source-sensitive family, early-career,
+  estate, and interpretive cautions.
+- [x] **T3/T5 caution:** Wikipedia, Commons, image pages, and popular pages
+  are navigation or image-rights aids only; they are not load-bearing for
+  interpretation.
+- [x] **Primary/doc excerpts:** short excerpts are explicitly marked as
+  document/source-language anchors; recheck source editions before classroom
+  quotation.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Іван Ілліч Скоропадський. [T1: IEU; T4:
+  Hurzhii]
+- **Pseudonyms / aliases:** Іван Скоропадський; Іван Ілліч Скоропадський;
+  Ivan Skoropadsky; Ivan Skoropadskyi; Skoropads'kyj in IEU transliteration;
+  source variants Шкуропадський, Шкуропадцький, Скуропацький appear in early
+  and later documents and should be tracked as source spellings, not normalized
+  public forms. [T1: IEU; T4: Hurzhii]
+- **Born:** **1646**, usually given as **Умань** / Uman. IEU gives 1646 in
+  Uman; Hurzhii cites Mykola Khanenko's 1722 diary note that Skoropadskyi died
+  in his 76th year, which supports the 1646 birth year. [T1: IEU; T4:
+  Hurzhii]
+- **Died:** **14 July 1722 N.S. / 3 July 1722 O.S.** in **Глухів**. IEU gives
+  14 July 1722 in Hlukhiv; burial was at the Hamaliivka Monastery near
+  Hlukhiv. [T1: IEU]
+- **Family / origin:** from the Skoropadskyi family associated with Uman and
+  later Left-Bank starshyna networks. Hurzhii treats later noble-origin claims
+  cautiously: eighteenth-century family petitions preserve useful leads, but
+  also contain chronological mistakes and status-building claims. Use
+  "Uman-linked noble/starshyna family, source-sensitive origin" when the
+  module does not inspect genealogical files directly. [T4: Hurzhii]
+- **Move to the Left Bank:** after the 1674 Ottoman-Tatar destruction of Uman,
+  Ivan and his brother Vasyl moved into Left-Bank Hetmanate service; a younger
+  brother remained a captivity/memory issue in family tradition. [T1: IEU; T4:
+  Hurzhii]
+- **Education:** source-sensitive. IEU does not foreground a school record,
+  while Kyiv-Mohyla's institutional note says he studied at the Academy. Use
+  "standard reference tradition connects him with Kyiv-Mohyla education; verify
+  before making it a central classroom claim." [T2: Kyiv-Mohyla virtual museum]
+- **Pre-hetman offices:** military chancellor / chancery official under Ivan
+  Samoilovych in **1675-1676**; Chernihiv regimental secretary in
+  **1681-1694**; general standard-bearer in **1698**; second general osaul in
+  **1701**; Starodub colonel from **1706** until the 1708 crisis. [T1: IEU;
+  T4: Hurzhii]
+- **Diplomatic service:** missions for Samoilovych to Moscow and Crimea, and
+  for Mazepa to Poland, Moscow, and the Zaporozhian Sich. This is central: he
+  was an experienced chancery and diplomatic administrator before becoming a
+  crisis hetman. [T1: IEU]
+- **Hetman office:** elected / installed at a Council of Officers in Hlukhiv on
+  **6 November 1708 O.S. / 17 November 1708 N.S.**, after Mazepa's break with
+  Peter I and after the destruction of Baturyn. [T1: IEU; T1: IEU Mazepa]
+- **Rule:** hetman of the Left-Bank Hetmanate from **1708 to 1722**, under
+  Russian military and resident oversight. [T1: IEU]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Origin and family status:** do not present the family as a settled
+   foreign noble import or a simple native starshyna line. Hurzhii shows that
+   the evidence is tangled and that later status claims need checking.
+2. **Birthplace and education:** Uman and Kyiv-Mohyla are standard reference
+   claims, but the education claim should remain a reference tradition unless a
+   lesson verifies archival or institutional evidence.
+3. **Starodub in 1708:** do not turn him into either Mazepa's secret successor
+   or Peter's willing instrument without source work. The safer claim is that
+   he was Mazepa's Starodub colonel and a trusted diplomatic-administrative
+   figure who ended up inside the Russian-controlled corridor when the crisis
+   unfolded.
+4. **Election legitimacy:** the Hlukhiv election was a Cossack-starshyna
+   procedure under direct tsarist pressure. "Elected" and "imposed under
+   coercion" both belong in the account.
+5. **Reshetylivka:** Skoropadskyi's petition asked for confirmation of rights
+   and military order; Peter's reply avoided a durable equal treaty and kept
+   key controls. Do not teach it as a successful restoration.
+6. **Collaboration label:** "collaborator" alone erases coercion and his
+   autonomy petitions; "defender" alone erases his dependence on Peter's
+   recognition, the military role at Poltava, estate interests, and limits of
+   resistance.
+7. **Patronage and estates:** he supported churches and the Kyiv-Mohyla
+   Academy, but also accumulated property and worked within starshyna estate
+   politics. Keep both layers visible.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Skoropadskyi came to power in the immediate aftermath of
+Mazepa's break, Baturyn's destruction, and a terror campaign against suspected
+Mazepa supporters. His hetmancy did not begin as a normal succession. It began
+as imperial damage control: Peter I needed a hetman to split the Cossack elite,
+hold the Left Bank, and make obedience appear institutionally Ukrainian rather
+than only externally imposed. [T1: IEU; T1: IEU Mazepa]
+
+**By whom:** Peter I and his military-administrative system in the coercive
+election, confirmation, command, finance, and Collegium layers; Russian
+residents and garrisons in day-to-day supervision; Skoropadskyi and the general
+starshyna in the constrained-governance layer; Mazepa, Orlyk, Hordiienko, and
+the Zaporozhian/exile side in the competing-legitimacy layer. No side should be
+erased.
+
+**Document references:** the 1708 Hlukhiv election sequence; the Baturyn and
+Poltava aftermath; the **Reshetylivka Articles / Prosytelni statti of 1709**;
+Peter's delayed confirmation documents; resident instructions; orders placing
+Cossack troops under Russian command; restrictions on printing and the
+Kyiv-Mohyla Academy; and the **Little Russian Collegium** of 1722. [T1: IEU;
+T1: IEU Reshetylivka; T1: IEU Little Russian Collegium]
+
+**Mechanism specifics:** imperial power used a recognizable Hetmanate office
+while stripping its room for action. The Cossack army was put under Russian
+command; artillery and military resources were removed; Russian troops were
+quartered at local expense; high offices became subject to tsarist approval; the
+capital was moved to Hlukhiv under resident oversight; and the Reshetylivka
+petition's rights language was answered without a binding restoration. In 1722
+the Collegium created a competing administrative, judicial, and fiscal center in
+the hetman capital itself. [T1: IEU; T1: IEU Little Russian Collegium]
+
+**What survived / what was distorted:** what survived is the evidence of a
+Hetmanate government still petitioning, issuing universals, supporting
+church/academy institutions, and trying to preserve procedure under coercion.
+What was distorted is the person. Imperial memory can turn him into proof that
+"reasonable" Cossack elites accepted incorporation; heroic shorthand can wish
+him into an autonomy savior. A decolonized BIO lesson should show the
+post-Poltava loss of room for action and the limited agency still exercised
+inside that loss.
+
+## 3. Major works / legacy
+
+Skoropadskyi left no literary corpus; "works" means offices, petitions,
+universals, institutional defense, patronage, and memory.
+
+- `1646` — born in the Uman-linked Skoropadskyi family; later family-origin
+  claims should be treated as source-sensitive. [T1: IEU; T4: Hurzhii]
+- `1674` — after Uman's destruction, moved to the Left Bank and entered the
+  Hetmanate service world. [T1: IEU; T4: Hurzhii]
+- `1675-1676` — served in Samoilovych's military chancery and carried missions
+  to Moscow; this trained him in petition, report, and negotiation practice.
+  [T1: IEU; T4: Hurzhii]
+- `1681-1694` — Chernihiv regimental secretary; gained administrative
+  experience and property ties in the Chernihiv region. [T1: IEU; T4: Hurzhii]
+- `1687-1689` — participated in the Crimean campaign environment and lived
+  through Samoilovych's fall, a key lesson in how military failure, starshyna
+  interests, and Moscow intervention could unseat a hetman. [T4: Hurzhii; T1:
+  IEU Samoilovych context]
+- `1687 and 1690` — received Mazepa universals confirming estate holdings;
+  useful for showing that his relationship to Mazepa was administrative,
+  patronage-based, and not simply invented in 1708. [T4: Hurzhii]
+- `1698` — general standard-bearer; a step into the general-starshyna world.
+  [T1: IEU]
+- `1701` — second general osaul under Mazepa; the office involved military
+  inspection, records, discipline, and investigations. [T1: IEU; T4: Hurzhii]
+- `1703-1705` — continued diplomatic and military service for Mazepa, including
+  sensitive missions around Right-Bank and Great Northern War politics. [T1:
+  IEU; T4: Hurzhii]
+- `1706` — appointed Starodub colonel, placing him in one of the most important
+  northern regimental commands as the war moved through the region. [T1: IEU;
+  T4: Hurzhii]
+- `October-November 1708` — Mazepa's break with Peter I, the destruction of
+  Baturyn, and the Russian seizure of initiative left Starodub and Hlukhiv in a
+  coercive field. Treat Skoropadskyi's conduct here as source-sensitive: he was
+  neither free of pressure nor without agency. [T1: IEU; T1: IEU Mazepa]
+- `6/17 November 1708` — Hlukhiv election / installation as hetman. Pavlo
+  Polubotok appears in the succession context as an alternative candidate in
+  several traditions; Peter's preference helped decide the result. [T1: IEU;
+  T1: IEU Little Russian Collegium; T4]
+- `1709` — fought with Cossack forces on Peter's side in the Poltava campaign;
+  IEU's Poltava entry places Skoropadskyi's loyal Cossack forces in the
+  movement that cut off possible Swedish retreat toward the Dnipro. This should
+  be taught as military fact and coercive-political context, not as a simple
+  moral verdict. [T1: IEU Poltava]
+- `17/28 July 1709` — sent the 14-point Reshetylivka petition asking for
+  confirmation of rights, military order, and practical protections. Peter's
+  reply confirmed some language in principle but kept Russian command,
+  garrisons, fiscal control, and unresolved restrictions. [T1: IEU
+  Reshetylivka; T1/T2: Institute-published Reshetylivka entry]
+- `1710` — formal confirmation of his hetmancy was delayed until after Peter
+  had tested loyalty and secured the post-Poltava field. [T1: IEU]
+- `1710s` — operated under resident oversight in Hlukhiv while Russian
+  commanders, garrisons, and officials increasingly entered Hetmanate affairs.
+  [T1: IEU]
+- `1714 and 1720` — Kyiv-Mohyla patronage: the institutional note says he
+  continued support to the Academy, assigned Yadlivka in 1714, and confirmed
+  Motovylivka for the Kyiv Brotherhood Monastery in 1720. Verify charters before
+  using exact text in a lesson. [T2: Kyiv-Mohyla virtual museum]
+- `1717` — Hurzhii notes a universal protecting a woman whose son was in
+  Ottoman captivity. Use as a lead for social-protection and captivity-memory
+  language, not as proof of broad social policy. [T4: Hurzhii]
+- `1720` — printing restrictions and pressure on Kyiv-Mohyla form the cultural
+  incorporation layer of his final years. [T1: IEU]
+- `27 May 1722` — Peter I established the Little Russian Collegium in Hlukhiv;
+  IEU describes it as an institution to oversee hetman, officers, regimental
+  and company starshyna, and later to usurp major powers after Skoropadskyi's
+  death. [T1: IEU Little Russian Collegium]
+- `3/14 July 1722` — death in Hlukhiv; burial at Hamaliivka. His death opened
+  the acting-hetman / Collegium crisis that leads directly into Pavlo
+  Polubotok and Danylo Apostol. [T1: IEU; T1: IEU Little Russian Collegium]
+- `later memory` — remembered as a constrained administrator after Poltava:
+  important because he shows institutional survival under pressure, not because
+  he provides an easy hero/traitor script. [T1/T4]
+
+## 4. Primary-source quotes (>=2 required)
+
+> **Honest tool note (#M-4):** no project `verify_quote` tool was run in this
+> pass. The excerpts below are short document/source-language anchors from
+> cited encyclopedia entries, source titles, and institutional summaries, not
+> corpus-certified classroom quotations. Recheck source editions before using
+> longer primary text in a module.
+
+**Anchor 1 — Reshetylivka petition title:**
+
+> "Просительні статті"
+
+Context: the 1709 petition's title itself matters. It names a supplicatory
+format, not an equal treaty negotiation. Use it to teach how formal deference
+and rights claims could appear in the same document. [T1/T2:
+Institute-published Reshetylivka entry; T1: IEU Reshetylivka]
+
+**Anchor 2 — rights-language core:**
+
+> "прав, вольностей і порядків військових"
+
+Context: the Institute-published Reshetylivka entry uses this formula for the
+rights and military order that the hetman government sought to have confirmed.
+This is the best compact phrase for learners to compare with Orlyk,
+Polubotok, and Apostol rights vocabulary. [T1/T2: Institute-published
+Reshetylivka entry]
+
+**Anchor 3 — Collegium title as imperial administrative language:**
+
+> "Малоросійська колегія"
+
+Context: treat this as an imperial institution name under analysis, not as a
+neutral identity label. IEU defines the first Collegium as established in
+Hlukhiv in 1722 to oversee the hetman and starshyna. [T1: IEU Little Russian
+Collegium]
+
+## 5. Language register and learner-use notes
+
+- **Register:** Cossack-chancery, petition, military-command, estate,
+  church-patronage, and imperial-administrative language.
+- **CEFR readiness for full reading:** B2-C1 for adapted biography; C1-C2 for
+  Reshetylivka clauses, resident instructions, universals, and Collegium
+  documents.
+- **Lexicon notes:** `гетьман`, `стародубський полковник`, `генеральний
+  осавул`, `генеральний бунчужний`, `старшина`, `булава`, `універсал`,
+  `Просительні статті`, `Решетилівські статті`, `права і вольності`,
+  `резидент`, `Глухів`, `Батурин`, `Полтава`, `Малоросійська колегія`,
+  `інкорпорація`, `автономія`, `покровительство`, `маєтність`.
+- **Learner-use notes:** this dossier supports a C1 lesson on constrained
+  agency: "was elected under pressure," "petitioned for confirmation,"
+  "operated under resident oversight," "could protest but not compel," "was
+  used to split legitimacy," "preserved some institutions while autonomy
+  narrowed."
+- **Stylistic features:** pair rights vocabulary (`права`, `вольності`,
+  `порядки військові`) with administrative-control vocabulary (`колегія`,
+  `резидент`, `гарнізон`, `податки`, `апеляційна інстанція`, `нагляд`).
+- **Sensitive framing:** do not ask learners whether Skoropadskyi was simply
+  "loyal" or "treacherous." Better prompt: "Which choices were his, which were
+  forced by the post-Poltava environment, and which protected institutions only
+  temporarily?"
+
+## 6. Contested points
+
+- **Coerced hetman or autonomous actor?** Both categories are needed. Peter's
+  coercive setting made the election deeply unequal, but Skoropadskyi still
+  issued universals, negotiated, petitioned, appointed, patronized, and built
+  estate networks.
+- **Mazepa relationship:** he was Mazepa's appointee and trusted official
+  before 1708, not a random replacement. After the break he became the hetman
+  of the obedient Left-Bank structure. A lesson should show the rupture without
+  pretending the previous relationship never existed.
+- **Orlyk relationship:** Orlyk belongs to the exile-constitutional path, while
+  Skoropadskyi remained in the constrained Left-Bank path. They are a useful
+  paired lesson in divergent survival strategies after Poltava; recheck
+  Orlyk's diary and correspondence before quoting personal assessments.
+- **Polubotok and Apostol corridor:** Polubotok's acting rule and imprisonment,
+  then Apostol's controlled restoration, follow directly from the institutional
+  crisis Skoropadskyi left behind. Do not isolate him from that sequence.
+- **Reshetylivka success or failure?** The petition preserved rights language
+  and recorded Hetmanate demands, but it did not reverse Peter's post-Poltava
+  policy. Teach it as documentary resistance inside a shrinking corridor.
+- **Resident oversight:** do not present "advice" from Russian residents as a
+  neutral advisory relationship. It was surveillance and constraint in the
+  hetman capital.
+- **Estate and family politics:** Hurzhii's research shows complex property,
+  marriage, dowry, and inheritance layers, including Anastasiia Markovych's
+  influence. These belong in an advanced lesson only with source caveats; they
+  should not become gossip or moral simplification.
+- **Social policy:** starshyna rights defense did not automatically mean broad
+  popular relief. The same government that petitioned for autonomy could
+  deepen elite landholding.
+- **Image authenticity:** the most available portraits are later works or later
+  copies. Do not imply a life portrait unless the file metadata proves
+  life-era provenance.
+- **Scope warning:** keep this BIO dossier on the early eighteenth-century
+  Hetmanate after Mazepa and Poltava. Do not turn it into unrelated
+  modern-statehood material or an all-rulers chronology.
+
+## 7. Cross-track links
+
+> Every curriculum plan path under **Existing** below was verified locally on
+> 2026-07-04. `docs/research/bio/*` entries are verified dossier files, not
+> existing BIO plan paths in this tree.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — origin point
+    for the rights-and-office vocabulary that post-Poltava actors still
+    invoked.
+  - `curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml` — earlier treaty and
+    elite-strategy comparison.
+  - `curriculum/l2-uk-en/plans/bio/ivan-mazepa.yaml` — direct predecessor and
+    rupture context.
+  - `curriculum/l2-uk-en/plans/bio/pylyp-orlyk.yaml` — exile-constitutional
+    path after Poltava.
+  - `curriculum/l2-uk-en/plans/bio/kost-hordiyenko.yaml` — Zaporozhian
+    autonomy and Mazepa-Orlyk alliance context.
+  - `curriculum/l2-uk-en/plans/bio/pavlo-polubotok.yaml` — immediate
+    post-Skoropadskyi acting hetman and Collegium resistance.
+  - `curriculum/l2-uk-en/plans/bio/danylo-apostol.yaml` — controlled
+    restoration after the Collegium/Polubotok crisis.
+  - `curriculum/l2-uk-en/plans/bio/petro-kalnyshevskyy.yaml` — later autonomy
+    liquidation comparison.
+- **Existing BIO dossiers (VERIFIED present; not curriculum plan paths):**
+  - `docs/research/bio/bohdan-khmelnytskyy.md`,
+    `docs/research/bio/ivan-vyhovskyi.md`,
+    `docs/research/bio/petro-doroshenko.md`,
+    `docs/research/bio/ivan-briukhovetskyi.md`,
+    `docs/research/bio/yakym-somko.md`,
+    `docs/research/bio/yurii-khmelnytskyi.md`,
+    `docs/research/bio/ivan-samoilovych.md`,
+    `docs/research/bio/ivan-mazepa.md`,
+    `docs/research/bio/pylyp-orlyk.md`,
+    `docs/research/bio/kost-hordiyenko.md`,
+    `docs/research/bio/pavlo-polubotok.md`,
+    `docs/research/bio/danylo-apostol.md`,
+    `docs/research/bio/petro-kalnyshevskyy.md`,
+    `docs/research/bio/kyrylo-rozumovskyi.md` — verified related
+    Cossack/Hetmanate dossiers.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — institutional
+    baseline for hetman, council, starshyna, regiments, and autonomy claims.
+  - `curriculum/l2-uk-en/plans/hist/ivan-mazepa-derzhavnyk.yaml`,
+    `curriculum/l2-uk-en/plans/hist/ivan-mazepa-kultura.yaml`,
+    `curriculum/l2-uk-en/plans/hist/ivan-mazepa-poltava.yaml` — Mazepa,
+    Poltava, Baturyn, and post-1708 rupture.
+  - `curriculum/l2-uk-en/plans/hist/pylyp-orlyk-konstytutsiia.yaml` — exile
+    constitutional comparison.
+  - `curriculum/l2-uk-en/plans/hist/pavlo-polubotok.yaml`,
+    `curriculum/l2-uk-en/plans/hist/danylo-apostol.yaml`,
+    `curriculum/l2-uk-en/plans/hist/kinets-hetmanshchyny.yaml` — Collegium,
+    controlled restoration, and incorporation arc.
+  - `curriculum/l2-uk-en/plans/hist/kost-hordiyenko-sich.yaml` — Zaporozhian
+    side of the Mazepa-Orlyk rupture.
+- **Existing ISTORIO/RUTH/LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/istorio/mazepa-tsykl.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/poltava-naslidky.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/konstytutsiia-orlyka.yaml` —
+    historiographical and source-memory context around Poltava and exile.
+  - `curriculum/l2-uk-en/plans/ruth/cossack-hierarchy.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/document-types.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/diplomatic-language.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/treason.yaml` — office, document,
+    diplomatic, and accusation vocabulary.
+  - `curriculum/l2-uk-en/plans/lit-hist-fic/lepkyi-mazepa.yaml`,
+    `curriculum/l2-uk-en/plans/lit/lepkyi-mazepa-trilogy.yaml` — literary
+    memory around Mazepa and the late-Hetmanate rupture.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `ivan-skoropadskyi` — future BIO plan/module if this dossier is promoted
+    into curriculum.
+  - `reshetylivski-statti-1709` — source lesson on rights vocabulary under
+    coercive petition format.
+  - `hlukhiv-election-1708` — crisis-succession lesson after Baturyn and
+    Mazepa's break.
+  - `persha-malorosiiska-kolehiia` — institution-level lesson on resident
+    oversight, fiscal extraction, and post-hetman usurpation.
+  - `skoropadskyi-universals` — chancery/register lesson using rights,
+    patronage, and estate documents with verified source editions.
+- **Potential LIT additions surfaced by this research:**
+  - A memory-history unit on how constrained hetmans are simplified in
+    textbooks, portraits, family memory, and museum captions.
+
+## 8. Naming-canonical
+
+- **Slug:** `ivan-skoropadskyi`
+- **EN canonical (project spelling):** Ivan Skoropadskyi
+- **UA canonical (with patronymic):** Іван Ілліч Скоропадський
+- **Aliases (track these for `aliases:` YAML field):** Іван Скоропадський;
+  Ivan Skoropadsky; Ivan Skoropadskyi; Skoropads'kyj; source spellings
+  Шкуропадський, Шкуропадцький, Скуропацький.
+- **Source/title variants to track carefully:** `гетьман Лівобережної
+  України`; `стародубський полковник`; `генеральний осавул`; `генеральний
+  бунчужний`; `гетьман у Глухові`; `Решетилівські статті`;
+  `Просительні статті`.
+- **Forbidden forms (Russian-imperial / flattening forms to flag in body
+  text):** Russian-only name forms as normalized Ukrainian/English body text;
+  "loyal provincial administrator" as the lead identity; "traitor" or
+  "collaborator" as factual total labels; imperial administrative terminology
+  as neutral identity.
+- **Term warning:** `Малоросійська колегія` is an imperial institution name.
+  Use it when naming the office, but do not normalize the underlying identity
+  term outside that context.
+- **Scope warning:** keep this dossier on the early eighteenth-century
+  Hetmanate after Mazepa, Baturyn, Poltava, and the lead-up to the Collegium.
+
+## 9. Image candidates
+
+- **Best likely portrait candidates:** Wikimedia Commons category `Ivan
+  Skoropadsky` and related portrait categories include the 1840s Stepan
+  Zemliukov portrait files. Verify each individual file page and PD-Art /
+  PD-old status before reuse. Caption as a later portrait tradition, not a
+  life portrait. [T5: Commons]
+- **IEU image candidates:** IEU links a 19th-century portrait, an 18th-century
+  portrait by an unknown artist, and an image of a 1719 universal issued by
+  Skoropadskyi. Use these as image leads only; verify rights on the image page
+  or a reuse-safe repository before publication. [T1/T5: IEU image leads]
+- **Context image candidates:** a rights-clear image of Hlukhiv, Hamaliivka
+  Monastery, a Reshetylivka document facsimile, or an image connected with the
+  Little Russian Collegium may be more pedagogically precise than a later
+  portrait.
+- **Document image candidate:** the 1719 universal image from IEU is useful
+  for teaching hetman document form, but rights and resolution must be checked.
+- **Authenticity caveat:** most accessible portraits are later or copied.
+  Captions must distinguish eighteenth-century subject from nineteenth-century
+  visualization and modern commemorative uses.
+- **Avoid:** generic Cossack stock art, images that aestheticize imperial
+  supervision, or images of unrelated namesakes / later family-memory material.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- [T1] Ohloblyn O. "Skoropadsky, Ivan" // *Internet Encyclopedia of Ukraine*.
+  URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CK%5CSkoropadskyIvan.htm
+  | resolved HTTP 200, accessed 2026-07-04. Core facts: birth/death,
+  Uman-to-Left-Bank move, offices, missions, Starodub colonelship, Hlukhiv
+  election, Reshetylivka, Poltava, resident oversight, troop quartering,
+  office restrictions, Collegium, printing/academy pressure, protests, burial.
+- [T1] "Reshetylivka Articles of 1709" // *Internet Encyclopedia of Ukraine*.
+  URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%2FR%2FE%2FReshetylivkaArticlesof1709.htm
+  | resolved HTTP 200, accessed 2026-07-04. Used for 14-point petition,
+  17 July 1709 date, rights/freedoms goal, Peter's 31 July reply, and retained
+  Russian command, garrisons, and tax control.
+- [T1] "Little Russian Collegium" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CL%5CI%5CLittleRussianCollegium.htm
+  | resolved HTTP 200, accessed 2026-07-04. Used for 27 May 1722 founding in
+  Hlukhiv, oversight purpose, Russian staff, Senate transfer, post-death
+  usurpation, appeal/fiscal powers, protests, and 1727 abolition.
+- [T1] "Poltava, Battle of" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CP%5CO%5CPoltavaBattleof.htm
+  | resolved HTTP 200, accessed 2026-07-04. Used for Poltava context, Cossack
+  forces under Skoropadskyi, defeat's autonomy consequences, and execution /
+  exile context for Cossacks under Swedish command.
+- [T1] Ohloblyn O. "Mazepa, Ivan" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkPath=pages%5CM%5CA%5CMazepaIvan.htm
+  | resolved HTTP 200, accessed 2026-07-04. Used for Mazepa break, Baturyn
+  destruction, engineered Hlukhiv election, terror against Mazepa supporters,
+  Poltava aftermath, and propaganda frame.
+- [T1/T2] Гуржій О.І. "Решетилівські статті 1709" // *Україна в міжнародних
+  відносинах: енциклопедичний словник-довідник*, issue 4. Kyiv: Institute of
+  History of Ukraine, 2013; Wikisource reproduction. URL:
+  https://uk.wikisource.org/wiki/Україна_в_міжнародних_відносинах/4/Решетилівські_статті_1709
+  | resolved HTTP 200, accessed 2026-07-04. Used for Prosytelni/Rishetylni
+  document structure, 28/17 July and 11 August/31 July dates, rights-language
+  formula, and autonomy-eroding effects.
+
+**Tier 2 (institutional / bibliographic):**
+
+- [T2] Віртуальний музей Києво-Могилянської академії, "Іван Скоропадський."
+  URL:
+  https://vm.ukma.edu.ua/person/іван-скоропадський/
+  | resolved HTTP 200, accessed 2026-07-04. Used for education/patronage leads:
+  Kyiv-Mohyla connection, continued treasury support, Yadlivka, Motovylivka.
+- [T2] НБУВ, електронна бібліотека "Україніка", Гуржій О.І. *Іван
+  Скоропадський*. Kyiv: Alternatyvy, 2004. URL:
+  https://irbis-nbuv.gov.ua/ulib/item/UKR0001590
+  | resolved HTTP 200, accessed 2026-07-04. Used as monograph bibliographic
+  anchor and interpretive lead; direct page-level claims not made from this
+  scanned monograph in this pass.
+
+**Tier 3 (encyclopedic — navigation only):**
+
+- [T3] Ukrainian Wikipedia, "Іван Скоропадський (гетьман)." URL:
+  https://uk.wikipedia.org/wiki/Іван_Скоропадський_(гетьман)
+  | accessed 2026-07-04. Used only for alias/date/image navigation; claims
+  cross-checked against IEU and Hurzhii.
+- [T3] English Wikipedia, "Ivan Skoropadsky." URL:
+  https://en.wikipedia.org/wiki/Ivan_Skoropadsky
+  | accessed 2026-07-04. Used only for English alias/image navigation; not
+  load-bearing.
+
+**Tier 4 (modern scholarly post-1991 / academic anchors):**
+
+- [T4] Гуржій О.І. "Гетьман Іван Скоропадський (1)" // *Український
+  історичний журнал*, 1998, no. 6, pp. 77-90. URL:
+  https://history.org.ua/JournALL/journal/1998/6/8.pdf
+  | resolved HTTP 200 and text-extracted locally, accessed 2026-07-04. Used for
+  source-sensitive family origin, Uman aftermath, early service, marriage,
+  estate formation, Samoilovych/Mazepa links, Starodub colonelship, and
+  caution around later family status claims.
+- [T4] Гуржій О.І. "Гетьман Іван Скоропадський (2)" // *Український
+  історичний журнал*, 1999, no. 1, pp. 98-104. URL:
+  https://resource.history.org.ua/publ/journal_1999_1_98
+  | resolved HTTP 200, accessed 2026-07-04. Bibliographic continuation anchor;
+  direct text not quoted in this pass.
+- [T4] Гуржій О.І. "Гетьман Іван Скоропадський (3)" // *Український
+  історичний журнал*, 1999, no. 2, pp. 141-153. URL:
+  https://resource.history.org.ua/publ/journal_1999_2_141
+  | resolved HTTP 200 via search/open metadata, accessed 2026-07-04.
+  Bibliographic conclusion anchor; direct text not quoted in this pass.
+- [T4] Горобець В. *Присмерк Гетьманщини: Україна в роки реформ Петра I*.
+  Kyiv, 1998. Bibliographic anchor via Reshetylivka entry.
+- [T4] Мельник Л. *Гетьманщина першої чверті XVIII століття*. Kyiv, 1997.
+  Bibliographic anchor via IEU Skoropadsky.
+- [T4] Ohloblyn O. *Ukraina za chasiv Skoropadskoho i Polubotka*. Kyiv, 1941.
+  Bibliographic anchor via IEU Skoropadsky.
+
+**Tier 5 (general web / image metadata — not load-bearing):**
+
+- [T5/image metadata] Wikimedia Commons, `Category:Ivan Skoropadsky`. URL:
+  https://commons.wikimedia.org/wiki/Category:Ivan_Skoropadsky
+  | accessed 2026-07-04. Used for image candidate discovery only.
+- [T5/image metadata] Wikimedia Commons, `File:Ivan Skoropadsky.png`. URL:
+  https://commons.wikimedia.org/wiki/File:Ivan_Skoropadsky.png
+  | accessed 2026-07-04. Used for PD-Art image-rights lead only.
+- [T5/image metadata] Wikimedia Commons, `File:Ivan Skoropadsky (Portrait,
+  1840s, Stepan Zemlyukov) 1.jpg`. URL:
+  https://commons.wikimedia.org/wiki/File:Ivan_Skoropadsky_(Portrait,_1840s,_Stepan_Zemlyukov)_1.jpg
+  | accessed 2026-07-04. Used for later-portrait candidate and authenticity
+  caveat only.
+- [T5/image lead] IEU picture page, `Universal of 1719 issued by Hetman Ivan
+  Skoropadsky`. URL:
+  https://www.encyclopediaofukraine.com/picturedisplay.asp?id=14430
+  | accessed 2026-07-04. Used as a document image lead only; rights require
+  separate verification.
+
+**Primary-source documents accessed / verification notes:**
+
+- Reshetylivka Articles / Prosytelni statti 1709: title, dates, rights formula,
+  and effect verified through IEU and the Institute-published dictionary entry;
+  original source edition not directly inspected.
+- Skoropadskyi universals and estate documents: early-career/property examples
+  verified through Hurzhii's article; full archival originals not inspected.
+- Kyiv-Mohyla patronage documents: support claims verified through the
+  institutional note; exact universal texts not inspected.
+- Little Russian Collegium founding and powers: verified through IEU; full
+  imperial ukaz and Collegium files not inspected.
+
+**Honest gaps:** this dossier did not inspect archival originals, full
+Skoropadskyi universal editions, the complete Hurzhii 2004 monograph text,
+Orlyk diary passages about Skoropadskyi, resident instructions, or all
+Collegium fiscal records. For module writing, recheck direct wording for the
+Reshetylivka petition and Peter's replies, the 1710 confirmation, resident
+oversight clauses, Kyiv-Mohyla patronage documents, Anastasiia Markovych estate
+records, and the 1722 Collegium ukaz.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Russian imperial power is treated as a coercive
+  and centralizing actor, not as the Hetmanate's natural administrative center.
+- [x] Skoropadskyi is not flattened into a loyal imperial administrator, simple
+  collaborator, or pure autonomy hero.
+- [x] The Hlukhiv election is not described as fully free; coercive context and
+  Peter's role are explicit.
+- [x] The Reshetylivka petition is treated as documentary rights defense under
+  constraint, not as a successful restoration.
+- [x] Mazepa, Orlyk, Polubotok, Apostol, and Hetmanate institutions are linked
+  through verified paths and source-cautious relationship claims.
+- [x] Patronage and estate politics are both visible; church/academy support is
+  not used to hide starshyna privilege or coercive oversight.
+- [x] The Little Russian Collegium is named as an imperial control institution,
+  not neutral modernization.
+- [x] No Russian-imperial transliterations in body text except variant/forbidden
+  forms in §8 and source-title contexts.
+- [x] Modern Ukrainian place/institution naming used with historical context:
+  Умань, Стародуб, Чернігів, Глухів, Батурин, Полтава, Гамаліївка,
+  Гетьманщина, Військо Запорозьке, Лівобережжя, Запорозька Січ.
+- [x] No unrelated later family/statehood material, unrelated ruler lists, or
+  all-rulers chronology added.
+
+## Validation checklist
+
+- [x] Single owned file only: `docs/research/bio/ivan-skoropadskyi.md`.
+- [x] Existing cross-track plan paths verified locally before citation.
+- [x] Lower-tier sources marked non-load-bearing.
+- [x] Guard terms for unrelated modern-statehood, namesake, and all-rulers
+  scope avoided.
+- [x] No generated `status/`, `audit/`, `review/`, or telemetry artifacts
+  referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans,
+  module files, activities, vocabulary, resources, site MDX, or wiki files
+  edited.


### PR DESCRIPTION
## Scope

Adds the BIO research dossier for Ivan Skoropadskyi, focused on the early eighteenth-century Hetmanate after Mazepa and Poltava, imperial pressure under Peter I, constrained institutional defense, elite politics, and the lead-up to the Little Russian Collegium.

## Changed files

- docs/research/bio/ivan-skoropadskyi.md

## Validation

- PASS: npx markdownlint-cli2 docs/research/bio/ivan-skoropadskyi.md
- PASS: /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/ivan-skoropadskyi.md
- PASS: git diff --check
- PASS: out-of-scope guard rg returned no matches
- PASS: /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py
- PASS: protected artifact/config guard confirmed only docs/research/bio/ivan-skoropadskyi.md changed

## Source and decolonization caveats

- Uses source-tiered anchors including Encyclopedia of Ukraine, Ukrainian encyclopedia/history references, academic/NBUV material, Kyiv-Mohyla museum material, and cautious lower-tier cross-checks.
- Frames Skoropadskyi as a constrained Hetmanate administrator under imperial pressure, not as either a simple autonomy savior or a simple collaborator.
- Flags caution around election legitimacy, autonomy petitions, resident oversight, estate/church patronage, and later memory overlays.
- Keeps BIO scope on this early eighteenth-century Hetmanate figure and avoids unrelated modern-statehood material or all-rulers chronology.

## Review gate

No independent review has been routed yet because the orchestrator handles that gate.
