### PR TITLE
docs(bio): add Ostap Dashkevych dossier

### DIFF
--- a/docs/research/bio/ostap-dashkevych.md
+++ b/docs/research/bio/ostap-dashkevych.md
@@ -1,0 +1,412 @@
+# Остафій Дашкович / Остап Дашкевич — Research Dossier
+
+**Slug:** `ostap-dashkevych`
+**Block:** BIO Cossack coverage — early frontier commanders and starosta
+figures
+**Tier:** 1b
+**Issue:** #4215
+**Researcher:** Codex GPT-5
+**Completed:** 2026-07-04
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Остафій Дашкович. The project slug uses
+  the learner-facing search form `ostap-dashkevych`; the dossier keeps both
+  the source-critical `Дашкович` and the common `Дашкевич` form visible.
+- **Pseudonyms / aliases:** Остафій Дашкевич; Остап Дашкевич; Остап
+  Дашкович; Євстахій Дашкевич; Ostafii Dashkevych; Ostap Dashkevych;
+  Ostafii Dashkovych; Ostap Dashkovych; Daškevyč; Eustachy Daszkiewicz.
+  Russian-imperial search forms such as `Евстафий Дашкевич` are aliases for
+  source discovery only and should not become body-text defaults.
+- **Born:** exact date and place unknown. IEU gives circa 1455; EIU leaves
+  the birth year unknown. He came from a landholding / boyar milieu in the
+  Kyiv-Ovruch region of the Grand Duchy of Lithuania.
+- **Died:** 1535; exact date, place, and cause are not securely attested.
+  Cherkas notes that by 26 February 1536 his sister Milokhna had received a
+  royal privilege connected with his testamentary estates, so death in 1535
+  is the secure working terminus.
+- **Family / education key facts:** EIU identifies him as from an Ovruch
+  noble family. Cherkas reconstructs him as a member of an old landholding
+  family of the southern Kyiv region, son of Ivan Dashkovych, with relatives
+  in Grand Duchy of Lithuania offices and possible Tatar noble ancestry. Some
+  later accounts mention early travel in Germany and France, but that is not
+  a load-bearing curriculum fact.
+
+Career anchors that can be treated as stable with source-tier caution:
+
+- Early sixteenth century — held Krychev office / starostvo in the Grand
+  Duchy of Lithuania context.
+- 1503-1507 — passed through Muscovite service after conflict and captivity
+  on the Lithuanian-Muscovite frontier; by 1507 returned to the
+  Lithuanian-Ruthenian political field during the Hlynsky revolt.
+- By 1510 — Kaniv office / namisnyk role is attested in Cherkas.
+- 1514-1535 — Cherkasy and Kaniv starosta offices become the main frame for
+  his public career.
+- 1532 — Cherkasy resisted the campaign of Crimean khan Saadet Giray I.
+- 1533 — at the Piotrków Sejm, Dashkovych presented a lower-Dnipro defense
+  and fortress / guard-service proposal; contemporary approval did not
+  produce the necessary funds or implementation.
+
+The dossier should teach Dashkovych as an early Cossack frontier commander and
+state officeholder, not as a confirmed founder of the Zaporizhian Sich or a
+formal Cossack hetman in the later institutional sense.
+
+## 2. Oppression mechanism
+
+This figure is not a Russian/Soviet police-oppression biography. The
+load-bearing mechanism is frontier violence, state extraction and control, and
+later historiographical appropriation of early Cossack origins.
+
+- **What happened:** Dashkovych operated in a militarized border zone where
+  Cherkasy and Kaniv had to withstand Crimean Tatar raids, Ottoman-Crimean
+  pressure, Lithuanian-Muscovite wars, unstable alliances, and chronic central
+  underfunding. His own office also participated in coercion: taxation,
+  judicial authority, population control, and the mobilization of armed
+  groups.
+- **When:** c. 1501-1535, with especially teachable moments in 1514-1519,
+  1521-1524, 1527, 1532, and 1533.
+- **By whom:** not a single agency. Relevant actors are the Grand Duchy of
+  Lithuania / Polish-Lithuanian state apparatus, frontier starostas including
+  Dashkovych himself, the Crimean Khanate, the Ottoman frontier system, and
+  Muscovy. Later national and imperial historiographies also reshaped his
+  memory.
+- **Document references:** EIU "Дашкевич Остафій"; IEU "Dashkevych,
+  Ostafii"; Galushko's EIU overview "Формування українського козацтва";
+  Cherkas's 2002 UHJ article using *Acta Tomiciana*, Lithuanian-Metryka, and
+  other early-modern documentary material.
+- **Mechanism specifics:** Cherkasy and Kaniv were not romantic "Cossack
+  homeland" abstractions. They were vulnerable fortified towns on the southern
+  edge of the Grand Duchy of Lithuania, close to the steppe routes and the
+  lower Dnipro crossings. Local administrators needed armed people who knew
+  the frontier, but central authorities also feared uncontrolled raids and
+  diplomatic incidents. This is the institutional tension behind the 1524
+  discussion of keeping Cossacks in state service and Dashkovych's 1533 plan
+  for lower-Dnipro fortifications.
+- **What survived / what was destroyed:** no corpus of personal writing by
+  Dashkovych is available for curriculum use. What survives is a documentary
+  trace in state correspondence, embassy records, chronicles, encyclopedic
+  synthesis, and later historiography. The main thing destroyed by careful
+  source work is the simple founder myth.
+
+For pedagogy, this section should help learners see why "Cossack" in the
+early sixteenth century was still a fluid frontier status and practice, not
+yet the later registered estate or Sich-centered political identity.
+
+## 3. Major works
+
+Dashkovych left no literary "works." The curriculum anchors are actions,
+offices, proposals, and later reception.
+
+- `1501` — campaign as Krychev officeholder against Muscovite forces near
+  Mstsislavl; important for the Lithuanian-Muscovite frontier setting.
+- `1503` — departure into Muscovite service after conflict with Lithuanian
+  authorities; useful for teaching early-modern service politics without
+  modern loyalty labels.
+- `1507-1508` — involvement around the Hlynsky revolt and return to the
+  Grand Duchy of Lithuania side.
+- `1510` — Kaniv office attested in Cherkas; establishes the lower-Dnipro /
+  middle-Dnipro frontier frame before the better-known 1514 date.
+- `1514` — Cherkasy and Kaniv starosta role becomes the central public
+  identity in EIU / IEU summaries.
+- `1515` — campaign with Cossack and Crimean Tatar elements toward
+  Muscovite lands; good example of unstable frontier alliances.
+- `1517` — diplomatic work connected with Crimean Khanate negotiations and
+  embassy security.
+- `1518-1519` — defense and counteraction around Tatar raids; Cherkas reads
+  the complaints about Cherkasy Cossacks as evidence of Dashkovych's
+  administrative role.
+- `1521` — expeditionary action against Muscovy with Crimean-Tatar alliance
+  context; should not be framed as "Ukrainians served Moscow" or as a simple
+  anti-Moscow national story.
+- `1522-1524` — early state discussion of keeping Cossacks on the Dnipro for
+  frontier service; a failed institutional project because funding did not
+  follow.
+- `1523` — action against Islam-Kermen on the lower Dnipro, treated by
+  Cherkas as part of broader state frontier policy rather than an ordinary
+  freebooting raid.
+- `1527` — Dashkovych's intelligence and participation around the battle of
+  Olshanytsia near Cherkasy.
+- `1532` — defense of Cherkasy during the campaign of Saadet Giray I.
+- `1533` — presentation at the Piotrków Sejm of a lower-Dnipro guard /
+  fortress proposal; approved in principle but not funded.
+- `1535` — final reported campaign into Muscovite lands with a large Cossack
+  force in Bielski's account; death followed the same year.
+
+## 4. Primary-source quotes (>=2 required)
+
+No reliable direct writing or recorded speech by Dashkovych was found. These
+are therefore source-language anchors about him and his frontier context, not
+personal quotations. Do not present them as Dashkovych's own words.
+
+- "весьма искусный въ военном деле" — Herberstein's near-contemporary
+  characterization as cited by Cherkas. Pedagogical value: shows that
+  contemporaries remembered him for military craft, not only for later
+  Cossack legend.
+- "славним козаком" — Lithuanian-Zhmud chronicle wording cited by Cherkas.
+  Pedagogical value: useful for discussing what "Cossack" could mean before
+  the later Sich / registered institutions.
+- "тысяча або две людей наших козаков" — wording in the 1524 service-project
+  discussion cited by Cherkas. Pedagogical value: anchors the state desire to
+  use Cossack manpower without yet creating a stable later institution.
+- "Черкаскіе и Каневскіе" Cossacks — Sahib Giray's complaint as cited by
+  Cherkas. Pedagogical value: ties Cossack activity directly to Cherkasy and
+  Kaniv without making Dashkovych a formal hetman.
+
+Production note: if the module later needs longer quotations, quote from a
+verified source edition such as *Acta Tomiciana* or Lithuanian-Metryka
+materials, not from unsourced web summaries.
+
+## 5. Language register
+
+- **Register:** early-modern bureaucratic, military-diplomatic, and
+  historiographic prose; no literary oeuvre by the figure.
+- **CEFR readiness for full reading:** B2 for adapted biography and maps; C1
+  for modern Ukrainian scholarly prose; C1/C2 for early-modern source
+  excerpts with Ruthenian / Polish / Church-Slavonic-influenced forms.
+- **Lexicon notes:** староста, намісник, Черкаси, Канів, Кримське ханство,
+  улус, ясир, Дике Поле, перевоз, низ Дніпра, город, сейм, упоминки,
+  козаки, козакування, реєстр.
+- **Stylistic features:** good lesson material includes source-modal verbs
+  and hedging: "ймовірно," "за свідченням," "у пізнішій традиції,"
+  "історіографія перебільшувала." Learners should practice distinguishing
+  office titles, military actions, and later memory claims.
+
+The best learner task is a three-column table: what the sources attest, what
+later tradition claims, and what a responsible textbook sentence can say.
+
+## 6. Contested points
+
+- **Name form:** EIU headword uses `Дашкевич (Дашкович) Остафій`; IEU uses
+  `Dashkevych, Ostafii` with `aka Dashkovych`. Cherkas argues from document
+  signatures that `Дашкович` is the source-critical form. The project slug
+  can remain `ostap-dashkevych` for searchability, but body text should flag
+  the issue instead of silently choosing one form.
+- **Birth chronology:** circa 1455 in IEU is a useful approximate date, but
+  EIU gives birth year unknown. Do not build lesson chronology on a precise
+  birth year.
+- **"First hetman" / founder myth:** older historiography and popular memory
+  often call Dashkovych one of the first Cossack hetmans or organizers. EIU
+  explicitly cautions that his relations with Cossacks were unofficial and
+  that he was primarily a Lithuanian-era military and state figure. IEU says
+  he is traditionally but incorrectly considered the first Cossack hetman.
+- **Early Cossack institution:** Galushko's EIU overview stresses that in the
+  first decades of the sixteenth century `козак` was not yet a stable social
+  estate but a way of life / occupation. It also says nineteenth-century
+  historiography exaggerated the role of frontier administrators as "first
+  hetmans." The first historically documented Zaporizhian Sich belongs in the
+  1570s Tomakivka frame, not Dashkovych's 1533 proposal.
+- **Raider, defender, or state servant:** none of these labels is sufficient.
+  Dashkovych defended Cherkasy and Kaniv, supported and directed Cossack
+  forces, joined campaigns against Muscovite lands, handled Crimean diplomacy,
+  and used coercive frontier authority. A lesson should show the mix rather
+  than selecting a single moralized role.
+- **Crimean Tatar / Ottoman framing:** some actions were anti-Crimean, some
+  involved diplomacy, and some involved Crimean alliances against Muscovy.
+  Avoid anti-Tatar or anti-Muslim essentializing language. The problem is
+  frontier politics and raiding economies, not ethnicity.
+- **Commonwealth-ruler centering:** Commonwealth crown and Sejm decisions are
+  necessary context for 1524 / 1533 funding failure, but the narrative should
+  not turn Dashkovych into an accessory in a royal biography. The center of
+  gravity is Cherkasy, Kaniv, the lower Dnipro, and early Cossack institutional
+  formation.
+- **Muscovy service:** his temporary service to Moscow and involvement around
+  the Hlynsky revolt should be framed as early-modern elite service politics,
+  not as modern treason, national conversion, or evidence that Muscovy owns
+  the Cossack-origin story.
+- **Local coercion:** Cherkas preserves debate over Dashkovych's treatment of
+  townspeople, taxes, and administrative pressure. This is a de-hagiographic
+  point: a frontier defender could also be a hard local officeholder.
+
+Safe production sentence: "Остафій Дашкович був черкаським і канівським
+старостою, який використовував і підтримував ранні козацькі загони на
+південному прикордонні, але не був засновником Січі чи доведено першим
+гетьманом у пізнішому інституційному сенсі."
+
+## 7. Cross-track links
+
+> **VERIFY BEFORE ASSERTING:** paths listed under "Existing" were checked
+> before inclusion. Unbuilt BIO / wiki connections stay under "Candidate."
+
+- **Existing BIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/bio/dmytro-vyshnevetsky.yaml` — later
+    Cherkasy / Kaniv starosta and founder-memory problem.
+  - `curriculum/l2-uk-en/plans/bio/severyn-nalyvaiko.yaml` — later Cossack
+    revolt and the shift from fluid frontier practice to wider political
+    mobilization.
+  - `curriculum/l2-uk-en/plans/bio/petro-sahaidachny.yaml` — later Cossack
+    institutional leadership, useful contrast with Dashkovych.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/kozatstvo-vytoky.yaml` — early Cossack
+    origins and `козакування`.
+  - `curriculum/l2-uk-en/plans/hist/zaporizka-sich.yaml` — later Sich
+    institution; use to avoid backdating.
+  - `curriculum/l2-uk-en/plans/hist/kozatski-povstannia-16.yaml` —
+    sixteenth-century Cossack frontier escalation.
+  - `curriculum/l2-uk-en/plans/hist/dmytro-vyshnevetskyi.yaml` — later
+    Cossack founder-memory comparison.
+  - `curriculum/l2-uk-en/plans/hist/kozatske-viisko.yaml` — Cossack military
+    organization and vocabulary.
+  - `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml` —
+    Polish-Lithuanian state context, handled as context rather than center.
+- **Existing RUTH / ISTORIO modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/ruth/cossack-hierarchy.yaml` — titles and
+    offices, with caution against anachronism.
+  - `curriculum/l2-uk-en/plans/ruth/szlachta-nobility.yaml` — Ruthenian /
+    Lithuanian noble service context.
+  - `curriculum/l2-uk-en/plans/ruth/diplomatic-language.yaml` — frontier
+    correspondence and embassy vocabulary.
+  - `curriculum/l2-uk-en/plans/ruth/treason.yaml` — early-modern service
+    switching and the risk of modern moral labels.
+  - `curriculum/l2-uk-en/plans/istorio/sich-dokumenty.yaml` — source
+    documents for later Sich memory.
+  - `curriculum/l2-uk-en/plans/istorio/kozatski-litopysy-ohliad.yaml` —
+    chronicle reception and retroactive founder narratives.
+- **Existing wiki / research files (VERIFIED present via `test -e`):**
+  - `wiki/periods/kozatstvo-vytoky.md` — mentions early Cossack context.
+  - `wiki/periods/zaporizka-sich.md` — mentions Dashkevych's 1533 project.
+  - `wiki/figures/dmytro-vyshnevetsky.md` — includes Dashkevych in early
+    Cossack chronology.
+  - `docs/research/bio/dmytro-vyshnevetsky.md` — paired founder-memory
+    caution.
+  - `docs/research/bio/petro-sahaidachny.md` — later institutional Cossack
+    leadership contrast.
+  - `docs/research/bio/mykhailo-doroshenko.md` — later Hetmanate-era
+    comparison.
+- **Candidate Phase 2+ cross-track connections (NOT existing files):**
+  - `curriculum/l2-uk-en/plans/bio/ostap-dashkevych.yaml` — BIO module plan
+    after dossier promotion.
+  - `wiki/figures/ostap-dashkevych.md` — future wiki packet after plan work.
+  - HIST / ISTORIO lesson on the 1524 and 1533 Cossack service proposals.
+  - HIST lesson slice on Cherkasy and Kaniv as early-sixteenth-century
+    frontier towns.
+  - Map activity showing Cherkasy, Kaniv, Tavan, Islam-Kermen, Ochakiv, and
+    lower-Dnipro routes without implying fixed national borders.
+- **Potential LIT additions surfaced by this research:**
+  - None. This dossier is better connected to HIST, RUTH, and ISTORIO than to
+    LIT because no personal literary corpus is known.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md` (#2313):
+
+- **Slug:** `ostap-dashkevych`
+- **EN canonical (BGN/PCGN 2010):** Ostap Dashkevych for the project slug and
+  learner-facing search. Use Ostafii Dashkovych / Ostafii Dashkevych in source
+  notes where the citation requires it.
+- **UA canonical (with patronymic if attested):** Остафій Дашкович. Display
+  alias: Остап Дашкевич.
+- **Aliases (track these for `aliases:` YAML field):** Остафій Дашкевич;
+  Остафій Дашкович; Остап Дашкевич; Остап Дашкович; Євстахій Дашкевич;
+  Ostafii Dashkevych; Ostafii Dashkovych; Ostap Dashkevych; Ostap
+  Dashkovych; Daškevyč; Eustachy Daszkiewicz.
+- **Forbidden forms (Russian-imperial transliterations to flag in body
+  text):** Evstafii Dashkevich; Evstafy Dashkevich; Ostafii Dashkevich;
+  Евстафий Дашкевич; Остафий Дашкевич; Дмитрий-style Anglicization patterns
+  are not applicable but the `-vich` default should be avoided.
+
+## 9. Image candidates
+
+Per `docs/best-practices/bio-image-rights.md` (#2316):
+
+- **Best PD/CC portrait:** Jan Matejko portrait of Ostafii Dashkevych is the
+  likely lead candidate because Matejko died in 1893, but the exact digital
+  file license must be checked before use. IEU displays the portrait but is
+  not itself an open-license source.
+- **Backup candidates:** Wikimedia Commons search for `Ostafii Dashkevych`,
+  `Ostap Dashkevych`, `Eustachy Daszkiewicz`, and `Jan Matejko Dashkevych`;
+  museum collection records for Matejko portraits; public-domain historical
+  maps of Cherkasy / Kaniv / lower Dnipro if no portrait file has clean rights.
+- **If no PD/CC portrait exists:** use a rights-clear map or context image
+  rather than modern fantasy Cossack art.
+- **Era-appropriate context image:** map of Cherkasy, Kaniv, Tavan,
+  Islam-Kermen, and Ochakiv; a rights-clear image of Cherkasy old-town /
+  fortress context; or a public-domain early-modern Dnipro frontier map.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- В. О. Щербак, "Дашкевич Остафій," *Енциклопедія історії України*, т. 2,
+  2004, https://www.history.org.ua/?termin=Dashkevych_O, accessed
+  2026-07-04.
+- "Dashkevych, Ostafii," *Internet Encyclopedia of Ukraine*,
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CD%5CA%5CDashkevychOstafii.htm,
+  accessed 2026-07-04.
+- К. Ю. Галушко, упоряд., "Формування українського козацтва,"
+  *Енциклопедія історії України: Україна-Українці*, кн. 2, 2019,
+  https://www.history.org.ua/?termin=2.%208.%206, accessed 2026-07-04.
+- В. О. Щербак, "Козацтво українське," *Енциклопедія історії України*, т. 4,
+  2007, https://www.history.org.ua/?termin=Kozatstvo_ukrainske, accessed
+  2026-07-04.
+- Д. П. Куштан, "Черкаси, обласний центр," *Енциклопедія історії України*,
+  т. 10, 2013, https://www.history.org.ua/?termin=Cherkasy_mst, accessed
+  2026-07-04.
+- "Cossacks," *Internet Encyclopedia of Ukraine*,
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CC%5CO%5CCossacks.htm,
+  accessed 2026-07-04.
+- "Registered Cossacks," *Internet Encyclopedia of Ukraine*,
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CE%5CRegisteredCossacks.htm,
+  accessed 2026-07-04.
+- "Cherkasy," *Internet Encyclopedia of Ukraine*,
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CC%5CH%5CCherkasy.htm,
+  accessed 2026-07-04.
+- "Lanckoroński, Predslav," *Internet Encyclopedia of Ukraine*,
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CL%5CA%5CLanckoroI8skiPredslav.htm,
+  accessed 2026-07-04.
+
+**Tier 2 (institutional / source-edition leads):**
+
+- *Acta Tomiciana*, Lithuanian-Metryka, and Archive of Southwestern Rus'
+  materials as cited and interpreted by Cherkas and EIU. These are source
+  leads, not directly quoted here except through the named scholarly article.
+
+**Tier 3 (encyclopedic):**
+
+- General encyclopedia and wiki-style pages were used only for search
+  navigation and were not load-bearing.
+
+**Tier 4 (modern scholarly post-1991):**
+
+- Б. В. Черкас, "Остафій Дашкович — черкаський і канівський староста XVI
+  ст.," *Український історичний журнал*, 2002, № 1, с. 53-67,
+  https://resource.history.org.ua/publ/journal_2002_1_53, accessed
+  2026-07-04. PDF mirror:
+  https://nasu-periodicals.org.ua/index.php/uhj/article/download/23935/21316.
+
+**Tier 5 (general web):**
+
+- None used as load-bearing evidence.
+
+**Primary-source documents accessed:**
+
+- No direct source edition was independently quoted in this dossier. Primary
+  material is mediated through Cherkas, EIU, and IEU until a later module
+  pass verifies source-edition pages.
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; Muscovy is one actor, not the narrative center.
+- [x] No Polish-ruler-centered biography; Sejm and royal funding decisions
+  are context, not the protagonist.
+- [x] No founder myth: "first hetman" and "founder of the Sich" claims are
+  explicitly qualified.
+- [x] No flattening into pure raider, bandit, proto-nationalist, or simple
+  Commonwealth-service figure.
+- [x] No anti-Tatar or anti-Muslim essentializing language.
+- [x] Cherkasy / Kaniv frontier context is central.
+- [x] Early Cossack institutional claims are separated from later Sich and
+  registered-Cossack structures.
+- [x] Modern-statehood Hetmanate analogies are not used as a frame.
+
+## Acceptance self-check
+
+- [x] All 10 dossier sections completed.
+- [x] At least three Tier 1 / Tier 2 sources cited.
+- [x] Oppression / pressure mechanism is specific to frontier violence,
+  state control, and historiographical appropriation.
+- [x] Direct personal quotes are not fabricated; source-language anchors are
+  labeled as non-personal.
+- [x] Existing cross-track paths were checked before inclusion.
+- [x] Naming-canonical issue is explicit.
+- [x] Image candidates identified with rights caveat.
+- [x] LLM-QG was not run, trusted, routed, persisted, or closed.


### PR DESCRIPTION
## Summary
- Adds the Ostap Dashkevych BIO Cossack research dossier.
- Keeps scope to source/content readiness only; no module, plan, wiki, generated, telemetry, or config changes.
- Notes contested early-Cossack institutional claims, Cherkasy/Kaniv frontier context, aliases/transliteration, source-tier caveats, and decolonization risks.

Epic: #4215

## Validation
- `npx markdownlint-cli2 docs/research/bio/ostap-dashkevych.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/ostap-dashkevych.md`
- `git diff --check origin/main...HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `git diff --name-only origin/main...HEAD` => `docs/research/bio/ostap-dashkevych.md`

LLM-QG was not run, trusted, routed, persisted, or closed.