### PR TITLE
feat(qg): define UA contact evidence schema

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -124,6 +124,57 @@ outputs under `/tmp` unless a durable audit report is explicitly in scope.
 
 ---
 
+## UA Evaluation Harness Schema
+
+The source-language-agnostic evidence contract for #2156 / #4307 lives in:
+
+- `docs/projects/ua-eval-harness/schema.md`
+- `scripts/audit/qg_schema.py`
+
+`qg_schema.py` is a library module, not a CLI. Downstream scorer adapters should
+import its builders and validators instead of inventing local finding shapes.
+
+Useful examples:
+
+```python
+from scripts.audit.qg_schema import (
+    build_dimension,
+    build_deterministic_curriculum_finding,
+    build_evidence_record,
+    build_semantic_false_friend_finding,
+    build_ua_gec_finding,
+    validate_record,
+)
+
+finding = build_ua_gec_finding(
+    error="являється",
+    correction="є",
+    tag="F/Calque",
+    file="module.md",
+    line=18,
+    span={"start": 210, "end": 218},
+    doc_id="0301",
+)
+record = build_evidence_record(
+    profile="ua_gec_eval",
+    evidence_kind="fixture",
+    fixture_id="ua-gec-0301",
+    dimensions={
+        "contact_calque": build_dimension(score=9.0, verdict="WARN", findings=[finding]),
+    },
+    verdict="WARN",
+    terminal_verdict="PASS",
+)
+validate_record(record)
+```
+
+The canonical schema version is `ua_contact_quality_evidence.v1`. Existing
+`curriculum_ua_qg_evidence.v1` and `llm_qg_evidence.v1` records remain valid
+projection profiles; do not regenerate module evidence just to adopt the new
+schema.
+
+---
+
 ## Wiki Knowledge Base
 
 The wiki is the research layer: compiled reference articles consumed as inline context during module generation. Source retrieval is pre-baked into SQLite, so module generation does not depend on live external search.

--- a/docs/projects/ua-eval-harness/README.md
+++ b/docs/projects/ua-eval-harness/README.md
@@ -44,26 +44,40 @@ These are NOT the harness, but they are the scorer-side foundation:
 - **СУМ-11 + Грінченко + ЕСУМ + slovnyk.me** — heritage-defense layer (`mcp__sources__search_heritage`) to avoid false-positives on authentic Ukrainian archaisms/dialectisms.
 - **UA-GEC errors index** — already MCP-exposed via `mcp__sources__search_ua_gec_errors` (filtered to F/Calque, F/Collocation, G/Case, G/Gender). 8,937 rows.
 
