### PR TITLE
fix(test): sync teacher-lesson ledger expectations to #4347 russianism rejects

### DIFF
--- a/tests/test_private_teacher_lesson_source_inventory.py
+++ b/tests/test_private_teacher_lesson_source_inventory.py
@@ -475,7 +475,7 @@ def test_private_teacher_second_decision_ledger_stays_review_only() -> None:
     assert summary == {
         "files": 1,
         "rows": 20,
-        "decision_counts": {"approve_for_publish": 20},
+        "decision_counts": {"approve_for_publish": 19, "reject": 1},
     }
     assert payload["source_queue"]["promotion_batch_size"] == 20
     assert payload["production_outputs_updated"] == []
@@ -697,7 +697,7 @@ def test_private_teacher_tenth_decision_ledger_stays_review_only() -> None:
     assert summary == {
         "files": 1,
         "rows": 21,
-        "decision_counts": {"approve_for_publish": 21},
+        "decision_counts": {"approve_for_publish": 20, "reject": 1},
     }
     assert payload["source_queue"]["generated_from_pr"] == 4205
     assert payload["source_queue"]["promotion_batch_size"] == 21


### PR DESCRIPTION
## Train-blocker: origin/main is RED on required `Test (pytest)`

**#4347** (`c49a5d8e41`, "reject 2 russianism entries") added a `reject` decision to the **second** and **tenth** teacher-lesson decision ledgers (e.g. rejecting the russianism `місцезнаходження`) but did **not** update `test_private_teacher_{second,tenth}_decision_ledger_stays_review_only`, whose `decision_counts` still hardcode all-approve.

Result: `Test (pytest)` has been RED on `origin/main` since #4347 merged — blocking **every** open PR (verified on a clean origin/main checkout: `2 failed, 30 passed`).

### Fix (stale-expectation sync, not a behaviour change)
| ledger | rows | was | now |
|---|---|---|---|
| second | 20 | `{approve_for_publish: 20}` | `{approve_for_publish: 19, reject: 1}` |
| tenth | 21 | `{approve_for_publish: 21}` | `{approve_for_publish: 20, reject: 1}` |

`reject` is a valid review decision; `production_outputs_updated == []` still holds, so the "stays review only" invariant is intact. Test file now **32 passed**.

> ⚠️ Process note: #4347 landed while breaking a required check — branch protection appears to have been bypassed. Worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)