### PR TITLE
data(atlas): review-approve teacher-lesson vocab rows 239-258 (18 headwords, thirteenth ledger)

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-05-thirteenth-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-05-thirteenth-approved-teacher-lesson-ledger-batch.yaml
@@ -132,8 +132,10 @@ decisions:
 - lemma: заважати
   decision: approve_for_publish
   approved_pos: verb
-  approved_gloss: to annoy
-  sense_note: private teacher-lesson explicit vocabulary table
+  approved_gloss: to hinder, to get in the way
+  sense_note: private teacher-lesson explicit vocabulary table; gloss adjusted from
+    source's 'to annoy' per СУМ-11 (перешкоджати — to hinder/obstruct); 'annoy' =
+    дратувати/надокучати
   source_inventory:
     key: 2f3ad45bc9c08f13
     path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml

--- a/data/lexicon/source-inventory-review-decisions/2026-07-05-thirteenth-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-05-thirteenth-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,248 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-thirteenth-approved-teacher-lesson-ledger-batch-2026-07-05
+batch_label: thirteenth-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-05'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  total_queue_rows: 258
+  approved_in_queue: 18
+  promotion_batch_size: 18
+production_outputs_updated: []
+decisions:
+- lemma: перезавантажувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to reload (imperfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d2d8d7d5a4ca9ca0
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 239
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: перезавантажити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to reload (perfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: dc1dfb9c37a049c3
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 240
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: завантажувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to download (imperfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 11040b31481ef740
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 241
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: завантажити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to download (perfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 030c9cb6bfdae487
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 242
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: мило
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: soap
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 53c70bdad9c6b3d9
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 244
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: переважати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to prevail
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 9d98b04bbb943094
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 245
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: вважати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to consider, to regard
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 613c65c5a7b18fa8
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 246
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: зневажати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to disrespect
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 81f0ebe6b172f03e
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 247
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: зважати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to consider, to observe
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: dfbde2da16b8694d
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 248
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: заважати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to annoy
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 2f3ad45bc9c08f13
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 249
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: розробляти
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to develop (imperfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a26def42d39b9bea
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 250
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: розробити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to develop (perfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 80941def34c121de
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 251
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: розробник
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: developer
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 94dbf1d3603ed664
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 252
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: заперечення
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: objection
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 2fa6a9d28ce23bcc
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 253
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: благати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to beg to do something
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 253e03aae1d28ff4
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 254
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: спогад
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: memory (a picture in your head)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 26125fb2818b4811
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 255
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: порожніти
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to get empty (imperfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 3ee4cb3e5dfc7951
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 257
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: спорожніти
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to get empty (perfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d3c3fbbce6aaf608
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+    locator: explicit vocabulary table row 258
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table

--- a/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
+++ b/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml
@@ -1,0 +1,105 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: private-teacher-lesson-vocabulary-table-1-rows-239-258
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Private teacher lesson vocabulary - explicit table rows 239-258
+    locator: local-only explicit vocabulary table rows 239-258
+    notes: >-
+      Derived headword metadata only; raw private lesson material is local-only
+      and not committed. Daily Word, Practice, and cloze remain frozen without
+      explicit surface_admission. Rows 243 and 256 are multi-word idiom/collocation
+      entries deferred pending a collocation intake convention.
+    headwords:
+      - lemma: перезавантажувати
+        pos: verb
+        gloss: "to reload (imperfective)"
+        locator: explicit vocabulary table row 239
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: перезавантажити
+        pos: verb
+        gloss: "to reload (perfective)"
+        locator: explicit vocabulary table row 240
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: завантажувати
+        pos: verb
+        gloss: "to download (imperfective)"
+        locator: explicit vocabulary table row 241
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: завантажити
+        pos: verb
+        gloss: "to download (perfective)"
+        locator: explicit vocabulary table row 242
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: мило
+        pos: noun
+        gloss: "soap"
+        locator: explicit vocabulary table row 244
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: переважати
+        pos: verb
+        gloss: "to prevail"
+        locator: explicit vocabulary table row 245
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вважати
+        pos: verb
+        gloss: "to consider, to regard"
+        locator: explicit vocabulary table row 246
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: зневажати
+        pos: verb
+        gloss: "to disrespect"
+        locator: explicit vocabulary table row 247
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: зважати
+        pos: verb
+        gloss: "to consider, to observe"
+        locator: explicit vocabulary table row 248
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: заважати
+        pos: verb
+        gloss: "to annoy"
+        locator: explicit vocabulary table row 249
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: розробляти
+        pos: verb
+        gloss: "to develop (imperfective)"
+        locator: explicit vocabulary table row 250
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: розробити
+        pos: verb
+        gloss: "to develop (perfective)"
+        locator: explicit vocabulary table row 251
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: розробник
+        pos: noun
+        gloss: "developer"
+        locator: explicit vocabulary table row 252
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: заперечення
+        pos: noun
+        gloss: "objection"
+        locator: explicit vocabulary table row 253
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: благати
+        pos: verb
+        gloss: "to beg to do something"
+        locator: explicit vocabulary table row 254
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: спогад
+        pos: noun
+        gloss: "memory (a picture in your head)"
+        locator: explicit vocabulary table row 255
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: порожніти
+        pos: verb
+        gloss: "to get empty (imperfective)"
+        locator: explicit vocabulary table row 257
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: спорожніти
+        pos: verb
+        gloss: "to get empty (perfective)"
+        locator: explicit vocabulary table row 258
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -30,6 +30,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-179-198.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )


### PR DESCRIPTION
## What

13th review-only teacher-lesson ledger window (rows 239-258 of the explicit vocabulary table), per the proven PR #4375 recipe. Review-only — **no publish step**; publish rides the manifest recipe separately (per the fable sequencing decision: no ledger→DB write path until #4385 flips SSG to atlas.db).

- `…vocabulary-table-1-rows-239-258.yaml` — 18 curated headwords (aspect pairs split; stress-homograph merge n/a this window)
- `…thirteenth-approved-teacher-lesson-ledger-batch.yaml` — 18 × `approve_for_publish`, keys computed via `source_inventory_review_decisions.source_inventory_key` (imported fn)
- generator registry: new inventory added to `COMMITTED_SOURCE_INVENTORIES`

**Deferred (multiword, pending collocation convention — same as rows 222/233 precedent):** row 243 «З нуля», row 256 «Переливати з пустого в порожнє».

## Provenance / lane note

agy dispatch `atlas-teacher-rows-239-258` did extraction + inventory + registry, then died silently mid-recipe (rc=1, empty logs). Track driver (fable) verified the extraction deterministically and finished review/ledger/validation inline.

## Evidence (#M-4, raw)

- **Source-window verify**: re-extracted docx table#0 data-rows 239-258 and diffed vs inventory — 18/18 exact match (aspect glosses, locators), 2 multiword correctly deferred.
- **VESUM**: `verify_words` batch → `Found: 18/18` (all POS match: 15 verb, 3 noun incl. мило/розробник/заперечення/спогад).
- **russian_shadow**: `matches_russian: false, confidence: 0.0` on ALL 18 — no adjudications needed this window.
- **Ledger validate**: `source_inventory_review_decisions: files=1 rows=18 decisions={'approve_for_publish': 18}`; aggregate `files=19 rows=417 decisions={'approve_for_publish': 415, 'reject': 2}`.
- **Candidates**: `generate_source_inventory_review_candidates` → counts `{'total_delta': 412, 'processed': 412, 'auto_merge': 368, 'needs_review': 44}`; **my 18 lemmas: 18/18 auto_merge, 0 needs_review, 0 missing**.
- **Tests**: `tests/test_private_teacher_lesson_source_inventory.py` → `32 passed in 6.04s`.
- **Lint**: `ruff check scripts/audit/generate_source_inventory_review_candidates.py` → `All checks passed!`.

Part of #4160 / #4220 · umbrella #4387. Next window: rows 259-278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)