### PR TITLE
fix(folk): require on-site reading excerpts

### DIFF
--- a/docs/projects/folk-reading-coverage-remediation.md
+++ b/docs/projects/folk-reading-coverage-remediation.md
@@ -1,0 +1,45 @@
+# FOLK Reading Coverage Remediation
+
+Status: active blocker
+Started: 2026-07-05
+
+## Standard
+
+FOLK seminar modules need learner-visible on-site shortened reading content. External full-text links can supplement the lesson, but they do not satisfy reading coverage by themselves.
+
+Acceptable readings must be:
+
+- verified against a real source text
+- rights-safe for a shortened on-site excerpt
+- shown in a structured `:::primary-reading{reading="<slug>"}` block
+- attributed in the block body
+- connected to a source or full-version link when available
+
+Unacceptable substitutes:
+
+- external link-only resources
+- orphan `:::primary-reading` snippets without a `reading="<slug>"` source link
+- paraphrase presented as primary text
+- silently normalized or reconstructed text
+- invented sayings, excerpts, captions, or source claims
+
+## Current Audit
+
+The hardened gate confirms this gap on current `origin/main`:
+
+- Already structurally present under the new minimum: M16 `rodynno-pobutovi-pisni`
+- Missing on-site structured reading content: M13 and M17-M22
+- Bad inline-only format: M23 `sotsialno-pobutovi-kazky`, M24 `narodni-lehendy`
+- Missing on-site structured reading content: M25-M36
+
+M1-M12 and M14-M15 still need a stricter reread before they are treated as fully cleared.
+
+## Remediation Order
+
+1. Land the gate hardening so new FOLK production cannot pass with link-only or orphan readings.
+2. Fix M13 and M16-M20 as the first content batch, unless the user selects a different order.
+3. Fix M21-M24 next, with M23-M24 converted away from inline orphan snippets.
+4. Continue in small PR-sized batches through M36.
+5. Resume M37/M38 production only after the user clears the reading blocker.
+
+Each content batch must include source verification notes, rights decisions, local gates, and independent review. DeepSeek is not an allowed reviewer for this stream.

--- a/docs/prompts/orchestrators/shared/reading-section-rules.md
+++ b/docs/prompts/orchestrators/shared/reading-section-rules.md
@@ -1,17 +1,18 @@
 # Shared Reading Section Rules
 
-Prompt suite component version: 0.2
-Last reviewed: 2026-06-21
+Prompt suite component version: 0.3
+Last reviewed: 2026-07-05
 
