### PR TITLE
docs(bio): add Mykola Lukash dossier

### DIFF
--- a/docs/research/bio/mykola-lukash.md
+++ b/docs/research/bio/mykola-lukash.md
@@ -1,0 +1,185 @@
+# Микола Олексійович Лукаш — Research Dossier
+
+**Slug:** `mykola-lukash`
+**Block:** +77 expansion — Social Resistance, State-Building, Language Infrastructure
+**Tier:** 1a
+**Issue:** BIO manifest dossier gap (`mykola-lukash`)
+**Researcher:** Codex GPT-5
+**Completed:** 2026-07-05
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] >=3 Tier 1/Tier 2 sources cited (ЕСУ, Internet Encyclopedia of Ukraine, KHPG, Ukrainian PEN, 1973 protocol publication)
+- [x] Oppression mechanism is specific: 23 March 1973 letter, 24 April / 23 May / 12 June 1973 Writers' Union proceedings, publication ban/ostracism, 1979 partial return to print, 1987 reinstatement
+- [x] Primary documentary voice quoted from Lukash's letter and recorded Writers' Union statements, without fabricated translation lines
+- [x] Cross-track links: every "Existing" path verified with `test -e` on 2026-07-05
+- [x] Naming-canonical applied
+- [x] Image candidates identified with rights caution
+- [x] Decolonization checklist self-applied
+- [x] LLM-QG was not run, trusted, routed, persisted, or closed
+
+> **Load-bearing frame:** Lukash should be taught as a translator and lexicographic mind whose work expanded the expressive range of Ukrainian under Russification pressure. His 1973 defense of Ivan Dziuba matters because it made the cultural politics of translation visible, not because it should flatten the whole biography into a martyr anecdote.
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Микола Олексійович Лукаш. [T1: ЕСУ; T1: Internet Encyclopedia of Ukraine; T2: KHPG]
+- **Pseudonyms / aliases:** no stable pen-name found in the core sources. Track bibliographic forms: Лукаш Микола Олексійович; Mykola Lukash; Mykola Oleksiiovych Lukash; Lukaš in older scholarly transliteration. Quarantine Russified forms in §8 only.
+- **Born:** 19 December 1919 | Кролевець, then Chernihiv gubernia / early Soviet-Ukrainian revolutionary borderland; now Сумська область, Україна. ЕСУ gives "м. Кролевець, нині Сум. обл."; IEU gives Krolevets, Chernihiv gubernia. [T1: ЕСУ; T1: IEU]
+- **Died:** 29 August 1988 | Київ, Ukrainian SSR. ЕСУ, IEU, and KHPG agree on date and place. [T1: ЕСУ; T1: IEU; T2: KHPG]
+- **Family / education key facts:** KHPG says he was born into a teachers' family and absorbed languages easily from childhood. He studied at Kyiv State University before the Second World War interrupted his education; ЕСУ gives Kyiv University study in 1937-1941 and graduation from Kharkiv Pedagogical Institute of Foreign Languages in 1947. [T1: ЕСУ; T2: KHPG]
+- **Professional path:** participant in the Second World War; teacher of English, German, and French in Kharkiv higher education institutions in 1947-1953; head of the poetry department at `Всесвіт` in 1958-1960; member of the Writers' Union of Ukraine from 1956 until expulsion in 1973 and again from 1987. [T1: ЕСУ; T2: KHPG]
+- **Recognition:** Maksym Rylskyi literary prize in 1988; Mykola Zerov prize in 1993; `Всесвіт` founded a Mykola Lukash translation prize in 1989. [T1: ЕСУ; T1: IEU]
+
+**Source disagreement note:** KHPG's Ukrainian profile says Lukash was restored to the Writers' Union on the wave of perestroika in 1988, while ЕСУ, the English KHPG profile, and the Ukrainian PEN archival essay place the formal restoration in 1987. Use **1987** for the formal restoration and **1988** for the Rylskyi prize/death chronology unless a union document supersedes this.
+
+## 2. Oppression mechanism
+
+- **What happened:** Soviet administrative and cultural repression: expulsion from the Writers' Union, dismissal from literary institutions, publication blockage, police surveillance / effective house arrest, threat of punitive psychiatric treatment, and long-term professional isolation.
+- **When:** 23 March 1973 letter to the chair of the Presidium of the Supreme Soviet of the Ukrainian SSR, the chair of the Supreme Court of the Ukrainian SSR, and the prosecutor of the Ukrainian SSR; 24 April 1973 Kyiv Writers' Union leadership discussion; 23 May 1973 Kyiv organization vote; 12 June 1973 Presidium of the Writers' Union of Ukraine confirmation of expulsion; partial return of signed publications in 1979; formal restoration in May 1987. [T2: Ukrainian PEN; Primary: Writers' Union protocols via Dnipro/Sumskyi Istorychnyi; T2: KHPG]
+- **By whom:** formally by the Writers' Union of Ukraine / Writers' Union of the USSR structures, acting inside the Soviet party-state censorship and security-pressure system. No separate criminal case against Lukash was found in this pass; the mechanism was administrative, censorial, and police-backed rather than a court sentence.
+- **Document references:** Lukash's 23 March 1973 letter is identified by Ukrainian PEN as case no. 457 in the Mykola Lukash archive at the National Museum of Literature of Ukraine. The Writers' Union protocols were printed by Vitalii Koval in `Дніпро`, 1991, nos. 11-12, pp. 198-201, and reproduced by Sumskyi Istorychnyi. [T2: Ukrainian PEN; Primary: Dnipro/Sumskyi Istorychnyi]
+- **Mechanism specifics:** Lukash wrote after Ivan Dziuba's 12-16 March 1973 trial and sentence, asking the Soviet authorities to let him serve Dziuba's punishment. PEN notes the letter was sent on 23 March 1973 and was grounded in Lukash's agreement with Dziuba's position, Dziuba's health, and Lukash's own refusal to treat Soviet "freedom" as materially different from imprisonment. The 23 May and 12 June protocols show that the union leadership demanded withdrawal or repentance and that Lukash would not retract the letter. The Presidium confirmed expulsion unanimously on 12 June 1973.
+- **What survived / what was damaged:** survived: the landmark translations, his reputation among translators, the moral witness of the Dziuba letter, and later posthumous volumes. Damaged or destroyed: publication access for most of the 1970s, income, health, and the lexicographic archive. ЕСУ states that after his death the materials he had gathered for phraseological, synonymic, surname, and euphemism dictionaries were destroyed. [T1: ЕСУ]
+
+This was not a case of physical imprisonment of Lukash. The exact dossier frame is professional destruction and civic punishment for defending a Ukrainian anti-Russification intellectual. The repression belongs to the late-Soviet attack on Ukrainian cultural autonomy: translation, vocabulary, and stylistic range were treated as politically dangerous when they made Ukrainian function as a full European literary language.
+
+## 3. Major works
+
+- `1955` — Johann Wolfgang von Goethe, **`Фауст`**, Ukrainian translation; republished in 1969, 1981, and 2001. ЕСУ and IEU treat it as one of his central achievements.
+- `1955; 1961; 1987; 2002` — Gustave Flaubert, **`Пані Боварі`**, Ukrainian translation.
+- `1959; 1965` — Robert Burns, **poetry**, Ukrainian translations with Vasyl Mysyk.
+- `1962` — Lope de Vega, **`Овеча криниця. Собака на сіні`**, Ukrainian translations of plays.
+- `1964; 1969; 1985; 2000; 2003` — Giovanni Boccaccio, **`Декамерон`**, Ukrainian translation; IEU's translated-literature survey calls its 1964 appearance a cultural landmark under Russification pressure.
+- `1967` — Imre Madach, **`Трагедія людини`**, Ukrainian translation.
+- `1968` — Paul Verlaine, **lyric poetry**, translations with Maksym Rylskyi and Hryhorii Kochur.
+- `1969` — Federico Garcia Lorca, **`Лірика`**, Ukrainian translations.
+- `1984` — Guillaume Apollinaire, **`Поезії`**, Ukrainian translations; delayed after the 1970s repression wave.
+- `1990` — **`Від Бокаччо до Аполлінера: Переклади`**, posthumous selected volume.
+- `1995` — Miguel de Cervantes, **`Премудрий ідальго Дон Кіхот з Ламанчі`**, Ukrainian translation completed after Lukash's death by Anatolii Perepadia.
+- `2003` — **`Шпигачки`**, original epigrams/poems; posthumous.
+
+## 4. Primary-source quotes / documentary voice
+
+**Quote 1 — the 23 March 1973 letter in defense of Ivan Dziuba**
+
+> **"Прошу ласкаво дозволити мені відбути ... визначене йому судом покарання."**
+
+Source: Lukash's letter to the Soviet Ukrainian state institutions, 23 March 1973, cited by Ukrainian PEN from archival case no. 457, National Museum of Literature of Ukraine. Pedagogically this quote shows why the authorities understood the letter as public defiance: the official politeness makes the moral refusal sharper, not softer.
+
+**Quote 2 — Writers' Union proceedings, May 1973**
+
+> **"Не відмовляюся."**
+
+Source: protocol of the Kyiv Writers' Union organization meeting, 23 May 1973, printed in `Дніпро` and reproduced by Sumskyi Istorychnyi. The one-word answer is useful for learners because it documents agency under pressure without turning Lukash into a slogan.
+
+**Quote 3 — Writers' Union Presidium, 12 June 1973**
+
+> **"не бачу в ній нічого націоналістичного."**
+
+Source: Lukash's recorded response about Dziuba's `Інтернаціоналізм чи русифікація?` in the 12 June 1973 Presidium protocol. This is a primary-document anchor for decolonization framing: the Soviet institution wanted the text treated as "nationalist"; Lukash refused that category.
+
+**Translation-sample caution:** this pass does not quote Lukash's `Фауст`, `Декамерон`, `Дон Жуан`, or other translations as classroom-ready samples. Future writers should verify exact edition lines and rights before using them in a learner-facing BIO or LIT module.
+
+## 5. Language register
+
+- **Register:** highly inventive literary translation, broad lexical range, and lexicographic-publicistic precision. Lukash is associated with reviving older Ukrainian words, creating neologisms, and moving between high literary, folk, comic, erotic, philosophical, and colloquial registers.
+- **CEFR readiness for full reading:** **C1-C2** for translation theory, close comparison, `Фауст`, `Декамерон`, `Дон Кіхот`, and Apollinaire/Lorca samples; **B2-C1** for carefully selected biographical documents and short letter/protocol excerpts.
+- **Lexicon notes:** learners need support for перекладознавство, адекватність, стильова домінанта, оказіоналізм, фразеологізм, архаїзм, діалектизм, русифікація, цензура, відлучення від професії.
+- **Stylistic features:** register-shifting, archaism, dialect and colloquial layers, playful phraseology, neologistic compounding, and dense allusive texture. IEU emphasizes his restoration of 17th- and 18th-century words and introduction of neologisms into contemporary Ukrainian literary language. [T1: IEU — Lukash, Mykola]
+
+The curriculum risk is to present "Lukashisms" as decorative eccentricity. A stronger frame is linguistic sovereignty: Lukash's translations argued in practice that Ukrainian could carry Goethe's metaphysics, Boccaccio's social registers, Cervantes's irony, Verlaine's music, and opera's theatrical compression without passing through Russian.
+
+## 6. Contested points
+
+- **Creative genius vs translator visibility:** Ukrainian memory often celebrates Lukash as "Mozart" of translation. That shorthand is useful only if paired with scrutiny of his method: creative expansion, archaism, dialect, and neologism could make the translation a new Ukrainian literary event, but future lessons should also let learners see why some critics worried about over-domestication or translator excess.
+- **Translation as resistance vs craft-first philology:** the decolonial frame is justified by IEU's translated-literature survey, which connects the `Декамерон` translation to language development under Russification and notes the 1970s attack on dialectal words as politically suspicious. Still, a module should not reduce every lexical choice to conscious dissidence. Lukash was also a craftsman solving genre, rhythm, and semantic problems.
+- **The Dziuba letter's consequences:** KHPG and Ukrainian PEN agree that the 1973 letter triggered expulsion and long professional isolation. PEN also records the later debate among friends over whether the letter "broke" his career or merely exposed a conflict already latent in the regime's hostility to principled Ukrainian intellectuals. Teach this as documented moral action with practical cost, not as a simple success/failure calculation.
+- **Administrative repression without court case:** because Lukash was not sentenced himself, vague phrases such as "Soviets imprisoned Lukash" would be false. The precise mechanism was administrative/cultural punishment backed by surveillance, censorship, and threats. That precision matters.
+- **Soviet/Russian framing:** labels such as "anti-Soviet," "nationalist," or "violating the statute" appear in the 1973 protocols as institutional charges. They should be quoted only as Soviet categories and rejected as neutral descriptions.
+- **Other-perspective considerations:** his translation corpus crosses Italian, German, French, Spanish, Polish, Hungarian, Scottish/English, and opera traditions. Any future comparison with Jewish/Yiddish, Polish, or Romani linguistic milieus in Krolevets needs independent source work; do not build it from anecdote alone.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-07-05. Candidate links are not asserted as files.
+
+- **Existing BIO plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/bio/ivan-dziuba.yaml` — the 1973 letter, `Інтернаціоналізм чи русифікація?`, and late-Soviet repression context.
+  - `curriculum/l2-uk-en/plans/bio/maksym-rylskyi.yaml` — translation-school inheritance, Rylskyi prize context, and older survived/censored generation.
+  - `curriculum/l2-uk-en/plans/bio/mykola-zerov.yaml` — the murdered neoclassical translation/philology line that later translators helped restore.
+  - `curriculum/l2-uk-en/plans/bio/ivan-svitlychnyi.yaml`, `curriculum/l2-uk-en/plans/bio/yevhen-sverstiuk.yaml`, `curriculum/l2-uk-en/plans/bio/vasyl-stus.yaml` — the dissident and literary-intellectual network around Dziuba, language, and cultural rights.
+- **Existing C2/LIT plans (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit/lukash-translation-as-resistance.yaml` — direct LIT seminar on Lukash's translation as cultural resistance.
+  - `curriculum/l2-uk-en/plans/lit/translation-as-cultural-weapon.yaml` — broader translation/decolonization frame that should use Lukash with nuance.
+  - `curriculum/l2-uk-en/plans/lit/rylsky-translations.yaml` — translation-school continuity and contrast.
+  - `curriculum/l2-uk-en/plans/c2/translation-theory.yaml`, `curriculum/l2-uk-en/plans/c2/translation-theory-ii.yaml`, `curriculum/l2-uk-en/plans/c2/literary-translation-ii.yaml`, `curriculum/l2-uk-en/plans/c2/translation-practice-ii.yaml` — upper-level translation theory/practice contexts already naming Lukash.
+- **Existing wiki/literature page (VERIFIED present):**
+  - `wiki/literature/works/lukash-translation-as-resistance.md` — existing literature work page; useful as a local surface to reconcile later, not a BIO dossier substitute.
+- **Candidate cross-track connections (Phase 2+, NOT existing files):**
+  - BIO plan `mykola-lukash` and wiki figure packet `wiki/figures/mykola-lukash.md`.
+  - BIO plan/wiki packet for `hryhorii-kochur`, currently dossier-only in this worktree; do not cite a nonexistent BIO plan as existing.
+  - A short source packet comparing the 23 March 1973 letter with the Writers' Union protocols and Dziuba's later account.
+  - A rights-cleared LIT close-reading set using exact edition lines from `Фауст`, `Декамерон`, or `Дон Жуан`.
+- **Potential LIT additions surfaced by this research:**
+  - A compact C2 phraseology lab on `Фразеологія перекладів Миколи Лукаша` after dictionary rights and excerpt limits are checked.
+
+## 8. Naming-canonical
+
+- **Slug:** `mykola-lukash`
+- **EN canonical (BGN/PCGN 2010):** Mykola Oleksiiovych Lukash; short public form Mykola Lukash.
+- **UA canonical (with patronymic):** Микола Олексійович Лукаш
+- **Aliases to track (`aliases:` YAML field):** Лукаш Микола Олексійович; Mykola Lukash; Mykola Oleksiyovych Lukash (older/less strict English variant); Lukaš (scholarly transliteration in IEU metadata).
+- **Forbidden Russian-imperial / Russified forms (flag in body text):** Nikolai Alekseevich Lukash; Nikolay Alekseyevich Lukash; Николай Алексеевич Лукаш. Do not use Russian-language metadata to overwrite the Ukrainian given name or patronymic.
+
+## 9. Image candidates
+
+- **Best portrait candidate:** Ukrainian PEN reproduces a 1967 portrait by V. Rudenko and identifies it as case no. 841 in the Mykola Lukash archive, National Museum of Literature of Ukraine. Rights are **not verified**; treat as a research lead, not a ready asset.
+- **Best immediately rights-clear context image:** Wikimedia Commons `File:Микола Лукаш аверс.jpg`, a 2019 National Bank of Ukraine commemorative coin image, license `PD-UA-exempt`. It is a contextual commemorative image, not a documentary portrait.
+- **Backup context candidates:** Wikimedia Commons `Category:Mykola Lukash` has CC/PD context files: memorial plaque, Krolevets school images, and coin reverse. `File:Кролевець Школа № 5 (1).jpg` is CC BY-SA 4.0 and documents the school building associated with Lukash.
+- **Book/object candidate:** Wikimedia Commons `File:Phraseological Dictionary by Lukash.gif`, marked public domain for simple text/cover information; useful only if a book-object fallback is acceptable.
+- **If no PD/CC portrait exists:** ship a text-first BIO/wiki page or use a verified Commons context image. Do not use unverified museum, media, or social-media portraits.
+
+## 10. Sources used
+
+**Tier 1 (authoritative):**
+- Р. П. Зорівчак, В. Р. Савчин. "Лукаш Микола Олексійович." `Енциклопедія Сучасної України`, 2017. https://esu.com.ua/article-59113. DOI: 10.5281/zenodo.19824012. Accessed 2026-07-05.
+- `Internet Encyclopedia of Ukraine`. "Lukash, Mykola." Original print source: `Encyclopedia of Ukraine`, vol. 3, 1993. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CL%5CU%5CLukashMykola.htm. Accessed 2026-07-05.
+- `Internet Encyclopedia of Ukraine`. "Translated literature." Used for the translation-history and 1970s Russification/censorship context. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CT%5CR%5CTranslatedliterature.htm. Accessed 2026-07-05.
+
+**Tier 2 (institutional / human-rights / archival-adjacent):**
+- Михайлина Коцюбинська, Ірина Рапп. "Лукаш Микола Олексійович." `Дисидентський рух в Україні`, Kharkiv Human Rights Protection Group, 2005/2016. https://museum.khpg.org/1113915428. Accessed 2026-07-05.
+- "LUKASH, Mykola Oleksiyovych." `Dissident movement in Ukraine`, Kharkiv Human Rights Protection Group. https://museum.khpg.org/en/1142681873. Accessed 2026-07-05.
+- Ольга Лучук. "Моральний чин Миколи Лукаша." Ukrainian PEN, 19 December 2019. https://pen.org.ua/moralnyj-chyn-mykoly-lukasha. Accessed 2026-07-05.
+
+**Tier 3 (local curriculum/source-surface navigation):**
+- `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md` and `docs/audits/bio-readiness-matrix-2026-06-29.md`, used for roster group and readiness status.
+- `curriculum/l2-uk-en/plans/lit/lukash-translation-as-resistance.yaml`, used only as local curriculum surface context, not as biographical authority.
+
+**Tier 4 (specialist source leads not fully accessed in this pass):**
+- Валентина Савчин. `Микола Лукаш — Моцарт українського перекладу`. Вінниця, 2009. Cited as a source lead from local plan metadata and ЕСУ bibliography; retrieve directly before close-reading claims.
+- Валентина Савчин. `Микола Лукаш — подвижник українського художнього перекладу`. Львів, 2014. Cited by IEU/ЕСУ bibliography; retrieve directly before deeper interpretation.
+
+**Tier 5 / image-rights and bibliography leads:**
+- Wikimedia Commons. `Category:Mykola Lukash`, `File:Микола Лукаш аверс.jpg`, `File:Кролевець Школа № 5 (1).jpg`, `File:Phraseological Dictionary by Lukash.gif`. Accessed 2026-07-05.
+- Бердянський державний педагогічний університет бібліотека. "Високий шлях Миколи Лукаша", 16 December 2019. Used as a bibliography lead, not as authority over core facts. https://library.bdpu.org.ua/tematychni-vystavky/vysokyy-shlyakh-mykoly-lukasha/. Accessed 2026-07-05.
+
+**Primary-source documents accessed:**
+- Mykola Lukash letter of 23 March 1973, archival case no. 457, National Museum of Literature of Ukraine, quoted via Ukrainian PEN.
+- "Із протоколів засідання Спілки письменників України про виключення перекладача Миколи Лукаша зі складу організації за підтримку дисидента Івана Дзюби [1973]." Printed source: Vitalii Koval, `Дніпро`, 1991, nos. 11-12, pp. 198-201; online reproduction by Sumskyi Istorychnyi. https://history.sumy.ua/sources/writing/z-protokoliv-zasidannia-spilky-pysmennykiv-ukrainy-pro-vykliuchennia-perekladacha-mykoly-lukasha-zi-skladu-orhanizatsii-za-pidtrymku-dysydenta-ivana-dziuby-1973/. Accessed 2026-07-05.
+
+**Honest gaps:** exact internal party/KGB instruction chain not located; no criminal case number because no criminal case against Lukash was found; no edition-verified translation excerpts approved for learner-facing use; no rights-cleared documentary portrait selected.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing: Lukash is named as a Ukrainian translator/linguist; Soviet institutions are named as mechanisms of repression.
+- [x] No Russian-imperial transliterations in body text except the forbidden list in §8.
+- [x] No Russocentric periodization; late-Soviet repression is tied to Russification and censorship without legitimizing Soviet categories.
+- [x] No uncritical Soviet propaganda terms: "anti-Soviet" and "nationalist" appear only as institutional charges.
+- [x] No false imprisonment claim: Lukash's repression is administrative/cultural, not a court sentence against him.
+- [x] Modern Ukrainian place names used where appropriate: Kyiv, Krolevets.
+- [x] Cross-track links assert only existing files unless explicitly marked candidate/nonexistent.
+- [x] No fabricated source paths, quotes, translation samples, or archival case IDs.
+- [x] LLM-QG was not run, trusted, routed, persisted, or closed.


### PR DESCRIPTION
## Summary

Adds the missing BIO manifest dossier for Mykola Lukash.

Changed file:
- `docs/research/bio/mykola-lukash.md`

## Checks run

- `git diff --name-only origin/main...HEAD` -> only `docs/research/bio/mykola-lukash.md`
- `git diff --check origin/main...HEAD`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/mykola-lukash.md`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Notes

- LLM-QG was not used, trusted, routed, persisted, or closed.
- No status/audit/review artifacts or telemetry files are included.
- No linter configs or `.python-version` changes are included.