### PR TITLE
feat(audit): add QG corpus report

### DIFF
--- a/docs/projects/ua-eval-harness/corpus-report.md
+++ b/docs/projects/ua-eval-harness/corpus-report.md
@@ -1,0 +1,59 @@
+# QG Corpus Report
+
+Issue: [#4311](https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4311)
+
+`scripts/audit/qg_corpus_report.py` aggregates stored QG evidence without live
+LLM calls. It reads `llm_qg_runs` plus optional saved
+`qg_workflow.py --format json` outputs.
+
+## Command
+
+```bash
+.venv/bin/python scripts/audit/qg_corpus_report.py \
+  --db data/telemetry/llm_qg.db \
+  --curriculum-root curriculum/l2-uk-en \
+  --format json \
+  --output /tmp/qg-corpus-report.json
+```
+
+The DB is local telemetry state and must not be committed.
+
+## Idempotency Rule
+
+Reports dedupe DB rows by the latest full composite identity:
+
+```text
+level + slug + content_sha + gate_version + prompt_hash
++ checker_version + level_policy_family + reviewer_model
+```
+
+Repeated `record_llm_qg()` calls grow rows because every run gets a new
+`run_id`; row count is not cache state. Cache hit/stale/miss is computed by
+looking for the latest exact composite for each target module.
+
+## Output Schema
+
+Top-level schema version: `qg_corpus_report.v1`.
+
+Required aggregate blocks:
+
+- `selection`: raw DB rows, latest composite rows, dedupe key, load errors.
+- `cache`: hit/stale/miss counts overall and by level.
+- `defect_rates`: overall, per-level, and per-policy-family defect rates.
+- `gold_metrics`: calque and grammar precision/recall/F1 when explicit gold
+  comparison metadata exists.
+- `gold_metrics.calque.with_contested` and
+  `gold_metrics.calque.without_contested`: contested-gold comparison.
+- `gold_metrics.calque.contested_delta`: with-contested minus
+  without-contested precision/recall/F1.
+- `gold_metrics.per_model_calque_f1`: per-reviewer-model calque F1.
+- `completion`: `SKIPPED_BUDGET`, `INCOMPLETE`, provider-error, and
+  parse/schema-failure counts.
+- `spend`: observed/estimated spend per accepted evidence record when stored
+  workflow outputs contain cost metadata.
+- `unlp_metric_schema`: `unlp_qg_aggregate_metrics.v1`, the #4312 input
+  contract.
+
+Contested gold is excluded from pass/fail defect rates and the
+`without_contested` metric variant. The `with_contested` variant remains visible
+so #4364 can quantify how contested rows move the calque aggregate.

--- a/docs/projects/ua-eval-harness/cost-aware-qg-workflow.md
+++ b/docs/projects/ua-eval-harness/cost-aware-qg-workflow.md
@@ -37,8 +37,7 @@ budget rails, and explicit human spend sign-off.
 - Seminar, contested-gold, and factual-sensitive review routes to `ask-agy
   --to-model gemini-3.1-pro-high`.
 - Escalation/disputed spot audit is Claude-only and is not the batch default.
-- DeepSeek/Hermes/OpenRouter reviewer routes are hard-banned for automated
-  LLM-QG batches.
+- DeepSeek/Hermes reviewer routes are hard-banned for automated LLM-QG batches.
 
 Live review also enforces cross-family lineage. The dispatcher resolves author
 family from explicit `--author-family`, committed metadata, or git history. If

--- a/scripts/audit/llm_reviewer_dispatch.py
+++ b/scripts/audit/llm_reviewer_dispatch.py
@@ -218,14 +218,14 @@ def route_for_review(
 
 
 def assert_route_allowed(route: ReviewerRoute) -> None:
-    """Hard-ban DeepSeek/Hermes->OpenRouter automated reviewer routes."""
+    """Hard-ban DeepSeek/Hermes automated reviewer routes."""
 
     haystack = " ".join(
         [route.route_name, route.reviewer_model_id, route.reviewer_family, *route.bridge_command]
     )
     lowered = haystack.lower()
     if normalize_family(haystack) == "deepseek" or "hermes" in lowered:
-        raise ReviewerRouteError("DeepSeek/Hermes/OpenRouter reviewer routes are forbidden")
+        raise ReviewerRouteError("DeepSeek/Hermes reviewer routes are forbidden")
 
 
 def resolve_author_lineage(

--- a/scripts/audit/qg_corpus_report.py
+++ b/scripts/audit/qg_corpus_report.py
@@ -1,0 +1,997 @@
+#!/usr/bin/env python3
+"""Aggregate stored QG evidence without live reviewer calls.
+
+The report is deliberately DB/file-backed: it reads persisted ``llm_qg_runs``
+rows plus optional stored ``qg_workflow.py --format json`` outputs. It never
+dispatches a reviewer.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.api.resilience import connect_sqlite
+from scripts.audit import llm_qg_store, llm_reviewer, qg_schema, qg_workflow
+from scripts.audit.content_surface_gates import policy_for_level
+from scripts.audit.curriculum_qg_harness import CHECKER_VERSION
+
+REPORT_SCHEMA_VERSION = "qg_corpus_report.v1"
+UNLP_METRIC_SCHEMA_VERSION = "unlp_qg_aggregate_metrics.v1"
+COMPOSITE_KEY_FIELDS = (
+    "level",
+    "slug",
+    "content_sha",
+    "gate_version",
+    "prompt_hash",
+    "checker_version",
+    "level_policy_family",
+    "reviewer_model",
+)
+
+@dataclass(frozen=True, slots=True)
+class ReportTarget:
+    level: str
+    slug: str
+    module_dir: Path
+
+
+@dataclass(frozen=True, slots=True)
+class ReportRecord:
+    run_id: str
+    level: str
+    slug: str
+    content_sha: str
+    gate_version: str
+    prompt_hash: str | None
+    checker_version: str | None
+    level_policy_family: str | None
+    reviewer_model: str | None
+    reviewer_family: str | None
+    source: str
+    payload: dict[str, Any]
+    created_at: str
+
+    @property
+    def module_id(self) -> str:
+        return f"{self.level}/{self.slug}"
+
+
+def build_report(
+    *,
+    db_path: Path | None = None,
+    targets: Sequence[ReportTarget] = (),
+    workflow_payloads: Sequence[Mapping[str, Any] | Sequence[Mapping[str, Any]]] = (),
+    gate_version: str = qg_workflow.DEFAULT_GATE_VERSION,
+    checker_version: str = CHECKER_VERSION,
+    reviewer_model_id: str = qg_workflow.DEFAULT_REVIEWER_MODEL_ID,
+) -> dict[str, Any]:
+    """Build the corpus report from stored DB rows and optional workflow JSON."""
+
+    resolved_db = llm_qg_store.db_path(db_path)
+    raw_records, load_errors = load_db_records(resolved_db)
+    latest_records = latest_records_by_composite(raw_records)
+    workflow_records = _flatten_workflow_payloads(workflow_payloads)
+    cache = cache_status_for_targets(
+        targets,
+        db_path=resolved_db,
+        gate_version=gate_version,
+        checker_version=checker_version,
+        reviewer_model_id=reviewer_model_id,
+    )
+
+    defect_rates = _defect_rates(latest_records, workflow_records)
+    gold_metrics = _gold_metrics(latest_records, workflow_records)
+    completion = _completion_summary(latest_records, workflow_records)
+    warn_conversion = _warn_conversion(workflow_records)
+    spend = _spend_summary(latest_records, workflow_records)
+
+    return {
+        "schema_version": REPORT_SCHEMA_VERSION,
+        "generated_at": _now_z(),
+        "source": {
+            "db": str(resolved_db),
+            "db_exists": resolved_db.exists(),
+            "workflow_records": len(workflow_records),
+            "target_count": len(targets),
+            "gate_version": gate_version,
+            "checker_version": checker_version,
+            "reviewer_model_id": reviewer_model_id,
+        },
+        "selection": {
+            "dedupe_key": list(COMPOSITE_KEY_FIELDS),
+            "latest_order": ["created_at DESC", "run_id DESC"],
+            "raw_db_rows": len(raw_records),
+            "latest_composite_records": len(latest_records),
+            "load_errors": load_errors,
+        },
+        "cache": cache,
+        "defect_rates": defect_rates,
+        "gold_metrics": gold_metrics,
+        "warn_to_reviewer_confirmed": warn_conversion,
+        "completion": completion,
+        "spend": spend,
+        "unlp_metric_schema": unlp_metric_schema(),
+    }
+
+
+def load_db_records(path: Path) -> tuple[list[ReportRecord], list[str]]:
+    """Return all persisted DB records; malformed payloads are reported, not fatal."""
+
+    if not path.exists():
+        return [], []
+    errors: list[str] = []
+    records: list[ReportRecord] = []
+    try:
+        with closing(connect_sqlite(str(path))) as conn:
+            llm_qg_store._ensure_composite_columns(conn)
+            conn.commit()
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT *
+                FROM llm_qg_runs
+                ORDER BY created_at DESC, run_id DESC
+                """
+            ).fetchall()
+    except sqlite3.DatabaseError as exc:
+        return [], [f"db_error: {exc}"]
+
+    for row in rows:
+        try:
+            payload = json.loads(str(row["payload_json"]))
+        except json.JSONDecodeError as exc:
+            errors.append(f"{row['run_id']}: payload_json: {exc}")
+            continue
+        records.append(
+            ReportRecord(
+                run_id=str(row["run_id"]),
+                level=str(row["level"]),
+                slug=str(row["slug"]),
+                content_sha=str(row["content_sha"]),
+                gate_version=str(row["gate_version"]),
+                prompt_hash=row["prompt_hash"],
+                checker_version=row["checker_version"],
+                level_policy_family=row["level_policy_family"],
+                reviewer_model=row["reviewer_model"],
+                reviewer_family=row["reviewer_family"],
+                source=str(row["source"]),
+                payload=payload,
+                created_at=str(row["created_at"]),
+            )
+        )
+    return records, errors
+
+
+def latest_records_by_composite(records: Iterable[ReportRecord]) -> list[ReportRecord]:
+    """Keep the newest row per composite identity; row growth is not a signal."""
+
+    latest: dict[tuple[Any, ...], ReportRecord] = {}
+    for record in records:
+        key = _composite_key(record)
+        current = latest.get(key)
+        if current is None or (record.created_at, record.run_id) > (current.created_at, current.run_id):
+            latest[key] = record
+    return sorted(latest.values(), key=lambda item: (item.level, item.slug, item.reviewer_model or "", item.created_at))
+
+
+def cache_status_for_targets(
+    targets: Sequence[ReportTarget],
+    *,
+    db_path: Path,
+    gate_version: str,
+    checker_version: str,
+    reviewer_model_id: str,
+) -> dict[str, Any]:
+    counts: Counter[str] = Counter()
+    by_level: dict[str, Counter[str]] = defaultdict(Counter)
+    modules: list[dict[str, Any]] = []
+    raw_records, _errors = load_db_records(db_path)
+    latest_by_composite = {_composite_key(record): record for record in latest_records_by_composite(raw_records)}
+    modules_with_any_record = {(record.level, record.slug) for record in raw_records}
+    for target in targets:
+        key = _target_composite_key(
+            target=target,
+            gate_version=gate_version,
+            checker_version=checker_version,
+            reviewer_model_id=reviewer_model_id,
+        )
+        record = latest_by_composite.get(key)
+        status = "hit" if record else "stale" if (target.level, target.slug) in modules_with_any_record else "miss"
+        counts[status] += 1
+        by_level[target.level][status] += 1
+        modules.append(
+            {
+                "module_id": f"{target.level}/{target.slug}",
+                "status": status,
+                "run_id": record.run_id if record else None,
+                "gate_version": record.gate_version if record else None,
+                "reviewer_model": record.reviewer_model if record else None,
+            }
+        )
+    return {
+        "hit": counts["hit"],
+        "stale": counts["stale"],
+        "miss": counts["miss"],
+        "by_level": {
+            level: {"hit": values["hit"], "stale": values["stale"], "miss": values["miss"]}
+            for level, values in sorted(by_level.items())
+        },
+        "modules": modules,
+    }
+
+
+def latest_composite_match_for_target(
+    target: ReportTarget,
+    *,
+    db_path: Path,
+    gate_version: str,
+    checker_version: str,
+    reviewer_model_id: str,
+) -> tuple[str, ReportRecord | None]:
+    """Return hit/stale/miss using the full workflow cache composite."""
+
+    if not db_path.exists():
+        return "miss", None
+    prompt_hash = _prompt_hash_for_target(target)
+    content_sha = llm_qg_store.content_sha_for_module(target.module_dir)
+    policy_family = policy_for_level(target.level).family
+    record = _latest_exact_composite(
+        db_path=db_path,
+        level=target.level,
+        slug=target.slug,
+        content_sha=content_sha,
+        gate_version=gate_version,
+        prompt_hash=prompt_hash,
+        checker_version=checker_version,
+        level_policy_family=policy_family,
+        reviewer_model=reviewer_model_id,
+    )
+    if record is not None:
+        return "hit", record
+    latest, _errors = load_db_records(db_path)
+    stale = any(record.level == target.level and record.slug == target.slug for record in latest)
+    return ("stale" if stale else "miss"), None
+
+
+def _target_composite_key(
+    *,
+    target: ReportTarget,
+    gate_version: str,
+    checker_version: str,
+    reviewer_model_id: str,
+) -> tuple[Any, ...]:
+    return (
+        target.level,
+        target.slug,
+        llm_qg_store.content_sha_for_module(target.module_dir),
+        gate_version,
+        _prompt_hash_for_target(target),
+        checker_version,
+        policy_for_level(target.level).family,
+        reviewer_model_id,
+    )
+
+
+def backfill_from_workflow_records(
+    workflow_payloads: Sequence[Mapping[str, Any] | Sequence[Mapping[str, Any]]],
+    *,
+    db_path: Path | None = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    """Insert missing/stale stored workflow evidence without overwriting matches."""
+
+    resolved_db = llm_qg_store.db_path(db_path)
+    records = _flatten_workflow_payloads(workflow_payloads)
+    counts: Counter[str] = Counter()
+    rows: list[dict[str, Any]] = []
+    for record in records:
+        decision = _backfill_decision(record, resolved_db)
+        status = str(decision["status"])
+        if status in {"missing", "stale"} and not dry_run:
+            module_dir = Path(str(record["provenance"]["module_dir"]))
+            llm_qg_store.record_llm_qg(
+                level=str(record["module_id"]).split("/", 1)[0],
+                slug=str(record["module_id"]).split("/", 1)[1],
+                module_dir=module_dir,
+                payload=_payload_from_workflow_record(record),
+                gate_version=str(record["qg_workflow"]["gate_version"]),
+                prompt_hash=record["qg_workflow"].get("prompt_hash"),
+                checker_version=record["qg_workflow"].get("checker_version"),
+                level_policy_family=str(record["level_policy"].get("family") or ""),
+                reviewer_model=str(record["qg_workflow"].get("reviewer_model_id") or ""),
+                reviewer_family=record["qg_workflow"].get("reviewer_family"),
+                source="qg_corpus_report_backfill",
+                path=resolved_db,
+            )
+            status = "inserted"
+        counts[status] += 1
+        rows.append({**decision, "status": status})
+    return {
+        "schema_version": "qg_corpus_backfill.v1",
+        "dry_run": dry_run,
+        "db": str(resolved_db),
+        "counts": dict(sorted(counts.items())),
+        "records": rows,
+    }
+
+
+def discover_targets(curriculum_root: Path) -> list[ReportTarget]:
+    """Discover built module directories under ``curriculum/l2-uk-en``."""
+
+    targets: list[ReportTarget] = []
+    if not curriculum_root.exists():
+        return targets
+    for level_dir in sorted(path for path in curriculum_root.iterdir() if path.is_dir()):
+        level = level_dir.name
+        for module_md in sorted(level_dir.glob("*/module.md")):
+            module_dir = module_md.parent
+            targets.append(ReportTarget(level=level, slug=module_dir.name, module_dir=module_dir))
+    return targets
+
+
+def load_workflow_json(path: Path) -> Mapping[str, Any] | Sequence[Mapping[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict):
+        return payload
+    if isinstance(payload, list) and all(isinstance(item, dict) for item in payload):
+        return payload
+    raise ValueError(f"{path}: expected workflow record object or list")
+
+
+def unlp_metric_schema() -> dict[str, Any]:
+    """Machine-readable aggregate schema stub for #4312."""
+
+    return {
+        "schema_version": UNLP_METRIC_SCHEMA_VERSION,
+        "required_aggregates": [
+            "gold_metrics.calque.with_contested",
+            "gold_metrics.calque.without_contested",
+            "gold_metrics.calque.contested_delta",
+            "defect_rates.by_level",
+            "gold_metrics.per_model_calque_f1",
+        ],
+        "metric_fields": {
+            "precision": "tp / (tp + fp), null when denominator is zero",
+            "recall": "tp / (tp + fn), null when denominator is zero",
+            "f1": "harmonic mean of precision and recall, null when both are unavailable or zero",
+            "contested_delta": "with_contested minus without_contested for precision/recall/f1",
+        },
+        "identity_fields": list(COMPOSITE_KEY_FIELDS),
+    }
+
+
+def _latest_exact_composite(
+    *,
+    db_path: Path,
+    level: str,
+    slug: str,
+    content_sha: str,
+    gate_version: str,
+    prompt_hash: str | None,
+    checker_version: str | None,
+    level_policy_family: str | None,
+    reviewer_model: str | None,
+) -> ReportRecord | None:
+    rows, errors = load_db_records(db_path)
+    if errors:
+        return None
+    wanted = (
+        level.strip().lower(),
+        slug.strip(),
+        content_sha,
+        gate_version,
+        prompt_hash,
+        checker_version,
+        level_policy_family,
+        reviewer_model,
+    )
+    matches = [record for record in rows if _composite_key(record) == wanted]
+    if not matches:
+        return None
+    return max(matches, key=lambda item: (item.created_at, item.run_id))
+
+
+def _backfill_decision(record: Mapping[str, Any], db_path: Path) -> dict[str, Any]:
+    module_id = str(record.get("module_id") or "")
+    if "/" not in module_id:
+        return {"module_id": module_id, "status": "invalid", "reason": "missing module_id"}
+    workflow = record.get("qg_workflow")
+    provenance = record.get("provenance")
+    level_policy = record.get("level_policy")
+    if not isinstance(workflow, Mapping) or not isinstance(provenance, Mapping) or not isinstance(level_policy, Mapping):
+        return {"module_id": module_id, "status": "invalid", "reason": "missing workflow metadata"}
+    module_dir = Path(str(provenance.get("module_dir") or ""))
+    if not module_dir.exists():
+        return {"module_id": module_id, "status": "invalid", "reason": "module_dir missing"}
+    current_content_sha = llm_qg_store.content_sha_for_module(module_dir)
+    record_content_sha = str(record.get("content_sha") or "")
+    if record_content_sha != current_content_sha:
+        return {"module_id": module_id, "status": "stale_source", "reason": "content_sha differs from module_dir"}
+    level, slug = module_id.split("/", 1)
+    exact = _latest_exact_composite(
+        db_path=db_path,
+        level=level,
+        slug=slug,
+        content_sha=record_content_sha,
+        gate_version=str(workflow.get("gate_version") or ""),
+        prompt_hash=workflow.get("prompt_hash"),
+        checker_version=workflow.get("checker_version"),
+        level_policy_family=str(level_policy.get("family") or ""),
+        reviewer_model=str(workflow.get("reviewer_model_id") or ""),
+    )
+    if exact is not None:
+        return {"module_id": module_id, "status": "current", "run_id": exact.run_id}
+    rows, _errors = load_db_records(db_path)
+    stale = any(item.level == level and item.slug == slug for item in rows)
+    return {"module_id": module_id, "status": "stale" if stale else "missing"}
+
+
+def _payload_from_workflow_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": record.get("schema_version", qg_schema.SCHEMA_VERSION),
+        "aggregate": dict(record.get("aggregate") if isinstance(record.get("aggregate"), Mapping) else {}),
+        "dimensions": dict(record.get("dimensions") if isinstance(record.get("dimensions"), Mapping) else {}),
+        "findings": _findings_from_payload(record),
+    }
+
+
+def _defect_rates(
+    db_records: Sequence[ReportRecord],
+    workflow_records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    buckets: dict[str, dict[str, Any]] = defaultdict(_empty_defect_bucket)
+    policy_buckets: dict[str, dict[str, Any]] = defaultdict(_empty_defect_bucket)
+    overall = _empty_defect_bucket()
+    for record in [*_records_as_mappings(db_records), *workflow_records]:
+        level = _level_for_record(record)
+        policy = _policy_family_for_record(record)
+        findings = _penalized_findings(_findings_from_payload(record))
+        _add_defect_record(overall, findings)
+        _add_defect_record(buckets[level], findings)
+        _add_defect_record(policy_buckets[policy], findings)
+    return {
+        "overall": _finalize_defect_bucket(overall),
+        "by_level": {key: _finalize_defect_bucket(value) for key, value in sorted(buckets.items())},
+        "by_policy_family": {key: _finalize_defect_bucket(value) for key, value in sorted(policy_buckets.items())},
+    }
+
+
+def _gold_metrics(
+    db_records: Sequence[ReportRecord],
+    workflow_records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    axes = {"calque": [], "grammar": []}
+    per_model: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for record in [*_records_as_mappings(db_records), *workflow_records]:
+        model = _reviewer_model_for_record(record)
+        for finding in _findings_from_payload(record):
+            vote = _metric_vote(finding)
+            if vote is None:
+                continue
+            if vote["axis"] in axes:
+                axes[vote["axis"]].append(vote)
+            if vote["axis"] == "calque":
+                per_model[model].append(vote)
+
+    calque_with = _score_votes(axes["calque"], include_contested=True)
+    calque_without = _score_votes(axes["calque"], include_contested=False)
+    grammar_with = _score_votes(axes["grammar"], include_contested=True)
+    grammar_without = _score_votes(axes["grammar"], include_contested=False)
+    return {
+        "calque": {
+            "with_contested": calque_with,
+            "without_contested": calque_without,
+            "contested_delta": _metric_delta(calque_with, calque_without),
+        },
+        "grammar": {
+            "with_contested": grammar_with,
+            "without_contested": grammar_without,
+            "contested_delta": _metric_delta(grammar_with, grammar_without),
+        },
+        "per_model_calque_f1": {
+            model: {
+                "with_contested": _score_votes(votes, include_contested=True),
+                "without_contested": _score_votes(votes, include_contested=False),
+            }
+            for model, votes in sorted(per_model.items())
+        },
+    }
+
+
+def _completion_summary(
+    db_records: Sequence[ReportRecord],
+    workflow_records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    completion_counts: Counter[str] = Counter()
+    workflow_verdict_counts: Counter[str] = Counter()
+    tier2_status_counts: Counter[str] = Counter()
+    provider_error = 0
+    parse_failure = 0
+    skipped_budget = 0
+    incomplete = 0
+    for record in [*_records_as_mappings(db_records), *workflow_records]:
+        aggregate = _aggregate(record)
+        completion = str(record.get("completion_status") or aggregate.get("completion_status") or "COMPLETE")
+        workflow_verdict = str(record.get("workflow_verdict") or aggregate.get("workflow_verdict") or aggregate.get("verdict") or "UNKNOWN")
+        completion_counts[completion] += 1
+        workflow_verdict_counts[workflow_verdict] += 1
+        if completion == "INCOMPLETE":
+            incomplete += 1
+        if workflow_verdict == "SKIPPED_BUDGET":
+            skipped_budget += 1
+        tier2 = _tier(record, 2)
+        status = str(tier2.get("status") or "")
+        if status:
+            tier2_status_counts[status] += 1
+        if status == "provider_error" or workflow_verdict == "PROVIDER_FAILURE":
+            provider_error += 1
+        if status in {"parse_failure", "schema_failure"} or workflow_verdict in {"PARSE_FAILURE", "SCHEMA_FAILURE"}:
+            parse_failure += 1
+    return {
+        "records": len(db_records) + len(workflow_records),
+        "completion_status_counts": dict(sorted(completion_counts.items())),
+        "workflow_verdict_counts": dict(sorted(workflow_verdict_counts.items())),
+        "tier2_status_counts": dict(sorted(tier2_status_counts.items())),
+        "skipped_budget": skipped_budget,
+        "incomplete": incomplete,
+        "provider_error": provider_error,
+        "parse_failure": parse_failure,
+    }
+
+
+def _warn_conversion(workflow_records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    warn_findings = 0
+    confirmed = 0
+    for record in workflow_records:
+        findings = _findings_from_payload(record)
+        reviewer_findings = [item for item in findings if item.get("confidence") == "llm_judgment"]
+        for finding in findings:
+            if finding.get("confidence") == "llm_judgment" or finding.get("severity") != "warning":
+                continue
+            warn_findings += 1
+            if _reviewer_confirms(finding, reviewer_findings):
+                confirmed += 1
+    return {
+        "warn_findings": warn_findings,
+        "reviewer_confirmed": confirmed,
+        "conversion_rate": _ratio(confirmed, warn_findings),
+    }
+
+
+def _spend_summary(
+    db_records: Sequence[ReportRecord],
+    workflow_records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    estimated = 0.0
+    observed = 0.0
+    records_with_cost = 0
+    accepted = 0
+    for record in [*_records_as_mappings(db_records), *workflow_records]:
+        if str(record.get("terminal_verdict") or _aggregate(record).get("terminal_verdict") or "").upper() == "PASS":
+            accepted += 1
+        tier2 = _tier(record, 2)
+        estimate = tier2.get("estimate") if isinstance(tier2.get("estimate"), Mapping) else {}
+        dispatch = tier2.get("dispatch") if isinstance(tier2.get("dispatch"), Mapping) else {}
+        cost_seen = False
+        if estimate.get("estimated_cost_usd") is not None:
+            estimated += float(estimate.get("estimated_cost_usd") or 0.0)
+            cost_seen = True
+        observed_value = (
+            dispatch["observed_cost_usd"]
+            if "observed_cost_usd" in dispatch
+            else tier2.get("observed_cost_usd")
+        )
+        if observed_value is not None:
+            observed += float(observed_value or 0.0)
+            cost_seen = True
+        if cost_seen:
+            records_with_cost += 1
+    numerator = observed if observed else estimated
+    return {
+        "accepted_evidence": accepted,
+        "records_with_cost": records_with_cost,
+        "estimated_cost_usd": round(estimated, 6),
+        "observed_cost_usd": round(observed, 6),
+        "spend_per_accepted_evidence_usd": _round_or_none(_ratio(numerator, accepted)),
+    }
+
+
+def _records_as_mappings(records: Sequence[ReportRecord]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for record in records:
+        aggregate = _aggregate(record.payload)
+        out.append(
+            {
+                "schema_version": record.payload.get("schema_version"),
+                "module_id": record.module_id,
+                "level_policy": {"family": record.level_policy_family},
+                "aggregate": aggregate,
+                "dimensions": record.payload.get("dimensions"),
+                "findings": _findings_from_payload(record.payload),
+                "verdict": aggregate.get("verdict"),
+                "terminal_verdict": aggregate.get("terminal_verdict"),
+                "completion_status": aggregate.get("completion_status", "COMPLETE"),
+                "workflow_verdict": aggregate.get("workflow_verdict", aggregate.get("verdict")),
+                "_store": {
+                    "run_id": record.run_id,
+                    "level": record.level,
+                    "slug": record.slug,
+                    "reviewer_model": record.reviewer_model,
+                    "reviewer_family": record.reviewer_family,
+                },
+            }
+        )
+    return out
+
+
+def _flatten_workflow_payloads(
+    payloads: Sequence[Mapping[str, Any] | Sequence[Mapping[str, Any]]],
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for payload in payloads:
+        if isinstance(payload, Mapping):
+            if payload.get("schema_version") == "qg_workflow_dry_run.v1":
+                continue
+            out.append(dict(payload))
+        else:
+            out.extend(dict(item) for item in payload if isinstance(item, Mapping))
+    return out
+
+
+def _findings_from_payload(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    findings = payload.get("findings")
+    if isinstance(findings, list):
+        return [dict(item) for item in findings if isinstance(item, Mapping)]
+    dimensions = payload.get("dimensions")
+    out: list[dict[str, Any]] = []
+    if isinstance(dimensions, Mapping):
+        for entry in dimensions.values():
+            if isinstance(entry, Mapping) and isinstance(entry.get("findings"), list):
+                out.extend(dict(item) for item in entry["findings"] if isinstance(item, Mapping))
+    return out
+
+
+def _metric_vote(finding: Mapping[str, Any]) -> dict[str, Any] | None:
+    metadata = finding.get("metadata") if isinstance(finding.get("metadata"), Mapping) else {}
+    qg_eval = metadata.get("qg_eval") if isinstance(metadata.get("qg_eval"), Mapping) else None
+    gold_eval = metadata.get("gold_eval") if isinstance(metadata.get("gold_eval"), Mapping) else None
+    ua_gec_gold = metadata.get("ua_gec_gold") if isinstance(metadata.get("ua_gec_gold"), Mapping) else None
+    if qg_eval is None and gold_eval is None:
+        return None
+    source = qg_eval or gold_eval or {}
+    axis = str(source.get("axis") or _axis_for_finding(finding, ua_gec_gold))
+    gold = bool(source.get("gold_label", source.get("gold", source.get("is_gold", False))))
+    predicted = bool(source.get("predicted", source.get("model_flagged", source.get("detected", False))))
+    matched = bool(source.get("matched", predicted and gold))
+    contested = bool(source.get("contested") or _finding_contested(finding))
+    return {
+        "axis": axis,
+        "gold": gold,
+        "predicted": predicted,
+        "matched": matched,
+        "contested": contested,
+    }
+
+
+def _score_votes(votes: Sequence[Mapping[str, Any]], *, include_contested: bool) -> dict[str, Any]:
+    filtered = [vote for vote in votes if include_contested or not vote.get("contested")]
+    tp = sum(1 for vote in filtered if vote.get("predicted") and vote.get("gold") and vote.get("matched"))
+    fp = sum(1 for vote in filtered if vote.get("predicted") and not (vote.get("gold") and vote.get("matched")))
+    fn = sum(1 for vote in filtered if vote.get("gold") and not vote.get("matched"))
+    precision = _ratio(tp, tp + fp)
+    recall = _ratio(tp, tp + fn)
+    f1 = None
+    if precision is not None and recall is not None and precision + recall:
+        f1 = round(2 * precision * recall / (precision + recall), 4)
+    return {
+        "gold_records": sum(1 for vote in filtered if vote.get("gold")),
+        "predicted_records": sum(1 for vote in filtered if vote.get("predicted")),
+        "contested_records": sum(1 for vote in filtered if vote.get("contested")),
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+        "precision": precision,
+        "recall": recall,
+        "f1": f1,
+    }
+
+
+def _metric_delta(with_contested: Mapping[str, Any], without_contested: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: _round_or_none(
+            None
+            if with_contested.get(key) is None or without_contested.get(key) is None
+            else float(with_contested[key]) - float(without_contested[key])
+        )
+        for key in ("precision", "recall", "f1")
+    } | {
+        "contested_gold_records": int(with_contested.get("gold_records") or 0)
+        - int(without_contested.get("gold_records") or 0),
+        "contested_predicted_records": int(with_contested.get("predicted_records") or 0)
+        - int(without_contested.get("predicted_records") or 0),
+    }
+
+
+def _empty_defect_bucket() -> dict[str, Any]:
+    return {
+        "records": 0,
+        "records_with_defects": 0,
+        "findings": 0,
+        "critical_findings": 0,
+        "warning_findings": 0,
+    }
+
+
+def _add_defect_record(bucket: dict[str, Any], findings: Sequence[Mapping[str, Any]]) -> None:
+    bucket["records"] += 1
+    bucket["findings"] += len(findings)
+    bucket["critical_findings"] += sum(1 for finding in findings if finding.get("severity") == "critical")
+    bucket["warning_findings"] += sum(1 for finding in findings if finding.get("severity") == "warning")
+    if findings:
+        bucket["records_with_defects"] += 1
+
+
+def _finalize_defect_bucket(bucket: Mapping[str, Any]) -> dict[str, Any]:
+    records = int(bucket["records"])
+    return {
+        "records": records,
+        "records_with_defects": int(bucket["records_with_defects"]),
+        "defect_rate": _ratio(int(bucket["records_with_defects"]), records),
+        "findings": int(bucket["findings"]),
+        "critical_findings": int(bucket["critical_findings"]),
+        "warning_findings": int(bucket["warning_findings"]),
+    }
+
+
+def _penalized_findings(findings: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        dict(finding)
+        for finding in findings
+        if finding.get("disposition", "defect") == "defect" and finding.get("severity") in {"critical", "warning"}
+        and not _finding_contested(finding)
+    ]
+
+
+def _reviewer_confirms(warn_finding: Mapping[str, Any], reviewer_findings: Sequence[Mapping[str, Any]]) -> bool:
+    for finding in reviewer_findings:
+        if finding.get("disposition", "defect") != "defect":
+            continue
+        if finding.get("excerpt") and finding.get("excerpt") == warn_finding.get("excerpt"):
+            return True
+        if (
+            finding.get("dimension") == warn_finding.get("dimension")
+            and finding.get("issue_class") == warn_finding.get("issue_class")
+        ):
+            return True
+    return False
+
+
+def _prompt_hash_for_target(target: ReportTarget) -> str | None:
+    texts = {}
+    for name in llm_qg_store.CONTENT_FILES:
+        path = target.module_dir / name
+        texts[name] = path.read_text(encoding="utf-8") if path.exists() else ""
+    prompt = llm_reviewer.build_reviewer_prompt(
+        level=target.level,
+        slug=target.slug,
+        module_md=texts.get("module.md", ""),
+        activities_yaml=texts.get("activities.yaml", ""),
+        vocabulary_yaml=texts.get("vocabulary.yaml", ""),
+        resources_yaml=texts.get("resources.yaml", ""),
+    )
+    return llm_qg_store.prompt_hash_for_text(prompt)
+
+
+def _composite_key(record: ReportRecord) -> tuple[Any, ...]:
+    return (
+        record.level,
+        record.slug,
+        record.content_sha,
+        record.gate_version,
+        record.prompt_hash,
+        record.checker_version,
+        record.level_policy_family,
+        record.reviewer_model,
+    )
+
+
+def _aggregate(record: Mapping[str, Any]) -> Mapping[str, Any]:
+    aggregate = record.get("aggregate")
+    return aggregate if isinstance(aggregate, Mapping) else {}
+
+
+def _tier(record: Mapping[str, Any], tier_number: int) -> dict[str, Any]:
+    workflow = record.get("qg_workflow")
+    tiers = workflow.get("tiers") if isinstance(workflow, Mapping) else []
+    if isinstance(tiers, list):
+        for tier in tiers:
+            if isinstance(tier, Mapping) and tier.get("tier") == tier_number:
+                return dict(tier)
+    return {}
+
+
+def _level_for_record(record: Mapping[str, Any]) -> str:
+    module_id = str(record.get("module_id") or "")
+    if "/" in module_id:
+        return module_id.split("/", 1)[0]
+    store = record.get("_store") if isinstance(record.get("_store"), Mapping) else {}
+    return str(store.get("level") or "unknown")
+
+
+def _policy_family_for_record(record: Mapping[str, Any]) -> str:
+    policy = record.get("level_policy")
+    if isinstance(policy, Mapping) and policy.get("family"):
+        return str(policy["family"])
+    return "unknown"
+
+
+def _reviewer_model_for_record(record: Mapping[str, Any]) -> str:
+    workflow = record.get("qg_workflow")
+    if isinstance(workflow, Mapping) and workflow.get("reviewer_model_id"):
+        return str(workflow["reviewer_model_id"])
+    store = record.get("_store") if isinstance(record.get("_store"), Mapping) else {}
+    return str(store.get("reviewer_model") or "unknown")
+
+
+def _axis_for_finding(finding: Mapping[str, Any], ua_gec_gold: Mapping[str, Any] | None = None) -> str:
+    issue_class = str(finding.get("issue_class") or "")
+    if issue_class in {"calque", "collocation", "false_friend"}:
+        return "calque"
+    if issue_class == "grammar":
+        return "grammar"
+    tag = str((ua_gec_gold or {}).get("gold_tag") or finding.get("ua_gec_tag") or "")
+    if tag.startswith("G/"):
+        return "grammar"
+    if tag.startswith("F/"):
+        return "calque"
+    return issue_class or "other"
+
+
+def _finding_contested(finding: Mapping[str, Any]) -> bool:
+    metadata = finding.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return False
+    gold = metadata.get("ua_gec_gold")
+    if isinstance(gold, Mapping) and (gold.get("contested_flag") or gold.get("contested")):
+        return True
+    qg_eval = metadata.get("qg_eval")
+    return isinstance(qg_eval, Mapping) and bool(qg_eval.get("contested"))
+
+
+def _ratio(numerator: float, denominator: float) -> float | None:
+    if not denominator:
+        return None
+    return round(float(numerator) / float(denominator), 4)
+
+
+def _round_or_none(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return round(float(value), 4)
+
+
+def _now_z() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def format_markdown(report: Mapping[str, Any]) -> str:
+    defect = report["defect_rates"]["overall"]
+    cache = report["cache"]
+    completion = report["completion"]
+    calque = report["gold_metrics"]["calque"]
+    lines = [
+        "# QG Corpus Report",
+        "",
+        f"- Schema: `{report['schema_version']}`",
+        f"- Latest composite records: {report['selection']['latest_composite_records']}",
+        f"- Raw DB rows: {report['selection']['raw_db_rows']}",
+        f"- Cache: hit {cache['hit']} / stale {cache['stale']} / miss {cache['miss']}",
+        f"- Overall defect rate: {_pct(defect['defect_rate'])}",
+        f"- Incomplete: {completion['incomplete']}",
+        f"- Provider errors: {completion['provider_error']}",
+        f"- Parse/schema failures: {completion['parse_failure']}",
+        f"- Calque precision with contested: {_pct(calque['with_contested']['precision'])}",
+        f"- Calque precision without contested: {_pct(calque['without_contested']['precision'])}",
+    ]
+    return "\n".join(lines)
+
+
+def format_backfill_markdown(backfill: Mapping[str, Any]) -> str:
+    counts = backfill.get("counts") if isinstance(backfill.get("counts"), Mapping) else {}
+    lines = [
+        "# QG Corpus Backfill",
+        "",
+        f"- Schema: `{backfill.get('schema_version')}`",
+        f"- Dry run: {backfill.get('dry_run')}",
+        f"- DB: `{backfill.get('db')}`",
+    ]
+    for key, value in sorted(counts.items()):
+        lines.append(f"- {key}: {value}")
+    return "\n".join(lines)
+
+
+def _pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value * 100:.1f}%"
+
+
+def _parse_target(raw: str) -> ReportTarget:
+    parts = raw.split(":", 2)
+    if len(parts) != 3:
+        raise ValueError("--target must be level:slug:module_dir")
+    return ReportTarget(level=parts[0].strip().lower(), slug=parts[1].strip(), module_dir=Path(parts[2]))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, help="Optional LLM-QG SQLite path.")
+    parser.add_argument("--curriculum-root", type=Path, help="Discover module targets under this root.")
+    parser.add_argument("--target", action="append", default=[], help="Repeatable level:slug:module_dir target.")
+    parser.add_argument("--workflow-json", action="append", type=Path, default=[], help="Stored qg_workflow JSON output.")
+    parser.add_argument("--backfill-from", action="append", type=Path, default=[], help="Workflow JSON to backfill into DB.")
+    parser.add_argument("--apply-backfill", action="store_true", help="Insert missing/stale backfill records.")
+    parser.add_argument("--gate-version", default=qg_workflow.DEFAULT_GATE_VERSION)
+    parser.add_argument("--checker-version", default=CHECKER_VERSION)
+    parser.add_argument("--reviewer-model-id", default=qg_workflow.DEFAULT_REVIEWER_MODEL_ID)
+    parser.add_argument("--format", choices=("json", "markdown"), default="json")
+    parser.add_argument("--output", type=Path, help="Optional output path.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        targets = [_parse_target(raw) for raw in args.target]
+        if args.curriculum_root:
+            targets.extend(discover_targets(args.curriculum_root))
+        workflow_payloads = [load_workflow_json(path) for path in args.workflow_json]
+        if args.backfill_from:
+            payloads = [load_workflow_json(path) for path in args.backfill_from]
+            output: Mapping[str, Any] = backfill_from_workflow_records(
+                payloads,
+                db_path=args.db,
+                dry_run=not args.apply_backfill,
+            )
+        else:
+            output = build_report(
+                db_path=args.db,
+                targets=targets,
+                workflow_payloads=workflow_payloads,
+                gate_version=args.gate_version,
+                checker_version=args.checker_version,
+                reviewer_model_id=args.reviewer_model_id,
+            )
+        if args.format == "json":
+            text = json.dumps(output, ensure_ascii=False, indent=2, sort_keys=True)
+        elif output.get("schema_version") == "qg_corpus_backfill.v1":
+            text = format_backfill_markdown(output)
+        else:
+            text = format_markdown(output)
+        if args.output:
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_text(text + "\n", encoding="utf-8")
+        else:
+            print(text)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/audit/test_qg_corpus_report.py
+++ b/tests/audit/test_qg_corpus_report.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from scripts.audit import llm_qg_store, qg_corpus_report, qg_schema, qg_workflow
+from scripts.audit.content_surface_gates import policy_for_level
+from scripts.audit.curriculum_qg_harness import CHECKER_VERSION
+
+
+def _module(tmp_path: Path, *, level: str = "b1", slug: str = "sample", body: str | None = None) -> Path:
+    module_dir = tmp_path / level / slug
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text(
+        body or "# Модуль\n\nУчні читають український текст і виконують завдання.\n",
+        encoding="utf-8",
+    )
+    (module_dir / "activities.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "resources.yaml").write_text("[]\n", encoding="utf-8")
+    return module_dir
+
+
+def _target(module_dir: Path, *, level: str = "b1", slug: str | None = None) -> qg_corpus_report.ReportTarget:
+    return qg_corpus_report.ReportTarget(level=level, slug=slug or module_dir.name, module_dir=module_dir)
+
+
+def _finding(
+    *,
+    issue_id: str = "TEST_CALQUE",
+    issue_class: str = "calque",
+    dimension: str = "contact_calque",
+    severity: str = "warning",
+    confidence: str = "llm_judgment",
+    disposition: str = "defect",
+    excerpt: str = "тестовий фрагмент",
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return qg_schema.build_finding(
+        issue_id=issue_id,
+        issue_class=issue_class,
+        dimension=dimension,
+        severity=severity,
+        file="module.md",
+        line=1,
+        span={"start": 0, "end": len(excerpt)},
+        excerpt=excerpt,
+        message="Test finding.",
+        contact_source_lang="ru",
+        confidence=confidence,
+        disposition=disposition,
+        detector={"adapter": "test", "rule_id": issue_id},
+        attribution={"corpus": "test", "evidence": "unit test"},
+        metadata=metadata,
+    )
+
+
+def _payload(*findings: dict[str, Any]) -> dict[str, Any]:
+    return qg_workflow._payload_from_findings(list(findings))
+
+
+def _record(
+    db_path: Path,
+    module_dir: Path,
+    *,
+    gate_version: str = "gate.v1",
+    reviewer_model: str = "model-a",
+    payload: dict[str, Any] | None = None,
+) -> llm_qg_store.StoredQG:
+    target = _target(module_dir)
+    return llm_qg_store.record_llm_qg(
+        level=target.level,
+        slug=target.slug,
+        module_dir=module_dir,
+        payload=payload or _payload(),
+        gate_version=gate_version,
+        prompt_hash=qg_corpus_report._prompt_hash_for_target(target),
+        checker_version=CHECKER_VERSION,
+        level_policy_family=policy_for_level(target.level).family,
+        reviewer_model=reviewer_model,
+        reviewer_family="test-family",
+        source="test",
+        path=db_path,
+    )
+
+
+def _set_created_at(db_path: Path, run_id: str, created_at: str) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE llm_qg_runs SET created_at = ? WHERE run_id = ?", (created_at, run_id))
+        conn.commit()
+
+
+def test_report_uses_latest_composite_row_and_cache_statuses(tmp_path: Path) -> None:
+    db_path = tmp_path / "qg.db"
+    hit = _module(tmp_path, slug="hit")
+    stale = _module(tmp_path, slug="stale")
+    miss = _module(tmp_path, slug="miss")
+
+    old = _record(db_path, hit, payload=_payload(_finding(excerpt="старий дефект")))
+    new = _record(db_path, hit, payload=_payload())
+    stale_record = _record(db_path, stale, payload=_payload())
+    _set_created_at(db_path, old.run_id, "2026-01-01T00:00:00Z")
+    _set_created_at(db_path, new.run_id, "2026-01-02T00:00:00Z")
+    _set_created_at(db_path, stale_record.run_id, "2026-01-03T00:00:00Z")
+    (stale / "module.md").write_text("# Модуль\n\nОновлений текст.\n", encoding="utf-8")
+
+    report = qg_corpus_report.build_report(
+        db_path=db_path,
+        targets=[_target(hit), _target(stale), _target(miss)],
+        gate_version="gate.v1",
+        checker_version=CHECKER_VERSION,
+        reviewer_model_id="model-a",
+    )
+
+    assert report["selection"]["raw_db_rows"] == 3
+    assert report["selection"]["latest_composite_records"] == 2
+    assert report["cache"]["hit"] == 1
+    assert report["cache"]["stale"] == 1
+    assert report["cache"]["miss"] == 1
+    assert report["defect_rates"]["overall"]["records_with_defects"] == 0
+
+
+def test_contested_gold_delta_and_per_model_calque_f1(tmp_path: Path) -> None:
+    db_path = tmp_path / "qg.db"
+    module_dir = _module(tmp_path)
+    calque_tp = _finding(
+        issue_id="CALQUE_TP",
+        metadata={"qg_eval": {"axis": "calque", "gold_label": True, "predicted": True, "matched": True}},
+    )
+    contested_fp = _finding(
+        issue_id="CALQUE_FP_CONTESTED",
+        metadata={
+            "qg_eval": {"axis": "calque", "gold_label": False, "predicted": True, "matched": False, "contested": True},
+            "ua_gec_gold": {"contested_flag": True, "gold_tag": "F/Calque"},
+        },
+    )
+    grammar_tp = _finding(
+        issue_id="GRAMMAR_TP",
+        issue_class="grammar",
+        dimension="contact_grammar",
+        metadata={"qg_eval": {"axis": "grammar", "gold_label": True, "predicted": True, "matched": True}},
+    )
+    grammar_fn = _finding(
+        issue_id="GRAMMAR_FN",
+        issue_class="grammar",
+        dimension="contact_grammar",
+        disposition="suppressed_fp",
+        metadata={"qg_eval": {"axis": "grammar", "gold_label": True, "predicted": False, "matched": False}},
+    )
+    _record(db_path, module_dir, payload=_payload(calque_tp, contested_fp, grammar_tp, grammar_fn))
+
+    report = qg_corpus_report.build_report(db_path=db_path)
+
+    calque = report["gold_metrics"]["calque"]
+    assert calque["with_contested"]["precision"] == 0.5
+    assert calque["without_contested"]["precision"] == 1.0
+    assert calque["contested_delta"]["precision"] == -0.5
+    assert report["gold_metrics"]["grammar"]["with_contested"]["recall"] == 0.5
+    assert report["gold_metrics"]["per_model_calque_f1"]["model-a"]["without_contested"]["f1"] == 1.0
+
+
+def test_workflow_records_count_failures_spend_and_warn_conversion(tmp_path: Path) -> None:
+    module_dir = _module(tmp_path, slug="warn")
+    deterministic_warn = _finding(confidence="deterministic", excerpt="спільний фрагмент")
+    reviewer_confirm = _finding(confidence="llm_judgment", excerpt="спільний фрагмент")
+    pass_record = _workflow_record(
+        module_dir,
+        slug="warn",
+        findings=[deterministic_warn, reviewer_confirm],
+        tier2_status="ran",
+        terminal_verdict="PASS",
+        workflow_verdict="WARN",
+        completion_status="COMPLETE",
+        estimated_cost=0.2,
+        observed_cost=0.4,
+    )
+    provider_record = _workflow_record(
+        _module(tmp_path, slug="provider"),
+        slug="provider",
+        tier2_status="provider_error",
+        terminal_verdict="FAIL",
+        workflow_verdict="PROVIDER_FAILURE",
+        completion_status="INCOMPLETE",
+        estimated_cost=0.1,
+        observed_cost=0.1,
+    )
+    parse_record = _workflow_record(
+        _module(tmp_path, slug="parse"),
+        slug="parse",
+        tier2_status="parse_failure",
+        terminal_verdict="FAIL",
+        workflow_verdict="PARSE_FAILURE",
+        completion_status="INCOMPLETE",
+    )
+
+    report = qg_corpus_report.build_report(workflow_payloads=[[pass_record, provider_record, parse_record]])
+
+    assert report["warn_to_reviewer_confirmed"]["warn_findings"] == 1
+    assert report["warn_to_reviewer_confirmed"]["reviewer_confirmed"] == 1
+    assert report["completion"]["provider_error"] == 1
+    assert report["completion"]["parse_failure"] == 1
+    assert report["completion"]["incomplete"] == 2
+    assert report["spend"]["accepted_evidence"] == 1
+    assert report["spend"]["observed_cost_usd"] == 0.5
+    assert report["spend"]["spend_per_accepted_evidence_usd"] == 0.5
+
+
+def test_backfill_inserts_missing_or_stale_but_skips_current(tmp_path: Path) -> None:
+    db_path = tmp_path / "qg.db"
+    first = _module(tmp_path, slug="first")
+    second = _module(tmp_path, slug="second")
+    first_record = _workflow_record(first, slug="first", terminal_verdict="PASS")
+    second_record = _workflow_record(second, slug="second", terminal_verdict="PASS")
+
+    first_result = qg_corpus_report.backfill_from_workflow_records([first_record], db_path=db_path, dry_run=False)
+    second_result = qg_corpus_report.backfill_from_workflow_records([first_record], db_path=db_path, dry_run=False)
+    _record(db_path, second, gate_version="old.gate", payload=_payload())
+    stale_result = qg_corpus_report.backfill_from_workflow_records([second_record], db_path=db_path, dry_run=False)
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute("SELECT count(*) FROM llm_qg_runs").fetchone()[0]
+
+    assert first_result["counts"] == {"inserted": 1}
+    assert second_result["counts"] == {"current": 1}
+    assert stale_result["counts"] == {"inserted": 1}
+    assert rows == 3
+
+
+def _workflow_record(
+    module_dir: Path,
+    *,
+    slug: str,
+    findings: list[dict[str, Any]] | None = None,
+    tier2_status: str = "ran",
+    terminal_verdict: str = "PASS",
+    workflow_verdict: str = "PASS",
+    completion_status: str = "COMPLETE",
+    estimated_cost: float | None = None,
+    observed_cost: float | None = None,
+) -> dict[str, Any]:
+    target = _target(module_dir, slug=slug)
+    payload = _payload(*(findings or []))
+    tier2: dict[str, Any] = {
+        "tier": 2,
+        "status": tier2_status,
+        "reviewer_model_id": "model-a",
+        "reviewer_family": "test-family",
+    }
+    if estimated_cost is not None:
+        tier2["estimate"] = {"estimated_cost_usd": estimated_cost}
+    if observed_cost is not None:
+        tier2["dispatch"] = {"observed_cost_usd": observed_cost}
+    return {
+        "schema_version": qg_schema.SCHEMA_VERSION,
+        "module_id": f"b1/{slug}",
+        "content_sha": llm_qg_store.content_sha_for_module(module_dir),
+        "level_policy": {"family": policy_for_level("b1").family},
+        "aggregate": {
+            **payload["aggregate"],
+            "completion_status": completion_status,
+            "workflow_verdict": workflow_verdict,
+        },
+        "dimensions": payload["dimensions"],
+        "findings": payload["findings"],
+        "terminal_verdict": terminal_verdict,
+        "workflow_verdict": workflow_verdict,
+        "completion_status": completion_status,
+        "provenance": {"module_dir": str(module_dir), "run_id": f"workflow-{slug}"},
+        "qg_workflow": {
+            "gate_version": "gate.v1",
+            "prompt_hash": qg_corpus_report._prompt_hash_for_target(target),
+            "checker_version": CHECKER_VERSION,
+            "reviewer_model_id": "model-a",
+            "reviewer_family": "test-family",
+            "tiers": [tier2],
+        },
+    }

--- a/tests/audit/test_qg_corpus_report.py
+++ b/tests/audit/test_qg_corpus_report.py
@@ -194,7 +194,10 @@ def test_workflow_records_count_failures_spend_and_warn_conversion(tmp_path: Pat
         completion_status="INCOMPLETE",
     )
 
-    report = qg_corpus_report.build_report(workflow_payloads=[[pass_record, provider_record, parse_record]])
+    report = qg_corpus_report.build_report(
+        workflow_payloads=[[pass_record, provider_record, parse_record]],
+        db_path=tmp_path / "empty.db",
+    )
 
     assert report["warn_to_reviewer_confirmed"]["warn_findings"] == 1
     assert report["warn_to_reviewer_confirmed"]["reviewer_confirmed"] == 1

--- a/tests/test_llm_reviewer_dispatch.py
+++ b/tests/test_llm_reviewer_dispatch.py
@@ -92,7 +92,12 @@ def test_deepseek_routes_are_excluded() -> None:
         output_usd_per_mtok=0.0,
     )
 
-    with pytest.raises(llm_reviewer_dispatch.ReviewerRouteError):
+    llm_reviewer_dispatch.assert_route_allowed(llm_reviewer_dispatch.GEMMA_SURFACE_ROUTE)
+
+    with pytest.raises(
+        llm_reviewer_dispatch.ReviewerRouteError,
+        match="DeepSeek/Hermes reviewer routes are forbidden",
+    ):
         llm_reviewer_dispatch.assert_route_allowed(bad_route)
     hermes_route = llm_reviewer_dispatch.ReviewerRoute(
         route_name="hermes_bad",
@@ -104,7 +109,10 @@ def test_deepseek_routes_are_excluded() -> None:
         output_usd_per_mtok=0.0,
     )
 
-    with pytest.raises(llm_reviewer_dispatch.ReviewerRouteError):
+    with pytest.raises(
+        llm_reviewer_dispatch.ReviewerRouteError,
+        match="DeepSeek/Hermes reviewer routes are forbidden",
+    ):
         llm_reviewer_dispatch.assert_route_allowed(hermes_route)
     assert all("deepseek" not in route.reviewer_model_id for route in llm_reviewer_dispatch.ROUTES)
 


### PR DESCRIPTION
Refs #4311
Refs #2156
Refs #4364
Refs #4312

## Summary

- Add `scripts/audit/qg_corpus_report.py` for corpus-scale QG aggregates over stored DB/workflow evidence only.
- Dedupe DB evidence by the latest full composite identity instead of row count, and add a backfill helper that inserts only missing/stale records.
- Report contested-gold calque metrics with and without contested rows, plus delta and per-model calque F1.
- Reword the reviewer-route hard-ban so OpenRouter is not over-banned when the route is not DeepSeek/Hermes.
- Document the report and UNLP aggregate schema contract.

## Changed Files

```text
$ git diff --name-only origin/main..HEAD
docs/projects/ua-eval-harness/corpus-report.md
docs/projects/ua-eval-harness/cost-aware-qg-workflow.md
scripts/audit/llm_reviewer_dispatch.py
scripts/audit/qg_corpus_report.py
tests/audit/test_qg_corpus_report.py
tests/test_llm_reviewer_dispatch.py
```

```text
$ git diff --name-only origin/main..HEAD | wc -l
6
```

```text
$ if git diff --name-only origin/main..HEAD | rg '(^\.python-version$|^\.yamllint$|^\.markdownlint\.json$|(^|/)status/.*\.json$|(^|/)audit/.*-review\.md$|(^|/)review/.*-review\.md$|^data/telemetry/)'; then exit 1; else printf 'no forbidden paths in origin/main..HEAD\n'; fi
no forbidden paths in origin/main..HEAD
```

```text
$ if rg -n 'sys\.executable' docs/projects/ua-eval-harness/corpus-report.md docs/projects/ua-eval-harness/cost-aware-qg-workflow.md scripts/audit/llm_reviewer_dispatch.py scripts/audit/qg_corpus_report.py tests/audit/test_qg_corpus_report.py tests/test_llm_reviewer_dispatch.py; then exit 1; else printf 'no sys.executable in changed files\n'; fi
no sys.executable in changed files
```

## Verification

Scoped pytest:

```text
$ .venv/bin/python -m pytest tests/audit/test_qg_corpus_report.py tests/test_llm_reviewer_dispatch.py -q
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4311b-corpus-report
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 14 items

tests/audit/test_qg_corpus_report.py ....                                [ 28%]
tests/test_llm_reviewer_dispatch.py ..........                           [100%]

============================== 14 passed in 0.53s ==============================
```

Scoped Ruff:

```text
$ .venv/bin/ruff check scripts/audit/qg_corpus_report.py scripts/audit/llm_reviewer_dispatch.py tests/audit/test_qg_corpus_report.py tests/test_llm_reviewer_dispatch.py
All checks passed!
```

Committed diff whitespace check:

```text
$ git diff origin/main..HEAD --check; status=$?; printf 'exit:%s\n' "$status"; exit "$status"
exit:0
```

Commit trailer lint:

```text
$ .venv/bin/python scripts/audit/lint_agent_trailer.py origin/main..HEAD
Checking 1 commit(s) in origin/main..HEAD:

  fa053a5ba9  PASS  X-Agent: codex/4311b-corpus-report

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

Full pytest was also run. It fails in existing repo-wide areas outside the changed files listed above:

```text
$ .venv/bin/python -m pytest
=================================== FAILURES ===================================
________________ test_registry_covers_all_external_source_files ________________
tests/test_channels_registry.py:26: in test_registry_covers_all_external_source_files
    assert set(channels) == source_files
E   AssertionError: assert {'imtgsh', 'i...istoria', ...} == set()
_ test_published_citations_resolve_invariant[wiki/grammar/b2/register-public-discourse.md] _
tests/test_citation_resolution_invariant.py:299: in test_published_citations_resolve_invariant
    assert not issues, f"{rel_path} has unresolved citations: {issues}"
E   AssertionError: wiki/grammar/b2/register-public-discourse.md has unresolved citations: ['unresolved registry entry S10 -> external https://www.president.gov.ua/ua/documents/constitution/konstituciya-ukrayini-rozdil-i']
________________ test_search_esum_berkut_returns_turkic_origin _________________
tests/test_esum_search.py:114: in test_search_esum_berkut_returns_turkic_origin
    assert [hit["lemma"] for hit in hits] == ["беркут"]
E   AssertionError: assert [] == ['беркут']
_ TestDiasporianaJsonlSchema.test_chunk_schema_matches_existing_litopys_waves __
tests/test_scrape_diasporiana.py:207: in test_chunk_schema_matches_existing_litopys_waves
    with fixture_path.open(encoding="utf-8") as handle:
E   FileNotFoundError: [Errno 2] No such file or directory: '/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4311b-corpus-report/data/literary_texts/wave12-krupnytsky-orlyk-biohrafiia.jsonl'
______________ test_registry_schema_covers_all_live_source_files _______________
tests/test_wiki_channels.py:20: in test_registry_schema_covers_all_live_source_files
    assert set(channels) == source_files
E   AssertionError: assert {'imtgsh', 'i...istoria', ...} == set()
___________ test_a1_letter_module_writer_prompt_stays_under_ceiling ____________
tests/test_writer_prompt_render_size.py:41: in test_a1_letter_module_writer_prompt_stays_under_ceiling
    assert len(prompt.encode("utf-8")) <= WRITER_PROMPT_CEILING_BYTES
E   assert 133515 <= 133120
________ test_mlx_fault_injection_halves_batch_and_preserves_row_order _________
tests/wiki/test_mlx_fault_injection.py:131: in test_mlx_fault_injection_halves_batch_and_preserves_row_order
    vectors = bridge.encode(texts, batch_size=16, max_length=512)
scripts/wiki/mlx_bridge.py:143: in _start_worker
    raise FileNotFoundError(f"embed worker python not found at {self._worker_python}")
E   FileNotFoundError: embed worker python not found at /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4311b-corpus-report/embed-venv/bin/python
=========================== short test summary info ============================
FAILED tests/test_channels_registry.py::test_registry_covers_all_external_source_files
FAILED tests/test_citation_resolution_invariant.py::test_published_citations_resolve_invariant[wiki/grammar/b2/register-public-discourse.md]
FAILED tests/test_esum_search.py::test_search_esum_berkut_returns_turkic_origin
FAILED tests/test_scrape_diasporiana.py::TestDiasporianaJsonlSchema::test_chunk_schema_matches_existing_litopys_waves
FAILED tests/test_wiki_channels.py::test_registry_schema_covers_all_live_source_files
FAILED tests/test_writer_prompt_render_size.py::test_a1_letter_module_writer_prompt_stays_under_ceiling
FAILED tests/wiki/test_mlx_fault_injection.py::test_mlx_fault_injection_halves_batch_and_preserves_row_order
= 7 failed, 9549 passed, 131 skipped, 11 xfailed, 3 warnings in 470.38s (0:07:50) =
```

Full Ruff was also run. It fails in existing repo-wide files outside the changed files listed above:

```text
$ .venv/bin/ruff check . --output-format concise
docs/reports/check_b2_plans.py:50:38: E701 Multiple statements on one line (colon)
docs/reports/check_b2_plans.py:51:33: E701 Multiple statements on one line (colon)
docs/reports/check_b2_plans.py:52:40: E701 Multiple statements on one line (colon)
docs/reports/check_b2_plans.py:53:37: E701 Multiple statements on one line (colon)
docs/reports/fix_mdx_frontmatter.py:6:27: SIM115 Use a context manager for opening files
docs/reports/fix_mdx_frontmatter.py:12:27: E701 Multiple statements on one line (colon)
docs/reports/fix_mdx_frontmatter.py:22:17: E722 Do not use bare `except`
docs/reports/inject_phases.py:49:17: E722 Do not use bare `except`
docs/reports/inject_upper_phases.py:40:36: E701 Multiple statements on one line (colon)
docs/reports/inject_upper_phases.py:42:35: E701 Multiple statements on one line (colon)
docs/reports/inject_upper_phases.py:49:17: E722 Do not use bare `except`
docs/reports/inject_upper_phases.py:73:5: SIM102 Use a single `if` statement instead of nested `if` statements
docs/reports/inject_upper_phases.py:90:21: E722 Do not use bare `except`
plans/fix_a2_final_exam.py:89:9: SIM102 Use a single `if` statement instead of nested `if` statements
plans/fix_a2_final_exam_2.py:29:5: SIM102 Use a single `if` statement instead of nested `if` statements
plans/fix_b1_37_part2.py:16:448: W291 Trailing whitespace
plans/fix_b2_36.py:5:9: F841 Local variable `text` is assigned to but never used
plans/fix_b2_36.py:25:581: W291 Trailing whitespace
plans/fix_b2_36.py:27:501: W291 Trailing whitespace
plans/fix_b2_36.py:36:336: W291 Trailing whitespace
plans/fix_b2_36.py:68:292: W291 Trailing whitespace
plans/fix_b2_36.py:85:312: W291 Trailing whitespace
plans/fix_b2_36.py:143:113: W291 Trailing whitespace
plans/fix_b2_36.py:183:48: W291 Trailing whitespace
plans/fix_b2_36.py:286:177: W291 Trailing whitespace
plans/fix_b2_36_c.py:14:585: W291 Trailing whitespace
plans/fix_m68.py:23:242: W291 Trailing whitespace
plans/patch_yaml.py:9:13: B007 Loop control variable `i` not used within loop body
Found 28 errors.
No fixes available (15 hidden fixes can be enabled with the `--unsafe-fixes` option).
```
