### PR TITLE
docs(bio): add Volodymyr Yermolenko dossier

### DIFF
--- a/docs/research/bio/volodymyr-yermolenko.md
+++ b/docs/research/bio/volodymyr-yermolenko.md
@@ -1,0 +1,297 @@
+# Володимир Анатолійович Єрмоленко - Research Dossier
+
+**Slug:** `volodymyr-yermolenko`
+**Block:** +77 expansion - language / translation / essayistics / public intellectual culture
+**Tier:** 2
+**Issue:** #2535 / BIO +77 readiness gate; readiness row #344
+**Researcher:** Codex (GPT-5)
+**Completed:** 2026-07-05
+
+**Source acronym legend:** PEN = PEN Ukraine; UW = UkraineWorld; IWM =
+Institute for Human Sciences; KMA = National University of Kyiv-Mohyla Academy /
+`Kyiv-Mohyla Humanities Journal`; IRF = International Renaissance Foundation;
+D&L = Dukh i Litera; VSL = Vydavnytstvo Staroho Leva / Old Lion Publishing
+House; ILB = international literature festival berlin; Commons = Wikimedia
+Commons.
+
+**Acceptance self-check:**
+
+- [x] All 10 sections completed
+- [x] At least 3 Tier 1/Tier 2 institutional, publisher, journal, or rights
+  sources cited
+- [x] Pressure mechanism framed as Russian war, imperial knowledge,
+  disinformation, cultural loss, public explanation, and wartime civic work; no
+  invented arrest, exile, camp term, or dissident sentence
+- [x] At least 2 primary-source text / voice anchors supplied with copyright
+  caution
+- [x] Cross-track links verified `test -e` / `rg` on 2026-07-05 where marked
+  existing
+- [x] Naming-canonical policy applied
+- [x] Image-rights policy applied
+- [x] Dossier-only scope observed
+
+## Decolonization self-check
+
+- [x] No Russocentric framing: Russian imperial and Soviet/RF information
+  systems are treated as objects of critique, not as neutral frames for Ukraine.
+- [x] Ukrainian agency is central: Yermolenko is framed as a Ukrainian
+  philosopher, essayist, editor, and PEN/civic public intellectual making
+  Ukrainian thought legible on its own terms.
+- [x] Living-figure claims are time-stamped: present institutional roles must be
+  rechecked before module build.
+- [x] Anti-hagiography retained: the dossier distinguishes completed works,
+  current wartime publicism, institutional roles, and contested reception.
+
+## 1. Verified facts
+
+- **Full name (UA, canonical):** Володимир Анатолійович Єрмоленко. The
+  patronymic is attested in library/catalogue and encyclopedic navigation
+  surfaces; PEN's own display form is `Єрмоленко Володимир`. [T2: PEN; T3:
+  Wikipedia/Wikidata navigation]
+- **Project English canonical:** Volodymyr Yermolenko.
+- **Birth:** PEN gives 1980, Kyiv. Exact-day sources in public catalogues and
+  encyclopedic records give 18 March 1980, Kyiv; treat the exact day as
+  secondary until a stable institutional CV is checked. [T2: PEN; T3: Wikipedia;
+  T5: Gazeta profile]
+- **Living figure:** Yermolenko is living. Recheck present-tense roles, awards,
+  and wartime projects before module build.
+- **Education / degrees:** PEN records NaUKMA graduation in 2002, Central
+  European University in Budapest in 2003, and a 2011 doctoral dissertation at
+  EHESS in Paris; the English PEN profile also lists a Ukrainian PhD /
+  kandydat degree in 2008. [T2: PEN]
+- **Current institutional roles, checked July 2026:** PEN's profile and 2025
+  election notice list him as President of PEN Ukraine, first elected in
+  November 2022 and re-elected on 24 January 2025 for a biennium. UW lists him
+  as editor-in-chief of UkraineWorld and Director of Analytics at Internews
+  Ukraine. KMA journal metadata identifies him as Associate Professor at the
+  Department of Philosophy and Religious Studies. IRF public materials list him
+  as chairman of the board; recheck IRF before using that role in present tense.
+  [T2: PEN; T2: UW; T2: KMA; T2: IRF]
+- **Core BIO identity:** philosopher, essayist, translator/editor of ideas,
+  journalist, Ukraine explainer in English-language media, and civic
+  intellectual linking Ukrainian cultural history, European intellectual
+  history, decolonization, and wartime public speech.
+
+## 2. Oppression / pressure mechanism
+
+- **Not a prison-case biography:** Do not invent arrest, exile, camp term, KGB
+  file, or formal dissident sentence. Yermolenko belongs to BIO because his
+  completed work and public role document and resist Russian imperial knowledge,
+  propaganda, war, and cultural destruction.
+- **Russian war and cultural loss:** Since 2014 and especially since the
+  full-scale invasion on 24 February 2022, his public writing has treated
+  Russian aggression as a war on Ukrainian life, language, culture, and civic
+  freedom. PEN International's 2026 publication of `Стіни життя` frames the war
+  through drone attacks, energy terror, frontline roads, and the civilian need
+  to protect children without making private suffering into spectacle. [T2: PEN
+  International / PEN Ukraine]
+- **Information and disinformation pressure:** PEN records that in 2017
+  Yermolenko co-initiated `Voice of the war: Veteran Stories` and edited `Words
+  and Wars: Ukraine Facing Kremlin Propaganda`. UW describes its post-2022 work
+  as frontline reporting, explaining Russian crimes, and combining information
+  work with volunteering. This is the central mechanism for lessons: imperial
+  violence is paired with a struggle over who gets to name Ukraine. [T2: PEN;
+  T2: UW]
+- **Imperial knowledge / decolonial frame:** His IWM fellowship project
+  `Ukraine and the Borders of Europe` studied European imaginaries about
+  Ukraine, Ukrainian imaginaries of Europe, and current debates over Ukraine in
+  Europe. This makes him useful for teaching Ukraine as a producer of
+  intellectual categories, not an object appended to Russian studies. [T2: IWM]
+- **Living wartime caution:** His publicism includes immediate wartime claims
+  and moral argument. Use exact dates and source labels. Do not convert a
+  2022/2026 essay into an undated "Yermolenko position" or a forecast about his
+  future national role.
+
+## 3. Major works / contributions
+
+- `2011` - *Оповідач і філософ: Вальтер Беньямін та його час*, monograph,
+  Krytyka. Establishes the philosopher-essayist line around narrative, memory,
+  and European modernity. [T2: PEN]
+- `2015` - *Далекі близькі. Есеї з філософії та літератури*, essays, VSL.
+  European literary-philosophical portraits read through closeness, weakness,
+  sensation, and meaning-making. [T2: PEN; T5: VSL/retail metadata]
+- `2017` - *Ловець океану: Історія Одіссея*, novel, VSL. A philosophical
+  sequel/reworking of Odysseus; useful for myth, guilt, return, and memory.
+  [T2: PEN; T4: scholarly article on the novel]
+- `2017` - `Voice of the war: Veteran Stories` and *Words and Wars: Ukraine
+  Facing Kremlin Propaganda*, Internews Ukraine projects/publication. Use for
+  information-war and testimony context. [T2: PEN]
+- `2018` - *Плинні ідеології. Ідеї та політика в Європі ХІХ-ХХ століть*, D&L.
+  Key course anchor for ideas, metaphors, totalitarianism, and political
+  language; winner of the 2018 Yuri Shevelyov Prize. [T2: D&L; T2: PEN]
+- `2020` - *Ukraine in Histories and Stories*, edited volume / international
+  Ukrainian studies bridge. [T5: ILB bibliography]
+- `2020-present` - `Kult`, `Explaining Ukraine`, and later `Thinking in Dark
+  Times` podcasts / public conversations with Tetyana Ogarkova and guests. Use
+  as listening or seminar anchors after checking episode rights. [T2: PEN; T2:
+  IWM]
+- `2023` - *Ерос і Психея: кохання і культура в Європі*, VSL, 496 pages.
+  Connects European love/culture narratives with Ukrainian themes including
+  Marko Vovchok, Lesia Ukrainka, Volodymyr Vynnychenko, Yurii Kosach, Mazepa,
+  and Sacher-Masoch. [T5: VSL/Book Lion metadata; T5: ILB bibliography]
+- `2025` - *Life on the Edge. Ukraine, Culture and War* with Tetyana Ogarkova,
+  D&L. Treat as a recent completed wartime-culture book; recheck edition details
+  before classroom use. [T5: ILB bibliography]
+- `2025` - "Life Despite Death: Palingenetic Element of the Ukrainian Culture,"
+  *Kyiv-Mohyla Humanities Journal* No. 12. Scholarly bridge to Ukrainian
+  cultural survival, resurrection imagery, and European intellectual history.
+  [T2/T4: KMA]
+
+## 4. Primary-source quote / text anchors
+
+Yermolenko is living and most works are copyright-protected. Use short anchors
+only in the dossier; verify any longer classroom excerpt against the printed
+edition, publisher permissions, or the page's reuse terms.
+
+- **Wartime civilian anchor:** `Правило двох стін` from `Стіни життя` (PEN
+  Ukraine, 24 February 2026). Pedagogically: a compact phrase linking household
+  survival, drone warfare, and the metaphor of walls. [Primary: PEN Ukraine]
+- **Freedom / death-politics anchor:** `свобода - це життя` from `Стіни життя`.
+  Pedagogically: a short phrase for discussing why Russian official history and
+  Ukrainian freedom are opposed in his wartime rhetoric. Check punctuation and
+  typography in the source before learner-facing quotation. [Primary: PEN
+  Ukraine]
+- **Memory-of-the-killed anchor:** `Ті, ким ми не стали` (PEN Ukraine / `Країна`,
+  14 July 2022). Pedagogically: title-level prompt for unrealized lives and war
+  memory; avoid long quotation because the piece is a crafted literary essay.
+  [Primary: PEN Ukraine / `Країна`]
+- **Ideas-history anchor:** *Плинні ідеології* as title and concept. It gives a
+  C1/C2 bridge from vocabulary (`ідеологія`, `метафора`, `політична уява`) to
+  European intellectual history. [Primary/publication metadata: D&L]
+
+## 5. Language register
+
+- **Register:** philosophical essayistics, public-intellectual Ukrainian,
+  European intellectual history, media-analysis prose, wartime witness,
+  podcast/conversation register, and occasional literary fiction.
+- **CEFR readiness:** B2+ for short public biographical notes and interview
+  clips; C1 for wartime essays and podcast excerpts with scaffolding; C2 for
+  *Плинні ідеології*, *Ерос і Психея*, and KMA scholarly articles.
+- **Core vocabulary:** `філософія`, `есеїстика`, `ідеологія`, `метафора`,
+  `імперське знання`, `пропаганда`, `дезінформація`, `суб'єктність`,
+  `Європа`, `межа`, `свобода`, `танатократія`, `війна`, `культура`,
+  `волонтерство`.
+- **Teaching caution:** His prose often moves quickly between intimate wartime
+  scene, abstract moral vocabulary, and European cultural reference. Scaffold
+  genre and source date before asking learners to generalize.
+
+## 6. Contested points
+
+- **Current-role drift:** PEN, UW, IRF, KMA, festival, and media pages do not
+  always use the same title wording: president / re-elected president,
+  director of European projects, Director of Analytics, senior lecturer,
+  associate professor, professor, board chair. Use the most current source for
+  each role and time-stamp the claim.
+- **English-language public-intellectual frame:** UkraineWorld and
+  international media make Yermolenko visible to non-Ukrainian audiences. A BIO
+  lesson should not let English-language visibility displace his Ukrainian
+  books and Ukrainian intellectual context.
+- **Cultural decolonization debate:** His post-2022 criticism of Russian
+  imperial literature and information war is part of a wider Ukrainian debate
+  over decolonization, translation, canons, and wartime ethics. Teach it as a
+  dated, argued position, not as a shortcut to "all Russian culture" summaries.
+- **War volunteering and family detail:** `Стіни життя` includes family and
+  frontline-volunteering detail. Use only what the author published himself,
+  avoid operational detail, and keep the focus on the public essay's form and
+  argument.
+- **Awards:** Sources consistently name the 2018 Yuri Shevelyov Prize and the
+  2021 Petro Mohyla Award; broader "Book of the Year" and newer awards should be
+  checked against the award organizer before use in a plan or module.
+
+## 7. Cross-track links
+
+- **Existing LIT-ESSAY plan/wiki surfaces (VERIFIED `test -e` 2026-07-05):**
+  `curriculum/l2-uk-en/plans/lit-essay/yermolenko-fluid-ideologies.yaml`,
+  `curriculum/l2-uk-en/lit-essay/discovery/yermolenko-fluid-ideologies.yaml`,
+  `wiki/literature/works/yermolenko-fluid-ideologies.md`,
+  `wiki/literature/works/yermolenko-fluid-ideologies.sources.yaml`
+- **Existing LIT-DOC / LIT / C2 plan surfaces (VERIFIED `test -e` / `rg`
+  2026-07-05):**
+  `curriculum/l2-uk-en/plans/lit-doc/yermolenko-philosophical-narrative.yaml`,
+  `curriculum/l2-uk-en/plans/lit/war-literature-as-movement.yaml`,
+  `curriculum/l2-uk-en/plans/c2/c1-bridge-assessment.yaml`
+- **Existing BIO research cross-links (VERIFIED `test -e` 2026-07-05):**
+  `docs/research/bio/mykola-riabchuk.md`,
+  `docs/research/bio/larysa-masenko.md`,
+  `docs/research/bio/oksana-zabuzhko.md`
+- **Existing site index surfaces (VERIFIED `rg` 2026-07-05; do not edit in this
+  dossier PR):** `site/src/content/docs/bio/index.mdx` includes
+  `volodymyr-yermolenko`; `site/src/content/docs/lit-essay/index.mdx` exposes
+  `yermolenko-fluid-ideologies`.
+- **Candidate / future BIO surfaces not created in this PR:**
+  `curriculum/l2-uk-en/plans/bio/volodymyr-yermolenko.yaml`,
+  `curriculum/l2-uk-en/bio/discovery/volodymyr-yermolenko.yaml`,
+  `wiki/figures/volodymyr-yermolenko.md`,
+  `site/src/content/docs/bio/volodymyr-yermolenko.mdx`,
+  `curriculum/l2-uk-en/bio/volodymyr-yermolenko/module.md`,
+  `curriculum/l2-uk-en/bio/volodymyr-yermolenko/activities.yaml`,
+  `curriculum/l2-uk-en/bio/volodymyr-yermolenko/vocabulary.yaml`,
+  `curriculum/l2-uk-en/bio/volodymyr-yermolenko/resources.yaml`
+
+## 8. Naming-canonical
+
+- **Slug:** `volodymyr-yermolenko`
+- **EN canonical (project):** Volodymyr Yermolenko.
+- **UA canonical:** Володимир Єрмоленко; full patronymic form Володимир
+  Анатолійович Єрмоленко when context needs it.
+- **Aliases future YAML:** `Єрмоленко Володимир`; `Володимир Анатолійович
+  Єрмоленко`; `Volodymyr Yermolenko`; `Volodymyr Anatoliyovych Yermolenko`;
+  `Wolodymyr Jermolenko`; `Wołodymyr Jermołenko`; `V. Yermolenko`.
+- **Forbidden / noncanonical learner-facing defaults:** `Vladimir Ermolenko`,
+  `Vladimir Yermolenko`, Russian-script `Владимир Ермоленко`, treating him as a
+  Russian or "post-Soviet Russian-language" thinker, or using "Yermak" variants
+  by confusion with a different public figure.
+- **Search note:** Use German/Polish variants only for catalogues, festival
+  pages, and Commons metadata. Keep learner-facing display as `Volodymyr
+  Yermolenko` / `Володимир Єрмоленко`.
+
+## 9. Image candidates
+
+- **Primary reusable candidate:** Commons `File:Yermolenko_2025.jpg`; photo
+  dated 5 November 2023, uploaded 6 May 2025 by Олександра Оберенко; license
+  CC BY 4.0. Commons metadata also lists copyright holder `Sarsenov Daniiar`;
+  verify attribution string before plan YAML use.
+- **Backup candidate:** Commons `File:Volodymyr_Yermolenko.jpg`; 7 May 2022
+  video still from `Як Ти Думаєш`, license CC BY-SA 4.0, 543 x 500. Lower
+  resolution and video-still origin make it secondary.
+- **Avoid by default:** PEN, festival, event, publisher, stock-agency, social
+  media, and screenshot portraits unless file-level reusable license is clear.
+- **Context images:** UkraineWorld / Internews materials, `Words and Wars`, or
+  `Плинні ідеології` cover may be useful as classroom context but should not be
+  embedded until rights are checked.
+
+## 10. Sources used
+
+**Tier 2 (institutional / author profile / civic organization):**
+
+- PEN Ukraine. "Єрмоленко Володимир." https://pen.org.ua/autors/yermolenko-volodymyr. Accessed 2026-07-05.
+- PEN Ukraine. "Yermolenko Volodymyr." https://pen.org.ua/en/autors/yermolenko-volodymyr. Accessed 2026-07-05.
+- PEN Ukraine. "President of PEN Ukraine re-elected; new Executive Board elected." Published 24 January 2025. https://pen.org.ua/en/pen-ukraine-elected-president-and-executive-board. Accessed 2026-07-05.
+- UkraineWorld. "About us." https://ukraineworld.org/en/about. Accessed 2026-07-05.
+- Institute for Human Sciences. "Volodymyr Yermolenko" / Documenting Ukraine grantee profile. https://www.iwm.at/documenting-ukraine/grantees/volodymyr-yermolenko. Accessed 2026-07-05.
+- Institute for Human Sciences. "Volodymyr Yermolenko" / fellowship profile. https://www.iwm.at/fellow/volodymyr-yermolenko. Accessed 2026-07-05.
+- International Renaissance Foundation. "The Board of the International Renaissance Foundation: who are they?" https://www.irf.ua/en/pravlinnya-2023/. Accessed 2026-07-05.
+
+**Tier 2 / Tier 4 (scholarly, publisher, and prize evidence):**
+
+- Kyiv-Mohyla Humanities Journal. "Life Despite Death: Palingenetic Element of the Ukrainian Culture." https://kmhj.ukma.edu.ua/article/view/348672. Accessed 2026-07-05.
+- Dukh i Litera. "Плинні ідеології. Ідеї та політика в Європі ХІХ-ХХ століть." https://duh-i-litera.com/bookstore/plinni-ideologii. Accessed 2026-07-05.
+- Dukh i Litera. "Володимир Єрмоленко - лауреат Премії Шевельова 2018!" https://duh-i-litera.com/news/volodymyr-yermolenko-laureat-prem%D1%96%D1%97-shevelova. Accessed 2026-07-05.
+- Foliaphilologica / Kyiv University scholarship on *Ловець океану*. https://foliaphilologica.uni.kyiv.ua/index.php/foliaphilologica/article/download/38/34. Accessed 2026-07-05.
+
+**Tier 3 / Tier 5 (bibliography, reception, and navigation only):**
+
+- international literature festival berlin. "Volodymyr Yermolenko." https://literaturfestival.com/en/authors/volodymyr-yermolenko/. Accessed 2026-07-05.
+- Book Lion / VSL retail metadata. "Eros and Psyche. Love and Culture in Europe." https://booklion.lviv.ua/en/eros-i-psykheia.-kokhannia-i-kultura-v-yevropi/. Accessed 2026-07-05.
+- Ukrainian Wikipedia / Wikidata were used only for exact-date and spelling navigation; institutional profiles above control final role and work claims.
+
+**Primary-source documents / text anchors accessed:**
+
+- Володимир Єрмоленко. "Стіни життя." PEN Ukraine, 24 February 2026. https://pen.org.ua/stiny-zhyttya. Accessed 2026-07-05.
+- Volodymyr Yermolenko. "Walls of Life." PEN Ukraine / PEN International English version, 24 February 2026. https://pen.org.ua/en/stiny-zhyttya. Accessed 2026-07-05.
+- Volodymyr Yermolenko. "Those whom we did not become." PEN Ukraine / `Країна`, 14 July 2022. https://pen.org.ua/en/ti-kim-mi-ne-stali. Accessed 2026-07-05.
+
+**Image-rights / portrait sources:**
+
+- Wikimedia Commons. `File:Yermolenko_2025.jpg`. https://commons.wikimedia.org/wiki/File:Yermolenko_2025.jpg. Accessed 2026-07-05.
+- Wikimedia Commons. `File:Volodymyr_Yermolenko.jpg`. https://commons.wikimedia.org/wiki/File:Volodymyr_Yermolenko.jpg. Accessed 2026-07-05.


### PR DESCRIPTION
## Summary

Adds the source-tiered BIO research dossier for Volodymyr Yermolenko.

Changed file:
- `docs/research/bio/volodymyr-yermolenko.md`

## Checks run

- `git diff --name-only origin/main...HEAD` -> only `docs/research/bio/volodymyr-yermolenko.md`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_bio_dossier_xref.py --paths docs/research/bio/volodymyr-yermolenko.md`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## LLM-QG

LLM-QG was not used. Did not run `run_llm_qg_parity.py` or `scripts/audit/module_quality_audit.py`.