### PR TITLE
[codex] add Mykhailo Khanenko BIO Cossack dossier

### DIFF
--- a/docs/research/bio/mykhailo-khanenko.md
+++ b/docs/research/bio/mykhailo-khanenko.md
@@ -1,0 +1,566 @@
+# Михайло Степанович Ханенко — Research Dossier
+
+**Slug:** `mykhailo-khanenko`
+**Block:** P1 BIO Cossack coverage (Ruin-era Right-Bank claimant hetman;
+Uman-regiment base; Ostroh Agreement; anti-Doroshenko / anti-Ottoman
+coalition politics; Commonwealth recognition and limits; Muscovy-facing
+post-1674 afterlife)
+**Tier:** 1b (strong Tier 1 outline, sparse personal record, newly expanded
+document base)
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ Khanenko, IEU Khanenko, ЕІУ
+  Ostroh Agreement, ЕІУ Batozka battle, IEU Uman regiment, Mytsyk archival
+  document publication)
+- [x] Source-tier checkboxes included and lower-tier sources kept
+  non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: Andrusovo-era
+  partition pressure, anti-Doroshenko factional war, Ostroh Agreement autonomy
+  limits, Buchach exclusion, Lysianka surrender to Samoilovych, 1677 arrest /
+  Baturyn imprisonment order)
+- [x] §4 includes short primary/document anchors from Khanenko letters and
+  instructions, with source-edition caveats
+- [x] Khanenko is framed as complex: Uman colonel, Right-Bank claimant,
+  Zaporizhian/Sirko-aligned anti-Doroshenko figure, Commonwealth-recognized
+  hetman, failed rival, later Muscovy-facing detainee, and a source-poor actor
+  whose record should not be flattened into "puppet" or "traitor"
+- [x] Cross-track links: every "Existing" plan path verified locally with
+  `test -e` on 2026-07-04
+- [x] Naming-canonical applied; `Mykhailo Khanenko` / `Михайло Ханенко` is
+  canonical, while Polish and older scholarly forms are tracked as variants
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+
+**Source-tier self-check:**
+
+- [x] **T1 baseline:** ЕІУ and Internet Encyclopedia of Ukraine anchor core
+  facts, office dates, Uman-regiment base, Ostroh Agreement, war with
+  Doroshenko, 1674 surrender of the mace, and 1677 arrest / imprisonment
+  frame.
+- [x] **T1 event context:** ЕІУ Ostroh Agreement and Batozka battle entries
+  anchor the treaty mechanism and the 1672 battlefield sequence; IEU Uman
+  regiment anchors the Khmelnytskyi-era regimental setting and later Mazepa-era
+  revival without making Mazepa part of Khanenko's biography.
+- [x] **T2/T4 document context:** Mytsyk's 2024 publication of Khanenko's
+  diplomatic correspondence gives source-language anchors and confirms that
+  Khanenko's documentary corpus is small and newly expanding.
+- [x] **T4 scholarship:** Chukhlib, Doroshenko, Smolii/Stepankov, Krykun, and
+  related Ruin scholarship are retained as interpretive and bibliographic
+  anchors, not as unsupported fact dumps.
+- [x] **T3/T5 caution:** Wikipedia, popular hetman summaries, blogs, school
+  pages, and image pages are navigation or image-rights aids only; they are
+  not load-bearing for interpretation.
+- [x] **Primary/doc excerpts:** short excerpts are explicitly marked as
+  document/source-language anchors; recheck source editions before classroom
+  quotation.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Михайло Степанович Ханенко. ЕІУ also points
+  through the Khanenko family entry to `Михайло Степанович (Стефанович)`;
+  keep `Стефанович` as a source-search variant, not the primary curriculum
+  form. [T1: ЕІУ Khanenko; T1: ЕІУ Khanenky family]
+- **Pseudonyms / aliases:** Михайло Ханенко; Михайло Степанович / Стефанович
+  Ханенко; Mykhailo Khanenko; Khanenko, Mykhailo; IEU bracket form `Xanenko,
+  Myxajlo`; Polish document form `Michał Chanenko`; `hetman Wojska
+  Zaporozkiego` / `гетьман Війська Запорозького` in document contexts. [T1:
+  ЕІУ; T1: IEU; T2/T4: Mytsyk]
+- **Born:** early 1620s / ca. 1620. ЕІУ gives "початок 1620-х рр."; IEU gives
+  `ca 1620-80`; Mytsyk's archival publication uses `(1620-1680)` in its
+  abstract. Do not invent an exact day or place. [T1: ЕІУ; T1: IEU; T2/T4:
+  Mytsyk]
+- **Died:** 1680, with exact place and circumstances not established in the
+  Tier 1 baseline used here. Use "died in 1680, place uncertain" unless a
+  later module verifies a source edition. [T1: ЕІУ; T1: IEU]
+- **Family / origin:** son of the Khanenko Cossack-starshyna family; the ЕІУ
+  family entry treats Stepan / Stefan Khanenko as the family founder in family
+  tradition and names Mykhailo as one of his sons. Mytsyk's 2024 document
+  publication adds usable leads about Khanenko's son Pavlo and family members
+  held or placed at the Commonwealth court, but those details need direct
+  source checking before becoming lesson facts. [T1: ЕІУ Khanenky family;
+  T2/T4: Mytsyk]
+- **Education:** no secure education record located in this pass. Do not infer
+  Kyiv-Mohyla or Polish-court schooling from elite status.
+- **Uman colonel:** ЕІУ says he served as Uman colonel from 1656 to 1669; IEU
+  gives Uman-regiment colonel in 1656-1660 and 1664-1669. Mytsyk summarizes
+  the office as Uman colonel in 1655-1669 with interruptions. Use "Uman
+  colonel in the 1650s-1660s, with source-sensitive date ranges." [T1: ЕІУ;
+  T1: IEU; T2/T4: Mytsyk]
+- **Khmelnytskyi-era context:** ЕІУ says Khanenko fought in the campaigns of
+  the Uman regiment during the mid-seventeenth-century National Revolution;
+  IEU Uman regiment says the regiment was founded in 1648 at the outbreak of
+  the Cossack-Polish War. This is the correct Khmelnytskyi-era frame, not a
+  later all-hetmans chronology. [T1: ЕІУ; T1: IEU Uman regiment]
+- **Yurii Khmelnytskyi / early Ruin role:** supported Yurii Khmelnytskyi,
+  signed the Pereiaslav Articles of 1659 and Chudniv / Slobodyshche settlement
+  of 1660, and served as acting hetman on the southeastern frontier in 1660.
+  [T1: ЕІУ]
+- **Commonwealth nobility:** received ennoblement from the Commonwealth crown
+  in 1661. This is a social-political datum, not permission to center the
+  dossier on Commonwealth royal biography. [T1: ЕІУ]
+- **Pavlo Teteria connection:** during Teteria's Right-Bank government he was
+  appointed acting colonel in 1663; Mytsyk's documents show continuing contact
+  with Teteria in the Commonwealth-emigration context. [T1: ЕІУ; T2/T4:
+  Mytsyk]
+- **Claimant hetmancy:** in 1669 a council near Uman elected him hetman of
+  the Zaporozhian Host from several Right-Bank regiments as a rival to Petro
+  Doroshenko. IEU narrows this to July 1669 after Petro Sukhovii's defeat,
+  while the office range is often given as 1669/70-1674. Teach the office as a
+  contested claimant hetmancy over only part of Right-Bank Ukraine. [T1: ЕІУ;
+  T1: IEU]
+- **Ostroh Agreement:** the agreement of 12/2 September 1670 with Commonwealth
+  representatives gave Khanenko recognition and aid but sharply limited
+  autonomy. ЕІУ says it preserved the status of the Kyiv-Mohyla Academy while
+  significantly narrowing Right-Bank Hetmanate autonomy; IEU stresses fealty
+  to the Commonwealth crown, restricted territory, and autonomy only for the
+  Cossack stratum.
+  [T1: ЕІУ Ostroh Agreement; T1: IEU Khanenko]
+- **Military base:** in 1672, ЕІУ lists Bratslav, Korsun, Mohyliv, Torhovytsia,
+  and Uman regiments among Khanenko's supporters, but the sequence quickly
+  deteriorated after Batozka / Batih-Chetvertynivka and Buchach. [T1: ЕІУ;
+  T1: ЕІУ Batozka battle]
+- **1674 surrender:** on 17 March 1674 at a general council near Lysianka he
+  yielded the mace to Left-Bank hetman Ivan Samoilovych and moved to the Left
+  Bank. IEU frames the transfer as an exchange for estates in Left-Bank
+  Ukraine. [T1: ЕІУ; T1: IEU]
+- **1677 arrest:** ЕІУ says he was arrested in 1677 for renewing ties with
+  Commonwealth royal authorities; IEU says he was accused of secret talks in
+  1677-1678 and that the tsar ordered Samoilovych to imprison him in Baturyn.
+  Use this as a source-sensitive Muscovy-facing coercion point. [T1: ЕІУ; T1:
+  IEU]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Birth and death:** early 1620s / ca. 1620 and 1680 are stable enough for
+   a dossier; exact birthplace, birthday, death place, and cause are not.
+2. **Uman colonel dates:** ЕІУ, IEU, and Mytsyk use different ranges. The
+   pedagogical point is continuity of a Uman-regiment base, not false exactness.
+3. **Hetman office dates:** `1669-1674`, `1669/70-1674`, and
+   Commonwealth-recognized phases all circulate. The key is contested,
+   partial Right-Bank authority against Doroshenko.
+4. **Ostroh date forms:** ЕІУ gives 12 (2) September 1670; IEU gives
+   2 September 1670. Spell out old/new-style conversion if teaching the
+   treaty date.
+5. **Political labels:** "pro-Polish" is descriptively useful only when tied
+   to documents, offices, aid, and constraints. It is not a complete identity.
+6. **Muscovy afterlife:** after 1674 Khanenko was not simply absorbed into a
+   safe retirement. The 1677 arrest / Baturyn imprisonment order matters.
+7. **Mazepa context:** IEU Uman regiment says the regiment was revived under
+   Ivan Mazepa in 1704, after Khanenko's death. This is a later institutional
+   echo, not part of Khanenko's own career.
+8. **Out-of-scope warning:** do not route this dossier into modern-statehood
+   Hetmanate analogies; the scope is seventeenth-century Right-Bank Cossack
+   politics.
+
+## 2. Oppression / appropriation mechanism
+
+**What happened:** Khanenko's career sits inside the post-Andrusovo Ruin, when
+Right-Bank Cossack politics were caught between the Commonwealth, Muscovy, the
+Ottoman Empire, the Crimean Khanate, Zaporizhian forces, and rival hetmans.
+Petro Doroshenko sought a high-risk Ottoman protectorate after the
+Moscow-Commonwealth partition. Khanenko became the leading
+Commonwealth-recognized counter-hetman on the Right Bank, but the Ostroh
+Agreement narrowed rather than expanded Hetmanate autonomy, and the military
+field moved faster than diplomatic guarantees. [T1: ЕІУ; T1: IEU; T1: ЕІУ
+Ostroh Agreement]
+
+**By whom:** Commonwealth power in the recognition, treaty, military-aid, and
+autonomy-limiting layers; Ottoman and Crimean power in the Doroshenko
+protectorate and campaign layer; Muscovy in the Andrusovo partition context,
+Left-Bank/Samoilovych pressure, and 1677 Baturyn imprisonment layer;
+Zaporizhian and Right-Bank Cossack factions in the anti-Doroshenko coalition
+and legitimacy layer; Khanenko himself in the agency layer. The dossier must
+tell the truth in every direction.
+
+**Document references:** the Pereiaslav Articles of 1659 and Chudniv /
+Slobodyshche settlement as early allegiance-switch context; the Andrusovo
+Armistice of 1667 as partition background; the anti-Doroshenko Uman council /
+1669 claimant election; the Stebliv battle of 1669; the **Ostroh Agreement of
+1670**; Khanenko's diplomatic letters and instructions published by Mytsyk;
+the **Batozka / Batih-Chetvertynivka battle of 1672**; the Buchach Peace of
+1672; the Lysianka council of 17 March 1674; and the 1677 arrest /
+imprisonment order. [T1/T2/T4 sources]
+
+**Mechanism specifics:** the simplest imperial memory move is to make
+Khanenko a "Polish puppet" and Doroshenko a "Turkish traitor," then turn
+Right-Bank Ukraine into a stage where outsiders alone have meaningful agency.
+The decolonized correction is not to rehabilitate Khanenko as a modern
+national leader. It is to show how a Cossack actor tried to preserve a
+Commonwealth-backed, Orthodox-Cossack autonomy track against Doroshenko's
+Ottoman-backed track, and how both tracks were squeezed by larger powers and
+by internal Cossack divisions.
+
+The Ostroh Agreement is the load-bearing document: it recognized Khanenko and
+offered aid, but only by accepting royal confirmation, narrowing autonomy,
+restricting the hetman's political space, and defining rights unevenly. That
+made Khanenko more than a private adventurer and less than a sovereign ruler.
+After the 1672 Ottoman campaign and Buchach, he was forced out of Ukraine; in
+1674 he yielded the mace to Samoilovych; and in 1677, when he was suspected of
+renewed Polish ties, Muscovy's tsarist command could convert diplomacy into
+detention.
+
+**What survived / what was distorted:** what survived is a thin but important
+document trail: Uman-regiment leadership, short diplomatic texts, treaty
+conditions, Polish-language signatures, military defeats, and later arrests.
+What was distorted is the biography. Khanenko is often only Doroshenko's foil:
+"the pro-Polish puppet." That hides the Orthodox-rights language, Zaporizhian
+alignment, actual regimental constituency, limited but real agency, and the
+post-1674 coercion by Muscovy. The opposite distortion makes him a
+proto-national unity figure. The stronger teaching frame is constrained
+statecraft under the Ruin, with a failed and morally costly political choice.
+
+## 3. Major works / legacy
+
+Khanenko left no literary corpus; "works" means offices, treaties, letters,
+military coalitions, and the political memory of a failed Right-Bank line.
+
+- `early 1620s` — born into the Khanenko Cossack-starshyna family, exact place
+  uncertain. [T1: ЕІУ; T1: IEU]
+- `1648-1650s` — participated in Uman-regiment campaigns during the
+  Khmelnytskyi-era National Revolution; use the Uman-regiment frame rather than
+  a generalized ruler list. [T1: ЕІУ; T1: IEU Uman regiment]
+- `1656-1669` — served as Uman colonel, with source-sensitive interruptions
+  and date ranges. [T1: ЕІУ; T1: IEU; T2/T4: Mytsyk]
+- `1659` — supported Yurii Khmelnytskyi and signed the Pereiaslav Articles.
+  [T1: ЕІУ]
+- `1660` — signed the Chudniv / Slobodyshche settlement and served as acting
+  hetman on the southeastern frontier; Mytsyk notes an overlooked 1660 source
+  reference that extends his acting-hetman chronology. [T1: ЕІУ; T2/T4:
+  Mytsyk]
+- `1661` — received ennoblement from the Commonwealth king; treat this as a
+  status and alliance marker, not as the center of the narrative. [T1: ЕІУ]
+- `1663` — appointed acting colonel in Pavlo Teteria's Right-Bank government.
+  [T1: ЕІУ]
+- `1668-1669` — joined the anti-Doroshenko Zaporozhian faction around Petro
+  Sukhovii and the Crimean-Tatar-supported opposition, then became the main
+  Commonwealth-backed alternative after Sukhovii's defeat. [T1: IEU]
+- `July / autumn 1669` — proclaimed or elected hetman by a council near Uman
+  representing only part of the Right Bank; immediately entered a contested
+  field rather than a settled office. [T1: ЕІУ; T1: IEU]
+- `29 October 1669` — defeated by Doroshenko at Stebliv; this prevented a
+  quick anti-Doroshenko consolidation and helped push him toward stronger
+  Commonwealth reliance. [T1: IEU; T1: ЕІУ Stebliv bibliography]
+- `12/2 September 1670` — Ostroh Agreement concluded by Khanenko's envoys with
+  Commonwealth representatives; it gave recognition and aid but sharply
+  limited autonomy. [T1: ЕІУ Ostroh Agreement; T1: IEU]
+- `1671` — fought alongside Commonwealth forces and took part in campaigns
+  around Bratslav, Yamphil, and Podilian/Right-Bank towns; Mytsyk's documents
+  show Khanenko reporting to and petitioning Commonwealth authorities while
+  still pressing Cossack-rights language. [T1: ЕІУ; T2/T4: Mytsyk]
+- `18/8 July 1672` — Batozka / Batih-Chetvertynivka battle: Doroshenko's
+  Ukrainian-Tatar-Ottoman forces defeated Commonwealth and Khanenko-aligned
+  troops near the Southern Buh. [T1: ЕІУ Batozka battle]
+- `1672` — Buchach Peace made Khanenko's position untenable; ЕІУ says he was
+  forced to leave Ukraine. [T1: ЕІУ]
+- `spring 1673` — returned to Ukraine; on 11 September his small force was
+  defeated near Kyiv. [T1: ЕІУ]
+- `17 March 1674` — at a general council near Lysianka, yielded the mace to
+  Ivan Samoilovych and crossed to the Left Bank. [T1: ЕІУ; T1: IEU]
+- `1677` — arrested / targeted for imprisonment after accusations of renewed
+  ties or secret talks with Commonwealth royal authorities. [T1: ЕІУ; T1:
+  IEU]
+- `1680` — died, with exact place and circumstances unresolved in the
+  baseline sources. [T1: ЕІУ; T1: IEU]
+- `posthumous institutional echo` — IEU Uman regiment says the regiment was
+  later revived under Ivan Mazepa in 1704 and dissolved in 1712; this is useful
+  for teaching the Right-Bank regimental afterlife, not for moving Khanenko
+  into Mazepa's biography. [T1: IEU Uman regiment]
+
+## 4. Primary-source quotes (>=2 required)
+
+> **Honest tool note:** no project `verify_quote` or LLM-QG tooling was run in
+> this pass. The excerpts below are short document/source-language anchors from
+> Mytsyk's 2024 archival publication and Chukhlib's source-language article.
+> Recheck the manuscript or source edition before using longer classroom
+> quotations.
+
+**Anchor 1 — Khanenko's anti-Doroshenko / anti-Ottoman accusation, 1669:**
+
+> "Всю нашу Україну ... в підданство Турському піддав"
+
+Context: Chukhlib cites Khanenko's letter language through *Akty
+Yugo-Zapadnoi Rossii*. Use this to teach Khanenko's rhetoric against
+Doroshenko's Ottoman protectorate, not as neutral proof that Doroshenko had no
+statecraft rationale. [T4: Chukhlib 2017]
+
+**Anchor 2 — Commonwealth-subject formula in Khanenko's 1671 letter:**
+
+> "wierny najniższy poddany / Michał Chanenko"
+
+Context: Mytsyk publishes the Polish-language document and Ukrainian
+translation. The formula is pedagogically valuable because it shows how far
+Khanenko's Commonwealth-recognition strategy moved into fealty language. [T2/T4:
+Mytsyk 2024]
+
+**Anchor 3 — Cossack-rights petition language after Ostroh:**
+
+> "при наших козацьких вольностях"
+
+Context: the same document publication shows that Khanenko's Commonwealth
+alignment also used Cossack-rights language. This phrase helps learners avoid
+the false binary of "puppet" versus "sovereign." [T2/T4: Mytsyk 2024]
+
+**Anchor 4 — late Right-Bank defense language, 1672:**
+
+> "ця остання частина України"
+
+Context: in a February 1672 letter, Khanenko pleaded for Commonwealth military
+support while describing the remaining contested Right-Bank space. Treat this
+as a source-language lead, with caution because the Ukrainian text is a modern
+published translation of a Polish document. [T2/T4: Mytsyk 2024]
+
+## 5. Language register and learner-use notes
+
+- **Register:** Cossack-chancery, treaty, military-diplomatic, Polish-court,
+  and early-modern Ruthenian/Polish formula language.
+- **CEFR readiness for full reading:** B2-C1 for adapted biography; C1-C2 for
+  Ostroh Agreement, diplomatic instructions, Polish-language letter formulas,
+  and source criticism.
+- **Lexicon notes:** `Правобережжя`, `Уманський полк`, `наказний гетьман`,
+  `булава`, `клейноди`, `кошовий отаман`, `Острозька угода`, `протекція`,
+  `підданство`, `козацькі вольності`, `унія`, `Річ Посполита`,
+  `Бучацький мир`, `Руїна`, `політична еміграція`, `зверхність`,
+  `гетьман-претендент`.
+- **Learner-use notes:** the dossier supports a C1 seminar on verbs and nouns
+  of dependency: `визнавати`, `піддавати`, `присягати`, `поступитися булавою`,
+  `зберегти вольності`, `отримати клейноди`, `бути затвердженим`. It also
+  supports contrastive work on `протекція` versus `підданство`.
+- **Stylistic features:** treaty and letter formulae often sound submissive
+  while preserving claims to rights. Learners should notice how early-modern
+  diplomatic language can combine humility, threat perception, and bargaining.
+- **Sensitive framing:** do not ask learners to decide whether Khanenko was
+  simply "for Poland" or "against Ukraine." A stronger prompt is: "Which
+  autonomy did Khanenko try to preserve, and what did the Ostroh strategy make
+  him give up?"
+
+## 6. Contested points
+
+- **Claimant hetman or hetman?** Khanenko held recognition from part of the
+  Right Bank, the Zaporizhian/Sich-aligned opposition, and the Commonwealth,
+  but not stable all-Right-Bank authority. Use `гетьман-претендент` or
+  "Commonwealth-recognized Right-Bank hetman" when precision matters.
+- **"Pro-Polish" as explanation:** the label is not wrong, but it is incomplete.
+  It must be unpacked through nobility status, Commonwealth aid, the Ostroh
+  Agreement, Cossack-rights petitions, royal confirmation, and later
+  disillusionment. Do not turn the label into a personality diagnosis.
+- **Doroshenko contrast:** Khanenko's anti-Ottoman rhetoric should be taught
+  alongside Doroshenko's post-Andrusovo logic. Doroshenko's Ottoman protectorate
+  was a desperate statecraft choice with catastrophic consequences; Khanenko's
+  Commonwealth track was an alternative with its own autonomy costs and
+  battlefield failures.
+- **Orthodox rights and union:** Ostroh preserved some Orthodox / educational
+  claims, including the Kyiv-Mohyla Academy status noted by ЕІУ, but it also
+  accepted terms that allowed the Union and the return of noble landholding.
+  This is a contested social and religious settlement, not a clean liberation
+  program.
+- **Zaporizhian and Sirko alignment:** Khanenko's anti-Doroshenko coalition
+  intersected with Sich politics and Ivan Sirko's anti-Ottoman stance. Avoid
+  making Sirko the pure patriotic foil and Khanenko the compromised politician;
+  both operated in the same fractured frontier field.
+- **Right-Bank society:** the main victim was not an abstract chessboard but
+  Right-Bank communities under repeated campaigns, sieges, elite return,
+  Ottoman/Crimean raids, Commonwealth forces, and competing Cossack
+  administrations. A dossier that only tracks hetman titles misses the social
+  cost.
+- **Muscovy's role:** Muscovy is not central in Khanenko's earliest
+  Right-Bank election, but it is central to the Andrusovo partition context,
+  the Samoilovych transfer, and the 1677 arrest / Baturyn imprisonment order.
+  Do not imply that Moscow was absent simply because the key treaty was with
+  the Commonwealth.
+- **Ottoman and Crimean power:** do not use "Turkish/Tatar" imagery as exotic
+  betrayal shorthand. The Ottoman Empire and Crimean Khanate were historical
+  powers in the Ruin; Khanenko's own rhetoric against them is evidence of his
+  political messaging, not our narrator's ethnic frame.
+- **Commonwealth perspective:** Commonwealth elites may appear in the sources
+  through royal commissions, diplomacy, and Sejm decisions, but the BIO subject
+  is Khanenko. Do not add Commonwealth rulers as BIO figures or let the
+  narrative become a royal-court story.
+- **Mazepa-era echo:** the Uman regiment's later revival under Mazepa is useful
+  for institutional continuity, but Khanenko died before Mazepa's Right-Bank
+  moves. Keep the echo in cross-track context, not biography.
+- **Modern memory and disinformation:** Russian-imperial or Soviet-leaning
+  narratives can use Khanenko to prove that Ukrainians were naturally divided
+  and needed imperial order. Commonwealth-centered narratives can make him a
+  useful helper in royal wars. Ukrainian popular memory can reduce him to
+  Doroshenko's failed rival. BIO should resist all three simplifications.
+
+## 7. Cross-track links
+
+> Every plan path under **Existing** below was verified with `test -e` on
+> 2026-07-04. Dossier-file links are listed separately and are not curriculum
+> plan paths. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — Khmelnytskyi-era Uman-regiment / National Revolution background.
+  - `curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml` — Hadiach-style Commonwealth alternative and later Ostroh contraction.
+  - `curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml` — Zaporozhian / anti-Ottoman context around Khanenko's anti-Doroshenko line.
+- **Existing BIO dossiers (VERIFIED present; not curriculum plan paths):**
+  - `docs/research/bio/yurii-khmelnytskyi.md` — early allegiance and 1659/1660 treaty context.
+  - `docs/research/bio/petro-doroshenko.md` — direct rival and Ottoman-protectorate comparison.
+  - `docs/research/bio/ivan-briukhovetskyi.md` — Left-Bank / Moscow-leverage comparison after Andrusovo.
+  - `docs/research/bio/ivan-sirko.md` — Sich and anti-Ottoman alignment context.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/ruina-i.yaml` — post-Khmelnytskyi fragmentation baseline.
+  - `curriculum/l2-uk-en/plans/hist/ruina-ii.yaml` — Doroshenko, Right-Bank rivalry, Ottoman/Commonwealth/Muscovy pressure.
+  - `curriculum/l2-uk-en/plans/hist/andrusivske-peremyrya.yaml` — partition background for Khanenko's and Doroshenko's rival strategies.
+  - `curriculum/l2-uk-en/plans/hist/kozatska-derzhava.yaml` — institutional vocabulary of hetman, regiments, councils, and autonomy.
+  - `curriculum/l2-uk-en/plans/hist/pereyaslavska-uhoda.yaml` — earlier protectorate vocabulary and later 1659/Pereiaslav source caution.
+- **Existing ISTORIO/RUTH plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/istorio/pereyaslavski-statti.yaml` — treaty/source-language background for 1659 and later allegiance disputes.
+  - `curriculum/l2-uk-en/plans/ruth/diplomatic-language.yaml` — diplomatic formulae, fealty language, and chancery register.
+  - `curriculum/l2-uk-en/plans/ruth/treason.yaml` — early-modern loyalty/treason vocabulary without modern moral flattening.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `mykhailo-khanenko` — future BIO plan/module if this dossier is promoted.
+  - `ostrozka-uhoda-1670` — source-critical module on narrowed autonomy and Commonwealth recognition.
+  - `steblivska-bytva-1669` — factional military rivalry before Ostroh.
+  - `batozka-bytva-1672` — Doroshenko/Khanenko battlefield case tied to Ottoman campaign and Buchach.
+  - `buchatskyi-myr-1672` — treaty lesson on exclusion and forced displacement.
+  - `pavlo-teteria`, `petro-sukhovii`, `ivan-samoilovych`, `demian-mnohohrishny` — support cluster for the Right-Bank / Left-Bank transition.
+- **Potential LIT additions surfaced by this research:**
+  - A future historical-drama / memory unit could check stage portrayals of
+    Khanenko against source scholarship, but no existing plan is asserted here.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykhailo-khanenko`
+- **EN canonical (BGN/PCGN-style project spelling):** Mykhailo Khanenko
+- **UA canonical (with patronymic):** Михайло Степанович Ханенко
+- **Aliases (track these for `aliases:` YAML field):** Михайло Ханенко;
+  Михайло Стефанович Ханенко; гетьман Михайло Ханенко; уманський полковник
+  Михайло Ханенко; Mykhailo Khanenko; Khanenko, Mykhailo; Michał Chanenko;
+  Xanenko, Myxajlo in IEU transliteration; Chanenko in Polish-language
+  archival documents.
+- **Forbidden forms (Russian-imperial / flattening forms to flag in body
+  text):** Михаил Ханенко as normalized Russian form; Mikhail Khanenko as
+  Russian-via-English form; `Hanenko` as a non-canonical English slug;
+  "Polish puppet," "traitor," "bandit," or "pure dynastic footnote" as factual
+  labels.
+- **Name collision warning:** do not confuse him with later Khanenko-family
+  figures such as Mykola Khanenko (1693-1760) or with museum patron Bohdan
+  Khanenko; do not confuse the Cossack-era title with later modern-statehood
+  uses of the hetman title.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons `File:Mykhailo Khanenko.jpg`,
+  described as a nineteenth-century Havrylo Vasko oil portrait after a
+  Velychko-chronicle miniature, from the Vasyl Tarnovskyi collection; Commons
+  marks the file as PD-old-100 / PD-Art public domain. Verify the individual
+  file page before wiki use.
+- **Backup candidates:** Wikimedia Commons derivative files from the same
+  portrait tradition, including extracted PNG or printed versions from
+  *Historical figures of Southwestern Russia in biographies and portraits*;
+  verify the specific file license and provenance.
+- **Institutional candidates with caution:** IEU displays a Khanenko portrait
+  but the picture page says "All Rights Reserved"; the Museum Fund of Ukraine
+  page for Danylo Narbut's 1992 painting at the National Historical-Cultural
+  Reserve "Chyhyryn" is useful for art/history context but not assumed
+  open-licensed.
+- **Document/context image:** a rights-clear facsimile of the Ostroh Agreement,
+  a Khanenko letter/instruction page, or a map/context image of Uman /
+  Right-Bank regiments would be pedagogically strong if license-cleared.
+- **Authenticity caveat:** the main portrait is a nineteenth-century
+  reconstruction after a chronicle miniature, not a life portrait. Caption it
+  as a later representation.
+- **Avoid:** generic Cossack stock art, images centered on Commonwealth rulers,
+  exoticized Ottoman battle imagery, or visuals that present Khanenko as a
+  one-word collaborator.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- [T1] Чухліб Т. В. "Ханенко Михайло Степанович" // *Енциклопедія історії України*, т. 10. URL: https://www.history.org.ua/?termin=Khanenko_M | accessed 2026-07-04. Core facts: early 1620s-1680; Uman colonel; support for Yurii Khmelnytskyi; 1659/1660 signatures; 1661 ennoblement; 1669 claimant election near Uman; Ostroh; 1671/1672 military sequence; Buchach displacement; 1674 Lysianka surrender; 1677 arrest; portrait and Verduum description lead.
+- [T1] "Khanenko, Mykhailo" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CH%5CKhanenkoMykhailo.htm | accessed 2026-07-04. Core facts: ca. 1620-80; Right-Bank hetman 1669/70-1674; Uman colonel; anti-Doroshenko / Sukhovii sequence; Stebliv defeat; Ostroh 2 September 1670; 1674 transfer to Samoilovych; 1677-1678 accusation and Baturyn imprisonment order.
+- [T1] Чухліб Т. В. "Острозька угода 1670" // *Енциклопедія історії України*, т. 7. URL: https://www.history.org.ua/?termin=Ostrozkyj_dohovir_1670 | accessed 2026-07-04. Used for treaty date, negotiation sequence, Doroshenko background, Khanenko envoys, and autonomy-limiting terms.
+- [T1] Степанков В. С. "Батоцька битва 1672 р." // *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Batozka_bytva_1672 | accessed 2026-07-04. Used for the July 1672 battle between Doroshenko's Ukrainian-Tatar-Ottoman forces and Commonwealth/Khanenko-aligned forces.
+- [T1] "Uman regiment" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CU%5CM%5CUmanregiment.htm | accessed 2026-07-04. Used for Uman-regiment foundation, Khanenko/Doroshenko split, 1686 disbandment, and Mazepa-era 1704 revival context.
+- [T1] "Sukhovii, Petro" // *Internet Encyclopedia of Ukraine*. URL: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CU%5CSukhoviiPetro.htm | accessed 2026-07-04. Used as a supporting T1 lead for the Sukhovii-to-Khanenko anti-Doroshenko sequence.
+
+**Tier 2 (institutional / archival):**
+
+- [T2/T4] Мицик Ю. "Дипломатичне листування гетьмана Михайла Ханенка за 1669-1671 роки." DOI: 10.47315/archives2024.339.101. PDF URL: https://irbis-nbuv.gov.ua/cgi-bin/opac/search.exe?C21COM=2&I21DBN=UJRN&IMAGE_FILE_DOWNLOAD=1&Image_file_name=PDF%2Fay_2024_2_9.pdf&P21DBN=UJRN | accessed 2026-07-04. Used for document-corpus scarcity, office-date nuance, family leads, 11 published documents, and short source-language anchors.
+- [T2] ЕІУ family entry "Ханенки." URL: https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Khanenky_rid&Z21ID= | accessed 2026-07-04. Used for family-name and Stepan/Stefan variant caution.
+
+**Tier 3 (encyclopedic — navigation only):**
+
+- [T3] "Михайло Ханенко" // Ukrainian Wikipedia. URL: https://uk.wikipedia.org/wiki/Михайло_Ханенко | accessed 2026-07-04. Used only for navigation to bibliography and image leads; core facts checked against T1/T2.
+- [T3/image metadata] Wikimedia Commons, `File:Mykhailo Khanenko.jpg`. URL: https://commons.wikimedia.org/wiki/File:Mykhailo_Khanenko.jpg | accessed 2026-07-04. Used for image-rights lead only; verify file page before Phase 4.
+
+**Tier 4 (modern scholarly post-1991 / academic):**
+
+- [T4] Чухліб Т. "Михайло Ханенко." In *Володарі гетьманської булави: Історичні портрети.* Київ: Варта, 1994, pp. 317-328/330 depending on edition metadata. Bibliographic anchor via ЕІУ, Internet Archive table of contents, and Mytsyk 2024.
+- [T4] Чухліб Т. "З історії політичної боротьби в Українській державі у 60-70-х роках ХVII ст.: Діяльність правобережного гетьмана Михайла Ханенка." In *Середньовічна Україна*, вип. 2. Київ, 1997. Bibliographic anchor via ЕІУ.
+- [T4] Чухліб Т. "Поняття 'Україна', 'Український', 'отчизна', 'народ' в офіційному дискурсі Війська Запорозького (1666-1672 рр.)." PDF hosted by Інститут історії України. URL: https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=2&I21DBN=EJRN&IMAGE_FILE_DOWNLOAD=1&Image_file_name=PDF%2FUcse_2017_17_5.pdf&P21DBN=EJRN | accessed 2026-07-04. Used for source-language examples of Khanenko's anti-Doroshenko rhetoric and `Україна` vocabulary.
+- [T4] Дорошенко Д. *Гетьман Петро Дорошенко: Огляд його життя та політичної діяльності.* Нью-Йорк, 1985. Bibliographic anchor via ЕІУ.
+- [T4] Чухліб Т. *Гетьмани Правобережної України в історії Центрально-Східної Європи (1663-1713).* Київ, 2004. Bibliographic anchor via ЕІУ.
+- [T4] Крикун М. *Між війною та радою: Козацтво Правобережної України в другій половині XVII - на початку XVIII століття.* Київ: Критика, 2006. Bibliographic anchor via ЕІУ Ostroh entry.
+- [T4] Смолій В., Степанков В. *Петро Дорошенко: Політичний портрет.* Київ, 2011. Bibliographic anchor via ЕІУ.
+
+**Tier 5 (general web / image metadata — not load-bearing):**
+
+- [T5/image metadata] IEU picture page, "Portrait of Hetman Mykhailo Khanenko." URL: https://www.encyclopediaofukraine.com/picturedisplay.asp?id=5554 | accessed 2026-07-04. Useful portrait lead, but page states all rights reserved.
+- [T5/image metadata] Музейний фонд України, `Картина "Михайло Ханенко - гетьман Правобережної України"`. URL: https://museum.mincult.gov.ua/collections/kartina-mihaylo-hanenko-getman-pravoberezhnoi-ukraini-149568 | accessed 2026-07-04. Used for institutional image/context lead only; not assumed open-licensed.
+- [T5] *100 великих постатей і подій козацької України*, "Михайло Ханенко." URL: https://uahistory.co/book/100-great-figures-and-events-of-cossack-ukraine/36.php | accessed 2026-07-04. Popular synthesis with useful Chukhlib-derived leads; not load-bearing.
+
+**Primary-source documents accessed / verification notes:**
+
+- Khanenko letters/instructions published by Mytsyk 2024 from Biblioteka
+  Książąt Czartoryskich and other Polish archival holdings: short excerpts
+  used only as source-language anchors; manuscripts not directly inspected.
+- Khanenko letter excerpts cited by Chukhlib 2017 through *Akty
+  Yugo-Zapadnoi Rossii*: short anti-Doroshenko phrases used only with
+  context; source edition not directly inspected.
+- Ostroh Agreement source references via ЕІУ: Biblioteka Czartoryskich,
+  *Volumina legum*, and *Akty Yugo-Zapadnoi Rossii* listed as source leads;
+  treaty text not fully transcribed in this dossier.
+
+**Honest gaps:** this dossier did not inspect Polish archival manuscripts,
+full *Akty Yugo-Zapadnoi Rossii* volumes, complete Ostroh Agreement text, or
+all Buchach / Lysianka / Baturyn materials. It also did not run quote-verifier
+or LLM-QG. For module writing, verify Khanenko's exact letter wording, office
+date ranges, family details, and 1677 imprisonment sequence against direct
+source editions.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Muscovy appears as a historical power in the
+  partition, Left-Bank, Samoilovych, and 1677 arrest layers, not as Ukraine's
+  natural arbiter.
+- [x] Khanenko is not flattened into a "Polish puppet," "traitor," "bandit,"
+  dynastic footnote, or proto-national hero.
+- [x] Doroshenko's Ottoman protectorate, Commonwealth recognition, Crimean
+  alliances, and Muscovite pressure are all treated as source-attributed
+  historical powers and choices.
+- [x] Commonwealth royal figures are included only as context-bearing powers;
+  they are not added as BIO subjects and do not center the narrative.
+- [x] No Russian-imperial transliterations in body text except variant /
+  forbidden forms in §8.
+- [x] The Right-Bank social cost is named directly; the dossier does not make
+  elite treaty maneuvers the whole story.
+- [x] Mazepa appears only as a later Uman-regiment institutional echo and
+  cross-track comparator, not as part of Khanenko's own biography.
+- [x] Modern-statehood Hetmanate analogies are explicitly out of scope.
+- [x] Modern Ukrainian place naming used with historical context: Uman,
+  Ostroh, Stebliv, Bratslav, Yamphil, Lysianka, Baturyn, Right Bank, Left Bank,
+  Chyhyryn, Kyiv.
+
+## Validation checklist
+
+- [x] Single owned file only: `docs/research/bio/mykhailo-khanenko.md`.
+- [x] Existing cross-track plan paths verified locally before citation.
+- [x] Lower-tier sources marked as non-load-bearing.
+- [x] No generated `status/`, `audit/`, `review/`, or telemetry artifacts
+  referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans,
+  module files, activities, vocabulary, resources, site MDX, or wiki files
+  edited.


### PR DESCRIPTION
## Summary

Adds the Phase 1 source/content readiness dossier for Mykhailo Khanenko under the BIO Cossack coverage epic (#4215).

Changed file:
- `docs/research/bio/mykhailo-khanenko.md`

## Notes

- Keeps the work scoped to a research dossier only; no plans, curriculum modules, wiki packets, generated artifacts, telemetry, or config files were edited.
- Frames Khanenko as a Ruin-era Right-Bank claimant hetman with source-tier discipline, office chronology uncertainty, alias/transliteration notes, Ottoman/Commonwealth/Muscovy context, Mazepa-era institutional echo caveat, and decolonization safeguards.
- Does not run or rely on LLM-QG.

## Validation

- `npx markdownlint-cli2 docs/research/bio/mykhailo-khanenko.md` — passed, 0 errors
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/mykhailo-khanenko.md` — passed
- `git diff --check origin/main...HEAD` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- `git diff --name-only origin/main...HEAD` — `docs/research/bio/mykhailo-khanenko.md` only