### PR TITLE
feat(qg): add curriculum Ukrainian quality harness

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -395,6 +395,7 @@ Additional audit guardrails:
 - `scripts/audit/atlas_source_census.py` - aggregate-only Word Atlas source intake census; public reports must not include raw source text, private paths, or candidate lemma lists
 - `scripts/audit/atlas_entry_model_census.py` - aggregate-only Word Atlas entry-model census; separates reviewed article entries by `entry_type` from alias/form records
 - `scripts/audit/atlas_source_entry_count.py` - aggregate-only Word Atlas source-corpus entry-demand census by finalized entry-model bucket; public reports must not include source text, private paths, filenames, or candidate lists
+- `scripts/audit/curriculum_qg_harness.py` - deterministic Ukrainian curriculum QG fixture harness; use it to calibrate B1-27, A1/A2 scaffolding, B1+ leakage, and seminar-register checks before changing QG behavior
 
 ### Build pipeline entry point
 
@@ -564,6 +565,8 @@ Use this before content generation to verify plan files still match `scripts/aud
 | `scripts/audit/atlas_source_census.py` | Build aggregate-safe Word Atlas source planning counts | `.venv/bin/python scripts/audit/atlas_source_census.py --markdown-out docs/runbooks/word-atlas-source-census-planning.md` |
 | `scripts/audit/atlas_entry_model_census.py` | Count reviewed Atlas entries by finalized `entry_type` bucket | `.venv/bin/python scripts/audit/atlas_entry_model_census.py --format markdown` |
 | `scripts/audit/atlas_source_entry_count.py` | Estimate aggregate source-corpus Atlas entry backlog by finalized bucket | `.venv/bin/python scripts/audit/atlas_source_entry_count.py --include-ohoiko-private --markdown-out docs/runbooks/word-atlas-source-entry-count.md` |
+| `scripts/audit/curriculum_qg_harness.py` | Run calibrated Ukrainian QG fixtures or scan one module into compact evidence | `.venv/bin/python scripts/audit/curriculum_qg_harness.py --fixtures tests/fixtures/curriculum_qg/fixtures.yaml` |
+| `scripts/audit/module_quality_audit.py` | Report surface and LLM-QG/compact evidence coverage by level | `.venv/bin/python scripts/audit/module_quality_audit.py --level b1 --format summary` |
 | `scripts/audit/lint_session_state.py` | Check handoff docs for missing env-file references | `.venv/bin/python scripts/audit/lint_session_state.py --all` |
 | `scripts/audit/lint_anti_menu.py` | Detect anti-menu sign-off prompts in markdown | `.venv/bin/python scripts/audit/lint_anti_menu.py --text docs/session-state/current.md` |
 | `scripts/audit/decision_lineage.py` | Scan decision git backlinks | `.venv/bin/python scripts/audit/decision_lineage.py --decision-id ADR-008` |
@@ -614,6 +617,48 @@ It checks:
 - Ukrainian quality
 - activity hints vs actual activities
 - integrated audit checks such as cross-file integrity and outline compliance
+
+### `scripts/audit/curriculum_qg_harness.py`
+
+Deterministic Ukrainian curriculum QG calibration harness for issue #2156.
+Use it before changing QG prompts, evidence persistence, or deterministic
+surface checks. It does not bulk-score the curriculum and does not write raw
+LLM logs.
+
+```bash
+# Run the labeled PR1 fixture suite
+.venv/bin/python scripts/audit/curriculum_qg_harness.py \
+  --fixtures tests/fixtures/curriculum_qg/fixtures.yaml
+
+# Scan one module and print compact evidence
+.venv/bin/python scripts/audit/curriculum_qg_harness.py \
+  --module-dir curriculum/l2-uk-en/b1/aspect-in-imperatives \
+  --level b1 \
+  --slug aspect-in-imperatives \
+  --format json
+```
+
+The fixture suite covers current and restored-bad B1-27 behavior, allowed
+A1/A2 English scaffolding, B1+ English leakage, local English glosses, and
+seminar-register pathos. Single-module scans emit compact evidence shaped like
+`qg_evidence.json`: module id, level policy, checker version/config/hash,
+content hash, dimensional scores/findings, compact spans/excerpts, LLM metadata
+placeholders, and provenance.
+
+### `scripts/audit/module_quality_audit.py`
+
+Coverage report for planned modules, built modules, deterministic surface
+failures, persisted LLM-QG records, and compact file-only `qg_evidence.json`
+records.
+
+```bash
+.venv/bin/python scripts/audit/module_quality_audit.py --level b1 --format summary
+.venv/bin/python scripts/audit/module_quality_audit.py --level b1 --format json
+```
+
+Use this before spending reviewer tokens. A current compact `qg_evidence.json`
+counts as current file-only QG evidence, but modules still remain in the DB
+persistence count until their LLM-QG result is stored in the telemetry DB.
 
 ### `pipeline.py`
 

--- a/docs/projects/ua-eval-harness/pr1-curriculum-qg-plan.md
+++ b/docs/projects/ua-eval-harness/pr1-curriculum-qg-plan.md
@@ -1,0 +1,77 @@
+# PR1 Plan: Curriculum Ukrainian Quality-Gate Harness
+
+Issue: [#2156](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/2156)
+
+## Context
+
+The original #2156 project is a broader UA-GEC / UNLP 2027 evaluation harness.
+The 2026-07-04 issue update narrows PR1 to the curriculum-facing production
+spine: deterministic checks first, B1-27 calibration, compact evidence, and a
+coverage report that prevents an expensive all-module LLM pass before evidence
+inventory is understood.
+
+## Fleet Inputs
+
+- L1 AGY architecture review noted the older academic `russianism_eval` path,
+  but local inspection shows PR1 should extend the existing curriculum QG stack:
+  `scripts/audit/content_surface_gates.py`,
+  `scripts/audit/llm_qg_canaries.py`,
+  `scripts/audit/llm_qg_store.py`, and
+  `scripts/audit/module_quality_audit.py`.
+- L2 AGY deterministic review recommended gold B1-27 fixtures for
+  `застосунок має бути відкритий`, `Застереження каже: ...`,
+  `радить не робити певної поведінки`,
+  `дія має дати конкретний результат чи описати процес?`,
+  `доконаний вид дає результат із вікном`, and `У кухні`.
+- L3 AGY evidence review recommended bounded excerpts/spans, checker version
+  and config hashes, source metadata, level policy, and score-null tolerance for
+  levels where numeric scores are not yet available.
+- Cursor planning was rate-limited. Claude Opus dispatch failed because the
+  runtime's native Claude binary is not installed; this PR will use AGY for
+  required non-Codex lanes and final prompt/checker review.
+
+## PR1 Scope
+
+1. Add a fixture runner for curriculum QG calibration, not a standalone
+   academic leaderboard.
+2. Add gold fixtures for B1-27 bad text plus small A1, A2, B1+, and seminar
+   calibration cases.
+3. Emit compact deterministic harness evidence with module id, level policy,
+   checker config/version/hash, content hash, per-dimension scores/findings,
+   exact bounded spans/excerpts, checker-source metadata, and reproducibility
+   metadata.
+4. Keep LLM review as a residual-judgment adapter: PR1 validates prompt/checker
+   behavior through canary-shaped labeled fixtures and existing LLM-QG prompt
+   rules, without bulk-running modules or committing raw LLM transcripts.
+5. Extend the corpus audit so git-tracked compact `qg_evidence.json` counts as
+   current file evidence. Current B1-27 must no longer appear as missing QG
+   evidence solely because the local SQLite DB is absent.
+
+## Non-Goals
+
+- No all-module LLM review.
+- No leaderboard or retrospective scoring.
+- No UA-GEC data import or large corpus extraction in this PR.
+- No raw prompts, raw responses, `llm_qg.json`, telemetry DBs, status JSONs, or
+  audit/review generated artifacts in git.
+- No migration of existing `llm_qg_evidence.v1` records to a new schema.
+
+## Target Files
+
+- New fixture harness under `scripts/audit/`.
+- New labeled fixture data under `tests/fixtures/`.
+- Focused tests under `tests/audit/`.
+- Small extension to `scripts/audit/module_quality_audit.py` and its tests so
+  compact file evidence is counted.
+- This plan and a runbook update documenting the calibration command.
+
+## Verification
+
+- Run the fixture harness against labeled fixtures.
+- Run current B1-27 calibration and confirm PASS.
+- Run `module_quality_audit.py --level b1 --format summary` and confirm B1-27
+  is counted as current file evidence.
+- Run targeted pytest for the new harness, module-quality audit, surface gates,
+  and LLM-QG store.
+- Run `git diff --check`, forbidden-file checks, and agent-trailer lint before
+  opening a PR.

--- a/docs/runbooks/module-quality-gates.md
+++ b/docs/runbooks/module-quality-gates.md
@@ -53,12 +53,13 @@ paths unless a task explicitly asks for a report:
 ```
 
 The report counts planned modules, built modules, surface-policy failures,
