### PR TITLE
feat(atlas): define entry model and census

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,17 @@ Direct `agy --model` calls use display labels from `agy models`, such as
 `Gemini 3.1 Pro (High)` and `Gemini 3.5 Flash (High)`. The bridge/runtime may
 map slugs such as `gemini-3.1-pro-high` to those labels.
 
+### 14. Do Not Leave PRs In Limbo
+
+Do not leave draft PRs or open PRs in limbo after checks are green. Every PR you
+create must end the task in one of these states: merged, closed with a reason,
+or explicitly handed off with the blocker, owner, and next action.
+
+Before the final response, check PR state, checks, mergeability, and whether the
+branch/worktree needs cleanup. If a PR remains open, the final response must say
+exactly why and what action is required. Leaving PRs in review hell wastes CI,
+agent, and human attention.
+
 ---
 
 ## Economical Multi-Agent Delegation

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -365,6 +365,8 @@ At `scripts/audit/checks/`:
 Additional audit guardrails:
 
 - `scripts/audit/lint_dispatch_brief.py` - dispatch brief `.venv/bin/python` worktree guardrail
+- `scripts/audit/atlas_source_census.py` - aggregate-only Word Atlas source intake census; public reports must not include raw source text, private paths, or candidate lemma lists
+- `scripts/audit/atlas_entry_model_census.py` - aggregate-only Word Atlas entry-model census; separates reviewed article entries by `entry_type` from alias/form records
 
 ### Build pipeline entry point
 
