### PR TITLE
fix(audit): calibrate #4309 reviewer prompt — FP/FN tweaks (#4370)

### DIFF
--- a/docs/projects/ua-eval-harness/calibration_criteria.md
+++ b/docs/projects/ua-eval-harness/calibration_criteria.md
@@ -2,6 +2,10 @@
 
 This document defines the calibration criteria, level profiles, false-positive/false-negative controls, and structural validation specifications implemented for the LLM reviewer layer in the Ukrainian-quality gates evaluation harness (#4309).
 
+> [!NOTE]
+> **Deterministic Layer Precedence**:
+> Lexical Russianisms, orthography, and baseline grammar validation are handled FIRST by deterministic gates (#4308, #912, curriculum QG). The LLM reviewer pass acts as a supplementary gate for style, register, and stylistic calques.
+
 ---
 
 ## 1. Level Profiles & Immersion Policies
@@ -28,18 +32,25 @@ Linguistic expectations and immersion rules are strictly partitioned by target C
 
 ---
 
-## 2. B1-27 Calibration Criteria (HARD Calibration)
+## 2. Severity Calibration Guidelines
+* **critical**: Factual errors, resource/evidence/pipeline leakages (AI personae, absolute paths), missing mandatory structural elements (such as model answers in B2+), and severe grammatical errors (such as case alignment or predicative-instrumental errors).
+* **warning**: Style and register issues (unnatural/syntactic calques, unnatural metalanguage/register, minor prepositions), or pedagogical mismatches.
+* **info**: Non-critical suggestions, minor stylistic alternatives, or optional improvements.
+
+---
+
+## 3. B1-27 Calibration Criteria (HARD Calibration)
 
 The B1-27 *restored-bad* examples contain unidiomatic or calqued Ukrainian constructions that are not lexical Russianisms (pure Russian words) but are stylistic/syntactic defects. The reviewer must detect:
 
-| Restored-Bad Phrase | Expected Issue ID | Dimension | Target Idiomatic Ukrainian | Rationale |
-|---|---|---|---|---|
-| `застосунок має бути відкритий` | `AWKWARD_PASSIVE_RESULT_STATE` | `ukrainian_style` | `відкрийте застосунок` / `застосунок має бути відкритим` | Impersonal/active voice is preferred over literal passive state translations. |
-| `Застереження каже: будь обережний` | `UNNATURAL_ANTHROPOMORPHISM` | `ukrainian_style` | `Зверніть увагу` / `Будьте обережні` | Abstract warning blocks must not be anthropomorphized as speakers. |
-| `радить не робити певної поведінки` | `UKRAINIAN_GRAMMAR_CALQUE` | `ukrainian_style` | `рекомендує уникати...` | Unnatural verbal government and nominalization. |
-| `дія має дати конкретний результат чи описати процес?` | `UNNATURAL_META_REGISTER` | `ukrainian_style` | (Avoid in learner-facing text) | Overly abstract syntactic metalanguage / prompt leakage. |
-| `доконаний вид дає результат із вікном` | `UKRAINIAN_GRAMMAR_CALQUE` | `ukrainian_style` | `доконаний вид позначає результат...` | Literal calqued metaphor and unidiomatic argument structure. |
-| `У кухні` | `CALQUED_PREPOSITION` | `ukrainian_style` | `На кухні` | Location prep calque; "На кухні" is the standard locative context. |
+| Restored-Bad Phrase | Expected Issue ID | Dimension | Severity | Target Idiomatic Ukrainian | Rationale |
+|---|---|---|---|---|---|
+| `застосунок має бути відкритий` | `AWKWARD_PASSIVE_RESULT_STATE` | `ukrainian_style` | `critical` | `відкрийте застосунок` / `застосунок має бути відкритим` | Predicative-instrumental case error (nominative instead of instrumental). Do NOT flag 'має бути відкритим'. |
+| `Застереження каже: будь обережний` | `UNNATURAL_ANTHROPOMORPHISM` | `ukrainian_style` | `warning` | `Зверніть увагу` / `Будьте обережні` | Abstract warnings must not speak. Scoped strictly to metalanguage; do NOT flag natural personifications like 'правило каже'. |
+| `радить не робити певної поведінки` | `UKRAINIAN_GRAMMAR_CALQUE` | `ukrainian_style` | `warning` | `рекомендує уникати...` | Unnatural verbal government and nominalization calque. Downgraded to warning. |
+| `дія має дати конкретний результат чи описати процес?` | `UNNATURAL_META_REGISTER` | `ukrainian_style` | `warning` | (Avoid in learner-facing text) | AI/reviewer metalanguage / dry syntactic jargon in learner-facing text. Downgraded to warning. |
+| `доконаний вид дає результат із вікном` | `UKRAINIAN_GRAMMAR_CALQUE` | `ukrainian_style` | `warning` | `доконаний вид позначає результат...` | Literal calqued metaphor and unidiomatic argument structure. Downgraded to warning. |
+| `У кухні` | `CALQUED_PREPOSITION` | `ukrainian_style` | `warning` | `На кухні` | Location prep calque. Downgraded to warning; do not auto-fail in informal contexts. |
 
 ---
 

--- a/scripts/audit/prompts/reviewer_prompt.md
+++ b/scripts/audit/prompts/reviewer_prompt.md
@@ -1,5 +1,9 @@
 # LLM Reviewer & Evaluator Prompt for Ukrainian Curriculum Quality
 
+> [!IMPORTANT]
+> **Deterministic Layer Precedence & Grammar/Mechanics Deferral**:
+> The deterministic quality gate layer (including #4308 `check_russicisms`, #912 `semantic_russianisms`, and general curriculum QG checks) handles lexical Russianisms, orthography, and fundamental hard-grammar validation FIRST. A clean LLM pass is NOT a full gate; this LLM reviewer is designed to catch style, register, complex calques, and pedagogical alignment. For spelling, orthography, and other fundamental mechanical grammar rules, explicitly defer to the deterministic gates or flag only if they escape them.
+
 You are an expert Ukrainian linguist, lexicographer, and language pedagogy specialist. Your role is to perform a rigorous quality gate review of curriculum modules for learners of Ukrainian as a second/foreign language.
 
 You must evaluate the input content across several dimensions and identify any issues, calques, register mismatches, or stylistic flaws.
@@ -26,17 +30,25 @@ You must adapt your judgment based on the CEFR target level of the module:
 
 ---
 
-## 2. Key Linguistic Checkpoints (Deterministic & Stylistic)
+## 2. Severity Calibration Guidelines
+Assign severities based on the following taxonomy:
+* **critical**: Factual errors, resource/evidence/pipeline leakages (AI personae, absolute paths), missing mandatory structural elements (such as model answers in B2+), and severe grammatical errors (such as case alignment or predicative-instrumental errors).
+* **warning**: Style and register issues (unnatural/syntactic calques, unnatural metalanguage/register, minor prepositions), or pedagogical mismatches.
+* **info**: Non-critical suggestions, minor stylistic alternatives, or optional improvements.
+
+---
+
+## 3. Key Linguistic Checkpoints (Deterministic & Stylistic)
 You must look for the following types of defects:
 
 ### A. Unnatural Ukrainian & Stylistic Calques
 Identify unidiomatic syntax or expressions, even if they are not lexical Russianisms:
-* **Awkward Passive Result States**: e.g., "застосунок має бути відкритий" -> flag as `AWKWARD_PASSIVE_RESULT_STATE` (`ukrainian_style`, `critical`). Recommend active/impersonal (e.g., "відкрийте застосунок" or "застосунок має бути відкритим").
-* **Unnatural Anthropomorphism**: e.g., "Застереження каже" -> flag as `UNNATURAL_ANTHROPOMORPHISM` (`ukrainian_style`, `critical`). Abstract grammatical labels or warnings should not speak or be anthropomorphized.
-* **Awkward Government / Nominalizations**: e.g., "радить не робити певної поведінки" -> flag as `UKRAINIAN_GRAMMAR_CALQUE` (`ukrainian_style`, `critical`).
-* **Unnatural Meta-Register**: e.g., "дія має дати конкретний результат чи описати процес?" -> flag as `UNNATURAL_META_REGISTER` (`ukrainian_style`, `critical`). Avoid prompt-like or overly dry syntactic terminology in learner-facing text.
-* **Awkward Metaphors / Calqued Syntax**: e.g., "доконаний вид дає результат із вікном" -> flag as `UKRAINIAN_GRAMMAR_CALQUE` (`ukrainian_style`, `critical`).
-* **Calqued Prepositions**: e.g., "У кухні" -> flag as `CALQUED_PREPOSITION` (`ukrainian_style`, `critical`). It must be "На кухні".
+* **Predicative-Instrumental Case Errors**: e.g., "застосунок має бути відкритий" (nominative adjective used with copula "бути") -> flag as `AWKWARD_PASSIVE_RESULT_STATE` (`ukrainian_style`, `critical`). The copula "бути" in passive result states requires the predicative-instrumental case (e.g., "застосунок має бути відкритим") or active/impersonal phrasing ("відкрийте застосунок"). Do NOT flag grammatically correct instrumental forms like "має бути відкритим".
+* **Unnatural Anthropomorphism**: e.g., warning text like "Застереження каже" -> flag as `UNNATURAL_ANTHROPOMORPHISM` (`ukrainian_style`, `warning`). This check is scoped strictly to AI/reviewer metalanguage only (e.g., warning boxes or metadata instructions speaking). Do NOT flag natural, standard personifications such as "правило каже" (the rule says) or "таблиця показує" (the table shows).
+* **Awkward Government / Nominalizations**: e.g., "радить не робити певної поведінки" -> flag as `UKRAINIAN_GRAMMAR_CALQUE` (`ukrainian_style`, `warning`).
+* **Unnatural Meta-Register**: e.g., "дія має дати конкретний результат чи описати процес?" -> flag as `UNNATURAL_META_REGISTER` (`ukrainian_style`, `warning`). This is scoped to AI/reviewer metalanguage (e.g., prompt leakage or dry syntactic jargon in learner-facing text). Do NOT flag regular pedagogical explanations.
+* **Awkward Metaphors / Calqued Syntax**: e.g., "доконаний вид дає результат із вікном" -> flag as `UKRAINIAN_GRAMMAR_CALQUE` (`ukrainian_style`, `warning`).
+* **Calqued Prepositions**: e.g., "У кухні" -> flag as `CALQUED_PREPOSITION` (`ukrainian_style`, `warning`). Standard locative contexts prefer "На кухні", but do NOT auto-fail or penalize "у кухні" in informal, dialectal, or non-standard register/colloquial contexts.
 
 ### B. Register and AI Leakage
 * **AI Personae & Leakage**: Look for phrases like "As an AI...", "Note to self", or internal pipeline commands. Flag as `AI_LEAKAGE` (`surface_leakage`, `critical`).

--- a/tests/audit/test_llm_reviewer.py
+++ b/tests/audit/test_llm_reviewer.py
@@ -33,7 +33,7 @@ B1_27_BAD_LLM_RESPONSE = """{
       "issue_id": "UNNATURAL_ANTHROPOMORPHISM",
       "issue_class": "other",
       "dimension": "ukrainian_style",
-      "severity": "critical",
+      "severity": "warning",
       "excerpt": "Застереження каже: будь обережний",
       "message": "Abstract lesson metalanguage should not be anthropomorphized as a speaker."
     },
@@ -41,7 +41,7 @@ B1_27_BAD_LLM_RESPONSE = """{
       "issue_id": "UKRAINIAN_GRAMMAR_CALQUE",
       "issue_class": "grammar",
       "dimension": "ukrainian_style",
-      "severity": "critical",
+      "severity": "warning",
       "excerpt": "радить не робити певної поведінки",
       "message": "The government and nominalized behavior phrase are translated and unnatural."
     },
@@ -49,7 +49,7 @@ B1_27_BAD_LLM_RESPONSE = """{
       "issue_id": "UNNATURAL_META_REGISTER",
       "issue_class": "register",
       "dimension": "ukrainian_style",
-      "severity": "critical",
+      "severity": "warning",
       "excerpt": "дія має дати конкретний результат чи описати процес?",
       "message": "This abstract prompt-like sentence is not natural learner-facing Ukrainian."
     },
@@ -57,7 +57,7 @@ B1_27_BAD_LLM_RESPONSE = """{
       "issue_id": "UKRAINIAN_GRAMMAR_CALQUE",
       "issue_class": "grammar",
       "dimension": "ukrainian_style",
-      "severity": "critical",
+      "severity": "warning",
       "excerpt": "доконаний вид дає результат із вікном",
       "message": "The metaphor and argument structure are literal and unidiomatic."
     },
@@ -65,7 +65,7 @@ B1_27_BAD_LLM_RESPONSE = """{
       "issue_id": "CALQUED_PREPOSITION",
       "issue_class": "calque",
       "dimension": "ukrainian_style",
-      "severity": "critical",
+      "severity": "warning",
       "excerpt": "У кухні",
       "message": "In this ordinary locative teaching context, use the idiomatic На кухні."
     }


### PR DESCRIPTION
Implements #4370 (#2156) — applies the 5 cursor-reviewed FP/FN calibration tweaks to the #4309 LLM reviewer prompt. Authored by AGY (dispatch 4370-prompt-calibration); PR opened by orchestrator (agy skipped gh pr create). Verified all 5 tweaks landed + severity taxonomy. **Gates #4310 live LLM runs.** Independent non-AGY review (orchestrator + originating cursor spec) in-thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)