### PR TITLE
docs(bio): add Demian Mnohohrishny dossier

### DIFF
--- a/docs/research/bio/demian-mnohohrishny.md
+++ b/docs/research/bio/demian-mnohohrishny.md
@@ -1,0 +1,731 @@
+# Дем'ян Гнатович Многогрішний — Research Dossier
+
+**Slug:** `demian-mnohohrishny`
+**Block:** G (politically charged Ruin-era / Left-Bank Hetmanate figure;
+Chernihiv colonel, Doroshenko-appointed acting hetman, Hlukhiv Articles
+settlement, voivoda/garrison pressure, starshyna coup, imperial arrest,
+deportation, and Siberian service)
+**Tier:** 1a
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ Mnohohrishny, IEU
+  Mnohohrishny, ЕІУ Hlukhiv Articles, IEU Hlukhiv Articles, ЕІУ Left-Bank
+  uprising, ЕІУ Baturyn conspiracy, ЕІУ Konotop Articles, ЕІУ deportations,
+  CDIAC archive exhibition)
+- [x] Source-tier checkboxes included and lower-tier sources kept
+  non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: post-Andrusovo
+  partition pressure, Moscow Articles backlash, Hlukhiv compromise,
+  voivoda/garrison limits and persistence, starshyna factional incentives,
+  Baturyn coup, Moscow investigation, death sentence commuted to Siberian
+  deportation, and service under imperial frontier command)
+- [x] §4 includes 4 short document/source-language anchors with verification
+  caveats
+- [x] Mnohohrishny is framed as complex: Chernihiv colonel, anti-Moscow
+  insurgent ally of Doroshenko, pragmatic negotiator with Moscow, autonomy
+  petitioner, hard-edged hetman, patronage/family builder, starshyna target,
+  punished prisoner, and Siberian service commander
+- [x] Cross-track links: every "Existing" plan path verified locally with
+  `rg --files` / `test -e` on 2026-07-04
+- [x] Naming-canonical applied
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+
+- [x] **T1 baseline:** ЕІУ and Internet Encyclopedia of Ukraine anchor core
+  facts, dates, offices, election, Hlukhiv Articles, anti-Moscow / Doroshenko
+  context, arrest, exile, Siberian service, and death uncertainty.
+- [x] **T1 institutional context:** ЕІУ entries on the Hlukhiv Articles,
+  Left-Bank uprising of 1668, Baturyn conspiracy, Konotop Articles, and
+  deportations frame the mechanism around the biography.
+- [x] **T2 institutional / archival context:** CDIAC's 350th-anniversary
+  exhibition page supplies document leads for the Hlukhiv Articles,
+  universals, chronicle copies, arrest/deportation summary, and image/context
+  cautions.
+- [x] **T4 scholarship:** Borysenko, Kryvosheia, Mytsyk, Pyrih, and Horobets
+  leads are used as scholarly/bibliographic anchors for follow-up, not as
+  unsupported fact dumps.
+- [x] **T3/T5 caution:** Wikipedia, Commons, popular articles, school pages,
+  and image pages are navigation or image-rights aids only; they are not
+  load-bearing for interpretation.
+- [x] **Primary/doc excerpts:** short excerpts are explicitly marked as
+  document/source-language anchors; recheck source editions before classroom
+  quotation.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Дем'ян Гнатович Многогрішний. ЕІУ gives
+  `МНОГОГРІШНИЙ (Ігнатович) Дем'ян Гнатович`; CDIAC frequently uses
+  `Дем'ян Ігнатович Многогрішний`; IEU gives `Mnohohrishny, Demian`
+  / `Mnohohrišnyj, Dem'jan`. [T1: ЕІУ; T1: IEU; T2: CDIAC]
+- **Pseudonyms / aliases:** Дем'ян Многогрішний; Дем'ян Ігнатович
+  Многогрішний; Демко Ігнатович; Demian Mnohohrishny; Demian Ihnatovych;
+  Demian Hnatovych; Mnohohrišnyj in IEU transliteration. Lower-tier summaries
+  sometimes use Shumeiko as a family-name frame; keep that as a source-search
+  lead unless a module verifies genealogy directly. [T1: ЕІУ; T1: IEU; T3]
+- **Born:** source-sensitive. ЕІУ gives **1621** and origin from a peasant
+  family near **Короп**; IEU gives **ca. 1630** in Korop; lower-tier summaries
+  often give **1631**. Use "born in the Korop area, probably in the first
+  third of the seventeenth century" when exact dating is not the lesson focus.
+  [T1: ЕІУ; T1: IEU; T3]
+- **Died:** source-sensitive. ЕІУ gives **after 1701**, with the last
+  lifetime mention in 1701 and likely death that year near Selenginsk; IEU
+  gives death after 1701 in Selenginsk Staryi; lower-tier pages often smooth
+  this into **1703**. Use "died after 1701, probably in or near Selenginsk"
+  unless teaching the date problem itself. [T1: ЕІУ; T1: IEU; T3]
+- **Family / origin:** son of Hnat / Ihnat, probably from a non-elite Korop
+  background. ЕІУ records brothers Vasyl, Zynovii, and Sava; son Petro;
+  daughter Olena; and possible, not settled, links to the Shumeiko Cossack
+  family. [T1: ЕІУ]
+- **Early service:** source-sensitive. ЕІУ says some researchers identify him
+  with a Khmelnytsky-era diplomatic agent and later military osaul /
+  Chyhyryn colonel, while others argue the "osaul Demian" in some documents
+  was a different person. Do not make early diplomatic service a hard
+  classroom fact without source-edition checking. [T1: ЕІУ]
+- **Chernihiv colonel:** after the failed 1664 Commonwealth-side campaign into
+  Siveria, he became Chernihiv colonel in **May 1665**. ЕІУ gives May
+  1665-1668; IEU gives Chernihiv colonel **1665-1669**. Use
+  "Chernihiv colonel from 1665 into the 1668-1669 transition" when precision
+  is not essential. [T1: ЕІУ; T1: IEU]
+- **1668 uprising and Doroshenko connection:** in 1668 he took part in the
+  Left-Bank uprising against Moscow-backed arrangements, supported Petro
+  Doroshenko, became general osaul by Doroshenko's will, and in June 1668 was
+  appointed acting / Siverian hetman on the Left Bank when Doroshenko withdrew
+  to the Right Bank. [T1: ЕІУ; T1: IEU; T1: ЕІУ Left-Bank uprising]
+- **Negotiation turn:** under pressure from Russian forces, remaining
+  garrisons, pro-Moscow clergy, and some starshyna, he entered talks with
+  Moscow representatives in Chernihiv in late September / early October 1668.
+  In December 1668 a council in Novhorod-Siverskyi elected him Siverian
+  hetman, and the March 1669 Hlukhiv council confirmed him as Left-Bank
+  hetman. [T1: ЕІУ; T1: IEU; T1: ЕІУ Left-Bank uprising]
+- **Hetman office:** confirmed / elected full hetman of Left-Bank Ukraine at
+  Hlukhiv on **13 March 1669 N.S. / 3 March 1669 O.S.** in the presence of a
+  tsarist representative. The treaty text is dated **16 March 1669 N.S.** in
+  the EIU/CDIAC record. [T1: ЕІУ; T1: ЕІУ Hlukhiv Articles; T2: CDIAC]
+- **Hlukhiv Articles:** signed with Moscow representatives in March 1669.
+  They replaced the harsh Moscow Articles of 1665, preserved some rights and
+  liberties language, reduced but did not remove voivodas/garrisons, barred
+  the hetman from independent foreign policy, and became a reference point for
+  later 1672, 1674, and 1687 article frameworks. [T1: ЕІУ Hlukhiv Articles;
+  T1: IEU Hlukhiv Articles]
+- **Policy profile:** sought to strengthen hetman authority, build a loyal
+  family/client group, support Orthodox and educational institutions, expand
+  influence toward Zaporizhia and the Sozh/Gomel corridor, and resist several
+  Moscow encroachments. These actions made him neither a simple Moscow client
+  nor a pure autonomy martyr. [T1: ЕІУ; T2: CDIAC]
+- **Fall:** a senior-starshyna group, with Russian military involvement,
+  planned the Baturyn coup in early March 1672 and arrested him in Baturyn on
+  the night of **12-13 March 1672**. EIU records his public arrest date as
+  **23 March 1672**, reflecting calendar/source-presentation differences that
+  should not be silently merged. [T1: ЕІУ Baturyn conspiracy; T1: IEU]
+- **Trial / punishment:** he and his brother Vasyl were taken to Moscow,
+  interrogated, tortured according to ЕІУ and IEU, charged with treason, and
+  sentenced to death; the sentence was commuted at the last moment to lifelong
+  exile/deportation in Siberia with family members. [T1: ЕІУ; T1: IEU; T1:
+  ЕІУ deportations]
+- **Siberian service:** after imprisonment in Tobolsk / Irkutsk and
+  Selenginsk, he was released after Samoilovych's fall, barred from returning
+  to Ukraine, recorded in a service-status category, participated in frontier
+  service and the 1689 Nerchinsk diplomatic environment, negotiated with Mongol
+  taishas, and was de facto commander / voivode of Selenginsk in **1691-1694**.
+  [T1: ЕІУ; T1: IEU]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Birth year:** 1621, ca. 1630, and 1631 circulate. Treat Korop-area origin
+   as much firmer than the exact birth year.
+2. **Name and patronymic:** `Гнатович`, `Ігнатович`, `Демко Ігнатович`, and
+   English `Demian Mnohohrishny` all matter for search. Do not normalize away
+   source spellings.
+3. **Shumeiko link:** the Shumeiko frame is useful for search but is not secure
+   enough for a public-facing identity claim without specialist follow-up.
+4. **Early Khmelnytsky-era service:** ЕІУ explicitly warns that some documents
+   may refer to another "osaul Demian." Keep early offices source-cautious.
+5. **Office dates:** IEU extends the Chernihiv-colonel label to 1669, while
+   ЕІУ emphasizes the May 1665-1668 office and the acting/Siverian hetman
+   transition. Explain the transition rather than forcing one date range.
+6. **Hlukhiv Articles:** they were a retreat from the Moscow Articles of 1665,
+   but not a restoration of full autonomy. They preserved limits and created
+   new vulnerabilities.
+7. **Doroshenko link:** secret contact and assistance to Doroshenko appear in
+   T1 references, but motives and exact plans are politically charged. Do not
+   turn them into either heroic unity work or treason proof without source
+   work.
+8. **Baturyn coup:** starshyna grievances, family patronage, Moscow
+   supervision, and regional foreign-policy fears all matter. The coup was not
+   only a local palace conflict and not only an external arrest.
+9. **Torture and trial:** ЕІУ, IEU, and CDIAC all report torture and a
+   commuted death sentence, but classroom quotation should still go back to
+   source editions before narrating procedural details.
+10. **Death:** "1703" is common but weaker here than "after 1701 / probably
+    around 1701" from the stronger reference layer.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Mnohohrishny's hetmancy emerged after the 1668 uprising
+against the Moscow Articles of 1665 and after the Andrusovo partition had made
+the Dnipro divide an imperial-diplomatic fact. Doroshenko briefly opened an
+all-bank possibility, but military pressure, Right-Bank vulnerability,
+Moscow garrisons, and Left-Bank starshyna divisions left Mnohohrishny
+negotiating from a weak position. The Hlukhiv Articles reduced the most
+dangerous 1665 terms but preserved tsarist supervision, garrisons, foreign-
+policy restrictions, and a mechanism by which treason accusations could
+override hetman authority. [T1: ЕІУ; T1: ЕІУ Left-Bank uprising; T1: ЕІУ
+Hlukhiv Articles]
+
+**By whom:** Moscow / tsarist power in the garrison, voivoda, recognition,
+foreign-policy, investigation, and deportation layers; Left-Bank starshyna in
+the factional, estate, and anti-hetman layer; Doroshenko and Right-Bank allies
+in the all-bank alternative layer; Crimean and Ottoman actors in the regional
+security layer; Mnohohrishny himself in the hard-edged hetman-authority and
+family/clientage layer. No side should be erased.
+
+**Document references:** the **Moscow Articles of 1665** as the backlash
+background; the **Andrusovo Armistice of 1667** as partition context; the
+**Left-Bank uprising of 1668**; the **Hlukhiv Articles of 1669**; Mnohohrishny
+universals preserved in archive collections; denunciation / coup materials
+around the **Baturyn conspiracy of 1672**; the Moscow investigation and
+sentence; deportation records; the **Konotop Articles of 1672** that
+formalized the post-coup succession settlement; and Siberian service /
+Nerchinsk-related records. [T1: ЕІУ entries; T2: CDIAC]
+
+**Mechanism specifics:** imperial power did not simply abolish the Hetmanate
+office. It used recognition, resident military presence, garrison placement,
+voivoda jurisdiction, restrictions on foreign relations, and treason
+investigation to make the office dependent. The Hlukhiv settlement narrowed
+some voivoda powers and restored rights language, but it also left Moscow with
+enough leverage to partner with local opponents when the hetman became
+inconvenient. The 1672 coup then converted starshyna fear of concentrated
+hetman power into an imperial criminal case.
+
+**What survived / what was distorted:** what survived is the record of a
+Left-Bank government still bargaining over rights, garrisons, taxes, council
+procedure, church support, and territorial questions under intense pressure.
+What was distorted is the person. Imperial memory can cast him as a provincial
+official punished for disloyalty; heroic shorthand can cast him only as a
+martyr of autonomy. A decolonized BIO lesson should show a constrained ruler
+with real agency, real coercive habits, and a punishment mechanism that made
+local factional conflict useful to empire.
+
+## 3. Major works / legacy
+
+Mnohohrishny left no literary corpus; "works" means offices, treaty
+negotiation, universals, military choices, patronage, factional rule, and
+memory.
+
+- `first third of the 1600s` — born in or near Korop, probably in a
+  non-elite family; exact birth year remains unsettled. [T1: ЕІУ; T1: IEU]
+- `1648-1650s` — possible Khmelnytsky-era service and diplomatic errands, but
+  ЕІУ warns that some "osaul Demian" references may identify another person.
+  [T1: ЕІУ]
+- `late 1650s-early 1660s` — possible military osaul and Chyhyryn-colonel
+  layer; use as a source lead, not a hard classroom claim. [T1: ЕІУ]
+- `1664` — the Commonwealth-side Siverian campaign context put the
+  Mnohohrishny brothers' estates at risk because they had shifted toward the
+  tsar's side; this is useful for teaching how property, allegiance, and
+  frontier war interacted. [T1: ЕІУ]
+- `May 1665` — became Chernihiv colonel after the campaign failed; this gave
+  him a major Left-Bank regimental base before the 1668 crisis. [T1: ЕІУ; T1:
+  IEU]
+- `January-June 1668` — the Left-Bank uprising began as a reaction against
+  Moscow Articles taxation, garrisons, and the Andrusovo partition; Mnohohrishny
+  participated in the anti-Moscow turn and then supported Doroshenko. [T1:
+  ЕІУ Left-Bank uprising; T1: IEU]
+- `June 1668` — Doroshenko appointed him acting / Siverian hetman on the Left
+  Bank after Doroshenko had to withdraw forces. This appointment placed
+  Mnohohrishny between all-bank ambitions and a Russian military return. [T1:
+  ЕІУ; T1: ЕІУ Left-Bank uprising]
+- `September-October 1668` — after Russian forces retook Chernihiv and under
+  pressure from starshyna and clergy, Mnohohrishny entered negotiations with
+  Moscow representatives. Teach this as constrained negotiation, not as a clean
+  conversion of allegiance. [T1: ЕІУ; T1: ЕІУ Left-Bank uprising]
+- `December 1668` — Novhorod-Siverskyi council elected him Siverian hetman,
+  creating an interim Left-Bank authority before the full Hlukhiv settlement.
+  [T1: ЕІУ; T1: IEU]
+- `13/3 March 1669` — Hlukhiv council confirmed his election as full
+  Left-Bank hetman in the presence of a tsarist representative. [T1: ЕІУ; T1:
+  IEU]
+- `16 March 1669` — Hlukhiv Articles concluded. The agreement removed the
+  worst Moscow Articles framework, reduced the number and role of voivodas,
+  confirmed some rights language, and gave the hetman fiscal and military
+  responsibilities, but it barred independent foreign relations and left
+  garrisons in key towns. [T1: ЕІУ Hlukhiv Articles; T1: IEU Hlukhiv Articles]
+- `1669-1671` — worked to consolidate authority on the Left Bank, weaken
+  Doroshenko's local supporters, strengthen his influence at the Sich, support
+  Orthodox and educational institutions, and form a loyal circle of relatives
+  and allies. [T1: ЕІУ; T2: CDIAC]
+- `1669-1672` — used universals to grant or confirm rights for monasteries,
+  towns, starshyna, and urban administrators. CDIAC notes relevant archival
+  universals; inspect facsimiles before quoting exact wording. [T2: CDIAC]
+- `1670-1671` — sought the return of Ukrainians exiled to Siberia and resisted
+  several Moscow pressures. This point is especially useful because he himself
+  would soon become a deported political figure. [T1: ЕІУ]
+- `1671` — appointed brother Vasyl as acting hetman with Council of Officers
+  approval, possibly to secure succession; IEU notes that this intensified
+  opposition among already aggrieved starshyna. [T1: IEU; T1: ЕІУ]
+- `early March 1672` — Baturyn conspiracy planned by senior starshyna and
+  Russian military actors. ЕІУ names Petro Zabila, Ivan Samoilovych,
+  Ivan Domontovych, and Kostiantyn Mokriievych in the starshyna layer, with
+  contacts to Russian military administrators. [T1: ЕІУ Baturyn conspiracy]
+- `12-13 March 1672` — arrested in Baturyn castle and sent through the
+  military-administrative corridor toward Moscow. [T1: ЕІУ Baturyn conspiracy;
+  T2: CDIAC]
+- `22 March 1672` — before the investigation had even begun, the tsar approved
+  the conspirators' actions, a detail that makes the coercive mechanism visible
+  for learners. [T1: ЕІУ Baturyn conspiracy]
+- `spring 1672` — interrogated, tortured according to T1 references, accused
+  of treason, sentenced to death, and then sent into Siberian exile with family
+  after commutation. [T1: ЕІУ; T1: IEU; T2: CDIAC]
+- `27/17 June 1672` — Konotop Articles accompanied the election of
+  Samoilovych and confirmed the post-Mnohohrishny settlement. ЕІУ emphasizes
+  that the treaty supplemented the Hlukhiv Articles, limited hetman power in
+  favor of the starshyna, and narrowed autonomy. [T1: ЕІУ Konotop Articles]
+- `1670s-1680s` — held in Tobolsk, Irkutsk, and Selenginsk contexts; IEU says
+  he was released from Irkutsk prison in 1682, received junior boyar status,
+  and was imprisoned again in 1684 at Samoilovych's request. [T1: IEU; T1:
+  ЕІУ]
+- `1688-1689` — released after Samoilovych's fall, barred from returning to
+  Ukraine, and involved in frontier service and the Nerchinsk diplomatic
+  environment. [T1: ЕІУ; T1: IEU]
+- `1691-1694` — de facto voivode / commander of Selenginsk, leading defense
+  of the region; ЕІУ records that his son Petro died in 1691 while leading a
+  Cossack-Buryat detachment. [T1: ЕІУ]
+- `1696` — accepted monastic tonsure according to ЕІУ and IEU. [T1: ЕІУ; T1:
+  IEU]
+- `after 1701` — last lifetime mention dates to 1701; likely died near
+  Selenginsk and was buried near the Savior Cathedral. [T1: ЕІУ; T1: IEU]
+- `later memory` — appears in Cossack chronicle and *Istoriia Rusov* memory as
+  a popular, punished hetman; modern commemorations often restore an
+  overlooked figure. Use memory as evidence of later framing, not as proof of
+  every event detail. [T1: IEU; T2/T5]
+
+## 4. Primary-source quotes (>=2 required)
+
+> **Honest tool note (#M-4):** no project `verify_quote` tool was run in this
+> pass. The excerpts below are short document/source-language anchors from
+> cited encyclopedia entries and archival descriptions, not corpus-certified
+> classroom quotations. Recheck source editions before using longer primary
+> text in a module.
+
+**Anchor 1 — accession treaty label:**
+
+> "Глухівські статті"
+
+Context: use the document title to introduce the March 1669 settlement, then
+explain both the rollback from 1665 and the remaining restrictions. [T1: ЕІУ
+Hlukhiv Articles; T2: CDIAC]
+
+**Anchor 2 — rights vocabulary:**
+
+> "права і вільності"
+
+Context: ЕІУ's Hlukhiv Articles entry uses this rights-and-liberties language
+for the treaty's guarantee layer. Pair it with the garrison and foreign-policy
+limits so learners do not hear the phrase as full sovereignty. [T1: ЕІУ
+Hlukhiv Articles]
+
+**Anchor 3 — interim office language:**
+
+> "сіверським гетьманом"
+
+Context: ЕІУ uses this term for the December 1668 Novhorod-Siverskyi council
+phase. It is useful for teaching acting/regional authority before the Hlukhiv
+confirmation. [T1: ЕІУ]
+
+**Anchor 4 — Siberian service-status term:**
+
+> "дети боярские"
+
+Context: ЕІУ records this service-status label after his release from
+Selenginsk imprisonment. Keep it as source-language evidence of incorporation
+into imperial frontier service, not as Ukrainian social identity. [T1: ЕІУ]
+
+## 5. Language register and learner-use notes
+
+- **Register:** Cossack-chancery, treaty, military-frontier, judicial,
+  deportation, and memory-history language.
+- **CEFR readiness for full reading:** B2-C1 for adapted biography; C1-C2 for
+  treaty clauses, coup/investigation narratives, and Siberian service context.
+- **Lexicon notes:** `гетьман`, `наказний гетьман`, `сіверський гетьман`,
+  `чернігівський полковник`, `генеральний осавул`, `старшина`,
+  `старшинська рада`, `Глухівські статті`, `воєвода`, `залога`,
+  `права і вільності`, `зовнішня політика`, `зрада`, `донос`, `катування`,
+  `смертний вирок`, `заслання`, `депортація`, `Селенгінськ`.
+- **Learner-use notes:** this dossier supports a C1 lesson on constrained
+  agency: "was appointed by," "was confirmed under pressure," "negotiated for,"
+  "accepted limits," "resisted encroachment," "concentrated power," "was
+  accused of," "was deported," and "was barred from returning."
+- **Stylistic features:** contrast clauses are essential. A good module should
+  practice formulations such as `хоча ... однак`, `попри це`, `водночас`,
+  `не лише ... а й`, and `не можна зводити до`.
+- **Sensitive framing:** do not ask learners whether Mnohohrishny was simply
+  "loyal" or "rebellious." Better prompt: "Which choices protected Hetmanate
+  institutions, which choices threatened local opponents, and which coercive
+  tools turned factional conflict into deportation?"
+
+## 6. Contested points
+
+- **Birth and death dates:** teach the uncertainty directly. The stronger
+  source layer supports Korop-area origin and post-1701 death more firmly than
+  exact years.
+- **Surname / identity:** the nickname-like surname can invite moralizing. Do
+  not make the name's literal meaning into interpretation of his character.
+- **Early career:** Khmelnytsky-era service and Chyhyryn roles are plausible
+  but source-sensitive; EIU explicitly flags an identification problem.
+- **Doroshenko relationship:** Mnohohrishny moved from Doroshenko's acting
+  hetman to negotiator with Moscow, then later looked again for understanding
+  with Doroshenko. This arc is not hypocrisy by default; it is a Ruin-era
+  survival problem.
+- **Hlukhiv settlement:** it was a real partial retreat from the 1665
+  arrangement, especially on voivodas, amnesty, rights language, and
+  garrison limits. It was also a restricted settlement that left Moscow with
+  decisive leverage.
+- **Hetman power:** he tried to strengthen the hetman office and build a loyal
+  family/client circle. That was partly institutional survival and partly
+  authoritarian/factional politics.
+- **Starshyna role:** the senior officers were not passive victims. They
+  defended their own authority and interests, then worked with Russian military
+  actors to remove him.
+- **Treason accusation:** secret contacts, Doroshenko ties, and Ottoman/Crimean
+  scenarios were politically charged. Teach accusation, investigation, and
+  source claim separately.
+- **Torture and death sentence:** sourced in T1/T2 references, but still
+  require direct source-edition checking before dramatic classroom quotation.
+- **Siberian service:** do not reduce the exile period to either victimhood or
+  loyal service. He remained a banned Ukrainian political exile while also
+  being used in imperial frontier command.
+- **Memory:** Cossack chronicle popularity and modern memorials can recover an
+  overlooked figure, but memory should not become hagiography.
+- **Image authenticity:** most usable portrait material is later/posthumous.
+  Caption as portrait tradition unless metadata proves life-era provenance.
+
+## 7. Cross-track links
+
+> Every curriculum plan path under **Existing** below was verified locally on
+> 2026-07-04. `docs/research/bio/*` entries are verified dossier files, not
+> existing BIO plan paths in this tree.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — origin point
+    for the Cossack state whose treaty-rights language Mnohohrishny tried to
+    recover through the Hlukhiv settlement.
+  - `curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml` — earlier diplomacy,
+    Hadiach comparison, and the problem of federal/autonomy alternatives.
+  - `curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml` — Zaporozhian and
+    Slobidska Ukraine military autonomy context around the 1668 upheaval.
+  - `curriculum/l2-uk-en/plans/bio/ivan-mazepa.yaml` — later article
+    settlement and autonomy comparison after the 1687 succession.
+  - `curriculum/l2-uk-en/plans/bio/pylyp-orlyk.yaml` — later exile and
+    legal-memory vocabulary after Hetmanate autonomy narrows.
+  - `curriculum/l2-uk-en/plans/bio/danylo-apostol.yaml`,
+    `curriculum/l2-uk-en/plans/bio/pavlo-polubotok.yaml` — later constrained
+    autonomy, petition, arrest, and imperial-supervision comparisons.
+- **Existing BIO dossiers (VERIFIED present; not curriculum plan paths):**
+  - `docs/research/bio/bohdan-khmelnytskyy.md`,
+    `docs/research/bio/ivan-vyhovskyi.md`,
+    `docs/research/bio/petro-doroshenko.md`,
+    `docs/research/bio/ivan-briukhovetskyi.md`,
+    `docs/research/bio/yakym-somko.md`,
+    `docs/research/bio/yurii-khmelnytskyi.md`,
+    `docs/research/bio/pavlo-teteria.md`,
+    `docs/research/bio/ivan-bohun.md`,
+    `docs/research/bio/ivan-samoilovych.md`,
+    `docs/research/bio/ivan-sirko.md`,
+    `docs/research/bio/ivan-mazepa.md`,
+    `docs/research/bio/pylyp-orlyk.md`,
+    `docs/research/bio/danylo-apostol.md`,
+    `docs/research/bio/pavlo-polubotok.md`,
+    `docs/research/bio/kyrylo-rozumovskyi.md` — verified related
+    Cossack/Hetmanate dossiers.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/bohdan-khmelnytskyi.yaml` — revolution and
+    treaty-rights baseline.
+  - `curriculum/l2-uk-en/plans/hist/ruina-i.yaml`,
+    `curriculum/l2-uk-en/plans/hist/ruina-ii.yaml` — direct Ruin and
+    post-Andrusovo frame.
+  - `curriculum/l2-uk-en/plans/hist/andrusivske-peremyrya.yaml` — Dnipro
+    partition context behind the 1668 uprising and Doroshenko/Mnohohrishny
+    choices.
+  - `curriculum/l2-uk-en/plans/hist/pereyaslavska-uhoda.yaml` — protectorate
+    and treaty-distortion vocabulary behind 1654/1659/1665/1669 comparisons.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — institutional
+    baseline for hetman, council, starshyna, regiments, rights, and liberties.
+  - `curriculum/l2-uk-en/plans/hist/ivan-sirko.yaml`,
+    `curriculum/l2-uk-en/plans/hist/ivan-mazepa-derzhavnyk.yaml`,
+    `curriculum/l2-uk-en/plans/hist/ivan-mazepa-kultura.yaml`,
+    `curriculum/l2-uk-en/plans/hist/ivan-mazepa-poltava.yaml`,
+    `curriculum/l2-uk-en/plans/hist/pylyp-orlyk-konstytutsiia.yaml`,
+    `curriculum/l2-uk-en/plans/hist/danylo-apostol.yaml`,
+    `curriculum/l2-uk-en/plans/hist/pavlo-polubotok.yaml`,
+    `curriculum/l2-uk-en/plans/hist/kinets-hetmanshchyny.yaml` — comparative
+    autonomy, cultural, petition, and incorporation arc.
+- **Existing ISTORIO/RUTH/LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/istorio/pereiaslav-tsykl.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/pereiaslav-alternatyvy.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/pereyaslavski-statti.yaml` — treaty
+    source-cycle and protectorate vocabulary.
+  - `curriculum/l2-uk-en/plans/ruth/the-ruin.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/cossack-hierarchy.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/diplomatic-language.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/document-types.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/treason.yaml` — older-language and
+    legal-political vocabulary around councils, offices, articles, documents,
+    and accusation language.
+  - `curriculum/l2-uk-en/plans/lit-hist-fic/lepkyi-mazepa.yaml`,
+    `curriculum/l2-uk-en/plans/lit/lepkyi-mazepa-trilogy.yaml` — later
+    literary-memory comparison around the late-seventeenth-century political
+    world.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `demian-mnohohrishny` — future BIO plan/module if this dossier is promoted
+    into curriculum.
+  - `hlukhivski-statti-1669` — source lesson on voivodas, garrisons, rights
+    language, and foreign-policy limits.
+  - `baturynska-zmova-1672` — accusation, starshyna politics, Russian military
+    involvement, and deportation mechanism.
+  - `siverskyi-hetman` — acting/regional authority vocabulary during the
+    Doroshenko-to-Hlukhiv transition.
+  - `hetmans-in-siberian-exile` — comparative lesson on deportation,
+    incorporation into frontier service, and memory.
+- **Potential LIT additions surfaced by this research:**
+  - A memory-history unit on how Cossack chronicles, *Istoriia Rusov*, archive
+    exhibitions, monuments, and popular biography restore overlooked hetmans
+    while risking simplified martyr narratives.
+
+## 8. Naming-canonical
+
+- **Slug:** `demian-mnohohrishny`
+- **EN canonical (project spelling):** Demian Mnohohrishny
+- **UA canonical (with patronymic):** Дем'ян Гнатович Многогрішний
+- **Aliases (track these for `aliases:` YAML field):** Дем'ян Многогрішний;
+  Дем'ян Ігнатович Многогрішний; Демко Ігнатович; Demian Mnohohrishny;
+  Demian Ihnatovych; Demian Hnatovych; Mnohohrišnyj; possible Shumeiko /
+  Шумейко search lead.
+- **Source/title variants to track carefully:** `сіверський гетьман`;
+  `наказний гетьман`; `гетьман Лівобережної України`; `чернігівський
+  полковник`; `генеральний осавул`; `Глухівські статті`; `Батуринська змова`;
+  `заслання`; `Селенгінськ`.
+- **Forbidden forms (Russian-imperial / flattening forms to flag in body
+  text):** Russian-only name forms as normalized Ukrainian/English body text;
+  "Moscow puppet" without agency/constraint analysis; "autonomy martyr"
+  without family/starshyna politics; "traitor" as factual label; "Little
+  Russian ruler" as identity rather than imperial terminology under analysis.
+- **Term warning:** `зрада` is accusation language in this dossier. Teach who
+  made the accusation, in which process, and what evidence is being cited.
+- **Scope warning:** keep this BIO dossier on seventeenth-century Left-Bank
+  survival, the Hlukhiv settlement, factional politics, deportation, and
+  Siberian service. Do not turn it into unrelated modern-statehood material or
+  an all-rulers chronology.
+
+## 9. Image candidates
+
+- **Best likely portrait candidate:** Wikimedia Commons file
+  `Demian Mnohohrishnyi (Historical figures of Southwestern Russia in
+  biographies and portraits. Portrait 15).jpg` / redirected
+  `Demian Mnohohrishny.png`, described as a 19th-century Havrylo Vasko
+  portrait based on a miniature from the Samiilo Velychko Chronicle. Verify the
+  file page and license before reuse. [T5: Commons]
+- **IEU image candidate:** IEU links a portrait of Demian Mnohohrishny from the
+  article. Use as an image lead only; verify rights on the image page or a
+  reuse-safe repository before publication. [T1/T5: IEU image lead]
+- **Signature candidate:** Commons category `Demian Mnohohrishny` includes
+  `D.Mnohohrishny Signature.png`; useful for a source-literacy activity only
+  after license and provenance checking. [T5: Commons]
+- **Context image candidates:** CDIAC's Hlukhiv Articles facsimile images,
+  Baturyn context imagery, a map of Left-Bank/Right-Bank Ukraine after
+  Andrusovo, or Selenginsk/Nerchinsk context may be more pedagogically precise
+  than a later portrait. [T2: CDIAC; T5]
+- **Commemoration candidates:** modern memorials in Baturyn, Novhorod-Siverskyi
+  or the Selenginsk region can support a memory-history lesson, but caption
+  them as modern commemoration, not seventeenth-century evidence. [T5]
+- **Authenticity caveat:** available portraits are later/posthumous. Caption
+  as portrait tradition unless metadata proves life-era provenance.
+- **Avoid:** generic Cossack stock art, images that naturalize Moscow
+  authority, exoticized frontier imagery, or battle scenes disconnected from
+  the 1668-1672 Left-Bank context.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- [T1] Мицик Ю.А., Горобець В.М., Хижняк З.І. "Многогрішний Дем'ян
+  Гнатович" // *Енциклопедія історії України*. URL:
+  https://www.history.org.ua/?termin=Mnohohrishnyj_D | resolved HTTP 200,
+  accessed 2026-07-04. Core facts: 1621 / after 1701, Korop-area origin,
+  family, early-service cautions, Chernihiv colonel, Doroshenko appointment,
+  Novhorod-Siverskyi and Hlukhiv elections, Hlukhiv Articles, policy,
+  Baturyn coup, Moscow interrogation, Siberian exile, Selenginsk service,
+  Nerchinsk context, death uncertainty.
+- [T1] Zhukovsky A. "Mnohohrishny, Demian" // *Internet Encyclopedia of
+  Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CM%5CN%5CMnohohrishnyDemian.htm
+  | resolved HTTP 200, accessed 2026-07-04. Core facts: ca. 1630 / after
+  1701, Chernihiv colonel, 1668 anti-Moscow rebellion, Doroshenko acting
+  appointment, 1669 election, Hlukhiv Articles, independence/autocratic-rule
+  framing, 1672 arrest, torture, Siberian exile, 1682/1684/1688 sequence,
+  Selenginsk command, monastic tonsure, chronicle memory.
+- [T1] Горобець В.М. "Глухівські статті 1669" // *Енциклопедія історії
+  України*. URL: https://www.history.org.ua/?termin=Glukhivski_statti_1669 |
+  resolved HTTP 200, accessed 2026-07-04. Used for treaty date, parties,
+  replacement of Moscow Articles 1665, debate over garrisons/voivodas, rights
+  language, amnesty, free hetman election, foreign-policy restriction, 1,000
+  hired troops, and later treaty sequence.
+- [T1] "Hlukhiv Articles" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CH%5CL%5CHlukhivArticles.htm
+  | resolved HTTP 200, accessed 2026-07-04. Used for English-language treaty
+  baseline, 27 points, towns retaining voivodas, local-government limits,
+  30,000 registered Cossacks, and fiscal/foreign-policy framing.
+- [T1] Горобець В.М. "Повстання Лівобережне 1668" // *Енциклопедія історії
+  України*. URL:
+  https://www.history.org.ua/?termin=povstannja_livoberezhne_1668 | resolved
+  HTTP 200, accessed 2026-07-04. Used for the 1668 uprising, Moscow Articles
+  backlash, Andrusovo partition, Doroshenko's Left-Bank intervention,
+  Mnohohrishny acting appointment, military pressure, and negotiation turn.
+- [T1] Горобець В.М. "Батуринська змова" // *Енциклопедія історії України*.
+  URL: https://www.history.org.ua/?termin=Baturynska_zmova_1672 | resolved
+  HTTP 200, accessed 2026-07-04. Used for coup participants, Russian military
+  contacts, 7-8 March planning, 12-13 March arrest, transfer to Moscow, and
+  tsarist approval before investigation.
+- [T1] Горобець В.М. "Конотопські статті 1672" // *Енциклопедія історії
+  України*. URL: https://www.history.org.ua/?termin=Konotopski_Statti_1672 |
+  resolved HTTP 200, accessed 2026-07-04. Used for post-coup succession,
+  Samoilovych election, supplement to the Hlukhiv Articles, starshyna limits
+  on hetman power, and autonomy narrowing.
+- [T1] Бажан О.Г. "Депортації в ретроспективі української історії" //
+  *Енциклопедія історії України*. URL:
+  https://www.history.org.ua/?termin=Deportacii_v_retrospektyvi | resolved
+  HTTP 200, accessed 2026-07-04. Used for deportation definition and the
+  explicit placement of Mnohohrishny among Hetmanate political figures
+  deported by tsarist order.
+
+**Tier 2 (institutional / archival / bibliographic):**
+
+- [T2] Центральний державний історичний архів України, м. Київ. "До
+  350-річчя укладення Глухівських статей та обрання на гетьманство Дем'яна
+  Ігнатовича (Многогрішного)." URL:
+  https://cdiak.archives.gov.ua/v_350_Hlukhivski_statti_hetmanstvo_Demyana_Mnohohrishnoho.php
+  | resolved HTTP 200, accessed 2026-07-04. Used for archival exhibition
+  context, date sequence, voivoda/garrison summary, implementation caveats,
+  universals as document leads, arrest/deportation summary, and document
+  inventory.
+- [T2] Наукова бібліотека НАН України / NASPLIB item, П. Пиріг, "Штрихи до
+  соціально-політичного портрета гетьмана Дем'яна Многогрішного,"
+  *Сіверянський літопис*, 2009, no. 2-3, pp. 9-22. URL:
+  https://nasplib.isofts.kiev.ua/items/09af4987-0ee2-4d22-8c3e-50a08ac1648c
+  | accessed 2026-07-04. Used as an institutional bibliographic lead for
+  specialist follow-up, not as load-bearing interpretation in this pass.
+- [T2] НБУВ / e-library item, *Володарі гетьманської булави: Історичні
+  портрети* (Kyiv, 1994). URL:
+  https://irbis-nbuv.gov.ua/ulib/item/ukr0000021787 | accessed 2026-07-04.
+  Used as a bibliographic lead for Borysenko's Demian Mnohohrishny chapter,
+  not as a directly inspected source edition.
+
+**Tier 3 (encyclopedic — navigation only):**
+
+- [T3] "Дем'ян Многогрішний" // Ukrainian Wikipedia. URL:
+  https://uk.wikipedia.org/wiki/Дем%27ян_Многогрішний | accessed
+  2026-07-04. Used only for alias/date/image navigation; cross-checked against
+  T1.
+- [T3] "Demian Mnohohrishny" // English Wikipedia. URL:
+  https://en.wikipedia.org/wiki/Demian_Mnohohrishny | accessed 2026-07-04.
+  Used only for English alias/image/navigation leads; not load-bearing.
+
+**Tier 4 (modern scholarly post-1991 / academic anchors):**
+
+- [T4] Борисенко В.Й. "Дем'ян Многогрішний," in *Володарі гетьманської
+  булави*. Київ, 1994, pp. 331-345. Bibliographic anchor via ЕІУ and NBUV;
+  direct pages not inspected in this pass.
+- [T4] Кривошея В.В. *Національна еліта Гетьманщини*, part 1. Київ, 1998.
+  Bibliographic anchor via ЕІУ; direct pages not inspected.
+- [T4] Мицик Ю. "Гетьман Дем'ян Многогрішний," in *Історичний календар:
+  2002*. Київ, 2002. Bibliographic anchor via ЕІУ; direct pages not inspected.
+- [T4] Пиріг П. "Штрихи до соціально-політичного портрета гетьмана Дем'яна
+  Многогрішного." *Сіверянський літопис*, 2009, no. 2-3, pp. 9-22.
+  Bibliographic anchor via NASPLIB item; direct PDF pages not relied on.
+- [T4] Горобець В.М. *Від союзу до інкорпорації: українсько-російські
+  відносини другої половини XVII - першої чверті XVIII ст.* Київ, 1995.
+  Bibliographic anchor via ЕІУ Hlukhiv Articles.
+
+**Tier 5 (general web / image metadata — not load-bearing):**
+
+- [T5/image metadata] Wikimedia Commons, `Category:Demian Mnohohrishny`. URL:
+  https://commons.wikimedia.org/wiki/Category:Demian_Mnohohrishny | accessed
+  2026-07-04. Used for image and signature leads only.
+- [T5/image metadata] Wikimedia Commons, `File:Demian Mnohohrishnyi (Historical
+  figures of Southwestern Russia in biographies and portraits. Portrait
+  15).jpg`. URL:
+  https://commons.wikimedia.org/wiki/File:Demian_Mnohohrishnyi_(Historical_figures_of_Southwestern_Russia_in_biographies_and_portraits._Portrait_15).jpg
+  | accessed 2026-07-04. Used for portrait candidate and authenticity caveat.
+- [T5/popular web] Local-history, museum, school, and popular-history pages
+  surfaced in search. Used only as commemoration/image leads; not load-bearing
+  against T1/T4.
+
+**Primary-source documents accessed / verification notes:**
+
+- Hlukhiv Articles 1669: title, date, archival-copy lead, and effects verified
+  through ЕІУ, IEU, and CDIAC; original source edition not directly inspected.
+- Mnohohrishny universals: CDIAC identifies universals granting or confirming
+  rights for monasteries, towns, starshyna, and urban administrators; facsimile
+  text not transcribed in this pass.
+- 1672 Baturyn coup materials: event sequence verified through ЕІУ Baturyn
+  conspiracy; full investigation files not directly inspected.
+- Moscow interrogation / sentence: torture, death sentence, and commutation
+  verified through ЕІУ, IEU, and CDIAC summaries; original trial records not
+  directly inspected.
+- Konotop Articles 1672: context verified through ЕІУ; original source edition
+  not directly inspected.
+- Siberian service / Nerchinsk context: verified through ЕІУ and IEU
+  summaries; Russian-Chinese relations document volume not inspected.
+
+**Honest gaps:** this dossier did not inspect archival originals, the full
+*Akty* volumes, the Hlukhiv Articles source edition, Mnohohrishny universals,
+trial/interrogation records, Siberian service records, or the full Borysenko /
+Pyrih / Kryvosheia scholarship. For module writing, recheck exact wording for
+the Hlukhiv clauses, universals, coup participants, torture/trial procedure,
+service-status labels, Nerchinsk participation, and death/burial details
+against source editions.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Moscow is treated as an intervening and
+  centralizing power, not as Ukraine's natural administrative center.
+- [x] Mnohohrishny is not flattened into a Moscow client, pure collaborator,
+  or spotless autonomy martyr.
+- [x] The dossier names both partial institutional defense and coercive /
+  factional rule.
+- [x] Starshyna agency is visible; senior officers are neither erased nor
+  romanticized.
+- [x] Doroshenko/Mnohohrishny/Samoilovych relations are kept source-cautious
+  and not turned into a morality play.
+- [x] Hlukhiv Articles language preserves both autonomy claims and imperial
+  constraints.
+- [x] Deportation is named as coercive punishment, while Siberian service is
+  not romanticized as free choice.
+- [x] No Russian-imperial transliterations in body text except variant /
+  forbidden forms and source-title contexts.
+- [x] No unrelated modern-statehood material or all-rulers chronology added.
+- [x] Modern Ukrainian place/institution naming used with historical context:
+  Короп, Чернігів, Новгород-Сіверський, Глухів, Батурин, Конотоп, Лівобережжя,
+  Правобережжя, Гетьманщина, Запорозька Січ, Селенгінськ.
+
+## Validation checklist
+
+- [x] Single owned file only: `docs/research/bio/demian-mnohohrishny.md`.
+- [x] Existing cross-track plan paths verified locally before citation.
+- [x] Lower-tier sources marked non-load-bearing.
+- [x] Guard terms for unrelated later-Hetmanate, modern-statehood, and
+  all-rulers scope avoided.
+- [x] No generated `status/`, `audit/`, `review/`, or telemetry artifacts
+  referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans,
+  module files, activities, vocabulary, resources, site MDX, or wiki files
+  edited.


### PR DESCRIPTION
## Scope

Adds the BIO Cossack P1 research dossier for Demian Mnohohrishny, focused on Left-Bank Hetmanate survival after the Ruin, the Hlukhiv Articles settlement, Moscow garrison/voivoda pressure, starshyna factional politics, imperial arrest/deportation, and Siberian exile/service.

## Changed files

- `docs/research/bio/demian-mnohohrishny.md`

## Validation

- `npx markdownlint-cli2 docs/research/bio/demian-mnohohrishny.md` — passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/demian-mnohohrishny.md` — passed
- `git diff --check` — passed
- `rg -n "Skoropadskyi|Скоропад|1918|Ukrainian State|Українськ.*Держав|Polish king|Polish kings|Польськ.*корол|польськ.*корол" docs/research/bio/demian-mnohohrishny.md` — no matches
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed

## Source and decolonization caveats

- Treats exact birth/death years, early Khmelnytsky-era service, name variants, Shumeiko genealogy, arrest/trial details, and Siberian service details as source-sensitive rather than flattened.
- Uses EIU/IEU and institutional archival sources as load-bearing; lower-tier web and image sources are marked as navigation or rights leads only.
- Frames Mnohohrishny as a constrained actor with real agency, not as a simple Moscow client or a pure autonomy martyr.

## Review note

No independent review has been routed yet because the orchestrator handles that gate for this epic.