### PR TITLE
[codex] Fix B2 professional surface leakage

### DIFF
--- a/curriculum/l2-uk-en/b2/professional-email-advanced/module.md
+++ b/curriculum/l2-uk-en/b2/professional-email-advanced/module.md
@@ -216,8 +216,13 @@ Follow-up має нагадувати без пасивної агресії. П
 
 Для повторюваних складних ситуацій корисно мати шаблони, але шаблон не має звучати як автоматична відповідь. Залишайте незмінною структуру - факт, вплив, дія, строк - і змінюйте конкретні дані. **"Просимо надати статус"** може бути шаблонною формулою, але поруч мають бути дата, номер запиту, назва проєкту або інший контекст. Інакше адресат відчуває, що лист написано не для нього, а для будь-кого.
 
-## Підсумок — Summary
+## Підсумок
 
-Advanced professional email writing balances evidence, tone and action. A claim or complaint needs facts, contractual or procedural grounds, consequences, demands and deadlines. Persuasion uses a thesis-evidence-conclusion structure, not pressure. Cover letters connect achievements to the role through concrete action verbs. Crisis emails prioritize facts, impact, next steps and follow-up timing.
+Поглиблене професійне листування поєднує докази, тон і дію. Претензія або скарга потребує фактів, договірних чи процедурних підстав, наслідків, вимог і строків. Переконання спирається на структуру теза — докази — висновок, а не на тиск. Супровідний лист пов'язує досягнення з посадою через конкретні дієслова дії. Кризові листи ставлять на перше місце факти, вплив, наступні кроки і час подальшого контакту.
 
-Self-check: what is the difference between a complaint that names facts and a message that only expresses frustration? How can you strengthen a request without sounding aggressive? Write one follow-up sentence that names the previous email, the pending action and the new deadline. Then rewrite one harsh sentence into an assertive but professional version.
+Самоперевірка: чим відрізняється скарга, що називає факти, від повідомлення, яке лише виражає роздратування? Як посилити прохання так, щоб воно не звучало агресивно? Напишіть одне речення-нагадування, у якому названо попередній лист, невиконану дію і новий строк. Потім перепишіть одне різке речення в наполегливу, але професійну версію.
+
+> [!model-answer]
+> Речення-нагадування: **Повертаємося до листа від 10 липня: просимо підтвердити доступ до тестового середовища сьогодні до 16:00, щоб команда встигла завершити перевірку.**
+>
+> Наполеглива версія: замість **"Ви знову затримуєте відповідь"** краще написати **"Оскільки підтвердження ще не отримано, просимо надіслати його сьогодні до 16:00"**.

--- a/curriculum/l2-uk-en/b2/professional-reports/module.md
+++ b/curriculum/l2-uk-en/b2/professional-reports/module.md
@@ -238,8 +238,13 @@ PESTEL додасть ширший контекст. Технологічний 
 
 Саме тому шаблон звіту має бути стабільним, а аналітичний зміст - живим. Не копіюйте торішній висновок, якщо дані змінилися. Не залишайте стару рекомендацію, якщо її вже виконано або вона втратила сенс. Професійний звіт показує не лише форму контролю, а здатність організації вчитися на власних даних.
 
-## Підсумок — Summary
+## Підсумок
 
-Business reports classify information, interpret data and recommend action. An informational report states facts; an analytical report explains causes and consequences; a strategic report connects evidence to decisions. Data language must distinguish description, interpretation and recommendation. SWOT, PESTEL and risk matrices help organize strategic thinking, but they only work when examples are concrete.
+Професійні звіти класифікують інформацію, тлумачать дані й рекомендують дію. Інформаційний звіт фіксує факти; аналітичний пояснює причини й наслідки; стратегічний пов'язує докази з рішеннями. Мова даних має розрізняти опис, інтерпретацію і рекомендацію. SWOT, PESTEL і матриці ризиків допомагають упорядкувати стратегічне мислення, але працюють лише тоді, коли приклади конкретні.
 
