### PR TITLE
[codex] add Mykola Arkas BIO dossier

### DIFF
--- a/docs/research/bio/mykola-arkas.md
+++ b/docs/research/bio/mykola-arkas.md
@@ -1,0 +1,196 @@
+# Микола Миколайович Аркас — Research Dossier
+
+**Slug:** `mykola-arkas`
+**Block:** B/I (imperial-era national-culture organizer; composer, popular historian, Prosvita patron)
+**Tier:** 1b
+**Issue:** Codex delegation — missing BIO manifest dossier
+**Researcher:** Codex GPT-5
+**Completed:** 2026-07-04
+
+**Source acronym legend:** EIU = *Енциклопедія історії України* / Інститут історії України НАН України; ESU = *Енциклопедія Сучасної України* / НАН України, НТШ; IEU = Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies; NBUV = Національна бібліотека України імені В. І. Вернадського; ULC = Ukrainian Live Classic.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1 / Tier 2 sources cited
+- [x] Composer, historian, and public-activist roles all represented
+- [x] Oppression / pressure mechanism specific and not inflated into martyrdom
+- [~] Primary-source snippets are short anchors; classroom quote cards still need edition/page checks
+- [x] Cross-track links verified with `test -e` / `rg` on 2026-07-04
+- [x] Naming-canonical applied
+- [x] Image candidate(s) identified
+- [x] Decolonization checklist self-applied
+
+> **Framing note.** Mykola Arkas should not be flattened into only the composer of `Катерина`, only a patriotic patron, or an uncritical textbook authority. The supported frame is a southern Ukrainian imperial-service elite who used family resources, amateur music, popular history, schools, and Mykolaiv `Просвіта` to widen Ukrainian-language public culture under Russian-imperial constraint. His `Історія України-Русі` was enormously influential as a popular national history, but sources explicitly call him an amateur historian and record serious contemporary scholarly criticism.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Микола Миколайович Аркас. [T1: EIU — Нерод; T1: ESU — Ульяновський; T1: IEU]
+- **Pseudonyms / aliases:** Mykola Arkas; Mykola Mykolaiovych Arkas; М. М. Аркас. Use "Микола Аркас старший" only when disambiguating him from his son Микола Аркас (1880-1938) and adopted grandson / namesake Микола Аркас (1898-1980). [T1: ESU]
+- **Born:** 26 December 1852 / 7 January 1853 | Mykolaiv, Kherson gubernia, Russian Empire | now Mykolaiv, Ukraine. ESU gives both old- and new-style dates; EIU and IEU give 7 January 1853. [T1: ESU; T1: EIU; T1: IEU]
+- **Died:** 13 / 26 March 1909 | Mykolaiv | Russian Empire. ESU gives both old- and new-style dates; IEU gives 26 March 1909. He was buried in the Arkas family crypt / Mykolaiv city cemetery tradition. [T1: ESU; T1: IEU; T2: Wikisource 1912 biographical preface]
+- **Family context:** Born into a high-ranking naval family: EIU identifies his father as the chief commander of the Black Sea Fleet and ports, Admiral Mykola Arkas. ESU also identifies him as owner of inherited estates at Bohdanivka and Khrystoforivka. The 1912 biographical preface and later music biographies add that his mother came from the Bohdanovych Cossack family; use that as a sourced family-memory detail, not as a proof of politics by bloodline. [T1: EIU; T1: ESU; T2: Wikisource 1912; T3: ULC]
+- **Education / service:** Graduated from Starodubtsev's private gymnasium in Odesa and the natural-sciences department of the physics-mathematics faculty at Novorossiisk University in Odesa in 1875. Served in the naval department in Mykolaiv from 1875 to 1898/1899, was an honorary justice of the peace in the Kherson district, and retired with the civil rank of state councillor. [T1: ESU; T1: IEU]
+- **Music education and role:** ESU explicitly says he had no professional musical education; Petro Nishchynskyi was his music mentor. The supported formula is composer-amateur / folklorist / national-theater contributor, not conservatory-trained professional composer. [T1: ESU; T1: IEU]
+- **History role:** ESU calls him an amateur historian; IEU says amateur historian. He collected, read, synthesized, and popularized Ukrainian history, but he should not be taught as a professional academic historian in the Hrushevskyi sense. [T1: ESU; T1: IEU]
+
+**Source disagreement note:** Sources differ in how they date `Катерина`: IEU and IEU-linked opera summaries often use 1891 or 1890 for the work; ESU gives 1891 and a 1897 first piano-vocal publication; EIU states the piano score was first printed in Mykolaiv in 1897 and the premiere was in Moscow in 1899. Keep composition, score publication, and first staging separate.
+
+## 2. Oppression / pressure mechanism
+
+Arkas was not executed, imprisoned long-term, or killed by the Russian state. The specific pressure mechanism is **Russian-imperial restriction of Ukrainian-language public culture**, reaching his opera, school projects, Prosvita work, and popular history.
+
+- **Opera censorship:** ESU states that the opera `Катерина` was banned by censorship before it reached the stage. The piano-vocal score appeared at Arkas's own expense in Mykolaiv in 1897; a staged premiere followed only in 1899 in Moscow through Marko Kropyvnytskyi's troupe. This is cultural censorship, not a criminal case. [T1: ESU; T1: EIU; T1: IEU]
+- **Language-school pressure:** IEU says Arkas established a Ukrainian-language elementary school at his expense on his Khrystoforivka / Bohdanivka estate and that the authorities closed it after two years. Kondrashov also notes a Ukrainian-language school in Bohdanivka that was soon forbidden by the authorities. [T1: IEU; T4: Kondrashov]
+- **Mykolaiv Prosvita under constraint:** EIU and ESU identify Arkas as organizer / head of the Mykolaiv `Просвіта` in 1907-1909. Kondrashov's article, drawing on Mykolaiv archival materials and the society's reports, describes registration in February 1907, sections for literature, music/art, library-bookstore, and economy, and work that constantly met the limits imposed by contemporary political conditions. [T1: EIU; T1: ESU; T4: Kondrashov]
+- **Publication under censorship:** The 1912 second-edition preface explains that the first edition of `Історія України-Русі` had to be prepared under difficult censorship conditions and that Arkas revised orthography and content after 1905. Treat the book as an artifact of constrained Ukrainian publishing in the Russian Empire. [T2: Wikisource 1912 second-edition preface; T2: NBUV 1908 record]
+- **Material cost:** NIBU's exhibition bibliography and summary note that printing the book, sustaining Ukrainian-language schooling, and supporting Mykolaiv `Просвіта` consumed Arkas's resources. Use this as a cautionary civic-patronage detail; do not turn it into a simplistic "the state killed him" narrative. [T2: NIBU exhibition]
+- **What survived / what was lost:** `Катерина`, `Історія України-Русі`, Prosvita reports, later reprints, and memory sites survived. ESU says two collections of Ukrainian folk-song arrangements, about 80 texts, were lost with part of the family archive; the archive-loss point should be kept source-specific. [T1: ESU]
+
+## 3. Major works / contributions
+
+- `1875-1898/1899` — naval-department and gubernial service in Mykolaiv, while collecting songs, reading Ukrainian history, and participating in local cultural work. [T1: ESU; T1: IEU]
+- `1880s` — Ukrainian folk-song collecting and arrangements. EIU identifies 1880 as among his first compositional attempts; IEU gives about 80 recorded / arranged folk songs. ESU says two song-arrangement collections were lost with part of the family archive. [T1: EIU; T1: IEU; T1: ESU]
+- `1891` — opera `Катерина`, with Arkas's own libretto after Taras Shevchenko's poem; piano-vocal score first printed in Mykolaiv in 1897. [T1: ESU; T1: EIU]
+- `1899` — premiere of `Катерина` in Moscow by Marko Kropyvnytskyi's troupe, followed by later stagings in Odesa, Kyiv touring contexts, Lviv, Warsaw, Krakow, and twentieth-century opera theaters. [T1: ESU; T1: EIU; T1: IEU]
+- `1901` — romances / songs including `Не співай нам тепер, бандуристе!` and `...Я не можу тобі розказать про любов`, as listed by ESU. [T1: ESU; T2: Ukrainian Art Song Project reference library]
+- `1905-1907` — patriotic poetry including `На вбивство лейтенанта Шмідта` and the poem `Пилип Орлик` (1907), which EIU reads in the context of the post-1907 imperial reaction and national movements. [T1: EIU; T1: ESU]
+- `1907-1909` — organizer and chair of the Mykolaiv `Просвіта`, including lectures, literary-musical evenings, theater, Ukrainian periodicals, book circulation, school and scholarship initiatives, and Shevchenko commemorations. [T1: EIU; T1: ESU; T4: Kondrashov; T4: Svitlenko]
+- `1908` — `Історія України-Русі`, a richly illustrated popular history in Ukrainian, printed in Saint Petersburg. NBUV records the 1908 edition as XVI + 384 pages with 210 illustrations/portraits and 9 maps; ESU says it was the first richly illustrated historical outline written in Ukrainian and that it long functioned as a "general people's textbook." [T1: ESU; T2: NBUV 1908 record]
+- `1912` — posthumous second edition of `Історія України-Русі` in Krakow, funded by Olha Arkasova and shaped by Vasyl Domanytskyi / Bohdan Lepkyi's editorial work. [T2: Wikisource 1912; T2: NIBU exhibition]
+
+## 4. Primary-source anchors and quote status
+
+No long quotation should be treated as classroom-ready until checked against a facsimile, a stable edition, and a page reference. The short anchors below are included to show source direction and classroom caution.
+
+**Anchor 1 — his own genre caveat.** In the first-edition preface, Arkas says he did not intend to write a "науковий твір." That short phrase is pedagogically useful because it aligns with ESU / IEU's amateur-history label. Use it to prevent overclaiming the book as an academic synthesis. [T2: Wikisource 1912 first-edition preface]
+
+**Anchor 2 — popular, accessible history.** The same preface frames the goal as a history accessible to every reader. For classroom use, pair this with modern historian framing: the value is public pedagogy and national awakening, not replacement of Hrushevskyi or professional historiography. [T2: Wikisource 1912 first-edition preface; T1: ESU]
+
+**Anchor 3 — `Катерина` reception lead.** The 1912 biographical preface reports a note Arkas wrote after a performance: "Я не спав цілу ніч." This is vivid, but it is a reported inscription preserved through a biographical preface, not a directly inspected autograph. Treat it as a research lead until the playbill / source edition is checked. [T2: Wikisource 1912 biographical preface]
+
+**Anchor 4 — Prosvita primary-source lead.** Kondrashov quotes the Mykolaiv `Просвіта` statute and annual reports from Mykolaiv archival fonds. These are stronger classroom sources than later memorial prose for explaining what Prosvita actually did: libraries, readings, lectures, performances, concerts, and Ukrainian-language educational advocacy. Quote cards should go back to the printed `Справоздання` or the cited archive files before publication. [T4: Kondrashov]
+
+**Anchor 5 — letters / reception lead.** Svitlenko's 2024 article cites Arkas-Domanytskyi correspondence, Chykalenko's diary, and early reviews to document the book's circulation and the comparison of its public impact to `Кобзар`. These are excellent teacher-background leads, but classroom quotations need the relevant diary / letter edition, not the secondary article alone. [T4: Svitlenko]
+
+## 5. Language register
+
+- **Register:** early twentieth-century Ukrainian popular-historical prose; civic Prosvita language; folk-song / theater-opera diction; public letters and lecture rhetoric.
+- **CEFR readiness:** selected Prosvita vocabulary and short biography passages can be adapted at **B1-B2**; `Історія України-Русі` excerpts usually require **B2-C1** support because of older orthography, period terminology, and long narrative sentences; historiography debates belong at **C1-C2**.
+- **Lexicon notes:** `історик-аматор`, `композитор-аматор`, `меценат`, `просвітянин`, `книгозбірня`, `читальня`, `кобзар`, `бандурист`, `лібрето`, `клавір`, `народно-побутова опера`, `історичний нарис`, `цензура`, `ярижка`, `кулішівка`.
+- **Orthography caution:** The 1908 / 1912 history uses historical spelling and punctuation. Keep original orthography in source excerpts, but provide modernized glosses for learners.
+- **Ethnonym caution:** The `Вступ` uses period ethnonyms and polemical labels for Russians, Jews, Poles, and others. Do not normalize those as contemporary classroom vocabulary; teach them as early twentieth-century source language with a clear note on current usage and harm.
+- **Stylistic features:** personal-address pedagogy, biography-centered history, Shevchenko-centered national memory, and the Prosvita habit of turning culture into public institution.
+
+## 6. Contested points
+
+- **Amateur historian vs public-history importance.** ESU and IEU explicitly call Arkas an amateur historian, while also noting the enormous popularity of `Історія України-Русі`. Teach the tension: the book mattered because it made Ukrainian history readable and emotionally available, not because it was the strongest professional synthesis of its age.
+- **Hrushevskyi criticism and public debate.** ESU records Mykhailo Hrushevskyi's negative assessment and names a wider discussion involving Viacheslav Lypynskyi, Borys Hrinchenko, Yevhen Chykalenko, Oleksandr Lototskyi, Hnat Khotkevych, and others. This is a built-in classroom debate, not a reason to discard the book or canonize it.
+- **Composer, but not only composer.** `Катерина` is essential, but Arkas's public profile also rests on Prosvita, Ukrainian-language schooling, patronage, Shevchenko memory, and popular historical writing.
+- **Imperial service vs Ukrainian identity.** His father and early career belong to imperial naval Mykolaiv; his cultural work belongs to the Ukrainian movement. The dossier should use this as a social-formation contrast, not as a loyalty test.
+- **Greek-root / Cossack-root simplification.** Later memorial sources often stress Greek paternal origin and Bohdanovych Cossack maternal roots. These are useful identity contexts, but they do not explain the politics by themselves. Arkas's choices and institutions matter more than ancestry.
+- **Death and causality.** He died suddenly in Mykolaiv in 1909. Sources mention heart attack / stroke traditions and financial strain; do not write that the empire killed him. The pressure mechanism is censorship, school closure, Prosvita surveillance / limits, and the cost of Ukrainian cultural work.
+- **`Катерина` date discipline.** Composition date, score publication date, orchestral fragment performance, and staged premiere differ. Lessons should not compress them into a single "first performed in 1891" sentence.
+- **Popular textbook afterlife.** Reprints in 1990, 1991, 1993, 1994 and later facsimile / gift editions show memory value, not automatic scholarly authority. Use modern scholarship to frame the old narrative.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` / `rg` on 2026-07-04 and resolves under `curriculum/l2-uk-en/plans/`. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml` — `Катерина`, Shevchenko memory, and Mykolaiv commemorations.
+  - `curriculum/l2-uk-en/plans/bio/marko-kropyvnytskyi.yaml` — staged `Катерина`; Theatre of Coryphaei link.
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml` — national music school and Arkas's 1903 acquaintance / musical context.
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml` — professional historiography and criticism of Arkas's popular history.
+  - `curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml` — reception / Prosvita-era public pedagogy and Ukrainian-language institution-building.
+  - `curriculum/l2-uk-en/plans/bio/yevhen-chykalenko.yaml` — reception, `Рада`, patronage, and Ukrainian public-sphere networks.
+  - `curriculum/l2-uk-en/plans/bio/hnat-khotkevych.yaml` — kobzar / bandura culture and reception network named by ESU.
+  - `curriculum/l2-uk-en/plans/bio/viacheslav-lypynskyi.yaml` — review debate around `Історія України-Русі`.
+  - `curriculum/l2-uk-en/plans/bio/mykola-mikhnovskyi.yaml` — same southern / Naddniprianshchyna national-movement era, with different political idiom.
+- **Existing HIST / ISTORIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` — wider language-ban context for Ukrainian print / stage culture.
+  - `curriculum/l2-uk-en/plans/hist/shevchenko-awakening.yaml` — Shevchenko-centered national awakening, the clearest Arkas bridge.
+  - `curriculum/l2-uk-en/plans/hist/rosiiska-imperiia-ukraina.yaml` — imperial setting of naval Mykolaiv and Ukrainian public work.
+  - `curriculum/l2-uk-en/plans/hist/hromady.yaml` — Ukrainian civic circles and pre-1917 associational infrastructure.
+  - `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml` — downstream public-sphere legacy through Chykalenko / Hrushevskyi / Prosvita networks.
+  - `curriculum/l2-uk-en/plans/istorio/pislya-emsa-halychyna.yaml` — Galician publishing route after Ems-era pressure; second edition in Krakow.
+  - `curriculum/l2-uk-en/plans/istorio/halychyna-natsionalnyi-rukh.yaml` — Prosvita / NTSh institutional comparison and reception in Galicia.
+- **Existing LIT / FOLK / C1 plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/women-in-kobzar.yaml` — Shevchenko's `Катерина` poem before Arkas's opera.
+  - `curriculum/l2-uk-en/plans/lit/mykhailo-starytsky.yaml` — Theatre of Coryphaei / national stage environment; useful comparison with Kropyvnytskyi.
+  - `curriculum/l2-uk-en/plans/c1/klasychna-muzyka-2-natsionalna-shkola.yaml` — Arkas as an amateur-adjacent national opera node beside Lysenko.
+  - `curriculum/l2-uk-en/plans/c1/vokalne-mystetstvo.yaml` — romances and song settings.
+  - `curriculum/l2-uk-en/plans/c1/kobzari-bandura.yaml` — kobzar / bandura sources he invited and collected from.
+  - `curriculum/l2-uk-en/plans/folk/kobzarstvo-lirnytstvo.yaml` — folk performance culture feeding `Катерина` and his song collecting.
+  - `curriculum/l2-uk-en/plans/folk/istorychni-perekazy.yaml` — existing module already uses Arkas 1912 as early public-memory context.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - `curriculum/l2-uk-en/plans/bio/mykola-arkas.yaml` — absent as of 2026-07-04; this dossier is the research base.
+  - `curriculum/l2-uk-en/plans/bio/vasyl-domanytskyi.yaml` — absent; needed for the editor of the 1908 / 1912 history.
+  - A dedicated module on **popular historiography before 1917**: Arkas / Hrushevskyi / Lypynskyi / Hrinchenko reception.
+  - A southern-Ukraine civic module on **Mykolaiv `Просвіта`**, schools, Shevchenko commemorations, and the Black Sea imperial city setting.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykola-arkas`
+- **EN canonical (project spelling):** Mykola Arkas
+- **UA canonical (with patronymic):** Микола Миколайович Аркас
+- **Aliases to track (`aliases:` YAML field):** Mykola Mykolaiovych Arkas; M. M. Arkas; М. М. Аркас; Микола Аркас старший; Mykola Arkas (Senior).
+- **Disambiguation hazards:** His son Микола Аркас (1880-1938) and namesake / adopted grandson Микола Аркас (1898-1980) have separate biographies; do not use portraits or military facts from `Mykola Arkas jr`.
+- **Forbidden Russian-imperial / Russified forms (flag in body text — listed here only):** Николай Николаевич Аркас; Nikolai Arkas; "Russian composer"; "Little Russian historian"; any unqualified Russian-imperial transliteration as canonical.
+
+## 9. Image candidates
+
+- **Best portrait candidate:** Wikimedia Commons category `Mykola Arkas (Senior)` and `File:Аркас Микола композитор.2.jpg`, used in the 1908/1912 history-file context. Verify file-page license and identity before production; do not rely on category-level assumptions.
+- **Book / source image:** Commons `File:Микола Аркас. Історія України-Русі (1912).pdf` or `File:Історія України-Русі. 1912. Микола Аркас.jpg`, useful for a source-history module. Verify Commons public-domain status and scan provenance.
+- **Opera context:** `Катерина` score / piano-vocal title page, if a public-domain scan is used and item-level rights are clear. Avoid quoting or reproducing modern editions without rights review.
+- **Prosvita / Mykolaiv context:** photos of Arkas's Mykolaiv house / memorial plaque / monument can be useful but often depend on modern photographers or sculptor rights. Verify freedom-of-panorama and Commons licenses individually.
+- **Avoid:** `File:Mykola Arkas jr.jpg` and other son/grandson images unless the lesson explicitly disambiguates the Arkas family.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+
+- Нерод В. О. "АРКАС Микола Миколайович." *Енциклопедія історії України*, т. 1. Інститут історії України НАН України. <https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIu&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Arkas_M&Z21ID=>. Accessed 2026-07-04.
+- Ульяновський В. І. "Аркас Микола Миколайович." *Енциклопедія Сучасної України*. <https://esu.com.ua/article-43245>. Accessed 2026-07-04.
+- "Arkas, Mykola." Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies. <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CA%5CR%5CArkasMykola.htm>. Accessed 2026-07-04.
+
+**Tier 2 (primary-text / institutional access):**
+
+- Аркас М. *Історія України-Русі* (Краків, 1912), Wikisource transcription, including title page, biographical preface, first-edition preface, second-edition preface, and `Вступ`. <https://uk.wikisource.org/wiki/Історія_України-Русі_(Аркас,_1912)>. Accessed 2026-07-04.
+- Аркас М. *Історія України-Русі : з 210 мал. і портр. та 9 картами* (Saint Petersburg, 1908). NBUV item `UKR0004090`. <https://irbis-nbuv.gov.ua/ulib/item/UKR0004090>. Accessed 2026-07-04.
+- Аркас М. М. *Історія України-Русі* (Kyiv: Vyshcha shkola, 1990), with V. Sarbei introductory / commentary apparatus. NBUV item `ukr0000018313`. <https://irbis-nbuv.gov.ua/ulib/item/ukr0000018313>. Accessed 2026-07-04.
+- НІБУ. "Микола Аркас (1853-1909)." National Historical Library of Ukraine exhibition bibliography and summary. <https://nibu.kyiv.ua/exhibitions/620/>. Accessed 2026-07-04.
+
+**Tier 3 (music / reference access):**
+
+- Ukrainian Live Classic. "Arkas Mykola. Biography." <https://ukrainianlive.org/arkas-mykola>. Accessed 2026-07-04.
+- Ukrainian Art Song Project. "Mykola Arkas" reference-library page. <https://ukrainianartsong.art/mykola-arkas/>. Accessed 2026-07-04.
+
+**Tier 4 (modern scholarly / source-critical):**
+
+- Кондрашов В. "Микола Аркас — організатор і керівник миколаївської `Просвіти`." *Україна: культурна спадщина, національна свідомість, державність* 19 (2010): 544-547. PDF: <https://www.inst-ukr.lviv.ua/files/21/090Kondrashov.pdf>. Accessed 2026-07-04.
+- Svitlenko, Serhiy. "M.M. Arkas and Preservation of Historical Memory of T.H. Shevchenko (Last Quarter of the 19th — Early 20th Century)." *Eminak* 2024, 2 (46). DOI: <https://doi.org/10.33782/eminak2024.2(46).715>. PDF inspected 2026-07-04.
+- Сарбей В. Г. "М. М. Аркас і його `Історія України-Русі`." *Український історичний журнал* 1990, no. 7, 100-113; also cited as introductory commentary in the 1990 facsimile edition. Bibliographic / source-critical pointer; full article not separately opened in this pass.
+- Старовойтенко І. "`Історія України-Русі` М. Аркаса у світлі відгуків та рецензій початку ХХ ст." *Український історичний журнал* 2009, no. 1, 102-116. Bibliographic pointer through Svitlenko and article references; not separately opened in this pass.
+
+**Tier 5 (navigation / media-rights sources):**
+
+- Wikimedia Commons category `Mykola Arkas (Senior)` and related file pages for portrait / title-page candidates. Used only for image-candidate discovery; item-level rights still need production verification.
+- Mykolaiv State Archive Arkas overview was identified as a useful source candidate by a read-only helper but was Cloudflare-blocked from this environment; it was not relied on for dossier claims.
+
+**Honest gaps:** No direct manuscript / archive file was opened. The 1912 Wikisource text is a useful transcription and facsimile gateway, but classroom quote cards should be checked against page images or a stable edition. The Mykolaiv State Archive overview was not accessible from this environment. This dossier avoids long quotations and does not close the Hrushevskyi / Arkas historiography debate.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing — Arkas's Ukrainian cultural work is centered; Russian imperial institutions appear as context and pressure.
+- [x] No Russian-imperial transliterations in body text except in the explicitly labelled risky-forms section.
+- [x] No uncritical Soviet or imperial labels — "amateur" is source-critical, not dismissive; "popular" is genre, not inferiority.
+- [x] No martyr inflation — natural death and material/censorship pressure are separated.
+- [x] The imperial naval-family context is included without converting it into cultural allegiance or disloyalty.
+- [x] `Катерина`, `Історія України-Русі`, Mykolaiv `Просвіта`, schools, and patronage are all present.
+- [x] Hrushevskyi criticism and the professional-history caveat are visible.
+- [x] Existing cross-track paths are verified; nonexistent Arkas / Domanytskyi plans are candidate-only.


### PR DESCRIPTION
## Summary

Adds the missing BIO manifest research dossier for Mykola Arkas, covering his composer, popular-historian, Mykolaiv Prosvita, patronage, and imperial naval-family contexts with source-critical caveats.

## Changed file

- `docs/research/bio/mykola-arkas.md`

## Verification

- `npx markdownlint-cli2 docs/research/bio/mykola-arkas.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/mykola-arkas.md`
- `git diff --check origin/main...HEAD`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Protected-path/artifact scan: no forbidden files in the diff
- Paused-tool scan: no LLM-QG references in the diff

## Tooling note

LLM-QG was not used.