### PR TITLE
[codex] docs(bio): add Martyn Pushkar dossier

### DIFF
--- a/docs/research/bio/martyn-pushkar.md
+++ b/docs/research/bio/martyn-pushkar.md
@@ -1,0 +1,682 @@
+# Мартин Пушкар — Research Dossier
+
+**Slug:** `martyn-pushkar`
+**Block:** P1 BIO Cossack coverage (Poltava colonelship, senior
+Khmelnytsky-era command, post-Khmelnytsky succession politics, opposition to
+Ivan Vyhovskyi, Pushkar-Barabash uprising, Moscow pressure, Crimean-allied
+counterinsurgency, civil-war violence, and memory-polarization risks)
+**Tier:** 1b (strong office/event record; thin early-life record and
+politically charged interpretation)
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ Pushkar, ЕІУ
+  Pushkar-Barabash uprising, ЕІУ civil wars, ЕІУ Poltava regiment, ЕІУ
+  Okhmativ, IEU Pushkar, IEU Barabash, Hrushevsky/Litopys source-language
+  page)
+- [x] Source-tier checkboxes included and lower-tier sources kept
+  non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: Poltava regiment
+  base, post-Khmelnytsky election grievance, Zaporizhian exclusion, social
+  pressure, Moscow recognition/aid signals, Vyhovskyi's Sich blockade,
+  Crimean-Tatar intervention, battle/captivity/repression, and later
+  imperial-memory reuse)
+- [x] §4 includes short source-language anchors with verification caveats
+- [x] Pushkar is framed as complex: senior Poltava colonel, Khmelnytsky-era
+  commander, acting-command figure, former Vyhovskyi supporter, anti-hetman
+  opposition leader, Moscow-seeking political actor, social-mobilization
+  beneficiary, and casualty of civil war
+- [x] Cross-track links: every "Existing" plan path verified locally with
+  `test -e` on 2026-07-04 after rebasing onto `origin/main`
+- [x] Naming-canonical applied; `Пушкаренко`, `Pushkar`, and `Puškar` are
+  tracked as variants, not separate people
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+
+- [x] **T1 baseline:** ЕІУ Pushkar anchors the canonical Ukrainian name,
+  unknown birth year, death date, Poltava colonelship, family-origin lead,
+  military career, 1657 support for Vyhovskyi, later opposition, Moscow
+  support-seeking, and death near Poltava.
+- [x] **T1 event context:** ЕІУ Pushkar-Barabash uprising, ЕІУ civil wars,
+  ЕІУ National Revolution, and ЕІУ Barabash frame the uprising's chronology,
+  social base, outside intervention, battle sequence, casualties, captivity,
+  Barabash aftermath, and civil-war consequences.
+- [x] **T1 institutional context:** ЕІУ Poltava regiment and Okhmativ anchor
+  the regiment, office dates, regional base, and one key 1655 battlefield
+  role.
+- [x] **T1 English support:** IEU Pushkar and IEU Barabash anchor English
+  metadata, name variants, candidate-for-hetmancy framing, alliance and
+  opposition context, and the June 1658 defeat/death summary.
+- [x] **T2/T4 source-language:** Hrushevsky's public Litopys text is used for
+  short source-language anchors and source criticism; it is not treated as a
+  clean transcript of Pushkar's voice without document-edition recheck.
+- [x] **T4 scholarship:** Hrushevsky, Horobets, Mytsyk, Yakovleva, Stetsiuk,
+  and Voskobiinyk bibliography leads are used as follow-up scaffolding, not as
+  unsupported replacements for Tier 1 facts.
+- [x] **T3/T5 caution:** Wikipedia, local-history pages, current monument
+  news, and image pages are navigation, memory, or rights leads only; they are
+  not load-bearing for core chronology.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Мартин Пушкар. ЕІУ gives
+  `ПУШКАР (Пушкаренко) Мартин`; IEU gives `Pushkar, Martyn [Пушкар,
+  Мартин; Puškar]`. Use `Martyn Pushkar` for English curriculum metadata.
+  [T1: ЕІУ Pushkar; T1: IEU Pushkar]
+- **Aliases / spelling variants:** Мартин Пушкар; Мартин Пушкаренко; Martyn
+  Pushkar; Pushkar, Martyn; Puškar. Lower-tier and local-memory materials
+  sometimes add patronymic or precise birthplace claims; keep those as source
+  leads unless directly checked. [T1: ЕІУ; T1: IEU; T3/T5]
+- **Born / early life:** birth year unknown. ЕІУ says he came from the
+  Pushkar-Resynsky zemiany family of the Liubech starostvo in Sivershchyna and
+  probably joined the Cossacks while young. IEU gives no birth date. Do not use
+  the common lower-tier 1598/Ovruch story as a Tier 1 fact. [T1: ЕІУ; T1:
+  IEU; T3/T5]
+- **Died:** **11 (1) June 1658** according to ЕІУ Pushkar; IEU gives
+  **11 June 1658 near Poltava**. Context entries date the wider battle around
+  late May / early June in Old Style / New Style forms, so lessons should
+  attribute exact calendar form. [T1: ЕІУ Pushkar; T1: IEU Pushkar; T1:
+  ЕІУ uprising; T1: ЕІУ civil wars]
+- **Office:** Poltava colonel from **1648 to 1658**. ЕІУ says he headed the
+  newly formed Poltava regiment in summer 1648; ЕІУ Poltava regiment lists him
+  as the first colonel, followed by Kyrylo Pushkarenko and Marko
+  Kolomak-Pushkarenko. [T1: ЕІУ Pushkar; T1: ЕІУ Poltava regiment]
+- **Regimental base:** the Poltava regiment was a Left-Bank military and
+  administrative unit created in 1648 with Poltava as center and 19 companies
+  in 1649. This makes Pushkar's biography a regional-power dossier, not only a
+  personal rivalry story. [T1: ЕІУ Poltava regiment]
+- **Khmelnytsky-era service:** ЕІУ says the Poltava regiment under Pushkar
+  participated in the major battles of the late 1640s and first half of the
+  1650s. He especially distinguished himself at Berestechko and for a time
+  performed acting-hetman duties; in December 1653 he was in a delegation to
+  Islam-Girei III, and in January 1654 in talks with Vasilii Buturlin. [T1:
+  ЕІУ Pushkar]
+- **Bratslav / Okhmativ layer:** ЕІУ says that in December 1654 Pushkar,
+  Ivan Bohun, and Mykhailo Zelensky directed Bratslav's defense during
+  Stefan Czarniecki's attack; at the end of January 1655 Pushkar led the
+  cavalry advance in the Okhmativ battle. ЕІУ Okhmativ specifically says
+  Colonel M. Pushkar distinguished himself there. [T1: ЕІУ Pushkar; T1:
+  ЕІУ Okhmativ]
+- **Political position before rupture:** ЕІУ places him in the moderate wing
+  of the Cossack starshyna that supported Bohdan Khmelnytsky. After Bohdan's
+  death, Pushkar supported Ivan Vyhovskyi in the 1657 hetman election before
+  turning against him later that year. [T1: ЕІУ Pushkar]
+- **Opposition to Vyhovskyi:** after Vyhovskyi's government tried to blockade
+  Zaporizhia economically, Pushkar and Yakiv Barabash became leading figures of
+  the anti-hetman opposition. ЕІУ says Pushkar tried to obtain support from
+  Moscow and rely on impoverished rank-and-file Cossacks and declassed
+  elements. IEU frames the coalition as a reaction to personal disappointment,
+  opposition to Vyhovskyi's Commonwealth-oriented politics, and resentment of
+  foreign appointments to the starshyna. [T1: ЕІУ Pushkar; T1: IEU Pushkar]
+- **Pushkar-Barabash uprising:** ЕІУ names Pushkar, Barabash, Semen Dovhal,
+  Ivan Donets, Ivan Iskra, and others as leaders of the opposition. It grew
+  especially among the Left-Bank Poltava, Lubny, and Myrhorod regimental
+  environments and attracted part of the poor rural population. [T1: ЕІУ
+  uprising]
+- **Moscow involvement:** ЕІУ uprising says the opposition maintained
+  intensive contacts with the tsarist government and that Pushkar and Barabash
+  acted with powerful Moscow support. ЕІУ civil wars adds that Moscow gave the
+  opposition moral and political help to prevent Vyhovskyi's independent
+  course. Treat this as intervention and leverage, not as proof that every
+  supporter was simply a paid proxy. [T1: ЕІУ uprising; T1: ЕІУ civil wars]
+- **Vyhovskyi response:** Vyhovskyi blocked routes from the Hetmanate to
+  Chortomlytska Sich, tried negotiations, sent smaller forces that failed, and
+  then used loyal regiments and Crimean-Tatar forces under Karach-bey. ЕІУ
+  records that in February 1658 Pushkar defeated a detachment under Ivan Bohun
+  near Poltava. [T1: ЕІУ uprising]
+- **Battle near Poltava:** ЕІУ uprising says Vyhovskyi moved toward Poltava
+  in late May, stood near Rybtsi and Zhuky, and defeated the opposition after
+  committing Karach-bey's force. Pushkar died in the battle; Barabash escaped
+  to Chortomlytska Sich. [T1: ЕІУ uprising]
+- **Violence and casualties:** sources disagree in number and emphasis. IEU
+  gives 8,000 to 15,000 supporters killed and says Poltava was razed. ЕІУ
+  civil wars gives about 15,000 killed in battle, 7,000 executed prisoners, and
+  captivity of civilians by Tatars. ЕІУ Vyhovskyi gives an even broader
+  "over 50,000" loss frame for battle and reprisals. Use attributed ranges and
+  do not turn numbers into a single exact classroom fact. [T1: IEU Pushkar;
+  T1: ЕІУ civil wars; T1: ЕІУ Vyhovskyi]
+- **Aftermath:** Barabash was later captured and executed by Vyhovskyi's order
+  after September 1658. Opposition did not disappear; later anti-Vyhovskyi
+  actors included Pushkar's son Kyrylo, Ivan Bezpalyi, and others under
+  Russian military protection. [T1: ЕІУ Barabash; T1: ЕІУ civil wars]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Birth year/place:** unknown in the strongest inspected sources. Do not
+   present 1598/Ovruch as a stable fact.
+2. **Name form:** `Пушкаренко` is an alias/source form, not a separate dossier.
+   Use `Мартин Пушкар` / `Martyn Pushkar` as canonical.
+3. **Office dates:** 1648-1658 is strong; if a module uses 1649 as the
+   effective regiment-list date, explain the source difference rather than
+   changing the dossier slug.
+4. **Acting hetman at Berestechko:** ЕІУ Pushkar supports a temporary
+   acting-command role, while ЕІУ Berestechko foregrounds Fedir Dzhalalii,
+   Matvii Hladkyi, and Ivan Bohun in the final camp stage. Teach it as a
+   temporary crisis function, not a stable hetmancy.
+5. **Candidate for hetmancy:** IEU says Pushkar was considered a candidate
+   after Bohdan Khmelnytsky's death; ЕІУ emphasizes that he supported
+   Vyhovskyi in the 1657 election. Both can be true if kept as sequence and
+   perspective, not contradiction.
+6. **Cause of uprising:** personal ambition, Zaporizhian exclusion, social
+   grievance, starshyna faction, foreign-policy fear, Moscow pressure, and
+   Vyhovskyi's own errors all appear in the source layer. No single cause is
+   enough.
+7. **Moscow support:** support-seeking and intervention are documented, but
+   "Moscow puppet" is too flat. Pushkar had a real Poltava base and local
+   grievances to mobilize.
+8. **Crimean-Tatar role:** Vyhovskyi's use of Crimean-Tatar forces was
+   militarily decisive and devastating for civilians. Do not hide it to
+   preserve a clean pro-Vyhovskyi narrative.
+9. **Casualty figures:** use ranges and attribution. Several Tier 1 entries
+   use different scales and event boundaries.
+10. **Memory:** modern local commemoration is being decolonized; that does not
+    make Pushkar a simple national hero, and it does not validate the old
+    friendship myth either.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Pushkar's biography exposes the first major post-Bohdan
+Khmelnytsky civil-war fracture. A senior colonel with a real regional power
+base initially supported Vyhovskyi, then joined Zaporizhian and Left-Bank
+opposition after disputes over election legitimacy, Sich access, social
+interests, starshyna power, and foreign alignment. Moscow treated that
+opposition as leverage against Vyhovskyi's independent course, while
+Vyhovskyi used treaty diplomacy, loyal regiments, and Crimean-Tatar force to
+defeat it. [T1: ЕІУ Pushkar; T1: ЕІУ uprising; T1: ЕІУ civil wars]
+
+**By whom:** Moscow / tsarist authorities in the recognition, correspondence,
+military-protection, and pressure layers; Vyhovskyi's hetman government in the
+Sich blockade, loyal-regiment, punitive, and alliance layers; Crimean-Tatar
+forces in the decisive-battle and captivity layer; Pushkar and Barabash in the
+anti-hetman mobilization, Moscow-appeal, and civil-war escalation layer;
+Left-Bank rank-and-file, townspeople, poor peasants, and starshyna factions in
+the social base. No side should be erased.
+
+**Document references:** Pushkar and Barabash appeals to Moscow preserved in
+the act/source tradition; Vyhovskyi letters and reports around Poltava;
+Hrushevsky's source-based reconstruction; ЕІУ's Pushkar-Barabash and civil-war
+entries; Barabash capture/execution notices; later treaty consequences around
+Hadiach and Pereiaslav 1659. [T1/T2/T4: ЕІУ; Hrushevsky/Litopys; act
+collection lead]
+
+**Mechanism specifics:** imperial memory can appropriate Pushkar as a loyal
+pro-Moscow figure whose opposition proves a natural bond with Moscow. That
+erases the local conflict, the Poltava regiment, social grievances, and the
+fact that Moscow used Ukrainian division to expand leverage. A simple
+anti-Moscow inversion is also weak: Pushkar's coalition had internal agency,
+caused violence, and helped open a civil-war spiral that damaged the young
+Hetmanate. A decolonized lesson should show how empire exploited division
+without pretending that division had no Ukrainian causes.
+
+**What survived / what was distorted:** what survived is the record of a major
+Poltava colonel whose career runs from Khmelnytsky-era institution-building to
+the Ruin's first rupture. What was distorted is the memory label. Local and
+imperial commemoration could turn him into a symbol of "friendship" with
+Russia; nationalist shorthand can answer by making him only a bad collaborator.
+The stronger reading is more demanding: experienced commander, regional
+patron, ambitious colonel, opposition leader, Moscow-seeking actor, and
+casualty of a civil war in which multiple powers used Ukrainian fractures.
+
+## 3. Major works / legacy
+
+Pushkar left no literary corpus; "works" means office, regimental leadership,
+military actions, political choices, appeals, uprising leadership, and memory.
+
+- `unknown-before 1648` — early life remains source-thin. ЕІУ gives a
+  Pushkar-Resynsky zemiany-family lead in the Liubech/Sivershchyna context and
+  probable early Cossack affiliation. [T1: ЕІУ Pushkar]
+- `summer 1648` — headed the newly formed Poltava regiment, making him one of
+  the first major Left-Bank regimental leaders of the Khmelnytsky era. [T1:
+  ЕІУ Pushkar; T1: ЕІУ Poltava regiment]
+- `1648-1650s` — led a regiment that participated in major battles and
+  campaigns of the period. Use this for regimental institution-building, not
+  generic battlefield hero prose. [T1: ЕІУ Pushkar; T1: ЕІУ Poltava regiment]
+- `1651` — distinguished himself at Berestechko and temporarily performed
+  acting-command functions according to ЕІУ Pushkar. Pair this with the
+  broader Berestechko command crisis rather than presenting him as sole savior.
+  [T1: ЕІУ Pushkar; T1: ЕІУ Berestechko]
+- `December 1653` — served in a delegation negotiating with Crimean Khan
+  Islam-Girei III; useful for teaching that Pushkar was not only a local
+  military man but part of high-level diplomatic traffic. [T1: ЕІУ Pushkar]
+- `January 1654` — participated in negotiations with Vasilii Buturlin. This is
+  a source lead for Pereiaslav-era political language; do not turn it into a
+  later "pro-Russian identity" claim. [T1: ЕІУ Pushkar]
+- `December 1654` — helped Ivan Bohun and Mykhailo Zelensky direct Bratslav's
+  defense during Czarniecki's attack. [T1: ЕІУ Pushkar]
+- `January-February 1655` — led the cavalry advance and distinguished himself
+  at Okhmativ / Dryzhypil. [T1: ЕІУ Pushkar; T1: ЕІУ Okhmativ]
+- `1657` — after Bohdan Khmelnytsky's death, supported Vyhovskyi's candidacy
+  in the hetman election despite IEU noting that Pushkar himself was considered
+  a possible candidate. This is the hinge that prevents a timeless
+  anti-Vyhovskyi biography. [T1: ЕІУ Pushkar; T1: IEU Pushkar]
+- `late 1657` — moved into opposition with Yakiv Barabash after the Sich
+  blockade and rising Left-Bank discontent. [T1: ЕІУ Pushkar; T1: ЕІУ
+  uprising]
+- `November 1657-spring 1658` — uprising widened in the Poltava, Lubny, and
+  Myrhorod environments; appeals to Moscow and rank-and-file grievances helped
+  turn political opposition into armed confrontation. [T1: ЕІУ uprising; T1:
+  ЕІУ civil wars; T1: IEU Pushkar]
+- `February 1658` — Pushkar defeated a force sent by Vyhovskyi under Ivan
+  Bohun near Poltava, showing that the opposition was militarily serious
+  before the final battle. [T1: ЕІУ uprising]
+- `May-June 1658` — Vyhovskyi crossed into the Poltava campaign with loyal
+  regiments and Karach-bey's force; fighting around Hovtva, Hadiach,
+  Reshetylivka, Rybtsi, Zhuky, and Poltava culminated in Pushkar's death. [T1:
+  ЕІУ uprising]
+- `11 (1) June 1658` — Pushkar died in the battle near Poltava. Teach the
+  date with calendar attribution and with the civilian/captive aftermath, not
+  as a clean duel ending. [T1: ЕІУ Pushkar; T1: IEU Pushkar; T1: ЕІУ civil
+  wars]
+- `September 1658` — Barabash was captured and executed; anti-Vyhovskyi
+  opposition continued under other leaders and became part of the wider Ruin
+  cycle. [T1: ЕІУ Barabash; T1: ЕІУ civil wars]
+- `modern memory` — Poltava commemoration is a live memory problem. Current
+  local reporting records a replacement plaque effort that removes an older
+  imperial friendship frame and points visitors toward Institute of History
+  research. Use this as memory-history material only, not as a source for the
+  seventeenth-century facts. [T5: Suspilne Poltava; T5: Poltavshchyna]
+
+## 4. Primary/source-language anchors (>=2 required)
+
+> **Honest tool note:** no project `verify_quote` run was used for this
+> dossier. The excerpts below are short source-language anchors from cited
+> reference entries and Hrushevsky's public Litopys page, not corpus-certified
+> classroom quotations. Recheck source editions before using longer text.
+
+**Anchor 1 — canonical source-title form:**
+
+> "ПУШКАР (Пушкаренко) Мартин"
+
+Context: this ЕІУ title is the safest name anchor. It supports tracking
+`Пушкаренко` as a variant while keeping the public dossier title
+`Мартин Пушкар`. [T1: ЕІУ Pushkar]
+
+**Anchor 2 — office / temporary authority:**
+
+> "гетьмана наказного"
+
+Context: ЕІУ Pushkar uses this phrase for his temporary Berestechko role. Use
+it to teach emergency acting authority, not a full separate hetmancy. [T1:
+ЕІУ Pushkar]
+
+**Anchor 3 — event-label anchor:**
+
+> "Пушкаря і Барабаша повстання 1658"
+
+Context: ЕІУ's event label is useful for source-search and module naming, but
+the dossier should still explain that the conflict began in late 1657 and
+continued after Pushkar's death. [T1: ЕІУ uprising]
+
+**Anchor 4 — Pushkar-side letter tradition:**
+
+> "повсякчас маємо війну з Виговським"
+
+Context: Hrushevsky presents this as a Pushkar letter report from late May Old
+Style. Use it as a source-language window into the opposition's own diplomatic
+tone, while rechecking the act edition before classroom quotation. [T2/T4:
+Hrushevsky/Litopys]
+
+## 5. Language register and learner-use notes
+
+- **Register:** Cossack military-administrative, diplomatic, legal-political,
+  and modern historiographic language; dense with office, regiment,
+  succession, and civil-war vocabulary.
+- **CEFR readiness for full reading:** B2-C1 for adapted biography; C1-C2 for
+  Hrushevsky/source-page excerpts, act collection language, and casualty /
+  intervention historiography.
+- **Lexicon notes:** `полтавський полковник`, `полк`, `сотня`, `гетьман`,
+  `наказний гетьман`, `кошовий отаман`, `кошовий гетьман`, `старшина`,
+  `чернь`, `Запорозька Січ`, `Лівобережжя`, `Руїна`, `повстання`,
+  `заколот`, `блокада`, `облога`, `перемир'я`, `ясир`, `булава`.
+- **Learner-use notes:** this dossier supports C1 work on avoiding totalizing
+  labels: "he supported, then opposed"; "he sought help from"; "the movement
+  drew on"; "the source says"; "the number is attributed"; "the memory frame
+  later changed."
+- **Stylistic features:** pair battlefield verbs (`очолив`, `керував`,
+  `відзначився`, `розбив`, `загинув`) with source-caution verbs
+  (`імовірно`, `вважається`, `за даними`, `джерела розходяться`).
+- **Sensitive framing:** do not ask learners whether Pushkar was simply
+  "pro-Moscow" or "anti-state." Better prompt: "Which grievances were local,
+  which were exploited by Moscow, and which choices made civil war worse?"
+
+## 6. Contested points
+
+- **Hero, traitor, or proxy?** All three labels are too small. Pushkar had a
+  real command record and Poltava base; he also sought Moscow support against
+  the hetman government and helped escalate civil war.
+- **Social movement or elite ambition?** The uprising drew rank-and-file and
+  poor support, but it was also led by starshyna and Sich figures with their
+  own political goals. Do not reduce it to either class revolt or personal
+  ambition.
+- **Zaporizhian exclusion:** Barabash and Sich actors were reacting to the way
+  the new hetman order treated Zaporizhia. This matters for legitimacy; it
+  does not excuse violence.
+- **Vyhovskyi responsibility:** the government blockade, failed negotiation,
+  punitive strategy, and use of Crimean-Tatar forces must stay visible. A
+  pro-Vyhovskyi decolonization story that hides civilian harm is not rigorous.
+- **Moscow responsibility:** Moscow's recognition and aid signals turned
+  Ukrainian division into leverage. But a decolonized reading should not erase
+  Ukrainian agency by saying Moscow created every grievance.
+- **Casualty numbers:** teach the scale and attribution, not a false exact
+  count. The source layer ranges from battlefield losses to broader reprisals
+  and captivity.
+- **Barabash relationship:** Pushkar and Barabash were allies, not the same
+  constituency. Poltava regimental power and Zaporizhian claims need separate
+  explanation.
+- **Berestechko memory:** acting-command language is important, but it should
+  not be made into a stable title or inflated into sole command of the whole
+  retreat.
+- **Current memory:** removing an imperial friendship inscription is a useful
+  decolonization case. It should not become an excuse to sanitize Pushkar's
+  anti-hetman violence or Moscow-facing politics.
+- **Image authenticity:** the strongest Commons candidate is a later Serhii
+  Vasylkivskyi panel of Pushkar's election, not a life portrait. Caption as
+  later visual memory.
+
+## 7. Cross-track links
+
+> Every curriculum plan path under **Existing** below was verified locally on
+> 2026-07-04 after rebasing onto `origin/main`. `docs/research/bio/*` entries
+> are verified dossier files, not existing BIO plan paths in this tree.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — baseline for
+    Pushkar's command career before the post-Bohdan succession crisis.
+  - `curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml` — direct opponent;
+    needed for Hadiach, legitimacy, and anti-hetman civil-war framing.
+  - `curriculum/l2-uk-en/plans/bio/yuriy-nemyrych.yaml` — Hadiach/federal
+    alternative context after the Pushkar-Barabash rupture weakened Vyhovskyi.
+  - `curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml` — Zaporizhian autonomy and
+    anti-hetman / anti-control comparison, not a direct Pushkar duplicate.
+- **Existing BIO dossiers (VERIFIED present; not curriculum plan paths):**
+  - `docs/research/bio/bohdan-khmelnytskyy.md`,
+    `docs/research/bio/ivan-vyhovskyi.md`,
+    `docs/research/bio/yuriy-nemyrych.md`,
+    `docs/research/bio/ivan-bohun.md`,
+    `docs/research/bio/ivan-sirko.md`,
+    `docs/research/bio/petro-doroshenko.md`,
+    `docs/research/bio/yurii-khmelnytskyi.md`,
+    `docs/research/bio/pavlo-teteria.md`,
+    `docs/research/bio/yakym-somko.md`,
+    `docs/research/bio/ivan-briukhovetskyi.md` — related Cossack/Ruin-era
+    dossiers for comparison.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — institution
+    vocabulary for regiment, colonel, council, and hetman authority.
+  - `curriculum/l2-uk-en/plans/hist/pereyaslavska-uhoda.yaml` — treaty and
+    Moscow-protectorate vocabulary behind later support-seeking.
+  - `curriculum/l2-uk-en/plans/hist/ruina-i.yaml`,
+    `curriculum/l2-uk-en/plans/hist/ruina-ii.yaml` — direct Ruin and
+    civil-war context.
+  - `curriculum/l2-uk-en/plans/hist/andrusivske-peremyrya.yaml` — later
+    partition consequence comparison after the early civil-war pattern.
+  - `curriculum/l2-uk-en/plans/hist/yurii-nemyrych.yaml` — Hadiach project and
+    Vyhovskyi-aligned constitutional alternative.
+- **Existing ISTORIO/RUTH/LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/istorio/pereiaslav-tsykl.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/pereiaslav-alternatyvy.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/pereyaslavski-statti.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/universaly-khmelnytkoho.yaml` —
+    treaty, article, and universal-source vocabulary.
+  - `curriculum/l2-uk-en/plans/ruth/the-ruin.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/cossack-hierarchy.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/diplomatic-language.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/document-types.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/treason.yaml` — older-language,
+    hierarchy, document, and accusation vocabulary.
+  - `curriculum/l2-uk-en/plans/lit/kostenko-marusia-churai-2.yaml` — Poltava
+    literary-memory connection; use source criticism so the literary Pushkar
+    layer is not treated as biography.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `martyn-pushkar` — future BIO plan/module if promoted from dossier.
+  - `pushkar-barabash-uprising-1658` — civil-war source lesson on legitimacy,
+    Moscow leverage, Sich claims, and social mobilization.
+  - `poltavskyi-polk` — institutional lesson on regiment, colonel, and
+    regional power.
+  - `battle-near-poltava-1658` — military/source-critical lesson on date,
+    casualty, and captive-number disagreement.
+  - `deineky-movement` — social-status and rank-and-file mobilization lesson.
+  - `pushkar-memory-poltava` — monument/plaque decolonization and local memory
+    lesson.
+- **Potential LIT/FOLK additions surfaced by this research:**
+  - A source-and-memory comparison around Lina Kostenko's Poltava world,
+    Vasylkivskyi's panel, and modern plaque language.
+
+## 8. Naming-canonical
+
+- **Slug:** `martyn-pushkar`
+- **EN canonical (project spelling):** Martyn Pushkar
+- **UA canonical:** Мартин Пушкар
+- **Aliases (track these for `aliases:` YAML field):** Мартин Пушкар;
+  Мартин Пушкаренко; Martyn Pushkar; Pushkar, Martyn; Puškar.
+- **Office/title variants to track carefully:** `полтавський полковник`;
+  `полковник Полтавського полку`; `гетьман наказний` in temporary
+  Berestechko context; `опозиційний ватажок`; source-language `кошовий
+  гетьман` belongs to Barabash, not Pushkar.
+- **Forbidden forms (flattening / imperial-memory forms to flag in body
+  text):** Russian-only name forms as normalized Ukrainian/English body text;
+  "pro-Moscow hero" as total identity; "Moscow puppet" as total identity;
+  "traitor" as factual label; "folk avenger" without starshyna agency;
+  "bandit" as source-neutral label; "class-war leader" as full explanation;
+  modern nationalist prototype.
+- **Term warning:** `чернь` is source language and often socially loaded. If a
+  module uses it, gloss it as a period term and explain who is speaking.
+- **Scope warning:** keep this BIO dossier on seventeenth-century Poltava,
+  succession, civil war, and memory. Do not turn it into an all-rulers
+  chronology or a later Hetmanate survey.
+
+## 9. Image candidates
+
+- **Best likely context image:** Wikimedia Commons file `Вибори полковником
+  Мартина Пушкаря Панно у Полтавському земстві.jpg`, a circa-1901 Serhii
+  Vasylkivskyi panel, is marked public domain on Commons. It is a later
+  historical panel, not a life-era portrait. Verify file metadata and required
+  United States public-domain tagging before publication. [T5: Commons]
+- **Commons category lead:** `Category:Martyn Pushkar` currently points to the
+  Vasylkivskyi panel as its only media item; use the category as a navigation
+  lead, not proof of image sufficiency. [T5: Commons]
+- **False-positive warning:** Commons `File:Pushkar.jpg` depicts Pushkar,
+  Rajasthan, India. Do not use it for Martyn Pushkar despite the filename.
+  [T5: Commons]
+- **Modern memory candidates:** Poltava monument / plaque photographs can
+  support a memory-history lesson on decolonization and local commemoration,
+  but rights, photographer credit, and freedom-of-panorama issues must be
+  checked file by file. [T5: Suspilne Poltava; T5: Poltavshchyna]
+- **Context alternatives:** a rights-clear map of the Poltava regiment, a
+  Hetmanate-regiment map, or a source facsimile around the 1658 correspondence
+  may be more pedagogically precise than a heroic portrait.
+- **Avoid:** generic Cossack stock art, image files for the Indian town
+  Pushkar, modern monument photos without license, or visuals that naturalize
+  the old imperial friendship frame.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- [T1] Горобець В. М. "Пушкар Мартин" // *Енциклопедія історії України*.
+  URL: https://www.history.org.ua/?termin=Pushkar_M | resolved HTTP 200,
+  accessed 2026-07-04. Core facts: name/title, unknown birth year,
+  Pushkar-Resynsky origin lead, Poltava colonelship, Berestechko
+  acting-command layer, diplomatic/service roles, Bratslav/Okhmativ,
+  support for Vyhovskyi, later opposition with Barabash, Moscow support-seeking,
+  death near Poltava.
+- [T1] "Pushkar, Martyn" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CP%5CU%5CPushkarMartyn.htm
+  | resolved HTTP 200, accessed 2026-07-04. Core facts: English metadata,
+  death near Poltava, Poltava colonelship, candidate-for-hetmancy frame,
+  coalition with Barabash, opposition to Vyhovskyi, June 1658 defeat and
+  casualty range.
+- [T1] Мицик Ю. А. "Пушкаря і Барабаша повстання 1658" //
+  *Енциклопедія історії України*. URL:
+  https://www.history.org.ua/?termin=Pushkaria_Barabasha_1657 | resolved HTTP
+  200, accessed 2026-07-04. Used for opposition leaders, social/regimental
+  base, Sich blockade, Moscow contacts/support, February 1658 Bohun detachment
+  defeat, final battle sequence, Barabash escape, and aftermath.
+- [T1] Горобець В. М. "Громадянські війни в Україні другої половини 1650 -
+  першої половини 1660-х років" // *Енциклопедія історії України*. URL:
+  https://www.history.org.ua/?termin=Gromad_vijny_v_Ukr | resolved HTTP 200,
+  accessed 2026-07-04. Used for structural causes, foreign intervention,
+  Zaporizhian grievance, Moscow aid signals, casualty/captivity layer, and
+  post-1658 civil-war consequences.
+- [T1] Горобець В. М. "Барабаш Яків Федорович" //
+  *Енциклопедія історії України*. URL:
+  https://www.history.org.ua/?termin=Barabash_Ya | resolved HTTP 200,
+  accessed 2026-07-04. Used for Barabash office, alliance with Pushkar,
+  post-defeat protection under Romodanovsky, capture, and execution date
+  context.
+- [T1] "Barabash, Yakiv" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CB%5CA%5CBarabashYakiv.htm
+  | resolved HTTP 200, accessed 2026-07-04. Used for English metadata,
+  Barabash/Pushkar uprising, Muscovy support framing, and execution summary.
+- [T1] Панашенко В. В. "Полтавський полк" //
+  *Енциклопедія історії України*. URL:
+  https://www.history.org.ua/?termin=Poltavskyj_polk | resolved HTTP 200,
+  accessed 2026-07-04. Used for regimental formation, administrative center,
+  first colonels, and institutional context.
+- [T1] Мицик Ю. А. "Охматівська битва 1655" //
+  *Енциклопедія історії України*. URL:
+  https://www.history.org.ua/?termin=Okhmativska_bytva_1655 | resolved HTTP
+  200, accessed 2026-07-04. Used for Pushkar's 1655 battlefield role and
+  broader Bratslav/Uman campaign context.
+- [T1] Степанков В. С. "Виговський Іван Остапович" //
+  *Енциклопедія історії України*. URL:
+  https://www.history.org.ua/?termin=Vyhovskyj_I | resolved HTTP 200,
+  accessed 2026-07-04. Used for post-Poltava casualty/repression frame,
+  Hadiach sequence, and source-cautious comparison with the Vyhovskyi dossier.
+- [T1] "Vyhovsky, Ivan" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CV%5CY%5CVyhovskyIvan.htm
+  | resolved HTTP 200, accessed 2026-07-04. Used for concise English linkage
+  between Pushkar-Barabash revolt, Poltava, Hadiach, and Konotop.
+- [T1] "Національна революція 1648-1676" //
+  *Енциклопедія історії України*. URL:
+  https://www.history.org.ua/?termin=Natsionalna_revoliutsiia | resolved HTTP
+  200, accessed 2026-07-04. Used for broad periodization and the transition
+  from protest to civil war.
+
+**Tier 2 / source-language / institutional:**
+
+- [T2/T4] Михайло Грушевський, *Історія України-Руси*, vol. 10, chapter II,
+  page "Бої під Полтавою, кінець Пушкаря..." on Litopys. URL:
+  http://litopys.org.ua/hrushrus/iurt100213.htm | accessed over HTTP and
+  decoded from Windows-1251 locally on 2026-07-04. Used for short
+  source-language anchors and the late-May letter/report tradition; recheck
+  the act edition before classroom quotation.
+- [T2/T4] Михайло Грушевський, *Історія України-Руси*, vol. 10, chapter II,
+  preceding page on Pushkar and Barabash appeals. URL:
+  http://litopys.org.ua/hrushrus/iurt100211.htm | accessed over HTTP and
+  decoded from Windows-1251 locally on 2026-07-04. Used for Moscow-appeal and
+  source-language context; not treated as direct quotation-ready text.
+
+**Tier 3 (encyclopedic — navigation only):**
+
+- [T3] "Мартин Пушкар" // Ukrainian Wikipedia. URL:
+  https://uk.wikipedia.org/wiki/Мартин_Пушкар | accessed 2026-07-04. Used only
+  for alias/image/navigation checks; cross-checked against T1.
+- [T3] "Martyn Pushkar" // English Wikipedia. URL:
+  https://en.wikipedia.org/wiki/Martyn_Pushkar | accessed 2026-07-04. Used
+  only for English navigation and image leads; not load-bearing.
+
+**Tier 4 (modern scholarly post-1991 / academic anchors):**
+
+- [T4] Горобець В. "Пушкар Мартин." In *Полководці Війська Запорозького:
+  історичні портрети*, book 1. Kyiv, 1998. Bibliographic anchor via ЕІУ.
+- [T4] Мицик Ю. А. *Гетьман Іван Виговський*. Kyiv, 2004. Bibliographic anchor
+  via ЕІУ uprising.
+- [T4] Яковлева Т. Г. *Гетьманщина в другій половині 50-х років XVII
+  століття: причини і початок Руїни*. Kyiv, 1998. Bibliographic anchor via
+  ЕІУ uprising and Barabash entry.
+- [T4] Воскобійник В. "Чинники антигетьманського виступу Мартина Пушкаря -
+  Якова Барабаша: історіографічний огляд проблеми." In *Гадяцька унія 1658
+  року: контроверсії минулого і сучасність*, 2009. Bibliographic lead surfaced
+  through Kyiv children's library reference page; direct article text not used
+  as load-bearing.
+- [T4] Korenets', D. "Povstannie Martyna Pushkaria," 1906; Stetsiuk, K.
+  *Narodni rukhy na Livoberezhnii i Slobidskii Ukraini v 50-70-kh rokakh XVII
+  st.* Kyiv, 1960. Bibliographic leads via IEU; use with historiographic
+  caution.
+
+**Tier 5 (general web / image metadata / memory — not load-bearing):**
+
+- [T5/image metadata] Wikimedia Commons, `Category:Martyn Pushkar`. URL:
+  https://commons.wikimedia.org/wiki/Category:Martyn_Pushkar | accessed
+  2026-07-04. Used for image navigation only.
+- [T5/image metadata] Wikimedia Commons, `File:Вибори полковником Мартина
+  Пушкаря Панно у Полтавському земстві.jpg`. URL:
+  https://commons.wikimedia.org/wiki/File:Вибори_полковником_Мартина_Пушкаря_Панно_у_Полтавському_земстві.jpg
+  | accessed 2026-07-04. Used for image candidate, public-domain lead, and
+  authenticity caveat.
+- [T5/image false-positive] Wikimedia Commons, `File:Pushkar.jpg`. URL:
+  https://commons.wikimedia.org/wiki/File:Pushkar.jpg | accessed 2026-07-04.
+  Used only as a false-positive warning because the file depicts Pushkar,
+  Rajasthan.
+- [T5/memory] Суспільне Полтава, "У Полтаві планують встановити нову табличку
+  на пам'ятнику Мартину Пушкарю." URL:
+  https://suspilne.media/poltava/1308369-u-poltavi-planuut-vstanoviti-novu-tablicku-na-pamatniku-martinu-puskaru/
+  | accessed 2026-07-04. Used for modern decolonization/memory context only.
+- [T5/memory] Полтавщина, "На полтавському пам'ятнику Мартину Пушкарю
+  встановлять нову табличку: вона буде без імперських наративів." URL:
+  https://poltava.to/news/86281/ | accessed 2026-07-04. Used for local
+  commemoration/memory context only.
+
+**Primary/source documents accessed / verification notes:**
+
+- Pushkar/Barabash appeals and Vyhovskyi correspondence: inspected through
+  Hrushevsky's Litopys text; original act volumes not directly inspected.
+- ЕІУ Pushkar cites *Akty, otnosiashchiesia k istorii Iuzhnoi i Zapadnoi
+  Rossii*, vols. 4, 7, 15, as source leads. These volumes were not inspected
+  directly in this pass.
+- Battle and casualty details: verified through ЕІУ/IEU reference layer;
+  direct military reports and act editions require follow-up before module
+  quotation.
+- Barabash capture/execution: verified through ЕІУ Barabash and IEU Barabash;
+  direct court/order text not inspected.
+
+**Honest gaps:** this dossier did not inspect archival originals, full act
+volumes, the full Horobets/Mytsyk/Yakovleva monographs, all Poltava local
+studies, or visual-rights metadata beyond Commons file pages. For module
+writing, recheck direct wording for Pushkar's letters, Vyhovskyi's
+correspondence, Barabash's capture, casualty/captive numbers, and the
+Vasylkivskyi panel rights before classroom use.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Moscow is treated as an intervening power and
+  support channel, not Ukraine's natural center.
+- [x] Pushkar is not flattened into a Russian/pro-Moscow hero, simple traitor,
+  pure folk avenger, bandit, class-war symbol, or modern nationalist prototype.
+- [x] Local Poltava/regimental agency and social grievances are visible.
+- [x] Moscow leverage and intervention are visible.
+- [x] Vyhovskyi's responsibility, including the Sich blockade, punitive
+  violence, and Crimean-Tatar alliance, is visible.
+- [x] Crimean-Tatar force is not ethnicized; military role and civilian harm
+  are named without dehumanizing language.
+- [x] Casualty and captivity numbers are attributed and not smoothed.
+- [x] Barabash/Zaporizhian claims are separated from Pushkar's Poltava
+  colonelship.
+- [x] Current decolonization of Poltava memory is treated as memory context,
+  not as proof of seventeenth-century interpretation.
+- [x] No out-of-scope later revival material, unrelated ruler lists, or
+  all-rulers chronology added.
+
+## Validation checklist
+
+- [x] Single owned file only: `docs/research/bio/martyn-pushkar.md`.
+- [x] Existing cross-track plan paths verified locally before citation.
+- [x] Lower-tier sources marked non-load-bearing.
+- [x] Guard terms for unrelated later-Hetmanate, modern-statehood, and
+  all-rulers scope avoided.
+- [x] No generated `status/`, `audit/`, `review/`, or telemetry artifacts
+  referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans,
+  module files, activities, vocabulary, resources, site MDX, wiki files, or
+  unrelated files edited.


### PR DESCRIPTION
## Scope

Adds one BIO readiness research dossier for Martyn Pushkar, scoped to the Cossack BIO coverage pipeline and the Poltava/Vyhovskyi/Pushkar-Barabash civil-war context.

## Changed files

- `docs/research/bio/martyn-pushkar.md`

## Validation

- `npx markdownlint-cli2 docs/research/bio/martyn-pushkar.md` — passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/martyn-pushkar.md` — passed
- `git diff --check` / staged diff check — passed
- Guard search for out-of-scope Skoropadskyi/1918/Polish-king terms — no matches
- Protected artifact/config guard — only `docs/research/bio/martyn-pushkar.md` changed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed

## Source and decolonization caveats

- Core chronology is anchored in ЕІУ and IEU entries for Pushkar, Pushkar-Barabash uprising, Barabash, Poltava regiment, Okhmativ, Vyhovskyi, and the broader civil-war context.
- Hrushevsky/Litopys is used only for short source-language anchors and source-critical leads; original act volumes were not directly inspected.
- Lower-tier pages, current monument/plaque news, and Commons pages are marked non-load-bearing and used only for navigation, memory, or image-rights context.
- The dossier deliberately avoids flattening Pushkar into a pro-Moscow hero, simple traitor, pure folk avenger, class-war symbol, bandit, or modern nationalist prototype.

## Review gate

No independent review has been routed yet because the orchestrator handles that gate.