### PR TITLE
[codex] add Volodymyr Hnatiuk BIO dossier

### DIFF
--- a/docs/research/bio/volodymyr-hnatiuk.md
+++ b/docs/research/bio/volodymyr-hnatiuk.md
@@ -1,0 +1,266 @@
+# Володимир Михайлович Гнатюк - Research Dossier
+
+**Slug:** `volodymyr-hnatiuk`
+**Block:** +77 backfill - Ukrainian ethnography / NTSh infrastructure / folklore methodology / Transcarpathian and diasporic Ukrainian fieldwork
+**Tier:** 1
+**Issue:** BIO manifest backfill - missing research dossier; BIO #358
+**Researcher:** Codex GPT-5
+**Completed:** 2026-07-04
+
+**Source acronym legend:** EIU = *Енциклопедія історії України* / Інститут історії України НАН України; ESU = *Енциклопедія Сучасної України*; IEU = Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies; UINP = Український інститут національної пам'яті; NBUV = Національна бібліотека України імені В. І. Вернадського; NTSh = Наукове товариство імені Шевченка; NZ = *Народознавчі зошити*; Commons = Wikimedia Commons; IA = Internet Archive; BIO / HIST / ISTORIO / FOLK / LIT / wiki = existing learn-ukrainian track materials.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1 / Tier 2 encyclopedia, institutional, and scholarly sources cited
+- [x] Hnatiuk is not reduced to a generic "folklorist"; NTSh, publishing, methodology, literary scholarship, linguistics, and civic infrastructure are represented
+- [x] Ties to Ivan Franko, Mykhailo Hrushevskyi, Fedir Vovk, and the Ethnographic Commission are specific
+- [x] Fieldwork / source-collection ethics include passportization, informant data, variant references, correspondence networks, and classroom handling of dialect and sensitive material
+- [x] Publication history covers `Етнографічний збірник`, `Матеріали до українсько-руської етнології`, `Літературно-науковий вістник`, the Ukrainian-Ruthenian Publishing Company, and key Hnatiuk collections
+- [x] Cross-track links verified with `test -e` / `rg` on 2026-07-04 where marked existing
+- [x] Naming-canonical applied
+- [x] Image / rights leads identified
+- [x] Decolonization checklist self-applied
+- [x] LLM-QG was not used
+
+> **Framing note.** Hnatiuk should be taught as a Ukrainian scholar, editor, fieldwork organizer, NTSh institution-builder, and connector of Ukrainian communities across Galicia, Transcarpathia, the Presov region, Backa, Banat, and the wider Slavic scholarly world. His folklore collections matter, but the central curriculum value is how he made Ukrainian oral literature, dialects, material culture, and regional evidence publishable with method, metadata, and Ukrainian scholarly agency under Habsburg, Hungarian, Polish, and Russian-imperial pressure.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Володимир Михайлович Гнатюк. [T1: EIU; T1: ESU; T1: IEU]
+- **Canonical EN:** Volodymyr Hnatiuk. IEU also lists the older scholarly form `Hnatjuk`; use it as a search alias, not the project display form. [T1: IEU]
+- **Birth:** 9 May 1871, Velesniv, Buchach county / Galicia; now Velesniv in Ternopil oblast, Ukraine. EIU, ESU, IEU, UINP, and NBUV agree on the date. [T1: EIU; T1: ESU; T1: IEU; T2: UINP; T2: NBUV]
+- **Death:** 6 October 1926, Lviv; buried at Lychakiv Cemetery. Sources agree on date and city. [T1: EIU; T1: ESU; T1: IEU; T2: UINP]
+- **Family / early formation:** Born in a large rural family; TNPU identifies his father as a village cantor. He studied in Buchach and Stanyslaviv / Stanislav gymnasia before entering Lviv University. Use school and family details as context for educational mobility, not as deterministic biography. [T1: EIU; T1: ESU; T2: TNPU]
+- **University and mentors:** At Lviv University, where he studied in 1894-1898, Hnatiuk encountered Ivan Franko, Mykhailo Hrushevskyi, Oleksandr Kolessa, and A. Kalina. IEU explicitly names Hrushevskyi and Franko as close lifelong collaborators. [T1: IEU; T1: ESU; T2: UINP]
+- **Early collection work:** He began collecting folklore as a student before university, then published early notes and recordings in periodicals including `Lud` and `Житє і слово`, the latter edited by Franko. ESU states that Fedir Vovk gave him methodological guidance for recording. [T1: ESU]
+- **NTSh core role:** IEU states that from 1898 until death he was general secretary of the Shevchenko Scientific Society in Lviv; ESU says he became the permanent secretary in 1898; EIU gives `from 1901` in a compressed summary. Use `from the late 1890s / early 1900s to death` unless a lesson needs the office chronology. From 1899 he was also secretary of the Philological Section. IEU says the NTSh reached its peak as an academy-like Ukrainian scholarly institution while he served as general secretary. [T1: IEU; T1: ESU; T1: EIU]
+- **Ethnographic Commission:** With Ivan Franko he founded the NTSh Ethnographic Commission in 1898. ESU gives him as secretary until 1912 and later head; IEU says he was elected secretary in 1898 and chairman in 1913; EIU summarizes the later chair role as from 1916. Use the safe curriculum wording: `secretary of the Ethnographic Commission from its founding period; later its head / chairman`, unless a lesson is about internal NTSh chronology. [T1: ESU; T1: IEU; T1: EIU]
+- **Fieldwork geography:** From 1895 to 1903 he made expeditions to Transcarpathian Ukraine, the Presov region, and Ukrainian / Rusyn communities in Backa, Banat, Serbia, Croatia, Romania, and Hungary. IEU counts five Transcarpathian research trips plus trips to Backa and Banat; ESU describes six expeditions over the broader region and diaspora settlement field. [T1: IEU; T1: ESU]
+- **Political and health pressure:** ESU says Hungarian police arrested him during the last expedition and that he developed asthma; IEU says tuberculosis in 1903 limited later fieldwork; UINP gives 1902 for tuberculosis. The stable claim is that early-1900s illness, after fieldwork and police pressure, shifted him from mostly direct collection to organized correspondence collection. [T1: ESU; T1: IEU; T2: UINP]
+- **Correspondence network:** After illness limited travel, Hnatiuk organized a large network of collectors. IEU estimates about 800 folklorists; ESU says his correspondence with nearly 800 people survives in western Ukrainian archives. [T1: IEU; T1: ESU]
+- **Publication corpus:** ESU states that in `Етнографічний збірник` and `Матеріали до українсько-руської етнології` he published large corpora: tales, animal tales, legends, anecdotes, songs, carols, kolomyikas, haivky, opryshky narratives, tobacco-worker narratives, demonological narratives, wedding descriptions, and funeral-custom descriptions. [T1: ESU; T1: EIU - `Етноґрафічний збірник`]
+- **Textual apparatus:** ESU highlights Hnatiuk's passportization of texts: place, time, collector, informant, biographies of key informants, and references to variants in other printed sources. This is a central classroom fact for source ethics. [T1: ESU]
+- **Publishing and editing:** He co-edited `Записки НТШ` with Hrushevskyi, edited `Хроніка НТШ`, edited 22 volumes of `Етнографічний збірник`, and edited / contributed to `Матеріали до українсько-руської етнології`. He served on the editorial board of `Літературно-науковий вістник` in 1899-1906 and 1922-1926. [T1: IEU; T1: ESU]
+- **Ukrainian-Ruthenian Publishing Company:** He was one of the founders, secretary, and director of the Ukrainian-Ruthenian Publishing Company / `Українсько-руська видавнича спілка`; IEU credits him with editing over 150 volumes of Ukrainian and European literature, while ESU says he prepared and issued over 140 books in two series, mostly with his own prefaces. [T1: IEU; T1: ESU]
+- **Literary scholarship and translations:** He studied old Ukrainian literature, especially Transcarpathian and Galician texts; wrote biographical sketches of Ukrainian and European writers; edited Ukrainian authors banned in tsarist Russia; and translated from all Slavic languages plus German, French, and Hungarian. [T1: ESU]
+- **Linguistics:** His work covered Ukrainian dialectology, sociolinguistics, etymology, onomastics, and lexicology, especially in the Carpathian region. ESU says he studied Lemko, Boiko, Hutsul, and Backa Rusyn / Ukrainian dialects and established the Ukrainian-Slovak language boundary; his manuscript dictionary of Ukrainian Transcarpathian dialects exceeded 30,000 words. [T1: ESU; T2: UINP]
+- **Recognition:** Corresponding member of the Petersburg Academy of Sciences from 1902, full member of NTSh from 1899, member of Czechoslovak / Prague and Austrian ethnographic bodies, and academician of VUAN / Ukrainian Academy of Sciences from 1924. Explain the Petersburg recognition as scholarly acknowledgement inside an imperial institution, not as identity framing. [T1: EIU; T1: ESU; T1: IEU]
+
+## 2. Political pressure mechanism
+
+The pressure mechanism is not one simple arrest story. It is a layered pattern: Ukrainian scholarship needed legal institutional shelter under empires, while Hnatiuk's fieldwork and publishing exposed the limits of those imperial frames.
+
+- **Habsburg legal space, Ukrainian agenda:** Lviv and the NTSh gave Hnatiuk a platform unavailable to many Ukrainian scholars under the Russian Empire. That does not make the Habsburg or Polish / Hungarian political environment neutral; it means Ukrainian scholars used the available Galician institutional opening to build an academy-like center. [T1: IEU; T1: EIU]
+- **Hungarian pressure in fieldwork:** ESU records that Hungarian police arrested Hnatiuk during his last expedition and that he fell ill with asthma. His protest `І ми в Європі` drew attention to the national, economic, and social oppression of Transcarpathian Ukrainians by Hungarian authorities. [T1: ESU]
+- **Field access as politics:** Later testimony from the Ethnographic Commission context notes that by the early 1920s fieldwork in Galicia was hard not only for lack of funds but for political reasons; access by an outside intellectual, especially with a camera, could be difficult. Teach fieldwork as negotiated access, not romantic wandering. [T2: Hlushko]
+- **Russian-imperial censorship context:** Hnatiuk's Galician publishing work mattered because many Ukrainian authors and scholarly texts could not circulate freely in tsarist Russia. ESU states that he researched and issued works by Ukrainian classics banned in tsarist Russia, and translated scholarly works by Ukrainian authors who could not publish them in their native language in Russia. [T1: ESU]
+- **Anti-Russophile stance:** IEU states that Hnatiuk supported the Ukrainian Radical Party and opposed Galician Russophiles and populists. Do not turn this into a simplistic party biography; for curriculum, the key is his defense of Ukrainian cultural and linguistic agency against Russophile absorption. [T1: IEU]
+- **Academy recognition caveat:** Petersburg Academy membership and later VUAN membership show cross-border scholarly recognition. They should not be used to subordinate him to Russian imperial scholarship. The discipline, corpus, and institutional labor were Ukrainian; the academy label is a source fact. [T1: EIU; T1: IEU]
+- **World War I and archive loss:** ESU says a significant part of Hnatiuk's folklore records was lost during World War I. This is a material-destruction pressure point: not every loss came from censorship, but war and state collapse damaged the evidence base. [T1: ESU]
+- **No martyr inflation:** Hnatiuk was not executed, imprisoned for years, or exiled in the Chubynskyi / Vovk pattern. The documented mechanism is police interference in fieldwork, illness, constrained access, censorship / language pressure around publication, war loss, and the need to build Ukrainian institutions inside unequal political structures.
+
+## 3. Major events / historical footprint
+
+- **1880s-1890 early collecting:** As a student in Buchach and Stanyslaviv, Hnatiuk recorded songs and narratives. TNPU says one early notebook had grown to more than 500 songs by 1890; use this as institutional memory rather than as a standalone Tier 1 count. [T2: TNPU]
+- **1894 Lviv University:** Entering the philosophy faculty put him in contact with Franko, Hrushevskyi, Kolessa, and other Ukrainian intellectuals who shaped his scholarly path. [T1: ESU; T2: UINP]
+- **1894-1897 `Житє і слово`:** Early work with Franko's journal placed Hnatiuk at the junction of folklore, criticism, and Ukrainian periodical culture before his full NTSh career. [T1: EIU; T1: ESU]
+- **1895-1903 expeditions:** The Transcarpathian, Presov, Backa, Banat, and diaspora-settlement expeditions are the fieldwork spine. A lesson should map the routes as Ukrainian contact zones across state borders, not as exotic peripheries. [T1: ESU; T1: IEU]
+- **1897 `Лірники`:** His early study of lyre players and their repertory / social world shows that he worked with living performers and professional folk transmission, not only anonymous song texts. [T1: ESU]
+- **1898 Franko jubilee and literary aid fund:** As head of `Академічна громада` in Lviv, Hnatiuk helped organize the 25-year celebration of Ivan Franko's literary work. ESU says the event helped Franko out of material hardship and led to a fund for needy writers, with Hnatiuk as chair. [T1: ESU]
+- **1898 Ethnographic Commission:** Together with Franko, he built the NTSh Ethnographic Commission, the main institutional platform for systematic Ukrainian folklore and ethnographic publication in Galicia. [T1: ESU; T2: NZ]
+- **Late 1890s-1926 NTSh secretariat:** As general secretary, editor, correspondent, and recruiter, Hnatiuk helped make NTSh function as a Ukrainian academy-like institution. IEU's phrase about NTSh's peak under his secretariat is useful, but modules should show the labor behind the phrase: correspondence, editing, serial production, contributors, international contacts, and finances. [T1: IEU; T1: ESU; T1: EIU]
+- **1899-1914 Hutsul-region work:** IEU records repeated summers in the Hutsul region, with artifact collection for the NTSh museum. Use this to link text collection with material culture and museum-building. [T1: IEU]
+- **1902 / 1903 health turn:** Serious illness sharply reduced personal field trips. He adapted by building a correspondence network and turning field method into distributed infrastructure. [T1: IEU; T1: ESU; T2: UINP]
+- **1904-1912 demonology and sensitive corpora:** `Знадоби до галицько-руської демонології` / `Знадоби до української демонології`, later demonological volumes, and `Das Geschlechtsleben des Ukrainischen Bauernvolkes` show his willingness to publish material that polite or nationalist pedagogy might hide. These are source-ethics anchors, not sensational reading targets. [T1: ESU; T1: IEU; T1: EIU - `Етноґрафічний збірник`]
+- **1905-1907 `Коломийки`:** The three-volume kolomyika corpus in `Етнографічний збірник` is one of the safest FOLK-track anchors for Hnatiuk's editorial method. [T1: EIU - `Етноґрафічний збірник`; T4: local FOLK research]
+- **1909 `Гаївки`:** Prepared with Filaret Kolessa and Osyp Rozdolskyi; for music / ritual lessons, treat Hnatiuk as editor-organizer and Kolessa / Rozdolskyi as part of the same NTSh network rather than a lone-author story. [T4: local BIO dossier - Filaret Kolessa]
+- **1916 / 1917 `Українська народна словесність`:** IEU identifies this as a systematic statement of recording, classifying, and publishing Ukrainian folklore. This is the clearest method-text anchor for a C1/C2 module. [T1: IEU; T3: Commons works scan lead]
+- **1910s-1920s publishing and LNV:** Hnatiuk edited and solicited work for `Літературно-науковий вістник`, `Записки НТШ`, `Хроніка НТШ`, `Етнографічний збірник`, and `Матеріали до українсько-руської етнології`; he also continued Ukrainian literary publishing through the Ukrainian-Ruthenian Publishing Company. [T1: IEU; T1: ESU]
+- **1924 VUAN academician:** The Ukrainian Academy of Sciences / VUAN recognized Hnatiuk as a full member; UINP says illness prevented a permanent move to Kyiv. This links Galician / NTSh scholarship with all-Ukrainian academic consolidation after 1917. [T1: ESU; T2: UINP]
+- **1926 death and commemoration:** Hnatiuk died in Lviv and was buried at Lychakiv Cemetery near Franko. The Velesniv museum, Ternopil university name, and memorials are afterlife anchors, but they should not replace the research corpus. [T2: UINP; T2: TNPU; T3: Commons]
+
+## 4. Pedagogical anchors
+
+- **Institution-builder before "folklorist":** Start with the NTSh desk, not a romantic village scene. Hnatiuk's distinctive value is that he turned collecting into a Ukrainian scholarly system: programs, questionnaires, metadata, correspondence, editing, serial publication, and archives.
+- **Fieldwork ethics:** ESU's passportization detail is load-bearing. Learners should ask: who recorded the text, from whom, where, when, under what conditions, and how variants were compared. This prevents the false voice `the people say` from erasing collectors and informants.
+- **Informants as people:** Because Hnatiuk included biographies of key informants, a module can teach that performers, storytellers, singers, and correspondents are not raw material. They are contributors inside a power relationship.
+- **Dialect as evidence, not error:** His work with Lemko, Boiko, Hutsul, Transcarpathian, and Backa / Banat speech is ideal for explaining dialectal forms as documented Ukrainian linguistic evidence. Do not normalize every form silently; explain when a text preserves local speech.
+- **Transcarpathia and diaspora without absorption:** Works titled around `Угорська Русь`, Backa, or Banat should be framed as Ukrainian / Rusyn communities under historical state borders. Avoid implying that Hungarian, Serbian, Croatian, Romanian, or imperial administrative labels define identity.
+- **Franko and Hrushevskyi network:** Hnatiuk is a bridge between Franko's literary / editorial world and Hrushevskyi's academy-building world. Pair biography with workplace practices: who edited, who solicited, who funded, who reviewed, who corresponded.
+- **Publication as cultural defense:** `Етнографічний збірник` and the Publishing Company made Ukrainian material visible with apparatus at a time when Russian-imperial censorship restricted Ukrainian-language scholarship and literature elsewhere.
+- **Sensitive folklore with care:** Demonology, erotic / obscene folklore, slurs, antisemitic or xenonym jokes, gendered violence, and sexual material must not be used as classroom color. Use them only in advanced source-ethics settings with warnings, historical framing, and alternatives for learners.
+- **Comparative method caveat:** Hnatiuk's comparative-historical approach belongs to its period. It can teach cross-Slavic scholarship, but it should not flatten Ukrainian material into generic Slavic parallels or make European recognition the measure of value.
+- **Material culture and museum work:** Hnatiuk collected artifacts for the NTSh museum. A good lesson can pair a song / legend record with a household object, building, textile, tool, or foodway note to show culture as a system.
+- **Numbers are not the whole story:** Source counts vary: ESU gives detailed counts by genre inside two NTSh series; UINP and TNPU give commemorative totals across broader collections. Counts are useful for scale, but the lesson should explain what is counted and where.
+
+## 5. Language register
+
+- **Register:** late-19th / early-20th-century scholarly Ukrainian, Galician editorial prose, dialect transcription, comparative folklore terminology, bibliographic notes, and civic-publicistic language.
+- **Publication-language caution:** Hnatiuk wrote and edited in Ukrainian, and also used German, Polish, Czech, Russian, and other scholarly channels. Publication language is not identity. It often reflects the available venue, audience, or censorship regime.
+- **CEFR readiness:** A2/B1 for a short biography and map of places; B1/B2 for a narrative about NTSh and Franko / Hrushevskyi; B2/C1 for `Етнографічний збірник`, fieldwork metadata, and publication history; C1/C2 for original methodological prose, dialect records, demonology, or comparative studies.
+- **Core vocabulary:** `Володимир Гнатюк`, `Наукове товариство імені Шевченка`, `НТШ`, `Етнографічна комісія`, `Етнографічний збірник`, `Матеріали до українсько-руської етнології`, `Літературно-науковий вістник`, `Українсько-руська видавнича спілка`, `фольклористика`, `етнографія`, `збирач`, `інформатор`, `паспортизація`, `варіант`, `діалект`, `говірка`, `коломийка`, `гаївка`, `колядка`, `щедрівка`, `легенда`, `анекдот`, `опришки`, `демонологія`, `похоронні звичаї`, `сороміцький фольклор`, `Закарпаття`, `Пряшівщина`, `Бачка`, `Банат`, `Гуцульщина`.
+- **Source-title caution:** Preserve historical titles in bibliographies: `Галицько-руські народні легенди`, `Етнографічні матеріали з Угорської Руси`, `Матеріали до українсько-руської етнології`, `Das Geschlechtsleben des Ukrainischen Bauernvolkes`. Explain the older ethnonyms and political geography before learners reuse them.
+- **Orthography caution:** Expect historical spellings such as `народня`, `словесність`, `матеріяли`, `українсько-руський`, and Galician forms. Do not silently modernize if the exercise is about source reading.
+- **Register contrast exercise:** Have learners compare a field passport line, a dialect text, a methodological instruction, and a publicistic protest sentence. The point is to identify genre before judging language difficulty.
+- **Learner safety:** For B1/B2 classes, choose neutral, short, culturally rich excerpts: collection metadata, a brief legend summary, a kolomyika source note, or a museum / publishing paragraph. Keep demonology and erotic / obscene folklore for opt-in advanced work.
+
+## 6. Risks / open questions
+
+- **Health chronology:** IEU says tuberculosis in 1903; UINP says tuberculosis was diagnosed in 1902; ESU emphasizes Hungarian police arrest during the last expedition and asthma. Use a broad formulation unless a medical / archival source is opened.
+- **Ethnographic Commission chronology:** Sources differ in shorthand dates for his transition from secretary to head / chairman: ESU says secretary until 1912 and later head; IEU says chairman in 1913; EIU summarizes head from 1916. Use role language unless the exact office date is central.
+- **Counts vary by scope:** ESU gives item counts for `Етнографічний збірник` and `Матеріали до українсько-руської етнології`; UINP gives a broader `58 volumes` summary with different genre counts; TNPU gives another commemorative count. Do not mix counts without naming the source frame.
+- **Rusyn / Ukrainian naming:** Hnatiuk's own and source titles use `руський`, `русини`, `угорська Русь`, and related historical terms. Modern curriculum prose should explain them as historical Ukrainian / Rusyn naming in Central European contexts, not as Russian identity.
+- **Imperial and state labels:** `Galicia`, `Kingdom of Galicia and Lodomeria`, `Austria-Hungary`, `Hungarian-ruled`, `Second Polish Republic`, `Petersburg Academy`, and `Imperial Academy` are context labels. They should not become the main frame of his identity or scholarship.
+- **Soviet publication afterlife:** Soviet-era and late-Soviet editions are useful but may normalize ideological wording, avoid sexual / religious material, or flatten national politics. Use them with edition notes.
+- **Sensitive materials:** Demonological stories, erotic folklore, obscene songs, and ethnic / gendered insults need content warnings, harm framing, and clear distinction between documentation and endorsement.
+- **Informant consent standards:** Hnatiuk's metadata was advanced for its time, but it is not modern research ethics. Do not claim modern informed consent standards; teach the historical method and its limits.
+- **Archive gap:** This pass did not open Hnatiuk's manuscript archive, the full `Листування Володимира Гнатюка з Михайлом Грушевським`, or the full `Володимир Гнатюк: документи і матеріали` volume.
+- **Image rights:** Commons gives promising public-domain leads, but item-level author, date, and license must be checked before production use.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` / `rg` on 2026-07-04. Forward-looking ties are under **Candidate**.
+
+- **Current BIO inventory state (VERIFIED `rg` 2026-07-04):** `site/src/content/docs/bio/index.mdx` lists BIO #358 `volodymyr-hnatiuk`; `curriculum/l2-uk-en/curriculum.yaml` includes the slug in the Ukrainian language, ethnography, translation, and scholarship additions block. The following production surfaces are absent before this dossier: `curriculum/l2-uk-en/plans/bio/volodymyr-hnatiuk.yaml`, `wiki/figures/volodymyr-hnatiuk.md`, `site/src/content/docs/bio/volodymyr-hnatiuk.mdx`, `curriculum/l2-uk-en/bio/volodymyr-hnatiuk/module.md`, `curriculum/l2-uk-en/bio/volodymyr-hnatiuk/activities.yaml`, `curriculum/l2-uk-en/bio/volodymyr-hnatiuk/vocabulary.yaml`, and `curriculum/l2-uk-en/bio/volodymyr-hnatiuk/resources.yaml`.
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml` - mentor, editor, Ethnographic Commission co-founder, and literary / publishing collaborator.
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml` - NTSh academy-building, `Записки НТШ`, correspondence, and VUAN continuity.
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-kotsiubynsky.yaml` - literary correspondence and the Kryvorivnia / Hutsul-region cultural network around Hnatiuk.
+  - `curriculum/l2-uk-en/plans/bio/lesya-ukrainka.yaml` - Ukrainian literary publishing, NTSh / LNV networks, and writers who visited Hnatiuk in Lviv and Kryvorivnia.
+  - `curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml` - Ukrainian-language publishing, bibliography, folklore collection, and cross-imperial cultural independence.
+- **Existing HIST / ISTORIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/habsburzka-halichyna.yaml` - Galician institutional context and legal space for Ukrainian scholarship.
+  - `curriculum/l2-uk-en/plans/hist/hromady.yaml` - broader Ukrainian civic-institutional work; use with caution because Hnatiuk's base is NTSh / Lviv, not Kyiv Hromada.
+  - `curriculum/l2-uk-en/plans/hist/franko-lesia-hrinchenko.yaml` - revival-generation literary infrastructure, periodicals, and cross-border Ukrainian culture.
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` - Russian-imperial censorship context that made Galician publication routes important.
+  - `curriculum/l2-uk-en/plans/istorio/halychyna-natsionalnyi-rukh.yaml` - national movement and institution-building in Galicia.
+  - `curriculum/l2-uk-en/plans/istorio/pislya-emsa-halychyna.yaml` - Galician publication and circulation routes after Russian-imperial language pressure.
+- **Existing FOLK / LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/folk/kolomyiky.yaml` - Hnatiuk's 1905-1907 `Коломийки` as a central edition target.
+  - `curriculum/l2-uk-en/plans/folk/holosinnya.yaml` - `Похоронні звичаї й обряди`, lament / funeral-custom source context, and sensitive classroom handling.
+  - `curriculum/l2-uk-en/plans/folk/narodni-lehendy.yaml` - `Галицько-руські народні легенди` and legend publication apparatus.
+  - `curriculum/l2-uk-en/plans/folk/narodni-opovidannia-buvalshchyny-memoraty.yaml` - demonological narratives, memorates, and field-source ethics.
+  - `curriculum/l2-uk-en/plans/folk/dytiachyi-folklor-kolyskovi.yaml` - child folklore / song collection links where source rows point to Hnatiuk and Chubynskyi.
+  - `curriculum/l2-uk-en/plans/folk/kalendarna-obriadovist-zvychai.yaml` - calendar ritual, carols, haivky, and seasonal songs.
+  - `curriculum/l2-uk-en/plans/folk/kupalski-rusalni-pisni.yaml` - rusalka / demonology and seasonal ritual-song context.
+  - `curriculum/l2-uk-en/plans/folk/narodni-tantsi.yaml` - dance-song / regional performance records, including kolomyika and Hutsul / Carpathian material.
+  - `curriculum/l2-uk-en/plans/folk/rehionalni-etnokulturni-tradytsii.yaml` - Transcarpathia, Hutsul region, Backa / Banat, and regional collection method.
+  - `curriculum/l2-uk-en/plans/lit/ethnography.yaml` - literature / ethnography interface and the politics of collected oral material.
+- **Existing wiki / dossier anchors (VERIFIED present):** `wiki/figures/ivan-franko.md`, `wiki/figures/mykhailo-hrushevskyi.md`, `wiki/periods/habsburzka-halichyna.md`, `wiki/periods/hromady.md`, `wiki/historiography/pislya-emsa-halychyna.md`, `wiki/folk/lyric/kolomyiky.md`, `wiki/folk/ritual/holosinnya.md`, `docs/research/bio/fedir-vovk.md`, `docs/research/bio/filaret-kolessa.md`.
+- **Candidate cross-track additions (Phase 2+, NOT existing files):**
+  - Dedicated BIO module `volodymyr-hnatiuk` on NTSh infrastructure, fieldwork ethics, publication history, and Ukrainian dialect / folklore evidence.
+  - Future BIO plans for `fedir-vovk`, `filaret-kolessa`, `klyment-kvitka`, `osyp-rozdolskyi`, `zenon-kuzelia`, `mykhailo-zubrytskyi`, and `oleksandr-kolessa`, all absent as plan paths in this worktree.
+  - A FOLK source-method module around Hnatiuk's `Українська народня словесність`: how to record, classify, passport, compare, and publish oral material.
+  - A regional Ukrainian communities module on Transcarpathia / Presov / Backa / Banat using Hnatiuk without collapsing Ukrainian, Rusyn, and local self-naming.
+  - A source-ethics module on demonology, obscene folklore, and harmful speech in historical collections.
+
+## 8. Name variants / search aliases
+
+- **Canonical UA:** `Володимир Михайлович Гнатюк`.
+- **Canonical EN:** `Volodymyr Hnatiuk`.
+- **Project slug:** `volodymyr-hnatiuk`.
+- **Common UA search forms:** `Володимир Гнатюк`, `В. Гнатюк`, `В. М. Гнатюк`, `Гнатюк Володимир Михайлович`.
+- **Pseudonyms / cryptonyms from ESU:** `В`, `В. Г.`, `М. Р.`, `Гн. В.`, `Літописець В.`.
+- **IEU / catalog variants:** `Volodymyr Hnatjuk`, `Volodymyr Mykhailovych Hnatiuk`, `V. M. Hnatiuk`, `Hnatiuk, V. M.`, `Hnatjuk`, `Hnatyuk`, `Hnatiouk`.
+- **Central European catalog variants:** `Volodymyr Mychajlovyč Hnatjuk`, `Volodýmyr Hnatiuk`, `Wołodymyr Hnatiuk`, `Volodimir Mihajlovič Hnatjuk`.
+- **Russian / imperial-search forms:** `Владимир Михайлович Гнатюк`, `Гнатюк Владимир Михайлович`, `Vladimir Gnatiouk`, `Vladimir Mikhaïlovitch Gnatiouk`, `Vladimir Hnatiuk`. Keep these for source discovery, library catalogs, and archival reconciliation only; do not use as learner-facing canonical names.
+- **Work / institution aliases:** `Етнографічний збірник`, `Матеріали до українсько-руської етнології`, `Українська народня словесність`, `Етнографічні матеріали з Угорської Руси`, `Коломийки`, `Гаївки`, `Галицько-руські народні легенди`, `Знадоби до української демонології`, `Народні оповідання про опришків`, `Похоронні звичаї й обряди`, `Літературно-науковий вістник`, `Українсько-руська видавнича спілка`, `НТШ`.
+- **Learner-facing display:** `Volodymyr Hnatiuk (Володимир Гнатюк, 1871-1926)`.
+- **Forbidden / caution forms:** "Russian ethnographer" as identity label; "Austrian ethnographer" as identity label; "Hungarian Ruthenian folklore" as a modern umbrella for all his Ukrainian materials; "folk material collected by Hnatiuk" without naming informants / collectors where the source record supplies them.
+
+## 9. Image rights / visual material notes
+
+- **Best portrait lead:** Wikimedia Commons `File:Hnatiuk Volodymyr.jpg` is listed with PD-old / public-domain marking but lacks author information. Treat it as promising, not automatic: verify author, source publication, date, and United States / Ukraine public-domain status before production use. [T3: Commons file]
+- **Commons category lead:** `Category:Volodymyr Hnatiuk` includes portraits, grave images, the 1898 writers' congress image, a Franko-Kotsiubynskyi-Hnatiuk image, and NTSh publication scans. Use item pages, not the category page, for license proof. [T3: Commons category]
+- **Works by Hnatiuk:** Commons `Category:Works by Volodymyr Hnatiuk` includes scans such as `Українська народня словесність`, `Кубанщина й Кубанські Українці`, and other public-domain publication leads. These are strong source-object visuals if item-level rights and scan quality are verified. [T3: Commons works category]
+- **IEU image caution:** IEU displays Hnatiuk and Hnatiuk-with-Kotsiubynskyi / Franko images. IEU pages are useful identification leads, but the site itself is not a production license. [T1: IEU]
+- **TNPU images:** TNPU has portraits, monument / bust images, and museum-context images. Treat as institutional discovery leads unless explicit reuse terms are confirmed. [T2: TNPU]
+- **Velesniv museum / Lychakiv grave:** Commons has museum, grave, and memorial categories. Modern memorial photographs depend on photographer license and local public-art rules.
+- **Primary-text visual:** A title page or method page from `Українська народня словесність` is likely better than a portrait alone because it shows the dossier's methodological frame.
+- **Avoid as main image:** generic folklore illustrations, AI portraits, decorative Hutsul / Carpathian imagery without source relation, and screenshots from social media or YouTube.
+- **Best production pairing:** one rights-cleared portrait plus one NTSh source object (`Етнографічний збірник`, `Українська народня словесність`, or a collection title page) would communicate both person and infrastructure.
+
+## 10. Sources used
+
+**Tier 1 (authoritative encyclopedia / scholarly baseline):**
+
+- Скрипник П. І. "Гнатюк Володимир Михайлович." *Енциклопедія історії України*, т. 2. Інститут історії України НАН України, 2004. <https://www.history.org.ua/?termin=Gnatyuk_V>. Accessed 2026-07-04.
+- "Гнатюк Володимир Михайлович." *Енциклопедія Сучасної України*. <https://esu.com.ua/article-30627>. Accessed 2026-07-04.
+- Mykola Mushynka. "Hnatiuk, Volodymyr." *Internet Encyclopedia of Ukraine*, Canadian Institute of Ukrainian Studies. <https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CH%5CN%5CHnatiukVolodymyr.htm>. Accessed 2026-07-04.
+- Руденко Н. В. "`Етноґрафічний збірник`." *Енциклопедія історії України*, т. 3. Інститут історії України НАН України, 2005. <https://www.history.org.ua/?termin=Etnografichny_zbirnyk>. Accessed 2026-07-04.
+
+**Tier 2 (institutional, scholarly, and primary-source access):**
+
+- "1871 - народився Володимир Гнатюк, етнограф." Український інститут національної пам'яті. <https://uinp.gov.ua/istorychnyy-kalendar/traven/9/1871-narodyvsya-volodymyr-gnatyuk-etnograf>. Accessed 2026-07-04.
+- "Гнатюк Володимир Михайлович." Національна бібліотека України імені В. І. Вернадського, electronic-library reference item `REF0009623`. <https://irbis-nbuv.gov.ua/ulib/item/REF0009623>. Accessed 2026-07-04.
+- "Володимир Гнатюк." Тернопільський національний педагогічний університет імені Володимира Гнатюка. <https://tnpu.edu.ua/volodimir-gnatyuk.php?clear_cache=Y>. Accessed 2026-07-04.
+- Ганна Сокіл. "Фольклористичні студії в Етнографічній комісії НТШ: історія та сучасність." *Народознавчі зошити* 2023, no. 4 (172), 832-840. <https://nz.lviv.ua/2023-4-4/>. Accessed 2026-07-04.
+- Михайло Глушко. "Етнографічна комісія." *Світогляд* 2023, no. 5 (103), 31-34. <https://www.mao.kiev.ua/biblio/jscans/svitogliad/svit-2023-18-5/svit-5-2023-glushko-08.pdf>. PDF inspected 2026-07-04.
+- "Листування Володимира Гнатюка з Михайлом Грушевським; Н. Д. Полонська-Василенко. Покажчик документальних матеріалів в архівах України: [Рецензійний огляд]." Hrushevsky portal / Інститут історії України. <https://hrushevsky.history.org.ua/item/0012325>. Accessed 2026-07-04. Used as a cautionary lead on the correspondence edition and commentary quality, not as a primary correspondence base.
+- Mykola Mushynka. *Volodymyr Hnatiuk: bibliography of printed works*. Edmonton: Canadian Institute of Ukrainian Studies, University of Alberta, 1987. IA record <https://archive.org/details/15mush>. Accessed 2026-07-04. Used as bibliography-scale / scan lead; not exhaustively read in this pass.
+
+**Tier 3 (media / image-rights and scan-navigation leads):**
+
+- Wikimedia Commons, `Category:Volodymyr Hnatiuk`. <https://commons.wikimedia.org/wiki/Category:Volodymyr_Hnatiuk>. Accessed 2026-07-04. Used only as image-candidate discovery; item-level rights still need production verification.
+- Wikimedia Commons, `File:Hnatiuk Volodymyr.jpg`. <https://commons.wikimedia.org/wiki/File:Hnatiuk_Volodymyr.jpg>. Accessed 2026-07-04. Used as portrait-rights lead; author/date still need checking.
+- Wikimedia Commons, `Category:Works by Volodymyr Hnatiuk`. <https://commons.wikimedia.org/wiki/Category:Works_by_Volodymyr_Hnatiuk>. Accessed 2026-07-04. Used as scan-navigation lead.
+- `mcp__sources.verify_source_attribution("Володимир Гнатюк Знадоби до української демонології Коломийки Етнографічний збірник", source="literary")`, run 2026-07-04. Returned evidence for Hnatiuk's `Знадоби до української демонології`, `Коломийки`, `Українські народні байки`, and `Етнографічний збірник` in the local literary corpus, but `discusses: false`; used as secondary corroboration only.
+
+**Tier 4 (learn-ukrainian local context checked 2026-07-04):**
+
+- `site/src/content/docs/bio/index.mdx`
+- `curriculum/l2-uk-en/curriculum.yaml`
+- `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md`
+- `docs/audits/bio-readiness-matrix-2026-06-29.md`
+- `docs/research/bio/fedir-vovk.md`
+- `docs/research/bio/filaret-kolessa.md`
+- `docs/research/bio/klyment-kvitka.md`
+- `docs/research/bio/ivan-franko.md`
+- `docs/research/bio/mykhailo-hrushevskyi.md`
+- `curriculum/l2-uk-en/plans/bio/ivan-franko.yaml`
+- `curriculum/l2-uk-en/plans/bio/mykhailo-hrushevskyi.yaml`
+- `curriculum/l2-uk-en/plans/bio/mykhailo-kotsiubynsky.yaml`
+- `curriculum/l2-uk-en/plans/bio/lesya-ukrainka.yaml`
+- `curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml`
+- `curriculum/l2-uk-en/plans/hist/habsburzka-halichyna.yaml`
+- `curriculum/l2-uk-en/plans/hist/hromady.yaml`
+- `curriculum/l2-uk-en/plans/hist/franko-lesia-hrinchenko.yaml`
+- `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml`
+- `curriculum/l2-uk-en/plans/istorio/halychyna-natsionalnyi-rukh.yaml`
+- `curriculum/l2-uk-en/plans/istorio/pislya-emsa-halychyna.yaml`
+- `curriculum/l2-uk-en/plans/folk/kolomyiky.yaml`
+- `curriculum/l2-uk-en/plans/folk/holosinnya.yaml`
+- `curriculum/l2-uk-en/plans/folk/narodni-lehendy.yaml`
+- `curriculum/l2-uk-en/plans/folk/narodni-opovidannia-buvalshchyny-memoraty.yaml`
+- `curriculum/l2-uk-en/plans/folk/dytiachyi-folklor-kolyskovi.yaml`
+- `curriculum/l2-uk-en/plans/folk/kalendarna-obriadovist-zvychai.yaml`
+- `curriculum/l2-uk-en/plans/folk/kupalski-rusalni-pisni.yaml`
+- `curriculum/l2-uk-en/plans/folk/narodni-tantsi.yaml`
+- `curriculum/l2-uk-en/plans/folk/rehionalni-etnokulturni-tradytsii.yaml`
+- `curriculum/l2-uk-en/plans/lit/ethnography.yaml`
+- `wiki/figures/ivan-franko.md`
+- `wiki/figures/mykhailo-hrushevskyi.md`
+- `wiki/periods/habsburzka-halichyna.md`
+- `wiki/periods/hromady.md`
+- `wiki/historiography/pislya-emsa-halychyna.md`
+- `wiki/folk/lyric/kolomyiky.md`
+- `wiki/folk/ritual/holosinnya.md`
+
+**Honest gaps:** No manuscript archive, full correspondence volume, full `Володимир Гнатюк: документи і матеріали`, full Mushynka monograph, or complete volume-by-volume read of `Етнографічний збірник` was opened in this pass. The health chronology, Ethnographic Commission office chronology, full item counts, informant biographies, and image rights need specialist / archive verification before production modules make fine-grained claims. LLM-QG was not used.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing - Hnatiuk is centered as a Ukrainian scholar, editor, methodologist, and NTSh institution-builder; Russian imperial institutions appear as censorship and recognition contexts, not identity owners.
+- [x] Ukrainian agency preserved - NTSh, the Ethnographic Commission, collectors, informants, publishers, and writers are active agents rather than passive folklore material.
+- [x] Imperial and state labels are source-labeled - `Угорська Русь`, `українсько-руський`, Habsburg / Hungarian / Polish labels, and Petersburg Academy membership are explained as historical contexts.
+- [x] No "neutral empire" narration - Galician legal space is treated as an opening Ukrainian scholars used, not as benevolent imperial gift.
+- [x] No martyr inflation - police arrest, illness, fieldwork difficulty, censorship context, and war losses are named without inventing imprisonment, exile, or execution.
+- [x] Folklore not decorative - oral literature, dialects, material culture, and metadata are treated as infrastructure for Ukrainian knowledge.
+- [x] Informants not erased - source-collection ethics foreground the collector / informant / place / time / variant chain.
+- [x] Sensitive material handled carefully - demonology, erotic folklore, obscene texts, and harmful speech are framed as advanced source-ethics material, not classroom spectacle.
+- [x] Russian-imperial / Russified forms are confined to alias and bibliography contexts, not learner display.


### PR DESCRIPTION
## Summary

- Adds the missing BIO research dossier for Volodymyr Hnatiuk.
- Frames Hnatiuk as a Ukrainian NTSh institution-builder, folklore/ethnography methodologist, editor, literary scholar, linguist, and fieldwork organizer.
- Includes verified source tiers, cross-track links, image/rights leads, naming notes, classroom cautions, honest gaps, and the decolonization self-check.

## Validation

- `npx markdownlint-cli2 docs/research/bio/volodymyr-hnatiuk.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/volodymyr-hnatiuk.md`
- `git diff --check origin/main...HEAD`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Changed file count confirmed as 1; no forbidden paths are in the diff.

LLM-QG was not used.