+## Current implementation artifacts
+
+- [PR1 curriculum QG plan](pr1-curriculum-qg-plan.md) documents the merged
+  curriculum-facing MVP.
+- [UA contact quality evidence schema](schema.md) documents
+  `ua_contact_quality_evidence.v1` and the helper module
+  `scripts/audit/qg_schema.py`.
+- [Agent fleet evidence for #4307](agent-fleet-4307.md) records the concrete
+  fleet lanes used for the schema slice and the observed strengths/weaknesses.
+
 ## Design TBD (these are the questions next session should answer)
 
 ### Eval shape — calque axis
+
 - Prompt-elicitation: what task family elicits calques best? (Translation EN→UK? Free generation in UK? Continuation from UK seed? Conversation-completion?)
 - Coverage: how many UA-GEC F/Calque examples form the eval set? Hold-out for validation?
 - Scoring: exact-match against gold edit-pairs? F1 over flagged spans? Semantic-equivalence aware?
 - Calibration: how do we compare LLM output to UA-GEC's human-edit format (which is corrective, not generative)?
 
 ### Eval shape — grammar axis
+
 - Which G/* tags do we score? G/Case, G/Gender, G/Number, G/Aspect, G/Verb? All?
 - Same prompt family as calque axis, or separate prompts that elicit grammar mistakes specifically?
 - Joint vs separate leaderboard: one ranking with two columns, or two separate rankings?
 
 ### Models in scope
+
 - Closed-source frontier: Claude, GPT-5.5, Gemini, Grok
 - Open-source frontier: DeepSeek, Qwen, Mistral, Kimi, MiniMax
 - Plus open-weight UA-fine-tuned: Lapa, MamayLM (covered by lang-uk leaderboard)
 - Cost ceiling per full eval pass
 
 ### Repo layout
+
 - Standalone repo or sub-project of `learn-ukrainian`?
 - Naming: `ua-eval-harness`? `uk-russian-shadow-eval`? `ua-gec-llm-eval`?
 - Reproducibility: requirements pinned, results-versioned, model-version-captured

--- a/docs/projects/ua-eval-harness/agent-fleet-4307.md
+++ b/docs/projects/ua-eval-harness/agent-fleet-4307.md
@@ -15,7 +15,7 @@ are local operational state, not committed artifacts.
 | Cursor review | `4307-cursor-schema-review` | read-only | `auto` | 66.399s | 2518 | 14849 | Completed. Strongest schema-blocker analysis. |
 | AGY review | `4307-agy-schema-review` | read-only | `Gemini 3.1 Pro (High)` | 95.123s | 2287 | 7644 | Completed. Good linguistic and false-positive blockers. |
 | DeepSeek review | `4307-deepseek-schema-review` | read-only | `deepseek-v4-pro` | 181.517s | 2522 | 0 | Timed out at initial response. |
-| Qwen review | `4307-qwen-schema-review` | read-only | `qwen/qwen3.6-plus` | 180.914s | 2514 | 0 | Timed out at initial response. |
+| Qwen review | `4307-qwen-schema-review` | read-only | `qwen/qwen3.6-plus` | 180.914s | 2514 | 0 | Timed out; not a desired #2156 lane going forward. |
 | Cursor implementation | `4307-cursor-schema-impl` | danger | `auto` | 59.495s | 2802 | 1683 | Produced schema/test patch and auto-finalized PR #4318. |
 
 The dispatch runtime exposes these delegate agents for this repo:
@@ -24,6 +24,12 @@ and `cursor`. It does not expose a literal `glm` delegate target in
 `scripts/delegate.py` or `scripts/agent_runtime/registry.py` as of this run.
 Older bakeoff docs mention GLM as a model-family participant, but there is no
 callable GLM lane to dispatch here yet.
+
+Routing update after this run: do not assign Qwen to #2156 work unless the user
+explicitly re-enables it. DeepSeek is still an expected review lane; its timeout
+in this repo should be treated as a learn-ukrainian runtime/config mismatch to
+debug against the working kubedojo DeepSeek setup, not as evidence that
+DeepSeek itself is unavailable.
 
 ## Findings by Lane
 
@@ -82,11 +88,11 @@ Observed failure:
 
 Observed fit:
 
-DeepSeek remains documented as a cheap review lane in repo guidance, but in
-this run it was not operationally reliable enough to use as a blocker or source
-of design evidence. Before relying on it for #4308 or PR review, rerun a small
-smoke task and check Hermes/OpenRouter credentials and initial-response
-timeout behavior.
+DeepSeek remains the desired cheap review lane for this project. This run shows
+that the learn-ukrainian dispatch path did not respond, while the user's
+kubedojo setup is known to work. Before relying on DeepSeek for #4308 or PR
+review, compare this repo's Hermes/delegate configuration and environment with
+kubedojo and rerun a tiny smoke prompt.
 
 ### Qwen Review
 
@@ -98,8 +104,9 @@ Observed failure:
 
 Observed fit:
 
-Qwen is wired through Hermes, but this run produced no usable output. Treat it
-as unavailable until a smoke task confirms prompt delivery and model response.
+Qwen is not a desired lane for #2156 work. The timeout is recorded for honesty
+because the lane was dispatched, but it should not be part of the follow-up
+reliability target unless the routing policy changes.
 
 ### Cursor Implementation
 
@@ -149,6 +156,8 @@ Tracked in
 
 - Wire or document a real GLM dispatch lane before promising GLM participation
   in future fleet tasks.
-- Smoke-test DeepSeek and Qwen before assigning them blocker status.
+- Restore DeepSeek by checking learn-ukrainian runtime/config parity against
+  kubedojo, where DeepSeek is known to work.
+- Do not use Qwen for #2156 work unless the user explicitly re-enables it.
 - Treat Cursor danger-mode auto-finalization as expected behavior unless
   delegate runtime configuration proves otherwise.

--- a/docs/projects/ua-eval-harness/agent-fleet-4307.md
+++ b/docs/projects/ua-eval-harness/agent-fleet-4307.md
@@ -1,0 +1,154 @@
+# Agent Fleet Evidence for #4307
+
+Date: 2026-07-04
+
+Issue: [#4307](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4307)
+
+This note records the concrete fleet lanes used for the source-language-agnostic
+schema slice. Raw task JSON/result files live under `batch_state/tasks/` and
+are local operational state, not committed artifacts.
+
+## Summary
+
+| Lane | Task id | Mode | Model | Duration | Prompt chars | Response chars | Result |
+| --- | --- | --- | --- | ---: | ---: | ---: | --- |
+| Cursor review | `4307-cursor-schema-review` | read-only | `auto` | 66.399s | 2518 | 14849 | Completed. Strongest schema-blocker analysis. |
+| AGY review | `4307-agy-schema-review` | read-only | `Gemini 3.1 Pro (High)` | 95.123s | 2287 | 7644 | Completed. Good linguistic and false-positive blockers. |
+| DeepSeek review | `4307-deepseek-schema-review` | read-only | `deepseek-v4-pro` | 181.517s | 2522 | 0 | Timed out at initial response. |
+| Qwen review | `4307-qwen-schema-review` | read-only | `qwen/qwen3.6-plus` | 180.914s | 2514 | 0 | Timed out at initial response. |
+| Cursor implementation | `4307-cursor-schema-impl` | danger | `auto` | 59.495s | 2802 | 1683 | Produced schema/test patch and auto-finalized PR #4318. |
+
+The dispatch runtime exposes these delegate agents for this repo:
+`codex`, `gemini`, `claude`, `grok`, `grok-build`, `deepseek`, `qwen`, `agy`,
+and `cursor`. It does not expose a literal `glm` delegate target in
+`scripts/delegate.py` or `scripts/agent_runtime/registry.py` as of this run.
+Older bakeoff docs mention GLM as a model-family participant, but there is no
+callable GLM lane to dispatch here yet.
+
+## Findings by Lane
+
+### Cursor Review
+
+Strengths:
+
+- Found the real blocker: existing deterministic evidence and LLM compact
+  evidence use different envelopes and dimension names.
+- Correctly separated `contact_source_lang` from learner-track L1.
+- Identified issue-id fragmentation between curriculum phrase rules,
+  russicism gates, UA-GEC lookup, and #912 semantic false friends.
+- Produced concrete field, mapping, and false-positive-control proposals.
+
+Weaknesses:
+
+- The recommendation still required integrator decisions on version naming and
+  projection policy.
+- It did not solve downstream adapter wiring; it scoped that correctly as
+  #4308 work.
+
+Observed fit:
+
+Cursor was the strongest fast architecture reviewer for this code-adjacent
+schema task.
+
+### AGY Review
+
+Strengths:
+
+- Independently confirmed "no blocker for schema PR" while flagging blockers
+  before scorer adapters.
+- Emphasized teaching-example masking, heritage/dialect guards, and rigid
+  CC-BY-4.0 attribution as adapter prerequisites.
+- Gave a useful #912 model: semantic false friends need sense context and must
+  not be blanket-failed.
+
+Weaknesses:
+
+- Less specific than Cursor on existing dual-envelope compatibility.
+- Suggested stricter UA-GEC severities in places where the existing repo keeps
+  bulk lookup as `info`; the integrator kept the repo's current safer default.
+
+Observed fit:
+
+AGY is useful for language taxonomy, false-positive risk, and prompt/reviewer
+calibration, especially as a non-Codex independent reviewer.
+
+### DeepSeek Review
+
+Observed failure:
+
+- Timed out after 181.517s at the initial-response gate.
+- `response_chars` was `0`; no schema judgment was available.
+- Worktree was clean on exit.
+
+Observed fit:
+
+DeepSeek remains documented as a cheap review lane in repo guidance, but in
+this run it was not operationally reliable enough to use as a blocker or source
+of design evidence. Before relying on it for #4308 or PR review, rerun a small
+smoke task and check Hermes/OpenRouter credentials and initial-response
+timeout behavior.
+
+### Qwen Review
+
+Observed failure:
+
+- Timed out after 180.914s at the initial-response gate.
+- `response_chars` was `0`; no schema judgment was available.
+- Worktree was clean on exit.
+
+Observed fit:
+
+Qwen is wired through Hermes, but this run produced no usable output. Treat it
+as unavailable until a smoke task confirms prompt delivery and model response.
+
+### Cursor Implementation
+
+Strengths:
+
+- Produced a focused two-file implementation with schema helpers and tests in
+  under one minute.
+- Covered stable finding ids, UA-GEC tag mapping, source-language validation,
+  #912 semantic false friends, and legacy-schema non-overwrite checks.
+
+Weaknesses:
+
+- The delegate runtime auto-finalized the dirty worktree into draft PR #4318
+  even though the worker brief said not to commit or push. That is an
+  operational hazard for danger-mode lanes.
+- The worker implementation used a finding-only schema version
+  (`ua_qg_finding.v1`) rather than the record-level
+  `ua_contact_quality_evidence.v1` contract accepted by the integrator.
+- The worker defaulted some contact grammar mappings to `unknown`; the
+  accepted contract defaults prioritized UA-GEC F/G tags to Russian unless a
+  source row or rule metadata says otherwise.
+
+Observed fit:
+
+Cursor is a strong bounded implementation lane, but danger-mode dispatch needs
+explicit auto-finalization expectations. For future implementation lanes, use
+read-only design first, then either accept that delegate may open a draft PR or
+disable auto-finalization if the runtime supports it.
+
+## Decisions Applied
+
+- The accepted contract is record-level `ua_contact_quality_evidence.v1`, not a
+  finding-only schema.
+- Existing `curriculum_ua_qg_evidence.v1` and `llm_qg_evidence.v1` stay as
+  compatible projection versions; no migration is required for #4307.
+- `contact_source_lang` is canonical; `source_lang` is retained as a
+  compatibility alias for issue text and future adapters.
+- UA-GEC bulk lookup remains `info` by default.
+- `F/Style` is not a deterministic-adapter input for #4308.
+- #912 emits `SEMANTIC_FALSE_FRIEND` with `sense_context` and
+  `contact_source_lang: ru`.
+
+## Operational Follow-Ups
+
+Tracked in
+[#4321](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4321).
+
+- Wire or document a real GLM dispatch lane before promising GLM participation
+  in future fleet tasks.
+- Smoke-test DeepSeek and Qwen before assigning them blocker status.
+- Treat Cursor danger-mode auto-finalization as expected behavior unless
+  delegate runtime configuration proves otherwise.

--- a/docs/projects/ua-eval-harness/schema.md
+++ b/docs/projects/ua-eval-harness/schema.md
@@ -1,0 +1,245 @@
+# UA Contact Quality Evidence Schema
+
+Issue: [#4307](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4307)
+
+This is the shared evidence contract for #2156 calque and grammar scoring. The
+Python helpers live in `scripts/audit/qg_schema.py`.
+
+The schema is additive. Existing `curriculum_ua_qg_evidence.v1` and
+`llm_qg_evidence.v1` records remain valid as projection profiles; this contract
+does not require a migration of PR1 compact evidence.
+
+## Version
+
+Canonical record version:
+
+```text
+ua_contact_quality_evidence.v1
+```
+
+Supported profiles:
+
+| Profile | Use |
+| --- | --- |
+| `curriculum_deterministic` | PR1 deterministic curriculum findings and fixtures. |
+| `curriculum_llm_compact` | Compact LLM-QG evidence projected into the shared fields. |
+| `ua_gec_eval` | UA-GEC-backed gold/eval rows. |
+| `leaderboard` | Future UNLP/leaderboard result rows. |
+
+## Core Fields
+
+Record fields:
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | `ua_contact_quality_evidence.v1`. |
+| `profile` | Projection profile listed above. |
+| `evidence_kind` | `module`, `fixture`, or `eval_item`. |
+| `module_id` / `eval_item_id` / `fixture_id` | One stable target id. |
+| `level_policy` | Curriculum policy family and English/register rules, when applicable. |
+| `content_sha` | Content hash for module-bound evidence. |
+| `checker_runs` | Adapter/version/config/provider/model metadata. |
+| `dimensions` | Per-dimension score, verdict, and canonical findings. |
+| `aggregate` | Min score, min dimension, failing/warning dimensions. |
+| `verdict` / `terminal_verdict` | Human-visible and build-gate verdicts. |
+| `provenance` | Run id, timestamp, source, and related fixture/corpus ids. |
+
+Finding fields:
+
+| Field | Meaning |
+| --- | --- |
+| `finding_id` | Stable hash over issue, locator, excerpt, and detector id. |
+| `issue_id` | Canonical uppercase issue id. |
+| `issue_class` | `calque`, `grammar`, `collocation`, `false_friend`, `register`, `leakage`, `pedagogy`, `fluency`, `mechanics`, or `other`. |
+| `dimension` | Scoring bucket. |
+| `severity` | `critical`, `warning`, or `info`. |
+| `contact_source_lang` | Contact language of the error: `ru`, `pl`, `en`, `unknown`, or `other`. |
+| `source_lang` | Compatibility alias for `contact_source_lang`. |
+| `track_l1` | Learner-track L1, separate from contact source language. |
+| `ua_gec_tag` | Original UA-GEC tag, if any. |
+| `confidence` | `deterministic`, `lookup_heuristic`, or `llm_judgment`. |
+| `disposition` | `defect`, `teaching_contrast`, `quoted_bad_form`, `heritage_allowed`, or `suppressed_fp`. |
+| `file`, `line`, `span`, `excerpt` | Bounded locator and quote. Excerpts are capped at 160 characters. |
+| `message` | Short human reason. |
+| `suggested_replacement` | Zero or more suggested forms. |
+| `detector` | Adapter, rule id, and pattern id. |
+| `attribution` | Corpus/license/doc/pair/evidence metadata. |
+| `sense_context` | Required for semantic false friends and sense-restricted calques. |
+
+Dimensions:
+
+| Dimension | Primary signal |
+| --- | --- |
+| `contact_calque` | Russian/Polish/English contact calques and false friends. |
+| `contact_grammar` | UA-GEC G/* case, gender, agreement, or government findings. |
+| `ukrainian_style` | Curriculum phrase rules and unnatural learner-facing Ukrainian. |
+| `level_policy` | Level-aware English scaffolding and support rules. |
+| `surface_leakage` | AI/persona/path/internal leakage. |
+| `naturalness` | LLM-only idiom, collocation, and register judgment. |
+| `pedagogical` | Teaching quality. |
+| `decolonization` | Historical/framing sensitivity. |
+| `engagement` | Learner value beyond filler. |
+| `tone` | Teacher voice and pathos. |
+| `seminar_sensitivity` | Advanced seminar-specific risk. |
+| `mechanics` | Orthography/punctuation when explicitly in scope. |
+
+## UA-GEC Mapping
+
+The helper `map_ua_gec_tag()` encodes the initial tag mapping:
+
+| UA-GEC tag | Issue id | Issue class | Dimension | Default severity | Default contact source |
+| --- | --- | --- | --- | --- | --- |
+| `F/Calque` | `CONTACT_CALQUE_UA_GEC` | `calque` | `contact_calque` | `info` | `ru` |
+| `F/Collocation` | `UNNATURAL_COLLOCATION` | `collocation` | `contact_calque` | `warning` | `ru` |
+| `G/Case` | `UKRAINIAN_GRAMMAR_CASE` | `grammar` | `contact_grammar` | `warning` | `ru` |
+| `G/Gender` | `UKRAINIAN_GRAMMAR_GENDER` | `grammar` | `contact_grammar` | `warning` | `ru` |
+| other `G/*` | `UKRAINIAN_GRAMMAR_UA_GEC` | `grammar` | `contact_grammar` | `warning` | `ru` |
+| other `F/*` | `UA_GEC_FLUENCY_OTHER` | `fluency` | `naturalness` | `info` | `unknown` |
+
+`F/Style` remains out of automated scorer scope for now. The schema can carry
+it as `UA_GEC_FLUENCY_OTHER` if a manual or LLM reviewer emits it, but #4308
+should not ingest it as a deterministic blocking rule.
+
+Bulk UA-GEC lookup defaults to `info`; confirmed phrase rules or reviewer
+judgment can escalate severity.
+
+## Examples
+
+Deterministic B1-27 finding:
+
+```json
+{
+  "issue_id": "AWKWARD_PASSIVE_RESULT_STATE",
+  "issue_class": "calque",
+  "dimension": "ukrainian_style",
+  "severity": "critical",
+  "contact_source_lang": "unknown",
+  "source_lang": "unknown",
+  "track_l1": "en",
+  "ua_gec_tag": null,
+  "confidence": "deterministic",
+  "disposition": "defect",
+  "file": "module.md",
+  "line": 3,
+  "span": { "start": 42, "end": 73 },
+  "excerpt": "застосунок має бути відкритий",
+  "message": "Use active/impersonal Ukrainian instead of a literal passive state.",
+  "suggested_replacement": [],
+  "detector": {
+    "adapter": "curriculum_qg_harness",
+    "rule_id": "b1_awkward_passive_result_state",
+    "pattern_id": "b1_awkward_passive_result_state"
+  },
+  "attribution": {
+    "corpus": "curriculum_phrase_rules",
+    "license": null,
+    "doc_id": null,
+    "pair_id": null,
+    "evidence": "B1-27 calibration fixture"
+  }
+}
+```
+
+UA-GEC F/Calque finding:
+
+```json
+{
+  "issue_id": "CONTACT_CALQUE_UA_GEC",
+  "issue_class": "calque",
+  "dimension": "contact_calque",
+  "severity": "info",
+  "contact_source_lang": "ru",
+  "source_lang": "ru",
+  "ua_gec_tag": "F/Calque",
+  "confidence": "lookup_heuristic",
+  "disposition": "defect",
+  "file": "module.md",
+  "line": 18,
+  "span": { "start": 210, "end": 218 },
+  "excerpt": "являється",
+  "message": "UA-GEC F/Calque pair: являється -> є (frequency 47).",
+  "suggested_replacement": ["є"],
+  "detector": {
+    "adapter": "ua_gec_lookup",
+    "rule_id": "F/Calque",
+    "pattern_id": "0301"
+  },
+  "attribution": {
+    "corpus": "UA-GEC v2",
+    "license": "CC-BY-4.0",
+    "doc_id": "0301",
+    "pair_id": null,
+    "evidence": "Syvokon et al., UNLP 2023"
+  }
+}
+```
+
+Semantic false friend finding for #912:
+
+```json
+{
+  "issue_id": "SEMANTIC_FALSE_FRIEND",
+  "issue_class": "false_friend",
+  "dimension": "contact_calque",
+  "severity": "critical",
+  "contact_source_lang": "ru",
+  "ua_gec_tag": null,
+  "confidence": "deterministic",
+  "file": "vocabulary.yaml",
+  "line": 12,
+  "excerpt": "**лук** (onion)",
+  "suggested_replacement": ["цибуля"],
+  "sense_context": {
+    "word": "лук",
+    "calque_sense": "onion",
+    "authentic_sense": "bow (weapon)",
+    "matched_gloss_pattern": "**лук** (onion)"
+  },
+  "detector": {
+    "adapter": "semantic_false_friends",
+    "rule_id": "SEMANTIC_FALSE_FRIEND",
+    "pattern_id": "лук"
+  }
+}
+```
+
+## False-Positive Controls
+
+Adapters must normalize false-positive decisions into `disposition`:
+
+| Disposition | Use |
+| --- | --- |
+| `defect` | Penalized finding. |
+| `quoted_bad_form` | The bad form is quoted, blockquoted, or shown as a bad example. |
+| `teaching_contrast` | The form appears in a contrast pair such as "not X, use Y". |
+| `heritage_allowed` | Heritage/SUM/Grinchenko evidence clears an otherwise suspicious form. |
+| `suppressed_fp` | Adapter matched text but the profile/track policy suppresses it. |
+
+Sense-restricted calques and semantic false friends must include
+`sense_context`. Do not blanket-fail words such as `любий`, `біля`,
+`на протязі`, or `лук` without the relevant sense/gloss context.
+
+## Stability Rules
+
+- New adapters should emit `ua_contact_quality_evidence.v1` records or
+  canonical findings from `scripts/audit/qg_schema.py`.
+- Existing PR1 evidence remains valid; do not rewrite `qg_evidence.json`
+  artifacts just to adopt this schema.
+- Additive fields can be introduced under `metadata`, `detector`, or
+  `attribution`.
+- Breaking changes require `ua_contact_quality_evidence.v2` and compatibility
+  tests against PR1 evidence plus UA-GEC fixtures.
+- Raw LLM transcripts, telemetry DBs, and generated audit/status files remain
+  out of git.
+
+## Before #4308
+
+The scorer-adapter issue should not start until these are stable:
+
+- `contact_source_lang` inference order: UA-GEC/source row, rule metadata,
+  Russian default for prioritized F/G tags, then `unknown`.
+- UA-GEC attribution is preserved on every emitted finding.
+- Teaching quotes, contrast pairs, heritage-safe forms, and OES/RUTH/historical
+  exemptions normalize to non-penalizing dispositions.
+- #912 semantic false friends emit `SEMANTIC_FALSE_FRIEND` with
+  `sense_context`, not a lexical-russicism finding.

--- a/scripts/audit/qg_schema.py
+++ b/scripts/audit/qg_schema.py
@@ -1,0 +1,615 @@
+"""Canonical quality-gate evidence schema helpers for the UA eval harness.
+
+The schema in this module is additive. It does not migrate existing
+``curriculum_ua_qg_evidence.v1`` or ``llm_qg_evidence.v1`` payloads; those stay
+valid as projection profiles while new calque, grammar, and LLM-review adapters
+normalize their findings into this shared shape.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+SCHEMA_VERSION = "ua_contact_quality_evidence.v1"
+LEGACY_EVIDENCE_SCHEMA_VERSIONS = frozenset(
+    {
+        "curriculum_ua_qg_evidence.v1",
+        "llm_qg_evidence.v1",
+    }
+)
+
+PROFILES = frozenset(
+    {
+        "curriculum_deterministic",
+        "curriculum_llm_compact",
+        "ua_gec_eval",
+        "leaderboard",
+    }
+)
+EVIDENCE_KINDS = frozenset({"module", "fixture", "eval_item"})
+VERDICTS = frozenset({"PASS", "WARN", "FAIL"})
+SOURCE_LANGS = frozenset({"ru", "pl", "en", "unknown", "other"})
+TRACK_L1S = frozenset({"uk", "en", "pl", "ru", "unknown", "other"})
+ISSUE_CLASSES = frozenset(
+    {
+        "calque",
+        "grammar",
+        "collocation",
+        "false_friend",
+        "register",
+        "leakage",
+        "pedagogy",
+        "fluency",
+        "mechanics",
+        "other",
+    }
+)
+DIMENSIONS = frozenset(
+    {
+        "contact_calque",
+        "contact_grammar",
+        "ukrainian_style",
+        "level_policy",
+        "surface_leakage",
+        "naturalness",
+        "pedagogical",
+        "decolonization",
+        "engagement",
+        "tone",
+        "seminar_sensitivity",
+        "mechanics",
+    }
+)
+SEVERITIES = frozenset({"critical", "warning", "info"})
+CONFIDENCE_LEVELS = frozenset({"deterministic", "lookup_heuristic", "llm_judgment"})
+DISPOSITIONS = frozenset(
+    {
+        "defect",
+        "teaching_contrast",
+        "quoted_bad_form",
+        "heritage_allowed",
+        "suppressed_fp",
+    }
+)
+
+DEFAULT_ATTRIBUTION = {
+    "corpus": None,
+    "license": None,
+    "doc_id": None,
+    "pair_id": None,
+    "evidence": None,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class UaGecTagMapping:
+    """Canonical mapping from one UA-GEC tag family to harness fields."""
+
+    tag: str
+    issue_id: str
+    issue_class: str
+    dimension: str
+    severity: str
+    default_source_lang: str
+
+    def asdict(self) -> dict[str, str]:
+        return {
+            "tag": self.tag,
+            "issue_id": self.issue_id,
+            "issue_class": self.issue_class,
+            "dimension": self.dimension,
+            "severity": self.severity,
+            "default_source_lang": self.default_source_lang,
+        }
+
+
+UA_GEC_TAG_MAPPINGS: dict[str, UaGecTagMapping] = {
+    "F/Calque": UaGecTagMapping(
+        tag="F/Calque",
+        issue_id="CONTACT_CALQUE_UA_GEC",
+        issue_class="calque",
+        dimension="contact_calque",
+        severity="info",
+        default_source_lang="ru",
+    ),
+    "F/Collocation": UaGecTagMapping(
+        tag="F/Collocation",
+        issue_id="UNNATURAL_COLLOCATION",
+        issue_class="collocation",
+        dimension="contact_calque",
+        severity="warning",
+        default_source_lang="ru",
+    ),
+    "G/Case": UaGecTagMapping(
+        tag="G/Case",
+        issue_id="UKRAINIAN_GRAMMAR_CASE",
+        issue_class="grammar",
+        dimension="contact_grammar",
+        severity="warning",
+        default_source_lang="ru",
+    ),
+    "G/Gender": UaGecTagMapping(
+        tag="G/Gender",
+        issue_id="UKRAINIAN_GRAMMAR_GENDER",
+        issue_class="grammar",
+        dimension="contact_grammar",
+        severity="warning",
+        default_source_lang="ru",
+    ),
+}
+UA_GEC_SUPPORTED_TAGS = frozenset(UA_GEC_TAG_MAPPINGS)
+
+_SOURCE_LANG_ALIASES = {
+    "": "unknown",
+    "russian": "ru",
+    "rus": "ru",
+    "ru": "ru",
+    "polish": "pl",
+    "pol": "pl",
+    "pl": "pl",
+    "english": "en",
+    "eng": "en",
+    "en": "en",
+    "unknown": "unknown",
+    "unk": "unknown",
+    "other": "other",
+}
+
+
+def _stable_json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def stable_hash(value: object) -> str:
+    """Return a stable SHA-256 hex digest for schema ids and config hashes."""
+    return hashlib.sha256(_stable_json(value).encode("utf-8")).hexdigest()
+
+
+def normalize_source_lang(value: str | None, *, default: str = "unknown") -> str:
+    """Normalize a source/contact language code into the schema enum."""
+    raw = (value if value is not None else default).strip().lower()
+    normalized = _SOURCE_LANG_ALIASES.get(raw, raw)
+    if normalized not in SOURCE_LANGS:
+        raise ValueError(f"unsupported contact source language: {value!r}")
+    return normalized
+
+
+def normalize_track_l1(value: str | None, *, default: str = "unknown") -> str:
+    """Normalize the learner track L1 separately from the contact-error source."""
+    raw = (value if value is not None else default).strip().lower()
+    normalized = _SOURCE_LANG_ALIASES.get(raw, raw)
+    if normalized not in TRACK_L1S:
+        raise ValueError(f"unsupported track L1: {value!r}")
+    return normalized
+
+
+def map_ua_gec_tag(tag: str, *, source_lang: str | None = None) -> dict[str, str]:
+    """Map a UA-GEC tag into the canonical finding fields.
+
+    ``source_lang`` here means the contact source of the error. When UA-GEC does
+    not provide a useful value, the high-signal F/G tags default to Russian
+    because #2156 prioritizes Russian-contact harm first.
+    """
+    if tag in UA_GEC_TAG_MAPPINGS:
+        mapping = UA_GEC_TAG_MAPPINGS[tag]
+        out = mapping.asdict()
+        out["source_lang"] = normalize_source_lang(source_lang, default=mapping.default_source_lang)
+        out["contact_source_lang"] = out["source_lang"]
+        return out
+
+    if tag.startswith("G/"):
+        source = normalize_source_lang(source_lang, default="ru")
+        return {
+            "tag": tag,
+            "issue_id": "UKRAINIAN_GRAMMAR_UA_GEC",
+            "issue_class": "grammar",
+            "dimension": "contact_grammar",
+            "severity": "warning",
+            "default_source_lang": "ru",
+            "source_lang": source,
+            "contact_source_lang": source,
+        }
+    if tag.startswith("F/"):
+        source = normalize_source_lang(source_lang, default="unknown")
+        return {
+            "tag": tag,
+            "issue_id": "UA_GEC_FLUENCY_OTHER",
+            "issue_class": "fluency",
+            "dimension": "naturalness",
+            "severity": "info",
+            "default_source_lang": "unknown",
+            "source_lang": source,
+            "contact_source_lang": source,
+        }
+    raise ValueError(f"unsupported UA-GEC tag: {tag!r}")
+
+
+def make_span(start: int | None, end: int | None) -> dict[str, int | None]:
+    """Return a normalized span object and validate ordering when both ends exist."""
+    if start is not None and not isinstance(start, int):
+        raise ValueError("span start must be an integer or None")
+    if end is not None and not isinstance(end, int):
+        raise ValueError("span end must be an integer or None")
+    if start is not None and start < 0:
+        raise ValueError("span start must be non-negative")
+    if end is not None and end < 0:
+        raise ValueError("span end must be non-negative")
+    if start is not None and end is not None and end < start:
+        raise ValueError("span end must be greater than or equal to start")
+    return {"start": start, "end": end}
+
+
+def make_finding_id(finding: Mapping[str, Any]) -> str:
+    """Build a stable finding id from locator and issue fields."""
+    detector = finding.get("detector")
+    detector_id = None
+    if isinstance(detector, Mapping):
+        detector_id = detector.get("rule_id") or detector.get("pattern_id") or detector.get("adapter")
+    payload = {
+        "issue_id": finding.get("issue_id"),
+        "file": finding.get("file"),
+        "line": finding.get("line"),
+        "span": finding.get("span"),
+        "excerpt": finding.get("excerpt"),
+        "detector": detector_id,
+    }
+    return stable_hash(payload)[:24]
+
+
+def build_finding(
+    *,
+    issue_id: str,
+    issue_class: str,
+    dimension: str,
+    severity: str,
+    file: str,
+    line: int | None,
+    span: Mapping[str, int | None] | None,
+    excerpt: str,
+    message: str,
+    contact_source_lang: str | None = None,
+    source_lang: str | None = None,
+    track_l1: str | None = "en",
+    ua_gec_tag: str | None = None,
+    confidence: str = "deterministic",
+    disposition: str = "defect",
+    suggested_replacement: str | Sequence[str] | None = None,
+    detector: Mapping[str, Any] | None = None,
+    attribution: Mapping[str, Any] | None = None,
+    sense_context: Mapping[str, Any] | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build and validate one canonical finding."""
+    normalized_source = normalize_source_lang(contact_source_lang or source_lang)
+    normalized_span = dict(span) if span is not None else make_span(None, None)
+    replacement: list[str] = []
+    if isinstance(suggested_replacement, str):
+        replacement = [suggested_replacement]
+    elif suggested_replacement:
+        replacement = [str(item) for item in suggested_replacement]
+
+    finding: dict[str, Any] = {
+        "issue_id": issue_id,
+        "issue_class": issue_class,
+        "dimension": dimension,
+        "severity": severity,
+        "contact_source_lang": normalized_source,
+        "source_lang": normalized_source,
+        "track_l1": normalize_track_l1(track_l1),
+        "ua_gec_tag": ua_gec_tag,
+        "confidence": confidence,
+        "disposition": disposition,
+        "file": file,
+        "line": line,
+        "span": normalized_span,
+        "excerpt": excerpt[:160],
+        "message": message,
+        "suggested_replacement": replacement,
+        "detector": dict(detector or {}),
+        "attribution": {**DEFAULT_ATTRIBUTION, **dict(attribution or {})},
+    }
+    if sense_context:
+        finding["sense_context"] = dict(sense_context)
+    if metadata:
+        finding["metadata"] = dict(metadata)
+    finding["finding_id"] = make_finding_id(finding)
+    validate_finding(finding)
+    return finding
+
+
+def build_deterministic_curriculum_finding(
+    *,
+    issue_id: str,
+    rule_id: str,
+    dimension: str,
+    severity: str,
+    file: str,
+    line: int,
+    span: Mapping[str, int | None],
+    excerpt: str,
+    message: str,
+    contact_source_lang: str | None = "unknown",
+    suggested_replacement: str | Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Build a curriculum deterministic finding such as the B1-27 canaries."""
+    return build_finding(
+        issue_id=issue_id,
+        issue_class="calque" if "CALQUE" in issue_id or "PASSIVE" in issue_id else "register",
+        dimension=dimension,
+        severity=severity,
+        file=file,
+        line=line,
+        span=span,
+        excerpt=excerpt,
+        message=message,
+        contact_source_lang=contact_source_lang,
+        confidence="deterministic",
+        suggested_replacement=suggested_replacement,
+        detector={
+            "adapter": "curriculum_qg_harness",
+            "rule_id": rule_id,
+            "pattern_id": rule_id,
+        },
+        attribution={
+            "corpus": "curriculum_phrase_rules",
+            "license": None,
+            "evidence": "B1-27 calibration fixture",
+        },
+    )
+
+
+def build_ua_gec_finding(
+    *,
+    error: str,
+    correction: str,
+    tag: str,
+    file: str,
+    line: int | None,
+    span: Mapping[str, int | None] | None,
+    source_lang: str | None = None,
+    doc_id: str | None = None,
+    pair_id: str | None = None,
+    frequency: int | None = None,
+    severity: str | None = None,
+    message: str | None = None,
+    adapter: str = "ua_gec_lookup",
+) -> dict[str, Any]:
+    """Build a canonical finding from one UA-GEC error/correction pair."""
+    mapped = map_ua_gec_tag(tag, source_lang=source_lang)
+    effective_severity = severity or mapped["severity"]
+    if effective_severity not in SEVERITIES:
+        raise ValueError(f"unsupported severity: {effective_severity!r}")
+    frequency_note = f" (frequency {frequency})" if frequency is not None else ""
+    default_message = f"UA-GEC {tag} pair: {error} -> {correction}{frequency_note}."
+    return build_finding(
+        issue_id=mapped["issue_id"],
+        issue_class=mapped["issue_class"],
+        dimension=mapped["dimension"],
+        severity=effective_severity,
+        file=file,
+        line=line,
+        span=span,
+        excerpt=error,
+        message=message or default_message,
+        contact_source_lang=mapped["contact_source_lang"],
+        ua_gec_tag=tag,
+        confidence="lookup_heuristic",
+        suggested_replacement=correction,
+        detector={
+            "adapter": adapter,
+            "rule_id": tag,
+            "pattern_id": pair_id or doc_id or error,
+        },
+        attribution={
+            "corpus": "UA-GEC v2",
+            "license": "CC-BY-4.0",
+            "doc_id": doc_id,
+            "pair_id": pair_id,
+            "evidence": "Syvokon et al., UNLP 2023",
+        },
+        metadata={
+            "ua_gec": {
+                "error": error,
+                "correction": correction,
+                "tag": tag,
+                "frequency": frequency,
+            }
+        },
+    )
+
+
+def build_semantic_false_friend_finding(
+    *,
+    word: str,
+    russian_meaning: str,
+    ukrainian_meaning: str,
+    replacement: str | None,
+    matched_gloss_pattern: str,
+    file: str,
+    line: int | None,
+    span: Mapping[str, int | None] | None,
+    excerpt: str,
+    severity: str = "critical",
+) -> dict[str, Any]:
+    """Build the #912 semantic false-friend finding shape."""
+    suggested = [replacement] if replacement else []
+    return build_finding(
+        issue_id="SEMANTIC_FALSE_FRIEND",
+        issue_class="false_friend",
+        dimension="contact_calque",
+        severity=severity,
+        file=file,
+        line=line,
+        span=span,
+        excerpt=excerpt,
+        message=(
+            f"{word!r} is valid Ukrainian as {ukrainian_meaning!r}, "
+            f"but this gloss uses the Russian meaning {russian_meaning!r}."
+        ),
+        contact_source_lang="ru",
+        ua_gec_tag=None,
+        confidence="deterministic",
+        suggested_replacement=suggested,
+        detector={
+            "adapter": "semantic_false_friends",
+            "rule_id": "SEMANTIC_FALSE_FRIEND",
+            "pattern_id": word,
+        },
+        attribution={
+            "corpus": "scripts.pipeline.semantic_russianisms",
+            "license": None,
+            "evidence": "Issue #912 semantic false-friend list",
+        },
+        sense_context={
+            "word": word,
+            "calque_sense": russian_meaning,
+            "authentic_sense": ukrainian_meaning,
+            "matched_gloss_pattern": matched_gloss_pattern,
+        },
+    )
+
+
+def build_dimension(
+    *,
+    verdict: str,
+    findings: Iterable[Mapping[str, Any]],
+    score: float | None = None,
+) -> dict[str, Any]:
+    """Build a dimension record with nested canonical findings."""
+    if verdict not in VERDICTS:
+        raise ValueError(f"unsupported verdict: {verdict!r}")
+    finding_list = [dict(item) for item in findings]
+    for item in finding_list:
+        validate_finding(item)
+    out: dict[str, Any] = {"score": score, "verdict": verdict, "findings": finding_list}
+    return out
+
+
+def build_evidence_record(
+    *,
+    profile: str,
+    evidence_kind: str,
+    module_id: str | None = None,
+    eval_item_id: str | None = None,
+    fixture_id: str | None = None,
+    level_policy: Mapping[str, Any] | None = None,
+    dimensions: Mapping[str, Mapping[str, Any]] | None = None,
+    checker_runs: Sequence[Mapping[str, Any]] | None = None,
+    content_sha: str | None = None,
+    provenance: Mapping[str, Any] | None = None,
+    verdict: str = "PASS",
+    terminal_verdict: str = "PASS",
+    aggregate: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build and validate one canonical evidence record."""
+    record: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "profile": profile,
+        "evidence_kind": evidence_kind,
+        "module_id": module_id,
+        "eval_item_id": eval_item_id,
+        "fixture_id": fixture_id,
+        "level_policy": dict(level_policy or {}),
+        "content_sha": content_sha,
+        "verdict": verdict,
+        "terminal_verdict": terminal_verdict,
+        "aggregate": dict(aggregate or {}),
+        "dimensions": {key: dict(value) for key, value in (dimensions or {}).items()},
+        "checker_runs": [dict(run) for run in (checker_runs or [])],
+        "provenance": dict(provenance or {}),
+        "compatibility": {
+            "legacy_projection_versions": sorted(LEGACY_EVIDENCE_SCHEMA_VERSIONS),
+            "migration_required": False,
+        },
+    }
+    validate_record(record)
+    return record
+
+
+def validate_finding(finding: Mapping[str, Any]) -> None:
+    """Validate a canonical finding and raise ``ValueError`` on mismatch."""
+    required = {
+        "finding_id",
+        "issue_id",
+        "issue_class",
+        "dimension",
+        "severity",
+        "contact_source_lang",
+        "source_lang",
+        "track_l1",
+        "confidence",
+        "disposition",
+        "file",
+        "line",
+        "span",
+        "excerpt",
+        "message",
+        "detector",
+        "attribution",
+    }
+    missing = sorted(key for key in required if key not in finding)
+    if missing:
+        raise ValueError(f"finding missing required fields: {', '.join(missing)}")
+    _require_member("issue_class", finding["issue_class"], ISSUE_CLASSES)
+    _require_member("dimension", finding["dimension"], DIMENSIONS)
+    _require_member("severity", finding["severity"], SEVERITIES)
+    _require_member("contact_source_lang", finding["contact_source_lang"], SOURCE_LANGS)
+    _require_member("source_lang", finding["source_lang"], SOURCE_LANGS)
+    _require_member("track_l1", finding["track_l1"], TRACK_L1S)
+    _require_member("confidence", finding["confidence"], CONFIDENCE_LEVELS)
+    _require_member("disposition", finding["disposition"], DISPOSITIONS)
+
+    span = finding["span"]
+    if not isinstance(span, Mapping):
+        raise ValueError("span must be a mapping")
+    make_span(span.get("start"), span.get("end"))
+    if not str(finding["issue_id"]).strip():
+        raise ValueError("issue_id must be non-empty")
+    if not str(finding["file"]).strip():
+        raise ValueError("file must be non-empty")
+    line = finding["line"]
+    if line is not None and (not isinstance(line, int) or line < 1):
+        raise ValueError("line must be a positive integer or None")
+    if not str(finding["excerpt"]).strip():
+        raise ValueError("excerpt must be non-empty")
+    if len(str(finding["excerpt"])) > 160:
+        raise ValueError("excerpt must be bounded to 160 characters")
+    if not isinstance(finding["detector"], Mapping):
+        raise ValueError("detector must be a mapping")
+    if not isinstance(finding["attribution"], Mapping):
+        raise ValueError("attribution must be a mapping")
+
+
+def validate_record(record: Mapping[str, Any]) -> None:
+    """Validate a canonical evidence record and all nested findings."""
+    if record.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"unsupported schema_version: {record.get('schema_version')!r}")
+    _require_member("profile", record.get("profile"), PROFILES)
+    _require_member("evidence_kind", record.get("evidence_kind"), EVIDENCE_KINDS)
+    _require_member("verdict", record.get("verdict"), VERDICTS)
+    _require_member("terminal_verdict", record.get("terminal_verdict"), VERDICTS)
+
+    dimensions = record.get("dimensions")
+    if not isinstance(dimensions, Mapping):
+        raise ValueError("dimensions must be a mapping")
+    for dim, entry in dimensions.items():
+        _require_member("dimension key", dim, DIMENSIONS)
+        if not isinstance(entry, Mapping):
+            raise ValueError(f"dimension {dim!r} must be a mapping")
+        _require_member(f"{dim}.verdict", entry.get("verdict"), VERDICTS)
+        findings = entry.get("findings", [])
+        if not isinstance(findings, list):
+            raise ValueError(f"{dim}.findings must be a list")
+        for finding in findings:
+            if not isinstance(finding, Mapping):
+                raise ValueError(f"{dim}.findings entries must be mappings")
+            validate_finding(finding)
+
+
+def _require_member(name: str, value: object, allowed: frozenset[str]) -> None:
+    if not isinstance(value, str) or value not in allowed:
+        raise ValueError(f"unsupported {name}: {value!r}")

--- a/tests/audit/test_qg_schema.py
+++ b/tests/audit/test_qg_schema.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.audit import qg_schema
+from scripts.audit.curriculum_qg_harness import EVIDENCE_SCHEMA_VERSION as CURRICULUM_QG_SCHEMA_VERSION
+from scripts.audit.llm_qg_store import EVIDENCE_SCHEMA_VERSION as LLM_QG_SCHEMA_VERSION
+
+
+def test_deterministic_b1_finding_uses_canonical_shape() -> None:
+    finding = qg_schema.build_deterministic_curriculum_finding(
+        issue_id="AWKWARD_PASSIVE_RESULT_STATE",
+        rule_id="b1_awkward_passive_result_state",
+        dimension="ukrainian_style",
+        severity="critical",
+        file="module.md",
+        line=3,
+        span={"start": 42, "end": 73},
+        excerpt="застосунок має бути відкритий",
+        message="Use active/impersonal Ukrainian instead of a literal passive state.",
+    )
+
+    qg_schema.validate_finding(finding)
+    assert finding["issue_class"] == "calque"
+    assert finding["contact_source_lang"] == "unknown"
+    assert finding["source_lang"] == "unknown"
+    assert finding["track_l1"] == "en"
+    assert finding["detector"] == {
+        "adapter": "curriculum_qg_harness",
+        "rule_id": "b1_awkward_passive_result_state",
+        "pattern_id": "b1_awkward_passive_result_state",
+    }
+    assert finding["finding_id"] == qg_schema.make_finding_id(finding)
+
+
+def test_ua_gec_f_calque_defaults_to_info_russian_contact_with_attribution() -> None:
+    finding = qg_schema.build_ua_gec_finding(
+        error="являється",
+        correction="є",
+        tag="F/Calque",
+        file="module.md",
+        line=18,
+        span={"start": 210, "end": 218},
+        doc_id="0301",
+        pair_id="ua-gec-0301-1",
+        frequency=47,
+    )
+
+    assert finding["issue_id"] == "CONTACT_CALQUE_UA_GEC"
+    assert finding["issue_class"] == "calque"
+    assert finding["dimension"] == "contact_calque"
+    assert finding["severity"] == "info"
+    assert finding["confidence"] == "lookup_heuristic"
+    assert finding["contact_source_lang"] == "ru"
+    assert finding["ua_gec_tag"] == "F/Calque"
+    assert finding["suggested_replacement"] == ["є"]
+    assert finding["attribution"] == {
+        "corpus": "UA-GEC v2",
+        "license": "CC-BY-4.0",
+        "doc_id": "0301",
+        "pair_id": "ua-gec-0301-1",
+        "evidence": "Syvokon et al., UNLP 2023",
+    }
+
+
+def test_ua_gec_g_case_can_preserve_non_russian_source_lang() -> None:
+    finding = qg_schema.build_ua_gec_finding(
+        error="по дорозі",
+        correction="дорогою",
+        tag="G/Case",
+        source_lang="pl",
+        file="module.md",
+        line=None,
+        span=None,
+    )
+
+    assert finding["issue_id"] == "UKRAINIAN_GRAMMAR_CASE"
+    assert finding["issue_class"] == "grammar"
+    assert finding["dimension"] == "contact_grammar"
+    assert finding["contact_source_lang"] == "pl"
+    assert finding["source_lang"] == "pl"
+
+
+@pytest.mark.parametrize("source_lang", ["ru", "pl", "en", "unknown", "other", "russian", "english"])
+def test_source_language_normalization_accepts_schema_values(source_lang: str) -> None:
+    normalized = qg_schema.normalize_source_lang(source_lang)
+
+    assert normalized in qg_schema.SOURCE_LANGS
+
+
+def test_invalid_source_language_dimension_and_tag_are_rejected() -> None:
+    with pytest.raises(ValueError, match="unsupported contact source language"):
+        qg_schema.normalize_source_lang("de")
+
+    finding = qg_schema.build_ua_gec_finding(
+        error="являється",
+        correction="є",
+        tag="F/Calque",
+        file="module.md",
+        line=1,
+        span={"start": 0, "end": 8},
+    )
+    finding["dimension"] = "calque"
+    with pytest.raises(ValueError, match="unsupported dimension"):
+        qg_schema.validate_finding(finding)
+
+    with pytest.raises(ValueError, match="unsupported UA-GEC tag"):
+        qg_schema.map_ua_gec_tag("P/Punctuation")
+
+
+def test_semantic_false_friend_finding_carries_sense_context() -> None:
+    finding = qg_schema.build_semantic_false_friend_finding(
+        word="лук",
+        russian_meaning="onion",
+        ukrainian_meaning="bow (weapon)",
+        replacement="цибуля",
+        matched_gloss_pattern="**лук** (onion)",
+        file="vocabulary.yaml",
+        line=12,
+        span={"start": 88, "end": 102},
+        excerpt="**лук** (onion)",
+    )
+
+    assert finding["issue_id"] == "SEMANTIC_FALSE_FRIEND"
+    assert finding["issue_class"] == "false_friend"
+    assert finding["dimension"] == "contact_calque"
+    assert finding["contact_source_lang"] == "ru"
+    assert finding["suggested_replacement"] == ["цибуля"]
+    assert finding["sense_context"] == {
+        "word": "лук",
+        "calque_sense": "onion",
+        "authentic_sense": "bow (weapon)",
+        "matched_gloss_pattern": "**лук** (onion)",
+    }
+
+
+def test_evidence_record_validates_nested_findings_and_keeps_legacy_versions() -> None:
+    finding = qg_schema.build_ua_gec_finding(
+        error="на протязі",
+        correction="протягом",
+        tag="F/Calque",
+        file="module.md",
+        line=5,
+        span={"start": 15, "end": 25},
+        doc_id="0490",
+    )
+    record = qg_schema.build_evidence_record(
+        profile="ua_gec_eval",
+        evidence_kind="fixture",
+        fixture_id="ua-gec-0490",
+        level_policy={"family": "b1_plus", "english_policy": "Ukrainian-led prose"},
+        dimensions={
+            "contact_calque": qg_schema.build_dimension(
+                score=9.0,
+                verdict="WARN",
+                findings=[finding],
+            )
+        },
+        checker_runs=[
+            {
+                "adapter": "ua_gec_lookup",
+                "version": "ua_gec_lookup.v1",
+                "config_hash": "abc123",
+                "provider": None,
+                "model": None,
+                "source_lang_filter": "ru",
+            }
+        ],
+        verdict="WARN",
+        terminal_verdict="PASS",
+    )
+
+    qg_schema.validate_record(record)
+    assert record["schema_version"] == "ua_contact_quality_evidence.v1"
+    assert record["compatibility"] == {
+        "legacy_projection_versions": ["curriculum_ua_qg_evidence.v1", "llm_qg_evidence.v1"],
+        "migration_required": False,
+    }
+    assert CURRICULUM_QG_SCHEMA_VERSION == "curriculum_ua_qg_evidence.v1"
+    assert LLM_QG_SCHEMA_VERSION == "llm_qg_evidence.v1"


### PR DESCRIPTION
## Summary

Closes #4307.
Refs #2156.

Defines the additive `ua_contact_quality_evidence.v1` schema for the UA calque
and grammar harness, without migrating existing PR1 evidence payloads.

Changes:

- adds `scripts/audit/qg_schema.py` with typed helpers, validators, stable
  finding ids, UA-GEC tag mapping, false-positive dispositions, and builders
  for deterministic curriculum, UA-GEC, and #912 semantic false-friend findings
- adds focused tests for the schema, legacy compatibility, source-language
  validation, UA-GEC examples, and semantic false friends
- documents the schema contract, versioning rules, examples, and #4308 adapter
  prerequisites
- updates `docs/SCRIPTS.md` and the UA eval harness README so future agents can
  discover the helper and know how to use it
- records fleet evidence for #4307, including Cursor/AGY successes, the
  learn-ukrainian DeepSeek timeout to repair against the working kubedojo path,
  Qwen being out of #2156 routing, GLM not being wired, and follow-up issue
  #4321

## Fleet / Review

- Cursor read-only schema review completed in 66.399s and identified the dual
  evidence-envelope blocker plus `contact_source_lang` vs `track_l1`.
- AGY read-only schema review completed in 95.123s and emphasized teaching
  examples, heritage guards, attribution, and #912 sense context.
- Cursor implementation lane produced a bounded schema/test patch; delegate
  auto-finalized it into draft PR #4318 despite the worker brief saying not to
  commit/push. That PR was reviewed, superseded, closed, and documented.
- DeepSeek timed out in this repo at the initial-response gate with zero output;
  follow-up #4321 now tracks restoring it by comparing learn-ukrainian config
  with the working kubedojo setup.
- Qwen also timed out during this run, but it is not a desired #2156 lane unless
  explicitly re-enabled.
- GLM is not currently exposed as a delegate agent; follow-up tracked in #4321.
- Final AGY staged-diff review completed in 105.205s: **APPROVE**, no blockers.

## Verification

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/audit/qg_schema.py tests/audit/test_qg_schema.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/audit/test_qg_schema.py tests/audit/test_curriculum_qg_harness.py tests/audit/test_llm_qg_store.py tests/audit/test_module_quality_audit.py` — 40 passed
- `/Users/krisztiankoos/projects/learn-ukrainian/node_modules/.bin/markdownlint-cli2 docs/projects/ua-eval-harness/schema.md docs/projects/ua-eval-harness/agent-fleet-4307.md docs/projects/ua-eval-harness/README.md docs/SCRIPTS.md`
- `git diff --cached --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Notes

This PR intentionally does not wire scorer adapters or ingest UA-GEC rows. It
unblocks #4306/#4308/#4309 by freezing the shared evidence shape and documenting
the compatibility rules.
