### PR TITLE
feat(skills): seminar-content-review — fact-check built seminar content against sources

### DIFF
--- a/agents_extensions/shared/skills/seminar-content-review/SKILL.md
+++ b/agents_extensions/shared/skills/seminar-content-review/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: seminar-content-review
+description: Fact-check BUILT seminar content (FOLK, HIST, BIO, ISTORIO, LIT and subtracks, OES, RUTH) against Wikipedia + Literary RAG + heritage dictionaries. Verifies every factual claim, catches ghost facts / ghost sources / confident fabrication, and runs decolonization + russicism checks. For built module CONTENT — not plans (use plan-review-seminar for plans, content-review for core levels).
+argument-hint: "<track/slug | path to a content file>"
+effort: xhigh
+---
+
+# Seminar Content Review: $ARGUMENTS
+
+**Scope: BUILT seminar CONTENT** (FOLK, HIST, BIO, ISTORIO, LIT + subtracks, OES, RUTH). For seminar PLANS use `/plan-review-seminar`; for core-level content use `/content-review`.
+
+**Why this exists (the gap it closes):** seminar quality = **factual accuracy + decolonization + source grounding** — none of which the deterministic linguistic gates (VESUM validity, russicism rate, immersion policy) can measure. A model that *sounds* scholarly can be **confidently fabricating** — and the linguistic gates pass it just the same. This reviewer verifies **every factual claim against real sources** so "sounds authoritative" is never mistaken for "is accurate." (Origin: the 2026-07-04 UK-writing bakeoff ranked a writer #1 for seminars on scholarly *tone* before any fact-check — `audit/2026-07-04-uk-writing-probe/REPORT.md`.)
+
+## Parse arguments
+
+- Path ending in `.md` / `.mdx` / `.txt` → a single content file (review it directly).
+- `{track}/{slug}` or a bare `{slug}` → the built module at `curriculum/l2-uk-en/{track}/{slug}/module.md` (+ its `vocabulary.yaml`).
+- `{track}` alone → every built module in that track.
+
+**Valid tracks:** folk, hist, bio, istorio, lit, lit-drama, lit-essay, lit-doc, lit-crimea, lit-fantastika, lit-hist-fic, lit-humor, lit-war, lit-youth, oes, ruth.
+
+## Execute
+
+1. **Deterministic linguistic backbone FIRST** (cheap, cite it): run the module's `python_qg`, or for a raw text sample `.venv/bin/python -m scripts.audit.probe_uk_writing_score <file>` (VESUM validity, russicism rate, immersion). This is NECESSARY but NOT SUFFICIENT — it cannot check facts.
+2. **Then the factual + decolonization layer** — the reviewer's real job. Read and follow [seminar-content-review-prompt.md](seminar-content-review-prompt.md): claim extraction → per-claim source verification (Wikipedia + Literary RAG + heritage) → ghost-source / fabrication catch → decolonization scan → output format.
+
+**Output path:** `curriculum/l2-uk-en/{track}/audit/{slug}-content-review.md` (or stdout for a raw file). Produce a per-claim verdict table (SUPPORTED / CONTRADICTED / UNATTESTED + source), a factual-accuracy score, a decolonization verdict, and CRITICAL/HIGH issues. **REPORT ONLY — do not fix.** Reference issue #729.

--- a/agents_extensions/shared/skills/seminar-content-review/seminar-content-review-prompt.md
+++ b/agents_extensions/shared/skills/seminar-content-review/seminar-content-review-prompt.md
@@ -1,0 +1,79 @@
+# Seminar Content Review Prompt
+
+You are fact-checking **built** Ukrainian seminar content (FOLK, HIST, BIO, ISTORIO, LIT + subtracks, OES, RUTH). The content already passed (or will pass) the linguistic gates. **Your job is the layer those gates cannot do: verify that every factual claim is TRUE and every source is REAL, from a Ukrainian, decolonized perspective.**
+
+**Core principle — "sounds scholarly" ≠ "is accurate".** Confident, specific prose (exact dates, named subtypes, technical terms, attributions) is the *highest*-risk content, not the safest: a fabrication is most dangerous when it is fluent. Treat every specific claim as UNVERIFIED until a source confirms it. Do NOT reward tone.
+
+## Authority sources — use ALL, in this order of trust
+
+1. **Ukrainian Wikipedia** — `mcp__sources__query_wikipedia` (modes: `summary`, `extract` for deep checks, `sections`/`section`, `search`). Primary authority for people, events, dates, places, cultural categories. Search in Ukrainian.
+2. **Literary / primary RAG** — `mcp__sources__search_literary` and `mcp__sources__search_sources` (unified) for primary-source and encyclopedic corpora (Енциклопедія українознавства, chronicles, folklore studies). Use to confirm named works, quotes, and specialist categories.
+3. **Heritage / dictionaries** — `mcp__sources__search_heritage`, `mcp__sources__search_esum` (etymology), `mcp__sources__search_grinchenko_1907` (pre-Soviet attestation). Use for etymology claims and to distinguish authentic archaisms/dialectisms from russicisms.
+4. **Quote / attribution verification** — `mcp__sources__verify_quote` and `mcp__sources__verify_source_attribution` for any quotation or "as X wrote" attribution.
+5. **VESUM + russicism** — `mcp__sources__verify_words`, `mcp__sources__check_russian_shadow` for the linguistic layer (or cite the deterministic scorer run).
+
+## Step 1 — Extract the claims
+
+Read the content and list every **checkable factual claim**, each as a short atomic statement. Categories to sweep:
+- **People** — names, dates (birth/death/floruit), roles/titles.
+- **Events** — what, when, where, who took part.
+- **Categories / typologies** — named subtypes, classifications, genre terms (e.g. "веснянки поділяються на … царинні"), technical claims (metre, scale, structure).
+- **Dates / periods** — calendar windows, historical periods ("від Благовіщення до Зелених свят").
+- **Etymology / language** — word origins, "походить від …".
+- **Attributions / quotes** — "як писав X", cited works, primary sources.
+- **Causal / interpretive claims** presented as fact.
+
+Number them (C1, C2, …). Aim for completeness — an unlisted claim is an unchecked claim.
+
+## Step 2 — Verify each claim
+
+For every claim, run the appropriate authority tool(s) and assign a verdict:
+
+- **SUPPORTED** — a source directly confirms it. Record the source + a short quote/locator.
+- **CONTRADICTED** — a source says otherwise. Record the correct fact + source. Severity **CRITICAL** (a wrong fact taught as truth).
+- **IMPRECISE** — roughly right but off in a checkable detail (wrong boundary date, conflated categories, over-broad claim). Record the precise version + source. Severity **HIGH**.
+- **UNATTESTED** — no source found to confirm OR deny. This is the **fabrication-risk** bucket — confident specificity with no corroboration. Severity **HIGH** (demand a source or removal); **CRITICAL** if it is a named person/event/primary-source that should be findable but isn't (ghost fact / ghost source).
+
+Do not pass a specific claim just because it is plausible. "Plausible + unverifiable" = UNATTESTED, not SUPPORTED.
+
+## Step 3 — Decolonization scan (MANDATORY, non-negotiable)
+
+- [ ] **No Russian-centric framing** — Ukrainian events on their own terms, not as an appendix to Russian history. Flag **HIGH**.
+- [ ] **No "common heritage / three brotherly nations / common Kyivan Rus" myths** — imperial propaganda. Flag **CRITICAL**.
+- [ ] **Correct terminology** — "Kyivan Rus" not "Kievan Russia"; "Ukrainian lands" not "Little Russia"; Ukrainian transliteration of names. Flag **HIGH**.
+- [ ] **Agency preserved** — Ukrainians as subjects of their own history, not passive recipients. Flag **MEDIUM**.
+- [ ] **No Soviet-era framing / sourcing** — no Soviet ideological gloss; prefer pre-Soviet (Грінченко/ЕСУМ) or modern independent attestation. Flag **HIGH** for Soviet framing presented uncritically.
+
+## Step 4 — Linguistic backbone (cite, don't re-derive)
+
+Cite the deterministic run (`python_qg` or `scripts.audit.probe_uk_writing_score`): VESUM-valid %, russicism tokens (VESUM-gated `check_russian_shadow` minus heritage attestation — spot-check any flag against `search_heritage` before calling it a russicism), immersion/English discipline. Note non-canonical apostrophes (U+2019) as a normalization need. A real russicism in learner-facing content = **HIGH**.
+
+## Output format
+
+```
+# Seminar Content Review — <track>/<slug>  (<date>)
+
+## Verdict: PASS | REVISE | REJECT
+Factual accuracy: <n_supported>/<n_claims> supported · <n> contradicted · <n> imprecise · <n> unattested
+Decolonization: CLEAN | ISSUES  ·  Linguistic: <vesum%> VESUM, <n> russicisms
+
+## Claim ledger
+| # | Claim (atomic) | Verdict | Source / correct fact |
+|---|---|---|---|
+| C1 | … | SUPPORTED | Wikipedia «…» / Енц. українознавства |
+| C2 | … | IMPRECISE | should be «…» — <source> |
+| C3 | … | UNATTESTED | no source confirms; demand citation or cut |
+...
+
+## CRITICAL / HIGH issues (ordered)
+- [CRITICAL] C7: <ghost fact / contradiction> — correct: <fact + source>
+- [HIGH] C3: unattested specific — <what to verify or cut>
+
+## Decolonization notes
+...
+
+## Recommendation
+<REVISE with the exact fixes, or PASS with the evidence>
+```
+
+**Rules:** REJECT on any CRITICAL (contradicted fact, ghost person/event/source, imperial myth). REVISE on HIGH (imprecise or unattested specifics, real russicism). Every SUPPORTED verdict MUST name its source — an unsourced "SUPPORTED" is itself a review failure. **Report only; never edit the content.** No self-review (the reviewer must not have authored the content). Reference issue #729.


### PR DESCRIPTION
**Creates the seminar reviewer the user asked for** — closes the gap the [UK-writing bakeoff](../blob/main/audit/2026-07-04-uk-writing-probe/REPORT.md) exposed: seminar quality is **factual accuracy + decolonization + source grounding**, which the deterministic linguistic gates (VESUM/russicism/immersion) **cannot** measure. So "sounds scholarly" got mistaken for "is accurate" (a writer was ranked #1 for seminars on *tone* alone, before any fact-check).

New skill `seminar-content-review` mirrors the proven `plan-review-seminar` but for **built content**:
1. **Extract every factual claim** (people/events/dates/typologies/etymology/attributions).
2. **Verify each** against Wikipedia + Literary RAG + heritage dicts + `verify_quote`/`verify_source_attribution` → **SUPPORTED / CONTRADICTED / IMPRECISE / UNATTESTED** (the fabrication-risk bucket).
3. **Decolonization scan** (no Russian-centric framing / imperial myths / Soviet gloss).
4. Cites the deterministic linguistic backbone (probe scorer / python_qg).

Core principle baked in: **"sounds scholarly" ≠ "is accurate"** — confident specificity is the *highest*-risk content, treated as UNVERIFIED until a source confirms. Report-only, no self-review, effort: xhigh. Lints clean; deploy-idempotency green.

**Next (fresh session, per user):** dogfood this on the 5 bakeoff seminar samples → the fact-grounded seminar scorecard, via the 3-round all-participate panel. Reference #729.

🤖 Generated with [Claude Code](https://claude.com/claude-code)