### PR TITLE
data(atlas): review-approve teacher-lesson vocab rows 219-238 (17 headwords)

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-05-twelfth-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-05-twelfth-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,235 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-twelfth-approved-teacher-lesson-ledger-batch-2026-07-05
+batch_label: twelfth-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-05'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  total_queue_rows: 238
+  approved_in_queue: 17
+  promotion_batch_size: 17
+production_outputs_updated: []
+decisions:
+- lemma: державний
+  decision: approve_for_publish
+  approved_pos: adj
+  approved_gloss: "governmental"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 0b62d38764966e9a
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 219
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: видаляти
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: "to remove (imperfective)"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 83cbbd32ff1f7c39
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 220
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: видалити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: "to remove (perfective)"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 0ed2ed598c7b686e
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 221
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: запобігати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: "to prevent (imperfective)"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: eb4411e703a5ae3f
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 223
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: запобігти
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: "to prevent (perfective)"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 8bd54837ebc8bbb9
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 224
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: вигорання
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: "burnout"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 48550fe555582e5a
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 225
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: насипати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: "to pour in, to add dry goods (e.g. onto a plate); imperfective насипати and perfective насипати are homographs distinguished by stress"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 771678f53ddc3d2a
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table rows 226-227
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: зволожувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: "to moisturise (imperfective)"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 7026574a1fbac4a9
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 228
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: зволожити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: "to moisturise (perfective)"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 9bee6bba04f426a8
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 229
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: клеїти
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: "to glue, to stick (imperfective)"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 4e7e20af73ecc262
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 230
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: приклеїти
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: "to glue on, to stick on (perfective)"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d7ce8ecbccd7f059
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 231
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: ділянка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: "area, plot, land, site"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 07e58ecee19232f1
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 232
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: надувний
+  decision: approve_for_publish
+  approved_pos: adj
+  approved_gloss: "inflatable"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a242e4d306775790
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 234
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: розвідка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: "intelligence, reconnaissance"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 95752fd345527312
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 235
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: склад
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: "content, warehouse"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 4af985cf314e667b
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 236
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: зависати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: "to freeze (computer/phone), to hang, to lag (imperfective)"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 414adc7d82f309a4
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 237
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: зависнути
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: "to freeze (computer/phone), to hang, to lag (perfective)"
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 5b7eb9e1622e29ea
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+    locator: explicit vocabulary table row 238
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table

--- a/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
+++ b/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml
@@ -1,0 +1,100 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: private-teacher-lesson-vocabulary-table-1-rows-219-238
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Private teacher lesson vocabulary - explicit table rows 219-238
+    locator: local-only explicit vocabulary table rows 219-238
+    notes: >-
+      Derived headword metadata only; raw private lesson material is local-only
+      and not committed. Daily Word, Practice, and cloze remain frozen without
+      explicit surface_admission. Rows 222 and 233 are multi-word idiom/collocation
+      entries deferred pending a collocation intake convention.
+    headwords:
+      - lemma: державний
+        pos: adj
+        gloss: "governmental"
+        locator: explicit vocabulary table row 219
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: видаляти
+        pos: verb
+        gloss: "to remove (imperfective)"
+        locator: explicit vocabulary table row 220
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: видалити
+        pos: verb
+        gloss: "to remove (perfective)"
+        locator: explicit vocabulary table row 221
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: запобігати
+        pos: verb
+        gloss: "to prevent (imperfective)"
+        locator: explicit vocabulary table row 223
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: запобігти
+        pos: verb
+        gloss: "to prevent (perfective)"
+        locator: explicit vocabulary table row 224
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вигорання
+        pos: noun
+        gloss: "burnout"
+        locator: explicit vocabulary table row 225
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: насипати
+        pos: verb
+        gloss: "to pour in, to add dry goods (e.g. onto a plate); imperfective насипати and perfective насипати are homographs distinguished by stress"
+        locator: explicit vocabulary table rows 226-227
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: зволожувати
+        pos: verb
+        gloss: "to moisturise (imperfective)"
+        locator: explicit vocabulary table row 228
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: зволожити
+        pos: verb
+        gloss: "to moisturise (perfective)"
+        locator: explicit vocabulary table row 229
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: клеїти
+        pos: verb
+        gloss: "to glue, to stick (imperfective)"
+        locator: explicit vocabulary table row 230
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: приклеїти
+        pos: verb
+        gloss: "to glue on, to stick on (perfective)"
+        locator: explicit vocabulary table row 231
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: ділянка
+        pos: noun
+        gloss: "area, plot, land, site"
+        locator: explicit vocabulary table row 232
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: надувний
+        pos: adj
+        gloss: "inflatable"
+        locator: explicit vocabulary table row 234
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: розвідка
+        pos: noun
+        gloss: "intelligence, reconnaissance"
+        locator: explicit vocabulary table row 235
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: склад
+        pos: noun
+        gloss: "content, warehouse"
+        locator: explicit vocabulary table row 236
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: зависати
+        pos: verb
+        gloss: "to freeze (computer/phone), to hang, to lag (imperfective)"
+        locator: explicit vocabulary table row 237
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: зависнути
+        pos: verb
+        gloss: "to freeze (computer/phone), to hang, to lag (perfective)"
+        locator: explicit vocabulary table row 238
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -29,6 +29,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-159-178.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )


### PR DESCRIPTION
## Word Atlas #4160/#4220 — teacher-lesson intake, table rows 219-238 (review-only)

Continues the private teacher-lesson source-inventory lane (rows 1-218 already shipped; ledgers 1-11).
**Review-only:** adds the committed source-inventory + the twelfth approved review-decision ledger. **No**
live Atlas manifest/search/browse change and **no** Daily/Practice/cloze admission (those stay frozen —
published separately).

### What's in the batch
17 approved headwords from the explicit vocabulary table rows 219-238 (e.g. `державний` governmental,
`вигорання` burnout, `розвідка` intelligence, `надувний` inflatable, `зависати/зависнути` to freeze).
- Rows **222** (`повісити носа`) and **233** (`сліпа зона`) deferred — multi-word idiom/collocation entries;
  no phrase precedent in committed rows 1-218, so held pending a collocation intake convention (not invented here).
- Rows **226/227** (`насипати` imperf/perf) merged into one entry — homographs distinguished only by stress
  (the Atlas keys stress-stripped).

### Review (tool-backed, not asserted)
- **VESUM: 21/21 valid**; **`check_russian_shadow`: 0.0 / not-russian on every lemma** → no russianisms.
- Review-candidate generator classes all 17 as `auto_merge` (valid, not already in Atlas, clean).
- Ledger passes `scripts.audit.source_inventory_review_decisions`; aggregate **18 files / 399 rows** valid
  (397 approve + 2 pre-existing reject). `ruff` clean. Teacher-lesson tests **44 pass**.
- Note: `test_review_workflow_rejects_live_atlas_outputs` is green on a normal checkout (8/8); it only trips
  locally because the review worktree symlinks the manifest outside the tree — not affected by this diff.

### Files
- `data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml` (new)
- `data/lexicon/source-inventory-review-decisions/2026-07-05-twelfth-approved-teacher-lesson-ledger-batch.yaml` (new)
- `scripts/audit/generate_source_inventory_review_candidates.py` (register the new inventory)

Privacy: only normalized headword + POS + English gloss + neutral locator; no raw lesson text, paths, or tab names.
