### PR TITLE
feat(atlas): count source entry backlog

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -367,6 +367,7 @@ Additional audit guardrails:
 - `scripts/audit/lint_dispatch_brief.py` - dispatch brief `.venv/bin/python` worktree guardrail
 - `scripts/audit/atlas_source_census.py` - aggregate-only Word Atlas source intake census; public reports must not include raw source text, private paths, or candidate lemma lists
 - `scripts/audit/atlas_entry_model_census.py` - aggregate-only Word Atlas entry-model census; separates reviewed article entries by `entry_type` from alias/form records
+- `scripts/audit/atlas_source_entry_count.py` - aggregate-only Word Atlas source-corpus entry-demand census by finalized entry-model bucket; public reports must not include source text, private paths, filenames, or candidate lists
 
 ### Build pipeline entry point
 
@@ -535,6 +536,7 @@ Use this before content generation to verify plan files still match `scripts/aud
 | `scripts/check_decisions.py` | Audit decision journal expiry | `.venv/bin/python scripts/check_decisions.py` |
 | `scripts/audit/atlas_source_census.py` | Build aggregate-safe Word Atlas source planning counts | `.venv/bin/python scripts/audit/atlas_source_census.py --markdown-out docs/runbooks/word-atlas-source-census-planning.md` |
 | `scripts/audit/atlas_entry_model_census.py` | Count reviewed Atlas entries by finalized `entry_type` bucket | `.venv/bin/python scripts/audit/atlas_entry_model_census.py --format markdown` |
+| `scripts/audit/atlas_source_entry_count.py` | Estimate aggregate source-corpus Atlas entry backlog by finalized bucket | `.venv/bin/python scripts/audit/atlas_source_entry_count.py --include-ohoiko-private --markdown-out docs/runbooks/word-atlas-source-entry-count.md` |
 | `scripts/audit/lint_session_state.py` | Check handoff docs for missing env-file references | `.venv/bin/python scripts/audit/lint_session_state.py --all` |
 | `scripts/audit/lint_anti_menu.py` | Detect anti-menu sign-off prompts in markdown | `.venv/bin/python scripts/audit/lint_anti_menu.py --text docs/session-state/current.md` |
 | `scripts/audit/decision_lineage.py` | Scan decision git backlinks | `.venv/bin/python scripts/audit/decision_lineage.py --decision-id ADR-008` |

--- a/docs/runbooks/word-atlas-source-entry-count.md
+++ b/docs/runbooks/word-atlas-source-entry-count.md
@@ -1,0 +1,198 @@
+# Word Atlas Source Entry Count
+
+- workflow: `atlas_source_entry_count.v1`
+- generated_at: `2026-07-04T14:14:57+00:00`
+- production_outputs_updated: []
+- raw_text_included: false
+- candidate_lemmas_included: false
+- private_paths_included: false
+- private_filenames_included: false
+
+## Exact Reviewed Atlas Baseline
+
+- manifest_loaded: true
+- manifest_sha256: `f585ea69643154028e1d467162144a3f40fa758fa75a25610c19acc4686e8929`
+- manifest_records: 5502
+- total_reviewed_entries: 5156
+
+| entry bucket | exact reviewed entries |
+| --- | ---: |
+| `lemma` | 3847 |
+| `expression` | 5 |
+| `phraseologism` | 0 |
+| `proverb` | 0 |
+| `multiword_term` | 1266 |
+| `proper_name` | 38 |
+
+### Exact Non-Entry Manifest Records
+
+| bucket | records |
+| --- | ---: |
+| `form_alias` | 336 |
+| `grammar_term` | 10 |
+| `noise_rejected` | 0 |
+| `invalid` | 0 |
+
+## Estimated Source-Corpus Backlog By Lane
+
+| source lane | source units | unique forms | explicit headwords | candidate entries | reviewed overlap | estimated backlog | lemma | expression | phraseologism | proverb | multiword term | proper name | needs review | unknown | noise rejected |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `module_activity` | 518 | 32511 | 0 | 14765 | 3191 | 11574 | 8959 | 0 | 0 | 0 | 0 | 0 | 2615 | 0 | 0 |
+| `module_all` | 1549 | 56853 | 7222 | 30269 | 7981 | 22288 | 16963 | 0 | 0 | 0 | 0 | 0 | 5325 | 0 | 0 |
+| `module_content` | 518 | 48556 | 0 | 19786 | 3372 | 16414 | 13591 | 0 | 0 | 0 | 0 | 0 | 2823 | 0 | 0 |
+| `module_vocabulary` | 513 | 16646 | 7222 | 15949 | 7844 | 8105 | 6790 | 0 | 0 | 0 | 0 | 0 | 1315 | 0 | 0 |
+| `ohoiko_private_text` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| `textbook_extracted_text` | 24 | 125294 | 0 | 70040 | 3161 | 66879 | 34736 | 0 | 0 | 0 | 0 | 0 | 32143 | 0 | 0 |
+| `textbook_jsonl_chunks` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| `textbook_sqlite_db` | 25714 | 277142 | 0 | 148329 | 3407 | 144922 | 60422 | 0 | 0 | 0 | 0 | 0 | 84500 | 0 | 0 |
+| `committed_source_inventory` | 31 | 0 | 377 | 377 | 358 | 18 | 14 | 0 | 0 | 0 | 0 | 0 | 4 | 0 | 0 |
+| `committed_inventory_curriculum` | 10 | 0 | 20 | 20 | 19 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| `committed_inventory_ohoiko` | 4 | 0 | 33 | 33 | 33 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| `committed_inventory_teacher_lesson` | 10 | 0 | 224 | 224 | 207 | 17 | 13 | 0 | 0 | 0 | 0 | 0 | 4 | 0 | 0 |
+| `committed_inventory_textbook` | 7 | 0 | 111 | 111 | 110 | 1 | 1 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+
+## Classification Methods By Lane
+
+| source lane | method | candidates |
+| --- | --- | ---: |
+| `module_activity` | `manifest_entry_type` | 3191 |
+| `module_activity` | `unknown_needs_review` | 2615 |
+| `module_activity` | `vesum_backed_lemma` | 8959 |
+| `module_all` | `heuristic_multiword_needs_review` | 861 |
+| `module_all` | `manifest_entry_type` | 7981 |
+| `module_all` | `module_explicit_headword` | 1800 |
+| `module_all` | `unknown_needs_review` | 4464 |
+| `module_all` | `vesum_backed_lemma` | 15163 |
+| `module_content` | `manifest_entry_type` | 3372 |
+| `module_content` | `unknown_needs_review` | 2823 |
+| `module_content` | `vesum_backed_lemma` | 13591 |
+| `module_vocabulary` | `heuristic_multiword_needs_review` | 861 |
+| `module_vocabulary` | `manifest_entry_type` | 7844 |
+| `module_vocabulary` | `module_explicit_headword` | 1800 |
+| `module_vocabulary` | `unknown_needs_review` | 454 |
+| `module_vocabulary` | `vesum_backed_lemma` | 4990 |
+| `ohoiko_private_text` | `none` | 0 |
+| `textbook_extracted_text` | `manifest_entry_type` | 3161 |
+| `textbook_extracted_text` | `unknown_needs_review` | 32143 |
+| `textbook_extracted_text` | `vesum_backed_lemma` | 34736 |
+| `textbook_jsonl_chunks` | `none` | 0 |
+| `textbook_sqlite_db` | `manifest_entry_type` | 3407 |
+| `textbook_sqlite_db` | `unknown_needs_review` | 84500 |
+| `textbook_sqlite_db` | `vesum_backed_lemma` | 60422 |
+| `committed_source_inventory` | `heuristic_multiword_needs_review` | 4 |
+| `committed_source_inventory` | `manifest_entry_type` | 358 |
+| `committed_source_inventory` | `noise_filter` | 1 |
+| `committed_source_inventory` | `source_inventory_headword` | 14 |
+| `committed_inventory_curriculum` | `manifest_entry_type` | 19 |
+| `committed_inventory_curriculum` | `noise_filter` | 1 |
+| `committed_inventory_ohoiko` | `manifest_entry_type` | 33 |
+| `committed_inventory_teacher_lesson` | `heuristic_multiword_needs_review` | 4 |
+| `committed_inventory_teacher_lesson` | `manifest_entry_type` | 207 |
+| `committed_inventory_teacher_lesson` | `source_inventory_headword` | 13 |
+| `committed_inventory_textbook` | `manifest_entry_type` | 110 |
+| `committed_inventory_textbook` | `source_inventory_headword` | 1 |
+
+## Textbook Grades By Lane
+
+| source lane | grade | source units | unique forms | candidate entries | reviewed overlap | estimated backlog | lemma | needs review | unknown |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `textbook_extracted_text` | `grade-02` | 2 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| `textbook_extracted_text` | `grade-03` | 2 | 14398 | 9252 | 1739 | 7513 | 6035 | 1478 | 0 |
+| `textbook_extracted_text` | `grade-04` | 1 | 7180 | 5062 | 1156 | 3906 | 3002 | 904 | 0 |
+| `textbook_extracted_text` | `grade-05` | 2 | 25532 | 16614 | 2145 | 14469 | 10073 | 4396 | 0 |
+| `textbook_extracted_text` | `grade-06` | 2 | 25254 | 16515 | 2212 | 14303 | 10320 | 3983 | 0 |
+| `textbook_extracted_text` | `grade-07` | 2 | 20841 | 13315 | 2057 | 11258 | 8058 | 3200 | 0 |
+| `textbook_extracted_text` | `grade-08` | 3 | 16636 | 10103 | 1559 | 8544 | 6261 | 2283 | 0 |
+| `textbook_extracted_text` | `grade-09` | 3 | 36774 | 25183 | 2254 | 22929 | 12229 | 10700 | 0 |
+| `textbook_extracted_text` | `grade-10` | 3 | 40334 | 23924 | 2317 | 21607 | 14304 | 7303 | 0 |
+| `textbook_extracted_text` | `grade-11` | 3 | 52101 | 30298 | 2670 | 27628 | 17937 | 9691 | 0 |
+| `textbook_extracted_text` | `unknown` | 1 | 4895 | 3716 | 903 | 2813 | 2074 | 739 | 0 |
+| `textbook_sqlite_db` | `grade-01` | 394 | 8588 | 6474 | 1194 | 5280 | 3064 | 2216 | 0 |
+| `textbook_sqlite_db` | `grade-02` | 746 | 20198 | 12377 | 1932 | 10445 | 7663 | 2782 | 0 |
+| `textbook_sqlite_db` | `grade-03` | 939 | 29508 | 17501 | 2240 | 15261 | 10874 | 4387 | 0 |
+| `textbook_sqlite_db` | `grade-04` | 986 | 28898 | 17592 | 2222 | 15370 | 10168 | 5202 | 0 |
+| `textbook_sqlite_db` | `grade-05` | 1820 | 53501 | 31802 | 2758 | 29044 | 18409 | 10635 | 0 |
+| `textbook_sqlite_db` | `grade-06` | 2467 | 70456 | 40827 | 2933 | 37894 | 23316 | 14578 | 0 |
+| `textbook_sqlite_db` | `grade-07` | 2834 | 78339 | 43796 | 2971 | 40825 | 25829 | 14996 | 0 |
+| `textbook_sqlite_db` | `grade-08` | 3290 | 79301 | 44861 | 2927 | 41934 | 24618 | 17316 | 0 |
+| `textbook_sqlite_db` | `grade-09` | 3257 | 81256 | 47822 | 2872 | 44950 | 24748 | 20202 | 0 |
+| `textbook_sqlite_db` | `grade-10` | 3066 | 78770 | 47382 | 2991 | 44391 | 25104 | 19287 | 0 |
+| `textbook_sqlite_db` | `grade-11` | 3978 | 91502 | 51991 | 3060 | 48931 | 27498 | 21433 | 0 |
+| `textbook_sqlite_db` | `unknown` | 1937 | 62069 | 26481 | 2849 | 23632 | 17194 | 6438 | 0 |
+
+## Input Availability
+
+```json
+{
+  "committed_source_inventories": {
+    "by_family": {
+      "curriculum": {
+        "deduped_candidates": 20,
+        "records": 20,
+        "source_units": 10
+      },
+      "ohoiko": {
+        "deduped_candidates": 33,
+        "records": 33,
+        "source_units": 4
+      },
+      "teacher_lesson": {
+        "deduped_candidates": 224,
+        "records": 228,
+        "source_units": 10
+      },
+      "textbook": {
+        "deduped_candidates": 111,
+        "records": 114,
+        "source_units": 7
+      }
+    },
+    "deduped_candidates": 377,
+    "included": true,
+    "inventory_files": 15,
+    "public_boundary": "aggregate counts only; no inventory filenames, source titles, paths, text, or candidate lists",
+    "records": 395
+  },
+  "modules": {
+    "l2_uk_direct_module_yaml": 180,
+    "l2_uk_en_activity_yaml": 338,
+    "l2_uk_en_module_md": 338,
+    "l2_uk_en_vocabulary_yaml": 338
+  },
+  "ohoiko_private_text": {
+    "private_roots_available": 0,
+    "public_boundary": "aggregate counts only; no private paths, filenames, text, or lemmas",
+    "text_files_scanned": 0
+  },
+  "textbook_extracted_text": {
+    "public_boundary": "aggregate counts by grade only; no textbook filenames or raw text",
+    "text_files_scanned": 24,
+    "text_root_available": true
+  },
+  "textbook_jsonl_chunks": {
+    "chunks_scanned": 0,
+    "jsonl_files_scanned": 0,
+    "jsonl_root_available": false,
+    "malformed_rows": 0,
+    "public_boundary": "aggregate counts by grade only; no JSONL chunk ids, filenames, or raw text"
+  },
+  "textbook_sqlite_db": {
+    "char_count": 16933213,
+    "chunks_scanned": 25714,
+    "public_boundary": "aggregate counts by grade only; no DB chunk ids, source files, titles, or raw text",
+    "source_files": 91,
+    "sources_db_available": true
+  }
+}
+```
+
+## Caveats
+
+- Reviewed Atlas counts are exact manifest article-entry counts; source-corpus counts are planning estimates.
+- VESUM-backed lanes count unique candidate lemmas inferred from unique surface forms; ambiguous forms may contribute more than one possible lemma.
+- Unrecognized forms, unreviewed multiword headwords, and unavailable lemmatizer lanes are counted as needs_review or unknown, not as approved entries.
+- Current Atlas reviewed entries, source-corpus candidates, and backlog counts are separate numbers and should not be added together.
+- Module content/activity/vocabulary lanes overlap; module_all is a convenience union for module surfaces.
+- SQLite, JSONL, and extracted-TXT textbook lanes can overlap; use SQLite as the primary local corpus lane when available and JSONL/TXT as availability or drift checks.
+- Committed source-inventory lanes are explicit reviewed/headword-style evidence, but they still require the normal Atlas review/publish gate for missing entries.
+- No Phase 2 design or POC drift was found beyond the entry-model drift already documented in PR #4245.

--- a/scripts/audit/atlas_source_entry_count.py
+++ b/scripts/audit/atlas_source_entry_count.py
@@ -1,0 +1,1061 @@
+#!/usr/bin/env python3
+"""Count aggregate source-corpus Atlas entry demand by finalized buckets.
+
+This Phase 2 census bridges the aggregate source-surface census and the
+finalized Word Atlas entry model. Public output is aggregate-only: it reports
+counts, methods, and caveats, but never source text, private paths, source
+filenames, Atlas entry lists, or candidate lemma lists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = Path(__file__).resolve().parent
+if sys.path and Path(sys.path[0]).resolve() == SCRIPT_DIR:
+    sys.path.pop(0)
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.audit import atlas_source_census
+from scripts.audit.atlas_entry_model_census import (
+    DEFAULT_MANIFEST,
+    ENTRY_TYPES,
+    NON_ENTRY_TYPES,
+    build_entry_model_census,
+    classify_entry,
+)
+from scripts.audit.atlas_intake_census import discover_inventory_paths
+from scripts.audit.source_inventory_intake import (
+    SourceInventoryCandidate,
+    SourceInventoryError,
+    SourceInventoryRecord,
+    read_source_inventories,
+    source_inventory_candidates,
+)
+from scripts.lexicon.build_data_manifest import _lemma_key
+from scripts.lexicon.content_lexicon_reconciler import VesumLookup, lemmatize_forms
+from scripts.lexicon.lemma_normalization import strip_acute_stress
+from scripts.verification.vesum import verify_words
+
+WORKFLOW_ID = "atlas_source_entry_count.v1"
+DETAIL_POLICY = "Local review-only details. Do not commit; public reports use aggregate counts only."
+
+SOURCE_ENTRY_BUCKETS = (
+    *ENTRY_TYPES,
+    "noise_rejected",
+    "needs_review",
+    "unknown",
+)
+DETAIL_LIMIT_DEFAULT = 200
+DEFAULT_TEXTBOOK_JSONL_ROOT = PROJECT_ROOT / "data" / "textbook_chunks"
+INVENTORY_ALL_LANE = "committed_source_inventory"
+INVENTORY_FAMILY_PREFIX = "committed_inventory_"
+TEXTBOOK_SURFACE_LANES = {
+    atlas_source_census.TEXTBOOK_DB,
+    atlas_source_census.TEXTBOOK_JSONL,
+    atlas_source_census.TEXTBOOK_TXT,
+}
+
+WORD_TOKEN_RE = re.compile(r"[A-Za-zА-Яа-яЄєІіЇїҐґ0-9'’ʼ-]+")
+MULTIWORD_DELIMITER_RE = re.compile(r"\s|/|\.\.\.")
+
+METHOD_PRIORITY = {
+    "manifest_entry_type": 100,
+    "source_inventory_headword": 80,
+    "module_explicit_headword": 75,
+    "vesum_backed_lemma": 70,
+    "heuristic_multiword_needs_review": 60,
+    "unknown_needs_review": 40,
+    "lemmatizer_unavailable": 30,
+    "noise_filter": 10,
+}
+
+
+@dataclass(frozen=True)
+class ReviewedAtlasState:
+    """Read-only reviewed Atlas state used for overlap and exact baseline."""
+
+    manifest_loaded: bool
+    manifest_sha256: str | None
+    reviewed_bucket_by_key: Mapping[str, str]
+    entry_census: Mapping[str, Any]
+
+
+@dataclass
+class LemmatizationSummary:
+    """Aggregate lemmatization metadata for one lane."""
+
+    available: bool
+    method: str
+    unique_forms: int = 0
+    forms_with_matches: int = 0
+    unrecognized_forms: int = 0
+    lemma_candidates: int = 0
+
+    def public_payload(self) -> dict[str, int | bool | str]:
+        return {
+            "available": self.available,
+            "method": self.method,
+            "unique_forms": self.unique_forms,
+            "forms_with_matches": self.forms_with_matches,
+            "unrecognized_forms": self.unrecognized_forms,
+            "lemma_candidates": self.lemma_candidates,
+        }
+
+
+@dataclass
+class CandidateRecord:
+    """One internal candidate record. Values appear only in local detail output."""
+
+    key: str
+    value: str
+    bucket: str
+    method: str
+    existing_reviewed: bool
+    occurrences: int = 0
+    source_count: int = 1
+
+
+@dataclass
+class LaneAccumulator:
+    """Aggregate candidate records for one source lane."""
+
+    lane_id: str
+    counting_method: str
+    candidates: dict[str, CandidateRecord]
+
+    @classmethod
+    def create(cls, lane_id: str, counting_method: str) -> LaneAccumulator:
+        return cls(lane_id=lane_id, counting_method=counting_method, candidates={})
+
+    def add(
+        self,
+        *,
+        key: str,
+        value: str,
+        bucket: str,
+        method: str,
+        existing_reviewed: bool,
+        occurrences: int = 0,
+        source_count: int = 1,
+    ) -> None:
+        current = self.candidates.get(key)
+        if current is None:
+            self.candidates[key] = CandidateRecord(
+                key=key,
+                value=value,
+                bucket=bucket,
+                method=method,
+                existing_reviewed=existing_reviewed,
+                occurrences=occurrences,
+                source_count=source_count,
+            )
+            return
+
+        current.occurrences += occurrences
+        current.source_count += source_count
+        if _method_priority(method) > _method_priority(current.method):
+            current.value = value
+            current.bucket = bucket
+            current.method = method
+            current.existing_reviewed = existing_reviewed
+
+    def public_payload(
+        self,
+        *,
+        source_units: int,
+        token_occurrences: int,
+        unique_surface_forms: int,
+        explicit_headwords: int,
+        lemmatization: LemmatizationSummary,
+    ) -> dict[str, Any]:
+        candidate_counts = _bucket_counts(self.candidates.values())
+        existing_counts = _bucket_counts(
+            candidate for candidate in self.candidates.values() if candidate.existing_reviewed
+        )
+        backlog_counts = _bucket_counts(
+            candidate
+            for candidate in self.candidates.values()
+            if not candidate.existing_reviewed and candidate.bucket != "noise_rejected"
+        )
+        method_counts = Counter(candidate.method for candidate in self.candidates.values())
+        existing_total = sum(existing_counts.values())
+        backlog_total = sum(backlog_counts.values())
+        return {
+            "counting_method": self.counting_method,
+            "source_units": source_units,
+            "token_occurrences": token_occurrences,
+            "unique_surface_forms": unique_surface_forms,
+            "explicit_headwords": explicit_headwords,
+            "candidate_entries": sum(candidate_counts.values()),
+            "existing_reviewed_overlap": existing_total,
+            "estimated_backlog": backlog_total,
+            "candidates_by_bucket": dict(candidate_counts),
+            "existing_reviewed_by_bucket": dict(existing_counts),
+            "estimated_backlog_by_bucket": dict(backlog_counts),
+            "classification_methods": dict(sorted(method_counts.items())),
+            "lemmatization": lemmatization.public_payload(),
+        }
+
+    def detail_rows(self, *, limit: int) -> list[dict[str, Any]]:
+        rows = sorted(
+            self.candidates.values(),
+            key=lambda candidate: (
+                candidate.existing_reviewed,
+                candidate.bucket,
+                -candidate.occurrences,
+                candidate.value.casefold(),
+            ),
+        )
+        return [
+            {
+                "value": candidate.value,
+                "bucket": candidate.bucket,
+                "method": candidate.method,
+                "existing_reviewed": candidate.existing_reviewed,
+                "occurrences": candidate.occurrences,
+                "source_count": candidate.source_count,
+            }
+            for candidate in rows[:limit]
+        ]
+
+
+@dataclass
+class Lemmatizer:
+    """Cached VESUM lookup wrapper that can degrade to unknown counts."""
+
+    vesum_lookup: VesumLookup | None
+    available: bool = True
+    unavailable_reason: str | None = None
+    cache: dict[str, list[dict[str, Any]]] | None = None
+
+    def __post_init__(self) -> None:
+        self.available = self.vesum_lookup is not None
+        self.cache = {}
+        if self.vesum_lookup is None:
+            self.unavailable_reason = "disabled"
+
+    def lookup(self, forms: Sequence[str]) -> dict[str, list[dict[str, Any]]] | None:
+        if not self.available:
+            return None
+        assert self.cache is not None
+        missing = [form for form in forms if form not in self.cache]
+        if missing:
+            try:
+                batch = lemmatize_forms(missing, vesum_lookup=self.vesum_lookup or verify_words)
+            except FileNotFoundError as exc:
+                self.available = False
+                self.unavailable_reason = str(exc).splitlines()[0]
+                return None
+            self.cache.update(batch)
+        return {form: self.cache.get(form, []) for form in forms}
+
+    def method_label(self) -> str:
+        if self.available:
+            return "VESUM-backed unique lemma estimate"
+        if self.unavailable_reason == "disabled":
+            return "lemmatizer disabled; counted as unknown source forms"
+        return "lemmatizer unavailable; counted as unknown source forms"
+
+
+@dataclass
+class SourceEntryCountResult:
+    """Public payload plus local-only detail rows."""
+
+    public_payload: dict[str, Any]
+    lane_details: Mapping[str, LaneAccumulator]
+    textbook_grade_details: Mapping[str, Mapping[str, LaneAccumulator]]
+
+
+def build_source_entry_count(
+    *,
+    root: Path = PROJECT_ROOT,
+    manifest_path: Path | None = DEFAULT_MANIFEST,
+    include_modules: bool = True,
+    include_committed_inventories: bool = True,
+    inventory_paths: Sequence[Path] | None = None,
+    include_ohoiko_private: bool = False,
+    ohoiko_private_roots: Sequence[Path] = (atlas_source_census.DEFAULT_OHOIKO_PRIVATE_ROOT,),
+    textbook_txt_root: Path | None = atlas_source_census.DEFAULT_TEXTBOOK_TXT_ROOT,
+    sources_db_path: Path | None = atlas_source_census.DEFAULT_SOURCES_DB,
+    textbook_jsonl_root: Path | None = DEFAULT_TEXTBOOK_JSONL_ROOT,
+    vesum_lookup: VesumLookup | None = verify_words,
+) -> SourceEntryCountResult:
+    """Build aggregate source-entry demand counts without publishing details."""
+    root = root.resolve()
+    manifest = _read_manifest_state(_resolve_optional_path(manifest_path, root))
+    lemmatizer = Lemmatizer(vesum_lookup=vesum_lookup)
+    source_surface_census = atlas_source_census.build_atlas_source_census(
+        root=root,
+        manifest_path=manifest_path,
+        include_modules=include_modules,
+        include_default_inventories=False,
+        include_ohoiko_private=include_ohoiko_private,
+        ohoiko_private_roots=ohoiko_private_roots,
+        textbook_txt_root=textbook_txt_root,
+        textbook_pdf_root=None,
+        sources_db_path=sources_db_path,
+        textbook_jsonl_root=textbook_jsonl_root,
+        include_pdfs=False,
+    )
+
+    lane_payloads: dict[str, Any] = {}
+    lane_details: dict[str, LaneAccumulator] = {}
+    for lane_id, stats in sorted(source_surface_census.surfaces.items()):
+        accumulator, lemmatization = _summarize_surface_lane(
+            lane_id=lane_id,
+            stats=stats,
+            reviewed_bucket_by_key=manifest.reviewed_bucket_by_key,
+            lemmatizer=lemmatizer,
+        )
+        lane_payloads[lane_id] = accumulator.public_payload(
+            source_units=stats.source_units,
+            token_occurrences=stats.token_occurrences,
+            unique_surface_forms=len({_lemma_key(form) for form in stats.forms}),
+            explicit_headwords=len({_lemma_key(headword) for headword in stats.explicit_headwords}),
+            lemmatization=lemmatization,
+        )
+        lane_details[lane_id] = accumulator
+
+    inventory_inputs: dict[str, Any] = {
+        "included": include_committed_inventories,
+        "inventory_files": 0,
+        "records": 0,
+        "deduped_candidates": 0,
+        "by_family": {},
+        "public_boundary": "aggregate counts only; no inventory filenames, source titles, paths, text, or candidate lists",
+    }
+    if include_committed_inventories:
+        inventory_payloads, inventory_details, inventory_inputs = _build_inventory_lanes(
+            inventory_paths=inventory_paths,
+            project_root=root,
+            reviewed_bucket_by_key=manifest.reviewed_bucket_by_key,
+        )
+        lane_payloads.update(inventory_payloads)
+        lane_details.update(inventory_details)
+
+    textbook_grade_payloads: dict[str, dict[str, Any]] = {}
+    textbook_grade_details: dict[str, dict[str, LaneAccumulator]] = {}
+    for lane_id, by_grade in sorted(source_surface_census.by_surface_grade.items()):
+        if lane_id not in TEXTBOOK_SURFACE_LANES:
+            continue
+        textbook_grade_payloads[lane_id] = {}
+        textbook_grade_details[lane_id] = {}
+        for grade, stats in sorted(by_grade.items(), key=lambda item: atlas_source_census._grade_sort_key(item[0])):
+            accumulator, lemmatization = _summarize_surface_lane(
+                lane_id=f"{lane_id}:{grade}",
+                stats=stats,
+                reviewed_bucket_by_key=manifest.reviewed_bucket_by_key,
+                lemmatizer=lemmatizer,
+                include_explicit_headwords=False,
+            )
+            textbook_grade_payloads[lane_id][grade] = accumulator.public_payload(
+                source_units=stats.source_units,
+                token_occurrences=stats.token_occurrences,
+                unique_surface_forms=len({_lemma_key(form) for form in stats.forms}),
+                explicit_headwords=0,
+                lemmatization=lemmatization,
+            )
+            textbook_grade_details[lane_id][grade] = accumulator
+
+    source_inputs = _public_source_inputs(source_surface_census.source_inputs)
+    source_inputs["committed_source_inventories"] = inventory_inputs
+    payload = {
+        "workflow": WORKFLOW_ID,
+        "generated_at": datetime.now(UTC).replace(microsecond=0).isoformat(),
+        "production_outputs_updated": [],
+        "safety": {
+            "public_payload_includes_raw_text": False,
+            "public_payload_includes_candidate_lemmas": False,
+            "public_payload_includes_private_paths": False,
+            "public_payload_includes_private_filenames": False,
+            "atlas_manifest_mutated": False,
+            "details_must_be_outside_repo": True,
+        },
+        "reviewed_atlas": {
+            "manifest_loaded": manifest.manifest_loaded,
+            "manifest_sha256": manifest.manifest_sha256,
+            "manifest_records": manifest.entry_census["manifest_records"],
+            "total_reviewed_entries": manifest.entry_census["total_reviewed_entries"],
+            "reviewed_entries_by_type": manifest.entry_census["reviewed_entries_by_type"],
+            "non_entry_records": manifest.entry_census["non_entry_records"],
+        },
+        "source_inputs": source_inputs,
+        "source_lanes": lane_payloads,
+        "textbook_grades_by_lane": textbook_grade_payloads,
+        "caveats": [
+            "Reviewed Atlas counts are exact manifest article-entry counts; source-corpus counts are planning estimates.",
+            "VESUM-backed lanes count unique candidate lemmas inferred from unique surface forms; ambiguous forms may contribute more than one possible lemma.",
+            "Unrecognized forms, unreviewed multiword headwords, and unavailable lemmatizer lanes are counted as needs_review or unknown, not as approved entries.",
+            "Current Atlas reviewed entries, source-corpus candidates, and backlog counts are separate numbers and should not be added together.",
+            "Module content/activity/vocabulary lanes overlap; module_all is a convenience union for module surfaces.",
+            "SQLite, JSONL, and extracted-TXT textbook lanes can overlap; use SQLite as the primary local corpus lane when available and JSONL/TXT as availability or drift checks.",
+            "Committed source-inventory lanes are explicit reviewed/headword-style evidence, but they still require the normal Atlas review/publish gate for missing entries.",
+            "No Phase 2 design or POC drift was found beyond the entry-model drift already documented in PR #4245.",
+        ],
+    }
+    return SourceEntryCountResult(
+        public_payload=payload,
+        lane_details=lane_details,
+        textbook_grade_details=textbook_grade_details,
+    )
+
+
+def format_markdown_report(payload: Mapping[str, Any]) -> str:
+    """Format a public-safe aggregate Markdown report."""
+    reviewed = payload["reviewed_atlas"]
+    lines = [
+        "# Word Atlas Source Entry Count",
+        "",
+        f"- workflow: `{payload['workflow']}`",
+        f"- generated_at: `{payload['generated_at']}`",
+        "- production_outputs_updated: []",
+        "- raw_text_included: false",
+        "- candidate_lemmas_included: false",
+        "- private_paths_included: false",
+        "- private_filenames_included: false",
+        "",
+        "## Exact Reviewed Atlas Baseline",
+        "",
+        f"- manifest_loaded: {str(reviewed['manifest_loaded']).lower()}",
+        f"- manifest_sha256: `{reviewed['manifest_sha256'] or 'none'}`",
+        f"- manifest_records: {reviewed['manifest_records']}",
+        f"- total_reviewed_entries: {reviewed['total_reviewed_entries']}",
+        "",
+        "| entry bucket | exact reviewed entries |",
+        "| --- | ---: |",
+    ]
+    for bucket in ENTRY_TYPES:
+        lines.append(f"| `{bucket}` | {reviewed['reviewed_entries_by_type'].get(bucket, 0)} |")
+
+    lines.extend(["", "### Exact Non-Entry Manifest Records", "", "| bucket | records |", "| --- | ---: |"])
+    for bucket in NON_ENTRY_TYPES:
+        lines.append(f"| `{bucket}` | {reviewed['non_entry_records'].get(bucket, 0)} |")
+
+    lines.extend(
+        [
+            "",
+            "## Estimated Source-Corpus Backlog By Lane",
+            "",
+            "| source lane | source units | unique forms | explicit headwords | candidate entries | reviewed overlap | estimated backlog | lemma | expression | phraseologism | proverb | multiword term | proper name | needs review | unknown | noise rejected |",
+            "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for lane_id, lane in payload["source_lanes"].items():
+        backlog = lane["estimated_backlog_by_bucket"]
+        lines.append(
+            f"| `{lane_id}` | {lane['source_units']} | {lane['unique_surface_forms']} | "
+            f"{lane['explicit_headwords']} | {lane['candidate_entries']} | "
+            f"{lane['existing_reviewed_overlap']} | {lane['estimated_backlog']} | "
+            f"{backlog.get('lemma', 0)} | {backlog.get('expression', 0)} | "
+            f"{backlog.get('phraseologism', 0)} | {backlog.get('proverb', 0)} | "
+            f"{backlog.get('multiword_term', 0)} | {backlog.get('proper_name', 0)} | "
+            f"{backlog.get('needs_review', 0)} | {backlog.get('unknown', 0)} | "
+            f"{backlog.get('noise_rejected', 0)} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Classification Methods By Lane",
+            "",
+            "| source lane | method | candidates |",
+            "| --- | --- | ---: |",
+        ]
+    )
+    for lane_id, lane in payload["source_lanes"].items():
+        methods = lane["classification_methods"] or {"none": 0}
+        for method, count in methods.items():
+            lines.append(f"| `{lane_id}` | `{method}` | {count} |")
+
+    lines.extend(
+        [
+            "",
+            "## Textbook Grades By Lane",
+            "",
+            "| source lane | grade | source units | unique forms | candidate entries | reviewed overlap | estimated backlog | lemma | needs review | unknown |",
+            "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    textbook_rows = payload["textbook_grades_by_lane"]
+    if textbook_rows:
+        for lane_id, by_grade in textbook_rows.items():
+            for grade, stats in by_grade.items():
+                backlog = stats["estimated_backlog_by_bucket"]
+                lines.append(
+                    f"| `{lane_id}` | `{grade}` | {stats['source_units']} | "
+                    f"{stats['unique_surface_forms']} | {stats['candidate_entries']} | "
+                    f"{stats['existing_reviewed_overlap']} | {stats['estimated_backlog']} | "
+                    f"{backlog.get('lemma', 0)} | {backlog.get('needs_review', 0)} | "
+                    f"{backlog.get('unknown', 0)} |"
+                )
+    else:
+        lines.append("| none | none | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |")
+
+    lines.extend(
+        [
+            "",
+            "## Input Availability",
+            "",
+            "```json",
+            json.dumps(payload["source_inputs"], ensure_ascii=False, indent=2, sort_keys=True),
+            "```",
+            "",
+            "## Caveats",
+            "",
+        ]
+    )
+    lines.extend(f"- {note}" for note in payload["caveats"])
+    return "\n".join(lines)
+
+
+def write_public_json(result: SourceEntryCountResult, out: Path) -> Path:
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        json.dumps(result.public_payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return out
+
+
+def write_public_markdown(result: SourceEntryCountResult, out: Path) -> Path:
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(format_markdown_report(result.public_payload) + "\n", encoding="utf-8")
+    return out
+
+
+def write_detail_json(
+    result: SourceEntryCountResult,
+    out: Path,
+    *,
+    project_root: Path,
+    limit: int = DETAIL_LIMIT_DEFAULT,
+) -> Path:
+    output_path = resolve_local_detail_output_path(out, project_root=project_root)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(detail_payload(result, limit=limit), ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return output_path
+
+
+def resolve_local_detail_output_path(out: Path, *, project_root: Path = PROJECT_ROOT) -> Path:
+    """Reject repository paths for detail outputs that include candidate values."""
+    output_path = out if out.is_absolute() else project_root / out
+    resolved = output_path.resolve()
+    if resolved.is_relative_to(project_root.resolve()):
+        raise SourceInventoryError("atlas source entry-count detail output must be written outside the repository")
+    return resolved
+
+
+def detail_payload(result: SourceEntryCountResult, *, limit: int = DETAIL_LIMIT_DEFAULT) -> dict[str, Any]:
+    """Return local-only details with candidate values for review planning."""
+    return {
+        "workflow": WORKFLOW_ID,
+        "policy": DETAIL_POLICY,
+        "generated_at": result.public_payload["generated_at"],
+        "production_outputs_updated": [],
+        "lanes": {
+            lane_id: accumulator.detail_rows(limit=limit)
+            for lane_id, accumulator in result.lane_details.items()
+        },
+        "textbook_grades_by_lane": {
+            lane_id: {
+                grade: accumulator.detail_rows(limit=limit)
+                for grade, accumulator in by_grade.items()
+            }
+            for lane_id, by_grade in result.textbook_grade_details.items()
+        },
+    }
+
+
+def _summarize_surface_lane(
+    *,
+    lane_id: str,
+    stats: atlas_source_census.SurfaceStats,
+    reviewed_bucket_by_key: Mapping[str, str],
+    lemmatizer: Lemmatizer,
+    include_explicit_headwords: bool = True,
+) -> tuple[LaneAccumulator, LemmatizationSummary]:
+    accumulator = LaneAccumulator.create(
+        lane_id=lane_id,
+        counting_method=(
+            "VESUM-backed unique lemma estimate for surface forms; explicit headwords retained as "
+            "source headword candidates; unrecognized forms and unreviewed multiword headwords require review"
+        ),
+    )
+    lemmatization = _add_surface_forms(
+        accumulator=accumulator,
+        forms=stats.forms,
+        reviewed_bucket_by_key=reviewed_bucket_by_key,
+        lemmatizer=lemmatizer,
+    )
+    if include_explicit_headwords:
+        for headword, count in stats.explicit_headwords.items():
+            _add_explicit_headword(
+                accumulator=accumulator,
+                value=headword,
+                pos=None,
+                reviewed_bucket_by_key=reviewed_bucket_by_key,
+                method="module_explicit_headword",
+                occurrences=count,
+            )
+    return accumulator, lemmatization
+
+
+def _add_surface_forms(
+    *,
+    accumulator: LaneAccumulator,
+    forms: Counter[str],
+    reviewed_bucket_by_key: Mapping[str, str],
+    lemmatizer: Lemmatizer,
+) -> LemmatizationSummary:
+    unique_forms = tuple(sorted(forms))
+    summary = LemmatizationSummary(
+        available=lemmatizer.available,
+        method=lemmatizer.method_label(),
+        unique_forms=len(unique_forms),
+    )
+    if not unique_forms:
+        return summary
+
+    matches_by_form = lemmatizer.lookup(unique_forms)
+    summary.available = lemmatizer.available
+    summary.method = lemmatizer.method_label()
+    if matches_by_form is None:
+        summary.unrecognized_forms = len(unique_forms)
+        for form in unique_forms:
+            accumulator.add(
+                key=_private_candidate_key("unknown", form),
+                value=form,
+                bucket="unknown",
+                method="lemmatizer_unavailable",
+                existing_reviewed=False,
+                occurrences=forms[form],
+            )
+        return summary
+
+    lemma_candidate_keys: set[str] = set()
+    for form in unique_forms:
+        matches = matches_by_form.get(form, [])
+        lemmas = _match_lemmas(matches)
+        if not lemmas:
+            summary.unrecognized_forms += 1
+            accumulator.add(
+                key=_private_candidate_key("unrecognized", form),
+                value=form,
+                bucket="needs_review",
+                method="unknown_needs_review",
+                existing_reviewed=False,
+                occurrences=forms[form],
+            )
+            continue
+        summary.forms_with_matches += 1
+        for lemma in lemmas:
+            lemma_key = _lemma_key(lemma)
+            if not lemma_key:
+                continue
+            lemma_candidate_keys.add(lemma_key)
+            bucket = reviewed_bucket_by_key.get(lemma_key, "lemma")
+            accumulator.add(
+                key=f"lemma:{lemma_key}",
+                value=lemma,
+                bucket=bucket,
+                method="manifest_entry_type" if lemma_key in reviewed_bucket_by_key else "vesum_backed_lemma",
+                existing_reviewed=lemma_key in reviewed_bucket_by_key,
+                occurrences=forms[form],
+            )
+    summary.lemma_candidates = len(lemma_candidate_keys)
+    return summary
+
+
+def _build_inventory_lanes(
+    *,
+    inventory_paths: Sequence[Path] | None,
+    project_root: Path,
+    reviewed_bucket_by_key: Mapping[str, str],
+) -> tuple[dict[str, Any], dict[str, LaneAccumulator], dict[str, Any]]:
+    paths = tuple(inventory_paths) if inventory_paths is not None else discover_inventory_paths()
+    records = read_source_inventories(paths, project_root=project_root) if paths else []
+    all_candidates = source_inventory_candidates(records) if records else []
+    payloads: dict[str, Any] = {}
+    details: dict[str, LaneAccumulator] = {}
+
+    all_accumulator = _inventory_accumulator(
+        lane_id=INVENTORY_ALL_LANE,
+        candidates=all_candidates,
+        records=records,
+        reviewed_bucket_by_key=reviewed_bucket_by_key,
+    )
+    payloads[INVENTORY_ALL_LANE] = all_accumulator.public_payload(
+        source_units=_inventory_source_units(records),
+        token_occurrences=0,
+        unique_surface_forms=0,
+        explicit_headwords=len(all_candidates),
+        lemmatization=LemmatizationSummary(
+            available=False,
+            method="explicit committed inventory headwords; no surface-form lemmatization",
+        ),
+    )
+    details[INVENTORY_ALL_LANE] = all_accumulator
+
+    records_by_family: dict[str, list[SourceInventoryRecord]] = defaultdict(list)
+    for record in records:
+        records_by_family[record.source_family].append(record)
+
+    inputs_by_family: dict[str, Any] = {}
+    for family, family_records in sorted(records_by_family.items()):
+        family_candidates = source_inventory_candidates(family_records)
+        lane_id = f"{INVENTORY_FAMILY_PREFIX}{family}"
+        accumulator = _inventory_accumulator(
+            lane_id=lane_id,
+            candidates=family_candidates,
+            records=family_records,
+            reviewed_bucket_by_key=reviewed_bucket_by_key,
+        )
+        payloads[lane_id] = accumulator.public_payload(
+            source_units=_inventory_source_units(family_records),
+            token_occurrences=0,
+            unique_surface_forms=0,
+            explicit_headwords=len(family_candidates),
+            lemmatization=LemmatizationSummary(
+                available=False,
+                method="explicit committed inventory headwords; no surface-form lemmatization",
+            ),
+        )
+        details[lane_id] = accumulator
+        inputs_by_family[family] = {
+            "records": len(family_records),
+            "deduped_candidates": len(family_candidates),
+            "source_units": _inventory_source_units(family_records),
+        }
+
+    inventory_inputs = {
+        "included": True,
+        "inventory_files": len(paths),
+        "records": len(records),
+        "deduped_candidates": len(all_candidates),
+        "by_family": inputs_by_family,
+        "public_boundary": "aggregate counts only; no inventory filenames, source titles, paths, text, or candidate lists",
+    }
+    return payloads, details, inventory_inputs
+
+
+def _inventory_accumulator(
+    *,
+    lane_id: str,
+    candidates: Sequence[SourceInventoryCandidate],
+    records: Sequence[SourceInventoryRecord],
+    reviewed_bucket_by_key: Mapping[str, str],
+) -> LaneAccumulator:
+    accumulator = LaneAccumulator.create(
+        lane_id=lane_id,
+        counting_method=(
+            "Explicit committed source-inventory headwords; existing reviewed entries bucketed from the "
+            "manifest; missing multiword headwords require review before bucket admission"
+        ),
+    )
+    del records
+    for candidate in candidates:
+        _add_explicit_headword(
+            accumulator=accumulator,
+            value=candidate.lemma,
+            pos=candidate.pos,
+            reviewed_bucket_by_key=reviewed_bucket_by_key,
+            method="source_inventory_headword",
+            occurrences=candidate.frequency,
+            source_count=max(candidate.source_count, 1),
+        )
+    return accumulator
+
+
+def _add_explicit_headword(
+    *,
+    accumulator: LaneAccumulator,
+    value: str,
+    pos: str | None,
+    reviewed_bucket_by_key: Mapping[str, str],
+    method: str,
+    occurrences: int = 0,
+    source_count: int = 1,
+) -> None:
+    normalized = _normalize_headword(value)
+    if normalized is None:
+        accumulator.add(
+            key=_private_candidate_key("noise", value),
+            value=value,
+            bucket="noise_rejected",
+            method="noise_filter",
+            existing_reviewed=False,
+            occurrences=occurrences,
+            source_count=source_count,
+        )
+        return
+
+    key = _lemma_key(normalized)
+    if key in reviewed_bucket_by_key:
+        accumulator.add(
+            key=f"entry:{key}",
+            value=normalized,
+            bucket=reviewed_bucket_by_key[key],
+            method="manifest_entry_type",
+            existing_reviewed=True,
+            occurrences=occurrences,
+            source_count=source_count,
+        )
+        return
+
+    if _looks_like_multiword(normalized):
+        bucket = "needs_review"
+        final_method = "heuristic_multiword_needs_review"
+    else:
+        bucket = "proper_name" if _looks_like_proper_name(pos) else "lemma"
+        final_method = method
+
+    accumulator.add(
+        key=f"headword:{key}",
+        value=normalized,
+        bucket=bucket,
+        method=final_method,
+        existing_reviewed=False,
+        occurrences=occurrences,
+        source_count=source_count,
+    )
+
+
+def _read_manifest_state(manifest_path: Path | None) -> ReviewedAtlasState:
+    if manifest_path is None or not manifest_path.exists():
+        empty_census = build_entry_model_census({"entries": []})
+        return ReviewedAtlasState(
+            manifest_loaded=False,
+            manifest_sha256=None,
+            reviewed_bucket_by_key={},
+            entry_census=empty_census,
+        )
+
+    raw = manifest_path.read_bytes()
+    payload = json.loads(raw.decode("utf-8"))
+    if not isinstance(payload, Mapping):
+        raise SourceInventoryError(f"Atlas manifest must contain a JSON object: {manifest_path}")
+
+    reviewed_bucket_by_key: dict[str, str] = {}
+    entries = payload.get("entries", [])
+    if not isinstance(entries, list):
+        raise SourceInventoryError(f"Atlas manifest has no entries list: {manifest_path}")
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        classification = classify_entry(entry)
+        if not classification.counts_as_entry:
+            continue
+        lemma = str(entry.get("lemma") or "").strip()
+        key = _lemma_key(lemma)
+        if key:
+            reviewed_bucket_by_key.setdefault(key, classification.bucket)
+
+    return ReviewedAtlasState(
+        manifest_loaded=True,
+        manifest_sha256=hashlib.sha256(raw).hexdigest(),
+        reviewed_bucket_by_key=reviewed_bucket_by_key,
+        entry_census=build_entry_model_census(payload),
+    )
+
+
+def _public_source_inputs(inputs: Mapping[str, Any]) -> dict[str, Any]:
+    """Return source-input metadata after stripping any accidental path-like keys."""
+    forbidden_keys = {"path", "paths", "filename", "filenames", "source_title", "source_titles"}
+
+    def clean(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return {
+                str(key): clean(item)
+                for key, item in value.items()
+                if str(key).casefold() not in forbidden_keys
+            }
+        if isinstance(value, list):
+            return [clean(item) for item in value]
+        return value
+
+    return clean(dict(inputs))
+
+
+def _match_lemmas(matches: Sequence[Mapping[str, Any]]) -> tuple[str, ...]:
+    lemmas = {
+        str(match.get("lemma", "")).strip()
+        for match in matches
+        if isinstance(match, Mapping) and str(match.get("lemma", "")).strip()
+    }
+    return tuple(sorted(lemmas, key=_lemma_key))
+
+
+def _normalize_headword(value: str) -> str | None:
+    text = strip_acute_stress(str(value).strip()).replace("ʼ", "'").replace("’", "'").replace("`", "'")
+    text = re.sub(r"\s+", " ", text).casefold().strip(" \t\r\n.,;:!?…")
+    if not text:
+        return None
+    letters = re.sub(r"[^а-щьюяєіїґ']", "", text, flags=re.IGNORECASE)
+    if len(letters.replace("'", "")) < 2:
+        return None
+    return text
+
+
+def _looks_like_multiword(value: str) -> bool:
+    return bool(MULTIWORD_DELIMITER_RE.search(value)) and len(WORD_TOKEN_RE.findall(value)) >= 2
+
+
+def _looks_like_proper_name(pos: str | None) -> bool:
+    if not pos:
+        return False
+    label = str(pos).casefold().replace("-", "_").replace(" ", "_")
+    return "proper" in label or label in {"propn", "prop_noun"}
+
+
+def _bucket_counts(candidates: Sequence[CandidateRecord]) -> Counter[str]:
+    counts = Counter(candidate.bucket for candidate in candidates)
+    return Counter({bucket: counts.get(bucket, 0) for bucket in SOURCE_ENTRY_BUCKETS})
+
+
+def _inventory_source_units(records: Sequence[SourceInventoryRecord]) -> int:
+    units = {
+        (
+            record.source_family,
+            record.source_id or "<missing-source-id>",
+            record.inventory_path,
+        )
+        for record in records
+    }
+    return len(units)
+
+
+def _method_priority(method: str) -> int:
+    return METHOD_PRIORITY.get(method, 0)
+
+
+def _private_candidate_key(prefix: str, value: str) -> str:
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:24]
+    return f"{prefix}:{digest}"
+
+
+def _resolve_path(path: Path, root: Path) -> Path:
+    return path if path.is_absolute() else root / path
+
+
+def _resolve_optional_path(path: Path | None, root: Path) -> Path | None:
+    if path is None:
+        return None
+    return _resolve_path(path, root)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build a public-safe Word Atlas source entry-count census.")
+    parser.add_argument("--root", type=Path, default=PROJECT_ROOT, help="Repository root to scan.")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST, help="Atlas manifest JSON path.")
+    parser.add_argument("--skip-modules", action="store_true", help="Do not scan committed module surfaces.")
+    parser.add_argument(
+        "--skip-committed-inventories",
+        action="store_true",
+        help="Do not scan committed source-inventory files.",
+    )
+    parser.add_argument(
+        "--inventory",
+        dest="inventory_paths",
+        action="append",
+        type=Path,
+        help="Committed source-inventory file to include; may be repeated.",
+    )
+    parser.add_argument(
+        "--include-ohoiko-private",
+        action="store_true",
+        help="Scan private Ohoiko text roots aggregate-only.",
+    )
+    parser.add_argument(
+        "--ohoiko-private-root",
+        type=Path,
+        action="append",
+        default=None,
+        help="Private Ohoiko text root; may be repeated.",
+    )
+    parser.add_argument(
+        "--textbook-txt-root",
+        type=Path,
+        default=atlas_source_census.DEFAULT_TEXTBOOK_TXT_ROOT,
+        help="Extracted textbook TXT root.",
+    )
+    parser.add_argument("--skip-textbook-txt", action="store_true", help="Do not scan extracted textbook TXT.")
+    parser.add_argument(
+        "--sources-db",
+        type=Path,
+        default=atlas_source_census.DEFAULT_SOURCES_DB,
+        help="Local sources.db path for the SQLite textbook corpus.",
+    )
+    parser.add_argument("--skip-sources-db", action="store_true", help="Do not scan SQLite textbook corpus.")
+    parser.add_argument(
+        "--textbook-jsonl-root",
+        type=Path,
+        default=DEFAULT_TEXTBOOK_JSONL_ROOT,
+        help="Textbook chunk JSONL root; availability is reported aggregate-only.",
+    )
+    parser.add_argument("--skip-textbook-jsonl", action="store_true", help="Do not scan textbook JSONL chunks.")
+    parser.add_argument("--skip-vesum", action="store_true", help="Do not lemmatize forms with VESUM.")
+    parser.add_argument("--json-out", type=Path, help="Write public-safe JSON census.")
+    parser.add_argument("--markdown-out", type=Path, help="Write public-safe Markdown report.")
+    parser.add_argument("--detail-out", type=Path, help="Write local-only detail JSON outside the repository.")
+    parser.add_argument("--detail-limit", type=int, default=DETAIL_LIMIT_DEFAULT, help="Top rows per lane in details.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.detail_limit < 1:
+        parser.error("--detail-limit must be positive")
+
+    root = args.root.resolve()
+    ohoiko_roots = tuple(args.ohoiko_private_root or (atlas_source_census.DEFAULT_OHOIKO_PRIVATE_ROOT,))
+    inventory_paths = tuple(args.inventory_paths) if args.inventory_paths else None
+    try:
+        result = build_source_entry_count(
+            root=root,
+            manifest_path=args.manifest,
+            include_modules=not args.skip_modules,
+            include_committed_inventories=not args.skip_committed_inventories,
+            inventory_paths=inventory_paths,
+            include_ohoiko_private=args.include_ohoiko_private,
+            ohoiko_private_roots=ohoiko_roots,
+            textbook_txt_root=None if args.skip_textbook_txt else args.textbook_txt_root,
+            sources_db_path=None if args.skip_sources_db else args.sources_db,
+            textbook_jsonl_root=None if args.skip_textbook_jsonl else args.textbook_jsonl_root,
+            vesum_lookup=None if args.skip_vesum else verify_words,
+        )
+        if args.json_out:
+            out = args.json_out if args.json_out.is_absolute() else root / args.json_out
+            write_public_json(result, out)
+        if args.markdown_out:
+            out = args.markdown_out if args.markdown_out.is_absolute() else root / args.markdown_out
+            write_public_markdown(result, out)
+        if args.detail_out:
+            write_detail_json(result, args.detail_out, project_root=root, limit=args.detail_limit)
+    except (OSError, json.JSONDecodeError, SourceInventoryError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if not args.json_out and not args.markdown_out:
+        print(format_markdown_report(result.public_payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_atlas_source_entry_count.py
+++ b/tests/test_atlas_source_entry_count.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from scripts.audit import atlas_source_census
+from scripts.audit import atlas_source_entry_count as entry_count
+from scripts.audit.source_inventory_intake import SourceInventoryError
+
+
+def test_vesum_backed_lane_counts_existing_and_backlog_without_form_aliases(tmp_path: Path) -> None:
+    module_dir = tmp_path / "curriculum" / "l2-uk-en" / "a1" / "demo"
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text("Коти бачать замки.", encoding="utf-8")
+    manifest_path = _write_manifest(
+        tmp_path,
+        [
+            _entry("кіт", entry_type="lemma"),
+            _entry("коти", form_of={"lemma": "кіт", "url_slug": "кіт"}),
+        ],
+    )
+
+    result = entry_count.build_source_entry_count(
+        root=tmp_path,
+        manifest_path=manifest_path,
+        include_committed_inventories=False,
+        textbook_txt_root=None,
+        sources_db_path=None,
+        textbook_jsonl_root=None,
+        vesum_lookup=_fake_vesum,
+    ).public_payload
+
+    reviewed = result["reviewed_atlas"]
+    lane = result["source_lanes"][atlas_source_census.MODULE_CONTENT]
+
+    assert reviewed["total_reviewed_entries"] == 1
+    assert reviewed["non_entry_records"]["form_alias"] == 1
+    assert lane["existing_reviewed_by_bucket"]["lemma"] == 1
+    assert lane["estimated_backlog_by_bucket"]["lemma"] == 2
+    assert lane["classification_methods"]["manifest_entry_type"] == 1
+    assert lane["classification_methods"]["vesum_backed_lemma"] == 2
+    public_json = json.dumps(result, ensure_ascii=False)
+    assert "Коти бачать" not in public_json
+    assert "замок" not in public_json
+    assert "кіт" not in public_json
+
+
+def test_explicit_multiword_headwords_use_reviewed_bucket_or_needs_review(tmp_path: Path) -> None:
+    module_dir = tmp_path / "curriculum" / "l2-uk-en" / "a1" / "demo"
+    module_dir.mkdir(parents=True)
+    (module_dir / "vocabulary.yaml").write_text(
+        yaml.safe_dump(
+            [
+                {"word": "будь ласка", "translation": "please"},
+                {"word": "доконаний вид", "translation": "perfective aspect"},
+                {"word": "зелена книга", "translation": "green book"},
+            ],
+            allow_unicode=True,
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    manifest_path = _write_manifest(
+        tmp_path,
+        [
+            _entry("будь ласка", entry_type="expression"),
+            _entry("доконаний вид", entry_type="multiword_term"),
+        ],
+    )
+
+    result = entry_count.build_source_entry_count(
+        root=tmp_path,
+        manifest_path=manifest_path,
+        include_committed_inventories=False,
+        textbook_txt_root=None,
+        sources_db_path=None,
+        textbook_jsonl_root=None,
+        vesum_lookup=_fake_vesum,
+    ).public_payload
+
+    lane = result["source_lanes"][atlas_source_census.MODULE_VOCABULARY]
+
+    assert lane["existing_reviewed_by_bucket"]["expression"] == 1
+    assert lane["existing_reviewed_by_bucket"]["multiword_term"] == 1
+    assert lane["estimated_backlog_by_bucket"]["needs_review"] == 1
+    assert lane["classification_methods"]["heuristic_multiword_needs_review"] == 1
+
+
+def test_committed_inventory_lanes_cover_source_families_and_proper_names(tmp_path: Path) -> None:
+    inventory = tmp_path / "inventory.yaml"
+    inventory.write_text(
+        """
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: teacher-safe
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Safe committed inventory
+    headwords:
+      - lemma: Київ
+        pos: proper_noun
+        gloss: Kyiv
+  - id: textbook-safe
+    source_family: textbook
+    extraction_mode: headword_inventory
+    title: Safe committed inventory
+    headwords:
+      - lemma: школа
+        pos: noun
+        gloss: school
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = entry_count.build_source_entry_count(
+        root=tmp_path,
+        manifest_path=_write_manifest(tmp_path, []),
+        include_modules=False,
+        inventory_paths=(inventory,),
+        textbook_txt_root=None,
+        sources_db_path=None,
+        textbook_jsonl_root=None,
+        vesum_lookup=_fake_vesum,
+    ).public_payload
+
+    assert result["source_inputs"]["committed_source_inventories"]["by_family"] == {
+        "teacher_lesson": {"deduped_candidates": 1, "records": 1, "source_units": 1},
+        "textbook": {"deduped_candidates": 1, "records": 1, "source_units": 1},
+    }
+    assert result["source_lanes"]["committed_inventory_teacher_lesson"]["estimated_backlog_by_bucket"][
+        "proper_name"
+    ] == 1
+    assert result["source_lanes"]["committed_inventory_textbook"]["estimated_backlog_by_bucket"]["lemma"] == 1
+    public_json = json.dumps(result, ensure_ascii=False)
+    assert "Safe committed inventory" not in public_json
+    assert "Київ" not in public_json
+
+
+def test_private_ohoiko_public_payload_is_aggregate_only(tmp_path: Path) -> None:
+    private_root = tmp_path / "private-ohoiko-root"
+    private_root.mkdir()
+    (private_root / "secret-note.md").write_text("Секретний уривок має слова.", encoding="utf-8")
+
+    result = entry_count.build_source_entry_count(
+        root=tmp_path,
+        manifest_path=_write_manifest(tmp_path, []),
+        include_modules=False,
+        include_committed_inventories=False,
+        include_ohoiko_private=True,
+        ohoiko_private_roots=(private_root,),
+        textbook_txt_root=None,
+        sources_db_path=None,
+        textbook_jsonl_root=None,
+        vesum_lookup=_fake_vesum,
+    ).public_payload
+
+    lane = result["source_lanes"][atlas_source_census.OHOIKO_PRIVATE]
+    assert lane["source_units"] == 1
+    assert lane["unique_surface_forms"] == 4
+    public_json = json.dumps(result, ensure_ascii=False)
+    assert "secret-note" not in public_json
+    assert "private-ohoiko-root" not in public_json
+    assert "Секретний уривок" not in public_json
+    assert "секретний" not in public_json
+
+
+def test_textbook_sqlite_and_jsonl_grade_counts_are_aggregate_only(tmp_path: Path) -> None:
+    db_path = tmp_path / "sources.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "create table textbooks (grade text, text text, source_file text, char_count integer)"
+        )
+        conn.execute(
+            "insert into textbooks values (?, ?, ?, ?)",
+            ("1", "Мами читають книгу.", "private-source-a.pdf", 20),
+        )
+
+    jsonl_root = tmp_path / "chunks" / "grade-02"
+    jsonl_root.mkdir(parents=True)
+    (jsonl_root / "book.jsonl").write_text(
+        json.dumps({"grade": 2, "text": "Школи мають класи.", "chunk_id": "private-chunk"}, ensure_ascii=False)
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = entry_count.build_source_entry_count(
+        root=tmp_path,
+        manifest_path=_write_manifest(tmp_path, []),
+        include_modules=False,
+        include_committed_inventories=False,
+        textbook_txt_root=None,
+        sources_db_path=db_path,
+        textbook_jsonl_root=tmp_path / "chunks",
+        vesum_lookup=_fake_vesum,
+    ).public_payload
+
+    sqlite_grade = result["textbook_grades_by_lane"][atlas_source_census.TEXTBOOK_DB]["grade-01"]
+    jsonl_grade = result["textbook_grades_by_lane"][atlas_source_census.TEXTBOOK_JSONL]["grade-02"]
+
+    assert sqlite_grade["source_units"] == 1
+    assert sqlite_grade["estimated_backlog_by_bucket"]["lemma"] == 3
+    assert jsonl_grade["source_units"] == 1
+    assert jsonl_grade["estimated_backlog_by_bucket"]["lemma"] == 3
+    public_json = json.dumps(result, ensure_ascii=False)
+    assert "private-source-a.pdf" not in public_json
+    assert "private-chunk" not in public_json
+    assert "book.jsonl" not in public_json
+    assert "Мами читають" not in public_json
+
+
+def test_detail_output_path_must_be_outside_repo(tmp_path: Path) -> None:
+    with pytest.raises(SourceInventoryError, match="outside the repository"):
+        entry_count.resolve_local_detail_output_path(tmp_path / "details.json", project_root=tmp_path)
+
+    outside = tmp_path.parent / "atlas-source-entry-count-details.json"
+    assert entry_count.resolve_local_detail_output_path(outside, project_root=tmp_path) == outside.resolve()
+
+
+def _entry(lemma: str, **overrides: object) -> dict[str, object]:
+    entry: dict[str, object] = {
+        "lemma": lemma,
+        "url_slug": lemma.replace(" ", "-"),
+        "gloss": "fixture",
+        "pos": "noun",
+        "primary_source": "test",
+        "course_usage": [],
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _write_manifest(tmp_path: Path, entries: list[dict[str, object]]) -> Path:
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    manifest_path.write_text(json.dumps({"entries": entries}, ensure_ascii=False), encoding="utf-8")
+    return manifest_path
+
+
+def _fake_vesum(words: list[str]) -> dict[str, list[dict[str, Any]]]:
+    matches = {
+        "бачать": [{"lemma": "бачити", "pos": "verb", "tags": "verb"}],
+        "будь": [{"lemma": "бути", "pos": "verb", "tags": "verb"}],
+        "вид": [{"lemma": "вид", "pos": "noun", "tags": "noun"}],
+        "доконаний": [{"lemma": "доконаний", "pos": "adj", "tags": "adj"}],
+        "зелена": [{"lemma": "зелений", "pos": "adj", "tags": "adj"}],
+        "замки": [{"lemma": "замок", "pos": "noun", "tags": "noun"}],
+        "книга": [{"lemma": "книга", "pos": "noun", "tags": "noun"}],
+        "класи": [{"lemma": "клас", "pos": "noun", "tags": "noun"}],
+        "книгу": [{"lemma": "книга", "pos": "noun", "tags": "noun"}],
+        "коти": [{"lemma": "кіт", "pos": "noun", "tags": "noun"}],
+        "ласка": [{"lemma": "ласка", "pos": "noun", "tags": "noun"}],
+        "мають": [{"lemma": "мати", "pos": "verb", "tags": "verb"}],
+        "мами": [{"lemma": "мама", "pos": "noun", "tags": "noun"}],
+        "читають": [{"lemma": "читати", "pos": "verb", "tags": "verb"}],
+        "слова": [{"lemma": "слово", "pos": "noun", "tags": "noun"}],
+        "секретний": [{"lemma": "секретний", "pos": "adj", "tags": "adj"}],
+        "уривок": [{"lemma": "уривок", "pos": "noun", "tags": "noun"}],
+        "школи": [{"lemma": "школа", "pos": "noun", "tags": "noun"}],
+    }
+    return {word: matches.get(word, []) for word in words}


### PR DESCRIPTION
## Summary

Implements Word Atlas #4220 Phase 2: an aggregate-only source-corpus entry-count census against the finalized entry model from PR #4245.

- Adds `scripts/audit/atlas_source_entry_count.py` to report exact reviewed Atlas counts separately from estimated source-corpus candidate/backlog counts by finalized bucket.
- Covers module content/activity/vocabulary, committed source inventories by family, private Ohoiko availability aggregate-only, SQLite textbook corpus, extracted textbook TXT, and JSONL availability.
- Persists the public aggregate report in `docs/runbooks/word-atlas-source-entry-count.md` and documents the script in `docs/SCRIPTS.md`.
- Keeps public output free of raw source text, private paths, filenames, source titles, Atlas entry lists, and candidate lemma lists.

## Current aggregate result

- Exact reviewed Atlas entries: 5,156 across 5,502 manifest records.
- Exact reviewed by type: lemma 3,847; expression 5; phraseologism 0; proverb 0; multiword_term 1,266; proper_name 38.
- Estimated source-corpus backlog highlights:
  - `module_all`: 22,288 estimated backlog candidates.
  - `textbook_sqlite_db`: 144,922 estimated backlog candidates.
  - `textbook_extracted_text`: 66,879 estimated backlog candidates.
  - `committed_source_inventory`: 18 estimated backlog candidates.
- JSONL textbook chunks were not locally available in this worktree; the report records the lane as unavailable/zero-count.

## Review

Independent non-Codex review route:

`.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy - --task-id review-atlas-source-entry-count --to-model gemini-3.1-pro-high --review`

AGY/Gemini returned two blocker findings caused by bridge redaction of code tokens:

- Claimed `token_occurrences=[REDACTED_SECRET]` at `scripts/audit/atlas_source_entry_count.py:322`; local code is `token_occurrences=stats.token_occurrences` and imports/runs successfully.
- Claimed `WORD_TOKEN_RE = [REDACTED_SECRET]`; local code is a compiled regex and `_looks_like_multiword()` is covered by tests.

Both were verified as false positives with local line inspection and import/runtime smoke check. No real findings remained.

## Validation

- `.venv/bin/python -m pytest tests/test_atlas_source_entry_count.py tests/test_atlas_source_census.py tests/test_atlas_entry_model_census.py -q` -> 18 passed.
- `.venv/bin/ruff check scripts/audit/atlas_source_entry_count.py tests/test_atlas_source_entry_count.py` -> clean.
- `/Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/markdownlint-cli2 docs/SCRIPTS.md docs/runbooks/word-atlas-source-entry-count.md` -> 0 errors.
- `.venv/bin/python scripts/audit/atlas_source_entry_count.py --include-ohoiko-private --markdown-out docs/runbooks/word-atlas-source-entry-count.md` -> completed.
- `git diff --cached --check` -> clean before commit.
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed.
- Pre-commit hooks on commit passed, including affected pytest, ruff, gitleaks, private-source export guard, and X-Agent trailer checks.
- Pre-push hooks passed.

## Design drift

Phase 2 did not expose new POC/design drift beyond the entry-model drift already documented in PR #4245, so no design/POC doc changes were needed.
