### PR TITLE
[codex] add Hryhorii Loboda BIO dossier

### DIFF
--- a/docs/research/bio/hryhorii-loboda.md
+++ b/docs/research/bio/hryhorii-loboda.md
@@ -1,0 +1,682 @@
+# Григорій Лобода — Research Dossier
+
+**Slug:** `hryhorii-loboda`
+**Block:** P1 BIO Cossack coverage (late-sixteenth-century Lowland Cossack
+leadership; Moldavian / lower-Danube campaigns; Ovruch control zone; Loboda /
+Nalyvaiko / Shaula coordination and rivalry; Solonytsia siege; internal-camp
+execution under suspicion; source-memory caution)
+**Tier:** 1b (strong event context through EIU / IEU; source-thin early life,
+office chronology, and death-date precision)
+**Issue:** #4215 (BIO full Cossack coverage epic — P1 dossier)
+**Researcher:** GPT-5 (Codex)
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕІУ Loboda, ЕІУ Moldavian campaigns,
+  ЕІУ Nalyvaiko uprising, ЕІУ Solonytskyi battle, IEU Loboda, Hrushevsky
+  chapter via Izbornyk)
+- [x] Source-tier checkboxes included and lower-tier sources kept
+  non-load-bearing
+- [x] Oppression/appropriation mechanism is specific (§2: externally useful
+  anti-Ottoman service, blocked return from Moldavia, Cossack quartering and
+  jurisdiction on the volost, Commonwealth punitive campaign, Solonytsia
+  blockade, internal suspicion, and post-defeat repression)
+- [x] §4 includes short source-language anchors with verification caveats
+- [x] Loboda is framed as complex: organized Lowland Cossack leader,
+  anti-Ottoman campaign commander, negotiation-oriented starshyna figure,
+  co-leader/rival of Nalyvaiko and Shaula, and victim of internal execution
+  during the siege
+- [x] Cross-track links: every "Existing" plan/wiki/dossier path verified
+  locally with `test -e` on 2026-07-04 after rebasing to `origin/main`
+- [x] Naming-canonical applied; `Григорій Лобода` / `Hryhorii Loboda` are
+  canonical, while older spellings and search variants are tracked as
+  source/search metadata only
+- [x] Image candidate(s) and rights caveats identified
+- [x] Decolonization checklist self-applied
+- [x] LLM-QG was not used
+
+**Source-tier self-check:**
+
+- [x] **T1 baseline:** ЕІУ `Лобода Григорій` anchors unknown birth year, June
+  1596 death, Cossack-starshyna identity, 1594-1596 hetman label, Orhei /
+  Akkerman / Moldavian campaigns, Ovruch headquarters, 8,000-10,000 force
+  estimate, readiness for reconciliation, Bila Tserkva fighting, secret
+  negotiations, and Solonytsia arrest/execution under suspicion.
+- [x] **T1 English baseline:** IEU `Loboda, Hryhorii` anchors English spelling,
+  uncertain birth in the Kyiv region, May 1596 death variant, registered
+  Cossack office with interruptions, Moldavian anti-Ottoman participation, and
+  death by Nalyvaiko supporters during Solonytsia after attempted
+  accommodation.
+- [x] **T1 event context:** ЕІУ Moldavian campaigns, Nalyvaiko uprising, and
+  Solonytskyi battle anchor the campaign sequence, Cossack international
+  military-political agency, Ovruch control zone, volost jurisdiction, punitive
+  campaign, Solonytsia camp geography, shortage/blockade, Loboda's execution,
+  capitulation, and post-capitulation violence.
+- [x] **T2/T4 source-critical layer:** Hrushevsky's chapter is used for
+  source-language and historiographic framing around Loboda as a central
+  Lowland Cossack figure, old-source social labeling, negotiation dynamics,
+  and the Solonytsia suspicion mechanism. It is not used as neutral classroom
+  quotation without caveat.
+- [x] **T4 specialist lead:** Lepiavko's *Cossack Wars of the Late Sixteenth
+  Century in Ukraine* is cited through EIU bibliographies and article
+  authorship; direct book text was not fully inspected in this worker pass.
+- [x] **T3/T5 caution:** Wikipedia, popular pages, commemorative posts,
+  textbook snippets, and image-search surfaces are navigation or rights leads
+  only; they are not load-bearing for fact or interpretation.
+
+---
+
+## 1. Verified Facts
+
+- **Full name (UA, canonical):** Григорій Лобода. ЕІУ titles the entry
+  `ЛОБОДА Григорій`; IEU gives `Loboda, Hryhorii [Лобода, Григорій]`. Use
+  `Hryhorii Loboda` for English curriculum metadata. [T1: ЕІУ Loboda; T1:
+  IEU Loboda]
+- **Aliases / spelling variants:** Григорій Лобода; Грицько Лобода as a
+  search variant in later retellings; Hryhorii Loboda; Hryhoriy Loboda;
+  Loboda, Hryhorii; older-source `Лобода Григорий`; Polish/Latin-script
+  `Loboda` / `Łoboda` forms in source indexes. Do not treat these as separate
+  people. [T1: ЕІУ; T1: IEU; T2/T4: Hrushevsky]
+- **Born:** unknown. IEU gives an uncertain Kyiv-region origin, while ЕІУ does
+  not secure a birthplace or birth year. Do not use the precise birth dates
+  found on lower-tier pages. [T1: ЕІУ Loboda; T1: IEU Loboda]
+- **Died:** during the Solonytsia crisis in 1596. ЕІУ Loboda gives death in
+  **June 1596**; IEU gives **May 1596**; the EIU Solonytskyi battle entry
+  places his killing before the 5-6 June bombardment/capitulation sequence.
+  Use "during the Solonytsia siege, late May / early June 1596" unless a
+  lesson is explicitly comparing calendars and source compression. [T1: ЕІУ
+  Loboda; T1: IEU Loboda; T1: ЕІУ Solonytskyi battle]
+- **Death mechanism:** he was arrested by Cossacks in the camp over suspicion
+  of treason and soon executed. IEU attributes the killing to Nalyvaiko's
+  supporters because Loboda was attempting to come to terms with the opposing
+  side; ЕІУ says he conducted secret negotiations and was killed after retreat
+  to the Solonytsia camp. Avoid turning this into a proven moral verdict
+  against Loboda or a clean "betrayal" scene. [T1: ЕІУ Loboda; T1: IEU
+  Loboda; T2/T4: Hrushevsky]
+- **Office / constituency:** ЕІУ calls him Cossack starshyna and hetman of the
+  Zaporozhian Host in **1594-1596**; IEU calls him hetman of the registered
+  Cossacks in **1593-1596, with interruptions**. Hrushevsky frames him as a
+  leader of the organized Lowland Cossacks. Use `Cossack leader / hetman`
+  with constituency and source caveat, not a timeless office label. [T1: ЕІУ
+  Loboda; T1: IEU Loboda; T2/T4: Hrushevsky]
+- **First secure notice:** ЕІУ says the first notice considered secure is a
+  late-1593 record that Loboda campaigned against Orhei in Moldavia. [T1: ЕІУ
+  Loboda]
+- **1594 Akkerman operation:** in March-April 1594 he commanded a Cossack
+  detachment in the campaign toward Akkerman / Bilhorod-Dnistrovskyi. [T1:
+  ЕІУ Loboda; T1: ЕІУ Moldavian campaigns]
+- **Autumn 1594 Moldavian campaign:** he was one of the commanders of the
+  Cossack force that occupied Moldavia. ЕІУ Moldavian campaigns gives a
+  combined Cossack force under Loboda, Nalyvaiko, and Jan Oryshovsky of up to
+  12,000 that took Moldavia including Iași and pushed the Moldavian ruler into
+  the anti-Ottoman coalition. [T1: ЕІУ Loboda; T1: ЕІУ Moldavian campaigns]
+- **1595 lower-Danube / Dniester campaign:** in February-May 1595 Loboda's and
+  Nalyvaiko's detachments operated within the anti-Ottoman Holy League context
+  alongside Moldavian, Wallachian, and Transylvanian forces. Teach this as
+  early-modern frontier coalition warfare, not as simple national alignment.
+  [T1: ЕІУ Loboda; T1: ЕІУ Moldavian campaigns; T1: IEU Loboda]
+- **International agency:** ЕІУ Moldavian campaigns concludes that the
+  Ukrainian Cossacks first appeared there as an independent subject of
+  international military-political relations. Use this cautiously: it means
+  military-diplomatic agency in a frontier coalition, not a modern diplomatic
+  state analogy. [T1: ЕІУ Moldavian campaigns]
+- **Autumn 1595-winter 1596 control zone:** ЕІУ Loboda says his force,
+  estimated at **8,000-10,000** Cossacks, effectively controlled Kyiv region
+  and southern Belarus, with Loboda's headquarters in Ovruch. ЕІУ Nalyvaiko
+  uprising places the main Cossack force, up to 10,000, in the army of Loboda
+  and Matvii Shaula, with separate regiments under other colonels. [T1: ЕІУ
+  Loboda; T1: ЕІУ Nalyvaiko uprising]
+- **How Loboda understood the 1595-1596 presence:** ЕІУ Loboda says he did not
+  regard these actions as disobedience to authority but as a way for Cossacks
+  to rebuild strength; documentary evidence shows readiness for reconciliation
+  with the government. Keep that source claim visible, while also naming the
+  coercive effects on local communities. [T1: ЕІУ Loboda; T1: ЕІУ Nalyvaiko
+  uprising]
+- **Volost coercion:** ЕІУ Nalyvaiko uprising says Cossack quartering fell
+  heavily on noble estates, local authority was paralyzed, peasant flight and
+  "becoming Cossack" accelerated, Cossack jurisdiction appeared in towns and
+  villages, and taxes were collected for the Zaporozhian Host. This is the
+  hard social layer behind Loboda's "restoring strength" argument. [T1: ЕІУ
+  Nalyvaiko uprising]
+- **Spring 1596 campaign:** Loboda fought against the Commonwealth punitive
+  force near Bila Tserkva. EIU event context also places Matvii Shaula, Sashko
+  Popovych/Sasko, and other officers in this military layer. [T1: ЕІУ Loboda;
+  T1: ЕІУ Nalyvaiko uprising; T1: ЕІУ Sasko]
+- **Solonytsia camp:** after retreat toward Lubny, the insurgent wagon camp
+  stood over the Solonytsia, near the Sula/Lubny area. ЕІУ Solonytskyi battle
+  describes a camp of wagons and earthworks, 6,000-12,000 people including
+  women and children, blockade, hunger and water shortage, internal conflict,
+  heavy bombardment, capitulation, and post-capitulation violence. [T1: ЕІУ
+  Solonytskyi battle; T2/T4: Hrushevsky]
+- **Relation to Nalyvaiko:** Loboda and Nalyvaiko cooperated in Moldavian and
+  anti-Ottoman operations, coordinated during the 1595-1596 pressure cycle,
+  and then clashed over strategy, social constituency, and possible terms of
+  settlement. Do not collapse Loboda into Nalyvaiko's biography or make
+  Nalyvaiko the only protagonist. [T1: ЕІУ Loboda; T1: ЕІУ Nalyvaiko uprising;
+  Existing dossier: `docs/research/bio/severyn-nalyvaiko.md`]
+
+**Source disagreement / correction note (flagged, not smoothed):**
+
+1. **Birth details:** unknown is the safe baseline. Kyiv-region origin is IEU
+   only; lower-tier exact dates should not be used.
+2. **Death month:** ЕІУ gives June; IEU gives May; event sequence points to
+   the Solonytsia siege before capitulation. Use late May / early June with
+   attribution.
+3. **Office title:** hetman / registered hetman / Zaporozhian hetman / Lowland
+   leader appear in different source layers. Explain constituency before
+   office.
+4. **"Registered" versus "Lowland":** IEU uses registered-Cossack language;
+   Hrushevsky and the event context emphasize the organized Lowland Cossack
+   Host. Avoid making these fixed moral categories.
+5. **Moldavian campaigns:** these were anti-Ottoman coalition operations inside
+   a volatile Danube-frontier field, not a simple story of one patron hiring
+   Cossacks.
+6. **1595-1596 volost presence:** Loboda's stated or source-attributed view
+   that the actions rebuilt Cossack strength must be held together with the
+   fact of quartering, local coercion, and social upheaval.
+7. **Negotiation:** readiness for reconciliation and secret talks are
+   source-supported; "traitor" is a camp accusation, not the dossier narrator's
+   verdict.
+8. **Death responsibility:** he was killed inside the Cossack camp under
+   suspicion, before the wider post-capitulation punishment. Do not describe
+   him as executed by Commonwealth authorities.
+9. **Nalyvaiko relation:** cooperation and rivalry both matter. A Loboda
+   lesson should not become only a Nalyvaiko appendix.
+10. **Modern shorthand:** do not make Loboda a proto-state ruler, national
+    founder, class-war symbol, or collaborator caricature.
+
+## 2. Oppression / Appropriation Mechanism
+
+**What happened:** Loboda's biography shows the late-sixteenth-century Cossack
+problem before the later register settlements made the categories more formal.
+The Cossacks were useful in anti-Ottoman warfare and had their own diplomatic
+contacts, but after Moldavian access was blocked and armed units remained on
+the volost, their quartering, taxation, and jurisdiction became a direct
+challenge to Commonwealth authority and local estate power. Loboda's own line,
+as preserved by ЕІУ, was that the actions rebuilt Cossack strength rather than
+announcing rebellion. The social effect was harsher: local authority weakened,
+peasants fled or joined Cossack status, and the punitive campaign followed.
+[T1: ЕІУ Loboda; T1: ЕІУ Moldavian campaigns; T1: ЕІУ Nalyvaiko uprising]
+
+**By whom:** Commonwealth authorities and local estate power in the punitive,
+legal, and coercive-return layers; organized Lowland Cossacks, Nalyvaiko's
+followers, and allied or rival Cossack regiments in the mobilization layer;
+Moldavian, Wallachian, Transylvanian, Ottoman, and Habsburg-linked actors in
+the anti-Ottoman coalition layer; Loboda himself in the command and negotiation
+layer. He had agency: he led campaigns, controlled a large force, sought or
+accepted talks, and made choices that other Cossack factions could read as
+survival strategy or betrayal.
+
+**Document references:** late-1593 Orhei notice; the 1594-1595 Moldavian
+campaign layer; diplomatic contacts around the Holy League campaign; the
+Ovruch headquarters and 8,000-10,000 force estimate; Cossack jurisdiction and
+tax-taking on the volost; Bila Tserkva fighting; Solonytsia siege and
+capitulation reports; Hrushevsky's use of relations and correspondence; and
+EIU's post-defeat event summaries. [T1: ЕІУ Loboda; T1: ЕІУ Moldavian
+campaigns; T1: ЕІУ Nalyvaiko uprising; T1: ЕІУ Solonytskyi battle; T2/T4:
+Hrushevsky]
+
+**Mechanism specifics:** the pressure point is legitimacy. Loboda's Cossacks
+could plausibly present themselves as a military force regrouping after
+frontier campaigns, but local communities experienced requisition, taxation,
+and replacement of ordinary jurisdiction. Commonwealth authorities framed that
+as disorder; Cossack factions framed negotiation either as prudence or treason.
+The Solonytsia blockade then turned political disagreement into a survival
+crisis: hunger, water shortage, bombardment, families in the wagon camp, and
+rumors made factional accusation deadly.
+
+**What survived / what was distorted:** what survived is a thinner memory than
+Nalyvaiko's: Loboda appears as a co-leader, a cautious negotiator, and the man
+killed by his own camp. What gets distorted is the simplicity. Commonwealth
+source language can reduce him to disorder; patriotic memory can erase the
+coercion experienced by the volost; Nalyvaiko-centered retellings can make
+Loboda only a suspicious moderate; Soviet inheritance can compress the whole
+cycle into class struggle. A decolonized reading keeps all layers visible:
+frontier agency, social pressure, coalition warfare, Cossack self-organization,
+internal Cossack politics, punitive state response, and source uncertainty.
+
+## 3. Major Works / Legacy
+
+Loboda left no literary corpus; "works" means command roles, campaigns,
+negotiations, institutional claims, and memory afterlife.
+
+- `before late 1593` — early life remains source-thin. Do not invent a
+  childhood, precise birth date, lineage, or Moldavian/Romanian descent claim
+  from lower-tier retellings. [T1: ЕІУ Loboda; T1: IEU Loboda]
+- `late 1593` — first secure notice: campaign against Orhei in Moldavia. [T1:
+  ЕІУ Loboda; T1: ЕІУ Moldavian campaigns]
+- `March-April 1594` — commanded Cossacks in the Akkerman / Bilhorod-Dnistrovskyi
+  operation. [T1: ЕІУ Loboda; T1: ЕІУ Moldavian campaigns]
+- `July 1594 context` — imperial and papal-linked envoys negotiated with
+  Cossack representatives at/around the Bazavluk Sich and Prague route; this
+  belongs to the wider diplomatic context of the Moldavian campaigns. Do not
+  overstate Loboda's personal role unless a source names him in the document.
+  [T1: ЕІУ Moldavian campaigns; T1: ЕІУ Sasko]
+- `autumn 1594` — co-commanded the Cossack force that occupied Moldavia and
+  affected the anti-Ottoman coalition balance. [T1: ЕІУ Loboda; T1: ЕІУ
+  Moldavian campaigns]
+- `February-May 1595` — Loboda's and Nalyvaiko's units fought on the lower
+  Danube / Dniester front alongside regional anti-Ottoman allies. [T1: ЕІУ
+  Loboda; T1: ЕІУ Moldavian campaigns]
+- `June-September 1595 context` — Nalyvaiko's separate Hungarian-front
+  activity shows that the coalition network did not map neatly onto one
+  commander. Keep Loboda and Nalyvaiko related but distinct. [T1: ЕІУ
+  Moldavian campaigns; Existing dossier:
+  `docs/research/bio/severyn-nalyvaiko.md`]
+- `autumn 1595-winter 1596` — Loboda's army, with Shaula and other Cossack
+  officers in the broader force, controlled Kyiv-region and southern Belarus
+  areas from an Ovruch base. This is the dossier's core social-political
+  teaching moment. [T1: ЕІУ Loboda; T1: ЕІУ Nalyvaiko uprising]
+- `early 1596` — the punitive campaign began after Cossack units remained on
+  the volost and local authority was disrupted. The biography should present
+  this as a conflict over armed status, jurisdiction, service, and social
+  control, not simply "rebellion." [T1: ЕІУ Nalyvaiko uprising; T2/T4:
+  Hrushevsky]
+- `spring 1596` — Loboda fought in the Bila Tserkva campaign layer and kept
+  negotiation channels open. [T1: ЕІУ Loboda; T1: ЕІУ Nalyvaiko uprising]
+- `May 1596` — retreat with a large wagon camp, families, equipment, and
+  competing plans toward Pereiaslav / Lubny / Solonytsia. Hrushevsky preserves
+  discussion of possible withdrawal, negotiation, or continued defense; use as
+  source-critical strategy context. [T1: ЕІУ Solonytskyi battle; T2/T4:
+  Hrushevsky]
+- `late May / early June 1596` — Solonytsia blockade. The camp's strength was
+  real, but shortages, artillery, families in the camp, and factional conflict
+  made the situation unstable. [T1: ЕІУ Solonytskyi battle; T2/T4: Hrushevsky]
+- `during Solonytsia` — Loboda was killed by Cossacks after suspicion of
+  treason linked to secret talks. Present this as internal-camp execution under
+  crisis pressure, not as the dossier's proof that he was guilty. [T1: ЕІУ
+  Loboda; T1: IEU Loboda; T2/T4: Hrushevsky]
+- `after Loboda` — Krempsky/Krempskyi appears in Hrushevsky and ЕІУ
+  Solonytskyi battle as a post-Loboda leader in the camp/breakout layer.
+  Treat this as a leadership-transition note, not a new biography here. [T1:
+  ЕІУ Solonytskyi battle; T2/T4: Hrushevsky]
+- `afterlife` — Loboda survives mostly as a co-leader of the Nalyvaiko cycle,
+  a commemorative stamp/coin-adjacent figure, and a cautionary example of
+  internal Cossack factional memory. No verified life portrait was found in
+  this pass. [Existing dossier: `docs/research/bio/severyn-nalyvaiko.md`; T5
+  image/navigation leads]
+
+## 4. Primary / Source-Language Anchors
+
+> **Honest tool note:** no project quote verifier, LLM-QG route, or source
+> edition collation was run for this dossier. The excerpts below are short
+> source-language anchors from EIU pages and Hrushevsky/Izbornyk text, useful
+> for research orientation only. Recheck source editions before classroom
+> quotation.
+
+**Anchor 1 — EIU social-control wording:**
+
+> "козац. присуд"
+
+Context: ЕІУ Nalyvaiko uprising uses this phrase for the Cossack jurisdiction
+introduced in towns and villages during the 1595-1596 volost presence. It is
+useful for teaching that the conflict was about jurisdiction and status, not
+only battlefield movement. [T1: ЕІУ Nalyvaiko uprising]
+
+**Anchor 2 — EIU international-agency wording:**
+
+> "самостійний суб'єкт"
+
+Context: ЕІУ Moldavian campaigns uses this phrase for Cossack military-political
+agency in the Moldavian campaign cycle. Use with the caveat that it does not
+authorize modern-state analogy. [T1: ЕІУ Moldavian campaigns]
+
+**Anchor 3 — Hrushevsky's Loboda-position phrase:**
+
+> "центральною фіґурою"
+
+Context: Hrushevsky makes Loboda central to the organized Cossack side up to
+his death in the Solonytsia camp. This is a valuable correction to
+Nalyvaiko-only narration, but it is a mediated historiographic statement, not
+a primary document quotation. [T2/T4: Hrushevsky, vol. 7, ch. IV]
+
+**Anchor 4 — Solonytsia conflict vocabulary:**
+
+> "semina niezgody"
+
+Context: Hrushevsky preserves this source-language formula around seeds of
+discord between Loboda and Nalyvaiko's faction. Use it for source stance and
+provocation analysis, not as transparent proof of guilt. [T2/T4: Hrushevsky,
+vol. 7, ch. IV]
+
+## 5. Language Register and Learner-Use Notes
+
+- **Register:** late-sixteenth-century Cossack military, frontier-diplomatic,
+  volost, punitive-campaign, camp, and source-critical vocabulary: Cossack
+  starshyna, Lowland Cossacks, Host, hetman, campaign, coalition, headquarters,
+  quartering, jurisdiction, tax, wagon camp, earthworks, blockade, negotiation,
+  suspicion, capitulation, breakout, and execution.
+- **CEFR readiness for full reading:** B1-B2 for an adapted biography; B2-C1
+  for the Ovruch / volost / Solonytsia mechanism; C1-C2 for Hrushevsky and
+  old-source passages because of older orthography, social labels, and
+  Commonwealth chancery vocabulary.
+- **Lexicon notes:** `Григорій Лобода`, `Військо Запорозьке`, `Низовці`,
+  `старшина`, `гетьман`, `Базавлуцька Січ`, `Молдова`, `Оргіїв`, `Акерман`,
+  `Овруч`, `Київщина`, `Південна Білорусь`, `волость`, `козацький присуд`,
+  `покозачення`, `Біла Церква`, `Переяслав`, `Лубни`, `Солониця`, `Сула`,
+  `обоз`, `вагенбург`, `облога`, `зрада`, `капітуляція`.
+- **Learner-use notes:** the strongest B2-C1 lesson is not "Loboda versus
+  Nalyvaiko: who was right?" but "How did armed service become jurisdiction,
+  and why did negotiation become suspect inside a besieged camp?"
+- **Stylistic features:** pair agency verbs (`очолив`, `командував`,
+  `контролював`, `вів переговори`) with caution verbs (`джерело називає`,
+  `приписує`, `підозрювали`, `не доведено`, `потребує перевірки`).
+- **Sensitive framing:** avoid prompts like "traitor or hero." Better prompts:
+  "What did Loboda think he was doing, and what did local communities
+  experience?" or "Why does Solonytsia show both Cossack solidarity and
+  Cossack factional conflict?"
+
+## 6. Contested Points
+
+- **Birthplace and birth date:** unknown is the safe baseline. Do not use
+  lower-tier exact dates or origin legends as fact.
+- **Office chronology:** 1594-1596, 1593-1596 with interruptions, and
+  Lowland-leader language all appear. Use source-specific phrasing.
+- **Registered label:** IEU's registered-Cossack phrase is useful for English
+  metadata, but the late-sixteenth-century situation should be taught through
+  constituency and practice, not a later tidy register model.
+- **Moldavian campaign meaning:** Cossack participation in the Holy League
+  context shows agency and coalition warfare. It does not make Loboda a
+  subordinate auxiliary or a modern foreign-policy actor.
+- **Ovruch control zone:** the 8,000-10,000 figure and control of Kyiv region /
+  southern Belarus are EIU-backed, but local episode maps should be checked
+  against specialist work before classroom use.
+- **Loboda's intent:** ЕІУ says he did not see the 1595-1596 actions as
+  disobedience and showed readiness for reconciliation. That is part of the
+  record, not proof that local coercion did not happen.
+- **Factional language:** old-source contrasts between organized Lowland
+  Cossacks and Nalyvaiko followers reflect social and hostile-source labels.
+  Use them as evidence of perception, not as narrator truth.
+- **Secret talks:** they are source-supported, but the inference from talks to
+  treason belongs to the camp conflict. The dossier should not convict Loboda.
+- **Solonytsia dates:** EIU battle chronology, biography death months, and old
+  calendar layers require attribution. Avoid quiz-style exact-day claims.
+- **Post-capitulation violence:** Loboda was already dead; the later seizure of
+  other leaders and violence against the camp are related but not his death
+  scene.
+- **Nalyvaiko-centered memory:** useful but risky. Loboda's dossier should
+  restore him as a co-leader with his own constituency and choices.
+- **Modern-national shorthand:** Loboda is not a modern-state founder,
+  collaborator template, or simple martyr. He belongs to early-modern Cossack
+  service, jurisdiction, social mobility, and frontier warfare.
+- **Image authenticity:** no contemporary life portrait was verified; later
+  commemorative images require rights and provenance checks.
+
+## 7. Cross-Track Links
+
+> Every path under **Existing** below was verified locally with `test -e` on
+> 2026-07-04 after the branch was reset to current `origin/main`. Forward-looking
+> ties are under **Candidate** or **Absent**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/severyn-nalyvaiko.yaml` — co-leader/rival
+    in the 1594-1596 cycle; use for Nalyvaiko relation without collapsing
+    Loboda into that biography.
+  - `curriculum/l2-uk-en/plans/bio/dmytro-vyshnevetsky.yaml` — earlier Sich /
+    Cossack-frontier origin comparison.
+  - `curriculum/l2-uk-en/plans/bio/petro-sahaidachny.yaml` — later
+    institutionalized Cossack military-diplomatic leadership; compare only
+    structurally.
+  - `curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml` — later
+    large-scale Cossack revolution contrast; avoid teleology.
+- **Existing BIO dossiers and research surfaces (VERIFIED present; not
+  curriculum plan paths):**
+  - `docs/research/bio/severyn-nalyvaiko.md` — paired figure and source-memory
+    caution.
+  - `docs/research/bio/kryshtof-kosynsky.md` — previous late-sixteenth-century
+    Cossack uprising and post-Kosynsky leadership transition.
+  - `docs/research/bio/dmytro-vyshnevetsky.md` — earlier frontier/Sich
+    baseline.
+  - `docs/research/bio/petro-sahaidachny.md` — later Cossack-diplomatic
+    comparison.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/kozatski-povstannia-16.yaml` — the direct
+    HIST frame for Kosynsky/Nalyvaiko/Loboda-era uprisings.
+  - `curriculum/l2-uk-en/plans/hist/kozatstvo-vytoky.yaml` — Cossack origins,
+    frontier mobility, and status formation.
+  - `curriculum/l2-uk-en/plans/hist/zaporizka-sich.yaml` — Sich and Lowland
+    Cossack organization.
+  - `curriculum/l2-uk-en/plans/hist/kozatske-viisko.yaml` — Host, command,
+    wagon camp, and military vocabulary.
+  - `curriculum/l2-uk-en/plans/hist/rich-pospolyta.yaml` — Commonwealth order,
+    estates, jurisdiction, and coercion.
+  - `curriculum/l2-uk-en/plans/hist/krymske-khanstvo.yaml` — frontier-war
+    context; use carefully because Loboda's strongest record here is
+    anti-Ottoman / Moldavian.
+- **Existing ISTORIO/RUTH plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/istorio/syntez-kozatski-dzherela.yaml` —
+    source-critical scaffold for EIU, Hrushevsky, chronicles, and relations.
+  - `curriculum/l2-uk-en/plans/istorio/kozatski-litopysy-ohliad.yaml` —
+    later chronicle-memory comparison, especially for Nalyvaiko/Loboda memory.
+  - `curriculum/l2-uk-en/plans/ruth/cossack-hierarchy.yaml` — hetman,
+    starshyna, Lowland, Host, and office vocabulary.
+  - `curriculum/l2-uk-en/plans/ruth/document-types.yaml` — letters,
+    universals, relations, capitulation terms, and source-type language.
+- **Existing wiki/research files (VERIFIED present; not curriculum plan paths):**
+  - `wiki/periods/kozatski-povstannia-16.md`
+  - `wiki/periods/kozatstvo-vytoky.md`
+  - `wiki/periods/zaporizka-sich.md`
+  - `wiki/periods/kozatske-viisko.md`
+  - `wiki/periods/rich-pospolyta.md`
+  - `wiki/historiography/syntez-kozatski-dzherela.md`
+  - `wiki/historiography/kozatski-litopysy-ohliad.md`
+- **Candidate / absent BIO surfaces (not present on 2026-07-04):**
+  - `curriculum/l2-uk-en/plans/bio/hryhorii-loboda.yaml` — absent; this
+    dossier can support a future BIO module.
+  - `wiki/figures/hryhorii-loboda.md` — absent; future wiki candidate.
+  - `docs/research/bio/matvii-shaula.md`,
+    `curriculum/l2-uk-en/plans/bio/matvii-shaula.yaml`, and
+    `wiki/figures/matvii-shaula.md` — absent; Shaula is a high-value paired
+    future candidate.
+  - `curriculum/l2-uk-en/plans/bio/kryshtof-kosynsky.yaml` — absent even
+    though the research dossier exists.
+- **Potential future module hooks:**
+  - Loboda and Ovruch as a lesson on Cossack jurisdiction, taxation, and
+    social pressure after frontier campaigns.
+  - Solonytsia as a source-critical lesson on blockade, families in the camp,
+    factional suspicion, and capitulation violence.
+  - Moldavian campaigns as a decolonized frontier-diplomacy lesson that treats
+    Cossacks as agents without modern-state analogy.
+
+## 8. Naming-Canonical
+
+- **Slug:** `hryhorii-loboda`
+- **EN canonical (project spelling):** Hryhorii Loboda
+- **UA canonical:** Григорій Лобода
+- **Aliases to track for future `aliases:` fields:** Григорій Лобода; Грицько
+  Лобода; Hryhorii Loboda; Hryhoriy Loboda; Loboda, Hryhorii; Hryhorii /
+  Hryhoriy Łoboda in bibliographic search contexts.
+- **Source/search variants:** older-source `Лобода Григорий`; `pan Loboda`
+  as a source-language social/status form in Hrushevsky's discussion; Latin or
+  Polish diacritic `Łoboda` in bibliographies.
+- **Office/title variants to track carefully:** `козацький старшина`;
+  `гетьман Війська Запорозького`; `гетьман реєстрових козаків`; `старший`;
+  `низовий гетьман`; `Низовці`; `Військо Запорозьке`.
+- **Forbidden forms / flattening forms to flag in body text:** Russian-only
+  name forms as normalized project display; "traitor" as narrator verdict;
+  "collaborator" as simple identity; "pure national leader"; "class-war
+  leader" as full explanation; "Moldavian/Romanian by descent" without a
+  checked specialist source; precise birth date without attribution.
+- **Name collision warning:** distinguish him from later or unrelated Loboda
+  figures in literature and scholarship; local searches also find Oles
+  Honchar's character Volodka Loboda and folklorist Andrii Loboda.
+- **Term warning:** `гетьман` here should be taught as a late-sixteenth-century
+  Cossack command title with volatile constituency, not as a later stable
+  office.
+
+## 9. Image Candidates
+
+- **Best current rule:** assume no verified contemporary portrait. No
+  life-era likeness or rights-clear individual image was verified in this
+  pass.
+- **Context image candidate:** a rights-clear map of the 1594-1596 Cossack
+  war cycle: Moldavia / Dniester / Ovruch / Bila Tserkva / Pereiaslav / Lubny
+  / Solonytsia. A project-created map may be more honest than an invented
+  face.
+- **Document/source candidate:** a public-domain page image from Hrushevsky or
+  an institutional source edition on Solonytsia, if page metadata and reuse
+  rights are checked.
+- **Commemorative candidate:** the Nalyvaiko/Loboda stamp or similar
+  commemorative images may be useful as memory artifacts only after rights
+  review; caption as later memory, not portrait evidence.
+- **Avoid:** generic Cossack stock art, unlicensed modern portrait drawings,
+  images that make Loboda only a traitor/moderate foil, and images that
+  visually erase the families and logistical crisis in the Solonytsia camp.
+- **Authenticity caveat:** if no rights-clear image survives review, prefer
+  geography or source-document context.
+
+## 10. Sources Used
+
+**Tier 1 (authoritative):**
+
+- [T1] Леп'явко С.А. "Лобода Григорій" // *Енциклопедія історії України*,
+  т. 6. URL: https://www.history.org.ua/?termin=Loboda_G | accessed
+  2026-07-04. Core facts: unknown birth, June 1596 death, Cossack starshyna,
+  hetman of the Zaporozhian Host 1594-1596, Orhei, Akkerman, Moldavian
+  campaigns, Holy League context, Ovruch headquarters, 8,000-10,000 Cossacks,
+  readiness for reconciliation, Bila Tserkva, secret negotiations, Solonytsia
+  arrest and execution under suspicion.
+- [T1] "Loboda, Hryhorii" // *Internet Encyclopedia of Ukraine*. URL:
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CL%5CO%5CLobodaHryhorii.htm
+  | accessed 2026-07-04. Used for English spelling, uncertain Kyiv-region
+  birth, May 1596 death variant, registered-Cossack office with interruptions,
+  Moldavian anti-Ottoman participation, and death by Nalyvaiko supporters
+  during Solonytsia.
+- [T1] Леп'явко С.А. "Молдовські походи козаків 1594-1595" //
+  *Енциклопедія історії України*. URL:
+  https://www.history.org.ua/?termin=Moldavski_pokhody_1594 | accessed
+  2026-07-04. Used for anti-Ottoman coalition context, Bazavluk/Prague
+  diplomacy, Orhei, Akkerman, Moldavian occupation, lower-Danube / Dniester
+  fighting, blocked campaign access, and Cossacks as independent
+  military-political subjects.
+- [T1] Леп'явко С.А. "Наливайка повстання 1594-1596" //
+  *Енциклопедія історії України*. URL:
+  https://www.history.org.ua/?termin=Nalyvajka_povstannia_1594 | accessed
+  2026-07-04. Used for campaign stages, Loboda/Shaula army estimate, Ovruch
+  headquarters, Cossack quartering, local authority paralysis, peasant flight,
+  Cossack jurisdiction/taxation, punitive campaign, Bila Tserkva, negotiations,
+  Solonytsia outcome, and post-defeat effects.
+- [T1] Леп'явко С.А. "Солоницький бій 1596" //
+  *Енциклопедія історії України*. URL:
+  https://www.history.org.ua/?termin=Solonytskyj_bij_1596 | accessed
+  2026-07-04. Used for camp geography, wagon/earthwork defense, force ranges,
+  families in camp, blockade, shortage, internal conflict, Loboda execution,
+  5-6 June bombardment, capitulation, 8 June violence, Krempsky breakout, and
+  later executions.
+- [T1] Леп'явко С.А. "Сасько (Сашко Федорович, Попович)" //
+  *Енциклопедія історії України*. URL: https://www.history.org.ua/?termin=Sasko
+  | accessed 2026-07-04. Used for Sasko as a Loboda-side colonel, Prague
+  embassy context, Moldavian campaigns, moderate-starshyna note, and death in
+  the Bila Tserkva campaign layer.
+- [T1] Мицик Ю.А. "Михай I Хоробрий" // *Енциклопедія історії України*,
+  т. 6. URL: https://www.history.org.ua/?termin=Mykhay_I_Khorobry | accessed
+  2026-07-04. Used only for regional anti-Ottoman context and the statement
+  that Michael acted in alliance with Austria and the Cossacks of Loboda and
+  Nalyvaiko; not used to center the dossier on Danubian rulers.
+
+**Tier 2 / Tier 4 (source-critical and scholarly leads):**
+
+- [T2/T4] Грушевський М. *Історія України-Руси*, т. 7, розд. IV, pages 5-8,
+  hosted by Ізборник/Litopys. URLs:
+  http://litopys.org.ua/hrushrus/iur70405.htm,
+  http://litopys.org.ua/hrushrus/iur70406.htm,
+  http://litopys.org.ua/hrushrus/iur70407.htm,
+  http://litopys.org.ua/hrushrus/iur70408.htm | accessed over HTTP and
+  converted from Windows-1251 on 2026-07-04. Used for source-critical framing
+  of Loboda as central Lowland Cossack figure, old-source social labels,
+  negotiation dynamics, Pereiaslav/Lubny/Solonytsia sequence, Loboda's death
+  in camp conflict, and post-capitulation source comparison.
+- [T4 lead] Леп'явко С. *Козацькі війни кінця XVI ст. в Україні.* Чернігів,
+  1996. Bibliographic anchor via EIU Loboda, Moldavian campaigns, Nalyvaiko
+  uprising, and Solonytskyi battle entries; direct book text was not fully
+  inspected in this worker pass.
+- [T4 lead] Грушевський М.С. *Історія України-Руси*, т. 7. Kyiv edition,
+  1995. Bibliographic anchor via ЕІУ; public Izbornyk text used for direct
+  source-critical reading.
+- [T4 lead] Яворницький Д.І. *Історія запорозьких козаків*, т. 2. Kyiv,
+  1990. Bibliographic lead from ЕІУ Solonytskyi battle; not load-bearing
+  without direct passage inspection.
+
+**Tier 3 / Tier 5 (navigation and rights leads only):**
+
+- [T3] Ukrainian and English Wikipedia pages for Hryhorii Loboda / Solonytsia
+  / Nalyvaiko cycle, accessed 2026-07-04. Used only for navigation to EIU,
+  source names, and image leads; facts were cross-checked against T1/T2.
+- [T5] Museum pages, popular-history pages, social posts, videos, classroom
+  presentations, and image-search results surfaced during navigation. Used
+  only as possible memory/image leads; not load-bearing for fact or
+  interpretation.
+
+**Primary-source documents accessed / verification notes:**
+
+- Hrushevsky's public Izbornyk text was accessed directly for short
+  source-language anchors and historiographic framing.
+- The full underlying relation/correspondence editions behind Hrushevsky's
+  footnotes were not separately inspected in this worker pass.
+- No quote verifier, LLM-QG route, or automated source-edition attestation was
+  used.
+- No archival documents, manuscript witnesses, or rights-cleared image files
+  were inspected.
+
+**Honest gaps:**
+
+- Loboda's birth year, birthplace, family background, and early career before
+  late 1593 remain unknown or source-thin.
+- The exact death date/month should be rechecked against specialist work
+  before becoming a quiz item.
+- The precise shape of secret negotiations at Solonytsia needs source-edition
+  comparison before any classroom text treats it as proven treason.
+- The social composition contrast between Loboda's organized Lowland Cossacks
+  and Nalyvaiko's followers is old-source/hostile-source language and requires
+  careful framing.
+- No independent non-Codex review has been routed by this worker; the
+  orchestrator owns that gate.
+
+---
+
+## Decolonization Self-Check
+
+- [x] No Russocentric framing; the dossier centers Cossack, Ukrainian-region,
+  Moldavian/Danube-frontier, and Commonwealth contexts rather than imperial
+  periodization.
+- [x] No Russian-imperial transliterations normalized in body text; older
+  spellings are marked as source/search variants only.
+- [x] No monarch-centered framing; Commonwealth authorities, offices, and
+  forces are named as structures rather than centering rulers.
+- [x] Loboda is not reduced to traitor, collaborator, coward, class-war symbol,
+  or modern national founder.
+- [x] Truth in every direction: Cossack jurisdiction and social coercion on the
+  volost are named, as are the punitive campaign, blockade, post-capitulation
+  violence, and internal Cossack killing.
+- [x] Nalyvaiko is not made the only protagonist; Loboda's own constituency,
+  strategy, and source problems are visible.
+- [x] Moldavian and lower-Danube campaigns are not flattened into permanent
+  ethnic alliances or enmities.
+- [x] Source labels such as rebellion, disorder, traitor, and old social
+  categories are treated as source vocabulary, not neutral narrator judgments.
+- [x] Modern Ukrainian place/context names are used with historical caution:
+  Оргіїв, Акерман / Білгород-Дністровський, Молдова, Овруч, Київщина,
+  Переяслав, Лубни, Солониця, Сула, Запорожжя.
+- [x] No unrelated modern-statehood analogy or out-of-scope ruler chronology
+  introduced.
+- [x] LLM-QG was not used.
+
+## Validation Checklist
+
+- [x] Single owned file only: `docs/research/bio/hryhorii-loboda.md`.
+- [x] Existing cross-track plan/wiki/dossier paths verified locally after the
+  branch was reset to current `origin/main`.
+- [x] Candidate/absent BIO and wiki surfaces marked absent locally.
+- [x] Lower-tier sources marked non-load-bearing.
+- [x] No generated `status/`, `audit/`, `review/`, or telemetry artifacts
+  referenced as changed.
+- [x] No linter configs, `.python-version`, package files, curriculum plans,
+  module files, activities, vocabulary, resources, site MDX, wiki files, or
+  unrelated files edited.
+- [x] `npx markdownlint-cli2 docs/research/bio/hryhorii-loboda.md`
+- [x] `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/hryhorii-loboda.md`
+- [x] `git diff --check origin/main...HEAD`
+- [x] `.venv/bin/python scripts/audit/lint_agent_trailer.py`
+- [x] Guard search for out-of-scope terms returns no matches


### PR DESCRIPTION
## Summary

Adds `docs/research/bio/hryhorii-loboda.md`, a historically cautious Cossack BIO research dossier for Hryhorii Loboda.

The dossier follows the recent P1 Cossack BIO pattern: source-tier self-checks, verified facts, oppression/appropriation mechanism, source-language anchors with caveats, contested points, verified cross-track links, naming guidance, image caveats, sources, decolonization self-check, and validation checklist.

LLM-QG was not used. I did not run, trust, route, persist, or close anything through LLM-QG.

## Historical/source caveats

- Loboda's birth year, birthplace, family background, and early career before late 1593 remain source-thin.
- Death timing is kept as late May / early June 1596 during the Solonytsia siege because EIU/IEU month phrasing differs.
- Secret talks at Solonytsia are treated as source-supported, but the dossier does not treat the camp's treason accusation as narrator fact.
- Cross-track links cite only verified local files under Existing; absent future surfaces are marked Candidate/Absent.

## Verification

- `npx markdownlint-cli2 docs/research/bio/hryhorii-loboda.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/hryhorii-loboda.md`
- `git diff --check origin/main...HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Guard scan for Skoropadskyi / 1918 Hetmanate / named Polish rulers / Sigismund / Sobieski / Casimir / Wladyslaw variants
- Scope guard confirmed one changed file only: `docs/research/bio/hryhorii-loboda.md`