### PR TITLE
[codex] docs(bio): add Taras Fedorovych Triasylo dossier

### DIFF
--- a/docs/research/bio/taras-fedorovych-triasylo.md
+++ b/docs/research/bio/taras-fedorovych-triasylo.md
@@ -139,8 +139,8 @@ coercion; Pereiaslav 1630; revolt memory and later literary afterlife)
 **What happened:** Fedorovych's 1630 uprising grew out of pressure on the
 Cossack register and on the Dnipro frontier after the Kurukove settlement. The
 Commonwealth needed Cossack military service but restricted recognized status,
-privileges, and pay. After the Livonian war, unpaid crown troops were quartered
-in Kyiv voivodeship and the Trans-Dnipro area, where Cossacks and
+privileges, and pay. After the Polish-Swedish War of 1626-1629, unpaid crown
+troops were quartered in Kyiv voivodeship and the Trans-Dnipro area, where Cossacks and
 not-yet-enserfed peasants were numerous. EIU and Shcherbak both connect the
 uprising to this pressure, while Kovalets emphasizes the accumulation of
 multiple causes rather than one simple spark. [T1: ЕІУ uprising; T4: Shcherbak;

--- a/docs/research/bio/taras-fedorovych-triasylo.md
+++ b/docs/research/bio/taras-fedorovych-triasylo.md
@@ -1,0 +1,598 @@
+# Тарас Федорович / Трясило — Research Dossier
+
+**Slug:** `taras-fedorovych-triasylo`
+**Block:** P1 BIO Cossack coverage (early-seventeenth-century Cossack
+pressure; registered/unregistered conflict; Commonwealth negotiation and
+coercion; Pereiaslav 1630; revolt memory and later literary afterlife)
+**Tier:** 1b (strong event context; thin and contested personal record)
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ Fedorovych, ЕІУ Fedorovych
+  uprising, IEU Fedorovych, Shcherbak UHJ article, Kovalets 2014/2016)
+- [x] Source-tier checkboxes included and lower-tier sources kept
+  non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: register pressure,
+  winter quartering of unpaid crown troops, violence against Ruthenian/Cossack
+  communities, Orthodox-rights rhetoric, Pereiaslav bargaining, and later
+  memory simplification)
+- [x] §4 includes short document/source-language anchors with verification
+  caveats
+- [x] Fedorovych is framed as complex: elected unregistered-Cossack leader,
+  contested-origin figure, revolt commander, negotiation loser, later borderland
+  actor, and memory figure
+- [x] Cross-track links: every "Existing" plan path verified locally with
+  `test -e` on 2026-07-04
+- [x] Naming-canonical applied; `Triasylo` retained as alias/memory slug, not
+  treated as a secure early source surname
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+
+- [x] **T1 baseline:** ЕІУ and Internet Encyclopedia of Ukraine anchor the core
+  chronology, offices, unknown birth/death, unregistered-Cossack hetmancy,
+  1629 Crimea campaign, 1630 uprising, Pereiaslav settlement, later Don/Moscow
+  movement, and contested identity.
+- [x] **T1 event context:** ЕІУ Fedorovych uprising anchors causes, campaign
+  geography, Pereiaslav camp, negotiation pressure, 29 May / 8 June settlement,
+  refusal to surrender Fedorovych, and Orendarenko's election.
+- [x] **T2/T4 scholarship:** Shcherbak and Kovalets are used for source-critical
+  context, universal/memory quotation leads, newly published relation material,
+  origin/name caution, and myth-correction.
+- [x] **T3/T5 caution:** Wikipedia, Commons, popular pages, school-prep pages,
+  and image pages are navigation or image-rights aids only; they are not
+  load-bearing for interpretation.
+- [x] **Primary/source-language anchors:** short excerpts from the Lviv
+  Chronicle, a universal quoted by Shcherbak, and Shevchenko's memory poem are
+  marked as anchors; recheck source editions before classroom quotation.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Тарас Федорович. ЕІУ gives `ФЕДОРОВИЧ
+  Тарас`; IEU gives `Fedorovych, Taras [Fedorovyč]`. Use `Taras Fedorovych`
+  for English curriculum metadata and keep `Triasylo` as an alias/memory label.
+  [T1: ЕІУ; T1: IEU]
+- **Pseudonyms / aliases:** Тарас Федорович; Тарас Трясило; Taras Fedorovych;
+  Taras Triasylo / Tryasylo; Taras Kozak in some source traditions; possible
+  identity with Taras Chornyi is a research problem, not a resolved alias.
+  `Трясило` is familiar because of nineteenth-century memory and Shevchenko,
+  but ЕІУ and Kovalets both warn that it appears late, first in *Історія Русів*
+  according to the inspected source layer. [T1: ЕІУ; T4: Kovalets 2016]
+- **Born / died:** exact dates unknown. IEU explicitly gives unknown birth and
+  death dates; ЕІУ gives unknown birth and death years. Lower-tier pages often
+  supply 1639 or 1637, but do not use those as core facts without a specialist
+  source. [T1: ЕІУ; T1: IEU; T3/T5]
+- **Origin / status:** contested. ЕІУ says researchers suppose either a
+  baptized Tatar origin connected with the name "murza Hasan" or an Ovruch
+  szlachta origin. The ЕІУ uprising article instead describes the uprising
+  leader as from a Chyhyryn Cossack family and notes source names Taras Kozak /
+  Taras Triasylo. Teach origin as unresolved, not as a settled ethnicity story.
+  [T1: ЕІУ; T1: ЕІУ uprising; T4: Gajecky lead via ЕІУ]
+- **Office / constituency:** elected several times by unregistered Cossacks as
+  hetman or leader: ЕІУ lists 1629, 1630, 1632, and 1634. IEU identifies him as
+  hetman of the unregistered Cossacks from 1629. [T1: ЕІУ; T1: IEU]
+- **1629 Crimea campaign:** led or co-led, with Hryhorii Chornyi, an
+  unsuccessful campaign connected with a claimant to the Crimean khan's throne;
+  the Cossack force suffered heavy losses near Perekop. [T1: ЕІУ; T1: IEU]
+- **1630 uprising:** in March 1630 he led the opening phase of the
+  peasant-Cossack / unregistered-Cossack uprising against Commonwealth
+  authority and local military pressure. ЕІУ says about 10,000 unregistered
+  Cossacks moved from the Bazavluk Sich toward Cherkasy; IEU summarizes that
+  his forces defeated Commonwealth troops at Korsun and Pereiaslav. [T1: ЕІУ
+  uprising; T1: IEU]
+- **Pereiaslav campaign:** the Cossack camp was established near Pereiaslav,
+  where fighting lasted about three weeks in May 1630. Source traditions place
+  the camp near the Trubizh and Alta river area; the Lviv Chronicle preserves a
+  detailed, partisan account embedded in the chronicle. [T1: ЕІУ uprising; T2:
+  Lviv Chronicle edition; T4: Kovalets 2014]
+- **Agreement / leadership split:** as negotiations opened, part of the
+  Zaporizhians refused compromise and persuaded Fedorovych to withdraw toward
+  the Bazavluk Sich. Anton Konashevych-But handled negotiations; under the
+  Pereiaslav agreement of **29 May 1630 O.S. / 8 June 1630 N.S.**, the Cossack
+  side acknowledged guilt but refused to surrender Fedorovych. The Kurukove
+  framework remained, and Tymofii Orendarenko was elected hetman of the
+  registered Cossacks. [T1: ЕІУ uprising; T1: IEU]
+- **After 1630:** ЕІУ records that Fedorovych stayed on Zaporizhia, made a
+  sea campaign in 1631, appeared at the 1632 Korsun council as Chyhyryn
+  registered colonel, led a Cossack detachment in the 1632-1634
+  Polish-Muscovite war, was forced to give up the mace at Kaniv in January
+  1635, participated in Ivan Sulyma's 1635 uprising, and in 1636 moved with a
+  group of Cossacks to the Muscovite state. [T1: ЕІУ]
+- **Later activity is contested:** IEU says he led part of the Zaporozhian Host
+  beyond the Don in 1635 and offered service to the Muscovite tsar in 1636.
+  Kovalets argues the later evidence becomes confused and that Fedorovych did
+  not take part in Pavlo But's 1637 uprising because he was outside Ukraine.
+  ЕІУ says participation in the 1637-1638 uprising is possible. Present this as
+  a source disagreement. [T1: IEU; T1: ЕІУ; T4: Kovalets 2016]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Triasylo name:** `Трясило` is the memory name, not securely the earliest
+   documentary name. Keep the filename/slug because this is the expected
+   curriculum/search form, but explain the alias.
+2. **Origin:** baptized Tatar, Ovruch szlachta, and Chyhyryn Cossack-family
+   framings all appear in the source layer. Do not force a single identity.
+3. **Hetmancy:** he was a leader of unregistered/Zaporizhian Cossacks and was
+   elected in volatile councils. Do not present him as stable head of one
+   continuous state institution.
+4. **1630 leadership:** he led the uprising's opening phase. During the
+   Pereiaslav negotiations, authority shifted to compromise-minded officers;
+   teaching him as sole signer or sole winner is inaccurate.
+5. **Pereiaslav agreement date:** use **29 May O.S. / 8 June N.S.** if the
+   lesson needs both calendars.
+6. **Death date:** unknown. 1639 is a lower-tier / chronicle-memory date unless
+   directly sourced.
+7. **Post-1636 identity:** ЕІУ says most researchers identify him with Taras
+   Chornyi, but the identity is not strictly proven.
+8. **Thirty Years' War claim:** ЕІУ calls participation in that war doubtful;
+   do not use it as a lesson fact.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Fedorovych's 1630 uprising grew out of pressure on the
+Cossack register and on the Dnipro frontier after the Kurukove settlement. The
+Commonwealth needed Cossack military service but restricted recognized status,
+privileges, and pay. After the Livonian war, unpaid crown troops were quartered
+in Kyiv voivodeship and the Trans-Dnipro area, where Cossacks and
+not-yet-enserfed peasants were numerous. EIU and Shcherbak both connect the
+uprising to this pressure, while Kovalets emphasizes the accumulation of
+multiple causes rather than one simple spark. [T1: ЕІУ uprising; T4: Shcherbak;
+T4: Kovalets 2016]
+
+**By whom:** Commonwealth military and administrative power in the quartering,
+register, and negotiation layers; local commanders and soldiers in the
+violence/abuse layer; registered Cossack officers in the compromise and
+leadership-split layer; unregistered Zaporizhians and broader frontier society
+in the mobilization layer. Fedorovych himself had agency: he used universals,
+armed pressure, and camp strategy, and he also lost control of the settlement
+process.
+
+**Document references:** Kurukove agreement context; Fedorovych's universals;
+reports around troop quartering and violence; the Lviv Chronicle's embedded
+1630 account; Pereiaslav battle/camp reports; Koniecpolski's relation letters
+published by Kovalets; and the Pereiaslav agreement articles. [T1: ЕІУ
+uprising; T2: Lviv Chronicle edition; T4: Shcherbak; T4: Kovalets 2014]
+
+**Mechanism specifics:** the conflict was not only battlefield success. The
+political issue was whether Cossack status belonged only to a narrow register
+or could expand to those who claimed Cossack service and protection. Shcherbak
+quotes Fedorovych's universal language calling those who had been Cossacks, and
+those who wanted to be, to come and enjoy Cossack liberties and defend the
+Orthodox faith. That is why this dossier belongs in BIO: one leader's biography
+teaches corporate status, frontier coercion, confessional rhetoric, and
+negotiated limitation at once. [T4: Shcherbak]
+
+**What survived / what was distorted:** what survived is the memory of the
+successful pressure that forced negotiations at Pereiaslav and made the
+unregistered Cossack issue visible. What gets distorted is the person and the
+event. Commonwealth-source language can reduce the uprising to disorder;
+Soviet/popular shorthand can flatten it into class struggle; nationalist
+memory can make Fedorovych a pure liberation prototype; romantic memory turns
+`Трясило` into the whole biography. A useful decolonized reading keeps the
+specific early-modern problem: register, service, coercion, faith rhetoric,
+negotiation, and memory.
+
+## 3. Major works / legacy
+
+Fedorovych left no literary corpus; "works" here means offices, campaigns,
+universals, council choices, and memory.
+
+- `before 1629` — personal record is mostly obscure; origin and earlier name
+  traditions remain contested. [T1: ЕІУ; T4: Kovalets 2016]
+- `1629` — elected or recognized as leader/hetman of unregistered Cossacks;
+  conducted or co-conducted a Crimean campaign that ended badly near Perekop.
+  [T1: ЕІУ; T1: IEU]
+- `early 1630` — again trusted with the mace by Zaporizhian / unregistered
+  Cossacks according to the source-critical reconstruction. [T1: ЕІУ; T4:
+  Kovalets 2016]
+- `March 1630` — moved from Bazavluk Sich toward Cherkasy with a large
+  unregistered Cossack force and opened the uprising. [T1: ЕІУ uprising]
+- `spring 1630` — issued universals calling people to the insurgent force,
+  Cossack liberties, and Orthodox protection. Use exact wording only from a
+  checked edition. [T4: Shcherbak]
+- `spring 1630` — Hryhorii Chornyi, the registered-Cossack leader associated
+  with compromise and union oath accusations in the Lviv Chronicle tradition,
+  was seized and executed by Cossacks. Teach as source-charged internal Cossack
+  conflict, not simple justice. [T1: ЕІУ uprising; T2: Lviv Chronicle edition]
+- `May 1630` — Pereiaslav camp and three-week confrontation; successful Cossack
+  raids, including the later-famous "golden company" episode, put
+  Koniecpolski's force under severe pressure. [T1: ЕІУ uprising; T2: Lviv
+  Chronicle edition; T4: Shcherbak; T4: Kovalets 2014]
+- `29 May / 8 June 1630` — Pereiaslav agreement: the Cossack side did not hand
+  Fedorovych over, but the settlement did not grant his broader maximal
+  program. [T1: ЕІУ uprising; T1: IEU]
+- `after May 1630` — Fedorovych withdrew with uncompromising Zaporizhians and
+  was removed from practical leadership; Tymofii Orendarenko became registered
+  Cossack hetman. [T1: ЕІУ uprising; T1: IEU]
+- `1631` — sea campaign after the uprising. [T1: ЕІУ]
+- `1632` — took part in the Korsun council and appears as Chyhyryn registered
+  colonel. [T1: ЕІУ]
+- `1634-1636` — later borderland career: Cossack detachment in the
+  Polish-Muscovite war; Kaniv council conflict; Sulyma uprising adjacency; Don
+  / Muscovite-state movement and service offer. Exact steps need source-edition
+  recheck before a module narrative. [T1: ЕІУ; T1: IEU; T4: Kovalets 2016]
+- `1830s-1840s memory` — Taras Shevchenko's "Тарасова ніч" made the Triasylo
+  memory name powerful in Ukrainian literary culture. Teach the poem as memory
+  and mobilizing Romantic narration, not as a literal chronicle of 1630. [T4:
+  Shcherbak; T4: Kovalets 2016; Existing BIO dossier:
+  `docs/research/bio/taras-shevchenko.md`]
+- `1863 memory corridor` — Pavlo Chubynsky's poem "Ще не вмерла Україна" names
+  Taras Triasylo alongside other revolt figures in the longer original text.
+  This is memory afterlife, not evidence for the seventeenth-century biography.
+  [T4: Kovalets 2016 bibliography]
+- `1926 visual memory` — the VUFKU silent film *Тарас Трясило* is a later
+  memory artifact and useful only with Soviet-era film-framing caveats. [T3/T5
+  image/film navigation; Existing dossier:
+  `docs/research/bio/vasyl-krychevskyi.md`]
+
+## 4. Primary/source-language anchors (>=2 required)
+
+> **Honest tool note:** no project `verify_quote` run was available for
+> Fedorovych. The excerpts below are short source-language anchors from
+> published source traditions or public-domain literary memory. Recheck source
+> editions before classroom quotation.
+
+**Anchor 1 — universal language as quoted by Shcherbak:**
+
+> "вольностей козацьких заживали"
+
+Context: Shcherbak quotes Fedorovych's universal as calling those who had been
+Cossacks, and those who wanted to be, into the movement. Use the phrase to
+teach status and legal-rights vocabulary; do not treat it as a full verified
+transcription until the original source edition is checked. [T4: Shcherbak
+2014]
+
+**Anchor 2 — Lviv Chronicle opening frame:**
+
+> "ходил за Дніпр козаков зносити"
+
+Context: the Lviv Chronicle introduces Koniecpolski's 1630 expedition through
+highly partisan language. The anchor is useful for source criticism: who is
+speaking, what violence is named, and how the chronicle frames the campaign.
+[T2: Lviv Chronicle edition at Izbornyk]
+
+**Anchor 3 — Shevchenko's memory name:**
+
+> "Обізвавсь Тарас Трясило"
+
+Context: this is a literary-memory anchor from Shevchenko's "Тарасова ніч."
+Kovalets argues that the popularity of `Трясило` owes much to the poem and the
+earlier *Історія Русів* layer. Use it to teach afterlife, not archival naming.
+[T4: Kovalets 2016; public-domain Shevchenko text]
+
+## 5. Language register and learner-use notes
+
+- **Register:** Cossack chancery, chronicle, treaty, and Commonwealth
+  administrative vocabulary: hetman, register, unregistered Cossacks,
+  Zaporizhia, Sich, liberties, universals, faith rhetoric, quartering, camp,
+  negotiations, agreement, guilt, surrender, election, and mace.
+- **CEFR readiness for full reading:** B1-B2 for adapted biography; B2-C1 for
+  the uprising narrative; C1-C2 for Lviv Chronicle / relation letters because
+  of early-modern orthography, mixed Ruthenian/Polish vocabulary, and partisan
+  religious language.
+- **Lexicon notes:** `повстання`, `реєстрові козаки`, `нереєстрові козаки`,
+  `виписчики`, `вольності`, `універсал`, `гетьман`, `булава`, `рада`,
+  `присяга`, `табір`, `обоз`, `угода`, `коронне військо`, `жовніри`.
+- **Learner-use notes:** this dossier works well for a B2-C1 lesson on
+  conditional historical phrasing: "sources suggest," "is identified with,"
+  "was elected by," "was removed from practical leadership," "the agreement
+  preserved X but did not grant Y."
+- **Stylistic features:** pair legal-status vocabulary (`реєстр`,
+  `вольності`, `угода`) with source-label vocabulary (`зносити`, `вина`,
+  `зрада`, `віру рятувати`) so learners see how documents persuade.
+- **Sensitive framing:** avoid prompts like "hero or bandit." Better prompt:
+  "Which pressures made unregistered Cossack status a political problem, and
+  how did later memory change the leader's name and meaning?"
+
+## 6. Contested points
+
+- **Name and slug:** keep `taras-fedorovych-triasylo` because learners and
+  sources search both names. In prose, lead with `Taras Fedorovych` and explain
+  `Triasylo/Tryasylo` as an alias and memory name.
+- **Origin:** do not turn the Tatar-origin hypothesis into exotic color or the
+  Ovruch-szlachta hypothesis into proof of elite status. Both are source
+  problems, not settled biography.
+- **Taras Chornyi identity:** ЕІУ says most researchers identify Fedorovych
+  with Taras Chornyi, while also saying strict proof is lacking. Treat the
+  Chornyi material as an advanced research lead.
+- **Registered versus unregistered:** the uprising should not be described as
+  all Cossacks versus the Commonwealth. Registered officers, compromise
+  factions, and unregistered Zaporizhians had different interests.
+- **Chornyi execution:** Hryhorii Chornyi's execution belongs to internal
+  Cossack conflict and accusation language; it should not be simplified into a
+  clean morality scene.
+- **Pereiaslav outcome:** Fedorovych's side forced negotiations and avoided his
+  surrender, but the final settlement did not give the unregistered side the
+  broad victory implied by later heroic memory.
+- **"Tarasova nich" event:** the night raid / "golden company" episode is
+  source-attested in partisan and later narrative layers, but lessons should
+  distinguish chronicle report, military reconstruction, and Shevchenko's poem.
+- **Later Moscow/Don activity:** service offers and movement after 1635 are
+  real parts of the record; do not erase them to keep a tidy nationalist story.
+  Also do not turn them into a claim that he was simply a Muscovite client.
+- **Pavlo But adjacency:** ЕІУ leaves possible 1637-1638 participation open;
+  Kovalets rejects participation in But's uprising because Fedorovych was
+  outside Ukraine. State the disagreement.
+- **Soviet/class-war inheritance:** older titles and summaries may use
+  "anti-feudal" language. Use it as historiographic vocabulary, not as the
+  dossier's explanation.
+
+## 7. Cross-track links
+
+> Every curriculum plan path under **Existing** below was verified locally on
+> 2026-07-04. `docs/research/bio/*`, `docs/research/folk/*`, and `wiki/*`
+> entries are verified files, not existing BIO plan paths. Forward-looking ties
+> are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/dmytro-vyshnevetsky.yaml` — earlier
+    Cossack frontier/Sich baseline.
+  - `curriculum/l2-uk-en/plans/bio/petro-sahaidachny.yaml` — previous
+    generation's Cossack military-political leverage and post-Khotyn register
+    pressure.
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — later
+    large-scale Cossack revolution/state-formation comparison.
+  - `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml` — literary-memory
+    afterlife through "Тарасова ніч."
+  - `curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml`,
+    `curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml` — later comparison for
+    Cossack council legitimacy, external alignment, and memory.
+- **Existing BIO dossiers and wiki surfaces (VERIFIED present; not curriculum
+  plan paths):**
+  - `docs/research/bio/dmytro-vyshnevetsky.md`,
+    `docs/research/bio/petro-sahaidachny.md`,
+    `docs/research/bio/bohdan-khmelnytskyy.md`,
+    `docs/research/bio/taras-shevchenko.md` — verified related dossiers.
+  - `wiki/figures/dmytro-vyshnevetsky.md`,
+    `wiki/figures/petro-sahaidachny.md`,
+    `wiki/figures/bohdan-khmelnytskyy.md`,
+    `wiki/figures/taras-shevchenko.md` — existing figure surfaces for related
+    people.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/kozatski-povstannia-16.yaml` — prior
+    Cossack uprising arc; compare Kosynsky/Nalyvaiko without conflation.
+  - `curriculum/l2-uk-en/plans/hist/kozatstvo-vytoky.yaml`,
+    `curriculum/l2-uk-en/plans/hist/syntez-kozatstvo-vytoky.yaml` — origins
+    and synthesis background for Cossack status.
+  - `curriculum/l2-uk-en/plans/hist/zaporizka-sich.yaml`,
+    `curriculum/l2-uk-en/plans/hist/kozatske-viisko.yaml` — Sich, Host,
+    register, and military-political vocabulary.
+  - `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml` — Commonwealth
+    political order, offices, and estate society.
+  - `curriculum/l2-uk-en/plans/hist/khotynska-viyna.yaml` — post-Khotyn
+    service/reward background for later Cossack pressure.
+  - `curriculum/l2-uk-en/plans/hist/pereyaslavska-uhoda.yaml` — later
+    Pereiaslav treaty/source vocabulary comparison; do not conflate dates.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — later
+    institutional contrast for what 1630 did not yet create.
+- **Existing LIT/FOLK/RUTH plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/young-shevchenko.yaml`,
+    `curriculum/l2-uk-en/plans/lit/cult-of-shevchenko.yaml` — Shevchenko
+    memory frame around "Тарасова ніч."
+  - `curriculum/l2-uk-en/plans/lit/the-ballads.yaml`,
+    `curriculum/l2-uk-en/plans/lit/haidamaky.yaml`,
+    `curriculum/l2-uk-en/plans/lit-hist-fic/andrian-kashchenko-cossack-myth.yaml`
+    — rebellion, historical memory, and Cossack myth comparison.
+  - `curriculum/l2-uk-en/plans/folk/istorychni-pisni.yaml` — historical-song
+    memory vocabulary.
+  - `curriculum/l2-uk-en/plans/ruth/cossack-hierarchy.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/szlachta-nobility.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/document-types.yaml` — office, estate,
+    and document-language support.
+- **Existing research/wiki files (VERIFIED present; not curriculum plan paths):**
+  - `docs/research/folk/dumy-sotsialno-pobutovi.md` — existing research note
+    that mentions Shevchenko's "Тарасова ніч" memory corridor.
+  - `wiki/literature/works/young-shevchenko.md`,
+    `wiki/literature/works/cult-of-shevchenko.md` — existing Shevchenko memory
+    surfaces.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `taras-fedorovych-triasylo` — future BIO plan/module if this dossier is
+    promoted into curriculum; absent in this pass.
+  - `fedorovych-uprising-1630` — HIST source-critical module on the uprising,
+    register conflict, Pereiaslav camp, and settlement.
+  - `pereiaslav-1630` — separate treaty/camp lesson carefully distinguished
+    from later Pereiaslav events.
+  - `tarasova-nich-memory` — LIT/FOLK lesson contrasting chronicle, relation,
+    and Shevchenko memory.
+  - `register-and-vypyschyky` — RUTH/HIST vocabulary lesson on registered,
+    unregistered, and expelled-from-register Cossacks.
+  - `ivan-sulyma`, `pavlo-pavliuk-but`, `yakiv-ostrianyn` — future BIO
+    Cossack-continuation candidates; plan/wiki surfaces absent locally on
+    2026-07-04.
+
+## 8. Naming-canonical
+
+- **Slug:** `taras-fedorovych-triasylo`
+- **EN canonical (project spelling):** Taras Fedorovych / Triasylo
+- **UA canonical:** Тарас Федорович; alias Тарас Трясило
+- **Aliases (track these for `aliases:` YAML field):** Тарас Федорович;
+  Тарас Трясило; Taras Fedorovych; Taras Triasylo; Taras Tryasylo; Taras Kozak;
+  Taras Chornyi [possible identity, unresolved]; "murza Hasan" / Hassan Tarasa
+  [origin hypothesis, not canonical name].
+- **Source/title variants to track carefully:** `гетьман нереєстрових
+  козаків`; `гетьман Війська Запорозького`; `Тарас Козак`; `Тиміш
+  Орендаренко`; `Антон Конашевич-Бут`; `Григорій Чорний`; `Базавлуцька Січ`;
+  `Переяславська угода 1630`; `Куруківська угода 1625`; `виписчики`.
+- **Forbidden forms (imperial / flattening forms to flag in body text):**
+  Russian-only name forms as normalized Ukrainian/English body text; "bandit"
+  as factual label; "pure class-war leader" as full explanation; "modern
+  nationalist founder" as full explanation; "Muscovite agent" as fact; any
+  claim that `Triasylo` is securely his earliest documentary surname.
+- **Term warning:** `Трясило` is a powerful literary-memory name. It should be
+  searchable and visible, but classroom prose should explain why the documentary
+  record more securely supports `Тарас Федорович`.
+- **Scope warning:** keep this BIO dossier on early-seventeenth-century
+  Cossack pressure, register politics, Pereiaslav 1630, and memory afterlife.
+  Do not turn it into an all-rulers chronology or unrelated modern-statehood
+  material.
+
+## 9. Image candidates
+
+- **Best candidate, with caveat:** IEU displays an image titled "Taras
+  Fedorovych (Triasylo)" on the article page. Use only after checking the
+  image metadata and reuse rights; IEU article display alone is not a reuse
+  license. [T1/T5: IEU image lead]
+- **Commons candidate:** Wikimedia Commons has `File:Taras Triasylo.jpg`,
+  described as an unknown-author image sourced through Ukrainians-World. Treat
+  as a later portrait/reconstruction or memory image unless provenance proves
+  more. Verify license, source chain, and whether the file page's origin claims
+  reproduce contested ethnicity language. [T5: Commons]
+- **Context image candidates:** a rights-clear map of the 1630 uprising,
+  Pereiaslav/Trubizh/Alta geography, Bazavluk Sich context, or an image of the
+  Lviv Chronicle edition may be pedagogically stronger than a portrait.
+- **Memory image candidates:** poster/still material from the 1926 VUFKU film
+  *Тарас Трясило* can support a memory-history lesson if rights and Soviet-era
+  framing are checked.
+- **Authenticity caveat:** no contemporary life portrait was verified in this
+  pass. Do not caption later art as an authentic likeness.
+- **Avoid:** generic Cossack stock art, battle images without source relation,
+  or images that turn Fedorovych into a simple folk avenger, ethnic mascot, or
+  modern nationalist prototype.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- [T1] Вортман Д.Я. "Федорович Тарас" // *Енциклопедія історії України:
+  Додатковий том. Кн. 1*. URL:
+  https://www.history.org.ua/?termin=Fedorovych_Taras | accessed 2026-07-04.
+  Core facts: unknown dates; contested origin; late `Трясило` sobriquet;
+  elections by unregistered Cossacks; 1629 Crimea campaign; first phase of the
+  1630 uprising; removal in May 1630; 1631-1636 activity; Taras Chornyi identity
+  caution; doubtful Thirty Years' War participation.
+- [T1] Щербак В.О. "Федоровича повстання 1630" // *Енциклопедія історії
+  України*, т. 10. URL:
+  https://www.history.org.ua/?termin=Fedorovycha_povstannia | accessed
+  2026-07-04. Used for uprising causes, 10,000 unregistered Cossacks from
+  Bazavluk, Pereiaslav camp/fighting, negotiation pressure, leader split,
+  29 May 1630 agreement, refusal to surrender Fedorovych, Kurukove continuity,
+  and Orendarenko election.
+- [T1] "Fedorovych, Taras" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CF%5CE%5CFedorovychTaras.htm
+  | accessed 2026-07-04. Used for English name form, unknown dates, hetman of
+  unregistered Cossacks from 1629, Crimea campaign, Korsun/Pereiaslav victories,
+  8 June Pereiaslav Treaty, dismissal, later Don movement, and 1636 service
+  offer.
+
+**Tier 2 (institutional / source-edition):**
+
+- [T2] Бевзо О.А., ed. "Львівський літопис. Текст" // *Ізборник*. URL:
+  http://litopys.org.ua/ostrog/ostr01.htm | accessed via HTTP and converted
+  from Windows-1251 on 2026-07-04. Used for source-language anchors and the
+  chronicle's embedded 1630 narrative; HTTPS certificate mismatch noted.
+- [T2/T5 image lead] Wikimedia Commons, `File:Taras Triasylo.jpg`. URL:
+  https://commons.wikimedia.org/wiki/File:Taras_Triasylo.jpg | accessed
+  2026-07-04. Used for image-rights/provenance caution only.
+
+**Tier 3 (encyclopedic — navigation only):**
+
+- [T3] "Тарас Федорович" // Ukrainian Wikipedia. URL:
+  https://uk.wikipedia.org/wiki/Тарас_Федорович | accessed 2026-07-04. Used
+  only for alias/date/image navigation; cross-checked against T1/T4.
+- [T3] "Taras Fedorovych" // English Wikipedia. URL:
+  https://en.wikipedia.org/wiki/Taras_Fedorovych | accessed 2026-07-04. Used
+  only for English alias and memory-afterlife navigation; not load-bearing.
+- [T3] "Повстання Федоровича" // Ukrainian Wikipedia. URL:
+  https://uk.wikipedia.org/wiki/Повстання_Федоровича | accessed 2026-07-04.
+  Used only for navigation to EIU/Kovalets and image leads.
+
+**Tier 4 (modern scholarly post-1991 / academic anchors):**
+
+- [T4] Щербак В.О. "Образ козацької України у творах Т. Шевченка."
+  *Український історичний журнал*, 2014, no. 2, pp. 61-78. URL:
+  https://history.org.ua/JournALL/journal/2014/2/6.pdf | accessed 2026-07-04.
+  Used for post-Khotyn/register pressure, Fedorovych universal excerpt,
+  Pereiaslav camp description, and Shevchenko "Тарасова ніч" memory framing.
+- [T4] Ковалець Т.Р. "Повстання 1630 р. в Україні за новознайденими польськими
+  реляціями: публікація джерел." *Наукові праці історичного факультету
+  Запорізького національного університету*, 2014, no. 41, pp. 197-203. URL:
+  https://irbis-nbuv.gov.ua/cgi-bin/irbis_nbuv/cgiirbis_64.exe?C21COM=2&I21DBN=UJRN&IMAGE_FILE_DOWNLOAD=1&Image_file_name=PDF%2FNpifznu_2014_41_37.pdf&P21DBN=UJRN
+  | accessed 2026-07-04. Used for Koniecpolski relation letters as source
+  corpus, source scarcity, Pereiaslav battle evidence, and relation-publication
+  lead.
+- [T4] Ковалець Т.Р. "Тарас Федорович: спроба реконструкції історичного
+  образу, або Козацька доля - наче голлівудський сценарій."
+  *Військово-науковий вісник Національної академії сухопутних військ імені
+  Петра Сагайдачного*, 2016, no. 25, pp. 33-46. URL:
+  https://irbis-nbuv.gov.ua/cgi-bin/irbis_nbuv/cgiirbis_64.exe?C21COM=2&I21DBN=UJRN&IMAGE_FILE_DOWNLOAD=1&Image_file_name=PDF%2Fvnv_2016_25_5.pdf&P21DBN=UJRN
+  | accessed 2026-07-04. Used for source-critical biography, `Не-Трясило`
+  argument, origin/name caution, accumulated-cause framing, and post-1636
+  confusion.
+- [T4] Gajecky G. "The origin of Taras Triasylo." *Harvard Ukrainian Studies*,
+  1981, vol. 5, no. 3. Bibliographic anchor via ЕІУ; direct article text was
+  not fully inspected in this pass.
+- [T4] Baran A., Gajecki G. *The Cossacks in the Thirty Years War*, vol. 2:
+  1625-1648. Rome, 1983. Bibliographic anchor via ЕІУ; direct volume not
+  inspected in this pass.
+- [T4] Щербак В. "Козацька верхівка другої половини XVI - середини XVII ст."
+  *Український історичний журнал*, 1997, no. 5. Bibliographic anchor via ЕІУ;
+  direct article not inspected in this pass.
+
+**Tier 5 (general web / popular — not load-bearing):**
+
+- [T5] School-prep, popular-history, video, and local-history pages surfaced in
+  search. Used only for navigation to better sources, alias/image discovery,
+  and public-memory awareness; not load-bearing against T1/T4.
+
+**Primary-source documents accessed / verification notes:**
+
+- Lviv Chronicle 1630 narrative: accessed through the Izbornyk edition; text is
+  source-language and partisan, with editor notes on difficult readings.
+- Fedorovych universal: accessed only through Shcherbak's short quotation in
+  the UHJ article; original source edition not directly checked.
+- Koniecpolski relation letters: accessed through Kovalets 2014 publication
+  summary and PDF; use as a source-edition lead for module writing.
+- Shevchenko "Тарасова ніч": public-domain literary memory anchor; use as
+  afterlife evidence, not biography.
+
+**Honest gaps:** this dossier did not inspect Gajecky's full HUS article,
+Baran/Gajecki vol. 2, the full Щербак 1997 article, all АЮЗР materials, or
+full archival relation originals. For module writing, recheck exact wording of
+the universal, Pereiaslav agreement articles, Chornyi execution accounts,
+Koniecpolski letters, Lviv Chronicle variants, and the post-1636 Taras Chornyi
+identification.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Muscovy/Moscow appears as a specific later
+  borderland actor, not as the default center of the story.
+- [x] No Russian-imperial transliterations normalized in body text.
+- [x] Fedorovych is not flattened into a folk avenger, bandit, pure class-war
+  emblem, or modern nationalist prototype.
+- [x] Registered/unregistered Cossack conflict, Commonwealth coercion, Orthodox
+  rhetoric, and leadership split are all visible.
+- [x] Source labels such as `зрада`, `вина`, `зносити`, `віру рятувати`, and
+  `вольності` are treated as source vocabulary, not neutral narration.
+- [x] Tatar-origin and szlachta-origin hypotheses are handled without exoticism
+  or status inflation.
+- [x] Shevchenko / Chubynsky / film memory is marked as afterlife, not source
+  fact.
+- [x] Soviet and popular "anti-feudal" shorthand is named only as a later
+  frame, not adopted as the dossier's explanation.
+- [x] Modern Ukrainian place/institution naming used with historical context:
+  Запорожжя, Базавлуцька Січ, Черкаси, Корсунь, Канів, Переяслав, Трубіж,
+  Альта, Подніпров'я, Київське воєводство, Річ Посполита, Військо Запорозьке.
+- [x] No unrelated modern-statehood material, all-rulers chronology, or
+  out-of-scope figures added.
+
+## Validation checklist
+
+- [x] Single owned file only:
+  `docs/research/bio/taras-fedorovych-triasylo.md`.
+- [x] Existing cross-track plan paths verified locally before citation.
+- [x] Lower-tier sources marked non-load-bearing.
+- [x] Guard terms for unrelated modern-statehood and all-rulers scope avoided.
+- [x] No generated `status/`, `audit/`, `review`, or telemetry artifacts
+  referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans,
+  module files, activities, vocabulary, resources, site MDX, or wiki files
+  edited.


### PR DESCRIPTION
## Scope

Adds one BIO research dossier for Taras Fedorovych / Triasylo as part of the BIO Cossack readiness pipeline. The dossier keeps the figure source-cautious: disputed origin, late `Triasylo` memory name, registered/unregistered Cossack tensions, Pereiaslav 1630 settlement, and later literary-memory afterlife.

## Changed files

- `docs/research/bio/taras-fedorovych-triasylo.md`

## Validation

- `npx markdownlint-cli2 docs/research/bio/taras-fedorovych-triasylo.md` — passed, 0 errors
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/taras-fedorovych-triasylo.md` — passed, no fabricated Existing cross-track plan paths found
- `git diff --check` — passed
- `git diff --cached --check` — passed before commit
- `rg -n "Skoropadskyi|Скоропад|1918|Ukrainian State|Українськ.*Держав|Polish king|Polish kings|Польськ.*корол|польськ.*корол" docs/research/bio/taras-fedorovych-triasylo.md` — passed, no matches
- Protected artifact/config guard — passed; staged diff was exactly one file and no protected generated/config paths matched
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- Commit/push hooks — passed, including gitleaks and BIO xref validator

## Source and decolonization caveats

- Load-bearing facts are anchored to ЕІУ and Internet Encyclopedia of Ukraine, with Shcherbak and Kovalets used for source-critical context.
- Lower-tier and popular sources are marked navigation-only.
- `Triasylo/Tryasylo` is retained for search and memory, but the dossier warns that the sobriquet is late in the inspected source layer.
- Origin, death date, Taras Chornyi identification, and post-1636 activity are explicitly contested.
- No Pavlo Skoropadskyi / 1918 Hetmanate scope, no all-rulers chronology, and no Polish kings were added.

## Review gate

No independent review has been routed yet because the orchestrator handles that gate.