### PR TITLE
[codex] docs(bio): add Kryshtof Kosynsky dossier

### DIFF
--- a/docs/research/bio/kryshtof-kosynsky.md
+++ b/docs/research/bio/kryshtof-kosynsky.md
@@ -1,0 +1,578 @@
+# Криштоф Косинський — Research Dossier
+
+**Slug:** `kryshtof-kosynsky`
+**Block:** P1 BIO core (early Cossack frontier leader; registered/service
+Cossack politics, private grievance, magnate pressure, and the first large
+Cossack uprising)
+**Tier:** 1b (medium source confidence; thin personal record, strong event
+context)
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ Kosynsky, ЕІУ Kosiński uprising,
+  IEU Kosynsky, Shcherbak autonomy article, Yarmoshyk article with translated
+  document appendix)
+- [x] Source-tier checkboxes included and lower-tier sources kept
+  non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: registered frontier
+  service, unpaid/uncertain Cossack status, Rokytne estate grievance, Ostrozky
+  / Vyshnevetsky magnate pressure, local official framing of Cossack action as
+  disorder, and later flattening into either banditry or nationalist prehistory)
+- [x] §4 includes 2 short document/source-language anchors with verification
+  caveats
+- [x] Kosynsky is framed as complex: Podlachian petty noble, Cossack officer,
+  Commonwealth service broker, injured estate claimant, uprising leader, and
+  early sign of Cossack political action
+- [x] Cross-track links: every "Existing" plan path verified locally with
+  `rg --files` / `test -e` on 2026-07-04
+- [x] Naming-canonical applied
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+
+- [x] **T1 baseline:** ЕІУ and Internet Encyclopedia of Ukraine anchor core
+  facts, dates, offices, Podlachian noble origin, 1586 / 1590 service, Rokytne
+  grievance, Bila Tserkva document seizure, Piatka defeat, Cherkasy death, and
+  uprising geography.
+- [x] **T1 event context:** ЕІУ Kosiński uprising anchors the broader causes:
+  restrictions on Cossack rights, spread of magnate landholding, Ostrozky
+  offices/land power, oath-taking, negotiations, Piatka capitulation, and
+  post-Kosynsky Cossack pressure.
+- [x] **T2/T4 scholarship:** Shcherbak, Yarmoshyk, Hrushevsky, Lepiavko,
+  Yakovenko, Ruda, and Serczyk are used for autonomy/memory/source-framing
+  context and documentary leads.
+- [x] **T3/T5 caution:** Wikipedia, Wikicytaty, Commons, popular-history
+  articles, and image pages are navigation or image-rights aids only; they are
+  not load-bearing for interpretation.
+- [x] **Primary/doc excerpts:** short excerpts from the Piatka capitulation
+  letter are marked as document/source-language anchors; recheck the original
+  АЮЗР / `Listy Stanislawa Zolkiewskiego` edition before classroom quotation.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Криштоф Косинський. ЕІУ gives
+  `КОСИНСЬКИЙ Криштоф`; IEU gives `Kosynsky, Kryshtof [Kosyns'kyj, Kryštof]`.
+  Use `Kryshtof Kosynsky` in English curriculum metadata unless a Polish-source
+  citation requires `Krzysztof Kosiński`. [T1: ЕІУ; T1: IEU]
+- **Pseudonyms / aliases:** Криштоф Косинський; Кшиштоф Косинський; Христофор
+  Косинський as occasional Ukrainianized/Christian-name variant; Krzysztof
+  Kosiński; Kryshtof Kosynsky; Kryštof / Kryschtof Kosynskyj in older
+  transliteration layers. Treat `Rawicz` / Равич as a heraldic search lead, not
+  a substitute name. [T1: ЕІУ; T1: IEU; T3/T5]
+- **Born:** unknown. Lower-tier pages often give **1545**, but the stronger
+  layer used here is cautious: ЕІУ gives only unknown birth year and IEU gives
+  `?–1593`. Use "born probably in the mid-sixteenth century, exact date
+  unknown" unless a lesson is specifically about source disagreement. [T1:
+  ЕІУ; T1: IEU; T3]
+- **Origin / status:** a nobleman from **Підляшшя / Podlachia**, probably from
+  the petty-noble environment, and a Cossack officer by the 1580s. He is not
+  cleanly classifiable as either an outsider adventurer or a modern national
+  revolutionary. [T1: ЕІУ; T1: IEU; T4: Lepiavko/Yakovenko leads]
+- **First secure career layer:** first mentioned in **1586** as a Cossack
+  starshyna / officer on Zaporizhia. In spring **1590**, under Sigismund III
+  Vasa's commission, he organized Cossacks for Podilia defense against Ottoman
+  and Crimean threats; as reward he received the Rokytne estate. [T1: ЕІУ]
+- **Estate grievance:** the immediate trigger was the loss or takeover of the
+  lands granted to him around **Рокитне**. ЕІУ names Prince **Janusz Ostrozky**
+  as the figure who appropriated the granted lands; later narrative layers
+  also bring in **Oleksandr Vyshnevetsky** as the intermediary/opponent around
+  the estate and Cherkasy conflict. Teach this as a property-and-office
+  grievance inside the magnate frontier, not as a single-cause explanation.
+  [T1: ЕІУ; T1: ЕІУ uprising; T4: Lepiavko/Yarmoshyk]
+- **1591-1593 uprising:** led the first major armed Cossack uprising against
+  Commonwealth state authority and magnate power. In late **1591** he seized
+  property documents in **Біла Церква**; the movement took much of Kyiv region
+  and part of Podilia / Bratslavshchyna, demanded oaths to Kosynsky as Cossack
+  hetman, and challenged local jurisdiction. [T1: ЕІУ; T1: ЕІУ uprising; T4:
+  Shcherbak]
+- **Piatka defeat:** in February **1593**, forces assembled by the Ostrozky
+  orbit defeated the Cossack army at **П'ятка**. The capitulation terms
+  focused on ending attacks on Ostrozky and allied estates, returning weapons /
+  goods / people, and removing Kosynsky from the hetmancy. [T1: ЕІУ uprising;
+  T2/T4: Yarmoshyk document appendix]
+- **Death:** killed in **May 1593** at or near **Черкаси**, during the renewed
+  campaign against Oleksandr Vyshnevetsky. ЕІУ states he was killed by servants
+  of the local starosta; IEU states he was killed during the siege of Cherkasy.
+  Keep the manner source-cautious. [T1: ЕІУ; T1: IEU]
+- **Aftermath:** his death did not immediately end Cossack pressure. ЕІУ notes
+  that in August 1593 Cossacks forced Vyshnevetsky to recognize traditional
+  Cossack rights, and in October they pressured the Kyiv authorities in a
+  similar direction. [T1: ЕІУ uprising]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Birth date:** 1545 is common online but not secure enough for core
+   classroom fact. Use unknown / mid-sixteenth century.
+2. **Name form:** `Krzysztof Kosiński` is the Polish-source form; `Kryshtof
+   Kosynsky` is the project English form; `Криштоф Косинський` is the Ukrainian
+   canonical form.
+3. **Status:** noble origin and Cossack command are both true in the source
+   layer. Do not erase either side.
+4. **Rokytne grievance:** the personal estate conflict matters, but ЕІУ
+   uprising context shows broader Cossack-rights and magnate-landholding
+   pressure.
+5. **Bila Tserkva / oath-taking:** the source layer supports document seizure
+   and compelled oath-taking, but exact local chronology and who swore where
+   should be checked before lesson maps.
+6. **Piatka date:** sources render the battle/capitulation dates through
+   different calendar and edition traditions. Use "February 1593" unless the
+   lesson teaches date conversion.
+7. **Death circumstances:** "killed at Cherkasy in May 1593" is firmer than
+   exact battle/ambush mechanics.
+8. **Political meaning:** Shcherbak and Hrushevsky-style readings allow an
+   autonomy/pre-statehood interpretation, but the evidence is indirect and
+   should not be retrofitted into modern nationalism.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Kosynsky's career sits at the moment when Cossack military
+service on the steppe frontier no longer fit cleanly inside Commonwealth
+office, pay, and land systems. Cossacks were useful against Ottoman and Crimean
+threats but were not reliably paid, incorporated, or protected from local
+magnate power. Kosynsky's Rokytne grievance supplied the personal spark, while
+unpaid service, restricted Cossack rights, and the expansion of magnate
+landholding supplied the wider constituency. [T1: ЕІУ; T1: ЕІУ uprising; T4:
+Shcherbak]
+
+**By whom:** the Commonwealth state in the legal/commissioning layer; the
+Ostrozky and Vyshnevetsky magnate orbit in the land, office, and local coercion
+layer; Cossack rank-and-file and frontier communities in the constituency
+layer; Kosynsky himself in the grievance-to-uprising leadership layer. No side
+should be made invisible.
+
+**Document references:** the 1590 Cossack mobilization / service framework;
+Rokytne grant and transfer/conflict leads; the late-1591 seizure of property
+documents in Bila Tserkva; the 1592 royal commission / negotiation failure;
+the January 1593 mobilization against the Cossacks; the Piatka capitulation
+letter; the 1593 sejm and local-authority response; and Kosynsky's 1592 letter
+to Sigismund III Vasa, preserved as a facsimile lead and discussed in autonomy
+scholarship. [T1: ЕІУ; T1: ЕІУ uprising; T2/T4: Yarmoshyk; T4: Shcherbak; T5:
+Commons facsimile]
+
+**Mechanism specifics:** the uprising became politically alarming because it
+was not just an estate raid. ЕІУ records that people in Bila Tserkva,
+Pereiaslav, Bohuslav, Korsun, and probably Cherkasy and Kaniv swore to
+Kosynsky as Cossack hetman; Shcherbak reads this as Cossack jurisdiction
+spreading from the Sich onto settled territories. That is the hinge for BIO:
+private injury became a claim over who could command, judge, tax, and protect
+people in the frontier zone.
+
+**What survived / what was distorted:** what survived is the memory of the
+first large Cossack rising and the first visible transfer of Sich-style
+self-rule onto the volost. What gets distorted is the person. Commonwealth and
+some later Polish frames can reduce him to a rebel or bandit; Soviet shorthand
+can flatten him into class struggle; nationalist shorthand can make him a
+fully formed modern liberation figure. The useful decolonized reading is more
+specific: Kosynsky shows the transition from military frontier service to
+Cossack political action under magnate-state pressure.
+
+## 3. Major works / legacy
+
+Kosynsky left no literary corpus; "works" here means offices, letters,
+campaigns, jurisdictional claims, and memory.
+
+- `unknown-mid-1500s` — born probably into a Podlachian noble milieu; exact
+  date and place remain unsettled. [T1: ЕІУ; T1: IEU]
+- `1586` — first secure mention as Cossack starshyna / officer on Zaporizhia.
+  [T1: ЕІУ]
+- `spring 1590` — organized Cossacks for Podilia defense under Commonwealth
+  commission and received the Rokytne estate reward. [T1: ЕІУ]
+- `1590-1591` — estate conflict with the Ostrozky / Vyshnevetsky magnate orbit
+  turned personal grievance into a mobilizing grievance among Cossacks whose
+  promised pay and status were also insecure. [T1: ЕІУ; T1: ЕІУ uprising; T4:
+  Shcherbak]
+- `late 1591` — seized property documents in Bila Tserkva and opened the armed
+  phase of the uprising. [T1: ЕІУ]
+- `1591-1592` — Cossack forces under Kosynsky took or dominated much of Kyiv
+  region and parts of Podilia / Bratslavshchyna, attacked magnate estates, and
+  compelled oaths to Cossack authority in several towns. [T1: ЕІУ uprising]
+- `March 1592` — royal commission / negotiation attempt failed; rebels
+  retreated from Bila Tserkva to Trypillia and continued the conflict. [T1:
+  ЕІУ uprising; T2/T4: Yarmoshyk]
+- `autumn 1592` — Kosynsky's letter to Sigismund III Vasa is treated by
+  Shcherbak as evidence of a claim that the Zaporozhian Host should not be
+  subordinated to frontier starostas and voivodes. Verify the exact document
+  wording before classroom quotation. [T4: Shcherbak; T5: Commons facsimile
+  lead]
+- `2 February 1593` — battle at Piatka; Cossack defeat by the Ostrozky-led
+  force. [T1: ЕІУ uprising; T2/T4: Yarmoshyk]
+- `February 1593` — capitulation letter: Kosynsky and Cossack officers
+  accepted conditions including his removal from hetmancy and non-attack
+  obligations toward the princes and their allies. [T2/T4: Yarmoshyk document
+  appendix]
+- `spring-May 1593` — renewed campaign after retreat to Zaporizhia; Kosynsky
+  moved toward Cherkasy and was killed there in May. [T1: ЕІУ; T1: IEU]
+- `after May 1593` — the movement persisted: Cossacks extracted recognition of
+  traditional rights from Vyshnevetsky and Kyiv authorities later in 1593.
+  [T1: ЕІУ uprising]
+- `1594-1596 memory corridor` — Severyn Nalyvaiko's later uprising belongs to
+  the same late-sixteenth-century Cossack-war sequence, but do not conflate the
+  two leaders, causes, or endings. [T1: ЕІУ; Existing dossier:
+  `docs/research/bio/severyn-nalyvaiko.md`]
+
+## 4. Primary-source quotes (>=2 required)
+
+> **Honest tool note:** no project `verify_quote` run was available for
+> Kosynsky's documents in this pass, and the strongest document layer is not an
+> easy modern corpus. The excerpts below are short source-language anchors from
+> the Piatka capitulation letter as translated in Yarmoshyk's appendix from
+> `Listy Stanislawa Zolkiewskiego`; the same document is noted there as also
+> published in АЮЗР. Recheck the original edition before classroom quotation.
+
+**Excerpt 1 — self-presentation as hetman and Host:**
+
+> "Я, Криштоф Косинський, на цей час гетьман..."
+
+Context: even in a defeated capitulation text, the opening formula identifies
+Kosynsky through the office of hetman and a collective Cossack signatory body.
+Use this to teach political language cautiously, not as proof of stable state
+authority. [T2/T4: Yarmoshyk appendix]
+
+**Excerpt 2 — capitulation condition on hetmancy:**
+
+> "пана Косинського за гетьмана мати не будемо"
+
+Context: the condition is negative evidence of his recognized command: the
+Ostrozky settlement required the Cossack side to stop treating him as hetman.
+This is useful precisely because it comes from a defeat settlement, not a later
+heroic story. [T2/T4: Yarmoshyk appendix]
+
+**Document anchor 3 — 1592 letter to Sigismund III Vasa:**
+
+Commons preserves facsimile images described as Kosynsky's letter to Sigismund
+III Vasa, dated 15 September 1592 and sourced from the Swedish National
+Archives. Shcherbak states that in autumn 1592 Kosynsky's letter argued for
+non-subordination of the Zaporozhian Host to frontier starostas and voivodes.
+This is a high-value source lead, but the facsimile text was not transcribed in
+this pass. [T4: Shcherbak; T5: Wikimedia Commons / Riksarkivet lead]
+
+## 5. Language register and learner-use notes
+
+- **Register:** Cossack chancery and Commonwealth legal-administrative
+  vocabulary: hetman, Host, sotnyks, otamans, service, oath, estate, starosta,
+  voivode, jurisdiction, capitulation conditions, and rights/privileges.
+- **CEFR readiness for full reading:** B1-B2 for adapted biography; B2-C1 for
+  uprising narrative; C1-C2 for original documents / translated appendix work
+  because of archaic legal language and multilingual Polish-Ruthenian context.
+- **Lexicon notes:** `повстання`, `шляхтич`, `старшина`, `гетьман`,
+  `реєстрові козаки`, `низові козаки`, `маєток`, `староста`, `воєвода`,
+  `присяга`, `послушенство`, `юрисдикція`, `посполите рушення`,
+  `капітуляція`, `вольності`.
+- **Learner-use notes:** this dossier works well for teaching how one event
+  can be explained at three scales: personal grievance, Cossack corporate
+  rights, and frontier political order. Learners should practice concessive
+  framing: "although the land grievance was real, the uprising cannot be
+  reduced to one lawsuit."
+- **Stylistic features:** source language repeatedly uses legitimacy labels
+  (`послушенство`, `присяга`, `сваволя`, `рицарство`). Teach who is applying
+  each label and why.
+- **Sensitive framing:** avoid a two-option prompt such as "criminal or
+  patriot." A better prompt: "When does a military service community begin
+  acting like a political body?"
+
+## 6. Contested points
+
+- **Bandit, claimant, or political leader?** The answer is not singular.
+  Kosynsky led destructive raids and seized documents; he also represented a
+  service-Cossack constituency whose promised status and pay were unstable.
+  Teach both layers.
+- **Personal grievance versus Cossack politics.** The Rokytne/Ostrozky dispute
+  is a real trigger. ЕІУ uprising and Shcherbak show that wider Cossack rights,
+  oath-taking, and jurisdictional claims made the conflict politically larger.
+- **Noble status.** His Podlachian noble origin should not be erased to create
+  a pure social-revolt figure. It also should not be used to deny his Cossack
+  command and frontier constituency.
+- **"First uprising" language.** IEU calls it the first large-scale uprising of
+  Ukrainian peasantry and Cossacks; ЕІУ calls the uprising the first armed
+  Cossack revolt against Commonwealth state authority. Use the precise source
+  frame needed for the lesson.
+- **Piatka casualty and detail inflation.** Letters and later narrative sources
+  disagree or exaggerate losses. Use Piatka as defeat and capitulation; avoid
+  precise casualty teaching unless a source edition is assigned.
+- **Death at Cherkasy.** Death in May 1593 is secure enough; exact ambush /
+  siege mechanics and responsibility should be source-caveated.
+- **Nalyvaiko adjacency.** Severyn Nalyvaiko belongs to the next phase of the
+  late-sixteenth-century Cossack-war sequence. Compare the two only to show
+  escalation and memory patterns, not to merge them.
+- **Muscovy / Crimean support rumors.** Hrushevsky and Shcherbak note reports
+  or accusations that Kosynsky considered external support. Treat these as
+  charged contemporary claims unless the exact letter/document is being read.
+- **Later autonomy interpretation.** Shcherbak and some Ukrainian scholarship
+  reasonably read the uprising as an early autonomy signal, but that is not
+  the same as a modern nationalist platform. Keep the chronological distance
+  visible.
+
+## 7. Cross-track links
+
+> Every curriculum plan path under **Existing** below was verified locally on
+> 2026-07-04. `docs/research/bio/*` and `wiki/figures/*` entries are verified
+> dossier/wiki files, not existing BIO plan paths in this tree. Forward-looking
+> ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/severyn-nalyvaiko.yaml` — adjacent
+    late-sixteenth-century Cossack uprising memory; compare without conflation.
+  - `curriculum/l2-uk-en/plans/bio/kostiantyn-vasyl-ostrozky.yaml` — magnate
+    power, Kyiv/Volhynian office, and Ostroh context around the Kosynsky
+    conflict.
+  - `curriculum/l2-uk-en/plans/bio/dmytro-vyshnevetsky.yaml` — earlier Cossack
+    origin figure for frontier/Sich vocabulary.
+  - `curriculum/l2-uk-en/plans/bio/petro-sahaidachny.yaml` — next-generation
+    Cossack institutionalization after the 1590s uprising cycle.
+- **Existing BIO dossiers and wiki surfaces (VERIFIED present; not curriculum
+  plan paths):**
+  - `docs/research/bio/severyn-nalyvaiko.md` — late-sixteenth-century
+    Cossack-war comparison and fact-vs-memory guard.
+  - `docs/research/bio/kostiantyn-vasyl-ostrozky.md` — magnate/Ostroh context
+    and caution about making the Ostrozky orbit one-dimensional.
+  - `wiki/figures/severyn-nalyvaiko.md`,
+    `wiki/figures/severyn-nalyvaiko.sources.yaml` — existing wiki surface for
+    the adjacent figure.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/kozatski-povstannia-16.yaml` — direct
+    late-sixteenth-century Cossack uprising module.
+  - `curriculum/l2-uk-en/plans/hist/syntez-kozatstvo-vytoky.yaml` — synthesis
+    arc from frontier service to political action.
+  - `curriculum/l2-uk-en/plans/hist/kozatstvo-vytoky.yaml` — Cossack origins,
+    service, frontier, and social vocabulary.
+  - `curriculum/l2-uk-en/plans/hist/zaporizka-sich.yaml` — Sich institution
+    and nizovyi Cossack background.
+  - `curriculum/l2-uk-en/plans/hist/kozatske-viisko.yaml` — Host, officer,
+    register, and military-political terminology.
+  - `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml` — Commonwealth
+    political order and estate society.
+  - `curriculum/l2-uk-en/plans/hist/liudy-ricchi-pospolytoi.yaml` — social
+    estates, noble status, townspeople, peasants, and frontier society.
+- **Existing LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/baroque-poetry-velychkovsky.yaml` — later
+    Cossack-Baroque memory and source-literacy frame.
+  - `curriculum/l2-uk-en/plans/lit/haidamaky.yaml` — later literary
+    rebellion-memory comparison; use only as a memory-history parallel.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `kryshtof-kosynsky` — future BIO plan/module if this dossier is promoted
+    into curriculum.
+  - `bila-tserkva-1591` — source lesson on property documents, oaths, and
+    Cossack jurisdiction.
+  - `piatka-1593` — battle/capitulation/source-comparison lesson.
+  - `rokytne-estate-grievance` — microhistory of service reward, land grant,
+    and magnate power.
+  - `kosynsky-letter-1592` — paleography / source-language lesson using the
+    facsimile and autonomy scholarship.
+- **Potential LIT / memory additions surfaced by this research:**
+  - A source-literacy unit contrasting official labels of `svaivolia`, Cossack
+    self-description as `rytsarstvo`, and later national/autonomy readings.
+
+## 8. Naming-canonical
+
+- **Slug:** `kryshtof-kosynsky`
+- **EN canonical (project spelling):** Kryshtof Kosynsky
+- **UA canonical:** Криштоф Косинський
+- **Aliases (track these for `aliases:` YAML field):** Криштоф Косинський;
+  Кшиштоф Косинський; Христофор Косинський; Krzysztof Kosiński; Kryštof
+  Kosynskyj; Kryshtof Kosynskyi; Kosynsky, Kryshtof.
+- **Source/title variants to track carefully:** `гетьман низових козаків`;
+  `гетьман Війська Запорозького`; `козацький гетьман`; `козацький старшина`;
+  `реєстрові козаки`; `П'ятка`; `Рокитне`; `Біла Церква`; `Черкаси`.
+- **Forbidden forms (imperial / flattening forms to flag in body text):**
+  Russian-only name forms as normalized Ukrainian/English body text; "bandit"
+  as factual label; "pure class-war leader" as full explanation; "modern
+  nationalist founder" as full explanation; any claim that the Piatka
+  capitulation ended Cossack political pressure.
+- **Term warning:** `сваволя` is accusation language used by authorities and
+  elites; teach it as a source term, not as the narrator's neutral label.
+- **Scope warning:** keep this BIO dossier on the sixteenth-century Cossack
+  frontier, registered/service politics, magnate conflict, uprising, and memory
+  afterlife. Do not turn it into unrelated modern-statehood material or an
+  all-rulers chronology.
+
+## 9. Image candidates
+
+- **Best document image candidate:** Wikimedia Commons category
+  `Krzysztof Kosiński (1545-1593)` includes facsimile files named
+  `Kryshtof Kosynsky letter 01.jpg` through `letter 04.jpg`, described as
+  Kosynsky's 15 September 1592 letter to Sigismund III Vasa from the Swedish
+  National Archives. Verify the individual file page, source chain, and
+  classroom legibility before use. [T5: Commons / Riksarkivet lead]
+- **Signature candidate:** Commons includes `Kosynsky signature.jpg`; useful for
+  a paleography/source-authenticity activity after license and provenance
+  checking. [T5: Commons]
+- **Portrait / art candidate:** Commons includes a modern SVG portrait-style
+  reconstruction. Use only if the file license is acceptable and caption it as
+  later reconstruction or visual memory, not a life portrait. [T5: Commons]
+- **Context image candidates:** a rights-clear image of Bila Tserkva, Rokytne,
+  Piatka/Chudniv area, Cherkasy, or a map of the 1591-1593 uprising may be more
+  pedagogically honest than a portrait.
+- **Commemoration candidates:** Commons has a subcategory for the monument to
+  the Kosynsky uprising in Bila Tserkva; use as modern memory if license and
+  metadata pass review. [T5: Commons]
+- **Authenticity caveat:** no contemporary life portrait was verified in this
+  pass. Do not caption later art as an authentic likeness.
+- **Avoid:** generic Cossack stock art, heroic battle scenes without source
+  relation, or images that visually reduce the dossier to simple banditry or
+  simple modern nationalism.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- [T1] Леп'явко С.А. "Косинський Криштоф" // *Енциклопедія історії України*,
+  т. 5. URL: https://www.history.org.ua/?termin=Kosinskii_K | resolved HTTP
+  200, accessed 2026-07-04. Core facts: unknown birth year / May 1593 death;
+  Podlachian noble origin; 1586 Cossack starshyna; 1590 Podilia-defense
+  organizing; Rokytne estate reward; Ostrozky appropriation; Bila Tserkva
+  document seizure; uprising geography; February 1593 defeat; May 1593 death
+  at Cherkasy.
+- [T1] Леп'явко С.А. "Косинського повстання 1591-1593" // *Енциклопедія
+  історії України*, т. 5. URL:
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Kosinskogo_Povstannya&Z21ID=
+  | resolved HTTP 200, accessed 2026-07-04. Used for causes, Cossack-rights
+  restrictions, magnate landholding, oath-taking, negotiation failure, Piatka
+  defeat/capitulation, Cherkasy death, and posthumous 1593 Cossack pressure.
+- [T1] "Kosynsky, Kryshtof" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CO%5CKosynskyKryshtof.htm
+  | resolved HTTP 200, accessed 2026-07-04. Used for English name form,
+  ?-1593 date caution, Ukrainian nobleman from Podlachia, hetman of
+  Zaporozhian / registered Cossacks, first large-scale uprising summary, and
+  Cherkasy death.
+
+**Tier 2 (institutional / source-access context):**
+
+- [T2] Ярмошик І. "Чуднівщина у козацько-селянській війні 1591-1593 рр."
+  PDF hosted by Zhytomyr Ivan Franko State University repository. URL:
+  https://eprints.zu.edu.ua/21968/1/%D0%86%D0%B2%D0%B0%D0%BD_%D0%AF%D1%80%D0%BC%D0%BE%D1%88%D0%B8%D0%BA_%D0%A7%D1%83%D0%B4%D0%BD%D1%96%D0%B2_-16.PDF
+  | accessed 2026-07-04. Used for Piatka interpretation, post-defeat
+  persistence, bibliography, and translated document appendix including
+  letters and the Kosynsky capitulation text; exact classroom quotations need
+  original-edition recheck.
+- [T2/T5 image metadata] Wikimedia Commons,
+  `Category:Krzysztof Kosiński (1545-1593)`. URL:
+  https://commons.wikimedia.org/wiki/Category:Krzysztof_Kosi%C5%84ski_(1545-1593)
+  | accessed 2026-07-04. Used for image and document-facsimile leads only.
+- [T2/T5 image metadata] Wikimedia Commons,
+  `File:Kryshtof Kosynsky letter 03.jpg`. URL:
+  https://commons.wikimedia.org/wiki/File:Kryshtof_Kosynsky_letter_03.jpg |
+  accessed 2026-07-04. Used for 15 September 1592 letter-facsimile lead,
+  Swedish National Archives source note, and public-domain rights note.
+
+**Tier 3 (encyclopedic — navigation only):**
+
+- [T3] "Криштоф Косинський" // Ukrainian Wikipedia. URL:
+  https://uk.wikipedia.org/wiki/Криштоф_Косинський | accessed 2026-07-04. Used
+  only for alias/date/image navigation; cross-checked against T1.
+- [T3] "Krzysztof Kosiński" // English Wikipedia. URL:
+  https://en.wikipedia.org/wiki/Krzysztof_Kosi%C5%84ski | accessed
+  2026-07-04. Used only for English alias/image navigation; not load-bearing.
+- [T3] "Powstanie Kosińskiego" // Polish Wikipedia and "Kosiński uprising" //
+  English Wikipedia. Accessed 2026-07-04. Used for bibliography/navigation
+  leads only; not load-bearing against T1.
+
+**Tier 4 (modern scholarly post-1991 / academic anchors):**
+
+- [T4] Щербак В.О. "Становлення ідеї козацької автономії в Речі Посполитій."
+  *Наукові записки НаУКМА. Історичні науки*, 2009, т. 91, pp. 5-9. URL:
+  https://ekmair.ukma.edu.ua/server/api/core/bitstreams/a77e1a51-5439-45a9-bf24-9dd517e7e358/content
+  | accessed 2026-07-04. Used for Cossack autonomy framing, oath/jurisdiction
+  interpretation, official-letter caution, and Kosynsky's 1592 letter as a
+  source lead.
+- [T4] Грушевський М. *Історія України-Руси*, т. 7; and online popular
+  synthesis "Нарис історії українського народу. XV. Козацтво й козацькі війни
+  до 1648 р." URL:
+  https://www.m-hrushevsky.name/uk/History/Popular/OutlineHistUkr/15.html |
+  accessed 2026-07-04. Used for cautious interpretation of grievance,
+  possible external-support rumors, Piatka defeat, Cherkasy death, and the
+  "interesting but unproven" political-plan question.
+- [T4] Леп'явко С. *Козацькі війни кінця XVI ст. в Україні*. Чернігів, 1996;
+  and "Криштоф Косинський," in *Історія України в особах:
+  Литовсько-польська доба*. Київ, 1997. Bibliographic anchors via ЕІУ; direct
+  book text not fully inspected in this pass.
+- [T4] Яковенко Н. "Що за війну описує Шимон Пекалід у поемі De bello
+  Ostrogiano?" in *Паралельний світ*. Київ: Критика, 2002. Bibliographic
+  anchor via Yarmoshyk bibliography; direct text not fully inspected.
+- [T4] Руда О. "Козацьке повстання під проводом Криштофа Косинського в
+  інтерпретації польських істориків кінця XIX - першої третини XX століття."
+  *Чорноморський літопис*, 2010, no. 2, pp. 132-139. Bibliographic anchor via
+  Yarmoshyk; useful for Polish historiography framing follow-up.
+- [T4] Serczyk W.A. *Na dalekiej Ukrainie: dzieje Kozaczyzny do 1648 roku*.
+  Krakow: Wydawnictwo Literackie, 1984. Bibliographic and quote-navigation
+  anchor via Wikicytaty / Wikipedia; direct pages not inspected in this pass.
+
+**Tier 5 (general web / image metadata — not load-bearing):**
+
+- [T5] "Krzysztof Kosiński" // Wikicytaty. URL:
+  https://pl.wikiquote.org/wiki/Krzysztof_Kosi%C5%84ski | accessed
+  2026-07-04. Used only as a navigation pointer to the Piatka capitulation
+  excerpt and Serczyk citation; not load-bearing.
+- [T5/popular web] Газета *День* / Ukraine Incognita, Kresy24, textbook /
+  popular-history pages, and school resources surfaced in search. Used only as
+  memory, bibliography, and public-facing framing leads; not load-bearing
+  against T1/T4.
+
+**Primary-source documents accessed / verification notes:**
+
+- Piatka capitulation letter, February 1593: short translated anchors accessed
+  through Yarmoshyk's appendix; Yarmoshyk cites `Listy Stanislawa
+  Zolkiewskiego 1584-1620` and notes АЮЗР publication. Original Polish /
+  Ruthenian edition not directly checked.
+- Kosynsky letter to Sigismund III Vasa, 15 September 1592: facsimile lead
+  verified through Commons metadata as sourced from the Swedish National
+  Archives; text not transcribed or translated in this pass.
+- Royal / official letters around March 1592 and January 1593: accessed as
+  translated appendix/source leads through Yarmoshyk; originals not directly
+  checked.
+- Post-Cherkasy / 1593 local noble letters: referenced through ЕІУ,
+  Hrushevsky, and Yarmoshyk; originals not directly checked.
+
+**Honest gaps:** this dossier did not inspect the full АЮЗР volume, full
+`Listy Stanislawa Zolkiewskiego`, Swedish archival scans beyond Commons
+metadata, the full Lepiavko monograph, Yakovenko's Piekalid study, Ruda's
+Polish-historiography article, or complete image provenance. For module
+writing, recheck exact wording of the 1592 Kosynsky letter, Piatka
+capitulation, casualty reports, Rokytne grant chain, Bila Tserkva document
+seizure, oath-taking geography, and Cherkasy death records against source
+editions.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Cossack service, Podlachian noble origin,
+  Commonwealth offices, Ukrainian frontier society, and magnate power are all
+  named in their own period terms.
+- [x] Kosynsky is not flattened into a bandit, pure class-war emblem, modern
+  nationalist prototype, or spotless autonomy founder.
+- [x] Personal grievance, Cossack corporate rights, unpaid/uncertain service,
+  and local magnate-state pressure are all visible.
+- [x] Ostrozky / Vyshnevetsky power is treated as local magnate power, not as
+  an ethnic morality play.
+- [x] Source labels such as `svaivolia`, `rebel`, `traitor`, and `rytsarstvo`
+  are treated as contested source vocabulary.
+- [x] Later autonomy interpretation is allowed but source-caveated; no modern
+  political category is back-projected as his program.
+- [x] Nalyvaiko adjacency is framed as a later/adjacent uprising memory, not
+  conflation.
+- [x] No Russian-imperial transliterations in body text except variant /
+  forbidden forms and source-title contexts.
+- [x] No unrelated modern-statehood material or all-rulers chronology added.
+- [x] Modern Ukrainian place/institution naming used with historical context:
+  Підляшшя, Запорожжя, Поділля, Київщина, Брацлавщина, Волинь, Рокитне, Біла
+  Церква, Трипілля, Переяслав, Богуслав, Корсунь, Канів, Черкаси, П'ятка,
+  Річ Посполита, Військо Запорозьке.
+
+## Validation checklist
+
+- [x] Single owned file only: `docs/research/bio/kryshtof-kosynsky.md`.
+- [x] Existing cross-track plan paths verified locally before citation.
+- [x] Lower-tier sources marked non-load-bearing.
+- [x] Guard terms for unrelated modern-statehood and all-rulers scope avoided.
+- [x] No generated `status/`, `audit/`, `review`, or telemetry artifacts
+  referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans,
+  module files, activities, vocabulary, resources, site MDX, or wiki files
+  edited.


### PR DESCRIPTION
## Scope

Adds the BIO Cossack P1 research dossier for Kryshtof Kosynsky only.

## Changed files

- `docs/research/bio/kryshtof-kosynsky.md`

## Validation

- `npx markdownlint-cli2 docs/research/bio/kryshtof-kosynsky.md` — passed, 0 errors
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/kryshtof-kosynsky.md` — passed, no fabricated Existing cross-track plan paths
- `git diff --check` / `git diff --cached --check` — passed
- Guard search for out-of-scope Skoropadskyi / 1918 / Polish-kings terms — passed, no matches
- Source URL spot-checks for cited Tier 1/Tier 2/Tier 4 web sources — HTTP 200
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- Pre-push hooks — passed

## Source and decolonization caveats

- Core facts are anchored in ЕІУ and the Internet Encyclopedia of Ukraine; lower-tier sources are marked as navigation or image-rights aids only.
- The dossier treats Kosynsky as complex: Podlachian noble, Cossack officer, service claimant, estate-grievance actor, uprising leader, and early Cossack political-action signal.
- It avoids flattening him into a bandit, class-war symbol, or modern nationalist prototype.
- It keeps Nalyvaiko as an adjacent later uprising-memory comparison, not a conflation.

## Review gate

No independent non-Codex review has been routed yet; the orchestrator handles that gate.