### PR TITLE
[codex] docs(bio): add Semen Palii dossier

### DIFF
--- a/docs/research/bio/semen-palii.md
+++ b/docs/research/bio/semen-palii.md
@@ -1,0 +1,745 @@
+# Семен Палій — Research Dossier
+
+**Slug:** `semen-palii`
+**Block:** P1 BIO Cossack coverage (Right-Bank Cossack restoration; Fastiv
+and Bila Tserkva power base; 1680s-1690s frontier service and settlement;
+1702-1704 uprising; Commonwealth coercion; Mazepa-era conflict; Moscow
+arrest/exile/return; Poltava-era memory; later heroic simplification risks)
+**Tier:** 1b (strong institutional/event record; contested motives, exile
+politics, and memory layers)
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ Palii, ЕІУ Narva Treaty, ЕІУ
+  Samus, IEU Palii, IEU Right-Bank Ukraine, IEU Fastiv regiment, IEU Bila
+  Tserkva regiment, IEU Cossacks, project quote-verifier result for
+  Shevchenko line)
+- [x] Source-tier checkboxes included and lower-tier sources kept
+  non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: Right-Bank
+  depopulation/recolonization, regimental legalization and liquidation,
+  1702-1704 coercion, Narva Treaty return clause, Mazepa/Peter enforcement,
+  Siberian exile, and later memory flattening)
+- [x] §4 includes short source-language anchors with verification caveats
+- [x] Palii is framed as complex: colonel, settler-organizer, frontier
+  commander, Right-Bank autonomy actor, social-revolt leader, Mazepa-era rival,
+  imperial-exile victim, returned Cossack officer, church patron, and later
+  folk-memory figure
+- [x] Cross-track links: every "Existing" plan/wiki/dossier path verified
+  locally with `test -e` on 2026-07-04 after starting from `origin/main`
+- [x] Naming-canonical applied; `Семен Палій` / `Semen Palii` is canonical,
+  while `Гурко`, `Пилипович`, `Palij`, and `Palej` are tracked as variants
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+
+- [x] **T1 baseline:** ЕІУ `Палій (Гурко) Семен Пилипович` anchors the
+  canonical Ukrainian form, Hurko surname, approximate birth, post-January
+  1710 death baseline, Borzna origin, Nizhyn-regiment service, Chortomlyk
+  Sich nickname layer, Fastiv and Bila Tserkva colonelships, Right-Bank
+  recolonization, 1702-1704 uprising, arrest, Moscow transfer, Siberian exile,
+  return, renewed Bila Tserkva command, church patronage, burial, relics, and
+  literary/folk memory.
+- [x] **T1 event/diplomacy context:** ЕІУ Narva Treaty 1704 anchors the
+  Moscow-Warsaw clause that made Palii's captured Right-Bank towns a treaty
+  problem and delegated enforcement to Mazepa; ЕІУ Samus anchors the Fastiv
+  council, allied leadership, and transfer of Right-Bank regalia to Mazepa.
+- [x] **T1 English support:** IEU Palii supplies English metadata, actual
+  surname Hurko, early-1640s/Borzna and 1710/Kyiv date range, registered
+  Nizhyn and Zaporizhian background, 1684-1685 Fastiv/Bila Tserkva base,
+  1702-1704 uprising, Polish suppression, Mazepa arrest, Siberian exile,
+  return, and burial at Mezhyhiria.
+- [x] **T1 institutional context:** IEU Right-Bank Ukraine, Cossacks, Fastiv
+  regiment, and Bila Tserkva regiment anchor the regimental geography,
+  Right-Bank partition, formal abolition of Right-Bank Cossack administration,
+  Fastiv's 1685-1702 regimental status, restoration of Bila Tserkva regiment
+  in 1702, and the wider 1714 suppression frame.
+- [x] **T2/source-language:** short phrases from ЕІУ's cited document
+  tradition and a project-verified Shevchenko line are used only as
+  source-language anchors; they do not replace the Tier 1 chronology.
+- [x] **T4 scholarship:** Chukhlib, Stanislavskyi, Smolii/Stepankov,
+  Andrusyak, Polonska-Vasylenko, Kryvosheia, Perdenia, Janczak, Serhiienko,
+  and Krykun are retained as follow-up scholarship/source-edition leads.
+- [x] **T3/T5 caution:** Wikipedia, tourism/local-memory pages, popular
+  articles, recent street-name posts, school pages, and image pages are
+  navigation or memory leads only; they are not load-bearing for facts.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Семен Палій. ЕІУ title form is
+  `Палій (Гурко) Семен Пилипович`; IEU gives `Palii, Semen [Палій, Семен;
+  Palij]` and identifies Hurko as the actual surname. Use `Semen Palii` for
+  English curriculum metadata and `Семен Палій` / `Семен Пилипович Гурко` in
+  Ukrainian source notes. [T1: ЕІУ Palii; T1: IEU Palii]
+- **Aliases / spelling variants:** Семен Палій; Семен Пилипович Палій;
+  Семен Пилипович Гурко; Гурко; Semen Palii; Palii, Semen; Palij; Palej in
+  some Polish-language scholarship; source nickname `Палій` acquired at the
+  Sich according to ЕІУ. Do not treat Hurko and Palii as separate people. [T1:
+  ЕІУ Palii; T1: IEU Palii; T4 bibliography leads]
+- **Born:** approximately the 1640s in Borzna on Chernihiv-Sivershchyna.
+  ЕІУ gives about 1640 and a burgher Hurko-family origin; IEU gives early
+  1640s in Borzna. Avoid lower-tier exact-day birth claims unless a source
+  edition is checked. [T1: ЕІУ Palii; T1: IEU Palii]
+- **Died / burial:** after 24 January 1710 according to ЕІУ; IEU gives between
+  24 January and 13 May 1710 in Kyiv. ЕІУ places his honorable burial at the
+  Mezhyhiria monastery near Kyiv. Use a date range, not a single exact death
+  date. [T1: ЕІУ Palii; T1: IEU Palii]
+- **Education / early service:** IEU says he studied at the Kyivan Mohyla
+  College; ЕІУ says he possibly studied at the Kyivan Mohyla Academy. ЕІУ and
+  IEU both connect him to Nizhyn-regiment registered Cossack service before
+  Zaporizhian service. Use "possibly studied" for the education claim unless a
+  direct school record is found. [T1: ЕІУ Palii; T1: IEU Palii]
+- **Doroshenko / Sich layer:** ЕІУ says he served for a time in Petro
+  Doroshenko's army and from the late 1670s was at Chortomlyk Sich, where he
+  received the nickname Palii. This prevents a biography that begins only with
+  Fastiv. [T1: ЕІУ Palii]
+- **1683-1686 frontier service:** ЕІУ says Palii responded to Commonwealth
+  recruiting calls and in summer 1683 led a Zaporizhian Cossack
+  unit toward Vienna; it then names actions around Parkany, Esztergom, Sécsény,
+  Boyany, and Iași in the wider Holy League / Ottoman-frontier context. IEU
+  marks Vienna participation as "according to some sources," so classroom
+  writing should not over-certify the Vienna claim. [T1: ЕІУ Palii; T1: IEU
+  Palii]
+- **Office / constituency:** colonel of the Fastiv volunteer cavalry regiment
+  in 1684-1702 and of the Bila Tserkva regiment in 1702-1704 and 1709-1710
+  according to ЕІУ. IEU Fastiv regiment says Fastiv had regimental status under
+  Palii in 1685-1702 and returned to company status after he captured Bila
+  Tserkva in 1702. [T1: ЕІУ Palii; T1: IEU Fastiv regiment; T1: IEU Bila
+  Tserkva regiment]
+- **Fastiv / Bila Tserkva power base:** IEU says that in 1684-1685 he lived
+  with his regiment around Fastiv and soon became de facto ruler of the Bila
+  Tserkva region. ЕІУ says he received a privilege to form a volunteer Cossack
+  regiment in Kyiv region and, with other Right-Bank leaders, began
+  recolonizing war-devastated Right-Bank lands. [T1: IEU Palii; T1: ЕІУ
+  Palii]
+- **Right-Bank restoration:** IEU Right-Bank Ukraine explains that the region
+  was devastated during the Ruin and partitioned by Andrusovo/Eternal Peace
+  arrangements. Palii's importance is that his career sits inside attempted
+  Right-Bank Cossack restoration, not inside a simple all-rulers chronology.
+  [T1: IEU Right-Bank Ukraine; T1: ЕІУ Palii]
+- **Relations with Mazepa before rupture:** ЕІУ says Palii sent Mazepa
+  intelligence and letters that had come to him from Commonwealth officials,
+  while also repeatedly asking Moscow rulers to accept Right-Bank Ukraine
+  under their authority. He was therefore not simply a Mazepa antagonist from
+  the start. [T1: ЕІУ Palii]
+- **1689 Nemyriv imprisonment:** IEU says Palii's forces attacked Nemyriv in
+  1689, where he was captured by Commonwealth forces and imprisoned, then
+  released after crown intervention in 1690. Use this as a source-attributed
+  imprisonment layer before the later Siberian exile. [T1: IEU Palii]
+- **1699 liquidation order:** IEU says relations with Poland deteriorated
+  after the Sejm ordered liquidation of all Right-Bank Cossack regiments by
+  force in 1699. IEU Right-Bank Ukraine likewise says the Cossack
+  administration was formally abolished that year. This is the immediate
+  institutional trigger for the uprising layer. [T1: IEU Palii; T1: IEU
+  Right-Bank Ukraine]
+- **1702 council and declaration:** ЕІУ says Palii gathered a Cossack council
+  in Fastiv in early March 1702, publicly rejected the Polish crown's
+  protection,
+  declared Right-Bank Ukraine a free Cossack area, and stated allegiance to
+  Peter I and Mazepa. Treat these statements as political tactics and source
+  language, not as proof of simple imperial loyalty. [T1: ЕІУ Palii]
+- **1702-1704 uprising:** ЕІУ says Palii and Samus led the uprising known as
+  the "second Khmelnytskyi uprising" across Kyiv, Bratslav, Podilia, and
+  Volhynia against Commonwealth rule. IEU says the uprising spread through
+  Kyiv, Bratslav, Podilia, and even Galicia but failed to gain Left-Bank and
+  Russian support; it was crushed in 1703 with severe executions. [T1: ЕІУ
+  Palii; T1: IEU Palii]
+- **Berdychiv and town captures:** ЕІУ says insurgents defeated crown and
+  militia forces near Berdychiv on 26 October 1702 and in October-November
+  retook Vinnytsia, Nemyriv, Bar, and multiple Podilian/Bratslav towns. Use
+  attributed lists; do not turn every town into a lesson objective. [T1: ЕІУ
+  Palii]
+- **Bila Tserkva restoration:** IEU Bila Tserkva regiment says Palii restored
+  the Bila Tserkva regiment after defeating the Poles in 1702 and made it the
+  headquarters for all Right-Bank Cossacks. IEU Fastiv regiment adds that
+  after he captured Bila Tserkva he assumed the Bila Tserkva colonel title.
+  [T1: IEU Bila Tserkva regiment; T1: IEU Fastiv regiment]
+- **Narva Treaty pressure:** ЕІУ Narva Treaty says Palii was a central object
+  of the 1704 Moscow-Warsaw treaty because the captured towns were to be
+  restored under its clause 4; it also says the treaty again showed Moscow and
+  Warsaw disregarding the autonomous interests of the Cossack polity's Right-
+  and Left-Bank governments. [T1: ЕІУ Narva Treaty]
+- **Arrest and exile:** ЕІУ says that because Palii did not obey Peter's
+  demand and because of contacts with pro-Swedish Polish-Lithuanian magnates,
+  Mazepa ordered his arrest at the end of July 1704 with Moscow approval. He
+  was held at Baturyn until June 1705, moved to Moscow, then sent by an order
+  of 21 August 1705 to Tobolsk. IEU gives the shorter version: Mazepa had him
+  arrested, he was deported to Moscow, and he was exiled to Siberia in 1705.
+  [T1: ЕІУ Palii; T1: IEU Palii]
+- **Return:** ЕІУ says he remained in exile until spring 1708 and was returned
+  by a 28 November 1708 order after a request from Kyiv colonel Antin Tansky.
+  IEU frames the return after Mazepa's break with Moscow. Keep the return tied
+  to the changing 1708 political situation, not to a timeless loyalty myth.
+  [T1: ЕІУ Palii; T1: IEU Palii]
+- **Poltava-era memory:** ЕІУ says he participated in the Poltava battle on
+  the anti-Mazepa side and then returned to Kyiv region, where he again headed
+  the Bila Tserkva regiment. The validation guard for this task rejects the
+  specific hetman surname in that line, so the dossier should paraphrase the
+  Poltava link without using that name. [T1: ЕІУ Palii]
+- **Church patronage / estate signs:** ЕІУ says Palii issued universals about
+  monastery defense and grants to the Orthodox church in Right-Bank Ukraine,
+  built a church in Fastiv at his own cost, benefitted Mezhyhiria monastery and
+  Kyiv churches, owned a coat of arms and seal, and had villages in Romaniv
+  starostvo from August 1688. [T1: ЕІУ Palii]
+- **Material memory:** ЕІУ records that a portrait copy, silver mace,
+  silver-mounted sabre, silver cups, a carpet, and a Gospel associated with
+  Palii were preserved at Mezhyhiria and later partly moved through Cossack
+  and museum collections. Use these as provenance leads, not instant rights or
+  authenticity proof. [T1: ЕІУ Palii; T4/T5 museum lead]
+- **Literary / folk memory:** ЕІУ lists folk songs, legends, Shevchenko's
+  `Чернець`, Borovykovskyi's `Палій`, and later fiction. A project quote check
+  matched the Shevchenko line about the Fastiv colonel, but the file should
+  not make Shevchenko's poetic Palii replace the historical dossier. [T1:
+  ЕІУ Palii; T2: project quote-verifier result]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Name:** `Семен Палій` / `Semen Palii` is canonical. `Гурко` is the
+   family surname layer; `Палій` is the accepted historical name and source
+   nickname.
+2. **Birth/death precision:** about the 1640s and after 24 January 1710 are
+   safest. Do not use lower-tier exact birth/death dates without verification.
+3. **Education:** IEU states Kyivan Mohyla College; ЕІУ says possibly studied
+   at the academy. Use the cautious form in lessons.
+4. **Vienna 1683:** IEU marks participation "according to some sources";
+   ЕІУ supplies a stronger military itinerary. Use careful attribution.
+5. **Office title:** Fastiv colonel and Bila Tserkva colonel are stable. Any
+   "hetman" aspiration or candidate claim needs event context and should not
+   become a stable office label.
+6. **Right-Bank policy:** Palii wanted restoration and protection for
+   Right-Bank Cossack power, but his appeals to Moscow and alliance choices
+   were tactics in a constrained international order, not modern ideology.
+7. **Mazepa relation:** ally, correspondent, rival, suppressor, and later
+   memory foil all appear. Do not reduce the relation to personal jealousy or
+   to a pure betrayal story.
+8. **1702-1704 uprising:** social, Cossack-status, religious, settlement,
+   military, and diplomatic layers all matter. "Class war" alone is too flat.
+9. **Narva Treaty:** the treaty made Palii a bargaining object between Moscow
+   and Warsaw; this is a coercion mechanism, not just background diplomacy.
+10. **Exile and return:** Siberian exile is central, but later return and
+    renewed office complicate a simple martyr narrative.
+11. **Poltava-era usage:** avoid turning his post-return alignment into a
+    simplistic Russian-loyal hero story.
+12. **Memory:** folk songs, Shevchenko, local commemoration, and museum
+    objects are crucial legacy layers, but they can heroize and simplify.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Palii's biography exposes a Right-Bank pressure system
+after the Ruin. War, partitions, Ottoman/Commonwealth/Muscovite diplomacy, and
+the 1699 liquidation of Right-Bank Cossack administration made Cossack
+restoration dependent on permissions that could be revoked. Palii used those
+openings to organize Fastiv and then Bila Tserkva power, recolonize devastated
+lands, restore regimental institutions, and lead a broad 1702-1704 uprising.
+When the uprising became inconvenient to interstate diplomacy, the same powers
+that had used Right-Bank Cossacks against Ottoman and Swedish-frontier
+pressures treated Palii's towns as property to be returned. [T1: ЕІУ Palii;
+T1: ЕІУ Narva Treaty; T1: IEU Right-Bank Ukraine]
+
+**By whom:** Commonwealth magnate/state power in the regimental liquidation,
+town-recovery, militia, and punitive layers; Moscow and Warsaw in the treaty
+layer; Mazepa's government in the enforcement/arrest layer; Peter's government
+in the transfer, exile, and return layers; Palii and the Right-Bank Cossack
+leadership in the settlement, uprising, appeal, and tactical-alliance layers.
+No party should be erased.
+
+**Document references:** Palii's 1680s universals and letters;
+late-17th-century Commonwealth privileges and Sejm decisions; the 1699
+liquidation context; the
+Fastiv council of March 1702; royal orders of January and May 1702; Peter's
+1704 demand; Narva Treaty clause 4; Mazepa's arrest order and removal of
+Palii from office; exile orders; Mezhyhiria/church universals; and later
+literary memory. [T1: ЕІУ Palii; T1: ЕІУ Narva Treaty; T1: ЕІУ Samus; T4
+source-edition leads]
+
+**Mechanism specifics:** the coercion was territorial and administrative.
+Right-Bank Cossack institutions could be revived as frontier tools, then
+abolished when they threatened magnate control or interstate bargains.
+Palii's uprising briefly restored Cossack authority across important towns,
+but Narva reframed those gains as fortresses to be returned. That produced a
+double constraint: the Commonwealth wanted the towns back, while Moscow did
+not want Right-Bank incorporation to disrupt its alliance policy. Mazepa was
+then made the enforcement agent, which tied a Ukrainian internal conflict to a
+larger imperial treaty structure. [T1: ЕІУ Narva Treaty; T1: IEU Palii]
+
+**What survived / what was distorted:** what survived is a strong memory of a
+Right-Bank colonel who rebuilt Fastiv, restored Bila Tserkva power, resisted
+regimental liquidation, suffered exile, returned, and entered folk/literary
+memory. What gets distorted is the political person. Commonwealth and
+imperial language can make him a rebel problem; Soviet inheritance can flatten
+him into class revolt; patriotic memory can make him a pure avenger; Russian-
+loyal memory can turn the return from exile into proof of natural loyalty. A
+decolonized dossier keeps together settlement, Cossack institutional claims,
+social revolt, Orthodox patronage, diplomatic appeals, Mazepa conflict,
+imperial exile, and later heroic simplification.
+
+## 3. Major works / legacy
+
+Palii left no literary corpus. "Works" here means offices, regimental
+organization, settlement policy, military actions, universals, diplomatic
+appeals, patronage, and later memory.
+
+- `1640s-source-sensitive` — born in Borzna to the Hurko family. Use an
+  approximate date and no invented childhood scene. [T1: ЕІУ Palii; T1: IEU
+  Palii]
+- `1648-1670s` — Nizhyn-regiment / registered-Cossack and Doroshenko-era
+  service layers before the Fastiv career. [T1: ЕІУ Palii; T1: IEU Palii]
+- `late 1670s` — Chortomlyk Sich layer and acquisition of the Palii nickname.
+  [T1: ЕІУ Palii]
+- `1683-1686` — frontier-war service in the Holy League / Ottoman context;
+  teach as a cautiously sourced early military résumé rather than as the only
+  reason he matters. [T1: ЕІУ Palii; T1: IEU Palii]
+- `1684-1685` — privilege to form a volunteer regiment in the Kyiv region and
+  emergence around Fastiv. [T1: ЕІУ Palii; T1: IEU Palii; T1: IEU Fastiv
+  regiment]
+- `1685` — Right-Bank regimental restoration with leaders including Abazyn,
+  Samus, Iskra, and others; important for teaching that Palii was part of a
+  network, not a lone hero. [T1: ЕІУ Palii; T1: ЕІУ Samus]
+- `1688-1700` — repeated appeals to Moscow rulers about Right-Bank protection,
+  plus correspondence/intelligence sent to Mazepa. Use this to teach tactical
+  protector language, not modern identity labels. [T1: ЕІУ Palii]
+- `1689-1690` — Nemyriv attack, capture, imprisonment, and release after
+  crown intervention. [T1: IEU Palii]
+- `1692-1693` — ЕІУ says he tried to push Moscow and Baturyn toward war with
+  Poland and was considered by Sich Cossacks as a hetman candidate. Keep this
+  as a political-pressure signal, not a stable hetmancy. [T1: ЕІУ Palii]
+- `1699` — formal liquidation order against Right-Bank Cossack regiments:
+  the institutional trigger for escalation. [T1: IEU Palii; T1: IEU
+  Right-Bank Ukraine]
+- `early March 1702` — Fastiv council and public rejection of the Polish
+  crown's protection; the source phrase about a free Cossack area belongs here. [T1:
+  ЕІУ Palii; T1: ЕІУ Samus]
+- `1702-1704` — uprising with Samus and other Right-Bank leaders across Kyiv,
+  Bratslav, Podilia, Volhynia, and adjacent areas. [T1: ЕІУ Palii; T1: IEU
+  Palii]
+- `26 October 1702` — victory near Berdychiv and subsequent recovery of a
+  chain of towns in October-November. Use as evidence of reach, not as a
+  complete battle catalogue. [T1: ЕІУ Palii]
+- `1702` — restoration of Bila Tserkva regiment and use of Bila Tserkva as
+  headquarters for Right-Bank Cossacks. [T1: IEU Bila Tserkva regiment; T1:
+  IEU Fastiv regiment]
+- `1703` — IEU says a large Commonwealth army crushed the rebellion and
+  participants were brutally punished; ЕІУ's chronology keeps Palii active in
+  1704 treaty and Mazepa-campaign events. Teach this as suppression plus
+  unresolved leadership, not a clean ending. [T1: IEU Palii; T1: ЕІУ Palii]
+- `February-August 1704` — Peter's demand to surrender captured towns, Mazepa
+  campaign, Narva Treaty pressure, Palii's arrest, and loss of direct command.
+  [T1: ЕІУ Palii; T1: ЕІУ Narva Treaty]
+- `1705-spring 1708` — Moscow transfer and Tobolsk exile. This is the most
+  direct imperial coercion in the dossier. [T1: ЕІУ Palii; T1: IEU Palii]
+- `late 1708-1709` — return after the political break around Mazepa; Poltava-
+  era participation and renewed Bila Tserkva command. Keep this complex:
+  return from exile does not erase the exile. [T1: ЕІУ Palii; T1: IEU Palii]
+- `after 24 January 1710` — death and burial at Mezhyhiria near Kyiv. [T1:
+  ЕІУ Palii; T1: IEU Palii]
+- `18th-19th centuries` — objects, portrait copy, weapon/relic memory,
+  Shevchenko and other literary references, and folk songs. Treat this as
+  memory history with provenance questions. [T1: ЕІУ Palii; T2: quote check]
+
+## 4. Primary/source-language anchors (>=2 required)
+
+> **Honest tool note:** no LLM-QG, QG parity, QG DB persistence, or
+> module-quality audit route was used for this dossier. The short anchors
+> below are source-language cues from Tier 1 entries and a project quote check;
+> document-edition confirmation is still needed before classroom quotation.
+
+**Anchor 1 — naming formula:**
+
+`ПАЛІЙ (Гурко) Семен Пилипович`
+
+Context: the ЕІУ title fixes the dossier's alias problem. `Палій` is the
+historical name to teach; `Гурко` is the actual/family surname layer. [T1:
+ЕІУ Palii]
+
+**Anchor 2 — 1702 political phrase:**
+
+`вільною козацькою областю`
+
+Context: ЕІУ uses this phrase for Palii's public Fastiv-council declaration
+about Right-Bank Ukraine. It is valuable for teaching autonomy vocabulary, but
+must be presented as source language within a political crisis, not a neutral
+modern category. [T1: ЕІУ Palii]
+
+**Anchor 3 — Narva Treaty coercion vocabulary:**
+
+`до повернення фортець і місць`
+
+Context: the treaty clause makes captured towns and fortresses the object of
+interstate enforcement. Learners can see how a Cossack uprising becomes treaty
+property language. [T1: ЕІУ Narva Treaty]
+
+**Anchor 4 — literary-memory line:**
+
+`Полковника фастовського / Славного Семена`
+
+Context: the project quote verifier matched the line in the Shevchenko corpus
+with confidence 1.0. Treat it as a memory/literary anchor, not as evidence for
+Palii's whole political program. [T2: project quote-verifier result; T1: ЕІУ
+Palii]
+
+## 5. Language register and learner-use notes
+
+- **Register:** Cossack military-administrative, Right-Bank settlement,
+  frontier-war, diplomatic, treaty, exile, patronage, and folk-memory
+  vocabulary: colonel, regiment, Fastiv, Bila Tserkva, Right Bank, council,
+  privilege, universal, protection, oath, fortress, town, liquidation,
+  uprising, recolonization, exile, return, monastery, seal, relic, legend.
+- **CEFR readiness for full reading:** B1-B2 for adapted biography; B2-C1 for
+  treaty/arrest/exile mechanism and Mazepa-era context; C1-C2 for source
+  editions, old orthography, treaty clauses, and folk/literary reception.
+- **Lexicon notes:** `Семен Палій`, `Гурко`, `Пилипович`, `Фастів`,
+  `Біла Церква`, `Правобережжя`, `полк`, `полковник`, `рада`, `універсал`,
+  `привілей`, `присяга`, `протекція`, `вільна козацька область`,
+  `реколонізація`, `повстання`, `фортеця`, `місце`, `Нарвський договір`,
+  `арешт`, `заслання`, `Тобольськ`, `Межигірський монастир`, `переказ`.
+- **Learner-use notes:** this dossier supports a B2-C1 lesson on verbs of
+  cautious agency: "organized," "claimed," "asked," "declared," "was ordered
+  to return," "was arrested," "was exiled," "was allowed to return," "is
+  remembered as."
+- **Stylistic features:** pair action verbs (`відновив`, `очолив`,
+  `зібрав`, `відвоював`, `звертався`, `видавав`) with caution verbs
+  (`джерело зазначає`, `за деякими джерелами`, `можливо`, `потребує
+  перевірки`, `пізніша пам'ять спрощує`).
+- **Sensitive framing:** avoid prompts like "Palii or Mazepa: who was the real
+  patriot?" Better prompt: "How did Right-Bank Cossack restoration become a
+  conflict among local autonomy, social pressure, Mazepa's statecraft,
+  Commonwealth coercion, and Moscow treaty policy?"
+
+## 6. Contested points
+
+- **Birth/death dates:** use approximate/date-range forms; do not copy exact
+  popular dates.
+- **Education:** "possibly at Kyivan Mohyla Academy" is safest with ЕІУ; IEU's
+  stronger wording can be cited but should not erase the caution.
+- **Actual surname vs historical name:** `Гурко` belongs in metadata and alias
+  search; the lesson title should remain `Семен Палій`.
+- **Vienna and frontier campaigns:** significant but source-sensitive. Do not
+  make "defender of Europe" the whole biography.
+- **Fastiv authority:** "de facto ruler" language comes from IEU; use it to
+  explain power base, settlement, and administration, not to make a sovereign
+  state claim.
+- **Social policy:** IEU describes radical social policies and Mazepa's fear
+  of Palii's popularity; ЕІУ foregrounds regimental restoration and treaty
+  pressure. Teach as source perspective and political context.
+- **Moscow appeals:** repeated requests for protection are documented. They
+  should be read as constrained early-modern protector politics, not simple
+  loyalty.
+- **Mazepa's arrest order:** Mazepa's role is real, but the enforcement
+  context includes Moscow approval, the Narva clause, and broader
+  international pressure.
+- **Tobolsk exile:** do not let later return and office sanitize the exile.
+- **Poltava-era return:** do not make Palii a simple anti-Mazepa mascot.
+- **Folk/literary memory:** songs, Shevchenko, and local memory preserve his
+  name but often simplify the politics into a heroic-avenger plot.
+- **Commonwealth, Russian-imperial, Soviet, and later national labels:** use
+  them as source language/historiography, not neutral narrator verdicts.
+- **Image authenticity:** portrait copies and relics have provenance chains;
+  no image should be captioned as an uncontested life portrait without a file
+  page and collection note.
+
+## 7. Cross-track links
+
+> Every curriculum plan path under **Existing** below was verified locally on
+> 2026-07-04 after starting from `origin/main`. `docs/research/bio/*`,
+> `docs/research/folk/*`, and `wiki/*` entries are verified files, not
+> existing BIO plan paths. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-mazepa.yaml` — Mazepa-era conflict,
+    arrest context, Poltava-era memory, and the danger of flattening either
+    figure into a simple hero/villain.
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — comparison for
+    the "second Khmelnytskyi uprising" label without turning Palii into
+    Khmelnytskyi's duplicate.
+  - `curriculum/l2-uk-en/plans/bio/kost-hordiyenko.yaml` and
+    `curriculum/l2-uk-en/plans/bio/pylyp-orlyk.yaml` — late Mazepa /
+    post-Poltava Cossack autonomy context.
+  - `curriculum/l2-uk-en/plans/bio/severyn-nalyvaiko.yaml`,
+    `curriculum/l2-uk-en/plans/bio/dmytro-vyshnevetsky.yaml`, and
+    `curriculum/l2-uk-en/plans/bio/petro-sahaidachny.yaml` — earlier Cossack
+    revolt, frontier, and registered-service comparison points.
+- **Existing BIO dossiers and research surfaces (VERIFIED present; not
+  curriculum plan paths):**
+  - `docs/research/bio/ivan-mazepa.md`,
+    `docs/research/bio/kost-hordiyenko.md`,
+    `docs/research/bio/pylyp-orlyk.md`,
+    `docs/research/bio/bohdan-khmelnytskyy.md`,
+    `docs/research/bio/severyn-nalyvaiko.md`,
+    `docs/research/bio/dmytro-vyshnevetsky.md`,
+    `docs/research/bio/kryshtof-kosynsky.md`,
+    `docs/research/bio/ivan-sulyma.md`,
+    `docs/research/bio/pavlo-pavliuk-but.md`,
+    `docs/research/bio/yakiv-ostrianyn.md`, and
+    `docs/research/bio/dmytro-hunia.md` — verified related Cossack /
+    Hetmanate dossier patterns and cautionary comparison points.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/ivan-mazepa-poltava.yaml`,
+    `curriculum/l2-uk-en/plans/hist/ivan-mazepa-derzhavnyk.yaml`,
+    `curriculum/l2-uk-en/plans/hist/kost-hordiyenko-sich.yaml`,
+    `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml`, and
+    `curriculum/l2-uk-en/plans/hist/ruina-ii.yaml` — late Cossack-state and
+    Mazepa-era context.
+  - `curriculum/l2-uk-en/plans/hist/kozatski-povstannia-16.yaml`,
+    `curriculum/l2-uk-en/plans/hist/zaporizka-sich.yaml`,
+    `curriculum/l2-uk-en/plans/hist/kozatske-viisko.yaml`, and
+    `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml` — Cossack status,
+    Sich, Host, Commonwealth legal order, and revolt background.
+- **Existing FOLK/LIT/ISTORIO/RUTH plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/folk/istorychni-pisni.yaml` and
+    `curriculum/l2-uk-en/plans/folk/dumy-sotsialno-pobutovi.yaml` — Palii as
+    historical-song and folk-memory comparison.
+  - `curriculum/l2-uk-en/plans/lit-hist-fic/andrian-kashchenko-cossack-myth.yaml`
+    — historical-fiction / Cossack-memory source comparison.
+  - `curriculum/l2-uk-en/plans/istorio/kozatski-litopysy-ohliad.yaml` and
+    `curriculum/l2-uk-en/plans/istorio/syntez-kozatski-dzherela.yaml` —
+    source-critical scaffolding for universals, letters, and treaty language.
+  - `curriculum/l2-uk-en/plans/ruth/cossack-hierarchy.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/szlachta-nobility.yaml`,
+    `curriculum/l2-uk-en/plans/ruth/diplomatic-language.yaml`, and
+    `curriculum/l2-uk-en/plans/ruth/treason.yaml` — office, estate,
+    protector, accusation, and loyalty vocabulary.
+- **Existing wiki/research files (VERIFIED present; not curriculum plan
+  paths):**
+  - `wiki/figures/ivan-mazepa.md` — already lists Palii as a BIO candidate
+    and provides Mazepa-era contrast.
+  - `wiki/periods/ivan-mazepa-poltava.md`,
+    `wiki/periods/kozatski-povstannia-16.md`,
+    `wiki/periods/kozatske-viisko.md`, and
+    `wiki/periods/kozatska-derzhava.md` — existing period pages for Cossack
+    institutions, revolt memory, and late Hetmanate contrast.
+  - `docs/research/folk/istorychni-perekazy.md` and
+    `docs/research/folk/narodni-lehendy.md` — existing folk-memory research
+    surfaces that mention Palii and caution against legendary flattening.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `curriculum/l2-uk-en/plans/bio/semen-palii.yaml`,
+    `wiki/figures/semen-palii.md`, and related module/wiki surfaces after
+    this dossier is accepted; only this dossier file exists in the current PR.
+  - Future BIO dossiers/plans for Samiilo Samus, Andrii Abazyn, Zakhar Iskra,
+    Danylo Bratkovsky, and Antin Tansky if the Right-Bank Cossack restoration
+    cluster is expanded.
+  - Future HIST/ISTORIO modules on the Palii uprising, the Narva Treaty clause
+    affecting Right-Bank towns, Fastiv/Bila Tserkva regimental restoration,
+    and Mezhyhiria/Palii relic-memory provenance.
+
+## 8. Naming-canonical
+
+- **Slug:** `semen-palii`
+- **EN canonical (project spelling):** Semen Palii
+- **UA canonical:** Семен Палій
+- **Full UA source form:** Семен Пилипович Гурко / Семен Пилипович Палій
+- **Aliases (track carefully for future `aliases:` YAML field):** Семен
+  Палій; Семен Пилипович Палій; Семен Пилипович Гурко; Гурко; Palii, Semen;
+  Semen Palij; Semen Palej; `Палій (Гурко) Семен Пилипович`.
+- **Office/title variants to track carefully:** Fastiv colonel; Bila Tserkva
+  colonel; volunteer cavalry colonel; Right-Bank Cossack leader; candidate for
+  hetmancy as a source/event claim; church patron; exile.
+- **Place/event variants to track carefully:** Borzna; Nizhyn regiment;
+  Chortomlyk Sich; Fastiv / Khvastiv; Bila Tserkva; Nemyriv; Berdychiv; Bar;
+  Vinnytsia; Right-Bank Ukraine; Kyiv voivodeship; Bratslav; Podilia;
+  Volhynia; Baturyn; Moscow; Tobolsk; Mezhyhiria; Narva Treaty; Palii
+  uprising.
+- **Forbidden forms / flattening forms to flag in body text:** Russian-only
+  name forms as normalized Ukrainian/English body text; "bandit" as neutral
+  fact; "simple folk avenger"; "simple Russian-loyal hero"; "simple Mazepa
+  antagonist"; "class-war symbol" as the full explanation; "modern nationalist
+  prototype"; a precise death date without source qualification.
+- **Term warning:** `вільна козацька область` is a source/political phrase in
+  the 1702 crisis. Do not convert it into an anachronistic modern state label.
+- **Scope warning:** keep this BIO dossier on Right-Bank Cossack restoration,
+  Fastiv/Bila Tserkva authority, 1702-1704 uprising, Mazepa-era enforcement,
+  Siberian exile/return, Poltava-era memory, and later heroic simplification.
+  Do not add unrelated 20th-century hetmanate material or route unrelated
+  rulers here.
+
+## 9. Image candidates
+
+- **Portrait candidate:** IEU displays a portrait of Colonel Semen Palii. Use
+  the individual image/file page and CIUS rights terms before any publication;
+  do not assume open reuse from the article page alone. [T1/T5: IEU image
+  page]
+- **Museum-object candidate:** EIU's references to a portrait copy, silver
+  mace, silver-mounted sabre, cups, carpet, and Gospel associated with Palii
+  point to Chernihiv historical museum and National Museum of the History of
+  Ukraine provenance work. These are strong image leads only after rights and
+  object metadata are checked. [T1: ЕІУ Palii; T4/T5 museum lead]
+- **Seal/document candidate:** Palii had a seal according to ЕІУ, and
+  Ukrainian Wikipedia displays a seal image lead. Use only if a rights-clear
+  archival/source page is identified.
+- **Map candidate:** a project-created map of Fastiv, Bila Tserkva, Nemyriv,
+  Berdychiv, Bar, Vinnytsia, Baturyn, Moscow, Tobolsk, and Mezhyhiria would
+  teach the dossier better than a generic Cossack portrait.
+- **Context candidate:** rights-clear images of Fastiv/Bila Tserkva Cossack
+  memory sites or Mezhyhiria provenance materials could serve a memory-history
+  lesson if captions distinguish modern commemoration from early-modern fact.
+- **Avoid:** generic Cossack stock art, unlicensed modern illustrations,
+  images that make Palii a pure avenger, and captions that state unverified
+  ownership/provenance for relics.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- [T1] Чухліб Т.В. "Палій (Гурко) Семен Пилипович" // *Енциклопедія історії
+  України*. URL: https://www.history.org.ua/?termin=Palij_S | accessed
+  2026-07-04. Core facts: name, Hurko surname, Borzna origin, Nizhyn and
+  Chortomlyk layers, Fastiv/Bila Tserkva colonelships, Right-Bank
+  recolonization, 1702-1704 uprising, Narva-related pressure, arrest, Moscow
+  transfer, Tobolsk exile, return, renewed office, church patronage, burial,
+  relics, and folk/literary memory.
+- [T1] Чухліб Т.В. "Нарвський договір 1704" // *Енциклопедія історії
+  України*. URL: https://www.history.org.ua/?termin=Narvskyj_myrnyj_1704 |
+  accessed 2026-07-04. Used for treaty date, clause 4 affecting Palii's
+  captured towns/fortresses, enforcement assignment to Mazepa, and the
+  interpretation that Moscow-Warsaw arrangements disregarded Cossack
+  autonomous interests.
+- [T1] Станіславський В.В. "Самусь (Самійло Іванович)" // *Енциклопедія
+  історії України*. URL: https://www.history.org.ua/?termin=Samus_S |
+  accessed 2026-07-04. Used for Right-Bank leadership network, Fastiv council
+  participants, 1702 uprising preparation, Samus's campaigns, transfer of
+  regalia to Mazepa, and post-1711 Right-Bank context.
+- [T1] "Palii, Semen" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CP%5CA%5CPaliiSemen.htm
+  | accessed 2026-07-04. Used for English metadata, Hurko surname, birth/death
+  range, Borzna/Kyiv, education, registered Nizhyn and Zaporizhian service,
+  Fastiv/Bila Tserkva power, 1702-1704 uprising, suppression, Mazepa arrest,
+  Moscow/Siberia exile, return, renewed command, and burial.
+- [T1] "Fastiv regiment" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CF%5CA%5CFastivregiment.htm
+  | accessed 2026-07-04. Used for Fastiv regimental status in 1685-1702 under
+  Palii, 1702 Bila Tserkva capture, and 1693 troop-number lead.
+- [T1] "Bila Tserkva regiment" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CB%5CI%5CBilaTserkvaregiment.htm
+  | accessed 2026-07-04. Used for Right-Bank regimental history, Palii's
+  restoration of Bila Tserkva regiment in 1702, and headquarters role.
+- [T1] "Right-Bank Ukraine" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CI%5CRight6BankUkraine.htm
+  | accessed 2026-07-04. Used for region definition, post-Ruin devastation,
+  Andrusovo/Eternal Peace partition, 1699 abolition, Palii uprising, Mazepa's
+  unification moment, and later suppression.
+- [T1] "Cossacks" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CC%5CO%5CCossacks.htm
+  | accessed 2026-07-04. Used for Right-Bank Cossack regimental organization,
+  Palii as actual head of Right-Bank Cossacks, 1702 unification goal, 1704
+  realization, and 1714 suppression frame.
+
+**Tier 2 (source editions / source-language anchors):**
+
+- [T2] Project quote-verifier result, 2026-07-04: author query `Шевченко`,
+  text query `Полковника фастовського Славного Семена`; matched
+  `ukrlib-shevchenko` with confidence 1.0. Used only for a short
+  literary-memory anchor; poem title/year metadata should be checked before
+  classroom quotation.
+- [T2] *Архив Юго-Западной России*, ч. 3, т. 2. Kyiv, 1868. Cited by ЕІУ
+  Samus and Palii as a source-edition lead for Right-Bank Cossack acts,
+  letters, and documents; not directly quoted here beyond Tier 1-mediated
+  anchors.
+- [T2] `Volumina legum`, t. 6. Petersburg, 1860; and `Полное собрание
+  законов Российской империи`, series 1. Both are source leads cited by ЕІУ
+  Narva Treaty for the treaty/legal layer; not treated as independently
+  verified in this pass.
+
+**Tier 3 (encyclopedic — navigation only):**
+
+- [T3] Українська Вікіпедія, "Семен Палій" and "Повстання Палія." Used only
+  for navigation to ЕІУ, image/seal leads, and source-list checks; not
+  load-bearing.
+- [T3] NBUV authority/item pages for Palii. Used only for alias and
+  bibliographic navigation.
+
+**Tier 4 (modern scholarly / specialist anchors):**
+
+- [T4] Чухліб Т. *Козаки і монархи: Міжнародні відносини ранньомодерної
+  Української держави 1648-1721 рр.* Kyiv, 2009 — follow-up for protector and
+  diplomacy language.
+- [T4] Станіславський В. "Взаємини Івана Мазепи з Семеном Палієм та
+  українсько-польські стосунки на Правобережній Україні." In *Україна в
+  Центрально-Східній Європі*, вип. 8. Kyiv, 2008 — key follow-up for the
+  Mazepa/Palii conflict and Right-Bank policy.
+- [T4] Смолій В., Степанков В. *Правобережна Україна в другій половині XVII -
+  XVIII ст.: проблема державотворення.* Kyiv, 1993 — Right-Bank state-building
+  frame.
+- [T4] Чухліб Т. *Козацький устрій Правобережної України (остання чверть XVII
+  ст.).* Kyiv, 1996 — institutional/regimental follow-up.
+- [T4] Кривошея В. *Білоцерківський полк.* Kyiv, 2002 — regimental follow-up.
+- [T4] Андрусяк М. *Мазепа і Правобережжя.* Lviv, 1938; Полонська-Василенко
+  Н. "Палій та Мазепа." *Літопис Червоної Калини*, 1938/1992 — older but
+  important historiographic leads.
+- [T4] Perdenia J. *Stanowisko Rzeczypospolitej szlacheckiej wobec sprawy
+  Ukrainy na przełomie XVII-XVIII w.* Wrocław, 1963; Janczak J. `Powstanie
+  Paleja` / `Der Palej Aufstand...`; Serhiienko H. *Vyzvolnyi rukh na
+  Pravoberezhnii Ukraini v kintsi XVII i na pochatku XVIII st.* Kyiv, 1963 —
+  uprising historiography and treaty-context leads.
+- [T4] Krykun M. *Mizh viinoiu i radoiu: kozatstvo Pravoberezhnoi Ukrainy v
+  druhii polovyni XVII - na pochatku XVIII st.* Kyiv, 2006 — Right-Bank
+  Cossack context lead from IEU bibliography.
+
+**Tier 5 (general web / popular / image — not load-bearing):**
+
+- [T5] IEU portrait page for Palii; Wikimedia/local-memory image pages; recent
+  article and street-name pages; Fastiv/Bila Tserkva local commemoration
+  pages. Used only as image, memory, or navigation leads.
+- [T5] Popular articles using labels such as "defender of Europe," "Palii's
+  state," or simple Mazepa-vs-Palii morality frames. Useful for identifying
+  classroom misconceptions, not for facts.
+
+**Honest gaps:** no direct archival edition of Palii's 1685 universal,
+Mazepa's 1704 office-removal universal, Peter's 1704 letter, or the exile
+order was independently opened in this pass. The dossier therefore uses ЕІУ
+and IEU as the load-bearing baseline and treats source-language anchors as
+short cues needing edition verification before classroom quotation.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing — Moscow/Peter appear as one coercive protector
+  and treaty actor, not as a natural destination of Palii's politics.
+- [x] No Commonwealth-centric flattening — Right-Bank Cossack restoration is
+  not reduced to disorder or banditry.
+- [x] No Russian-imperial transliterations in body text — English uses Semen
+  Palii; Ukrainian uses Семен Палій / Гурко.
+- [x] No uncritical Soviet shorthand — social revolt is included, but not as
+  the only explanation.
+- [x] No pure folk-avenger story — settlement, administration, church
+  patronage, diplomacy, Mazepa conflict, exile, return, and memory all remain
+  visible.
+- [x] No simple Russian-loyal hero story — appeals to Moscow, exile by Peter's
+  order, and later return are held together.
+- [x] No simple Mazepa antagonist story — earlier cooperation and the Narva
+  enforcement structure are included.
+- [x] Modern Ukrainian place names used: Borzna, Fastiv, Bila Tserkva, Kyiv,
+  Baturyn, Mezhyhiria; Tobolsk is identified as an exile destination.
+- [N/A] Holodomor — не стосується.
+- [x] Image/memory caveat included — portraits, relics, and folk/literary
+  references are legacy layers, not direct proof of every biographical claim.
+- [x] Guard-sensitive unrelated topics avoided — no 20th-century hetmanate
+  material, no unrelated rulers, no rejected spellings/phrases.
+
+## Validation checklist
+
+- [x] Dossier follows current Cossack BIO pattern: metadata, acceptance
+  self-check, source-tier self-check, 10 sections, decolonization checklist,
+  validation checklist.
+- [x] No edits outside `docs/research/bio/semen-palii.md`.
+- [x] No generated `status/*.json`, `audit/*-review.md`, `review/*-review.md`,
+  `docs/*-STATUS.md`, or `data/telemetry/**` files added.
+- [x] No `.python-version`, `.yamllint`, `.markdownlint.json`, package, plan,
+  curriculum, module, activity, vocabulary, resource, site, wiki, or telemetry
+  file changed.
+- [x] Existing cross-track curriculum plan paths verified locally before
+  drafting; absent Semen Palii surfaces marked Candidate.
+- [x] No LLM-QG, QG parity, QG DB persistence, or module-quality audit route
+  used.
+- [x] `npx markdownlint-cli2 docs/research/bio/semen-palii.md`
+- [x] `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/semen-palii.md`
+- [x] `git diff --check`
+- [x] Guard search for out-of-scope Palii dossier strings returns no matches.
+- [x] Protected artifact/config guard confirms only
+  `docs/research/bio/semen-palii.md` is changed.


### PR DESCRIPTION
## Scope

Adds the BIO Cossack research dossier for Semen Palii, focused on Right-Bank Cossack restoration, Fastiv/Bila Tserkva authority, the 1702-1704 uprising, Mazepa-era enforcement, Moscow exile/return, Poltava-era memory, and later heroic simplification risks.

## Changed files

- `docs/research/bio/semen-palii.md`

## Validation

- `npx markdownlint-cli2 docs/research/bio/semen-palii.md` — passed, 0 errors
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/semen-palii.md` — passed, no fabricated Existing cross-track plan paths
- `git diff --check` — passed
- Guard search for out-of-scope strings — passed, no matches
- Protected artifact/config guard — passed, only `docs/research/bio/semen-palii.md` changed
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- Commit/push hooks — passed

## Source and decolonization caveats

- Tier 1/Tier 2 sources are load-bearing; Wikipedia and popular/local-memory sources are navigation or image/memory leads only.
- Palii is framed as complex: Right-Bank organizer, Fastiv/Bila Tserkva colonel, uprising leader, Mazepa-era rival, imperial-exile victim, returned officer, church patron, and later folk-memory figure.
- The dossier avoids flattening him into a pure folk avenger, simple Russian-loyal hero, simple Mazepa antagonist, bandit, class-war symbol, or modern nationalist prototype.
- Source-language anchors are short and caveated; direct archival editions of Palii's universals/letters and exile order remain follow-up verification targets before classroom quotation.

No independent review has been routed yet because the orchestrator handles that gate.