### PR TITLE
fix(pipeline): close seminar NO_VERIFY fidelity-gate bypass for primary readings

### DIFF
--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -9052,7 +9052,10 @@ def run_python_qg(
         "published_quote_for_publishable_refs",
         _published_quote_for_publishable_refs_gate(module_text, plan, module_dir),
     )
-    record("textbook_quote_fidelity", _textbook_quote_fidelity_gate(module_text, level=level))
+    record(
+        "textbook_quote_fidelity",
+        _textbook_quote_fidelity_gate(module_text, level=level, module_slug=slug),
+    )
     telemetry_present = _writer_tool_call_telemetry_present(module_dir)
     record(
         "resources_search_attempted",
@@ -15754,17 +15757,25 @@ def _strip_frontmatter(text: str) -> str:
 def _strip_frontmatter_and_headings(text: str) -> str:
     text = _strip_frontmatter(text)
     return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
-def _textbook_quote_fidelity_gate(module_text: str, level: str | None = None) -> dict[str, Any]:
+def _textbook_quote_fidelity_gate(
+    module_text: str,
+    level: str | None = None,
+    *,
+    module_slug: str | None = None,
+) -> dict[str, Any]:
     """Verify textbook quote fidelity against the sources DB."""
     import re
 
     from rapidfuzz import distance
 
+    from scripts.build.seminar_quote_exemptions import lookup_seminar_quote_exemption
     from scripts.wiki.sources_db import search_literary, search_textbooks
 
     violations: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
     checked = 0
     level_key = str(level or "").strip().lower()
+    slug_key = str(module_slug or "").strip().lower()
     quotes = _extract_blockquote_records(module_text, level=level)
 
     def _normalize(s: str) -> str:
@@ -15777,32 +15788,11 @@ def _textbook_quote_fidelity_gate(module_text: str, level: str | None = None) ->
             and re.search(r"\bp\.?\s*\d+", attribution, flags=re.IGNORECASE)
         )
 
-    for q in quotes:
-        text = q["quote"]
-        attr = q["attribution"]
-        nv = q["no_verify"]
-
-        if not text:
-            continue
-
-        checked += 1
-
-        if not attr:
-            if not nv:
-                violations.append({
-                    "quote": text,
-                    "attribution": "",
-                    "reason": "Missing attribution without NO_VERIFY"
-                })
-            continue
-
-        if nv:
-            continue
-
+    def _corpus_fidelity_violation(text: str, attr: str) -> dict[str, Any] | None:
         ukr_words = re.findall(r'[а-яіїєґА-ЯІЇЄҐ]+', text)
         keywords = {w.lower() for w in ukr_words if len(w) >= 3}
         if not keywords:
-            continue
+            return None
 
         search_fn = search_textbooks
         corpus_name = "textbook corpus"
@@ -15816,12 +15806,11 @@ def _textbook_quote_fidelity_gate(module_text: str, level: str | None = None) ->
             hits = []
 
         if not hits:
-            violations.append({
+            return {
                 "quote": text,
                 "attribution": attr,
-                "reason": f"No match in {corpus_name}"
-            })
-            continue
+                "reason": f"No match in {corpus_name}",
+            }
 
         norm_quote = _normalize(text)
         best_diff = float('inf')
@@ -15854,19 +15843,77 @@ def _textbook_quote_fidelity_gate(module_text: str, level: str | None = None) ->
                     best_source_text = chunk
 
         if best_diff >= 3:
