### PR TITLE
docs(bio): add Larysa Masenko dossier

### DIFF
--- a/docs/research/bio/larysa-masenko.md
+++ b/docs/research/bio/larysa-masenko.md
@@ -1,0 +1,148 @@
+# Лариса Терентіївна Масенко - Research Dossier
+
+**Slug:** `larysa-masenko`
+**Block:** +77 expansion - sociolinguistics / language policy / de-Russification
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; BIO #341
+**Researcher:** Codex (GPT-5)
+**Completed:** 2026-07-04
+
+**Source acronym legend:** ESU = Encyclopedia of Modern Ukraine; IUL-NASU = Institute of the Ukrainian Language, NAS of Ukraine; UKMA = National University of Kyiv-Mohyla Academy / NaUKMA Library; NBUV = Vernadsky National Library of Ukraine; UKRMOVA = journal `Українська мова`; eKMAIR = NaUKMA institutional repository; IIU = Institute of History of Ukraine portal; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional or scholarly sources cited
+- [x] Pressure mechanism framed as Soviet/Russian imperial language policy, sociolinguistic hierarchy, Russification, and contested post-Soviet policy debate; no invented arrest, exile, camp term, or dissident sentence
+- [x] At least 2 primary-source text / title anchors supplied with classroom cautions
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-04 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check (run before submitting)
+
+- [x] No Russocentric framing: Russian/Soviet imperial language policy is named as Masenko's object of analysis, not as the neutral baseline for Ukrainian language history.
+- [x] Ukrainian agency is central: Masenko is framed as a scholar building Ukrainian sociolinguistic concepts, archives, surveys, and policy arguments, not as a generic language-policy activist.
+- [x] Russification is handled structurally: the dossier distinguishes state/imperial policy, urban communicative pressure, and propaganda from individual Russian-speaking Ukrainians.
+- [x] Living scholar claims are time-stamped: current institutional roles and public-policy positions must be rechecked at module build time.
+- [x] Anti-hagiography retained: Masenko's concepts of language conflict, linguocide, surzhyk, and language stability are powerful teaching anchors but should be read as arguments in contested sociolinguistic and policy contexts.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Лариса Терентіївна Масенко.
+- **Project English canonical:** Larysa Masenko.
+- **Birth:** ESU gives 14 November 1942, village Bezimenne, Saratov oblast, Russian Federation / RSFSR context. UKMA Library gives the same date and locality; treat birthplace as a wartime/family biographical fact, not as an identity frame.
+- **Living figure:** Masenko is a living linguist, sociolinguist, professor, and public intellectual. Re-verify current roles and public statements before module build.
+- **Education / degrees:** IUL-NASU says she graduated from Kyiv State University, philological faculty, in 1964; defended the candidate dissertation `Гідронімія басейну Південного Бугу` in 1972; and defended the doctoral dissertation `Українська мова в соціолінгвістичному аспекті` in 2005. ESU lists doctor of philological sciences from 2006 and professor from 2007.
+- **Core institutional roles:** ESU records work at the Institute of Linguistics, Academy of Sciences of the Ukrainian SSR, in 1964-1991; work at the Institute of the Ukrainian Language, NASU, from 1991 with an interruption; Kyiv University in 1996-2001; and NaUKMA from 2001, where she headed the Ukrainian-language department in 2001-2010 and then served as professor. IUL-NASU lists her as professor at NaUKMA and leading research fellow of the Institute of the Ukrainian Language, NASU.
+- **Field identity:** ESU and IUL-NASU identify her fields as sociolinguistics, stylistics, onomastics, and the history of the Ukrainian literary language. Her later public-scholarly profile centers language policy, Russification, language conflict, surzhyk, Soviet totalitarian discourse, language stability, and postcolonial language hierarchy.
+- **School-building:** IUL-NASU states that she created a school of sociolinguistics and supervised 8 candidate and 2 doctoral dissertations. Use this as institutional field-building evidence, not as vague prestige language.
+- **Recognition:** IUL-NASU lists awards including Borys Hrinchenko Prize (2005), Oleksa Hirnyk Prize (2009), Vasyl Stus Prize (2010), Petro Mohyla Prize (2011), Yaroslav the Wise award (2012), Dmytro Nytchenko Prize (2016), and honorary professor status at Borys Hrinchenko Kyiv University in 2016.
+
+## 2. Oppression / pressure mechanism
+
+- **Not a prison-case biography:** Do not invent arrest, exile, camp sentence, KGB case, or formal dissident conviction for Masenko. Her dossier belongs to BIO because she documents and theorizes language as a site of imperial pressure, not because her life follows a direct repression plot.
+- **Soviet language policy as object of study:** UKRMOVA's 2022 overview of Masenko's work says a number of her publications analyze Soviet language policy aimed at limiting Ukrainian-language functions and artificially interfering with Ukrainian structure to bring it closer to Russian. This is the main oppression mechanism: institutional engineering of language status, corpus, prestige, education, publishing, and public use.
+- **Linguocide / Russification archive:** `Українська мова у ХХ сторіччі: історія лінгвоциду` is a document-and-materials project rather than a simple polemic. It should be taught as evidence-based documentation of language-policy pressure, including the artificial narrowing of Ukrainian functions and lexical/structural interference.
+- **Urban communicative pressure:** Masenko's work on Kyiv, surzhyk, and bilingual public space helps explain why "choice of language" in a Russified urban environment is not a neutral individual preference. Classroom use should avoid shaming speakers; the point is how institutions and prestige systems shape behavior.
+- **Post-Soviet policy conflict:** Her 2018 article `Мовний конфлікт в Україні: шляхи розв'язання` frames Ukrainian language policy through conflict between state-building and pro-Russian political forces, especially around the 2012 language law and later civil-society pressure. Teach this as a dated policy argument, not as a timeless description of all bilingual Ukrainians.
+- **Soviet totalitarian discourse:** `Мова радянського тоталітаризму` analyzes Soviet political language as deception, terror, enemy-making, and national unification pressure. This bridges BIO to propaganda literacy and discourse analysis without reducing Masenko to "anti-Soviet activism."
+- **Decolonization after 2014/2022:** Later reception of Masenko's work became sharper in wartime and decolonization debates. Keep chronology visible: do not back-project 2022 wartime vocabulary into 1990s/2000s sociolinguistic surveys unless the source itself does so.
+
+## 3. Major works / contributions
+
+- **Onomastics / hydronymy base:** `Гідронімія Східного Поділля` (1979), `Словник гідронімів України` (co-compiler, 1979), `Етимологічний словник літописних географічних назв Південної Русі` (co-compiler, 1985), and `Українські імена і прізвища` (1990) show that her sociolinguistics grew from philological, lexical, and onomastic work.
+- **Language and politics:** `Мова і політика` (1999) and `Мова і суспільство: постколоніальний вимір` (2004) are early independent-Ukraine anchors for connecting language choice, institutions, postcolonial hierarchy, and national identity.
+- **Linguocide documentation:** `Українська мова у ХХ сторіччі: історія лінгвоциду` (2005; edited/compiled with co-authors) is essential for teaching Soviet interference through documents, not only retrospective opinion.
+- **Sociolinguistic method:** `Нариси з соціолінгвістики` (2010) and the doctoral topic `Українська мова в соціолінгвістичному аспекті` frame her as a method-builder: parameters of language situation, communicative power, demographic power, education/media/state domains, intergenerational transmission, attitudes, and regional comparison.
+- **Surzhyk:** `Суржик: між мовою і язиком` (ESU lists 2011; later bibliography/review records a 2019 edition) is the main C1 bridge. It should be taught as a study of mixed speech under long Ukrainian-Russian contact and hierarchy, not as a license for humiliating learners or speakers.
+- **Soviet totalitarian language:** `Мова радянського тоталітаризму` (2017) analyzes deception, terror, enemy categories, euphemisms, slogans, and national unification in Soviet discourse. eKMAIR and IIU preserve metadata and summaries.
+- **Language conflict / policy:** `Мовний конфлікт в Україні: шляхи розв'язання` (UKRMOVA, 2018, DOI 10.15407/ukrmova2018.02.020) and `Конфлікт мов та ідентичностей у пострадянській Україні` (2020; second edition listed by Klio/Chytomo in 2021 contexts) anchor post-Maidan debates over the state-language law, civil society, media, identity, and Russian-world pressure.
+- **Shevelov transmission:** ESU and NBUV record Masenko's editing/introductions for Yurii Shevelov texts, including `Українська мова в першій половині двадцятого століття (1900-1941): Стан і статус`, `Портрети українських мовознавців`, and `Вибрані праці: Мовознавство`. This makes her a bridge between Shevelov's decolonizing language history and contemporary sociolinguistics.
+
+## 4. Primary-source quote / visual anchors
+
+Use short excerpts only. Masenko is living, and books/articles are copyright-protected unless a specific open license is confirmed. For classroom use, verify wording against the article/PDF/book page and avoid extracting long passages from publisher previews, eKMAIR PDFs, or retail pages.
+
+- **Postcolonial title anchor:** `Мова і суспільство: постколоніальний вимір` is the safest title-level prompt for discussing language as social structure, hierarchy, identity, and decolonization. Use title only unless the book text is cleared for quotation.
+- **Surzhyk title anchor:** `Суржик: між мовою і язиком` is a compact prompt because the title itself contrasts `мова` and `язик`. Classroom caution: explain that `язик` here is a deliberate marked form, not a general synonym learners should copy casually.
+- **Policy title anchor:** `Мовний конфлікт в Україні: шляхи розв'язання` gives a dated 2018 article anchor with DOI. Use it to ask what "conflict" means in policy discourse; do not turn it into a claim that everyday bilingual speakers are the conflict.
+- **Totalitarian-language anchor:** eKMAIR/IIU summaries preserve the short phrase `мова великого ошуканства` for `Мова радянського тоталітаризму`. Treat it as a source-page summary/title-adjacent phrase until checked in the book itself.
+- **Identity title anchor:** `Конфлікт мов та ідентичностей у пострадянській Україні` lets a C2 class connect language policy to identity formation after empire. Use excerpts only after checking the exact edition.
+- **Visual anchor:** Commons `File:Масенко Лариса Терентіївна.jpg`; source listed as Academy of Sciences of Higher Education of Ukraine; date before 2012; license CC BY-SA 3.0 Unported. It is low-resolution and older; acceptable as a rights-cleared portrait with attribution/share-alike, but prefer a higher-quality Commons or institutional-license file if found later.
+
+## 5. Language register
+
+- **Register:** scholarly sociolinguistic, policy-analytic, public-intellectual, source-critical; moves between academic terminology, legal/policy detail, surveys, and polemical decolonization vocabulary.
+- **CEFR readiness:** B2+/C1 for guided interview or short publicistic excerpts; C1 for accessible chapters from `Суржик` and `Нариси з соціолінгвістики`; C2 for policy articles and Soviet discourse analysis because students must track law, ideology, irony, corpus/status planning, and contested public rhetoric.
+- **Core vocabulary:** `соціолінгвістика`, `мовна ситуація`, `мовна політика`, `державна мова`, `мовне законодавство`, `русифікація`, `лінгвоцид`, `суржик`, `двомовність`, `диглосія`, `інтерференція`, `калька`, `мовна стійкість`, `комунікативна потужність`, `ідентичність`, `постколоніальний вимір`, `денаціоналізація`.
+- **Teaching caution:** Avoid a classroom dynamic where learners treat surzhyk as personal failure. Masenko is most valuable when students can separate a speaker's biography from the structural history of prestige, schooling, migration, media, and coercive policy.
+- **Bridge activities:** Ask learners to map a claim at three levels: individual language behavior, urban/institutional pressure, and state/imperial policy. Then ask which level a given Masenko source actually documents.
+
+## 6. Contested points
+
+- **Present-tense roles:** IUL-NASU and ESU list long institutional careers and current/ongoing roles, but Masenko is living. Recheck IUL-NASU, NaUKMA, and public pages before using present-tense titles in a live lesson.
+- **Birthplace handling:** Because she was born in Saratov oblast, careless summaries can misframe her as "Russian-born" in a way that distracts from her Ukrainian scholarly identity and family/history context. Use the full sourced fact once, then move to education, institutions, and work.
+- **"Language conflict" terminology:** Her frame is a policy/sociolinguistic argument. It must not be simplified into hostility toward Russian-speaking citizens, nor into a denial of minority-language rights. Pair it with legal/historical context and the distinction between Russian state imperial policy and plural Ukrainian society.
+- **Surzhyk stigma:** The word often carries shame in public discourse. Future modules should use Masenko's analysis to show causes and functions, not to mock, correct, or rank students by purity.
+- **Linguocide as term:** `Лінгвоцид` is strong and politically charged, but Masenko's 2005 project is explicitly document-based. Teach it with source packets, dates, and policy mechanisms rather than as an unexamined slogan.
+- **Public-intellectual reception:** Chytomo, publisher pages, and event reports can summarize her arguments sharply. Use them for reception and book metadata; do not substitute them for the article/book text when making close-reading claims.
+- **Transliteration variants:** `Larysa Masenko` is project canonical. `Larisa Masenko`, `Larysa Terentiivna Masenko`, and Russian-script `Лариса Терентьевна Масенко` occur in catalogues/search contexts. Keep noncanonical forms in search notes only.
+- **Copyright / quotes:** Wikiquote and retail pages may circulate short lines without enough edition control. For learner-facing direct quotation, prefer the UKRMOVA article page/PDF, eKMAIR item, NBUV catalogue, or a checked book edition.
+
+## 7. Cross-track links
+
+- **Existing C1 Surzhyk plan/discovery surfaces (VERIFIED `test -e` / `rg` 2026-07-04):** `curriculum/l2-uk-en/plans/c1/surzhyk.yaml`, `curriculum/l2-uk-en/c1/discovery/surzhyk.yaml`
+- **Existing C2 language-policy module surfaces (VERIFIED `test -e` / `rg` 2026-07-04):** `curriculum/l2-uk-en/plans/c2/language-policy-decolonization.yaml`, `curriculum/l2-uk-en/c2/discovery/language-policy-decolonization.yaml`
+- **Existing Shevelov / language-history wiki and research surfaces (VERIFIED `test -e` / `rg` 2026-07-04):** `wiki/literature/works/shevelov-history-language.md`, `wiki/literature/works/shevelov-history-language.sources.yaml`, `docs/research/bio/george-shevelov.md`
+- **Existing site index surface (VERIFIED `rg` 2026-07-04):** `site/src/content/docs/bio/index.mdx` includes `num: 341`, `slug: larysa-masenko`, status locked.
+- **Candidate / future BIO surfaces not created in this PR:** `curriculum/l2-uk-en/plans/bio/larysa-masenko.yaml`, `curriculum/l2-uk-en/bio/discovery/larysa-masenko.yaml`, `wiki/figures/larysa-masenko.md`, `site/src/content/docs/bio/larysa-masenko.mdx`, `curriculum/l2-uk-en/bio/larysa-masenko/module.md`, `curriculum/l2-uk-en/bio/larysa-masenko/activities.yaml`, `curriculum/l2-uk-en/bio/larysa-masenko/vocabulary.yaml`, `curriculum/l2-uk-en/bio/larysa-masenko/resources.yaml`
+
+## 8. Naming-canonical
+
+- **Slug:** `larysa-masenko`
+- **EN canonical (project):** Larysa Masenko.
+- **UA canonical:** Лариса Терентіївна Масенко.
+- **Aliases future YAML:** `Лариса Масенко`; `Масенко Лариса Терентіївна`; `Л. Т. Масенко`; `Larysa Masenko`; `Larysa Terentiivna Masenko`; `Masenko Larysa`; `Larysa T. Masenko`; `Larisa Masenko` (catalogue/search only, noncanonical).
+- **Forbidden / noncanonical learner-facing defaults:** Russian `Лариса Терентьевна Масенко`; `Larisa` as the English display default; reducing her identity to "language activist"; using `surzhyk` as a learner-facing insult.
+- **Search note:** Use `Лариса Терентіївна Масенко`, `Л. Т. Масенко`, `Larysa Masenko`, `Larisa Masenko`, and `Masenko L.` for catalogues, DOI pages, and transliteration-heavy bibliographies. Keep course display as `Larysa Masenko`.
+
+## 9. Image candidates
+
+- **Primary reusable candidate:** Commons `File:Масенко Лариса Терентіївна.jpg`; original 192 x 266 pixels; source Academy of Sciences of Higher Education of Ukraine; date before 2012; author listed as АН вищої школи України; license CC BY-SA 3.0 Unported. Use with attribution and share-alike compliance.
+- **Quality caveat:** The Commons portrait is small and older. It is useful for a basic BIO card but may look poor in high-resolution layouts.
+- **Candidate search path:** Check Commons category `Larysa Masenko`, NaUKMA / IUL-NASU pages, and event photos only for metadata; embed only files with file-level reusable licenses.
+- **Avoid by default:** NaUKMA news photos, IUL-NASU profile images, eKMAIR thumbnails, publisher/retail book covers, and social-media/event screenshots unless a reusable license is verified.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / institutional):**
+
+- Енциклопедія Сучасної України. "Масенко Лариса Терентіївна." https://esu.com.ua/article-64148. Accessed 2026-07-04.
+- Інститут української мови НАН України. "Масенко Лариса Терентіївна." https://iul-nasu.org.ua/personnel/masenko-larysa-terentiyivna. Accessed 2026-07-04.
+- Наукова бібліотека НаУКМА. "Масенко Лариса" (особова колекція). https://library.ukma.edu.ua/kolektsii/kolektsii/291-masenko-larysy. Accessed 2026-07-04.
+- Національна бібліотека України імені В. І. Вернадського. "Народилася Лариса Масенко..." https://www.nbuv.gov.ua/node/4427. Accessed 2026-07-04.
+
+**Tier 2 (scholarly / catalogue / repository evidence):**
+
+- Svitlana Sokolova. "L. T. Masenko: a strategy for researching the language situation in Ukraine and language development." `Українська мова`, 4 (84), 2022. https://ukrmova.iul-nasu.org.ua/en/vypusky-zhurnalu-en/2022-2/zhurnal-ukrayinska-mova-4-84-2022/l-t-masenko-strategiya-doslidzhennya-movnoyi-sytuatsiyi-v-ukrayini-ta-movnogo-rozvytku.html. Accessed 2026-07-04.
+- Лариса Масенко. "Мовний конфлікт в Україні: шляхи розв'язання." `Українська мова`, 2 (66), 2018. DOI 10.15407/ukrmova2018.02.020. https://ukrmova.iul-nasu.org.ua/vypusky-zhurnalu-en/2018-2/zhurnal-ukrayinska-mova-2-66-2018/movnyj-konflikt-v-ukrayini-shlyahy-rozv-yazannya.html. Accessed 2026-07-04.
+- eKMAIR / НаУКМА repository. "Мова радянського тоталітаризму." https://ekmair.ukma.edu.ua/items/ca812e11-f1f8-488d-8e2f-8911ddff1a30. Accessed 2026-07-04.
+- Інститут історії України НАН України. "Масенко Л. Мова радянського тоталітаризму (2017)." https://resource.history.org.ua/item/0013972. Accessed 2026-07-04.
+- НБУВ electronic catalogue author search, `Масенко Л$`, including doctoral abstract, `Мова і політика`, `Мова і суспільство`, `Українська мова у ХХ сторіччі`, and Shevelov editions. https://irbis-nbuv.gov.ua/cgi-bin/irbis_nbuv/cgiirbis_64.exe?C21COM=S&I21DBN=EC&P21DBN=EC&S21CNR=20&S21COLORTERMS=1&S21FMT=fullwebr&S21P01=0&S21P02=0&S21P03=A%3D&S21REF=10&S21STN=1&S21STR=%D0%9C%D0%B0%D1%81%D0%B5%D0%BD%D0%BA%D0%BE+%D0%9B%24&Z21ID=. Accessed 2026-07-04.
+- National Library digital item. "Мова і суспільство: постколоніальний вимір." https://search.nbuv.gov.ua/cgi-bin/ua/elib.exe?C21COM=S&I21DBN=UKRLIB&P21DBN=UKRLIB&S21CNR=20&S21FMT=online_book&S21P01=0&S21P02=0&S21P03=FF%3D&S21REF=10&S21STN=1&S21STR=ukr0001187&Z21ID=. Accessed 2026-07-04.
+
+**Tier 3 (public humanities / publisher / reception):**
+
+- National University of Kyiv-Mohyla Academy. "Larysa Masenko presented her new book in the Kyiv-Mohyla Academy." Published 12 February 2018. https://www.ukma.edu.ua/eng/index.php/news/729-larysa-masenko-presented-her-new-book-in-the-kyiv-mohyla-academy. Accessed 2026-07-04.
+- Читомо. "Лариса Масенко. Конфлікт мов та ідентичностей у пострадянській Україні." https://chytomo.com/book/konflikt-mov-ta-identychnostej-u-postradianskij-ukraini/. Accessed 2026-07-04.
+- Klio publisher page. "Конфлікт мов та ідентичностей у пострадянській Україні." https://www.clio.in.ua/knyharnya/knyharnya/978-617-7755-14-1-detail.html. Accessed 2026-07-04.
+- `Cognitive Studies | Etudes cognitives` review page for `Larysa Masenko, Surzhyk: Mizh Movoju i Jazykom`. https://journals.ispan.edu.pl/index.php/cs-ec/en/article/view/cs.2288/6059. Accessed 2026-07-04.
+
+**Tier 4 (image-rights / navigation only):**
+
+- Wikimedia Commons. `Category:Larysa Masenko`. https://commons.wikimedia.org/wiki/Category:Larysa_Masenko. Accessed 2026-07-04.
+- Wikimedia Commons. `File:Масенко Лариса Терентіївна.jpg`. https://commons.wikimedia.org/wiki/File:%D0%9C%D0%B0%D1%81%D0%B5%D0%BD%D0%BA%D0%BE_%D0%9B%D0%B0%D1%80%D0%B8%D1%81%D0%B0_%D0%A2%D0%B5%D1%80%D0%B5%D0%BD%D1%82%D1%96%D1%97%D0%B2%D0%BD%D0%B0.jpg. Accessed 2026-07-04.
+- Ukrainian Wikipedia / Wikidata / Wikiquote were used only as navigation leads; no learner-facing facts depend on Wikipedia alone.


### PR DESCRIPTION
## Summary

- Added the missing BIO manifest research dossier for Larysa Masenko.
- Kept scope to `docs/research/bio/larysa-masenko.md`.
- Covered sociolinguistics, Russification, decolonization, public-intellectual work, contested policy contexts, source caveats, classroom-readiness cautions, cross-track links, naming, image rights, and tiered sources.

## Changed file

- `docs/research/bio/larysa-masenko.md`

## Verification

- `npx markdownlint-cli2 docs/research/bio/larysa-masenko.md` — pass
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/larysa-masenko.md` — pass
- `git diff --check origin/main...HEAD` — pass
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — pass
- Protected-path/artifact scan — pass; no forbidden files, status/audit/review artifacts, telemetry, protected configs, or `sys.executable` in the diff
- Paused-QG scan — pass; no LLM-QG, parity, or module-quality-audit references in the diff

## LLM-QG

LLM-QG was not used, routed, trusted, persisted, or closed for this PR.