### PR TITLE
feat(qg): add live reviewer dispatcher gates

### DIFF
--- a/docs/projects/ua-eval-harness/cost-aware-qg-workflow.md
+++ b/docs/projects/ua-eval-harness/cost-aware-qg-workflow.md
@@ -1,6 +1,7 @@
 # Cost-Aware Curriculum QG Workflow
 
-Issue: [#4310](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4310)
+Issues: [#4310](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4310),
+[#4311](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4311)
 
 `scripts/audit/qg_workflow.py` composes the #4308 scorer adapters and the #4309
 reviewer helpers into one canonical `ua_contact_quality_evidence.v1` record
@@ -23,9 +24,27 @@ is used for richer diagnostics.
 
 Seminar-family modules must be eligible for Tier 2 because factual,
 decolonization, register, and living-subject risks are not fully covered by
-Tier 0/1. Live Tier-2 dispatch remains flag-off until #4370 calibration lands;
-callers must provide a precomputed reviewer response, reuse a cache hit, or run
-with dry-run estimates only.
+Tier 0/1. Live Tier-2 dispatch is available only through
+`--live-reviewer`; broad execution remains gated by dry-run approval, canaries,
+budget rails, and explicit human spend sign-off.
+
+## Live Dispatcher
+
+`scripts/audit/llm_reviewer_dispatch.py` owns live reviewer routing:
+
+- B1+ surface review routes to `ask-gemma` with
+  `openrouter/google/gemma-4-31b-it`.
+- Seminar, contested-gold, and factual-sensitive review routes to `ask-agy
+  --to-model gemini-3.1-pro-high`.
+- Escalation/disputed spot audit is Claude-only and is not the batch default.
+- DeepSeek/Hermes/OpenRouter reviewer routes are hard-banned for automated
+  LLM-QG batches.
+
+Live review also enforces cross-family lineage. The dispatcher resolves author
+family from explicit `--author-family`, committed metadata, or git history. If
+lineage is unavailable, the live call fails closed. If the reviewer family
+matches the author family, the call is blocked as self-review; there is no
+silent fallback to a same-family reviewer.
 
 ## Cost Controls
 
@@ -40,15 +59,25 @@ Use `--dry-run` before broad reviewer spend:
 
 Dry-run writes nothing. It reports per-tier module counts, Tier-1 gold-row
 matches, and Tier-2 token/cost estimates bucketed by level-policy family. The
-current estimator uses prompt size with profile-specific completion budgets;
-future telemetry can replace the estimator without changing the evidence
-contract.
+dry-run JSON also contains a gateable artifact with:
+
+- exact module list and chosen reviewer route/model,
+- per-tier counts,
+- warm/cold/stale cache estimate,
+- expected spend by reviewer model,
+- stale-cache count,
+- exact non-dry run command.
+
+The current estimator uses prompt size with route-specific completion budgets.
+Use `--calibrate --live-reviewer` on a small, approved probe set before trusting
+broad frontier totals; calibration reports an observed/estimated cost factor.
 
 Tier-2 budgets are checked before any reviewer call:
 
 - `--max-llm-calls` is the primary per-run ceiling.
-- `--max-cost-usd` caps the whole run.
-- `--max-daily-cost-usd` is a local safety rail.
+- `--max-cost-usd` caps the whole run and is required for live non-dry runs.
+- `--max-daily-cost-usd` is a local safety rail persisted under
+  `data/telemetry/`.
 - `--max-module-cost-usd` blocks pathological prompts.
 
 Budget exhaustion is explicit: the evidence carries
@@ -57,9 +86,14 @@ Budget exhaustion is explicit: the evidence carries
 schema-valid by using top-level `verdict: FAIL` and `terminal_verdict: FAIL`
 when fail-closed mode is active.
 
-Broad Tier-2 batches require a passing canary result from
-`scripts/audit/llm_qg_canaries.py` before reviewer spend. Dry-run does not need
-the canary because it does not call the reviewer.
+Any live Tier-2 call requires a passing dispatcher canary artifact for the same
+level, gate version, prompt template hash, reviewer model, reviewer family, and
+route. Mixed-level batches need one canary artifact per level family. Dry-run
+does not need the canary because it does not call the reviewer.
+
+The batch aborts and marks remaining records `INCOMPLETE` when any hard rail
+fires: canary failure, self-review, parse/schema failure rate above 5%,
+provider error rate above 10%, or observed cost above 125% of the estimate.
 
 ## Cache Key
 

--- a/scripts/audit/llm_reviewer_dispatch.py
+++ b/scripts/audit/llm_reviewer_dispatch.py
@@ -1,0 +1,812 @@
+#!/usr/bin/env python3
+"""Live LLM reviewer dispatcher for the QG workflow.
+
+This module owns model routing, cross-family lineage checks, canary artifact
+exactness, and local spend persistence. The workflow calls it through the same
+``Reviewer(target, prompt)`` shape used by precomputed reviewer responses.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import yaml
+
+from scripts.audit import llm_qg_canaries, llm_reviewer
+from scripts.audit.content_surface_gates import policy_for_level
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DAILY_SPEND_PATH = PROJECT_ROOT / "data" / "telemetry" / "llm_reviewer_spend.jsonl"
+CANARY_SCHEMA_VERSION = "llm_reviewer_dispatch_canary.v1"
+
+GEMMA_MODEL_ID = "openrouter/google/gemma-4-31b-it"
+FRONTIER_MODEL_ID = "gemini-3.1-pro-high"
+CLAUDE_SPOT_AUDIT_MODEL_ID = "claude-opus-4.6"
+
+_TOKEN_DIVISOR = 3.5
+_AUTHOR_FIELDS = (
+    "author_family",
+    "writer_family",
+    "agent_family",
+    "family",
+    "writer",
+    "agent",
+    "model",
+    "reviewer",
+)
+_X_AGENT_RE = re.compile(r"^X-Agent:\s*([^/\s:]+)", re.IGNORECASE | re.MULTILINE)
+_COAUTHOR_RE = re.compile(r"^Co-Authored-By:\s*([^<\n]+)", re.IGNORECASE | re.MULTILINE)
+
+
+class ReviewerDispatchError(RuntimeError):
+    """Base error for dispatcher hard gates."""
+
+
+class ReviewerProviderError(ReviewerDispatchError):
+    """Provider invocation failed before a parseable reviewer response."""
+
+
+class ReviewerLineageError(ReviewerDispatchError):
+    """Module author lineage is unavailable in live mode."""
+
+
+class ReviewerSelfReviewError(ReviewerDispatchError):
+    """Reviewer route is from the same model family as the module author."""
+
+
+class ReviewerRouteError(ReviewerDispatchError):
+    """Reviewer route is disallowed or incoherent."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReviewerRoute:
+    """One concrete reviewer route."""
+
+    route_name: str
+    bridge_command: tuple[str, ...]
+    reviewer_model_id: str
+    reviewer_family: str
+    purpose: str
+    input_usd_per_mtok: float
+    output_usd_per_mtok: float
+
+    def asdict(self) -> dict[str, Any]:
+        return {
+            **asdict(self),
+            "bridge_command": list(self.bridge_command),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorLineage:
+    """Resolved module author family and where it came from."""
+
+    family: str | None
+    source: str
+    evidence: str | None = None
+
+    @property
+    def available(self) -> bool:
+        return self.family is not None
+
+
+@dataclass(frozen=True, slots=True)
+class DispatchContext:
+    """Routing context for one module or canary."""
+
+    level: str
+    slug: str
+    module_dir: Path
+    policy_family: str
+    gate_version: str
+    contested_gold_suppressed: bool = False
+    factual_sensitive: bool = False
+    escalation: bool = False
+    author_family: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DispatchResult:
+    """Provider response plus audited dispatch metadata."""
+
+    response_text: str
+    reviewer_model_id: str
+    reviewer_family: str
+    route_name: str
+    observed_prompt_tokens: int | None = None
+    observed_completion_tokens: int | None = None
+    observed_cost_usd: float | None = None
+    usage: Mapping[str, Any] | None = None
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "reviewer_model_id": self.reviewer_model_id,
+            "reviewer_family": self.reviewer_family,
+            "route_name": self.route_name,
+            "observed_prompt_tokens": self.observed_prompt_tokens,
+            "observed_completion_tokens": self.observed_completion_tokens,
+            "observed_cost_usd": self.observed_cost_usd,
+            "usage": dict(self.usage or {}),
+        }
+
+
+ProviderRunner = Callable[[ReviewerRoute, str, str], DispatchResult | str]
+
+GEMMA_SURFACE_ROUTE = ReviewerRoute(
+    route_name="gemma_surface",
+    bridge_command=("ask-gemma", "--model", GEMMA_MODEL_ID),
+    reviewer_model_id=GEMMA_MODEL_ID,
+    reviewer_family="google",
+    purpose="B1+ surface naturalness/register/calque review",
+    input_usd_per_mtok=0.12,
+    output_usd_per_mtok=0.35,
+)
+FRONTIER_FACTUAL_ROUTE = ReviewerRoute(
+    route_name="agy_frontier",
+    bridge_command=("ask-agy", "--to-model", FRONTIER_MODEL_ID, "--review"),
+    reviewer_model_id=FRONTIER_MODEL_ID,
+    reviewer_family="google",
+    purpose="Seminar, contested-gold, or factual-sensitive review",
+    input_usd_per_mtok=1.25,
+    output_usd_per_mtok=10.0,
+)
+CLAUDE_SPOT_AUDIT_ROUTE = ReviewerRoute(
+    route_name="claude_spot_audit",
+    bridge_command=("ask-claude", "--to-model", CLAUDE_SPOT_AUDIT_MODEL_ID, "--review"),
+    reviewer_model_id=CLAUDE_SPOT_AUDIT_MODEL_ID,
+    reviewer_family="anthropic",
+    purpose="Escalation/disputed spot audit only",
+    input_usd_per_mtok=15.0,
+    output_usd_per_mtok=75.0,
+)
+ROUTES: tuple[ReviewerRoute, ...] = (
+    GEMMA_SURFACE_ROUTE,
+    FRONTIER_FACTUAL_ROUTE,
+    CLAUDE_SPOT_AUDIT_ROUTE,
+)
+
+
+def normalize_family(raw: Any) -> str | None:
+    """Normalize agent/model labels into cross-review family buckets."""
+
+    if raw is None:
+        return None
+    text = str(raw).strip().lower()
+    if not text:
+        return None
+    text = text.replace("_", "-")
+    if "deepseek" in text:
+        return "deepseek"
+    if any(marker in text for marker in ("gemma", "gemini", "agy", "google")):
+        return "google"
+    if any(marker in text for marker in ("codex", "openai", "gpt-")):
+        return "openai"
+    if any(marker in text for marker in ("claude", "anthropic", "opus", "sonnet")):
+        return "anthropic"
+    if any(marker in text for marker in ("cursor", "composer")):
+        return "cursor"
+    if any(marker in text for marker in ("grok", "xai")):
+        return "xai"
+    if "qwen" in text:
+        return "qwen"
+    return text.split()[0].split("(")[0].strip("-") or None
+
+
+def route_for_review(
+    *,
+    policy_family: str,
+    contested_gold_suppressed: bool = False,
+    factual_sensitive: bool = False,
+    escalation: bool = False,
+) -> ReviewerRoute:
+    """Return the allowed reviewer route for this content type."""
+
+    if escalation:
+        return CLAUDE_SPOT_AUDIT_ROUTE
+    if policy_family == "seminar" or contested_gold_suppressed or factual_sensitive:
+        return FRONTIER_FACTUAL_ROUTE
+    return GEMMA_SURFACE_ROUTE
+
+
+def assert_route_allowed(route: ReviewerRoute) -> None:
+    """Hard-ban DeepSeek/Hermes->OpenRouter automated reviewer routes."""
+
+    haystack = " ".join(
+        [route.route_name, route.reviewer_model_id, route.reviewer_family, *route.bridge_command]
+    )
+    lowered = haystack.lower()
+    if normalize_family(haystack) == "deepseek" or "hermes" in lowered:
+        raise ReviewerRouteError("DeepSeek/Hermes/OpenRouter reviewer routes are forbidden")
+
+
+def resolve_author_lineage(
+    *,
+    level: str,
+    slug: str,
+    module_dir: Path,
+    explicit_author_family: str | None = None,
+) -> AuthorLineage:
+    """Resolve module author family from explicit input, metadata, then git."""
+
+    explicit = normalize_family(explicit_author_family)
+    if explicit:
+        return AuthorLineage(family=explicit, source="explicit", evidence=explicit_author_family)
+    metadata = _lineage_from_metadata(level=level, slug=slug, module_dir=module_dir)
+    if metadata.available:
+        return metadata
+    git_lineage = _lineage_from_git(level=level, slug=slug, module_dir=module_dir)
+    if git_lineage.available:
+        return git_lineage
+    return AuthorLineage(
+        family=None,
+        source="unavailable",
+        evidence="pass --author-family for live reviewer runs",
+    )
+
+
+def validate_cross_family(route: ReviewerRoute, lineage: AuthorLineage) -> None:
+    """Fail closed when reviewer and author are same-family or unknown."""
+
+    assert_route_allowed(route)
+    if not lineage.family:
+        raise ReviewerLineageError("author family unavailable; pass --author-family")
+    if route.reviewer_family == lineage.family:
+        raise ReviewerSelfReviewError(
+            f"self-review blocked: reviewer_family={route.reviewer_family} "
+            f"author_family={lineage.family}"
+        )
+
+
+def estimate_tokens(text: str) -> int:
+    """Return a conservative text-token estimate for budgeting."""
+
+    return max(1, round(len(text.encode("utf-8")) / _TOKEN_DIVISOR))
+
+
+def estimate_route_cost(
+    prompt: str,
+    route: ReviewerRoute,
+    *,
+    completion_tokens: int | None = None,
+    policy_family: str | None = None,
+) -> dict[str, Any]:
+    """Estimate route-specific spend for one reviewer call."""
+
+    prompt_tokens = estimate_tokens(prompt)
+    estimated_completion_tokens = completion_tokens or (900 if policy_family == "seminar" else 600)
+    cost = (
+        prompt_tokens * route.input_usd_per_mtok
+        + estimated_completion_tokens * route.output_usd_per_mtok
+    ) / 1_000_000
+    return {
+        "policy_family": policy_family,
+        "route_name": route.route_name,
+        "reviewer_model_id": route.reviewer_model_id,
+        "reviewer_family": route.reviewer_family,
+        "estimated_prompt_tokens": prompt_tokens,
+        "estimated_completion_tokens": estimated_completion_tokens,
+        "estimated_total_tokens": prompt_tokens + estimated_completion_tokens,
+        "estimated_cost_usd": round(cost, 6),
+        "basis": "route-specific prompt byte estimate; calibrate before broad spend",
+    }
+
+
+def prompt_template_hash() -> str:
+    """Stable hash of the calibrated reviewer prompt template."""
+
+    return _sha256_text(llm_reviewer.load_reviewer_prompt_template())
+
+
+class LiveReviewerDispatcher:
+    """Callable reviewer that routes and invokes the approved live model."""
+
+    def __init__(
+        self,
+        *,
+        policy_family: str,
+        gate_version: str,
+        contested_gold_suppressed: bool = False,
+        factual_sensitive: bool = False,
+        escalation: bool = False,
+        author_family: str | None = None,
+        runner: ProviderRunner | None = None,
+    ) -> None:
+        self.policy_family = policy_family
+        self.gate_version = gate_version
+        self.contested_gold_suppressed = contested_gold_suppressed
+        self.factual_sensitive = factual_sensitive
+        self.escalation = escalation
+        self.author_family = author_family
+        self.runner = runner or invoke_bridge_route
+
+    def route(self) -> ReviewerRoute:
+        return route_for_review(
+            policy_family=self.policy_family,
+            contested_gold_suppressed=self.contested_gold_suppressed,
+            factual_sensitive=self.factual_sensitive,
+            escalation=self.escalation,
+        )
+
+    def __call__(self, target: Any, prompt: str) -> DispatchResult:
+        route = self.route()
+        lineage = resolve_author_lineage(
+            level=str(target.level),
+            slug=str(target.slug),
+            module_dir=Path(target.module_dir),
+            explicit_author_family=self.author_family,
+        )
+        validate_cross_family(route, lineage)
+        task_id = f"llm-qg-{target.level}-{target.slug}-{uuid4().hex[:8]}"
+        raw = self.runner(route, prompt, task_id)
+        if isinstance(raw, DispatchResult):
+            result = raw
+        else:
+            result = DispatchResult(
+                response_text=str(raw),
+                reviewer_model_id=route.reviewer_model_id,
+                reviewer_family=route.reviewer_family,
+                route_name=route.route_name,
+                observed_prompt_tokens=estimate_tokens(prompt),
+                observed_completion_tokens=estimate_tokens(str(raw)),
+                observed_cost_usd=_cost_for_observed_text(prompt, str(raw), route),
+            )
+        if (
+            result.reviewer_model_id != route.reviewer_model_id
+            or result.reviewer_family != route.reviewer_family
+            or result.route_name != route.route_name
+        ):
+            raise ReviewerProviderError("provider returned mismatched reviewer identity")
+        return result
+
+
+def invoke_bridge_route(route: ReviewerRoute, prompt: str, task_id: str) -> DispatchResult:
+    """Invoke the route's approved backend and return response text.
+
+    Gemma uses the same opencode helper behind ``ask-gemma`` because that bridge
+    command records responses in the inbox rather than returning them. AGY and
+    Claude are invoked through their public bridge commands with temporary
+    output files where supported.
+    """
+
+    assert_route_allowed(route)
+    if route.route_name == GEMMA_SURFACE_ROUTE.route_name:
+        from scripts.ai_agent_bridge._opencode import _invoke_opencode
+
+        try:
+            response = _invoke_opencode(
+                prompt,
+                route.reviewer_model_id,
+                output_format="json",
+            )
+        except SystemExit as exc:
+            raise ReviewerProviderError(str(exc)) from exc
+        return _result_from_text(prompt, response, route)
+    if route.route_name == FRONTIER_FACTUAL_ROUTE.route_name:
+        return _invoke_output_path_bridge(
+            route,
+            prompt,
+            task_id,
+            [
+                ".venv/bin/python",
+                "scripts/ai_agent_bridge/__main__.py",
+                "ask-agy",
+                "-",
+                "--task-id",
+                task_id,
+                "--to-model",
+                route.reviewer_model_id,
+                "--review",
+                "--stdout-only",
+                "--output-path",
+            ],
+        )
+    if route.route_name == CLAUDE_SPOT_AUDIT_ROUTE.route_name:
+        return _invoke_agent_runtime("claude", route, prompt, task_id)
+    raise ReviewerRouteError(f"unsupported reviewer route: {route.route_name}")
+
+
+def build_canary_prompt(level: str) -> str:
+    """Build a canary module prompt using the calibrated reviewer template."""
+
+    canaries = llm_qg_canaries.list_canaries(level)
+    snippets = "\n\n".join(f"- `{canary.canary_id}`: {canary.snippet}" for canary in canaries)
+    return llm_reviewer.build_reviewer_prompt(
+        level=level,
+        slug=f"canary-{_canonical_level(level)}",
+        module_md=(
+            "# LLM-QG Canary Module\n\n"
+            "Review these snippets exactly as learner-facing module content.\n\n"
+            f"{snippets}\n"
+        ),
+        activities_yaml="[]\n",
+        vocabulary_yaml="[]\n",
+        resources_yaml="[]\n",
+    )
+
+
+def run_canary(
+    *,
+    level: str,
+    gate_version: str,
+    author_family: str,
+    runner: ProviderRunner | None = None,
+) -> dict[str, Any]:
+    """Run a live canary through the same dispatcher route used by a batch."""
+
+    policy = policy_for_level(level)
+    prompt = build_canary_prompt(level)
+    dispatcher = LiveReviewerDispatcher(
+        policy_family=policy.family,
+        gate_version=gate_version,
+        author_family=author_family,
+        runner=runner,
+    )
+    target = _CanaryTarget(level=level, slug=f"canary-{_canonical_level(level)}", module_dir=PROJECT_ROOT)
+    result = dispatcher(target, prompt)
+    payload = _json_payload_from_response(result.response_text)
+    report = llm_qg_canaries.evaluate_canaries(payload, level)
+    route = dispatcher.route()
+    return {
+        "schema_version": CANARY_SCHEMA_VERSION,
+        "created_at": _now_z(),
+        "level": _canonical_level(level),
+        "gate_version": gate_version,
+        "prompt_hash": _sha256_text(prompt),
+        "prompt_template_hash": prompt_template_hash(),
+        "reviewer_model_id": route.reviewer_model_id,
+        "reviewer_family": route.reviewer_family,
+        "route_name": route.route_name,
+        "passed": bool(report.get("passed")),
+        "report": report,
+    }
+
+
+def canary_artifact_passes(path: Path, *, level: str, gate_version: str, route: ReviewerRoute) -> bool:
+    """Return True only when a canary artifact exactly matches this live route."""
+
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return canary_payload_passes(payload, level=level, gate_version=gate_version, route=route)
+
+
+def canary_payload_passes(
+    payload: Mapping[str, Any],
+    *,
+    level: str,
+    gate_version: str,
+    route: ReviewerRoute,
+) -> bool:
+    """Validate exact canary identity without reading from disk."""
+
+    return (
+        payload.get("schema_version") == CANARY_SCHEMA_VERSION
+        and payload.get("level") == _canonical_level(level)
+        and payload.get("gate_version") == gate_version
+        and payload.get("prompt_template_hash") == prompt_template_hash()
+        and payload.get("reviewer_model_id") == route.reviewer_model_id
+        and payload.get("reviewer_family") == route.reviewer_family
+        and payload.get("route_name") == route.route_name
+        and payload.get("passed") is True
+    )
+
+
+def read_daily_spend(path: Path | None = None, *, day: date | None = None) -> float:
+    """Read local daily reviewer spend from JSONL telemetry."""
+
+    ledger = path or DEFAULT_DAILY_SPEND_PATH
+    if not ledger.exists():
+        return 0.0
+    wanted = (day or datetime.now(UTC).date()).isoformat()
+    total = 0.0
+    for line in ledger.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if row.get("date") != wanted:
+            continue
+        total += float(row.get("observed_cost_usd") or row.get("estimated_cost_usd") or 0.0)
+    return round(total, 6)
+
+
+def append_daily_spend(
+    *,
+    path: Path | None = None,
+    level: str,
+    slug: str,
+    route: ReviewerRoute,
+    estimated_cost_usd: float,
+    observed_cost_usd: float | None,
+) -> None:
+    """Persist one local spend row under ``data/telemetry``."""
+
+    ledger = path or DEFAULT_DAILY_SPEND_PATH
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    row = {
+        "timestamp": now.isoformat().replace("+00:00", "Z"),
+        "date": now.date().isoformat(),
+        "level": level,
+        "slug": slug,
+        "route_name": route.route_name,
+        "reviewer_model_id": route.reviewer_model_id,
+        "reviewer_family": route.reviewer_family,
+        "estimated_cost_usd": round(float(estimated_cost_usd), 6),
+        "observed_cost_usd": (
+            round(float(observed_cost_usd), 6) if observed_cost_usd is not None else None
+        ),
+    }
+    with ledger.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def _lineage_from_metadata(*, level: str, slug: str, module_dir: Path) -> AuthorLineage:
+    for path in _metadata_candidates(level=level, slug=slug, module_dir=module_dir):
+        if not path.exists() or not path.is_file():
+            continue
+        data = _read_structured(path)
+        if not isinstance(data, Mapping):
+            continue
+        family = _family_from_mapping(data)
+        if family:
+            return AuthorLineage(family=family, source=str(path), evidence=_evidence_from_mapping(data))
+    return AuthorLineage(family=None, source="metadata_missing")
+
+
+def _metadata_candidates(*, level: str, slug: str, module_dir: Path) -> list[Path]:
+    level_dir = module_dir.parent
+    return [
+        module_dir / "build_meta.json",
+        module_dir / "writer_meta.json",
+        module_dir / "dispatch_meta.json",
+        module_dir / "module_meta.json",
+        level_dir / "meta" / f"{slug}.yaml",
+        level_dir / "meta" / f"{slug}.yml",
+        level_dir / "orchestration" / slug / "build_meta.json",
+        *sorted((level_dir / "orchestration" / slug / "dispatch").glob("*-meta.json")),
+        PROJECT_ROOT / "curriculum" / "l2-uk-en" / level / "meta" / f"{slug}.yaml",
+        *sorted(
+            (
+                PROJECT_ROOT
+                / "curriculum"
+                / "l2-uk-en"
+                / level
+                / "orchestration"
+                / slug
+                / "dispatch"
+            ).glob("*-meta.json")
+        ),
+    ]
+
+
+def _read_structured(path: Path) -> Any:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        if path.suffix in {".yaml", ".yml"}:
+            return yaml.safe_load(text)
+        return json.loads(text)
+    except (json.JSONDecodeError, yaml.YAMLError):
+        return None
+
+
+def _family_from_mapping(data: Mapping[str, Any]) -> str | None:
+    for field in _AUTHOR_FIELDS:
+        family = normalize_family(data.get(field))
+        if family:
+            return family
+    for value in data.values():
+        if isinstance(value, Mapping):
+            family = _family_from_mapping(value)
+            if family:
+                return family
+    return None
+
+
+def _evidence_from_mapping(data: Mapping[str, Any]) -> str | None:
+    for field in _AUTHOR_FIELDS:
+        value = data.get(field)
+        if isinstance(value, str) and value.strip():
+            return f"{field}={value.strip()}"
+    return None
+
+
+def _lineage_from_git(*, level: str, slug: str, module_dir: Path) -> AuthorLineage:
+    paths = _module_git_paths(level=level, slug=slug, module_dir=module_dir)
+    if not paths:
+        return AuthorLineage(family=None, source="git_no_paths")
+    try:
+        result = subprocess.run(
+            ["git", "log", "--format=%B%n---END---", "--max-count=30", "--", *paths],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return AuthorLineage(family=None, source="git_unavailable")
+    if result.returncode != 0:
+        return AuthorLineage(family=None, source="git_failed", evidence=result.stderr[-400:])
+    for body in result.stdout.split("---END---"):
+        family = _family_from_commit_body(body)
+        if family:
+            return AuthorLineage(family=family, source="git_history", evidence=body.strip().splitlines()[0])
+    return AuthorLineage(family=None, source="git_no_family")
+
+
+def _module_git_paths(*, level: str, slug: str, module_dir: Path) -> list[str]:
+    candidates = [module_dir]
+    level_dir = PROJECT_ROOT / "curriculum" / "l2-uk-en" / level
+    candidates.extend(
+        [
+            level_dir / slug,
+            level_dir / "activities" / f"{slug}.yaml",
+            level_dir / "vocabulary" / f"{slug}.yaml",
+            level_dir / "resources" / f"{slug}.yaml",
+            level_dir / "meta" / f"{slug}.yaml",
+        ]
+    )
+    out: list[str] = []
+    for path in candidates:
+        try:
+            rel = path.resolve().relative_to(PROJECT_ROOT)
+        except (OSError, ValueError):
+            continue
+        text = str(rel)
+        if text not in out:
+            out.append(text)
+    return out
+
+
+def _family_from_commit_body(body: str) -> str | None:
+    for match in _X_AGENT_RE.finditer(body):
+        family = normalize_family(match.group(1))
+        if family:
+            return family
+    for match in _COAUTHOR_RE.finditer(body):
+        family = normalize_family(match.group(1))
+        if family:
+            return family
+    return None
+
+
+def _invoke_output_path_bridge(
+    route: ReviewerRoute,
+    prompt: str,
+    task_id: str,
+    base_argv: Sequence[str],
+) -> DispatchResult:
+    with tempfile.TemporaryDirectory(prefix="llm-reviewer-") as tmp:
+        output_path = Path(tmp) / "response.txt"
+        argv = [*base_argv, str(output_path)]
+        try:
+            result = subprocess.run(
+                argv,
+                input=prompt,
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+                timeout=1800,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise ReviewerProviderError(str(exc)) from exc
+        if result.returncode != 0:
+            raise ReviewerProviderError(result.stderr[-2000:] or result.stdout[-2000:])
+        try:
+            response = output_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise ReviewerProviderError(f"bridge did not write response: {exc}") from exc
+    return _result_from_text(prompt, response, route)
+
+
+def _invoke_agent_runtime(agent: str, route: ReviewerRoute, prompt: str, task_id: str) -> DispatchResult:
+    try:
+        from scripts.agent_runtime import runner as agent_runner
+
+        result = agent_runner.invoke(
+            agent,
+            prompt,
+            mode="read-only",
+            cwd=PROJECT_ROOT,
+            model=route.reviewer_model_id,
+            task_id=task_id,
+            session_id=None,
+            tool_config=None,
+            entrypoint="bridge",
+            hard_timeout=1800,
+            stall_timeout=600,
+        )
+    except Exception as exc:
+        raise ReviewerProviderError(str(exc)) from exc
+    if not result.ok or not result.response:
+        raise ReviewerProviderError(result.stderr_excerpt or "provider returned no response")
+    usage = result.usage_record or {}
+    return DispatchResult(
+        response_text=result.response,
+        reviewer_model_id=route.reviewer_model_id,
+        reviewer_family=route.reviewer_family,
+        route_name=route.route_name,
+        observed_prompt_tokens=estimate_tokens(prompt),
+        observed_completion_tokens=estimate_tokens(result.response),
+        observed_cost_usd=_cost_for_observed_text(prompt, result.response, route),
+        usage=usage,
+    )
+
+
+def _result_from_text(prompt: str, response: str, route: ReviewerRoute) -> DispatchResult:
+    return DispatchResult(
+        response_text=response,
+        reviewer_model_id=route.reviewer_model_id,
+        reviewer_family=route.reviewer_family,
+        route_name=route.route_name,
+        observed_prompt_tokens=estimate_tokens(prompt),
+        observed_completion_tokens=estimate_tokens(response),
+        observed_cost_usd=_cost_for_observed_text(prompt, response, route),
+    )
+
+
+def _cost_for_observed_text(prompt: str, response: str, route: ReviewerRoute) -> float:
+    prompt_tokens = estimate_tokens(prompt)
+    completion_tokens = estimate_tokens(response)
+    return round(
+        (
+            prompt_tokens * route.input_usd_per_mtok
+            + completion_tokens * route.output_usd_per_mtok
+        )
+        / 1_000_000,
+        6,
+    )
+
+
+def _json_payload_from_response(response_text: str) -> Mapping[str, Any]:
+    text = response_text.strip()
+    if "```json" in text:
+        text = text.split("```json", 1)[1].split("```", 1)[0].strip()
+    elif "```" in text:
+        text = text.split("```", 1)[1].split("```", 1)[0].strip()
+    payload = json.loads(text)
+    if not isinstance(payload, Mapping):
+        raise ValueError("reviewer response JSON must be an object")
+    return payload
+
+
+def _canonical_level(level: str) -> str:
+    policy = policy_for_level(level)
+    if policy.family == "seminar":
+        return "seminar"
+    clean = str(level).strip().lower()
+    if clean.startswith("b1"):
+        return "b1"
+    return clean
+
+
+def _sha256_text(text: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _now_z() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True, slots=True)
+class _CanaryTarget:
+    level: str
+    slug: str
+    module_dir: Path

--- a/scripts/audit/qg_workflow.py
+++ b/scripts/audit/qg_workflow.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import sys
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
@@ -27,7 +28,13 @@ if str(SCRIPTS_DIR) not in sys.path:
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts.audit import llm_qg_canaries, llm_qg_store, llm_reviewer, qg_schema
+from scripts.audit import (
+    llm_qg_canaries,
+    llm_qg_store,
+    llm_reviewer,
+    llm_reviewer_dispatch,
+    qg_schema,
+)
 from scripts.audit.content_surface_gates import policy_for_level
 from scripts.audit.curriculum_qg_harness import CHECKER_VERSION, checker_config_hash
 from scripts.audit.qg_adapters import (
@@ -43,7 +50,7 @@ DEFAULT_REVIEWER_FAMILY = "qg_workflow"
 LLM_POLICY_FAMILIES = frozenset({"b1_plus", "seminar"})
 CONTENT_HASH_BASIS = "llm_qg_store.CONTENT_FILES"
 
-Reviewer = Callable[["ReviewTarget", str], str | Mapping[str, Any]]
+Reviewer = Callable[["ReviewTarget", str], Any]
 
 
 @dataclass(frozen=True, slots=True)
@@ -64,6 +71,11 @@ class WorkflowOptions:
     gate_version: str = DEFAULT_GATE_VERSION
     reviewer_model_id: str = DEFAULT_REVIEWER_MODEL_ID
     reviewer_family: str = DEFAULT_REVIEWER_FAMILY
+    live_reviewer: bool = False
+    author_family: str | None = None
+    canary_artifacts: Mapping[str, Path] | None = None
+    daily_spend_path: Path | None = None
+    run_command: str | None = None
     enable_llm: bool = False
     force_llm: bool = False
     llm_on_fail: bool = False
@@ -97,9 +109,9 @@ class BudgetState:
             return False, "max_daily_cost_usd"
         return True, None
 
-    def record_spend(self, estimate: Mapping[str, Any]) -> None:
+    def record_spend(self, estimate: Mapping[str, Any], *, observed_cost_usd: float | None = None) -> None:
         self.llm_calls += 1
-        cost = float(estimate.get("estimated_cost_usd") or 0.0)
+        cost = float(observed_cost_usd if observed_cost_usd is not None else estimate.get("estimated_cost_usd") or 0.0)
         self.cost_usd += cost
         self.daily_cost_usd += cost
 
@@ -198,6 +210,8 @@ def review_module(
         llm_required_by_policy=bool(tier2.get("llm_required_by_policy")),
         llm_required_by_harness=tier0_verdict != "PASS",
         llm_cost_override=bool(tier2.get("llm_cost_override")),
+        reviewer_model_id=str(tier2.get("reviewer_model_id") or effective_options.reviewer_model_id),
+        reviewer_family=str(tier2.get("reviewer_family") or effective_options.reviewer_family),
         options=effective_options,
     )
 
@@ -215,6 +229,11 @@ def dry_run_modules(
         gate_version=dry_options.gate_version,
         reviewer_model_id=dry_options.reviewer_model_id,
         reviewer_family=dry_options.reviewer_family,
+        live_reviewer=dry_options.live_reviewer,
+        author_family=dry_options.author_family,
+        canary_artifacts=dry_options.canary_artifacts,
+        daily_spend_path=dry_options.daily_spend_path,
+        run_command=dry_options.run_command,
         enable_llm=True,
         force_llm=dry_options.force_llm,
         llm_on_fail=dry_options.llm_on_fail,
@@ -276,12 +295,25 @@ def dry_run_modules(
                     bucket["estimated_cost_usd"] += float(estimate.get("estimated_cost_usd") or 0.0)
                 if tier.get("status") == "skipped_budget":
                     counts["tier2_skipped_budget"] += 1
+    gateable = _dry_run_gateable_artifact(
+        records=records,
+        counts=counts,
+        level_profiles=dict(sorted(by_family.items())),
+        options=dry_options,
+    )
     return {
         "schema_version": "qg_workflow_dry_run.v1",
         "dry_run": True,
         "writes": 0,
         "counts": counts,
         "level_profiles": dict(sorted(by_family.items())),
+        "module_list": gateable["module_list"],
+        "per_tier_counts": gateable["per_tier_counts"],
+        "cache_estimate": gateable["cache_estimate"],
+        "expected_spend": gateable["expected_spend"],
+        "stale_cache_count": gateable["cache_estimate"]["stale"],
+        "exact_run_command": gateable["exact_run_command"],
+        "gateable_artifact": gateable,
         "modules": records,
     }
 
@@ -296,23 +328,37 @@ def review_modules(
     """Run the workflow over a bounded target list with shared budget state."""
 
     effective_options = options or WorkflowOptions()
-    if (
+    if effective_options.live_reviewer:
+        _validate_live_reviewer_preflight(targets, effective_options)
+    elif (
         len(targets) > 1
         and _llm_enabled_for_any_target(targets, effective_options)
         and not effective_options.canary_passed
     ):
         raise ValueError("broad LLM batches require an explicit passing canary pre-gate")
-    budget = BudgetState()
-    return [
-        review_module(
+    budget = BudgetState(daily_cost_usd=_initial_daily_spend(effective_options))
+    records: list[dict[str, Any]] = []
+    for index, target in enumerate(targets):
+        record = review_module(
             target,
             options=effective_options,
             reviewer=reviewer,
             store_path=store_path,
             budget=budget,
         )
-        for target in targets
-    ]
+        records.append(record)
+        abort_reason = _batch_abort_reason(records)
+        if abort_reason and index + 1 < len(targets):
+            for remaining in targets[index + 1:]:
+                records.append(
+                    _build_aborted_record(
+                        remaining,
+                        options=effective_options,
+                        reason=abort_reason,
+                    )
+                )
+            break
+    return records
 
 
 def canary_result_passes(path: Path, *, level: str) -> bool:
@@ -321,6 +367,199 @@ def canary_result_passes(path: Path, *, level: str) -> bool:
     payload = json.loads(path.read_text(encoding="utf-8"))
     report = llm_qg_canaries.evaluate_canaries(payload, level)
     return bool(report.get("passed"))
+
+
+def _dry_run_gateable_artifact(
+    *,
+    records: Sequence[Mapping[str, Any]],
+    counts: Mapping[str, Any],
+    level_profiles: Mapping[str, Mapping[str, Any]],
+    options: WorkflowOptions,
+) -> dict[str, Any]:
+    module_list: list[dict[str, Any]] = []
+    expected_by_reviewer: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"modules": 0, "estimated_cost_usd": 0.0, "estimated_total_tokens": 0}
+    )
+    warm = cold = stale = 0
+    total_cost = 0.0
+    total_tokens = 0
+    for record in records:
+        tier2 = _tier_from_record(record, 2)
+        estimate = tier2.get("estimate") if isinstance(tier2.get("estimate"), Mapping) else {}
+        cache_status = "warm" if tier2.get("status") == "cache_hit" else estimate.get("cache_status") or "none"
+        if cache_status == "warm":
+            warm += 1
+        elif cache_status == "stale":
+            stale += 1
+        elif tier2.get("status") == "dry_run_estimate":
+            cold += 1
+        reviewer_model = str(tier2.get("reviewer_model_id") or record["qg_workflow"]["reviewer_model_id"])
+        cost = float(estimate.get("estimated_cost_usd") or 0.0)
+        tokens = int(estimate.get("estimated_total_tokens") or 0)
+        total_cost += cost
+        total_tokens += tokens
+        if cost or tokens:
+            bucket = expected_by_reviewer[reviewer_model]
+            bucket["modules"] += 1
+            bucket["estimated_cost_usd"] += cost
+            bucket["estimated_total_tokens"] += tokens
+        module_list.append(
+            {
+                "module_id": record["module_id"],
+                "level": str(record["module_id"]).split("/", 1)[0],
+                "slug": str(record["module_id"]).split("/", 1)[1],
+                "module_dir": record["provenance"]["module_dir"],
+                "policy_family": record["level_policy"]["family"],
+                "tier2_status": tier2.get("status"),
+                "reviewer_model_id": reviewer_model,
+                "reviewer_family": tier2.get("reviewer_family"),
+                "reviewer_route": tier2.get("reviewer_route"),
+                "cache_status": cache_status,
+                "estimated_cost_usd": cost,
+            }
+        )
+    return {
+        "schema_version": "qg_workflow_dry_run_gate.v1",
+        "module_list": module_list,
+        "per_tier_counts": dict(counts),
+        "level_profiles": dict(level_profiles),
+        "cache_estimate": {
+            "warm": warm,
+            "cold": cold,
+            "stale": stale,
+        },
+        "expected_spend": {
+            "estimated_cost_usd": round(total_cost, 6),
+            "estimated_total_tokens": total_tokens,
+            "by_reviewer_model": {
+                model: {
+                    "modules": values["modules"],
+                    "estimated_cost_usd": round(float(values["estimated_cost_usd"]), 6),
+                    "estimated_total_tokens": values["estimated_total_tokens"],
+                }
+                for model, values in sorted(expected_by_reviewer.items())
+            },
+        },
+        "exact_run_command": options.run_command or "",
+    }
+
+
+def _validate_live_reviewer_preflight(
+    targets: Sequence[ReviewTarget],
+    options: WorkflowOptions,
+) -> None:
+    if options.dry_run:
+        return
+    if _llm_enabled_for_any_target(targets, options) and options.max_cost_usd is None:
+        raise ValueError("live Tier-2 runs require --max-cost-usd")
+
+
+def _initial_daily_spend(options: WorkflowOptions) -> float:
+    if not options.live_reviewer or options.max_daily_cost_usd is None:
+        return 0.0
+    return llm_reviewer_dispatch.read_daily_spend(options.daily_spend_path)
+
+
+def _batch_abort_reason(records: Sequence[Mapping[str, Any]]) -> str | None:
+    attempted = 0
+    provider_errors = 0
+    parse_failures = 0
+    for record in records:
+        tier2 = _tier_from_record(record, 2)
+        status = str(tier2.get("status"))
+        if status in {"ran", "provider_error", "parse_failure", "schema_failure", "cost_overrun"}:
+            attempted += 1
+        if status == "provider_error":
+            provider_errors += 1
+        if status in {"parse_failure", "schema_failure"}:
+            parse_failures += 1
+        if status == "cost_overrun":
+            return "cost_overrun"
+        if status == "self_review_blocked":
+            return "self_review_blocked"
+        if status == "lineage_required":
+            return "lineage_required"
+        if status == "skipped_canary_required":
+            return "canary_required"
+    if attempted and parse_failures / attempted > 0.05:
+        return "parse_failure_rate"
+    if attempted and provider_errors / attempted > 0.10:
+        return "provider_error_rate"
+    return None
+
+
+def _build_aborted_record(
+    target: ReviewTarget,
+    *,
+    options: WorkflowOptions,
+    reason: str,
+) -> dict[str, Any]:
+    level = target.level.strip().lower()
+    slug = target.slug.strip() or target.module_dir.name
+    policy = policy_for_level(level)
+    texts = _read_module_texts(target.module_dir)
+    prompt = llm_reviewer.build_reviewer_prompt(
+        level=level,
+        slug=slug,
+        module_md=texts.get("module.md", ""),
+        activities_yaml=texts.get("activities.yaml", ""),
+        vocabulary_yaml=texts.get("vocabulary.yaml", ""),
+        resources_yaml=texts.get("resources.yaml", ""),
+    )
+    prompt_hash = llm_qg_store.prompt_hash_for_text(prompt)
+    content_sha = llm_qg_store.content_sha_for_module(target.module_dir)
+    route = _tier2_route(
+        options=options,
+        policy_family=policy.family,
+        contested_gold_suppressed=False,
+    )
+    reviewer_model_id = route.reviewer_model_id if route else options.reviewer_model_id
+    reviewer_family = route.reviewer_family if route else options.reviewer_family
+    tiers = [
+        {"tier": 0, "name": "deterministic_structural", "status": "not_run_batch_aborted"},
+        {"tier": 1, "name": "ua_gec_gold_fixture", "status": "not_run_batch_aborted"},
+        {
+            "tier": 2,
+            "name": "llm_reviewer",
+            "status": "aborted_batch",
+            "reason": reason,
+            "llm_required_by_policy": policy.family in LLM_POLICY_FAMILIES,
+            "policy_family": policy.family,
+            "reviewer_model_id": reviewer_model_id,
+            "reviewer_family": reviewer_family,
+            "findings": 0,
+        },
+    ]
+    return _build_evidence_record(
+        level=level,
+        slug=slug,
+        target=target,
+        policy_family=policy.family,
+        policy_english=policy.english_policy,
+        content_sha=content_sha,
+        prompt_hash=prompt_hash,
+        findings=[],
+        tier_results=tiers,
+        workflow_verdict="INCOMPLETE",
+        completion_status="INCOMPLETE",
+        llm_used=False,
+        llm_required_by_policy=policy.family in LLM_POLICY_FAMILIES,
+        llm_required_by_harness=False,
+        llm_cost_override=False,
+        reviewer_model_id=reviewer_model_id,
+        reviewer_family=reviewer_family,
+        options=options,
+    )
+
+
+def _tier_from_record(record: Mapping[str, Any], tier_number: int) -> dict[str, Any]:
+    workflow = record.get("qg_workflow")
+    tiers = workflow.get("tiers") if isinstance(workflow, Mapping) else []
+    if isinstance(tiers, list):
+        for tier in tiers:
+            if isinstance(tier, Mapping) and tier.get("tier") == tier_number:
+                return dict(tier)
+    return {}
 
 
 def _tier0_findings(
@@ -385,15 +624,32 @@ def _run_tier2(
         or options.calibration_sample
         or contested_gold_suppressed
     )
+    route = _tier2_route(
+        options=options,
+        policy_family=policy_family,
+        contested_gold_suppressed=contested_gold_suppressed,
+    )
+    reviewer_model_id = route.reviewer_model_id if route else options.reviewer_model_id
+    reviewer_family = route.reviewer_family if route else options.reviewer_family
     base_result: dict[str, Any] = {
         "tier": 2,
         "name": "llm_reviewer",
         "llm_required_by_policy": policy_eligible,
         "policy_family": policy_family,
+        "reviewer_model_id": reviewer_model_id,
+        "reviewer_family": reviewer_family,
         "findings": 0,
     }
+    if route is not None:
+        base_result["reviewer_route"] = route.route_name
+        base_result["bridge_command"] = list(route.bridge_command)
     if not policy_eligible:
-        return {"findings": [], "result": {**base_result, "status": "skipped_policy"}}
+        return {
+            "findings": [],
+            "result": {**base_result, "status": "skipped_policy"},
+            "reviewer_model_id": reviewer_model_id,
+            "reviewer_family": reviewer_family,
+        }
     if tier0_hard_fail and not (options.llm_on_fail or options.calibration_sample):
         return {
             "findings": [],
@@ -404,6 +660,8 @@ def _run_tier2(
                 "reason": "Tier-0 hard FAIL short-circuits LLM by default; use --llm-on-fail to opt in.",
             },
             "llm_cost_override": True,
+            "reviewer_model_id": reviewer_model_id,
+            "reviewer_family": reviewer_family,
         }
     if not options.enable_llm:
         return {
@@ -413,7 +671,27 @@ def _run_tier2(
                 "status": "skipped_flag_off",
                 "reason": "Live Tier-2 reviewer remains flag-off until #4370 calibration lands.",
             },
+            "reviewer_model_id": reviewer_model_id,
+            "reviewer_family": reviewer_family,
         }
+
+    if options.live_reviewer:
+        blocked = _live_reviewer_block(
+            target=target,
+            level=level,
+            slug=slug,
+            route=route,
+            options=options,
+        )
+        if blocked is not None:
+            return {
+                "findings": [],
+                "result": {**base_result, **blocked},
+                "workflow_verdict": "INCOMPLETE",
+                "completion_status": "INCOMPLETE",
+                "reviewer_model_id": reviewer_model_id,
+                "reviewer_family": reviewer_family,
+            }
 
     cached = llm_qg_store.current_llm_qg_for_module(
         level,
@@ -423,7 +701,7 @@ def _run_tier2(
         prompt_hash=prompt_hash,
         checker_version=CHECKER_VERSION,
         level_policy_family=policy_family,
-        reviewer_model=options.reviewer_model_id,
+        reviewer_model=reviewer_model_id,
         path=store_path,
     )
     if cached is not None:
@@ -437,9 +715,39 @@ def _run_tier2(
                 "cache_run_id": cached.run_id,
             },
             "llm_used": True,
+            "reviewer_model_id": reviewer_model_id,
+            "reviewer_family": reviewer_family,
         }
 
-    estimate = estimate_llm_cost(prompt, policy_family)
+    stale_cache = _has_stale_cache(
+        level=level,
+        slug=slug,
+        gate_version=options.gate_version,
+        checker_version=CHECKER_VERSION,
+        level_policy_family=policy_family,
+        reviewer_model=reviewer_model_id,
+        store_path=store_path,
+    )
+    estimate = (
+        llm_reviewer_dispatch.estimate_route_cost(prompt, route, policy_family=policy_family)
+        if route is not None
+        else estimate_llm_cost(prompt, policy_family)
+    )
+    estimate["cache_status"] = "stale" if stale_cache else "cold"
+    if options.live_reviewer and not options.dry_run and options.max_cost_usd is None:
+        return {
+            "findings": [],
+            "result": {
+                **base_result,
+                "status": "skipped_budget_required",
+                "reason": "max_cost_usd_required",
+                "estimate": estimate,
+            },
+            "workflow_verdict": "SKIPPED_BUDGET",
+            "completion_status": "INCOMPLETE",
+            "reviewer_model_id": reviewer_model_id,
+            "reviewer_family": reviewer_family,
+        }
     allowed, reason = budget.spend_allowed(estimate, options)
     if not allowed:
         return {
@@ -452,6 +760,8 @@ def _run_tier2(
             },
             "workflow_verdict": "SKIPPED_BUDGET",
             "completion_status": "INCOMPLETE",
+            "reviewer_model_id": reviewer_model_id,
+            "reviewer_family": reviewer_family,
         }
     if options.dry_run:
         return {
@@ -460,9 +770,21 @@ def _run_tier2(
                 **base_result,
                 "status": "dry_run_estimate",
                 "estimate": estimate,
+                "stale_cache": stale_cache,
             },
+            "reviewer_model_id": reviewer_model_id,
+            "reviewer_family": reviewer_family,
         }
-    if reviewer is None:
+    effective_reviewer = reviewer
+    if effective_reviewer is None and options.live_reviewer and route is not None:
+        effective_reviewer = llm_reviewer_dispatch.LiveReviewerDispatcher(
+            policy_family=policy_family,
+            gate_version=options.gate_version,
+            contested_gold_suppressed=contested_gold_suppressed,
+            factual_sensitive=policy_family == "seminar",
+            author_family=options.author_family,
+        )
+    if effective_reviewer is None:
         return {
             "findings": [],
             "result": {
@@ -473,18 +795,109 @@ def _run_tier2(
             },
             "workflow_verdict": "INCOMPLETE",
             "completion_status": "INCOMPLETE",
+            "reviewer_model_id": reviewer_model_id,
+            "reviewer_family": reviewer_family,
         }
 
-    budget.record_spend(estimate)
-    raw_response = reviewer(target, prompt)
-    response_text = json.dumps(raw_response, ensure_ascii=False) if isinstance(raw_response, Mapping) else str(raw_response)
-    findings = llm_reviewer.parse_and_evaluate_llm_response(
-        response_text,
-        module_md=texts.get("module.md", ""),
-        activities_yaml=texts.get("activities.yaml", ""),
-        vocabulary_yaml=texts.get("vocabulary.yaml", ""),
-        resources_yaml=texts.get("resources.yaml", ""),
-    )
+    try:
+        raw_response = effective_reviewer(target, prompt)
+    except llm_reviewer_dispatch.ReviewerDispatchError as exc:
+        budget.record_spend(estimate)
+        return {
+            "findings": [],
+            "result": {
+                **base_result,
+                "status": "provider_error",
+                "reason": type(exc).__name__,
+                "message": str(exc),
+                "estimate": estimate,
+            },
+            "workflow_verdict": "PROVIDER_FAILURE",
+            "completion_status": "INCOMPLETE",
+            "reviewer_model_id": reviewer_model_id,
+            "reviewer_family": reviewer_family,
+        }
+    response_text, dispatch_meta = _coerce_reviewer_response(raw_response)
+    actual_model_id = str(dispatch_meta.get("reviewer_model_id") or reviewer_model_id)
+    actual_family = str(dispatch_meta.get("reviewer_family") or reviewer_family)
+    observed_cost = _observed_cost(dispatch_meta)
+    budget.record_spend(estimate, observed_cost_usd=observed_cost)
+    if route is not None:
+        _record_daily_spend(
+            options=options,
+            level=level,
+            slug=slug,
+            route=route,
+            estimate=estimate,
+            observed_cost_usd=observed_cost,
+        )
+    if actual_model_id != reviewer_model_id or actual_family != reviewer_family:
+        return {
+            "findings": [],
+            "result": {
+                **base_result,
+                "status": "provider_error",
+                "reason": "reviewer_identity_mismatch",
+                "actual_reviewer_model_id": actual_model_id,
+                "actual_reviewer_family": actual_family,
+                "estimate": estimate,
+            },
+            "workflow_verdict": "PROVIDER_FAILURE",
+            "completion_status": "INCOMPLETE",
+            "reviewer_model_id": actual_model_id,
+            "reviewer_family": actual_family,
+        }
+    if _cost_overrun(estimate, observed_cost):
+        return {
+            "findings": [],
+            "result": {
+                **base_result,
+                "status": "cost_overrun",
+                "estimate": estimate,
+                "observed_cost_usd": observed_cost,
+                "reason": "observed_cost_gt_125pct_estimate",
+            },
+            "workflow_verdict": "COST_OVERRUN",
+            "completion_status": "INCOMPLETE",
+            "reviewer_model_id": reviewer_model_id,
+            "reviewer_family": reviewer_family,
+        }
+    try:
+        findings = llm_reviewer.parse_and_evaluate_llm_response(
+            response_text,
+            module_md=texts.get("module.md", ""),
+            activities_yaml=texts.get("activities.yaml", ""),
+            vocabulary_yaml=texts.get("vocabulary.yaml", ""),
+            resources_yaml=texts.get("resources.yaml", ""),
+        )
+    except ValueError as exc:
+        return {
+            "findings": [],
+            "result": {
+                **base_result,
+                "status": "schema_failure",
+                "reason": str(exc),
+                "estimate": estimate,
+            },
+            "workflow_verdict": "SCHEMA_FAILURE",
+            "completion_status": "INCOMPLETE",
+            "reviewer_model_id": reviewer_model_id,
+            "reviewer_family": reviewer_family,
+        }
+    if _parse_failed(findings):
+        return {
+            "findings": findings,
+            "result": {
+                **base_result,
+                "status": "parse_failure",
+                "findings": len(findings),
+                "estimate": estimate,
+            },
+            "workflow_verdict": "PARSE_FAILURE",
+            "completion_status": "INCOMPLETE",
+            "reviewer_model_id": reviewer_model_id,
+            "reviewer_family": reviewer_family,
+        }
     payload = _payload_from_findings(findings)
     llm_qg_store.record_llm_qg(
         level=level,
@@ -495,8 +908,8 @@ def _run_tier2(
         prompt_hash=prompt_hash,
         checker_version=CHECKER_VERSION,
         level_policy_family=policy_family,
-        reviewer_model=options.reviewer_model_id,
-        reviewer_family=options.reviewer_family,
+        reviewer_model=reviewer_model_id,
+        reviewer_family=reviewer_family,
         source="qg_workflow",
         path=store_path,
     )
@@ -507,9 +920,185 @@ def _run_tier2(
             "status": "ran",
             "findings": len(findings),
             "estimate": estimate,
+            "dispatch": dispatch_meta,
         },
         "llm_used": True,
+        "reviewer_model_id": reviewer_model_id,
+        "reviewer_family": reviewer_family,
     }
+
+
+def _tier2_route(
+    *,
+    options: WorkflowOptions,
+    policy_family: str,
+    contested_gold_suppressed: bool,
+) -> llm_reviewer_dispatch.ReviewerRoute | None:
+    if not options.live_reviewer:
+        return None
+    return llm_reviewer_dispatch.route_for_review(
+        policy_family=policy_family,
+        contested_gold_suppressed=contested_gold_suppressed,
+        factual_sensitive=policy_family == "seminar",
+    )
+
+
+def _live_reviewer_block(
+    *,
+    target: ReviewTarget,
+    level: str,
+    slug: str,
+    route: llm_reviewer_dispatch.ReviewerRoute | None,
+    options: WorkflowOptions,
+) -> dict[str, Any] | None:
+    if route is None:
+        return None
+    if options.dry_run:
+        return None
+    try:
+        lineage = llm_reviewer_dispatch.resolve_author_lineage(
+            level=level,
+            slug=slug,
+            module_dir=target.module_dir,
+            explicit_author_family=options.author_family,
+        )
+        llm_reviewer_dispatch.validate_cross_family(route, lineage)
+    except llm_reviewer_dispatch.ReviewerSelfReviewError as exc:
+        return {
+            "status": "self_review_blocked",
+            "reason": "self_review",
+            "message": str(exc),
+        }
+    except llm_reviewer_dispatch.ReviewerLineageError as exc:
+        return {
+            "status": "lineage_required",
+            "reason": "author_family_unavailable",
+            "message": str(exc),
+        }
+    except llm_reviewer_dispatch.ReviewerRouteError as exc:
+        return {
+            "status": "provider_error",
+            "reason": "disallowed_reviewer_route",
+            "message": str(exc),
+        }
+    if not options.dry_run and not _exact_canary_passes(level=level, route=route, options=options):
+        return {
+            "status": "skipped_canary_required",
+            "reason": "exact_canary_required",
+            "message": "live Tier-2 calls require a passing same-route canary artifact",
+        }
+    return None
+
+
+def _exact_canary_passes(
+    *,
+    level: str,
+    route: llm_reviewer_dispatch.ReviewerRoute,
+    options: WorkflowOptions,
+) -> bool:
+    artifacts = options.canary_artifacts or {}
+    for key in (_canary_level_key(level), level.strip().lower(), "seminar"):
+        path = artifacts.get(key)
+        if path and llm_reviewer_dispatch.canary_artifact_passes(
+            path,
+            level=level,
+            gate_version=options.gate_version,
+            route=route,
+        ):
+            return True
+    return False
+
+
+def _canary_level_key(level: str) -> str:
+    policy = policy_for_level(level)
+    if policy.family == "seminar":
+        return "seminar"
+    clean = level.strip().lower()
+    if clean.startswith("b1"):
+        return "b1"
+    return clean
+
+
+def _coerce_reviewer_response(raw_response: Any) -> tuple[str, dict[str, Any]]:
+    if isinstance(raw_response, llm_reviewer_dispatch.DispatchResult):
+        return raw_response.response_text, raw_response.metadata()
+    if isinstance(raw_response, Mapping):
+        dispatch = raw_response.get("_llm_reviewer_dispatch")
+        if isinstance(dispatch, Mapping):
+            response = raw_response.get("response_text") or raw_response.get("response")
+            if isinstance(response, str):
+                return response, dict(dispatch)
+        return json.dumps(raw_response, ensure_ascii=False), {}
+    return str(raw_response), {}
+
+
+def _observed_cost(dispatch_meta: Mapping[str, Any]) -> float | None:
+    value = dispatch_meta.get("observed_cost_usd")
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _cost_overrun(
+    estimate: Mapping[str, Any],
+    observed_cost: float | None,
+) -> bool:
+    if observed_cost is None:
+        return False
+    estimated = float(estimate.get("estimated_cost_usd") or 0.0)
+    if estimated <= 0:
+        return False
+    return observed_cost > estimated * 1.25
+
+
+def _record_daily_spend(
+    *,
+    options: WorkflowOptions,
+    level: str,
+    slug: str,
+    route: llm_reviewer_dispatch.ReviewerRoute,
+    estimate: Mapping[str, Any],
+    observed_cost_usd: float | None,
+) -> None:
+    if not options.live_reviewer:
+        return
+    llm_reviewer_dispatch.append_daily_spend(
+        path=options.daily_spend_path,
+        level=level,
+        slug=slug,
+        route=route,
+        estimated_cost_usd=float(estimate.get("estimated_cost_usd") or 0.0),
+        observed_cost_usd=observed_cost_usd,
+    )
+
+
+def _parse_failed(findings: Sequence[Mapping[str, Any]]) -> bool:
+    return any(str(finding.get("issue_id")) == "LLM_RESPONSE_PARSE_FAILURE" for finding in findings)
+
+
+def _has_stale_cache(
+    *,
+    level: str,
+    slug: str,
+    gate_version: str,
+    checker_version: str,
+    level_policy_family: str,
+    reviewer_model: str,
+    store_path: Path | None,
+) -> bool:
+    latest = llm_qg_store.latest_llm_qg(
+        level,
+        slug,
+        gate_version=gate_version,
+        checker_version=checker_version,
+        level_policy_family=level_policy_family,
+        reviewer_model=reviewer_model,
+        path=store_path,
+    )
+    return latest is not None
 
 
 def estimate_llm_cost(prompt: str, policy_family: str) -> dict[str, Any]:
@@ -546,6 +1135,8 @@ def _build_evidence_record(
     llm_required_by_policy: bool,
     llm_required_by_harness: bool,
     llm_cost_override: bool,
+    reviewer_model_id: str,
+    reviewer_family: str,
     options: WorkflowOptions,
 ) -> dict[str, Any]:
     dimensions = dimensions_from_findings(findings)
@@ -575,7 +1166,12 @@ def _build_evidence_record(
             "llm_policy_families": sorted(LLM_POLICY_FAMILIES),
         },
         dimensions=dimensions,
-        checker_runs=_checker_runs(tier_results, options),
+        checker_runs=_checker_runs(
+            tier_results,
+            options,
+            reviewer_model_id=reviewer_model_id,
+            reviewer_family=reviewer_family,
+        ),
         content_sha=content_sha,
         provenance={
             "created_at": _now_z(),
@@ -590,12 +1186,13 @@ def _build_evidence_record(
     record["qg_workflow"] = {
         "gate_version": options.gate_version,
         "prompt_hash": prompt_hash,
-        "checker_version": CHECKER_VERSION,
-        "checker_config_hash": checker_config_hash(),
-        "reviewer_model_id": options.reviewer_model_id,
-        "content_hash_basis": CONTENT_HASH_BASIS,
-        "content_files": list(llm_qg_store.CONTENT_FILES),
-        "tiers": [dict(item) for item in tier_results],
+            "checker_version": CHECKER_VERSION,
+            "checker_config_hash": checker_config_hash(),
+            "reviewer_model_id": reviewer_model_id,
+            "reviewer_family": reviewer_family,
+            "content_hash_basis": CONTENT_HASH_BASIS,
+            "content_files": list(llm_qg_store.CONTENT_FILES),
+            "tiers": [dict(item) for item in tier_results],
     }
     record["llm_review"] = {
         "used": llm_used,
@@ -616,6 +1213,9 @@ def _build_evidence_record(
 def _checker_runs(
     tier_results: Sequence[Mapping[str, Any]],
     options: WorkflowOptions,
+    *,
+    reviewer_model_id: str,
+    reviewer_family: str,
 ) -> list[dict[str, Any]]:
     runs = [
         {
@@ -642,8 +1242,8 @@ def _checker_runs(
                 "source": "llm_reviewer",
                 "checker": options.gate_version,
                 "config_hash": None,
-                "provider": options.reviewer_family,
-                "model": options.reviewer_model_id,
+                "provider": reviewer_family,
+                "model": reviewer_model_id,
             }
         )
     return runs
@@ -777,6 +1377,109 @@ def _reviewer_from_response(path: Path | None) -> Reviewer | None:
     return reviewer
 
 
+def calibrate_modules(
+    targets: Sequence[ReviewTarget],
+    *,
+    options: WorkflowOptions,
+    reviewer: Reviewer | None = None,
+    store_path: Path | None = None,
+    probes: int = 5,
+) -> dict[str, Any]:
+    """Run a small live probe set and report observed/estimated cost factors."""
+
+    if not options.live_reviewer:
+        raise ValueError("--calibrate requires --live-reviewer")
+    if options.max_cost_usd is None:
+        raise ValueError("--calibrate requires --max-cost-usd")
+    sample = list(targets[: max(1, probes)])
+    calibration_options = WorkflowOptions(
+        gate_version=options.gate_version,
+        reviewer_model_id=options.reviewer_model_id,
+        reviewer_family=options.reviewer_family,
+        live_reviewer=True,
+        author_family=options.author_family,
+        canary_artifacts=options.canary_artifacts,
+        daily_spend_path=options.daily_spend_path,
+        run_command=options.run_command,
+        enable_llm=True,
+        force_llm=True,
+        llm_on_fail=True,
+        calibration_sample=True,
+        dry_run=False,
+        canary_passed=options.canary_passed,
+        max_llm_calls=options.max_llm_calls,
+        max_cost_usd=options.max_cost_usd,
+        max_daily_cost_usd=options.max_daily_cost_usd,
+        max_module_cost_usd=options.max_module_cost_usd,
+        fail_closed_on_llm_skip=options.fail_closed_on_llm_skip,
+    )
+    records = review_modules(
+        sample,
+        options=calibration_options,
+        reviewer=reviewer,
+        store_path=store_path,
+    )
+    factors: list[float] = []
+    probes_out: list[dict[str, Any]] = []
+    for record in records:
+        tier2 = _tier_from_record(record, 2)
+        estimate = tier2.get("estimate") if isinstance(tier2.get("estimate"), Mapping) else {}
+        dispatch = tier2.get("dispatch") if isinstance(tier2.get("dispatch"), Mapping) else {}
+        estimated_cost = float(estimate.get("estimated_cost_usd") or 0.0)
+        observed_cost = _observed_cost(dispatch)
+        if estimated_cost > 0 and observed_cost is not None:
+            factors.append(observed_cost / estimated_cost)
+        probes_out.append(
+            {
+                "module_id": record["module_id"],
+                "status": tier2.get("status"),
+                "reviewer_model_id": tier2.get("reviewer_model_id"),
+                "estimated_cost_usd": estimated_cost,
+                "observed_cost_usd": observed_cost,
+            }
+        )
+    factor = sorted(factors)[len(factors) // 2] if factors else None
+    return {
+        "schema_version": "qg_workflow_calibration.v1",
+        "probe_count": len(probes_out),
+        "cost_factor_median": round(factor, 4) if factor is not None else None,
+        "probes": probes_out,
+        "run_command": options.run_command,
+    }
+
+
+def _canary_artifacts_from_args(
+    args: argparse.Namespace,
+    targets: Sequence[ReviewTarget],
+) -> dict[str, Path]:
+    artifacts: dict[str, Path] = {}
+    for spec in args.canary_artifact or []:
+        if "=" not in spec:
+            raise ValueError("--canary-artifact must use LEVEL=PATH")
+        level, raw_path = spec.split("=", 1)
+        artifacts[_canary_level_key(level)] = Path(raw_path)
+    if args.canary_result and args.live_reviewer and len(targets) == 1:
+        artifacts.setdefault(_canary_level_key(targets[0].level), args.canary_result)
+    return artifacts
+
+
+def _exact_run_command(argv: Sequence[str]) -> str:
+    filtered: list[str] = []
+    skip_next = False
+    drop_value_after = {"--output"}
+    for item in argv:
+        if skip_next:
+            skip_next = False
+            continue
+        if item == "--dry-run":
+            continue
+        if item in drop_value_after:
+            skip_next = True
+            continue
+        filtered.append(item)
+    return ".venv/bin/python scripts/audit/qg_workflow.py " + shlex.join(filtered)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--module-dir", type=Path, help="Single module directory to review.")
@@ -793,28 +1496,48 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--force-llm", action="store_true", help="Enable Tier-2 for this run and override A1/A2 policy skip.")
     parser.add_argument("--llm-on-fail", action="store_true", help="Run Tier-2 even after Tier-0 hard FAIL.")
     parser.add_argument("--calibration-sample", action="store_true", help="Treat targets as an explicit calibration sample.")
+    parser.add_argument("--live-reviewer", action="store_true", help="Use the live reviewer dispatcher; requires budget and exact canary artifacts.")
+    parser.add_argument("--author-family", help="Explicit module author family for live cross-family review.")
     parser.add_argument("--max-llm-calls", type=int, help="Per-run reviewer call ceiling.")
     parser.add_argument("--max-cost-usd", type=float, help="Per-run cost ceiling.")
     parser.add_argument("--max-daily-cost-usd", type=float, help="Per-day safety rail for this local run.")
     parser.add_argument("--max-module-cost-usd", type=float, help="Per-module pathological prompt cost cap.")
+    parser.add_argument("--daily-spend-ledger", type=Path, help="Optional local JSONL spend ledger path.")
     parser.add_argument("--gate-version", default=DEFAULT_GATE_VERSION)
     parser.add_argument("--reviewer-model-id", default=DEFAULT_REVIEWER_MODEL_ID)
     parser.add_argument("--reviewer-family", default=DEFAULT_REVIEWER_FAMILY)
     parser.add_argument("--db", type=Path, help="Optional LLM-QG SQLite cache path.")
     parser.add_argument("--llm-response-json", type=Path, help="Precomputed reviewer response JSON; no live dispatch.")
     parser.add_argument("--canary-result", type=Path, help="Reviewer canary JSON that must pass before broad LLM.")
+    parser.add_argument(
+        "--canary-artifact",
+        action="append",
+        default=[],
+        help="Exact dispatcher canary artifact in LEVEL=PATH form; repeat for mixed-level live batches.",
+    )
+    parser.add_argument("--calibrate", action="store_true", help="Run up to five live probes to calibrate route cost estimates.")
+    parser.add_argument("--calibration-probes", type=int, default=5, help="Number of live probes for --calibrate.")
     parser.add_argument("--format", choices=("json", "summary"), default="summary")
     parser.add_argument("--output", type=Path, help="Optional output file.")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+    argv_list = list(argv) if argv is not None else sys.argv[1:]
+    args = build_parser().parse_args(argv_list)
     try:
         targets = _targets_from_args(args)
-        enable_llm = bool(args.force_llm or args.llm_response_json or args.dry_run or args.db)
+        canary_artifacts = _canary_artifacts_from_args(args, targets)
+        enable_llm = bool(
+            args.force_llm
+            or args.llm_response_json
+            or args.dry_run
+            or args.db
+            or args.live_reviewer
+            or args.calibrate
+        )
         canary_passed = False
-        if not args.dry_run and len(targets) > 1 and _llm_enabled_for_any_target(
+        if not args.dry_run and not args.live_reviewer and len(targets) > 1 and _llm_enabled_for_any_target(
             targets,
             WorkflowOptions(
                 enable_llm=enable_llm,
@@ -832,10 +1555,15 @@ def main(argv: list[str] | None = None) -> int:
             gate_version=args.gate_version,
             reviewer_model_id=args.reviewer_model_id,
             reviewer_family=args.reviewer_family,
+            live_reviewer=args.live_reviewer or args.calibrate,
+            author_family=args.author_family,
+            canary_artifacts=canary_artifacts,
+            daily_spend_path=args.daily_spend_ledger,
+            run_command=_exact_run_command(argv_list),
             enable_llm=enable_llm,
             force_llm=args.force_llm,
             llm_on_fail=args.llm_on_fail,
-            calibration_sample=args.calibration_sample,
+            calibration_sample=args.calibration_sample or args.calibrate,
             dry_run=args.dry_run,
             canary_passed=canary_passed,
             max_llm_calls=args.max_llm_calls,
@@ -843,7 +1571,15 @@ def main(argv: list[str] | None = None) -> int:
             max_daily_cost_usd=args.max_daily_cost_usd,
             max_module_cost_usd=args.max_module_cost_usd,
         )
-        if args.dry_run:
+        if args.calibrate:
+            payload = calibrate_modules(
+                targets,
+                options=options,
+                reviewer=_reviewer_from_response(args.llm_response_json),
+                store_path=args.db,
+                probes=args.calibration_probes,
+            )
+        elif args.dry_run:
             payload: dict[str, Any] | list[dict[str, Any]] = dry_run_modules(
                 targets,
                 options=options,
@@ -880,6 +1616,12 @@ def _summary(payload: Mapping[str, Any] | Sequence[Mapping[str, Any]]) -> str:
             f"Tier-1 gold rows matched: {counts['tier1_gold_rows_matched']}\n"
             f"Tier-2 estimated calls: {counts['tier2_estimated_calls']}"
         )
+    if isinstance(payload, Mapping) and payload.get("schema_version") == "qg_workflow_calibration.v1":
+        return (
+            "QG workflow calibration\n"
+            f"Probes: {payload['probe_count']}\n"
+            f"Median cost factor: {payload['cost_factor_median']}"
+        )
     records = [payload] if isinstance(payload, Mapping) else list(payload)
     lines = ["QG workflow evidence"]
     for record in records:
@@ -893,6 +1635,8 @@ def _summary(payload: Mapping[str, Any] | Sequence[Mapping[str, Any]]) -> str:
 def _passes(payload: Mapping[str, Any] | Sequence[Mapping[str, Any]]) -> bool:
     if isinstance(payload, Mapping) and payload.get("dry_run") is True:
         return True
+    if isinstance(payload, Mapping) and payload.get("schema_version") == "qg_workflow_calibration.v1":
+        return all(str(probe.get("status")) == "ran" for probe in payload.get("probes", []))
     records = [payload] if isinstance(payload, Mapping) else list(payload)
     return all(str(record.get("terminal_verdict")) == "PASS" for record in records)
 

--- a/tests/test_llm_reviewer_dispatch.py
+++ b/tests/test_llm_reviewer_dispatch.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.audit import llm_reviewer_dispatch, qg_workflow
+
+
+def _write_module(tmp_path: Path, *, level: str = "b1", slug: str = "sample") -> Path:
+    module_dir = tmp_path / level / slug
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text(
+        "# Модуль\n\nУчні читають український текст і виконують коротке завдання.\n",
+        encoding="utf-8",
+    )
+    (module_dir / "activities.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "resources.yaml").write_text("[]\n", encoding="utf-8")
+    return module_dir
+
+
+def _target(module_dir: Path, *, level: str = "b1") -> qg_workflow.ReviewTarget:
+    return qg_workflow.ReviewTarget(level=level, slug=module_dir.name, module_dir=module_dir)
+
+
+def _tier(record: dict[str, Any], tier_number: int) -> dict[str, Any]:
+    return next(tier for tier in record["qg_workflow"]["tiers"] if tier["tier"] == tier_number)
+
+
+def _canary_artifact(tmp_path: Path, *, level: str = "b1") -> Path:
+    route = llm_reviewer_dispatch.route_for_review(policy_family="seminar" if level == "seminar" else "b1_plus")
+    path = tmp_path / f"{level}-canary.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": llm_reviewer_dispatch.CANARY_SCHEMA_VERSION,
+                "level": level,
+                "gate_version": qg_workflow.DEFAULT_GATE_VERSION,
+                "prompt_template_hash": llm_reviewer_dispatch.prompt_template_hash(),
+                "reviewer_model_id": route.reviewer_model_id,
+                "reviewer_family": route.reviewer_family,
+                "route_name": route.route_name,
+                "passed": True,
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _dispatch_result(response: str, *, observed_cost_usd: float = 0.0) -> llm_reviewer_dispatch.DispatchResult:
+    route = llm_reviewer_dispatch.GEMMA_SURFACE_ROUTE
+    return llm_reviewer_dispatch.DispatchResult(
+        response_text=response,
+        reviewer_model_id=route.reviewer_model_id,
+        reviewer_family=route.reviewer_family,
+        route_name=route.route_name,
+        observed_cost_usd=observed_cost_usd,
+    )
+
+
+def test_routing_b1_surface_uses_gemma_and_seminar_uses_frontier() -> None:
+    b1_route = llm_reviewer_dispatch.route_for_review(policy_family="b1_plus")
+    seminar_route = llm_reviewer_dispatch.route_for_review(policy_family="seminar")
+
+    assert b1_route.bridge_command[0] == "ask-gemma"
+    assert b1_route.reviewer_model_id == "openrouter/google/gemma-4-31b-it"
+    assert seminar_route.bridge_command[:2] == ("ask-agy", "--to-model")
+    assert seminar_route.reviewer_model_id == "gemini-3.1-pro-high"
+
+
+def test_self_review_hard_fails() -> None:
+    route = llm_reviewer_dispatch.GEMMA_SURFACE_ROUTE
+    lineage = llm_reviewer_dispatch.AuthorLineage(family="google", source="test")
+
+    with pytest.raises(llm_reviewer_dispatch.ReviewerSelfReviewError):
+        llm_reviewer_dispatch.validate_cross_family(route, lineage)
+
+
+def test_deepseek_routes_are_excluded() -> None:
+    bad_route = llm_reviewer_dispatch.ReviewerRoute(
+        route_name="deepseek_bad",
+        bridge_command=("ask-deepseek",),
+        reviewer_model_id="deepseek-v4-pro",
+        reviewer_family="deepseek",
+        purpose="forbidden",
+        input_usd_per_mtok=0.0,
+        output_usd_per_mtok=0.0,
+    )
+
+    with pytest.raises(llm_reviewer_dispatch.ReviewerRouteError):
+        llm_reviewer_dispatch.assert_route_allowed(bad_route)
+    hermes_route = llm_reviewer_dispatch.ReviewerRoute(
+        route_name="hermes_bad",
+        bridge_command=("ask-hermes",),
+        reviewer_model_id="openrouter/hermes/deepseek-r1",
+        reviewer_family="openrouter",
+        purpose="forbidden",
+        input_usd_per_mtok=0.0,
+        output_usd_per_mtok=0.0,
+    )
+
+    with pytest.raises(llm_reviewer_dispatch.ReviewerRouteError):
+        llm_reviewer_dispatch.assert_route_allowed(hermes_route)
+    assert all("deepseek" not in route.reviewer_model_id for route in llm_reviewer_dispatch.ROUTES)
+
+
+def test_live_single_call_requires_exact_canary(tmp_path: Path) -> None:
+    module_dir = _write_module(tmp_path)
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        nonlocal calls
+        calls += 1
+        return _dispatch_result('{"findings": []}')
+
+    record = qg_workflow.review_module(
+        _target(module_dir),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            live_reviewer=True,
+            author_family="openai",
+            max_cost_usd=1.0,
+            daily_spend_path=tmp_path / "spend.jsonl",
+        ),
+        reviewer=reviewer,
+    )
+
+    assert _tier(record, 2)["status"] == "skipped_canary_required"
+    assert record["completion_status"] == "INCOMPLETE"
+    assert calls == 0
+
+
+def test_missing_canary_aborts_remaining_records(tmp_path: Path) -> None:
+    first = _write_module(tmp_path, slug="first")
+    second = _write_module(tmp_path, slug="second")
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        nonlocal calls
+        calls += 1
+        return _dispatch_result('{"findings": []}')
+
+    records = qg_workflow.review_modules(
+        [_target(first), _target(second)],
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            live_reviewer=True,
+            author_family="openai",
+            max_cost_usd=1.0,
+            daily_spend_path=tmp_path / "spend.jsonl",
+        ),
+        reviewer=reviewer,
+    )
+
+    assert [_tier(record, 2)["status"] for record in records] == [
+        "skipped_canary_required",
+        "aborted_batch",
+    ]
+    assert records[1]["completion_status"] == "INCOMPLETE"
+    assert calls == 0
+
+
+def test_live_cli_requires_max_cost_usd(tmp_path: Path) -> None:
+    module_dir = _write_module(tmp_path)
+    canary = _canary_artifact(tmp_path)
+    output = tmp_path / "out.json"
+
+    code = qg_workflow.main(
+        [
+            "--module-dir",
+            str(module_dir),
+            "--level",
+            "b1",
+            "--live-reviewer",
+            "--author-family",
+            "openai",
+            "--canary-artifact",
+            f"b1={canary}",
+            "--format",
+            "json",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert code == 2
+    assert not output.exists()
+
+
+def test_abort_gate_emits_incomplete_records_after_parse_failure(tmp_path: Path) -> None:
+    first = _write_module(tmp_path, slug="first")
+    second = _write_module(tmp_path, slug="second")
+    canary = _canary_artifact(tmp_path)
+    calls: list[str] = []
+
+    def reviewer(target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        calls.append(target.slug)
+        return _dispatch_result("not json")
+
+    records = qg_workflow.review_modules(
+        [_target(first), _target(second)],
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            live_reviewer=True,
+            author_family="openai",
+            canary_artifacts={"b1": canary},
+            max_cost_usd=1.0,
+            daily_spend_path=tmp_path / "spend.jsonl",
+        ),
+        reviewer=reviewer,
+    )
+
+    assert [_tier(record, 2)["status"] for record in records] == ["parse_failure", "aborted_batch"]
+    assert records[1]["completion_status"] == "INCOMPLETE"
+    assert calls == ["first"]
+
+
+def test_schema_failures_use_parse_schema_abort_threshold() -> None:
+    record = {"qg_workflow": {"tiers": [{"tier": 2, "status": "schema_failure"}]}}
+
+    assert qg_workflow._batch_abort_reason([record]) == "parse_failure_rate"
+
+
+def test_cost_overrun_gate_fails_closed(tmp_path: Path) -> None:
+    module_dir = _write_module(tmp_path)
+    canary = _canary_artifact(tmp_path)
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        return _dispatch_result('{"findings": []}', observed_cost_usd=10.0)
+
+    record = qg_workflow.review_module(
+        _target(module_dir),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            live_reviewer=True,
+            author_family="openai",
+            canary_artifacts={"b1": canary},
+            max_cost_usd=20.0,
+            daily_spend_path=tmp_path / "spend.jsonl",
+        ),
+        reviewer=reviewer,
+    )
+
+    assert _tier(record, 2)["status"] == "cost_overrun"
+    assert record["completion_status"] == "INCOMPLETE"
+
+
+def test_dry_run_gateable_artifact_shape(tmp_path: Path) -> None:
+    first = _write_module(tmp_path, slug="one")
+    second = _write_module(tmp_path, slug="two")
+    output = tmp_path / "dry-run.json"
+
+    code = qg_workflow.main(
+        [
+            "--target",
+            f"b1:one:{first}",
+            "--target",
+            f"b1:two:{second}",
+            "--dry-run",
+            "--live-reviewer",
+            "--format",
+            "json",
+            "--output",
+            str(output),
+        ]
+    )
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    artifact = payload["gateable_artifact"]
+
+    assert code == 0
+    assert artifact["schema_version"] == "qg_workflow_dry_run_gate.v1"
+    assert len(artifact["module_list"]) == 2
+    assert artifact["per_tier_counts"]["tier2_estimated_calls"] == 2
+    assert artifact["cache_estimate"]["cold"] == 2
+    assert artifact["expected_spend"]["estimated_cost_usd"] > 0
+    assert artifact["exact_run_command"].startswith(".venv/bin/python scripts/audit/qg_workflow.py")
+    assert "--dry-run" not in artifact["exact_run_command"]


### PR DESCRIPTION
## Summary

- Add a live reviewer dispatcher for QG Tier-2 review with calibrated prompt routing, DeepSeek/Hermes exclusion, cross-family author-lineage checks, and provider spend accounting.
- Wire `qg_workflow` live mode to exact canary artifacts, required live budgets, daily spend rails, abort gates, dry-run gate artifacts, and calibration probes.
- Add mocked dispatcher/workflow tests and document the gated live-review flow.

Refs #4311
Refs #2156
Refs #4310

This PR is machinery only. It does not run a broad/live LLM batch; execution remains gated on dry-run approval, fleet review, and explicit USER dollar sign-off.

## #M-4 verification preamble (raw output)

### routing correct / self-review hard-fails / deepseek excluded / canary required / budget fail-closed / abort gates fire

Command: `.venv/bin/python -m pytest tests/test_llm_reviewer_dispatch.py -q`

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4311a-reviewer-dispatch
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 10 items

tests/test_llm_reviewer_dispatch.py ..........                           [100%]

============================== 10 passed in 0.41s ==============================
```

### no live spend

The tests inject fake reviewer callables and fake `DispatchResult` values; no provider CLI is invoked.

Command: `rg -n "def reviewer|_dispatch_result|DispatchResult" tests/test_llm_reviewer_dispatch.py`

```text
55:def _dispatch_result(response: str, *, observed_cost_usd: float = 0.0) -> llm_reviewer_dispatch.DispatchResult:
57:    return llm_reviewer_dispatch.DispatchResult(
116:    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
119:        return _dispatch_result('{"findings": []}')
143:    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
146:        return _dispatch_result('{"findings": []}')
201:    def reviewer(target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
203:        return _dispatch_result("not json")
233:    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
234:        return _dispatch_result('{"findings": []}', observed_cost_usd=10.0)
```

### B1-27 green

Command: `.venv/bin/python -m pytest tests/test_qg_workflow.py::test_current_b1_27_production_stays_green_without_llm_bulk_run -q`

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4311a-reviewer-dispatch
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 1 item

tests/test_qg_workflow.py .                                              [100%]

============================== 1 passed in 0.41s ===============================
```

### ruff clean

Command: `.venv/bin/ruff check scripts/audit/llm_reviewer_dispatch.py scripts/audit/qg_workflow.py tests/test_llm_reviewer_dispatch.py`

```text
All checks passed!
```

### trailer

Command: `.venv/bin/python scripts/audit/lint_agent_trailer.py origin/main..HEAD`

```text
Checking 1 commit(s) in origin/main..HEAD:

  2fa5e2bacc  PASS  X-Agent: codex/4311a-reviewer-dispatch

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

### broader targeted QG tests

Command: `.venv/bin/python -m pytest tests/test_llm_reviewer_dispatch.py tests/test_qg_workflow.py tests/audit/test_module_quality_audit.py -q`

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4311a-reviewer-dispatch
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 34 items

tests/test_llm_reviewer_dispatch.py ..........                           [ 29%]
tests/test_qg_workflow.py .......                                        [ 50%]
tests/audit/test_module_quality_audit.py .................               [100%]

============================== 34 passed in 0.56s ==============================
```

### full suite attempt

Command: `.venv/bin/python -m pytest`

```text
= 7 failed, 9543 passed, 131 skipped, 11 xfailed, 3 warnings in 478.27s (0:07:58) =
```

Failures were outside this PR scope and appear tied to existing registry/data/environment fixtures:
`test_channels_registry`, `test_citation_resolution_invariant`, `test_esum_search`, `test_scrape_diasporiana`, `test_wiki_channels`, `test_writer_prompt_render_size`, and `tests/wiki/test_mlx_fault_injection.py` missing `embed-venv/bin/python`.

## Independent review

Agy/Gemini read-only review was requested after PR creation. It found three issues, all addressed in the final commit:

- Canary failures now flow through normal `INCOMPLETE` records and abort remaining records instead of raising early.
- `schema_failure` now counts against the parse/schema >5% abort gate, not the provider >10% gate.
- Hermes routes are explicitly banned alongside DeepSeek routes.

## Notes for reviewers

- The dispatcher refuses DeepSeek/Hermes OpenRouter reviewer routes for automated review paths.
- Live Tier-2 calls require an exact canary artifact and a non-dry-run `--max-cost-usd` budget.
- Daily spend ledgers are written under `data/telemetry/` and are not committed.
- No generated `status/*.json`, `audit/*-review.md`, `review/*-review.md`, or telemetry files are included.
