### PR TITLE
[codex] docs(bio): add Yakiv Ostrianyn dossier

### DIFF
--- a/docs/research/bio/yakiv-ostrianyn.md
+++ b/docs/research/bio/yakiv-ostrianyn.md
@@ -1,0 +1,682 @@
+# Яків Острянин — Research Dossier
+
+**Slug:** `yakiv-ostrianyn`
+**Block:** P1 BIO Cossack coverage (post-1637 repression; registered /
+unregistered Cossack split; 1638 uprising; Hovtva, Lubny, Zhovnyn, and
+Starets sequence; flight to Slobidska Ukraine / Chuhuiv; Muscovite-border
+refuge and later heroic simplification risks)
+**Tier:** 1b (strong event context; thin, source-contested personal record)
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ Ostrianyn, ЕІУ Hovtva, ЕІУ
+  Zhovnyn, ЕІУ Ordinance, IEU Ostrianyn, IEU Hunia, IEU Skydan, IEU
+  Slobidska Ukraine, IEU Okolski, Velychko/Okolski source texts via Litopys)
+- [x] Source-tier checkboxes included and lower-tier sources kept
+  non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: post-Pavliuk
+  repression, register restriction, commissioner control, registered-Cossack
+  enforcement, military-territorial attachment, anti-Sich monitoring, and
+  Muscovite-border refuge)
+- [x] §4 includes short source-language anchors with verification caveats
+- [x] Ostrianyn is framed as complex: registered-Cossack colonel, unregistered
+  hetman, revolt organizer, tactically successful but strategically unstable
+  commander, refugee leader, Chuhuiv settler, and later memory figure
+- [x] Cross-track links: every "Existing" plan path verified locally with
+  `test -e` on 2026-07-04
+- [x] Naming-canonical applied; `Остряниця`, `Яцько`, and `Stefan/Krystof`
+  variants are tracked as aliases/source-layer problems, not forced into the
+  canonical title
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+
+- [x] **T1 baseline:** ЕІУ Ostrianyn anchors unknown birth year, 1641 death,
+  1633 first documentary mention as registered-Cossack colonel in the
+  Polish-Muscovite War, autumn 1637 organization on Poltava-region ground,
+  spring 1638 election as hetman of the unregistered Cossacks, universals,
+  Left-Bank town captures, Lubny/Zhovnyn retreat, movement to Slobidska
+  Ukraine, Chuhuiv settlement, and death in internal conflict.
+- [x] **T1 event context:** ЕІУ Hovtva and Zhovnyn anchor battle chronology,
+  campaign geography, fortified-camp vocabulary, and the leadership transition
+  to Dmytro Hunia.
+- [x] **T1 legal/register context:** ЕІУ Ordinance, Registered Cossacks, and
+  Mykytynska Sich anchor the post-1637 legal regime: curtailed Cossack
+  self-rule, abolished elective office for the register, commissioner control,
+  passports for movement to Zaporizhia, garrison duty, and monitoring of Sich
+  access.
+- [x] **T1 English context:** IEU Ostrianyn, Hunia, Skydan, Chuhuiv,
+  Slobidska Ukraine, and Okolski are used for English metadata, related
+  leaders, Chuhuiv / Sloboda migration, and Okolski diary context.
+- [x] **T2 source-language:** Velychko and Okolski/Lukomsky texts via Litopys
+  are used for short source-language anchors only. Velychko's own source
+  framing, the editor's notes, and the hostile Okolski layer make them
+  source-critical, not transparent fact.
+- [x] **T4 scholarship:** Hrushevsky, Figurnyi, Holobutsky, and Shcherbak
+  bibliography leads are used for historiographic scaffolding and source
+  leads; none overrides the Tier 1 baseline.
+- [x] **T3/T5 caution:** Wikipedia, regional pages, school-prep pages, and
+  anniversary/heritage retellings are navigation or memory leads only; they
+  are not load-bearing for fact or interpretation.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Яків Острянин. ЕІУ gives `ОСТРЯНИН Яків`;
+  IEU gives `Ostrianyn, Yakiv [Острянин, Яків; Ostrjanyn, Jakiv]`. Use
+  `Yakiv Ostrianyn` for English curriculum metadata. [T1: ЕІУ Ostrianyn; T1:
+  IEU Ostrianyn]
+- **Aliases / spelling variants:** Яків Острянин; Яків Остряниця; Яцько
+  Острянин; Jatsko / Iatsko Ostrianyn; Yakiv Ostrianyn; Yakiv Ostryanyn;
+  Ostrianytsia; Ostrjanyn; old-source `Остранинъ`; Velychko-universal
+  `Стефан-Криштоф` is a source-layer problem, not a secure given name. [T1:
+  ЕІУ; T1: IEU; T2: Velychko]
+- **Born / died:** birth year unknown; died in **1641**. IEU gives birth in
+  Oster and death about 6 May 1641 near Chuhuiv; the inspected ЕІУ baseline is
+  more cautious, giving unknown birth and 1641 death without a birth scene.
+  Use exact date/place only with attribution. [T1: ЕІУ Ostrianyn; T1: IEU
+  Ostrianyn]
+- **Origin claim:** IEU names Oster in Chernihiv region; lower-tier retellings
+  often build a fuller family drama around Oster and the name `Iskra`. Treat
+  Oster as an IEU-supported origin lead and `Iskra` as a separate family /
+  memory lead requiring recheck before YAML aliases. [T1: IEU Ostrianyn; T3/T5]
+- **First secure career layer:** ЕІУ says Ostrianyn is first mentioned in
+  documents in **1633** as a colonel of registered Cossacks participating in
+  the Polish-Muscovite War of 1632-1634. IEU similarly places him in the
+  Novhorod-Siverskyi theater as a registered-Cossack colonel. [T1: ЕІУ
+  Ostrianyn; T1: IEU Ostrianyn]
+- **1637 adjacency:** ЕІУ says he organized insurgent detachments on the
+  Poltava-region side in autumn 1637. IEU says he participated in Pavlo
+  Pavliuk's 1637 rebellion and fled to the Sich after Kumeiky. Present this as
+  adjacency to the Pavliuk/But cycle, not as a full biography of Pavliuk. [T1:
+  ЕІУ Ostrianyn; T1: IEU Ostrianyn]
+- **Office / constituency:** in spring **1638** Ostrianyn was elected hetman
+  of the unregistered Cossacks. The safer teaching formula is "leader or
+  hetman of unregistered / Zaporizhian Cossacks," because his authority came
+  through a crisis council and did not survive the campaign. [T1: ЕІУ
+  Ostrianyn; T1: IEU Ostrianyn]
+- **Universals:** before moving onto the settled lands, he sent universals
+  calling for struggle against crown forces. Velychko preserves a long
+  universal text, but the Litopys editorial note flags later editorial traces
+  and the problematic `Стефан-Криштоф` naming. Use the universal for rhetoric
+  and source criticism, not as clean autobiography. [T1: ЕІУ Ostrianyn; T2:
+  Velychko]
+- **Campaign opening:** ЕІУ says the insurgents took Kremenchuk, Khorol,
+  Hovtva, and other Left-Bank towns and townlets. IEU says Ostrianyn, Karpo
+  Skydan, and Dmytro Hunia renewed the 1638 rebellion on both banks of the
+  Dnipro. [T1: ЕІУ Ostrianyn; T1: IEU Ostrianyn; T1: IEU Skydan; T1: IEU
+  Hunia]
+- **Hovtva:** ЕІУ Hovtva calls it the first of the main battles of the 1638
+  uprising under Ostrianyn, dated **5-6 May / 25-26 April O.S.** The article
+  places the main Cossack force, at least about 2,000 people, moving from
+  Kremenchuk up the Psel toward Omelnyk and Hovtva, using Hovtva's natural and
+  built defenses, and forcing Stanislaw Potocki to withdraw toward Lubny. [T1:
+  ЕІУ Hovtva]
+- **Lubny / Zhovnyn:** ЕІУ Ostrianyn says that after an unsuccessful battle
+  near Lubny, he withdrew to Zhovnyn expecting support from Kyiv-region
+  insurgent groups. ЕІУ Zhovnyn says the main insurgent forces concentrated
+  near Zhovnyn after the Lubny-area fighting and built a fortified camp on the
+  Sula. [T1: ЕІУ Ostrianyn; T1: ЕІУ Zhovnyn]
+- **Leadership break:** ЕІУ Zhovnyn says the 30-31 May battle pushed
+  Ostrianyn, with part of the Cossacks, to leave the camp, cross the Sula, and
+  move toward Slobidska Ukraine; Dmytro Hunia was then elected hetman and the
+  remaining forces continued at Zhovnyn/Starets. IEU gives the Zhovnyn attack
+  in New Style dating and says about 1,000 followers fled with Ostrianyn. [T1:
+  ЕІУ Zhovnyn; T1: IEU Ostrianyn; T1: IEU Hunia]
+- **Starets after Ostrianyn:** Hunia led the continued defense at Starets for
+  more than a month according to ЕІУ Hunia; this belongs in the same campaign
+  sequence but is not evidence that Ostrianyn himself commanded the final
+  defense. [T1: ЕІУ Hunia; T1: IEU Hunia]
+- **Chuhuiv / Sloboda layer:** ЕІУ says the Cossacks, with permission of the
+  tsarist government, settled at the Chuhuiv site. IEU Chuhuiv says Chuhuiv was
+  founded in 1638 as a frontier settlement by Ostrianyn and his Cossacks; IEU
+  Slobidska Ukraine says about 1,000 migrants led by Hetman Yakiv Ostrianyn
+  settled near Chuhuiv in 1638. [T1: ЕІУ Ostrianyn; T1: IEU Chuhuiv; T1: IEU
+  Slobidska Ukraine]
+- **Death tradition:** ЕІУ says Ostrianyn was killed in 1641 as a result of
+  internal strife; IEU says he was murdered by former supporters near Chuhuiv.
+  Do not narrate a detailed death scene without checking Muscovite-border
+  documentation. [T1: ЕІУ Ostrianyn; T1: IEU Ostrianyn]
+- **Post-1638 legal aftermath:** ЕІУ Ordinance says the 1638 ordinance
+  radically changed the political, legal, and military organization of the
+  registered Host: traditional rights, elected starshyna, and Cossack courts
+  were curtailed; a commissioner replaced the hetman for the register; and
+  movement to Zaporizhia without a passport could be punished severely. [T1:
+  ЕІУ Ordinance; T1: ЕІУ Registered Cossacks]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Name:** use `Яків Острянин` / `Yakiv Ostrianyn` as canonical. Keep
+   `Остряниця` as a common alias, not a second separate person.
+2. **Given name variants:** `Яцько` is a familiar vernacular form; `Стефан` /
+   `Криштоф` appears in Velychko's universal layer and should be treated as a
+   source problem until a document edition is checked.
+3. **Birthplace:** IEU supports Oster; ЕІУ is more cautious. Do not open a
+   module with a precise childhood scene.
+4. **Registered vs unregistered:** both career layers matter. He was a
+   registered-Cossack colonel in 1633 and later hetman of unregistered
+   Cossacks in 1638.
+5. **Pavliuk/But relation:** Ostrianyn belongs after the 1637 defeat and
+   repression, but this dossier should not absorb Pavlo But's biography.
+6. **Date conversion:** Hovtva and Zhovnyn appear in Old Style / New Style
+   forms across sources. Use month and attribution unless teaching calendars.
+7. **Zhovnyn "flight" language:** Okolski/Velychko and later narratives often
+   moralize Ostrianyn's departure. Treat "flight," "abandonment," and betrayal
+   vocabulary as source language.
+8. **Chuhuiv founding:** IEU and Sloboda-region memory support the connection,
+   but Chuhuiv's earlier frontier-site chronology and later settlement layers
+   need careful local-history sourcing before a map claim.
+9. **Death:** murdered / killed by former supporters is the secure summary.
+   Motive and exact mechanics remain source-thin.
+10. **Political meaning:** do not turn him into a pure folk avenger, bandit,
+    Soviet class-war emblem, or modern nationalist prototype.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Ostrianyn's biography exposes the coercive pressure that
+followed Pavlo But/Pavliuk's defeat: executions, register revision, attacks on
+Zaporizhia, pressure on registered officers, and a campaign to prevent
+unregistered Cossacks from turning Sich authority back onto the settled lands.
+The 1638 uprising was therefore not an isolated outburst. It grew from a
+political and military system that needed Cossack service while narrowing who
+could legally be a Cossack and who could move, elect officers, hold courts, or
+go to Zaporizhia. [T1: ЕІУ Ostrianyn; T1: ЕІУ Ordinance; T1: ЕІУ Registered
+Cossacks]
+
+**By whom:** Commonwealth military and administrative power in the legal,
+commissioner, and punishment layers; crown and magnate military forces in the
+campaign layer; registered-Cossack officers and units in the enforcement layer;
+unregistered Zaporizhians and broader frontier society in the mobilization
+layer; Muscovite frontier authorities in the refuge / settlement layer.
+Ostrianyn also had agency: he had served in the register, accepted insurgent
+leadership, sent mobilizing texts, made tactical choices, left the Zhovnyn
+camp, and led followers across the border.
+
+**Document references:** Pavliuk/But defeat and Borovytsia settlement context;
+Ostrianyn's universals; Okolski's hostile field diary; the 1638 Ordinance;
+Masliv Stav implementation; registered-Cossack passport and garrison rules;
+Muscovite-border settlement records around Chuhuiv as a research lead. [T1:
+ЕІУ Ordinance; T1: ЕІУ Mykytynska Sich; T2: Velychko/Okolski; T4:
+Hrushevsky/Figurnyi leads]
+
+**Mechanism specifics:** the conflict was about status and movement as much as
+battle. The 1638 legal order tried to turn the registered Host into a closely
+supervised service body: a commissioner, appointed from the nobility, replaced
+elected leadership for the register; movement to Zaporizhia required a
+passport; one territorial regiment was to be on duty near the Sich; and
+unauthorized presence or raids were treated as a security problem. Ostrianyn's
+campaign resisted that narrowing, but his coalition could not hold together
+after setbacks around Lubny and Zhovnyn. [T1: ЕІУ Ordinance; T1: ЕІУ
+Mykytynska Sich; T1: ЕІУ Zhovnyn]
+
+**What survived / what was distorted:** what survived is a strong memory of the
+1638 revolt as the last major pre-Khmelnytsky Cossack rising and a Sloboda /
+Chuhuiv migration marker. What gets distorted is the person. Commonwealth and
+Okolski-style language can reduce him to disorder; Soviet inheritance can
+flatten him into class struggle; patriotic memory can make him a pure
+liberation hero; regional memory can make Chuhuiv settlement a simple founding
+legend. A decolonized reading keeps all layers visible: registered service,
+unregistered mobilization, coercive law, insurgent violence, leadership
+failure, frontier refuge, and memory-making.
+
+## 3. Major works / legacy
+
+Ostrianyn left no literary corpus; "works" means offices, campaign decisions,
+universals, settlement action, and memory.
+
+- `before 1633` — early life remains source-thin. IEU gives Oster as origin;
+  ЕІУ does not build a childhood biography. [T1: IEU Ostrianyn; T1: ЕІУ
+  Ostrianyn]
+- `1633` — first secure documentary layer: registered-Cossack colonel in the
+  Polish-Muscovite War of 1632-1634. This prevents a simple story of a lifelong
+  unregistered outlaw. [T1: ЕІУ Ostrianyn; T1: IEU Ostrianyn]
+- `autumn 1637` — organized insurgent detachments on Poltava-region ground
+  after the Pavliuk/But uprising phase. Use as post-defeat mobilization, not as
+  a duplicate Pavliuk biography. [T1: ЕІУ Ostrianyn]
+- `winter-spring 1638` — moved into the Sich crisis environment after the 1637
+  defeat; IEU connects him with Pavliuk's rebellion and flight to the Sich
+  after Kumeiky. [T1: IEU Ostrianyn; T1: IEU Hunia]
+- `spring 1638` — elected hetman of unregistered Cossacks; sent universals
+  calling for struggle and warning against disclosure through registered
+  channels. [T1: ЕІУ Ostrianyn; T2: Velychko]
+- `March-April 1638` — campaign moved from Zaporizhia onto the Left Bank;
+  Kremenchuk, Khorol, Hovtva, and other places entered the insurgent geography.
+  [T1: ЕІУ Ostrianyn; T1: ЕІУ Hovtva]
+- `5-6 May / 25-26 April O.S. 1638` — Hovtva victory: insurgents used terrain,
+  fieldworks, flanking movement, artillery, and obstacles to force Stanislaw
+  Potocki away from Hovtva. [T1: ЕІУ Hovtva]
+- `May 1638` — Lubny / Sula maneuvering: ЕІУ Ostrianyn and Zhovnyn anchor an
+  unsuccessful Lubny-area phase before concentration at Zhovnyn. Detailed
+  tactical sequence belongs in HIST or ISTORIO after checking Okolski and
+  Hrushevsky directly. [T1: ЕІУ Ostrianyn; T1: ЕІУ Zhovnyn; T4: Hrushevsky
+  lead]
+- `30-31 May O.S. / June N.S. 1638` — Zhovnyn battle: Ostrianyn left the camp
+  with part of the force and moved across the Sula toward Slobidska Ukraine;
+  Dmytro Hunia became hetman for the remaining defense. [T1: ЕІУ Zhovnyn; T1:
+  IEU Ostrianyn; T1: IEU Hunia]
+- `June-July 1638` — Starets defense under Hunia continued after Ostrianyn's
+  departure. Keep it connected but do not credit Ostrianyn with the whole final
+  defense. [T1: ЕІУ Hunia; T1: IEU Hunia]
+- `1638` — settlement near Chuhuiv: IEU Chuhuiv and Slobidska Ukraine connect
+  Ostrianyn and about 1,000 migrants with a frontier settlement near Chuhuiv.
+  [T1: IEU Chuhuiv; T1: IEU Slobidska Ukraine]
+- `1641` — killed in internal conflict near Chuhuiv / in the Chuhuiv
+  environment; exact death-day detail needs stronger documentation. [T1: ЕІУ
+  Ostrianyn; T1: IEU Ostrianyn]
+- `later source memory` — Okolski's diary, Velychko's chronicle, Hrushevsky's
+  synthesis, and Sloboda-region retellings made Ostrianyn a reusable figure for
+  discussions of rebellion, failure, and borderland settlement. [T1: IEU
+  Okolski; T2: Velychko/Okolski; T4: Hrushevsky]
+
+## 4. Primary/source-language anchors (>=2 required)
+
+> **Honest tool note:** no project `verify_quote` run was used for this
+> dossier. The excerpts below are short source-language anchors from public
+> source-text pages or source summaries. Recheck document editions before
+> classroom quotation.
+
+**Anchor 1 — Velychko universal rhetoric:**
+
+> "народу нашого православного"
+
+Context: the long Velychko universal frames the intended audience through
+Orthodox communal language. Use this to teach rhetoric and constituency; do
+not treat the whole universal as a clean 1638 transcript because the Litopys
+notes flag later redaction and name problems. [T2: Velychko/Litopys]
+
+**Anchor 2 — coercion vocabulary in the same universal layer:**
+
+> "ярмо, неволю"
+
+Context: the phrase marks the universal's liberation rhetoric. It is powerful
+for learners, but it should be paired with source criticism: Velychko writes
+after the event and embeds a pro-Cossack explanatory frame. [T2:
+Velychko/Litopys]
+
+**Anchor 3 — hostile diary frame around departure:**
+
+> "Остранинъ війшолъ зъ Запорожя"
+
+Context: the Okolski/Lukomsky/Velychko text preserves hostile and moralizing
+language around the campaign. Use it to teach source position: a diary from
+the Commonwealth military side is evidence, but not neutral narration. [T2:
+Okolski/Lukomsky via Litopys; T1: IEU Okolski]
+
+**Anchor 4 — legal-control vocabulary:**
+
+`старший комісар`, `паспорт`, `смертна кара`, and `запобігання заколотам` are
+key 1638 Ordinance terms for lessons on law and movement control. They should
+be taught as coercive administrative vocabulary, not as naturalized order. [T1:
+ЕІУ Ordinance; T1: ЕІУ Mykytynska Sich]
+
+## 5. Language register and learner-use notes
+
+- **Register:** Cossack military, legal-administrative, frontier, chronicle,
+  diary, and settlement vocabulary: registered Cossacks, unregistered Cossacks,
+  register, Sich, hetman, colonel, universal, commissioner, passport, garrison,
+  fortified camp, wagon-fort, Sula, Starets, Slobidska Ukraine, Chuhuiv,
+  rebel, oath, punishment, and refuge.
+- **CEFR readiness for full reading:** B1-B2 for adapted biography; B2-C1 for
+  register/Ordinance mechanism and campaign geography; C1-C2 for Velychko,
+  Okolski/Lukomsky, Hrushevsky, and legal texts because of old orthography,
+  partisan labels, and mixed Polish/Ruthenian/Church-Slavonic forms.
+- **Lexicon notes:** `нереєстрові козаки`, `реєстрові козаки`, `випищики`,
+  `гетьман`, `полковник`, `універсал`, `волость`, `Запорозька Січ`,
+  `комісар`, `паспорт`, `залога`, `шанець`, `окоп`, `табір`, `переправа`,
+  `Слобідська Україна`, `Чугуїв`.
+- **Learner-use notes:** this dossier supports a B2-C1 lesson on source
+  stance: "ЕІУ says," "IEU gives," "Velychko preserves but warns," "Okolski's
+  side frames," "the ordinance controls," and "later memory simplifies."
+- **Stylistic features:** pair legal/control vocabulary (`комісар`,
+  `паспорт`, `залога`, `кара`) with agency vocabulary (`обраний`,
+  `розіслав універсали`, `оволоділи`, `відійшов`, `обрали Гуню`,
+  `оселилися`).
+- **Sensitive framing:** avoid prompts like "coward or hero" and "failed
+  national liberator." Better prompt: "How did post-1637 coercion shape
+  Ostrianyn's choices, and why did tactical success at Hovtva not produce a
+  durable political result?"
+
+## 6. Contested points
+
+- **Canonical name:** `Yakiv Ostrianyn` / `Яків Острянин` is the project form.
+  `Остряниця` is important for search and memory, but do not create duplicate
+  person records.
+- **Birth and origin:** Oster is IEU-supported; exact birth year and family
+  narrative remain source-thin.
+- **`Iskra` / `Stefan-Krystof` variants:** use only with caveats. They belong
+  in a source-criticism note unless a specialist genealogy/source edition is
+  inspected.
+- **Office title:** `hetman` in 1638 means crisis leader of unregistered /
+  Zaporizhian Cossacks, not a stable later state office.
+- **1637 role:** the Pavliuk/But aftermath is essential, but Ostrianyn should
+  not be made the main author of every 1637 event.
+- **Universals:** source-supported as a practice, but exact wording and date
+  require source-edition care. Velychko's preserved text has later redaction
+  signals.
+- **Hovtva strength:** ЕІУ says the main force was at least about 2,000 at the
+  Hovtva phase; other narratives give larger numbers later. Tie numbers to
+  specific moments.
+- **Calendar conversions:** avoid unsupported day precision unless the module
+  explicitly teaches Old Style / New Style.
+- **Zhovnyn departure:** present the departure as a documented leadership break
+  and retreat, not a moral verdict. Okolski/Velychko vocabulary is charged.
+- **Hunia's command:** after Ostrianyn leaves, Dmytro Hunia is the relevant
+  commander for Starets. Keep the sequence clear.
+- **Chuhuiv settlement:** strong as a Sloboda/IEU memory and settlement lead;
+  source details around permission, numbers, and later rebellion need
+  Muscovite-border archival recheck.
+- **Death:** "killed/murdered by former supporters in 1641" is safer than a
+  detailed motive story.
+- **Later memory:** Velychko, Okolski, Hrushevsky, Soviet-era narrative,
+  regional heritage, and patriotic retelling all select different meanings.
+
+## 7. Cross-track links
+
+> Every curriculum plan path under **Existing** below was verified locally on
+> 2026-07-04. `docs/research/bio/*`, `docs/research/folk/*`, and `wiki/*`
+> entries are verified files, not existing BIO plan paths. Forward-looking ties
+> are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/dmytro-vyshnevetsky.yaml` — earlier Sich /
+    frontier and Ottoman-border comparison.
+  - `curriculum/l2-uk-en/plans/bio/petro-sahaidachny.yaml` — earlier
+    registered-service and military-privilege baseline.
+  - `curriculum/l2-uk-en/plans/bio/severyn-nalyvaiko.yaml` — earlier revolt,
+    repression, execution, and martyr-memory comparison.
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — later
+    large-scale Cossack revolution/state-formation contrast after the
+    "Golden Peace" period.
+  - `curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml` — later Sich leadership
+    and frontier-memory comparison.
+  - `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml` — later Cossack
+    revolt memory and poetic afterlife comparisons.
+- **Existing BIO dossiers and research surfaces (VERIFIED present; not
+  curriculum plan paths):**
+  - `docs/research/bio/kryshtof-kosynsky.md`,
+    `docs/research/bio/severyn-nalyvaiko.md`,
+    `docs/research/bio/taras-fedorovych-triasylo.md`,
+    `docs/research/bio/ivan-sulyma.md`,
+    `docs/research/bio/ivan-bohun.md`,
+    `docs/research/bio/demian-mnohohrishny.md` — related Cossack or Hetmanate
+    dossier patterns and cautionary comparison points.
+  - `docs/research/folk/dumy-sotsialno-pobutovi.md` — social-memory and
+    Cossack-freedom vocabulary comparison.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/kozatski-povstannia-16.yaml` — earlier
+    Cossack uprising arc; use for Kosynsky/Nalyvaiko comparison without
+    conflation.
+  - `curriculum/l2-uk-en/plans/hist/kozatstvo-vytoky.yaml`,
+    `curriculum/l2-uk-en/plans/hist/syntez-kozatstvo-vytoky.yaml` — Cossack
+    status, mobility, and frontier background.
+  - `curriculum/l2-uk-en/plans/hist/zaporizka-sich.yaml`,
+    `curriculum/l2-uk-en/plans/hist/kozatske-viisko.yaml` — Sich, Host,
+    register, council, and military vocabulary.
+  - `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml` — Commonwealth
+    political order, estates, offices, and coercive legal context.
+  - `curriculum/l2-uk-en/plans/hist/khotynska-viyna.yaml`,
+    `curriculum/l2-uk-en/plans/hist/petro-sahaidachnyi.yaml` — earlier
+    service/reward background and Cossack privilege pressure.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — later
+    institutional contrast for what the 1638 uprising did not create.
+- **Existing LIT/FOLK/ISTORIO/RUTH plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit-hist-fic/andrian-kashchenko-cossack-myth.yaml`
+    — historical-fiction / Cossack-memory pairing.
+  - `curriculum/l2-uk-en/plans/folk/dumy-sotsialno-pobutovi.yaml` — Cossack
+    social-memory vocabulary around constraint and freedom.
+  - `curriculum/l2-uk-en/plans/istorio/kozatski-litopysy-ohliad.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/syntez-kozatski-dzherela.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/sich-dokumenty.yaml` — chronicle,
+    diary, and document-source scaffolding for Velychko/Okolski and universals.
+  - `curriculum/l2-uk-en/plans/ruth/cossack-hierarchy.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/szlachta-nobility.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/document-types.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/treason.yaml` — office, estate, document,
+    and accusation vocabulary.
+- **Existing wiki/research files (VERIFIED present; not curriculum plan paths):**
+  - `wiki/periods/slobozhanshchyna.md` — already mentions the 1638 arrival of
+    Ostrianyn's group near Chuhuiv.
+  - `wiki/periods/syntez-viyna.md` — already lists the 1638 Ostrianyn uprising
+    as an armed-resistance marker.
+  - `wiki/linguistics/ruthenian/velychko-ruin-baroque-1.md`,
+    `wiki/linguistics/ruthenian/velychko-ruin-baroque-2.md` — existing
+    Velychko/Okolski source-context surfaces.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `yakiv-ostrianyn` — future BIO plan/module and wiki figure if this dossier
+    is promoted; `curriculum/l2-uk-en/plans/bio/yakiv-ostrianyn.yaml` and
+    `wiki/figures/yakiv-ostrianyn.md` absent locally on 2026-07-04.
+  - `pavlo-pavliuk-but` and `semen-palii` — future BIO Cossack continuation
+    candidates; plan/dossier/wiki surfaces absent locally on 2026-07-04.
+  - `ostrianyn-uprising-1638` / `zhovnyn-1638` — future HIST modules on the
+    1638 campaign, leadership break, and post-Pavliuk repression; absent
+    locally on 2026-07-04.
+  - `okolski-diary-1638` — future ISTORIO source-critical packet on the
+    hostile diary layer; absent locally on 2026-07-04.
+  - `chuhuiv-ostrianyn-memory` — future HIST/ISTORIO/Sloboda packet on
+    borderland refuge, migration, and founding memory.
+
+## 8. Naming-canonical
+
+- **Slug:** `yakiv-ostrianyn`
+- **EN canonical (project spelling):** Yakiv Ostrianyn
+- **UA canonical:** Яків Острянин
+- **Aliases (track carefully for future `aliases:` YAML field):** Яків
+  Острянин; Яків Остряниця; Яцько Острянин; Yakiv Ostrianyn; Yakiv Ostryanyn;
+  Yakiv Ostrianytsia; Ostrianyn, Yakiv; Ostrjanyn, Jakiv; Jatsko / Iatsko
+  Ostrianyn; `Остранинъ` [old-source spelling].
+- **Source-sensitive / not canonical without recheck:** `Стефан-Криштоф`;
+  `Степан Остряниця`; `Іскра-Острянин`; exact `Яків Стефан Іскра-Острянин`
+  composite forms from lower-tier or memory layers.
+- **Office/title variants to track carefully:** `гетьман нереєстрових
+  козаків`; `запорозький гетьман`; `полковник реєстровців`; `старший`;
+  `ватажок`; `випищики`; `реєстрові козаки`; `нереєстрові козаки`.
+- **Place/event variants to track carefully:** `Остер`; `Запорозька Січ`;
+  `Кременчук`; `Хорол`; `Омельник`; `Говтва / Голтва`; `Лубни`;
+  `Жовнин / Жовнине`; `Сула`; `Старець`; `Слобідська Україна`; `Чугуїв`;
+  `Павло Бут / Павлюк`; `Карпо Скидан`; `Дмитро Гуня`; `Станіслав Потоцький`;
+  `Миколай Потоцький`; `Ярема Вишневецький`.
+- **Forbidden forms / flattening forms to flag in body text:** "bandit" as
+  neutral fact; "coward" as narrator voice; "traitor" for registered Cossacks
+  as narrator voice; "pure class-war leader" as full explanation; "modern
+  nationalist prototype" as full explanation; exact birth/death story without
+  source caveat; `Stefan/Krystof` as canonical without recheck.
+- **Term warning:** `hetman` is a volatile early-modern office label here.
+  Explain constituency and context rather than mapping it automatically onto
+  later institutions.
+- **Scope warning:** keep this BIO dossier on post-1637 repression, 1638
+  uprising, register politics, Zhovnyn/Starets sequence, Sloboda/Chuhuiv
+  refuge, and memory. Do not turn it into an all-rulers chronology or unrelated
+  modern-statehood material.
+
+## 9. Image candidates
+
+- **Best context candidate:** a rights-clear map of the Hovtva-Lubny-Zhovnyn /
+  Sula-Dnipro campaign corridor, if a public-domain or project-created map can
+  be verified. This may teach the dossier better than a portrait.
+- **Sloboda/Chuhuiv candidate:** a historical map or early image of Chuhuiv /
+  Slobidska Ukraine with explicit reuse terms. Caption as settlement/migration
+  context, not as a life portrait.
+- **Portrait candidates:** Wikimedia Commons and regional pages surface
+  "Yakiv Ostrianyn/Ostrianytsia" portraits. Verify author, date, license, and
+  provenance before reuse; do not caption later heroic art as a contemporary
+  likeness.
+- **Source candidate:** a page image from a public-domain Velychko or Okolski
+  edition could support an ISTORIO source-criticism lesson if reproduction
+  rights and legibility are verified.
+- **Institutional image lead:** IEU Chuhuiv includes an 1860s Chuhuiv street
+  photo; useful for city history only, not for the 1638 event.
+- **Authenticity caveat:** no contemporary life portrait was verified in this
+  pass. Use "later visual memory" or "context image" captions unless metadata
+  proves life-era provenance.
+- **Avoid:** generic Cossack stock art, battle images without source relation,
+  unlicensed modern portraits, and images that frame Ostrianyn as a simple
+  avenger or simple failure.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- [T1] Щербак В.О. "Острянин Яків" // *Енциклопедія історії України*, т. 7.
+  URL: https://www.history.org.ua/?termin=Ostrianyn_Y | accessed 2026-07-04.
+  Core facts: unknown birth year, 1641 death, 1633 registered-colonel mention,
+  autumn 1637 Poltava-region organization, spring 1638 unregistered-Cossack
+  hetmancy, universals, Kremenchuk/Khorol/Hovtva captures, Lubny/Zhovnyn
+  retreat, Slobidska Ukraine / Chuhuiv settlement, death in internal conflict.
+- [T1] Вирський Д.С. "Говтва, битва 1638" // *Енциклопедія історії України*,
+  т. 2. URL: https://www.history.org.ua/?termin=Govtva_bytva_1638 | accessed
+  2026-07-04. Used for Hovtva date, battle geography, campaign plan, terrain,
+  fortifications, registered-Cossack / hired-infantry assault, and Potocki's
+  retreat.
+- [T1] Щербак В.О. "Жовнинська битва 1638" // *Енциклопедія історії України*.
+  URL: https://www.history.org.ua/?termin=Zhovnynska_bytva_1638 | accessed
+  2026-07-04. Used for Zhovnyn camp, 30-31 May battle, Ostrianyn's departure,
+  Hunia's election, and Starets continuation.
+- [T1] Щербак В.О. "Гуня Дмитро Тимошевич" // *Енциклопедія історії України*.
+  URL: https://www.history.org.ua/?termin=Gunya_D | accessed 2026-07-04. Used
+  for Hunia's role after Kumeiky/Borovytsia, spring 1638 Sich defense, joining
+  Ostrianyn/Skydan, Starets defense, and later Don movement.
+- [T1] Сас П.М. "Ординація Війська Запорозького 1638" // *Енциклопедія
+  історії України*, т. 7. URL:
+  https://www.history.org.ua/?termin=Ordynatsiia_Vijska_1638 | accessed
+  2026-07-04. Used for legal/administrative coercion: abolished traditional
+  rights, commissioner structure, passport controls, garrison rules,
+  territorial attachment, and Masliv Stav implementation.
+- [T1] Щербак В.О. "Реєстрові козаки" // *Енциклопедія історії України*.
+  URL: https://www.history.org.ua/?termin=Reiestrovi_kozaky | accessed
+  2026-07-04. Used for register context, territorial-polks system, participation
+  in uprisings, and the 1638 restriction of self-rule.
+- [T1] Щербак В.О. "Микитинська Січ" // *Енциклопедія історії України*.
+  URL: https://www.history.org.ua/?termin=Mykytynska_sich | accessed
+  2026-07-04. Used for post-1638 Sich monitoring, registered garrison duty, and
+  prohibition on unauthorized presence.
+- [T1] "Ostrianyn, Yakiv" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CO%5CS%5COstrianynYakiv.htm
+  | accessed 2026-07-04. Used for English metadata, Oster/Chuhuiv date-place
+  leads, 1633-1634 registered-colonel context, Pavliuk adjacency, Hovtva,
+  Zhovnyn, Slobidska Ukraine retreat, and death by former supporters.
+- [T1] "Hunia, Dmytro" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CH%5CU%5CHuniaDmytro.htm
+  | accessed 2026-07-04. Used for Hunia's role in 1637, spring 1638, Zhovnyn
+  aftermath, and continued command.
+- [T1] "Skydan, Karpo" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CK%5CSkydanKarpo.htm
+  | accessed 2026-07-04. Used for Skydan as unregistered-Cossack colonel and
+  co-leader in 1637-1638.
+- [T1] "Chuhuiv" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CC%5CH%5CChuhuiv.htm
+  | accessed 2026-07-04. Used for the 1638 frontier-settlement statement and
+  Chuhuiv context.
+- [T1] "Slobidska Ukraine" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CL%5CSlobidskaUkraine.htm
+  | accessed 2026-07-04. Used for Ukrainian migration to Slobidska Ukraine,
+  about 1,000 migrants led by Ostrianyn near Chuhuiv, and Muscovite-government
+  frontier incentives.
+- [T1] "Okolski, Szymon" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CO%5CK%5COkolskiSzymon.htm
+  | accessed 2026-07-04. Used for Okolski's role as chaplain with Potocki's
+  forces, his diaries, and their use in Velychko/Lukomsky.
+
+**Tier 2 (source editions / source-language anchors):**
+
+- [T2] Самійло Величко, *Літопис*, "Додатки" / "О войне Остраниновой..." text
+  via Izbornyk/Litopys. URL: https://litopys.org.ua/velichko/vel14.htm |
+  accessed 2026-07-04. Used for short universal-language anchors, Velychko's
+  source framing, the `Стефан-Криштоф` naming problem, and warnings about later
+  editorial traces.
+- [T2] "Щоденник Симеона Окольського. 1638" / Lukomsky-Velychko transmission
+  via Izbornyk/Litopys. URL: https://litopys.org.ua/samovyd/sam21.htm |
+  accessed 2026-07-04. Used for hostile source-language framing around
+  Ostrianyn, Hovtva, Zhovnyn, Hunia, and the campaign. Treat as partisan and
+  translation-layer evidence.
+
+**Tier 3 (encyclopedic — navigation only):**
+
+- [T3] "Яків Острянин" and "Повстання Острянина" // Ukrainian Wikipedia,
+  accessed 2026-07-04. Used only to navigate aliases, date claims, and source
+  leads; cross-checked against T1/T2.
+- [T3] "Ostryanyn uprising" // English Wikipedia, accessed 2026-07-04. Used
+  only for navigation to Okolski/Velychko and public-memory claims; not
+  load-bearing.
+
+**Tier 4 (modern scholarly / specialist anchors):**
+
+- [T4] Грушевський М. *Історія України-Руси*, т. 8 / English e-archive record
+  *History of Ukraine-Rus'*, vol. 8: *The Cossack Age, 1626-1650*. URL:
+  https://hrushevsky.history.org.ua/item/0001720 | accessed 2026-07-04. Used
+  as a specialist narrative/source lead for the wars of 1637-1638, Hovtva,
+  Lubny, Zhovnyn, Starets, Masliv Stav, and Chuhuiv/Ostrianyn migration.
+- [T4] Фігурний Ю.С. "Перший етап козацького збройного виступу 1638 р. під
+  орудою Якова Острянина (Остряниці)..." *Збірник наукових праць ННДІУВІ*,
+  том ХХХ, 2013, pp. 48-67. URL:
+  https://ndiu.knu.ua/images/elektr_bibl/30.pdf | accessed 2026-07-04. Used
+  for source leads, historiographic framing, Okolski/Shcherbak quotations, and
+  caution that the first campaign stage lacked unified coordination.
+- [T4/T5] Голобуцький В.О. "Запорозьке козацтво під час повстання
+  1637-1638 років" via Izbornyk/Litopys. URL:
+  https://litopys.org.ua/holob/hol12.htm | accessed 2026-07-04. Used only for
+  Soviet-era narrative comparison, source-note leads, and how Velychko/Okolski
+  material entered popular synthesis; not load-bearing.
+- [T4 lead] Щербак В.О. *Антифеодальні рухи на Україні напередодні визвольної
+  війни 1648-1654 рр.* Kyiv, 1989. Bibliographic anchor via ЕІУ Ostrianyn,
+  Hovtva, Zhovnyn, and Hunia; direct book text not fully inspected in this
+  pass.
+- [T4 lead] *Селянський рух на Україні 1569-1647 рр.: збірник документів і
+  матеріалів*. Kyiv, 1993. Bibliographic/source-edition lead via Figurnyi and
+  NB UV item metadata; direct document pages not fully inspected in this pass.
+
+**Not used as load-bearing:** regional "hetman" pages, school-prep materials,
+anniversary essays, image pages, generic Cossack popularizations, and
+lower-tier exact-date claims. For module writing, recheck the original
+document editions for Ostrianyn's universals, Okolski's printed diary,
+Muscovite-border Chuhuiv records, and Masliv Stav materials before exact
+quotation or map/timeline precision.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Muscovy/Moscow appears only as neighboring
+  power, border authority, or source channel, not as the default center.
+- [x] No Russian-imperial transliterations normalized in body text.
+- [x] Ostrianyn is not flattened into a folk avenger, bandit, coward, class-war
+  symbol, or modern nationalist prototype.
+- [x] Registered service, unregistered leadership, campaign agency, legal
+  coercion, leadership failure, Sloboda refuge, and death conflict are all
+  visible.
+- [x] Source labels such as `бунт`, `свавілля`, `зрада`, `втеча`, `лях`, and
+  hostile diary language are treated as source vocabulary, not neutral
+  narration.
+- [x] Registered Cossacks are not treated as timeless villains; coercion,
+  service structure, status, and commissioner control are named.
+- [x] Velychko and Okolski are marked as source-critical memory/document
+  layers, not used as transparent documentary biography.
+- [x] Sloboda/Chuhuiv memory is marked as settlement afterlife and borderland
+  context, not as proof of a simple liberation arc.
+- [x] Soviet/class-war shorthand is named only as historiographic inheritance,
+  not adopted as the dossier's explanation.
+- [x] Modern Ukrainian place/institution naming used with historical context:
+  Запорозька Січ, Запорожжя, Дніпро, Кременчук, Хорол, Говтва, Лубни, Жовнин,
+  Сула, Старець, Слобідська Україна, Чугуїв, Річ Посполита, Військо
+  Запорозьке.
+- [x] No unrelated modern-statehood material, all-rulers chronology, or
+  out-of-scope figures added.
+
+## Validation checklist
+
+- [x] Single owned file only: `docs/research/bio/yakiv-ostrianyn.md`.
+- [x] Existing cross-track plan paths verified locally before citation.
+- [x] Future Yakiv/Pavliuk/Palii/HIST/ISTORIO surfaces marked absent locally.
+- [x] Lower-tier sources marked non-load-bearing.
+- [x] Guard terms for unrelated modern-statehood, unrelated hetmanate scope,
+  and all-rulers scope avoided.
+- [x] No generated `status/`, `audit/`, `review`, or telemetry artifacts
+  referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans,
+  module files, activities, vocabulary, resources, site MDX, or wiki files
+  edited.


### PR DESCRIPTION
## Scope

Adds one BIO Cossack readiness research dossier for Yakiv Ostrianyn/Ostrianytsia. The dossier covers post-1637 repression, the 1638 uprising, registered/unregistered Cossack conflict, Hovtva/Lubny/Zhovnyn/Starets sequencing, Slobidska Ukraine/Chuhuiv refuge, naming caveats, image-rights notes, and decolonization checks.

No LLM-QG, QG parity, QG DB persistence, or module-quality audit gates were run.

## Changed Files

- `docs/research/bio/yakiv-ostrianyn.md`

## Validation

- `npx markdownlint-cli2 docs/research/bio/yakiv-ostrianyn.md` — passed, 0 errors
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/yakiv-ostrianyn.md` — passed, no fabricated Existing cross-track plan paths found
- `git diff --check` — passed
- `rg -n "Skoropadskyi|Скоропад|1918|Ukrainian State|Українськ.*Держав|Polish king|Polish kings|Польськ.*корол|польськ.*корол" docs/research/bio/yakiv-ostrianyn.md` — no matches
- Protected artifact/config guard — passed; diff contains only `docs/research/bio/yakiv-ostrianyn.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed for 1 commit

## Source / Decolonization Caveats

- EIU and IEU entries are load-bearing for core biography, event chronology, register/Ordinance context, Chuhuiv/Sloboda migration, and related leaders.
- Velychko and Okolski/Lukomsky source-text anchors are treated as source-critical, not transparent fact; universal wording and hostile diary labels require edition checks before classroom quotation.
- Lower-tier pages and memory retellings are non-load-bearing navigation/image leads only.
- The dossier keeps Ostrianyn complex: registered-Cossack colonel, unregistered hetman, revolt organizer, tactical commander, leadership-break figure, refugee leader, and memory subject. It avoids folk-avenger, bandit, pure class-war, and modern nationalist prototype flattening.

## Review Gate

No independent review has been routed yet; the orchestrator handles that gate after this writer-worker PR is opened.