### PR TITLE
[codex] Add Markiian Shashkevych BIO dossier

### DIFF
--- a/docs/research/bio/markiian-shashkevych.md
+++ b/docs/research/bio/markiian-shashkevych.md
@@ -1,0 +1,324 @@
+# Маркіян Семенович Шашкевич - Research Dossier
+
+**Slug:** `markiian-shashkevych`
+**Block:** BIO manifest expansion - Galician vernacular revival / Ruthenian
+Triad
+**Tier:** 1b
+**Issue:** BIO manifest dossier gap
+**Researcher:** Codex GPT-5
+**Completed:** 2026-07-04
+
+**Source acronym legend:** EHIU = Encyclopedia of History of Ukraine
+(NANU Institute of History); IEU = Internet Encyclopedia of Ukraine; ERNiE =
+Encyclopedia of Romantic Nationalism in Europe; NIBU = National Historical
+Library of Ukraine; IA = Internet Archive; Commons = Wikimedia Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 sources cited
+- [x] Pressure mechanism is specific: Habsburg Galician censorship,
+  seminary / clerical constraint, anti-vernacular language pressure,
+  poverty, and tuberculosis; no invented arrest or security-service case
+- [x] At least 2 primary-source text anchors supplied from the 1837 almanac
+- [x] Cross-track links verified `test -e` on 2026-07-04 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Маркіян Семенович Шашкевич.
+- **Project English canonical:** Markiian Shashkevych.
+- **Pseudonym / literary signature:** Руслан; printed in `Русалка
+  Дністровая` as `Руслан Шашкєвичь` in the 1837 orthography. [S6]
+- **Birth / death:** 6 November 1811, Pidlyssia, Zolochiv circle, Galicia;
+  7 June 1843, Novosilky Lisni / Новосілки Лісні. EHIU and IEU agree on the
+  dates and basic geography; EHIU gives modern local administrative notes for
+  Pidlyssia, Knyazhe, and his later parishes. [S1] [S2]
+- **Family / formation:** Born in the family of a Greek-Catholic priest. He
+  studied in Zolochiv, Lviv, and Berezhany, then at Lviv University / the
+  Greek Catholic Theological Seminary in Lviv, graduating in 1838. [S1] [S2]
+- **Clerical work:** Greek-Catholic priest in rural Galician parishes,
+  including Humnyska, Nestanychi, and Novosilky Lisni according to EHIU. [S1]
+- **Core BIO identity:** priest, poet, translator, organizer of the `Руська
+  трійця` / Ruthenian Triad, and a decisive figure in the Galician move from
+  church-bookish / elite languages toward Ukrainian vernacular writing,
+  sermons, folklore collection, and phonetic orthography. [S1] [S2] [S3]
+- **Burial / memory:** Buried first at Novosilky; EHIU says his remains were
+  transferred to Lviv and reburied at Lychakiv Cemetery in 1893. Monuments,
+  museums, and Shashkevych commemorations later made him a Galician cultural
+  memory figure. [S1]
+
+## 2. Oppression / pressure mechanism
+
+Shashkevych should not be turned into a generic martyr biography. The
+documented pressure is cultural, institutional, and material: censorship of
+vernacular Ukrainian publication in Habsburg Galicia, clerical-seminary limits,
+resistance to a living Ukrainian literary language and Cyrillic phonetic
+orthography, restricted parish prospects, poverty, and illness.
+
+- **Censorship of the Triad's publications:** The manuscript collections
+  `Син Русі` (1833) and `Зоря` (1834) did not appear in print. IEU identifies
+  `Русалка Дністровая` as the breakthrough publication and says 800 of 1,000
+  copies were confiscated; the separate IEU almanac article attributes the
+  Galician ban to provincial censor Venedykt Levytsky, who objected to the
+  language, orthography, and parts of the contents. [S3] [S4]
+- **Print geography mattered:** The almanac was printed at Buda / Budim rather
+  than Lviv because the project had to maneuver around local censorship. ERNiE
+  notes that complaints to censors delayed publication and that the post-
+  publication ban lasted until 1848. [S5]
+- **Language pressure:** Shashkevych's program was not merely "romantic
+  nationalism." It challenged the assumption that educated Galician Ruthenians
+  should write in church-bookish, Polish, Latinized, or artificial mixed forms.
+  EHIU highlights his work for a living Ukrainian language, phonetic spelling,
+  `hrazhdanka` print, sermons in the vernacular, and opposition to Latinizing
+  Ukrainian writing. [S1]
+- **Personal cost:** EHIU records that his last years were marked by poverty
+  and tuberculosis. This can be taught as the material vulnerability of a
+  rural Greek-Catholic priest and cultural organizer, not as a fabricated
+  prison or exile story. [S1]
+- **What survived / what was blocked:** `Русалка Дністровая` survived because
+  enough copies escaped confiscation to circulate among Ukrainian readers.
+  Smaller manuscripts, schoolbook projects, translations, and sermons show a
+  broader language program than one famous almanac. [S1] [S2] [S4]
+
+## 3. Major works / contributions
+
+- **1833 - `Син Русі`:** manuscript folklore / poetry collection associated
+  with the Triad; not published in its own moment. [S3] [S5]
+- **1834 - `Зоря`:** attempted folklore and literary collection; not published
+  because of censorship. [S3] [S5]
+- **1835 - `Азбука і abecadlo`:** brochure against Latinizing Ukrainian
+  writing; a key alphabet-policy source for the Galician language question.
+  [S1] [S2]
+- **1835 - first published poem:** IEU says his first published poem appeared
+  in 1835; keep the exact title source-specific until a text witness is
+  consulted. [S2]
+- **1836 / 1837 - `Русалка Дністровая`:** almanac compiled by the Ruthenian
+  Triad and printed in Buda. IEU dates the printing to December 1836; modern
+  catalog and public memory usually cite the 1837 title-page date. Use
+  `1836/1837` in timelines unless the activity is explicitly distinguishing
+  print date from title-page year. [S4] [S6]
+- **Poetry:** `Веснівка`, `Підлисся`, `Руська мати нас родила`,
+  `Побратимові`, `Згадка`, `Погоня`, `Сумрак вечірній`, and other lyrics /
+  historical poems. EHIU calls `Веснівка` a pearl of his lyric poetry and
+  notes his early sonnets. [S1]
+- **Translation and old-text mediation:** One of the early translators of
+  `Слово о полку Ігоревім` into Ukrainian; translator from Serbian, Czech,
+  Polish, Greek, Latin, and German according to EHIU. [S1]
+- **1842 - New Testament vernacular translation:** IEU says he translated the
+  New Testament into the vernacular. Treat this as a language-history anchor,
+  not as a claim that his translation became the standard church Bible. [S2]
+- **1850 - `Читанка для малих дітей`:** reader for children, published
+  posthumously by Yakiv Holovatsky. [S2] NIBU also places his `Азбука` and
+  `Читанка` work in the 1835-1836 schoolbook context. [S7]
+
+## 4. Primary-source quote / text anchors
+
+Use short excerpts only. The 1837 almanac is public-domain, but the orthography
+is archaic and OCR is noisy; future lessons should use the Litopys / Izbornyk
+text page as the vetted first stop and compare against a facsimile before
+assigning exact spelling. [S6] [S9]
+
+- **Orthography anchor:** `пиши як чуєшь, а читай як видишь` appears in the
+  IA OCR of `Русалка Дністровая`'s orthography explanation. It is excellent for
+  a C1 activity on phonetic spelling, but students should first route through
+  Litopys / Izbornyk for vetted text and then use the facsimile/OCR witness for
+  original-page comparison. Explain the modern equivalent `пиши як чуєш, а
+  читай як видиш/видишъ` as historical spelling, not as today's norm. [S6] [S9]
+- **Position-in-time anchor:** `Судило нам ся послЬдним бути` appears near the
+  opening of the almanac preface in the IA OCR. Use it to frame Galician
+  lateness in vernacular print relative to other Slavic revivals, with a note
+  that the `Ь` / old-spelling form is a text witness, not a modern classroom
+  model. [S6] [S9]
+- **Material patronage anchor:** `Поклони-ся Русалко наша` begins the thanks
+  to patron Mykola Vereshchynsky in the almanac OCR. Good for showing that the
+  book was a networked cultural project, not simply an isolated authorial act.
+  [S6] [S9]
+- **Almanac title-page anchor:** `Ruthenische Volks-Lieder`, Buda / Budim,
+  1837. This German subtitle is useful because it shows the Habsburg publishing
+  setting and the period's bilingual / multilingual documentation. [S6] [S9]
+- **Classroom caution:** The historical words `Русь`, `руський`, and
+  `русинський` in this material refer to Galician Ruthenian / Ukrainian
+  self-description in the nineteenth-century setting. They must not be silently
+  modernized into "Russian," and they also should not be erased; the lesson
+  should teach the semantic shift explicitly.
+
+## 5. Language register
+
+- **Register:** early nineteenth-century Galician vernacular revival, Romantic
+  historical and folk register, Greek-Catholic clerical education, schoolbook
+  prose, polemic about alphabet choice, and archaic phonetic Cyrillic.
+- **CEFR readiness:** B2 can work with a modernized short excerpt and a
+  vocabulary frame. C1 is better for the preface, orthography debate, and
+  `Русь` / `руський` terminology.
+- **Learner lexicon:** `Русь`, `русин`, `руський`, `народна мова`,
+  `правопис`, `фонетичний`, `етимологічний`, `гражданка`, `напівустав`,
+  `абетка`, `латинізація`, `семінарія`, `греко-католицький`, `альманах`,
+  `передмова`, `фольклор`, `цензура`.
+- **Stylistic features:** compact patriotic address, diminutives and folk-song
+  cadence, historical memory vocabulary, sermon / schoolbook clarity, and a
+  deliberate preference for a living spoken basis over learned mixed language.
+- **Tone note for future BIO builders:** Let students see Shashkevych as a
+  priest-intellectual and organizer who used poetry, alphabet policy, sermons,
+  folklore, and schoolbooks to make a language community legible. Avoid a
+  single-text myth in which `Русалка Дністровая` does all the historical work
+  by itself.
+
+## 6. Contested points / simplification risks
+
+- **Ruthenian terminology:** In Galicia of Shashkevych's lifetime,
+  `Ruthenian`, `Rusyn`, `руський`, and `Русь` were historical self-description
+  terms for the local East Slavic Ukrainian community. A learner-safe module
+  should say this directly, then connect it to modern Ukrainian identity
+  without implying that nineteenth-century actors used today's vocabulary in
+  today's way.
+- **Pan-Slav context:** IEU notes a Romantic Pan-Slav interest and Old Slavic
+  pseudonyms; ERNiE connects the almanac's milieu to broader Romantic
+  nationalism. Do not let that become a Russian-imperial frame. The same IEU
+  article states that the Triad held Galician, Bukovynian, and Transcarpathian
+  Ruthenians to be part of one Ukrainian people with their own language,
+  culture, and history. [S3]
+- **Not "Galician Russophilia":** Some modern summaries flatten the era into
+  Russophile categories. For this dossier, the load-bearing fact is
+  Shashkevych's vernacular Ukrainian program, not a later political
+  Russophile orientation. If a future lesson contrasts the Triad with later
+  Galician Russophiles, keep chronology and terminology separate.
+- **Not a single-text myth:** `Русалка Дністровая` is central, but EHIU and IEU
+  show a broader program: folklore collection, grammar / dictionary work,
+  orthography reform, sermons, anti-Latinization polemic, a children's reader,
+  translations, and historical memory work. [S1] [S2]
+- **Not a generic Romantic nationalist hero:** The specific institutional
+  setting matters: Greek-Catholic seminary networks, rural parishes, Habsburg
+  censorship, Polish cultural dominance in Galicia, and the absence of a
+  stable Ukrainian secular publishing infrastructure.
+- **Classroom quote caution:** Use old-spelling excerpts as artifacts. Ask
+  learners what changes in modern spelling and what does not change in the
+  argument; do not ask them to imitate the 1837 orthography as current
+  Ukrainian.
+
+## 7. Cross-track links
+
+> Paths under "Existing" were each confirmed with `test -e` on 2026-07-04.
+
+- **Existing LIT modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/lit/ruthenian-triad-rusalka-dnistrova.yaml` -
+    direct almanac / Ruthenian Triad module; Shashkevych should be treated as
+    one organizer among a group, with his preface and orthography work as
+    anchors.
+- **Existing HIST modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/hist/habsburzka-halichyna.yaml` - Habsburg
+    Galicia, Greek-Catholic institutions, censorship, and the emergence of
+    Ukrainian Piedmont framing.
+- **Existing C1 modules (VERIFIED present via `test -e`):**
+  - `curriculum/l2-uk-en/plans/c1/halychyna.yaml` - advanced Galician
+    identity, terminology, and memory context.
+- **Candidate cross-track connections (Phase 2+ - NOT existing files):**
+  - BIO-to-BIO: `yakiv-holovatsky`, `ivan-vahylevych`, `ivan-kotliarevskyi`,
+    `taras-shevchenko`, `ivan-franko`, `mykhailo-verbytskyi`, `andrey-sheptytsky`
+    for language, church, and Galician memory arcs.
+  - LIT follow-up: a source-critical mini-module on `Азбука і abecadlo` and
+    the alphabet debate; a C1 reading lab comparing a facsimile passage, a
+    normalized Ukrainian edition, and an English paraphrase.
+  - HIST / ISTORIO follow-up: a focused lesson on Greek-Catholic seminary
+    networks as cultural infrastructure before 1848.
+
+## 8. Naming-canonical
+
+- **Slug:** `markiian-shashkevych`
+- **EN canonical (project):** Markiian Shashkevych
+- **UA canonical (with patronymic):** Маркіян Семенович Шашкевич
+- **Aliases / metadata forms:** Руслан; Руслан Шашкєвичь; Markian
+  Shashkevych; Markiyan Shashkevych; Markijan / Šaškevyč in scholarly
+  transliteration; Szaszkiewicz in Polish-family / Habsburg archival contexts.
+- **Do not normalize away:** `Русь`, `руський`, and `русин` when quoting or
+  explaining nineteenth-century Galician sources.
+- **Forbidden / caution forms:** "Russian Triad," "Russian almanac,"
+  "Ruthenian = Russian" in explanatory prose. These are inaccurate in the
+  Shashkevych context unless a source is being critiqued.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Commons `File:Markian Shashkevych.jpg`, described
+  as a late nineteenth-century pencil portrait by Ivan Trush and tagged
+  `PD-art` on Commons. Because Trush died in 1941, this is likely safe under
+  life-plus-70 regimes, but a future module should still verify the file page
+  before production use. [S8]
+- **Backup portrait / print candidates:** Commons category `Markiian
+  Shashkevych` includes several portrait and book-related files. Verify each
+  individual license rather than relying on the category page. [S9]
+- **Text-object image:** Commons category `Rusalka Dnistrovaya` includes a
+  title-page image and a DjVu of the almanac. This may be more pedagogically
+  valuable than a portrait for an orthography / almanac lesson. [S10]
+- **Context image:** Lychakiv Cemetery grave photographs on Commons, including
+  CC BY-SA photographs, can support a memory / reburial activity if attribution
+  is handled.
+- **Avoid without rights check:** NIBU exhibit images and museum-site portraits
+  unless their reuse terms are separately confirmed.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- [S1] Стеблій Ф. І. "Шашкевич Маркіян." *Енциклопедія історії України*,
+  т. 10. НАН України, Інститут історії України, 2013.
+  https://history.org.ua/?termin=Shashkevych_M | accessed 2026-07-04
+- [S2] Michael Marunchak, "Shashkevych, Markiian." *Internet Encyclopedia of
+  Ukraine*, vol. 4, 1993 / online. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CH%5CShashkevychMarkiian.htm
+  | accessed 2026-07-04
+- [S3] Danylo Husar Struk, "Ruthenian Triad." *Internet Encyclopedia of
+  Ukraine*, vol. 4, 1993 / online. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CU%5CRuthenianTriad.htm
+  | accessed 2026-07-04
+- [S4] Roman Senkus, "Rusalka Dnistrovaia." *Internet Encyclopedia of
+  Ukraine*, vol. 4, 1993 / online. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CU%5CRusalkaDnistrovaiaIT.htm
+  | accessed 2026-07-04
+
+**Tier 2 (institutional / scholarly reference):**
+
+- [S5] Olha Voznyuk, "`Rusalka Dnistrovaja`: The first Ukrainian-language
+  almanac in Habsburg Galicia." *Encyclopedia of Romantic Nationalism in
+  Europe*. https://ernie.uva.nl/viewer.p/21/56/object/122-159992 | accessed
+  2026-07-04
+- [S7] "Шашкевич Маркіян Семенович (1811-1843)." National Historical Library
+  of Ukraine virtual exhibition, 2021.
+  https://nibu.kyiv.ua/exhibitions/494/ | accessed 2026-07-04
+
+**Primary-source / text witnesses:**
+
+- [S6] Litopys / Izbornyk, "Маркіян Шашкевич. Поезії. Письменники Західної
+  України 30-50-х років XIX ст." Includes Shashkevych texts and `Русалка
+  Дністровая` title-page material. http://litopys.org.ua/zahpysm/zah02.htm |
+  accessed 2026-07-04
+- [S9] *Русалка Дністровая* (Budim / Buda, 1837), Internet Archive scan and
+  derived OCR. https://archive.org/details/swsvet_gmail_1837 | accessed
+  2026-07-04
+
+**Image / rights leads:**
+
+- [S8] Commons, `File:Markian Shashkevych.jpg`.
+  https://commons.wikimedia.org/wiki/File:Markian_Shashkevych.jpg | accessed
+  2026-07-04
+- [S9] Commons, `Category:Markiian Shashkevych`.
+  https://commons.wikimedia.org/wiki/Category:Markiian_Shashkevych | accessed
+  2026-07-04
+- [S10] Commons, `Category:Rusalka Dnistrovaya`.
+  https://commons.wikimedia.org/wiki/Category:Rusalka_Dnistrovaya | accessed
+  2026-07-04
+
+---
+
+## Decolonization self-check
+
+- [x] Historical `Ruthenian` / `Rusyn` / `руський` terminology explained
+  without translating it as modern "Russian"
+- [x] Shashkevych framed through Galician Greek-Catholic, Habsburg, and
+  vernacular-language revival context
+- [x] `Русалка Дністровая` treated as central but not the whole biography
+- [x] Pan-Slav Romantic context included without Russian-imperial framing
+- [x] No invented arrest, exile, prison file, or martyrdom mechanism
+- [x] Censorship and confiscation claims grounded in IEU / ERNiE
+- [x] Primary-source quotes kept short and classroom cautions attached
+- [x] Existing cross-track paths verified before listing


### PR DESCRIPTION
## Summary

- Added the missing BIO manifest research dossier for Markiian Shashkevych.
- Covered Ruthenian Triad / Rusalka Dnistrova, Galician Greek-Catholic, censorship, orthography, and vernacular-language revival context with source cautions.

## Changed file

- `docs/research/bio/markiian-shashkevych.md`

## Verification

- `npx markdownlint-cli2 docs/research/bio/markiian-shashkevych.md`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/markiian-shashkevych.md`
- `git diff --check origin/main...HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Protected-path/artifact scan: clean; changed file count is 1.
- LLM-QG diff scan: clean.

## LLM-QG

LLM-QG was not used, run, trusted, routed, persisted, or closed for this change.