### PR TITLE
[codex] add Nadiia Surovtsova BIO research dossier

### DIFF
--- a/docs/research/bio/nadiia-surovtsova.md
+++ b/docs/research/bio/nadiia-surovtsova.md
@@ -1,0 +1,213 @@
+# Надія Віталіївна Суровцова - Research Dossier
+
+**Slug:** `nadiia-surovtsova`
+**Block:** +77 backfill - Ukrainian Revolution diplomacy / women's international networks / Soviet political prisoner / Uman dissident salon / Gulag memoir witness
+**Tier:** 2
+**Issue:** BIO manifest backfill - missing research dossier; BIO #350
+**Researcher:** Codex GPT-5
+**Completed:** 2026-07-04
+
+**Source acronym legend:** EIU = *Енциклопедія історії України* / Інститут історії України НАН України; KHPG = Харківська правозахисна група, Virtual Museum "Dissident Movement in Ukraine"; CSAMLM = Центральний державний архів-музей літератури і мистецтва України; NBUV = Національна бібліотека України імені В. І. Вернадського; UINP = Український інститут національної пам'яті; BIO / HIST / ISTORIO / wiki = existing learn-ukrainian track materials.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1 / Tier 2 institutional, archival, human-rights, and primary-text sources cited
+- [x] Soviet pressure mechanism is specific: GPU informant recruitment, fabricated espionage accusation, prison/camp/exile terms, 1950 rearrest, post-1957 surveillance, and KGB searches
+- [x] Source and archival caveats included for date drift, office-title drift, release chronology, and image rights
+- [x] Cross-track links verified with `test -e` / `rg` on 2026-07-04 where marked existing
+- [x] Naming-canonical applied
+- [x] Image candidate(s) and rights leads identified
+- [x] Decolonization checklist self-applied
+- [x] LLM-QG was not used
+
+> **Framing note.** Surovtsova should be taught as a Ukrainian public intellectual, diplomatic worker, international women's-network participant, national-communist returnee, Soviet political prisoner, memoirist, and Uman cultural node. Do not reduce her to "Solzhenitsyn's source" or to a generic victim biography. Her life shows how Ukrainian Revolution-era state work, the 1920s Ukrainization hope, Stalinist coercion, and the 1960s-1970s dissident network touched one person.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Надія Віталіївна Суровцова; source-title form **Суровцова-Олицька** appears after her marriage to D. Olytskyi/Olytsky. [T1: EIU; T2: KHPG]
+- **Canonical EN:** Nadiia Surovtsova. Use the married-name form `Surovtsova-Olytska` only when matching source titles or archive catalogues.
+- **Birth:** EIU gives **17(05).03.1896**, Kyiv; KHPG gives 05.03.1896 old style; UINP uses 17 March. CSAMLM and NBUV commemorative pages use 18 March 1896. Use `17 March 1896` in learner-facing copy unless a date-comparison exercise explicitly explains the disagreement. [T1: EIU; T2: KHPG; T2: UINP; T2: CSAMLM; T2: NBUV]
+- **Death:** 13 April 1985, Uman. [T1: EIU; T2: KHPG; T2: CSAMLM]
+- **Family:** Born in Kyiv in a family of intelligentsia. KHPG says her father came from minor Poltava landowners, worked as a lawyer, defended peasants without charge during the 1905-1907 reaction, and helped Jews during pogroms; her mother was a teacher. CSAMLM says the family moved to Uman in 1905. [T2: KHPG; T2: CSAMLM]
+- **Education:** Fundukleivska gymnasium in Kyiv and Uman gymnasium; from 1913 she studied at the historical-philological faculty of the Higher Women's Courses / Bestuzhev courses in Saint Petersburg/Petrograd but did not finish because of revolution. KHPG also records Ukrainian underground-student circles and the group around Yevhen Neronovych. [T1: EIU; T2: KHPG]
+- **Kyiv 1917-1918:** In 1917 she returned to Ukraine, worked in Ukrainian Revolution-era civic and government settings, and studied in Kyiv. EIU identifies her as a Peasant Union activist, journalist, Kyiv University student, and staff member of the UNR Ministry of Foreign Affairs secretariat. KHPG says she worked first in the Secretariat of Internal Affairs and then headed / managed a general section of the Ministry of Foreign Affairs; CSAMLM says that during the Hetmanate she was chief of a diplomatic department. Treat exact office title as source-sensitive. [T1: EIU; T2: KHPG; T2: CSAMLM]
+- **Diplomatic mission / emigration:** In late 1918 she joined a diplomatic mission of the Directory of the UNR, worked in Vienna, and remained in Austria in 1919-1925. CSAMLM says she was secretary of the mission's information bureau and had been included in the delegation to the Paris Peace Conference but did not reach Paris because of political circumstances. [T1: EIU; T2: KHPG; T2: CSAMLM]
+- **Vienna scholarship and networks:** She completed the philosophy faculty at the University of Vienna and defended a dissertation on Bohdan Khmelnytskyi and the idea of Ukrainian statehood, receiving a PhD. UINP records her activity in the International Women's League for Peace and Freedom and international congresses; KHPG records famine-relief committee work and a 1924 Peace Train tour in the United States and Canada. [T1: EIU; T2: KHPG; T2: UINP]
+- **Return to Soviet Ukraine:** She returned to the USSR on 19 April 1925 and worked in Kharkiv at RATAU, the People's Commissariat of Foreign Affairs of the Ukrainian SSR, Holovlit foreign-press censorship, Dmytro Bahalii's research environment, translation, publicism, and fiction. [T1: EIU; T2: KHPG; T2: NBUV]
+- **First arrest and long imprisonment/exile:** KHPG gives the concrete chain: after refusing the Kharkiv GPU's 1926 proposal to become a secret collaborator, she was arrested on 29 November 1927; on 28 September 1928 she was sentenced on an espionage accusation to five years; on 16 October 1932 the OGPU exiled her to Arkhangelsk; she was arrested again in 1936 and 1950. EIU summarizes that she spent 29 years in prisons, camps, and exile, including Kolyma. [T1: EIU; T2: KHPG; T2: CSAMLM]
+- **Marriage in exile:** During her Arkhangelsk exile she married the Russian Socialist Revolutionary D. Olytskyi; KHPG says he was rearrested and executed in 1937. Use this to explain the married-name archive form, not to shift the biography away from Surovtsova's Ukrainian intellectual and political arc. [T2: KHPG]
+- **Rehabilitation and Uman:** She was fully rehabilitated in 1957 and returned to Ukraine. In Uman she worked with local history materials, Sofiyivka, the local museum, and her memoirs; her home became an important meeting place for Ukrainian intellectuals and dissidents. [T1: EIU; T2: KHPG; T2: CSAMLM; T3: ReHERIT]
+- **Archives:** NBUV reports personal fond 284 with 1830 archival units, much of it deposited by Surovtsova herself in 1966 and 1977. CSAMLM reports fond 302 for N. V. Surovtsova and local historian D. P. Kaliuzhnyi, 227 archival units for 1913-1991, with images, interrogation records, and Uman materials. [T2: NBUV; T2: CSAMLM]
+
+## 2. Political pressure mechanism
+
+The pressure mechanism is a long Soviet coercion chain after earlier Ukrainian state and international work. It should be presented in phases, not as one undifferentiated "Gulag story."
+
+- **Imperial and wartime setting:** Before 1917, Surovtsova's Ukrainian student work in Petrograd belonged to a semi-underground setting shaped by Russian imperial suspicion of Ukrainian civic organizing. This is background pressure, not the main arrest mechanism. [T2: KHPG]
+- **Ukrainian Revolution state work:** Her 1917-1919 record shows a young Ukrainian woman doing administrative, diplomatic, and information work for Ukrainian governments. The state-building anchor is office work, correspondence, foreign-language information, and mission logistics, not only battlefield politics. [T1: EIU; T2: CSAMLM]
+- **Return under Ukrainization:** Her 1925 return was tied to real hope that Soviet Ukrainian institutions could serve Ukrainian culture and state-related work. Do not retroactively mock that hope; teach it as a historically situated national-communist choice during Ukrainization. [T1: EIU; T2: KHPG]
+- **GPU recruitment and refusal:** The clean pressure hinge is her refusal to work as a secret collaborator for the GPU. KHPG states that the Kharkiv GPU approached her in 1926, she refused, and she was arrested in 1927; EIU also links the arrest to refusal to become a secret collaborator. [T1: EIU; T2: KHPG]
+- **Fabricated accusation:** She was sentenced as a supposed Polish spy. The curriculum should not repeat "spy" as fact except in quoted or source-labeled accusation language; the dossier frame is a coercive case built after refusal to collaborate. [T1: EIU; T2: KHPG]
+- **Prison, camp, exile, rearrest:** KHPG's chronology gives 1927 arrest, 1928 sentence, 1932 exile, and later arrests in 1936 and 1950; CSAMLM adds that after release in summer 1942 she was forbidden to return to Ukraine, worked as a free-hired laborer in 1942-1949, was imprisoned a third time in 1950, and exiled to Seimchan in Magadan oblast. Use this as a staged timeline rather than saying she was continuously imprisoned from 1928 to 1957. [T2: KHPG; T2: CSAMLM]
+- **Uman surveillance:** After rehabilitation she did not become politically invisible. CSAMLM says a 1972 search followed because her home gathered Ukrainian intelligentsia and dissenters, after which KGB agents kept her under constant surveillance. KHPG records repeated searches in 1972, 1977, 1979, and 1981, including attempts to close the salon and seize memoirs. [T2: CSAMLM; T2: KHPG]
+- **Archival self-defense:** Her decision to place memoirs and papers in archival fonds in the 1970s was a survival strategy for memory under surveillance. Teach archive-building as political action. [T2: KHPG; T2: NBUV; T2: CSAMLM]
+
+## 3. Major events / historical footprint
+
+- **Kyiv and Uman childhood:** The Kyiv birth and Uman formation create a useful city-map arc: Kyiv, Uman, Petrograd, Kyiv, Vienna, Kharkiv, Arkhangelsk, Kolyma / Seimchan, Uman.
+- **1913-1917 Bestuzhev courses and Ukrainian circles:** Her formation in Petrograd shows that Ukrainian political identity could grow inside imperial educational institutions while resisting imperial identification.
+- **1917-1918 Ukrainian government offices:** General Secretariat / Ministry work gives BIO a non-military state-building anchor and a chance to teach women's administrative labor in the Ukrainian Revolution.
+- **1918-1920 Directory diplomatic mission in Vienna:** Her role in the mission's information bureau connects Ukrainian statehood to foreign-language press, international recognition, and public diplomacy.
+- **1919-1925 Vienna:** University of Vienna PhD, famine-relief committee, women's international organizations, peace congresses, journalism, and translation make her a transnational Ukrainian figure.
+- **1924 Peace Train tour:** KHPG records the U.S. and Canada tour; this is a strong diaspora / international-women's-network lead but should be cross-checked before building a detailed lesson.
+- **1925 return to Kharkiv:** Her work at RATAU, NKZS USRR, Holovlit, and Bahalii's historical-culture chair shows the attraction and danger of 1920s Ukrainization.
+- **1927-1957 repression arc:** First arrest, fabricated espionage accusation, prison, exile, Kolyma, 1950 rearrest, and rehabilitation are the load-bearing Soviet-terror sequence.
+- **1957-1985 Uman salon:** Her house connected older Ukrainian Revolution memory, Gulag testimony, local history, Sofiyivka heritage, writers, dissidents, former prisoners, and samvydav circulation.
+- **Memoirs and letters:** `Спогади` (1996; expanded two-volume Komora edition in 2025) and `Листи. Книга I` (2001) are the main source anchors. The Institute of History item for the 2025 edition describes `Спогади` as a major documentary memoir of the period; use the text carefully and page-cite any classroom excerpt.
+- **Archive fonds:** NBUV fond 284 and CSAMLM fond 302 make her unusually strong for archive-literacy exercises: learners can distinguish memoir, letter, interrogation record, photograph, and commemorative article.
+
+## 4. Pedagogical anchors
+
+- **Office work as state-building:** A lesson can trace the verbs of diplomacy and administration: write, translate, collect press, route information, maintain files, staff a mission.
+- **Women in revolutions:** Pair her with women's wartime relief, the International Women's League for Peace and Freedom, and later Ukrainian women's political work. Avoid a decorative "women also helped" frame.
+- **Ukrainization hope:** Her return to Soviet Ukraine is a strong case for teaching why many Ukrainian intellectuals believed work inside Soviet Ukrainian institutions might still be possible in the mid-1920s.
+- **Refusal as action:** The refusal to become a GPU informant is a concise B2/C1 ethical and political anchor. It also prevents a passive victim-only narrative.
+- **Memoir as evidence:** `Спогади` lets learners ask how a memoir records the Ukrainian Revolution, emigration, the Soviet bureaucracy, prison, and camp life. Any excerpt must be checked against the 1996 or 2025 edition and handled as testimony, not omniscient narration.
+- **Uman as a memory node:** Her Uman home links local history, park heritage, literary visitors, dissidents, and Soviet surveillance. This is a useful antidote to Kyiv-only dissident geography.
+- **Solzhenitsyn caution:** KHPG, UINP, and NBUV connect her memoirs / testimony to Solzhenitsyn's work. That is a source trail, not the center of her significance. Do not make a Ukrainian woman primarily a footnote to a Russian author.
+- **Archive exercise:** Use NBUV and CSAMLM fonds to ask what kinds of evidence survive and who placed them there. Her own archival deposits are part of the story.
+
+## 5. Language register
+
+- **Register:** memoiristic, diplomatic-administrative, international women's-movement, journalistic, translation, Soviet legal-repressive, camp / exile, and local-history vocabulary.
+- **CEFR readiness:** B1/B2 for short biography, city map, and family/school/work narrative; B2/C1 for diplomatic and women's-movement vocabulary; C1/C2 for memoir excerpts, Soviet legal accusations, national-communist self-description, and source criticism.
+- **Core vocabulary:** `Надія Суровцова`, `Суровцова-Олицька`, `Українська Центральна Рада`, `Міністерство закордонних справ`, `дипломатична місія`, `Інформаційне бюро`, `Відень`, `докторка філософії`, `Міжнародна жіноча ліга миру і свободи`, `українізація`, `РАТАУ`, `ДПУ`, `секретний співробітник`, `арешт`, `заслання`, `Колима`, `Сеймчан`, `реабілітація`, `самвидав`, `мемуари`, `Умань`, `Софіївка`.
+- **Office-title caution:** Exact title drift matters. Use `MFA staffer / diplomatic-information worker` in low-context copy unless quoting a source-specific title such as CSAMLM's `начальник дипломатичного відділу`.
+- **Date caution:** Use `1896-1985` or source-labeled `17 March 1896` in low-context copy. Do not quiz 17 vs 18 March without making the source discrepancy the point.
+- **Term caution:** `націонал-комуністка` can be used as a historical self-position / interpretive label, not as ridicule or proof of loyalty to Soviet imperial rule.
+- **Place-name caution:** Use `Saint Petersburg / Petrograd` for the imperial capital as historical context, but do not narrate her as "Russian" because she studied there or married a Russian Socialist Revolutionary in exile.
+- **Classroom sensitivity:** Camp and interrogation materials should be taught as evidence of state violence, not as spectacle. Keep the focus on mechanisms, choices, and surviving documents.
+
+## 6. Risks / open questions
+
+- **Birth-date conflict:** EIU gives 17(05).03.1896; UINP gives 17 March; KHPG gives 05.03.1896; CSAMLM and NBUV anniversary pages give 18 March. Use EIU as the metadata baseline and note the discrepancy before production.
+- **Office-title conflict:** EIU, KHPG, and CSAMLM describe overlapping but not identical 1917-1918 offices. Before a module states "first woman X" or "head of Y," verify the exact title against archival employment records or a specialist study.
+- **Diplomatic rank caution:** She was a diplomatic-mission information worker and MFA official, not necessarily an ambassador or formally ranked diplomat. Use "diplomatic worker" unless a source supplies the precise rank.
+- **Release chronology:** NBUV says she was released in 1954; KHPG emphasizes full rehabilitation in 1957 and 29 years total; CSAMLM distinguishes summer 1942 release with ban on return, 1950 rearrest, and 1957 permission to return. A detailed timeline should reconcile these layers before learner publication.
+- **Memoir quotation:** Do not lift long excerpts from `Спогади` from web mirrors. Use the 1996 edition, the 2025 Komora edition, or archival page images with page citations and copyright review.
+- **UINP commemorative article caution:** UINP is useful, but some commemorative prose is condensed. Cross-check colorful details before using them in activities.
+- **Solzhenitsyn link:** He visited her and used her testimony/memoir material according to KHPG/UINP/NBUV, but a module should still center Surovtsova's Ukrainian memoir and archive.
+- **Women's-network scope:** UINP lists Vienna, Dresden, The Hague, Amsterdam, Paris, and Washington congresses. Build exact congress chronology only after checking the International Women's League for Peace and Freedom records.
+- **Archive/image rights:** NBUV and CSAMLM provide rich images and fonds metadata, but rights clearance is not automatic. Production must check file-level conditions and request permissions where needed.
+- **Name collisions:** `Суровцова`, `Суровцева`, and `Олицька` forms can point to different people or catalog conventions. Keep the full name and dates visible in research notes.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` / `rg` on 2026-07-04. Forward-looking ties are under **Candidate**.
+
+- **Current BIO inventory state (VERIFIED `rg` 2026-07-04):** `site/src/content/docs/bio/index.mdx` lists BIO #350 `nadiia-surovtsova`; `curriculum/l2-uk-en/curriculum.yaml` includes the slug. The following production surfaces are absent before this dossier: `curriculum/l2-uk-en/plans/bio/nadiia-surovtsova.yaml`, `curriculum/l2-uk-en/bio/discovery/nadiia-surovtsova.yaml`, `wiki/figures/nadiia-surovtsova.md`, `site/src/content/docs/bio/nadiia-surovtsova.mdx`, `curriculum/l2-uk-en/bio/nadiia-surovtsova/module.md`, `curriculum/l2-uk-en/bio/nadiia-surovtsova/activities.yaml`, `curriculum/l2-uk-en/bio/nadiia-surovtsova/vocabulary.yaml`, and `curriculum/l2-uk-en/bio/nadiia-surovtsova/resources.yaml`.
+- **Existing BIO plan anchors (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml` - Central Rada and Ukrainian Revolution leadership context.
+  - `curriculum/l2-uk-en/plans/bio/volodymyr-vynnychenko.yaml` - 1917-1918 government context and revolutionary politics.
+  - `curriculum/l2-uk-en/plans/bio/symon-petliura.yaml` - Directory / UNR diplomatic-mission context.
+  - `curriculum/l2-uk-en/plans/bio/milena-rudnytska.yaml` - women's international advocacy comparison.
+  - `curriculum/l2-uk-en/plans/bio/liudmyla-starytska.yaml` - older Ukrainian intellectual woman under Soviet repression.
+  - `curriculum/l2-uk-en/plans/bio/nadiia-svitlychna.yaml` - information labor, prison memory, and postwar dissident networks.
+  - `curriculum/l2-uk-en/plans/bio/ivan-dziuba.yaml` - 1960s-1970s dissent and cultural-defense context.
+  - `curriculum/l2-uk-en/plans/bio/alla-horska.yaml` - dissident-era visitor/network comparison; keep the connection source-labeled if used.
+- **Existing HIST / ISTORIO plan anchors (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml` - 1917 Ukrainian state-building context.
+  - `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml` - Directory mission and UNR diplomacy context.
+  - `curriculum/l2-uk-en/plans/istorio/universaly-unr.yaml` - Ukrainian Revolution document culture.
+  - `curriculum/l2-uk-en/plans/istorio/zhinky-v-revoiuutsiiakh.yaml` - women in revolutionary civic and diplomatic work.
+  - `curriculum/l2-uk-en/plans/hist/hromady.yaml` - Ukrainian civic circles and pre-1917 organizing.
+  - `curriculum/l2-uk-en/plans/hist/rosiiska-imperiia-ukraina.yaml` - imperial setting for Ukrainian student and language pressure.
+  - `curriculum/l2-uk-en/plans/hist/mekhanizm-teroru.yaml` - Soviet terror mechanisms.
+  - `curriculum/l2-uk-en/plans/istorio/mekhanizm-znyshchennia.yaml` - destruction mechanisms and source work.
+  - `curriculum/l2-uk-en/plans/istorio/samvydav-shcho-tse.yaml` - Uman salon / samvydav circulation context.
+  - `curriculum/l2-uk-en/plans/istorio/ukrayinskyi-visnyk.yaml` - repression-reporting memory channel; use as later-history context, not as direct authorship by Surovtsova.
+- **Existing wiki / dossier anchors (VERIFIED present):** `wiki/periods/tsentralna-rada.md`, `wiki/periods/dyrektoriia.md`, `wiki/historiography/zhinky-v-revoiuutsiiakh.md`, `wiki/historiography/samvydav-shcho-tse.md`, `wiki/historiography/ukrayinskyi-visnyk.md`, `docs/research/bio/nadiia-svitlychna.md`, `docs/research/bio/milena-rudnytska.md`, `docs/research/bio/liudmyla-starytska.md`.
+- **Candidate cross-track additions (Phase 2+, NOT existing files):**
+  - A BIO module on Surovtsova's own life as a bridge between Ukrainian Revolution diplomacy, Soviet repression, and Uman dissident memory.
+  - A source-study module on `Спогади` as Ukrainian Gulag memoir, paired carefully with NBUV / CSAMLM archive records.
+  - A local-history / place module on Uman as cultural memory node: Sofiyivka, local museum work, apartment museum, and dissident visitors.
+  - A women's-internationalism lesson connecting Surovtsova, Milena Rudnytska, Sofiia Rusova, and the International Women's League for Peace and Freedom. Not a dedicated plan yet.
+
+## 8. Name variants / search aliases
+
+- **Canonical UA:** `Надія Віталіївна Суровцова`.
+- **Married / archive title form:** `Надія Віталіївна Суровцова-Олицька`; `Суровцова-Олицька`.
+- **Canonical EN:** `Nadiia Surovtsova`.
+- **Common EN / transliteration forms:** `Nadia Surovtsova`, `Nadiya Surovtsova`, `Nadiia Vitaliivna Surovtsova`, `Nadia Surovtsova-Olytska`, `Surovtsova-Olytska`.
+- **Common UA search forms:** `Надія Суровцова`, `Суровцова Надія`, `Н. Суровцова`, `Н. В. Суровцова`, `Надія Суровцова-Олицька`.
+- **Russian / imperial-search forms:** `Надежда Суровцова`, `Надежда Витальевна Суровцова`, `Nadezhda Surovtsova`, `Nadia Surovtseva`, `Суровцева`. Keep these for source discovery and catalog reconciliation only, not learner display.
+- **Institution / topic aliases:** `Bestuzhev Courses`, `Higher Women's Courses`, `International Women's League for Peace and Freedom`, `UNR diplomatic mission`, `RATAU`, `GPU`, `Kolyma`, `Seimchan`, `Uman salon`, `Спогади`, `Листи`.
+- **Learner-facing display:** `Nadiia Surovtsova (Надія Суровцова, 1896-1985)`.
+
+## 9. Image rights / visual material notes
+
+- **Best portrait / archive candidates:** CSAMLM displays an undated portrait of N. V. Surovtsova from fond 302 and a Kolyma / early-1950s exile photograph, plus 1972 interrogation-protocol images and a 1982 Uman photo with D. Kaliuzhnyi and M. Kotsiubynska. These are excellent identification and source-study leads, but rights must be cleared with CSAMLM before production use.
+- **NBUV archive candidates:** NBUV's jubilee page points to personal fond 284 and displays / links items including a 1954 Nizhnii Seimchan photograph, correspondence, newspaper clippings, and the typescript memoir deposit. Treat these as archive-discovery leads; check Institute of Manuscript permissions before using images.
+- **UINP portrait lead:** UINP uses a portrait credited to `incognita.day.kiev.ua`. Useful for identification, not rights-cleared by default.
+- **Apartment-museum context image:** Ukrainian Wikipedia hosts `Файл:Музей-квартира Суровцової Умань.jpg`, an own-work photo released by the uploader to public domain on ukwiki. It is a context image of the Uman museum apartment, not a portrait; production must still review Ukrainian freedom-of-panorama / building-image issues and whether to transfer/use from ukwiki.
+- **ReHERIT object page:** ReHERIT's "Будинок Надії Суровцової" page, text by Serhy Yekelchyk, uses archival photography from the Uman Local History Museum and is strong for place context. Do not assume photo reuse rights.
+- **Commons context:** Commons `Category:Uman Local Museum` is useful for general Uman local-history-museum context but is not a Surovtsova portrait category and should not be used as identity proof.
+- **Primary-text visual candidates:** 2025 Komora `Спогади` covers and contents pages are current publication leads; covers are likely under publisher copyright and require review before classroom image reuse.
+- **Avoid default:** unattributed social-media portraits, AI colorizations, screenshots from commemorative posts, and any image that shifts the visual center to Solzhenitsyn rather than Surovtsova.
+
+## 10. Sources used
+
+**Tier 1 (authoritative encyclopedia / institutional baseline):**
+
+- Герасимова Г. П. "Суровцова-Олицька Надія Віталіївна." *Енциклопедія історії України*. Інститут історії України НАН України. <https://www.history.org.ua/?termin=Surovtsova_N>. Accessed 2026-07-04.
+
+**Tier 2 (institutional, archival, human-rights, and primary-text access):**
+
+- Рапп І. "Суровцова Надія Віталіївна." KHPG Virtual Museum "Dissident Movement in Ukraine." <https://museum.khpg.org/1114000414>. Accessed 2026-07-04.
+- Резнік І. "Надія Віталіївна Суровцова (1896-1985)." Центральний державний архів-музей літератури і мистецтва України, 2024-03-19. <https://csamm.archives.gov.ua/2024/03/19/nadiya-vitaliyivna-surovczova-1896-1985/>. Accessed 2026-07-04.
+- "Надія Суровцова-Олицька (18.03.1896-13.04.1985) - видатна українська письменниця, перекладачка, громадська та політична діячка." NBUV. <https://nbuv.gov.ua/node/2957>. Accessed 2026-07-04.
+- "1896 - народилася Надія Суровцова, журналістка, перекладачка." UINP historical calendar. <https://www.uinp.gov.ua/istorychnyy-kalendar/berezen/17/1896-narodylasya-nadiya-surovcova-zhurnalistka-perekladachka>. Accessed 2026-07-04.
+- Суровцова Н. *Спогади: Мемуари*, т. 1 / упоряд. О. Юркова. Київ: Видавничий дім "Комора", 2025. Institute of History electronic-library item: <https://resource.history.org.ua/item/0018761>. Accessed 2026-07-04.
+- Суровцова Н. *Спогади: Мемуари*, т. 2 / упоряд. О. Юркова; перекл. з рос. Т. Калитенко, О. Лилик. Київ: Видавничий дім "Комора", 2025. Institute of History electronic-library item: <https://resource.history.org.ua/item/0018762>. Accessed 2026-07-04.
+- NBUV / Ukrainian digital library reference item "Суровцова Надія Віталіївна." <https://irbis-nbuv.gov.ua/ulib/item/REF0008925>. Accessed 2026-07-04.
+
+**Tier 3 (heritage / place context and source leads):**
+
+- Yekelchyk, Serhy. "Будинок Надії Суровцової." ReHERIT. <https://reherit.org.ua/object/muzej-kvartyra-nadiyi-surovtsovoyi/>. Accessed 2026-07-04.
+- Ukrainian Wikipedia, "Меморіальний музей-квартира Надії Суровцової." Used only as museum-location and media-file lead, not as core biographical authority.
+- Ukrainian Wikipedia file page `Файл:Музей-квартира Суровцової Умань.jpg`. Used only as a media-rights lead.
+
+**Tier 4 (learn-ukrainian local context checked 2026-07-04):**
+
+- `site/src/content/docs/bio/index.mdx`
+- `curriculum/l2-uk-en/curriculum.yaml`
+- `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md`
+- `docs/audits/bio-readiness-matrix-2026-06-29.md`
+- `docs/research/bio/nadiia-svitlychna.md`
+- `docs/research/bio/milena-rudnytska.md`
+- `docs/research/bio/liudmyla-starytska.md`
+- `docs/research/bio/sofiia-rusova.md`
+- `docs/research/bio/serhii-yefremov.md`
+- `docs/research/bio/dmytro-doroshenko.md`
+- `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`
+- `curriculum/l2-uk-en/plans/hist/dyrektoriia.yaml`
+- `curriculum/l2-uk-en/plans/istorio/zhinky-v-revoiuutsiiakh.yaml`
+- `curriculum/l2-uk-en/plans/istorio/samvydav-shcho-tse.yaml`
+
+**Honest gaps:** No archival criminal case file was opened in this pass. The 2025 Komora `Спогади` edition was used through the Institute of History bibliographic / contents records, not full-text reading. Exact office title, release chronology, and women's-congress itinerary need archive/specialist verification before learner-facing claims become precise. LLM-QG was not used.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing - Petrograd, Vienna, Kharkiv, Arkhangelsk, Kolyma, and Uman are placed in a Ukrainian intellectual and political life story.
+- [x] Ukrainian agency preserved - Surovtsova is a state worker, journalist, translator, international organizer, prisoner, memoirist, archivist, and local-history actor, not only a victim.
+- [x] Soviet accusation language source-labeled - "spy" appears only as fabricated accusation / prosecution language, not narrator fact.
+- [x] No martyr inflation - terror, exile, and surveillance are named concretely without turning the biography into sacred pathos.
+- [x] Women's political labor foregrounded - diplomatic-information work, women's international networks, famine-relief work, and Uman salon labor are treated as political infrastructure.
+- [x] National-communist arc handled historically - her 1925 return is contextualized in Ukrainization-era hopes and later Soviet coercion, not presented as a simple moral failure.
+- [x] Russian-imperial / Russified forms are confined to search aliases and not used for learner display.
+- [x] Archive caveats explicit - date drift, office-title drift, release chronology, and image-rights gaps are documented.


### PR DESCRIPTION
## Summary

- Adds the missing BIO research dossier for Nadiia Surovtsova.
- Documents source tiers, Ukrainian/decolonial framing, archival caveats, verified cross-track links, image/rights leads, naming notes, and classroom cautions.
- Keeps the change scoped to `docs/research/bio/nadiia-surovtsova.md`.

## Verification

- `npx markdownlint-cli2 docs/research/bio/nadiia-surovtsova.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/nadiia-surovtsova.md`
- `git diff --check origin/main...HEAD`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Notes

- LLM-QG was not used.
- Changed file count: 1.
- No forbidden generated/status/audit/review/telemetry/config/version paths are in the diff.