-            violations.append({
+            return {
                 "quote": text,
                 "attribution": attr,
                 "reason": f"Text differs by >=3 chars (diff: {best_diff})",
-                "nearest_source": best_source_text
+                "nearest_source": best_source_text,
+            }
+        return None
+
+    for q in quotes:
+        text = q["quote"]
+        attr = q["attribution"]
+        nv = q["no_verify"]
+
+        if not text:
+            continue
+
+        checked += 1
+
+        if not attr:
+            if not nv:
+                violations.append({
+                    "quote": text,
+                    "attribution": "",
+                    "reason": "Missing attribution without NO_VERIFY"
+                })
+            continue
+
+        if nv and level_key not in SEMINAR_LEVELS:
+            continue
+
+        violation = _corpus_fidelity_violation(text, attr)
+        if violation is None:
+            continue
+
+        if nv and level_key in SEMINAR_LEVELS:
+            exemption = lookup_seminar_quote_exemption(slug_key, text)
+            if exemption:
+                warnings.append({
+                    "quote": text,
+                    "attribution": attr,
+                    "reason": "NO_VERIFY seminar quote exempted from corpus match",
+                    "exemption": exemption,
+                })
+                continue
+            violations.append({
+                "quote": text,
+                "attribution": attr,
+                "reason": (
+                    "NO_VERIFY on seminar level but fragment not corpus-attested "
+                    "and not exempted"
+                ),
             })
+            continue
+
+        violations.append(violation)
 
     passed = len(violations) == 0
+    if violations:
+        message = f"verify_quote: {checked} checked, {len(violations)} violations"
+    elif warnings:
+        message = (
+            f"verify_quote: {checked} verified, {len(warnings)} seminar exemptions"
+        )
+    else:
+        message = f"verify_quote: {checked} verified"
     return {
         "passed": passed,
         "checked": checked,
         "violations": violations,
-        "message": f"verify_quote: {checked} checked, {len(violations)} violations" if violations else f"verify_quote: {checked} verified",
-        "verdict": "PASS" if passed else "REJECT",
-        "severity": "HARD" if not passed else None
+        "warnings": warnings,
+        "message": message,
+        "verdict": "WARN" if passed and warnings else "PASS" if passed else "REJECT",
+        "severity": "WARN" if passed and warnings else "HARD" if not passed else None,
     }

--- a/scripts/build/seminar_quote_exemptions.json
+++ b/scripts/build/seminar_quote_exemptions.json
@@ -1,0 +1,3 @@
+{
+  "exemptions": {}
+}

--- a/scripts/build/seminar_quote_exemptions.py
+++ b/scripts/build/seminar_quote_exemptions.py
@@ -1,0 +1,47 @@
+"""Registered exemptions for seminar primary-reading quotes that fail corpus auto-match."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+_EXEMPTIONS_PATH = Path(__file__).with_name("seminar_quote_exemptions.json")
+
+
+def normalize_seminar_quote_text(text: str) -> str:
+    return re.sub(r"[^а-яіїєґА-ЯІЇЄҐ0-9]", "", text.lower())
+
+
+def seminar_quote_exemption_key(module_slug: str, quote_text: str) -> str:
+    normalized = normalize_seminar_quote_text(quote_text)
+    payload = f"{module_slug.strip().lower()}\n{normalized}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+@lru_cache(maxsize=1)
+def load_seminar_quote_exemptions() -> dict[str, dict[str, Any]]:
+    if not _EXEMPTIONS_PATH.is_file():
+        return {}
+    data = json.loads(_EXEMPTIONS_PATH.read_text(encoding="utf-8"))
+    exemptions = data.get("exemptions", {})
+    if not isinstance(exemptions, dict):
+        return {}
+    return {
+        str(key): entry
+        for key, entry in exemptions.items()
+        if isinstance(entry, dict)
+    }
+
+
+def lookup_seminar_quote_exemption(
+    module_slug: str,
+    quote_text: str,
+    *,
+    exemptions: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, Any] | None:
+    registry = load_seminar_quote_exemptions() if exemptions is None else exemptions
+    return registry.get(seminar_quote_exemption_key(module_slug, quote_text))

--- a/tests/test_textbook_quote_fidelity_gate.py
+++ b/tests/test_textbook_quote_fidelity_gate.py
@@ -1,4 +1,5 @@
 from scripts.build.linear_pipeline import _textbook_quote_fidelity_gate
+from scripts.build.seminar_quote_exemptions import seminar_quote_exemption_key
 
 
 def test_match(monkeypatch):
@@ -210,3 +211,119 @@ def test_core_level_does_not_accept_seminar_embedded_attribution(monkeypatch):
     assert core_result["passed"] is False
     assert core_result["violations"][0]["reason"] == "Missing attribution without NO_VERIFY"
     assert calls == {"textbooks": 0}
+
+
+def test_seminar_no_verify_attested_fragment_passes(monkeypatch):
+    calls = {"literary": 0}
+
+    def mock_search_literary(keywords, limit=20):
+        calls["literary"] += 1
+        return [{"text": "Ой на горі вогонь горить, а в долині вода."}]
+
+    monkeypatch.setattr("scripts.wiki.sources_db.search_literary", mock_search_literary)
+
+    module_text = """
+<!-- NO_VERIFY: корпусно звірений фрагмент -->
+> Ой на горі вогонь горить, а в долині вода.
+
+*— народна дума [S1]*
+"""
+    result = _textbook_quote_fidelity_gate(
+        module_text,
+        level="folk",
+        module_slug="narodni-balady",
+    )
+
+    assert result["passed"] is True
+    assert result["violations"] == []
+    assert result["warnings"] == []
+    assert calls["literary"] == 1
+
+
+def test_seminar_no_verify_fabricated_fragment_fails_without_exemption(monkeypatch):
+    monkeypatch.setattr("scripts.wiki.sources_db.search_literary", lambda keywords, limit=20: [])
+
+    module_text = """
+<!-- NO_VERIFY: корпусно звірений фрагмент -->
+> Цей уривок вигаданий і не має бути в корпусі.
+
+*— Kupala [S1]*
+"""
+    result = _textbook_quote_fidelity_gate(
+        module_text,
+        level="folk",
+        module_slug="narodni-balady",
+    )
+
+    assert result["passed"] is False
+    assert result["violations"] == [
+        {
+            "quote": "Цей уривок вигаданий і не має бути в корпусі.",
+            "attribution": "Kupala [S1]",
+            "reason": (
+                "NO_VERIFY on seminar level but fragment not corpus-attested "
+                "and not exempted"
+            ),
+        }
+    ]
+
+
+def test_seminar_no_verify_fabricated_fragment_with_exemption_warns(monkeypatch):
+    quote = "Цей уривок вигаданий і не має бути в корпусі."
+    exemption_key = seminar_quote_exemption_key("narodni-balady", quote)
+    exemption = {
+        "module_slug": "narodni-balady",
+        "reason": "manual reviewer attestation pending corpus ingest",
+        "reviewer": "folk-track-driver",
+        "date": "2026-07-05",
+    }
+
+    monkeypatch.setattr("scripts.wiki.sources_db.search_literary", lambda keywords, limit=20: [])
+    monkeypatch.setattr(
+        "scripts.build.seminar_quote_exemptions.load_seminar_quote_exemptions",
+        lambda: {exemption_key: exemption},
+    )
+
+    module_text = f"""
+<!-- NO_VERIFY: корпусно звірений фрагмент -->
+> {quote}
+
+*— Kupala [S1]*
+"""
+    result = _textbook_quote_fidelity_gate(
+        module_text,
+        level="folk",
+        module_slug="narodni-balady",
+    )
+
+    assert result["passed"] is True
+    assert result["violations"] == []
+    assert len(result["warnings"]) == 1
+    assert result["warnings"][0]["reason"] == (
+        "NO_VERIFY seminar quote exempted from corpus match"
+    )
+    assert result["warnings"][0]["exemption"] == exemption
+    assert result["verdict"] == "WARN"
+    assert result["severity"] == "WARN"
+
+
+def test_core_no_verify_fragment_still_skipped(monkeypatch):
+    calls = {"textbooks": 0}
+
+    def mock_search_textbooks(keywords, limit=20):
+        calls["textbooks"] += 1
+        return []
+
+    monkeypatch.setattr("scripts.wiki.sources_db.search_textbooks", mock_search_textbooks)
+
+    module_text = """
+<!-- NO_VERIFY: orchestrator review pending -->
+> Це цитата без джерела.
+
+*— Захарійчук, Grade 1, p.24*
+"""
+    result = _textbook_quote_fidelity_gate(module_text, level="a1")
+
+    assert result["passed"] is True
+    assert result["violations"] == []
+    assert calls["textbooks"] == 0


### PR DESCRIPTION
## Problem — `NO_VERIFY` silently bypasses the fidelity gate on seminar primary readings

The V7 quality gate `_textbook_quote_fidelity_gate` (`scripts/build/linear_pipeline.py`) verifies that
blockquoted primary-source fragments actually exist in the corpus. But a `<!-- NO_VERIFY: … -->` marker
made it **skip verification entirely** (`if nv: continue`).

On **FOLK** (a seminar level, so the gate searches the *literary* corpus), this honor-system escape hatch
is used on the most fabrication-prone content — embedded primary-reading fragments (веснянки/гаївки/ballads/
literary-origin songs). Shipped usage: `narodni-tantsi` (7), `narodni-balady` (2),
`pisni-literaturnoho-pokhodzhennia` (2) = **11 markers; folk is the only track that uses `NO_VERIFY`**.
Result: **zero CI fidelity coverage on exactly the content most likely to be fabricated** — the same vector
that produced a fabricated reading in the istorychni-pisni pilot (caught only by manual corpus-hammer).

## Fix (root cause)

For **seminar levels only**, `NO_VERIFY` no longer skips. The gate runs the same corpus verification it
already does; a fragment must be **corpus-attested** or carry a **registered reviewer exemption**
(`scripts/build/seminar_quote_exemptions.json`, sha256-keyed by `(module_slug, normalized_quote)`) — never
a silent free pass. **Core levels keep the existing skip** (scoped strictly to seminar). New `warnings`/WARN
verdict surfaces exempted quotes without failing the build.

## Verification (raw evidence)

**STOP-gate — all 3 shipped folk modules pass the new gate, fragments now actually verified (not skipped):**
```
narodni-tantsi: passed=True checked=7 violations=0 msg=verify_quote: 7 verified
narodni-balady: passed=True checked=2 violations=0 msg=verify_quote: 2 verified
pisni-literaturnoho-pokhodzhennia: passed=True checked=2 violations=0 msg=verify_quote: 2 verified
ALL_PASS= True
```
(Fragments independently confirmed attested by the folk-track driver: «А ми просо сіяли»→Hrushevsky 1.0;
«Ой на горі вогонь горить…»→folk ballad `ukrlib-narod-dumy`; «Реве та стогне Дніпр широкий»→Shevchenko
«Причинна» 1.0; «Знаю, що смерть — як коса замашна»→Skovoroda.)

**Tests — 62 pass (13 gate incl. the fabrication-catch, 42 gate/pipeline, 7 vesum-blockquote callers):**
```
tests/test_textbook_quote_fidelity_gate.py ............. 13 passed
tests/test_textbook_quote_fidelity_gate.py + test_linear_pipeline_* + test_python_qg_correction_loop → 42 passed
tests/test_vesum_blockquote_exempt.py ....... 7 passed
```
Key new tests: seminar `NO_VERIFY` attested → pass; seminar `NO_VERIFY` fabricated + no exemption → **HARD
violation**; exemption → WARN+pass; core `NO_VERIFY` → still skipped.

**Lint:** `ruff check` → `All checks passed!`

**Diff scope (`git diff --name-status origin/main...HEAD`):**
```
M	scripts/build/linear_pipeline.py
A	scripts/build/seminar_quote_exemptions.json
A	scripts/build/seminar_quote_exemptions.py
M	tests/test_textbook_quote_fidelity_gate.py
```

## Provenance & boundary
Authored by cursor (composer-2.5) under a folk-track-driver dispatch; the dispatch was rate-limited before
push/PR, so the folk-track driver independently ran the STOP-gate + full test/lint verification and finalized.
**Non-merging — folk-track driver opens PRs; the orchestrator reconciles/promotes `main`.** No content
(module/MDX) touched; no changes to `main`.
