### PR TITLE
feat(atlas): phase-1 local enrichment fill for atlas.db (#4378)

### DIFF
--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -446,6 +446,7 @@ Additional audit guardrails:
 - `scripts/audit/atlas_source_census.py` - aggregate-only Word Atlas source intake census; public reports must not include raw source text, private paths, or candidate lemma lists
 - `scripts/audit/atlas_entry_model_census.py` - aggregate-only Word Atlas entry-model census; separates reviewed article entries by `entry_type` from alias/form records
 - `scripts/audit/atlas_source_entry_count.py` - aggregate-only Word Atlas source-corpus entry-demand census by finalized entry-model bucket; public reports must not include source text, private paths, filenames, or candidate lists
+- `scripts/atlas/fill_local.py` - Phase-1 offline local enrichment writer for `data/atlas.db`; reads local dictionary/cache data only and reports per-section before/after coverage
 - `scripts/audit/curriculum_qg_harness.py` - deterministic Ukrainian curriculum QG fixture harness; use it to calibrate B1-27, A1/A2 scaffolding, B1+ leakage, and seminar-register checks before changing QG behavior
 
 ### Build pipeline entry point
@@ -616,6 +617,7 @@ Use this before content generation to verify plan files still match `scripts/aud
 | `scripts/audit/atlas_source_census.py` | Build aggregate-safe Word Atlas source planning counts | `.venv/bin/python scripts/audit/atlas_source_census.py --markdown-out docs/runbooks/word-atlas-source-census-planning.md` |
 | `scripts/audit/atlas_entry_model_census.py` | Count reviewed Atlas entries by finalized `entry_type` bucket | `.venv/bin/python scripts/audit/atlas_entry_model_census.py --format markdown` |
 | `scripts/audit/atlas_source_entry_count.py` | Estimate aggregate source-corpus Atlas entry backlog by finalized bucket | `.venv/bin/python scripts/audit/atlas_source_entry_count.py --include-ohoiko-private --markdown-out docs/runbooks/word-atlas-source-entry-count.md` |
+| `scripts/atlas/fill_local.py` | Fill `data/atlas.db` with Phase-1 local Atlas enrichment rows | `.venv/bin/python -m scripts.atlas.fill_local --db data/atlas.db --report-json /tmp/atlas-fill-local-report.json` |
 | `scripts/audit/curriculum_qg_harness.py` | Run calibrated Ukrainian QG fixtures or scan one module into compact evidence | `.venv/bin/python scripts/audit/curriculum_qg_harness.py --fixtures tests/fixtures/curriculum_qg/fixtures.yaml` |
 | `scripts/audit/ingest_ua_gec_gold.py` | Curate the small attributed UA-GEC gold fixture for the #2156 eval harness | `.venv/bin/python scripts/audit/ingest_ua_gec_gold.py --dry-run` |
 | `scripts/audit/module_quality_audit.py` | Report surface and LLM-QG/compact evidence coverage by level | `.venv/bin/python scripts/audit/module_quality_audit.py --level b1 --format summary` |

--- a/scripts/atlas/fill_local.py
+++ b/scripts/atlas/fill_local.py
@@ -1,0 +1,469 @@
+"""Phase-1 local enrichment writer for ``data/atlas.db``.
+
+The writer reuses ``scripts.lexicon.enrich_manifest.enrich_entry`` and stores
+each attached field as a resumable row in ``enrichment``. Phase 1 is forced
+offline with ``LEXICON_SLOVNYK_OFFLINE=1``: existing local caches may be read,
+but cache misses must stay absent and never open a socket.
+
+Absent-vs-uncovered rule:
+
+- Phase-2-fillable sections stay absent when Phase 1 has no payload:
+  ``meaning``, ``definition_cards``, ``synonyms``, ``idioms``, and
+  ``wiki_reference``.
+- Optional evidence sections stay absent when no source-attested datum exists:
+  ``antonyms``, ``literary_attestation``, and ``calque_note``.
+- General local article fields that Phase 2 will not fill are marked with an
+  empty ``phase='uncovered'`` row when missing: ``cefr``, ``etymology``,
+  ``morphology``, ``pronunciation``, ``stress``, ``translation``, and
+  ``heritage_status``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sqlite3
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.atlas import atlas_db
+from scripts.lexicon import enrich_manifest
+
+DEFAULT_DB = atlas_db.DEFAULT_DB
+DEFAULT_SOURCES_DB = enrich_manifest.SOURCES_DB
+DEFAULT_KAIKKI_LOOKUP = enrich_manifest.KAIKKI_LOOKUP
+
+PHASE = "local"
+UNCOVERED_PHASE = "uncovered"
+UNCOVERED_SOURCE = "phase1-local:uncovered"
+CALQUE_NOTE_KEY = "\u00a76_note"
+
+PHASE2_FILLABLE_SECTIONS = {
+    "meaning",
+    "definition_cards",
+    "synonyms",
+    "idioms",
+    "wiki_reference",
+}
+OPTIONAL_EVIDENCE_SECTIONS = {
+    "antonyms",
+    "calque_note",
+    "literary_attestation",
+}
+UNCOVERED_ON_EMPTY_SECTIONS = (
+    "cefr",
+    "etymology",
+    "heritage_status",
+    "morphology",
+    "pronunciation",
+    "stress",
+    "translation",
+)
+
+enrich_entry = enrich_manifest.enrich_entry
+
+
+@dataclass(frozen=True)
+class CoverageCell:
+    rows: int
+    uncovered: int
+
+
+@dataclass(frozen=True)
+class FillResult:
+    total: int
+    considered: int
+    inserted: int
+    skipped_existing: int
+    before: dict[str, CoverageCell]
+    after: dict[str, CoverageCell]
+
+
+def _iso_now() -> str:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat()
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _article_rows(conn: sqlite3.Connection, slug: str | None) -> list[sqlite3.Row]:
+    sql = "SELECT * FROM articles"
+    params: tuple[str, ...] = ()
+    if slug:
+        sql += " WHERE slug = ?"
+        params = (slug,)
+    sql += " ORDER BY slug"
+    return list(conn.execute(sql, params).fetchall())
+
+
+def _source_provenance(conn: sqlite3.Connection, slug: str) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """SELECT source_family, source_locator, extraction_mode
+           FROM article_provenance
+           WHERE slug = ?
+           ORDER BY rowid""",
+        (slug,),
+    ).fetchall()
+    return [
+        {
+            "source_family": row["source_family"],
+            "source_locator": row["source_locator"],
+            "extraction_mode": row["extraction_mode"],
+        }
+        for row in rows
+    ]
+
+
+def _entry_from_article(conn: sqlite3.Connection, row: sqlite3.Row) -> dict[str, Any]:
+    provenance = _source_provenance(conn, row["slug"])
+    entry: dict[str, Any] = {
+        "lemma": row["lemma"],
+        "url_slug": row["slug"],
+        "display_head": row["display_head"],
+        "entry_type": row["entry_type"],
+        "review_state": row["review_state"],
+        "visibility": row["visibility"],
+    }
+    for key in ("pos", "gloss", "created_at", "updated_at"):
+        if row[key]:
+            entry[key] = row[key]
+    if provenance:
+        entry["source_provenance"] = provenance
+        if provenance[0].get("source_family"):
+            entry["primary_source"] = provenance[0]["source_family"]
+    return entry
+
+
+def _existing_payloads(conn: sqlite3.Connection, slug: str) -> dict[str, Any]:
+    rows = conn.execute(
+        "SELECT section, payload_json FROM enrichment WHERE slug = ?",
+        (slug,),
+    ).fetchall()
+    payloads: dict[str, Any] = {}
+    for row in rows:
+        try:
+            payload = json.loads(row["payload_json"])
+        except (TypeError, ValueError):
+            payload = {}
+        payloads[str(row["section"])] = payload
+    return payloads
+
+
+@contextmanager
+def _skip_existing_extractors(existing_payloads: dict[str, Any]) -> Iterator[None]:
+    replacements: dict[str, Callable[..., Any]] = {}
+    if "pronunciation" in existing_payloads:
+        replacements["_kaikki_pronunciation"] = lambda *args, **kwargs: None
+    if "synonyms" in existing_payloads:
+        replacements["_synonyms_slovnyk"] = lambda *args, **kwargs: None
+    if "antonyms" in existing_payloads:
+        replacements["_antonyms_wiktionary"] = lambda *args, **kwargs: None
+    if "idioms" in existing_payloads:
+        replacements["_idioms"] = lambda *args, **kwargs: None
+    if "stress" in existing_payloads:
+        replacements["_stress_display_form"] = lambda *args, **kwargs: ""
+        replacements["_kaikki_stress"] = lambda *args, **kwargs: None
+    if "cefr" in existing_payloads:
+        replacements["_cefr"] = lambda *args, **kwargs: None
+    if "morphology" in existing_payloads:
+        replacements["_morphology"] = lambda *args, **kwargs: None
+    if "meaning" in existing_payloads:
+        replacements["_meaning"] = lambda *args, **kwargs: None
+        replacements["_proper_noun_wikipedia_meaning"] = lambda *args, **kwargs: None
+    if "definition_cards" in existing_payloads:
+        replacements["_definition_cards"] = lambda *args, **kwargs: []
+    if "etymology" in existing_payloads:
+        replacements["_etymology"] = lambda *args, **kwargs: None
+    if "literary_attestation" in existing_payloads:
+        replacements["_literary_attestation"] = lambda *args, **kwargs: None
+    if "translation" in existing_payloads:
+        replacements["_translation"] = lambda *args, **kwargs: None
+    if "wiki_reference" in existing_payloads:
+        replacements["_wiki_reference"] = lambda *args, **kwargs: None
+    if "heritage_status" in existing_payloads:
+        heritage_payload = existing_payloads["heritage_status"]
+        if isinstance(heritage_payload, dict):
+            replacements["classify_lemma"] = lambda *args, **kwargs: dict(heritage_payload)
+            replacements["_warning_slovnyk"] = lambda *args, **kwargs: None
+
+    originals = {name: getattr(enrich_manifest, name) for name in replacements}
+    try:
+        for name, replacement in replacements.items():
+            setattr(enrich_manifest, name, replacement)
+        yield
+    finally:
+        for name, original in originals.items():
+            setattr(enrich_manifest, name, original)
+
+
+def _source_values(value: Any) -> list[str]:
+    if isinstance(value, dict):
+        out: list[str] = []
+        for key in ("source", "source_label", "source_pill", "attribution"):
+            raw = value.get(key)
+            if isinstance(raw, list | tuple | set):
+                out.extend(str(item) for item in raw if item)
+            elif raw:
+                out.append(str(raw))
+        nested = value.get("sources")
+        if isinstance(nested, list | tuple | set):
+            out.extend(str(item) for item in nested if item)
+        return out
+    if isinstance(value, list | tuple):
+        out = []
+        for item in value:
+            out.extend(_source_values(item))
+        return out
+    return []
+
+
+def _source_label(section: str, payload: Any) -> str | None:
+    values = list(dict.fromkeys(_source_values(payload)))
+    if values:
+        return " + ".join(values)
+    if section == "heritage_status":
+        return "heritage_classifier"
+    if section == "wiki_reference":
+        return "query_wikipedia/cache"
+    return None
+
+
+def _add_payload(out: dict[str, Any], section: str, payload: Any) -> None:
+    if section not in atlas_db.ENRICHMENT_SECTIONS:
+        return
+    if not payload:
+        return
+    out[section] = payload
+
+
+def entry_payloads(entry: dict[str, Any]) -> dict[str, Any]:
+    payloads: dict[str, Any] = {}
+
+    enrichment = entry.get("enrichment")
+    if isinstance(enrichment, dict):
+        for section, payload in enrichment.items():
+            if section == "sources":
+                continue
+            _add_payload(payloads, str(section), payload)
+
+    sections = entry.get("sections")
+    if isinstance(sections, dict):
+        for section, payload in sections.items():
+            _add_payload(payloads, str(section), payload)
+
+    for section in ("pronunciation", "wiki_reference", "heritage_status"):
+        _add_payload(payloads, section, entry.get(section))
+
+    heritage = entry.get("heritage_status")
+    if isinstance(heritage, dict):
+        _add_payload(payloads, "calque_note", heritage.get(CALQUE_NOTE_KEY))
+
+    return payloads
+
+
+def _uncovered_sections(payloads: dict[str, Any]) -> list[str]:
+    return [section for section in UNCOVERED_ON_EMPTY_SECTIONS if section not in payloads]
+
+
+def _coverage(conn: sqlite3.Connection) -> dict[str, CoverageCell]:
+    rows = conn.execute(
+        """SELECT section,
+                  COUNT(DISTINCT slug) AS row_count,
+                  COUNT(DISTINCT CASE WHEN phase = 'uncovered' THEN slug END) AS uncovered_count
+           FROM enrichment
+           GROUP BY section"""
+    ).fetchall()
+    by_section = {
+        str(row["section"]): CoverageCell(rows=int(row["row_count"]), uncovered=int(row["uncovered_count"]))
+        for row in rows
+    }
+    return {
+        section: by_section.get(section, CoverageCell(rows=0, uncovered=0))
+        for section in sorted(atlas_db.ENRICHMENT_SECTIONS)
+    }
+
+
+def _coverage_json(cells: dict[str, CoverageCell]) -> dict[str, dict[str, int]]:
+    return {section: {"rows": cell.rows, "uncovered": cell.uncovered} for section, cell in cells.items()}
+
+
+def format_coverage_table(
+    before: dict[str, CoverageCell],
+    after: dict[str, CoverageCell],
+    total: int,
+) -> str:
+    lines = [
+        "section                 before       after        uncovered_after",
+        "----------------------  -----------  -----------  ---------------",
+    ]
+    for section in sorted(atlas_db.ENRICHMENT_SECTIONS):
+        before_cell = before[section]
+        after_cell = after[section]
+        lines.append(
+            f"{section:<22}  "
+            f"{before_cell.rows:>5}/{total:<5}  "
+            f"{after_cell.rows:>5}/{total:<5}  "
+            f"{after_cell.uncovered:>15}"
+        )
+    return "\n".join(lines)
+
+
+@contextmanager
+def _phase1_offline_env() -> Iterator[None]:
+    previous = os.environ.get("LEXICON_SLOVNYK_OFFLINE")
+    os.environ["LEXICON_SLOVNYK_OFFLINE"] = "1"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("LEXICON_SLOVNYK_OFFLINE", None)
+        else:
+            os.environ["LEXICON_SLOVNYK_OFFLINE"] = previous
+
+
+def fill_local(
+    db_path: Path = DEFAULT_DB,
+    sources_db_path: Path = DEFAULT_SOURCES_DB,
+    kaikki_lookup_path: Path = DEFAULT_KAIKKI_LOOKUP,
+    *,
+    slug: str | None = None,
+    refresh: bool = False,
+) -> FillResult:
+    with _phase1_offline_env():
+        return _fill_local(
+            db_path,
+            sources_db_path,
+            kaikki_lookup_path,
+            slug=slug,
+            refresh=refresh,
+        )
+
+
+def _fill_local(
+    db_path: Path = DEFAULT_DB,
+    sources_db_path: Path = DEFAULT_SOURCES_DB,
+    kaikki_lookup_path: Path = DEFAULT_KAIKKI_LOOKUP,
+    *,
+    slug: str | None = None,
+    refresh: bool = False,
+) -> FillResult:
+    if hasattr(enrich_manifest, "_CEFR_ESTIMATE_LEVEL_BY_KEY"):
+        enrich_manifest._CEFR_ESTIMATE_LEVEL_BY_KEY.clear()
+
+    with _connect(db_path) as atlas_conn, sqlite3.connect(sources_db_path) as sources_conn:
+        articles = _article_rows(atlas_conn, slug)
+        if slug and not articles:
+            raise ValueError(f"slug not found in atlas DB: {slug}")
+
+        total = int(atlas_conn.execute("SELECT COUNT(*) FROM articles").fetchone()[0])
+        before = _coverage(atlas_conn)
+        kaikki_lookup = enrich_manifest._load_kaikki_lookup(kaikki_lookup_path)
+        has_sum11_flags = enrich_manifest._sum11_has_flag_columns(sources_conn)
+        filled_at = _iso_now()
+        inserted = 0
+        skipped_existing = 0
+
+        for article in articles:
+            entry = _entry_from_article(atlas_conn, article)
+            existing_payloads = {} if refresh else _existing_payloads(atlas_conn, article["slug"])
+            with _skip_existing_extractors(existing_payloads):
+                enrich_entry(entry, sources_conn, kaikki_lookup, has_sum11_flags=has_sum11_flags)
+            payloads = entry_payloads(entry)
+            uncovered = set(_uncovered_sections(payloads))
+            for section in uncovered:
+                payloads[section] = {}
+
+            existing = set(existing_payloads)
+            for section, payload in sorted(payloads.items()):
+                if section in existing:
+                    skipped_existing += 1
+                    continue
+                phase = UNCOVERED_PHASE if section in uncovered else PHASE
+                source = UNCOVERED_SOURCE if phase == UNCOVERED_PHASE else _source_label(section, payload)
+                atlas_conn.execute(
+                    """INSERT OR REPLACE INTO enrichment
+                       (slug, section, payload_json, source, filled_at, phase)
+                       VALUES (?, ?, ?, ?, ?, ?)""",
+                    (
+                        article["slug"],
+                        section,
+                        json.dumps(payload, ensure_ascii=False, sort_keys=True),
+                        source,
+                        filled_at,
+                        phase,
+                    ),
+                )
+                inserted += 1
+            atlas_conn.commit()
+
+        after = _coverage(atlas_conn)
+
+    return FillResult(
+        total=total,
+        considered=len(articles),
+        inserted=inserted,
+        skipped_existing=skipped_existing,
+        before=before,
+        after=after,
+    )
+
+
+def _write_report_json(path: Path, result: FillResult) -> None:
+    payload = {
+        "total": result.total,
+        "considered": result.considered,
+        "inserted": result.inserted,
+        "skipped_existing": result.skipped_existing,
+        "before": _coverage_json(result.before),
+        "after": _coverage_json(result.after),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fill data/atlas.db with Phase-1 local enrichment rows.")
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB, help="Path to atlas.db.")
+    parser.add_argument("--sources-db", type=Path, default=DEFAULT_SOURCES_DB, help="Path to data/sources.db.")
+    parser.add_argument(
+        "--kaikki-lookup",
+        type=Path,
+        default=DEFAULT_KAIKKI_LOOKUP,
+        help="Path to data/lexicon/kaikki_uk_lookup.json.",
+    )
+    parser.add_argument("--slug", help="Fill one atlas article slug.")
+    parser.add_argument("--refresh", action="store_true", help="Replace existing rows for sections produced now.")
+    parser.add_argument("--report-json", type=Path, help="Write machine-readable before/after coverage report.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = fill_local(
+        args.db,
+        args.sources_db,
+        args.kaikki_lookup,
+        slug=args.slug,
+        refresh=args.refresh,
+    )
+    print(format_coverage_table(result.before, result.after, result.total))
+    print(
+        "filled "
+        f"{result.inserted} rows across {result.considered}/{result.total} articles "
+        f"(skipped_existing={result.skipped_existing}, refresh={args.refresh})"
+    )
+    if args.report_json:
+        _write_report_json(args.report_json, result)
+        print(f"wrote report_json={args.report_json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -166,6 +166,7 @@ _SLOVNYK_UKRENG_LABEL = "Українсько-англійський словн�
 _SLOVNYK_UKRENG_SOURCE = f"slovnyk.me: {_SLOVNYK_UKRENG_LABEL}"
 _SLOVNYK_BASE = "https://slovnyk.me"
 _SLOVNYK_CACHE_SCHEMA_VERSION = 2
+_OFFLINE_VALUES = {"1", "true", "yes", "on"}
 _WARNING_CLASSIFICATIONS = {"russianism", "sovietism", "surzhyk"}
 
 _SYNONYM_LABEL_WORDS = {
@@ -758,6 +759,10 @@ def _unescape_html_entities(text: str) -> str:
     return previous.replace("\u00a0", " ")
 
 
+def _phase1_offline_mode() -> bool:
+    return os.environ.get("LEXICON_SLOVNYK_OFFLINE", "").strip().casefold() in _OFFLINE_VALUES
+
+
 def clean_html_entities(text: str) -> str:
     """Unescape HTML entities, including double-escaped ones, and normalise spaces."""
     return re.sub(r"\s+", " ", _unescape_html_entities(text)).strip()
@@ -1105,6 +1110,9 @@ def _fetch_slovnyk_entry(lemma: str, lookup_word: str, slug: str) -> dict[str, A
     ``_SlovnykTransientError`` only after exhausting retries (caller leaves the slug uncached
     so a later run retries it).
     """
+    if _phase1_offline_mode():
+        return None
+
     url = f"{_SLOVNYK_BASE}/dict/{slug}/{quote(lookup_word)}"
     for attempt in range(_SLOVNYK_MAX_RETRIES + 1):
         _polite_slovnyk_delay()
@@ -1181,6 +1189,9 @@ def _slovnyk_cache(lemma: str) -> dict[str, Any]:
     else:
         cache = _new_slovnyk_cache(lemma, lookup_word)
         lookups = cache["lookups"]
+
+    if _phase1_offline_mode():
+        return cache
 
     for slug in _SLOVNYK_LOOKUP_SLUGS:
         if slug in lookups:
@@ -2964,6 +2975,9 @@ def _grac_word_candidates(word: str) -> list[str]:
 
 
 def _fetch_grac_frequency_batch(words: list[str]) -> dict[str, dict[str, Any] | None]:
+    if _phase1_offline_mode():
+        return {word: None for word in words}
+
     candidates_by_word = {word: _grac_word_candidates(word) for word in words}
     candidate_to_words: dict[str, list[str]] = {}
     for word, candidates in candidates_by_word.items():
@@ -3008,6 +3022,9 @@ def _ensure_grac_frequency_cache(words: list[str]) -> None:
     global _GRAC_FREQUENCY_CACHE_DIRTY
     cache = _load_grac_frequency_cache()
     missing = [word for word in words if word not in cache]
+    if _phase1_offline_mode():
+        return
+
     for start in range(0, len(missing), _GRAC_BATCH_SIZE):
         batch = missing[start : start + _GRAC_BATCH_SIZE]
         results = _fetch_grac_frequency_batch(batch)
@@ -3607,6 +3624,9 @@ def query_wikipedia(title: str) -> dict[str, Any] | None:
     missing article is not re-requested). Tests replace the whole function via
     monkeypatch, so the cache does not interfere with mocking.
     """
+    if _phase1_offline_mode():
+        return None
+
     try:
         from scripts.rag.source_query import wikipedia_summary
 
@@ -3621,6 +3641,9 @@ def _cached_wikipedia_summary(title: str) -> dict[str, Any] | None:
     if title in cache:
         cached = cache[title]
         return cached if isinstance(cached, dict) else None
+    if _phase1_offline_mode():
+        return None
+
     wiki_data = query_wikipedia(title)
     cache[title] = wiki_data if isinstance(wiki_data, dict) else None
     _WIKI_REFERENCE_CACHE_DIRTY = True

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "60367f42ef5f2dda11f6e7c52bc55c16353f3ca84a5c516c3972c89e7d992ce1",
+  "fingerprint": "ea02563d9451d48b47ad8cf25bb15212ce661f0539c40480214f304128c60430",
   "inputs": {
     "lexicon_code": [
       {
@@ -44,7 +44,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "8822ed30fc2079358826311e3ec4feecd82d427705a6c2a2c3fae9019c3a9f1c"
+        "sha256": "57981fe28cf8416e9253906febd1dcc3efd9d61745379c7c1a261bc9f58c0813"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/data/lexicon-manifest.pointer.json
+++ b/site/src/data/lexicon-manifest.pointer.json
@@ -2,12 +2,12 @@
   "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest.json.gz",
   "release_tag": "atlas-manifest",
   "manifest_version": "0.1",
-  "manifest_fingerprint": "60367f42ef5f2dda11f6e7c52bc55c16353f3ca84a5c516c3972c89e7d992ce1",
+  "manifest_fingerprint": "ea02563d9451d48b47ad8cf25bb15212ce661f0539c40480214f304128c60430",
   "fingerprint_schema_version": 1,
   "generated_at": "2026-07-04T22:22:04+00:00",
-  "gz_sha256": "e98cb437b26a381fec9881c266d9ded1c18b63c4f7e0c8b0172d8ff4a9ebdf5c",
-  "json_sha256": "c7e964cefdf6223fdb80fd93dfbfd71b5d61ae15fa853d74e1c0f657c02d7878",
-  "gz_bytes": 6550065,
+  "gz_sha256": "7a5bc568423833a9d7e4f4307b2381f1c499ea9ee90f7e89352980c86c1ce5ee",
+  "json_sha256": "28ef63ca4ce65854bf4df6313155fb39f26410bec64322674d9223b9d6fa1600",
+  "gz_bytes": 6550066,
   "json_bytes": 46592116,
   "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON."
 }

--- a/tests/test_atlas_fill_local.py
+++ b/tests/test_atlas_fill_local.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sqlite3
+from pathlib import Path
+
+from scripts.atlas import atlas_db, fill_local
+from scripts.lexicon import enrich_manifest
+
+
+def _build_atlas_db(tmp_path: Path) -> Path:
+    manifest = {
+        "entries": [
+            {
+                "lemma": "прапор",
+                "url_slug": "прапор",
+                "gloss": "flag",
+                "pos": "noun",
+                "primary_source": "fixture",
+                "enrichment": {
+                    "meaning": {
+                        "definitions": ["стяг"],
+                        "source": "fixture meaning",
+                    }
+                },
+            },
+            {
+                "lemma": "бігти",
+                "url_slug": "бігти",
+                "gloss": "run",
+                "pos": "verb",
+                "primary_source": "fixture",
+            },
+            {
+                "lemma": "сліпа зона",
+                "url_slug": "сліпа-зона",
+                "gloss": "blind spot",
+                "pos": "noun",
+                "primary_source": "fixture",
+            },
+        ]
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False), encoding="utf-8")
+    db_path = tmp_path / "atlas.db"
+    atlas_db.migrate_manifest(manifest_path, db_path)
+    return db_path
+
+
+def _empty_sources_db(tmp_path: Path) -> Path:
+    path = tmp_path / "sources.db"
+    sqlite3.connect(path).close()
+    return path
+
+
+def _rows(db_path: Path) -> dict[tuple[str, str], sqlite3.Row]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    rows = {
+        (row["slug"], row["section"]): row
+        for row in conn.execute(
+            "SELECT slug, section, payload_json, source, phase FROM enrichment ORDER BY slug, section"
+        )
+    }
+    conn.close()
+    return rows
+
+
+def test_section_mapping_writes_local_rows_and_honest_uncovered(tmp_path, monkeypatch):
+    db_path = _build_atlas_db(tmp_path)
+    sources_db_path = _empty_sources_db(tmp_path)
+
+    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags):
+        if entry["lemma"] == "прапор":
+            entry["heritage_status"] = {
+                "classification": "standard",
+                "attestations": [{"source": "VESUM"}],
+                "\u00a76_note": {"note": "native alternative", "source": ["Антоненко"]},
+            }
+            entry["pronunciation"] = {"ipa": "[ˈprɑpɔr]", "source": "Kaikki"}
+            entry["sections"] = {
+                "synonyms": {"items": ["стяг"], "source": "fixture synonyms"},
+                "antonyms": {"items": ["безпрапорність"], "source": "fixture antonyms"},
+                "idioms": {"items": ["під прапором"], "source": "fixture idioms"},
+            }
+            entry["enrichment"] = {
+                "stress": {"form": "пра́пор", "source": "stress fixture"},
+                "morphology": {"pos": "noun", "form_count": 7, "source": "VESUM"},
+                "translation": {"en": ["flag"], "source": "Kaikki"},
+                "sources": ["not a section"],
+            }
+        return True
+
+    monkeypatch.setattr(fill_local, "enrich_entry", fake_enrich_entry)
+
+    result = fill_local.fill_local(db_path, sources_db_path, tmp_path / "missing-kaikki.json")
+    rows = _rows(db_path)
+
+    assert result.considered == 3
+    assert json.loads(rows[("прапор", "meaning")]["payload_json"]) == {
+        "definitions": ["стяг"],
+        "source": "fixture meaning",
+    }
+    assert rows[("прапор", "meaning")]["phase"] == "migration"
+    assert json.loads(rows[("прапор", "synonyms")]["payload_json"])["items"] == ["стяг"]
+    assert rows[("прапор", "synonyms")]["phase"] == "local"
+    assert rows[("прапор", "calque_note")]["source"] == "Антоненко"
+    assert rows[("прапор", "pronunciation")]["source"] == "Kaikki"
+    assert ("сліпа-зона", "wiki_reference") not in rows
+    assert ("сліпа-зона", "synonyms") not in rows
+    assert json.loads(rows[("сліпа-зона", "cefr")]["payload_json"]) == {}
+    assert rows[("сліпа-зона", "cefr")]["phase"] == "uncovered"
+
+
+def test_idempotent_rerun_skips_existing_sections(tmp_path, monkeypatch):
+    db_path = _build_atlas_db(tmp_path)
+    sources_db_path = _empty_sources_db(tmp_path)
+
+    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags):
+        entry["enrichment"] = {"stress": {"form": f"{entry['lemma']}́", "source": "stress fixture"}}
+        entry["heritage_status"] = {"classification": "unknown"}
+        return True
+
+    monkeypatch.setattr(fill_local, "enrich_entry", fake_enrich_entry)
+
+    first = fill_local.fill_local(db_path, sources_db_path, tmp_path / "missing-kaikki.json")
+    first_count = len(_rows(db_path))
+    second = fill_local.fill_local(db_path, sources_db_path, tmp_path / "missing-kaikki.json")
+    second_count = len(_rows(db_path))
+
+    assert first.inserted > 0
+    assert second.inserted == 0
+    assert second.skipped_existing > 0
+    assert second_count == first_count
+
+
+def test_refresh_replaces_existing_section_payload(tmp_path, monkeypatch):
+    db_path = _build_atlas_db(tmp_path)
+    sources_db_path = _empty_sources_db(tmp_path)
+
+    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags):
+        entry["enrichment"] = {"meaning": {"definitions": ["оновлено"], "source": "refresh fixture"}}
+        entry["heritage_status"] = {"classification": "unknown"}
+        return True
+
+    monkeypatch.setattr(fill_local, "enrich_entry", fake_enrich_entry)
+
+    fill_local.fill_local(db_path, sources_db_path, tmp_path / "missing-kaikki.json", slug="прапор", refresh=True)
+    rows = _rows(db_path)
+
+    assert json.loads(rows[("прапор", "meaning")]["payload_json"]) == {
+        "definitions": ["оновлено"],
+        "source": "refresh fixture",
+    }
+    assert rows[("прапор", "meaning")]["phase"] == "local"
+
+
+def test_phase1_offline_guard_blocks_slovnyk_wikipedia_and_grac_network(tmp_path, monkeypatch):
+    db_path = _build_atlas_db(tmp_path)
+    sources_db_path = _empty_sources_db(tmp_path)
+    monkeypatch.setenv("LEXICON_SLOVNYK_OFFLINE", "0")
+
+    def fail_network(*args, **kwargs):
+        raise AssertionError("Phase-1 local fill attempted a network call")
+
+    monkeypatch.setattr(enrich_manifest.requests, "get", fail_network)
+    monkeypatch.setattr(socket, "socket", fail_network)
+    monkeypatch.setattr(enrich_manifest, "WIKI_REFERENCE_CACHE", tmp_path / "wiki_reference.json")
+    monkeypatch.setattr(enrich_manifest, "_WIKI_REFERENCE_CACHE_DATA", None)
+    monkeypatch.setattr(enrich_manifest, "_WIKI_REFERENCE_CACHE_DIRTY", False)
+    enrich_manifest.query_wikipedia.cache_clear()
+
+    def fake_enrich_entry(entry, conn, kaikki_lookup, *, has_sum11_flags):
+        assert enrich_manifest._fetch_slovnyk_entry("немає", "немає", "vts") is None
+        assert enrich_manifest._cached_wikipedia_summary("Тестова стаття без кешу") is None
+        assert enrich_manifest._fetch_grac_frequency_batch(["немає"]) == {"немає": None}
+        entry["enrichment"] = {"stress": {"form": "нема́є", "source": "stress fixture"}}
+        entry["heritage_status"] = {"classification": "unknown"}
+        return True
+
+    monkeypatch.setattr(fill_local, "enrich_entry", fake_enrich_entry)
+
+    fill_local.fill_local(db_path, sources_db_path, tmp_path / "missing-kaikki.json", slug="бігти")
+    assert os.environ["LEXICON_SLOVNYK_OFFLINE"] == "0"


### PR DESCRIPTION
## What

Adds `scripts/atlas/fill_local.py`, a runnable Phase-1 local enrichment writer for `data/atlas.db`, plus fixture tests for section mapping, idempotency, refresh behavior, and the offline network guard.

Also adds `LEXICON_SLOVNYK_OFFLINE=1` handling inside the slovnyk.me, Wikipedia, and GRAC network exits used by `enrich_manifest.py`, so Phase-1 cache misses return `None` without opening sockets. Existing cache hits remain usable.

Part of #4378 / umbrella #4387.

## Why

Roadmap step 2 needs a resumable DB writer that fills per-entry enrichment rows without rewriting the JSON manifest and without firing Phase-2 network fetches.

## Full fill coverage

Command:

```bash
.venv/bin/python -m scripts.atlas.fill_local --db data/atlas.db --report-json /tmp/atlas-fill-local-report.json
```

Raw output:

```text
section                 before       after        uncovered_after
----------------------  -----------  -----------  ---------------
antonyms                   67/5181      68/5181                 0
calque_note                 0/5181       5/5181                 0
cefr                     3835/5181    5181/5181              1346
definition_cards         3744/5181    3744/5181                 0
etymology                2902/5181    5181/5181              2279
heritage_status          5181/5181    5181/5181                 0
idioms                   1125/5181    1126/5181                 0
literary_attestation     3644/5181    3644/5181                 0
meaning                  3128/5181    3128/5181                 0
morphology               3532/5181    5181/5181              1511
pronunciation            3082/5181    5181/5181              2099
stress                   3868/5181    5181/5181              1313
synonyms                 1629/5181    1689/5181                 0
translation              3470/5181    5181/5181              1648
wiki_reference           1292/5181    1292/5181                 0
filled 10464 rows across 5181/5181 articles (skipped_existing=25870, refresh=False)
wrote report_json=/tmp/atlas-fill-local-report.json
```

## Sample verification

Full local rows were printed and eyeball-checked for five diverse articles: noun `фактчекінг`, verb `обговорімо`, multiword term `мікрохвильова-піч`, russianism `міроприємство`, and sparse/uncovered `singularia-tantum`.

For a copyright-safe PR body, long free-text source excerpts are omitted below; the structural rows, phases, sources, and non-excerpt payloads are shown.

```json
{
  "фактчекінг": {
    "article": {"entry_type": "lemma", "gloss": "fact-checking", "lemma": "фактчекінг", "pos": "noun", "slug": "фактчекінг"},
    "rows": [
      {"section": "cefr", "phase": "migration", "source": "estimated (GRAC frequency)", "payload": {"level": "C1", "source": "estimated (GRAC frequency)", "text": "C1 (орієнтовно / estimated; GRAC 0.06/million, rank 1917/2149)"}},
      {"section": "etymology", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "heritage_status", "phase": "migration", "source": null, "payload": {"classification": "standard", "vesum_attested": true, "is_russianism": false, "russian_shadow": false}},
      {"section": "meaning", "phase": "migration", "source": "Вікісловник", "payload": {"definitions": ["діяльність з перевірки фактів"], "source": "Вікісловник"}},
      {"section": "morphology", "phase": "migration", "source": "VESUM", "payload": {"form_count": 9, "pos": "іменник", "source": "VESUM"}},
      {"section": "pronunciation", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "stress", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "translation", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}}
    ]
  },
  "обговорімо": {
    "article": {"entry_type": "lemma", "gloss": "let's discuss", "lemma": "обговорімо", "pos": "verb", "slug": "обговорімо"},
    "rows": [
      {"section": "definition_cards", "phase": "migration", "source": null, "payload": [{"id": "vts", "source": "ВТС"}, {"id": "sum20", "source": "СУМ-20"}]},
      {"section": "etymology", "phase": "migration", "source": "kaikki/Wiktionary (CC BY-SA 3.0) (etymology of base form обговорити)"},
      {"section": "meaning", "phase": "migration", "source": "kaikki/Wiktionary (CC BY-SA 3.0) (base form обговорити)", "payload": {"source": "kaikki/Wiktionary (CC BY-SA 3.0) (base form обговорити)"}},
      {"section": "stress", "phase": "migration", "source": "ukrainian-word-stress", "payload": {"form": "обговорі́мо", "source": "ukrainian-word-stress"}},
      {"section": "translation", "phase": "migration", "source": "dmklinger (base form обговорити)", "payload": {"en": ["discuss (to converse or debate concerning a particular topic)", "(transitive) to discuss, to debate, to talk over"], "pos": "verb", "source": "dmklinger (base form обговорити)"}}
    ]
  },
  "мікрохвильова-піч": {
    "article": {"entry_type": "multiword_term", "gloss": "microwave oven", "lemma": "мікрохвильова піч", "pos": "noun", "slug": "мікрохвильова-піч"},
    "rows": [
      {"section": "heritage_status", "phase": "migration", "payload": {"classification": "unknown", "is_russianism": false}},
      {"section": "translation", "phase": "migration", "source": "dmklinger", "payload": {"en": ["microwave oven"], "pos": "noun", "source": "dmklinger"}},
      {"section": "cefr", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "etymology", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "morphology", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "pronunciation", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "stress", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}}
    ]
  },
  "міроприємство": {
    "article": {"entry_type": "lemma", "gloss": "avoid: захід", "lemma": "міроприємство", "pos": "noun", "slug": "міроприємство"},
    "rows": [
      {"section": "calque_note", "phase": "local", "source": "antonenko-p044 + glazova-10", "payload": {"corrections": ["захід", "заходи"], "note": "рос. мероприятие; use захід / заходи"}},
      {"section": "heritage_status", "phase": "migration", "payload": {"classification": "russianism", "is_russianism": true, "warning_severity": "russianism_red", "calque_warning": {"standard_alternatives": ["захід", "заходи"]}}},
      {"section": "cefr", "phase": "migration", "source": "estimated (GRAC frequency)"},
      {"section": "etymology", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "morphology", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "pronunciation", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "stress", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "translation", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}}
    ]
  },
  "singularia-tantum": {
    "article": {"entry_type": "multiword_term", "gloss": "singular-only nouns", "lemma": "singularia tantum", "pos": "grammar term", "slug": "singularia-tantum"},
    "rows": [
      {"section": "heritage_status", "phase": "migration", "payload": {"classification": "unknown", "is_russianism": false}},
      {"section": "cefr", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "etymology", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "morphology", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "pronunciation", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "stress", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}},
      {"section": "translation", "phase": "uncovered", "source": "phase1-local:uncovered", "payload": {}}
    ]
  }
}
```

Eyeball result: payloads are source-backed dictionary/corpus/cache data or explicit empty uncovered markers. No fabricated filler rows were added.

## Verification

Tests pass (`.venv/bin/python -m pytest tests/test_atlas_db.py tests/test_atlas_fill_local.py`):

```text
============================== 6 passed in 0.42s ===============================
```

Offline guard pass line:

```text
tests/test_atlas_fill_local.py::test_phase1_offline_guard_blocks_slovnyk_wikipedia_and_grac_network PASSED [100%]
```

Lint clean (`.venv/bin/ruff check scripts/atlas/ tests/test_atlas_fill_local.py`):

```text
All checks passed!
```

Commit landed:

```text
fe5c529bfe feat(atlas): phase-1 local enrichment fill for atlas.db (#4378)
```


