### PR TITLE
[codex] Add Fedir Vovk BIO research dossier

### DIFF
--- a/docs/research/bio/fedir-vovk.md
+++ b/docs/research/bio/fedir-vovk.md
@@ -1,0 +1,340 @@
+# Федір Вовк — Research Dossier
+
+**Slug:** `fedir-vovk`
+**Block:** BIO expansion · Hromada / ethnography / anthropology infrastructure
+**Tier:** 1
+**Issue:** BIO Ukrainian expansion manifest gap, 2026-06-29 audit
+**Researcher:** Codex GPT-5
+**Completed:** 2026-07-04
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Федір Кіндратович Вовк. Historical Ukrainian spelling:
+  Хведір Кіндратович Вовк.
+- **Pseudonyms / aliases:** Хведір Вовк; Вовк Федір Кіндратович; Fedir Vovk;
+  Khvedir Vovk; Theodore Volkov; Th. Volkov; Волков; Кондратович; Лупулеску;
+  Сірко; Яструбець; Вчік; С-о; Th. V.; LBC; Новостроенко; Хв. В.
+- **Born:** 5 March 1847 Old Style / 17 March 1847 New Style | с. Крячківка,
+  Пирятинський повіт, Полтавська губернія, Russian Empire, now Poltava oblast,
+  Ukraine. ESU, IEU, EIU, KNU, and UINP agree on the 17 March New Style date.
+- **Died:** 29 June 1918 | Жлобин, Homel region, now Belarus, while travelling
+  from Petrograd toward Ukraine. ESU, UINP, KNU, NIBU, and Ukrainian Wikipedia give
+  29 June 1918; IEU gives 30 June 1918. EIU's online line currently shows a later
+  Old/New Style pair, `25.08(13.07).1918`, which conflicts with the other Tier 1/Tier
+  2 sources. Use 29 June with a source note unless a death-registration document is
+  retrieved.
+- **Family / education key facts:** Born in a family described by KNU and EIU as
+  old Cossack-rooted; his father was a retired officer. He studied at the Nizhyn
+  gymnasium, Novorossiisk University in Odesa, and the University of Saint
+  Volodymyr in Kyiv, graduating in 1871. In Kyiv he entered the Hromada milieu and
+  worked with Volodymyr Antonovych, Pavlo Chubynskyi, Mykhailo Drahomanov, and
+  other Ukrainian cultural organizers.
+- **Core roles:** ethnographer, anthropologist, archaeologist, folklorist,
+  publisher, museum worker, pedagogue, civic figure. Member of the Shevchenko
+  Scientific Society from 1899; head of its Ethnographic Commission from 1906;
+  member of the Ukrainian Scientific Society in Kyiv from 1908; doctor of the
+  Sorbonne and other institutions; recipient of the Godard Prize, the Broca medal,
+  and the French Legion of Honour.
+
+The stable curriculum claim is not that Vovk "proved" a modern biological thesis
+about Ukrainians. The stable claim is narrower: he made Ukrainian ethnography,
+folklore, archaeology, and physical-anthropology data visible in European scholarly
+institutions while Russian imperial policy treated Ukrainian culture as derivative,
+regional, or suspect.
+
+## 2. Oppression mechanism
+
+- **What happened:** imperial censorship, police pressure, forced emigration,
+  professional displacement away from Ukraine, and later Soviet memory
+  distortion.
+- **When:** Hromada/Southwestern Branch pressure in the 1870s; exile from 1879 to
+  1905; permission to return in 1906 with a ban on living in Ukraine, per UINP; long
+  posthumous Soviet marginalization.
+- **By whom:** Russian imperial security and censorship institutions; later Soviet
+  ideological institutions and scholarly gatekeeping.
+- **Document references:** EIU states that Hromada members were accused of
+  separatism and that Vovk faced punishment for attempting to move an underground
+  printing press into Ukraine. UINP states that his 1906 return permit still barred
+  residence in Ukraine. KNU states that in the Soviet totalitarian period his name
+  was effectively removed from public history and attached to the label "Ukrainian
+  nationalist."
+- **Mechanism specifics:** Vovk's work joined scholarship to Ukrainian civic
+  infrastructure. He helped publish uncensored Shevchenko material abroad, worked
+  in the Kyiv Hromada network, helped institutionalize Ukrainian ethnographic
+  collection, and later created or supported Ukrainian sections inside institutions
+  that were formally imperial. This made him vulnerable to the usual imperial
+  pattern: Ukrainian research could be tolerated as regional folklore only until it
+  became evidence of a living people with language, territory, institutions, and
+  international scholarly visibility.
+- **What survived / what was destroyed:** His printed scholarship, collections,
+  and archive survived, but the continuity of his school was fragmented by exile,
+  imperial institutional dependence, and Soviet ideological suspicion. The
+  Institute of Archaeology of the National Academy of Sciences of Ukraine now lists
+  his personal archival fond as 5,104 units, and its "Digital Memory Repository:
+  Archive of Khvedir Vovk (1847-1918)" makes the survival of that record visible.
+
+This is not a martyrdom-by-execution dossier. It is a dossier about how empire
+pushes Ukrainian scholarship out of Ukraine, then later reabsorbs or discredits it
+when it becomes too useful for national self-knowledge.
+
+## 3. Major works
+
+- `1876` and `1878` - participation in uncensored foreign editions of Shevchenko's
+  *Kobzar* and related publication work with Hromada networks.
+- `1879` - "Т. Г. Шевченко і його думки про громадське життя", signed with a
+  cryptonym, an early political reading of Shevchenko.
+- `1883` - "Задунайська Січ по місцевим згадкам і розповідям", historical and
+  ethnographic work on the Danubian Sich.
+- `1891-1892` - *Rites et usages nuptiaux en Ukraine* / "Шлюбний ритуал та обряди
+  на Україні", comparative ethnographic study of Ukrainian wedding ritual.
+- `1895` - *Le traineau dans les rites funeraires de l'Ukraine*, study of the
+  funeral-sled motif in Ukrainian rites.
+- `1900-1905` - *Variations squelettiques du pied chez les Primates et chez les
+  races humaines*, Sorbonne doctoral dissertation; use the title as historical
+  evidence of the period's physical-anthropology vocabulary, not as modern framing.
+- `1906` - "Украинцы в антропологическом отношении", a public scholarly
+  intervention on Ukrainian distinctiveness in the language of early-20th-century
+  physical anthropology.
+- `1908` - "Антропометричні досліди українського населення Галичини, Буковини й
+  Угорщини: Гуцули", a regional anthropometric study; handle with the same
+  source-context warning.
+- `1908` - first excavation of the Upper Paleolithic Mizyn site, according to IEU
+  and EIU.
+- `1916` - "Антропологічні особливості українського народу" and "Етнографічні
+  особливості українського народу" in the collective work *Украинский народ в его
+  прошлом и настоящем*, volume 2.
+- `1928` - posthumous Prague selection *Студії з української етнографії та
+  антропології* / *Матеріали до української етнографії та антропології*.
+
+For curriculum planning, the ethnographic and institutional works are safer entry
+points than the physical-anthropology syntheses. The latter can be taught only as
+history of science plus anti-imperial context, with explicit distance from outdated
+taxonomy.
+
+## 4. Primary-source quotes
+
+Local deterministic quote checks were attempted with `mcp__sources.verify_quote`
+for the two short excerpts below. Both returned `matched: false` and
+`best_confidence: 0.0`. Treat them as source-cited leads, not classroom-ready
+quotations.
+
+- "на рідній землі для рідної науки" - short excerpt from the epigraph printed in
+  the 2016 Savchuk sample of Vovk's selected works. It is pedagogically useful
+  because it frames his return-to-Ukraine desire, but the underlying archival
+  source and page were not verified locally.
+- "не мають ніякого національного чи політичного значення" - NIBU attributes this
+  short idea to Vovk's own caution about his anthropological conclusions. It can
+  support a discussion of how he tried to separate measurement from propaganda, but
+  the original-language page has not been corpus-verified.
+
+Safe source-text alternative: use titles and paraphrase until primary pages are
+locked. Titles such as *Шлюбний ритуал та обряди на Україні* and "Етнографічні
+особливості українського народу" are enough for a B2/C1 activity on scholarly
+register without risking an unverified quote.
+
+## 5. Language register
+
+- **Register:** high scholarly ethnography, comparative anthropology, archaeology,
+  folklore studies, and civic-publicistic prose.
+- **Languages of publication:** Ukrainian, Russian, French, and other European
+  scholarly channels. Do not infer identity from publication language; he wrote
+  within the institutional languages available to a Ukrainian scholar under empire
+  and in exile.
+- **CEFR readiness for full reading:** B2 for brief biographical narrative; C1 for
+  ethnographic passages about ritual, housing, dress, foodways, and regional
+  practice; C2 for physical-anthropology and French dissertation material.
+- **Lexicon notes:** етнографія, антропологія, антропометрія, археологія, обряд,
+  звичай, весілля, похорон, побратимство, житло, одяг, Мізинська стоянка,
+  Громада, цензура, еміграція.
+- **Stylistic features:** accumulation of terms, regional comparison, long
+  evidentiary chains, and a 19th/early-20th-century confidence that material
+  collection can answer political denial.
+
+Vovk is useful for learners when the lesson goal is to read scholarly Ukrainian
+about culture, not when the goal is conversational fluency. A strong C1 lesson can
+ask students to separate three layers: observed practice, classification language,
+and political use of scholarship.
+
+## 6. Contested points
+
+- **Physical anthropology and outdated categories:** Vovk worked inside a
+  European physical-anthropology school that used body measurement and typological
+  categories now unsuitable as narrator truth. Curriculum text must not say that he
+  "proved Ukrainians are a race" or repeat "Dinaric" language as a modern fact. The
+  careful formulation is: he used the tools of his discipline to contest imperial
+  denial of Ukrainian distinctiveness; the tools themselves now require historical
+  critique.
+- **Anti-imperial usefulness versus scientific limits:** Later summaries often
+  celebrate Vovk because his work opposed claims that Ukrainians were only
+  Polonized Russians or Russified Poles. That context matters, but it does not make
+  every measurement, sample, or typological conclusion usable today. The better
+  teaching question is why colonized peoples needed empirical archives at all.
+- **Death date discrepancy:** Prefer 29 June 1918 with an explicit note that IEU
+  gives 30 June and EIU's online line conflicts with both. Do not build timeline
+  exercises around the death date without the caveat.
+- **Name politics:** `Fedir Vovk` is the locked project slug/canonical
+  transliteration. `Khvedir` is historically attested and useful in source context.
+  `Volkov` / `Theodore Volkov` appear in Russian- and French-language scholarly
+  records; use them only as aliases, not to absorb him into Russian scholarship.
+- **Soviet memory:** The local literary corpus contains Soviet-era phrasing that
+  labels his anthropology "bourgeois nationalist." This is evidence of Soviet
+  framing, not a neutral assessment.
+- **Hidden / obscene folklore materials:** Modern work by Maria Mayerchyk and
+  Olena Boriak on Vovk's hidden collections shows that his archive includes sexual,
+  obscene, and Jewish-swearword materials. That topic can support advanced
+  source-ethics work, but it needs content warnings and care not to exoticize
+  marginalized speech.
+
+The safest pedagogical stance is anti-hagiographic. Vovk was a Ukrainian
+institution-builder and European-level scholar, but he also worked through
+imperial institutions and dated scientific categories. The dossier should preserve
+both facts.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-07-04.
+> Candidate paths are explicitly marked as not existing in this worktree.
+
+- **Existing BIO plans:**
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-drahomanov.yaml` - Hromada exile
+    network, Geneva publishing, and Ukrainian civic scholarship abroad.
+  - `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml` - Galician scholarly contact,
+    NTSh context, and shared Ukrainian cultural infrastructure.
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml` - the collective
+    project *Украинский народ в его прошлом и настоящем* and Ukrainian scholarly
+    institution-building.
+  - `curriculum/l2-uk-en/plans/bio/stepan-rudnytskyi.yaml` - Ukrainian geography
+    and empirical arguments against imperial spatial framing.
+- **Existing HIST plans:**
+  - `curriculum/l2-uk-en/plans/hist/hromady.yaml` - Kyiv Hromada and Ukrainian civic
+    organization under empire.
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` - censorship regime
+    around Ukrainian-language publishing and the need for foreign editions.
+  - `curriculum/l2-uk-en/plans/hist/rosiiska-imperiia-ukraina.yaml` - imperial
+    institutional frame of his education, persecution, and publication languages.
+  - `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml` - 1917-1918 return
+    invitation context, with timeline caveats.
+- **Existing FOLK/LIT plans:**
+  - `curriculum/l2-uk-en/plans/folk/narodna-kultura-yak-systema.yaml` - Vovk's
+    ethnographic method treats culture as linked practices, not decorative trivia.
+  - `curriculum/l2-uk-en/plans/folk/rodynna-obriadovist-zvychai.yaml` - wedding and
+    funeral ritual material.
+  - `curriculum/l2-uk-en/plans/folk/vesilni-pisni.yaml` - wedding-ritual source
+    context for *Rites et usages nuptiaux en Ukraine*.
+  - `curriculum/l2-uk-en/plans/folk/rehionalni-etnokulturni-tradytsii.yaml` -
+    regional fieldwork across Poltava, Chernihiv, Volyn, Galicia, Bukovyna,
+    Transcarpathia, Kuban, and Taman.
+  - `curriculum/l2-uk-en/plans/lit/ethnography.yaml` - literature/ethnography
+    interface and the political work of collecting culture.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `curriculum/l2-uk-en/plans/bio/fedir-vovk.yaml` - target BIO module implied by
+    the manifest gap; absent in this worktree.
+  - `curriculum/l2-uk-en/plans/bio/pavlo-chubynskyi.yaml` - close ethnographic and
+    Southwestern Branch connection; absent in this worktree.
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-antonovych.yaml` - mentor and Hromada
+    archaeology link; absent in this worktree.
+  - A science-ethics micro-module on how to read historical anthropology without
+    repeating its taxonomy.
+
+## 8. Naming-canonical
+
+- **Slug:** `fedir-vovk`
+- **EN canonical (BGN/PCGN-style project spelling):** Fedir Vovk.
+- **UA canonical:** Федір Кіндратович Вовк.
+- **Historical UA variant:** Хведір Кіндратович Вовк.
+- **Aliases to track (`aliases:` YAML field):** Khvedir Vovk; Theodore Volkov; Th.
+  Volkov; Fedor Volkov; Волков; Кондратович; Сірко; Яструбець; Лупулеску.
+- **Forbidden or cautionary forms:** `fedyr-vovk` as a slug; "Russian
+  anthropologist" unless explicitly discussing imperial institutional affiliation;
+  "Fedor Volkov" as the primary classroom name.
+
+## 9. Image candidates
+
+- **Best likely portrait candidate:** Wikimedia Commons `File:Vovk.Fedir.jpg` and
+  the Commons category `Fedir Vovk`; verify individual file license and US public
+  domain status before packaging.
+- **Best institutional archive candidate:** Institute of Archaeology НАН України,
+  "Digital Memory Repository: Archive of Khvedir Vovk (1847-1918)", especially
+  "Portraits and other photographs"; rights are held by the Institute, so use only
+  with clear permission/terms.
+- **Context image:** Mizyn-site photographs from the Institute archive, if rights
+  are cleared, would support the archaeology angle better than a generic portrait.
+- **Avoid as main image:** anthropological "types" plates unless the module is
+  explicitly about historical anthropology and includes a visual-framing warning.
+  Without that warning they can reproduce outdated typological thinking.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- В. І. Наулко, "Вовк Федір Кіндратович," *Енциклопедія Сучасної України*,
+  https://esu.com.ua/article-35231, accessed 2026-07-04.
+- В. О. Горбик, "Вовк (Волков) Федір Кіндратович," *Енциклопедія історії
+  України*, https://history.org.ua/?termin=Vovk_F, accessed 2026-07-04.
+- Mykola Mushynka, "Vovk, Fedir," *Internet Encyclopedia of Ukraine*,
+  https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CV%5CO%5CVovkFedir.htm,
+  accessed 2026-07-04.
+
+**Tier 2 (institutional):**
+
+- Київський національний університет імені Тараса Шевченка, "Вовк (Волков)
+  Федір Кіндратович (1847-1918),"
+  https://knu.ua/ua/geninf/osobystosti/vovk/, accessed 2026-07-04.
+- Український інститут національної пам'яті, "1847 - народився Федір Вовк,
+  етнограф,"
+  https://uinp.gov.ua/istorychnyy-kalendar/berezen/17/1847-narodyvsya-etnograf-fedir-vovk,
+  accessed 2026-07-04.
+- Національна історична бібліотека України, "Федір (Хведір) Кіндратович Вовк:
+  «Про Україну й для України»,"
+  https://www.nibu.kyiv.ua/exhibitions/558/, accessed 2026-07-04.
+- Інститут археології НАН України, "Науковим архівом Інституту археології
+  реалізовано проект «Цифрове сховище пам'яті. Архів Хведора Вовка
+  (1847-1918)»," https://iananu.org.ua/novini/ogoloshennya/1336-naukovim-arkhivom-institutu%20arkheologiji-realizovano-proekt-tsifrove-skhovishche-pam-yati-arkhiv-khvedora%20vovka-1847-1918,
+  accessed 2026-07-04.
+- Інститут археології НАН України, "Фонди Наукового архіву,"
+  https://iananu.org.ua/struktura-ia/naukovo-dopomizhni-pidrozdili/naukovij-arkhiv/fondi-naukovogo-arkhivu,
+  accessed 2026-07-04.
+- НБУВ Україніка, "Вовк Хведір Кіндратович,"
+  https://irbis-nbuv.gov.ua/ulib/item/REF0002473, accessed 2026-07-04.
+
+**Tier 3 (encyclopedic / local corpus):**
+
+- Ukrainian Wikipedia via `mcp__sources.query_wikipedia`, "Вовк Федір
+  Кіндратович," extract read 2026-07-04, used only after ESU/EIU/IEU and
+  institutional checks.
+- Local `mcp__sources.search_sources` result from *Шевченківський словник* and
+  related local corpus chunks, used as evidence of Soviet-era labeling and
+  Shevchenko-publication context, not as neutral historiography.
+
+**Tier 4 (modern scholarship and critical leads):**
+
+- Оксана Франко, "Наукова діяльність Федора Вовка," *Український історичний
+  журнал*, 2006, no. 3, PDF at https://history.org.ua/JournALL/journal/2006/3/3.pdf,
+  accessed 2026-07-04.
+- Оксана Франко, *Федір Вовк: вчений і громадський діяч*, Київ, 2000, cited by IEU
+  and Ukrainian Wikipedia bibliographies.
+- Maria Mayerchyk and Olena Boriak, *Inventing the Obscene: The Hidden Collections
+  of Fedir Vovk*, Krytyka / HURI listing,
+  https://books.huri.harvard.edu/books/inventing-the-obscene-the-hidden-collections-of-fedir-vovk,
+  accessed 2026-07-04.
+
+**Primary-source documents accessed:**
+
+- Short excerpts from the 2016 Savchuk sample PDF for Vovk selected works,
+  https://savchook.com/wp-content/uploads/2016/11/Vybrane-Vovk.pdf, accessed
+  2026-07-04. These excerpts were not verified by local quote tooling.
+- Work titles and publication contexts for Vovk's own writings as listed by ESU,
+  IEU, KNU, NIBU, and Ukrainian Wikipedia.
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; imperial institutions are named as context, not as
+  ownership of the scholar.
+- [x] No Russian-imperial transliteration is used as the primary name; `Volkov` is
+  confined to aliases/source-context.
+- [x] `fedir-vovk` is used as the locked slug, not `fedyr-vovk`.
+- [x] Outdated physical-anthropology categories are treated as historical
+  source-context, not narrator truth.
+- [x] Soviet accusations and labels are described as labels, not neutral facts.
+- [x] Existing cross-track file paths were checked with `test -e`; nonexistent
+  connections are marked Candidate/Phase 2.


### PR DESCRIPTION
## Summary

- Add the missing BIO research dossier for Fedir Vovk at `docs/research/bio/fedir-vovk.md`.
- Follow the existing 10-section BIO dossier pattern with verified facts, oppression mechanism, works, quote-integrity caveats, cross-track links, naming, image candidates, sources, and a decolonization self-check.
- Keep Vovk's physical-anthropology vocabulary as historical source-context, not narrator truth.

## Verification

- `npx markdownlint-cli2 docs/research/bio/fedir-vovk.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/fedir-vovk.md`
- `git diff --check origin/main...HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Local protected-path/artifact scan: no protected paths in `origin/main...HEAD`; diff is exactly `docs/research/bio/fedir-vovk.md`.
- Local racial/imperial framing scan: sensitive terms appear only in alias/source-context or explicit cautionary framing.

## Notes

LLM-QG was not used, run, trusted, routed, persisted, or closed for this PR.

Historical/source caveats: two candidate Vovk excerpts were checked with local quote tooling and did not verify (`matched: false`), so the dossier labels them as source-cited leads rather than classroom-ready quotes. The death date is recorded as 29 June 1918 with an explicit note that IEU gives 30 June and EIU's online line conflicts with the other sources.