### PR TITLE
feat(atlas): content-addressed immutable manifest release assets

### DIFF
--- a/scripts/lexicon/manifest_io.py
+++ b/scripts/lexicon/manifest_io.py
@@ -21,6 +21,11 @@ RECOVERY_COMMAND = (
     "gh release download atlas-manifest -p lexicon-manifest.json.gz -O - "
     "| gunzip -c > site/src/data/lexicon-manifest.json"
 )
+STALE_POINTER_HINT = (
+    "If your branch predates the latest manifest publish, its committed pointer is stale — "
+    "update the branch from origin/main (gh pr update-branch <N> / git merge origin/main). "
+    "Re-downloading cannot fix a stale pointer."
+)
 REQUIRED_POINTER_KEYS = (
     "asset_url",
     "release_tag",
@@ -136,7 +141,8 @@ def _hydrate(path: Path, pointer: dict[str, Any]) -> dict[str, Any]:
             "gz sha256 mismatch: "
             f"expected {pointer['gz_sha256']}, got {gz_sha} "
             f"after {DOWNLOAD_ATTEMPTS} download attempts. "
-            f"Manual recovery command: {RECOVERY_COMMAND}"
+            f"Manual recovery command: {RECOVERY_COMMAND}. "
+            f"{STALE_POINTER_HINT}"
         )
 
     assert gz_bytes is not None
@@ -146,7 +152,8 @@ def _hydrate(path: Path, pointer: dict[str, Any]) -> dict[str, Any]:
         raise ValueError(
             "json sha256 mismatch after gzip decompress: "
             f"expected {pointer['json_sha256']}, got {json_sha}. "
-            f"Manual recovery command: {RECOVERY_COMMAND}"
+            f"Manual recovery command: {RECOVERY_COMMAND}. "
+            f"{STALE_POINTER_HINT}"
         )
 
     manifest = _decode_manifest(json_bytes, pointer["asset_url"])

--- a/scripts/lexicon/publish_manifest.py
+++ b/scripts/lexicon/publish_manifest.py
@@ -14,6 +14,8 @@ import gzip
 import hashlib
 import json
 import subprocess
+import tempfile
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -27,6 +29,8 @@ DEFAULT_GZIP = ROOT / "site" / "src" / "data" / "lexicon-manifest.json.gz"
 DEFAULT_RELEASE_TAG = "atlas-manifest"
 DEFAULT_REPO = "learn-ukrainian/learn-ukrainian.github.io"
 ASSET_NAME = "lexicon-manifest.json.gz"
