### PR TITLE
feat(audit): LLM reviewer prompt + evaluator for Ukrainian quality (#4309)

### DIFF
--- a/docs/projects/ua-eval-harness/calibration_criteria.md
+++ b/docs/projects/ua-eval-harness/calibration_criteria.md
@@ -1,0 +1,66 @@
+# Calibration Criteria & Level Profiles for LLM Quality Gate Reviewer
+
+This document defines the calibration criteria, level profiles, false-positive/false-negative controls, and structural validation specifications implemented for the LLM reviewer layer in the Ukrainian-quality gates evaluation harness (#4309).
+
+---
+
+## 1. Level Profiles & Immersion Policies
+
+Linguistic expectations and immersion rules are strictly partitioned by target CEFR level:
+
+### A1/A2 (Scaffolded Support)
+* **Goal**: Provide beginner-appropriate bilingual grounding.
+* **Scaffolding Policy**: Substantial English instruction and translation scaffolding are expected and allowed.
+* **Defect Handling**: Do NOT flag English text as leakage. English is only rejected if it contains AI personae, temporary paths, or internal metadata.
+* **Max-Immersion Constraint**: Never recommend increasing the English ratio or adding English translations where Ukrainian-only content exists. Respect the level's maximum immersion goal.
+
+### B1+ (Ukrainian-led Immersion)
+* **Goal**: Transition learners to full immersion.
+* **Immersion Policy**: All instructional prose, grammar explanations, and metadata directions must be written in natural Ukrainian.
+* **Defect Handling**: Any English-led paragraphs or English explanations are flagged as `ENGLISH_LEAKAGE` (`level_policy` dimension, `critical` severity).
+* **Gloss Exemption**: Brief bilingual vocabulary glosses (e.g. `**Застосунок** - app.`) are allowed and must not be flagged.
+
+### Seminar Register & Factual Sensitivity (bio, folk, hist, istorio, lit, oes, ruth, etc.)
+* **Goal**: Achieve scholarly register, factual correctness, and historical sensitivity.
+* **Pathos/Register Control**: Strictly avoid marketing language, enthusiastic hype, and patriotic slogans (e.g., "неймовірна подорож", "пориньмо у захопливий світ"). The register must remain objective and formal.
+* **Vital Status Check**:Biography modules must verify whether the subject is living or deceased. For LIVING subjects, headers or prose sections implying death or legacy (e.g., "Last Years" / `Останні роки` or "Legacy" / `Спадщина`) are strictly forbidden as they mimic obituaries. Instead, use "Contemporary Stage" / `Сучасний етап` or "Influence" / `Вплив`.
+* **Factual Grounding**: All historical and cultural details must be verified against primary resources (e.g., `litopys.org.ua`). The YouTube channel "REALNA ISTORIIA" (Akim Galimov) is the gold standard for historical modules. Reject low-quality propaganda channels.
+
+---
+
+## 2. B1-27 Calibration Criteria (HARD Calibration)
+
+The B1-27 *restored-bad* examples contain unidiomatic or calqued Ukrainian constructions that are not lexical Russianisms (pure Russian words) but are stylistic/syntactic defects. The reviewer must detect:
+
+| Restored-Bad Phrase | Expected Issue ID | Dimension | Target Idiomatic Ukrainian | Rationale |
+|---|---|---|---|---|
+| `застосунок має бути відкритий` | `AWKWARD_PASSIVE_RESULT_STATE` | `ukrainian_style` | `відкрийте застосунок` / `застосунок має бути відкритим` | Impersonal/active voice is preferred over literal passive state translations. |
+| `Застереження каже: будь обережний` | `UNNATURAL_ANTHROPOMORPHISM` | `ukrainian_style` | `Зверніть увагу` / `Будьте обережні` | Abstract warning blocks must not be anthropomorphized as speakers. |
+| `радить не робити певної поведінки` | `UKRAINIAN_GRAMMAR_CALQUE` | `ukrainian_style` | `рекомендує уникати...` | Unnatural verbal government and nominalization. |
+| `дія має дати конкретний результат чи описати процес?` | `UNNATURAL_META_REGISTER` | `ukrainian_style` | (Avoid in learner-facing text) | Overly abstract syntactic metalanguage / prompt leakage. |
+| `доконаний вид дає результат із вікном` | `UKRAINIAN_GRAMMAR_CALQUE` | `ukrainian_style` | `доконаний вид позначає результат...` | Literal calqued metaphor and unidiomatic argument structure. |
+| `У кухні` | `CALQUED_PREPOSITION` | `ukrainian_style` | `На кухні` | Location prep calque; "На кухні" is the standard locative context. |
+
+---
+
+## 3. False-Positive / False-Negative Controls
+
+To maintain high precision, the LLM reviewer must distinguish actual defects from valid teaching contexts:
+
+* **Contrastive Examples**: The presence of a bad form (e.g., in a "Correct vs Incorrect" table or strikethrough like `~~wrong form~~`) is a `teaching_contrast` or `quoted_bad_form` disposition and must not penalize the module.
+* **Heritage/SUM Attestation**: Authentic Ukrainian archaisms, dialectal forms, and complex syntax validated by VESUM/СУМ/Grinchenko must not be flagged as calques or Russianisms.
+* **Level Simplicity**: A1/A2 grammatical simplicity (e.g., SVO rigidity or explicit copula `є` in early A1) must not be flagged as unnatural.
+
+---
+
+## 4. Structural Model Answer Check Spec
+
+For modules graded at level B2, C1, or C2, all productive writing tasks (specifically `type: essay-response` in `activities.yaml`) must contain a `model_answer` field, and the answer must start with the markdown callout:
+```markdown
+> [!model-answer]
+```
+If missing, it triggers a `MISSING_MODEL_ANSWER` defect:
+* **Dimension**: `pedagogical`
+* **Severity**: `critical`
+* **Disposition**: `defect`
+* **Confidence**: `deterministic`

--- a/scripts/audit/llm_reviewer.py
+++ b/scripts/audit/llm_reviewer.py
@@ -1,0 +1,271 @@
+"""LLM reviewer prompt + evaluator layer.
+
+Performs deterministic structural checks (like model answers in B2+) and
+evaluates naturalness, register, and grammar using LLM review prompts.
+Conforms to the canonical schema version ua_contact_quality_evidence.v1.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.audit import qg_schema
+
+PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+DEFAULT_PROMPT_PATH = PROMPTS_DIR / "reviewer_prompt.md"
+
+
+def load_reviewer_prompt_template(path: Path | None = None) -> str:
+    """Load the LLM reviewer prompt template from disk."""
+    resolved_path = path or DEFAULT_PROMPT_PATH
+    if not resolved_path.exists():
+        raise FileNotFoundError(f"Reviewer prompt template not found at {resolved_path}")
+    return resolved_path.read_text(encoding="utf-8")
+
+
+def build_reviewer_prompt(
+    level: str,
+    slug: str,
+    module_md: str,
+    activities_yaml: str = "",
+    vocabulary_yaml: str = "",
+    resources_yaml: str = "",
+    template_path: Path | None = None,
+) -> str:
+    """Assemble the complete prompt for the LLM reviewer."""
+    template = load_reviewer_prompt_template(template_path)
+
+    # We construct a detailed user prompt with context and module content
+    content_block = f"""## Module Metadata
+Level: {level}
+Slug: {slug}
+
+## File: module.md
+```markdown
+{module_md}
+```
+"""
+    if activities_yaml.strip():
+        content_block += f"\n## File: activities.yaml\n```yaml\n{activities_yaml}\n```\n"
+    if vocabulary_yaml.strip():
+        content_block += f"\n## File: vocabulary.yaml\n```yaml\n{vocabulary_yaml}\n```\n"
+    if resources_yaml.strip():
+        content_block += f"\n## File: resources.yaml\n```yaml\n{resources_yaml}\n```\n"
+
+    # Format user prompt with context and instructions
+    prompt = f"""{template}
+
+---
+
+## Target Module Content to Review:
+{content_block}
+"""
+    return prompt
+
+
+def run_structural_checks(
+    level: str,
+    activities_yaml: str,
+    file_name: str = "activities.yaml",
+) -> list[dict[str, Any]]:
+    """Perform deterministic structural checks, e.g., missing model answers for B2+/C1/C2 productive tasks."""
+    findings: list[dict[str, Any]] = []
+    level_lower = level.strip().lower()
+
+    # Structural check applies to levels starting with b2, c1, c2 (e.g. b2, c1, c2, c1-bio)
+    if not level_lower.startswith(("b2", "c1", "c2")):
+        return findings
+
+    if not activities_yaml.strip():
+        return findings
+
+    try:
+        activities = yaml.safe_load(activities_yaml)
+    except Exception:
+        # If YAML is malformed, let the syntax checkers handle it
+        return findings
+
+    if not isinstance(activities, list):
+        return findings
+
+    for activity in activities:
+        if not isinstance(activity, dict):
+            continue
+
+        act_type = activity.get("type")
+        # Production/productive tasks are typically essay-response
+        if act_type == "essay-response":
+            model_answer = activity.get("model_answer")
+            act_id = activity.get("id", "unknown")
+
+            # Find the line of the activity for locator accuracy
+            line_no = 1
+            lines = activities_yaml.splitlines()
+            for idx, line in enumerate(lines, 1):
+                if f"id: {act_id}" in line or f"id: '{act_id}'" in line or f'id: "{act_id}"' in line:
+                    line_no = idx
+                    break
+
+            span_start = activities_yaml.find(f"id: {act_id}")
+            if span_start == -1:
+                span_start = activities_yaml.find(act_id)
+            span_end = span_start + len(act_id) if span_start != -1 else None
+            span = {"start": span_start if span_start != -1 else None, "end": span_end}
+
+            excerpt = f"id: {act_id}"
+
+            is_missing = False
+            if model_answer is None or not isinstance(model_answer, str) or "> [!model-answer]" not in model_answer:
+                is_missing = True
+
+            if is_missing:
+                findings.append(
+                    qg_schema.build_finding(
+                        issue_id="MISSING_MODEL_ANSWER",
+                        issue_class="pedagogy",
+                        dimension="pedagogical",
+                        severity="critical",
+                        file=file_name,
+                        line=line_no,
+                        span=span,
+                        excerpt=excerpt,
+                        message=(
+                            f"Productive activity '{act_id}' at level '{level}' is missing the "
+                            "mandatory model answer block starting with '> [!model-answer]'."
+                        ),
+                        confidence="deterministic",
+                        disposition="defect",
+                        detector={
+                            "adapter": "llm_reviewer_structural",
+                            "rule_id": "missing_model_answer",
+                        },
+                        attribution={
+                            "corpus": "curriculum_structure_rules",
+                            "evidence": "Mandatory model-answer block for B2+/C1/C2",
+                        }
+                    )
+                )
+
+    return findings
+
+
+def locate_excerpt(text: str, excerpt: str) -> tuple[int | None, dict[str, int | None]]:
+    """Helper to locate line number and span of an excerpt in text."""
+    if not excerpt:
+        return None, {"start": None, "end": None}
+
+    start = text.find(excerpt)
+    if start == -1:
+        return None, {"start": None, "end": None}
+
+    line = text.count("\n", 0, start) + 1
+    return line, {"start": start, "end": start + len(excerpt)}
+
+
+def parse_and_evaluate_llm_response(
+    response_text: str,
+    module_md: str,
+    activities_yaml: str = "",
+    vocabulary_yaml: str = "",
+    resources_yaml: str = "",
+) -> list[dict[str, Any]]:
+    """Parse JSON response from the LLM and map findings to qg_schema."""
+    findings: list[dict[str, Any]] = []
+
+    try:
+        # Simple extraction of JSON from raw response text in case it has markdown wrappers
+        clean_text = response_text.strip()
+        if "```json" in clean_text:
+            clean_text = clean_text.split("```json")[1].split("```")[0].strip()
+        elif "```" in clean_text:
+            clean_text = clean_text.split("```")[1].split("```")[0].strip()
+
+        data = json.loads(clean_text)
+    except Exception as e:
+        # Return a parsing defect finding if JSON parsing completely fails
+        return [
+            qg_schema.build_finding(
+                issue_id="LLM_RESPONSE_PARSE_FAILURE",
+                issue_class="other",
+                dimension="mechanics",
+                severity="critical",
+                file="llm_response",
+                line=None,
+                span=None,
+                excerpt="JSON parsing failed",
+                message=f"Failed to parse JSON from LLM reviewer response: {e}",
+                confidence="llm_judgment",
+                detector={
+                    "adapter": "llm_reviewer_parser",
+                    "rule_id": "json_parse_error",
+                }
+            )
+        ]
+
+    raw_findings = data.get("findings", [])
+    if not isinstance(raw_findings, list):
+        return findings
+
+    for item in raw_findings:
+        if not isinstance(item, dict):
+            continue
+
+        issue_id = item.get("issue_id", "UNKNOWN_ISSUE")
+        issue_class = item.get("issue_class", "other")
+        dimension = item.get("dimension", "naturalness")
+        severity = item.get("severity", "warning")
+        excerpt = item.get("excerpt", "").strip()
+        message = item.get("message", "No message provided.")
+        suggested_replacement = item.get("suggested_replacement")
+
+        # Decide which file this excerpt lives in
+        file_name = "module.md"
+        file_text = module_md
+
+        if excerpt:
+            if excerpt in module_md:
+                file_name = "module.md"
+                file_text = module_md
+            elif activities_yaml and excerpt in activities_yaml:
+                file_name = "activities.yaml"
+                file_text = activities_yaml
+            elif vocabulary_yaml and excerpt in vocabulary_yaml:
+                file_name = "vocabulary.yaml"
+                file_text = vocabulary_yaml
+            elif resources_yaml and excerpt in resources_yaml:
+                file_name = "resources.yaml"
+                file_text = resources_yaml
+
+        line_no, span = locate_excerpt(file_text, excerpt)
+
+        findings.append(
+            qg_schema.build_finding(
+                issue_id=issue_id,
+                issue_class=issue_class,
+                dimension=dimension,
+                severity=severity,
+                file=file_name,
+                line=line_no,
+                span=span,
+                excerpt=excerpt or "unknown excerpt",
+                message=message,
+                confidence="llm_judgment",
+                disposition="defect",
+                suggested_replacement=suggested_replacement,
+                detector={
+                    "adapter": "llm_reviewer_evaluator",
+                    "rule_id": f"llm_{issue_id.lower()}",
+                },
+                attribution={
+                    "corpus": "curriculum_review",
+                    "evidence": "LLM reviewer judgment",
+                }
+            )
+        )
+
+    return findings

--- a/scripts/audit/prompts/reviewer_prompt.md
+++ b/scripts/audit/prompts/reviewer_prompt.md
@@ -1,0 +1,73 @@
+# LLM Reviewer & Evaluator Prompt for Ukrainian Curriculum Quality
+
+You are an expert Ukrainian linguist, lexicographer, and language pedagogy specialist. Your role is to perform a rigorous quality gate review of curriculum modules for learners of Ukrainian as a second/foreign language.
+
+You must evaluate the input content across several dimensions and identify any issues, calques, register mismatches, or stylistic flaws.
+
+---
+
+## 1. Level Profiles & Immersion Policies
+You must adapt your judgment based on the CEFR target level of the module:
+
+### A1/A2 (Scaffolded Support)
+* English scaffolding and translations are expected and allowed to guide the beginner.
+* **Immersion Rule**: Do NOT flag English text as a defect in A1/A2 unless it represents a leakage (such as AI personae, paths, etc.).
+* **Max-Immersion Constraint**: Never recommend raising the amount of English. Do not advise adding English explanations where Ukrainian-only text is present.
+
+### B1+ (Ukrainian-led Immersion)
+* All learner-facing instruction, explanation, and prose MUST be Ukrainian-led. No English-led paragraphs or English explanations.
+* English is only allowed for local vocabulary glosses/hints (e.g., `**Застосунок** - app.`).
+* Flag any English explanation paragraphs in B1+ as `ENGLISH_LEAKAGE` (`level_policy` dimension, `critical` severity).
+
+### Seminar Register & Factual Sensitivity (bio, folk, hist, istorio, lit, oes, ruth, etc.)
+* The register must be formal, scholarly, and objective. Avoid pathos, hype, motivational marketing talk (e.g., "неймовірна подорож", "пориньмо у захопливий світ"), and over-simplified or patriotic propaganda.
+* **Biography Subject Vital Status**: Check if the subject is living or deceased. For LIVING subjects, headers or prose like "Last Years" (Останні роки) or "Legacy" (Спадщина) are strictly FORBIDDEN (they read like an obituary). Use "Contemporary Stage" (Сучасний етап) or "Influence" (Вплив) instead.
+* **Factual & Source Purity**: Ground historical and literary claims in authoritative sources like `litopys.org.ua`. The YouTube channel "REALNA ISTORIIA" by Akim Galimov is the gold standard for history modules; avoid low-quality biased sources.
+
+---
+
+## 2. Key Linguistic Checkpoints (Deterministic & Stylistic)
+You must look for the following types of defects:
+
+### A. Unnatural Ukrainian & Stylistic Calques
+Identify unidiomatic syntax or expressions, even if they are not lexical Russianisms:
+* **Awkward Passive Result States**: e.g., "застосунок має бути відкритий" -> flag as `AWKWARD_PASSIVE_RESULT_STATE` (`ukrainian_style`, `critical`). Recommend active/impersonal (e.g., "відкрийте застосунок" or "застосунок має бути відкритим").
+* **Unnatural Anthropomorphism**: e.g., "Застереження каже" -> flag as `UNNATURAL_ANTHROPOMORPHISM` (`ukrainian_style`, `critical`). Abstract grammatical labels or warnings should not speak or be anthropomorphized.
+* **Awkward Government / Nominalizations**: e.g., "радить не робити певної поведінки" -> flag as `UKRAINIAN_GRAMMAR_CALQUE` (`ukrainian_style`, `critical`).
+* **Unnatural Meta-Register**: e.g., "дія має дати конкретний результат чи описати процес?" -> flag as `UNNATURAL_META_REGISTER` (`ukrainian_style`, `critical`). Avoid prompt-like or overly dry syntactic terminology in learner-facing text.
+* **Awkward Metaphors / Calqued Syntax**: e.g., "доконаний вид дає результат із вікном" -> flag as `UKRAINIAN_GRAMMAR_CALQUE` (`ukrainian_style`, `critical`).
+* **Calqued Prepositions**: e.g., "У кухні" -> flag as `CALQUED_PREPOSITION` (`ukrainian_style`, `critical`). It must be "На кухні".
+
+### B. Register and AI Leakage
+* **AI Personae & Leakage**: Look for phrases like "As an AI...", "Note to self", or internal pipeline commands. Flag as `AI_LEAKAGE` (`surface_leakage`, `critical`).
+* **Path Leakage**: Look for absolute paths (e.g., `/Users/...`, `/tmp/...`). Flag as `PATH_LEAKAGE` (`surface_leakage`, `critical`).
+
+---
+
+## 3. Required Output Format
+
+You must output a JSON object containing a list of findings. Do not output any markdown wrapper (no ```json ... ```) or explanation before/after. Return ONLY the JSON object.
+
+The output shape must be:
+```json
+{
+  "findings": [
+    {
+      "issue_id": "AWKWARD_PASSIVE_RESULT_STATE",
+      "issue_class": "calque",
+      "dimension": "ukrainian_style",
+      "severity": "critical",
+      "excerpt": "застосунок має бути відкритий",
+      "message": "Use active or impersonal Ukrainian instruction instead of a literal passive state.",
+      "suggested_replacement": "відкрийте застосунок"
+    }
+  ]
+}
+```
+
+### Constraints:
+* The `excerpt` MUST be an exact substring from the provided content.
+* The `issue_class` must be one of: `calque`, `grammar`, `collocation`, `false_friend`, `register`, `leakage`, `pedagogy`, `fluency`, `mechanics`, `other`.
+* The `dimension` must be one of: `contact_calque`, `contact_grammar`, `ukrainian_style`, `level_policy`, `surface_leakage`, `naturalness`, `pedagogical`, `decolonization`, `engagement`, `tone`, `seminar_sensitivity`, `mechanics`.
+* The `severity` must be one of: `critical`, `warning`, `info`.
+* Be extremely rigorous and literal. If the text has no issues, return `{"findings": []}`.

--- a/tests/audit/test_llm_reviewer.py
+++ b/tests/audit/test_llm_reviewer.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from scripts.audit import llm_reviewer, qg_schema
+
+# Ground truth bad content text for B1-27
+B1_27_BAD_TEXT = """# Вид у наказовому способі
+
+Тут застосунок має бути відкритий. Застереження каже: будь обережний.
+Він радить не робити певної поведінки.
+Подумай: дія має дати конкретний результат чи описати процес?
+Крім того, доконаний вид дає результат із вікном. У кухні стоїть стіл.
+"""
+
+B1_27_GOOD_TEXT = """# Вид у наказовому способі
+
+Відкрийте застосунок, щоб виконати завдання. Будьте обережні.
+Зверніть увагу на правила вживання доконаного виду.
+Подумайте, який результат ви очікуєте отримати.
+На кухні стоїть стіл.
+"""
+
+B1_27_BAD_LLM_RESPONSE = """{
+  "findings": [
+    {
+      "issue_id": "AWKWARD_PASSIVE_RESULT_STATE",
+      "issue_class": "calque",
+      "dimension": "ukrainian_style",
+      "severity": "critical",
+      "excerpt": "застосунок має бути відкритий",
+      "message": "Use an active or impersonal Ukrainian instruction instead of a literal passive state."
+    },
+    {
+      "issue_id": "UNNATURAL_ANTHROPOMORPHISM",
+      "issue_class": "other",
+      "dimension": "ukrainian_style",
+      "severity": "critical",
+      "excerpt": "Застереження каже: будь обережний",
+      "message": "Abstract lesson metalanguage should not be anthropomorphized as a speaker."
+    },
+    {
+      "issue_id": "UKRAINIAN_GRAMMAR_CALQUE",
+      "issue_class": "grammar",
+      "dimension": "ukrainian_style",
+      "severity": "critical",
+      "excerpt": "радить не робити певної поведінки",
+      "message": "The government and nominalized behavior phrase are translated and unnatural."
+    },
+    {
+      "issue_id": "UNNATURAL_META_REGISTER",
+      "issue_class": "register",
+      "dimension": "ukrainian_style",
+      "severity": "critical",
+      "excerpt": "дія має дати конкретний результат чи описати процес?",
+      "message": "This abstract prompt-like sentence is not natural learner-facing Ukrainian."
+    },
+    {
+      "issue_id": "UKRAINIAN_GRAMMAR_CALQUE",
+      "issue_class": "grammar",
+      "dimension": "ukrainian_style",
+      "severity": "critical",
+      "excerpt": "доконаний вид дає результат із вікном",
+      "message": "The metaphor and argument structure are literal and unidiomatic."
+    },
+    {
+      "issue_id": "CALQUED_PREPOSITION",
+      "issue_class": "calque",
+      "dimension": "ukrainian_style",
+      "severity": "critical",
+      "excerpt": "У кухні",
+      "message": "In this ordinary locative teaching context, use the idiomatic На кухні."
+    }
+  ]
+}"""
+
+
+def test_reviewer_prompt_loads_and_assembles() -> None:
+    template = llm_reviewer.load_reviewer_prompt_template()
+    assert "LLM Reviewer & Evaluator Prompt" in template
+    assert "A1/A2" in template
+    assert "B1+" in template
+    assert "Seminar Register" in template
+
+    prompt = llm_reviewer.build_reviewer_prompt(
+        level="b1",
+        slug="aspect-in-imperatives",
+        module_md=B1_27_BAD_TEXT,
+    )
+    assert "aspect-in-imperatives" in prompt
+    assert "застосунок має бути відкритий" in prompt
+
+
+def test_structural_checks_for_model_answers() -> None:
+    # B2 productive task missing model answer -> FAIL
+    bad_activities = """
+- id: wb-essay-missing
+  type: essay-response
+  title: Напишіть есе
+  instruction: Напишіть 120-160 слів.
+  prompt: "Поясніть роль..."
+"""
+    findings = llm_reviewer.run_structural_checks("b2", bad_activities)
+    assert len(findings) == 1
+    assert findings[0]["issue_id"] == "MISSING_MODEL_ANSWER"
+    assert findings[0]["dimension"] == "pedagogical"
+    assert findings[0]["severity"] == "critical"
+    assert findings[0]["file"] == "activities.yaml"
+    assert findings[0]["line"] == 2
+    qg_schema.validate_finding(findings[0])
+
+    # B2 productive task with correct model answer -> PASS
+    good_activities = """
+- id: wb-essay-good
+  type: essay-response
+  title: Напишіть есе
+  instruction: Напишіть 120-160 слів.
+  prompt: "Поясніть роль..."
+  model_answer: |
+    > [!model-answer]
+    > Це правильна модельна відповідь.
+"""
+    findings_good = llm_reviewer.run_structural_checks("b2", good_activities)
+    assert len(findings_good) == 0
+
+    # Low level (A1) task missing model answer -> PASS (no structural check for model answer in A1/A2/B1)
+    findings_a1 = llm_reviewer.run_structural_checks("a1", bad_activities)
+    assert len(findings_a1) == 0
+
+
+def test_b1_27_bad_calibration_produces_expected_findings() -> None:
+    findings = llm_reviewer.parse_and_evaluate_llm_response(
+        B1_27_BAD_LLM_RESPONSE,
+        module_md=B1_27_BAD_TEXT,
+    )
+
+    # 6 expected style/grammar defects
+    assert len(findings) == 6
+
+    # Ensure they are valid schema findings
+    for finding in findings:
+        qg_schema.validate_finding(finding)
+
+    by_issue = {f["issue_id"] for f in findings}
+    assert {
+        "AWKWARD_PASSIVE_RESULT_STATE",
+        "UNNATURAL_ANTHROPOMORPHISM",
+        "UKRAINIAN_GRAMMAR_CALQUE",
+        "UNNATURAL_META_REGISTER",
+        "CALQUED_PREPOSITION",
+    } <= by_issue
+
+    # Verify excerpt line mapping
+    passive_finding = next(f for f in findings if f["issue_id"] == "AWKWARD_PASSIVE_RESULT_STATE")
+    assert passive_finding["line"] == 3
+    assert passive_finding["file"] == "module.md"
+    assert passive_finding["span"]["start"] is not None
+
+
+def test_b1_27_good_calibration_passes() -> None:
+    # Good text returned from LLM with zero findings
+    findings = llm_reviewer.parse_and_evaluate_llm_response(
+        '{"findings": []}',
+        module_md=B1_27_GOOD_TEXT,
+    )
+    assert len(findings) == 0
+
+
+def test_seminar_vital_status_and_pathos_calibration() -> None:
+    # Living subject biography with "Legacy" or "Last Years" header -> FAIL
+    living_subject_bad = """---
+level: bio
+slug: oleksandra-matviichuk
+---
+
+# Олександра Матвійчук
+
+Олександра Матвійчук — відома українська правозахисниця.
+
+## Останні роки
+Вона продовжує очолювати Центр громадянських свобод.
+"""
+    living_subject_bad_llm_response = """{
+      "findings": [
+        {
+          "issue_id": "SEMINAR_OBITUARY_STYLE",
+          "issue_class": "register",
+          "dimension": "seminar_sensitivity",
+          "severity": "critical",
+          "excerpt": "## Останні роки",
+          "message": "Living biography subjects must not use obituary-style headers like 'Last Years'."
+        }
+      ]
+    }"""
+
+    findings = llm_reviewer.parse_and_evaluate_llm_response(
+        living_subject_bad_llm_response,
+        module_md=living_subject_bad,
+    )
+    assert len(findings) == 1
+    assert findings[0]["issue_id"] == "SEMINAR_OBITUARY_STYLE"
+    assert findings[0]["dimension"] == "seminar_sensitivity"
+    assert findings[0]["severity"] == "critical"
+    qg_schema.validate_finding(findings[0])
+
+
+def test_llm_response_parse_failure_emits_valid_finding() -> None:
+    # Malformed LLM response
+    findings = llm_reviewer.parse_and_evaluate_llm_response(
+        "This is not JSON",
+        module_md=B1_27_BAD_TEXT,
+    )
+    assert len(findings) == 1
+    assert findings[0]["issue_id"] == "LLM_RESPONSE_PARSE_FAILURE"
+    assert findings[0]["dimension"] == "mechanics"
+    assert findings[0]["severity"] == "critical"
+    qg_schema.validate_finding(findings[0])


### PR DESCRIPTION
Implements #4309 (#2156 Phase 2) — the LLM reviewer prompt/evaluator layer for judgments deterministic rules can't make (naturalness, register, phrase-grammar, level-fit, pedagogy) + `> [!model-answer]` structural checks.

Authored by AGY (dispatch `4309-llm-reviewer-prompt`, status=done rc=0); PR opened by orchestrator (agy skipped `gh pr create`). Artifacts: `scripts/audit/prompts/reviewer_prompt.md`, `scripts/audit/llm_reviewer.py`, `docs/projects/ua-eval-harness/calibration_criteria.md`, `tests/audit/test_llm_reviewer.py`. Disjoint from #4308 (adapters). Independent non-AGY/non-Codex review + #M-4a verification by orchestrator to follow in-thread before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)