### PR TITLE
feat(audit): add cost-aware QG workflow

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -697,6 +697,45 @@ seminar-register pathos. Single-module scans emit compact evidence shaped like
 content hash, dimensional scores/findings, compact spans/excerpts, LLM metadata
 placeholders, and provenance.
 
+### `scripts/audit/qg_workflow.py`
+
+Cost-aware tiered curriculum QG workflow for #2156 / #4310. It composes
+deterministic structural checks, optional UA-GEC gold lookup, and the gated LLM
+reviewer into one canonical `qg_schema` evidence record. Live LLM dispatch is
+not wired by default; Tier 2 uses a composite cache hit or an explicitly
+provided reviewer response until #4370 calibration lands.
+
+```bash
+# Dry-run before broad reviewer spend; writes nothing
+.venv/bin/python scripts/audit/qg_workflow.py \
+  --target b1:aspect-in-imperatives:curriculum/l2-uk-en/b1/aspect-in-imperatives \
+  --dry-run \
+  --format json
+
+# Single-module deterministic workflow evidence
+.venv/bin/python scripts/audit/qg_workflow.py \
+  --module-dir curriculum/l2-uk-en/b1/aspect-in-imperatives \
+  --level b1 \
+  --slug aspect-in-imperatives \
+  --format json
+```
+
+Tier 0 always runs `DeterministicRuleAdapter` and
+`llm_reviewer.run_structural_checks()`. A hard Tier-0 `FAIL` skips Tier 2 by
+default for cost, overriding the harness's `llm_review.required` flag; use
+`--llm-on-fail` only when richer diagnostics are worth reviewer spend. Tier 2
+is eligible by `policy_for_level(level).family` (`b1_plus` and `seminar`) or by
+explicit `--force-llm` / calibration sample. Broad Tier-2 runs require a
+passing `llm_qg_canaries.py` result and budget ceilings such as
+`--max-llm-calls` or `--max-cost-usd`.
+
+The LLM cache reuses `scripts/audit/llm_qg_store.py` with the composite key
+`content_sha + gate_version + prompt_hash + checker_version +
+level_policy.family + reviewer_model_id`. The content basis is
+`llm_qg_store.CONTENT_FILES` (`module.md`, `activities.yaml`,
+`vocabulary.yaml`, `resources.yaml`), not the promotion sidecar's plan-inclusive
+hash.
+
 ### `scripts/audit/ingest_ua_gec_gold.py`
 
 Curates the small tracked UA-GEC fixture for the #2156 eval harness. It reads

--- a/docs/projects/ua-eval-harness/README.md
+++ b/docs/projects/ua-eval-harness/README.md
@@ -53,6 +53,8 @@ These are NOT the harness, but they are the scorer-side foundation:
   `scripts/audit/qg_schema.py`.
 - [Scorer adapter boundaries](scorer-adapters.md) document the #4308
   deterministic, UA-GEC-fixture, and LLM-placeholder adapter layer.
