### PR TITLE
[codex] add Pavlo Chubynskyi BIO dossier

### DIFF
--- a/docs/research/bio/pavlo-chubynskyi.md
+++ b/docs/research/bio/pavlo-chubynskyi.md
@@ -1,0 +1,240 @@
+# Павло Платонович Чубинський - Research Dossier
+
+**Slug:** `pavlo-chubynskyi`
+**Block:** +77 backfill - Ukrainian ethnography / statistics / Kyiv Hromada / South-Western Branch / anthem source history
+**Tier:** 1
+**Issue:** BIO manifest backfill - missing research dossier; BIO #354
+**Researcher:** Codex GPT-5
+**Completed:** 2026-07-04
+
+**Source acronym legend:** EIU = *Енциклопедія історії України* / Інститут історії України НАН України; IEU = Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies; UINP = Український інститут національної пам'яті; NBUV = Національна бібліотека України імені В. І. Вернадського; NIBU = Національна історична бібліотека України; UHJ = *Український історичний журнал*; VRU = Верховна Рада України legislation database; Commons = Wikimedia Commons; BIO / HIST / ISTORIO / FOLK / wiki = existing learn-ukrainian track materials.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1 / Tier 2 encyclopedia, legal, institutional, and scholarly sources cited
+- [x] Chubynskyi is not reduced to only the anthem text
+- [x] Ethnographic, statistical, legal-custom, Kyiv census, and publication work represented
+- [x] Political pressure mechanism is specific: 1862 arrest and northern exile, police supervision, Hromada surveillance, 1875 denunciations, Ems Ukase, closure of the South-Western Branch, and residence restrictions
+- [x] South-Western Branch context includes imperial caveats and Kyiv Hromada agency
+- [x] Anthem source history includes poem, first publication, attribution drift, Verbytskyi setting, 1992 / 2003 state status, and quote cautions
+- [x] Cross-track links verified with `test -e` / `rg` on 2026-07-04 where marked existing
+- [x] Naming-canonical applied
+- [x] Image / rights leads identified
+- [x] Decolonization checklist self-applied
+- [x] LLM-QG was not used
+
+> **Framing note.** Chubynskyi should be taught as a Ukrainian ethnographer, statistician, legal-custom researcher, civic organizer, Kyiv Hromada actor, and source-builder for Ukrainian self-knowledge under Russian imperial pressure. The anthem text matters, but it is one visible result of a broader life: he helped make Ukrainian language, custom, territory, song, law, and social life legible through collective research when imperial institutions tried to treat Ukrainian culture as regional material inside a "West-Russian" frame.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Павло Платонович Чубинський. [T1: EIU; T1: IEU]
+- **Canonical EN:** Pavlo Chubynskyi. IEU uses `Pavlo Chubynsky`; the project slug uses `pavlo-chubynskyi`. Keep `Chubynsky` and `Chubinsky` as search aliases, not as the primary project spelling.
+- **Birth:** 15 January 1839 Old Style / 27 January 1839 New Style. EIU places the birth on the Chubynsky farm, now Chubynske in Boryspil raion, Kyiv oblast; IEU gives Boryspil, Oster county, Chernihiv gubernia. Use `27 January 1839, near Boryspil / Chubynske` in low-context copy, with source notes for administrative geography. [T1: EIU; T1: IEU; T2: NBUV]
+- **Death:** 14 January 1884 Old Style / 26 January 1884 New Style, Kyiv; buried in Boryspil. EIU and IEU agree on the 26 January New Style date. [T1: EIU; T1: IEU; T2: NBUV]
+- **Family / early education:** NBUV describes him as coming from Ukrainian gentry and gives a family-memory link to a Cossack ancestor, Ivan Chub. He studied at the Second Kyiv Gymnasium and then the law faculty of Saint Petersburg University, graduating in 1861. Use the family-root note as context, not as proof of politics by ancestry. [T1: EIU; T2: NBUV]
+- **Early public work:** As a student and young public figure he was connected to Ukrainian circles in Saint Petersburg and wrote for `Основа` under the pseudonym `Павлусь`. [T1: EIU; T2: NBUV]
+- **Kyiv Hromada / khlopoman milieu:** EIU places him in the core of the Kyiv Hromada alongside Volodymyr Antonovych, Mykhailo Drahomanov, Pavlo Zhytetskyi, Tadei Rylsky, and others. IEU's Kyiv Hromada and khlopoman entries identify him among early Sunday-school / populist-Ukrainian civic workers. [T1: EIU; T1: IEU - Hromada of Kyiv; T1: IEU - Khlopoman]
+- **Poem that became the anthem:** EIU states that he wrote `Ще не вмерла України і слава і воля` in 1862; the poem became a solemn song with music by Mykhailo Verbytskyi and, in independent Ukraine, the state anthem. UINP and EIU both note the first publication in the Lviv journal `Мета` in 1863 and the temporary attribution drift to Taras Shevchenko. [T1: EIU; T2: UINP; T1: EIU - anthem]
+- **Arrest and northern exile:** In autumn 1862, after gendarme reports and the label of political unreliability, he was arrested and exiled under police supervision to Pinega, then moved in 1863 to Arkhangelsk. In Arkhangelsk he worked in statistical and newspaper offices while publishing historical, ethnographic, and statistical research. [T1: EIU; T2: NBUV]
+- **Return to research work:** In 1869 he headed an ethnographic-statistical expedition into the imperial "South-Western Krai" framework: chiefly Kyiv, Volyn, and Podillia gubernias, with broader materials from Ukrainian-inhabited and adjacent areas. The official title and territory names are imperial source language; the collected evidence is central to Ukrainian cultural history. [T1: EIU; T1: IEU; T2: UHJ - Kotenko; T2: NBUV]
+- **Major publication:** `Труды этнографическо-статистической экспедиции в Западно-Русский край` appeared in seven volumes / nine books in 1872-1878, with materials collected by Chubynskyi and edited / arranged with collaborators. IEU summarizes the volumes as covering beliefs, proverbs, riddles, tales, calendar and ritual songs, family rites, folk songs, legal customs, and peoples living in Ukraine. [T1: EIU; T1: IEU; T2: NBUV scan records]
+- **Awards:** EIU and IEU record major recognition: a Russian Geographical Society gold medal in 1873, a Paris award in 1875, and the Uvarov Prize of the Petersburg Academy of Sciences in 1879. Kotenko's UHJ article describes the Paris recognition more specifically as a second-class medal at the Paris geographical congress. Do not build a quiz around the exact Paris award wording without checking the congress record. [T1: EIU; T1: IEU; T2: UHJ - Kotenko]
+- **South-Western Branch:** In 1873 the South-Western Branch of the Imperial Russian Geographical Society was established in Kyiv with Chubynskyi's direct participation. IEU says the association was formally an imperial learned body but was largely staffed by Kyiv Hromada members; Chubynskyi was managing director and later vice-president. [T1: EIU; T1: IEU - South-Western Branch]
+- **Kyiv census:** Under Chubynskyi's plan and leadership, the South-Western Branch organized the one-day Kyiv census of 2 March 1874, using student registrars and producing a detailed picture of the city population. [T2: NBUV]
+- **Ems Ukase pressure:** After denunciations, especially by Mikhail Yuzefovich, imperial authorities closed the South-Western Branch and tightened Ukrainian-language repression through the Ems Ukase. EIU states that Chubynskyi and Drahomanov were barred from living in Ukraine, Moscow, and Saint Petersburg; UINP says the Third Section was instructed to remove them under secret surveillance and bar them from Ukrainian gubernias and capitals. [T1: EIU; T2: UINP; T1: IEU - South-Western Branch]
+- **Last years:** Thanks to petitions by the Geographical Society presidium and friends, he was allowed in autumn 1876 to move to Saint Petersburg, where he worked in the Ministry of Railways. He returned home ill in 1879 and spent the last five years of his life in Ukraine. [T1: EIU; T2: NBUV]
+
+## 2. Political pressure mechanism
+
+The pressure mechanism is Russian imperial surveillance and censorship of Ukrainian civic infrastructure, not a generic "hard life of a scholar."
+
+- **Early Hromada suspicion:** Chubynskyi's Ukrainian educational and cultural work belonged to the Kyiv Hromada / khlopoman milieu: Sunday schools, popular education, Ukrainian-language and folklore work, and "going to the people." These activities were described by participants as legal cultural work, but imperial and reactionary circles treated them as politically suspect. [T1: IEU - Hromada of Kyiv; T1: IEU - Khlopoman]
+- **1862 arrest and exile:** The clean first coercive hinge is the autumn 1862 arrest and exile. EIU says he was labeled politically unreliable on the basis of gendarme reports; NBUV preserves the order's logic as punishment for "harmful influence" on common people. Use the accusation as imperial language, not narrator truth. [T1: EIU; T2: NBUV]
+- **Exile as containment and extraction:** Pinega / Arkhangelsk removed him from Kyiv while still using his skills in imperial regional administration: statistical committee work, newspaper editing, and special assignments. A module should show both sides: the exile punished Ukrainian activity, and Chubynskyi used the imposed setting to keep doing empirical research. [T1: EIU; T2: NBUV]
+- **Imperial commission plus Ukrainian agenda:** Kotenko's UHJ article is essential for avoiding a simple heroic or simple institutional story. The expedition served imperial post-1863 depolonization and "state-task" goals, yet Chubynskyi and Old Hromada allies also used it to study and map a Ukrainian national space. Teach this double frame directly. [T2: UHJ - Kotenko]
+- **South-Western Branch alarm:** The branch's public lectures, publications, census, museum, library, and Ukrainian-themed research made Ukrainian studies visible inside Kyiv. IEU states that denunciations increased after Antonovych became president and Chubynskyi vice-president in 1875. [T1: IEU - South-Western Branch]
+- **Yuzefovich denunciation and Ems:** EIU identifies the 1875 denunciation by Yuzefovich and the 1876 internal-ministry memorandum on the "harmful activity" of the Kyiv branch as steps toward the Ems Ukase. The result included closure of the South-Western Branch, curbing of the Hromada, and residence restrictions on Chubynskyi and Drahomanov. [T1: EIU; T2: UINP]
+- **Ems as knowledge control:** The Ems Ukase was not only a publication ban. In this case it targeted the institutional sites where Ukrainian language, folklore, statistics, and public education were becoming evidence of a people and territory. [T1: EIU; T2: UINP; T1: IEU - South-Western Branch]
+- **Imperial awards caveat:** Chubynskyi received awards from imperial and European scholarly bodies. That recognition does not make the institutions neutral authorities over Ukrainian culture. It shows that Ukrainian evidence could be valued scientifically while the Ukrainian movement around it was politically repressed. [T1: EIU; T1: IEU; T2: UHJ - Kotenko]
+- **No Soviet-style flattening:** Do not present him only as "a folklorist persecuted for a song." The documented pressure connects anthem-era civic work, Hromada networks, empirical scholarship, institutional Ukrainian studies, and the Ems anti-Ukrainian regime.
+
+## 3. Major events / historical footprint
+
+- **1850s-1861 education and formation:** Second Kyiv Gymnasium, Saint Petersburg University law faculty, student Ukrainian circles, and `Основа` connect legal education, journalism, and Ukrainian civic work. [T1: EIU; T2: NBUV]
+- **1859-1863 Kyiv Hromada and Sunday schools:** IEU places Chubynskyi among early Kyiv Hromada / khlopoman actors. This gives the BIO track a civic-education anchor before state politics: teaching, language, literature, and service to common people. [T1: IEU - Hromada of Kyiv; T1: IEU - Khlopoman]
+- **1862 poem:** `Ще не вмерла України і слава і воля` was written in the same period as Hromada mobilization and imperial suspicion. It should be taught as movement song / civic poetry before it is treated as a state symbol. [T1: EIU; T1: EIU - anthem; T2: UINP]
+- **1863 `Мета` publication:** The poem appeared unsigned in the Lviv journal `Мета`, near Shevchenko material, which caused attribution drift. This is useful for source-literacy: publication context can distort authorship. [T1: EIU - anthem; T2: UINP; T2: NBUV]
+- **1862-1869 northern exile:** Pinega and Arkhangelsk show both coercion and research continuity. Chubynskyi's northern statistical and legal-custom work matters because it trained and demonstrated the empirical method later applied to Ukrainian material. [T1: EIU; T2: NBUV]
+- **1869-1870 ethnographic-statistical expedition:** The expedition gathered material on folklore, dialects, customs, legal practice, rituals, social groups, and statistics. It should be taught as collaborative fieldwork, not a lone-collector myth. EIU notes teachers, students, clergy, and other helpers; IEU and NBUV show the resulting volumes. [T1: EIU; T1: IEU; T2: NBUV]
+- **1872-1878 `Труды...`:** The seven-volume / nine-book publication became one of the major source repositories for Ukrainian folk culture, legal custom, song, ritual, and social statistics. Use the imperial title as a bibliographic title with caveat, not as a modern geographic label. [T1: EIU; T1: IEU; T2: NBUV scan records]
+- **1873-1876 South-Western Branch:** The branch created a learned institutional home for Ukrainian studies under an imperial umbrella. It published `Записки`, supported Veresai / duma materials, folk-song collections, Drahomanov / Antonovych historical songs, the Kyiv census, and public lectures. [T1: IEU - South-Western Branch]
+- **1874 Kyiv census:** The one-day census is a strong statistics lesson anchor: data gathering, city social structure, student registrars, and Ukrainian urban evidence. [T2: NBUV]
+- **1875-1876 denunciations and closure:** The Yuzefovich accusation, imperial commission, Ems Ukase, and closure of the branch show how Ukrainian empirical scholarship became politically dangerous once it was institutionally visible. [T1: EIU; T1: IEU - South-Western Branch; T2: UINP]
+- **1876-1879 Saint Petersburg ministry work:** After residence restrictions, Chubynskyi worked in the Ministry of Railways. Do not narrate this as a free career move; place it after coercion and petitions that limited his options. [T1: EIU]
+- **1879-1884 return and death:** His final years in Ukraine were marked by illness and constrained life after the Ems repression. [T1: EIU; T2: NBUV]
+
+## 4. Pedagogical anchors
+
+- **Beyond "author of the anthem":** Start with the anthem only if it opens into Hromada, ethnography, statistics, and source history. A one-line "anthem author" lesson wastes the figure.
+- **Source title as evidence:** `Западно-Русский край`, `Юго-Западный отдел`, and `Малороссия` are historical source titles. Learners should see why a Ukrainian dossier preserves them in citations but does not adopt them as neutral categories.
+- **Ethnography as national infrastructure:** Songs, riddles, legal customs, foodways, clothing, dialects, and census tables are not decorative folklore. In this context they are evidence that Ukrainian life had language, territory, social practice, and institutions.
+- **Statistics as civic work:** The 1874 Kyiv census lets learners work with data vocabulary and urban modernity, not only rural folk culture.
+- **Imperial institutions and Ukrainian agency:** Chubynskyi used formal imperial channels because those were the available legal structures, while Ukrainian Hromada networks shaped the research agenda. This is a good C1/C2 source-criticism problem.
+- **Poem / song / law sequence:** A module can separate stages: 1862 poem, 1863 publication in `Мета`, Verbytskyi's Galician musical setting, mass song, Ukrainian Revolution usage, 1992 state anthem status, and 2003 legal text.
+- **Attribution drift exercise:** The temporary Shevchenko attribution is a compact lesson in how layout, reputation, unsigned publication, and later memory can affect source history.
+- **Ems as institutional attack:** Pair Chubynskyi with Drahomanov to show that the Ems regime attacked books, residence, universities, newspapers, and learned societies together.
+- **Collaborative scholarship:** Do not write the `Труды...` as if Chubynskyi personally collected every item. He organized, edited, and shaped a networked corpus with many contributors and later editors.
+- **Decolonial caution:** A decolonial frame should not erase the imperial paperwork. It should expose how those categories worked, then show how Ukrainian actors repurposed constrained spaces.
+
+## 5. Language register
+
+- **Register:** nineteenth-century Ukrainian civic poetry, Russian-imperial bureaucratic and scholarly titles, ethnographic description, statistical reporting, legal-custom terminology, and anthem-law language.
+- **CEFR readiness:** A2/B1 for a short biography and anthem authorship; B1/B2 for Kyiv Hromada and exile narrative; B2/C1 for the South-Western Branch, Ems Ukase, publication history, and census vocabulary; C1/C2 for Kotenko-style source criticism of the expedition as both imperial project and Ukrainian national-territorial work.
+- **Core vocabulary:** `Павло Чубинський`, `Київська громада`, `хлопомани`, `Основа`, `недільні школи`, `заслання`, `Пінега`, `Архангельськ`, `статистичний комітет`, `етнографічно-статистична експедиція`, `Південно-Західний відділ`, `Російське географічне товариство`, `перепис`, `Емський указ`, `жандармські донесення`, `народні звичаї`, `звичаєве право`, `приказки`, `загадки`, `календарні пісні`, `весільний обряд`, `Державний Гімн України`.
+- **Source-title caution:** Preserve exact old titles in bibliographies: `Труды этнографическо-статистической экспедиции...`, `Очерк народных юридических обычаев и понятий в Малороссии`, `Сопілка Павлуся`. Explain the imperial / historical language before learners reuse it.
+- **Anthem text caution:** The current legal text is the first stanza and refrain of Chubynskyi's work as adopted by law. Quote only short compliant excerpts in ordinary lessons; use the VRU law for the official wording when needed.
+- **Gendered civic language:** `браття` belongs to the historical / official text. In classroom discussion, explain it as source language and do not let it erase women or non-male participants in Ukrainian civic history.
+- **Place-name caution:** Use modern Ukrainian place names in explanatory prose: Kyiv, Boryspil, Chubynske, Ukrainian lands / Ukrainian-inhabited areas. Use Pinega and Arkhangelsk as places of exile in today's Russian Federation where relevant.
+- **Register contrast exercise:** Have learners compare three registers: a lyric anthem line, a census / statistics sentence, and an imperial bureaucratic accusation.
+
+## 6. Risks / open questions
+
+- **Birthplace administrative drift:** EIU gives the Chubynsky farm, now Chubynske in Boryspil raion; IEU gives Boryspil, Oster county, Chernihiv gubernia. Avoid overprecise modern administrative claims unless the lesson uses a map note.
+- **Death-date confusion in weaker sources:** EIU and IEU support 26 January 1884 New Style. Some web biographies use different New Style conversions. Prefer EIU / IEU.
+- **Paris award wording:** EIU / IEU summarize the 1875 Paris award as a gold medal; Kotenko cites a second-class medal at the Paris geographical congress. Use broad wording `Paris recognition / medal` unless a production module opens the congress proceedings.
+- **Expedition motive simplification:** Kotenko's article complicates the usual story. The expedition was both an imperial depolonization project and a Ukrainian national-space project for Chubynskyi and Old Hromada circles. Flattening either half will mislead learners.
+- **Imperial-title harm:** `West-Russian`, `Little Russia`, and `South-Western Krai` can smuggle imperial geography into modern narration. Keep them quoted, source-labeled, or bibliographic.
+- **Authorship anecdote caution:** EIU and UINP mention versions of the poem's composition, including the gathering with Serbs and a Serbian song influence. Teach this as source history with variant accounts, not as a theatrical certainty unless a primary witness is cited.
+- **Shevchenko attribution drift:** The poem's first publication context caused temporary attribution to Shevchenko. Do not turn that into a mystery gimmick; it is a source-layout and canon-authority problem.
+- **Verbytskyi / Lysenko / Stetsenko sequencing:** EIU says Mykola Lysenko and Kyrylo Stetsenko also set the text, while Verbytskyi's Galician setting became the powerful anthem form. Keep composer roles separate.
+- **State anthem chronology:** EIU records 1992 state-anthem approval and the 2003 law for the official words. A lesson should not imply the 2003 law created the song or that the song had no national function before state adoption.
+- **Quote rights:** The official anthem text is in law, but song/poem editions and modern arrangements still need copyright and edition review. Keep ordinary quotation short and use paraphrase.
+- **Image rights:** Commons and institutional pages provide leads, not automatic production clearance. Check every file page and source institution before packaging images.
+- **Archive gap:** No gendarme case file, South-Western Branch archive file, or Chubynskyi correspondence manuscript was opened in this pass.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` / `rg` on 2026-07-04. Forward-looking ties are under **Candidate**.
+
+- **Current BIO inventory state (VERIFIED `rg` 2026-07-04):** `site/src/content/docs/bio/index.mdx` lists BIO #354 `pavlo-chubynskyi`; `curriculum/l2-uk-en/curriculum.yaml` includes the slug in the Ukrainian language, ethnography, translation, and scholarship additions block. The following production surfaces are absent before this dossier: `curriculum/l2-uk-en/plans/bio/pavlo-chubynskyi.yaml`, `curriculum/l2-uk-en/bio/discovery/pavlo-chubynskyi.yaml`, `wiki/figures/pavlo-chubynskyi.md`, `site/src/content/docs/bio/pavlo-chubynskyi.mdx`, `curriculum/l2-uk-en/bio/pavlo-chubynskyi/module.md`, `curriculum/l2-uk-en/bio/pavlo-chubynskyi/activities.yaml`, `curriculum/l2-uk-en/bio/pavlo-chubynskyi/vocabulary.yaml`, and `curriculum/l2-uk-en/bio/pavlo-chubynskyi/resources.yaml`.
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-drahomanov.yaml` - Kyiv Hromada, South-Western Branch, Ems repression, and paired residence restrictions.
+  - `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml` - attribution drift around `Мета`, Shevchenko-centered national memory, and anthem reception context.
+  - `curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml` - later Hromada / language infrastructure and dictionary work as downstream cultural institution-building.
+- **Existing HIST / ISTORIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/hromady.yaml` - Kyiv Hromada, Old Hromada, Sunday schools, and civic-cultural organizing under empire.
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` - Valuev / Ems regime, South-Western Branch closure, and bans on Ukrainian-language public work.
+  - `curriculum/l2-uk-en/plans/hist/rosiiska-imperiia-ukraina.yaml` - Russian imperial administrative frame and pressure on Ukrainian culture.
+  - `curriculum/l2-uk-en/plans/hist/shevchenko-awakening.yaml` - Shevchenko memory, `Мета` publication context, and song-canon formation.
+  - `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml` - later Ukrainian Revolution state-symbol context; use as afterlife, not direct Chubynskyi activity.
+  - `curriculum/l2-uk-en/plans/istorio/pislya-emsa-halychyna.yaml` - Galician publication / circulation routes after imperial language pressure.
+- **Existing FOLK plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/folk/narodna-kultura-yak-systema.yaml` - Chubynskyi's corpus as linked evidence of language, ritual, belief, law, and social practice.
+  - `curriculum/l2-uk-en/plans/folk/prykazky-ta-pryslivia.yaml` - proverbs and sayings in `Труды...` volume 1 and later proverb-source chains.
+  - `curriculum/l2-uk-en/plans/folk/zahadky.yaml` - riddle materials in `Труды...` volume 1.
+  - `curriculum/l2-uk-en/plans/folk/kalendarna-obriadovist-zvychai.yaml` - calendar songs and ritual year materials, especially volume 3.
+  - `curriculum/l2-uk-en/plans/folk/vesilni-pisni.yaml` - wedding and family-rite materials, especially volume 4.
+- **Existing wiki / dossier anchors (VERIFIED present):** `wiki/periods/hromady.md`, `wiki/historiography/pislya-emsa-halychyna.md`, `docs/research/bio/fedir-vovk.md`, `docs/research/bio/mykhailo-drahomanov.md`.
+- **Candidate cross-track additions (Phase 2+, NOT existing files):**
+  - Dedicated BIO module `pavlo-chubynskyi` on ethnography, statistics, anthem-source history, and Ems pressure.
+  - Future BIO modules / plans for `fedir-vovk`, `volodymyr-antonovych`, `mykhailo-verbitskyi`, `pavlo-zhytetskyi`, and `mykhailo-lysenko`, all absent as plan paths in this worktree.
+  - A source-study module on `Труды...` as a corpus: how to read imperial titles, collected Ukrainian oral material, editorial layers, and digitized scans.
+  - A statistics / urban-history micro-module around the 1874 Kyiv one-day census.
+  - An anthem-source-history module that separates poem, publication, musical setting, movement song, state symbol, and legal text.
+
+## 8. Name variants / search aliases
+
+- **Canonical UA:** `Павло Платонович Чубинський`.
+- **Canonical EN:** `Pavlo Chubynskyi`.
+- **Project slug:** `pavlo-chubynskyi`.
+- **IEU / scholarly variants:** `Pavlo Chubynsky`, `Pavlo Platonovych Chubynsky`, `Čubyns'kyj`, `P. P. Chubynsky`.
+- **Common English / catalog variants:** `Pavlo Chubinsky`, `Paul Chubinsky`, `Pavel Chubinsky`, `Pavlo Tchoubynsky`, `Pawlo Tschubynskyj`.
+- **Common UA search forms:** `Павло Чубинський`, `П. Чубинський`, `П. П. Чубинський`, `Павлусь`, `Сопілка Павлуся`.
+- **Russian / imperial-search forms:** `Павел Платонович Чубинский`, `П. П. Чубинский`, `Павел Чубинский`, `Чубинский Павел`. Keep these for source discovery, bibliographic titles, and archival reconciliation only; do not use them as learner-facing canonical names.
+- **Work / institution aliases:** `Ще не вмерла Україна`, `Ще не вмерла України і слава і воля`, `Мета 1863`, `Труды этнографическо-статистической экспедиции`, `Юго-Западный отдел`, `Південно-Західний відділ`, `Southwestern Branch`, `Kyiv Hromada`, `Old Hromada`, `Ems Ukase`.
+- **Learner-facing display:** `Pavlo Chubynskyi (Павло Чубинський, 1839-1884)`.
+- **Forbidden / caution forms:** "Russian ethnographer" as identity label; "West-Russian region" as modern geography; "Little Russian customs" outside a quoted / bibliographic title; any claim that the anthem text is anonymous, Shevchenko's, or only folk-authored.
+
+## 9. Image rights / visual material notes
+
+- **Best portrait lead:** Wikimedia Commons `Category:Pavlo Chubynskyi` includes several portrait files (`Pavlo Chubynsky.jpg`, `Pavlo Chubynsky, Kyiv.jpg`, `Pavlo Chubynskyi.jpg`) and related images. Verify each file page, source, author/date, and United States / Ukraine public-domain status before production use.
+- **Institutional portrait caution:** IEU displays a Chubynskyi image, but IEU pages are marked all rights reserved. Use only as identification lead unless permission is obtained.
+- **NBUV gallery leads:** NBUV's `Павло Чубинський - автор українського національного гімну` page displays portrait, gymnasium, `Труды...`, and `Сопілка Павлуся` images. Treat these as institutional discovery leads; check item-level rights and scan provenance.
+- **Primary-text / scan candidates:** NBUV electronic-library records for `Труды...` volume scans are strong source-study visuals. Because the underlying editions are 1870s public-domain publications, the main remaining questions are scan terms, page quality, and attribution.
+- **Anthem source visual:** A facsimile of `Мета`, 1863, no. 4 would be the strongest source-history image, but this dossier did not verify a rights-clear facsimile. Do not use random screenshots.
+- **Context image:** Commons also lists images of plaques, monuments, Boryspil / Chubynske memorial sites, and `Труды...` title-page images. Modern plaques and monument photos depend on photographer license and local public-art rules.
+- **Avoid as main image:** modern patriotic graphics, AI colorizations, unattributed social-media portraits, or visuals that show only the anthem text while hiding his research work.
+- **Best production pairing:** one portrait plus one source object (`Труды...` title page, census table, or `Мета` facsimile) would better communicate the dossier frame than a portrait alone.
+
+## 10. Sources used
+
+**Tier 1 (authoritative encyclopedia / legal baseline):**
+
+- Шип Н. А. "Чубинський Павло Платонович." *Енциклопедія історії України*, т. 10. Інститут історії України НАН України, 2013. <https://www.history.org.ua/?termin=Chubynskyj_P>. Accessed 2026-07-04.
+- Petro Odarchenko. "Chubynsky, Pavlo." *Internet Encyclopedia of Ukraine*, Canadian Institute of Ukrainian Studies. <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CC%5CH%5CChubynskyPavlo.htm>. Accessed 2026-07-04.
+- Bohdan Kravtsiv. "Southwestern Branch of the Imperial Russian Geographic Society." *Internet Encyclopedia of Ukraine*. <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CO%5CSouthwesternBranchoftheImperialRussianGeographicSociety.htm>. Accessed 2026-07-04.
+- Arkadii Zhukovsky. "Hromada of Kyiv." *Internet Encyclopedia of Ukraine*. <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CH%5CR%5CHromadaofKyiv.htm>. Accessed 2026-07-04.
+- Arkadii Zhukovsky. "Khlopoman." *Internet Encyclopedia of Ukraine*. <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CH%5CKhlopomanIT.htm>. Accessed 2026-07-04.
+- Шип Н. А. "Ще не вмерла України, Нац. і Держ. гімн України." *Енциклопедія історії України*, т. 10. Інститут історії України НАН України, 2013. <https://www.history.org.ua/?termin=Sche_ne_vmerla>. Accessed 2026-07-04.
+- Закон України "Про Державний Гімн України" від 06.03.2003 № 602-IV. Верховна Рада України. <https://zakon.rada.gov.ua/go/602-15>. Accessed 2026-07-04.
+
+**Tier 2 (institutional, scholarly, and primary-source access):**
+
+- "2003 - ухвалення Закону України `Про Державний Гімн України`." Український інститут національної пам'яті. <https://uinp.gov.ua/istorychnyy-kalendar/berezen/6/2003-uhvalennya-zakonu-ukrayiny-pro-derzhavnyy-gimn-ukrayiny>. Accessed 2026-07-04.
+- "1876 - підписано Емський указ." Український інститут національної пам'яті. <https://uinp.gov.ua/istorychnyy-kalendar/traven/30/1876-emskyy-ukaz>. Accessed 2026-07-04.
+- "Павло Чубинський - автор українського національного гімну." Національна бібліотека України імені В. І. Вернадського. <https://www.nbuv.gov.ua/node/536>. Accessed 2026-07-04.
+- "Народився Павло Чубинський..." Національна бібліотека України імені В. І. Вернадського, `Україніка в датах`. <https://www.nbuv.gov.ua/node/4592>. Accessed 2026-07-04.
+- "Чубинський Павло Платонович." NBUV electronic-library reference item `REF0002480`. <https://irbis-nbuv.gov.ua/ulib/item/REF0002480>. Accessed 2026-07-04.
+- "Чубинский П. П. Труды этнографическо-статистической экспедиции... Т. 5." NBUV electronic-library item `UKR0002685`, with related volume links. <https://irbis-nbuv.gov.ua/ulib/item/UKR0002685>. Accessed 2026-07-04.
+- Котенко А. Л. "Етнографічно-статистична експедиція П. Чубинського в Південно-Західний край." *Український історичний журнал* 2014, no. 3, 128-151. <https://nasu-periodicals.org.ua/index.php/uhj/article/view/29408>. PDF inspected 2026-07-04.
+- "Павло Платонович Чубинський (1839-1884)." Національна історична бібліотека України. <https://nibu.kyiv.ua/exhibitions/631/>. Accessed 2026-07-04.
+- "Павло Платонович Чубинський за спогадами Федора Вовка." Національна історична бібліотека України. <https://nibu.kyiv.ua/news/277/>. Accessed 2026-07-04.
+
+**Tier 3 (media / image-rights and navigation leads):**
+
+- Wikimedia Commons, `Category:Pavlo Chubynskyi`. <https://commons.wikimedia.org/wiki/Category:Pavlo_Chubynskyi>. Accessed 2026-07-04. Used only as image-candidate discovery; item-level rights still need production verification.
+- Internet Archive record for `Труды Этнографическо-статистической экспедиции...` full set. <https://archive.org/details/trudyetnograficheskostatisticheskojeksp89>. Accessed 2026-07-04. Used as scan-navigation lead, not as the primary bibliographic authority.
+
+**Tier 4 (learn-ukrainian local context checked 2026-07-04):**
+
+- `site/src/content/docs/bio/index.mdx`
+- `curriculum/l2-uk-en/curriculum.yaml`
+- `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md`
+- `docs/audits/bio-readiness-matrix-2026-06-29.md`
+- `docs/research/bio/fedir-vovk.md`
+- `docs/research/bio/mykhailo-drahomanov.md`
+- `curriculum/l2-uk-en/plans/bio/mykhailo-drahomanov.yaml`
+- `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml`
+- `curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml`
+- `curriculum/l2-uk-en/plans/hist/hromady.yaml`
+- `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml`
+- `curriculum/l2-uk-en/plans/hist/rosiiska-imperiia-ukraina.yaml`
+- `curriculum/l2-uk-en/plans/hist/shevchenko-awakening.yaml`
+- `curriculum/l2-uk-en/plans/hist/tsentralna-rada.yaml`
+- `curriculum/l2-uk-en/plans/istorio/pislya-emsa-halychyna.yaml`
+- `curriculum/l2-uk-en/plans/folk/narodna-kultura-yak-systema.yaml`
+- `curriculum/l2-uk-en/plans/folk/prykazky-ta-pryslivia.yaml`
+- `curriculum/l2-uk-en/plans/folk/zahadky.yaml`
+- `curriculum/l2-uk-en/plans/folk/kalendarna-obriadovist-zvychai.yaml`
+- `curriculum/l2-uk-en/plans/folk/vesilni-pisni.yaml`
+- `wiki/periods/hromady.md`
+- `wiki/historiography/pislya-emsa-halychyna.md`
+
+**Honest gaps:** No archival gendarme file, South-Western Branch file, Chubynskyi correspondence manuscript, or `Мета` 1863 facsimile was opened in this pass. The NBUV and Internet Archive `Труды...` records were used as scan leads rather than fully read volume-by-volume. Exact Paris award wording, the poem-composition witness chain, image rights, and manuscript locations need specialist / archive verification before production modules make fine-grained claims. LLM-QG was not used.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing - Chubynskyi is centered as a Ukrainian scholar and civic actor; Russian imperial institutions appear as pressure, constraint, and formal publication setting.
+- [x] Ukrainian agency preserved - Hromada networks, field collection, census work, editing, song authorship, and institution-building are active choices, not passive folklore preservation.
+- [x] Imperial titles are source-labeled - `Западно-Русский край`, `Малороссия`, and related terms appear only as titles / historical categories with caveats.
+- [x] No "neutral empire" narration - the South-Western Branch is treated as both an imperial learned body and a Hromada-used Ukrainian research platform.
+- [x] No martyr inflation - exile, residence restrictions, closure of institutions, and illness are named concretely without inventing imprisonment or execution.
+- [x] Anthem not overcentered - the song history is included, but ethnographic, statistical, and legal-custom work carry equal dossier weight.
+- [x] Source-history complexity retained - `Мета`, Shevchenko attribution drift, Verbytskyi setting, and the 2003 law are separated.
+- [x] Awards are not used to legitimize imperial authority - they are evidence of scholarly recognition inside unequal institutions.
+- [x] Russian-imperial / Russified forms are confined to alias and bibliography contexts, not learner display.


### PR DESCRIPTION
## Summary

- Adds the missing BIO research dossier for Pavlo Chubynskyi.
- Covers ethnographic/statistical work, Kyiv Hromada context, exile and surveillance pressure, South-Western Branch context with imperial caveats, and the source history of the poem/song that became Ukraine's anthem.
- Includes source tiers, verified existing cross-track links, image/rights leads, naming notes, classroom cautions, honest gaps, and decolonization self-check.

## Changed file

- `docs/research/bio/pavlo-chubynskyi.md`

## Verification

- `npx markdownlint-cli2 docs/research/bio/pavlo-chubynskyi.md` - pass
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/pavlo-chubynskyi.md` - pass
- `git diff --check origin/main...HEAD` - pass
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py` - pass
- Changed file count: 1
- Forbidden paths in diff: none

LLM-QG was not used.