### PR TITLE
docs(bio): add Filaret Kolessa dossier

### DIFF
--- a/docs/research/bio/filaret-kolessa.md
+++ b/docs/research/bio/filaret-kolessa.md
@@ -1,0 +1,192 @@
+# Філарет Михайлович Колесса — Research Dossier
+
+**Slug:** `filaret-kolessa`
+**Block:** +77 expansion — folklore / ethnomusicology infrastructure
+**Tier:** 2
+**Issue:** BIO Ukrainian expansion research, 2026-06-29
+**Researcher:** Codex GPT-5
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited
+- [x] Oppression/pressure mechanism is specific without inventing a martyr or security-service case
+- [~] Primary-source anchors identified; no classroom-ready first-person quote verified by local page-level tooling
+- [x] Cross-track links: every "Existing" path checked by local xref linter
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Філарет Михайлович Колесса. [T1: ЕСУ; T1: ЕІУ; T1: IEU]
+- **Pseudonyms / aliases:** Філярет Колесса in older spelling; Filaret Kolessa; Filaret Mykhailovych Kolessa; Filaret Mykhaylovych Kolessa. Russified/imperial forms are listed only in §8.
+- **Born:** 17 July 1871 | село Татарське, Стрийський повіт, Galicia | now село Піщани, Стрийський район, Львівська область, Україна. ЕСУ and ЕІУ give Татарське / нині Піщани; IEU gives Tatarske, Stryi county, Galicia. [T1: ЕСУ; T1: ЕІУ; T1: IEU]
+- **Died:** 3 March 1947 | Львів | buried at Личаківське кладовище. ЕСУ, ЕІУ, IEU, and УІНП agree on the death date and city; burial detail from УІНП. [T1: ЕСУ; T1: ЕІУ; T1: IEU; T2: УІНП]
+- **Family / education key facts:** From a priest's family. Brother of Олександр Колесса, father of composer Микола Колесса and singer Дарія Колесса-Залеська. Finished Стрийська гімназія in 1891; studied at the Vienna theological seminary in 1891-1892; heard harmony with Антон Брукнер in Vienna; graduated from the philosophy faculty of Львівський університет in 1896; received a doctorate in Slavic philology at Віденський університет in 1918. Full member of НТШ from 1909 and академік ВУАН from 1929. [T1: ЕСУ; T1: ЕІУ; T1: IEU]
+
+**Source disagreement / naming note:** The older village name appears as Татарське; the modern locality is Піщани. Use Піщани for modern geography, but preserve Татарське when explaining the 1871 birth context. The spelling `Філярет` appears in older publications such as the NBVU listing for `Українська усна словесність`; modern curriculum metadata should use `Філарет`.
+
+## 2. Oppression / pressure mechanism
+
+- **What happened:** Kolessa is not a repression-primary or martyr biography. The verified pressure frame is institutional: a Ukrainian scholar built folklore, ethnomusicology, museum, and NTSh infrastructure across Habsburg Galicia, interwar Polish rule, Soviet occupation/annexation of Western Ukraine, Nazi occupation, and renewed Soviet rule.
+- **When:** Core institution-building runs from the 1890s through 1947. Key Soviet-era pressure begins after 1939, when Soviet authorities incorporated Western Ukrainian cultural institutions into state structures and used prominent Galician scholars for legitimacy.
+- **By whom:** Competing imperial and state regimes shaped the working conditions: Habsburg/Austrian Galicia, interwar Polish Lviv, Soviet Ukrainian institutions after 1939, and wartime occupation. This pass found no dossier-ready NKVD/KGB case, arrest file, rehabilitation record, or execution claim for Kolessa himself.
+- **Document references:** ЕІУ records his 1939 appointment as professor and chair at Lviv University, and from 1940 his leadership roles in the Lviv branch of the Academy folklore/ethnography institute and the ethnographic museum. УІНП explicitly frames the Soviet state as making him an object of propaganda and notes the 1945 edited collection `Фольклор Вітчизняної війни`, with Red Army, partisan, and Stalin-centered material. [T1: ЕІУ; T2: УІНП]
+- **Mechanism specifics:** Teach the late career as co-optation and constrained continuity, not as neutral Soviet success and not as fabricated dissidence. Soviet posts and awards are real; they do not erase his earlier NTSh, Prosvita, Galician, and pan-Ukrainian scholarly work.
+- **What survived / what was damaged:** Survived: his notations of dumy, folk-song rhythmics, Ukrainian oral-literature synthesis, regional fieldwork, NTSh institutional network, and later published collected works. Damaged: interpretive clarity. Soviet-era editions and honors can flatten a scholar of Ukrainian cultural unity into an official Soviet folklorist unless the curriculum keeps the NTSh/Lesia Ukrainka/Kvitka/Lysenko context visible.
+
+## 3. Major works / contributions
+
+- `1898` — `Людові вірування на Підгір'ю в селі Ходовичах Стрийського повіту`, with a preface by Іван Франко; an early ethnographic monograph. [T1: ЕСУ; T2: УІНП]
+- `1895-1902` — early choral and folk-song arrangements, including `Вулиця`, `Квартети на хор мужеський`, `Обжинки`, and `Наша дума. Українсько-руські народні пісні`. Treat `українсько-руські` here as a historical title, not as narrator terminology. [T1: ЕСУ]
+- `1902-1904` — more than 50 transcriptions of instrumental music and songs from Hutsul material for Володимир Шухевич's `Гуцульщина`. [T1: ЕСУ]
+- `1905/1907` — `Ритміка українських народних пісень`, finished in 1905 and published in Kyiv in 1907 with Ivan Franko's support; a core work for rhythm and form. [T1: ЕСУ; local folk dossiers]
+- `1905` — `Огляд українсько-руської народної поезії`, important for teaching Ukrainian cultural unity across the border between the Russian and Austro-Hungarian empires; keep the title's historical wording source-bound. [T1: IEU; T2: УІНП]
+- `1908-1913` — Poltava phonograph expedition and `Мелодії українських народних дум`, published as two NTSh series in 1910 and 1913. The project involved Lesia Ukrainka, Klyment Kvitka, Opanas Slastion, kobzars, and lirnyks; do not credit the whole documentary act to Kolessa alone. [T1: ЕСУ; T1: IEU; T4: Dovhaliuk; local IMFE PDF check]
+- `1909` — `Гаївки`, prepared with Володимир Гнатюк and Осип Роздольський; Kolessa supplied 180 melodies and classified them by syllabic and strophic structure. [T1: ЕСУ]
+- `1920-1921` — `Українські народні думи` and `Про генезу українських народних дум`; central for the dumy/holosinnia hypothesis, but not a final closed answer. [T1: ЕСУ; T1: IEU]
+- `1923/1938/1929` — collections from Південне Підкарпаття / Підкарпатська Русь and `Народні пісні з Галицької Лемківщини`, pioneering work on Ukrainian musical dialects and regional repertoires. [T1: ЕСУ; T1: IEU]
+- `1932/1995` — Polissia fieldwork with Kazimierz Moszynski; 220 songs and 26 instrumental melodies later published as `Музичний фольклор з Полісся у записах Ф. Колесси та К. Мошинського`. [T1: ЕСУ]
+- `1938` — `Українська усна словесність`, a 643-page Prosvita synthesis of Ukrainian oral literature, documented in NBVU's Ukrainica library. [T2: NBVU]
+- `1939-1946` — literary-folklore studies on Shevchenko, Franko, and Lesia Ukrainka, including `Студії над поетичною творчістю Т. Шевченка`, `Народнопісенна ритміка в поезіях Івана Франка`, and `Леся Українка і український музичний фольклор`. [T1: ЕСУ; T1: ЕІУ]
+
+## 4. Primary-source anchors and quote status
+
+No short first-person Kolessa quotation was verified to classroom-ready standard in this pass. The locally checked `Мелодії українських народних дум` PDF is an OCR-backed 1969 IMFE/Naukova Dumka reprint of the 1910/1913 NTSh publication, and NBVU documents `Українська усна словесність` as a 1938 Prosvita book, but extracting a quotable line still needs page-level checking against a scan or a trusted edition.
+
+Safe primary/source anchors for future module work:
+
+- **`Мелодії українських народних дум`** — use for notation history, named performers, phonograph expedition context, and the move from oral performance to scholarly transcription. Verify any song line, melody attribution, or performer claim against a page image before classroom use. [T4: Dovhaliuk; local IMFE PDF check]
+- **`Українська усна словесність` (1938)** — use as Kolessa's own synthesis of Ukrainian oral genres. NBVU confirms the title, author, publisher, date, length, and scope; quote extraction still needs page-level scan/OCR verification. [T2: NBVU]
+- **`Ритміка українських народних пісень`** — use as a research-work anchor for rhythm and form. Local folk dossiers already rely on it as a form source, but this pass did not verify a quotable passage from the original edition. [T1: ЕСУ; local folk dossiers]
+
+Quote caveat: УІНП reproduces Lesia Ukrainka's praise of Kolessa's dumy work, and a popular epigraph attributes a general statement about folklore to Kolessa. Those are useful leads, not classroom-ready quotations until matched to a letter edition or page scan.
+
+## 5. Language register
+
+- **Register:** scholarly Galician Ukrainian, ethnographic and musicological terminology, older orthographic forms in pre-1939 publications, and historical publication titles that include `українсько-руський` or related terms. Teacher narration should use modern Ukrainian naming while preserving historical titles when citing works.
+- **CEFR readiness:** B2 for a short biographical profile and institutional vocabulary; C1 for source-method, regional musical dialects, comparative Slavic folklore, dumy genesis, and Soviet co-optation.
+- **Lexicon notes:** `фольклористика`, `етномузикологія`, `етнографія`, `дума`, `кобзар`, `лірник`, `фонограф`, `транскрипція`, `речитатив`, `голосіння`, `коломийковий вірш`, `лемківський`, `підкарпатський`, `НТШ`, `ВУАН`.
+- **Stylistic features:** genre classification, rhythmic analysis, comparative method, region-sensitive vocabulary, and careful movement between oral performance, notation, print, archive, and classroom.
+
+## 6. Contested points
+
+- **Founder label:** Kolessa is often called a founder of Ukrainian ethnographic musicology. That is defensible as a shorthand for curriculum metadata, but the module should show the network: Lysenko's earlier musical folklore work, Franko and Hnatiuk at NTSh, Rozdolskyi and Liudkevych, Lesia Ukrainka and Kvitka, Slastion, and the performers themselves.
+- **Dumy genesis:** Kolessa argued for a connection between dumy recitative and funeral lament. ЕСУ says he defended that theory but also cautions that it can be accepted only partly because the content and historical function differ. Local FOLK dossiers already preserve this as a hypothesis, not a closed origin story.
+- **Expedition credit:** The 1908 Poltava project should not become a lone-scholar myth. Sources consistently tie it to Lesia Ukrainka's and Klyment Kvitka's initiative, Lesia Ukrainka's funding, Slastion's recordings, and the artistry of named kobzars and lirnyks.
+- **Historical labels:** `українсько-руський`, `Галицька Лемківщина`, `Підкарпатська Русь`, and similar source terms are important historical metadata. They should not become the teacher voice's shortcut for Ukrainian identity or regional culture.
+- **Soviet late-career frame:** Soviet titles, posts, and awards are real but incomplete. УІНП's note on the 1945 `Фольклор Вітчизняної війни` collection is a warning: official Soviet uses of folklore can praise state power and Stalin while standing beside an earlier Ukrainian scholarly record that cannot be reduced to that frame.
+- **Public-domain text temptation:** Kolessa's sources contain many songs, dumy, and quoted folk texts. Do not copy a convenient line into a module unless `verify_quote` or equivalent deterministic checking confirms the exact text, performer/source, and edition.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml` — Lysenko-line musical folklore model and Kolessa's Lysenko studies.
+  - `curriculum/l2-uk-en/plans/bio/oleksandr-koshyts.yaml` — choral transmission and Ukrainian song as cultural evidence abroad.
+  - `curriculum/l2-uk-en/plans/bio/mykola-leontovych.yaml` — folk-song transcription/arrangement line and later global song-memory.
+  - `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml` — Franko's support, preface work, and shared NTSh/folklore-literature ecology.
+  - `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml` — Kolessa's Shevchenko studies and the broader national-poetic canon.
+- **Existing BIO dossiers / research notes (VERIFIED present, no plan path asserted):**
+  - `docs/research/bio/stanislav-liudkevych.md` — NTSh/Galician professional music and folklore infrastructure.
+- **Existing FOLK plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/folk/kobzarstvo-lirnytstvo.yaml` — phonograph recordings, kobzar/lirnyk repertoire, and `Мелодії українських народних дум`.
+  - `curriculum/l2-uk-en/plans/folk/dumy-nevilnytski-lytsarski.yaml` — dumy melody, performer evidence, and genre theory.
+  - `curriculum/l2-uk-en/plans/folk/dumy-sotsialno-pobutovi.yaml` — performer-specific dumy variants and Kolessa's transcription role.
+  - `curriculum/l2-uk-en/plans/folk/holosinnya.yaml` — recitative and the Kolessa hypothesis about links between lament and dumy form.
+  - `curriculum/l2-uk-en/plans/folk/kolomyiky.yaml` — rhythmics and fourteen-syllable verse/form analysis.
+  - `curriculum/l2-uk-en/plans/folk/rodynno-pobutovi-pisni.yaml` — rhythm/form approach to lyrical song, not individual lyric attribution.
+  - `curriculum/l2-uk-en/plans/folk/koliadky-shchedrivky.yaml` — winter-song repertory and early Kolessa song-arrangement context.
+  - `curriculum/l2-uk-en/plans/folk/vesilni-pisni.yaml` — ritual-song analysis where performer/region/edition must be checked.
+  - `curriculum/l2-uk-en/plans/folk/rehionalni-etnokulturni-tradytsii.yaml` — Lemko, Hutsul, Polissia, and Subcarpathian regional evidence.
+  - `curriculum/l2-uk-en/plans/folk/narodna-kultura-ta-vysoka-kultura-mistky.yaml` — oral tradition to notation, archive, school, and stage.
+- **Existing C1 plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/c1/checkpoint-folk-music.yaml` — advanced folk-music checkpoint where Kolessa can anchor source method.
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-2-natsionalna-shkola.yaml` — national music school bridge through Lysenko and Galician scholarship.
+  - `curriculum/l2-uk-en/plans/c1/halychyna.yaml` — Galician institutional context.
+  - `curriculum/l2-uk-en/plans/c1/kobzari-bandura.yaml` — kobzar/bandura interpretive bridge.
+  - `curriculum/l2-uk-en/plans/c1/kolyskovi-ta-dumy.yaml` — compact advanced route into lullabies, laments, and dumy.
+- **Existing HIST/LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/franko-lesia-hrinchenko.yaml` — national-cultural work around Franko, Lesia Ukrainka, and Hrinchenko.
+  - `curriculum/l2-uk-en/plans/hist/shevchenko-awakening.yaml` — Shevchenko-centered national awakening that Kolessa studied through folklore/literature.
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — imperial language/culture suppression background for pan-Ukrainian print culture.
+  - `curriculum/l2-uk-en/plans/lit/franko-biography.yaml` — direct Franko link.
+  - `curriculum/l2-uk-en/plans/lit/franko-social-poetry.yaml` — Franko public-poetic context.
+  - `curriculum/l2-uk-en/plans/lit/cult-of-shevchenko.yaml` — Shevchenko reception and cultural memory.
+- **Candidate cross-track connections (not asserted as existing plans):**
+  - `plans/bio/filaret-kolessa.yaml` — not present in this checkout as of 2026-07-04; the dossier prepares it but does not cite it as existing.
+  - Future BIO plans for Володимир Гнатюк, Климент Квітка, Лариса Косач / Леся Українка as expedition infrastructure figures, and Опанас Сластьон as artist/recordist.
+  - A source-method mini-module on "phonograph -> transcription -> archive -> classroom" using one verified performer page from `Мелодії українських народних дум`.
+
+## 8. Naming-canonical
+
+Per `docs/best-practices/bio-naming-canonical.md`:
+
+- **Slug:** `filaret-kolessa`.
+- **EN canonical (BGN/PCGN-style project spelling):** Filaret Kolessa.
+- **UA canonical (with patronymic):** Філарет Михайлович Колесса.
+- **Aliases to track (`aliases:` YAML field later):** Філярет Колесса; Філарет Колесса; Filaret Mykhailovych Kolessa; Filaret Mykhaylovych Kolessa; Filaret M. Kolessa.
+- **Related-name disambiguation:** Олександр Колесса is his brother; Іван Колесса is his brother; Микола Колесса is his son; Любка Колесса is his niece. Do not conflate their BIO or music-history roles.
+- **Forbidden Russian-imperial / Russified forms (flag in body text):** Филарет Михайлович Колесса; Filaret Mikhailovich Kolessa; Filaret Kolesa; Russian/Polish/German imperial place spellings used as neutral teacher voice. Historical source titles may retain original orthography with context.
+
+## 9. Image candidates
+
+- **Best PD portrait candidate:** Wikimedia Commons category / file for Filaret Kolessa, likely pre-1947 portrait. Verify the individual file page and US/public-domain status before use; do not rely on category-level assumptions.
+- **Context image candidates:**
+  - Title page or scan page from `Мелодії українських народних дум` in the IMFE access PDF, if rights and edition status are cleared for project use.
+  - NBVU `Українська усна словесність` listing or title page, pending rights and image-capture review.
+  - Grave/family tomb at Lychakiv Cemetery, if a freely licensed image is available.
+- **Do not use:** a random kobzar/lirnyk image as Kolessa's portrait, or an unverified scan of a folk song as if it proves a classroom quote.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Енциклопедія Сучасної України. "Колесса Філарет Михайлович." https://esu.com.ua/article-5631. Accessed 2026-07-04.
+- Інститут історії України НАН України / Енциклопедія історії України. Галайчак Т. Ю. "Колесса Філарет Михайлович." https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Kolessa_F&Z21ID=. Accessed 2026-07-04.
+- Internet Encyclopedia of Ukraine. Wytwycky, Wasyl. "Kolessa, Filaret." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CO%5CKolessaFilaret.htm. Updated 2004; accessed 2026-07-04.
+
+**Tier 2 (institutional):**
+
+- Український інститут національної пам'яті. "1871 - народився Філарет Колесса, український музикознавець, композитор, фольклорист." https://uinp.gov.ua/istorychnyy-kalendar/lypen/17/1871-narodyvsya-filaret-kolessa-ukrayinskyy-muzykoznavec-kompozytor-folkloryst. Accessed 2026-07-04.
+- Національна бібліотека України імені В. І. Вернадського, електронна бібліотека "Україніка." "Колесса Ф. Українська усна словесність (1938)." https://irbis-nbuv.gov.ua/ulib/item/UKR0001149. Accessed 2026-07-04.
+
+**Tier 4 (modern scholarly / source-method):**
+
+- Довгалюк Ірина. "До історії експедиції Філарета Колесси на Наддніпрянську Україну." `Вісник Львівського університету. Серія філологічна`, 2009, вип. 47, с. 5-27. Accessed via Wikisource transcription, https://uk.wikisource.org/wiki/До_історії_експедиції_Філарета_Колесси_на_Наддніпрянську_Україну, 2026-07-04.
+- Local IMFE access PDF check: `kolessa_f_m_melodii_ukrainskih_narodnih_dum.pdf` downloaded to `/tmp` from `https://www.etnolog.org.ua/pdf/e-biblioteka/mystectv/muz/kolessa_f_m_melodii_ukrainskih_narodnih_dum.pdf`; `pdfinfo` reported 598 pages and ABBYY OCR metadata; `pdftotext` confirmed the 1969 title/reprint framing and 1910/1913 publication statement. Used for source anchoring, not for classroom-ready quotation.
+
+**Local dossier / project sources:**
+
+- `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md` — roster rationale for adding `filaret-kolessa`.
+- `docs/research/folk/kobzarstvo-lirnytstvo.md`, `docs/research/folk/dumy-nevilnytski-lytsarski.md`, `docs/research/folk/dumy-sotsialno-pobutovi.md`, `docs/research/folk/holosinnya.md`, `docs/research/folk/kolomyiky.md`, `docs/research/folk/rodynno-pobutovi-pisni.md` — local cross-track usage of Kolessa as form, notation, and source-method anchor.
+- `docs/research/bio/mykola-lysenko.md`, `docs/research/bio/mykola-leontovych.md`, `docs/research/bio/oleksandr-koshyts.md`, `docs/research/bio/stanislav-liudkevych.md` — pattern and music-history analogues.
+
+**Primary-source documents accessed / located:**
+
+- `Мелодії українських народних дум` — 1969 IMFE/Naukova Dumka reprint of the 1910/1913 NTSh series, locally inspected from the IMFE PDF as above.
+- `Українська усна словесність` — 1938 Prosvita book located through NBVU Ukrainica metadata; document listing inspected, but no page-level quote extracted.
+
+**Honest gaps:**
+
+- No first-person Kolessa quote is classroom-ready from this pass.
+- No security-service or court-file primary document was found or used; the dossier deliberately avoids inventing a repression case.
+- The exact quotation path for Lesia Ukrainka's praise of `Мелодії українських народних дум` should be verified against a letter edition before use in learner-facing material.
+- Media rights for portrait or scan images were not cleared.
+
+---
+
+## Decolonization self-check
+
+- [x] Ukrainian scholarly infrastructure, NTSh, and fieldwork are the primary frame.
+- [x] Soviet posts and awards are visible but not treated as Kolessa's core identity.
+- [x] No fabricated martyr, arrest, or security-service case.
+- [x] `українсько-руський` and related historical labels appear only as source titles or discussed labels.
+- [x] Kolessa's dumy/holosinnia theory is marked as a scholarly hypothesis with limits.
+- [x] Expedition credit includes Lesia Ukrainka, Klyment Kvitka, Opanas Slastion, performers, and institutions.
+- [x] No unverified song, quote, or manuscript claim is treated as classroom-ready.
+- [x] Existing cross-track paths were validated by the project xref linter.


