### PR TITLE
docs(bio): add Hryhorii Kochur dossier

### DIFF
--- a/docs/research/bio/hryhorii-kochur.md
+++ b/docs/research/bio/hryhorii-kochur.md
@@ -1,0 +1,164 @@
+# Григорій Порфирович Кочур — Research Dossier
+
+**Slug:** `hryhorii-kochur`
+**Block:** D (survived Soviet imprisonment and censorship; translation school / cultural continuity)
+**Tier:** 1a
+**Issue:** BIO manifest dossier gap (`hryhorii-kochur`)
+**Researcher:** Codex GPT-5
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] >=3 source anchors cited (ЕСУ; KHPG dissident-movement profile; Kochur memorial site; Palgrave Shakespeare preview; Ukrainian Wikipedia only as navigation)
+- [x] Oppression mechanism is specific: 1943 arrest, 1944 sentence, Inta camp, post-release settlement limits, 1973 Writers' Union expulsion/publication ban
+- [x] Quote and translation-sample limitations stated honestly; no unverified passage is treated as classroom-ready
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-07-04
+- [x] Naming-canonical applied, with spelling variants separated from Russian-imperial forms
+- [x] Image candidate(s) identified with rights caution
+- [x] Decolonization checklist self-applied
+- [x] LLM-QG was not used
+
+> **Load-bearing frame:** Kochur should not be reduced to "former prisoner" or to an abstract symbol of resistance. The useful curriculum frame is a translator, editor, theorist, and mentor whose Irpin home and translation practice kept Ukrainian literary continuity alive under censorship. Soviet repression matters here because it shaped what could be published, who could gather, and which translation lineages survived.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Григорій Порфирович Кочур. [T1: ЕСУ; T2: KHPG; T3: uk.wikipedia]
+- **Pseudonyms / aliases:** no stable pen-name found in this pass. English transliteration variants to track: Hryhorii Kochur, Hryhoriy Kochur, Hryhory Kochur; patronymic form Hryhorii Porfyrovych Kochur. Russified/Russian-imperial forms to quarantine in §8 only: Grigoriy Kochur; Григорий Порфирьевич Кочур.
+- **Born:** 4 (17) November 1908 | село Феськівка, then Sosnytsia povit / Chernihiv gubernia; now Менська міська громада, Корюківський район, Чернігівська область, Україна. [T1: ЕСУ; T2: KHPG; T3: uk.wikipedia; T6: Decentralization.ua]
+- **Died:** 15 December 1994 | source disagreement: ЕСУ gives **Kyiv** and burial in Irpin; KHPG and Ukrainian Wikipedia give **Irpin, Kyiv region**. Treat the place of death as needing page-level confirmation before lesson publication. Burial/memory center: Irpin. [T1: ЕСУ; T2: KHPG; T3: uk.wikipedia]
+- **Family / education key facts:** born into a peasant family; studied at the Kyiv Institute of People's Education, graduating in 1932. His teachers/circle included Mykola Zerov, Mykhailo Kalynovych, Oleksandr Biletskyi, Borys Yakubskyi, Serhii Maslov, and other figures of the high philological culture that Soviet policy soon attacked. Married Ірина Воронович, who was arrested and sentenced with him. [T1: ЕСУ; T2: KHPG; T4: Kochur memorial site]
+- **Professional path before arrest:** after graduation taught in Balta/Tiraspol; from 1936 to 1941 headed the literature department at Vinnytsia Pedagogical Institute. [T1: ЕСУ; T2: KHPG]
+- **Recognition:** member of the Writers' Union of Ukraine in 1968-1973 and again from 1988; full member of the Shevchenko Scientific Society; Maksym Rylskyi Prize 1989; Shevchenko National Prize 1995, posthumous. [T1: ЕСУ; T4: Kochur memorial site]
+
+**Source disagreement note:** arrest date appears as **5 October 1943** in ЕСУ and **8 October 1943** in KHPG; rehabilitation is given as **1962** in ЕСУ/Ukrainian Wikipedia and **8 January 1957** in KHPG. Keep both discrepancies visible until an archival or critical-biography source is checked.
+
+## 2. Oppression mechanism
+
+This is the load-bearing section, but it should not swallow the biography.
+
+- **What happened:** Soviet security organs arrested Kochur and his wife in occupied/recaptured wartime Poltava, accused them of OUN membership and "Ukrainian bourgeois nationalism," sentenced them to camp terms, and then constrained his publication and institutional life after release. The OUN link is recorded as a Soviet charge, not accepted as proven fact; KHPG says Kochur denied guilt. [T1: ЕСУ; T2: KHPG; T3: uk.wikipedia]
+- **When:** arrest in October 1943 (date discrepancy: 5 vs 8 October); sentence on 11 March 1944 according to KHPG; release on 8 January 1953 according to ЕСУ; rehabilitation date disputed as 1957 vs 1962; Writers' Union expulsion in 1973; reinstatement in 1988. [T1: ЕСУ; T2: KHPG]
+- **By whom:** wartime Soviet security/judicial structures, later the Writers' Union and KGB pressure network of the Ukrainian SSR. KHPG specifically names the pressure to testify against Yevhen Sverstiuk in the 1973 repression wave. [T2: KHPG]
+- **Mechanism specifics:** the sentence was **10 years of deprivation of liberty**; KHPG adds **5 years loss of rights**. Kochur served in the Inta camp system in the Komi ASSR/Republic, worked under camp conditions, and continued creative work by writing poems, translating, and learning languages with other prisoners. Some popular accounts say many camp translations were destroyed or later reconstructed; this dossier does **not** treat that claim as classroom-ready without a page-level source.
+- **After release:** the family settled in Irpin, partly because former prisoners were restricted from living in Kyiv. His Irpin home became an informal meeting place for translators, writers, and opposition-minded cultural figures. [T2: KHPG; T4: Kochur memorial site]
+- **1960s-1970s repression:** Kochur signed public protest letters in the 1960s, including defense of arrested Ukrainian intellectuals. In 1973 he was expelled from the Writers' Union after refusing to give the KGB-desired testimony against Yevhen Sverstiuk; KHPG says this nearly eliminated his ability to publish. [T2: KHPG; T1: ЕСУ]
+- **What survived / what was damaged:** his translation school, private mentorship, editorial memory, and scholarly work survived; publishability, institutional protection, and some camp-era textual history were damaged. The key survival story is cultural infrastructure, not only personal endurance.
+
+## 3. Major works
+
+- `1964; reprints 1969, 1991, 2003` — **William Shakespeare, «Гамлет, принц данський»**, Ukrainian translation. ЕСУ records multiple editions and stage use; Palgrave calls Kochur's Hamlet especially influential in the Ukrainian Shakespeare tradition. [T1: ЕСУ; T5: Palgrave preview]
+- `1966` — **Микола Зеров, «Вибране»**, co-prepared with V. Petrov; important to the rehabilitation and republication of the neoclassical line. [T1: ЕСУ]
+- `1969` — **«Відлуння»**, selected translations. [T1: ЕСУ; T4: Kochur memorial site]
+- `1989` — **«Інтинський зошит»**, original camp poems from 1945-1953. Use only after checking the 1989 or later full edition for exact lines. [T1: ЕСУ; T2: KHPG; T4: Kochur memorial site]
+- `1990` — **Микола Зеров, «Твори: у 2 томах»**, co-prepared with Dmytro Pavlychko; a major act of restoring a murdered translation/philology lineage. [T1: ЕСУ; IEU Zerov cross-reference]
+- `1991` — **«Друге відлуння»**, selected translations. [T1: ЕСУ; T2: KHPG]
+- `2000; 2008` — **«Третє відлуння»**, expanded posthumous translation volume. [T1: ЕСУ; T4: Kochur memorial site]
+- `2008` — **«Література та переклад: Дослідження. Рецензії. Літературні портрети. Інтерв'ю»**, posthumous collection of translation studies, criticism, portraits, and interviews. [T5: Palgrave references; curriculum plans]
+- **Anthology/editorial work:** translations and commentary for Czech, Slovak, Lusatian, ancient, and world-poetry anthologies; prefaces and studies on Verlaine, Schiller, Boccaccio, Hasek, and Ukrainian translators. [T1: ЕСУ]
+
+**Suppression note:** do not frame the bibliography as a smooth career arc. His 1969 «Відлуння» was followed by the 1973 expulsion and publication blockage; the fuller recovery came only in 1988-1991 and posthumously.
+
+## 4. Primary-source quotes / translation samples
+
+**Honest verification note:** No local deterministic quote verifier was run against a Kochur corpus in this pass, and no local primary-text corpus entry was found by simple repo search. Therefore this dossier does **not** present any Kochur quote, Hamlet line, or camp-poem excerpt as classroom-ready.
+
+**Candidate 1 — camp poems from «Інтинський зошит»:** useful for a future BIO/LIT lesson because the poems connect language work, carceral space, and intellectual survival. Before use, verify lines against the 1989 edition or the 2024 fuller edition and record page numbers.
+
+**Candidate 2 — «Гамлет» translation:** useful for comparing Ukrainian Shakespeare renderings, but do not quote a line from Kochur's Hamlet until it is checked against a published edition. Palgrave supports the importance of the translation but the accessible preview does not provide classroom-ready excerpts. [T5: Palgrave preview]
+
+**Candidate 3 — «Література і переклад» / «Література та переклад»:** useful for translation theory modules on stylistic precision and literary continuity. The local plans cite Kochur's translation-theory work; future lesson writers should verify exact passages from the 2008 Smoloskyp collection before quoting.
+
+## 5. Language register
+
+- **Register:** high literary translation, translation-theoretical prose, and scholarly-critical essay. Kochur's value is not "Ukrainianizing at any cost"; ЕСУ explicitly describes his caution about excessive domestication and lexical/structural connotations. The curriculum should teach precision, not sloganized cultural weaponry.
+- **CEFR readiness for full reading:** **C1-C2** for translation-theory essays, Shakespeare comparison, and ancient/European poetry translations; **B2-C1** for short, heavily scaffolded biographical excerpts about Inta and Irpin.
+- **Lexicon notes:** художній переклад, перекладознавство, адекватність, стилістична автентичність, першоджерело, домістифікація, очуження, шістдесятництво, цензура, реабілітація, табірна поезія.
+- **Stylistic features:** disciplined equivalent-seeking; attention to historical register; preservation of authorial style; philological commentary; mentorship vocabulary around "school" and "craft."
+
+## 6. Contested points
+
+- **Arrest and rehabilitation chronology:** keep the ESU/KHPG differences visible: arrest 5 vs 8 October 1943; rehabilitation 1957 vs 1962. A future classroom chronology should use an archival or scholarly biography to settle the dates.
+- **OUN accusation:** record it as the Soviet charge. Do not write that Kochur "belonged to the OUN" unless a non-Soviet evidentiary source is produced. KHPG explicitly says he denied guilt.
+- **Death place:** Kyiv vs Irpin remains unresolved across accessible sources. Irpin is safe as residence, museum, burial/memory site; exact death place needs confirmation.
+- **Translation as resistance vs translation as craft:** the decolonial point is real, but Kochur's method was also rigorous, comparative, and often anti-simplification. Avoid reducing him to a martyr-translator or to a purely political emblem.
+- **Camp text transmission:** claims about destroyed translations, rewrites from memory, and exact prison-language learning are plausible and repeated in accessible accounts, but lesson writers should cite a memoir/critical edition before using them as close-reading evidence.
+- **Russian/Soviet framing:** Soviet labels such as "bourgeois nationalism" and "anti-Soviet" should appear only as regime charges, not as neutral descriptors.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-07-04. Candidate links are not asserted as files.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/maksym-rylskyi.yaml` — Rylskyi as the older translation-school figure and post-GULAG support context.
+  - `curriculum/l2-uk-en/plans/bio/mykola-zerov.yaml` — Kochur's teacher/lineage and the later restoration of Zerov's work.
+  - `curriculum/l2-uk-en/plans/bio/ivan-svitlychnyi.yaml`, `curriculum/l2-uk-en/plans/bio/yevhen-sverstiuk.yaml`, `curriculum/l2-uk-en/plans/bio/ivan-dziuba.yaml`, `curriculum/l2-uk-en/plans/bio/vasyl-stus.yaml` — the 1960s-1970s dissident and translation-intelligentsia network around protest letters, private discussion, and repression.
+- **Existing C2/LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/c2/translation-theory.yaml` — cites Kochur's translation-theory work and the Kochur/Lukash cultural-impact frame.
+  - `curriculum/l2-uk-en/plans/c2/translation-theory-ii.yaml` — stylistic authenticity and overcoming imperial layers.
+  - `curriculum/l2-uk-en/plans/c2/literary-translation-ii.yaml` — prose/translation-theory continuation with Kochur as a named source.
+  - `curriculum/l2-uk-en/plans/c2/translation-practice-ii.yaml` — Shakespeare/Dante practice through Ukrainian masters.
+  - `curriculum/l2-uk-en/plans/lit/lukash-translation-as-resistance.yaml` — peer/contrast with Mykola Lukash; useful for comparing creative expansion vs disciplined equivalence.
+  - `curriculum/l2-uk-en/plans/lit/translation-as-cultural-weapon.yaml` — should be nuanced with Kochur's anti-excessive-domestication stance.
+  - `curriculum/l2-uk-en/plans/lit/rylsky-translations.yaml` — translation-school inheritance from Rylskyi to Kochur/Lukash.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - BIO plan `hryhorii-kochur` / `hryhoriy-kochur` slug reconciliation. The site index locks `hryhorii-kochur`; an older Rylskyi dossier mentions `hryhoriy-kochur.yaml`, but no BIO plan file exists in this worktree.
+  - A LIT seminar on Kochur's Hamlet after exact edition lines are verified.
+  - A C2 translation-theory module using Kochur against the false binary "literal fidelity vs nationalist domestication."
+  - A HIST/BIO micro-module on Irpin as an informal cultural node under late Soviet censorship.
+
+## 8. Naming-canonical
+
+- **Slug:** `hryhorii-kochur`
+- **EN canonical (project spelling):** Hryhorii Kochur
+- **UA canonical (with patronymic):** Григорій Порфирович Кочур
+- **Aliases to track (`aliases:` YAML field):** Hryhorii Porfyrovych Kochur; Hryhoriy Kochur; Hryhory Kochur; Григорій Кочур.
+- **Forbidden Russian-imperial / Russified forms (flag in body text):** Grigoriy Kochur; Grigory Kochur; Григорий Порфирьевич Кочур. Do not use Russian-language metadata to overwrite the Ukrainian patronymic or transliteration.
+- **Slug caution:** current user task and site index use `hryhorii-kochur`; do not silently switch to `hryhoriy-kochur` in generated links.
+
+## 9. Image candidates
+
+- **Best portrait candidate:** individual file pages in Wikimedia Commons or the Kochur memorial site. Kochur died in 1994, so many photos may still be in copyright; verify the file license before reuse.
+- **Context image candidates:** the Irpin literary museum; a rights-cleared photo of the Kochur house/museum; a title page or cover of «Відлуння», «Друге відлуння», «Інтинський зошит», or «Література та переклад» if rights permit.
+- **Pedagogical image caution:** a camp/Inta image can easily over-flatten the biography into martyrdom. Prefer a portrait plus translation/editorial artifact when rights allow.
+- **If no rights-clear portrait clears review:** use a rights-cleared image of the Irpin museum or a neutral bibliographic cover only if the licensing path is explicit.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Енциклопедія Сучасної України. Роксолана Зорівчак, "Кочур Григорій Порфирович." https://esu.com.ua/article-1300. Accessed 2026-07-04. Used for birth/death baseline, education, arrest/release/rehabilitation chronology, membership/awards, bibliography, and translation range.
+
+**Tier 2 (institutional / human-rights / primary-adjacent):**
+- Kharkiv Human Rights Protection Group, Dissident Movement in Ukraine. "KOCHUR, Hryhory Porfyrovych." https://museum.khpg.org/en/1142682757. Accessed 2026-07-04. Used for arrest/sentence details, denial of guilt, Inta activity, Irpin home, protest letters, 1973 expulsion, publication blockage, and 1988 reinstatement.
+- "Григорій Кочур" memorial site. "Біографія." https://kochur.com/biografiya/. Accessed 2026-07-04. Used for family/education details, Irpin house/museum, works list, honors, and memory infrastructure. Family/memorial site, so factual claims are cross-checked where possible.
+
+**Tier 3 (scholarly / specialist reference preview):**
+- Nataliya Torkut. "Kochur, Hryhoriy." *The Palgrave Encyclopedia of Global Shakespeare*. Palgrave Macmillan, 2022. https://doi.org/10.1007/978-3-319-99378-2_181-1. Accessed 2026-07-04. Preview used only for Shakespeare/Hamlet significance and bibliography pointers, not for paywalled details.
+
+**Tier 4 (encyclopedic navigation):**
+- Українська Вікіпедія. "Кочур Григорій Порфирович." https://uk.wikipedia.org/wiki/Кочур_Григорій_Порфирович. Accessed 2026-07-04. Used for navigation and cross-checking, not as sole authority for contested claims.
+- Internet Encyclopedia of Ukraine cross-references: "Translated literature," "Shakespeare, William," and "Zerov, Mykola" entries. Used to situate Kochur in the Ukrainian translation and Zerov-restoration lineage.
+
+**Tier 6 (administrative place verification):**
+- Decentralization.ua. "Менська територіальна громада - Склад громади." https://decentralization.ua/newgromada/4951/composition. Accessed 2026-07-04. Used only to verify that modern Феськівка is in Менська територіальна громада, Корюківський район.
+
+**Primary-source / corpus checks:**
+- No Kochur primary text was verified with local deterministic quote tooling in this pass.
+- No LLM-QG route, persistence, parity script, or module quality audit was used.
+- Future quote work should verify exact passages from «Інтинський зошит», «Гамлет», or «Література та переклад» against a published edition with page numbers before classroom use.
+
+**Honest gaps:** archival case number and tribunal file not located; rehabilitation date unresolved; exact death place unresolved; no rights-cleared portrait selected; no translation sample approved for learner-facing use.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing: Soviet agencies and labels are named as repressive mechanisms, not neutral categories.
+- [x] No Russian-imperial transliterations in body text except the forbidden list in §8.
+- [x] No martyrdom-only flattening: translator, editor, scholar, and mentor roles remain central.
+- [x] No uncritical Soviet propaganda terms: "OUN membership" and "bourgeois nationalism" are described as Soviet charges.
+- [x] No fabricated quotes, edition lines, or translation samples.
+- [x] Modern Ukrainian place names used, with historical/administrative changes flagged.
+- [x] Cross-track links assert only existing files unless explicitly marked candidate/nonexistent.
+- [x] LLM-QG was not run, trusted, routed, persisted, or closed.