-The global reading reference is the seminar equivalent of a lexicon: modules should connect learners to original texts, either hosted on-site when copyright allows or linked externally when hosting is not allowed.
+The global reading reference is the seminar equivalent of a lexicon: modules should connect learners to original texts. For FOLK, external links are supplementary only; the lesson itself must contain rights-safe, on-site shortened reading content.
 
 ## Required Reading Coverage
 
 - A seminar module's reading layer is a **researched primary-text catalog**, not a single token reading. Before writing, survey the corpus and source registries for **every distinct, verifiable primary text** that belongs to the module's topic (each song, duma, poem, chronicle passage, or other primary artifact appropriate to the track) — then surface as many as the corpus genuinely supports.
 - **Per-track minimum (corpus-bound).** Each seminar track sets a primary-text floor. **FOLK targets ≥4 distinct primary readings per module when the gate-safe corpus holds ≥4 distinct verified fragments** (`docs/folk-epic/EXEMPLAR-STANDARD.md` §3). A module may surface fewer **only** when the corpus genuinely lacks that many distinct verified texts — e.g. `zamovliannia` / `narodni-viruvannia`, whose gate-safe corpus carries the genre only as encyclopedia-embedded formulas, not standalone primary rows (record `reading-needed`). **Availability is a verified number, never an assumption:** the preflight audit (#3696) found the koliadky corpus holds 6 distinct carols (not the 2 an earlier note guessed), so its floor is ≥4 — survey the corpus before concluding a topic is genuinely low.
+- **FOLK on-site minimum.** Every active FOLK module must include at least one learner-visible on-site shortened primary reading excerpt, and should include 2-4 when the verified rights-safe corpus permits. A link-only external source does not satisfy the minimum; the external full version may be listed only as a supplement.
 - **Never backfill to the floor.** Do not pad the catalog to hit a number with from-memory text, paraphrase, reconstructed fragments, or scholarly-quoted snippets. Under-coverage relative to corpus availability is recorded as a `reading-needed` finding — never hidden, never faked.
 - If no usable reading is present yet, record it as a blocker or explicit `reading-needed` task; do not silently omit readings.
-- A reading can be a full original text, an excerpt, a chronicle/source passage, a literary work, a folk text, or another primary artifact appropriate to the track.
+- A reading can be a full original text, a shortened verbatim excerpt, a chronicle/source passage, a literary work, a folk text, or another primary artifact appropriate to the track.
 
 ## Primary Text vs Scholarship
 
@@ -57,8 +58,8 @@ When the module has `resources.yaml`, include one or more `role: reading` entrie
 Every reading candidate must carry a decision:
 
 - `hosted`: public-domain or otherwise clearly hostable; create/update `site/src/content/readings/<slug>.mdx`.
-- `linked-only`: not hostable or uncertain, but a stable public teaching/source URL exists; add `role: reading` link and learner task.
-- `excerpt-only`: only a short compliant excerpt may be quoted; link to the original when possible.
+- `linked-only`: not hostable or uncertain, but a stable public teaching/source URL exists; add `role: reading` link and learner task. For FOLK, this is supplementary and never counts as the required on-site shortened reading.
+- `excerpt-only`: only a short compliant excerpt may be quoted; include that shortened on-site excerpt with attribution when rights-safe, and link to the original when possible.
 - `omit`: no reliable, learner-safe, or pedagogically usable source exists after search; record the search and reason.
 - `reading-needed`: the module needs the source, but no verified usable text or rights decision exists yet; record it as a blocker.
 
@@ -81,9 +82,11 @@ The body should render the text with `PrimaryReading` and include source/copyrig
 
 ## Lesson Linking
 
-- Use `:::primary-reading` blocks for verbatim source work inside FOLK lesson sources.
+- Use `:::primary-reading{reading="<slug>"}` blocks for verbatim source work inside FOLK lesson sources, with a source attribution line in the block body beginning with an em dash, for example `— Джерело, назва`.
 - The generator links `PrimaryReading` boxes to `/readings/<slug>/` only when the reading file exists; missing files must not create broken links.
-- For link-only or excerpt-only readings, add a student-facing `role: reading` resource and mention the reading task in the lesson without pretending the full text is hosted.
+- Orphan `:::primary-reading` snippets without a `reading="<slug>"` source link do not satisfy FOLK reading coverage.
+- For link-only readings, add a student-facing `role: reading` resource and mention the reading task in the lesson without pretending the full text is hosted.
+- For excerpt-only readings, include the shortened on-site excerpt as the reading content and treat external full/source links as supplementary.
 
 - Hosted reading pages are public learner pages when `published` and `canonical` are not false. They may name the public source and show the public URL, but must not expose the build workflow: no `chunk_id`, `source_chunk`, corpus/service IDs, `source hammer`, `hosted reading`, `public reading`, `learner-facing`, or validation-tool language. Unpublished or noncanonical retained readings may carry maintenance notes only while they remain unroutable.
 

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -13131,6 +13131,7 @@ def _extract_plan_pronunciation_video_urls(plan: Mapping[str, Any]) -> list[dict
 
 _HOSTED_READING_VALUES = frozenset({"host", "hosted"})
 _READING_COVERAGE_FLOOR = 4
+_READING_COVERAGE_MIN_STRUCTURED = 1
 _READING_TITLE_STRIP_CHARS = " \t\r\n«»„“”\"'‘’"
 _READING_COVERAGE_BLOCK_RE = re.compile(
     r"^:::primary-reading(?P<attrs>[^\n]*)\n(?P<body>.*?)^:::\s*$",
@@ -13167,6 +13168,21 @@ def _primary_reading_slug_attrs(blocks: Sequence[re.Match[str]]) -> set[str]:
     }
 
 
+def _structured_primary_reading_blocks(blocks: Sequence[re.Match[str]]) -> list[re.Match[str]]:
+    """Return blocks that are both on-site linked and attributed."""
+
+    structured_blocks: list[re.Match[str]] = []
+    for block in blocks:
+        if not _primary_reading_attribution_lines(block.group("body")):
+            continue
+        has_reading_slug = any(
+            match.group("slug").strip() for match in _PRIMARY_READING_SLUG_ATTR_RE.finditer(block.group("attrs"))
+        )
+        if has_reading_slug:
+            structured_blocks.append(block)
+    return structured_blocks
+
+
 def _hosted_plan_readings(plan: Mapping[str, Any]) -> list[dict[str, str]]:
     readings = plan.get("readings")
     if not isinstance(readings, list):
@@ -13200,6 +13216,9 @@ def _reading_coverage_gate(module_text: str, plan: Mapping[str, Any]) -> dict[st
         for line in _primary_reading_attribution_lines(block.group("body"))
     ]
     reading_slug_attrs = _primary_reading_slug_attrs(blocks)
+    structured_blocks = _structured_primary_reading_blocks(blocks)
+    structured_reading_slug_attrs = _primary_reading_slug_attrs(structured_blocks)
+    unstructured_primary_readings = len(blocks) - len(structured_blocks)
 
     missing: list[dict[str, str]] = []
     matched: list[dict[str, str]] = []
@@ -13213,9 +13232,15 @@ def _reading_coverage_gate(module_text: str, plan: Mapping[str, Any]) -> dict[st
         # Source modules can surface generated hosted readings before MDX conversion
         # as a primary-reading directive attribute rather than a rendered link.
         matched_by_directive_attr = bool(slug and slug in reading_slug_attrs)
-        if matched_by_title or matched_by_slug or matched_by_directive_attr:
+        matched_by_structured_directive = bool(slug and slug in structured_reading_slug_attrs)
+        matched_by_on_site_reading = matched_by_structured_directive
+        if level_key != "folk":
+            matched_by_on_site_reading = matched_by_title or matched_by_slug or matched_by_directive_attr
+        if matched_by_on_site_reading:
             matched_by = "title"
-            if matched_by_slug:
+            if matched_by_structured_directive:
+                matched_by = "structured_primary_reading"
+            elif matched_by_slug:
                 matched_by = "reading_link"
             elif matched_by_directive_attr:
                 matched_by = "primary_reading_attr"
@@ -13223,15 +13248,28 @@ def _reading_coverage_gate(module_text: str, plan: Mapping[str, Any]) -> dict[st
         else:
             missing.append(reading)
 
-    passed = not missing
+    missing_on_site_reading = level_key == "folk" and len(structured_reading_slug_attrs) < _READING_COVERAGE_MIN_STRUCTURED
+    passed = not missing and not missing_on_site_reading
     report: dict[str, Any] = {
         "passed": passed,
         "severity": "HARD" if not passed else None,
         "checked": len(hosted_readings),
         "surfaced_primary_readings": len(blocks),
+        "structured_on_site_readings": len(structured_blocks),
+        "unstructured_primary_readings": unstructured_primary_readings,
         "matched_hosted_readings": matched,
         "missing_hosted_readings": missing,
     }
+    if missing_on_site_reading:
+        report["missing_on_site_reading"] = {
+            "severity": "HARD",
+            "message": (
+                "FOLK modules require at least one structured on-site "
+                'primary-reading block with a reading="..." slug and attribution; '
+                "external link-only resources and orphan inline snippets are supplementary only"
+            ),
+            "expected_minimum": _READING_COVERAGE_MIN_STRUCTURED,
+        }
 
     exception = str(plan.get("reading_coverage_exception") or "").strip()
     if len(blocks) < _READING_COVERAGE_FLOOR and not exception:

--- a/tests/test_reading_coverage_gate.py
+++ b/tests/test_reading_coverage_gate.py
@@ -18,8 +18,9 @@ def _run_fixture_gate(tmp_path: Path, plan: dict[str, Any], module_text: str) ->
     return _reading_coverage_gate(module_path.read_text(encoding="utf-8"), loaded_plan)
 
 
-def _primary_reading_block(title: str) -> str:
-    return f""":::primary-reading
+def _primary_reading_block(title: str, slug: str | None = None) -> str:
+    attrs = f'{{reading="{slug}"}}' if slug else ""
+    return f""":::primary-reading{attrs}
 > Рядок першоджерела.
 
 — Народна творчість, {title}
@@ -27,13 +28,16 @@ def _primary_reading_block(title: str) -> str:
 """
 
 
-def _module_with_four_blocks(first_title: str = "«Інший текст»") -> str:
+def _module_with_four_blocks(
+    first_title: str = "«Інший текст»",
+    first_slug: str = "pershyi-tekst",
+) -> str:
     return "\n".join(
         [
-            _primary_reading_block(first_title),
-            _primary_reading_block("«Другий текст»"),
-            _primary_reading_block("«Третій текст»"),
-            _primary_reading_block("«Четвертий текст»"),
+            _primary_reading_block(first_title, first_slug),
+            _primary_reading_block("«Другий текст»", "druhyi-tekst"),
+            _primary_reading_block("«Третій текст»", "tretii-tekst"),
+            _primary_reading_block("«Четвертий текст»", "chetvertyi-tekst"),
         ]
     )
 
@@ -43,7 +47,7 @@ def test_reading_coverage_gate_registered_in_python_qg_order() -> None:
     assert PYTHON_QG_GATE_ORDER.index("reading_coverage") < PYTHON_QG_GATE_ORDER.index("resources_url_resolve")
 
 
-def test_hard_pass_when_host_reading_title_is_in_primary_reading_attribution(tmp_path: Path) -> None:
+def test_hard_pass_when_host_reading_is_structured_on_site_excerpt(tmp_path: Path) -> None:
     plan = {
         "level": "folk",
         "readings": [
@@ -51,14 +55,15 @@ def test_hard_pass_when_host_reading_title_is_in_primary_reading_attribution(tmp
         ],
     }
 
-    result = _run_fixture_gate(tmp_path, plan, _module_with_four_blocks('"Ой весна"'))
+    result = _run_fixture_gate(tmp_path, plan, _module_with_four_blocks('"Ой весна"', "oi-vesna"))
 
     assert result["passed"] is True
     assert result["missing_hosted_readings"] == []
+    assert result["structured_on_site_readings"] == 4
     assert "warning" not in result
 
 
-def test_hard_pass_when_host_reading_slug_link_is_in_module(tmp_path: Path) -> None:
+def test_hard_fail_when_host_reading_has_only_bare_external_link(tmp_path: Path) -> None:
     plan = {
         "level": "folk",
         "readings": [
@@ -68,8 +73,13 @@ def test_hard_pass_when_host_reading_slug_link_is_in_module(tmp_path: Path) -> N
 
     result = _run_fixture_gate(tmp_path, plan, "Read the hosted source at /readings/oi-vesna/.")
 
-    assert result["passed"] is True
-    assert result["missing_hosted_readings"] == []
+    assert result["passed"] is False
+    assert result["severity"] == "HARD"
+    assert result["structured_on_site_readings"] == 0
+    assert result["missing_hosted_readings"] == [
+        {"title": "«Ой весна»", "reading_slug": "oi-vesna"},
+    ]
+    assert result["missing_on_site_reading"]["severity"] == "HARD"
     assert result["warning"]["severity"] == "WARNING"
 
 
@@ -102,13 +112,13 @@ def test_title_normalization_matches_quote_glyphs_case_and_whitespace(tmp_path: 
         ],
     }
 
-    result = _run_fixture_gate(tmp_path, plan, _module_with_four_blocks("„думи нічні“"))
+    result = _run_fixture_gate(tmp_path, plan, _module_with_four_blocks("„думи нічні“", "dumy-nichni"))
 
     assert result["passed"] is True
     assert result["missing_hosted_readings"] == []
 
 
-def test_linked_only_reading_omission_is_not_a_failure(tmp_path: Path) -> None:
+def test_linked_only_reading_omission_is_failure_for_folk(tmp_path: Path) -> None:
     plan = {
         "level": "folk",
         "readings": [
@@ -116,19 +126,42 @@ def test_linked_only_reading_omission_is_not_a_failure(tmp_path: Path) -> None:
         ],
     }
 
-    result = _run_fixture_gate(tmp_path, plan, _module_with_four_blocks())
+    result = _run_fixture_gate(tmp_path, plan, "")
 
-    assert result["passed"] is True
+    assert result["passed"] is False
+    assert result["severity"] == "HARD"
     assert result["checked"] == 0
     assert result["missing_hosted_readings"] == []
+    assert result["missing_on_site_reading"]["severity"] == "HARD"
+
+
+def test_orphan_inline_snippets_do_not_count_as_folk_on_site_reading(tmp_path: Path) -> None:
+    plan = {"level": "folk", "readings": []}
+    module_text = "\n".join([_primary_reading_block("«Один»"), _primary_reading_block("«Два»")])
+
+    result = _run_fixture_gate(tmp_path, plan, module_text)
+
+    assert result["passed"] is False
+    assert result["severity"] == "HARD"
+    assert result["surfaced_primary_readings"] == 2
+    assert result["structured_on_site_readings"] == 0
+    assert result["unstructured_primary_readings"] == 2
+    assert result["missing_on_site_reading"]["severity"] == "HARD"
 
 
 def test_floor_warning_is_advisory_and_exception_suppresses_it(tmp_path: Path) -> None:
     plan = {"level": "folk", "readings": []}
-    module_text = "\n".join([_primary_reading_block("«Один»"), _primary_reading_block("«Два»")])
+    module_text = "\n".join(
+        [
+            _primary_reading_block("«Один»", "odyn"),
+            _primary_reading_block("«Два»", "dva"),
+        ]
+    )
 
     warning_result = _run_fixture_gate(tmp_path, plan, module_text)
     assert warning_result["passed"] is True
+    assert warning_result["structured_on_site_readings"] == 2
+    assert "missing_on_site_reading" not in warning_result
     assert warning_result["warning"] == {
         "severity": "WARNING",
         "message": (
@@ -146,6 +179,7 @@ def test_floor_warning_is_advisory_and_exception_suppresses_it(tmp_path: Path) -
     }
     exception_result = _run_fixture_gate(tmp_path, exception_plan, module_text)
     assert exception_result["passed"] is True
+    assert "missing_on_site_reading" not in exception_result
     assert "warning" not in exception_result
 
 
@@ -176,7 +210,7 @@ def test_non_seminar_level_is_skipped(tmp_path: Path) -> None:
                     },
                 ],
             },
-            _module_with_four_blocks("«Ой весна»"),
+            _module_with_four_blocks("«Ой весна»", "oi-vesna"),
             False,
             id="hosted-title-attribution",
         ),
@@ -191,7 +225,7 @@ def test_non_seminar_level_is_skipped(tmp_path: Path) -> None:
                     },
                 ],
             },
-            _module_with_four_blocks("«Гей, соколи»"),
+            _module_with_four_blocks("«Гей, соколи»", "hei-sokoly"),
             False,
             id="hosted-alias-attribution",
         ),
@@ -206,7 +240,10 @@ def test_non_seminar_level_is_skipped(tmp_path: Path) -> None:
                     },
                 ],
             },
-            _module_with_four_blocks("«Дума про втечу трьох братів з Азова»"),
+            _module_with_four_blocks(
+                "«Дума про втечу трьох братів з Азова»",
+                "duma-pro-vtechu-trokh-brativ-z-azova",
+            ),
             False,
             id="long-hosted-title-attribution",
         ),
@@ -221,7 +258,7 @@ def test_non_seminar_level_is_skipped(tmp_path: Path) -> None:
                     },
                 ],
             },
-            _module_with_four_blocks("«Щедрий вечір»"),
+            _module_with_four_blocks("«Щедрий вечір»", "shchedryi-vechir"),
             False,
             id="hosted-title-no-floor-warning",
         ),
@@ -234,6 +271,7 @@ def test_fixture_folk_modules_all_pass_reading_coverage(
 
     assert result["passed"] is True
     assert result["missing_hosted_readings"] == []
+    assert result["structured_on_site_readings"] == 4
     if expect_floor_warning:
         assert result["warning"]["severity"] == "WARNING"
     else:


### PR DESCRIPTION
## Summary

- harden FOLK reading coverage so link-only resources and orphan `PrimaryReading` snippets no longer satisfy the gate
- require at least one structured on-site shortened excerpt via `:::primary-reading{reading="..."}` with attribution for FOLK modules
- update reading-section worker rules and add a remediation plan for M13/M16+ batches

## Current audit under the hardened gate

- PASS: M16 `rodynno-pobutovi-pisni` has one structured on-site excerpt
- FAIL: M13 and M17-M22 have no structured on-site reading
- FAIL: M23-M24 have inline snippets but no structured on-site reading slug
- FAIL: M25-M36 have no structured on-site reading

This PR intentionally blocks future FOLK production until affected modules receive verified, rights-safe shortened readings or explicit reading-needed blockers.

## Independent review

Claude Opus 4.8 via project bridge, task `review-folk-reading-gate-hardening`: PASS, no blockers. One minor prompt-clarity note was addressed by requiring dash-led source attribution in the shared reading rules.

## Verification

- `.venv/bin/python -m pytest tests/test_reading_coverage_gate.py -q` — 13 passed
- `.venv/bin/python -m ruff check scripts/build/linear_pipeline.py tests/test_reading_coverage_gate.py` — passed
- `.venv/bin/python scripts/lint_prompts.py` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- `git diff --check` — passed
- protected/generated file scan — clean
