### PR TITLE
[codex] add Oleksandr Barvinskyi BIO dossier

### DIFF
--- a/docs/research/bio/oleksandr-barvinskyi.md
+++ b/docs/research/bio/oleksandr-barvinskyi.md
@@ -1,0 +1,167 @@
+# Барвінський Олександр Григорович — Research Dossier
+
+**Slug:** `oleksandr-barvinskyi`
+**Block:** BIO manifest gap; Galician Ukrainian institution-builder
+**Tier:** 1
+**Issue:** no issue number supplied; delegated manifest backfill
+**Researcher:** Codex GPT-5
+**Completed:** 2026-07-04
+
+**Acceptance self-check:**
+- [x] All 10 dossier sections completed
+- [x] Core facts cross-checked against ЕСУ, ЕІУ, IEU, Lviv Interactive, and modern Arkusha scholarship
+- [x] Date disagreement retained rather than silently flattened
+- [x] Habsburg/Galician institutions distinguished from imperial-ruler narratives
+- [x] Cross-track links under **Existing** verified with `test -e` on 2026-07-04
+- [x] Naming-canonical policy applied
+- [x] Image/rights leads identified
+- [x] Classroom cautions and decolonization checklist included
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Олександр Григорович Барвінський.
+- **Pseudonyms / aliases:** Подолянин; Австрієць; Verax; Oleksander Barvinsky in IEU; Oleksandr Barvinsky / Barvinskyi in English search metadata.
+- **Born:** Preferred working date **1847-06-08** | с. Шляхтинці, now in Ternopil region, Ukraine | then Habsburg Galicia. ЕСУ, IEU, Lviv Interactive, and modern Arkusha scholarship give 8 June 1847; ЕІУ gives 6 June 1847, so retain the discrepancy in research notes.
+- **Died:** **1926-12-25** | Lviv | then Second Polish Republic; buried with Yevheniia Barvinska in the Barvinsky family tomb at Lychakiv Cemetery, per Lviv Interactive.
+- **Identity:** Ukrainian Galician historian, pedagogue, politician, publisher, and conservative Christian-social institution-builder. Teach him as a Ukrainian actor working through Habsburg/Galician representative and school institutions, not as a loyalist ornament of Vienna.
+- **Family / education key facts:** Born into a Greek-Catholic priestly family with older noble-lineage memory; completed the Ternopil gymnasium and Lviv University philosophy faculty, with emphasis on history, literature, and Slavic languages. Husband of Yevheniia Barvinska; father of historian Bohdan Barvinskyi and composer Vasyl Barvinskyi; brother of Volodymyr and Osyp Barvinskyi.
+- **Institutional roles:** Co-founder/contributor around `Правда`; organizer in the populist/narodovets current; early builder of `Діло`; deputy in the Austrian State Council / Imperial Council in Vienna (1891-1907), member of the Galician Diet (1894-1903/1904), member of the Galician School Council (1889/1893-1918 depending on source scope), lifelong member of the Austrian House of Lords from 1917, and education/religious-affairs secretary in the ZUNR government in 1918-1919.
+- **Cultural-educational roles:** Chair of the Shevchenko Scientific Society (1893-1897 in ЕСУ; Lviv Interactive gives 1892-1897), head of the Ruthenian/Ukrainian Pedagogical Society (1891-1896), deputy head of Prosvita, editor/initiator for `Записки НТШ`, `Учитель`, `Дзвінок`, `Руслан`, and `Руська історична бібліотека`.
+
+## 2. Oppression / constraint mechanism
+
+Barvinskyi was **not arrested, exiled, or executed**. His dossier belongs to the indirect/structural category: Ukrainian institution-building under constrained Galician politics, intra-Ukrainian delegitimization over compromise strategy, Polish-state closure of the ZUNR horizon, and later memory flattening.
+
+- **What happened:** He used Habsburg constitutional and Galician school structures to widen Ukrainian education, scholarship, publishing, and parliamentary representation. Those structures were real arenas of action, but they were not sovereign Ukrainian institutions and were shaped by Polish provincial dominance, imperial priorities, and limited concessions.
+- **When:** Main political arc 1860s-1923: student/narodovets organizing in the 1860s; education and publishing work from the 1870s; `нова ера` negotiations in 1890-1894; parliamentary/Diet work in 1891-1907; House of Lords appointment in 1917; ZUNR education secretariat in 1918-1919; withdrawal from active politics after Eastern Galicia was assigned to Poland in 1923.
+- **By whom / by what structures:** No single repressive agency. Constraints came from Polish-dominated Galician institutions, Habsburg imperial strategic interests, Russophile attacks on Ukrainian-language and phonetic-orthography work, Polish military/political control after the defeat of the ZUNR, and later Soviet/Russocentric narratives that treated Galician Ukrainian conservatism as either provincial loyalism or clerical reaction.
+- **Mechanism specifics:** His strategy of `органічна праця` and negotiated school gains made him vulnerable to criticism from Ukrainian opposition circles, especially after the failure of the `нова ера`. The caution for writers is not to call that criticism "oppression"; it is a contested political choice inside a colonized/stateless society. The oppression/constraint mechanism is the absence of Ukrainian state power and the need to bargain for school, language, and scholarly infrastructure inside other people's institutions.
+- **What survived / what was destroyed:** His memoirs, historical textbooks, literary-history works, the `Руська історична бібліотека`, NTSh institutional growth, and the Barvinsky family archive/memory survived. The ZUNR state-building project was defeated; the conservative Christian-social current lost centrality; Soviet-era teaching largely bypassed him or reduced Galician politics to class/clerical labels.
+
+## 3. Major works / institutional legacy
+
+- `1867` — involvement with `Правда`, the Galician Ukrainian journal that connected local narodovets circles with all-Ukrainian literary and political communication.
+- `1870-1871` — `Руска читанка` / school-reader work for higher gymnasium classes; DNPB notes its importance for making Shevchenko and other Ukrainian writers available in school and for preparing the shift toward phonetic orthography.
+- `1880s` — organizing in Prosvita and around the first daily newspaper of Galician populists, `Діло`, alongside his brother Volodymyr.
+- `1886-1904` — `Руська історична бібліотека`; IEU records 24 volumes, edited and published by Barvinskyi with Oleksander Konysky's assistance and Volodymyr Antonovych's help in planning a broad Ukrainian-history series.
+- `1892/1893-1897` — chairing the Shevchenko Scientific Society during its transformation into a serious scholarly institution; also editing the first volumes of `Записки НТШ`.
+- `1896-1911` — Catholic Ruthenian-People's Union / Christian-social political current, later the Christian Social Party; associated newspaper `Руслан` (1897-1914), founded by Barvinskyi and Anatol Vakhnianyn.
+- `1904` — `Історія України-Руси`, a historical synthesis for broad Ukrainian use.
+- `1912-1913` — `Спомини з мого життя`, published lifetime memoir volumes; later manuscript continuations and editions are major sources for western Ukrainian political history.
+- `1918-1919` — education and religious-affairs secretary in the ZUNR government; useful bridge to school-language policy and state-building rather than battlefield narrative.
+- `1920-1926` — literary-history and Ukrainian-history works, including `Історія української літератури` and `Коротка історія українського народу`.
+
+## 4. Primary-source quotes / documentary expressions
+
+Use these as short source expressions or epigraph checks; verify page numbers in the printed editions before learner-facing publication.
+
+- `Das Höchste des Menschen ist die Pflicht` — Goethe line that Arkusha reports Barvinskyi treated as a life motto in his memoirs. It is pedagogically useful for his duty-centered self-fashioning, but should be framed as self-presentation, not neutral character proof.
+- `засіви будущини народу` — short phrase from a school/parliamentary education argument quoted by DNPB. Use to show why schooling, language, and national future were inseparable in his public rhetoric.
+- `власністю всієї руської суспільності` — DNPB's cited phrase for the aim of making history socially available through the `Руська історична бібліотека`. Classroom note: `руської` here belongs to Galician Ruthenian/Ukrainian usage, not Russian national identity.
+
+## 5. Language register
+
+- **Register:** late-19th/early-20th-century Galician Ukrainian public prose: pedagogical, parliamentary, memoiristic, historical-popular, and Christian-social.
+- **CEFR readiness:** B2 for adapted biography and school-policy excerpts; C1 for full memoir/political passages because of historical orthography, long syntax, and institutional vocabulary.
+- **Lexicon notes:** `народовці`, `русини`, `українсько-руський`, `фонетичний правопис`, `краєва шкільна рада`, `сейм`, `посол`, `державна рада`, `органічна праця`, `порозуміння`, `НТШ`.
+- **Orthography caution:** Titles may contain `руський`, `руско-`, `україньско-руський`, `Істория`, or older `ї/і/ѣ`-era spellings. Do not modernize them silently in bibliographies; gloss them for learners.
+- **Stylistic features:** argument from duty and education; historically grounded national language; pragmatic institutional vocabulary rather than revolutionary rhetoric.
+
+## 6. Contested points and classroom cautions
+
+- **The `нова ера` problem:** Barvinskyi's 1890s Polish-Ukrainian compromise strategy is the central controversy. Teach it as a high-stakes strategy in a stateless society, not as simple betrayal or enlightened moderation. It brought some school/cultural gains but failed politically and damaged his popularity among many Galician Ukrainians.
+- **Habsburg context:** Do not narrate his work as "the emperor gave Ukrainians rights." The accurate frame is Galician Ukrainians using constitutional openings, councils, diets, schools, and learned societies while negotiating with imperial and Polish provincial power.
+- **All-Ukrainian link:** His contacts with Kyiv/Dnipro Ukrainian figures such as Volodymyr Antonovych, Oleksander Konysky, and the older `Громада` networks matter because Galicia could host Ukrainian-language institutional work that the Russian Empire constrained. This is a decolonial point, not a claim that Galicia was free.
+- **Russophile / Russian confusion:** Barvinskyi opposed Russophile currents and promoted Ukrainian school language and phonetic orthography. Older `Ruthenian` labels should be explained as historical Ukrainian self-naming in Galicia, not folded into Russian identity.
+- **Clergy and class:** He came from the Greek-Catholic priestly intelligentsia. This explains access to education and networks; it should not become either hagiography of clerical leadership or a caricature of "clerical reaction."
+- **Popular-memory flattening:** He is often overshadowed by Mykhailo Hrushevskyi in NTSh history and by his son Vasyl Barvinskyi in music-memory work. Pairing them can show institutional continuity without turning Oleksandr into a footnote.
+- **Date caution:** Keep `1847-06-08` as the working birth date, while noting ЕІУ's `1847-06-06`.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-07-04 and resolves in the current worktree.
+
+- **Existing HIST / ISTORIO modules (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/habsburzka-halichyna.yaml` — institutional arena for Galician Ukrainian politics.
+  - `curriculum/l2-uk-en/plans/istorio/halychyna-pid-avstriieyu.yaml` — Habsburg Galicia framing and source work.
+  - `curriculum/l2-uk-en/plans/istorio/halychyna-natsionalnyi-rukh.yaml` — narodovets, Russophile, school-language, and national movement context.
+  - `curriculum/l2-uk-en/plans/hist/zunr.yaml` — ZUNR government context for his education/religious-affairs secretariat.
+- **Existing BIO modules (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml` — NTSh succession and all-Ukrainian historiography.
+  - `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml` — Galician Ukrainian politics and alternative radical/national-democratic currents.
+  - `curriculum/l2-uk-en/plans/bio/vasyl-barvinskyi.yaml` — family/institutional continuation into Ukrainian music education and later Soviet repression.
+  - `curriculum/l2-uk-en/plans/bio/andrey-sheptytsky.yaml` — Greek-Catholic and Galician institution-building context; use cautiously, not as a forced alliance.
+- **Existing wiki / research files (VERIFIED present):**
+  - `wiki/periods/habsburzka-halichyna.md`
+  - `wiki/periods/zunr.md`
+  - `wiki/periods/hrushevskyi.md`
+  - `docs/research/bio/vasyl-barvinskyi.md`
+  - `docs/research/bio/oleksa-novakivskyi.md` — portrait lead and cultural-memory bridge.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - A BIO plan for Oleksandr Barvinskyi focused on education, NTSh, and political compromise.
+  - A source-reading mini-module on `нова ера` as a negotiation strategy under stateless conditions.
+  - A school-language policy module comparing phonetic orthography, Ukrainian-Ruthenian naming, and Russophile resistance.
+
+## 8. Naming-canonical
+
+- **Slug:** `oleksandr-barvinskyi`
+- **EN canonical (project spelling):** Oleksandr Barvinskyi.
+- **Legacy English search alias:** Oleksander Barvinsky; Oleksandr Barvinsky.
+- **UA canonical:** Олександр Григорович Барвінський.
+- **Historical title/name forms to preserve in source titles:** Олександер Барвінський; `українсько-руський`; `руський` in Galician Ukrainian/Ruthenian contexts.
+- **Aliases for future YAML:** Подолянин; Австрієць; Verax.
+- **Forbidden / caution forms:** Russian-imperial normalization through `Александр Григорьевич Барвинский`, `Alexander Grigorievich Barvinsky`, or treating `руський` in his titles as "Russian." Use only if documenting search aliases or hostile metadata.
+
+## 9. Image candidates
+
+- **Best PD/CC portrait:** Wikimedia Commons category `Oleksandr Barvinskyi (cultural figure and politician)` includes `Олександр Барвінський, 1904 рік.png`; verify the file page license before site use.
+- **Backup candidates:** Wikimedia Commons `Родина Барвінських.jpg`; use only after confirming date/source/license and whether the lesson needs family context.
+- **Institutional/context candidates:** Lychakiv Cemetery Barvinsky family tomb image; NTSh-related building/context image; former Sobieshchyzna / Barvinskykh street context via Lviv Interactive. Verify licenses individually.
+- **Art-history lead:** Oleksa Novakivskyi portrait of Oleksander Barvinskyi (noted by IEU image metadata and local Novakivskyi dossier) is a strong cultural-memory lead, but rights clearance is required.
+- **If no rights-clear portrait clears review:** Use a rights-cleared NTSh or Galician school/publication context image rather than a generic Habsburg imperial portrait.
+
+## 10. Sources used
+
+**Tier 1 (authoritative encyclopedic / scholarly reference):**
+- Енциклопедія Сучасної України, "Барвінський Олександр Григорович" | https://esu.com.ua/article-40500 | accessed 2026-07-04.
+- Енциклопедія історії України, Аркуша О. Г., "Барвінський Олександр Григорович" | https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Barvinskyj_O_H&Z21ID= | accessed 2026-07-04.
+- Internet Encyclopedia of Ukraine, "Barvinsky, Oleksander" | https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CB%5CA%5CBarvinskyOleksander.htm | accessed 2026-07-04.
+
+**Tier 2 (institutional / educational):**
+- Центр міської історії, Lviv Interactive, "Олександр Барвінський" | https://lia.lvivcenter.org/uk/persons/oleksandr-barvinskyi/ | accessed 2026-07-04.
+- ДНПБ України ім. В. О. Сухомлинського, "Біографія О. Г. Барвінського" | https://dnpb.gov.ua/informatsiyno-bibliohrafichni-resursy/vydatni-pedahohy/barvinskyy-o-h/biohrafiya/ | accessed 2026-07-04.
+
+**Tier 3 (encyclopedic / navigation):**
+- Українська Вікіпедія, "Барвінський Олександр Григорович" — used only for orientation and bibliography leads.
+- Wikimedia Commons, `Category:Oleksandr Barvinskyi (cultural figure and politician)` | https://commons.wikimedia.org/wiki/Category:Oleksandr_Barvinskyi_(cultural_figure_and_politician) | accessed 2026-07-04.
+- Вікіджерела, "Автор:Олександр Барвінський" | https://uk.wikisource.org/wiki/Автор:Олександр_Барвінський | accessed 2026-07-04.
+
+**Tier 4 (modern scholarly post-1991):**
+- Олена Аркуша, "Між Львовом, Віднем і Києвом: Олександр Барвінський та геополітичні вибори України на зламі ХІХ-ХХ століть," Інститут українознавства ім. І. Крип'якевича НАН України, 2024 | https://www.inst-ukr.lviv.ua/download.php?portfolioitemid=1108 | accessed 2026-07-04.
+- "Олександр Барвінський" in `ЗУНР 1918-1923. Уряди. Постаті` | https://www.inst-ukr.lviv.ua/files/18/040Barvinsk.pdf | accessed 2026-07-04.
+
+**Primary-source documents / text leads:**
+- Барвінський О. `Спомини з мого життя`, Львів, 1912-1913; later expanded editions listed in Arkusha 2024.
+- Барвінський О. `Історія України-Руси`, Львів, 1904; Winnipeg edition 1920 listed in Wikisource.
+- Барвінський О. `Історія української літератури`, parts 1-2, Lviv, 1920-1921.
+- Барвінський O. school readers and pedagogical articles cited by DNPB; page-level verification needed before classroom excerpting.
+
+**Honest gaps:**
+- Full manuscript continuations of the memoirs and correspondence were not opened in archival form.
+- The exact parliamentary source for the DNPB education quote needs page-level verification before publishing as a learner text.
+- Birth-date disagreement remains unresolved: prefer 8 June 1847 but retain EIU's 6 June 1847 in notes.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing; `руський` / `українсько-руський` is explained as Galician Ukrainian/Ruthenian historical usage.
+- [x] No Russian-imperial transliteration normalized in body prose.
+- [x] Habsburg Galicia is treated as a constrained political-institutional arena, not a benevolent imperial gift.
+- [x] Polish-Ukrainian conflict and compromise are named without turning either side into a one-line villain.
+- [x] The `нова ера` controversy is preserved as a contested strategy.
+- [x] ZUNR role is linked to education and state-building, not only war chronology.
+- [x] Family/Greek-Catholic intelligentsia context is included without hagiography.
+- [x] Classroom cautions identify date, naming, and orthography risks.


### PR DESCRIPTION
## Summary

Adds the missing BIO research dossier for Oleksandr Barvinskyi at `docs/research/bio/oleksandr-barvinskyi.md`.

The dossier follows the established BIO research format with verified facts, institutional/oppression framing, works and source leads, source tiers, cross-track links only to existing paths, naming/canonical notes, image/rights leads, and classroom cautions. The framing treats Barvinskyi as a Galician Ukrainian institution-builder working through constrained Habsburg/Galician and ZUNR contexts, not as an imperial-ruler narrative.

LLM-QG was not used.

## Validation

- `npx markdownlint-cli2 docs/research/bio/oleksandr-barvinskyi.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/oleksandr-barvinskyi.md`
- `git diff --check origin/main...HEAD`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Confirmed `git diff --name-only origin/main...HEAD` contains exactly one file and no forbidden paths.