+- [Cost-aware curriculum QG workflow](cost-aware-qg-workflow.md) documents the
+  #4310 tiered, short-circuiting workflow and composite LLM cache key.
 - [Agent fleet evidence for #4307](agent-fleet-4307.md) records the concrete
   fleet lanes used for the schema slice and the observed strengths/weaknesses.
 

--- a/docs/projects/ua-eval-harness/cost-aware-qg-workflow.md
+++ b/docs/projects/ua-eval-harness/cost-aware-qg-workflow.md
@@ -1,0 +1,98 @@
+# Cost-Aware Curriculum QG Workflow
+
+Issue: [#4310](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4310)
+
+`scripts/audit/qg_workflow.py` composes the #4308 scorer adapters and the #4309
+reviewer helpers into one canonical `ua_contact_quality_evidence.v1` record
+per module. It is deliberately cost-aware: deterministic and lookup tiers run
+first, and the LLM reviewer is never bulk-run by default.
+
+## Tiers
+
+| Tier | Source | Default behavior |
+| --- | --- | --- |
+| 0 | `DeterministicRuleAdapter` plus `run_structural_checks()` | Always runs. A hard `FAIL` short-circuits Tier 2 by default. |
+| 1 | `UaGecGoldFixtureAdapter` | Cheap lookup. Dry-run reports `gold rows matched: N`, not "all modules hit Tier 1". |
+| 2 | `llm_reviewer` prompt/parser | Eligible only for `policy_for_level(level).family` in `b1_plus` or `seminar`, or explicit `--force-llm` / calibration sample. |
+
+The Tier-0 short-circuit intentionally overrides
+`curriculum_qg_harness.llm_review.required` for cost. The harness still marks
+non-`PASS` modules as LLM-required; this workflow skips the expensive tier on
+hard deterministic failures unless `--llm-on-fail` or calibration sample mode
+is used for richer diagnostics.
+
+Seminar-family modules must be eligible for Tier 2 because factual,
+decolonization, register, and living-subject risks are not fully covered by
+Tier 0/1. Live Tier-2 dispatch remains flag-off until #4370 calibration lands;
+callers must provide a precomputed reviewer response, reuse a cache hit, or run
+with dry-run estimates only.
+
+## Cost Controls
+
+Use `--dry-run` before broad reviewer spend:
+
+```bash
+.venv/bin/python scripts/audit/qg_workflow.py \
+  --target b1:aspect-in-imperatives:curriculum/l2-uk-en/b1/aspect-in-imperatives \
+  --dry-run \
+  --format json
+```
+
+Dry-run writes nothing. It reports per-tier module counts, Tier-1 gold-row
+matches, and Tier-2 token/cost estimates bucketed by level-policy family. The
+current estimator uses prompt size with profile-specific completion budgets;
+future telemetry can replace the estimator without changing the evidence
+contract.
+
+Tier-2 budgets are checked before any reviewer call:
+
+- `--max-llm-calls` is the primary per-run ceiling.
+- `--max-cost-usd` caps the whole run.
+- `--max-daily-cost-usd` is a local safety rail.
+- `--max-module-cost-usd` blocks pathological prompts.
+
+Budget exhaustion is explicit: the evidence carries
+`workflow_verdict: SKIPPED_BUDGET` and `completion_status: INCOMPLETE`. Because
+`qg_schema` only admits `PASS/WARN/FAIL`, incomplete LLM-required records stay
+schema-valid by using top-level `verdict: FAIL` and `terminal_verdict: FAIL`
+when fail-closed mode is active.
+
+Broad Tier-2 batches require a passing canary result from
+`scripts/audit/llm_qg_canaries.py` before reviewer spend. Dry-run does not need
+the canary because it does not call the reviewer.
+
+## Cache Key
+
+The workflow reuses `scripts/audit/llm_qg_store.py`; it does not create a
+parallel store. Current Tier-2 cache lookup is composite:
+
+```text
+content_sha
++ gate_version
++ prompt_hash
++ checker_version
++ level_policy.family
++ reviewer_model_id
+```
+
+The canonical content basis is `llm_qg_store.CONTENT_FILES`:
+
+```text
+module.md, activities.yaml, vocabulary.yaml, resources.yaml
+```
+
+Plan YAML is intentionally not part of this workflow cache hash. This differs
+from `scripts/build/promote_quality_gate.py`, whose promotion sidecar hashes
+the plan plus learner files. Workflow evidence records document the chosen
+basis under `qg_workflow.content_hash_basis` and
+`qg_workflow.content_files`, so cache invalidation is auditable.
+
+`gate_version` and `prompt_hash` must bump when #4370 changes reviewer
+calibration; stale LLM evidence then misses the composite cache automatically.
+
+## Contested Gold
+
+Tier 1 preserves #4364 contested-gold metadata. If a UA-GEC gold row is marked
+contested, the workflow suppresses that lookup finding but keeps the module
+eligible for Tier 2 in LLM-eligible families. This avoids a recall hole where a
+noisy gold row hides a real b1-plus or seminar issue from reviewer judgment.

--- a/scripts/audit/llm_qg_store.py
+++ b/scripts/audit/llm_qg_store.py
@@ -43,6 +43,8 @@ class StoredQG:
     content_sha: str
     gate_version: str
     prompt_hash: str | None
+    checker_version: str | None
+    level_policy_family: str | None
     reviewer_model: str | None
     reviewer_family: str | None
     source: str
@@ -132,6 +134,8 @@ def init_db(path: Path | None = None) -> Path:
                 content_sha     TEXT NOT NULL,
                 gate_version    TEXT NOT NULL,
                 prompt_hash     TEXT,
+                checker_version TEXT,
+                level_policy_family TEXT,
                 reviewer_model  TEXT,
                 reviewer_family TEXT,
                 source          TEXT NOT NULL,
@@ -164,8 +168,32 @@ def init_db(path: Path | None = None) -> Path:
                 ON llm_qg_findings(category, severity);
             """
         )
+        _ensure_composite_columns(conn)
+        conn.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_llm_qg_composite
+                ON llm_qg_runs(
+                    level, slug, content_sha, gate_version, prompt_hash,
+                    checker_version, level_policy_family, reviewer_model,
+                    created_at DESC
+                )
+            """
+        )
         conn.commit()
     return resolved
+
+
+def _ensure_composite_columns(conn: sqlite3.Connection) -> None:
+    """Backfill optional composite-key columns on older local stores."""
+    rows = conn.execute("PRAGMA table_info(llm_qg_runs)").fetchall()
+    existing = {str(row[1]) for row in rows}
+    additions = {
+        "checker_version": "TEXT",
+        "level_policy_family": "TEXT",
+    }
+    for name, column_type in additions.items():
+        if name not in existing:
+            conn.execute(f"ALTER TABLE llm_qg_runs ADD COLUMN {name} {column_type}")
 
 
 def _aggregate(payload: dict[str, Any]) -> dict[str, Any]:
@@ -210,6 +238,8 @@ def record_llm_qg(
     payload: dict[str, Any],
     gate_version: str,
     prompt_hash: str | None = None,
+    checker_version: str | None = None,
+    level_policy_family: str | None = None,
     reviewer_model: str | None = None,
     reviewer_family: str | None = None,
     source: str = "pipeline",
@@ -232,10 +262,11 @@ def record_llm_qg(
             """
             INSERT INTO llm_qg_runs (
                 run_id, created_at, level, slug, content_sha, gate_version,
-                prompt_hash, reviewer_model, reviewer_family, source, verdict,
-                terminal_verdict, min_score, min_dim, payload_json
+                prompt_hash, checker_version, level_policy_family,
+                reviewer_model, reviewer_family, source, verdict, terminal_verdict,
+                min_score, min_dim, payload_json
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(run_id) DO UPDATE SET
                 created_at = excluded.created_at,
                 level = excluded.level,
@@ -243,6 +274,8 @@ def record_llm_qg(
                 content_sha = excluded.content_sha,
                 gate_version = excluded.gate_version,
                 prompt_hash = excluded.prompt_hash,
+                checker_version = excluded.checker_version,
+                level_policy_family = excluded.level_policy_family,
                 reviewer_model = excluded.reviewer_model,
                 reviewer_family = excluded.reviewer_family,
                 source = excluded.source,
@@ -260,6 +293,8 @@ def record_llm_qg(
                 content_sha,
                 gate_version,
                 prompt_hash,
+                checker_version,
+                level_policy_family,
                 reviewer_model,
                 reviewer_family,
                 source,
@@ -300,6 +335,8 @@ def record_llm_qg(
         content_sha=content_sha,
         gate_version=gate_version,
         prompt_hash=prompt_hash,
+        checker_version=checker_version,
+        level_policy_family=level_policy_family,
         reviewer_model=reviewer_model,
         reviewer_family=reviewer_family,
         source=source,
@@ -316,6 +353,8 @@ def _row_to_record(row: sqlite3.Row) -> StoredQG:
         content_sha=str(row["content_sha"]),
         gate_version=str(row["gate_version"]),
         prompt_hash=row["prompt_hash"],
+        checker_version=row["checker_version"],
+        level_policy_family=row["level_policy_family"],
         reviewer_model=row["reviewer_model"],
         reviewer_family=row["reviewer_family"],
         source=str(row["source"]),
@@ -329,6 +368,11 @@ def latest_llm_qg(
     slug: str,
     *,
     content_sha: str | None = None,
+    gate_version: str | None = None,
+    prompt_hash: str | None = None,
+    checker_version: str | None = None,
+    level_policy_family: str | None = None,
+    reviewer_model: str | None = None,
     path: Path | None = None,
 ) -> StoredQG | None:
     """Return the newest persisted QG run for a module, optionally hash-bound."""
@@ -337,11 +381,21 @@ def latest_llm_qg(
         return None
     params: list[Any] = [level.strip().lower(), slug.strip()]
     where = "level = ? AND slug = ?"
-    if content_sha is not None:
-        where += " AND content_sha = ?"
-        params.append(content_sha)
+    for column, value in (
+        ("content_sha", content_sha),
+        ("gate_version", gate_version),
+        ("prompt_hash", prompt_hash),
+        ("checker_version", checker_version),
+        ("level_policy_family", level_policy_family),
+        ("reviewer_model", reviewer_model),
+    ):
+        if value is not None:
+            where += f" AND {column} = ?"
+            params.append(value)
     try:
         with closing(connect_sqlite(str(resolved))) as conn:
+            _ensure_composite_columns(conn)
+            conn.commit()
             conn.row_factory = sqlite3.Row
             row = conn.execute(
                 f"""
@@ -363,6 +417,11 @@ def current_llm_qg_for_module(
     slug: str,
     module_dir: Path,
     *,
+    gate_version: str | None = None,
+    prompt_hash: str | None = None,
+    checker_version: str | None = None,
+    level_policy_family: str | None = None,
+    reviewer_model: str | None = None,
     path: Path | None = None,
 ) -> StoredQG | None:
     """Return the newest QG run whose content hash matches current artifacts."""
@@ -370,6 +429,11 @@ def current_llm_qg_for_module(
         level,
         slug,
         content_sha=content_sha_for_module(module_dir),
+        gate_version=gate_version,
+        prompt_hash=prompt_hash,
+        checker_version=checker_version,
+        level_policy_family=level_policy_family,
+        reviewer_model=reviewer_model,
         path=path,
     )
 
@@ -379,10 +443,25 @@ def current_payload_for_module(
     slug: str,
     module_dir: Path,
     *,
+    gate_version: str | None = None,
+    prompt_hash: str | None = None,
+    checker_version: str | None = None,
+    level_policy_family: str | None = None,
+    reviewer_model: str | None = None,
     path: Path | None = None,
 ) -> dict[str, Any] | None:
     """Return the current QG payload for a module, or ``None`` if missing/stale."""
-    record = current_llm_qg_for_module(level, slug, module_dir, path=path)
+    record = current_llm_qg_for_module(
+        level,
+        slug,
+        module_dir,
+        gate_version=gate_version,
+        prompt_hash=prompt_hash,
+        checker_version=checker_version,
+        level_policy_family=level_policy_family,
+        reviewer_model=reviewer_model,
+        path=path,
+    )
     if record is None:
         return None
     return {
@@ -392,6 +471,10 @@ def current_payload_for_module(
             "created_at": record.created_at,
             "content_sha": record.content_sha,
             "gate_version": record.gate_version,
+            "prompt_hash": record.prompt_hash,
+            "checker_version": record.checker_version,
+            "level_policy_family": record.level_policy_family,
+            "reviewer_model": record.reviewer_model,
             "source": record.source,
         },
     }
@@ -431,6 +514,8 @@ def compact_evidence_for_record(
         "content_sha": record.content_sha,
         "gate_version": record.gate_version,
         "prompt_hash": record.prompt_hash,
+        "checker_version": record.checker_version,
+        "level_policy_family": record.level_policy_family,
         "provenance": {
             "created_at": record.created_at,
             "run_id": record.run_id,

--- a/scripts/audit/llm_qg_store.py
+++ b/scripts/audit/llm_qg_store.py
@@ -258,6 +258,7 @@ def record_llm_qg(
 
     with closing(connect_sqlite(str(resolved))) as conn:
         conn.execute("PRAGMA foreign_keys = ON")
+        _ensure_composite_columns(conn)
         conn.execute(
             """
             INSERT INTO llm_qg_runs (

--- a/scripts/audit/qg_workflow.py
+++ b/scripts/audit/qg_workflow.py
@@ -215,7 +215,7 @@ def dry_run_modules(
         gate_version=dry_options.gate_version,
         reviewer_model_id=dry_options.reviewer_model_id,
         reviewer_family=dry_options.reviewer_family,
-        enable_llm=dry_options.enable_llm,
+        enable_llm=True,
         force_llm=dry_options.force_llm,
         llm_on_fail=dry_options.llm_on_fail,
         calibration_sample=dry_options.calibration_sample,
@@ -812,9 +812,9 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         targets = _targets_from_args(args)
-        enable_llm = bool(args.force_llm or args.llm_response_json)
+        enable_llm = bool(args.force_llm or args.llm_response_json or args.dry_run or args.db)
         canary_passed = False
-        if len(targets) > 1 and _llm_enabled_for_any_target(
+        if not args.dry_run and len(targets) > 1 and _llm_enabled_for_any_target(
             targets,
             WorkflowOptions(
                 enable_llm=enable_llm,

--- a/scripts/audit/qg_workflow.py
+++ b/scripts/audit/qg_workflow.py
@@ -1,0 +1,901 @@
+#!/usr/bin/env python3
+"""Cost-aware tiered curriculum quality-gate workflow.
+
+This composes the deterministic/lookup adapters and the gated LLM reviewer into
+one canonical ``qg_schema`` evidence record per module. Live reviewer dispatch
+is intentionally absent until #4370 calibrates the prompt and canary runbook;
+callers must inject a reviewer response or reuse a composite cache hit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.audit import llm_qg_canaries, llm_qg_store, llm_reviewer, qg_schema
+from scripts.audit.content_surface_gates import policy_for_level
+from scripts.audit.curriculum_qg_harness import CHECKER_VERSION, checker_config_hash
+from scripts.audit.qg_adapters import (
+    DeterministicRuleAdapter,
+    ScorerInput,
+    UaGecGoldFixtureAdapter,
+    dimensions_from_findings,
+)
+
+DEFAULT_GATE_VERSION = "qg_workflow.v1"
+DEFAULT_REVIEWER_MODEL_ID = "llm-reviewer-disabled-until-4370"
+DEFAULT_REVIEWER_FAMILY = "qg_workflow"
+LLM_POLICY_FAMILIES = frozenset({"b1_plus", "seminar"})
+CONTENT_HASH_BASIS = "llm_qg_store.CONTENT_FILES"
+
+Reviewer = Callable[["ReviewTarget", str], str | Mapping[str, Any]]
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewTarget:
+    """One module review target."""
+
+    level: str
+    slug: str
+    module_dir: Path
+    fixture_id: str | None = None
+    plan_path: Path | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowOptions:
+    """Runtime policy for the cost-aware review workflow."""
+
+    gate_version: str = DEFAULT_GATE_VERSION
+    reviewer_model_id: str = DEFAULT_REVIEWER_MODEL_ID
+    reviewer_family: str = DEFAULT_REVIEWER_FAMILY
+    enable_llm: bool = False
+    force_llm: bool = False
+    llm_on_fail: bool = False
+    calibration_sample: bool = False
+    dry_run: bool = False
+    canary_passed: bool = False
+    max_llm_calls: int | None = None
+    max_cost_usd: float | None = None
+    max_daily_cost_usd: float | None = None
+    max_module_cost_usd: float | None = None
+    fail_closed_on_llm_skip: bool = True
+
+
+@dataclass(slots=True)
+class BudgetState:
+    """Mutable per-run budget accounting."""
+
+    llm_calls: int = 0
+    cost_usd: float = 0.0
+    daily_cost_usd: float = 0.0
+
+    def spend_allowed(self, estimate: Mapping[str, Any], options: WorkflowOptions) -> tuple[bool, str | None]:
+        cost = float(estimate.get("estimated_cost_usd") or 0.0)
+        if options.max_module_cost_usd is not None and cost > options.max_module_cost_usd:
+            return False, "max_module_cost_usd"
+        if options.max_llm_calls is not None and self.llm_calls >= options.max_llm_calls:
+            return False, "max_llm_calls"
+        if options.max_cost_usd is not None and self.cost_usd + cost > options.max_cost_usd:
+            return False, "max_cost_usd"
+        if options.max_daily_cost_usd is not None and self.daily_cost_usd + cost > options.max_daily_cost_usd:
+            return False, "max_daily_cost_usd"
+        return True, None
+
+    def record_spend(self, estimate: Mapping[str, Any]) -> None:
+        self.llm_calls += 1
+        cost = float(estimate.get("estimated_cost_usd") or 0.0)
+        self.cost_usd += cost
+        self.daily_cost_usd += cost
+
+
+def review_module(
+    target: ReviewTarget,
+    *,
+    options: WorkflowOptions | None = None,
+    reviewer: Reviewer | None = None,
+    store_path: Path | None = None,
+    budget: BudgetState | None = None,
+) -> dict[str, Any]:
+    """Run all eligible tiers for one module and return canonical evidence."""
+
+    effective_options = options or WorkflowOptions()
+    effective_budget = budget or BudgetState()
+    module_dir = target.module_dir
+    level = target.level.strip().lower()
+    slug = target.slug.strip() or module_dir.name
+    policy = policy_for_level(level)
+    texts = _read_module_texts(module_dir)
+    prompt = llm_reviewer.build_reviewer_prompt(
+        level=level,
+        slug=slug,
+        module_md=texts.get("module.md", ""),
+        activities_yaml=texts.get("activities.yaml", ""),
+        vocabulary_yaml=texts.get("vocabulary.yaml", ""),
+        resources_yaml=texts.get("resources.yaml", ""),
+    )
+    prompt_hash = llm_qg_store.prompt_hash_for_text(prompt)
+    content_sha = llm_qg_store.content_sha_for_module(module_dir)
+    all_findings: list[dict[str, Any]] = []
+    tier_results: list[dict[str, Any]] = []
+
+    tier0_findings = _tier0_findings(target, level, slug, texts)
+    all_findings.extend(tier0_findings)
+    tier0_verdict = _verdict_for_findings(tier0_findings)
+    tier0_hard_fail = any(finding.get("severity") == "critical" for finding in tier0_findings)
+    tier_results.append(
+        {
+            "tier": 0,
+            "name": "deterministic_structural",
+            "status": "ran",
+            "findings": len(tier0_findings),
+            "verdict": tier0_verdict,
+        }
+    )
+
+    tier1_findings, tier1_meta = _tier1_findings(target)
+    all_findings.extend(tier1_findings)
+    tier_results.append(
+        {
+            "tier": 1,
+            "name": "ua_gec_gold_fixture",
+            "status": "ran",
+            "gold_rows_matched": tier1_meta["gold_rows_matched"],
+            "gold_rows_suppressed_contested": tier1_meta["gold_rows_suppressed_contested"],
+            "findings": len(tier1_findings),
+        }
+    )
+
+    tier2 = _run_tier2(
+        target=target,
+        level=level,
+        slug=slug,
+        policy_family=policy.family,
+        texts=texts,
+        prompt=prompt,
+        prompt_hash=prompt_hash,
+        tier0_hard_fail=tier0_hard_fail,
+        contested_gold_suppressed=bool(tier1_meta["gold_rows_suppressed_contested"]),
+        options=effective_options,
+        reviewer=reviewer,
+        store_path=store_path,
+        budget=effective_budget,
+    )
+    tier_results.append(tier2["result"])
+    all_findings.extend(tier2["findings"])
+
+    merged_findings = _dedupe_by_finding_id(all_findings)
+    workflow_verdict = tier2.get("workflow_verdict")
+    completion_status = tier2.get("completion_status", "COMPLETE")
+    return _build_evidence_record(
+        level=level,
+        slug=slug,
+        target=target,
+        policy_family=policy.family,
+        policy_english=policy.english_policy,
+        content_sha=content_sha,
+        prompt_hash=prompt_hash,
+        findings=merged_findings,
+        tier_results=tier_results,
+        workflow_verdict=workflow_verdict,
+        completion_status=completion_status,
+        llm_used=bool(tier2.get("llm_used")),
+        llm_required_by_policy=bool(tier2.get("llm_required_by_policy")),
+        llm_required_by_harness=tier0_verdict != "PASS",
+        llm_cost_override=bool(tier2.get("llm_cost_override")),
+        options=effective_options,
+    )
+
+
+def dry_run_modules(
+    targets: Sequence[ReviewTarget],
+    *,
+    options: WorkflowOptions | None = None,
+    store_path: Path | None = None,
+) -> dict[str, Any]:
+    """Return per-tier counts and cost estimates without writing cache records."""
+
+    dry_options = options or WorkflowOptions()
+    dry_options = WorkflowOptions(
+        gate_version=dry_options.gate_version,
+        reviewer_model_id=dry_options.reviewer_model_id,
+        reviewer_family=dry_options.reviewer_family,
+        enable_llm=dry_options.enable_llm,
+        force_llm=dry_options.force_llm,
+        llm_on_fail=dry_options.llm_on_fail,
+        calibration_sample=dry_options.calibration_sample,
+        dry_run=True,
+        canary_passed=dry_options.canary_passed,
+        max_llm_calls=dry_options.max_llm_calls,
+        max_cost_usd=dry_options.max_cost_usd,
+        max_daily_cost_usd=dry_options.max_daily_cost_usd,
+        max_module_cost_usd=dry_options.max_module_cost_usd,
+        fail_closed_on_llm_skip=dry_options.fail_closed_on_llm_skip,
+    )
+    budget = BudgetState()
+    records = [
+        review_module(target, options=dry_options, store_path=store_path, budget=budget)
+        for target in targets
+    ]
+    by_family: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {
+            "modules": 0,
+            "tier2_eligible": 0,
+            "tier2_estimated_calls": 0,
+            "estimated_prompt_tokens": 0,
+            "estimated_cost_usd": 0.0,
+        }
+    )
+    counts = {
+        "modules": len(records),
+        "tier0_modules": len(records),
+        "tier0_hard_fail": 0,
+        "tier1_gold_rows_matched": 0,
+        "tier1_gold_rows_suppressed_contested": 0,
+        "tier2_cache_hits": 0,
+        "tier2_estimated_calls": 0,
+        "tier2_skipped_budget": 0,
+    }
+    for record in records:
+        family = str(record["level_policy"]["family"])
+        bucket = by_family[family]
+        bucket["modules"] += 1
+        for tier in record["qg_workflow"]["tiers"]:
+            if tier["tier"] == 0 and tier.get("verdict") == "FAIL":
+                counts["tier0_hard_fail"] += 1
+            if tier["tier"] == 1:
+                counts["tier1_gold_rows_matched"] += int(tier.get("gold_rows_matched") or 0)
+                counts["tier1_gold_rows_suppressed_contested"] += int(
+                    tier.get("gold_rows_suppressed_contested") or 0
+                )
+            if tier["tier"] == 2:
+                if tier.get("llm_required_by_policy"):
+                    bucket["tier2_eligible"] += 1
+                if tier.get("status") == "cache_hit":
+                    counts["tier2_cache_hits"] += 1
+                if tier.get("status") == "dry_run_estimate":
+                    counts["tier2_estimated_calls"] += 1
+                    bucket["tier2_estimated_calls"] += 1
+                    estimate = tier.get("estimate") if isinstance(tier.get("estimate"), Mapping) else {}
+                    bucket["estimated_prompt_tokens"] += int(estimate.get("estimated_prompt_tokens") or 0)
+                    bucket["estimated_cost_usd"] += float(estimate.get("estimated_cost_usd") or 0.0)
+                if tier.get("status") == "skipped_budget":
+                    counts["tier2_skipped_budget"] += 1
+    return {
+        "schema_version": "qg_workflow_dry_run.v1",
+        "dry_run": True,
+        "writes": 0,
+        "counts": counts,
+        "level_profiles": dict(sorted(by_family.items())),
+        "modules": records,
+    }
+
+
+def review_modules(
+    targets: Sequence[ReviewTarget],
+    *,
+    options: WorkflowOptions | None = None,
+    reviewer: Reviewer | None = None,
+    store_path: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Run the workflow over a bounded target list with shared budget state."""
+
+    effective_options = options or WorkflowOptions()
+    if (
+        len(targets) > 1
+        and _llm_enabled_for_any_target(targets, effective_options)
+        and not effective_options.canary_passed
+    ):
+        raise ValueError("broad LLM batches require an explicit passing canary pre-gate")
+    budget = BudgetState()
+    return [
+        review_module(
+            target,
+            options=effective_options,
+            reviewer=reviewer,
+            store_path=store_path,
+            budget=budget,
+        )
+        for target in targets
+    ]
+
+
+def canary_result_passes(path: Path, *, level: str) -> bool:
+    """Evaluate a reviewer canary result JSON using the existing canary gate."""
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    report = llm_qg_canaries.evaluate_canaries(payload, level)
+    return bool(report.get("passed"))
+
+
+def _tier0_findings(
+    target: ReviewTarget,
+    level: str,
+    slug: str,
+    texts: Mapping[str, str],
+) -> list[dict[str, Any]]:
+    deterministic = DeterministicRuleAdapter().findings(
+        ScorerInput(
+            module_dir=target.module_dir,
+            level=level,
+            slug=slug,
+            fixture_id=target.fixture_id,
+            plan_path=target.plan_path,
+        )
+    )
+    structural = llm_reviewer.run_structural_checks(
+        level,
+        texts.get("activities.yaml", ""),
+        file_name="activities.yaml",
+    )
+    return _dedupe_by_finding_id([*deterministic, *structural])
+
+
+def _tier1_findings(target: ReviewTarget) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    if not target.fixture_id:
+        return [], {"gold_rows_matched": 0, "gold_rows_suppressed_contested": 0}
+    raw_findings = UaGecGoldFixtureAdapter().findings(ScorerInput(fixture_id=target.fixture_id))
+    kept: list[dict[str, Any]] = []
+    suppressed = 0
+    for finding in raw_findings:
+        if _gold_contested(finding):
+            suppressed += 1
+            continue
+        kept.append(finding)
+    return kept, {
+        "gold_rows_matched": len(raw_findings),
+        "gold_rows_suppressed_contested": suppressed,
+    }
+
+
+def _run_tier2(
+    *,
+    target: ReviewTarget,
+    level: str,
+    slug: str,
+    policy_family: str,
+    texts: Mapping[str, str],
+    prompt: str,
+    prompt_hash: str | None,
+    tier0_hard_fail: bool,
+    contested_gold_suppressed: bool,
+    options: WorkflowOptions,
+    reviewer: Reviewer | None,
+    store_path: Path | None,
+    budget: BudgetState,
+) -> dict[str, Any]:
+    policy_eligible = (
+        policy_family in LLM_POLICY_FAMILIES
+        or options.force_llm
+        or options.calibration_sample
+        or contested_gold_suppressed
+    )
+    base_result: dict[str, Any] = {
+        "tier": 2,
+        "name": "llm_reviewer",
+        "llm_required_by_policy": policy_eligible,
+        "policy_family": policy_family,
+        "findings": 0,
+    }
+    if not policy_eligible:
+        return {"findings": [], "result": {**base_result, "status": "skipped_policy"}}
+    if tier0_hard_fail and not (options.llm_on_fail or options.calibration_sample):
+        return {
+            "findings": [],
+            "result": {
+                **base_result,
+                "status": "skipped_tier0_hard_fail",
+                "cost_override": True,
+                "reason": "Tier-0 hard FAIL short-circuits LLM by default; use --llm-on-fail to opt in.",
+            },
+            "llm_cost_override": True,
+        }
+    if not options.enable_llm:
+        return {
+            "findings": [],
+            "result": {
+                **base_result,
+                "status": "skipped_flag_off",
+                "reason": "Live Tier-2 reviewer remains flag-off until #4370 calibration lands.",
+            },
+        }
+
+    cached = llm_qg_store.current_llm_qg_for_module(
+        level,
+        slug,
+        target.module_dir,
+        gate_version=options.gate_version,
+        prompt_hash=prompt_hash,
+        checker_version=CHECKER_VERSION,
+        level_policy_family=policy_family,
+        reviewer_model=options.reviewer_model_id,
+        path=store_path,
+    )
+    if cached is not None:
+        findings = _findings_from_payload(cached.payload)
+        return {
+            "findings": findings,
+            "result": {
+                **base_result,
+                "status": "cache_hit",
+                "findings": len(findings),
+                "cache_run_id": cached.run_id,
+            },
+            "llm_used": True,
+        }
+
+    estimate = estimate_llm_cost(prompt, policy_family)
+    allowed, reason = budget.spend_allowed(estimate, options)
+    if not allowed:
+        return {
+            "findings": [],
+            "result": {
+                **base_result,
+                "status": "skipped_budget",
+                "reason": reason,
+                "estimate": estimate,
+            },
+            "workflow_verdict": "SKIPPED_BUDGET",
+            "completion_status": "INCOMPLETE",
+        }
+    if options.dry_run:
+        return {
+            "findings": [],
+            "result": {
+                **base_result,
+                "status": "dry_run_estimate",
+                "estimate": estimate,
+            },
+        }
+    if reviewer is None:
+        return {
+            "findings": [],
+            "result": {
+                **base_result,
+                "status": "skipped_no_reviewer",
+                "estimate": estimate,
+                "reason": "No live reviewer dispatcher is wired until #4370; provide a reviewer response.",
+            },
+            "workflow_verdict": "INCOMPLETE",
+            "completion_status": "INCOMPLETE",
+        }
+
+    budget.record_spend(estimate)
+    raw_response = reviewer(target, prompt)
+    response_text = json.dumps(raw_response, ensure_ascii=False) if isinstance(raw_response, Mapping) else str(raw_response)
+    findings = llm_reviewer.parse_and_evaluate_llm_response(
+        response_text,
+        module_md=texts.get("module.md", ""),
+        activities_yaml=texts.get("activities.yaml", ""),
+        vocabulary_yaml=texts.get("vocabulary.yaml", ""),
+        resources_yaml=texts.get("resources.yaml", ""),
+    )
+    payload = _payload_from_findings(findings)
+    llm_qg_store.record_llm_qg(
+        level=level,
+        slug=slug,
+        module_dir=target.module_dir,
+        payload=payload,
+        gate_version=options.gate_version,
+        prompt_hash=prompt_hash,
+        checker_version=CHECKER_VERSION,
+        level_policy_family=policy_family,
+        reviewer_model=options.reviewer_model_id,
+        reviewer_family=options.reviewer_family,
+        source="qg_workflow",
+        path=store_path,
+    )
+    return {
+        "findings": findings,
+        "result": {
+            **base_result,
+            "status": "ran",
+            "findings": len(findings),
+            "estimate": estimate,
+        },
+        "llm_used": True,
+    }
+
+
+def estimate_llm_cost(prompt: str, policy_family: str) -> dict[str, Any]:
+    """Estimate reviewer token/cost by level profile."""
+
+    prompt_tokens = max(1, len(prompt.encode("utf-8")) // 4)
+    completion_tokens = 900 if policy_family == "seminar" else 600
+    per_1k = 0.012 if policy_family == "seminar" else 0.008 if policy_family == "b1_plus" else 0.004
+    total_tokens = prompt_tokens + completion_tokens
+    return {
+        "policy_family": policy_family,
+        "estimated_prompt_tokens": prompt_tokens,
+        "estimated_completion_tokens": completion_tokens,
+        "estimated_total_tokens": total_tokens,
+        "estimated_cost_usd": round(total_tokens / 1000.0 * per_1k, 6),
+        "basis": "prompt byte estimate; replace with telemetry median when available",
+    }
+
+
+def _build_evidence_record(
+    *,
+    level: str,
+    slug: str,
+    target: ReviewTarget,
+    policy_family: str,
+    policy_english: str,
+    content_sha: str,
+    prompt_hash: str | None,
+    findings: Sequence[Mapping[str, Any]],
+    tier_results: Sequence[Mapping[str, Any]],
+    workflow_verdict: str | None,
+    completion_status: str,
+    llm_used: bool,
+    llm_required_by_policy: bool,
+    llm_required_by_harness: bool,
+    llm_cost_override: bool,
+    options: WorkflowOptions,
+) -> dict[str, Any]:
+    dimensions = dimensions_from_findings(findings)
+    aggregate = _aggregate_from_dimensions(dimensions)
+    schema_verdict = aggregate["verdict"]
+    terminal_verdict = aggregate["terminal_verdict"]
+    if completion_status == "INCOMPLETE" and options.fail_closed_on_llm_skip:
+        schema_verdict = "FAIL"
+        terminal_verdict = "FAIL"
+    aggregate.update(
+        {
+            "workflow_verdict": workflow_verdict or schema_verdict,
+            "completion_status": completion_status,
+            "finding_count": len(findings),
+            "content_hash_basis": CONTENT_HASH_BASIS,
+            "content_files": list(llm_qg_store.CONTENT_FILES),
+        }
+    )
+    record = qg_schema.build_evidence_record(
+        profile="curriculum_llm_compact",
+        evidence_kind="module",
+        module_id=f"{level}/{slug}",
+        fixture_id=target.fixture_id,
+        level_policy={
+            "family": policy_family,
+            "english_policy": policy_english,
+            "llm_policy_families": sorted(LLM_POLICY_FAMILIES),
+        },
+        dimensions=dimensions,
+        checker_runs=_checker_runs(tier_results, options),
+        content_sha=content_sha,
+        provenance={
+            "created_at": _now_z(),
+            "run_id": f"qg-workflow-{uuid4().hex}",
+            "source": "qg_workflow",
+            "module_dir": str(target.module_dir),
+        },
+        verdict=schema_verdict,
+        terminal_verdict=terminal_verdict,
+        aggregate=aggregate,
+    )
+    record["qg_workflow"] = {
+        "gate_version": options.gate_version,
+        "prompt_hash": prompt_hash,
+        "checker_version": CHECKER_VERSION,
+        "checker_config_hash": checker_config_hash(),
+        "reviewer_model_id": options.reviewer_model_id,
+        "content_hash_basis": CONTENT_HASH_BASIS,
+        "content_files": list(llm_qg_store.CONTENT_FILES),
+        "tiers": [dict(item) for item in tier_results],
+    }
+    record["llm_review"] = {
+        "used": llm_used,
+        "required_by_policy": llm_required_by_policy,
+        "required_by_harness": llm_required_by_harness,
+        "cost_override_applied": llm_cost_override,
+        "default_fail_override": (
+            "Tier-0 hard FAIL short-circuits the LLM tier by default for cost; "
+            "use --llm-on-fail or calibration sample mode for richer diagnostics."
+        ),
+    }
+    record["workflow_verdict"] = aggregate["workflow_verdict"]
+    record["completion_status"] = completion_status
+    qg_schema.validate_record(record)
+    return record
+
+
+def _checker_runs(
+    tier_results: Sequence[Mapping[str, Any]],
+    options: WorkflowOptions,
+) -> list[dict[str, Any]]:
+    runs = [
+        {
+            "source": "deterministic",
+            "checker": CHECKER_VERSION,
+            "config_hash": checker_config_hash(),
+            "provider": None,
+            "model": None,
+        }
+    ]
+    if any(tier.get("tier") == 1 and int(tier.get("gold_rows_matched") or 0) for tier in tier_results):
+        runs.append(
+            {
+                "source": "lookup",
+                "checker": "ua_gec_gold_fixture",
+                "config_hash": None,
+                "provider": None,
+                "model": None,
+            }
+        )
+    if any(tier.get("tier") == 2 and tier.get("status") in {"ran", "cache_hit"} for tier in tier_results):
+        runs.append(
+            {
+                "source": "llm_reviewer",
+                "checker": options.gate_version,
+                "config_hash": None,
+                "provider": options.reviewer_family,
+                "model": options.reviewer_model_id,
+            }
+        )
+    return runs
+
+
+def _payload_from_findings(findings: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    dimensions = dimensions_from_findings(findings)
+    return {
+        "schema_version": qg_schema.SCHEMA_VERSION,
+        "aggregate": _aggregate_from_dimensions(dimensions),
+        "dimensions": dimensions,
+        "findings": [dict(finding) for finding in findings],
+    }
+
+
+def _findings_from_payload(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    findings = payload.get("findings")
+    if isinstance(findings, list):
+        out = [dict(item) for item in findings if isinstance(item, Mapping)]
+        for finding in out:
+            qg_schema.validate_finding(finding)
+        return out
+    dimensions = payload.get("dimensions")
+    out: list[dict[str, Any]] = []
+    if isinstance(dimensions, Mapping):
+        for entry in dimensions.values():
+            if not isinstance(entry, Mapping) or not isinstance(entry.get("findings"), list):
+                continue
+            out.extend(dict(item) for item in entry["findings"] if isinstance(item, Mapping))
+    for finding in out:
+        qg_schema.validate_finding(finding)
+    return out
+
+
+def _aggregate_from_dimensions(dimensions: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
+    has_fail = any(entry.get("verdict") == "FAIL" for entry in dimensions.values())
+    has_warn = any(entry.get("verdict") == "WARN" for entry in dimensions.values())
+    verdict = "FAIL" if has_fail else "WARN" if has_warn else "PASS"
+    return {
+        "verdict": verdict,
+        "terminal_verdict": "FAIL" if has_fail else "PASS",
+        "failing_dims": [dim for dim, entry in dimensions.items() if entry.get("verdict") == "FAIL"],
+        "warning_dims": [dim for dim, entry in dimensions.items() if entry.get("verdict") == "WARN"],
+    }
+
+
+def _verdict_for_findings(findings: Sequence[Mapping[str, Any]]) -> str:
+    if any(finding.get("severity") == "critical" for finding in findings):
+        return "FAIL"
+    if findings:
+        return "WARN"
+    return "PASS"
+
+
+def _dedupe_by_finding_id(findings: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+    for finding in findings:
+        qg_schema.validate_finding(finding)
+        finding_id = str(finding["finding_id"])
+        if finding_id in seen:
+            continue
+        seen.add(finding_id)
+        out.append(dict(finding))
+    return out
+
+
+def _gold_contested(finding: Mapping[str, Any]) -> bool:
+    metadata = finding.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return False
+    gold = metadata.get("ua_gec_gold")
+    if not isinstance(gold, Mapping):
+        return False
+    return bool(gold.get("contested_flag") or gold.get("contested"))
+
+
+def _read_module_texts(module_dir: Path) -> dict[str, str]:
+    texts: dict[str, str] = {}
+    for name in llm_qg_store.CONTENT_FILES:
+        path = module_dir / name
+        texts[name] = path.read_text(encoding="utf-8") if path.exists() else ""
+    return texts
+
+
+def _llm_enabled_for_any_target(targets: Sequence[ReviewTarget], options: WorkflowOptions) -> bool:
+    if not options.enable_llm:
+        return False
+    return any(
+        policy_for_level(target.level).family in LLM_POLICY_FAMILIES
+        or options.force_llm
+        or options.calibration_sample
+        for target in targets
+    )
+
+
+def _now_z() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _targets_from_args(args: argparse.Namespace) -> list[ReviewTarget]:
+    if args.target:
+        targets = []
+        for raw in args.target:
+            parts = raw.split(":", 2)
+            if len(parts) != 3:
+                raise ValueError("--target must be level:slug:module_dir")
+            targets.append(ReviewTarget(level=parts[0], slug=parts[1], module_dir=Path(parts[2])))
+        return targets
+    if not args.module_dir or not args.level:
+        raise ValueError("--module-dir requires --level")
+    return [
+        ReviewTarget(
+            level=args.level,
+            slug=args.slug or Path(args.module_dir).name,
+            module_dir=Path(args.module_dir),
+            fixture_id=args.fixture_id,
+            plan_path=args.plan_path,
+        )
+    ]
+
+
+def _reviewer_from_response(path: Path | None) -> Reviewer | None:
+    if path is None:
+        return None
+    response_text = path.read_text(encoding="utf-8")
+
+    def reviewer(_target: ReviewTarget, _prompt: str) -> str:
+        return response_text
+
+    return reviewer
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--module-dir", type=Path, help="Single module directory to review.")
+    parser.add_argument("--level", help="Level for --module-dir, e.g. b1 or folk.")
+    parser.add_argument("--slug", help="Slug for --module-dir; defaults to directory name.")
+    parser.add_argument("--fixture-id", help="Optional UA-GEC/curriculum fixture id.")
+    parser.add_argument("--plan-path", type=Path, help="Optional plan path for deterministic plan checks.")
+    parser.add_argument(
+        "--target",
+        action="append",
+        help="Repeatable broad target in level:slug:module_dir form.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print per-tier counts and cost estimates; write nothing.")
+    parser.add_argument("--force-llm", action="store_true", help="Enable Tier-2 for this run and override A1/A2 policy skip.")
+    parser.add_argument("--llm-on-fail", action="store_true", help="Run Tier-2 even after Tier-0 hard FAIL.")
+    parser.add_argument("--calibration-sample", action="store_true", help="Treat targets as an explicit calibration sample.")
+    parser.add_argument("--max-llm-calls", type=int, help="Per-run reviewer call ceiling.")
+    parser.add_argument("--max-cost-usd", type=float, help="Per-run cost ceiling.")
+    parser.add_argument("--max-daily-cost-usd", type=float, help="Per-day safety rail for this local run.")
+    parser.add_argument("--max-module-cost-usd", type=float, help="Per-module pathological prompt cost cap.")
+    parser.add_argument("--gate-version", default=DEFAULT_GATE_VERSION)
+    parser.add_argument("--reviewer-model-id", default=DEFAULT_REVIEWER_MODEL_ID)
+    parser.add_argument("--reviewer-family", default=DEFAULT_REVIEWER_FAMILY)
+    parser.add_argument("--db", type=Path, help="Optional LLM-QG SQLite cache path.")
+    parser.add_argument("--llm-response-json", type=Path, help="Precomputed reviewer response JSON; no live dispatch.")
+    parser.add_argument("--canary-result", type=Path, help="Reviewer canary JSON that must pass before broad LLM.")
+    parser.add_argument("--format", choices=("json", "summary"), default="summary")
+    parser.add_argument("--output", type=Path, help="Optional output file.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        targets = _targets_from_args(args)
+        enable_llm = bool(args.force_llm or args.llm_response_json)
+        canary_passed = False
+        if len(targets) > 1 and _llm_enabled_for_any_target(
+            targets,
+            WorkflowOptions(
+                enable_llm=enable_llm,
+                force_llm=args.force_llm,
+                calibration_sample=args.calibration_sample,
+            ),
+        ):
+            canary_passed = args.canary_result is not None and canary_result_passes(
+                args.canary_result,
+                level=targets[0].level,
+            )
+            if not canary_passed:
+                raise ValueError("broad Tier-2 runs require a passing llm_qg_canaries.py result")
+        options = WorkflowOptions(
+            gate_version=args.gate_version,
+            reviewer_model_id=args.reviewer_model_id,
+            reviewer_family=args.reviewer_family,
+            enable_llm=enable_llm,
+            force_llm=args.force_llm,
+            llm_on_fail=args.llm_on_fail,
+            calibration_sample=args.calibration_sample,
+            dry_run=args.dry_run,
+            canary_passed=canary_passed,
+            max_llm_calls=args.max_llm_calls,
+            max_cost_usd=args.max_cost_usd,
+            max_daily_cost_usd=args.max_daily_cost_usd,
+            max_module_cost_usd=args.max_module_cost_usd,
+        )
+        if args.dry_run:
+            payload: dict[str, Any] | list[dict[str, Any]] = dry_run_modules(
+                targets,
+                options=options,
+                store_path=args.db,
+            )
+        else:
+            payload = review_modules(
+                targets,
+                options=options,
+                reviewer=_reviewer_from_response(args.llm_response_json),
+                store_path=args.db,
+            )
+            if len(payload) == 1:
+                payload = payload[0]
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    output = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) if args.format == "json" else _summary(payload)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(output + "\n", encoding="utf-8")
+    else:
+        print(output)
+    return 0 if _passes(payload) else 1
+
+
+def _summary(payload: Mapping[str, Any] | Sequence[Mapping[str, Any]]) -> str:
+    if isinstance(payload, Mapping) and payload.get("dry_run") is True:
+        counts = payload["counts"]
+        return (
+            "QG workflow dry-run\n"
+            f"Modules: {counts['modules']}\n"
+            f"Tier-1 gold rows matched: {counts['tier1_gold_rows_matched']}\n"
+            f"Tier-2 estimated calls: {counts['tier2_estimated_calls']}"
+        )
+    records = [payload] if isinstance(payload, Mapping) else list(payload)
+    lines = ["QG workflow evidence"]
+    for record in records:
+        lines.append(
+            f"- {record['module_id']}: {record['workflow_verdict']} "
+            f"({record['completion_status']}, findings={record['aggregate']['finding_count']})"
+        )
+    return "\n".join(lines)
+
+
+def _passes(payload: Mapping[str, Any] | Sequence[Mapping[str, Any]]) -> bool:
+    if isinstance(payload, Mapping) and payload.get("dry_run") is True:
+        return True
+    records = [payload] if isinstance(payload, Mapping) else list(payload)
+    return all(str(record.get("terminal_verdict")) == "PASS" for record in records)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_qg_workflow.py
+++ b/tests/test_qg_workflow.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.audit import llm_qg_store, llm_reviewer, qg_schema, qg_workflow
+from scripts.audit.curriculum_qg_harness import CHECKER_VERSION
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_FILE = PROJECT_ROOT / "tests" / "fixtures" / "curriculum_qg" / "fixtures.yaml"
+B1_27_DIR = PROJECT_ROOT / "curriculum" / "l2-uk-en" / "b1" / "aspect-in-imperatives"
+
+
+def _fixture_by_id(fixture_id: str) -> dict[str, Any]:
+    payload = yaml.safe_load(FIXTURE_FILE.read_text(encoding="utf-8"))
+    for fixture in payload["fixtures"]:
+        if fixture["id"] == fixture_id:
+            return fixture
+    raise AssertionError(f"missing fixture {fixture_id}")
+
+
+def _write_fixture_module(tmp_path: Path, fixture_id: str) -> Path:
+    fixture = _fixture_by_id(fixture_id)
+    module_dir = tmp_path / fixture["slug"]
+    module_dir.mkdir()
+    for name, body in fixture["module"].items():
+        (module_dir / name).write_text(str(body).rstrip() + "\n", encoding="utf-8")
+    return module_dir
+
+
+def _write_module(
+    tmp_path: Path,
+    *,
+    level: str = "b1",
+    slug: str = "clean-module",
+    module_md: str | None = None,
+    activities_yaml: str = "[]\n",
+) -> Path:
+    module_dir = tmp_path / level / slug
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text(
+        module_md
+        or "# Чистий модуль\n\nУчні читають український текст і виконують коротке завдання.\n",
+        encoding="utf-8",
+    )
+    (module_dir / "activities.yaml").write_text(activities_yaml, encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "resources.yaml").write_text("[]\n", encoding="utf-8")
+    return module_dir
+
+
+def _reviewer_response(issue_id: str = "LLM_STYLE_REVIEW") -> str:
+    return json.dumps(
+        {
+            "findings": [
+                {
+                    "issue_id": issue_id,
+                    "issue_class": "fluency",
+                    "dimension": "naturalness",
+                    "severity": "warning",
+                    "excerpt": "український текст",
+                    "message": "Injected reviewer warning.",
+                }
+            ]
+        },
+        ensure_ascii=False,
+    )
+
+
+def _target(module_dir: Path, *, level: str = "b1", slug: str | None = None) -> qg_workflow.ReviewTarget:
+    return qg_workflow.ReviewTarget(
+        level=level,
+        slug=slug or module_dir.name,
+        module_dir=module_dir,
+    )
+
+
+def _tier(record: dict[str, Any], number: int) -> dict[str, Any]:
+    return next(tier for tier in record["qg_workflow"]["tiers"] if tier["tier"] == number)
+
+
+def test_tier_order_and_tier0_hard_fail_short_circuits_llm(tmp_path: Path) -> None:
+    module_dir = _write_fixture_module(tmp_path, "b1-27-restored-bad")
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> str:
+        nonlocal calls
+        calls += 1
+        return '{"findings": []}'
+
+    record = qg_workflow.review_module(
+        _target(module_dir, slug="aspect-in-imperatives"),
+        options=qg_workflow.WorkflowOptions(enable_llm=True),
+        reviewer=reviewer,
+    )
+
+    assert [tier["tier"] for tier in record["qg_workflow"]["tiers"]] == [0, 1, 2]
+    assert _tier(record, 0)["verdict"] == "FAIL"
+    assert _tier(record, 2)["status"] == "skipped_tier0_hard_fail"
+    assert record["llm_review"]["cost_override_applied"] is True
+    assert calls == 0
+
+
+def test_tier2_policy_gate_reaches_seminar_and_skips_a1_a2(tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    def reviewer(target: qg_workflow.ReviewTarget, _prompt: str) -> str:
+        calls.append(target.level)
+        return '{"findings": []}'
+
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="calm-seminar",
+        module_md="# Семінар\n\nУчасники аналізують джерела спокійно й уважно.\n",
+    )
+    a1_dir = _write_module(tmp_path, level="a1", slug="a1-clean")
+    a2_dir = _write_module(tmp_path, level="a2", slug="a2-clean")
+
+    seminar = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="calm-seminar"),
+        options=qg_workflow.WorkflowOptions(enable_llm=True, reviewer_model_id="test-reviewer"),
+        reviewer=reviewer,
+        store_path=tmp_path / "seminar-qg.db",
+    )
+    a1 = qg_workflow.review_module(
+        _target(a1_dir, level="a1", slug="a1-clean"),
+        options=qg_workflow.WorkflowOptions(enable_llm=True, reviewer_model_id="test-reviewer"),
+        reviewer=reviewer,
+    )
+    a2 = qg_workflow.review_module(
+        _target(a2_dir, level="a2", slug="a2-clean"),
+        options=qg_workflow.WorkflowOptions(enable_llm=True, reviewer_model_id="test-reviewer"),
+        reviewer=reviewer,
+    )
+
+    assert _tier(seminar, 2)["status"] == "ran"
+    assert _tier(seminar, 2)["llm_required_by_policy"] is True
+    assert _tier(a1, 2)["status"] == "skipped_policy"
+    assert _tier(a2, 2)["status"] == "skipped_policy"
+    assert calls == ["folk"]
+
+
+def test_composite_cache_invalidates_on_gate_version_bump(tmp_path: Path) -> None:
+    module_dir = _write_module(tmp_path)
+    db_path = tmp_path / "qg.db"
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> str:
+        nonlocal calls
+        calls += 1
+        return _reviewer_response()
+
+    options_v1 = qg_workflow.WorkflowOptions(
+        enable_llm=True,
+        gate_version="gate.v1",
+        reviewer_model_id="test-reviewer",
+    )
+    first = qg_workflow.review_module(
+        _target(module_dir),
+        options=options_v1,
+        reviewer=reviewer,
+        store_path=db_path,
+    )
+    second = qg_workflow.review_module(
+        _target(module_dir),
+        options=options_v1,
+        reviewer=None,
+        store_path=db_path,
+    )
+    third = qg_workflow.review_module(
+        _target(module_dir),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            gate_version="gate.v2",
+            reviewer_model_id="test-reviewer",
+        ),
+        reviewer=reviewer,
+        store_path=db_path,
+    )
+
+    assert _tier(first, 2)["status"] == "ran"
+    assert _tier(second, 2)["status"] == "cache_hit"
+    assert _tier(third, 2)["status"] == "ran"
+    assert calls == 2
+
+
+def test_budget_exhaustion_emits_skipped_budget_and_incomplete(tmp_path: Path) -> None:
+    module_dir = _write_module(tmp_path)
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> str:
+        nonlocal calls
+        calls += 1
+        return '{"findings": []}'
+
+    record = qg_workflow.review_module(
+        _target(module_dir),
+        options=qg_workflow.WorkflowOptions(enable_llm=True, max_llm_calls=0),
+        reviewer=reviewer,
+    )
+
+    assert _tier(record, 2)["status"] == "skipped_budget"
+    assert _tier(record, 2)["reason"] == "max_llm_calls"
+    assert record["workflow_verdict"] == "SKIPPED_BUDGET"
+    assert record["completion_status"] == "INCOMPLETE"
+    assert record["terminal_verdict"] == "FAIL"
+    assert calls == 0
+
+
+def test_workflow_dedupes_cached_tier2_findings_by_finding_id(tmp_path: Path) -> None:
+    activities = (
+        "- id: wb-essay-missing\n"
+        "  type: essay-response\n"
+        "  title: Напишіть есе\n"
+        "  instruction: Напишіть 120 слів.\n"
+    )
+    module_dir = _write_module(
+        tmp_path,
+        level="b2",
+        slug="model-answer-module",
+        activities_yaml=activities,
+    )
+    target = _target(module_dir, level="b2", slug="model-answer-module")
+    duplicate_findings = llm_reviewer.run_structural_checks("b2", activities)
+    assert len(duplicate_findings) == 1
+    prompt = llm_reviewer.build_reviewer_prompt(
+        level="b2",
+        slug="model-answer-module",
+        module_md=(module_dir / "module.md").read_text(encoding="utf-8"),
+        activities_yaml=activities,
+        vocabulary_yaml="[]\n",
+        resources_yaml="[]\n",
+    )
+    db_path = tmp_path / "qg.db"
+    llm_qg_store.record_llm_qg(
+        level="b2",
+        slug="model-answer-module",
+        module_dir=module_dir,
+        payload=qg_workflow._payload_from_findings(duplicate_findings),
+        gate_version="gate.v1",
+        prompt_hash=llm_qg_store.prompt_hash_for_text(prompt),
+        checker_version=CHECKER_VERSION,
+        level_policy_family="b1_plus",
+        reviewer_model="test-reviewer",
+        path=db_path,
+    )
+
+    record = qg_workflow.review_module(
+        target,
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            llm_on_fail=True,
+            gate_version="gate.v1",
+            reviewer_model_id="test-reviewer",
+        ),
+        store_path=db_path,
+    )
+
+    findings = [
+        finding
+        for dimension in record["dimensions"].values()
+        for finding in dimension["findings"]
+        if finding["issue_id"] == "MISSING_MODEL_ANSWER"
+    ]
+    assert _tier(record, 2)["status"] == "cache_hit"
+    assert len(findings) == 1
+    qg_schema.validate_record(record)
+
+
+def test_current_b1_27_production_stays_green_without_llm_bulk_run() -> None:
+    record = qg_workflow.review_module(
+        qg_workflow.ReviewTarget(
+            level="b1",
+            slug="aspect-in-imperatives",
+            module_dir=B1_27_DIR,
+        )
+    )
+
+    assert record["module_id"] == "b1/aspect-in-imperatives"
+    assert record["verdict"] == "PASS"
+    assert record["terminal_verdict"] == "PASS"
+    assert record["llm_review"]["used"] is False
+    assert _tier(record, 2)["status"] == "skipped_flag_off"
+    qg_schema.validate_record(record)

--- a/tests/test_qg_workflow.py
+++ b/tests/test_qg_workflow.py
@@ -211,6 +211,36 @@ def test_budget_exhaustion_emits_skipped_budget_and_incomplete(tmp_path: Path) -
     assert calls == 0
 
 
+def test_dry_run_estimates_tier2_without_reviewer_or_canary(tmp_path: Path) -> None:
+    first = _write_module(tmp_path, slug="clean-one")
+    second = _write_module(tmp_path, slug="clean-two")
+    output = tmp_path / "dry-run.json"
+
+    code = qg_workflow.main(
+        [
+            "--target",
+            f"b1:clean-one:{first}",
+            "--target",
+            f"b1:clean-two:{second}",
+            "--dry-run",
+            "--format",
+            "json",
+            "--output",
+            str(output),
+        ]
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+
+    assert code == 0
+    assert payload["dry_run"] is True
+    assert payload["writes"] == 0
+    assert payload["counts"]["modules"] == 2
+    assert payload["counts"]["tier2_estimated_calls"] == 2
+    assert payload["level_profiles"]["b1_plus"]["tier2_estimated_calls"] == 2
+    assert payload["level_profiles"]["b1_plus"]["estimated_prompt_tokens"] > 0
+    assert payload["level_profiles"]["b1_plus"]["estimated_cost_usd"] > 0
+
+
 def test_workflow_dedupes_cached_tier2_findings_by_finding_id(tmp_path: Path) -> None:
     activities = (
         "- id: wb-essay-missing\n"


### PR DESCRIPTION
## Summary

Implements #4310 for #2156 Phase 3 by adding a tiered curriculum QG workflow that composes deterministic checks, UA-GEC lookup, and gated LLM reviewer evidence into one `qg_schema` module record.

Changes:
- adds `scripts/audit/qg_workflow.py` with Tier 0 deterministic/structural checks, Tier 1 gold lookup, Tier 2 policy/budget/cache gating, dry-run estimates, and explicit `SKIPPED_BUDGET` / `INCOMPLETE` evidence handling
- extends `scripts/audit/llm_qg_store.py` with composite cache columns/filters: `content_sha + gate_version + prompt_hash + checker_version + level_policy.family + reviewer_model_id`
- documents the workflow and canonical content basis (`llm_qg_store.CONTENT_FILES`, not plan-inclusive promotion hashes)

Tier 2 live reviewer dispatch remains flag-off by default until #4370 calibration lands. Broad Tier-2 spend requires a passing canary result before the reviewer is enabled; dry-run estimates do not require a canary because they do not call the reviewer.

## #M-4 Verification Preamble

Raw tool output for the required checks:

```text
$ .venv/bin/python -m pytest tests/test_qg_workflow.py -q -vv
tests/test_qg_workflow.py::test_tier_order_and_tier0_hard_fail_short_circuits_llm PASSED [ 14%]
tests/test_qg_workflow.py::test_tier2_policy_gate_reaches_seminar_and_skips_a1_a2 PASSED [ 28%]
tests/test_qg_workflow.py::test_composite_cache_invalidates_on_gate_version_bump PASSED [ 42%]
tests/test_qg_workflow.py::test_budget_exhaustion_emits_skipped_budget_and_incomplete PASSED [ 57%]
tests/test_qg_workflow.py::test_dry_run_estimates_tier2_without_reviewer_or_canary PASSED [ 71%]
tests/test_qg_workflow.py::test_workflow_dedupes_cached_tier2_findings_by_finding_id PASSED [ 85%]
tests/test_qg_workflow.py::test_current_b1_27_production_stays_green_without_llm_bulk_run PASSED [100%]
============================== 7 passed in 0.47s ===============================
```

```text
$ .venv/bin/python -m pytest tests/test_qg_workflow.py -q
tests/test_qg_workflow.py .......                                        [100%]
============================== 7 passed in 0.51s ===============================
```

```text
$ .venv/bin/python -m pytest tests/audit/test_llm_qg_store.py -q
tests/audit/test_llm_qg_store.py ......                                  [100%]
============================== 6 passed in 0.43s ===============================
```

```text
$ .venv/bin/ruff check scripts/audit/llm_qg_store.py scripts/audit/qg_workflow.py tests/test_qg_workflow.py
All checks passed!
```

```text
$ node_modules/.bin/markdownlint-cli2 docs/SCRIPTS.md docs/projects/ua-eval-harness/README.md docs/projects/ua-eval-harness/cost-aware-qg-workflow.md
Summary: 0 error(s)
```

```text
$ git diff --cached --check
```

```text
$ .venv/bin/python scripts/audit/lint_agent_trailer.py origin/main..HEAD
Checking 2 commit(s) in origin/main..HEAD:

  7ba784742b  PASS  X-Agent: codex/4310-cost-aware-workflow
  035794b84b  PASS  X-Agent: codex/4310-cost-aware-workflow

✅ All 2 non-skipped commit(s) carry an X-Agent trailer.
```

```text
$ .venv/bin/python scripts/audit/qg_workflow.py --module-dir curriculum/l2-uk-en/b1/aspect-in-imperatives --level b1 --slug aspect-in-imperatives --dry-run --format summary
QG workflow dry-run
Modules: 1
Tier-1 gold rows matched: 0
Tier-2 estimated calls: 0
```

## Independent Review

Agy/Gemini (`gemini-3.1-pro-high`, read-only) reviewed the committed diff and initially returned `OVERALL VERDICT: REJECT` with findings on dry-run/cache CLI wiring, broad dry-run canary bypass, write-path migration robustness, and missing dry-run coverage. Follow-up commit `7ba784742b` addresses those findings:

- dry-run and cache-only CLI paths now enter Tier 2 without enabling live dispatch
- broad dry-run bypasses the canary requirement because it writes nothing and calls no reviewer
- `record_llm_qg()` now backfills composite columns on the write path too
- `test_dry_run_estimates_tier2_without_reviewer_or_canary` covers the dry-run estimate path

## Review / Merge Notes

- Independent non-Codex review has been run; follow-up fixes are included.
- Full fleet gate is still required before any corpus-scale run (#4311).
- This PR must not be auto-merged.

Fixes #4310.
Refs #2156.
