### PR TITLE
fix(atlas): harden entry-model DB — enum CHECKs, private metaterms, timestamp split (#4378)

### DIFF
--- a/scripts/atlas/atlas_db.py
+++ b/scripts/atlas/atlas_db.py
@@ -56,17 +56,32 @@ ENRICHMENT_SECTIONS = {
     "calque_note",
 }
 
-SCHEMA = """
+REVIEW_STATES = {"approved", "needs_review", "rejected"}
+VISIBILITIES = {"public", "private"}
+ENRICHMENT_PHASES = {"migration", "local", "slovnyk", "uncovered"}
+
+
+def _sql_enum(values: set[str]) -> str:
+    """Render a Python enum set as a deterministic SQL IN-list."""
+    return ", ".join(f"'{v}'" for v in sorted(values))
+
+
+# CHECK constraints are generated from the Python enum sets above so the
+# entry-model gates are load-bearing at the STORAGE layer: a Phase-1/2 filler
+# bug cannot silently insert an invalid entry_type/kind/section — the DB
+# rejects it. The DB is rebuilt by migrate_manifest, so schema evolution is a
+# code change, never an in-place migration.
+SCHEMA = f"""
 PRAGMA journal_mode = WAL;
 CREATE TABLE IF NOT EXISTS articles (
     slug TEXT PRIMARY KEY,
     display_head TEXT NOT NULL,
     lemma TEXT NOT NULL,
-    entry_type TEXT NOT NULL,
+    entry_type TEXT NOT NULL CHECK (entry_type IN ({_sql_enum(ARTICLE_ENTRY_TYPES)})),
     pos TEXT,
     gloss TEXT,
-    review_state TEXT NOT NULL,
-    visibility TEXT NOT NULL,
+    review_state TEXT NOT NULL CHECK (review_state IN ({_sql_enum(REVIEW_STATES)})),
+    visibility TEXT NOT NULL CHECK (visibility IN ({_sql_enum(VISIBILITIES)})),
     cefr TEXT,
     heritage_classification TEXT,
     created_at TEXT,
@@ -81,7 +96,7 @@ CREATE TABLE IF NOT EXISTS article_provenance (
 );
 CREATE TABLE IF NOT EXISTS aliases (
     alias TEXT NOT NULL,
-    kind TEXT NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN ({_sql_enum(ALIAS_KINDS)})),
     source TEXT,
     target_slug TEXT NOT NULL,
     UNIQUE (alias, kind, target_slug)
@@ -96,11 +111,11 @@ CREATE TABLE IF NOT EXISTS related_entries (
 );
 CREATE TABLE IF NOT EXISTS enrichment (
     slug TEXT NOT NULL,
-    section TEXT NOT NULL,
+    section TEXT NOT NULL CHECK (section IN ({_sql_enum(ENRICHMENT_SECTIONS)})),
     payload_json TEXT NOT NULL,
     source TEXT,
     filled_at TEXT,
-    phase TEXT,
+    phase TEXT CHECK (phase IS NULL OR phase IN ({_sql_enum(ENRICHMENT_PHASES)})),
     UNIQUE (slug, section),
     FOREIGN KEY (slug) REFERENCES articles(slug)
 );
@@ -181,6 +196,7 @@ def migrate_manifest(manifest_path: Path, db_path: Path) -> dict[str, int]:
         slug = str(e.get("url_slug") or lemma).strip()
         if not lemma or not slug:
             continue
+        display_head = str(e.get("display_head") or lemma).strip()
 
         # form_of records -> alias rows, not articles (only if target is a real article)
         form_of = e.get("form_of")
@@ -205,13 +221,20 @@ def migrate_manifest(manifest_path: Path, db_path: Path) -> dict[str, int]:
         if isinstance(enrichment.get("cefr"), dict):
             cefr_val = enrichment["cefr"].get("level")
 
+        # Grammar metaterms (pluralia tantum, знахідний відмінок, …) are reference
+        # data, not learner-facing dictionary articles — #3776's lexeme_filter
+        # excludes them at every manifest consumer. Encode that decision at the
+        # SSOT layer so DB-driven site generation cannot resurrect them as
+        # public articles.
+        visibility = "private" if e.get("pos") == "grammar term" else "public"
         cur.execute(
             """INSERT OR REPLACE INTO articles
                (slug, display_head, lemma, entry_type, pos, gloss, review_state,
                 visibility, cefr, heritage_classification, created_at, updated_at)
                VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
-            (slug, lemma, lemma, etype, e.get("pos"), e.get("gloss"),
-             "approved", "public", cefr_val, heritage_cls, _iso(e), _iso(e)),
+            (slug, display_head, lemma, etype, e.get("pos"), e.get("gloss"),
+             "approved", visibility, cefr_val, heritage_cls,
+             e.get("created_at"), e.get("updated_at")),
         )
         counts["articles"] += 1
 

--- a/tests/test_atlas_db.py
+++ b/tests/test_atlas_db.py
@@ -1,4 +1,4 @@
-"""Tests for the Word Atlas entry-model v1 SQLite store (scripts/lexicon/atlas_db.py)."""
+"""Tests for the Word Atlas entry-model v1 SQLite store (scripts/atlas/atlas_db.py)."""
 
 from __future__ import annotations
 
@@ -65,3 +65,54 @@ def test_alias_helpers():
     assert atlas_db.transliterate("розвідка") == "rozvidka"
     assert atlas_db.classify_entry_type({"lemma": "сліпа зона"}) == "multiword_term"
     assert atlas_db.classify_entry_type({"lemma": "розвідка"}) == "lemma"
+
+
+def test_hardening_gates(tmp_path):
+    """PR #4380 review findings: metaterm visibility, CHECKs, timestamps, display_head."""
+    entries = [
+        # grammar metaterm -> article kept but PRIVATE (the #3776 lexeme_filter
+        # decision, encoded at the SSOT layer)
+        {"lemma": "pluralia tantum", "url_slug": "pluralia-tantum", "gloss": "plural-only",
+         "pos": "grammar term", "primary_source": "curriculum"},
+        # distinct created_at / updated_at survive separately (agy finding);
+        # display_head honored when present
+        {"lemma": "ка́ва", "url_slug": "кава", "gloss": "coffee", "pos": "noun",
+         "display_head": "ка́ва", "created_at": "2026-01-01", "updated_at": "2026-06-30",
+         "primary_source": "curriculum"},
+    ]
+    p = tmp_path / "manifest.json"
+    p.write_text(json.dumps({"entries": entries}, ensure_ascii=False), encoding="utf-8")
+    db = tmp_path / "atlas.db"
+    atlas_db.migrate_manifest(p, db)
+    conn = sqlite3.connect(db)
+
+    # metaterm is private, real word is public
+    rows = dict(conn.execute("SELECT slug, visibility FROM articles").fetchall())
+    assert rows == {"pluralia-tantum": "private", "кава": "public"}
+
+    # timestamps not conflated; display_head kept verbatim (incl. stress mark)
+    head, created, updated = conn.execute(
+        "SELECT display_head, created_at, updated_at FROM articles WHERE slug='кава'"
+    ).fetchone()
+    assert head == "ка́ва"
+    assert (created, updated) == ("2026-01-01", "2026-06-30")
+
+    # CHECK constraints are load-bearing: invalid enum values are REJECTED by
+    # the storage layer (a filler bug cannot silently write them)
+    import pytest
+
+    for stmt, params in [
+        ("INSERT INTO articles(slug, display_head, lemma, entry_type, review_state, visibility) VALUES (?,?,?,?,?,?)",
+         ("x", "x", "x", "grammar term", "approved", "public")),  # not an entry-model type
+        ("INSERT INTO articles(slug, display_head, lemma, entry_type, review_state, visibility) VALUES (?,?,?,?,?,?)",
+         ("y", "y", "y", "lemma", "looks_fine", "public")),  # invalid review_state
+        ("INSERT INTO aliases(alias, kind, source, target_slug) VALUES (?,?,?,?)",
+         ("z", "typo_kind", "test", "кава")),  # invalid alias kind
+        ("INSERT INTO enrichment(slug, section, payload_json, phase) VALUES (?,?,?,?)",
+         ("кава", "unknown_section", "{}", "local")),  # invalid section
+        ("INSERT INTO enrichment(slug, section, payload_json, phase) VALUES (?,?,?,?)",
+         ("кава", "meaning", "{}", "guessed")),  # invalid phase
+    ]:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(stmt, params)
+    conn.close()

--- a/tests/test_atlas_db.py
+++ b/tests/test_atlas_db.py
@@ -115,4 +115,11 @@ def test_hardening_gates(tmp_path):
     ]:
         with pytest.raises(sqlite3.IntegrityError):
             conn.execute(stmt, params)
+
+    # NULL phase and NULL pos remain valid (the CHECKs constrain values, not presence)
+    conn.execute("INSERT INTO enrichment(slug, section, payload_json) VALUES ('кава', 'etymology', '{}')")
+    conn.execute(
+        "INSERT INTO articles(slug, display_head, lemma, entry_type, review_state, visibility)"
+        " VALUES ('тест', 'тест', 'тест', 'lemma', 'approved', 'public')"
+    )
     conn.close()


### PR DESCRIPTION
## What

Applies the [PR #4380 review findings](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/4380#issuecomment-4885561702) (mine + [agy's verified pass](https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/4380#issuecomment-4885572369)) that were posted pre-merge but not folded in before the merge landed:

1. **CHECK constraints generated from the Python enum sets** — `entry_type`, `review_state`, `visibility`, alias `kind`, enrichment `section`/`phase`. The entry-model gates become load-bearing at the STORAGE layer: a Phase-1/2 filler bug can no longer silently insert invalid rows (previously the enums existed only as unused Python sets + test assertions).
2. **Grammar metaterms → `visibility='private'`** (10 live entries: `pluralia tantum`, `знахідний відмінок`, …). Encodes #3776's `lexeme_filter` decision at the SSOT so roadmap §6.5 (site generation FROM the DB) cannot resurrect them as public articles.
3. **`created_at`/`updated_at` passed separately** (agy: `_iso()` conflated them — no data affected today, 0 entries carry either field, but Phase-1 fill is about to start stamping real timestamps).
4. **`display_head` honored when present** (falls back to lemma).
5. Stale test docstring path.

## Verification (#M-4a)

- `pytest tests/test_atlas_db.py` → **3 passed** (new `test_hardening_gates`: private metaterm, timestamp fidelity, display_head verbatim incl. stress mark, and **5 IntegrityError-rejection cases** proving each CHECK fires).
- `ruff` → clean.
- **Real-manifest migration re-run** (5,517 entries): `{"articles": 5181, "aliases": 6598, "provenance": 5199, "enrichment": 40747, "form_aliases": 336}` — identical to pre-hardening; **10 private** (exactly the grammar terms); 0 orphans; FTS 5181.

Part of #4378 (entry-model v1 epic). Follow-up still open from the review: VESUM-generated inflected aliases + reusable named gates (plan §6.1 wording vs shipped scope) — that's Phase-1-fill scope, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)