-Self-check: what is the difference between an informational and analytical report? Describe one trend with **зростання**, **спад** or **стабілізація**. Then write one recommendation that includes data, reason and action. Finally, adapt the same finding for a board of directors and for a public update without changing the fact.
+Самоперевірка: чим відрізняється інформаційний звіт від аналітичного? Опишіть одну тенденцію зі словами **зростання**, **спад** або **стабілізація**. Потім напишіть одну рекомендацію, у якій є дані, причина і дія. На завершення адаптуйте той самий висновок для ради директорів і для публічного оновлення, не змінюючи факту.
+
+> [!model-answer]
+> Інформаційний звіт фіксує факт: **кількість повторних звернень зросла на 18% за місяць**. Аналітичний звіт пояснює причину: **зростання пов'язане з новою інструкцією, яку клієнти читають не до кінця**.
+>
+> Рекомендація: **оновити перший екран інструкції і через два тижні порівняти частку повторних звернень**. Для ради директорів: **ризик перевитрат часу підтримки зростає**. Для публічного оновлення: **ми спростимо інструкцію, щоб клієнтам було легше завершити дію з першого разу**.

--- a/site/src/content/docs/b2/professional-email-advanced.mdx
+++ b/site/src/content/docs/b2/professional-email-advanced.mdx
@@ -270,11 +270,17 @@ Follow-up має нагадувати без пасивної агресії. П
 
 Для повторюваних складних ситуацій корисно мати шаблони, але шаблон не має звучати як автоматична відповідь. Залишайте незмінною структуру - факт, вплив, дія, строк - і змінюйте конкретні дані. **"Просимо надати статус"** може бути шаблонною формулою, але поруч мають бути дата, номер запиту, назва проєкту або інший контекст. Інакше адресат відчуває, що лист написано не для нього, а для будь-кого.
 
-## 📋 Підсумок — Summary
+## 📋 Підсумок
 
-Advanced professional email writing balances evidence, tone and action. A claim or complaint needs facts, contractual or procedural grounds, consequences, demands and deadlines. Persuasion uses a thesis-evidence-conclusion structure, not pressure. Cover letters connect achievements to the role through concrete action verbs. Crisis emails prioritize facts, impact, next steps and follow-up timing.
+Поглиблене професійне листування поєднує докази, тон і дію. Претензія або скарга потребує фактів, договірних чи процедурних підстав, наслідків, вимог і строків. Переконання спирається на структуру теза — докази — висновок, а не на тиск. Супровідний лист пов'язує досягнення з посадою через конкретні дієслова дії. Кризові листи ставлять на перше місце факти, вплив, наступні кроки і час подальшого контакту.
 
-Self-check: what is the difference between a complaint that names facts and a message that only expresses frustration? How can you strengthen a request without sounding aggressive? Write one follow-up sentence that names the previous email, the pending action and the new deadline. Then rewrite one harsh sentence into an assertive but professional version.
+Самоперевірка: чим відрізняється скарга, що називає факти, від повідомлення, яке лише виражає роздратування? Як посилити прохання так, щоб воно не звучало агресивно? Напишіть одне речення-нагадування, у якому названо попередній лист, невиконану дію і новий строк. Потім перепишіть одне різке речення в наполегливу, але професійну версію.
+
+:::success[✅ Модельна відповідь]
+Речення-нагадування: **Повертаємося до листа від 10 липня: просимо підтвердити доступ до тестового середовища сьогодні до 16:00, щоб команда встигла завершити перевірку.**
+
+Наполеглива версія: замість **"Ви знову затримуєте відповідь"** краще написати **"Оскільки підтвердження ще не отримано, просимо надіслати його сьогодні до 16:00"**.
+:::
 
 </TabItem>
 <TabItem label="Словник">

--- a/site/src/content/docs/b2/professional-reports.mdx
+++ b/site/src/content/docs/b2/professional-reports.mdx
@@ -293,11 +293,17 @@ PESTEL додасть ширший контекст. Технологічний 
 
 Саме тому шаблон звіту має бути стабільним, а аналітичний зміст - живим. Не копіюйте торішній висновок, якщо дані змінилися. Не залишайте стару рекомендацію, якщо її вже виконано або вона втратила сенс. Професійний звіт показує не лише форму контролю, а здатність організації вчитися на власних даних.
 
-## 📋 Підсумок — Summary
+## 📋 Підсумок
 
