### PR TITLE
[codex] Add Ivan Lysiak-Rudnytskyi BIO dossier

### DIFF
--- a/docs/research/bio/ivan-lysiak-rudnytskyi.md
+++ b/docs/research/bio/ivan-lysiak-rudnytskyi.md
@@ -1,0 +1,183 @@
+# Іван Павлович Лисяк-Рудницький — Research Dossier
+
+**Slug:** `ivan-lysiak-rudnytskyi`
+**Block:** +77 expansion — Ukrainian intellectual history / diaspora scholarly institutions / political thought
+**Tier:** 1b
+**Issue:** BIO manifest dossier backfill
+**Researcher:** Codex (`codex/bio-ivan-lysiak-rudnytskyi-dossier`)
+**Completed:** 2026-07-04
+
+**Source acronym legend:** IEU = Internet Encyclopedia of Ukraine; ESU = Encyclopedia of Modern Ukraine; EIU = Encyclopedia of the History of Ukraine; CIUS = Canadian Institute of Ukrainian Studies; NBUV = National Library of Ukraine digital catalogue; IA = Internet Archive scan of the 1987 CIUS volume.
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional or scholarly sources cited
+- [x] Pressure mechanism stated honestly as exile, non-recognition/suppression of Ukrainian history as an independent field, and posthumous editorial mediation; no invented arrest or camp term
+- [x] Primary-source anchors verified locally from `Essays in Modern Ukrainian History` via `pdftotext` on 2026-07-04
+- [x] Cross-track links checked with `test -e` on 2026-07-04 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights caveats included
+- [x] Decolonization checklist self-applied
+- [x] LLM-QG was not used
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Іван Павлович Лисяк-Рудницький. IEU gives the English headword as **Ivan Lysiak Rudnytsky** and the Ukrainian form `Лисяк-Рудницький, Іван`; ESU/EIU give Іван Павлович Лисяк-Рудницький. [T1: IEU; T1: ESU; T1: EIU]
+- **Project English canonical:** Ivan Lysiak-Rudnytskyi. Use this for the BIO slug and learner-facing project display unless a source title prints `Ivan L. Rudnytsky` or `Ivan Lysiak Rudnytsky`.
+- **Pseudonyms / aliases:** IEU lists Ivanna Brusna and Ivan Brusny; ESU expands the pseudonym/cryptonym set to Іванна Брусна, Іна Брусна, І. Брусний, Іван Брусний, Е.-О., І. Л., Ponticus, and others. Keep these as search aliases, not as the default learner-facing name. [T1: IEU; T1: ESU]
+- **Born:** 27 October 1919, Vienna, Austria. [T1: IEU; T1: ESU; T1: EIU]
+- **Died:** 25 April 1984, Edmonton, Alberta, Canada. [T1: IEU; T1: ESU; T1: EIU]
+- **Family:** son of lawyer/political activist Pavlo Lysiak and parliamentarian/feminist leader Milena Rudnytska; nephew of Ivan Kedryn-Rudnytsky, Mykhailo Rudnytsky, and Antin Rudnytsky; husband of Alexandra Chernenko; father of Peter L. Rudnytsky. [T1: IEU; T1: ESU; T2: Pritsak introduction in CIUS 1987 volume]
+- **Education:** Academic Gymnasium of Lviv; Lviv University, 1937-1939; University of Berlin, 1940-1943; Charles University in Prague, PhD 1945; Graduate Institute of International Studies in Geneva, 1946-1951; Columbia University, 1951-1953. [T1: IEU; T1: ESU; T1: EIU]
+- **Academic posts:** University of Wisconsin, 1953-1954; La Salle College, 1956-1967; American University, 1967-1971; University of Alberta, 1971-1984. IEU states that he helped found CIUS and served as associate director, 1976-1980. [T1: IEU; T1: ESU]
+- **Field identity:** historian of Ukrainian socio-political thought, scholar-publicist, political thinker, and "communicator" of Ukrainian intellectual values across Ukrainian, North American, Polish, and broader scholarly publics. [T1: IEU; T1: ESU; T2: Pritsak introduction]
+
+**Source disagreement / spelling note:** project spelling uses `Rudnytskyi`, while his English publications and the CIUS/IEU record usually use `Rudnytsky` or `Ivan L. Rudnytsky`. Preserve source spellings in bibliography, but do not let the older English form overwrite the project slug.
+
+**Source disagreement / publication metadata note:** the locally checked 1987 IA scan of *Essays in Modern Ukrainian History* has the title page `Canadian Institute of Ukrainian Studies, University of Alberta, Edmonton 1987`; some catalogue and wiki records list Harvard/Harvard University Press metadata. Treat the CIUS title page as the verified imprint for this dossier until a physical copy or publisher catalogue resolves the series/distribution history.
+
+## 2. Oppression / pressure mechanism
+
+- **Not a direct prison-case biography:** Do not invent an arrest, camp sentence, execution, KGB case, or formal Soviet prosecution. His pressure mechanism is exile from Soviet-occupied Western Ukraine, the non-recognition of Ukrainian history as an independent field in much of North American academia, and the Soviet-era restriction of the field inside Ukraine.
+- **1939 rupture and emigration:** ESU/EIU state that after Soviet forces entered Western Ukraine in 1939 he left for Germany and continued studies in Berlin, Prague, Geneva, and then the United States. This is the biographical rupture that made his scholarship an exile career rather than a Soviet-Ukrainian institutional career. [T1: ESU; T1: EIU]
+- **Field non-recognition:** Peter L. Rudnytsky's preface to the 1987 CIUS volume says his father's Ukrainian focus did not ease academic advancement because Ukrainian history was not generally recognized by American colleagues as an independent field. That pressure is institutional and epistemic, not only personal. [T2: CIUS 1987 preface]
+- **Institution-building response:** IEU/ESU identify him as a founder/helper in the founding of CIUS at the University of Alberta; this should be taught as the building of scholarly infrastructure abroad, not flattened into generic "diaspora activity." He worked in specific institutions with specific debates, funders, colleagues, and editorial projects. [T1: IEU; T1: ESU]
+- **Soviet history-writing constraint:** his essay on Pereiaslav describes the Soviet "reunification" myth as a state-backed mold for Ukrainian historical memory. Use this as an intellectual-history pressure: Ukrainian history was not merely neglected; its interpretive frame was policed. [T2: CIUS 1987 text, locally extracted]
+- **What survived:** essays, correspondence, library, editorial projects, and the University of Alberta archival record. IEU says his papers and extensive correspondence are preserved at the University of Alberta archives; his diary appeared in Kyiv in 2019. [T1: IEU]
+- **What was mediated after death:** the major collections are edited/posthumous. *Essays in Modern Ukrainian History* was edited by Peter L. Rudnytsky; *Історичні есе* was posthumously assembled and includes original Ukrainian texts plus translations from English and some texts published from typescripts. Do not treat every Ukrainian passage in later editions as an unmediated classroom quote until the edition and language history are checked. [T2: CIUS 1987; T2: NBUV record]
+
+## 3. Major works / contributions
+
+- `1945` — Prague PhD on Mykhailo Drahomanov and the development of political ideas in Eastern Europe; Pritsak identifies the later Drahomanov essay as a revision of this dissertation. [T2: Pritsak introduction]
+- `1952` — editor, *Mykhaylo Drahomanov: A Symposium and Selected Writings*; his essay "Drahomanov as a Political Theorist" appears in the volume and later in *Essays in Modern Ukrainian History*. [T2: CIUS 1987 contents/publication notes]
+- `1963` — "The Role of Ukraine in Modern History," originally in *Slavic Review*; important for his continuity/discontinuity model of modern Ukrainian history. [T2: CIUS 1987 publication notes]
+- `1966` — "Ukraine between East and West," a compact typological essay on Ukraine's European location and eastern influences. [T2: CIUS 1987 publication notes]
+- `1973` — *Між історією і політикою: статті до історії та критики української суспільно-політичної думки* (Munich), the Ukrainian collection whose title names his central scholarly zone. [T1: IEU; T1: EIU]
+- `1976` — editor of Osyp Nazaruk correspondence with Viacheslav Lypynsky; this belongs with his long-running work on Ukrainian conservative and statist political thought. [T1: IEU; T2: Pritsak introduction]
+- `1981` — editor, *Rethinking Ukrainian History*, conference papers from a major Canadian Ukrainian studies gathering. [T1: IEU; T2: Pritsak introduction]
+- `1982` — *Pereiaslav 1654: A Historiographical Study* by John Basarab, with Rudnytsky's introduction "Pereiaslav: History and Myth" later reprinted in *Essays in Modern Ukrainian History*. [T2: CIUS 1987 publication notes]
+- `1987` — *Essays in Modern Ukrainian History* (CIUS, Edmonton), 23 English-language essays edited by Peter L. Rudnytsky after his death. [T1: IEU; T2: IA/CIUS scan]
+- `1991` — *Нариси з історії нової України* (Lviv), listed in EIU's works section. [T1: EIU]
+- `1994` — *Історичні есе*, 2 vols. NBUV describes the edition as a collection from two earlier books plus other writings from 1943-1984, including some first publications from typescripts; it contains original Ukrainian texts and translations of English-language articles. [T1: IEU; T2: NBUV]
+- `2019` — *Щоденники* / diaries, edited by Yaroslav Hrytsak and Frank Sysyn through CIUS and published in Kyiv, useful for source-sensitive work on his wartime and emigration milieu. [T1: IEU]
+
+## 4. Primary-source quote / text anchors
+
+The following anchors were verified locally from `/tmp/essaysinmodernuk00rudn.txt`, produced with `pdftotext -layout` from the IA scan of *Essays in Modern Ukrainian History* on 2026-07-04. They are short English fragments from the 1987 CIUS volume. Ukrainian translations should not be treated as primary quotations unless checked against the relevant Ukrainian edition.
+
+- **Civilizational placement anchor:** `organic part of the community of European peoples` — from "Ukraine between East and West." Use this as a compact prompt about Ukraine's European history without denying eastern influences.
+- **Anti-Pereiaslav-myth anchor:** `Pereiaslav did not amount to a "reunification"` — from "Pereiaslav: History and Myth." Use with care: the full essay argues historically against a Soviet dogma, not against serious source-critical debate about 1654.
+- **Historical-memory anchor:** `pressed into a prefabricated mould` — his image for Soviet manipulation of Ukrainian historical memory in the Pereiaslav essay. This is strong for a C1/C2 discussion of historiography and propaganda.
+- **Essay-title anchors verified in the 1987 contents:** "Ukraine between East and West"; "The Role of Ukraine in Modern History"; "Observations on the Problem of 'Historical' and 'Non-Historical' Nations"; "Pereiaslav: History and Myth"; "Drahomanov as a Political Theorist"; "Viacheslav Lypynsky: Statesman, Historian, and Political Thinker"; "Soviet Ukraine in Historical Perspective"; "The Political Thought of Soviet Ukrainian Dissidents."
+- **Do not use without edition check:** the project LIT-ESSAY plan contains a Ukrainian quote beginning `Проблема новочасної української історії...`. This dossier does not treat it as classroom-ready because it was not verified against a primary edition in this pass.
+
+## 5. Language register
+
+- **Register:** scholarly-publicistic essay prose: analytical, comparativist, polemical without slogan language, and built around conceptual pairs such as historical/non-historical nation, state/people, autonomy/independence, East/West, history/myth.
+- **CEFR readiness:** C1 for carefully excerpted passages with scaffolded vocabulary; C2 for full essays because students must follow dense historical comparison, conceptual abstraction, and implicit debates with Hrushevsky, Drahomanov, Lypynsky, Soviet historiography, Polish historiography, and North American Slavic studies.
+- **Core vocabulary:** `історіографія`, `суспільно-політична думка`, `історична нація`, `неісторична нація`, `державність`, `національна свідомість`, `Переяславська міфологія`, `модерна історія`, `інтелектуальна історія`, `діаспора`, `еміграція`, `інституція`, `лібералізм`, `державницька школа`.
+- **Pedagogical caution:** avoid reducing his prose to "Cold War anti-Soviet" shorthand. His best classroom value is method: comparison, conceptual distinction, and source-sensitive argument about how political ideas shape historical memory.
+- **Translation caution:** many classroom-accessible Ukrainian editions are posthumous and partly translated from English. A lesson may use translated Ukrainian text, but the teacher notes should identify whether a passage is original Ukrainian, translated from English, or restored from typescript.
+
+## 6. Contested points
+
+- **Political labels:** ESU/EIU trace movement from early conservative/hetmanite interests through contacts with URDP circles and later cooperation with an OUN-abroad current that had moved away from totalitarian Dontsovite ideology; they also state that he remained politically neutral and liberal in worldview. Present these as historically situated reports, not as a simple label such as "nationalist," "liberal," "diaspora conservative," or "Cold War scholar." [T1: ESU; T1: EIU]
+- **"Diaspora" is not a single ideology:** his intellectual environment included Ukrainian, Polish, American, and Canadian interlocutors; CIUS, HURI, UVAN/UAAS, NTSh, *Suchasnist*, and North American university history departments were different arenas. Avoid treating "the diaspora" as one political actor.
+- **Colonial framing nuance:** EIU records his skepticism toward a simple colonial-status formula for Ukraine in the Russian Empire and his debate with Ohloblyn around that language. Teach this as a contested analytical vocabulary, not as denial of imperial domination. [T1: EIU]
+- **Pereiaslav and Soviet myth:** his critique targets Soviet/Russian "reunification" dogma and the use of history to drain Ukrainian subjectivity; it should not be simplified into a claim that 1654 has no real legal/historiographic complexity.
+- **Nationalism debate:** he opposed totalitarian and exclusivist nationalist ideology while taking Ukrainian nationhood seriously. If paired with Dontsov or Lypynsky, preserve the distinctions between ethnic nationalism, civic/statist thought, liberalism, and conservative statehood theory.
+- **Posthumous reception:** later Ukrainian reception in the 1990s and after is partly a recovery of texts that circulated abroad. Distinguish what he wrote, what editors selected, what translators rendered, and what later readers made canonical.
+- **Name and slug anomaly nearby:** the existing LIT-ESSAY plan slug is `lysiah-rudnytsky-history`, not the project BIO slug `ivan-lysiak-rudnytskyi`. Do not silently "fix" this in lesson references; flag it if future cross-track cleanup is authorized.
+
+## 7. Cross-track links
+
+> Every plan path under **Existing** below was verified with `test -e` on 2026-07-04 and resolves under `curriculum/l2-uk-en/plans/`.
+
+- **Existing LIT-ESSAY plan surfaces (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit-essay/lysiah-rudnytsky-history.yaml` — direct work/essay module for his historical essays; slug spelling anomaly noted in §6.
+  - `curriculum/l2-uk-en/plans/lit-essay/drahomanov-chudatski-dumky.yaml` — Drahomanov as a central figure in his scholarship.
+  - `curriculum/l2-uk-en/plans/lit-essay/franko-some-words.yaml` — adjacent late-19th-century Ukrainian intellectual-history context.
+- **Existing HIST plan surfaces (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/hromady.yaml` — plan cites Lysiak-Rudnytsky on hromady and the role of civic-intellectual circles.
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — plan references Lysiak-Rudnytsky in the history of imperial language policy.
+- **Existing BIO plan surfaces (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/milena-rudnytska.yaml` — his mother; key family and intellectual milieu.
+  - `curriculum/l2-uk-en/plans/bio/serhii-plokhy.yaml` — later North American Ukrainian-history field-builder; use as successor/field context, not as a direct student lineage unless sourced.
+  - `curriculum/l2-uk-en/plans/bio/yulian-bachynskyi.yaml` — plan cites Lysiak-Rudnytsky as a secondary authority in Ukrainian political thought.
+- **Existing research/dossier surfaces (VERIFIED by `test -e` / local read):**
+  - `docs/research/bio/milena-rudnytska.md` — family context and the Rudnytska intellectual household.
+  - `docs/research/bio/viacheslav-lypynskyi.md` — major object of his scholarship and a key contrast in Ukrainian political thought.
+  - `docs/research/bio/omelian-pritsak.md` — colleague/friend and author of the 1987 introduction used here.
+- **Candidate / future BIO surfaces not created in this PR:**
+  - `curriculum/l2-uk-en/plans/bio/ivan-lysiak-rudnytskyi.yaml` — not present as of 2026-07-04.
+  - `curriculum/l2-uk-en/bio/discovery/ivan-lysiak-rudnytskyi.yaml` — not present as of 2026-07-04.
+  - `wiki/figures/ivan-lysiak-rudnytskyi.md` — not present as of 2026-07-04.
+
+## 8. Naming-canonical
+
+- **Slug:** `ivan-lysiak-rudnytskyi`
+- **EN canonical (project):** Ivan Lysiak-Rudnytskyi.
+- **Common source spelling:** Ivan Lysiak Rudnytsky; Ivan L. Rudnytsky.
+- **UA canonical:** Іван Павлович Лисяк-Рудницький.
+- **Aliases future YAML:** `Іван Лисяк-Рудницький`; `Лисяк-Рудницький Іван Павлович`; `Ivan Lysiak-Rudnytskyi`; `Ivan Lysiak Rudnytsky`; `Ivan L. Rudnytsky`; `Ivan Pavlovych Lysiak-Rudnytskyi`; `Ivanna Brusna`; `Ivan Brusny`; `Іванна Брусна`; `Іна Брусна`; `Іван Брусний`; `Ponticus`.
+- **Forbidden / noncanonical learner-facing defaults:** Russian `Иван Лысяк-Рудницкий`; `Ivan Rudnitsky` as default display; `Rudnytskyi` back-applied inside exact English source titles that print `Rudnytsky`.
+- **Search note:** use `Rudnytsky`, `Rudnytskyi`, `Lysiak Rudnytsky`, `Lysiak-Rudnytskyi`, and `Іван Лисяк-Рудницький` when searching catalogues; older North American records usually omit the final `i`.
+
+## 9. Image candidates
+
+- **Portrait candidate:** Wikipedia currently displays a 1982 portrait of Lysiak-Rudnytsky; do not embed from the article until the underlying file page and license are checked. The search pass did not confirm a clean Wikimedia Commons category for him.
+- **Institutional candidates:** University of Alberta / CIUS event and archive pages may hold portraits or group photos; treat these as rights-managed unless a file-level reusable license is explicit.
+- **Context image candidate:** title page or cover of *Essays in Modern Ukrainian History* (1987 CIUS scan) or *Історичні есе* (1994/2019) can anchor the essayist/intellectual-history theme; verify reuse rights before embedding.
+- **Family/context candidate:** Milena Rudnytska Commons material may illustrate family background, but only use it when the module explicitly discusses the Rudnytska-Lysiak household and the file-page license is clear.
+- **Default safe stance:** no learner-facing portrait should be assumed rights-clear from this dossier alone.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / encyclopedic):**
+
+- Internet Encyclopedia of Ukraine. "Rudnytsky, Ivan Lysiak." https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CU%5CRudnytskyIvanLysiak.htm. Accessed 2026-07-04.
+- Енциклопедія Сучасної України. "Лисяк-Рудницький Іван Павлович." https://esu.com.ua/article-55035. Accessed 2026-07-04.
+- Енциклопедія історії України. Кульчицький С.В. "Лисяк-Рудницький Іван Павлович." Т. 6, 2009. https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIu&P21DBN=&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Lysyak_Rudnitsky_I_P&Z21ID=. Accessed 2026-07-04.
+
+**Tier 2 (primary / institutional / edition evidence):**
+
+- Rudnytsky, Ivan L. *Essays in Modern Ukrainian History*. Edited by Peter L. Rudnytsky. Canadian Institute of Ukrainian Studies, University of Alberta, Edmonton, 1987. IA scan downloaded to `/tmp/essaysinmodernuk00rudn.pdf`; text extracted with `pdftotext -layout` on 2026-07-04. https://archive.org/details/essaysinmodernuk00rudn.
+- Pritsak, Omeljan. "Ivan Lysiak-Rudnytsky, Scholar and 'Communicator'." Introduction in *Essays in Modern Ukrainian History*, CIUS, 1987. Locally checked in the IA scan on 2026-07-04.
+- NBUV digital catalogue. "Лисяк-Рудницький І. Історичні есе. Т. 2 (1994)." https://irbis-nbuv.gov.ua/ulib/item/UKR0002716. Accessed 2026-07-04.
+- CIUS Archives. "Browse Items" tagged Ivan Lysiak-Rudnytsky; used to confirm `Essays in Modern Ukrainian History` and seminar/event surfaces, not as a source for unverified biographical claims. https://cius-archives.ca/items/browse?tags=Ivan+Lysiak-Rudnytsky. Accessed 2026-07-04.
+
+**Tier 3 (publisher / navigation / reception context):**
+
+- Dukh i Litera author page. "Лисяк-Рудницький Іван." Used for modern publisher framing and book navigation only. https://duh-i-litera.com/lisjak-rudnitskij-ivan. Accessed 2026-07-04.
+- Harvard Ukrainian Studies books page. "Історичні есе." Used as a navigation lead; exact source lines were not available through the fetcher. https://www.husj.harvard.edu/books/istorichni-ese. Accessed 2026-07-04.
+- Wikipedia, "Ivan L. Rudnytsky." Used only as a navigation and image-lead source; dossier facts above rest on IEU/ESU/EIU/CIUS/NBUV. https://en.wikipedia.org/wiki/Ivan_L._Rudnytsky. Accessed 2026-07-04.
+
+**Local project sources consulted:**
+
+- `curriculum/l2-uk-en/plans/lit-essay/lysiah-rudnytsky-history.yaml` — existing lesson plan; used for cross-track awareness only, not as a primary source.
+- `docs/research/bio/milena-rudnytska.md`, `docs/research/bio/viacheslav-lypynskyi.md`, `docs/research/bio/omelian-pritsak.md` — local dossier pattern and adjacent-context checks.
+
+**Honest gaps:**
+
+- No archival correspondence was opened. University of Alberta archive holdings are cited through IEU/Pritsak, not independently inspected.
+- The Ukrainian quote-like line in the existing LIT-ESSAY plan was not verified against a primary edition.
+- The exact translation history of every essay in *Історичні есе* was not reconstructed; future module work should mark source language per text.
+- Image rights are unresolved; no portrait is cleared for reuse by this dossier.
+- LLM-QG was not used.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing: Ukrainian intellectual history is the subject; Russian/Soviet narratives appear as objects of analysis and pressure, not as default truth.
+- [x] Ukrainian subjectivity remains primary: he is framed as a Ukrainian historian and political thinker whose work made Ukrainian history legible as its own field.
+- [x] No Russian-imperial transliteration used in learner-facing defaults.
+- [x] No invented Soviet repression: exile and field suppression are named; no false arrest/camp/death claim is introduced.
+- [x] Diaspora not flattened: CIUS, HURI/Harvard-adjacent networks, Ukrainian academy/NTSh circles, and North American universities are treated as distinct institutions and arenas.
+- [x] No lazy Cold War shorthand: his anti-Soviet historical analysis is presented as method and historiographic argument, not reduced to geopolitical camp identity.
+- [x] Political labels handled cautiously: early conservative interests, later liberal neutrality, anti-totalitarian anti-nationalism, and selective cooperation are not collapsed into a single narrator label.
+- [x] Posthumous/translated editions caveat retained.
+- [x] Existing cross-track paths verified; candidate/nonexistent surfaces explicitly marked.
+- [x] LLM-QG was not used.


### PR DESCRIPTION
## Summary

Adds the missing BIO research dossier for Ivan Lysiak-Rudnytskyi at `docs/research/bio/ivan-lysiak-rudnytskyi.md`.

The dossier follows the existing manifest BIO research pattern and keeps the scope to one source file. It frames Lysiak-Rudnytskyi as a historian of Ukrainian socio-political thought and an institution-builder in Ukrainian studies, with caveats around exile, diaspora institutions, political labels, translated/posthumous editions, and image rights.

LLM-QG was not used. I did not run, trust, route, persist, or close anything through LLM-QG, and I did not run `run_llm_qg_parity.py` or `scripts/audit/module_quality_audit.py`.

## Verification

- `npx markdownlint-cli2 docs/research/bio/ivan-lysiak-rudnytskyi.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/ivan-lysiak-rudnytskyi.md`
- `git diff --check origin/main...HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Local protected-path/artifact scan: changed file count is 1; no `.python-version`, `.yamllint`, `.markdownlint.json`, status/audit/review artifacts, or `data/telemetry/**` in the diff; no `sys.executable` in the changed file.
- Local framing scan reviewed diaspora / Cold War / Soviet / Russian / imperial / colonial terms in the dossier; uses are caveated rather than narrator-flattened.

## Historical / Source Caveats

- No archival correspondence was opened; University of Alberta archive holdings are cited through IEU/Pritsak rather than independently inspected.
- Direct quote anchors are short fragments verified from a locally extracted IA scan of `Essays in Modern Ukrainian History`; Ukrainian translations should be checked per edition before lesson use.
- The existing LIT-ESSAY plan contains a Ukrainian quote-like line that was not verified against a primary edition here, so the dossier marks it as not classroom-ready.
- The exact translation history of every text in `Історичні есе` was not reconstructed.
- Image rights remain unresolved; no portrait is cleared for reuse by this dossier.