### PR TITLE
[codex] feat(audit): add scorer adapter layer

### DIFF
--- a/docs/projects/ua-eval-harness/README.md
+++ b/docs/projects/ua-eval-harness/README.md
@@ -51,6 +51,8 @@ These are NOT the harness, but they are the scorer-side foundation:
 - [UA contact quality evidence schema](schema.md) documents
   `ua_contact_quality_evidence.v1` and the helper module
   `scripts/audit/qg_schema.py`.
+- [Scorer adapter boundaries](scorer-adapters.md) document the #4308
+  deterministic, UA-GEC-fixture, and LLM-placeholder adapter layer.
 - [Agent fleet evidence for #4307](agent-fleet-4307.md) records the concrete
   fleet lanes used for the schema slice and the observed strengths/weaknesses.
 

--- a/docs/projects/ua-eval-harness/scorer-adapters.md
+++ b/docs/projects/ua-eval-harness/scorer-adapters.md
@@ -1,0 +1,48 @@
+# Scorer Adapter Boundaries
+
+Issue: [#4308](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4308)
+
+The adapter layer lives in `scripts/audit/qg_adapters.py`. Its only job is to
+normalize scorer signals into `scripts/audit/qg_schema.py` findings; it does
+not define new scoring policy, dispatch LLM prompts, or bulk-run curriculum
+modules.
+
+## Adapter Sources
+
+| Adapter | Source | Confidence |
+| --- | --- | --- |
+| `DeterministicRuleAdapter` | `scan_curriculum_module()`, `check_russicisms()`, and #912 `scan_plan_for_russianisms()` | `deterministic` |
+| `UaGecGoldFixtureAdapter` | `data/ua-gec-gold/ua-gec-gold.json` curated rows | `lookup_heuristic` |
+| `LlmJudgmentAdapter` | Pre-supplied structured placeholder judgments only | `llm_judgment` |
+
+## Deterministic Before LLM
+
+Cheap deterministic checks stay in `DeterministicRuleAdapter` so routing can run
+them before any future LLM-only reviewer work. The #912 semantic false-friends
+linter is wired through `scan_plan_for_russianisms(plan_path)` and converted
+with `qg_schema.build_semantic_false_friend_finding()`. The content Russicism
+gate is normalized from `check_russicisms(content, file_path=...)`.
+
+## UA-GEC Gold Limitations
+
+`UaGecGoldFixtureAdapter` preserves each fixture row's gold tag and canonical
+finding. It intentionally does not re-label `F/Calque` rows, because the fixture
+documents known noise on that axis. The adapter carries a metadata hook:
+
+```json
+{
+  "ua_gec_gold": {
+    "gold_relabelled": false,
+    "contested_flag": null,
+    "contested_flag_follow_up": "#4364"
+  }
+}
+```
+
+That hook is for the contested-flag review layer tracked separately in #4364.
+
+## LLM Placeholder
+
+`LlmJudgmentAdapter` accepts already-structured judgments and sets
+`confidence: llm_judgment`. Prompt templates, model selection, reviewer
+profiles, and dispatch belong to #4309 and are deliberately out of this layer.

--- a/scripts/audit/qg_adapters.py
+++ b/scripts/audit/qg_adapters.py
@@ -1,0 +1,321 @@
+"""Adapter layer for normalizing quality-gate scorer signals.
+
+The adapters in this module are intentionally thin: they route existing scorer
+outputs into the canonical ``qg_schema`` finding shape and keep cheap
+deterministic checks separate from future LLM judgment. They do not bulk-run
+curriculum modules and they do not dispatch prompts.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+from scripts.audit import qg_schema
+from scripts.audit.checks.russicism_detection import check_russicisms
+from scripts.audit.curriculum_qg_harness import scan_curriculum_module
+from scripts.pipeline.semantic_russianisms import scan_plan_for_russianisms
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+UA_GEC_GOLD_PATH = PROJECT_ROOT / "data" / "ua-gec-gold" / "ua-gec-gold.json"
+
+_LEGACY_DIMENSION_ALIASES = {
+    "tone_register": "tone",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ScorerInput:
+    """One bounded scorer target for adapter normalization.
+
+    ``module_dir`` triggers a single deterministic curriculum scan when paired
+    with ``level``. ``text`` triggers the existing Russicism/calque gate.
+    ``plan_path`` triggers the #912 semantic false-friend linter. LLM judgments
+    must be supplied as structured data; this layer never calls a model.
+    """
+
+    text: str | None = None
+    file: str = "module.md"
+    module_dir: Path | None = None
+    level: str | None = None
+    slug: str | None = None
+    plan_path: Path | None = None
+    fixture_id: str | None = None
+    llm_judgments: Sequence[Mapping[str, Any]] = field(default_factory=tuple)
+
+
+class FindingAdapter(Protocol):
+    """Small interface shared by deterministic, lookup, and LLM adapters."""
+
+    name: str
+    confidence: str
+
+    def findings(self, target: ScorerInput) -> list[dict[str, Any]]:
+        """Return canonical ``qg_schema`` findings for one bounded target."""
+
+
+def _schema_dimension(value: str) -> str:
+    return _LEGACY_DIMENSION_ALIASES.get(value, value)
+
+
+def _first_excerpt(text: str, fallback: str) -> str:
+    for line in text.splitlines():
+        clean = line.strip()
+        if clean:
+            return clean[:160]
+    return fallback[:160] or "deterministic scorer finding"
+
+
+def _locate_excerpt(text: str, excerpt: str) -> tuple[int | None, dict[str, int | None]]:
+    start = text.find(excerpt)
+    if start < 0:
+        return None, qg_schema.make_span(None, None)
+    return text.count("\n", 0, start) + 1, qg_schema.make_span(start, start + len(excerpt))
+
+
+class DeterministicRuleAdapter:
+    """Normalize cheap deterministic curriculum and Russianism/calque findings.
+
+    Sources:
+    - `scan_curriculum_module()` for the B1-27 deterministic fixture rules.
+    - `check_russicisms()` for the existing Russianism/calque text gate.
+    - `scan_plan_for_russianisms()` from #912 for semantic false friends in
+      plan `vocabulary_hints`.
+    """
+
+    name = "deterministic_rules"
+    confidence = "deterministic"
+
+    def findings(self, target: ScorerInput) -> list[dict[str, Any]]:
+        findings: list[dict[str, Any]] = []
+        if target.module_dir is not None:
+            findings.extend(self._curriculum_findings(target))
+        if target.text is not None:
+            findings.extend(self._russicism_findings(target.text, target.file))
+        if target.plan_path is not None:
+            findings.extend(self._semantic_plan_findings(target.plan_path))
+        return findings
+
+    def _curriculum_findings(self, target: ScorerInput) -> list[dict[str, Any]]:
+        if not target.level:
+            raise ValueError("DeterministicRuleAdapter requires level with module_dir")
+        evidence = scan_curriculum_module(
+            target.module_dir,
+            level=target.level,
+            slug=target.slug,
+            fixture_id=target.fixture_id,
+        )
+        normalized: list[dict[str, Any]] = []
+        for finding in _iter_dimension_findings(evidence):
+            normalized.append(
+                qg_schema.build_deterministic_curriculum_finding(
+                    issue_id=str(finding["issue_id"]),
+                    rule_id=str(finding.get("rule_id") or finding["issue_id"]),
+                    dimension=_schema_dimension(str(finding["dimension"])),
+                    severity=str(finding["severity"]),
+                    file=str(finding["file"]),
+                    line=int(finding["line"]),
+                    span=finding["span"],
+                    excerpt=str(finding["excerpt"]),
+                    message=str(finding["message"]),
+                    contact_source_lang="unknown",
+                )
+            )
+        return normalized
+
+    def _russicism_findings(self, text: str, file: str) -> list[dict[str, Any]]:
+        normalized: list[dict[str, Any]] = []
+        for violation in check_russicisms(text, file_path=file):
+            excerpt = str(violation.get("matched") or _first_excerpt(text, str(violation.get("issue") or "")))
+            normalized.append(
+                qg_schema.build_finding(
+                    issue_id=str(violation.get("type") or "RUSSICISM_DETECTED"),
+                    issue_class="calque",
+                    dimension="contact_calque",
+                    severity=str(violation.get("severity") or "warning"),
+                    file=file,
+                    line=None,
+                    span=None,
+                    excerpt=excerpt,
+                    message=str(violation.get("issue") or "Russicism/calque detected."),
+                    contact_source_lang="ru",
+                    confidence=self.confidence,
+                    detector={
+                        "adapter": "russicism_detection",
+                        "rule_id": str(violation.get("type") or "RUSSICISM_DETECTED"),
+                        "pattern_id": str(violation.get("type") or "RUSSICISM_DETECTED"),
+                    },
+                    attribution={
+                        "corpus": "scripts.audit.checks.russicism_detection",
+                        "license": None,
+                        "evidence": "deterministic Russianism/calque regex gate",
+                    },
+                    metadata={
+                        "deterministic_gate": {
+                            "raw_type": violation.get("type"),
+                            "fix": violation.get("fix"),
+                        }
+                    },
+                )
+            )
+        return normalized
+
+    def _semantic_plan_findings(self, plan_path: Path) -> list[dict[str, Any]]:
+        plan_text = plan_path.read_text(encoding="utf-8") if plan_path.exists() else ""
+        normalized: list[dict[str, Any]] = []
+        for finding in scan_plan_for_russianisms(plan_path):
+            excerpt = str(finding.get("original_entry") or finding.get("word") or "semantic false friend")
+            line, span = _locate_excerpt(plan_text, excerpt)
+            normalized.append(
+                qg_schema.build_semantic_false_friend_finding(
+                    word=str(finding["word"]),
+                    russian_meaning=str(finding["meaning_found"]),
+                    ukrainian_meaning=str(finding["ukrainian_meaning"]),
+                    replacement=finding.get("replacement"),
+                    matched_gloss_pattern=excerpt,
+                    file=str(plan_path),
+                    line=line,
+                    span=span,
+                    excerpt=excerpt,
+                    severity="critical",
+                )
+            )
+        return normalized
+
+
+class UaGecGoldFixtureAdapter:
+    """Normalize curated UA-GEC gold-fixture rows without re-labeling gold tags."""
+
+    name = "ua_gec_gold_fixture"
+    confidence = "lookup_heuristic"
+
+    def __init__(self, fixture_path: Path = UA_GEC_GOLD_PATH) -> None:
+        self.fixture_path = fixture_path
+
+    def findings(self, target: ScorerInput) -> list[dict[str, Any]]:
+        items = self._load_items()
+        if target.fixture_id:
+            items = [item for item in items if item.get("id") == target.fixture_id]
+        return [self._normalize_item(item) for item in items]
+
+    @property
+    def known_limitations(self) -> dict[str, Any]:
+        payload = self._load_payload()
+        limitations = payload.get("known_limitations")
+        return dict(limitations) if isinstance(limitations, Mapping) else {}
+
+    def _load_payload(self) -> dict[str, Any]:
+        payload = json.loads(self.fixture_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("UA-GEC gold fixture must be a JSON object")
+        return payload
+
+    def _load_items(self) -> list[dict[str, Any]]:
+        payload = self._load_payload()
+        items = payload.get("items")
+        if not isinstance(items, list):
+            raise ValueError("UA-GEC gold fixture missing items list")
+        return [item for item in items if isinstance(item, dict)]
+
+    def _normalize_item(self, item: Mapping[str, Any]) -> dict[str, Any]:
+        finding = dict(item.get("finding") or {})
+        qg_schema.validate_finding(finding)
+        finding["confidence"] = self.confidence
+        detector = dict(finding.get("detector") or {})
+        detector["adapter"] = self.name
+        finding["detector"] = detector
+        metadata = dict(finding.get("metadata") or {})
+        metadata["ua_gec_gold"] = {
+            "fixture_id": item.get("id"),
+            "gold_tag": item.get("tag"),
+            "gold_relabelled": False,
+            "known_limitations": self.known_limitations,
+            "contested_flag": None,
+            "contested_flag_follow_up": "#4364",
+        }
+        finding["metadata"] = metadata
+        qg_schema.validate_finding(finding)
+        return finding
+
+
+class LlmJudgmentAdapter:
+    """Placeholder normalizer for future #4309 LLM judgments.
+
+    The adapter accepts already-structured judgments and tags them with
+    `llm_judgment` confidence. Prompt construction, model dispatch, and profile
+    policy stay out of this layer.
+    """
+
+    name = "llm_judgment_placeholder"
+    confidence = "llm_judgment"
+
+    def findings(self, target: ScorerInput) -> list[dict[str, Any]]:
+        return [self._normalize_judgment(judgment) for judgment in target.llm_judgments]
+
+    def _normalize_judgment(self, judgment: Mapping[str, Any]) -> dict[str, Any]:
+        return qg_schema.build_finding(
+            issue_id=str(judgment["issue_id"]),
+            issue_class=str(judgment["issue_class"]),
+            dimension=str(judgment["dimension"]),
+            severity=str(judgment["severity"]),
+            file=str(judgment.get("file") or "llm-review"),
+            line=judgment.get("line"),
+            span=judgment.get("span"),
+            excerpt=str(judgment["excerpt"]),
+            message=str(judgment["message"]),
+            contact_source_lang=judgment.get("contact_source_lang") or judgment.get("source_lang") or "unknown",
+            ua_gec_tag=judgment.get("ua_gec_tag"),
+            confidence=self.confidence,
+            disposition=str(judgment.get("disposition") or "defect"),
+            suggested_replacement=judgment.get("suggested_replacement"),
+            detector={
+                "adapter": self.name,
+                "rule_id": str(judgment.get("rule_id") or judgment["issue_id"]),
+                "pattern_id": str(judgment.get("pattern_id") or judgment["issue_id"]),
+            },
+            attribution=judgment.get("attribution"),
+            sense_context=judgment.get("sense_context"),
+            metadata={
+                "llm": {
+                    "provider": judgment.get("provider"),
+                    "model": judgment.get("model"),
+                    "prompt_version": judgment.get("prompt_version"),
+                    "placeholder_only": True,
+                }
+            },
+        )
+
+
+def _iter_dimension_findings(evidence: Mapping[str, Any]) -> Iterable[Mapping[str, Any]]:
+    dimensions = evidence.get("dimensions")
+    if not isinstance(dimensions, Mapping):
+        return []
+    findings: list[Mapping[str, Any]] = []
+    for entry in dimensions.values():
+        if isinstance(entry, Mapping) and isinstance(entry.get("findings"), list):
+            findings.extend(item for item in entry["findings"] if isinstance(item, Mapping))
+    return findings
+
+
+def dimensions_from_findings(findings: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Group canonical findings into schema-valid dimension records."""
+
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for finding in findings:
+        qg_schema.validate_finding(finding)
+        grouped.setdefault(str(finding["dimension"]), []).append(finding)
+    return {
+        dimension: qg_schema.build_dimension(verdict=_verdict_for_findings(items), findings=items)
+        for dimension, items in grouped.items()
+    }
+
+
+def _verdict_for_findings(findings: Sequence[Mapping[str, Any]]) -> str:
+    if any(finding.get("severity") == "critical" for finding in findings):
+        return "FAIL"
+    if findings:
+        return "WARN"
+    return "PASS"

--- a/scripts/audit/qg_adapters.py
+++ b/scripts/audit/qg_adapters.py
@@ -164,7 +164,9 @@ class DeterministicRuleAdapter:
         return normalized
 
     def _semantic_plan_findings(self, plan_path: Path) -> list[dict[str, Any]]:
-        plan_text = plan_path.read_text(encoding="utf-8") if plan_path.exists() else ""
+        if not plan_path.exists():
+            return []
+        plan_text = plan_path.read_text(encoding="utf-8")
         normalized: list[dict[str, Any]] = []
         for finding in scan_plan_for_russianisms(plan_path):
             excerpt = str(finding.get("original_entry") or finding.get("word") or "semantic false friend")
@@ -194,12 +196,14 @@ class UaGecGoldFixtureAdapter:
 
     def __init__(self, fixture_path: Path = UA_GEC_GOLD_PATH) -> None:
         self.fixture_path = fixture_path
+        self._payload_cache: dict[str, Any] | None = None
 
     def findings(self, target: ScorerInput) -> list[dict[str, Any]]:
         items = self._load_items()
         if target.fixture_id:
             items = [item for item in items if item.get("id") == target.fixture_id]
-        return [self._normalize_item(item) for item in items]
+        known_limitations = self.known_limitations
+        return [self._normalize_item(item, known_limitations) for item in items]
 
     @property
     def known_limitations(self) -> dict[str, Any]:
@@ -208,10 +212,12 @@ class UaGecGoldFixtureAdapter:
         return dict(limitations) if isinstance(limitations, Mapping) else {}
 
     def _load_payload(self) -> dict[str, Any]:
-        payload = json.loads(self.fixture_path.read_text(encoding="utf-8"))
-        if not isinstance(payload, dict):
-            raise ValueError("UA-GEC gold fixture must be a JSON object")
-        return payload
+        if self._payload_cache is None:
+            payload = json.loads(self.fixture_path.read_text(encoding="utf-8"))
+            if not isinstance(payload, dict):
+                raise ValueError("UA-GEC gold fixture must be a JSON object")
+            self._payload_cache = payload
+        return self._payload_cache
 
     def _load_items(self) -> list[dict[str, Any]]:
         payload = self._load_payload()
@@ -220,9 +226,8 @@ class UaGecGoldFixtureAdapter:
             raise ValueError("UA-GEC gold fixture missing items list")
         return [item for item in items if isinstance(item, dict)]
 
-    def _normalize_item(self, item: Mapping[str, Any]) -> dict[str, Any]:
+    def _normalize_item(self, item: Mapping[str, Any], known_limitations: Mapping[str, Any]) -> dict[str, Any]:
         finding = dict(item.get("finding") or {})
-        qg_schema.validate_finding(finding)
         finding["confidence"] = self.confidence
         detector = dict(finding.get("detector") or {})
         detector["adapter"] = self.name
@@ -232,7 +237,7 @@ class UaGecGoldFixtureAdapter:
             "fixture_id": item.get("id"),
             "gold_tag": item.get("tag"),
             "gold_relabelled": False,
-            "known_limitations": self.known_limitations,
+            "known_limitations": dict(known_limitations),
             "contested_flag": None,
             "contested_flag_follow_up": "#4364",
         }

--- a/tests/test_qg_adapters.py
+++ b/tests/test_qg_adapters.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.audit import qg_schema
+from scripts.audit.qg_adapters import (
+    DeterministicRuleAdapter,
+    LlmJudgmentAdapter,
+    ScorerInput,
+    UaGecGoldFixtureAdapter,
+    dimensions_from_findings,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_FILE = PROJECT_ROOT / "tests" / "fixtures" / "curriculum_qg" / "fixtures.yaml"
+
+
+def _fixture_by_id(fixture_id: str) -> dict[str, Any]:
+    payload = yaml.safe_load(FIXTURE_FILE.read_text(encoding="utf-8"))
+    for fixture in payload["fixtures"]:
+        if fixture["id"] == fixture_id:
+            return fixture
+    raise AssertionError(f"missing fixture {fixture_id}")
+
+
+def _write_fixture_module(tmp_path: Path, fixture: dict[str, Any]) -> Path:
+    module_dir = tmp_path / fixture["slug"]
+    module_dir.mkdir()
+    for name, body in fixture["module"].items():
+        (module_dir / name).write_text(str(body).rstrip() + "\n", encoding="utf-8")
+    return module_dir
+
+
+def test_deterministic_adapter_normalizes_b1_27_fixture_findings(tmp_path: Path) -> None:
+    fixture = _fixture_by_id("b1-27-restored-bad")
+    module_dir = _write_fixture_module(tmp_path, fixture)
+
+    findings = DeterministicRuleAdapter().findings(
+        ScorerInput(
+            module_dir=module_dir,
+            level=fixture["level"],
+            slug=fixture["slug"],
+            fixture_id=fixture["id"],
+        )
+    )
+
+    by_issue = {finding["issue_id"] for finding in findings}
+    assert "AWKWARD_PASSIVE_RESULT_STATE" in by_issue
+    assert "CALQUED_PREPOSITION" in by_issue
+    assert all(finding["confidence"] == "deterministic" for finding in findings)
+    assert all(finding["detector"]["adapter"] == "curriculum_qg_harness" for finding in findings)
+    for finding in findings:
+        qg_schema.validate_finding(finding)
+
+
+def test_deterministic_adapter_wraps_russianism_calque_gate() -> None:
+    findings = DeterministicRuleAdapter().findings(
+        ScorerInput(
+            text="Він буде приймати участь у вправі.",
+            file="curriculum/l2-uk-en/b1/example/module.md",
+        )
+    )
+
+    assert [finding["issue_id"] for finding in findings] == ["RUSSICISM_DETECTED"]
+    finding = findings[0]
+    qg_schema.validate_finding(finding)
+    assert finding["confidence"] == "deterministic"
+    assert finding["issue_class"] == "calque"
+    assert finding["contact_source_lang"] == "ru"
+
+
+def test_deterministic_adapter_wires_912_semantic_false_friend_linter(tmp_path: Path) -> None:
+    plan_path = tmp_path / "aspect-in-imperatives.yaml"
+    plan_path.write_text(
+        "vocabulary_hints:\n"
+        "  required:\n"
+        "    - 'лук (onion) — everyday food'\n",
+        encoding="utf-8",
+    )
+
+    findings = DeterministicRuleAdapter().findings(ScorerInput(plan_path=plan_path))
+
+    assert len(findings) == 1
+    finding = findings[0]
+    qg_schema.validate_finding(finding)
+    assert finding["issue_id"] == "SEMANTIC_FALSE_FRIEND"
+    assert finding["confidence"] == "deterministic"
+    assert finding["suggested_replacement"] == ["цибуля"]
+    assert finding["sense_context"]["word"] == "лук"
+    assert finding["line"] == 3
+    assert isinstance(finding["span"]["start"], int)
+
+
+def test_ua_gec_fixture_adapter_preserves_gold_tag_and_noisy_axis_hook() -> None:
+    findings = UaGecGoldFixtureAdapter().findings(ScorerInput(fixture_id="ua-gec-gold-001"))
+
+    assert len(findings) == 1
+    finding = findings[0]
+    qg_schema.validate_finding(finding)
+    assert finding["confidence"] == "lookup_heuristic"
+    assert finding["ua_gec_tag"] == "F/Calque"
+    assert finding["detector"]["adapter"] == "ua_gec_gold_fixture"
+    gold = finding["metadata"]["ua_gec_gold"]
+    assert gold["gold_relabelled"] is False
+    assert gold["contested_flag"] is None
+    assert gold["contested_flag_follow_up"] == "#4364"
+    assert "gold_noise" in gold["known_limitations"]
+
+
+def test_llm_placeholder_adapter_normalizes_supplied_judgment_without_dispatch() -> None:
+    findings = LlmJudgmentAdapter().findings(
+        ScorerInput(
+            llm_judgments=[
+                {
+                    "issue_id": "LLM_UNNATURAL_COLLOCATION",
+                    "issue_class": "collocation",
+                    "dimension": "naturalness",
+                    "severity": "warning",
+                    "file": "module.md",
+                    "line": 7,
+                    "span": {"start": 12, "end": 31},
+                    "excerpt": "неприродна сполука",
+                    "message": "Placeholder reviewer judgment for #4309.",
+                    "contact_source_lang": "unknown",
+                    "provider": "placeholder",
+                    "model": "none",
+                    "prompt_version": "pending-4309",
+                }
+            ]
+        )
+    )
+
+    assert len(findings) == 1
+    finding = findings[0]
+    qg_schema.validate_finding(finding)
+    assert finding["confidence"] == "llm_judgment"
+    assert finding["detector"]["adapter"] == "llm_judgment_placeholder"
+    assert finding["metadata"]["llm"]["placeholder_only"] is True
+
+
+def test_three_adapter_sources_share_one_schema_record() -> None:
+    deterministic = DeterministicRuleAdapter().findings(
+        ScorerInput(
+            text="Він буде приймати участь у вправі.",
+            file="curriculum/l2-uk-en/b1/example/module.md",
+        )
+    )[:1]
+    ua_gec = UaGecGoldFixtureAdapter().findings(ScorerInput(fixture_id="ua-gec-gold-033"))
+    llm = LlmJudgmentAdapter().findings(
+        ScorerInput(
+            llm_judgments=[
+                {
+                    "issue_id": "LLM_STYLE_REVIEW",
+                    "issue_class": "fluency",
+                    "dimension": "naturalness",
+                    "severity": "info",
+                    "file": "module.md",
+                    "line": None,
+                    "span": None,
+                    "excerpt": "стилістично сумнівний фрагмент",
+                    "message": "Placeholder LLM-only judgment.",
+                }
+            ]
+        )
+    )
+    findings = [*deterministic, *ua_gec, *llm]
+
+    record = qg_schema.build_evidence_record(
+        profile="curriculum_llm_compact",
+        evidence_kind="fixture",
+        fixture_id="adapter-compatibility",
+        dimensions=dimensions_from_findings(findings),
+        verdict="WARN",
+        terminal_verdict="PASS",
+    )
+
+    qg_schema.validate_record(record)
+    assert {finding["confidence"] for finding in findings} == {
+        "deterministic",
+        "lookup_heuristic",
+        "llm_judgment",
+    }

--- a/tests/test_qg_adapters.py
+++ b/tests/test_qg_adapters.py
@@ -94,6 +94,12 @@ def test_deterministic_adapter_wires_912_semantic_false_friend_linter(tmp_path: 
     assert isinstance(finding["span"]["start"], int)
 
 
+def test_deterministic_adapter_ignores_missing_plan_path(tmp_path: Path) -> None:
+    findings = DeterministicRuleAdapter().findings(ScorerInput(plan_path=tmp_path / "missing.yaml"))
+
+    assert findings == []
+
+
 def test_ua_gec_fixture_adapter_preserves_gold_tag_and_noisy_axis_hook() -> None:
     findings = UaGecGoldFixtureAdapter().findings(ScorerInput(fixture_id="ua-gec-gold-001"))
 


### PR DESCRIPTION
## Summary

Closes #4308. Refs #2156.

Adds `scripts/audit/qg_adapters.py`, a thin normalization layer over three scorer sources:

- deterministic rules: curriculum QG fixture scan, Russicism/calque gate, and #912 semantic false-friend plan linter
- UA-GEC gold fixture rows from `data/ua-gec-gold/ua-gec-gold.json`, preserving noisy `F/Calque` gold tags and adding the #4364 contested-flag metadata hook
- LLM-only placeholder judgments tagged as `llm_judgment`, with no prompt construction or model dispatch

Also adds focused adapter tests and documents the boundaries in `docs/projects/ua-eval-harness/scorer-adapters.md`.

## #M-4 Verification Preamble

Claim: adapters produce schema-valid findings.

```text
$ .venv/bin/python - <<'PY' ... qg_schema.validate_finding(...)
qg_schema.validate_finding assertions passed: 3
confidence tiers: deterministic, llm_judgment, lookup_heuristic
```

```text
$ .venv/bin/python -m pytest tests/test_qg_adapters.py -q
============================== 7 passed in 0.40s ===============================
```

Claim: #912 is wired, not merely documented.

```text
$ rg -n "scan_plan_for_russianisms|build_semantic_false_friend_finding|#912" scripts/audit/qg_adapters.py docs/projects/ua-eval-harness/scorer-adapters.md tests/test_qg_adapters.py
scripts/audit/qg_adapters.py:20:from scripts.pipeline.semantic_russianisms import scan_plan_for_russianisms
scripts/audit/qg_adapters.py:36:    ``plan_path`` triggers the #912 semantic false-friend linter. LLM judgments
scripts/audit/qg_adapters.py:171:        for finding in scan_plan_for_russianisms(plan_path):
scripts/audit/qg_adapters.py:175:                qg_schema.build_semantic_false_friend_finding(
```

```text
$ .venv/bin/python -m pytest tests/test_qg_adapters.py::test_deterministic_adapter_wires_912_semantic_false_friend_linter -q
============================== 1 passed in 0.41s ===============================
```

Claim: B1-27 handled.

```text
$ .venv/bin/python -m pytest tests/test_qg_adapters.py::test_deterministic_adapter_normalizes_b1_27_fixture_findings -q
============================== 1 passed in 0.41s ===============================
```

Claim: ruff clean.

```text
$ .venv/bin/ruff check scripts/audit/qg_adapters.py tests/test_qg_adapters.py
All checks passed!
```

Claim: trailer present.

```text
$ .venv/bin/python scripts/audit/lint_agent_trailer.py origin/main..HEAD
Checking 2 commit(s) in origin/main..HEAD:

  66e8b83163  PASS  X-Agent: codex/4308-scorer-adapters
  35665fb406  PASS  X-Agent: codex/4308-scorer-adapters

✅ All 2 non-skipped commit(s) carry an X-Agent trailer.
```

Additional hygiene:

```text
$ git diff --check origin/main..HEAD
<no output>
```

```text
$ git diff --name-only origin/main..HEAD | wc -l
4
```

## Independent Review

AGY/Gemini read-only review was routed after PR creation. It returned findings on UA-GEC fixture payload caching, raw-fixture validation order, and missing-plan handling; all three were addressed in `66e8b83163`.

```text
All three findings have been successfully resolved in the provided diff:
...
No blockers remain based on the provided diff.
```

## Notes

This PR deliberately does not add #4309 prompts, reviewer profiles, model routing, or corpus-scale module runs. Final gate remains independent non-Codex review before any corpus-scale run.