### PR TITLE
docs(2156): lang-uk leaderboard boundary + README status refresh (#4289)

### DIFF
--- a/docs/projects/ua-eval-harness/README.md
+++ b/docs/projects/ua-eval-harness/README.md
@@ -1,6 +1,6 @@
 # Project: Ukrainian Calque + Grammar Evaluation Harness
 
-> **Status:** Scoping. We want to build this for **UNLP 2027** publication. Scope: a dedicated LLM evaluation harness covering both **calque** (Russianism / contact-borrowing patterns) and **grammar** in Ukrainian generation.
+> **Status (2026-07-05):** Curriculum-facing machinery Phases 1–4 MERGED — schema (#4322/#4307), F/Calque gold curation (#4306), 3-tier scorer adapters (#4308), LLM reviewer prompt+evaluator (#4309), cost-aware workflow (#4310), calibration scaffolding (#4370), reviewer-dispatch (#4311a), corpus report (#4311b). **Active now: tool-augmenting the reviewer** (grounded fact-checking via opencode + sources MCP; fleet-reviewed design v2, 2026-07-05) → then the seminar tier bakeoff. Publication target: **UNLP 2027**.
 
 > **For future sessions: this is the canonical pick-up entrypoint.** When the user says "let's continue the eval harness work" or asks about the UNLP project, read this file first.
 
@@ -57,6 +57,11 @@ These are NOT the harness, but they are the scorer-side foundation:
   #4310 tiered, short-circuiting workflow and composite LLM cache key.
 - [Agent fleet evidence for #4307](agent-fleet-4307.md) records the concrete
   fleet lanes used for the schema slice and the observed strengths/weaknesses.
+- [Model evidence](model-evidence.md) — per-model probe results (Gemma 4 bakeoff,
+  the opencode-vs-hermes tooled fact-check experiment) that ground routing and
+  harness-transport decisions.
+- [Leaderboard boundary](leaderboard-boundary.md) — what #2156 measures vs what is
+  delegated to the lang-uk leaderboard, plus the metadata interop bridge (#4289).
 
 ## Design TBD (these are the questions next session should answer)
 
@@ -90,7 +95,7 @@ These are NOT the harness, but they are the scorer-side foundation:
 
 - **Surzhyk-specific eval (spoken register)** — calques are a subset of Surzhyk patterns; an eval scoped narrowly to spoken-register Surzhyk is a different shape and could be a follow-on project.
 - **Polonisms, anglicisms as primary scope** — schema supports them via `source_lang`, but Russian is priority-1 because that is where empirical LLM harm concentrates today.
-- **General Ukrainian LLM capability** — covered by the lang-uk leaderboard.
+- **General Ukrainian LLM capability** — covered by the lang-uk leaderboard; the boundary + interop bridge are documented in [leaderboard-boundary.md](leaderboard-boundary.md) (#4289). Surzhyk follow-up = #4287; polonism/anglicism expansion = #4288.
 
 ## Timeline anchors (loose)
 

--- a/docs/projects/ua-eval-harness/README.md
+++ b/docs/projects/ua-eval-harness/README.md
@@ -1,6 +1,6 @@
 # Project: Ukrainian Calque + Grammar Evaluation Harness
 
-> **Status (2026-07-05):** Curriculum-facing machinery Phases 1–4 MERGED — schema (#4322/#4307), F/Calque gold curation (#4306), 3-tier scorer adapters (#4308), LLM reviewer prompt+evaluator (#4309), cost-aware workflow (#4310), calibration scaffolding (#4370), reviewer-dispatch (#4311a), corpus report (#4311b). **Active now: tool-augmenting the reviewer** (grounded fact-checking via opencode + sources MCP; fleet-reviewed design v2, 2026-07-05) → then the seminar tier bakeoff. Publication target: **UNLP 2027**.
+> **Status (2026-07-05):** Curriculum-facing machinery Phases 1–4 MERGED — schema (#4322/#4307), F/Calque gold curation (#4306), 3-tier scorer adapters (#4308), LLM reviewer prompt+evaluator (#4309), cost-aware workflow (#4310), calibration scaffolding (#4370), reviewer-dispatch (#4311a), corpus report (#4311b). **Active now: tool-augmenting the reviewer** (grounded fact-checking via opencode + sources MCP; fleet-reviewed design v2, 2026-07-05) → then the seminar tier bakeoff. Note: the live Tier-2 reviewer itself remains flag-off until #4370 calibration completes (`DEFAULT_REVIEWER_MODEL_ID = "llm-reviewer-disabled-until-4370"`); the workflow gate version is `qg_workflow.v1` today and bumps to v2 with the tooling PRs. Publication target: **UNLP 2027**.
 
 > **For future sessions: this is the canonical pick-up entrypoint.** When the user says "let's continue the eval harness work" or asks about the UNLP project, read this file first.
 

--- a/docs/projects/ua-eval-harness/leaderboard-boundary.md
+++ b/docs/projects/ua-eval-harness/leaderboard-boundary.md
@@ -1,0 +1,56 @@
+# Boundary: #2156 harness vs the lang-uk Ukrainian LLM leaderboard (#4289)
+
+- status: agreed boundary (documents the #2156 scoping decision; no new leaderboard is built here)
+- decided: 2026-07-05 (elevated from follow-up #4289, user directive 2026-07-05)
+- leaderboard: <https://huggingface.co/spaces/lang-uk/ukrainian-llm-leaderboard>
+
+## The one-sentence boundary
+
+**lang-uk ranks how capable a model is in Ukrainian; #2156 measures whether specific generated Ukrainian is
+contaminated (calques, contact-grammar errors, register defects) with span-level, gold-anchored evidence.**
+Neither substitutes for the other, and this repo will not build a general-capability leaderboard.
+
+## What #2156 evaluates that lang-uk does not
+
+| #2156 axis | shape | anchor |
+|---|---|---|
+| Calque / Russianism contamination | span-level findings (`excerpt` must be an exact substring) | UA-GEC F/Calque gold (CC-BY-4.0) + Антоненко-Давидович + VESUM/heritage merge |
+| Contact grammar (G/Case, G/Gender, …) | span-level findings | UA-GEC G/* gold |
+| Naturalness / register / level fit | curriculum-facing judgments, CEFR-aware | reviewer prompt profiles + deterministic surface gates |
+| Seminar factual grounding | tool-verified claim audit (CONFIRMED/REFUTED_BY_CONTRADICTION/UNATTESTED_AFTER_SEARCH/CONTESTED/UNVERIFIED_INSUFFICIENT_SEARCH) | sources MCP (wiki/literary/heritage/ЕСУМ/Грінченко/GRAC) — design brief v2, 2026-07-05 |
+| Compact module evidence | `ua_contact_quality_evidence.v1` records (schema.md) with content hash, source_lang, scorer provenance | `scripts/audit/qg_schema.py` |
+
+Empirical demonstration of why capability ranking is not contamination measurement: gemma-4-26b is **#1 on
+the lang-uk leaderboard**, and gemma-4-31b scored deterministically perfect on our surface gates — yet
+fabricated folk-culture specifics in seminar content that only tool-grounded fact-checking caught
+(`model-evidence.md`, 2026-07-04/05). Capability-high ≠ contamination-free.
+
+## What is delegated to lang-uk (never duplicated here)
+
+- General Ukrainian LLM capability measurement (translation, reasoning, QA, IFEval) and its maintenance.
+- Broad all-model benchmark ranking, including UA-fine-tuned open weights (Lapa, MamayLM).
+- Public leaderboard infrastructure and submission workflow.
+
+When a #2156 conversation drifts toward "which model is best at Ukrainian overall" → the answer lives at
+lang-uk; we may *cite* it (as the model-evidence doc does) but never re-measure it.
+
+## Metadata bridge (small, interop-only)
+
+To make #2156 findings comparable against lang-uk rows without copying their scope, each harness run
+records — all already present in `ua_contact_quality_evidence.v1` or the run store:
+
+1. **Exact model identity** (`reviewer_model_id` / writer model slug, provider-qualified, e.g.
+   `openrouter/google/gemma-4-31b-it`) — joinable to a lang-uk leaderboard row when one exists.
+2. **Schema + gate version** (`ua_contact_quality_evidence.v1`, `qg_workflow.v2`) — so cross-citations pin
+   the harness contract they were measured under.
+3. **Content hash + source_lang** — reproducibility anchors lang-uk doesn't need but any joint analysis does.
+
+That is the whole bridge. No shared scoring, no synced releases, no scraped leaderboard data.
+
+## Non-goals (restating #4289's)
+
+- No general-purpose Ukrainian LLM leaderboard in this repo.
+- No all-model capability ranking under #2156 (the step-3 bakeoff ranks *reviewer configurations* on ~3-4
+  seminars — a harness-calibration exercise, not a capability leaderboard).
+- No broad capability claims from curriculum QG scores alone — a model that reviews seminars well is not
+  thereby "good at Ukrainian", and vice versa (the gemma result cuts both ways).

--- a/docs/projects/ua-eval-harness/leaderboard-boundary.md
+++ b/docs/projects/ua-eval-harness/leaderboard-boundary.md
@@ -39,11 +39,14 @@ lang-uk; we may *cite* it (as the model-evidence doc does) but never re-measure 
 To make #2156 findings comparable against lang-uk rows without copying their scope, each harness run
 records — all already present in `ua_contact_quality_evidence.v1` or the run store:
 
-1. **Exact model identity** (`reviewer_model_id` / writer model slug, provider-qualified, e.g.
-   `openrouter/google/gemma-4-31b-it`) — joinable to a lang-uk leaderboard row when one exists.
-2. **Schema + gate version** (`ua_contact_quality_evidence.v1`, `qg_workflow.v2`) — so cross-citations pin
+1. **Exact model identity** — `reviewer_model_id` (run store `llm_qg_runs`) / writer model slug,
+   provider-qualified (e.g. `openrouter/google/gemma-4-31b-it`) — joinable to a lang-uk leaderboard row
+   when one exists.
+2. **Schema + gate version** — the schema identity (`ua_contact_quality_evidence.v1`) and the workflow
+   `gate_version` (`qg_workflow.v1` today; v2 lands with the reviewer-tooling PRs) — so cross-citations pin
    the harness contract they were measured under.
-3. **Content hash + source_lang** — reproducibility anchors lang-uk doesn't need but any joint analysis does.
+3. **`content_sha` + `source_lang`** (schema record fields) — reproducibility anchors lang-uk doesn't need
+   but any joint analysis does.
 
 That is the whole bridge. No shared scoring, no synced releases, no scraped leaderboard data.
 


### PR DESCRIPTION
Implements #4289 (elevated follow-up, user directive 2026-07-05):

- **`leaderboard-boundary.md`** — the one-sentence boundary (lang-uk ranks capability; #2156 measures contamination with span-level gold-anchored evidence), what each side owns, the empirical proof they're orthogonal (gemma-4: lang-uk #1 / surface-perfect, yet fabricates folk facts only tool-grounding catches), and the minimal 3-field metadata bridge (model identity, schema+gate version, content hash + source_lang) — all fields already exist in `ua_contact_quality_evidence.v1`/the run store, so the bridge costs nothing.
- **README refresh** — the "Status: Scoping" line predated the Phases 1–4 merges (flagged stale in the session handoff); now carries the authoritative sequencing + the active tool-augmentation work, and links the two evidence docs.

Docs-only. Closes #4289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)