@@ -531,6 +533,8 @@ Use this before content generation to verify plan files still match `scripts/aud
 | `scripts/assess_research.py` | Assess and upgrade research | `.venv/bin/python scripts/assess_research.py hist --upgrade` |
 | `scripts/consultation_cli.py` | Review consultation proposals | `.venv/bin/python scripts/consultation_cli.py list` |
 | `scripts/check_decisions.py` | Audit decision journal expiry | `.venv/bin/python scripts/check_decisions.py` |
+| `scripts/audit/atlas_source_census.py` | Build aggregate-safe Word Atlas source planning counts | `.venv/bin/python scripts/audit/atlas_source_census.py --markdown-out docs/runbooks/word-atlas-source-census-planning.md` |
+| `scripts/audit/atlas_entry_model_census.py` | Count reviewed Atlas entries by finalized `entry_type` bucket | `.venv/bin/python scripts/audit/atlas_entry_model_census.py --format markdown` |
 | `scripts/audit/lint_session_state.py` | Check handoff docs for missing env-file references | `.venv/bin/python scripts/audit/lint_session_state.py --all` |
 | `scripts/audit/lint_anti_menu.py` | Detect anti-menu sign-off prompts in markdown | `.venv/bin/python scripts/audit/lint_anti_menu.py --text docs/session-state/current.md` |
 | `scripts/audit/decision_lineage.py` | Scan decision git backlinks | `.venv/bin/python scripts/audit/decision_lineage.py --decision-id ADR-008` |

--- a/docs/best-practices/git-hygiene.md
+++ b/docs/best-practices/git-hygiene.md
@@ -22,13 +22,13 @@ was blocked because the working tree was missing
 day before. The working tree had 489 dirty entries (modified + deleted
 + untracked). A mix of:
 
-- 43 `.worktree-briefs/*.md` — consumed dispatch prompts that had
++ 43 `.worktree-briefs/*.md` — consumed dispatch prompts that had
   already produced merged PRs (pure noise)
-- 99 `curriculum/l2-uk-en/a1/colors/**` — stale output from pre-ADR-007
++ 99 `curriculum/l2-uk-en/a1/colors/**` — stale output from pre-ADR-007
   pilot runs
-- 16 files modified to pre-merge state (pre-#1498, pre-#1513, pre-#1515,
++ 16 files modified to pre-merge state (pre-#1498, pre-#1513, pre-#1515,
   pre-ADR-007) — drift from never-reset local state
-- 3 tests deleted in the working tree that had been ADDED by recent
++ 3 tests deleted in the working tree that had been ADDED by recent
   PRs (never materialized in the checkout)
 
 Every one of these was resolvable in under a minute at the time of the
@@ -51,10 +51,10 @@ a hygiene violation.
 Dirty file classes:
 
 | Marker | Meaning | Default action |
-|---|---|---|
-| ` M` | Modified in working tree | Commit, restore to HEAD, or stash |
-| `MM` / `M ` | Modified + staged (partial) | Finish staging and commit |
-| ` D` | Deleted in working tree | Either commit the deletion or restore |
+| --- | --- | --- |
+| `SP+M` | Modified in working tree | Commit, restore to HEAD, or stash |
+| `MM` / `M+SP` | Modified + staged (partial) | Finish staging and commit |
+| `SP+D` | Deleted in working tree | Either commit the deletion or restore |
 | `??` | Untracked | Either commit, delete, or gitignore |
 
 ## Exemption paths
@@ -63,12 +63,12 @@ These paths are **expected to be dirty** during active work and don't
 count toward the "end session clean" rule. They're either output from
 running builds or local-only state:
 
-- `wiki/**` — wiki builder runs in parallel and emits new/modified
++ `wiki/**` — wiki builder runs in parallel and emits new/modified
   files constantly. Snapshot-commit periodically (`feat(wiki): snapshot
   built wikis — batch YYYY-MM-DD`), don't restore.
-- `data/corpus_audit/draft_tickets/*.md` — local-only audit drafts
++ `data/corpus_audit/draft_tickets/*.md` — local-only audit drafts
   (already unignored/allowed per existing `.gitignore` rule)
-- `.venv/`, `node_modules/`, `starlight/dist/`, etc. — gitignored build
++ `.venv/`, `node_modules/`, `starlight/dist/`, etc. — gitignored build
   artifacts. If any of these show up in `git status`, something is
   miswired.
 
@@ -98,11 +98,11 @@ This is the most dangerous. Files you didn't touch, but that HEAD
 moved ahead on. Working tree "rejects" the new state by holding the
 old one. Spot the pattern:
 
-- Working tree has functions/classes that no longer exist on main
++ Working tree has functions/classes that no longer exist on main
   (tests for KILLed infrastructure, pre-refactor helpers, etc.)
-- Working tree is missing files that main added (new shared modules,
++ Working tree is missing files that main added (new shared modules,
   new tests, new pre-commit hooks)
-- Line counts differ from HEAD despite no intentional edits
++ Line counts differ from HEAD despite no intentional edits
 
 Detection is trivial:
 
@@ -160,6 +160,20 @@ and wants to resume it. The warning makes sure you don't work *past*
 the problem without noticing.
 
 See `scripts/claude/session-start-hygiene.sh --help` for overrides.
+
+## PR Lifecycle Hygiene
+
+Do not leave draft PRs or open PRs in limbo after checks are green. Every PR an
+agent creates must finish the task in one of these states:
+
++ merged
++ closed with the reason recorded
++ explicitly handed off with the blocker, owner, and next action
+
+Before the final response, check PR state, checks, mergeability, and whether the
+branch/worktree needs cleanup. If a PR remains open, the final response must say
+exactly why and what action is required. Leaving PRs in review hell wastes CI,
+agent, and human attention.
 
 ## Monitor API surface
 

--- a/docs/best-practices/word-atlas-design.md
+++ b/docs/best-practices/word-atlas-design.md
@@ -90,6 +90,20 @@ Provenance discipline: every badge cites the specific tool result that triggered
 
 ## 6. Data model
 
+### Entry Model Revision (2026-07-04)
+
+The original design below is lemma-first. The current architecture decision is
+lemma-first but not lemma-only: Atlas article entries now have a required
+`entry_type` model covering `lemma`, `expression`, `phraseologism`, `proverb`,
+`multiword_term`, and `proper_name`. Generated form aliases and existing
+`form_of` records are search helpers, not reviewed Atlas entries.
+
+The authoritative entry model and drift gates are in
+[`docs/runbooks/word-atlas-entry-model.md`](../runbooks/word-atlas-entry-model.md).
+Implementation work must update the manifest schema, static API counts, search
+aliases, and POC route map against that runbook before adding non-lemma article
+pages.
+
 Per-lemma canonical record. Cached as `data/lexicon/{lemma}.json` for static build (v1+) OR computed on-demand (v0/v3+ long tail):
 
 ```yaml

--- a/docs/poc/word-atlas/README.md
+++ b/docs/poc/word-atlas/README.md
@@ -12,3 +12,32 @@ Each file is the single source for the route or route variant listed here.
 All three files share `word-atlas.css`, which contains the light/dark `--lu-*`
 tokenized styles extracted from the original POC. The legacy top-level POC path
 is kept as a short compatibility stub for existing links.
+
+## Entry Model Alignment
+
+The route map predates the finalized entry model in
+[`docs/runbooks/word-atlas-entry-model.md`](../../runbooks/word-atlas-entry-model.md).
+Implementation must treat `/lexicon/{slug}` as an Atlas entry route, not as a
+lemma-only route. The current POC covers lemma-style articles only; the next
+design pass must add at least one expression-like detail view before shipping
+first-class `expression`, `phraseologism`, `proverb`, or `multiword_term`
+article support.
+
+Required future POC coverage:
+
+| Missing design source | Route | Entry model surface |
+| --- | --- | --- |
+| `expression-detail.html` or equivalent | `/lexicon/{slug}` | Fixed formula, idiom/proverb, or multiword term article with component lemma backlinks |
+
+## Drift Prevention
+
+- POC route map changes and implementation route changes must land together.
+- Any supported `entry_type` must have a named article template or an explicit
+  documented reason it reuses another template.
+- Public search and status APIs must count approved article entries separately
+  from alias/form records.
+- Expression-like pages must show component lemma cross-links without rendering
+  broken public links.
+- POC docs may show aggregate counts and invented examples, but must not include
+  private source text, private paths, raw textbook snippets, private Ohoiko
+  content, or candidate lemma lists.

--- a/docs/runbooks/word-atlas-entry-model-census.md
+++ b/docs/runbooks/word-atlas-entry-model-census.md
@@ -1,0 +1,50 @@
+# Word Atlas Entry Model Census
+
+- workflow: `atlas_entry_model_census.v1`
+- generated_at: `2026-07-04T07:14:13+00:00`
+- production_outputs_updated: []
+- raw_text_included: false
+- candidate_lemmas_included: false
+- private_paths_included: false
+- manifest_records: 5502
+- total_reviewed_entries: 5156
+
+## Reviewed Entries By Type
+
+| entry type | count |
+| --- | ---: |
+| `lemma` | 3847 |
+| `expression` | 5 |
+| `phraseologism` | 0 |
+| `proverb` | 0 |
+| `multiword_term` | 1266 |
+| `proper_name` | 38 |
+
+## Non-Entry Records
+
+| record bucket | count |
+| --- | ---: |
+| `form_alias` | 336 |
+| `grammar_term` | 10 |
+| `noise_rejected` | 0 |
+| `invalid` | 0 |
+
+## Classification Sources
+
+| source | records |
+| --- | ---: |
+| `legacy_pos` | 53 |
+| `legacy_shape` | 5113 |
+| `form_of` | 336 |
+
+## Warnings
+
+| warning | records |
+| --- | ---: |
+| `legacy_multiword_defaulted_to_multiword_term` | 1266 |
+
+## Notes
+
+- Counts are aggregate-only and do not expose entry text.
+- Legacy manifests without entry_type are classified by conservative shape and POS heuristics.
+- form_of records are treated as alias/form records and excluded from reviewed entry totals.

--- a/docs/runbooks/word-atlas-entry-model.md
+++ b/docs/runbooks/word-atlas-entry-model.md
@@ -1,0 +1,232 @@
+# Word Atlas Entry Model
+
+- workflow: `word_atlas_entry_model.v1`
+- decided_at: `2026-07-04`
+- raw_text_included: false
+- candidate_lemmas_included: false
+- private_paths_included: false
+- discussion_inputs: Codex main synthesis, AGY/Gemini 3.1 Pro High critique
+- unavailable_discussion_inputs: Claude CLI could not run locally because the native binary was not installed
+
+## Decision
+
+Word Atlas remains lemma-first, but it is not lemma-only. A public Atlas entry
+is an approved, source-backed, searchable article record with a stable slug,
+an `entry_type`, public-safe provenance, and deterministic cross-links. Raw
+surface forms, private-source rows, generated form aliases, and rejected
+candidates are not Atlas entries.
+
+The model has two layers:
+
+- **Article entries**: reviewed records that can have `/lexicon/{slug}` pages
+  and are counted in public Atlas entry totals.
+- **Evidence and alias records**: surface evidence, inflected forms, spelling
+  variants, transliterations, and rejected/noise decisions. These can support
+  search or planning, but they do not count as entries.
+
+## Entry Types
+
+| `entry_type` | Counts as Atlas entry | Definition |
+| --- | --- | --- |
+| `lemma` | yes | Canonical dictionary head for a single lexical item. It should normally be backed by VESUM, a heritage-source fallback, or a narrow modern-term allowlist. |
+| `expression` | yes | Fixed functional formula or pragmatic set phrase that learners search as a unit, such as greetings, politeness formulas, discourse markers, and other socially fixed phrases. It is not a generic collocation bin. |
+| `phraseologism` | yes | Idiomatic fixed expression whose meaning, register, or usage cannot be predicted from component lemmas. |
+| `proverb` | yes | Complete traditional sentential expression that carries a conventional lesson, cultural norm, or evaluative point. |
+| `multiword_term` | yes | Compositional but domain-important term naming one concept, grammatical unit, institutional term, or course-relevant lexical unit. |
+| `proper_name` | yes | Named entity admitted because it is course-relevant, lexically useful, or needed for Atlas cross-links. |
+
+`noise / rejected` is a candidate-review bucket, not a public `entry_type`.
+Existing `form_of` records and future generated form aliases should be handled
+as alias/form records and excluded from reviewed entry totals.
+
+## Admission Rules
+
+Create a standalone page only when an item has public-safe reviewed provenance
+and at least one of these admission reasons:
+
+- It is an explicit curriculum or reviewed source-inventory target.
+- It has meaning, register, government, translation, or usage that is not
+  predictable from component lemmas.
+- It is a fixed functional formula that learners are likely to look up as a
+  unit and is backed by curriculum inclusion or public-corpus frequency.
+- It is a phraseologism or proverb that needs its own definition, origin,
+  usage note, or cultural framing.
+- It is a domain term or grammatical/pedagogical unit that names one concept.
+- It is a proper name with course relevance and public source backing.
+
+Keep a phrase only inside lemma pages when it is a productive collocation,
+ordinary example sentence, context-specific quote, or source-only surface form
+without approved article-level provenance.
+
+For private or copyrighted sources, the standalone head must be reduced to the
+canonical minimum form. Do not publish surrounding context, full extracted
+sentences, private file paths, private source titles, or raw candidate lists.
+
+## Tie-Breakers
+
+- `expression` vs `phraseologism`: choose `expression` for literal but socially
+  fixed formulas; choose `phraseologism` when the meaning is figurative,
+  opaque, or idiomatic.
+- `expression` vs `multiword_term`: choose `expression` for conversational or
+  pragmatic formulas; choose `multiword_term` when the phrase names a domain
+  concept or behaves like a terminological unit.
+- `phraseologism` vs `proverb`: choose `proverb` only for complete sentential
+  traditional sayings. Short idiomatic noun/verb phrases stay
+  `phraseologism`.
+- `lemma` vs `proper_name`: choose `proper_name` for named entities even when
+  VESUM lists the form.
+- Unknown multiword candidates must not default into `expression`. If no
+  idiom/proverb/formula evidence exists, default reviewed multiword articles
+  to `multiword_term`; otherwise keep the item as lemma-page evidence until
+  reviewed.
+
+## Search Aliases And Forms
+
+Every article entry needs:
+
+- `url_slug`: one stable route segment.
+- `display_head`: the public headword or phrase shown to users.
+- `entry_type`: one of the article types above.
+- `search_aliases`: public-safe alias records with `alias`, `kind`, `source`,
+  and `target_slug`.
+
+Allowed alias kinds:
+
+- `canonical`: the display head normalized for search.
+- `unstressed`: stress marks removed.
+- `transliteration`: Latin user query support.
+- `inflected_form`: generated or reviewed inflected form.
+- `spelling_variant`: approved orthographic variant.
+- `translation_hint`: short public translation used for search ranking.
+- `component_head`: component lemma backlink for multiword entries.
+
+Alias rules:
+
+- Alias `target_slug` must resolve to an approved public Atlas article.
+- Public aliases must be deduplicated before search-index generation.
+- Private/copyrighted source surfaces may not be emitted as aliases unless
+  independently approved as canonical minimum forms.
+- Lemma inflections may be generated from VESUM or committed reviewed alias
+  maps. Multiword aliases require curated entries or reviewed templates;
+  do not blindly combine component paradigms.
+
+## Cross-Linking
+
+Lemma pages should include related fixed expressions, phraseologisms, proverbs,
+multiword terms, and proper names through `related_entries` records:
+
+```yaml
+related_entries:
+  - slug: byty-baidyky
+    entry_type: phraseologism
+    relation: contains_component
+    component_role: verb
+```
+
+Expression-like pages should link back to component lemmas with explicit
+component roles where useful. A standalone multiword entry may temporarily link
+to a component that is queued but not yet published only when the unresolved
+component is marked in aggregate-only internal planning output; public pages
+must not render broken links.
+
+## Provenance Requirements
+
+Every public article entry must carry public-safe provenance:
+
+- `source_family`: curriculum, public dictionary, Ohoiko/ULP, textbook,
+  teacher_lesson, corpus, or reviewer decision.
+- `source_locator`: safe public locator or neutral internal label. Do not
+  expose private paths, private titles, raw snippets, or copyrighted text.
+- `extraction_mode`: curated headword, curriculum headword, reviewed inventory,
+  public dictionary head, generated alias, or explicit rejection.
+- `review_state`: `approved`, `needs_review`, or `rejected`.
+- `visibility`: `public` for publishable article/alias data; private-source
+  evidence stays non-public by default.
+
+Additional type-specific requirements:
+
+- `lemma`: VESUM, heritage fallback, deliberate warning entry, proper-name
+  exemption, or modern-term allowlist path must be explainable.
+- `expression`: evidence that the whole phrase is a fixed functional formula.
+- `phraseologism`: idiom or phraseological source, or explicit reviewer
+  decision with definition.
+- `proverb`: source or reviewer decision identifying it as a proverb/saying.
+- `multiword_term`: course, grammar, domain, or dictionary evidence that it is
+  one concept.
+- `proper_name`: public source or curriculum evidence, plus a reason it belongs
+  in Atlas rather than only in a lesson.
+
+## Counting Rules
+
+Public Atlas counts must use these aggregates:
+
+- `reviewed_entries_by_type`: approved article entries only, grouped by
+  `entry_type`.
+- `total_reviewed_entries`: sum of approved article entries.
+- `alias_records`: form aliases, `form_of` records, spelling variants, and
+  generated search rows. These are excluded from entry totals.
+- `candidate_evidence_by_bucket`: aggregate-only planning counts from source
+  surfaces or reviewed inventories.
+- `noise_rejected`: aggregate count of candidates explicitly rejected or
+  filtered as noise.
+
+Do not call raw surface counts "entries", "lemmas", or "vocabulary size".
+Surface counts from lessons, activities, textbooks, or private notes are
+evidence for prioritization until lemmatized and reviewed.
+
+## POC And Schema Changes Required
+
+The current implementation is still per-lemma in several places. The next
+implementation phase must update these surfaces together:
+
+- Manifest schema: require `entry_type`, `review_state`, `visibility`,
+  `display_head`, and public-safe `source_provenance` on article records.
+- Route semantics: treat `/lexicon/{slug}` as an entry slug, not as a lemma
+  parameter, even if the current Astro file is named `[lemma].astro`.
+- Article component: branch section labels and morphology expectations by
+  `entry_type`; proverbs and phraseologisms should not be forced through lemma
+  morphology.
+- Search index: index article entries and alias records separately, with
+  aliases resolving to approved article slugs.
+- POC route map: include at least one expression-like detail design, not only
+  lemma pages.
+- Static API status: publish entry counts by `entry_type`, plus separate alias
+  and candidate-evidence counts.
+
+## Acceptance Gates
+
+Implementation must not proceed without deterministic gates for:
+
+- `entry_type_enum`: every article record has a valid `entry_type`.
+- `entry_type_shape`: `lemma` is single-head unless explicitly allowed;
+  expression-like types are multiword or otherwise explicitly justified.
+- `article_vs_alias_count`: `form_of` and alias records do not increment
+  reviewed entry totals.
+- `alias_target_integrity`: every alias `target_slug` resolves to an approved
+  public article entry.
+- `alias_deduplication`: duplicate aliases collapse before public search-index
+  generation.
+- `component_cross_links`: expression-like entries link to existing component
+  lemmas or omit broken public links.
+- `provenance_by_type`: every article type meets its source requirement.
+- `privacy_boundary`: public docs, APIs, search rows, and reports contain no
+  private paths, private raw text, private source titles, candidate lemma lists,
+  or copyrighted textbook snippets.
+- `static_api_counts_by_type`: public status JSON reports reviewed counts by
+  type and keeps alias/candidate counts separate.
+- `poc_route_map_alignment`: the POC route map names the entry templates that
+  implementation claims to support.
+- `scripts_documented`: any new or materially changed Atlas operational script
+  is documented in `docs/SCRIPTS.md`.
+
+## Open Decisions
+
+- Whether `form_of` records stay in the manifest as non-entry records or move
+  fully into a separate alias/search artifact.
+- Exact public-corpus frequency threshold for standalone `expression`
+  admission when no curriculum target exists.
+- Whether component lemmas are required before publishing an expression-like
+  article, or whether a queued component can temporarily suppress the public
+  link.
+- Whether the route source file should be renamed from `[lemma].astro` to
+  `[slug].astro` when the schema migration lands.

--- a/scripts/audit/atlas_entry_model_census.py
+++ b/scripts/audit/atlas_entry_model_census.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Count public Atlas entries against the finalized entry model.
+
+This audit is aggregate-only. It reads the current manifest, separates reviewed
+article entries from legacy alias/form records, and reports counts by the
+entry-model buckets defined in docs/runbooks/word-atlas-entry-model.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = Path(__file__).resolve().parent
+if sys.path and Path(sys.path[0]).resolve() == SCRIPT_DIR:
+    sys.path.pop(0)
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.lexicon.lemma_normalization import strip_acute_stress
+from scripts.lexicon.manifest_io import load_manifest
+
+WORKFLOW_ID = "atlas_entry_model_census.v1"
+DEFAULT_MANIFEST = PROJECT_ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
+
+ENTRY_TYPES = (
+    "lemma",
+    "expression",
+    "phraseologism",
+    "proverb",
+    "multiword_term",
+    "proper_name",
+)
+NON_ENTRY_TYPES = (
+    "form_alias",
+    "grammar_term",
+    "noise_rejected",
+    "invalid",
+)
+EXPLICIT_REJECTED_TYPES = {"noise", "rejected", "noise_rejected"}
+WORD_TOKEN_RE = re.compile(r"[A-Za-zА-Яа-яЄєІіЇїҐґ0-9'’ʼ-]+")
+WHITESPACE_RE = re.compile(r"\s")
+DELIMITED_RE = re.compile(r"\.\.\.|/")
+
+
+@dataclass(frozen=True)
+class EntryClassification:
+    """One aggregate-safe classification result."""
+
+    bucket: str
+    counts_as_entry: bool
+    source: str
+    warning: str | None = None
+
+
+def _is_default_manifest(path: Path) -> bool:
+    return path.resolve() == DEFAULT_MANIFEST.resolve()
+
+
+def _read_manifest(path: Path) -> dict[str, Any]:
+    if _is_default_manifest(path):
+        return load_manifest(path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _normalize_label(value: object) -> str:
+    text = strip_acute_stress(str(value or "")).strip().casefold()
+    text = text.replace("-", "_").replace(" ", "_").replace("/", "_")
+    return re.sub(r"_+", "_", text).strip("_")
+
+
+def _normalize_entry_type(value: object) -> str | None:
+    label = _normalize_label(value)
+    aliases = {
+        "idiom": "phraseologism",
+        "idiom_phrase": "phraseologism",
+        "phraseological_unit": "phraseologism",
+        "fixed_expression": "expression",
+        "set_phrase": "expression",
+        "formula": "expression",
+        "saying": "proverb",
+        "proper_noun": "proper_name",
+        "multiword": "multiword_term",
+        "multi_word_term": "multiword_term",
+        "term": "multiword_term",
+    }
+    if label in ENTRY_TYPES or label in NON_ENTRY_TYPES:
+        return label
+    if label in EXPLICIT_REJECTED_TYPES:
+        return "noise_rejected"
+    return aliases.get(label)
+
+
+def _base_pos(entry: Mapping[str, Any]) -> str:
+    return _normalize_label(entry.get("pos")).split(":", 1)[0]
+
+
+def _has_multiword_shape(value: str) -> bool:
+    return bool(WHITESPACE_RE.search(value)) or bool(DELIMITED_RE.search(value))
+
+
+def _is_genuine_multiword(value: str) -> bool:
+    return len(WORD_TOKEN_RE.findall(value)) >= 2
+
+
+def _legacy_multiword_type(entry: Mapping[str, Any], lemma: str) -> EntryClassification:
+    pos = _base_pos(entry)
+    if "proverb" in pos or "pryslivia" in pos:
+        return EntryClassification("proverb", True, "legacy_pos")
+    if "phraseologism" in pos or "idiom" in pos:
+        return EntryClassification("phraseologism", True, "legacy_pos")
+    if "expression" in pos or "formula" in pos or "greeting" in pos:
+        return EntryClassification("expression", True, "legacy_pos")
+    if "proper_noun" in pos or "proper_name" in pos:
+        return EntryClassification("proper_name", True, "legacy_pos")
+    if _is_genuine_multiword(lemma):
+        return EntryClassification(
+            "multiword_term",
+            True,
+            "legacy_shape",
+            "legacy_multiword_defaulted_to_multiword_term",
+        )
+    return EntryClassification(
+        "invalid",
+        False,
+        "legacy_shape",
+        "multiword_shape_without_two_tokens",
+    )
+
+
+def classify_entry(entry: Mapping[str, Any]) -> EntryClassification:
+    """Classify one manifest record without exposing its text in reports."""
+
+    lemma = str(entry.get("lemma") or "").strip()
+    slug = str(entry.get("url_slug") or "").strip()
+    if not lemma or not slug:
+        return EntryClassification("invalid", False, "structural", "missing_lemma_or_url_slug")
+
+    if entry.get("form_of"):
+        return EntryClassification("form_alias", False, "form_of")
+
+    explicit_type = _normalize_entry_type(entry.get("entry_type"))
+    if explicit_type in ENTRY_TYPES:
+        return EntryClassification(explicit_type, True, "entry_type")
+    if explicit_type in NON_ENTRY_TYPES:
+        return EntryClassification(explicit_type, False, "entry_type")
+    if entry.get("entry_type") is not None:
+        return EntryClassification("invalid", False, "entry_type", "unknown_entry_type")
+
+    pos = _base_pos(entry)
+    if pos == "grammar_term":
+        return EntryClassification("grammar_term", False, "legacy_pos")
+    if pos in {"proper_noun", "proper_name"}:
+        return EntryClassification("proper_name", True, "legacy_pos")
+    if _has_multiword_shape(lemma):
+        return _legacy_multiword_type(entry, lemma)
+    return EntryClassification("lemma", True, "legacy_shape")
+
+
+def build_entry_model_census(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    entries = [entry for entry in manifest.get("entries", []) if isinstance(entry, Mapping)]
+    reviewed_counts: Counter[str] = Counter({entry_type: 0 for entry_type in ENTRY_TYPES})
+    non_entry_counts: Counter[str] = Counter({entry_type: 0 for entry_type in NON_ENTRY_TYPES})
+    classification_sources: Counter[str] = Counter()
+    warnings: Counter[str] = Counter()
+
+    for entry in entries:
+        classification = classify_entry(entry)
+        classification_sources[classification.source] += 1
+        if classification.warning:
+            warnings[classification.warning] += 1
+        if classification.counts_as_entry:
+            reviewed_counts[classification.bucket] += 1
+        else:
+            non_entry_counts[classification.bucket] += 1
+
+    return {
+        "workflow": WORKFLOW_ID,
+        "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+        "production_outputs_updated": [],
+        "safety": {
+            "public_payload_includes_raw_text": False,
+            "public_payload_includes_candidate_lemmas": False,
+            "public_payload_includes_private_paths": False,
+            "manifest_content_mutated": False,
+            "manifest_hydrated_from_release": False,
+        },
+        "manifest_records": len(entries),
+        "total_reviewed_entries": sum(reviewed_counts.values()),
+        "reviewed_entries_by_type": dict(reviewed_counts),
+        "non_entry_records": dict(non_entry_counts),
+        "classification_sources": dict(classification_sources),
+        "warnings": dict(warnings),
+        "notes": [
+            "Counts are aggregate-only and do not expose entry text.",
+            "Legacy manifests without entry_type are classified by conservative shape and POS heuristics.",
+            "form_of records are treated as alias/form records and excluded from reviewed entry totals.",
+        ],
+    }
+
+
+def format_markdown_report(payload: Mapping[str, Any]) -> str:
+    lines = [
+        "# Word Atlas Entry Model Census",
+        "",
+        f"- workflow: `{payload['workflow']}`",
+        f"- generated_at: `{payload['generated_at']}`",
+        "- production_outputs_updated: []",
+        "- raw_text_included: false",
+        "- candidate_lemmas_included: false",
+        "- private_paths_included: false",
+        f"- manifest_records: {payload['manifest_records']}",
+        f"- total_reviewed_entries: {payload['total_reviewed_entries']}",
+        "",
+        "## Reviewed Entries By Type",
+        "",
+        "| entry type | count |",
+        "| --- | ---: |",
+    ]
+    for entry_type, count in payload["reviewed_entries_by_type"].items():
+        lines.append(f"| `{entry_type}` | {count} |")
+
+    lines.extend(
+        [
+            "",
+            "## Non-Entry Records",
+            "",
+            "| record bucket | count |",
+            "| --- | ---: |",
+        ]
+    )
+    for bucket, count in payload["non_entry_records"].items():
+        lines.append(f"| `{bucket}` | {count} |")
+
+    lines.extend(
+        [
+            "",
+            "## Classification Sources",
+            "",
+            "| source | records |",
+            "| --- | ---: |",
+        ]
+    )
+    for source, count in payload["classification_sources"].items():
+        lines.append(f"| `{source}` | {count} |")
+
+    if payload["warnings"]:
+        lines.extend(["", "## Warnings", "", "| warning | records |", "| --- | ---: |"])
+        for warning, count in payload["warnings"].items():
+            lines.append(f"| `{warning}` | {count} |")
+
+    lines.extend(["", "## Notes", ""])
+    for note in payload["notes"]:
+        lines.append(f"- {note}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Count Atlas manifest records by finalized entry-model bucket.")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST, help="Atlas manifest JSON path.")
+    parser.add_argument("--json-out", type=Path, help="Write aggregate JSON report.")
+    parser.add_argument("--markdown-out", type=Path, help="Write aggregate Markdown report.")
+    parser.add_argument("--format", choices=("text", "json", "markdown"), default="text", help="Print format.")
+    parser.add_argument(
+        "--fail-on-legacy-heuristic",
+        action="store_true",
+        help="Exit non-zero if any record had to be classified without explicit entry_type.",
+    )
+    return parser
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    manifest_path = args.manifest if args.manifest.is_absolute() else PROJECT_ROOT / args.manifest
+    manifest_existed = manifest_path.exists()
+    payload = build_entry_model_census(_read_manifest(manifest_path))
+    payload["safety"]["manifest_hydrated_from_release"] = (
+        _is_default_manifest(manifest_path) and not manifest_existed and manifest_path.exists()
+    )
+
+    if args.json_out:
+        out = args.json_out if args.json_out.is_absolute() else PROJECT_ROOT / args.json_out
+        _write_text(out, json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+    if args.markdown_out:
+        out = args.markdown_out if args.markdown_out.is_absolute() else PROJECT_ROOT / args.markdown_out
+        _write_text(out, format_markdown_report(payload) + "\n")
+
+    if args.format == "json":
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    elif args.format == "markdown":
+        print(format_markdown_report(payload))
+    else:
+        print(
+            "Atlas entry-model census: "
+            f"{payload['total_reviewed_entries']} reviewed entries across "
+            f"{payload['manifest_records']} manifest records."
+        )
+        print("reviewed_entries_by_type=" + json.dumps(payload["reviewed_entries_by_type"], sort_keys=True))
+        print("non_entry_records=" + json.dumps(payload["non_entry_records"], sort_keys=True))
+
+    if args.fail_on_legacy_heuristic:
+        legacy_count = sum(
+            count
+            for source, count in payload["classification_sources"].items()
+            if source.startswith("legacy_")
+        )
+        if legacy_count:
+            print(f"--fail-on-legacy-heuristic matched {legacy_count} records")
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_atlas_entry_model_census.py
+++ b/tests/test_atlas_entry_model_census.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from scripts.audit.atlas_entry_model_census import build_entry_model_census, classify_entry
+
+
+def _entry(**overrides: object) -> dict:
+    entry = {
+        "lemma": "слово",
+        "url_slug": "слово",
+        "gloss": "word",
+        "pos": "noun",
+        "primary_source": "test",
+        "course_usage": [],
+    }
+    entry.update(overrides)
+    return entry
+
+
+def test_explicit_entry_type_counts_reviewed_article() -> None:
+    classification = classify_entry(_entry(entry_type="phraseologism", lemma="бити байдики", url_slug="бити-байдики"))
+
+    assert classification.bucket == "phraseologism"
+    assert classification.counts_as_entry is True
+    assert classification.source == "entry_type"
+
+
+def test_form_of_records_are_not_reviewed_entries() -> None:
+    payload = build_entry_model_census(
+        {
+            "entries": [
+                _entry(lemma="слово", url_slug="слово", entry_type="lemma"),
+                _entry(
+                    lemma="слова",
+                    url_slug="слова",
+                    form_of={"lemma": "слово", "url_slug": "слово"},
+                ),
+            ]
+        }
+    )
+
+    assert payload["reviewed_entries_by_type"]["lemma"] == 1
+    assert payload["total_reviewed_entries"] == 1
+    assert payload["non_entry_records"]["form_alias"] == 1
+
+
+def test_legacy_records_use_conservative_buckets() -> None:
+    payload = build_entry_model_census(
+        {
+            "entries": [
+                _entry(lemma="Ілля", url_slug="ілля", pos="proper noun:sg"),
+                _entry(lemma="доконаний вид", url_slug="доконаний-вид", pos="noun phrase"),
+                _entry(lemma="pluralia tantum", url_slug="pluralia-tantum", pos="grammar term"),
+            ]
+        }
+    )
+
+    assert payload["reviewed_entries_by_type"]["proper_name"] == 1
+    assert payload["reviewed_entries_by_type"]["multiword_term"] == 1
+    assert payload["non_entry_records"]["grammar_term"] == 1
+    assert payload["warnings"]["legacy_multiword_defaulted_to_multiword_term"] == 1
+
+
+def test_missing_required_fields_are_invalid_non_entries() -> None:
+    for entry in (
+        _entry(lemma="", url_slug="слово"),
+        _entry(lemma="слово", url_slug=""),
+    ):
+        classification = classify_entry(entry)
+        assert classification.bucket == "invalid"
+        assert classification.counts_as_entry is False
+        assert classification.warning == "missing_lemma_or_url_slug"
+
+
+def test_explicit_rejected_types_are_non_entry_records() -> None:
+    payload = build_entry_model_census(
+        {
+            "entries": [
+                _entry(entry_type="noise"),
+                _entry(entry_type="rejected", lemma="неприйняте", url_slug="неприйняте"),
+            ]
+        }
+    )
+
+    assert payload["non_entry_records"]["noise_rejected"] == 2
+    assert payload["total_reviewed_entries"] == 0
+
+
+def test_public_payload_is_aggregate_only() -> None:
+    payload = build_entry_model_census(
+        {
+            "entries": [
+                _entry(entry_type="phraseologism", lemma="бити байдики", url_slug="бити-байдики"),
+                _entry(entry_type="proverb", lemma="Без труда нема плода", url_slug="без-труда-нема-плода"),
+            ]
+        }
+    )
+
+    public_json = json.dumps(payload, ensure_ascii=False)
+    assert "бити байдики" not in public_json
+    assert "Без труда" not in public_json
+    assert payload["reviewed_entries_by_type"]["phraseologism"] == 1
+    assert payload["reviewed_entries_by_type"]["proverb"] == 1
+
+
+def test_cli_emits_json_and_markdown(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "entries": [
+                    _entry(entry_type="lemma"),
+                    _entry(entry_type="expression", lemma="будь ласка", url_slug="будь-ласка"),
+                ]
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    json_result = subprocess.run(
+        [
+            ".venv/bin/python",
+            "scripts/audit/atlas_entry_model_census.py",
+            "--manifest",
+            str(manifest_path),
+            "--format",
+            "json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(json_result.stdout)["reviewed_entries_by_type"]["expression"] == 1
+
+    md_result = subprocess.run(
+        [
+            ".venv/bin/python",
+            "scripts/audit/atlas_entry_model_census.py",
+            "--manifest",
+            str(manifest_path),
+            "--format",
+            "markdown",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "# Word Atlas Entry Model Census" in md_result.stdout
+
+
+def test_cli_can_fail_on_legacy_heuristic(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"entries": [_entry()]}), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            ".venv/bin/python",
+            "scripts/audit/atlas_entry_model_census.py",
+            "--manifest",
+            str(manifest_path),
+            "--fail-on-legacy-heuristic",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert "--fail-on-legacy-heuristic matched 1 records" in result.stdout


### PR DESCRIPTION
## Summary

- Defines the finalized Word Atlas entry model in `docs/runbooks/word-atlas-entry-model.md`.
- Adds `scripts/audit/atlas_entry_model_census.py` plus tests to count approved Atlas article entries by the finalized buckets while keeping alias/form records separate.
- Persists the aggregate-only count report in `docs/runbooks/word-atlas-entry-model-census.md`.
- Updates the Word Atlas design and POC route-map docs with drift-prevention gates.
- Adds PR lifecycle hygiene rules to `AGENTS.md` and `docs/best-practices/git-hygiene.md`, and documents Atlas census tooling in `docs/SCRIPTS.md`.

## Current Aggregate Count

- Reviewed Atlas entries: 5,156
- By type: lemma 3,847; expression 5; phraseologism 0; proverb 0; multiword_term 1,266; proper_name 38
- Non-entry records: form_alias 336; grammar_term 10; noise_rejected 0; invalid 0

## Review

- Ran bounded design discussion with AGY/Gemini 3.1 Pro High.
- Claude bridge leg was unavailable because the local Claude native binary is not installed.
- Ran independent AGY/Gemini pre-commit review of the full diff and applied the actionable findings: removed two dead/redundant mappings and added invalid/rejected-state tests. Dropped two false positives: review transport redacted a regex, and the suggested `sys.executable` change conflicts with repo rules.

## Validation

- `.venv/bin/python -m pytest tests/test_atlas_entry_model_census.py tests/test_atlas_source_census.py tests/test_atlas_conformance.py -q` -> 42 passed, 1 skipped
- `.venv/bin/ruff check --fix scripts/audit/atlas_entry_model_census.py tests/test_atlas_entry_model_census.py` -> clean
- `node_modules/.bin/markdownlint-cli2 AGENTS.md docs/SCRIPTS.md docs/best-practices/git-hygiene.md docs/best-practices/word-atlas-design.md docs/poc/word-atlas/README.md docs/runbooks/word-atlas-entry-model.md docs/runbooks/word-atlas-entry-model-census.md` -> 0 errors
- `git diff --check` -> clean
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed
- Pre-commit and pre-push hooks passed

## PR Lifecycle

This PR is opened ready for review, not draft. If CI is green and no review blockers remain, it should be merged rather than left open.