### PR DESCRIPTION
## Summary

- Adds the missing BIO research dossier for Hryhorii Kochur at `docs/research/bio/hryhorii-kochur.md`.
- Follows the existing 10-section BIO manifest dossier pattern with verified facts, oppression mechanism, works, quote/sample limitations, cross-track links, naming, image candidates, sources, and decolonization self-check.
- Keeps the dossier historically cautious: Soviet OUN/"bourgeois nationalism" labels are treated as regime charges; date/death-place disagreements are preserved; no Kochur quote or translation sample is marked classroom-ready without local deterministic/page-level verification.

LLM-QG was not used. I did not run, trust, route, persist, or close anything through LLM-QG, and did not run `run_llm_qg_parity.py` or `scripts/audit/module_quality_audit.py`.

## Verification

- `npx markdownlint-cli2 docs/research/bio/hryhorii-kochur.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/hryhorii-kochur.md`
- `git diff --check origin/main...HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Protected-path/artifact scan: diff contains only `docs/research/bio/hryhorii-kochur.md`; no `.python-version`, `.yamllint`, `.markdownlint.json`, status/audit/review artifacts, or `data/telemetry/**` files.
- Diff scan for `sys.executable`: no matches in this PR diff.
- Framing scan reviewed Soviet/imperial/OУН/martyrdom language in the dossier; labels are marked as Soviet charges and caveats are explicit.

Note: this worktree does not contain its own `.venv`; Python checks were run from the visible worktree using the existing project venv interpreter at `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python`.

## Historical/source caveats

- Arrest date differs across accessible sources: ЕСУ gives 5 October 1943; KHPG gives 8 October 1943.
- Rehabilitation date differs: ЕСУ/Ukrainian Wikipedia give 1962; KHPG gives 8 January 1957.
- Death place differs: ЕСУ gives Kyiv with burial in Irpin; KHPG/Ukrainian Wikipedia give Irpin.
- No archival case number or page-verified Kochur quote/translation sample was located in this pass, so the dossier names those limits instead of supplying unverified classroom material.