-Business reports classify information, interpret data and recommend action. An informational report states facts; an analytical report explains causes and consequences; a strategic report connects evidence to decisions. Data language must distinguish description, interpretation and recommendation. SWOT, PESTEL and risk matrices help organize strategic thinking, but they only work when examples are concrete.
+Професійні звіти класифікують інформацію, тлумачать дані й рекомендують дію. Інформаційний звіт фіксує факти; аналітичний пояснює причини й наслідки; стратегічний пов'язує докази з рішеннями. Мова даних має розрізняти опис, інтерпретацію і рекомендацію. SWOT, PESTEL і матриці ризиків допомагають упорядкувати стратегічне мислення, але працюють лише тоді, коли приклади конкретні.
 
-Self-check: what is the difference between an informational and analytical report? Describe one trend with **зростання**, **спад** or **стабілізація**. Then write one recommendation that includes data, reason and action. Finally, adapt the same finding for a board of directors and for a public update without changing the fact.
+Самоперевірка: чим відрізняється інформаційний звіт від аналітичного? Опишіть одну тенденцію зі словами **зростання**, **спад** або **стабілізація**. Потім напишіть одну рекомендацію, у якій є дані, причина і дія. На завершення адаптуйте той самий висновок для ради директорів і для публічного оновлення, не змінюючи факту.
+
+:::success[✅ Модельна відповідь]
+Інформаційний звіт фіксує факт: **кількість повторних звернень зросла на 18% за місяць**. Аналітичний звіт пояснює причину: **зростання пов'язане з новою інструкцією, яку клієнти читають не до кінця**.
+
+Рекомендація: **оновити перший екран інструкції і через два тижні порівняти частку повторних звернень**. Для ради директорів: **ризик перевитрат часу підтримки зростає**. Для публічного оновлення: **ми спростимо інструкцію, щоб клієнтам було легше завершити дію з першого разу**.
+:::
 
 </TabItem>
 <TabItem label="Словник">


### PR DESCRIPTION
Fixes #4281

## Changed files
- `curriculum/l2-uk-en/b2/professional-email-advanced/module.md`
- `curriculum/l2-uk-en/b2/professional-reports/module.md`
- `site/src/content/docs/b2/professional-email-advanced.mdx`
- `site/src/content/docs/b2/professional-reports.mdx`

## Verification
- Deterministic audit: `.venv/bin/python scripts/audit/track_deterministic_audit.py --track b2 --range 80-81 --format summary --fail-on never` PASS; high=0, no remaining `english_internal_leakage`; only two info findings for optional missing `resources.yaml` artifacts.
- MDX generation: `.venv/bin/python scripts/generate_mdx.py l2-uk-en b2 80` PASS; `.venv/bin/python scripts/generate_mdx.py l2-uk-en b2 81` PASS. The prompt's `--level/--slug` form was attempted and is not supported by this repo revision's positional CLI.
- MDX drift: `.venv/bin/python scripts/audit/check_mdx_generation_drift.py --changed-vs-base origin/main` PASS; generated MDX is current for changed curriculum sources.
- MDX forward parity: `.venv/bin/python scripts/audit/check_mdx_forward_parity.py --changed-vs-base origin/main` PASS; 0 findings.
- Agent trailer lint: `.venv/bin/python scripts/audit/lint_agent_trailer.py` PASS.
- Whitespace diff check: `git diff --check origin/main...HEAD` PASS.

## Independent review
- Route: AGY / Gemini 3.1 Pro High via `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy ... --review`.
- Review outcome: initial findings about bilingual summary headings, dash typography, and model answers were addressed in-source and regenerated into MDX. Final AGY pass returned generated-MDX callout-format findings; these were rebutted as false positives because source modules use the required `> [!model-answer]` format and `scripts/generate_mdx` intentionally converts `model-answer` callouts to `:::success[✅ Модельна відповідь]` for site MDX.
- Unresolved substantive findings: 0.

## Hygiene
- Protected artifacts/configs untouched: no `status/`, `audit/`, `review/`, `data/telemetry/**`, `.python-version`, `.yamllint`, `.markdownlint.json`, root `package.json`, or root `package-lock.json` changes.
- Old LLM-QG was not run; no B2 LLM-QG rows, telemetry, `llm_qg.json`, or reviewer score artifacts were created or changed.