### PR TITLE
[codex] docs(bio): add Mykhailo Doroshenko dossier

### DIFF
--- a/docs/research/bio/mykhailo-doroshenko.md
+++ b/docs/research/bio/mykhailo-doroshenko.md
@@ -1,0 +1,648 @@
+# Михайло Дорошенко — Research Dossier
+
+**Slug:** `mykhailo-doroshenko`
+**Block:** P1 BIO Cossack coverage (early registered-Cossack hetmanship;
+Kurukove settlement; registered/unregistered split; Zaporizhian-Crimean
+diplomacy; Black Sea / Crimean-Ottoman frontier politics; Doroshenko-family
+memory without collapsing him into Petro Doroshenko)
+**Tier:** 1b (strong Tier 1 baseline for office, Kurukove, and 1628 Crimean
+campaign; source-thin early life and contested office chronology)
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ Doroshenko, ЕІУ Kurukove, ЕІУ
+  Zaporizhian-Crimean treaty, ЕІУ Mehmed Giray III, ЕІУ Crimean Khanate
+  overview, IEU Doroshenko, IEU Kurukove, IEU Registered Cossacks)
+- [x] Source-tier checkboxes included and lower-tier sources kept
+  non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: register as
+  recognition/control, Kurukove restrictions, registered/unregistered split,
+  coerced return of excluded Cossacks, foreign-policy limits, and
+  Crimean-Ottoman alliance politics)
+- [x] §4 includes short source-language anchors with verification caveats
+- [x] Mykhailo Doroshenko is framed as complex: registered-Cossack leader,
+  negotiator, enforcer of a restrictive settlement, Orthodox/right-defense
+  advocate, Crimean-alliance actor, frontier commander, and family-memory
+  founder
+- [x] Cross-track links: every "Existing" plan/wiki/dossier path verified
+  locally with `test -e` on 2026-07-04
+- [x] Naming-canonical applied; `Михайло Дорошенко` / `Mykhailo Doroshenko`
+  are canonical, while older transliterations and Polish forms are tracked as
+  search variants only
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+
+- [x] **T1 baseline:** ЕІУ `Дорошенко Михайло` anchors unknown birth year,
+  1628 death, registered-Cossack hetmancy in 1625-1628, Doroshenko-family
+  foundation, Sahaidachny connection, Khotyn participation, Zhmailo/Kurukove
+  sequence, Bila Tserkva victory, and the Crimean campaign/death at the Alma.
+- [x] **T1 English baseline:** IEU `Doroshenko, Mykhailo` anchors English
+  spelling, registered-Cossack office, 1616 colonel note, Sahaidachny/Muscovy
+  and Khotyn participation, Kurukove, six-regiment creation, conflict with
+  Zaporozhians, Crimean Giray support, and the Kaffa death-location variant.
+- [x] **T1 event/legal context:** ЕІУ and IEU Kurukove entries anchor the 1625
+  settlement, 6,000-person register, six regiments, election/right limits,
+  foreign-policy ban, campaign restrictions, and excluded-Cossack problem.
+- [x] **T1 diplomatic/frontier context:** ЕІУ Zaporizhian-Crimean treaty,
+  Mehmed Giray III, and Crimean Khanate overview anchor the 1624 alliance, the
+  Shahin Giray/Muhammad Giray setting, Ottoman/Nogai pressure, and the 31 May
+  1628 Alma battle context.
+- [x] **T2/T4 source-critical leads:** Hrushevsky's encyclopedia entry with
+  editorial comments, Mytsyk's specialist article lead, Chukhlib's
+  Ukrainian-Crimean alliance work, and Kovalevska/Doroshenko's iconography
+  article are used for chronology/source criticism and image caution, not to
+  override Tier 1 facts.
+- [x] **T3/T5 caution:** Wikipedia, museum/fund pages, school pages, popular
+  posts, and modern commemorative imagery are navigation or memory leads only;
+  they are not load-bearing for fact or interpretation.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Михайло Дорошенко. Use `Mykhailo
+  Doroshenko` for English metadata. ЕІУ titles the entry `ДОРОШЕНКО Михайло`;
+  IEU gives `Doroshenko, Mykhailo [Dorošenko, Myxajlo]`. [T1: ЕІУ
+  Doroshenko; T1: IEU Doroshenko]
+- **Aliases / spelling variants:** Михайло Дорошенко; гетьман Михайло
+  Дорошенко; Mykhailo Doroshenko; Doroshenko, Mykhailo; Dorošenko, Myxajlo;
+  Michal / Michał Doroszenko as Polish-search variants. Do not treat these as
+  separate people. [T1: IEU; T2/T4 bibliography leads]
+- **Born / died:** birth year unknown; died in **1628**. ЕІУ's short entry
+  gives unknown birth and death in 1628. The broader ЕІУ Crimean Khanate
+  overview gives **31 May 1628** for the Alma battle in which he died. [T1:
+  ЕІУ Doroshenko; T1: ЕІУ Crimean Khanate overview]
+- **Death-location caution:** ЕІУ Doroshenko says he died in battle on the
+  Alma while the Cossack army moved from Perekop toward Bakhchysarai; the ЕІУ
+  Crimean Khanate overview gives the same Alma battle and says the Cossacks
+  then broke through to Bakhchysarai. IEU compresses the end as death during
+  the siege of Kaffa / Teodosiia. Use `Alma / Bakhchysarai campaign, 1628`
+  unless a module is explicitly comparing source traditions. [T1: ЕІУ
+  Doroshenko; T1: ЕІУ Crimean Khanate overview; T1: IEU Doroshenko]
+- **Office / constituency:** ЕІУ calls him hetman of the registered Cossacks
+  in **1625-1628** and senior of the Zaporozhian Host after Kurukove. IEU also
+  gives registered-Cossack hetmancy in 1625-1628. Hrushevsky's entry with
+  later editorial comments points to earlier, unstable elections in 1623-1624.
+  Teach the difference between volatile Cossack-election leadership and the
+  better-attested post-Kurukove registered office. [T1: ЕІУ Doroshenko; T1:
+  IEU Doroshenko; T2: Hrushevsky/commentary]
+- **Early career:** IEU says he became a Cossack colonel in 1616 and
+  participated in Petro Konashevych-Sahaidachny's campaign against Muscovy and
+  in the Battle of Khotyn in 1621. Hrushevsky/commentary says the first
+  source notices begin in 1618 around the 1618 Muscovy campaign. Use
+  `by the late 1610s` if exact first attestation is not being taught. [T1:
+  IEU Doroshenko; T2: Hrushevsky/commentary]
+- **Sahaidachny / Khotyn context:** ЕІУ identifies him as a comrade of
+  Petro Konashevych-Sahaidachny and participant in the Khotyn War of 1621.
+  This makes him part of the post-Sahaidachny leadership generation, not a
+  disconnected family preface to Petro Doroshenko. [T1: ЕІУ Doroshenko; T1:
+  IEU Doroshenko]
+- **Religious and rights politics:** ЕІУ says he belonged to the registered
+  elite, sought protection for Cossack rights and privileges, and defended
+  Orthodoxy. Do not over-modernize this into later national ideology; the
+  safe teaching frame is estate, confession, military service, and frontier
+  political autonomy. [T1: ЕІУ Doroshenko]
+- **1624 Zaporizhian-Crimean treaty:** ЕІУ's treaty entry says the preserved
+  Polish-language oath letter was written from Shahin Giray to Hetman
+  M. Doroshenko, the osauls, and the whole Zaporozhian Host. The treaty
+  committed the sides to non-harm and mutual military aid. [T1: ЕІУ
+  Zaporizhian-Crimean treaty]
+- **Limits of the 1624 treaty:** ЕІУ stresses that the treaty was signed by
+  the kalga-sultan Shahin Giray, not by the khan, and therefore had limited
+  legal force and duration. It also failed to deliver Crimean aid during the
+  1625 Zhmailo uprising. Teach this as early-modern frontier diplomacy, not as
+  a simple permanent alliance. [T1: ЕІУ Zaporizhian-Crimean treaty]
+- **1625 Zhmailo/Kurukove sequence:** ЕІУ Doroshenko says Doroshenko, then a
+  colonel, participated in Marko Zhmailo's uprising and was elected senior of
+  the Zaporozhian Host in the same year. ЕІУ Zhmailo says the Kurukove
+  agreement was signed by M. Doroshenko and rejected by Zhmailo and some
+  Cossacks, who withdrew to Zaporizhia. [T1: ЕІУ Doroshenko; T1: ЕІУ Zhmailo]
+- **Kurukove settlement:** ЕІУ Kurukove gives 5 November (26 October) 1625 near
+  Kurukove Lake / Vedmezhi Lozy. It increased the register to 6,000 and became
+  the basis for six registered regiments: Korsun, Cherkasy, Bila Tserkva,
+  Chyhyryn, Kaniv, and Pereiaslav. [T1: ЕІУ Kurukove; T1: IEU Kurukove]
+- **Kurukove restrictions:** the registered Cossacks could choose a candidate
+  for senior/hetman, but that choice required ruler confirmation; they were
+  barred from independent relations with foreign powers and from campaigns
+  against Ottoman holdings. Excluded Cossacks were expected to return under
+  landlord authority. [T1: ЕІУ Kurukove; T1: IEU Kurukove; T1: IEU Registered
+  Cossacks]
+- **Registered/unregistered conflict:** IEU says that in the following year
+  Doroshenko led the registered Cossacks against Zaporozhian Cossacks opposed
+  to the treaty. This is crucial for complexity: he was not simply a raider or
+  rebel, but also a leader who enforced a restrictive settlement. [T1: IEU
+  Doroshenko]
+- **1626 Bila Tserkva victory:** ЕІУ Doroshenko says Cossack forces under him
+  defeated a Crimean force near Bila Tserkva in autumn 1626. The broader ЕІУ
+  Cossack-uprisings overview presents this as a joint operation with
+  Commonwealth military command that showed the practical advantage of
+  military cooperation. [T1: ЕІУ Doroshenko; T1: ЕІУ Cossack-uprisings
+  overview]
+- **1628 Crimean campaign:** in spring 1628 Doroshenko led a campaign to
+  Crimea in support of Khan Muhammad / Mehmed Giray III, who was fighting
+  Janibek Giray, an Ottoman-backed rival. The ЕІУ Crimean Khanate overview
+  says Shahin Giray called on him when Mehmed Giray III and Shahin were
+  besieged; the Cossacks moved in a fortified camp and reached the Alma after
+  six days. [T1: ЕІУ Doroshenko; T1: ЕІУ Mehmed Giray III; T1: ЕІУ Crimean
+  Khanate overview]
+- **Death and aftermath:** the 31 May 1628 Alma battle cost the Cossacks
+  Doroshenko and several hundred companions, but the force broke through to
+  Bakhchysarai. The broader Giray struggle still failed; the point for BIO is
+  not "Cossacks always fought Crimea" but that Cossack-Crimean relations
+  included alliance, mutual aid, rivalry, raids, and imperial-Ottoman pressure.
+  [T1: ЕІУ Crimean Khanate overview; T1: ЕІУ Mehmed Giray III]
+- **Family legacy:** ЕІУ Doroshenko calls him founder of the Doroshenko
+  family. ЕІУ Doroshenky says the elder branch descends through his son
+  Dorofii Mykhailovych; Petro Doroshenko was Dorofii's son and thus Mykhailo's
+  grandson. Keep Mykhailo's biography independent while noting the family
+  memory line. [T1: ЕІУ Doroshenko; T1: ЕІУ Doroshenky; Existing dossier:
+  `docs/research/bio/petro-doroshenko.md`]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Office dates:** the safe Tier 1 display is `hetman of registered Cossacks,
+   1625-1628`; source-critical notes may mention unstable earlier elections
+   in 1623-1624.
+2. **First attestation:** IEU gives a 1616 colonel note; Hrushevsky/commentary
+   points to 1618 source notices. Do not make either date carry more than the
+   source allows.
+3. **Kurukove agency:** Doroshenko signed a restrictive agreement after a
+   failed uprising. This was not simply surrender or triumph; it preserved a
+   recognized register while excluding many Cossacks and curbing foreign
+   policy.
+4. **Registered versus Zaporizhian:** he belonged to the registered elite and
+   also appears in Zaporizhian-Crimean diplomacy. Avoid turning registered and
+   Zaporozhian into fixed moral categories.
+5. **Crimean alliance:** supporting Mehmed Giray III/Shahin Giray was not a
+   generic anti-Crimean raid. It was intervention in a Crimean-Ottoman/Nogai
+   power struggle.
+6. **Death location:** Alma/Bakhchysarai campaign is the best Tier 1 Ukrainian
+   baseline; IEU's Kaffa line should be treated as a variant/compression until
+   source editions are compared directly.
+7. **Family memory:** Mykhailo is not just "Petro's grandfather." Petro
+   Doroshenko belongs to a later Ruin-era statecraft problem.
+8. **Dmytro Doroshenko:** the historian Dmytro Doroshenko may appear as an
+   author in bibliography. He is not the subject and should not be conflated
+   with Mykhailo or Petro.
+9. **Iconography:** modern images of Mykhailo are imaginative. Do not imply a
+   life portrait.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Mykhailo Doroshenko's biography exposes the early
+seventeenth-century register as both recognition and control. Kurukove gave a
+larger recognized Cossack register and six regiments, but it also separated
+registered from excluded Cossacks, restricted independent diplomacy, banned
+unauthorized campaigns against Ottoman holdings, and pushed non-registered
+Cossacks back under landlord authority. Doroshenko's leadership sits inside
+that contradiction: he defended Cossack rights and Orthodoxy, signed a
+restrictive settlement, enforced it against some Zaporozhians, and then
+re-entered Crimean alliance politics when frontier conditions changed. [T1:
+ЕІУ Doroshenko; T1: ЕІУ Kurukove; T1: IEU Registered Cossacks]
+
+**By whom:** Commonwealth military and administrative power in the register,
+confirmation, pay, campaign-ban, and landlord-return layers; Cossack starshyna
+and registered units in the enforcement layer; excluded and Zaporozhian
+Cossacks in the resistance layer; Crimean Giray factions, Nogai forces,
+Ottoman authority, and Cossack military councils in the Black Sea/frontier
+diplomacy layer. Doroshenko also had agency: he negotiated, enforced, fought,
+sent or led forces, maintained alliances, and died commanding a campaign.
+
+**Document references:** the 1624 Zaporizhian-Crimean oath-letter treaty; the
+1625 Kurukove agreement; the 6,000-person register and six-regiment structure;
+the foreign-policy and campaign bans; the 1628 Crimean campaign reports; and
+later source-critical work by Hrushevsky, Mytsyk, Chukhlib, and Crimean
+Khanate scholars. [T1: ЕІУ Zaporizhian-Crimean treaty; T1: ЕІУ Kurukove; T2:
+Hrushevsky/commentary; T4: Chukhlib lead]
+
+**Mechanism specifics:** Kurukove made Cossack status legible to the
+Commonwealth by naming who counted, who was paid, who could elect leadership
+under confirmation, and who had to stop acting internationally. It also
+produced a volatile boundary around those left outside the register. The
+Zaporizhian-Crimean treaty shows the opposite impulse: the Host acting as a
+frontier diplomatic subject. Doroshenko's life belongs between those poles.
+
+**What survived / what was distorted:** what survived is a memory of a capable
+Cossack commander who helped shape the early register, entered international
+frontier diplomacy, and founded a family later associated with Petro
+Doroshenko. What gets distorted is the complexity. Commonwealth language can
+reduce the problem to "order" versus Cossack disorder; imperial and Soviet
+frames can flatten Cossack-Crimean relations into permanent enmity or class
+formula; patriotic memory can turn him into a pure proto-national hero; family
+memory can make him only a preface to Petro. A decolonized reading keeps
+recognition, coercion, religious/estate rights, alliance politics, Cossack
+agency, and internal Cossack conflict visible at the same time.
+
+## 3. Major works / legacy
+
+Doroshenko left no literary corpus; "works" means command roles, treaties,
+military operations, office-building, and later family/image memory.
+
+- `by the late 1610s` — appears in Cossack military leadership around
+  Sahaidachny's generation. Use the exact first-attestation date cautiously:
+  IEU gives 1616 for colonel status, while Hrushevsky/commentary points to
+  1618 source notices. [T1: IEU Doroshenko; T2: Hrushevsky/commentary]
+- `1618` — Hrushevsky/commentary places him in the campaign connected with
+  the 1618 Muscovy campaign, commanding Cossack detachments in actions
+  against Muscovite forces. Treat detail-level place lists as T2/T4 leads
+  unless a lesson directly inspects Mytsyk. [T2: Hrushevsky/commentary]
+- `1621` — Khotyn War participation; Hrushevsky/commentary preserves a
+  Sobieski-linked description of him as respected by Cossacks for courage and
+  viewed as cooperative by Commonwealth circles. [T1: ЕІУ Doroshenko; T1:
+  IEU Doroshenko; T2: Hrushevsky/commentary]
+- `1623-1624, source-sensitive` — possible earlier election cycles as hetman /
+  acting leader according to Hrushevsky/commentary on Mytsyk. Use for advanced
+  source criticism, not as a simple timeline unless the source edition is
+  read. [T2: Hrushevsky/commentary; T4: Mytsyk lead]
+- `24 December 1624` — Zaporizhian-Crimean treaty on the Dnipro island
+  Karayteben. Its preserved oath-letter text names Hetman M. Doroshenko, the
+  osauls, and the whole Host, and frames mutual non-harm and military aid.
+  [T1: ЕІУ Zaporizhian-Crimean treaty]
+- `1625` — participated as colonel in the Zhmailo uprising and then signed the
+  Kurukove settlement after becoming senior/hetman. The settlement became a
+  foundation for six registered regiments but alienated excluded Cossacks.
+  [T1: ЕІУ Doroshenko; T1: ЕІУ Kurukove; T1: ЕІУ Zhmailo]
+- `5 November / 26 October 1625` — Kurukove agreement near Lake Kurukove /
+  Vedmezhi Lozy: register 6,000, salary, election under confirmation, foreign
+  relations and Ottoman-campaign restrictions. [T1: ЕІУ Kurukove; T1: IEU
+  Kurukove]
+- `late 1625-1626` — registration and enforcement phase. Hrushevsky/commentary
+  says he began implementing the register soon after Kurukove and tried to
+  prevent unauthorized sea campaigns; IEU says he led registered Cossacks
+  against treaty-opposing Zaporozhians. [T1: IEU Doroshenko; T2:
+  Hrushevsky/commentary]
+- `autumn 1626` — victory over a Crimean force near Bila Tserkva, presented in
+  ЕІУ as a successful operation and in the broader Cossack-uprisings overview
+  as evidence that cooperation with Commonwealth military command could work
+  tactically. [T1: ЕІУ Doroshenko; T1: ЕІУ Cossack-uprisings overview]
+- `1627` — Hrushevsky/commentary says Doroshenko sent petitions/embassies to
+  soften Kurukove terms, unsuccessfully. Use as a source-critical lead for his
+  moderate-negotiator profile. [T2: Hrushevsky/commentary]
+- `spring 1628` — led Cossacks into Crimea to assist Mehmed Giray III and
+  Shahin Giray against Janibek Giray's Ottoman-backed side and Nogai/Cantemir
+  pressure. [T1: ЕІУ Doroshenko; T1: ЕІУ Mehmed Giray III; T1: ЕІУ Crimean
+  Khanate overview]
+- `31 May 1628` — died in the Alma battle during the breakthrough toward
+  Bakhchysarai. This is a better teaching endpoint than a generic "raid":
+  he died while fulfilling a frontier alliance obligation in a contested
+  Crimean-Ottoman political field. [T1: ЕІУ Crimean Khanate overview]
+- `afterlife` — remembered as founder of the Doroshenko family and grandfather
+  of Petro Doroshenko. Modern iconography is mostly post-1991 imaginative
+  portraiture; no life portrait has been found in the scholarship consulted
+  here. [T1: ЕІУ Doroshenky; T4: Kovalevska/Doroshenko iconography]
+
+## 4. Primary / source-language anchors (verify before classroom quotation)
+
+> **Honest tool note:** no source-edition quote verifier or LLM-QG route was
+> run in this worker pass. The excerpts below are short source-language anchors
+> from inspected Tier 1/T2 pages and should be rechecked against full editions
+> before becoming classroom quotation exercises.
+
+**Anchor 1 — 1624 Zaporizhian-Crimean treaty language:**
+
+> "кривд", "шкод" і "зла"
+
+Context: ЕІУ's treaty entry summarizes the preserved Polish-language
+oath-letter as committing both sides not to inflict wrongs, harms, or evil on
+one another and to punish peace-breakers under their authority. Use the
+excerpt to teach treaty vocabulary and the fact of mutual obligations, not to
+claim a stable long-term alliance. [T1: ЕІУ Zaporizhian-Crimean treaty]
+
+**Anchor 2 — Kurukove restriction vocabulary:**
+
+> "заборонялося вступати в зносини з іноз. д-вами"
+
+Context: ЕІУ Kurukove uses this compact wording for the foreign-relations ban.
+This is useful for showing how recognition of Cossack status came with a curb
+on autonomous diplomacy. Expand abbreviations and verify against the agreement
+text before classroom quoting. [T1: ЕІУ Kurukove]
+
+**Anchor 3 — Sobieski-linked reputation note via Hrushevsky/commentary:**
+
+> "з доброю репутацією у молодців за свою хоробрість"
+
+Context: the editorial commentary to Hrushevsky's encyclopedia entry cites
+Mytsyk's use of a Sobieski characterization from the Khotyn context. This is a
+source-critical lead for how Doroshenko could be respected in Cossack ranks
+and acceptable to Commonwealth circles. Treat it as mediated until Mytsyk and
+the underlying source are checked directly. [T2: Hrushevsky/commentary; T4:
+Mytsyk lead]
+
+## 5. Language register and learner-use notes
+
+- **Register:** early-modern military, diplomatic, confessional, and legal
+  vocabulary; Cossack office titles; treaty constraints; frontier alliance
+  terms.
+- **CEFR readiness for full reading:** B2-C1 for an adapted biography; C1-C2
+  for source excerpts from Kurukove, oath letters, and old historiographic
+  prose.
+- **Lexicon notes:** `реєстрові козаки`, `нереєстрові козаки`,
+  `Військо Запорозьке`, `старший`, `гетьман`, `осаул`, `реєстр`,
+  `вольності`, `привілеї`, `православ'я`, `угода`, `присяжний лист`,
+  `калга-султан`, `хан`, `сеймен`, `укріплений табір`, `фронтир`,
+  `Пониззя`, `Запорожжя`.
+- **Learner-use notes:** the dossier supports a lesson on how one term,
+  `реєстр`, can mean privilege, salary, military service, legal status, and
+  social exclusion at the same time.
+- **Stylistic features:** strong contrast pairs work well: `визнання /
+  контроль`, `реєстрові / нереєстрові`, `угода / примус`, `союз /
+  зобов'язання`, `фронтир / метрополія`, `пам'ять / іконографія`.
+- **Sensitive framing:** do not ask learners to sort Doroshenko into hero or
+  collaborator. Better prompts: "What did Kurukove preserve, and whom did it
+  exclude?" or "Why does the 1628 campaign challenge a simple story of
+  permanent Cossack-Crimean hostility?"
+
+## 6. Contested points
+
+- **When was he first hetman?** Tier 1 public references use 1625-1628 for
+  the registered-Cossack office; Hrushevsky/commentary on Mytsyk points to
+  earlier, repeated election cycles in 1623-1624. Keep the post-Kurukove office
+  in the main timeline and use earlier dates only with a caveat.
+- **Was Kurukove a success or defeat?** It was both. The register and six
+  regiments gave a recognized structure; the restrictions and excluded-Cossack
+  return order created pressure that fed later uprisings.
+- **Registered leader or Zaporizhian diplomat?** Both layers appear in
+  sources. The 1624 treaty names him in a Zaporizhian diplomatic setting, while
+  the 1625-1628 office is registered-Cossack leadership. Do not erase either.
+- **Moderate or coercive?** Hrushevsky/commentary presents a moderate,
+  compromise-oriented leader, but IEU's note that he led registered Cossacks
+  against treaty-opposing Zaporozhians keeps the coercive enforcement layer
+  visible.
+- **Anti-Ottoman, anti-Crimean, or Crimean ally?** He fought Crimean forces
+  near Bila Tserkva in 1626 and supported Giray allies in Crimea in 1628. This
+  is frontier politics, not a single permanent ethnic line.
+- **Death at Alma or Kaffa?** Use Alma/Bakhchysarai campaign as the Tier 1
+  Ukrainian baseline; record IEU's Kaffa statement as a variant/compression.
+- **Source-language names:** Muhammad / Mehmed / Мухаммед / Мегмед Giray III
+  and Shahin / Шагін Giray vary by source language and transliteration. Keep
+  forms consistent within a lesson and list variants in notes.
+- **Family afterlife:** the family link to Petro Doroshenko is real and useful,
+  but Mykhailo's dossier should teach early registered-Cossack politics and
+  Crimean diplomacy, not simply introduce the Ruin.
+- **Iconography:** modern portraits can be useful memory artifacts, but the
+  consulted iconography article says no lifetime portrait has been found and
+  the modern image tradition is imaginative.
+- **Russian-imperial/Soviet simplification:** the old habit of treating Cossack
+  history as a prelude to Moscow-centered narratives makes his 1618 Muscovy
+  campaign, 1624 treaty, and 1628 Crimean alliance easy to distort. Center the
+  Cossack Host's own constraints and choices.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on
+> 2026-07-04 and resolves locally. Forward-looking ties are under
+> **Candidate** or **Absent**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/petro-sahaidachny.yaml` — Doroshenko
+    belongs to the leadership generation after Sahaidachny and appears in the
+    Khotyn/Sahaidachny military-diplomatic environment.
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — the 1624
+    Zaporizhian-Crimean treaty is a predecessor to later Cossack-Crimean
+    alliance politics under Khmelnytskyy; use cautiously and structurally.
+  - `curriculum/l2-uk-en/plans/bio/severyn-nalyvaiko.yaml` — earlier
+    registered/unregistered and Cossack-uprising pressures provide a
+    comparison point for the Kurukove settlement.
+- **Existing BIO dossiers (VERIFIED present):**
+  - `docs/research/bio/petro-sahaidachny.md` — Sahaidachny generation and
+    Khotyn context.
+  - `docs/research/bio/ivan-sulyma.md` — later Black Sea / Ottoman-frontier
+    raiding and register-control pressures.
+  - `docs/research/bio/taras-fedorovych-triasylo.md` — post-Kurukove and
+    post-Pereiaslav uprising cycle after registered/unregistered pressure
+    sharpened.
+  - `docs/research/bio/petro-doroshenko.md` — grandson and later Doroshenko
+    family memory; compare carefully without collapsing the two biographies.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/khotynska-viyna.yaml` — 1621 Khotyn
+    campaign and Cossack-Commonwealth military cooperation.
+  - `curriculum/l2-uk-en/plans/hist/krymske-khanstvo.yaml` — Crimean Khanate
+    politics and Cossack-Crimean alliance/rivalry beyond stereotype.
+  - `curriculum/l2-uk-en/plans/hist/kozatske-viisko.yaml` — register, command,
+    offices, and military organization.
+  - `curriculum/l2-uk-en/plans/hist/kozatski-povstannia-16.yaml` — uprising
+    sequence leading into Zhmailo/Kurukove and later pressure.
+  - `curriculum/l2-uk-en/plans/hist/kozatstvo-vytoky.yaml` — Cossack origins,
+    frontier society, and early autonomy.
+- **Existing ISTORIO/LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/istorio/krym-bahatosharovyi.yaml` —
+    decolonized Crimean frame; useful for avoiding permanent-enmity narratives.
+  - `curriculum/l2-uk-en/plans/istorio/syntez-kozatski-dzherela.yaml` —
+    source-critical work with treaties, chronicles, and later historical
+    synthesis.
+  - `curriculum/l2-uk-en/plans/lit/aliev-musayeva-crimean-tatar-ukrainian.yaml`
+    — modern Crimean Tatar/Ukrainian cultural adjacency; use only as a broad
+    cross-cultural bridge, not as a direct early-modern source.
+- **Existing wiki pages (VERIFIED present):**
+  - `wiki/figures/petro-sahaidachny.md`
+  - `wiki/periods/khotynska-viyna.md`
+  - `wiki/periods/krymske-khanstvo.md`
+  - `wiki/periods/kozatske-viisko.md`
+  - `wiki/historiography/krym-bahatosharovyi.md`
+- **Candidate / absent BIO surfaces (not present on 2026-07-04):**
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-doroshenko.yaml` — absent; this
+    dossier can support a future BIO module.
+  - `wiki/figures/mykhailo-doroshenko.md` — absent; future wiki candidate.
+  - `curriculum/l2-uk-en/plans/bio/ivan-sulyma.yaml` and
+    `curriculum/l2-uk-en/plans/bio/taras-fedorovych-triasylo.yaml` — absent
+    even though research dossiers exist.
+- **Potential future module hooks:**
+  - Kurukove as a legal-language lesson on recognition/control.
+  - The 1624 Zaporizhian-Crimean treaty as a source-reading lesson on mutual
+    obligations and limited legal force.
+  - The 1628 Alma/Bakhchysarai campaign as a frontier-diplomacy lesson that
+    resists single-enemy narratives.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykhailo-doroshenko`
+- **EN canonical (project spelling):** Mykhailo Doroshenko
+- **UA canonical:** Михайло Дорошенко
+- **Aliases to track for future `aliases:` fields:** Михайло Дорошенко;
+  гетьман Михайло Дорошенко; Mykhailo Doroshenko; Doroshenko, Mykhailo;
+  Dorošenko, Myxajlo; Michal Doroszenko; Michał Doroszenko.
+- **Search-only / source-language variants:** Doroszenko in Polish-language
+  bibliography; older Russian-language bibliographic forms when citing
+  Hrushevsky's 1913 encyclopedia context or Melnyk/Antonovych source editions.
+  Do not normalize those forms into project display.
+- **Forbidden body-text forms:** Russian-normalized `Михаил Дорошенко` as a
+  project display form; "Cossack pirate" as a summary identity; "Petro
+  Doroshenko's grandfather" as the only descriptor; `Dmytro Doroshenko` as the
+  subject.
+- **Name collision warning:** distinguish him from Petro Doroshenko
+  (Right-Bank hetman, 1665-1676) and Dmytro Doroshenko (historian and author).
+
+## 9. Image candidates
+
+- **Best current rule:** assume no verified lifetime portrait. The
+  Kovalevska/Doroshenko iconography article states that no lifetime portrait
+  has been found and that modern iconography is imaginative, shaped after
+  independence by education, museum, commemorative, and patriotic needs. [T4:
+  Kovalevska/Doroshenko iconography]
+- **Possible image route:** use an image only if the individual file page is
+  rights-clear and captioned as an imaginative/modern representation, not a
+  life portrait. Verify whether the item is CC BY, CC BY-SA, CC BY-NC, public
+  domain, or all-rights-reserved.
+- **Better context alternatives:** rights-clear map/context image of
+  Bakhchysarai/Chufut-Kale/Alma campaign geography; Khotyn fortress context;
+  Kurukove/Kremenchuk-area context; a rights-clear facsimile of a treaty or
+  register if found in an institutional collection.
+- **Avoid:** generic Cossack stock art, modern portraits without license,
+  images that visually make him only a sea raider, and Petro Doroshenko images
+  miscaptioned as Mykhailo.
+- **Rights caveat:** the iconography article page is published under a
+  Creative Commons non-commercial journal license, but embedded/reproduced
+  images may have separate rights. Use the article as a scholarly warning, not
+  as blanket permission to reuse every image.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- [T1] Щербак В. О. "Дорошенко Михайло" // *Енциклопедія історії України*,
+  т. 2. URL: https://www.history.org.ua/?termin=Doroshenko_M | accessed
+  2026-07-04. Core facts: unknown birth, 1628 death, registered-Cossack
+  hetmancy 1625-1628, Doroshenko-family founder, Sahaidachny/Khotyn context,
+  registered elite, rights/Orthodoxy, Zhmailo/Kurukove, Bila Tserkva victory,
+  1628 Crimean campaign and Alma death.
+- [T1] "Doroshenko, Mykhailo" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CD%5CO%5CDoroshenkoMykhailo.htm
+  | accessed 2026-07-04. Core facts: English spelling, registered-Cossack
+  office, 1616 colonel note, Sahaidachny/Muscovy and Khotyn participation,
+  Kurukove, six regiments, conflict with treaty-opposing Zaporozhians, Crimean
+  Giray support, Kaffa death-location variant.
+- [T1] Щербак В. О. "Куруківська угода 1625" // *Енциклопедія історії
+  України*, т. 5. URL: https://www.history.org.ua/?termin=KurukiVska_Ugoda_1625
+  | accessed 2026-07-04. Used for date/place, Doroshenko/Koniecpolski
+  negotiation frame, register number, six regiments, pay, election/confirmation
+  rule, foreign-relations and Ottoman-campaign bans, excluded-Cossack pressure.
+- [T1] "Kurukove, Treaty of" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CU%5CKurukoveTreatyof.htm
+  | accessed 2026-07-04. Used for English summary of agreement, amnesty,
+  6,000-person register, salary, leader election, and foreign/campaign
+  restrictions.
+- [T1] Sas P. M. "Запорозько-Кримський договір 1624" //
+  *Енциклопедія історії України*, т. 3. URL:
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21STR=Zaporozko_krymsky_dogovir_1624
+  | accessed 2026-07-04. Used for treaty date/place, Shahin Giray oath letter
+  to Doroshenko and the Host, mutual non-harm/military-aid terms, limited legal
+  force, and diplomatic-subject interpretation.
+- [T1] Галенко О. І. "Мегмед-Ґерей III" // *Енциклопедія історії України*,
+  т. 6. URL:
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21STR=Megmed_G_III
+  | accessed 2026-07-04. Used for Mehmed/Shahin Giray, Ottoman conflict,
+  Zaporizhian alliance under Doroshenko, Nogai/Cantemir pressure, and
+  Crimean-Ottoman context.
+- [T1] "Кримський ханат у середині 16 - середині 17 ст." //
+  *Енциклопедія історії України: Україна - Українці*, кн. 2. URL:
+  https://history.org.ua/?termin=2.+9.+7 | accessed 2026-07-04. Used for the
+  1628 siege-relief context, fortified-camp movement, 31 May 1628 Alma battle,
+  Doroshenko's death, and breakthrough to Bakhchysarai.
+- [T1] "Registered Cossacks" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CE%5CRegisteredCossacks.htm
+  | accessed 2026-07-04. Used for register concept, government control of
+  Zaporozhian campaigns, 1625 Kurukove register, election right, and later
+  registered/unregistered pressure.
+- [T1] Томазов В. В. "Дорошенки" // *Енциклопедія історії України*, т. 2.
+  URL: https://www.history.org.ua/?termin=Doroshenky | accessed 2026-07-04.
+  Used for Doroshenko-family foundation, Dorofii Mykhailovych line, and Petro
+  Doroshenko as grandson context.
+- [T1] Щербак В. О. "Жмайло Марко" // *Енциклопедія історії України*, т. 3.
+  URL: https://www.history.org.ua/?termin=Zhmaylo_M | accessed 2026-07-04.
+  Used for Zhmailo uprising, Kurukove negotiation, Doroshenko signature, and
+  Zhmailo faction rejection/withdrawal.
+- [T1] "Гетьманування Петра Конашевича-Сагайдачного. Козацькі повстання
+  1620-1630-х pp." // *Енциклопедія історії України*. URL:
+  https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=EIU&S21STR=2.+9.+6
+  | accessed 2026-07-04. Used for Kurukove implementation context, 1626 Bila
+  Tserkva operation, relative calm under Doroshenko, 1628 Crimean intervention,
+  and succession by Hryhorii Chornyi.
+
+**Tier 2 / Tier 4 (source-critical and scholarly leads):**
+
+- [T2] Грушевський М. "Дорошенко Михайло" (1913), in *М. С. Грушевський.
+  Твори: у 50 т.*, т. 9, with editorial comments. URL:
+  https://hrushevsky.history.org.ua/cgi-bin/Hrushevsky/person.exe?C21COM=2&I21DBN=ELIBH&IMAGE_FILE_DOWNLOAD=1&Image_file_name=DOC%2F0001313.pdf&P21DBN=ELIBH&Z21ID=
+  | accessed 2026-07-04. Used for source-critical notes on early notices,
+  1623-1624 office chronology, Khotyn reputation, Kurukove implementation,
+  1627 petitions, and 1628 campaign bibliography.
+- [T4] Мицик Ю. "Михайло Дорошенко" // *Україна в минулому*. Київ; Львів,
+  1994. Вип. 5. С. 156-170. Bibliographic lead cited through
+  Hrushevsky/commentary and Kovalevska/Doroshenko; direct article not fully
+  inspected in this worker pass.
+- [T4] Чухліб Т. *Козаки і татари. Україно-кримські союзи 1500-1700-х
+  років.* Kyiv: Kyievo-Mohylianska Akademiia, 2017. Bibliographic lead from
+  Kovalevska/Doroshenko and modern alliance framing; not directly read here.
+- [T4] Гайворонський О. "Гетьман, що загинув за хана: огляд подій кримського
+  походу Михайла Дорошенка 1628 року." Ніжин, 2019. Bibliographic lead from
+  Kovalevska/Doroshenko; direct text not fully inspected here.
+- [T4] Дорошенко О.; Ковалевська О. "Уявна іконографія Михайла Дорошенка
+  (1991-2021)" // *Чорноморська минувшина*, №16, 2021. DOI:
+  https://doi.org/10.18524/2519-2523.2021.16.245745 | accessed 2026-07-04.
+  Used for image-rights and iconography caution: no known lifetime portrait,
+  modern images are imaginative and post-1991.
+- [T4] Мельник К. [Антонович В.] "Сведения о походе в Крым Михаила
+  Дорошенка (1628)" // *Киевская старина*, 1896, №11, С. 274-286.
+  Bibliographic lead via Hrushevsky/commentary and iconography article; not
+  used as load-bearing fact in this pass.
+
+**Tier 3 / Tier 5 (navigation only):**
+
+- [T3] "Михайло Дорошенко (гетьман)" // Ukrainian Wikipedia. Used only for
+  navigation to EIU, older bibliography, and image leads; facts were
+  cross-checked against Tier 1/T2.
+- [T5] Museum/fund pages, popular commemorative posts, school summaries, and
+  general web pages. Not load-bearing for this dossier.
+
+**Honest gaps:**
+
+- The worker did not inspect the full Polish-language text of the 1624
+  oath-letter or the full Kurukove agreement source edition.
+- Mytsyk 1994, Chukhlib 2017, and Haivoronskyi 2019 were identified as strong
+  specialist leads but not fully read directly in this pass.
+- The IEU Kaffa death-location statement remains unresolved against the
+  Ukrainian Tier 1 Alma/Bakhchysarai baseline; a module should compare source
+  editions before using an exact death-place sentence in learner-facing copy.
+- No independent review has been routed by this worker; the orchestrator owns
+  that gate.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Muscovy appears as a historical power in the
+  1610s campaign context, not as the natural center of the narrative.
+- [x] Cossack-Crimean relations are not flattened into permanent hostility;
+  alliance, rivalry, mutual aid, raids, and Ottoman/Nogai pressure are kept
+  visible.
+- [x] Kurukove is not romanticized; it is treated as recognition plus coercive
+  control, with excluded-Cossack consequences named directly.
+- [x] Doroshenko is not reduced to maritime raider, bandit, proto-nationalist,
+  family footnote, or simple predecessor of Petro Doroshenko.
+- [x] Petro Doroshenko and Dmytro Doroshenko are separated from Mykhailo.
+- [x] Commonwealth, Ottoman, Crimean, Muscovite, Russian-imperial, and Soviet
+  labels are treated as source/power language, not neutral narrator categories.
+- [x] No out-of-scope twentieth-century Hetmanate, all-rulers chronology, or
+  unrelated rulers added.
+- [x] Modern Ukrainian place/context names are used with historical caution:
+  Курукове / Kremenchuk area, Біла Церква, Перекоп, Бахчисарай, Альма,
+  Кафа / Феодосія.
+- [x] Image memory is handled critically; imaginative modern portraits are not
+  treated as likenesses.
+
+## Validation checklist
+
+- [x] Single owned file only: `docs/research/bio/mykhailo-doroshenko.md`.
+- [x] Existing cross-track paths verified locally before citation.
+- [x] Lower-tier sources marked as non-load-bearing.
+- [x] No generated `status/`, `audit/`, `review/`, or telemetry artifacts
+  referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans,
+  module files, activities, vocabulary, resources, site MDX, wiki files, or
+  unrelated files edited.


### PR DESCRIPTION
## Scope

Adds one BIO readiness research dossier for Mykhailo Doroshenko, scoped to early registered-Cossack hetmanship, Kurukove, registered/unregistered pressure, Zaporizhian-Crimean diplomacy, the 1628 Crimean campaign, and Doroshenko-family memory without collapsing the subject into Petro Doroshenko.

## Changed files

- `docs/research/bio/mykhailo-doroshenko.md`

## Validation

- `npx markdownlint-cli2 docs/research/bio/mykhailo-doroshenko.md` — passed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/mykhailo-doroshenko.md` — passed
- `git diff --check` — passed
- `rg -n "Skoropadskyi|Скоропад|1918|Ukrainian State|Українськ.*Держав|Polish king|Polish kings|Польськ.*корол|польськ.*корол" docs/research/bio/mykhailo-doroshenko.md` — no matches
- Protected artifact/config guard — only `docs/research/bio/mykhailo-doroshenko.md` changed; no linter config, `.python-version`, generated status/audit/review, telemetry, plan, curriculum, module, activity, vocabulary, resource, site, wiki, or package files changed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed after commit

## Source and decolonization caveats

- Tier 1 baseline is ЕІУ/IEU plus Kurukove, registered-Cossack, Zaporizhian-Crimean treaty, Mehmed Giray III, and Crimean Khanate context entries.
- Mytsyk 1994, Chukhlib 2017, Haivoronskyi 2019, and full source editions are retained as strong follow-up leads, not treated as fully inspected load-bearing sources in this worker pass.
- The dossier flags 1623/1625 office chronology and Alma/Kaffa death-location variants instead of smoothing them.
- Cossack-Crimean relations are treated as alliance/rivalry/frontier politics rather than permanent-enmity shorthand.
- No LLM-QG, QG parity, QG DB persistence, or module-quality audits were run.

No independent review has been routed yet because the orchestrator handles that gate.