### PR DESCRIPTION
## Summary

- Adds the missing BIO research dossier for Filaret Kolessa.
- Frames Kolessa as a Ukrainian folklore / ethnomusicology infrastructure figure without inventing a martyr or security-service case.
- Keeps quote, song, manuscript, and cross-track claims cautious: no classroom-ready first-person quote is asserted without page-level verification, and only existing plan paths are listed under Existing.

## Verification

- `npx markdownlint-cli2 docs/research/bio/filaret-kolessa.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/filaret-kolessa.md`
- `git diff --check origin/main...HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Local protected-path/artifact scan: only `docs/research/bio/filaret-kolessa.md` is in the diff; no status/audit/review artifacts or telemetry files.
- Local framing scan reviewed the only Russian-imperial hits as intentional source-title / forbidden-form discussion.

## LLM-QG

LLM-QG was not used. I did not run, trust, route, persist, or close anything through LLM-QG, and I did not run `run_llm_qg_parity.py` or `scripts/audit/module_quality_audit.py`.

## Caveats

- No first-person Kolessa quote is classroom-ready from this pass.
- The IMFE `Мелодії українських народних дум` PDF was inspected as a source anchor, not used for unverified learner-facing quotations.
- The dossier deliberately avoids asserting a personal repression/security-file case for Kolessa.