### PR TITLE
[codex] docs(bio): add Dmytro Hunia dossier

### DIFF
--- a/docs/research/bio/dmytro-hunia.md
+++ b/docs/research/bio/dmytro-hunia.md
@@ -1,0 +1,732 @@
+# Дмитро Гуня — Research Dossier
+
+**Slug:** `dmytro-hunia`
+**Block:** P1 BIO Cossack coverage (Pavliuk aftermath; Kumeiky /
+Borovytsia survival; early-1638 Sich defense; Ostrianyn / Skydan coordination;
+Zhovnyn leadership transition; Starets defense and negotiated survival;
+registered/unregistered conflict; Don / Ottoman-frontier afterlife; uncertain
+fate and source-memory risk)
+**Tier:** 1b (strong event context; source-thin personal record and contested
+late chronology)
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ Hunia, ЕІУ Starets, ЕІУ
+  Zhovnyn, ЕІУ Kumeiky, ЕІУ Ordinance, ЕІУ Mykytynska Sich, IEU Hunia, IEU
+  Registered Cossacks, IEU Skydan, Okolski/Lukomsky via Litopys)
+- [x] Source-tier checkboxes included and lower-tier sources kept
+  non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: register
+  restriction, commissioner control, punitive expeditions against Sich,
+  registered-Cossack enforcement, blockade, negotiation, and post-1638
+  passport/garrison rules)
+- [x] §4 includes short source-language anchors with verification caveats
+- [x] Hunia is framed as complex: Pavliuk-era survivor, Zaporizhian crisis
+  leader, Starets commander, negotiator, escape/survival figure, and later
+  source-memory problem
+- [x] Cross-track links: every "Existing" plan/wiki/dossier path verified
+  locally with `test -e` on 2026-07-04 after rebasing to `origin/main`
+- [x] Naming-canonical applied; `Дмитро Гуня` / `Dmytro Hunia` is canonical,
+  while `Тимошевич`, `Hunja`, `Gunia`, and old-source forms are tracked as
+  aliases/source-search variants
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+
+- [x] **T1 baseline:** ЕІУ `Гуня Дмитро Тимошевич` anchors unknown birth and
+  death, leadership in the 1637-1638 uprising, Zaporizhian hetman label,
+  Kumeiky/Borovytsia survival, early-1638 victory over K. Meletsky's punitive
+  detachment, March 1638 joining with Ostrianyn, Dnipro-crossing command,
+  Starets defense, breakout to Zaporizhia, Don movement, and unknown later
+  fate.
+- [x] **T1 event context:** ЕІУ Kumeiky, Zhovnyn, and Starets anchor the
+  sequence from the December 1637 defeat through Hunia's election and the
+  fortified defense at the mouth of the Starets.
+- [x] **T1 legal/register context:** ЕІУ Ordinance, ЕІУ Mykytynska Sich, and
+  IEU Registered Cossacks anchor the legal aftermath: curtailed election and
+  court rights, commissioner control, passport restrictions, registered
+  garrison duty, and exclusion of unregistered Cossacks from legal status.
+- [x] **T1 English context:** IEU Hunia and Skydan are used for English name
+  metadata, relation to Pavliuk/Ostrianyn/Skydan, spring-1640 campaign note,
+  and fate uncertainty.
+- [x] **T2 source-language:** Okolski/Lukomsky/Velychko transmission via
+  Litopys is used only for short source-language anchors and hostile-source
+  vocabulary. It is not treated as neutral narration.
+- [x] **T4 scholarship:** Shcherbak, Vyrskyi, Borowiak, and Hrushevsky-related
+  bibliography leads are retained as follow-up scholarship/source-edition
+  leads; none overrides the Tier 1 baseline here.
+- [x] **T3/T5 caution:** Wikipedia, textbook mentions, school pages, social
+  posts, and generic image pages are navigation or memory leads only; they are
+  not load-bearing for fact or interpretation.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Дмитро Гуня. ЕІУ's article title is
+  `ГУНЯ Дмитро Тимошевич`; IEU gives `Hunia, Dmytro [Гуня, Дмитро; Hunja]`.
+  Use `Dmytro Hunia` for English curriculum metadata and `Дмитро Гуня` /
+  `Дмитро Тимошевич Гуня` in Ukrainian source notes. [T1: ЕІУ Hunia; T1:
+  IEU Hunia]
+- **Aliases / spelling variants:** Дмитро Гуня; Дмитро Тимошевич Гуня; Dmytro
+  Hunia; Hunia, Dmytro; Hunja; Dmytro Gunia / Gunya as search variants;
+  old-source `Дмитро Тимошевичъ Гуня`. Do not treat these as separate people.
+  [T1: ЕІУ; T1: IEU; T2: Okolski/Lukomsky]
+- **Born / died:** birth year and death year are unknown. ЕІУ explicitly gives
+  unknown birth and death; IEU gives both as unknown and says his subsequent
+  fate is unknown after the 1640 campaign note. [T1: ЕІУ Hunia; T1: IEU
+  Hunia]
+- **Office / constituency:** ЕІУ calls him a Zaporizhian hetman and one of
+  the leaders of the 1637-1638 Cossack uprising. IEU says Cossacks elected him
+  hetman at the Sich after Kumeiky/Borovytsia. Use "Zaporizhian / insurgent
+  Cossack leader" before a bare "hetman" label, because his authority arose
+  through a crisis-military council and changed with the campaign. [T1: ЕІУ
+  Hunia; T1: IEU Hunia]
+- **1637 Pavliuk context:** Hunia participated in Pavlo Pavliuk / But's
+  uprising. ЕІУ Kumeiky says that after Pavliuk and Skydan left the broken
+  wagon camp, the remnants were led by Hunia, who brought them by night toward
+  Borovytsia. This makes him more than a late-1638 appendix. [T1: ЕІУ
+  Kumeiky; T1: IEU Hunia; Existing dossier:
+  `docs/research/bio/pavlo-pavliuk-but.md`]
+- **Kumeiky / Borovytsia survival:** ЕІУ Hunia says that after the failed
+  December 1637 battle near Kumeiky, Hunia, with part of the insurgents, broke
+  through the enemy encirclement and took new positions at Borovytsia. IEU
+  similarly connects him with retreat from Kumeiky/Borovytsia to the Sich.
+  [T1: ЕІУ Hunia; T1: ЕІУ Kumeiky; T1: IEU Hunia]
+- **Early 1638 Sich defense:** ЕІУ says Cossacks under Hunia defeated a
+  punitive detachment under rotmistr K. Meletsky that attempted to seize the
+  Bazavluk Sich. IEU states more generally that his forces routed the
+  registered-Cossack expedition sent to subdue the Sich. Keep the distinction:
+  one source names the officer; IEU gives the English summary and force type.
+  [T1: ЕІУ Hunia; T1: IEU Hunia]
+- **March 1638 coordination:** ЕІУ says Hunia joined the army of Yakiv
+  Ostrianyn in March 1638. He commanded a Cossack detachment moving up the
+  Dnipro to seize main river crossings; the entry names Kremenchuk, Pyliavets,
+  and Chyhyryn-Dibrova in that movement. [T1: ЕІУ Hunia; Existing dossier:
+  `docs/research/bio/yakiv-ostrianyn.md`]
+- **Relation to Karpo Skydan:** IEU Skydan calls Skydan a colonel of
+  unregistered Zaporozhian Cossacks and says he returned to aid Hunia in 1638,
+  was badly wounded near Zhovnyn, captured, and presumably executed. Treat
+  Skydan as a linked commander, not as a footnote to Hunia. [T1: IEU Skydan]
+- **Zhovnyn leadership transition:** ЕІУ Zhovnyn says Ostrianyn left the camp
+  with part of the Cossacks, crossed the Sula, and moved toward Slobidska
+  Ukraine; the remaining insurgents elected Hunia hetman. This is the safe
+  point at which Hunia becomes the relevant commander for the final defense.
+  [T1: ЕІУ Zhovnyn; T1: ЕІУ Starets; T1: IEU Hunia]
+- **Starets defense:** ЕІУ Hunia says the insurgents built a well-fortified
+  camp at the mouth of the Sula on the Starets, an old Dnipro channel, and for
+  more than a month, until late July, repelled attacks by superior forces.
+  ЕІУ Starets gives the fuller battle range as 22 (12) June to 6 August
+  (27 July) 1638 and explains the defensive geography near modern Veremiivka,
+  much of it later submerged by the Kremenchuk Reservoir. [T1: ЕІУ Hunia; T1:
+  ЕІУ Starets]
+- **Blockade and negotiation:** ЕІУ Starets says the attackers realized the
+  battle would be decided by blockade and by preventing supporting detachments
+  from reaching the camp. It also says shortage of supplies pushed the
+  insurgents toward agreement and that Hunia and Filonenko left before the
+  capitulation. Use "left / escaped before capitulation" with attribution
+  rather than moralizing "betrayed" or romanticizing "vanished." [T1: ЕІУ
+  Starets; T2: Okolski/Lukomsky]
+- **Breakout and Zaporizhia:** ЕІУ Hunia says a small detachment under Hunia
+  managed in August to break out of encirclement and retreat to Zaporizhia.
+  This survival note is central for a BIO lesson: his story does not end in a
+  clean execution scene like Pavliuk/But's. [T1: ЕІУ Hunia]
+- **Don / Ottoman-frontier afterlife:** ЕІУ says Hunia went from the Sich to
+  the Don and distinguished himself in battles with Turks and Tatars. IEU says
+  that in spring 1640 he led a campaign of Zaporozhian and Don Cossacks
+  against Turkey. Use the 1640 campaign as a source-supported late lead, but
+  do not invent a final death, settlement, or later office. [T1: ЕІУ Hunia;
+  T1: IEU Hunia]
+- **Post-1638 legal aftermath:** ЕІУ Ordinance and IEU Registered Cossacks
+  show that the suppression of the 1637-1638 cycle hardened the register:
+  Cossack self-rule, election rights, court rights, movement to Zaporizhia,
+  and unregistered legal status were sharply curtailed. [T1: ЕІУ Ordinance;
+  T1: IEU Registered Cossacks]
+- **Sich monitoring after the defeat:** ЕІУ Mykytynska Sich says that after
+  the 1637-1638 uprising and the liquidation of Bazavluk Sich, the new
+  Mykytyn Sich operated under conditions shaped by the 1638 ordinance: one
+  registered regiment in garrison under official oversight, and severe
+  punishment for unauthorized Cossack presence. [T1: ЕІУ Mykytynska Sich]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Name:** use `Дмитро Гуня` / `Dmytro Hunia` as canonical. `Тимошевич` is
+   supported by ЕІУ and old-source signature layers, but not every learning
+   title needs the patronymic.
+2. **Birth/death:** unknown is the baseline. Do not add a birthplace, family,
+   death year, or death scene from lower-tier retellings.
+3. **Office:** `hetman` is a crisis office here. It should be explained
+   through constituency and election context rather than mapped onto a later
+   stable Hetmanate office.
+4. **Dmytro-name confusion:** do not conflate Hunia with Dmytro
+   Vyshnevetsky, Dmytro Doroshenko, Mykhailo Doroshenko, or other Dmytro /
+   Doroshenko figures.
+5. **Pavliuk relation:** Hunia participated in the 1637 uprising and helped
+   preserve remnants after Kumeiky, but Pavliuk/But remains a separate
+   biography.
+6. **Ostrianyn relation:** Hunia joined and then succeeded Ostrianyn in the
+   final defense sequence. Do not credit Ostrianyn with Starets command after
+   the leadership break.
+7. **Skydan relation:** Skydan's wounded/captured return to aid Hunia is
+   important; it should not be folded into a single-commander story.
+8. **Dates:** Zhovnyn/Starets dates appear in Old Style / New Style and
+   compressed forms across sources. Use month and attribution unless a lesson
+   is explicitly about calendars.
+9. **Starets geography:** Starets is an old Dnipro channel / bay near the Sula
+   mouth, not a modern town-centered battlefield that can be mapped without
+   source care.
+10. **Escape language:** hostile diary and later summary vocabulary can make
+    Hunia's departure cowardice or clever survival. Treat that as source
+    language, not neutral narrator judgment.
+11. **Fate after 1640:** Don/Ottoman-frontier activity is supported, but the
+    later life remains unknown.
+12. **Political meaning:** do not turn Hunia into a pure folk avenger, bandit,
+    class-war emblem, or modern nationalist prototype.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Hunia's biography exposes the point where Cossack
+repression shifted from battlefield suppression into legal and spatial
+control. He appears first as a survivor of the Pavliuk/But defeat, then as a
+Sich-based crisis leader resisting a punitive expedition, then as a field
+commander in the 1638 renewal, and finally as the elected leader of a fortified
+camp whose survival depended on supplies, crossings, reinforcements, and
+negotiation. The conflict was not only "rebellion" in the abstract; it was a
+struggle over who could claim Cossack status, move to Zaporizhia, elect
+leaders, hold court, and remain outside estate dependency. [T1: ЕІУ Hunia;
+T1: ЕІУ Starets; T1: ЕІУ Ordinance]
+
+**By whom:** Commonwealth military and administrative power in the punitive,
+register, commissioner, and post-campaign legal layers; crown and magnate
+forces in the campaign/blockade layer; registered-Cossack units in enforcement
+and interception roles; unregistered and Zaporizhian Cossacks in the
+mobilization layer; Don Cossack and Ottoman-frontier contexts in the late
+source trail. Hunia also had agency: he brought remnants through Kumeiky's
+collapse, accepted or held crisis command, fought at/through the Sich and
+Dnipro crossing layer, commanded at Starets, negotiated, and left before the
+final settlement.
+
+**Document references:** Pavliuk/But defeat and Borovytsia settlement; Okolski
+diary / Lukomsky-Velychko transmission; Zhovnyn and Starets battle entries;
+the 1638 Ordinance; Mykytyn Sich garrison / passport context; registered
+Cossack structure; and IEU's Hunia / Skydan entries for English metadata and
+related leaders. [T1: ЕІУ Kumeiky; T1: ЕІУ Starets; T1: ЕІУ Mykytynska Sich;
+T1: IEU Registered Cossacks; T2: Okolski/Lukomsky]
+
+**Mechanism specifics:** the state response treated mobility and recognition
+as control points. The 1638 ordinance curtailed traditional rights, replaced
+elected leadership for the register with a commissioner, restricted movement
+to Zaporizhia without passport authorization, and tied registered service to
+territory and official supervision. The same logic appears militarily at
+Starets: the camp's strength mattered, but the blockade, interception of
+supporting detachments, and supply shortage made negotiation unavoidable. [T1:
+ЕІУ Ordinance; T1: ЕІУ Starets]
+
+**What survived / what was distorted:** what survived is a strong memory of
+Starets as the closing defense of the 1638 Cossack war and Hunia as the figure
+who continued after Ostrianyn's departure. What gets distorted is the person.
+Commonwealth and Okolski-style language can reduce him to disorder; Soviet
+inheritance can flatten the conflict into class struggle; patriotic memory can
+turn him into a flawless last defender; campaign summaries can make his escape
+look like either betrayal or triumph. A decolonized reading keeps all layers
+visible: coercive law, registered/unregistered pressure, insurgent agency,
+military skill, supply limits, negotiation, survival, and uncertainty.
+
+## 3. Major works / legacy
+
+Hunia left no literary corpus; "works" means command roles, councils,
+campaign decisions, fortified defense, negotiation documents, and later memory.
+
+- `before 1637` — early life remains source-thin. Use unknown birth, unknown
+  origin, and no secure family scene as the baseline. [T1: ЕІУ Hunia; T1: IEU
+  Hunia]
+- `1637` — participated in Pavlo Pavliuk / But's uprising. Do not make him the
+  initiator of the 1637 movement; his secure role becomes clearer in the
+  retreat/survival phase. [T1: IEU Hunia; Existing dossier:
+  `docs/research/bio/pavlo-pavliuk-but.md`]
+- `16 (6) December 1637` — Kumeiky: after the wagon camp was broken and
+  Pavliuk / Skydan left or withdrew, Hunia led remnants by night toward
+  Borovytsia. This is a high-value detail for teaching non-single-commander
+  history. [T1: ЕІУ Kumeiky]
+- `late December 1637` — Borovytsia and retreat-to-Sich context. IEU says
+  Hunia and other rebels retreated to the Zaporozhian Sich, where he was
+  elected hetman. [T1: IEU Hunia; T1: ЕІУ Hunia]
+- `early 1638` — defeated K. Meletsky's punitive detachment / the expedition
+  sent to subdue the Sich. This belongs to the post-Pavliuk repression layer,
+  not only to the later Ostrianyn campaign. [T1: ЕІУ Hunia; T1: IEU Hunia]
+- `March 1638` — joined Ostrianyn's army and commanded a Dnipro-crossing
+  detachment. The campaign geography includes Kremenchuk, Pyliavets,
+  Chyhyryn-Dibrova, Left-Bank movement, crown forces, and magnate detachments.
+  [T1: ЕІУ Hunia]
+- `May-June 1638 source-sensitive` — Zhovnyn: Ostrianyn left with part of the
+  force; the remaining Cossacks elected Hunia. Use this as leadership
+  transition, not as a morality play about Ostrianyn. [T1: ЕІУ Zhovnyn; T1:
+  ЕІУ Starets]
+- `20 (10) June 1638, source-sensitive` — Starets move: ЕІУ Starets says
+  Hunia's Cossacks built a bridge over the Sula and moved from the Zhovnyn
+  area toward the Starets position. The exact classroom date should be
+  attributed because the event sequence uses calendar conversions. [T1: ЕІУ
+  Starets]
+- `22 (12) June-August 1638` — Starets defense: a fortified camp at the
+  Starets / old Dnipro channel resisted superior forces for more than a month.
+  Teach the camp as military geography: water, marshes, hills, crossings,
+  supply, and blockade. [T1: ЕІУ Hunia; T1: ЕІУ Starets]
+- `July-August 1638` — negotiation and departure: shortage of supplies pushed
+  the camp toward agreement; Hunia and Filonenko left before the capitulation.
+  Present this with source-critical verbs: "ЕІУ Starets says," "Okolski's
+  hostile layer frames," "the dossier should not moralize." [T1: ЕІУ Starets;
+  T2: Okolski/Lukomsky]
+- `August 1638` — small detachment under Hunia broke out and retreated to
+  Zaporizhia according to ЕІУ Hunia. This is the secure survival baseline.
+  [T1: ЕІУ Hunia]
+- `post-1638` — legal aftermath: the 1638 ordinance and Mykytyn Sich regime
+  restricted Cossack movement and narrowed legal recognition. Use the aftermath
+  to connect Hunia's defense to institutional coercion, not to an all-rulers
+  chronology. [T1: ЕІУ Ordinance; T1: ЕІУ Mykytynska Sich; T1: IEU Registered
+  Cossacks]
+- `spring 1640` — IEU says Hunia led a campaign of Zaporozhian and Don
+  Cossacks against Turkey; ЕІУ says he went to the Don and distinguished
+  himself in fighting with Turks and Tatars. Use this as late-source evidence
+  and keep final fate unknown. [T1: IEU Hunia; T1: ЕІУ Hunia]
+- `later source memory` — Okolski's hostile diary, Lukomsky/Velychko
+  transmission, EIU/IEU summaries, school histories, and Cossack-memory
+  retellings made Hunia a reusable figure for lessons on final defense,
+  negotiation, and survival. [T1: ЕІУ Okolski; T2: Okolski/Lukomsky]
+
+## 4. Primary/source-language anchors (>=2 required)
+
+> **Honest tool note:** no project `verify_quote` tool or LLM-QG route was
+> used for this dossier. The excerpts below are short source-language anchors
+> from a public Litopys/Izbornyk text of the Okolski/Lukomsky/Velychko
+> transmission and should be rechecked against a scholarly source edition
+> before classroom quotation.
+
+**Anchor 1 — office/signature vocabulary:**
+
+> "Дмитро Тимошевичъ Гуня, старшій надъ войскомъ"
+
+Context: the old-source formula is useful for teaching `старший` / military
+authority language without turning it into a stable later office. It also
+supports the patronymic as a source-layer form. [T2: Okolski/Lukomsky via
+Litopys]
+
+**Anchor 2 — Starets place formula:**
+
+> "на устю Старца"
+
+Context: the phrase helps learners see that `Старець` is a water/geography
+term in the source layer, tied to the mouth of the old channel / bay, not just
+a modern place label. [T2: Okolski/Lukomsky via Litopys; T1: ЕІУ Starets]
+
+**Anchor 3 — council/negotiation scene:**
+
+> "казалъ Гуня вязанку сЂна принести"
+
+Context: the scene around envoys and council procedure is vivid but must be
+handled as hostile-source narrative. Use it to teach source stance and ritual
+description, not as transparent psychological evidence. [T2: Okolski/Lukomsky
+via Litopys; T1: ЕІУ Okolski]
+
+**Anchor 4 — legal-control vocabulary:**
+
+`старший комісар`, `паспорт`, `смертна кара`, `залога`, and `запобігання
+заколотам` are key 1638 ordinance / Sich-control terms for lessons on how law
+and garrison practice controlled Cossack movement after the defeat. [T1: ЕІУ
+Ordinance; T1: ЕІУ Mykytynska Sich]
+
+## 5. Language register and learner-use notes
+
+- **Register:** Cossack military, legal-administrative, frontier, chronicle,
+  diary, siege, and negotiation vocabulary: registered Cossacks,
+  unregistered Cossacks, Sich, hetman, starshyi, colonel, wagon camp, bridge,
+  crossing, Sula, Starets, blockade, envoy, passport, commissioner, garrison,
+  oath, capitulation, escape, and unknown fate.
+- **CEFR readiness for full reading:** B1-B2 for adapted biography; B2-C1 for
+  register/Ordinance mechanism and Starets geography; C1-C2 for
+  Okolski/Lukomsky/Velychko source language because of old orthography,
+  partisan labels, and mixed Ruthenian/Polish/Latin forms.
+- **Lexicon notes:** `Дмитро Гуня`, `Дмитро Тимошевич`, `гетьман`,
+  `старший`, `реєстрові козаки`, `нереєстрові козаки`, `випищики`,
+  `Запорозька Січ`, `Базавлуцька Січ`, `Жовнин`, `Старець`, `Сула`,
+  `табір`, `вагенбург`, `окоп`, `переправа`, `облога`, `блокада`,
+  `посли`, `присяга`, `комісар`, `паспорт`, `залога`, `Дон`.
+- **Learner-use notes:** this dossier supports a B2-C1 lesson on verbs of
+  source caution: "is elected," "is called," "is said to have broken out,"
+  "the hostile diary frames," "ЕІУ states," "IEU gives," "later fate remains
+  unknown."
+- **Stylistic features:** pair military verbs (`прорвав`, `очолив`,
+  `укріпив`, `відбивав`, `перейшов`, `вийшов з оточення`) with uncertainty
+  verbs (`невідомо`, `джерело називає`, `переказує`, `формулює`,
+  `потребує перевірки`).
+- **Sensitive framing:** avoid prompts like "hero or coward" and "last true
+  defender." Better prompt: "How did Starets combine military skill,
+  logistical limits, negotiation, and later memory?"
+
+## 6. Contested points
+
+- **Birth, origin, and death:** unknown. This is not a biography where a
+  childhood scene or final martyrdom can be safely narrated.
+- **Patronymic:** `Тимошевич` is supported by ЕІУ and source-language layers;
+  keep it available for metadata and search but do not overbuild genealogy.
+- **Office title:** `гетьман` and `старший` appear in reference/source layers.
+  Explain the crisis constituency instead of making him a later-state ruler.
+- **Pavliuk / Ostrianyn / Skydan sequence:** Hunia is connected to all three,
+  but he should not be used to absorb their separate biographies.
+- **Kumeiky role:** ЕІУ Kumeiky makes his night withdrawal of remnants
+  important. Do not let Pavliuk's defeat narrative erase the survival layer.
+- **Sich victory:** the early-1638 defeat of the punitive expedition is
+  secure, but exact unit labels and officer names should be attributed.
+- **Zhovnyn dates:** the transition from Zhovnyn to Starets is the core
+  sequence. Exact day precision needs calendar/source notes.
+- **Starets geography:** old channel, Sula mouth, marshes, crossings, and
+  later reservoir changes make simple map captions risky.
+- **Negotiation and departure:** Hunia's leaving before capitulation is not a
+  simple moral verdict. It may be taught as survival, command responsibility,
+  collapse, or hostile framing only with source comparison.
+- **Registered Cossacks:** do not call all registered Cossacks "traitors" in
+  narrator voice. They appear as a pressured service group, enforcement layer,
+  and sometimes rebel participants.
+- **Don / 1640 layer:** supported by ЕІУ/IEU, but final fate remains unknown.
+- **Class-war shorthand:** older "anti-feudal" explanations may be useful as
+  historiographic vocabulary, not as the full explanation.
+- **Modern-national shorthand:** Hunia is not a modern nationalist prototype.
+  The dossier is about early-modern Cossack status, frontier warfare,
+  coercive law, siege, negotiation, and memory.
+- **Image authenticity:** no contemporary life portrait was verified; later
+  images must be captioned as memory or context.
+
+## 7. Cross-track links
+
+> Every curriculum plan path under **Existing** below was verified locally on
+> 2026-07-04 after rebasing to `origin/main`. `docs/research/bio/*` and
+> `wiki/*` entries are verified files, not existing BIO plan paths.
+> Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/dmytro-vyshnevetsky.yaml` — earlier Sich /
+    frontier comparison; keep distinct from Dmytro Hunia.
+  - `curriculum/l2-uk-en/plans/bio/petro-sahaidachny.yaml` — earlier
+    registered-service, Black Sea campaign, and Cossack privilege baseline.
+  - `curriculum/l2-uk-en/plans/bio/severyn-nalyvaiko.yaml` — earlier revolt,
+    suppression, execution, and martyr-memory comparison.
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — later
+    large-scale revolution contrast after the post-1638 repression cycle.
+  - `curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml` — later Sich leadership,
+    frontier action, and heroic-memory comparison.
+  - `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml` — later Cossack
+    revolt memory and poetic afterlife comparisons.
+- **Existing BIO dossiers and research surfaces (VERIFIED present; not
+  curriculum plan paths):**
+  - `docs/research/bio/dmytro-vyshnevetsky.md`,
+    `docs/research/bio/petro-sahaidachny.md`,
+    `docs/research/bio/kryshtof-kosynsky.md`,
+    `docs/research/bio/severyn-nalyvaiko.md`,
+    `docs/research/bio/taras-fedorovych-triasylo.md`,
+    `docs/research/bio/ivan-sulyma.md`,
+    `docs/research/bio/pavlo-pavliuk-but.md`,
+    `docs/research/bio/yakiv-ostrianyn.md`,
+    `docs/research/bio/bohdan-khmelnytskyy.md`,
+    `docs/research/bio/ivan-sirko.md`,
+    `docs/research/bio/ivan-bohun.md` — verified related Cossack / Hetmanate
+    dossier patterns and cautionary comparison points.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/kozatski-povstannia-16.yaml` — earlier
+    uprising arc and pre-1648 comparison frame.
+  - `curriculum/l2-uk-en/plans/hist/kozatstvo-vytoky.yaml`,
+    `curriculum/l2-uk-en/plans/hist/syntez-kozatstvo-vytoky.yaml` — Cossack
+    status, mobility, and frontier background.
+  - `curriculum/l2-uk-en/plans/hist/zaporizka-sich.yaml`,
+    `curriculum/l2-uk-en/plans/hist/kozatske-viisko.yaml` — Sich, Host,
+    register, council, and military vocabulary.
+  - `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml` — Commonwealth
+    political order, estate pressure, offices, and legal coercion.
+  - `curriculum/l2-uk-en/plans/hist/khotynska-viyna.yaml`,
+    `curriculum/l2-uk-en/plans/hist/petro-sahaidachnyi.yaml` — earlier
+    service/reward background and Cossack privilege pressure.
+  - `curriculum/l2-uk-en/plans/hist/slobozhanshchyna.yaml` — compare
+    Ostrianyn's Sloboda movement without moving Hunia there.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — later
+    institutional contrast for what the 1638 uprising did not create.
+  - `curriculum/l2-uk-en/plans/hist/khmelnychchyna-prychyny.yaml` — later
+    build-up to 1648; use after the post-1638 legal repression is understood.
+- **Existing LIT/FOLK/ISTORIO/RUTH plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/folk/dumy-sotsialno-pobutovi.yaml`,
+    `curriculum/l2-uk-en/plans/folk/istorychni-pisni.yaml` — social memory,
+    Cossack-freedom language, and heroic-song comparison.
+  - `curriculum/l2-uk-en/plans/lit-hist-fic/andrian-kashchenko-cossack-myth.yaml`
+    — historical-fiction / Cossack-memory source comparison.
+  - `curriculum/l2-uk-en/plans/istorio/kozatski-litopysy-ohliad.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/syntez-kozatski-dzherela.yaml`,
+    `curriculum/l2-uk-en/plans/istorio/sich-dokumenty.yaml` — chronicle,
+    diary, and Cossack document-language scaffolding for Okolski/Lukomsky and
+    source-critical anchors.
+  - `curriculum/l2-uk-en/plans/ruth/cossack-hierarchy.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/szlachta-nobility.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/document-types.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/treason.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/diplomatic-language.yaml` — office,
+    estate, document, accusation, and negotiation vocabulary.
+- **Existing wiki/research files (VERIFIED present; not curriculum plan
+  paths):**
+  - `wiki/periods/slobozhanshchyna.md` — already mentions the 1638 arrival of
+    Ostrianyn's group near Chuhuiv; useful for contrast, not Hunia's own
+    route.
+  - `wiki/periods/syntez-viyna.md` — already lists the 1638 Ostrianyn uprising
+    as an armed-resistance marker.
+  - `wiki/periods/kozatski-povstannia-16.md`,
+    `wiki/periods/kozatstvo-vytoky.md`,
+    `wiki/periods/kozatske-viisko.md`,
+    `wiki/periods/kozatska-derzhava.md` — existing wiki context for Cossack
+    uprisings, Host vocabulary, and later institutional contrast.
+  - `wiki/linguistics/ruthenian/velychko-ruin-baroque-1.md`,
+    `wiki/linguistics/ruthenian/velychko-ruin-baroque-2.md`,
+    `wiki/historiography/sich-dokumenty.md`,
+    `wiki/linguistics/ruthenian/cossack-hierarchy.md`,
+    `wiki/linguistics/ruthenian/document-types.md` — existing source and
+    vocabulary surfaces for old-language work.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `dmytro-hunia` — future BIO plan/module and wiki figure if this dossier is
+    promoted; `curriculum/l2-uk-en/plans/bio/dmytro-hunia.yaml` and
+    `wiki/figures/dmytro-hunia.md` absent locally on 2026-07-04.
+  - `karpo-skydan` — future BIO dossier/plan/wiki candidate; verified absent
+    locally as `docs/research/bio/karpo-skydan.md`,
+    `curriculum/l2-uk-en/plans/bio/karpo-skydan.yaml`, and
+    `wiki/figures/karpo-skydan.md` on 2026-07-04.
+  - `yakiv-ostrianyn` and `pavlo-pavliuk-but` — existing dossiers but future
+    plan/wiki candidates; their BIO plan and wiki figure files were absent
+    locally on 2026-07-04.
+  - `ostrianyn-uprising-1638`, `zhovnyn-1638`, `starets-1638` — future HIST /
+    ISTORIO modules on the campaign, leadership break, and fortified defense;
+    these plan files were absent locally on 2026-07-04.
+  - `okolski-diary-1638` — future ISTORIO source-critical packet on hostile
+    diary narration and translation/transmission layers.
+
+## 8. Naming-canonical
+
+- **Slug:** `dmytro-hunia`
+- **EN canonical (project spelling):** Dmytro Hunia
+- **UA canonical:** Дмитро Гуня
+- **Full UA source form:** Дмитро Тимошевич Гуня
+- **Aliases (track carefully for future `aliases:` YAML field):** Дмитро
+  Гуня; Дмитро Тимошевич Гуня; Dmytro Hunia; Hunia, Dmytro; Hunja; Dmytro
+  Gunia; Dmytro Gunya; `Дмитро Тимошевичъ Гуня` [old-source spelling].
+- **Office/title variants to track carefully:** `запорозький гетьман`;
+  `гетьман`; `старший`; `старший над військом`; `рейментар` as
+  source/hostile vocabulary; `ватажок`; `керівник повстання`; `реєстрові
+  козаки`; `нереєстрові козаки`; `випищики`.
+- **Place/event variants to track carefully:** `Кумейки`; `Боровиця`;
+  `Базавлуцька Січ`; `Запорозька Січ`; `Кременчук`; `Пилявець`;
+  `Чигирин-Діброва`; `Жовнин / Жовнине`; `Сула`; `Старець / Starets`;
+  `Дніпро`; `Запорожжя`; `Дон`; `Павло Бут / Павлюк`; `Яків Острянин`;
+  `Карпо Скидан`; `Філоненко`; `Миколай Потоцький`; `Станіслав Потоцький`;
+  `К. Мелецький`.
+- **Forbidden forms / flattening forms to flag in body text:** Russian-only
+  name forms as normalized Ukrainian/English body text; "bandit" as neutral
+  fact; "coward" as narrator voice; "traitor" for registered Cossacks as
+  narrator voice; "pure class-war leader" as full explanation; "modern
+  nationalist prototype" as full explanation; a precise death scene; conflation
+  with Dmytro Vyshnevetsky, Dmytro Doroshenko, Mykhailo Doroshenko, or other
+  similarly named figures.
+- **Term warning:** `гетьман` in this dossier is an early-modern crisis and
+  military leadership term. Explain constituency, source, and event context
+  before using it as a headline.
+- **Scope warning:** keep this BIO dossier on post-Pavliuk repression, the
+  1638 uprising, register politics, Zhovnyn/Starets command, negotiated
+  survival, Don afterlife, and source-memory uncertainty. Do not turn it into
+  an all-rulers chronology or unrelated modern-statehood material.
+
+## 9. Image candidates
+
+- **Best context candidate:** a rights-clear map of Kumeiky-Borovytsia /
+  Zhovnyn-Starets / Sula-Dnipro geography, ideally project-created or from a
+  verified public-domain source. This may teach the dossier better than a
+  portrait.
+- **Starets context candidate:** a map or historical geography image showing
+  the Sula mouth, old Dnipro channels, and modern reservoir changes. Caption
+  carefully because much of the historic terrain has changed.
+- **Sich context candidate:** a verified rights-clear map or source image for
+  Bazavluk / Mykytyn Sich context, paired with the 1638 ordinance/garrison
+  layer. Do not imply that a later Sich image depicts Hunia's own camp.
+- **Source candidate:** a public-domain page image from Okolski or a
+  Lukomsky/Velychko printed edition could support an ISTORIO source-criticism
+  lesson if edition metadata and reuse rights are verified.
+- **Portrait candidates:** no contemporary life portrait was verified in this
+  pass. Any portrait-style image found in popular or Wikimedia-adjacent spaces
+  should be treated as later visual memory unless metadata proves provenance.
+- **Authenticity caveat:** the most honest first image may be geography or
+  document context, not a face.
+- **Avoid:** generic Cossack stock art, unlicensed modern illustrations,
+  images that make Hunia a simple avenger or simple fugitive, and captions
+  that treat Starets as a clean modern battlefield without source caveat.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- [T1] Щербак В.О. "Гуня Дмитро Тимошевич" // *Енциклопедія історії України*,
+  т. 2. URL: https://www.history.org.ua/?termin=Gunya_D | accessed
+  2026-07-04. Core facts: unknown birth/death, 1637-1638 leadership,
+  Zaporizhian hetman label, Kumeiky/Borovytsia breakout, early-1638 Sich
+  defense, March 1638 joining with Ostrianyn, Dnipro-crossing detachment,
+  Starets defense, breakout to Zaporizhia, Don movement, and unknown fate.
+- [T1] Вирський Д.С. "Старець, битва над затокою 1638" // *Енциклопедія
+  історії України*. URL: https://www.history.org.ua/?termin=Starets_1638 |
+  accessed 2026-07-04. Used for Starets dates, geography, defensive camp,
+  bridge/crossing, blockade logic, supporting detachments, supply shortage,
+  Hunia/Filonenko departure, and outcome framing.
+- [T1] Щербак В.О. "Жовнинська битва 1638" // *Енциклопедія історії України*.
+  URL: https://www.history.org.ua/?termin=Zhovnynska_bytva_1638 | accessed
+  2026-07-04. Used for Zhovnyn camp, Ostrianyn's departure, Hunia's election,
+  and move toward Starets.
+- [T1] Вирський Д.С. "Кумейки, битва 1637" // *Енциклопедія історії України*,
+  т. 5. URL: https://www.history.org.ua/?termin=Kumeiki_Bitva_1637 |
+  accessed 2026-07-04. Used for Kumeiky date, failed concentration, wagon-camp
+  defeat, Pavliuk/Skydan withdrawal, and Hunia's night withdrawal of remnants
+  toward Borovytsia.
+- [T1] Щербак В.О. "Павлюка повстання 1637" // *Енциклопедія історії України*.
+  URL: https://www.history.org.ua/?termin=Pavliuka_povstannia_1637 | accessed
+  2026-07-04. Used for Pavliuk uprising context, rights/privileges and faith
+  rhetoric, register conflict, Kumeiky, Borovytsia, and Khmelnytsky clerk
+  signature context.
+- [T1] Сас П.М. "Ординація Війська Запорозького 1638" // *Енциклопедія
+  історії України*, т. 7. URL:
+  https://www.history.org.ua/?termin=Ordynatsiia_Vijska_1638 | accessed
+  2026-07-04. Used for post-defeat legal control: curtailed traditional
+  rights, commissioner structure, passport controls, garrison rules, territorial
+  attachment, and anti-uprising enforcement.
+- [T1] Щербак В.О. "Микитинська Січ" // *Енциклопедія історії України*.
+  URL: https://www.history.org.ua/?termin=Mykytynska_sich | accessed
+  2026-07-04. Used for post-1638 Sich monitoring, registered garrison duty,
+  and prohibition on unauthorized presence.
+- [T1] Герасименко Н.О. "Окольський Симеон" // *Енциклопедія історії України*.
+  URL: https://www.history.org.ua/?termin=Okolskyj_S | accessed 2026-07-04.
+  Used for Okolski's role, hostile-source position, 1637-1638 diary context,
+  and later Ukrainian translation/use by Velychko and Lukomsky.
+- [T1] "Hunia, Dmytro" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CH%5CU%5CHuniaDmytro.htm
+  | accessed 2026-07-04. Used for English metadata, unknown birth/death,
+  Pavliuk participation, Kumeiky/Borovytsia/Sich sequence, early-1638 defense,
+  spring-1638 Ostrianyn/Skydan connection, post-Zhovnyn command, 1640 campaign,
+  and unknown subsequent fate.
+- [T1] "Skydan, Karpo" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CK%5CSkydanKarpo.htm
+  | accessed 2026-07-04. Used for Skydan as unregistered-Cossack colonel,
+  1637-1638 co-leader, return to aid Hunia, wound/capture, and presumed
+  execution.
+- [T1] "Registered Cossacks" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CE%5CRegisteredCossacks.htm
+  | accessed 2026-07-04. Used for register mechanics, loss of election/court
+  rights after 1638, commissioner control, and enserfment / exclusion risks for
+  those outside the register.
+
+**Tier 2 (source editions / source-language anchors):**
+
+- [T2] "Щоденник Симеона Окольського. 1638" / Lukomsky-Velychko transmission
+  via Izbornyk/Litopys. URL: https://litopys.org.ua/samovyd/sam21.htm |
+  accessed 2026-07-04. Used for short source-language anchors around Hunia's
+  title/signature, Starets camp vocabulary, envoy/council scene, and hostile
+  narration. Treat as partisan and transmission-layer evidence.
+
+**Tier 3 (encyclopedic — navigation only):**
+
+- [T3] Ukrainian and English Wikipedia pages for Dmytro Hunia / the 1637-1638
+  uprising cycle, accessed 2026-07-04. Used only for navigation to names,
+  bibliography, and image leads; cross-checked against T1/T2.
+
+**Tier 4 (modern scholarly / specialist anchors):**
+
+- [T4 lead] Щербак В.О. *Антифеодальні рухи на Україні напередодні визвольної
+  війни 1648-1654 рр.* Kyiv, 1989. Bibliographic anchor via ЕІУ Hunia,
+  Zhovnyn, and Pavliuk uprising entries; direct book text not fully inspected
+  in this pass.
+- [T4 lead] Вирський Д.С. *Річпосполитська історіографія України (XVI —
+  середина ХVII ст.)*. Kyiv, 2008. Bibliographic anchor via ЕІУ Starets for
+  Okolski / "Mars Savromatski" historiography; direct book text not fully
+  inspected in this pass.
+- [T4 lead] Borowiak A. *Powstanie kozackie 1638*. Zabrze, 2010.
+  Bibliographic anchor via ЕІУ Starets; not load-bearing without direct text
+  inspection.
+- [T4 lead] Грушевський М. *Історія України-Руси*, т. 8. Bibliographic anchor
+  via ЕІУ Zhovnyn and Kumeiky entries and related Cossack-cycle dossiers;
+  direct Hunia/Starets passages not fully rechecked for this file beyond the
+  source-language Litopys page.
+
+**Tier 5 (general web / image metadata — not load-bearing):**
+
+- [T5/image metadata] General web, Commons-adjacent, textbook, and popular
+  image/search results surfaced during navigation, accessed 2026-07-04. Used
+  only as image-rights or memory leads; no image cleared for reuse in this
+  pass.
+
+**Primary-source documents accessed / verification notes:**
+
+- Okolski/Lukomsky/Velychko transmission for Hunia/Starets was accessed via
+  Litopys and used only for short anchors.
+- Original 1638/1639 Okolski printings, full modern Polish editions, and
+  manuscript/facsimile witnesses were not inspected.
+- Ordinance details were verified through ЕІУ, not through a full Volumina
+  legum source edition in this pass.
+- No archival records for Hunia's Don/1640 afterlife were inspected.
+
+**Honest gaps:** this dossier did not inspect archival originals, complete
+Okolski printings, full Hrushevsky / Shcherbak / Vyrskyi / Borowiak passages,
+Muscovite or Don Cossack records for Hunia after Starets, or complete
+visual-rights metadata. For module writing, recheck exact quotation, date
+conversion, Starets map captions, and the 1640 campaign layer against source
+editions.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Muscovy/Moscow is not used as the default
+  center and is not needed for this BIO surface beyond border/frontier context.
+- [x] No Russian-imperial transliterations normalized in body text; `Gunia` /
+  `Gunya` are search variants only.
+- [x] Hunia is not flattened into a folk avenger, bandit, coward, class-war
+  symbol, or modern nationalist prototype.
+- [x] Registered service, unregistered leadership, Sich defense, Starets
+  command, negotiation, escape, legal coercion, and unknown fate are all
+  visible.
+- [x] Source labels such as hostile diary vocabulary, `рейментар`,
+  "rebellion," "fled," "disorder," and "traitor" are treated as source
+  vocabulary, not neutral narration.
+- [x] Registered Cossacks are not treated as timeless villains; coercion,
+  service structure, status, garrison duty, and commissioner control are
+  named.
+- [x] Okolski/Lukomsky/Velychko layers are marked as source-critical, not used
+  as transparent biography.
+- [x] Starets defense includes military skill, geography, supply limits,
+  negotiation, and collapse/survival ambiguity.
+- [x] Soviet/class-war shorthand is named only as historiographic inheritance,
+  not adopted as the dossier's explanation.
+- [x] Modern Ukrainian place/institution naming used with historical context:
+  Запорозька Січ, Базавлуцька Січ, Кумейки, Боровиця, Жовнин, Сула, Старець,
+  Дніпро, Запорожжя, Дон, Річ Посполита, Військо Запорозьке.
+- [x] No unrelated modern-statehood material, all-rulers chronology, or
+  out-of-scope figures added.
+
+## Validation checklist
+
+- [x] Single owned file only: `docs/research/bio/dmytro-hunia.md`.
+- [x] Existing cross-track plan/wiki/dossier paths verified locally after the
+  branch was rebased to `origin/main`.
+- [x] Future Hunia/Skydan/Ostrianyn/Pavliuk/HIST/ISTORIO surfaces marked
+  absent locally when cited as candidates.
+- [x] Lower-tier sources marked non-load-bearing.
+- [x] Guard terms for unrelated modern-statehood, unrelated hetmanate scope,
+  unrelated monarch scope, and all-rulers scope avoided.
+- [x] No generated `status/`, `audit/`, `review/`, or telemetry artifacts
+  referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans,
+  module files, activities, vocabulary, resources, site MDX, or wiki files
+  edited.
+- [x] Required validation planned/run before PR:
+  `npx markdownlint-cli2 docs/research/bio/dmytro-hunia.md`,
+  `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/dmytro-hunia.md`,
+  `git diff --check`, protected-scope guard, and unrelated-term guard.


### PR DESCRIPTION
## Scope

Adds the BIO readiness research dossier for Dmytro Hunia, scoped to the 1637-1638 Cossack uprising cycle: Kumeiky/Borovytsia survival, early-1638 Sich defense, Zhovnyn leadership transition, Starets defense, negotiated survival, registered/unregistered conflict, and source-memory uncertainty.

LLM-QG remains paused and was not run.

## Changed files

- `docs/research/bio/dmytro-hunia.md`

## Validation

- `npx markdownlint-cli2 docs/research/bio/dmytro-hunia.md` - passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/dmytro-hunia.md` - passed
- `git diff --check` - passed
- `git diff --cached --check` before commit - passed
- Guard search for unrelated modern-statehood / monarch scope terms - no matches
- Protected artifact/config guard - only `docs/research/bio/dmytro-hunia.md` changed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` - passed
- Commit/push hooks - passed

## Source and decolonization caveats

- Tier 1 load-bearing sources are ЕІУ/IEU entries for Hunia, Starets, Zhovnyn, Kumeiky, the 1638 Ordinance, Mykytyn Sich, Registered Cossacks, Skydan, and Okolski.
- Okolski/Lukomsky/Velychko material is used only for short source-language anchors and is treated as hostile / transmission-layer evidence, not neutral biography.
- Hunia is framed as source-thin and complex: not a pure folk avenger, bandit, class-war symbol, modern nationalist prototype, or interchangeable Dmytro/Doroshenko figure.
- Final fate after the Don / spring-1640 source layer remains unknown.

## Review note

No independent review has been routed yet because the orchestrator handles that gate.