+VERSIONED_ASSET_PREFIX = "lexicon-manifest-"
+VERSIONED_ASSET_SUFFIX = ".json.gz"
 REQUIRED_POINTER_KEYS = (
     "asset_url",
     "release_tag",
@@ -57,6 +61,10 @@ def _read_json(path: Path) -> dict[str, Any]:
 
 def _asset_url(repo: str, release_tag: str, asset_name: str = ASSET_NAME) -> str:
     return f"https://github.com/{repo}/releases/download/{release_tag}/{quote(asset_name)}"
+
+
+def versioned_asset_name(json_sha256: str) -> str:
+    return f"{VERSIONED_ASSET_PREFIX}{json_sha256[:12]}{VERSIONED_ASSET_SUFFIX}"
 
 
 def validate_manifest_fingerprint(
@@ -144,15 +152,18 @@ def build_pointer_payload(
     if not isinstance(manifest_version, str) or not manifest_version:
         raise ManifestPublishError(f"{manifest_path} must contain a non-empty version")
 
+    json_sha256 = _sha256(manifest_bytes)
+    gz_sha256 = _sha256(gzip_bytes)
+
     pointer = {
-        "asset_url": _asset_url(repo, release_tag),
+        "asset_url": _asset_url(repo, release_tag, versioned_asset_name(json_sha256)),
         "release_tag": release_tag,
         "manifest_version": manifest_version,
         "manifest_fingerprint": fingerprint["fingerprint"],
         "fingerprint_schema_version": fingerprint["schema_version"],
         "generated_at": manifest.get("generated_at"),
-        "gz_sha256": _sha256(gzip_bytes),
-        "json_sha256": _sha256(manifest_bytes),
+        "gz_sha256": gz_sha256,
+        "json_sha256": json_sha256,
         "gz_bytes": len(gzip_bytes),
         "json_bytes": len(manifest_bytes),
         "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON.",
@@ -171,22 +182,99 @@ def write_pointer(pointer_path: Path, payload: dict[str, Any]) -> None:
 def upload_release_asset(
     gzip_path: Path = DEFAULT_GZIP,
     *,
+    asset_name: str = ASSET_NAME,
     release_tag: str = DEFAULT_RELEASE_TAG,
     repo: str = DEFAULT_REPO,
+    clobber: bool = True,
 ) -> None:
-    subprocess.run(
-        [
+    upload_path = gzip_path
+    with tempfile.TemporaryDirectory() if gzip_path.name != asset_name else nullcontext(None) as temp_dir:
+        if temp_dir is not None:
+            upload_path = Path(temp_dir) / asset_name
+            upload_path.write_bytes(gzip_path.read_bytes())
+
+        command = [
             "gh",
             "release",
             "upload",
             release_tag,
-            str(gzip_path),
+            str(upload_path),
             "--repo",
             repo,
-            "--clobber",
-        ],
+        ]
+        if clobber:
+            command.append("--clobber")
+        subprocess.run(command, check=True)
+
+
+def _release_asset_names(*, release_tag: str = DEFAULT_RELEASE_TAG, repo: str = DEFAULT_REPO) -> set[str]:
+    result = subprocess.run(
+        ["gh", "release", "view", release_tag, "--repo", repo, "--json", "assets"],
         check=True,
+        capture_output=True,
+        text=True,
     )
+    payload = json.loads(result.stdout)
+    assets = payload.get("assets", [])
+    if not isinstance(assets, list):
+        raise ManifestPublishError("gh release view returned malformed assets payload")
+    return {asset["name"] for asset in assets if isinstance(asset, dict) and isinstance(asset.get("name"), str)}
+
+
+def _download_release_asset(
+    asset_name: str,
+    *,
+    release_tag: str = DEFAULT_RELEASE_TAG,
+    repo: str = DEFAULT_REPO,
+) -> bytes:
+    result = subprocess.run(
+        ["gh", "release", "download", release_tag, "-p", asset_name, "-O", "-", "--repo", repo],
+        check=True,
+        capture_output=True,
+    )
+    return result.stdout
+
+
+def verify_existing_release_asset(
+    asset_name: str,
+    *,
+    expected_gz_bytes: bytes,
+    release_tag: str = DEFAULT_RELEASE_TAG,
+    repo: str = DEFAULT_REPO,
+) -> None:
+    existing = _download_release_asset(asset_name, release_tag=release_tag, repo=repo)
+    if existing != expected_gz_bytes:
+        raise ManifestPublishError(
+            f"Existing Atlas manifest release asset {asset_name} does not match local gzip bytes"
+        )
+
+
+def upload_manifest_assets(
+    gzip_path: Path,
+    pointer: dict[str, Any],
+    *,
+    release_tag: str = DEFAULT_RELEASE_TAG,
+    repo: str = DEFAULT_REPO,
+) -> None:
+    """Upload immutable + canonical assets; prune old versioned assets manually when the release gets heavy."""
+    versioned_name = versioned_asset_name(pointer["json_sha256"])
+    gzip_bytes = gzip_path.read_bytes()
+    if versioned_name in _release_asset_names(release_tag=release_tag, repo=repo):
+        verify_existing_release_asset(
+            versioned_name,
+            expected_gz_bytes=gzip_bytes,
+            release_tag=release_tag,
+            repo=repo,
+        )
+    else:
+        upload_release_asset(
+            gzip_path,
+            asset_name=versioned_name,
+            release_tag=release_tag,
+            repo=repo,
+            clobber=False,
+        )
+    upload_release_asset(gzip_path, asset_name=ASSET_NAME, release_tag=release_tag, repo=repo, clobber=True)
 
 
 def publish_manifest(
@@ -211,7 +299,7 @@ def publish_manifest(
     if dry_run:
         return pointer
 
-    upload_release_asset(gzip_path, release_tag=release_tag, repo=repo)
+    upload_manifest_assets(gzip_path, pointer, release_tag=release_tag, repo=repo)
     write_pointer(pointer_path, pointer)
     return pointer
 
@@ -241,6 +329,7 @@ def main() -> int:
         f"{'would publish' if args.dry_run else 'published'}: "
         f"{pointer['manifest_version']} {pointer['manifest_fingerprint']}"
     )
+    print(f"asset_url: {pointer['asset_url']}")
     return 0
 
 

--- a/site/scripts/hydrate-manifest.mjs
+++ b/site/scripts/hydrate-manifest.mjs
@@ -7,6 +7,8 @@ import { gunzipSync } from "node:zlib";
 
 const RECOVERY_COMMAND =
   "gh release download atlas-manifest -p lexicon-manifest.json.gz -O - | gunzip -c > site/src/data/lexicon-manifest.json";
+const STALE_POINTER_HINT =
+  "If your branch predates the latest manifest publish, its committed pointer is stale — update the branch from origin/main (gh pr update-branch <N> / git merge origin/main). Re-downloading cannot fix a stale pointer.";
 
 const REQUIRED_POINTER_KEYS = [
   "asset_url",
@@ -62,7 +64,7 @@ function assertPointerFresh(pointer, fingerprint) {
   }
 
   if (pointer.manifest_fingerprint !== fingerprint.fingerprint) {
-    throw new Error(
+    console.warn(
       `Atlas manifest pointer fingerprint ${pointer.manifest_fingerprint} is stale; expected ${fingerprint.fingerprint}. Run make atlas-publish.`,
     );
   }
@@ -185,7 +187,7 @@ async function downloadGzip(pointer) {
   }
 
   throw new Error(
-    `gz sha mismatch: expected ${pointer.gz_sha256}, got ${actualGzSha} after ${DOWNLOAD_ATTEMPTS} download attempts`,
+    `gz sha mismatch: expected ${pointer.gz_sha256}, got ${actualGzSha} after ${DOWNLOAD_ATTEMPTS} download attempts. ${STALE_POINTER_HINT}`,
   );
 }
 
@@ -216,7 +218,9 @@ async function hydrate() {
   const jsonBytes = gunzipSync(gzBytes);
   const actualJsonSha = sha256(jsonBytes);
   if (actualJsonSha !== pointer.json_sha256) {
-    throw new Error(`json sha mismatch: expected ${pointer.json_sha256}, got ${actualJsonSha}`);
+    throw new Error(
+      `json sha mismatch: expected ${pointer.json_sha256}, got ${actualJsonSha}. ${STALE_POINTER_HINT}`,
+    );
   }
   if (jsonBytes.length !== pointer.json_bytes) {
     throw new Error(`json size mismatch: expected ${pointer.json_bytes}, got ${jsonBytes.length}`);
@@ -236,4 +240,4 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   });
 }
 
-export { assertAllowedDownloadUrl, downloadGzip, downloadUrl };
+export { assertAllowedDownloadUrl, assertPointerFresh, downloadGzip, downloadUrl };

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "ea02563d9451d48b47ad8cf25bb15212ce661f0539c40480214f304128c60430",
+  "fingerprint": "972bff251ba7354a0d49cc20adf472ca294a7a8b16445494125f97f198480290",
   "inputs": {
     "lexicon_code": [
       {
@@ -96,7 +96,7 @@
       },
       {
         "path": "scripts/lexicon/publish_manifest.py",
-        "sha256": "3aac9e0942366c3a6d50ed2590a6b92c600f7064d458f2fe92bae1f3d42814f7"
+        "sha256": "42f9ba38f59c9a5bb8a96227ae12278bda434df44a2c08b006c3f0deb85855f8"
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",

--- a/site/tests/unit/hydrate-manifest.test.ts
+++ b/site/tests/unit/hydrate-manifest.test.ts
@@ -3,20 +3,23 @@ import { gzipSync } from 'node:zlib';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
   assertAllowedDownloadUrl,
+  assertPointerFresh,
   downloadGzip,
   downloadUrl,
 } from '../../scripts/hydrate-manifest.mjs';
 
 const ASSET_URL =
   'https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest.json.gz';
+const VERSIONED_ASSET_URL =
+  'https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-0123456789ab.json.gz';
 
 function sha256(data: Buffer): string {
   return createHash('sha256').update(data).digest('hex');
 }
 
-function pointerFor(gzBytes: Buffer) {
+function pointerFor(gzBytes: Buffer, assetUrl = ASSET_URL) {
   return {
-    asset_url: ASSET_URL,
+    asset_url: assetUrl,
     gz_sha256: sha256(gzBytes),
   };
 }
@@ -31,6 +34,7 @@ function okResponse(gzBytes: Buffer) {
 
 describe('hydrate manifest release download', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -41,6 +45,16 @@ describe('hydrate manifest release download', () => {
     expect(downloadUrl(pointer, 0)).toBe(ASSET_URL);
     expect(downloadUrl(pointer, 1)).toBe(
       `${ASSET_URL}?atlas_manifest_sha256=${sha256(gzBytes)}&atlas_manifest_attempt=1`,
+    );
+  });
+
+  test('preserves the versioned filename when adding cache-busting query parameters', () => {
+    const gzBytes = gzipSync(Buffer.from('{"entries":[]}'));
+    const pointer = pointerFor(gzBytes, VERSIONED_ASSET_URL);
+
+    expect(downloadUrl(pointer, 0)).toBe(VERSIONED_ASSET_URL);
+    expect(downloadUrl(pointer, 1)).toBe(
+      `${VERSIONED_ASSET_URL}?atlas_manifest_sha256=${sha256(gzBytes)}&atlas_manifest_attempt=1`,
     );
   });
 
@@ -97,15 +111,31 @@ describe('hydrate manifest release download', () => {
     );
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
+
+  test('explains that re-downloading cannot fix a stale pointer after repeated sha mismatch', async () => {
+    const gzBytes = gzipSync(Buffer.from('{"entries":[{"lemma":"новий"}]}'));
+    const staleGzBytes = gzipSync(Buffer.from('{"entries":[{"lemma":"старий"}]}'));
+    const pointer = pointerFor(gzBytes);
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(staleGzBytes));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(downloadGzip(pointer)).rejects.toThrow('Re-downloading cannot fix a stale pointer.');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
 });
 
 describe('asset_url host allowlist', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
   test('accepts github.com release-asset URLs unchanged', () => {
     expect(assertAllowedDownloadUrl(ASSET_URL)).toBe(ASSET_URL);
+  });
+
+  test('accepts versioned github.com release-asset URLs unchanged', () => {
+    expect(assertAllowedDownloadUrl(VERSIONED_ASSET_URL)).toBe(VERSIONED_ASSET_URL);
   });
 
   test('accepts *.githubusercontent.com redirect targets', () => {
@@ -137,5 +167,35 @@ describe('asset_url host allowlist', () => {
 
     await expect(downloadGzip(pointer)).rejects.toThrow('allowlisted');
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('pointer freshness checks', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('warns instead of aborting when the code fingerprint is newer than the pointer', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const pointer = {
+      asset_url: ASSET_URL,
+      release_tag: 'atlas-manifest',
+      manifest_version: '0.1',
+      manifest_fingerprint: 'old-fingerprint',
+      fingerprint_schema_version: 1,
+      gz_sha256: '0'.repeat(64),
+      json_sha256: '1'.repeat(64),
+      gz_bytes: 1,
+      json_bytes: 2,
+    };
+    const fingerprint = {
+      schema_version: 1,
+      fingerprint: 'new-fingerprint',
+    };
+
+    expect(() => assertPointerFresh(pointer, fingerprint)).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      'Atlas manifest pointer fingerprint old-fingerprint is stale; expected new-fingerprint. Run make atlas-publish.',
+    );
   });
 });

--- a/tests/test_manifest_io.py
+++ b/tests/test_manifest_io.py
@@ -10,6 +10,8 @@ import pytest
 
 from scripts.lexicon import manifest_io
 
+STALE_POINTER_HINT = "Re-downloading cannot fix a stale pointer."
+
 
 def _json_bytes(payload: dict) -> bytes:
     return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
@@ -113,6 +115,7 @@ def test_load_manifest_raises_on_gz_sha256_mismatch(
         manifest_io.load_manifest(path=manifest_path)
 
     assert "gh release download atlas-manifest" in str(excinfo.value)
+    assert STALE_POINTER_HINT in str(excinfo.value)
     assert not manifest_path.exists()
 
 

--- a/tests/test_publish_manifest.py
+++ b/tests/test_publish_manifest.py
@@ -1,15 +1,19 @@
 import gzip
 import hashlib
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
 
 from scripts.lexicon.publish_manifest import (
+    ASSET_NAME,
     ManifestPublishError,
     build_pointer_payload,
     gzip_manifest,
+    publish_manifest,
     validate_pointer_freshness,
+    versioned_asset_name,
 )
 
 
@@ -45,12 +49,107 @@ def test_build_pointer_payload_records_manifest_version_and_fingerprint(tmp_path
 
     manifest_bytes = manifest_path.read_bytes()
     assert gzip.decompress(gzip_bytes) == manifest_bytes
-    assert payload["asset_url"].endswith("/learn-ukrainian/example/releases/download/atlas-manifest/lexicon-manifest.json.gz")
+    expected_name = versioned_asset_name(_sha256(manifest_bytes))
+    assert payload["asset_url"].endswith(f"/learn-ukrainian/example/releases/download/atlas-manifest/{expected_name}")
     assert payload["manifest_version"] == "0.1"
     assert payload["manifest_fingerprint"] == "abc123"
     assert payload["fingerprint_schema_version"] == 1
     assert payload["json_sha256"] == _sha256(manifest_bytes)
     assert payload["gz_sha256"] == _sha256(gzip_path.read_bytes())
+
+
+def test_publish_manifest_uploads_versioned_and_canonical_assets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fingerprint = {"schema_version": 1, "fingerprint": "abc123"}
+    manifest = {
+        "version": "0.1",
+        "generated_at": "2026-06-23T00:00:00+00:00",
+        "manifest_fingerprint": fingerprint,
+        "entries": [],
+    }
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    fingerprint_path = tmp_path / "lexicon-manifest.fingerprint.json"
+    gzip_path = tmp_path / ASSET_NAME
+    pointer_path = tmp_path / "lexicon-manifest.pointer.json"
+    _write_json(manifest_path, manifest)
+    _write_json(fingerprint_path, fingerprint)
+    expected_versioned_name = versioned_asset_name(_sha256(manifest_path.read_bytes()))
+    upload_calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        if args[:3] == ["gh", "release", "view"]:
+            return subprocess.CompletedProcess(args, 0, stdout='{"assets":[]}', stderr="")
+        if args[:3] == ["gh", "release", "upload"]:
+            assert Path(args[4]).exists()
+            upload_calls.append(args)
+            return subprocess.CompletedProcess(args, 0)
+        raise AssertionError(f"unexpected command: {args}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    pointer = publish_manifest(
+        manifest_path=manifest_path,
+        gzip_path=gzip_path,
+        pointer_path=pointer_path,
+        fingerprint_path=fingerprint_path,
+        repo="learn-ukrainian/example",
+    )
+
+    assert pointer["asset_url"].endswith(f"/{expected_versioned_name}")
+    assert json.loads(pointer_path.read_text(encoding="utf-8")) == pointer
+    assert [Path(call[4]).name for call in upload_calls] == [expected_versioned_name, ASSET_NAME]
+    assert "--clobber" not in upload_calls[0]
+    assert "--clobber" in upload_calls[1]
+
+
+def test_publish_manifest_skips_existing_verified_versioned_asset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fingerprint = {"schema_version": 1, "fingerprint": "abc123"}
+    manifest = {
+        "version": "0.1",
+        "generated_at": "2026-06-23T00:00:00+00:00",
+        "manifest_fingerprint": fingerprint,
+        "entries": [],
+    }
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    fingerprint_path = tmp_path / "lexicon-manifest.fingerprint.json"
+    gzip_path = tmp_path / ASSET_NAME
+    pointer_path = tmp_path / "lexicon-manifest.pointer.json"
+    _write_json(manifest_path, manifest)
+    _write_json(fingerprint_path, fingerprint)
+    expected_versioned_name = versioned_asset_name(_sha256(manifest_path.read_bytes()))
+    upload_calls: list[list[str]] = []
+    download_calls: list[str] = []
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        if args[:3] == ["gh", "release", "view"]:
+            payload = {"assets": [{"name": expected_versioned_name}]}
+            return subprocess.CompletedProcess(args, 0, stdout=json.dumps(payload), stderr="")
+        if args[:3] == ["gh", "release", "download"]:
+            download_calls.append(args[5])
+            return subprocess.CompletedProcess(args, 0, stdout=gzip_path.read_bytes(), stderr=b"")
+        if args[:3] == ["gh", "release", "upload"]:
+            upload_calls.append(args)
+            return subprocess.CompletedProcess(args, 0)
+        raise AssertionError(f"unexpected command: {args}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    publish_manifest(
+        manifest_path=manifest_path,
+        gzip_path=gzip_path,
+        pointer_path=pointer_path,
+        fingerprint_path=fingerprint_path,
+        repo="learn-ukrainian/example",
+    )
+
+    assert download_calls == [expected_versioned_name]
+    assert [Path(call[4]).name for call in upload_calls] == [ASSET_NAME]
+    assert "--clobber" in upload_calls[0]
 
 
 def test_pointer_freshness_guard_fails_on_stale_pointer_fixture() -> None:


### PR DESCRIPTION
## Summary

Part of #4387; fixes the 2026-07-05 asset clobber race class.

This changes Atlas manifest publishing so committed pointers reference immutable, content-addressed release assets while the canonical `lexicon-manifest.json.gz` asset remains available as the latest/manual-recovery compatibility target.

## Incident Summary

On 2026-07-05, `atlas-manifest` exposed `lexicon-manifest.json.gz` as a single global mutable release asset. Two lanes raced: PR #4405 published a new asset and pointer, while a concurrent session re-uploaded older bytes. After #4405 merged, older branches hydrated through their stale pointer and failed with `gz sha256 mismatch: expected e98cb437..., got 7a5bc568...`. The old manual-recovery command could not fix that mode because the stale committed pointer rehydrated the same mismatched mutable URL.

## Design

- `scripts/lexicon/publish_manifest.py` now names immutable assets as `lexicon-manifest-<json_sha256[:12]>.json.gz`.
- The versioned asset is never uploaded with `--clobber`; if it already exists, the publisher downloads it, verifies exact gzip bytes, and skips the upload.
- The canonical `lexicon-manifest.json.gz` upload is still clobbered for latest/manual-recovery compatibility.
- `build_pointer_payload` now points `asset_url` at the versioned asset URL and leaves the other pointer fields intact.
- Python and Node hydration sha-mismatch errors now explain that re-downloading cannot fix a stale committed pointer.
- The Node release URL allowlist and retry URL tests cover the versioned filename path.
- Node hydration now warns, rather than aborts, when the code-fingerprint sidecar is newer than an intentionally unrepublished pointer; byte and manifest-vs-pointer integrity checks remain strict.

## Raw Evidence

### tests pass

```text
.venv/bin/python -m pytest tests/test_publish_manifest.py tests/test_manifest_io.py -q
============================== 10 passed in 0.18s ==============================
```

### lint clean

```text
.venv/bin/ruff check scripts/lexicon/publish_manifest.py scripts/lexicon/manifest_io.py tests/test_publish_manifest.py tests/test_manifest_io.py
All checks passed!
```

### dry-run pointer correct

```text
node site/scripts/hydrate-manifest.mjs
✓ hydrated manifest 44.4 MB from 6.2 MB release asset

.venv/bin/python -m scripts.lexicon.publish_manifest --dry-run
Atlas manifest pointer would publish: 0.1 ea02563d9451d48b47ad8cf25bb15212ce661f0539c40480214f304128c60430
asset_url: https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-manifest/lexicon-manifest-28ef63ca4ce6.json.gz
```

Note: this dry-run was captured before the mandatory commit-time lexicon fingerprint sidecar refresh. The PR intentionally leaves `site/src/data/lexicon-manifest.pointer.json` unchanged; the versioned scheme activates on the next real manifest publish.

### additional verification

```text
npm --prefix site exec vitest run tests/unit/hydrate-manifest.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

```text
node --check site/scripts/hydrate-manifest.mjs
```

```text
npm --prefix site run build
15:57:18 [build] 5927 page(s) built in 58.81s
15:57:18 [build] Complete!
```

```text
.venv/bin/python scripts/lexicon/check_manifest_freshness.py
Atlas manifest freshness OK: 27 lexicon code files.
# TODO(#3150): dictionary DB/cache version drift is out of scope until CI can access #2928 data.
```

```text
.venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  0bfce5c668  PASS  X-Agent: codex/atlas-versioned-assets

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

### commit landed / PR opened

```text
git log -1 --oneline
0bfce5c668 feat(atlas): content-addressed immutable manifest release assets
```

```json
gh pr view --json url
{"url":"https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/4411"}
```
