### PR TITLE
[codex] add Oleksandr Konyskyi BIO dossier

### DIFF
--- a/docs/research/bio/oleksandr-konyskyi.md
+++ b/docs/research/bio/oleksandr-konyskyi.md
@@ -1,0 +1,237 @@
+# Олександр Якович Кониський - Research Dossier
+
+**Slug:** `oleksandr-konyskyi`
+**Block:** +77 backfill - Hromada networks / education and legal advocacy / Shevchenko Society and NTSh / publishing / Shevchenko biography / spiritual hymn source history
+**Tier:** 2
+**Issue:** BIO manifest backfill - missing research dossier; BIO #356
+**Researcher:** Codex GPT-5
+**Completed:** 2026-07-04
+
+**Source acronym legend:** EIU = *Енциклопедія історії України* / Institute of History of Ukraine, NASU; ESU = *Енциклопедія Сучасної України* / NASU and NTSh; IEU = Internet Encyclopedia of Ukraine / Canadian Institute of Ukrainian Studies; UINP = Ukrainian Institute of National Memory; NBUV = Vernadsky National Library of Ukraine; NIBU = National Historical Library of Ukraine; VUAM = Всеукраїнська асоціація музеїв; Commons = Wikimedia Commons; BIO / HIST / ISTORIO / LIT / wiki = existing learn-ukrainian track materials.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1 / Tier 2 encyclopedia, institutional, and source-access sources cited
+- [x] Konyskyi is not reduced to only the `Боже великий, єдиний` / `Молитва за Україну` text
+- [x] Ukrainian civic organizing, Poltava and Kyiv Hromada work, education, publishing, legal advocacy, Shevchenko biography, exile / surveillance pressure, literary work, and hymn authorship represented
+- [x] Source caveats included for `Молитва за Україну`, death date, NTSh date wording, image rights, Soviet-era reception, and Shevchenko-biography use
+- [x] Cross-track links verified with `test -e` / `rg` on 2026-07-04 where marked existing
+- [x] Naming-canonical applied
+- [x] Image / rights leads identified
+- [x] Decolonization checklist self-applied
+- [x] LLM-QG was not used
+
+## Decolonization self-check
+
+- [x] No Russocentric biography frame: Konyskyi is centered as a Ukrainian civic organizer, educator, lawyer, publisher, writer, and institution-builder under Russian imperial restriction.
+- [x] Ukrainian agency preserved: Hromada schools, cross-imperial Galicia links, NTSh conversion, `Вік`, Shevchenko research, and legal-popular work are active strategies, not cultural residue inside imperial life.
+- [x] Imperial terms are source-labeled: `Юго-Западный край`, `малорусский`, Russian titles, and imperial legal offices appear only as historical / bibliographic language.
+- [x] Repression is specific: 1863 arrest, extra-judicial exile to Vologda / Totma, police surveillance in Katerynoslav, censorship of school and legal texts, and Soviet-era suppression of works.
+- [x] Anti-hagiography included: his literature can be didactic and programmatic; his Shevchenko biography is foundational but must be used with later textual scholarship.
+- [x] Hymn not overcentered: the spiritual hymn is covered as one source-history anchor within a larger civic and publishing biography.
+- [x] Russian / Russified search forms are confined to source discovery and archival reconciliation, not learner display.
+
+> **Framing note.** Konyskyi should be taught as one of the people who turned Ukrainian civic work into schools, books, legal self-defense, publishing networks, Galician partnerships, and scholarly institutions when Russian imperial policy tried to keep Ukrainian language and public organization marginal. `Молитва за Україну` matters, but it is a doorway into a wider biography of everyday institution-building.
+
+## 1. Identity / chronology
+
+- **Canonical UA:** `Олександр Якович Кониський`. [T1: EIU; T1: ESU]
+- **Canonical EN:** `Oleksandr Konyskyi` for project display. IEU uses `Oleksander Konysky`; keep `Konysky`, `Konys'kyj`, and `Konissky` as search aliases. [T1: IEU; T1: ESU]
+- **Core identity:** Ukrainian writer, publicist, literary critic, educator, lawyer, Hromada activist, publisher, Shevchenko biographer, initiator / patron of the Shevchenko Society and NTSh, and author of the words to `Боже великий, єдиний` / `Молитва за Україну`. [T1: EIU; T1: ESU; T1: IEU; T2: UINP]
+- **Birth:** 6 August 1836 Old Style / 18 August 1836 New Style, khutir Perekhodivka / Perekhodivtsi, now in Chernihiv oblast. EIU and ESU give `х. Переходівка`; IEU gives Perekhodivtsi khutir, Nizhyn county, Chernihiv gubernia. Use `18 August 1836, Perekhodivka, Chernihiv region` in low-context copy. [T1: EIU; T1: ESU; T1: IEU; T2: UINP]
+- **Death:** EIU and ESU give 29 November Old Style / 12 December 1900 New Style, Kyiv. IEU gives 11 December 1900; use `12 December 1900, Kyiv` with a note if comparing sources. [T1: EIU; T1: ESU; T1: IEU]
+- **Education and early legal career:** EIU records Nizhyn noble school, Chernihiv gymnasium, an unsuccessful attempt at the Nizhyn juridical lyceum, military service, and work from 1854 in lower offices of the Poltava Criminal Chamber. He passed external examinations for candidate of law and after the 1861 peasant reform practiced law, hoping to defend the interests of newly emancipated peasants. [T1: EIU; T2: UINP]
+- **Hromada and schools:** ESU identifies him as a member of the Poltava and Kyiv Hromadas and an organizer of Sunday and evening schools, public libraries, and literacy societies. UINP says he personally taught history in five Poltava Sunday schools, including an evening school for adults. [T1: ESU; T2: UINP; T1: IEU]
+- **Educational publishing:** He published `Українські прописи` in 1862, `Арихметика, або Щотниця` in 1863, and a reader / grammar for Ukrainian schools in the early 1880s; a legal primer for peasants was prepared but blocked by censorship. [T1: EIU; T1: ESU; T2: UINP]
+- **Arrest and exile:** In January 1863 he was arrested on suspicion of anti-government political activity and exiled without trial to Vologda, then Totma. In 1865 he received permission to travel abroad for treatment; from 1866 he lived in Ukraine again, including Katerynoslav, under public police surveillance, and moved to Kyiv after surveillance was lifted in 1872. [T1: EIU; T1: ESU; T1: IEU; T2: UINP]
+- **Legal and civic-publicistic work:** In the 1860s-1880s he wrote on civil procedure, customary law, peasant rights, world courts, chinsh tenure, and rights inside the Russian Empire; EIU names legal articles in `Судебный вестник`, `Земский обзор`, and `Правда`. [T1: EIU; T2: UINP]
+- **Galician partnership and NTSh:** EIU, ESU, and IEU identify him as a key initiator of the Shevchenko Society in Lviv in 1873 and of its transformation into the Shevchenko Scientific Society in 1892 / 1893. EIU's NTSh entry says the scientific statute was adopted 13 March 1892 and approved 16 November 1892; ESU's biographical entry uses 1893. Use `1892-1893 transformation` unless the exact legal step is being taught. [T1: EIU; T1: ESU; T1: IEU; T2: NIBU]
+- **Publishing house `Вік`:** EIU's `Вік` entry says the Kyiv publishing house was founded in 1895 on Konyskyi's initiative and existed until 1918; it became a major Ukrainian-language publishing project under censorship. [T1: EIU - `Вік`; T2: VUAM]
+- **General Ukrainian organization:** EIU states that the General Ukrainian Non-Party Democratic Organization / ZUBDO was founded in Kyiv in September 1897 on the initiative of Volodymyr Antonovych and Konyskyi, to unite Ukrainian intelligentsia for national-cultural work. [T1: EIU - ZUBDO]
+- **Shevchenko biography:** ESU and EIU identify `Тарас Шевченко-Грушівський: Хроніка його життя` as a major two-volume biography / chronicle of Shevchenko; volume 1 appeared in Lviv in 1898, volume 2 posthumously in 1901, and a modern NBUV record documents the 1991 edition. [T1: EIU; T1: ESU; T2: NBUV; T2: NIBU]
+- **`Молитва за Україну`:** ESU and UINP state that in 1885 Konyskyi wrote the words of `Боже великий, єдиний` / `Молитва за Україну`, with music by Mykola Lysenko; EIU says the text in Oleksandr Koshyts's arrangement and Lysenko's music has been used at presidential inaugurations and other official ceremonies. [T1: EIU; T1: ESU; T2: UINP]
+
+## 2. Political pressure mechanism
+
+- **Valuev-era public work:** Konyskyi's Poltava and Kyiv Hromada activity overlapped with the post-1863 crackdown on Ukrainian-language schools and print. IEU explicitly places his arrest within the suppression of Ukrainian culture following the Valuev Circular. [T1: IEU; T1: EIU]
+- **Education as political risk:** Sunday schools, Ukrainian copybooks, arithmetic, readers, and libraries were not neutral charity in this setting. They made Ukrainian-language public education practical, which is why censorship and police suspicion targeted school texts and organizers. [T1: EIU; T1: ESU; T2: UINP]
+- **Extra-judicial exile:** The 1863 arrest and exile did not follow an ordinary trial. Teach `позасудове заслання` as an imperial administrative tool that could punish Ukrainian civic work without proving a crime. [T1: EIU; T1: ESU; T2: UINP]
+- **Surveillance after return:** The Katerynoslav period was not a simple relocation. EIU and UINP say he lived under public police supervision until the early 1870s, while continuing legal and literary work. [T1: EIU; T2: UINP]
+- **Censorship of legal knowledge:** His planned book explaining laws needed by peasants was not allowed to print. This links language policy, legal literacy, and post-emancipation peasant advocacy: legal knowledge in Ukrainian contexts could itself be treated as dangerous. [T1: EIU; T2: UINP]
+- **Galicia as workaround, not exile fantasy:** Konyskyi's ties with Galician journals and the Shevchenko Society were a cross-imperial strategy. Ukrainian writers in the Russian Empire used Lviv because print conditions there were comparatively less restrictive; EIU's NTSh entry explicitly frames Lviv's role against the Valuev restrictions in the east. [T1: EIU - NTSh; T1: EIU; T1: IEU]
+- **Institution-building under divided rule:** The Shevchenko Society / NTSh story should not be taught as "Galicia helps the East" or "the East funds Galicia" alone. Konyskyi's work joined eastern Ukrainian initiative, Galician legal possibility, donors, publishers, and scholars into one Ukrainian infrastructure across imperial borders. [T1: EIU - NTSh; T2: NIBU]
+- **Publishing after Ems:** IEU calls the 1881 almanac `Луна`, co-published by Konyskyi and Luka Ilnytsky, the first Ukrainian publication in Russian-ruled Ukraine after the Ems Ukase. Use this as a precise source-history claim and avoid implying Ukrainian print was freely restored. [T1: IEU]
+- **Late-career organization:** ZUBDO shows how older Hromada networks fed broader civic coordination before open party politics. It did not yet have a formal political program, but EIU says it helped create the ground and personnel for future Ukrainian political organizations. [T1: EIU - ZUBDO]
+- **Soviet erasure:** ESU and IEU both note that from the late 1920s to the 1980s Konyskyi's works were banned / suppressed and he was denigrated as a nationalist. That afterlife belongs in the pressure mechanism, but it should not flatten nineteenth-century imperial pressure into Soviet policy. [T1: ESU; T1: IEU; T2: UINP]
+
+## 3. Major events / historical footprint
+
+- **1854-1861 Poltava legal formation:** Low-level court work, external law examinations, and advocacy after emancipation anchor him in practical legal culture, not just literary activism. [T1: EIU; T2: UINP]
+- **1858 literary debut:** ESU says his literary activity began in 1858; IEU names `Chernigovskie gubernskie vedomosti` as an early publication venue. [T1: ESU; T1: IEU]
+- **1862-1863 Ukrainian school texts:** `Українські прописи` and `Арихметика, або Щотниця` give concrete classroom artifacts for a BIO module about language, schooling, and literacy under restriction. [T1: ESU; T1: EIU]
+- **January 1863 arrest / Vologda and Totma exile:** This is the clearest coercive hinge in the biography and should be linked to Hromada work and Ukrainian school organizing, not to a vague "unrest" label. [T1: EIU; T1: IEU; T2: UINP]
+- **1865-1872 Galicia, Bukovyna, Katerynoslav, Kyiv:** Travel for treatment, western Ukrainian ties, surveillance in Katerynoslav, and move to Kyiv form the transition from punished activist to cross-imperial organizer. [T1: EIU; T1: IEU]
+- **1873 Shevchenko Society in Lviv:** EIU's NTSh entry names Konyskyi as the eastern Ukrainian initiator of the society. This is a major institution-building anchor, especially after the Valuev restrictions and before the Ems Ukase. [T1: EIU - NTSh; T2: NIBU]
+- **1881 `Луна`:** The almanac included previously unpublished works by Shevchenko, Starytskyi, Nechui-Levytskyi, Shchoholiv, and Konyskyi himself; IEU highlights its post-Ems significance. [T1: ESU; T1: IEU]
+- **1880s Kyiv city and legal-publicist work:** EIU says he was elected to the Kyiv city duma and wrote about customary law and chinsh tenure. IEU adds that he tried to introduce Ukrainian into city schools as a council member. [T1: EIU; T1: IEU]
+- **1885 `Молитва за Україну`:** The hymn text provides a compact music / literature / civic-religious anchor with Lysenko and later Koshyts. Use it to show how a prayer-song could carry national language and civic hope without replacing the rest of the biography. [T1: EIU; T1: ESU; T2: UINP]
+- **1892-1893 NTSh transformation:** Konyskyi helped push the Shevchenko Society from a literary-publishing body toward a scientific institution; ESU's NTSh library entry adds that he donated 392 books, while IEU says he bequeathed 10,000 rubles to the society. [T1: EIU - NTSh; T1: ESU; T1: IEU; T1: ESU - NTSh library]
+- **1895 `Вік`:** The Kyiv publishing house initiative connects him to the younger generation of Domanytskyi, Durdurkivskyi, Yefremov, Lototskyi, Matushevskyi, and others. Teach as intergenerational publishing infrastructure, not a single-person enterprise. [T1: EIU - `Вік`; T2: VUAM]
+- **1897 ZUBDO:** The organization founded on Antonovych's and Konyskyi's initiative became a bridge from Old Hromada circles to broader Ukrainian civic and political organization. [T1: EIU - ZUBDO]
+- **1898-1901 `Тарас Шевченко-Грушівський`:** The chronicle became a foundational Shevchenko-biography work and a source still visible in the project's local literary corpus. It should be handled as a major source-builder, not as the final word on Shevchenko. [T1: ESU; T1: EIU; T2: NBUV; T2: NIBU; T4: local corpus]
+
+## 4. Pedagogical anchors
+
+- **"Not only the hymn":** Begin with `Молитва за Україну` only if it opens into schools, Hromadas, law, publishing, NTSh, and Shevchenko biography.
+- **School texts as resistance:** `Українські прописи`, arithmetic, readers, and Sunday-school teaching let learners see basic literacy as civic infrastructure.
+- **Law and peasants:** His legal career after the 1861 reform and writings on world courts / customary law make a strong C1 legal-language module: emancipation did not automatically create justice without access to law.
+- **Cross-imperial Ukrainian network:** Pair Kyiv / Poltava / Katerynoslav with Lviv / Galicia / Bukovyna to show how Ukrainian public life moved around censorship borders.
+- **NTSh as institution, not ornament:** Konyskyi's role in the Shevchenko Society and NTSh is a better measure of historical footprint than a list of poems.
+- **Publishing under censorship:** `Луна`, `Вік`, `Правда`, `Зоря`, `Світ`, and `Діло` can become a source-literacy exercise about where Ukrainian writing could appear and why.
+- **Shevchenko biography as archive work:** His final decade of Shevchenko research involved collecting memories, manuscripts, letters, and official documents; learners should compare his chronicle with later scholarship instead of treating any one biography as scripture. [T2: UINP; T1: ESU]
+- **Hymn source history:** Separate words by Konyskyi, music by Mykola Lysenko, later arrangement / ceremonial use by Oleksandr Koshyts, and modern performances. Do not blur the spiritual hymn with the state anthem.
+- **Soviet reception lesson:** The long ban on his works after the late 1920s lets learners discuss canon formation, ideological labeling, and recovery in the 1980s-1990s.
+- **Anti-hagiography:** Some of his fiction is openly didactic and programmatic. That makes it historically revealing, not automatically aesthetically weak or strong.
+
+## 5. Language register
+
+- **Register:** nineteenth-century Ukrainian civic prose and poetry, legal-popular language, schoolbook terminology, Hromada / publishing vocabulary, Galician periodical language, Shevchenko-biography / source-chronicle style, spiritual hymn register.
+- **CEFR readiness:** A2/B1 short biography and hymn authorship; B1/B2 school, exile, and Hromada chronology; B2/C1 legal advocacy, censorship, NTSh, ZUBDO, and publishing networks; C1/C2 source criticism of `Тарас Шевченко-Грушівський` and cross-imperial Ukrainian institution-building.
+- **Core vocabulary:** `Олександр Кониський`, `Переходівка`, `Полтавська громада`, `Київська громада`, `недільна школа`, `вечірня школа`, `Українські прописи`, `Арихметика`, `правнича допомога`, `звичаєве право`, `мировий суд`, `чинш`, `цензура`, `позасудове заслання`, `Вологда`, `Тотьма`, `гласний нагляд поліції`, `Літературне товариство імені Шевченка`, `НТШ`, `Вік`, `ЗУБДО`, `Тарас Шевченко-Грушівський`, `Молитва за Україну`.
+- **Title-language caution:** Preserve source titles exactly: `Судебный вестник`, `Земский обзор`, `Письма из Юго-Западного края`, `Права чоловіка в імперії Російській`, `Тарас Шевченко-Грушівський`, `Боже великий, єдиний`. Explain imperial / Russian titles rather than normalizing them into learner prose.
+- **Name-language caution:** Use `Oleksandr Konyskyi` / `Олександр Кониський` in learner-facing copy. Use `Konysky`, `Konys'kyj`, `Конисский`, and `А. Я. Конисский` only for source discovery.
+- **Hymn quotation caution:** Treat `Боже великий, єдиний` primarily as a title / incipit. For lessons, quote only short excerpts and rely on paraphrase unless a rights review clears a specific text / score use. Lysenko's original setting and Koshyts's arrangement have separate source and rights questions from Konyskyi's words.
+- **Place-name caution:** Use modern Ukrainian forms in explanatory prose: Kyiv, Poltava, Dnipro / historical Katerynoslav with note, Chernihiv region, Lviv. Use Vologda and Totma as places of exile in today's Russian Federation.
+
+## 6. Risks / open questions
+
+- **Death date drift:** EIU / ESU support 12 December 1900 New Style; IEU gives 11 December 1900. Use 12 December unless a module is explicitly comparing calendar / reference traditions.
+- **NTSh date wording:** EIU's institutional entry distinguishes 13 March 1892 adoption and 16 November 1892 approval of the new statute; ESU biography says he initiated the transformation in 1893. Use `1892-1893` in low-context copy.
+- **Hymn title and status drift:** Sources use `Боже Великий, Єдиний`, `Боже великий, єдиний`, and `Молитва за Україну`. Call it a spiritual hymn / prayer-song, not the state anthem. Do not imply it has the same legal status as `Ще не вмерла України`.
+- **Hymn source chain:** This pass did not open the original manuscript, Lysenko archive file, or first score. The 1885 words / Lysenko music claim is well attested in ESU, EIU, and UINP, but exact month, first performance, and textual variants need specialist verification.
+- **Shevchenko biography limitations:** `Тарас Шевченко-Грушівський` is foundational and source-rich, but it reflects late nineteenth-century methods and Konyskyi's own national-pedagogical agenda. Use alongside later critical editions and scholarship.
+- **Literary evaluation:** ESU and IEU both describe his didactic / populist literary tendencies. Avoid turning civic importance into blanket aesthetic praise.
+- **Legal writings:** The dossier did not open full texts of the legal articles in `Судебный вестник`, `Земский обзор`, or `Правда`; claims here follow EIU / UINP summaries.
+- **ZUBDO scope:** EIU supports Konyskyi's co-initiative with Antonovych in 1897, but most of ZUBDO's development occurred after Konyskyi's death. Do not assign later party outcomes personally to him.
+- **Image rights:** Commons portrait metadata is useful but thin: author unknown, before 1900, source linked to YouTube, and the file page warns a US public-domain tag is needed. Do not ship it without file-level rights review.
+- **Archive gap:** No police file, correspondence manuscript, NTSh board minutes, `Молитва` autograph, or `Вік` internal records were opened in this pass.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` / `rg` on 2026-07-04. Forward-looking ties are under **Candidate**.
+
+- **Existing BIO inventory state (VERIFIED `rg` 2026-07-04):** `site/src/content/docs/bio/index.mdx` lists BIO #356 `oleksandr-konyskyi`; `curriculum/l2-uk-en/curriculum.yaml` includes the slug in the Ukrainian language, ethnography, translation, and scholarship additions block. The current dossier is the first source dossier for that manifest item.
+- **Existing BIO plan / dossier anchors (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml` and `docs/research/bio/mykola-lysenko.md` - `Молитва за Україну`, Lysenko setting, music / civic culture bridge.
+  - `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml` and `docs/research/bio/taras-shevchenko.md` - Shevchenko biography, memory, source criticism.
+  - `curriculum/l2-uk-en/plans/bio/mykhailo-drahomanov.yaml` and `docs/research/bio/mykhailo-drahomanov.md` - Hromada networks, Galicia links, censorship pressure.
+  - `curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml` and `docs/research/bio/borys-hrinchenko.md` - later Ukrainian publishing, education, dictionary, and civic language infrastructure.
+  - `docs/research/bio/oleksandr-barvinskyi.md` - western Ukrainian / NTSh institutional counterpart.
+  - `docs/research/bio/pavlo-chubynskyi.md` - comparison for Hromada-era civic work, exile, and song-source history.
+- **Existing HIST / ISTORIO / LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/hromady.yaml` - Poltava / Kyiv Hromada and Old Hromada context.
+  - `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml` - Valuev / Ems censorship regime around schools, books, and public Ukrainian language.
+  - `curriculum/l2-uk-en/plans/hist/drahomanov.yaml` - Hromada / Galicia / imperial pressure parallels.
+  - `curriculum/l2-uk-en/plans/istorio/valuevskyi-tsyrkuliar-tekst.yaml` - source-language study of the Valuev restriction.
+  - `curriculum/l2-uk-en/plans/istorio/emskyi-ukaz-tekst.yaml` - source-language study of the Ems restriction.
+  - `curriculum/l2-uk-en/plans/lit/young-shevchenko.yaml`, `curriculum/l2-uk-en/plans/lit/cult-of-shevchenko.yaml`, and `curriculum/l2-uk-en/plans/lit-essay/drahomanov-shevchenko.yaml` - Shevchenko biography and reception anchors that already cite Konyskyi's chronicle in source files.
+- **Existing wiki / source anchors (VERIFIED present):** `wiki/periods/hromady.md`, `wiki/periods/valuevskyi-emskyi.md`, `wiki/literature/works/young-shevchenko.md`, `wiki/literature/works/cult-of-shevchenko.md`, `wiki/literature/works/drahomanov-shevchenko.md`, `wiki/literature/works/young-shevchenko.sources.yaml`, `wiki/literature/works/cult-of-shevchenko.sources.yaml`, `wiki/literature/works/drahomanov-shevchenko.sources.yaml`, `wiki/figures/mykola-lysenko.md`, `wiki/figures/taras-shevchenko.md`, `wiki/figures/mykhailo-drahomanov.md`, `wiki/figures/borys-hrinchenko.md`, `wiki/historiography/pislya-emsa-halychyna.md`, `wiki/historiography/halychyna-natsionalnyi-rukh.md`.
+- **Existing local corpus / audit anchors (VERIFIED `rg` 2026-07-04):** `docs/archive/RAG-LITERARY-CATALOG.md` lists 927 chunks for `Кониський - Шевченко-Грушівський: Хроніка життя`; `docs/archive/RAG-LITERARY-CONTENTS.md` lists the chronicle as LIT / BIO corpus material; `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md` and `docs/audits/bio-readiness-matrix-2026-06-29.md` identify Konyskyi as a missing BIO item.
+- **Candidate / absent BIO #356 surfaces (VERIFIED absent `test -e` 2026-07-04):** `curriculum/l2-uk-en/plans/bio/oleksandr-konyskyi.yaml`, `curriculum/l2-uk-en/bio/discovery/oleksandr-konyskyi.yaml`, `wiki/figures/oleksandr-konyskyi.md`, `site/src/content/docs/bio/oleksandr-konyskyi.mdx`, `curriculum/l2-uk-en/bio/oleksandr-konyskyi/module.md`, `curriculum/l2-uk-en/bio/oleksandr-konyskyi/activities.yaml`, `curriculum/l2-uk-en/bio/oleksandr-konyskyi/vocabulary.yaml`, and `curriculum/l2-uk-en/bio/oleksandr-konyskyi/resources.yaml`.
+- **Candidate cross-track additions:** a BIO module on Konyskyi as civic organizer / publisher; a source-study micro-module on `Тарас Шевченко-Грушівський`; a music-literature activity around `Молитва за Україну` with Mykola Lysenko; an NTSh / `Вік` institution-building module; a C1 legal-language activity on customary law and peasant rights after 1861.
+
+## 8. Name variants / search aliases
+
+- **Canonical UA:** `Олександр Якович Кониський`.
+- **Canonical EN:** `Oleksandr Konyskyi`.
+- **Project slug:** `oleksandr-konyskyi`.
+- **Common UA search forms:** `Олександр Кониський`, `Кониський Олександр`, `Кониський Олександр Якович`, `О. Кониський`, `О. Я. Кониський`, `Олександер Кониський`.
+- **Pseudonyms / cryptonyms:** ESU and UINP list many forms. Useful high-signal examples: `Верниволя`, `Горовенко`, `Семен Жук`, `О. Кошовий`, `Одовець Кость`, `Олександр Переходовець`, `Яковенко О.`, `Перебендя`, `Галайда`, `Дрозд`, `Полтавець`, `О. Старий`, `Маруся К.`, `Сирота`. [T1: ESU; T2: UINP]
+- **Common EN / transliteration forms:** `Oleksandr Konyskyi`, `Oleksander Konysky`, `Oleksandr Konysky`, `Oleksander Konys'kyj`, `Aleksander Konysky`, `A. Konyskyi`.
+- **Russified / imperial-search forms:** `Александр Яковлевич Конисский`, `А. Я. Конисский`, `Konissky`, `Konisskii`, `Конисский`. Keep for bibliography and archival search only.
+- **Institution / work aliases:** `Полтавська громада`, `Київська громада`, `Літературне товариство імені Шевченка`, `Наукове товариство імені Шевченка`, `НТШ`, `Вік`, `ЗУБДО`, `Загальна українська безпартійна демократична організація`, `Тарас Шевченко-Грушівський`, `Хроніка його життя`, `Боже великий, єдиний`, `Молитва за Україну`.
+- **Learner-facing display:** `Oleksandr Konyskyi (Олександр Кониський, 1836-1900)`.
+- **Forbidden / caution forms:** "Russian writer" as identity label; "Little Russian author" outside source-language discussion; "author of Ukraine's anthem" without specifying spiritual hymn vs state anthem; any claim that he founded NTSh alone.
+
+## 9. Image rights / visual material notes
+
+- **Primary portrait lead:** Commons `File:Олександр Кониський 2.jpg` depicts Konyskyi, is dated before 1900, and is marked public domain / PD-old, but the source is a YouTube link, author is unknown, and Commons warns that a United States public-domain tag is still needed. Good discovery lead, not production-cleared without file review.
+- **Institutional portrait lead:** UINP displays a late-nineteenth-century portrait credited to `vuam.org.ua`; UINP site text is CC BY 4.0 unless otherwise noted, but the photo credit means image rights still need item-level confirmation. [T2: UINP; T2: VUAM]
+- **VUAM `Вік` page:** VUAM has a portrait lead and a contextual image of `Вік` collaborators, with the group photo dated Kyiv, 1902, by Vasyl Domanytskyi. Because Konyskyi died in 1900, the group photo is a context image for his publishing legacy, not a portrait of him. [T2: VUAM]
+- **Source-object candidates:** NBUV / NIBU records for `Тарас Шевченко-Грушівський` volume 1 (1898), volume 2 (1901), and the 1991 edition are strong source-study visual leads. The underlying 1898 / 1901 editions are old, but scan terms and page quality still need review.
+- **NTSh source-object candidate:** Commons / NBUV-style scans of early `Записки НТШ` volumes may help show the institutional frame, especially if a file includes Konyskyi-related pages. Verify file identity before use.
+- **Hymn visual caution:** Do not use random modern lyric cards, church slides, or social-media graphics for `Молитва за Україну`. Prefer a rights-cleared early score, manuscript lead from the Lysenko archive, or a source-labeled institutional page after review.
+- **Avoid default:** AI colorizations, unsourced portraits, screenshots from YouTube / social media, or visuals that reduce him to only hymn text.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / encyclopedia / institutional baseline):**
+
+- Усенко І. Б. "Кониський Олександр Якович." *Енциклопедія історії України*, т. 5. Інститут історії України НАН України, 2008. https://www.history.org.ua/?termin=Koniskii_O. Accessed 2026-07-04.
+- Гаєвська Л. О. "Кониський Олександр Якович." *Енциклопедія Сучасної України*, НАН України / НТШ, 2014. https://esu.com.ua/article-4843. Accessed 2026-07-04.
+- Koshelivets, Ivan. "Konysky, Oleksander." *Internet Encyclopedia of Ukraine*, Canadian Institute of Ukrainian Studies. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CO%5CKonyskyOleksander.htm. Accessed 2026-07-04.
+- Лавров Ю. П. "Загальна українська безпартійна демократична організація (ЗУБДО)." *Енциклопедія історії України*, т. 3. https://history.org.ua/?termin=ZUBDO. Accessed 2026-07-04.
+- Купчинський О. А. "Наукове товариство ім. Шевченка." *Енциклопедія історії України*, т. 7. https://history.org.ua/?termin=naukove_lvovi. Accessed 2026-07-04.
+- Корнієвська О. В. "`Вік`." *Енциклопедія історії України*, т. 1. https://www.history.org.ua/?termin=Vik. Accessed 2026-07-04.
+- "Бібліотека наукового товариства імені Шевченка." *Енциклопедія Сучасної України*. https://esu.com.ua/article-39661. Accessed 2026-07-04.
+
+**Tier 2 (institutional / source-rich / source-access):**
+
+- UINP, "1836 - народився Олександр Кониський, письменник, видавець, педагог." https://uinp.gov.ua/istorychnyy-kalendar/serpen/18/1836-narodyvsya-oleksandr-konyskyy-pysmennyk-vydavec-pedagog. Accessed 2026-07-04.
+- National Historical Library of Ukraine, "Наукове товариство імені Т. Г. Шевченка." https://nibu.kyiv.ua/exhibitions/710/. Accessed 2026-07-04.
+- NBUV, "Кониський О. Я. Тарас Шевченко-Грушівський. Т. 1 (1898)." https://irbis-nbuv.gov.ua/ulib/item/ukr0000026598. Accessed 2026-07-04.
+- NBUV, "Кониський О. Я. Тарас Шевченко-Грушівський (1991)." https://irbis-nbuv.gov.ua/ulib/item/UKR0002105. Accessed 2026-07-04.
+- NIBU Omeka, "Тарас Шевченко-Грушівський, хроніка його життя. Том 2." https://omeka.nibu.kyiv.ua/s/nibu/item/1445. Accessed 2026-07-04.
+- VUAM, "`ВІК`." https://vuam.org.ua/uk/802:%D0%92%D0%86%D0%9A. Accessed 2026-07-04.
+
+**Tier 3 (legacy bibliography / phase-2 scholarship leads):**
+
+- Франко І. *Про житє і діяльність Олександра Кониського*. Львів, 1901. Listed in ESU / IEU bibliographies; not opened in this pass.
+- Доманицький В. "Библиографический указатель сочинений А. Я. Конисского, написанных по-малорусски." *Киевская старина*, 1901, no. 1. Listed in EIU / ESU / IEU bibliographies; not opened in this pass.
+- Авдикович О. *Огляд літературної діяльності Олександра Кониського*. Перемишль, 1908. Listed in EIU / ESU bibliographies; not opened in this pass.
+- Мисюра О. *Олександр Якович Кониський (1836-1900)*. Чернігів, 2008. Listed in ESU bibliography; not opened in this pass.
+- `Листи Олександра Кониського до Іллі Шрага`. Чернігів, 2011. Listed in ESU bibliography; not opened in this pass.
+
+**Tier 4 (learn-ukrainian cross-track sources checked 2026-07-04):**
+
+- `site/src/content/docs/bio/index.mdx`
+- `curriculum/l2-uk-en/curriculum.yaml`
+- `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md`
+- `docs/audits/bio-readiness-matrix-2026-06-29.md`
+- `docs/archive/RAG-LITERARY-CATALOG.md`
+- `docs/archive/RAG-LITERARY-CONTENTS.md`
+- `docs/research/bio/mykola-lysenko.md`
+- `docs/research/bio/taras-shevchenko.md`
+- `docs/research/bio/mykhailo-drahomanov.md`
+- `docs/research/bio/borys-hrinchenko.md`
+- `docs/research/bio/oleksandr-barvinskyi.md`
+- `docs/research/bio/pavlo-chubynskyi.md`
+- `curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml`
+- `curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml`
+- `curriculum/l2-uk-en/plans/bio/mykhailo-drahomanov.yaml`
+- `curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml`
+- `curriculum/l2-uk-en/plans/hist/hromady.yaml`
+- `curriculum/l2-uk-en/plans/hist/valuevskyi-emskyi.yaml`
+- `curriculum/l2-uk-en/plans/hist/drahomanov.yaml`
+- `curriculum/l2-uk-en/plans/istorio/valuevskyi-tsyrkuliar-tekst.yaml`
+- `curriculum/l2-uk-en/plans/istorio/emskyi-ukaz-tekst.yaml`
+- `curriculum/l2-uk-en/plans/lit/young-shevchenko.yaml`
+- `curriculum/l2-uk-en/plans/lit/cult-of-shevchenko.yaml`
+- `curriculum/l2-uk-en/plans/lit-essay/drahomanov-shevchenko.yaml`
+- `wiki/periods/hromady.md`
+- `wiki/periods/valuevskyi-emskyi.md`
+- `wiki/literature/works/young-shevchenko.md`
+- `wiki/literature/works/cult-of-shevchenko.md`
+- `wiki/literature/works/drahomanov-shevchenko.md`
+- `wiki/figures/mykola-lysenko.md`
+- `wiki/figures/taras-shevchenko.md`
+- `wiki/figures/mykhailo-drahomanov.md`
+- `wiki/figures/borys-hrinchenko.md`
+
+**Tier 5 (image-rights / media-rights sources):**
+
+- Wikimedia Commons, `Category:Oleksandr Konysky`. https://commons.wikimedia.org/wiki/Category:Oleksandr_Konysky. Accessed 2026-07-04.
+- Wikimedia Commons, `File:Олександр Кониський 2.jpg`. https://commons.wikimedia.org/wiki/File:%D0%9E%D0%BB%D0%B5%D0%BA%D1%81%D0%B0%D0%BD%D0%B4%D1%80_%D0%9A%D0%BE%D0%BD%D0%B8%D1%81%D1%8C%D0%BA%D0%B8%D0%B9_2.jpg. Accessed 2026-07-04.
+
+**Honest gaps:** No original police file, censor's decision file, Hromada correspondence, NTSh board minutes, `Вік` internal records, `Молитва за Україну` manuscript / first score, or full legal-article texts were opened in this pass. The dossier therefore uses encyclopedia / institutional summaries for core chronology and flags exact hymn-text, image-rights, and source-biography questions for Phase 2 verification. LLM-QG was not used.


### PR DESCRIPTION
## Summary

- Add the missing BIO research dossier for Oleksandr Konyskyi at `docs/research/bio/oleksandr-konyskyi.md`.
- Cover Hromada work, education and legal advocacy, publishing, NTSh / Shevchenko Society work, Shevchenko biography, exile and surveillance pressure, literary work, and `Молитва за Україну` source caveats.
- Keep the change scoped to one source file; no generated status/audit/review artifacts or telemetry files are included.

## Verification

- `npx markdownlint-cli2 docs/research/bio/oleksandr-konyskyi.md`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/oleksandr-konyskyi.md`
- `git diff --check origin/main...HEAD`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Confirmed changed file count is 1 and forbidden-path scan returned no matches.

LLM-QG was not used.