-current DB-backed LLM-QG records, file-only fallback records, stale records, and
-missing records. It also reports the same coverage by `a1`, `a2`, `b1_plus`,
-and `seminar` reviewer profiles. Each built-module row includes reviewer
-family/model, gate version, prompt hash, content hash, and whether a second
-cross-family review is recommended because the module is seminar, surface-gate
-flagged, or missing/stale LLM-QG.
+current DB-backed LLM-QG records, current compact `qg_evidence.json` file
+records, file-only fallback records, stale records, and missing records. It also
+reports the same coverage by `a1`, `a2`, `b1_plus`, and `seminar` reviewer
+profiles. Each built-module row includes reviewer family/model, gate version,
+prompt hash, content hash, and whether a second cross-family review is
+recommended because the module is seminar, surface-gate flagged, or
+missing/stale LLM-QG.
 
 ## LLM Gates
 
@@ -162,6 +163,23 @@ The canary set includes required-catch cases (`застосунок має бу�
 `Застереження каже: ...`, AI leakage, path/internal leakage, B1/seminar English
 leakage, seminar pathos) and false-positive protection for allowed A1/A2
 English scaffolding.
+
+Run the PR1 curriculum fixture harness before changing deterministic checks or
+reviewer prompts:
+
+```bash
+.venv/bin/python scripts/audit/curriculum_qg_harness.py \
+  --fixtures tests/fixtures/curriculum_qg/fixtures.yaml
+
+.venv/bin/python scripts/audit/curriculum_qg_harness.py \
+  --module-dir curriculum/l2-uk-en/b1/aspect-in-imperatives \
+  --level b1 --slug aspect-in-imperatives
+```
+
+The fixture harness emits compact `curriculum_ua_qg_evidence.v1` records with
+module id, level policy, checker version/config hash, content hash,
+per-dimension scores, exact bounded findings/spans, and deterministic/LLM-source
+metadata. It is a calibration harness, not a bulk LLM runner.
 
 ## Batch Rollout
 

--- a/scripts/audit/curriculum_qg_harness.py
+++ b/scripts/audit/curriculum_qg_harness.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+"""Curriculum-facing Ukrainian quality-gate calibration harness.
+
+This is a deterministic fixture runner for issue #2156's PR1 scope. It does
+not replace the V7 LLM-QG reviewer; it verifies the cheap, high-precision
+checks and emits compact evidence so known production failures stay covered
+before any costly LLM pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+AUDIT_DIR = Path(__file__).resolve().parent
+if str(AUDIT_DIR) not in sys.path:
+    sys.path.insert(0, str(AUDIT_DIR))
+
+from content_surface_gates import policy_for_level, scan_module_surface
+from llm_qg_store import CONTENT_FILES, content_sha_for_module
+
+FIXTURE_SCHEMA_VERSION = "curriculum_ua_qg_fixtures.v1"
+EVIDENCE_SCHEMA_VERSION = "curriculum_ua_qg_evidence.v1"
+CHECKER_VERSION = "curriculum_ua_qg_harness.v1"
+DIMENSION_ORDER = (
+    "surface_leakage",
+    "level_policy",
+    "ukrainian_style",
+    "tone_register",
+    "seminar_sensitivity",
+)
+SEVERITY_WEIGHTS = {"critical": 2.5, "warning": 0.75, "info": 0.0}
+_LATIN_WORD_RE = re.compile(r"\b[A-Za-z][A-Za-z'-]*\b")
+_CYRILLIC_WORD_RE = re.compile(r"[\u0400-\u04ff][\u0400-\u04ff'ʼ-]*")
+
+
+@dataclass(frozen=True, slots=True)
+class PhraseRule:
+    """One deterministic phrase-level regression rule."""
+
+    rule_id: str
+    issue_id: str
+    dimension: str
+    severity: str
+    pattern: re.Pattern[str]
+    message: str
+
+
+PHRASE_RULES: tuple[PhraseRule, ...] = (
+    PhraseRule(
+        rule_id="b1_awkward_passive_result_state",
+        issue_id="AWKWARD_PASSIVE_RESULT_STATE",
+        dimension="ukrainian_style",
+        severity="critical",
+        pattern=re.compile(r"застосунок\s+має\s+бути\s+відкритий", re.IGNORECASE),
+        message="Use an active or impersonal Ukrainian instruction instead of a literal passive state.",
+    ),
+    PhraseRule(
+        rule_id="b1_unnatural_anthropomorphic_warning",
+        issue_id="UNNATURAL_ANTHROPOMORPHISM",
+        dimension="ukrainian_style",
+        severity="critical",
+        pattern=re.compile(r"Застереження\s+каже:\s*будь\s+обережн[а-яіїєґ]*", re.IGNORECASE),
+        message="Abstract lesson metalanguage should not be anthropomorphized as a speaker.",
+    ),
+    PhraseRule(
+        rule_id="b1_bad_behavior_government",
+        issue_id="UKRAINIAN_GRAMMAR_CALQUE",
+        dimension="ukrainian_style",
+        severity="critical",
+        pattern=re.compile(r"радить\s+не\s+робити\s+певної\s+поведінки", re.IGNORECASE),
+        message="The government and nominalized behavior phrase are translated and unnatural.",
+    ),
+    PhraseRule(
+        rule_id="b1_abstract_result_process_calque",
+        issue_id="UNNATURAL_META_REGISTER",
+        dimension="ukrainian_style",
+        severity="critical",
+        pattern=re.compile(
+            r"дія\s+має\s+дати\s+конкретний\s+результат\s+чи\s+описати\s+процес\?",
+            re.IGNORECASE,
+        ),
+        message="This abstract prompt-like sentence is not natural learner-facing Ukrainian.",
+    ),
+    PhraseRule(
+        rule_id="b1_window_result_calque",
+        issue_id="UKRAINIAN_GRAMMAR_CALQUE",
+        dimension="ukrainian_style",
+        severity="critical",
+        pattern=re.compile(r"доконаний\s+вид\s+дає\s+результат\s+із\s+вікном", re.IGNORECASE),
+        message="The metaphor and argument structure are literal and unidiomatic.",
+    ),
+    PhraseRule(
+        rule_id="b1_kitchen_locative_context",
+        issue_id="CALQUED_PREPOSITION",
+        dimension="ukrainian_style",
+        severity="critical",
+        pattern=re.compile(r"\bУ\s+кухні\b"),
+        message="In this ordinary locative teaching context, use the idiomatic На кухні.",
+    ),
+)
+
+
+def _now_z() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def checker_config_hash() -> str:
+    """Return a stable hash for deterministic harness configuration."""
+    payload = {
+        "checker_version": CHECKER_VERSION,
+        "dimensions": DIMENSION_ORDER,
+        "phrase_rules": [
+            {
+                "rule_id": rule.rule_id,
+                "issue_id": rule.issue_id,
+                "dimension": rule.dimension,
+                "severity": rule.severity,
+                "pattern": rule.pattern.pattern,
+            }
+            for rule in PHRASE_RULES
+        ],
+        "severity_weights": SEVERITY_WEIGHTS,
+    }
+    return _sha256_text(_json_dumps(payload))
+
+
+def _read_module_texts(module_dir: Path) -> dict[str, str]:
+    texts: dict[str, str] = {}
+    for name in CONTENT_FILES:
+        path = module_dir / name
+        if path.exists():
+            texts[name] = path.read_text(encoding="utf-8")
+    return texts
+
+
+def _line_no(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _span_for_excerpt(text: str, excerpt: str, line_hint: int | None = None) -> dict[str, int | None]:
+    start = text.find(excerpt)
+    if start < 0 and line_hint:
+        lines = text.splitlines(keepends=True)
+        prefix_len = sum(len(line) for line in lines[: max(line_hint - 1, 0)])
+        line_text = lines[line_hint - 1] if 0 <= line_hint - 1 < len(lines) else ""
+        line_offset = line_text.find(excerpt)
+        if line_offset >= 0:
+            start = prefix_len + line_offset
+    if start < 0:
+        return {"start": None, "end": None}
+    return {"start": start, "end": start + len(excerpt)}
+
+
+def _finding(
+    *,
+    issue_id: str,
+    rule_id: str,
+    dimension: str,
+    severity: str,
+    file: str,
+    line: int,
+    excerpt: str,
+    message: str,
+    text: str,
+    source: str = "deterministic",
+) -> dict[str, Any]:
+    span = _span_for_excerpt(text, excerpt, line)
+    return {
+        "issue_id": issue_id,
+        "rule_id": rule_id,
+        "dimension": dimension,
+        "severity": severity,
+        "source": source,
+        "file": file,
+        "line": line,
+        "span": span,
+        "excerpt": excerpt[:160],
+        "message": message,
+    }
+
+
+def _surface_issue_id(finding_type: str, profile: str) -> str:
+    if finding_type == "english_led_line" or finding_type == "english_ratio":
+        return "ENGLISH_LEAKAGE"
+    if finding_type == "ai_leakage":
+        return "AI_LEAKAGE"
+    if finding_type == "path_leakage":
+        return "PATH_LEAKAGE"
+    if finding_type == "pathos_or_register" and profile == "seminar":
+        return "SEMINAR_REGISTER_PATHOS"
+    if finding_type == "pathos_or_register":
+        return "PATHOS_REGISTER_OVERREACH"
+    if finding_type == "ukrainian_grammar_calque":
+        return "UKRAINIAN_GRAMMAR_CALQUE"
+    return finding_type.upper()
+
+
+def _surface_dimension(finding_type: str, profile: str) -> str:
+    if finding_type in {"english_led_line", "english_ratio"}:
+        return "level_policy"
+    if finding_type in {"ai_leakage", "path_leakage"}:
+        return "surface_leakage"
+    if finding_type == "pathos_or_register" and profile == "seminar":
+        return "seminar_sensitivity"
+    if finding_type == "pathos_or_register":
+        return "tone_register"
+    return "ukrainian_style"
+
+
+def _surface_findings(module_dir: Path, level: str, texts: Mapping[str, str], profile: str) -> list[dict[str, Any]]:
+    report = scan_module_surface(module_dir, level=level)
+    findings: list[dict[str, Any]] = []
+    for item in report.get("findings", []):
+        if not isinstance(item, Mapping):
+            continue
+        file = str(item.get("source") or "module.md")
+        excerpt = str(item.get("text") or "").strip()
+        if not excerpt:
+            continue
+        text = texts.get(file, "")
+        finding_type = str(item.get("type") or "surface")
+        issue_id = _surface_issue_id(finding_type, profile)
+        severity = str(item.get("severity") or "warning")
+        if issue_id == "SEMINAR_REGISTER_PATHOS":
+            severity = "critical"
+        findings.append(
+            _finding(
+                issue_id=issue_id,
+                rule_id=f"surface_{finding_type}",
+                dimension=_surface_dimension(finding_type, profile),
+                severity=severity,
+                file=file,
+                line=int(item.get("line") or 0),
+                excerpt=excerpt,
+                message=str(item.get("message") or finding_type),
+                text=text,
+            )
+        )
+    return findings
+
+
+def _phrase_findings(texts: Mapping[str, str]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    for file, text in texts.items():
+        for rule in PHRASE_RULES:
+            for match in rule.pattern.finditer(text):
+                findings.append(
+                    _finding(
+                        issue_id=rule.issue_id,
+                        rule_id=rule.rule_id,
+                        dimension=rule.dimension,
+                        severity=rule.severity,
+                        file=file,
+                        line=_line_no(text, match.start()),
+                        excerpt=match.group(0),
+                        message=rule.message,
+                        text=text,
+                    )
+                )
+    return findings
+
+
+def _anchor_findings(texts: Mapping[str, str], profile: str) -> list[dict[str, Any]]:
+    """Catch A1 modules where English replaces the Ukrainian anchor entirely."""
+    if profile != "a1":
+        return []
+    text = texts.get("module.md", "")
+    latin_words = _LATIN_WORD_RE.findall(text)
+    cyrillic_words = _CYRILLIC_WORD_RE.findall(text)
+    if len(latin_words) < 16 or cyrillic_words:
+        return []
+    excerpt = next(
+        (
+            line.strip()
+            for line in text.splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ),
+        text[:80],
+    )
+    return [
+        _finding(
+            issue_id="ENGLISH_LEAKAGE",
+            rule_id="a1_missing_ukrainian_anchor",
+            dimension="level_policy",
+            severity="critical",
+            file="module.md",
+            line=_line_no(text, text.find(excerpt)) if excerpt in text else 1,
+            excerpt=excerpt,
+            message="A1 may use substantial English scaffolding, but it still needs a Ukrainian anchor.",
+            text=text,
+        )
+    ]
+
+
+def _dedupe_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[tuple[Any, ...]] = set()
+    out: list[dict[str, Any]] = []
+    for finding in findings:
+        key = (
+            finding.get("issue_id"),
+            finding.get("file"),
+            finding.get("line"),
+            finding.get("excerpt"),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(finding)
+    return out
+
+
+def _dimension_scores(findings: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    dimensions: dict[str, dict[str, Any]] = {}
+    for dim in DIMENSION_ORDER:
+        dim_findings = [finding for finding in findings if finding.get("dimension") == dim]
+        penalty = sum(SEVERITY_WEIGHTS.get(str(finding.get("severity")), 0.0) for finding in dim_findings)
+        score = max(0.0, round(10.0 - penalty, 1))
+        has_critical = any(finding.get("severity") == "critical" for finding in dim_findings)
+        has_warning = any(finding.get("severity") == "warning" for finding in dim_findings)
+        dimensions[dim] = {
+            "score": score,
+            "verdict": "FAIL" if has_critical else "WARN" if has_warning else "PASS",
+            "findings": dim_findings,
+        }
+    return dimensions
+
+
+def _aggregate(dimensions: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
+    scored = {
+        dim: float(entry.get("score", 0.0))
+        for dim, entry in dimensions.items()
+        if isinstance(entry.get("score"), int | float)
+    }
+    min_dim = min(scored, key=scored.__getitem__) if scored else None
+    has_fail = any(entry.get("verdict") == "FAIL" for entry in dimensions.values())
+    has_warn = any(entry.get("verdict") == "WARN" for entry in dimensions.values())
+    return {
+        "verdict": "FAIL" if has_fail else "WARN" if has_warn else "PASS",
+        "terminal_verdict": "FAIL" if has_fail else "PASS",
+        "min_score": scored[min_dim] if min_dim else None,
+        "min_dim": min_dim,
+        "failing_dims": [dim for dim, entry in dimensions.items() if entry.get("verdict") == "FAIL"],
+        "warning_dims": [dim for dim, entry in dimensions.items() if entry.get("verdict") == "WARN"],
+    }
+
+
+def scan_curriculum_module(
+    module_dir: Path,
+    *,
+    level: str,
+    slug: str | None = None,
+    fixture_id: str | None = None,
+) -> dict[str, Any]:
+    """Scan one module directory and return compact deterministic evidence."""
+    module_dir = module_dir.resolve()
+    clean_level = level.strip().lower()
+    clean_slug = slug or module_dir.name
+    policy = policy_for_level(clean_level)
+    texts = _read_module_texts(module_dir)
+    findings = _dedupe_findings(
+        [
+            *_surface_findings(module_dir, clean_level, texts, policy.family),
+            *_phrase_findings(texts),
+            *_anchor_findings(texts, policy.family),
+        ]
+    )
+    dimensions = _dimension_scores(findings)
+    aggregate = _aggregate(dimensions)
+    config_hash = checker_config_hash()
+    return {
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
+        "module_id": f"{clean_level}/{clean_slug}",
+        "level": clean_level,
+        "slug": clean_slug,
+        "level_policy": {
+            "family": policy.family,
+            "english_policy": policy.english_policy,
+        },
+        "checker_config": {
+            "version": CHECKER_VERSION,
+            "config_hash": config_hash,
+        },
+        "content_sha": content_sha_for_module(module_dir),
+        "verdict": aggregate["verdict"],
+        "terminal_verdict": aggregate["terminal_verdict"],
+        "aggregate": aggregate,
+        "dimensions": dimensions,
+        "checker_runs": [
+            {
+                "source": "deterministic",
+                "checker": CHECKER_VERSION,
+                "config_hash": config_hash,
+                "provider": None,
+                "model": None,
+            }
+        ],
+        "llm_review": {
+            "used": False,
+            "required": aggregate["verdict"] != "PASS",
+            "provider": None,
+            "model": None,
+            "reason": "Residual LLM-QG review is required for FAIL/WARN modules.",
+        },
+        "provenance": {
+            "created_at": _now_z(),
+            "run_id": f"curriculum-qg-{uuid4().hex}",
+            "source": "curriculum_qg_harness",
+            "fixture_id": fixture_id,
+        },
+    }
+
+
+def _write_fixture_module(root: Path, fixture: Mapping[str, Any]) -> Path:
+    module = fixture.get("module")
+    if not isinstance(module, Mapping):
+        raise ValueError(f"fixture {fixture.get('id')} missing module mapping")
+    module_dir = root / str(fixture.get("level") or "fixture") / str(fixture.get("slug") or fixture.get("id"))
+    module_dir.mkdir(parents=True, exist_ok=True)
+    for name in CONTENT_FILES:
+        value = module.get(name)
+        if value is None:
+            value = "[]\n" if name.endswith((".yaml", ".yml")) else ""
+        (module_dir / name).write_text(str(value).rstrip() + "\n", encoding="utf-8")
+    return module_dir
+
+
+def _load_fixture_source_module(fixture: Mapping[str, Any]) -> Path:
+    raw = fixture.get("source_module_dir")
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError(f"fixture {fixture.get('id')} missing source_module_dir")
+    path = Path(raw)
+    if not path.is_absolute():
+        path = PROJECT_ROOT / path
+    return path
+
+
+def _normalize_text(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip().casefold()
+
+
+def _expected_findings_pass(
+    evidence: Mapping[str, Any],
+    expected: list[Mapping[str, Any]],
+) -> tuple[bool, list[dict[str, Any]]]:
+    actual: list[Mapping[str, Any]] = []
+    dimensions = evidence.get("dimensions")
+    if isinstance(dimensions, Mapping):
+        for entry in dimensions.values():
+            if isinstance(entry, Mapping) and isinstance(entry.get("findings"), list):
+                actual.extend(item for item in entry["findings"] if isinstance(item, Mapping))
+
+    missing: list[dict[str, Any]] = []
+    for wanted in expected:
+        issue_id = str(wanted.get("issue_id") or "")
+        excerpt = _normalize_text(wanted.get("excerpt"))
+        dimension = str(wanted.get("dimension") or "")
+        severity = str(wanted.get("severity") or "")
+
+        matched = False
+        for item in actual:
+            if issue_id and item.get("issue_id") != issue_id:
+                continue
+            if dimension and item.get("dimension") != dimension:
+                continue
+            if severity and item.get("severity") != severity:
+                continue
+            actual_excerpt = _normalize_text(item.get("excerpt"))
+            if excerpt and excerpt not in actual_excerpt:
+                continue
+            matched = True
+            break
+        if not matched:
+            missing.append(dict(wanted))
+    return not missing, missing
+
+
+def evaluate_fixture(fixture: Mapping[str, Any], *, temp_root: Path) -> dict[str, Any]:
+    """Evaluate one labeled fixture and compare it to gold expectations."""
+    fixture_id = str(fixture.get("id") or "")
+    level = str(fixture.get("level") or "")
+    slug = str(fixture.get("slug") or fixture_id)
+    if fixture.get("source_module_dir"):
+        module_dir = _load_fixture_source_module(fixture)
+    else:
+        module_dir = _write_fixture_module(temp_root, fixture)
+
+    evidence = scan_curriculum_module(
+        module_dir,
+        level=level,
+        slug=slug,
+        fixture_id=fixture_id,
+    )
+    expected_verdict = str(fixture.get("expected_verdict") or "").upper()
+    verdict_passed = not expected_verdict or evidence["verdict"] == expected_verdict
+    expected_findings = fixture.get("expected_findings")
+    if not isinstance(expected_findings, list):
+        expected_findings = []
+    findings_passed, missing_findings = _expected_findings_pass(evidence, expected_findings)
+    return {
+        "id": fixture_id,
+        "level": level,
+        "slug": slug,
+        "expected_verdict": expected_verdict,
+        "actual_verdict": evidence["verdict"],
+        "passed": verdict_passed and findings_passed,
+        "missing_findings": missing_findings,
+        "evidence": evidence,
+    }
+
+
+def run_fixtures(path: Path) -> dict[str, Any]:
+    """Run a fixture YAML file and return result rows plus summary."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, Mapping):
+        raise ValueError("fixture file must be a mapping")
+    if data.get("schema_version") != FIXTURE_SCHEMA_VERSION:
+        raise ValueError(f"unsupported fixture schema: {data.get('schema_version')}")
+    fixtures = data.get("fixtures")
+    if not isinstance(fixtures, list):
+        raise ValueError("fixture file must contain a fixtures list")
+
+    with tempfile.TemporaryDirectory(prefix="curriculum-qg-fixtures-") as raw_tmp:
+        tmp_root = Path(raw_tmp)
+        results = [
+            evaluate_fixture(fixture, temp_root=tmp_root)
+            for fixture in fixtures
+            if isinstance(fixture, Mapping)
+        ]
+    passed = sum(1 for result in results if result["passed"])
+    return {
+        "schema_version": FIXTURE_SCHEMA_VERSION,
+        "fixture_file": str(path),
+        "summary": {
+            "total": len(results),
+            "passed": passed,
+            "failed": len(results) - passed,
+        },
+        "results": results,
+    }
+
+
+def _summary_text(payload: Mapping[str, Any]) -> str:
+    if "results" in payload:
+        summary = payload["summary"]
+        lines = [
+            "Curriculum Ukrainian QG Fixtures",
+            f"Total: {summary['total']}",
+            f"Passed: {summary['passed']}",
+            f"Failed: {summary['failed']}",
+        ]
+        for result in payload["results"]:
+            mark = "PASS" if result["passed"] else "FAIL"
+            lines.append(
+                f"- {mark} {result['id']}: expected={result['expected_verdict']} actual={result['actual_verdict']}"
+            )
+        return "\n".join(lines)
+    aggregate = payload["aggregate"]
+    return (
+        "Curriculum Ukrainian QG Evidence\n"
+        f"Module: {payload['module_id']}\n"
+        f"Verdict: {payload['verdict']}\n"
+        f"Min score: {aggregate['min_score']} ({aggregate['min_dim']})"
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--module-dir", type=Path, help="Module directory to scan.")
+    source.add_argument("--fixtures", type=Path, help="Fixture YAML file to run.")
+    parser.add_argument("--level", help="Level for --module-dir, e.g. b1.")
+    parser.add_argument("--slug", help="Slug for --module-dir. Defaults to directory name.")
+    parser.add_argument("--format", choices=("json", "summary"), default="summary")
+    parser.add_argument("--output", type=Path, help="Optional output path.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.fixtures:
+            payload = run_fixtures(args.fixtures)
+            failed = int(payload["summary"]["failed"])
+        else:
+            if not args.level:
+                raise ValueError("--module-dir requires --level")
+            payload = scan_curriculum_module(
+                args.module_dir,
+                level=args.level,
+                slug=args.slug,
+            )
+            failed = 0 if payload["terminal_verdict"] == "PASS" else 1
+    except (OSError, ValueError, yaml.YAMLError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    output = (
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+        if args.format == "json"
+        else _summary_text(payload)
+    )
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(output + "\n", encoding="utf-8")
+    else:
+        print(output)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/module_quality_audit.py
+++ b/scripts/audit/module_quality_audit.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
@@ -27,7 +28,10 @@ if str(AUDIT_DIR) not in sys.path:
 from content_surface_gates import scan_module_surface
 from llm_qg_canaries import evaluate_canaries
 from llm_qg_store import (
+    EVIDENCE_SCHEMA_VERSION,
+    SUPPORTED_EVIDENCE_GATE_VERSIONS,
     current_llm_qg_for_module,
+    evidence_record_is_current_for_module,
     latest_llm_qg,
     llm_qg_file_is_current_for_module,
 )
@@ -208,15 +212,63 @@ def llm_qg_status_for_module(
         return _record_status("current_db", current)
 
     latest = latest_llm_qg(level, slug, path=db_path)
+    compact = _compact_evidence_file_status(module_dir)
+    if compact is not None and compact["status"] == "current_file_only":
+        return compact
+
     file_path = module_dir / "llm_qg.json"
     file_exists = file_path.exists()
     if file_exists and llm_qg_file_is_current_for_module(module_dir, file_path):
         return _empty_status("current_file_only", source="llm_qg.json")
     if latest is not None:
         return _record_status("stale_db", latest)
+    if compact is not None:
+        return compact
     if file_exists:
         return _empty_status("stale_file", source="llm_qg.json")
     return _empty_status("missing")
+
+
+def _compact_evidence_file_status(module_dir: Path) -> dict[str, Any] | None:
+    """Return status for git-friendly compact QG evidence, if present."""
+    path = module_dir / "qg_evidence.json"
+    if not path.exists():
+        return None
+    try:
+        evidence = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, ValueError):
+        return _empty_status("stale_file", source="qg_evidence.json")
+    if not isinstance(evidence, dict):
+        return _empty_status("stale_file", source="qg_evidence.json")
+
+    current = (
+        evidence.get("schema_version") == EVIDENCE_SCHEMA_VERSION
+        and evidence.get("gate_version") in SUPPORTED_EVIDENCE_GATE_VERSIONS
+        and evidence_record_is_current_for_module(evidence, module_dir)
+    )
+    return {
+        "status": "current_file_only" if current else "stale_file",
+        "source": "qg_evidence.json",
+        "run_id": _nested_str(evidence, "provenance", "run_id"),
+        "gate_version": _optional_str(evidence.get("gate_version")),
+        "prompt_hash": _optional_str(evidence.get("prompt_hash")),
+        "content_sha": _optional_str(evidence.get("content_sha")),
+        "reviewer_family": _nested_str(evidence, "reviewer", "family"),
+        "reviewer_model": _nested_str(evidence, "reviewer", "model"),
+    }
+
+
+def _optional_str(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _nested_str(data: Mapping[str, Any], *keys: str) -> str | None:
+    value: Any = data
+    for key in keys:
+        if not isinstance(value, Mapping):
+            return None
+        value = value.get(key)
+    return value if isinstance(value, str) else None
 
 
 def _record_status(status: str, record: Any) -> dict[str, Any]:

--- a/tests/audit/test_curriculum_qg_harness.py
+++ b/tests/audit/test_curriculum_qg_harness.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.audit.curriculum_qg_harness import (
+    CHECKER_VERSION,
+    EVIDENCE_SCHEMA_VERSION,
+    checker_config_hash,
+    main,
+    run_fixtures,
+    scan_curriculum_module,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_FILE = PROJECT_ROOT / "tests" / "fixtures" / "curriculum_qg" / "fixtures.yaml"
+B1_27_DIR = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "b1" / "aspect-in-imperatives"
+
+
+def _result_by_id(report: dict) -> dict[str, dict]:
+    return {row["id"]: row for row in report["results"]}
+
+
+def _write_module(root: Path, body: str) -> Path:
+    module_dir = root / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text(body, encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "resources.yaml").write_text("[]\n", encoding="utf-8")
+    return module_dir
+
+
+def test_curriculum_qg_fixture_suite_matches_gold_expectations() -> None:
+    report = run_fixtures(FIXTURE_FILE)
+
+    assert report["summary"] == {"total": 8, "passed": 8, "failed": 0}
+    by_id = _result_by_id(report)
+    assert by_id["b1-27-restored-bad"]["actual_verdict"] == "FAIL"
+    assert by_id["b1-27-current-production"]["actual_verdict"] == "PASS"
+    assert by_id["a1-english-scaffold-allowed"]["actual_verdict"] == "PASS"
+    assert by_id["a2-english-support-warning"]["actual_verdict"] == "WARN"
+    assert by_id["a1-english-led-rejected"]["actual_verdict"] == "FAIL"
+    assert by_id["b1-english-led-rejected"]["actual_verdict"] == "FAIL"
+    assert by_id["b1-local-english-gloss-allowed"]["actual_verdict"] == "PASS"
+    assert by_id["seminar-pathos-rejected"]["actual_verdict"] == "FAIL"
+
+
+def test_b1_27_restored_bad_fixture_has_gold_spanned_findings() -> None:
+    report = run_fixtures(FIXTURE_FILE)
+    bad = _result_by_id(report)["b1-27-restored-bad"]
+    evidence = bad["evidence"]
+    findings = [
+        finding
+        for entry in evidence["dimensions"].values()
+        for finding in entry["findings"]
+    ]
+    by_issue = {finding["issue_id"] for finding in findings}
+
+    assert bad["passed"] is True
+    assert bad["missing_findings"] == []
+    assert {
+        "AWKWARD_PASSIVE_RESULT_STATE",
+        "UNNATURAL_ANTHROPOMORPHISM",
+        "UKRAINIAN_GRAMMAR_CALQUE",
+        "UNNATURAL_META_REGISTER",
+        "CALQUED_PREPOSITION",
+    } <= by_issue
+    assert all(finding["file"] == "module.md" for finding in findings)
+    assert all(isinstance(finding["line"], int) and finding["line"] > 0 for finding in findings)
+    assert all(isinstance(finding["span"]["start"], int) for finding in findings)
+    assert all(isinstance(finding["span"]["end"], int) for finding in findings)
+
+
+def test_current_b1_27_scans_as_pass_with_compact_evidence_shape() -> None:
+    module_text = (B1_27_DIR / "module.md").read_text(encoding="utf-8")
+
+    assert module_text.strip()
+    assert "Відкрийте застосунок" in module_text
+
+    evidence = scan_curriculum_module(
+        B1_27_DIR,
+        level="b1",
+        slug="aspect-in-imperatives",
+    )
+
+    assert evidence["schema_version"] == EVIDENCE_SCHEMA_VERSION
+    assert evidence["checker_config"]["version"] == CHECKER_VERSION
+    assert evidence["checker_config"]["config_hash"] == checker_config_hash()
+    assert evidence["module_id"] == "b1/aspect-in-imperatives"
+    assert evidence["verdict"] == "PASS"
+    assert evidence["terminal_verdict"] == "PASS"
+    assert evidence["llm_review"]["used"] is False
+    assert evidence["llm_review"]["required"] is False
+    assert evidence["dimensions"]["ukrainian_style"]["findings"] == []
+
+
+def test_module_cli_warn_uses_terminal_verdict_for_exit_code(tmp_path: Path) -> None:
+    module_dir = _write_module(
+        tmp_path,
+        "# Grammar Basics\n\n"
+        "This section explains the grammar before Ukrainian examples appear in the lesson body.\n\n"
+        "**Ми читаємо.**\n",
+    )
+    output = tmp_path / "evidence.json"
+
+    code = main(
+        [
+            "--module-dir",
+            str(module_dir),
+            "--level",
+            "a2",
+            "--format",
+            "json",
+            "--output",
+            str(output),
+        ]
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert code == 0
+    assert payload["verdict"] == "WARN"
+    assert payload["terminal_verdict"] == "PASS"

--- a/tests/audit/test_module_quality_audit.py
+++ b/tests/audit/test_module_quality_audit.py
@@ -11,7 +11,7 @@ from scripts.audit.llm_qg_canaries import (
     extract_issue_ids,
     list_canaries,
 )
-from scripts.audit.llm_qg_store import record_llm_qg
+from scripts.audit.llm_qg_store import content_sha_for_module, record_llm_qg
 from scripts.audit.module_quality_audit import audit_modules, main, planned_modules
 
 
@@ -126,6 +126,57 @@ def test_audit_modules_reports_surface_and_llm_qg_coverage(tmp_path: Path) -> No
     assert rows[("b1", "bad-style")]["surface_verdict"] == "FAIL"
     assert rows[("b1", "bad-style")]["second_review_reason"] == "surface_fail"
     assert rows[("b1", "not-built")]["llm_qg_status"] == "not_built"
+
+
+def test_audit_modules_counts_compact_qg_evidence_as_current_file_evidence(tmp_path: Path) -> None:
+    (tmp_path / "plans").mkdir(parents=True)
+    (tmp_path / "curriculum.yaml").write_text(
+        yaml.safe_dump({"levels": {"b1": {"modules": ["27-aspect-in-imperatives"]}}}),
+        encoding="utf-8",
+    )
+    module_dir = _write_module(
+        tmp_path,
+        "b1",
+        "aspect-in-imperatives",
+        "## Урок\n\n**Відкрийте застосунок** і перейдіть далі.\n",
+    )
+    (module_dir / "qg_evidence.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "llm_qg_evidence.v1",
+                "level": "b1",
+                "slug": "aspect-in-imperatives",
+                "content_sha": content_sha_for_module(module_dir),
+                "gate_version": "v7.llm_qg.1",
+                "prompt_hash": "prompt-sha",
+                "provenance": {"run_id": "llm-qg-test", "source": "test"},
+                "reviewer": {"family": "agy-tools", "model": "gemini-test"},
+                "terminal_verdict": "PASS",
+                "verdict": "PASS",
+                "dimensions": {"naturalness": {"score": 9.5, "verdict": "PASS"}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = audit_modules(
+        curriculum_root=tmp_path,
+        level_ids=["b1"],
+        db_path=tmp_path / "missing.db",
+        include_findings=False,
+    )
+
+    row = report["modules"][0]
+    assert report["summary"]["current_file_only_llm_qg_modules"] == 1
+    assert report["summary"]["missing_llm_qg_modules"] == 0
+    assert report["summary"]["modules_needing_llm_review"] == 0
+    assert report["summary"]["modules_needing_db_persistence"] == 1
+    assert row["llm_qg_status"] == "current_file_only"
+    assert row["llm_qg_source"] == "qg_evidence.json"
+    assert row["llm_qg_run_id"] == "llm-qg-test"
+    assert row["llm_qg_prompt_hash"] == "prompt-sha"
+    assert row["llm_qg_reviewer_family"] == "agy-tools"
+    assert row["second_review_recommended"] is False
 
 
 def test_cli_json_output(tmp_path: Path, capsys) -> None:

--- a/tests/fixtures/curriculum_qg/fixtures.yaml
+++ b/tests/fixtures/curriculum_qg/fixtures.yaml
@@ -1,0 +1,173 @@
+schema_version: curriculum_ua_qg_fixtures.v1
+fixtures:
+  - id: b1-27-restored-bad
+    level: b1
+    slug: aspect-in-imperatives
+    expected_verdict: FAIL
+    module:
+      module.md: |-
+        # Вид у наказовому способі
+
+        Тут застосунок має бути відкритий. Застереження каже: будь обережний.
+        Він радить не робити певної поведінки.
+        Подумай: дія має дати конкретний результат чи описати процес?
+        Крім того, доконаний вид дає результат із вікном. У кухні стоїть стіл.
+      activities.yaml: |-
+        []
+      vocabulary.yaml: |-
+        []
+      resources.yaml: |-
+        []
+    expected_findings:
+      - issue_id: AWKWARD_PASSIVE_RESULT_STATE
+        excerpt: застосунок має бути відкритий
+        dimension: ukrainian_style
+        severity: critical
+      - issue_id: UNNATURAL_ANTHROPOMORPHISM
+        excerpt: "Застереження каже: будь обережний"
+        dimension: ukrainian_style
+        severity: critical
+      - issue_id: UKRAINIAN_GRAMMAR_CALQUE
+        excerpt: радить не робити певної поведінки
+        dimension: ukrainian_style
+        severity: critical
+      - issue_id: UNNATURAL_META_REGISTER
+        excerpt: дія має дати конкретний результат чи описати процес?
+        dimension: ukrainian_style
+        severity: critical
+      - issue_id: UKRAINIAN_GRAMMAR_CALQUE
+        excerpt: доконаний вид дає результат із вікном
+        dimension: ukrainian_style
+        severity: critical
+      - issue_id: CALQUED_PREPOSITION
+        excerpt: У кухні
+        dimension: ukrainian_style
+        severity: critical
+
+  - id: b1-27-current-production
+    level: b1
+    slug: aspect-in-imperatives
+    expected_verdict: PASS
+    source_module_dir: curriculum/l2-uk-en/b1/aspect-in-imperatives
+
+  - id: a1-english-scaffold-allowed
+    level: a1
+    slug: scaffolded-dialogue
+    expected_verdict: PASS
+    module:
+      module.md: |-
+        # Short Dialogue
+
+        Read the dialogue.
+
+        **Я тут.** - I am here.
+      activities.yaml: |-
+        []
+      vocabulary.yaml: |-
+        []
+      resources.yaml: |-
+        []
+
+  - id: a2-english-support-warning
+    level: a2
+    slug: english-support-warning
+    expected_verdict: WARN
+    module:
+      module.md: |-
+        # Grammar Basics
+
+        This section explains the grammar before Ukrainian examples appear in the lesson body.
+
+        **Ми читаємо.**
+      activities.yaml: |-
+        []
+      vocabulary.yaml: |-
+        []
+      resources.yaml: |-
+        []
+    expected_findings:
+      - issue_id: ENGLISH_LEAKAGE
+        excerpt: This section explains the grammar before Ukrainian examples appear in the lesson body.
+        dimension: level_policy
+        severity: warning
+
+  - id: a1-english-led-rejected
+    level: a1
+    slug: missing-ukrainian-anchor
+    expected_verdict: FAIL
+    module:
+      module.md: |-
+        # Greetings
+
+        This lesson explains how greetings work before any Ukrainian appears. The learner reads the English explanation first and never receives a Ukrainian anchor.
+      activities.yaml: |-
+        []
+      vocabulary.yaml: |-
+        []
+      resources.yaml: |-
+        []
+    expected_findings:
+      - issue_id: ENGLISH_LEAKAGE
+        excerpt: This lesson explains how greetings work before any Ukrainian appears.
+        dimension: level_policy
+        severity: critical
+
+  - id: b1-english-led-rejected
+    level: b1
+    slug: intermediate-verbs
+    expected_verdict: FAIL
+    module:
+      module.md: |-
+        # Intermediate Verbs
+
+        Welcome to B1! In this module, we will explore advanced grammar. You must understand how this works.
+
+        **Читайте уважно.**
+      activities.yaml: |-
+        []
+      vocabulary.yaml: |-
+        []
+      resources.yaml: |-
+        []
+    expected_findings:
+      - issue_id: ENGLISH_LEAKAGE
+        excerpt: Welcome to B1!
+        dimension: level_policy
+        severity: critical
+
+  - id: b1-local-english-gloss-allowed
+    level: b1
+    slug: local-english-gloss
+    expected_verdict: PASS
+    module:
+      module.md: |-
+        # Локальна підказка
+
+        **Застосунок** - app. Далі відкрийте застосунок, увійдіть у профіль і перевірте налаштування безпеки перед роботою.
+      activities.yaml: |-
+        []
+      vocabulary.yaml: |-
+        []
+      resources.yaml: |-
+        []
+
+  - id: seminar-pathos-rejected
+    level: folk
+    slug: motivational-seminar
+    expected_verdict: FAIL
+    module:
+      module.md: |-
+        # Мотиваційний семінар
+
+        Розпочнімо неймовірну подорож, яка пробудить гордість і об'єднає всіх навколо правильної позиції.
+      activities.yaml: |-
+        []
+      vocabulary.yaml: |-
+        []
+      resources.yaml: |-
+        []
+    expected_findings:
+      - issue_id: SEMINAR_REGISTER_PATHOS
+        excerpt: неймовірну подорож
+        dimension: seminar_sensitivity
+        severity: critical


### PR DESCRIPTION
## Summary

Refs #2156. Implements the PR1 curriculum-facing MVP for #2156; the broader UA-GEC/UNLP track remains open.

- Adds a deterministic curriculum Ukrainian QG harness with labeled fixtures for B1-27, A1/A2 scaffolding, B1 English leakage, local gloss allowance, and seminar pathos.
- Emits compact durable `qg_evidence.json`-compatible records with module id, level policy, checker version/config/hash, content hash, dimensional scores/findings, compact spans/excerpts, LLM metadata placeholders, and provenance.
- Teaches `module_quality_audit.py` to count current compact file evidence as current file-only LLM-QG coverage while still reporting DB persistence as needed.
- Documents PR1 scope, the module quality-gate workflow, and tool discovery/usage in `docs/SCRIPTS.md`.

## Follow-up Scope Split

Core #2156 follow-ups:
- #4307 — source-language-agnostic calque/grammar scoring schema.
- #4306 — UA-GEC gold-set ingestion and attribution path.
- #4308 — scorer adapter layer for deterministic, UA-GEC, and LLM signals.
- #4309 — LLM reviewer prompt/evaluator for naturalness/register/level fit.
- #4310 — cost-aware curriculum QG review workflow.
- #4311 — corpus-scale QG reporting and evidence backfill.
- #4312 — UNLP 2027 documentation and results track.

Out-of-scope follow-ups:
- #4287 — Surzhyk-specific spoken-register eval.
- #4288 — later Polonism/anglicism eval expansion.
- #4289 — boundary with the lang-uk leaderboard for general Ukrainian LLM capability.

## Verification

- `.venv/bin/python scripts/audit/curriculum_qg_harness.py --fixtures tests/fixtures/curriculum_qg/fixtures.yaml` -> 8/8 passed
- `.venv/bin/python scripts/audit/curriculum_qg_harness.py --module-dir curriculum/l2-uk-en/b1/aspect-in-imperatives --level b1 --slug aspect-in-imperatives` -> PASS, min score 10.0
- `.venv/bin/python scripts/audit/module_quality_audit.py --level b1 --format summary` -> current file-only LLM-QG: 1, missing: 93
- `.venv/bin/ruff check scripts/audit/curriculum_qg_harness.py scripts/audit/module_quality_audit.py tests/audit/test_curriculum_qg_harness.py tests/audit/test_module_quality_audit.py`
- `npx --no-install markdownlint-cli2 docs/SCRIPTS.md docs/runbooks/module-quality-gates.md docs/projects/ua-eval-harness/pr1-curriculum-qg-plan.md`
- `.venv/bin/python -m pytest tests/audit/test_curriculum_qg_harness.py tests/audit/test_module_quality_audit.py tests/audit/test_content_surface_gates.py tests/audit/test_llm_qg_store.py` -> 37 passed before final rebase; after latest rebase, targeted audit pytest -> 21 passed
- `git diff --check origin/main..HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- pre-commit/pre-push hooks -> passed

## Review Notes

- AGY planning/review lanes inspected deterministic scope, compact evidence, and checker behavior.
- AGY final PR gate review found no blockers and returned merge-ready.
- AGY issue-plan review approved the follow-up split and recommended the dependency order now reflected above.
- Claude Opus review was requested through the project runtime but could not run because the native Claude binary is unavailable in this environment.