### PR TITLE
[codex] add Dmytro Doroshenko BIO dossier

### DIFF
--- a/docs/research/bio/dmytro-doroshenko.md
+++ b/docs/research/bio/dmytro-doroshenko.md
@@ -1,0 +1,192 @@
+# Дмитро Іванович Дорошенко — Research Dossier
+
+**Slug:** `dmytro-doroshenko`
+**Block:** K / statehood-school historian, Ukrainian Revolution diplomat, forced emigration scholar
+**Tier:** 1b
+**Issue:** BIO manifest backfill — missing research dossier
+**Researcher:** Codex GPT-5
+**Completed:** 2026-07-04
+
+**Source acronym legend:** EIU = *Енциклопедія історії України* / Інститут історії України НАН України; ESU = *Енциклопедія Сучасної України* / НАН України, НТШ; IEU = Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies; HUS = *Harvard Ukrainian Studies*; UVU = Український вільний університет; UVAN = Українська вільна академія наук.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1 / Tier 2 sources cited
+- [x] Oppression mechanism specific and not inflated into martyrdom
+- [x] Primary-source snippets included only where locally or visibly verified
+- [x] Cross-track links verified with `test -e` / `rg` on 2026-07-04
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+> **Framing note.** Dmytro Doroshenko was not executed or imprisoned by the Soviet state. His oppression frame is forced emigration, repeated displacement by Russian and Soviet power, exclusion from Soviet Ukraine, and the diaspora-preservation route of his scholarship. He should be taught as a statehood-school historian and practical diplomat without flattening him into either a "conservative hero" or a Soviet-style "bourgeois nationalist."
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Дмитро Іванович Дорошенко. [T1: EIU — Осташко; T1: ESU — Веденєєв; T1: IEU]
+- **Pseudonyms / aliases:** М. Жученко, per EIU. English / scholarly variants include Dmytro Doroshenko, Dmytro Ivanovych Doroshenko, and older transliteration Dorošenko in IEU metadata.
+- **Born:** **27 March / 8 April 1882** | Вільно, now Вільнюс / Vilnius, Lithuania | Russian Empire. EIU and ESU use the old/new-style date pair; IEU gives 8 April 1882. [T1: EIU; T1: ESU; T1: IEU]
+- **Died:** **19 March 1951** | Munich, West Germany. [T1: EIU; T1: ESU; T1: IEU]
+- **Family / education key facts:** Husband of Nataliia Doroshenko. Descended from the old Cossack-starshyna / hetman Doroshenko line; EIU specifies a side branch of the Doroshenko / Klymchenko-Doroshenko family and calls him a nephew of P. Ya. Doroshenko. Studied at Warsaw and Saint Petersburg universities and graduated from Kyiv University's historical-philological faculty in 1909. [T1: EIU; T1: ESU; T1: IEU]
+- **Civic formation:** While in Saint Petersburg he headed the Ukrainian Student Hromada in 1903 and worked with `Ukrainskii vestnik` in 1906. In Kyiv and Katerynoslav he worked with Prosvita, the Katerynoslav archival commission, `Dniprovi khvyli`, `Rada`, `Literaturno-naukovyi vistnyk`, and the Ukrainian Scientific Society. [T1: IEU; T1: EIU]
+- **Revolution / state service:** One of the Central Rada founders; deputy head 4-10 March 1917; Provisional Government commissioner for Galicia and Bukovyna in 1917; Chernihiv gubernial commissioner for the Central Rada; Minister of Foreign Affairs of the Ukrainian State under Pavlo Skoropadskyi in May-November 1918. [T1: EIU; T1: ESU; T1: IEU]
+- **Academic and diaspora offices:** Professor at the Ukrainian Free University in Vienna, Prague, and Munich (1921-1951), Charles University in Prague (1926-1936), Ukrainian Scientific Institute in Berlin director (1926-1931), Warsaw University professor (1936-1939), first president of UVAN (1945-1951), and Saint Andrew's College professor in Winnipeg (1947-1950). [T1: EIU; T1: ESU; T1: IEU]
+
+**Source disagreement note:** EIU says "від 1920 — на еміграції"; IEU says he emigrated in 1919 and ESU describes the August 1919-January 1920 Red Cross mission before the longer UVU period. Treat this as an emigration transition across 1919-1921, not as a single clean departure date.
+
+## 2. Oppression mechanism
+
+Doroshenko's biography does not fit an execution / prison template. The specific pressure mechanism is **loss of Ukrainian statehood, forced emigration, exclusion from Soviet Ukraine, and archival / institutional displacement**.
+
+- **What happened (state collapse and forced emigration):** After the Ukrainian Revolution's defeat and the collapse of the Ukrainian State / UNR institutional field, Doroshenko left Ukraine and made his scholarly career abroad. EIU places him "від 1920 — на еміграції"; IEU states he emigrated in 1919 and never returned to Ukraine. [T1: EIU; T1: IEU]
+- **What happened (war displacement):** In 1945 he moved west with the Ukrainian Free University, away from the advancing Soviet army. The 2002 Institute of History edition's biographical preface notes that on leaving Prague he again had to abandon books, archives, notes, and manuscripts. This is a material scholarly loss, not merely a change of residence. [T2: Institute of History 2002 edition / K. Halushko preface]
+- **By whom / by what system:** Bolshevik and later Soviet state power destroyed the independent Ukrainian political space in which Doroshenko had served, made his conservative-statehood and Hetmanite orientation impossible inside Soviet Ukraine, and later defined much Ukrainian non-Soviet statehood memory as hostile nationalism. Nazi Germany and wartime Europe also shaped his displacement, but the Ukraine-specific exclusion mechanism is Soviet.
+- **Mechanism specifics:** His Ukrainian-state career included a Central Rada role, Chernihiv commissioner office, and Hetmanate foreign ministry. ESU states that as foreign minister he built the ministry's central structure, drafted organizational-legal acts for diplomatic and consular institutions, sought Brest-Litovsk ratification and Ukrainian ethnic territories, signed agreements with post-imperial states, and resigned over Skoropadskyi's federation manifesto with non-Bolshevik Russia. [T1: ESU]
+- **What survived / what was destroyed:** His texts survived through Prague, Warsaw, Berlin, Winnipeg, Munich, and later republications in Ukraine. What was destroyed or displaced was his ability to work inside Ukraine and parts of his archive / working library during repeated flight. His statehood-school synthesis reached Soviet Ukrainian readers only after Soviet censorship weakened and Ukraine reissued major works in the 1990s-2000s.
+
+## 3. Major works
+
+- `1917` — *Покажчик нової української літератури в Росії за 1798-1897 роки*, a bibliographic project before full political exile. [T1: ESU]
+- `1918` — *Коротенька історія Чернігівщини*. [T1: ESU]
+- `1922` — *Слав'янський світ в його минулому й сучасному*, 3 vols. [T1: ESU; T1: IEU]
+- `1923` — *Огляд української історіографії*, Prague; later reissued Kyiv 1996 and translated as *A Survey of Ukrainian Historiography* with Oleksander Ohloblyn. [T1: EIU; T1: IEU]
+- `1923-1924` — *Мої спомини про недавнє-минуле (1914-1920)*, 4 vols. [T1: ESU; T1: IEU]
+- `1930-1932` — *Історія України. 1917-1923 рр.*, 2 vols., Uzhhorod; reissued Kyiv 2002 by Tempora / Institute of History portal. [T1: EIU; T1: ESU; T2: Institute of History item]
+- `1932-1933` — *Нарис історії України*, 2 vols., Warsaw; reissued Munich 1966 and Kyiv 1992; English abridgment *History of the Ukraine* appeared in Edmonton in 1939 and later *A Survey of Ukrainian History* in Winnipeg, 1975. [T1: EIU; T1: ESU; T1: IEU]
+- `1936` — *З історії української політичної думки за часів світової війни*. [T1: ESU; T1: IEU]
+- `1940` — *Православна Церква в минулому й сучасному житті українського народу*. [T1: EIU; T1: ESU; T1: IEU]
+- `1941` — *Початок гетьманування Петра Дорошенка (1665-1666)*; he also prepared broader work on the seventeenth-century hetman, a family and statehood-history anchor. [T1: ESU; T1: IEU]
+- `1949` — *Мої спомини про давнє-минуле (1901-1914)* and *Короткий нарис Історії Христіянської Церкви*. [T1: ESU; T1: IEU]
+- `1929-1946` — *Тарас Шевченко — національний поет України*, issued in German, French, Italian, and English editions. [T1: ESU]
+
+## 4. Primary-source quotes
+
+> **Verification note.** LLM-QG was not used. The worktree does not contain `data/literary_texts/wave13-doroshenko-narys-istoriyi-ukrayiny-t1.jsonl` or `t2.jsonl`, although local docs mention those corpus files. Two short Ukrainian snippets below were verified by temporarily downloading the Institute of History PDF of *Історія України, 1917-1923*, t. 1 to `/tmp` and running `pdftotext`; that temporary file was not added to the repo. Treat them as research anchors, not polished learner excerpts, until a source edition / page citation is reviewed in production.
+
+**Quote 1 — Doroshenko on limits of eyewitness history:**
+
+> "я не претендую на вичерпуюче-повне змалювання подій"
+
+Source: Doroshenko's preface to *Історія України, 1917-1923*, t. 1, p. 27 in the 2002 Institute of History / Tempora PDF edition. Pedagogical use: a good humility anchor for memoir-history and witness history. The surrounding paragraph says a truly scientific-objective history of the liberation struggle is a task for future generations.
+
+**Quote 2 — Doroshenko on Russian occupation policy in Galicia:**
+
+> "знищення всіх проявів українського національного життя"
+
+Source: *Історія України, 1917-1923*, t. 1, p. 30 in the same PDF, describing the program behind Russian occupation policy in Galicia during the First World War. Pedagogical use: a precise anti-imperial anchor, but it needs classroom framing because the chapter includes period vocabulary and hostile labels from the source context.
+
+**Additional corpus lead, not classroom-ready:** `mcp__sources.verify_source_attribution` over the literary source, claim "вивчити й науково освітити багате історичне минуле України," found a Doroshenko `Нарис історії України`, t. 1 OCR chunk with confidence 1.0. Because the underlying JSONL file is absent from this worktree and the OCR chunk is visibly noisy, do not quote it in learner materials without a cleaner edition check.
+
+## 5. Language register
+
+- **Register:** academic-historiographic, diplomatic, memoiristic, and publicistic Ukrainian; diaspora editions may use interwar orthography and older vocabulary.
+- **CEFR readiness for full reading:** C1-C2 for `Нарис`, `Огляд української історіографії`, and church-history prose; B2-C1 for carefully excerpted memoir passages with context.
+- **Lexicon notes:** `державність`, `державницька школа`, `історіографія`, `гетьманат`, `автономія`, `федерація`, `Центральна Рада`, `Українська Держава`, `Директорія`, `УВУ`, `УВАН`, `еміграція`.
+- **Stylistic features:** long documentary paragraphs; witness-history caveats; emphasis on offices, institutions, elites, diplomacy, church structures, and the survival or collapse of state forms.
+- **Classroom caution:** His English translation *History of the Ukraine* uses dated phrasing such as "the Ukraine" and older transliterations. Use it as a historical source, not as a model for contemporary English usage.
+
+## 6. Contested points
+
+- **Statehood school vs. populist school:** IEU identifies Doroshenko as the first historian to write a Ukrainian history survey from the perspective of Ukrainian statehood and national elite. ESU says he became a founder and leading representative of the statehood school while still recognizing the achievements of populist historians. Teach him beside Hrushevskyi, not as Hrushevskyi's simple replacement.
+- **Central Rada break:** ESU and EIU both describe his 1917 refusal / failure to head a new General Secretariat. ESU explains the conflict around whether wealthy strata and old-administration personnel should be drawn into state-building. This should not be flattened into "anti-democratic" or "anti-Ukrainian"; it is a real strategic dispute over state capacity, class politics, and revolutionary legitimacy.
+- **Hetmanate role:** As Skoropadskyi's foreign minister he built institutional diplomacy and pursued Ukrainian state interests, but he served in a regime dependent on German military power and contested by socialist and republican Ukrainian actors. The pedagogically honest formulation is "state-builder within a compromised wartime Hetmanate," not "collaborator" or "unambiguous savior."
+- **Federation / Russia labels:** Doroshenko's early party milieu included autonomist-federalist politics, and his resignation in 1918 over the federation manifesto is central. Do not treat "federalist" as narrator shorthand for loyalty to Russia; in 1917 it was one Ukrainian strategy within a rapidly changing imperial-collapse context.
+- **Diaspora and Hetmanite movement:** IEU and ESU identify him as an important emigre Hetmanite / conservative figure. This is not a reason to collapse him into Lypynskyi or Skoropadskyi. His own profile is historian-diplomat-institution-builder.
+- **Russian/Soviet framing:** Soviet categories such as "bourgeois nationalism" should appear only as labels of Soviet attack or erasure. The curriculum should state the concrete archival, institutional, and political facts instead of echoing Soviet verdicts.
+- **Name and family confusion:** Keep Dmytro Doroshenko distinct from Hetman Petro Doroshenko, Mykhailo Doroshenko, Petro Yakovych Doroshenko, and Dmytro Dontsov. The surname is a high-risk collision in BIO/HIST materials.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` / `rg` on 2026-07-04 and resolves under `curriculum/l2-uk-en/plans/` unless explicitly marked as a dossier or wiki path. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plan / dossier anchors (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml` — contrasting historical school and Central Rada relationship.
+  - `curriculum/l2-uk-en/plans/bio/viacheslav-lypynskyi.yaml` — statehood-school / Hetmanite intellectual counterpart; Doroshenko-Lypynskyi letters are a key source trail.
+  - `curriculum/l2-uk-en/plans/bio/mykola-vasylenko.yaml` — Ukrainian State ministerial / academic milieu.
+  - `curriculum/l2-uk-en/plans/bio/nataliia-polonska-vasylenko.yaml` — later statehood-school historian and exile-scholar comparison.
+  - `curriculum/l2-uk-en/plans/bio/yevhen-chykalenko.yaml` — pre-1917 civic press and moderate political networks.
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-vynnychenko.yaml` — Central Rada / Directory contrast.
+  - `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml` — UNR exile-state and 1919-1920 comparison.
+  - `docs/research/bio/petro-doroshenko.md` — existing dossier for the seventeenth-century hetman; use to prevent name/family conflation.
+  - `docs/research/bio/mykhailo-doroshenko.md` — existing dossier for the earlier hetman; use to prevent Doroshenko-family conflation.
+- **Existing HIST plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml` — Doroshenko as founder / early Central Rada figure.
+  - `curriculum/l2-uk-en/plans/hist/skoropadskyi.yaml` — Hetmanate foreign ministry and statehood-school interpretation.
+  - `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml` — post-Hetmanate transition and UNR context.
+  - `curriculum/l2-uk-en/plans/hist/zunr.yaml` — Galicia / Bukovyna and 1918-1919 western Ukrainian statehood context.
+  - `curriculum/l2-uk-en/plans/hist/bilshovytsko-ukrainska-viyna.yaml` — the conflict setting for the collapse of Ukrainian state institutions.
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — broader language-repression background for the pre-1917 publishing and press world.
+- **Existing ISTORIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/istorio/druha-khvylia-politychna.yaml` — political emigration / second-wave historiography already names Doroshenko in wiki context.
+  - `curriculum/l2-uk-en/plans/istorio/diaspora-ta-zakhidni-istoriky.yaml` — diaspora and Western historians.
+  - `curriculum/l2-uk-en/plans/istorio/diaspora-naukovtsi.yaml` — emigre scholarly institutions including UVU / UVAN contexts.
+  - `curriculum/l2-uk-en/plans/istorio/syntez-diaspora.yaml` — diaspora synthesis and preservation of statehood narratives.
+  - `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml` — Central Rada / UNR documents that Doroshenko narrates in `Історія України, 1917-1923`.
+- **Existing LIT-essay / method plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit-essay/lypynsky-letters-brothers.yaml` — conservative statehood thought context.
+  - `curriculum/l2-uk-en/plans/lit-essay/hrytsak-history-ukraine.yaml` — later synthetic-history comparison, not a direct Doroshenko module.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `curriculum/l2-uk-en/plans/bio/dmytro-doroshenko.yaml` — absent as of 2026-07-04; this dossier is the research base for creating it.
+  - A dedicated HIST or ISTORIO module on the **державницька школа** (Hrushevskyi / Lypynskyi / Doroshenko / Polonska-Vasylenko) — not yet a dedicated plan.
+  - A source-reading module on Doroshenko's preface to *Історія України, 1917-1923* as witness-history methodology — not yet a dedicated plan.
+  - A BIO plan for Petro Yakovych Doroshenko — absent; do not confuse him with Hetman Petro Doroshenko.
+
+## 8. Naming-canonical
+
+- **Slug:** `dmytro-doroshenko`
+- **EN canonical (BGN/PCGN-style project spelling):** Dmytro Doroshenko
+- **UA canonical (with patronymic):** Дмитро Іванович Дорошенко
+- **Aliases to track (`aliases:` YAML field):** Dmytro Ivanovych Doroshenko; Dmytro Doroshenko; М. Жученко; Dorošenko (older scholarly transliteration).
+- **Forbidden / risky forms (flag in body text — listed here only):** Дмитрий Иванович Дорошенко; Dmitri / Dmitry Doroshenko when used as Russian-via-English transliteration; "Dimitri" / "Demeter" from older English editions except as source metadata; any unqualified "Doroshenko" where Petro, Mykhailo, Petro Yakovych, or Dmytro might be confused.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons `File:Dmytro Doroshenko.jpg`, sourced to `Записки НТШ` 1936, author unknown, public-domain tagged. Commons identifies it as before 1936 and depicts Dmytro Doroshenko; verify file-page license and identity during production image review.
+- **Backup portrait candidates:** IEU entry images of Dmytro Doroshenko as student and later portraits; use only if rights and source metadata are clear.
+- **Context image:** title page / cover of *Огляд української історіографії* (1923) or *Історія України, 1917-1923* (2002 reprint page on Institute of History portal), rights permitting.
+- **Memorial image:** Commons `Grave Doroshenko 2019b.jpg`, CC BY-SA 4.0, showing the Munich Waldfriedhof tombstone of Dmytro Doroshenko and Nataliia Doroshenko; useful for exile / memory context, not as lead portrait.
+- **Avoid default:** images of Hetman Petro Doroshenko, Mykhailo Doroshenko, Petro Yakovych Doroshenko, or generic Doroshenko-family material unless the caption explicitly explains the relationship.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Осташко Т. С. "ДОРОШЕНКО Дмитро Іванович." *Енциклопедія історії України*, т. 2. Інститут історії України НАН України. <https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Doroshenko_D&Z21ID=>. Accessed 2026-07-04.
+- Веденєєв Д. В. "Дорошенко Дмитро Іванович." *Енциклопедія Сучасної України*. <https://esu.com.ua/article-21046>. Accessed 2026-07-04.
+- "Doroshenko, Dmytro." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies. <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CD%5CO%5CDoroshenkoDmytro.htm>. Accessed 2026-07-04.
+
+**Tier 2 (institutional / scholarly / primary-text access):**
+
+- Дорошенко Д. *Історія України, 1917-1923: документально-наукове видання*, т. 1: *Доба Центральної Ради* / упорядн., передм. та комент. К. Ю. Галушка. Київ: Темпора, 2002. Institute of History portal item and PDF: <https://resource.history.org.ua/item/0009615>. PDF inspected via temporary `/tmp` download and `pdftotext` on 2026-07-04.
+- Prymak, Thomas M. "Dmytro Doroshenko: A Ukrainian Emigre Historian of the Interwar Period." *Harvard Ukrainian Studies* 25, no. 1-2 (2001): 31-56. <https://husj.harvard.edu/articles/dmytro-doroshenko-a-ukrainian-emigre-historian-of-the-interwar-period>. Bibliographic / scholarly framing source; full text not extracted into the dossier.
+- Doroshenko, Dmytro. *History of the Ukraine*, abridged English translation by Hanna Chykalenko-Keller. Edmonton: Institute Press, 1939. Public-domain transcription by Bill Thayer: <https://penelope.uchicago.edu/Thayer/E/Gazetteer/Places/Europe/Ukraine/_Topics/history/_Texts/DORHOU/home.html>. Used only as a primary-text access lead with caution about dated translation choices.
+- Doroshenko, Dmytro. *A Survey of Ukrainian Historiography*. Public-domain transcription lead: <https://penelope.uchicago.edu/Thayer/E/Gazetteer/Places/Europe/Ukraine/_Topics/history/_Texts/DORSUH/home.html>. Used as a source-location lead; not quoted as classroom-ready.
+
+**Tier 3 / local project context:**
+
+- `docs/rag-gap-1026.md` — notes the Doroshenko `Нарис історії України` Wave 13 corpus status but also that it is not available as site content.
+- `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md` and `docs/audits/bio-readiness-matrix-2026-06-29.md` — local audit context identifying `dmytro-doroshenko` as a missing BIO research figure.
+- `docs/research/bio/mykhailo-hrushevskyi.md`, `docs/research/bio/viacheslav-lypynskyi.md`, `docs/research/bio/nataliia-polonska-vasylenko.md`, `docs/research/bio/yevhen-chykalenko.md`, `docs/research/bio/symon-petliura.md`, and `docs/research/bio/volodymyr-vynnychenko.md` — dossier-structure and cross-track pattern references.
+
+**Tier 5 (image-rights / media-rights sources):**
+
+- Commons `File:Dmytro Doroshenko.jpg`. <https://commons.wikimedia.org/wiki/File:Dmytro_Doroshenko.jpg>. Accessed 2026-07-04.
+- Commons `File:Grave Doroshenko 2019b.jpg`. <https://commons.wikimedia.org/wiki/File:Grave_Doroshenko_2019b.jpg>. Accessed 2026-07-04.
+
+**Honest gaps:** The visible worktree lacks the Doroshenko Wave 13 JSONL source files named in local docs, so project-corpus quotes from `Нарис історії України` were not treated as production-ready. HUS / JSTOR scholarly article text was not extracted; only bibliographic and search-visible metadata were used. This dossier did not use LLM-QG.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing — Doroshenko's own statehood-school frame and Ukrainian institutional service carry the narrative.
+- [x] No Russian-imperial transliterations in body text except in the explicitly labelled risky-forms section.
+- [x] No uncritical Soviet labels — Soviet categories appear only as attack / erasure mechanisms.
+- [x] No martyr inflation — death in Munich and exile mechanism stated plainly.
+- [x] Central Rada / Hetmanate / Directory treated as Ukrainian statehood contexts, not generic "Civil War" fragments.
+- [x] Federalist and conservative labels are contextualized instead of treated as narrator verdicts.
+- [x] Diaspora scholarship is treated as institutional continuity, not a failed afterlife.
+- [x] Doroshenko-family name collisions are explicitly flagged.


