### PR TITLE
docs(bio): add Yurii Lutskyi dossier

### DIFF
--- a/docs/research/bio/yurii-lutskyi.md
+++ b/docs/research/bio/yurii-lutskyi.md
@@ -1,0 +1,185 @@
+# Юрій Остапович Луцький — Research Dossier
+
+**Slug:** `yurii-lutskyi`
+**Block:** +77 expansion — Social Resistance, State-Building, Language Infrastructure / diaspora literary scholarship
+**Tier:** 2
+**Issue:** BIO manifest dossier backfill; roster slot 343
+**Researcher:** Codex (`codex/bio-yurii-lutskyi-dossier`)
+**Completed:** 2026-07-05
+
+**Source acronym legend:** ESU = Encyclopedia of Modern Ukraine; IEU = Internet Encyclopedia of Ukraine; UTARMS = University of Toronto Archives and Records Management Services; UVAN = Ukrainian Academy of Arts and Sciences in the U.S.; CFUS = Canadian Foundation for Ukrainian Studies; NBUV = National Library of Ukraine catalogue / Ukrainica; JI = `Ї` magazine Antonovych Prize lecture page.
+
+**Acceptance self-check:**
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional or scholarly sources cited
+- [x] Pressure mechanism framed as Soviet occupation, family destruction by the NKVD, exile/non-return, and Soviet literary censorship; no invented arrest or camp sentence for Yurii Lutskyi himself
+- [x] Primary-source anchors supplied from Lutskyi's own lecture / writing, with source-language cautions
+- [x] Cross-track links checked with `test -e` on 2026-07-05 where marked existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights caveats included
+- [x] Decolonization checklist self-applied
+- [x] LLM-QG was not used
+
+---
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Юрій Остапович Луцький. ESU uses this patronymic form. IEU gives the fuller birth-name form `Луцький, Юрій Степан Нестор` and the English headword `Luckyj, George Stephen Nestor`; keep both in aliases. [T1: ESU; T1: IEU]
+- **Project English canonical:** Yurii Lutskyi. Use the project transliteration for BIO slug/display; preserve `George S. N. Luckyj` in source titles, English bibliography, and archival references.
+- **Pseudonyms / aliases:** George Stephen Nestor Luckyj; George S. N. Luckyj; George Luckyj; Юрій Степан Нестор Луцький; Юрій Луцький; Ю. О. Луцький; source spellings `Yuriy Lutsky`, `Yurij Luc'kyj`, and `Lutsky` for catalogue search. [T1: IEU; T2: UTARMS; T2: NBUV]
+- **Born:** 11 June 1919 | Янчин, Перемишлянський повіт, Галичина, now Іванівка, Львівська область, Ukraine. [T1: ESU; T1: IEU]
+- **Died:** Toronto, Canada, November 2001. Source disagreement: ESU gives **29 November 2001**; IEU gives **22 November 2001**. Do not silently normalize the day until a death notice or archive record is checked. [T1: ESU; T1: IEU]
+- **Family:** son of Ostap Lutskyi (poet, cooperative and political figure, victim of Soviet repression) and Irena Smal-Stotska; grandson of Stepan Smal-Stotsky; nephew of Roman Smal-Stotsky. [T1: IEU; T1: ESU — Ostap Lutskyi]
+- **Education:** Academic Gymnasium of Lviv, graduated 1937; University of Berlin, 1937-1939; University of Birmingham, BA 1942 and MA 1943; Columbia University, PhD 1953. [T1: ESU; T1: IEU]
+- **Career:** University of Saskatchewan, 1947-1949; University of Toronto, 1952-1984, including chair of Slavic Languages and Literatures, 1957-1961; associate director of CIUS Toronto office, 1976-1982; first editor of `Canadian Slavonic Papers`, 1956-1961; English-language editor for the `Encyclopedia of Ukraine` project until 1982. [T1: ESU; T1: IEU; T2: UTARMS]
+- **Core BIO identity:** diaspora literary scholar, translator, editor, institution-builder, and public mediator who made Ukrainian literature legible to English-language readers without folding it into Russian/Soviet studies. [T1: IEU; T4: Odrekhivska 2024]
+
+## 2. Oppression / pressure mechanism
+
+- **Not a direct prison-case biography:** Do not invent an arrest, camp sentence, KGB case, or Soviet trial for Yurii Lutskyi. The mechanism is forced non-return after the Soviet occupation of Western Ukraine, family destruction by the NKVD, and the long academic struggle against Soviet censorship and Russocentric knowledge structures.
+- **1937-1939 rupture:** Lutskyi left Lviv in 1937 for Berlin and, on his father's advice, left Berlin before the Second World War for summer study at Cambridge; he remained in Britain. IEU frames this decision as the turning point that kept him outside Soviet-occupied Western Ukraine. [T1: IEU]
+- **Family repression:** ESU states that with the establishment of Soviet power in Western Ukraine, Ostap Lutskyi was arrested by the NKVD on **2 October 1939** and died in imprisonment on **8 October 1941** near Kotlas, Arkhangelsk region, Russian Federation. This is the concrete Soviet violence that made Yurii's exile a family history, not an abstract diaspora label. [T1: ESU — Ostap Lutskyi]
+- **Intellectual pressure:** Lutskyi's dissertation became *Literary Politics in the Soviet Ukraine, 1917-1934* (1956; revised 1990; Ukrainian translation 2000), a study of the political destruction of 1920s-1930s Ukrainian literary life. In his Antonovych lecture he remembered learning from witnesses of that destruction around UVAN in New York and said he had learned "строгої об'єктивності в науці" in Western universities. [Primary: JI Antonovych lecture; T1: IEU]
+- **By whom / structures:** NKVD acted directly against his father; the Soviet party-state and literary bureaucracy controlled the corpus that Lutskyi studied; Soviet and Russocentric academic habits treated Ukrainian literature as provincial or subordinate. Use "Soviet literary politics", "party censorship", and "Russocentric Slavic studies" precisely. Do not write "Russia arrested Yurii Lutskyi" or imply a direct KGB file without evidence.
+- **Document references:** no Yurii Lutskyi Soviet case-file citation was located, because no direct arrest is claimed. For Ostap Lutskyi, this pass located the ESU arrest/death statement but not a stable NKVD archival signature. Future source work should check ГДА СБУ / family correspondence and the UTARMS fonds for any copied case documents.
+- **What survived:** UTARMS preserves Luckyj personal/family records, correspondence, manuscripts, publication files, photographs, and materials on the University of Toronto Ukrainian Studies chair and Encyclopedia of Ukraine project. His scholarship also survived as books, translations, bibliographies, journals, and anthologies that could circulate outside Soviet censorship. [T2: UTARMS; T1: IEU]
+
+## 3. Major works / contributions
+
+- `1949` — *A Modern Ukrainian Grammar* (with Jaroslav Rudnyckyj), teaching Ukrainian in Canadian academic context. [T1: IEU]
+- `1956 / 1990 / 2000` — *Literary Politics in the Soviet Ukraine, 1917-1934*, Columbia dissertation turned monograph; revised Duke edition; Ukrainian translation as *Літературна політика в радянській Україні 1917-1934*. [T1: IEU; T2: Diasporiana scan; T2: NBUV]
+- `1960` — *Stories from the Ukraine* by Mykola Khvylovy, translated/introduced for English readers; a key act of recovering 1920s Ukrainian modernism. [T1: IEU; T4: Odrekhivska 2024]
+- `1961` — editor, *Taras Shevchenko. Poems*, a short multilingual anthology. [T1: ESU]
+- `1963 / 1967 / 1977` — VAPLITE source and document projects, including *Vaplitianskyi zbirnyk*, returning the 1920s modernist archive to readers. [T1: ESU; T1: IEU]
+- `1971 / 1998` — *Between Gogol' and Sevčenko: Polarity in the Literary Ukraine, 1798-1847*; Ukrainian translation *Між Гоголем і Шевченком*. [T1: ESU; T2: NBUV; T2: Diasporiana]
+- `1972-1981` — major English translations/editions of Pidmohylnyi, Kulish, Kulish's *Sonata Pathétique*, Sverstiuk's *Clandestine Essays*, and Kotsiubynskyi's *Shadows of Forgotten Ancestors*. [T1: IEU]
+- `1980` — *Shevchenko and the Critics*, still a major English-language critical collection on Shevchenko. [T1: IEU; T2: Roman Senkus in UVAN Annals]
+- `1987` — *Keeping a Record: Literary Purges in Soviet Ukraine (1930s): A Bio-Bibliography* and privately circulated memoir *Whistling in the Dark*. [T1: IEU]
+- `1989` — editor, *Самі про себе: автобіографії видатних українців XIX-го століття*. [T1: IEU; T2: NBUV]
+- `1991-1992` — *Young Ukraine: The Brotherhood of Saints Cyril and Methodius, 1845-1847* and *Ukrainian Literature in the Twentieth Century: A Reader's Guide*. [T1: IEU]
+- `1996` — *Towards an Intellectual History of Ukraine: An Anthology of Ukrainian Thought from 1710 to 1995* (with Ralph Lindheim) and *Shevchenko's Unforgotten Journey*. [T1: IEU; T4: Odrekhivska 2024]
+- `1997 / 2002 UA` — *The Anguish of Mykola Hohol, a.k.a. Nikolai Gogol*; Ukrainian publication as *Страдництво Миколи Гоголя, знаного також як Ніколай Гоголь*. [T1: IEU; T2: NBUV]
+- `1999-2004` — memoir and diary publications: *На перехресті* (1999), *На сторожі* (2000), *З двох світів* (2002, posthumous essays), *Роки сподівань і втрат* (2004, diary). [T1: IEU; T2: NBUV]
+
+## 4. Primary-source quote / text anchors
+
+Use short excerpts only; much of Lutskyi's work remains copyright-protected, and several scans are image-only.
+
+- **Scholarly method anchor:** `Не вузьколобою пропагандою, а справжньою науковою роботою зарекомендуємо Україну найкраще світові.` Source: Lutskyi autobiographical etude quoted in I. Odrekhivska, 2024, from the Korohodskyi-edited source. Context: this is the cleanest classroom anchor for his anti-propagandistic, decolonized scholarly stance: defend Ukrainian culture by doing rigorous work, not by narrowing it into slogans.
+- **Literature and language anchor:** `language became the most effective weapon in the Ukrainian armory.` Source: George S. N. Luckyj, introduction to *Seven Lives* in *The Annals of UVAN*, vol. XX (1998-1999). Context: use as an English primary-source line about why literary language mattered politically in nineteenth-century Ukraine; translate only with a source-language note.
+- **Biography/history anchor:** `History is not treated as mere background but as part of the writers' individuality.` Source: *Seven Lives*, introduction. Context: useful for BIO writers because it explains his method: life, text, and colonial historical setting belong together.
+- **Do not use without recheck:** the existing LIT-ESSAY plan contains a Ukrainian line about a diaspora "обов'язок"; this pass did not verify that wording against a primary edition, so it should not be treated as a classroom-ready quotation.
+
+## 5. Language register
+
+- **Register:** bilingual scholarly-publicistic prose; English academic Ukrainian studies; Ukrainian memoir/essay register after 1991; editorial and bibliographic prose.
+- **CEFR readiness:** C1 for curated Ukrainian memoir/essay excerpts; C1-C2 for the English scholarly prose because learners must follow historiography, literary-politics vocabulary, and source framing; C2 for full *Literary Politics* chapters.
+- **Core vocabulary:** `україністика`, `діаспора`, `еміграція`, `літературна політика`, `переклад`, `упорядник`, `пара-текст`, `ВАПЛІТЕ`, `розгром літератури`, `русифікація`, `колоніальний наратив`, `інтелектуальна історія`, `об'єктивна наукова перспектива`.
+- **Stylistic features:** careful contextualization, controlled polemic, bibliography as argument, translator/editor apparatus, and refusal of both Soviet reduction and patriotic simplification.
+- **Pedagogical caution:** do not flatten him into "diaspora voice from outside." His value is the method: he built institutions, editions, translations, and English-language scholarly frames that let Ukrainian literature be read as a full European literature.
+
+## 6. Contested points
+
+- **Name and identity:** his English academic career used `George S. N. Luckyj`; the BIO project should still display `Yurii Lutskyi` because the subject is a Ukrainian cultural biography. Use the English form when citing English publications and archival fonds.
+- **Death date discrepancy:** ESU and IEU conflict on 22 vs 29 November 2001. Keep the discrepancy visible until checked against UTARMS, a Canadian obituary, or a family notice.
+- **Diaspora framing:** "diaspora" must not be treated as exile nostalgia or one ideology. Lutskyi moved through Berlin, Britain, the British Army, Saskatchewan, Columbia/UVAN, Toronto, CIUS, and post-1991 Kyiv/Lviv publication networks. These are distinct institutional arenas.
+- **Objectivity vs distance:** his insistence on Western-style scholarly objectivity can be misread as detachment from Ukraine. Odrekhivska's 2024 reading is more precise: distance was part of his method for widening interpretive frames and giving Ukrainian literature symbolic capital in global scholarship.
+- **Gogol/Hohol problem:** *Between Gogol and Shevchenko* and later Hohol work should not be taught as a simple "reclaim Gogol as Ukrainian" exercise. Lutskyi's stronger classroom value is the cultural dilemma: how a Ukrainian-born writer entered Russian imperial literary space, while Shevchenko made Ukrainian literary subjectivity unavoidable.
+- **Russocentric academic environment:** his work challenged the default Western habit of approaching Ukrainian writing through Russian studies or Soviet studies. Future lessons should name that structure without turning all Slavic studies colleagues into caricatures.
+- **Polish / Galician / British / Canadian perspectives:** his family came from Galician public life under Austria-Hungary and interwar Poland; he served in the British Army and worked in Canadian universities. These contexts should be named as institutional settings, not as evidence against Ukrainian identity.
+- **Popular simplification:** remembering him only as a translator understates his role as editor, bibliographer, institution-builder, and architect of English-language Ukrainian studies.
+
+## 7. Cross-track links
+
+> Every path under **Existing** below was verified with `test -e` on 2026-07-05. Candidate paths are future surfaces, not assertions that files exist.
+
+- **Existing LIT-ESSAY plan surfaces (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/lit-essay/lutsky-diaspora-bridge.yaml` — direct plan for his argumentative prose and diaspora-bridge role.
+- **Existing HIST plan surfaces (VERIFIED present):**
+  - `curriculum/l2-uk-en/plans/hist/diaspora.yaml` — broader Ukrainian diaspora historical context.
+- **Existing local wiki / discovery surfaces (VERIFIED present):**
+  - `curriculum/l2-uk-en/lit-essay/discovery/lutsky-diaspora-bridge.yaml`
+  - `wiki/literature/works/lutsky-diaspora-bridge.md`
+- **Candidate cross-track connections (Phase 2+ — NOT existing files unless listed above):**
+  - `curriculum/l2-uk-en/plans/bio/yurii-lutskyi.yaml` — future BIO plan after this dossier passes.
+  - `wiki/figures/yurii-lutskyi.md` and `wiki/figures/yurii-lutskyi.sources.yaml` — future wiki packet.
+  - Ostap Lutskyi BIO or research packet — family repression and "Moloda Muza" context; no such BIO plan/dossier was present in this pass.
+  - George Shevelov, Yurii Lavrynenko, Ivan Lysiak-Rudnytskyi, Mykola Riabchuk, Hryhorii Kochur, Mykola Lukash — adjacent diaspora / translation / public-intellectual context.
+- **Potential LIT additions surfaced by this research:**
+  - Source-based lesson on *Literary Politics in the Soviet Ukraine* as a recovered map of 1920s-1930s literary terror.
+  - Comparative module on `Gogol/Hohol - Shevchenko` as an imperial literary-choice problem, not a simplistic ethnicity debate.
+
+## 8. Naming-canonical
+
+- **Slug:** `yurii-lutskyi`
+- **EN canonical (project):** Yurii Lutskyi.
+- **Common English source form:** George Stephen Nestor Luckyj; George S. N. Luckyj.
+- **UA canonical:** Юрій Остапович Луцький.
+- **Birth-name / source variant:** Юрій Степан Нестор Луцький.
+- **Aliases future YAML:** `Юрій Луцький`; `Юрій Остапович Луцький`; `Юрій Степан Нестор Луцький`; `George Stephen Nestor Luckyj`; `George S. N. Luckyj`; `George Luckyj`; `Yuriy Lutsky`; `Yurij Luc'kyj`; `Lutsky, Yurii`; `Luckyj, George Stephen Nestor`.
+- **Forbidden / noncanonical learner-facing defaults:** Russian `Юрий Луцкий`; `Юрий Остапович Луцкий`; `George Luckyj` as the only learner-facing name in a Ukrainian BIO page; `Kiev` for Kyiv in modern context.
+- **Search note:** use `Luckyj`, `Lutsky`, `Lutskyi`, `Luc'kyj`, `Юрій Луцький`, and `George S. N. Luckyj` when searching catalogues.
+
+## 9. Image candidates
+
+- **Best candidate located, not rights-cleared:** IEU's `Luckyj, George Stephen Nestor` entry displays a portrait of George Stephen Nestor Luckyj and a 1937 image with Stepan Smal-Stotsky and Yurii Lutsky. Treat these as image leads only; IEU pages do not by themselves provide a reusable license suitable for embedding.
+- **Institutional candidates:** UTARMS finding aids list photoprints in the Luckyj records. These are likely rights-managed archival images; request permission before use.
+- **Commemorative / context candidate:** CFUS's George S. N. Luckyj Ukrainian Literature Translation Prize page may be used as institutional context, but it is not a portrait source and its site graphics should not be reused without license checking.
+- **Book-cover / title-page candidates:** title pages of *Between Gogol and Shevchenko*, *Literary Politics*, *Seven Lives*, or *Towards an Intellectual History of Ukraine* can illustrate the scholarly-output theme only if reuse rights are verified. Assume post-1971 book covers are copyright-protected unless proven otherwise.
+- **Fallback strategy:** ship text-only or use a rights-cleared context image of University of Toronto / CIUS / UVAN publication infrastructure if a file-level reusable license is located during wiki work. Do not generate an AI portrait.
+
+## 10. Sources used
+
+**Tier 1 (authoritative / encyclopedic):**
+
+- Rozumnyi, Ya. H. "Луцький Юрій Остапович." *Енциклопедія Сучасної України*. NASU / NTSh, 2017. https://esu.com.ua/article-59473. Accessed 2026-07-05.
+- Senkus, Roman. "Luckyj, George Stephen Nestor." *Internet Encyclopedia of Ukraine*. Updated 2015. https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CL%5CU%5CLuckyjGeorgeStephenNestor.htm. Accessed 2026-07-05.
+- Poliek, V. T. "Луцький Остап Михайлович." *Енциклопедія Сучасної України*. 2017, updated 2023. https://esu.com.ua/article-59465. Accessed 2026-07-05.
+
+**Tier 2 (institutional / archival / source-edition evidence):**
+
+- University of Toronto, Petro Jacyk Central & East European Resource Centre / UTARMS. "Luckyj (George S.N.) Records" finding-aid summaries. https://pjrc.library.utoronto.ca/special-collections-subject/22?page=1. Accessed 2026-07-05.
+- Luckyj, George S. N. *Seven Lives: Vignettes of Ukrainian Writers in the Nineteenth Century*. *The Annals of the Ukrainian Academy of Arts and Sciences in the U.S.*, vol. XX, nos. 47-48, 1998-1999. https://uvan.org/wp-content/uploads/2014/05/Annals-of-UVAN-1998-1999.pdf. Accessed 2026-07-05.
+- Senkus, Roman. "George S. N. Luckyj, Octogenarian." In *The Annals of UVAN*, vol. XX, 1998-1999, pp. 199-204. Same PDF as above.
+- Canadian Foundation for Ukrainian Studies. "The George S. N. Luckyj Ukrainian Literature Translation Prize." https://cfus.ca/programs-funds/the-george-s-n-luckyj-ukrainian-literature-translation-prize/. Accessed 2026-07-05.
+- NBUV catalogue / Ukrainica entries for *Між Гоголем і Шевченком*, *На перехресті*, *Самi про себе*, *Страдництво Миколи Гоголя*, and related Lutskyi records. https://irbis-nbuv.gov.ua/ and https://search.nbuv.gov.ua/. Accessed 2026-07-05.
+- Diasporiana. "Luckyj G. S.N. Between Gogol and Shevchenko: Polarity in the Literary Ukraine, 1798-1847." https://diasporiana.org.ua/literaturoznavstvo/18981-luckyj-g-s-n-between-gogol-and-shevchenko-polarity-in-the-literary-ukraine-1798-1847/. Accessed 2026-07-05.
+- Diasporiana. "Луцький Ю. Листування з Євгеном Сверстюком." https://diasporiana.org.ua/ukrainica/6289-lutskiy-yu-listuvannya-z-yevgenom-sverstyukom/. Accessed 2026-07-05.
+- Diasporiana. "Луцький Ю. Остап Луцький - молодомузівець." https://diasporiana.org.ua/literaturoznavstvo/4819-lutskiy-yu-ostap-lutskiy-molodomuzivets/. Accessed 2026-07-05.
+- JI magazine. "Юрій Луцький. На шляхах української науки." Antonovych Prize lecture, Kyiv, 28 May 1999. https://www.ji-magazine.lviv.ua/Promovy_laureativ_premii_Antonovychiv/lutskyj.htm. Accessed 2026-07-05.
+
+**Tier 4 (modern scholarly post-1991):**
+
+- Odrekhivska, I. M. "Едитологічна концепція перекладу Юрія Луцького як пропозиція глобального розвитку українських студій." *Наукові записки. Серія: Філологічні науки*, no. 3 (210), 2024. DOI: 10.32782/2522-4077-2024-210-30. https://discovery.ucl.ac.uk/10198957/1/Odrekhivska_editorial%20concept%20of%20Luckyj.pdf. Accessed 2026-07-05.
+
+**Tier 3 / navigation only:**
+
+- Ukrainian Wikipedia, "Юрій Луцький" / English Wikipedia, "George S. N. Luckyj." Used only for bibliography/navigation leads; core facts above rest on ESU, IEU, UTARMS, UVAN, NBUV, and scholarly sources.
+
+**Primary-source documents accessed:**
+
+- George S. N. Luckyj, *Seven Lives* introduction, UVAN Annals PDF; text verified through web extraction on 2026-07-05.
+- George S. N. Luckyj, *Literary Politics in the Soviet Ukraine, 1917-1934*, revised 1990 edition, Diasporiana PDF downloaded to `/tmp/lutsky-literary-politics.pdf` and extracted with `pdftotext -layout` on 2026-07-05; OCR was noisy, so no long verbatim quote was used.
+- Diasporiana scans of *Between Gogol and Shevchenko*, *Остап Луцький - молодомузівець*, and *Листування з Євгеном Сверстюком* were opened as source leads; they are image-only in this environment, so no OCR-dependent quotation was used.
+
+**Honest gaps:**
+
+- Death date needs archival confirmation because T1 sources disagree.
+- No NKVD/GDA SBU archival file for Ostap Lutskyi was opened; ESU supplies the arrest/death facts used here.
+- No UTARMS boxes were inspected directly; finding aids confirm archival holdings only.
+- Image rights remain unresolved; no PD/CC portrait is cleared by this dossier.
+- LLM-QG was not used.
+
+---
+
+## Decolonization self-check
+
+- [x] No Russocentric framing: Ukrainian literature and Ukrainian studies are treated as the subject, not as a branch of Russian/Soviet studies.
+- [x] No Russian-imperial transliterations in learner-facing defaults; Russian forms appear only as forbidden aliases.
+- [x] No invented direct repression: Yurii's pressure mechanism is exile/non-return, family NKVD destruction, and Soviet literary censorship; his father has the direct NKVD arrest/death claim.
+- [x] Soviet sources are not used as authority over identity or motive.
+- [x] Diaspora is not flattened: Berlin, Britain, Columbia/UVAN, Saskatchewan, Toronto, CIUS, and post-1991 Ukraine are distinct arenas.
+- [x] Hohol/Gogol issue kept as a cultural-history dilemma, not an ethnic possession claim.
+- [x] Existing cross-track paths verified; candidate paths explicitly marked.
+- [x] All place names use modern Ukrainian canonical forms in project voice.
+- [x] LLM-QG was not used.


### PR DESCRIPTION
## Summary

Adds the missing BIO research dossier for Yurii Lutskyi.

Changed file:
- `docs/research/bio/yurii-lutskyi.md`

## Validation

- `git diff --name-only origin/main...HEAD` -> `docs/research/bio/yurii-lutskyi.md` only
- `git diff --check` -> passed
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/yurii-lutskyi.md` -> passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` -> passed
- Commit/push pre-commit hooks -> passed

LLM-QG was not used. I did not run `run_llm_qg_parity.py` or `scripts/audit/module_quality_audit.py`.