### PR TITLE
[codex] Add Kyrylo Stetsenko BIO dossier

### DIFF
--- a/docs/research/bio/kyrylo-stetsenko.md
+++ b/docs/research/bio/kyrylo-stetsenko.md
@@ -1,0 +1,176 @@
+# Кирило Григорович Стеценко — Research Dossier
+
+**Slug:** `kyrylo-stetsenko`
+**Block:** B/I (national-culture institution-builder; imperial/Soviet pressure, not executed)
+**Tier:** 1b
+**Issue:** Codex delegation — missing BIO manifest dossier
+**Researcher:** Codex GPT-5
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited
+- [x] Oppression mechanism is specific and cautious
+- [~] Primary-source quotes located only through secondary transcriptions; classroom use requires checking the cited 1981 source edition
+- [x] Cross-track links: every "Existing" path verified with `test -e`
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Кирило Григорович Стеценко. [T1: ЕІУ — Бондарчук, "Стеценко Кирило Григорович"; T1: IEU — "Stetsenko, Kyrylo"]
+- **Pseudonyms / aliases:** Kyrylo Hryhorovych Stetsenko; Kyrylo Stetsenko; Кирило Стеценко. English "Stecenko" appears in IEU as a variant transliteration. Russified/imperial forms are listed only in §8.
+- **Born:** 12/24 May 1882 | село Квітки, Канівський повіт, Київська губернія, then Russian Empire | now Квітки, Черкаська область, Україна. Modern administrative listings place Kvitky in the Звенигородський район/Selyshchenska community; older Ukrainian references use former Корсунь-Шевченківський район. [T1: ЕІУ; T1: IEU; geographic note from current public gazetteer/Wikipedia check]
+- **Died:** 29 April 1922 | село Веприк, Васильківський повіт, Київська губернія | now Веприк, Фастівський район, Київська область, Україна. [T1: ЕІУ; T1: IEU]
+- **Death-cause note:** the retrieved Tier 1 encyclopedia entries state the place/date but do not give a medical record. Ukrainian Art Song Project and multiple memorial/museum-oriented sources state that he died of typhus during an outbreak, often while serving or caring for the sick. This is plausible and widely repeated, but should be cited as "reported typhus death" unless a primary medical/parish record is checked. [T2: UASP; T5 memorial sources]
+- **Family / education key facts:** Son of Григорій Михайлович Стеценко, an icon/folk painter; studied in Kyiv church-school and seminary settings, then in music institutions around the Lysenko circle. ЕІУ states that he graduated from the Kyiv Theological Seminary in 1903, studied at the Russian Music Society music school in 1904 and the Mykola Lysenko Music and Drama School in 1904-1907, and took composition lessons with Hryhorii Liubomyrskyi. IEU records his early recognition in the Saint Michael's Golden-Domed Monastery choir and joining Mykola Lysenko's choir in 1899. [T1: ЕІУ; T1: IEU]
+
+**Source disagreement note:** Count conventions vary. ЕІУ lists "хори (бл. 90)" and "солоспіви (бл. 50)"; IEU gives "more than 40" art songs and "over 100" sacred and secular choral pieces; the 2013 sacred-works edition lists three liturgies and a much larger religious corpus, while older English summaries often say two liturgies plus a requiem. Use source-qualified numbers rather than one smoothed total. [T1: ЕІУ; T1: IEU; T2: "Кирило Стеценко. Духовні твори"]
+
+## 2. Oppression mechanism
+
+This dossier should not cast Stetsenko as only a church composer or only a nationalist martyr. The supported mechanism is **repeated imperial and early-Soviet pressure on Ukrainian-language musical, educational, and ecclesiastical institution-building**, followed by a short life cut off by epidemic disease rather than a documented execution.
+
+- **What happened:** Russian-imperial authorities removed him from Kyiv after 1907 political/revolutionary activity; later, under Bolshevik consolidation, the choral-cultural structures he helped build were disrupted or disbanded, and he retreated to parish work in Vepryk while still organizing choirs, publishing, and UAOC music. [T1: ЕІУ; T1: IEU; T2: UASP; T4: NMAU article]
+- **When:** 1907 exile/removal from Kyiv; 1917-1920 public cultural work in Kyiv and across Ukraine; 1920-1922 Vepryk parish and UAOC/music work; death on 29 April 1922. [T1: ЕІУ; T1: IEU; T4: NMAU article]
+- **By whom:** Russian-imperial police/censorship environment in 1907; Bolshevik/Soviet state power and the broader anti-Ukrainian institutional pressure of 1920-1922. No retrieved source provides a personal Soviet criminal case, Cheka execution order, or NKVD-style file for him.
+- **Mechanism specifics:** ЕІУ says that in 1907 he was expelled from Kyiv for participation in revolutionary activity. A 2020 NMAU article, citing earlier scholarship, frames his use of Ukrainian folk song in education as leading to persecution for "nationalism," searches, arrests, and assignment to the Oleksandro-Hrushivska church-teacher school in the Donbas. IEU adds an arrest/exile period of 1907-1910. [T1: ЕІУ; T1: IEU; T4: NMAU article]
+- **Ukrainian-state and cooperative institutions:** In the revolutionary period he worked around the music department/committees of Ukrainian cultural administration, helped organize the Ukrainian Republican Capella with Oleksandr Koshyts, worked with Dniprosoiuz choral publishing and touring capellas, and pursued a dense network of schools, choirs, libraries, and music-pedagogy institutions. Some institutional labels differ by source because administrations shifted quickly during 1917-1920; cite the specific source rather than merging them into one office. [T1: ЕІУ; T1: IEU; T2: UASP; T4: NMAU article]
+- **Church pressure and UAOC context:** Stetsenko was ordained in 1911 and later became a priest of the Ukrainian autocephaly milieu. Sources connect him to Ukrainian-language church music, the All-Ukrainian Church Council, the 1921 UAOC council, and services at Saint Sophia after its transfer to the Ukrainian church. This should be taught as cultural-institutional work inside the church, not as a simple proof-text for later denominational polemics. [T2: "Наша Парафія"; T4: NMAU article]
+- **What survived / what was delayed:** his art songs, choral works, children's operas, stage music, sacred cycles, and teaching materials survived unevenly through archives, choirs, and later editions. The 2013 "Духовні твори" page states that it was the first complete publication of his religious works, underscoring how long the sacred corpus remained scattered. [T2: "Кирило Стеценко. Духовні твори"]
+
+## 3. Major works
+
+- `1906` — **"Луна"** repertory songbook, containing Ukrainian folk-song arrangements by Lysenko, Leontovych, Koshyts, and Stetsenko; important for school/music-pedagogy history. [T4: NMAU article]
+- `1909` — music to **"Сватання на Гончарівці"**. [T1: ЕІУ]
+- `1911` — children's operas **"Лисичка, Котик і Півник"** and **"Івасик-Телесик"**. [T1: ЕІУ]
+- `1916` — music to **"Про що тирса шелестіла"**. [T1: ЕІУ]
+- `1917-1918` — three issues of **"Шкільний співаник"** and other school-song/method materials. [T4: NMAU article]
+- `1918-1920` — choral tours and institutional work around national choirs, Dniprosoiuz, and the Republican Capella network. [T1: IEU; T4: NMAU article]
+- `1919` — music to **"Гайдамаки"** after Shevchenko; a direct cross-link to Les Kurbas's landmark staging. [T1: ЕІУ; local dossier cross-link]
+- `1920` — First and Second Dniprosoiuz traveling choral capellas; the Second Capella toured Ukraine under Stetsenko with Pavlo Tychyna as second conductor. [T4: NMAU article; `docs/research/bio/mykola-leontovych.md`]
+- `1921` — UAOC council/church-music participation; services, council music, and Ukrainian liturgical practice. [T4: NMAU article]
+- `1922` — **"Іфігенія в Тавриді"** after Lesya Ukrainka. ЕІУ lists it among operas; use caution on completion/stage status until a score/source note is checked. [T1: ЕІУ]
+- `undated / across career` — operas **"Кармалюк"** and **"Полонянка"** (unfinished); cantatas **"Слава Лисенку," "Шевченкові," "Єднаймося," "У неділеньку, у святу"**; satirical song-scene **"Цар Горох"**; about 90 choruses by the ЕІУ count; about 40-50 art songs depending on source; arrangements of carols, shchedrivky, and folk songs; sacred music including liturgies, **Всенічна**, **Панахида**, and many smaller church works. [T1: ЕІУ; T1: IEU; T2: "Духовні твори"]
+
+## 4. Primary-source quotes
+
+No quote in this dossier should be treated as classroom-ready until checked against a stable primary/source edition such as **Кирило Стеценко: Спогади. Листи. Матеріали** (Музична Україна, 1981) or the named article/letter in facsimile. The following are **research leads in secondary transcription**, not final quote cards.
+
+**Quote lead 1 — education and civic purpose.** A 2020 NMAU article quotes Stetsenko's 25 April 1917 Vinnytsia teachers' congress report "Українська пісня в народній школі":
+
+> "...виховати таких людей, які б мали тверду волю в проведенні у життя найвищих ідей <...> правди, краси, добра на користь рідного краю і народу нашого"
+
+Source chain: NMAU 2020 article -> Stetsenko report -> cited earlier edition, p. 19. Use this as a research lead for a music-education module only after edition verification. [T4: NMAU article]
+
+**Quote lead 2 — the divided life.** The same NMAU article quotes a letter to Ivan Marianenko:
+
+> "Вас будуть дивувати ці зигзаги мого життя: то архієрей, то театральний капельмейстер..."
+
+The line is pedagogically useful because it refuses to reduce him to either priest or theater musician, but the classroom card should wait for the letter's source-edition check. [T4: NMAU article]
+
+**Quote lead 3 — music criticism.** The NMAU article excerpts his criticism of Meyerbeer's **"Гугеноти"** and several conductor/choral observations. These are valuable for showing Stetsenko as critic, not only composer-priest, but should remain "candidate excerpts" until traced to the 1981 edition or original press publication. [T4: NMAU article]
+
+**Not quoted here:** hymn/choral text, liturgical text, and stage excerpts are not quoted as Stetsenko's words. Many are settings, translations, or liturgical/common texts; they require score-level attribution before classroom use.
+
+## 5. Language register
+
+- **Register:** Ukrainian choral, educational, journalistic, and ecclesiastical-public language of the early twentieth century. His set texts range from folk-song and carol/shchedrivka diction to Shevchenko/Lesya Ukrainka/Oleksandr Oles literary texts and liturgical vocabulary.
+- **CEFR readiness:** children's opera excerpts and simple school songs can be adapted at **A2-B1**; art-song poetry and choral texts usually sit at **B1-B2** with glossary support; the church autocephaly, Dniprosoiuz, and cultural-institution debates belong at **C1**.
+- **Lexicon notes:** хормейстер, регент, капела, мандрівна капела, солоспів, кантата, обробка, колядка, щедрівка, літургія, всенічна, панахида, автокефалія, парафія, богослужіння, просвітництво, кобзарська школа, музично-педагогічний.
+- **Stylistic features:** sources consistently emphasize melodic richness, choral/vocal convenience, folk-song and church-chant intonations, and the Lysenko school inheritance. His classroom value is the bridge: folk song -> school repertoire -> professional choral art -> Ukrainian church music -> national cultural institutions.
+
+## 6. Contested points
+
+- **Priest vs composer vs institution-builder.** Popular memory often selects one role. The sources support all of them: composer, conductor/choirmaster, teacher, critic, publisher/organizer, priest, and UAOC musical worker. A good lesson should show how those roles collided rather than pretending they formed a neat career ladder.
+- **Death-cause detail.** "Died of typhus while tending the sick" is widely repeated by UASP and memorial sources; the retrieved Tier 1 entries do not provide a medical document. Treat it as a reported biographical tradition unless a parish/medical record is located.
+- **Liturgy counts and sacred corpus.** Older summaries state two liturgies plus requiem/panakhyda; the 2013 sacred-works publication page lists three liturgies and a broad corpus. This is likely an edition/completion/cataloging issue, not a reason to choose one unsourced count for all lessons.
+- **UAOC framing.** Russian church-imperial narratives commonly treat Ukrainian autocephaly as illegitimate "separatism"; Ukrainian memorial narratives can also overflatten the complexity of 1921 church governance. For curriculum, state the verifiable points: Stetsenko worked in the Ukrainian autocephaly milieu, participated in church music and council activity, and wrote/edited Ukrainian sacred music. Avoid adjudicating later canonical disputes unless the module is explicitly on church history.
+- **UPR vs Soviet institutional labels.** Sources name work in UPR Ministry of Education music structures, All-Ukrainian music committees, and Dniprosoiuz/early Soviet cultural contexts. The period was administratively unstable; lesson prose should date and source each office instead of presenting one continuous ministry career.
+- **Not a Leontovych duplicate.** Pairing him with Mykola Leontovych is essential, but Stetsenko should not be used only as a supporting character in the Shchedryk/Leontovych story. His educational, sacred, publishing, theater, and capella work are independent BIO value.
+
+## 7. Cross-track links
+
+> Every path under **Existing** was verified with `test -e` on 2026-07-04 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml` — teacher/model and the national-composer school Stetsenko inherited.
+  - `curriculum/l2-uk-en/plans/bio/mykola-leontovych.yaml` — choral-generation peer; Dniprosoiuz, memorial society, and shared repression-era context.
+  - `curriculum/l2-uk-en/plans/bio/oleksandr-koshyts.yaml` — Republican Capella organization and cultural-diplomacy choral network.
+  - `curriculum/l2-uk-en/plans/bio/pavlo-tychyna.yaml` — second conductor / chronicler on Stetsenko's capella tour.
+  - `curriculum/l2-uk-en/plans/bio/vasyl-lypkivskyi.yaml` — UAOC and Ukrainian-language church context.
+  - `curriculum/l2-uk-en/plans/bio/oleksandr-oles.yaml` — Stetsenko set Oles lyrics; Ukrainian Revolution song canon.
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-samiilenko.yaml` — **"Вечірня пісня"** connection through Stetsenko's setting.
+  - `curriculum/l2-uk-en/plans/bio/les-kurbas.yaml` — **"Гайдамаки"** theater/stage-music link.
+- **Existing C1 / music-oriented plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-2-natsionalna-shkola.yaml` — explicitly names Stetsenko in the national-school music arc.
+  - `curriculum/l2-uk-en/plans/c1/vokalne-mystetstvo.yaml` — art song / vocal-culture route.
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-3-modernizm-i-suchasnist.yaml` — follow-on modernism and later Ukrainian music institutions.
+- **Existing HIST / ISTORIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml` — UNR cultural-diplomacy/capella context.
+  - `curriculum/l2-uk-en/plans/hist/bilshovytsko-ukrainska-viyna.yaml` — political-military context for 1919-1921 cultural disruption.
+  - `curriculum/l2-uk-en/plans/hist/pravoslavna-tserkva-17.yaml` — deeper Orthodox/church-history background.
+  - `curriculum/l2-uk-en/plans/hist/tomos.yaml` — later autocephaly framing, useful only with chronological guardrails.
+  - `curriculum/l2-uk-en/plans/istorio/radianska-antyrelihiyna-polityka.yaml` — Soviet anti-religious context after his death; use for legacy, not direct biography.
+  - `curriculum/l2-uk-en/plans/istorio/syntez-relihiina-identychnist.yaml` — religious identity synthesis context.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A dedicated `curriculum/l2-uk-en/plans/bio/kyrylo-stetsenko.yaml` plan does **not** exist yet, despite `kyrylo-stetsenko` appearing in `curriculum/l2-uk-en/curriculum.yaml`.
+  - A MUSIC listening/score module on Stetsenko's liturgies and **"Вечірня пісня"** would bridge B1 lyric listening and C1 institutional history.
+
+## 8. Naming-canonical
+
+- **Slug:** `kyrylo-stetsenko`
+- **EN canonical (project spelling):** Kyrylo Stetsenko
+- **UA canonical (with patronymic):** Кирило Григорович Стеценко
+- **Aliases to track (`aliases:` YAML field):** Kyrylo Hryhorovych Stetsenko; K. H. Stetsenko; Кирило Стеценко; К. Г. Стеценко; Stecenko (IEU variant).
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Кирилл Григорьевич Стеценко; Kirill Stetsenko; "Russian composer" framing. Do not normalize the Ukrainian `Kyrylo` through Russian `Kirill`.
+
+## 9. Image candidates
+
+- **Best portrait candidate:** Wikimedia Commons category/page for **Kyrylo Stetsenko** or the IEU portrait. Verify the individual file page for PD-old/Ukraine/US status before publication; do not rely on category-level assumptions.
+- **Museum/context candidate:** Memorial Museum of K. H. Stetsenko in Vepryk, where he lived in 1920-1922. The museum site documents the institution and its mission, but image rights require item-level review. [T2: Memorial Museum page]
+- **Score/context image:** title page or excerpt from **"Кирило Стеценко. Духовні твори"** or a score of **"Вечірня пісня"**, only after verifying score/publication rights and avoiding modern-edition copyright issues.
+- **Church/capella context:** Saint Sophia / UAOC council context, Dniprosoiuz capella tour material, or a Republican Capella photograph/poster may be pedagogically stronger than a generic portrait if rights clear.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Бондарчук П. М. "Стеценко Кирило Григорович." *Енциклопедія історії України*. https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIu&P21DBN=&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Stetsenko_K&Z21ID=. Accessed 2026-07-04.
+- Wytwycky, Wasyl. "Stetsenko, Kyrylo." *Internet Encyclopedia of Ukraine*. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CT%5CStetsenkoKyrylo.htm. Accessed 2026-07-04.
+
+**Tier 2 (institutional / edition access):**
+- Ukrainian Art Song Project. "Kyrylo Stetsenko" and continuation page. https://ukrainianartsong.ca/composers-1-1-1-1-1 and https://ukrainianartsong.ca/stetsenko-pg2. Accessed 2026-07-04.
+- "Стеценко Кирило, прот." *Наша Парафія*. https://parafia.org.ua/person/stetsenko-kyrylo-prot/. Accessed 2026-07-04.
+- "Кирило Стеценко. Духовні твори." *Наша Парафія*. https://parafia.org.ua/collection/kyrylo-stetsenko-duhovni-tvory/. Accessed 2026-07-04.
+- КЗ КОР "Меморіальний музей К. Г. Стеценка." "Про музей." https://stetsenko.in.ua/pro-muzej/. Accessed 2026-07-04.
+
+**Tier 3 (encyclopedic / navigation, cross-checked):**
+- Українська Вікіпедія. "Стеценко Кирило Григорович"; "Квітки." Used for orientation and current locality cross-checks only, not as sole support for contested claims. Accessed 2026-07-04.
+- ВУЕ. "Стеценко, Кирило Григорович." Search result consulted; full page not relied on because authoritative T1 entries were available.
+
+**Tier 4 (modern scholarly post-1991 / academic):**
+- Черкашина-Губаренко М. "Українська музика: персональний вимір." *Науковий вісник НМАУ ім. П. І. Чайковського*, 2020, PDF. https://naukvisnyknmau.com.ua/article/view/213872/214653. Accessed 2026-07-04.
+- Мороз І. "Літургійна творчість Кирила Стеценка в контексті розвитку української духовної музики. Порівняльний аналіз Другої та Третьої літургій." Львівська національна музична академія ім. М. В. Лисенка, master's thesis PDF, 2022. Accessed 2026-07-04.
+
+**Primary-source documents / source editions identified but not directly verified:**
+- **Кирило Стеценко: Спогади. Листи. Матеріали** / упоряд. Є. Федотова. Київ: Музична Україна, 1981. Cited by multiple scholarly sources; not directly opened in this pass.
+- Stetsenko report **"Українська пісня в народній школі"** (25 April 1917, Vinnytsia) — quoted in secondary scholarship, not directly opened.
+- Letter to Ivan Marianenko — quoted in secondary scholarship, not directly opened.
+
+**Honest gaps:** No local primary edition was available for deterministic quote verification; no medical/parish death record was opened; exact completion/status of **"Іфігенія в Тавриді"** requires score/catalog verification; exact sacred-work counts should follow the edition used in a lesson.
+
+---
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing — Russian/Soviet power appears as the pressure context, not as the owner of the cultural field.
+- [x] No Russian-imperial transliterations in body text — confined to §8 as forbidden forms.
+- [x] No Russocentric periodization — uses Ukrainian Revolution / UPR / Bolshevik-Ukrainian war context, not generic "Civil War."
+- [x] No uncritical Soviet propaganda terms.
+- [x] No fabricated martyrdom — no execution/arrest file invented; typhus death caveated.
+- [x] No church-imperial framing — UAOC context stated with source limits and without accepting Moscow categories.
+- [x] Existing cross-track paths verified; nonexistent `plans/bio/kyrylo-stetsenko.yaml` marked candidate/nonexistent.
+- [x] LLM-QG not used.


### PR DESCRIPTION
## Summary
- Adds the missing BIO research dossier for Kyrylo Stetsenko.
- Keeps the profile source-grounded across composer, conductor, priest, educator, UAOC, Dniprosoiuz, and Ukrainian cultural-institution contexts.
- Marks unverified quote/death-cause/liturgical details as source caveats rather than classroom-ready claims.

## Verification
- `npx markdownlint-cli2 docs/research/bio/kyrylo-stetsenko.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/kyrylo-stetsenko.md`
- `git diff --check origin/main...HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Protected-path/artifact scan: no `.python-version`, linter config, status/audit/review artifacts, or `data/telemetry/**` files in diff.
- Framing scan: only intentional caveat/checklist/forbidden-alias lines surfaced.

## Notes
- LLM-QG was not used.
- The dossier explicitly notes that primary quotes found through secondary transcriptions require source-edition verification before classroom quote cards.
- Reported typhus death is preserved as a caveated tradition because no primary medical/parish death record was opened in this pass.