### PR TITLE
fix(deploy): preserve *-epic driver-handoff dirs (unbreak agents:deploy)

### DIFF
--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -40,11 +40,14 @@ fi
 # scheduled_tasks.lock is a runtime state file managed by Claude
 # Code's task scheduler — it must never be deleted by the deploy
 # script or in-flight scheduled tasks get orphaned.
-# folk-epic/ bio-epic/ — curriculum-track driver handoffs (CLAUDE-DRIVER-HANDOFF.md)
-#          live here as gitignored LOCAL state, NOT a source artifact (user policy
-#          2026-06-23: driver handoffs out of git/PRs, in .claude/). Runtime-only,
-#          machine-specific; declare so rsync --delete preserves them on every deploy.
-ORPHAN_PATHS_CLAUDE="scheduled_tasks.lock worktrees folk-epic bio-epic"
+# *-epic/ — curriculum-track driver handoffs (CLAUDE-DRIVER-HANDOFF.md), e.g.
+#          folk-epic/ bio-epic/ atlas-epic/. Live here as gitignored LOCAL state,
+#          NOT a source artifact (user policy 2026-06-23: driver handoffs out of
+#          git/PRs, in .claude/). Runtime-only, machine-specific. Declared as a
+#          GLOB so rsync --delete preserves them AND future epics don't re-break
+#          deploy (the enumerated form silently orphaned atlas-epic — a new epic
+#          the allowlist hadn't been told about — aborting every deploy).
+ORPHAN_PATHS_CLAUDE="scheduled_tasks.lock worktrees *-epic"
 # wake/  — scheduled-task state written by the Claude Code wake scheduler.
 # cache/ — Monitor API client disk cache (see scripts/ai_agent_bridge/_monitor_cache.py),
 #          stores rules.body/session.body + ETag metadata so cold-start is ~780 B instead of 75 KB.

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -189,6 +189,33 @@ def test_agent_transient_briefs_are_preserved(tmp_path: Path) -> None:
     assert dispatch.exists(), "dispatch-3098-slice3.md was wiped by rsync --delete"
 
 
+def test_claude_epic_dirs_are_preserved(tmp_path: Path) -> None:
+    """Curriculum-track *-epic/ driver-handoff dirs in .claude/ must survive deploy.
+
+    Regression: the ORPHAN_PATHS_CLAUDE allowlist enumerated only ``folk-epic``
+    and ``bio-epic``, so when the atlas track created ``.claude/atlas-epic/`` the
+    preflight guard flagged it as an undeclared orphan and aborted EVERY deploy —
+    blocking all agent-def / rule / skill propagation until manually unbroken.
+    The allowlist is now a ``*-epic`` GLOB, so any current OR FUTURE epic dir is
+    preserved. This test uses a brand-new epic name (``hist-epic``) the allowlist
+    was never explicitly told about, to prove the glob generalizes.
+    """
+    repo = _init_checkout(tmp_path)
+    for epic in ("atlas-epic", "hist-epic"):
+        handoff = repo / ".claude" / epic / "CLAUDE-DRIVER-HANDOFF.md"
+        handoff.parent.mkdir(parents=True, exist_ok=True)
+        handoff.write_text(f"{epic} driver handoff — runtime state\n", encoding="utf-8")
+
+    deploy_result = _run(repo, DEPLOY_SCRIPT)
+    assert deploy_result.returncode == 0, (
+        "deploy aborted with a *-epic driver-handoff dir present:\n"
+        f"stdout: {deploy_result.stdout}\nstderr: {deploy_result.stderr}"
+    )
+    for epic in ("atlas-epic", "hist-epic"):
+        handoff = repo / ".claude" / epic / "CLAUDE-DRIVER-HANDOFF.md"
+        assert handoff.exists(), f".claude/{epic}/ was wiped by rsync --delete"
+
+
 def test_drift_is_caught(tmp_path: Path) -> None:
     """Post-deploy edits to a target tree must be reported as drift."""
     repo = _init_checkout(tmp_path)


### PR DESCRIPTION
## Problem

`npm run agents:deploy` aborts on **every** run in the current tree:

```
⚠️  agents_extensions/shared → .claude: undeclared orphan 'atlas-epic' in destination
❌ Deploy aborted: undeclared orphan paths would be deleted.
```

The atlas track created `.claude/atlas-epic/CLAUDE-DRIVER-HANDOFF.md` — runtime driver-handoff state, exactly like `folk-epic/` and `bio-epic/`. But `ORPHAN_PATHS_CLAUDE` **enumerated** only `folk-epic bio-epic`, so the orphan-path guard flagged `atlas-epic` as an undeclared orphan that `rsync --delete` would wipe, and refused to deploy. This blocked **all** agent-def / rule / skill propagation to the runtime targets (`.claude/.codex/.agent/.gemini`) until manually unbroken — surfaced while deploying the merged `ask-gemma` `model-assignment.md` change (#4348).

## Root cause & fix

The enumerated allowlist re-breaks deploy every time a new epic track spins up (whack-a-mole). Fix generalizes the two literals to a **`*-epic` glob**, consistent with the script's other glob entries (`*-brief.md`, `dispatch-*.md`). Current and future epic-handoff dirs are preserved without further edits.

- `scripts/deploy_prompts.sh` — `ORPHAN_PATHS_CLAUDE` `folk-epic bio-epic` → `*-epic` (+ comment)
- `tests/test_deploy_script_idempotency.py` — new `test_claude_epic_dirs_are_preserved`: asserts deploy does **not** abort and preserves `.claude/<epic>/`, using a **brand-new** epic name (`hist-epic`) the allowlist was never told about — proving the glob generalizes.

## Verification (tool-backed)

- New test **FAILS on the enumerated form** (`assert 1 == 0`, deploy aborts) and **PASSES on the `*-epic` glob** — confirmed by stashing the script change. Load-bearing, not vacuous.
- `pytest tests/test_deploy_script_idempotency.py` — **7 passed**
- `ruff` clean · `bash -n` clean

## Note

Separately cleaned 4 stale `rules/headroom.md` orphan copies from the local deploy targets — dead artifacts of the retired Headroom MCP (#4338); target-only, gitignored, **not** part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)