### PR DESCRIPTION
## Summary

- Adds the missing BIO research dossier for Dmytro Doroshenko.
- Follows the existing 10-section BIO dossier pattern with verified facts, oppression mechanism, source caveats, cross-track links, naming/image notes, and decolonization self-check.
- Keeps scope to `docs/research/bio/dmytro-doroshenko.md` only.

## Verification

- `npx markdownlint-cli2 docs/research/bio/dmytro-doroshenko.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/dmytro-doroshenko.md`
- `git diff --check origin/main...HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Protected-path/artifact scan: changed diff contains only `docs/research/bio/dmytro-doroshenko.md`; no `.python-version`, linter configs, status/audit/review artifacts, or `data/telemetry/**`.
- Framing scan reviewed intentional risky-form mentions only in the forbidden/risky naming section and self-check.

## Source / process caveats

LLM-QG was not used. `run_llm_qg_parity.py` and `scripts/audit/module_quality_audit.py` were not run.

The dossier treats primary-source quotes cautiously: the visible worktree lacks the Doroshenko Wave 13 JSONL files mentioned in local docs, so project-corpus quote leads are not marked classroom-ready. Two short Ukrainian snippets were checked through a temporary `/tmp` `pdftotext` extraction of the Institute of History PDF and documented as research anchors.