### PR TITLE
feat(audit): #2156 PR-B — grounded reviewer contract + deterministic gates

### DIFF
--- a/scripts/ai_agent_bridge/_opencode.py
+++ b/scripts/ai_agent_bridge/_opencode.py
@@ -371,7 +371,7 @@ class OpencodeStreamParse:
     deduped, ordered tuple of MCP/tool invocations the model made during the
     run — the per-run observability the tool-theatre and grounding gates
     (#2156) are built on. Each event is a minimal
-    ``{tool, input, status, tool_call_id}`` dict.
+    ``{tool, input, status, tool_call_id, output}`` dict.
     """
 
     text: str
@@ -489,11 +489,11 @@ def _invoke_opencode_detailed(
 
 
 def _extract_tool_event(event: dict) -> dict | None:
-    """Normalize one NDJSON tool event to ``{tool, input, status, tool_call_id}``.
+    """Normalize one NDJSON tool event to a compact telemetry dict.
 
     Handles the observed opencode shape (top-level ``type == "tool_use"`` with a
-    nested ``part`` whose ``state`` carries ``input``/``status`` and whose
-    ``callID`` is the tool-call id) while tolerating flatter/older shapes.
+    nested ``part`` whose ``state`` carries ``input``/``status``/``output`` and
+    whose ``callID`` is the tool-call id) while tolerating flatter/older shapes.
     """
     part = event.get("part")
     if not isinstance(part, dict):
@@ -503,6 +503,7 @@ def _extract_tool_event(event: dict) -> dict | None:
         return None
     state = part.get("state") if isinstance(part.get("state"), dict) else {}
     tool_input = state.get("input", part.get("input"))
+    output = state.get("output", part.get("output"))
     status = state.get("status") or part.get("status") or event.get("status")
     tool_call_id = part.get("callID") or part.get("tool_call_id") or part.get("id") or event.get("callID")
     return {
@@ -510,6 +511,7 @@ def _extract_tool_event(event: dict) -> dict | None:
         "input": tool_input,
         "status": status if isinstance(status, str) else None,
         "tool_call_id": tool_call_id if isinstance(tool_call_id, str) else None,
+        "output": output if isinstance(output, str) else None,
     }
 
 

--- a/scripts/audit/llm_reviewer.py
+++ b/scripts/audit/llm_reviewer.py
@@ -8,7 +8,7 @@ Conforms to the canonical schema version ua_contact_quality_evidence.v1.
 from __future__ import annotations
 
 import json
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
@@ -173,22 +173,18 @@ def parse_and_evaluate_llm_response(
     activities_yaml: str = "",
     vocabulary_yaml: str = "",
     resources_yaml: str = "",
-) -> list[dict[str, Any]]:
+    *,
+    return_payload: bool = False,
+) -> list[dict[str, Any]] | dict[str, Any]:
     """Parse JSON response from the LLM and map findings to qg_schema."""
     findings: list[dict[str, Any]] = []
 
     try:
         # Simple extraction of JSON from raw response text in case it has markdown wrappers
-        clean_text = response_text.strip()
-        if "```json" in clean_text:
-            clean_text = clean_text.split("```json")[1].split("```")[0].strip()
-        elif "```" in clean_text:
-            clean_text = clean_text.split("```")[1].split("```")[0].strip()
-
-        data = json.loads(clean_text)
+        data = _json_payload_from_response(response_text)
     except Exception as e:
         # Return a parsing defect finding if JSON parsing completely fails
-        return [
+        parse_findings = [
             qg_schema.build_finding(
                 issue_id="LLM_RESPONSE_PARSE_FAILURE",
                 issue_class="other",
@@ -206,10 +202,14 @@ def parse_and_evaluate_llm_response(
                 }
             )
         ]
+        if return_payload:
+            return {"findings": parse_findings, "fact_checks": [], "evidence_gaps": []}
+        return parse_findings
 
     raw_findings = data.get("findings", [])
     if not isinstance(raw_findings, list):
-        return findings
+        payload = {"findings": findings, "fact_checks": [], "evidence_gaps": []}
+        return payload if return_payload else findings
 
     for item in raw_findings:
         if not isinstance(item, dict):
@@ -222,6 +222,7 @@ def parse_and_evaluate_llm_response(
         excerpt = item.get("excerpt", "").strip()
         message = item.get("message", "No message provided.")
         suggested_replacement = item.get("suggested_replacement")
+        grounding = item.get("grounding") if isinstance(item.get("grounding"), dict) else None
 
         # Decide which file this excerpt lives in
         file_name = "module.md"
@@ -257,6 +258,7 @@ def parse_and_evaluate_llm_response(
                 confidence="llm_judgment",
                 disposition="defect",
                 suggested_replacement=suggested_replacement,
+                grounding=grounding,
                 detector={
                     "adapter": "llm_reviewer_evaluator",
                     "rule_id": f"llm_{issue_id.lower()}",
@@ -268,4 +270,32 @@ def parse_and_evaluate_llm_response(
             )
         )
 
-    return findings
+    payload = {
+        "findings": findings,
+        "fact_checks": _list_of_mappings(data.get("fact_checks")),
+        "evidence_gaps": _list_of_mappings(data.get("evidence_gaps")),
+    }
+    return payload if return_payload else findings
+
+
+def validate_reviewer_payload(payload: Mapping[str, Any], policy_family: str | None) -> None:
+    """Validate a parsed reviewer payload before persistence or cache reuse."""
+    qg_schema.validate_reviewer_payload(payload, policy_family)
+
+
+def _json_payload_from_response(response_text: str) -> Mapping[str, Any]:
+    clean_text = response_text.strip()
+    if "```json" in clean_text:
+        clean_text = clean_text.split("```json")[1].split("```")[0].strip()
+    elif "```" in clean_text:
+        clean_text = clean_text.split("```")[1].split("```")[0].strip()
+    data = json.loads(clean_text)
+    if not isinstance(data, Mapping):
+        raise ValueError("reviewer response JSON must be an object")
+    return data
+
+
+def _list_of_mappings(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [dict(item) for item in value if isinstance(item, Mapping)]

--- a/scripts/audit/llm_reviewer_dispatch.py
+++ b/scripts/audit/llm_reviewer_dispatch.py
@@ -15,6 +15,7 @@ import shutil
 import subprocess
 import tempfile
 from collections.abc import Callable, Iterator, Mapping, Sequence
+from contextlib import suppress
 from dataclasses import asdict, dataclass
 from datetime import UTC, date, datetime
 from pathlib import Path
@@ -23,7 +24,7 @@ from uuid import uuid4
 
 import yaml
 
-from scripts.audit import llm_qg_canaries, llm_reviewer
+from scripts.audit import llm_qg_canaries, llm_reviewer, qg_schema
 from scripts.audit.content_surface_gates import policy_for_level
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -42,8 +43,14 @@ CLAUDE_SPOT_AUDIT_MODEL_ID = "claude-opus-4.6"
 # The sources MCP endpoint opencode reviewer routes ground against (mirrors the
 # `sources` entry in ~/.config/opencode/opencode.jsonc).
 SOURCES_MCP_URL = "http://127.0.0.1:8766/mcp"
+MAX_REVIEWER_TOOLS = 40
+INVALID_TOOL_THEATRE = "INVALID_TOOL_THEATRE"
+RETRY_EXHAUSTED = "RETRY_EXHAUSTED"
+UNGROUNDED_FINDINGS = "ungrounded_findings"
+DEEP_READ_REQUIRED = "deep_read_required"
 
 _TOKEN_DIVISOR = 3.5
+_TOKEN_RE = re.compile(r"[\w’'-]+", re.UNICODE)
 _AUTHOR_FIELDS = (
     "author_family",
     "writer_family",
@@ -56,6 +63,27 @@ _AUTHOR_FIELDS = (
 )
 _X_AGENT_RE = re.compile(r"^X-Agent:\s*([^/\s:]+)", re.IGNORECASE | re.MULTILINE)
 _COAUTHOR_RE = re.compile(r"^Co-Authored-By:\s*([^<\n]+)", re.IGNORECASE | re.MULTILINE)
+_SOURCE_TOOL_PREFIXES = ("sources_", "mcp__sources")
+_WIKI_TOOL_MARKERS = ("wikipedia", "wiki")
+_DEEP_READ_WIKI_MODES = {"section", "sections", "extract", "article", "page"}
+
+_THEATRE_RETRY_REMINDER = """
+
+---
+
+## Reviewer Retry: Tools Required
+
+The prior seminar/factual review did not satisfy the deterministic tool gate. You must call the sources MCP tools before answering. Use relevant queries that overlap the factual claims, then return only the required JSON object.
+"""
+
+_DEEP_READ_RETRY_REMINDER = """
+
+---
+
+## Reviewer Retry: Deep Read Required
+
+The prior response used only wiki summary-mode access for an unattested or unverified claim. Re-run the relevant wiki query in section/extract mode before deciding the verdict, then return only the required JSON object.
+"""
 
 
 class ReviewerDispatchError(RuntimeError):
@@ -139,6 +167,7 @@ class DispatchResult:
     usage: Mapping[str, Any] | None = None
     tool_call_count: int = 0
     tools_used: tuple[str, ...] = ()
+    tool_events: tuple[Mapping[str, Any], ...] = ()
 
     def metadata(self) -> dict[str, Any]:
         return {
@@ -151,7 +180,18 @@ class DispatchResult:
             "usage": dict(self.usage or {}),
             "tool_call_count": self.tool_call_count,
             "tools_used": list(self.tools_used),
+            "tool_events": [dict(event) for event in self.tool_events],
         }
+
+
+@dataclass(frozen=True, slots=True)
+class GroundingGateResult:
+    """Result of anti-fabricated-grounding filtering."""
+
+    payload: dict[str, Any]
+    ungrounded_findings: int = 0
+    required_ungrounded_findings: int = 0
+    invalid_fact_checks: int = 0
 
 
 ProviderRunner = Callable[[ReviewerRoute, str, str], DispatchResult | str]
@@ -835,6 +875,7 @@ def _result_from_stream(prompt: str, parse: Any, route: ReviewerRoute) -> Dispat
         observed_cost_usd=_cost_for_observed_text(prompt, response, route),
         tool_call_count=len(tool_events),
         tools_used=_distinct_tools(tool_events),
+        tool_events=tuple(dict(event) for event in tool_events),
     )
 
 
@@ -846,6 +887,292 @@ def _distinct_tools(tool_events: Sequence[Mapping[str, Any]]) -> tuple[str, ...]
         if isinstance(name, str) and name and name not in seen:
             seen.append(name)
     return tuple(seen)
+
+
+# --- Deterministic reviewer gates (design D4) ------------------------------
+
+
+def reviewer_retry_prompt(prompt: str, reason: str) -> str:
+    """Append a deterministic retry reminder to the reviewer prompt."""
+    if reason == DEEP_READ_REQUIRED:
+        return f"{prompt}{_DEEP_READ_RETRY_REMINDER}"
+    return f"{prompt}{_THEATRE_RETRY_REMINDER}"
+
+
+def tool_events_from_dispatch_meta(dispatch_meta: Mapping[str, Any]) -> tuple[dict[str, Any], ...]:
+    """Return normalized tool events from dispatch metadata."""
+    raw_events = dispatch_meta.get("tool_events")
+    if not isinstance(raw_events, Sequence) or isinstance(raw_events, (str, bytes)):
+        return ()
+    return tuple(dict(event) for event in raw_events if isinstance(event, Mapping))
+
+
+def tool_call_count_from_dispatch_meta(dispatch_meta: Mapping[str, Any]) -> int:
+    """Return the deterministic tool-call count, preferring explicit metadata."""
+    raw_count = dispatch_meta.get("tool_call_count")
+    try:
+        count = int(raw_count) if raw_count is not None else 0
+    except (TypeError, ValueError):
+        count = 0
+    return max(count, len(tool_events_from_dispatch_meta(dispatch_meta)))
+
+
+def enforce_tool_budget(dispatch_meta: Mapping[str, Any]) -> None:
+    """Hard-fail reviewer runs that exceed the tool budget."""
+    count = tool_call_count_from_dispatch_meta(dispatch_meta)
+    if count > MAX_REVIEWER_TOOLS:
+        raise ReviewerDispatchError(
+            f"reviewer used {count} tools; hard cap is {MAX_REVIEWER_TOOLS}"
+        )
+
+
+def tool_theatre_violation(
+    *,
+    policy_family: str,
+    payload: Mapping[str, Any],
+    dispatch_meta: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Return a theatre-gate violation for grounded routes, else None."""
+    if not _requires_grounded_tools(policy_family, dispatch_meta):
+        return None
+    count = tool_call_count_from_dispatch_meta(dispatch_meta)
+    if count <= 0:
+        return {"status": INVALID_TOOL_THEATRE, "reason": "no_tool_calls"}
+
+    events = tool_events_from_dispatch_meta(dispatch_meta)
+    claim_tokens = _payload_claim_tokens(payload)
+    if events:
+        if not any(_source_event_relevant(event, claim_tokens) for event in events):
+            return {"status": INVALID_TOOL_THEATRE, "reason": "irrelevant_tool_calls"}
+        return None
+
+    tools_used = dispatch_meta.get("tools_used")
+    if (
+        isinstance(tools_used, Sequence)
+        and not isinstance(tools_used, (str, bytes))
+        and any(_is_source_tool(str(tool)) for tool in tools_used)
+    ):
+        return None
+    return {"status": INVALID_TOOL_THEATRE, "reason": "no_relevant_source_tool_calls"}
+
+
+def deep_read_required(payload: Mapping[str, Any], dispatch_meta: Mapping[str, Any]) -> bool:
+    """Return True when summary-only wiki access requires one forced retry."""
+    events = tool_events_from_dispatch_meta(dispatch_meta)
+    if not events:
+        return False
+    fact_checks = payload.get("fact_checks")
+    if not isinstance(fact_checks, list):
+        return False
+    for fact_check in fact_checks:
+        if not isinstance(fact_check, Mapping):
+            continue
+        verdict = str(fact_check.get("verdict") or "")
+        if not verdict.startswith(("UNATTESTED", "UNVERIFIED")):
+            continue
+        if fact_check.get("deep_read_attempted") is True:
+            continue
+        claim_tokens = _tokenize(str(fact_check.get("claim") or ""))
+        summary_seen = False
+        deep_seen = False
+        for event in events:
+            if not _is_wiki_event(event):
+                continue
+            query_tokens = _event_query_tokens(event)
+            if claim_tokens and not claim_tokens.intersection(query_tokens):
+                continue
+            mode = _event_mode(event)
+            summary_seen = summary_seen or mode == "summary"
+            deep_seen = deep_seen or mode in _DEEP_READ_WIKI_MODES
+        if summary_seen and not deep_seen:
+            return True
+    return False
+
+
+def mark_deep_read_attempted(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Mark unattested/unverified fact checks as having received the forced retry."""
+    out = dict(payload)
+    marked: list[dict[str, Any]] = []
+    for fact_check in payload.get("fact_checks", []):
+        if not isinstance(fact_check, Mapping):
+            continue
+        item = dict(fact_check)
+        verdict = str(item.get("verdict") or "")
+        if verdict.startswith(("UNATTESTED", "UNVERIFIED")):
+            item["deep_read_attempted"] = True
+        marked.append(item)
+    out["fact_checks"] = marked
+    return out
+
+
+def enforce_grounding_against_tool_events(
+    payload: Mapping[str, Any],
+    dispatch_meta: Mapping[str, Any],
+    *,
+    policy_family: str,
+) -> GroundingGateResult:
+    """Drop findings whose claimed grounding is not present in this run's tools."""
+    events = tool_events_from_dispatch_meta(dispatch_meta)
+    if not events:
+        return GroundingGateResult(payload=dict(payload))
+
+    kept_findings: list[dict[str, Any]] = []
+    ungrounded = 0
+    required_ungrounded = 0
+    for finding in payload.get("findings", []):
+        if not isinstance(finding, Mapping):
+            continue
+        item = dict(finding)
+        grounding = item.get("grounding")
+        if isinstance(grounding, Mapping) and not _grounding_matches_events(grounding, events):
+            ungrounded += 1
+            if qg_schema.finding_requires_grounding(item, policy_family):
+                required_ungrounded += 1
+            continue
+        kept_findings.append(item)
+
+    invalid_fact_checks = 0
+    for fact_check in payload.get("fact_checks", []):
+        if not isinstance(fact_check, Mapping):
+            continue
+        grounding = fact_check.get("grounding")
+        if isinstance(grounding, Mapping) and not _grounding_matches_events(grounding, events):
+            invalid_fact_checks += 1
+
+    out = dict(payload)
+    out["findings"] = kept_findings
+    return GroundingGateResult(
+        payload=out,
+        ungrounded_findings=ungrounded,
+        required_ungrounded_findings=required_ungrounded,
+        invalid_fact_checks=invalid_fact_checks,
+    )
+
+
+def factual_sweep_incomplete(
+    payload: Mapping[str, Any],
+    *,
+    policy_family: str,
+    invalid_fact_checks: int = 0,
+) -> bool:
+    """Return True when a seminar response lacks a complete factual sweep."""
+    if str(policy_family).strip().lower() != "seminar":
+        return False
+    fact_checks = payload.get("fact_checks")
+    if not isinstance(fact_checks, list) or not fact_checks:
+        return True
+    if invalid_fact_checks:
+        return True
+    for fact_check in fact_checks:
+        if not isinstance(fact_check, Mapping):
+            return True
+        if fact_check.get("verdict") == "UNVERIFIED_INSUFFICIENT_SEARCH":
+            return True
+    return False
+
+
+def _requires_grounded_tools(policy_family: str, dispatch_meta: Mapping[str, Any]) -> bool:
+    route_name = str(dispatch_meta.get("route_name") or "")
+    return str(policy_family).strip().lower() == "seminar" or route_name == FRONTIER_OPENCODE_ROUTE.route_name
+
+
+def _is_source_tool(tool: str) -> bool:
+    clean = tool.strip().lower()
+    return clean.startswith(_SOURCE_TOOL_PREFIXES) or clean.startswith("search_") or clean.startswith("query_")
+
+
+def _source_event_relevant(event: Mapping[str, Any], claim_tokens: set[str]) -> bool:
+    tool = str(event.get("tool") or "")
+    if not _is_source_tool(tool):
+        return False
+    if not claim_tokens:
+        return True
+    return bool(claim_tokens.intersection(_event_query_tokens(event)))
+
+
+def _payload_claim_tokens(payload: Mapping[str, Any]) -> set[str]:
+    texts: list[str] = []
+    fact_checks = payload.get("fact_checks")
+    if isinstance(fact_checks, list):
+        texts.extend(str(item.get("claim") or "") for item in fact_checks if isinstance(item, Mapping))
+    findings = payload.get("findings")
+    if isinstance(findings, list):
+        for finding in findings:
+            if isinstance(finding, Mapping):
+                texts.append(str(finding.get("excerpt") or ""))
+                texts.append(str(finding.get("message") or ""))
+    return _tokenize(" ".join(texts))
+
+
+def _tokenize(text: str) -> set[str]:
+    return {token.lower() for token in _TOKEN_RE.findall(text) if len(token) >= 3}
+
+
+def _event_query_tokens(event: Mapping[str, Any]) -> set[str]:
+    return _tokenize(" ".join(_tool_query_candidates(event)))
+
+
+def _tool_query_candidates(event: Mapping[str, Any]) -> list[str]:
+    tool_input = event.get("input")
+    candidates: list[str] = []
+    if isinstance(tool_input, Mapping):
+        for key in ("query", "q", "claim", "word", "headword", "lemma", "text"):
+            value = tool_input.get(key)
+            if isinstance(value, str) and value.strip():
+                candidates.append(value.strip())
+        query = tool_input.get("query") or tool_input.get("q")
+        mode = tool_input.get("mode")
+        if isinstance(query, str) and isinstance(mode, str):
+            candidates.append(f"{query.strip()} mode={mode.strip()}")
+        with suppress(TypeError, ValueError):
+            candidates.append(json.dumps(tool_input, ensure_ascii=False, sort_keys=True))
+    elif isinstance(tool_input, str) and tool_input.strip():
+        candidates.append(tool_input.strip())
+    return candidates
+
+
+def _event_mode(event: Mapping[str, Any]) -> str:
+    tool_input = event.get("input")
+    if isinstance(tool_input, Mapping):
+        mode = tool_input.get("mode")
+        if isinstance(mode, str):
+            return mode.strip().lower()
+    return ""
+
+
+def _is_wiki_event(event: Mapping[str, Any]) -> bool:
+    tool = str(event.get("tool") or "").lower()
+    return any(marker in tool for marker in _WIKI_TOOL_MARKERS)
+
+
+def _grounding_matches_events(
+    grounding: Mapping[str, Any],
+    events: Sequence[Mapping[str, Any]],
+) -> bool:
+    query = str(grounding.get("query") or "").strip()
+    excerpt = str(grounding.get("evidence_excerpt") or "").strip()
+    call_id = str(grounding.get("tool_call_id") or "").strip()
+    if not query or not excerpt or not call_id:
+        return False
+    for event in events:
+        if str(event.get("tool_call_id") or "") != call_id:
+            continue
+        if not _event_input_matches_query(event, query):
+            return False
+        output = event.get("output")
+        return isinstance(output, str) and excerpt in output
+    return False
+
+
+def _event_input_matches_query(event: Mapping[str, Any], query: str) -> bool:
+    normalized = _normalize_query(query)
+    if not normalized:
+        return False
+    return any(_normalize_query(candidate) == normalized for candidate in _tool_query_candidates(event))
+
+
+def _normalize_query(value: str) -> str:
+    return " ".join(str(value).strip().lower().split())
 
 
 # --- Sources MCP fail-fast (design D0; step-1 lesson) ----------------------

--- a/scripts/audit/prompts/reviewer_prompt.md
+++ b/scripts/audit/prompts/reviewer_prompt.md
@@ -1,5 +1,88 @@
 # LLM Reviewer & Evaluator Prompt for Ukrainian Curriculum Quality
 
+## 0. Grounded Evidence Contract
+
+For seminar content and fact-sensitive reviews, source grounding is REQUIRED for:
+* findings in `seminar_sensitivity` or `decolonization`;
+* calque, false-friend, russicism, or heritage-contact judgments on seminar content.
+
+Style, register, tone, and naturalness judgments outside those factual/contact categories remain prompt-only judgments and do not require source grounding.
+
+### Seminar Fact-Check Sweep
+
+For every seminar module, enumerate the factual claims in the learner-facing content, verify each claim, and return a top-level `fact_checks` list. Each fact check MUST use exactly one verdict from this taxonomy:
+
+* `CONFIRMED`: authoritative source text directly supports the claim.
+* `REFUTED_BY_CONTRADICTION`: authoritative source text contradicts the claim.
+* `UNATTESTED_AFTER_SEARCH`: the required source set was searched and nothing attests the claim.
+* `CONTESTED`: credible sources disagree or the best authority explicitly marks the matter uncertain.
+* `UNVERIFIED_INSUFFICIENT_SEARCH`: the search protocol was not completed or tool budget was exhausted.
+
+Few-shot anchors:
+* `UNATTESTED_AFTER_SEARCH`: Claim: "During spring-song rituals, people displayed `гаї` as ribbon-decorated symbolic trees." Searches: wiki section/extract for веснянки/гаївки, `search_literary`, `search_text`, and `search_grinchenko_1907`. If no source attests the ribbon-tree ritual, verdict is `UNATTESTED_AFTER_SEARCH`; list the searched source set.
+* `CONTESTED`: Claim: "`гаївка` comes from `гай`." ЕСУМ says the etymology is unclear (`неясне`) and presents multiple theories, including a link to `гай` and another explanation. Verdict is `CONTESTED`; present both theories without choosing one.
+
+### Required Search Protocol
+
+Use the deterministic minimum source set for each claim type:
+* Folk/ritual claim: wiki sections/extracts plus `search_literary`, `search_text`, and `search_grinchenko_1907`.
+* Etymology claim: `search_esum` plus `search_heritage`.
+* Usage/attestation claim: `query_grac`.
+* Russicism/contact claim: `search_heritage` plus `search_style_guide`; use Antonenko-Davydovych prose when relevant.
+
+### Citation Admissibility
+
+Search snippets alone cannot `CONFIRM` or `REFUTE` a claim. Wiki `summary` may orient the search, but wiki `section` or `extract` text is required for a factual verdict. `UNATTESTED_AFTER_SEARCH` requires listing the searched source set and queries.
+
+### Tool Budget
+
+Use at most 3 tool calls per claim and at most 40 tool calls total. After the budget is exhausted, use `UNVERIFIED_INSUFFICIENT_SEARCH` and set `budget_exhausted: true`.
+
+### Grounded Output Shape
+
+Findings may include a grounding object:
+
+```json
+{
+  "grounding": {
+    "tool": "sources_query_wikipedia",
+    "query": "Веснянки mode=section",
+    "evidence_excerpt": "exact excerpt copied from a tool result",
+    "tool_call_id": "call_123"
+  }
+}
+```
+
+Seminar responses MUST also include:
+
+```json
+{
+  "fact_checks": [
+    {
+      "claim": "A factual claim from the content.",
+      "verdict": "CONFIRMED",
+      "grounding": {
+        "tool": "sources_query_wikipedia",
+        "query": "Веснянки",
+        "evidence_excerpt": "exact excerpt copied from a tool result",
+        "tool_call_id": "call_123"
+      },
+      "deep_read_attempted": false,
+      "budget_exhausted": false
+    }
+  ],
+  "evidence_gaps": [
+    {
+      "claim": "A suspected issue that cannot yet be grounded.",
+      "suspected_issue": "Possible invented ritual detail.",
+      "searches": ["sources_search_text: веснянки гаї стрічками"],
+      "status": "unresolved",
+      "reason": "Required sources did not attest the specific detail."
+    }
+  ]
+}
+```
+
 > [!IMPORTANT]
 > **Deterministic Layer Precedence & Grammar/Mechanics Deferral**:
 > The deterministic quality gate layer (including #4308 `check_russicisms`, #912 `semantic_russianisms`, and general curriculum QG checks) handles lexical Russianisms, orthography, and fundamental hard-grammar validation FIRST. A clean LLM pass is NOT a full gate; this LLM reviewer is designed to catch style, register, complex calques, and pedagogical alignment. For spelling, orthography, and other fundamental mechanical grammar rules, explicitly defer to the deterministic gates or flag only if they escape them.

--- a/scripts/audit/qg_factcheck_scoring.py
+++ b/scripts/audit/qg_factcheck_scoring.py
@@ -1,0 +1,55 @@
+"""Step-3 bakeoff scoring for grounded reviewer fact-check verdicts.
+
+This module is intentionally pure and not wired into live gates. It scores
+offline proof rows where the harness knows whether a claim is true or planted.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+CONFIRMED_ON_TRUE = 20
+CONFIRMED_ON_FABRICATED = -100
+REFUTED_ON_FABRICATED = 30
+UNATTESTED_ON_FABRICATED = 10
+UNATTESTED_OR_UNVERIFIED_ON_TRUE = -10
+REFUTED_ON_TRUE = -50
+
+
+def score_verdict(verdict: str, *, claim_is_true: bool) -> int:
+    """Score one fact-check verdict against known truth."""
+    normalized = verdict.strip().upper()
+    if claim_is_true:
+        if normalized == "CONFIRMED":
+            return CONFIRMED_ON_TRUE
+        if normalized == "REFUTED_BY_CONTRADICTION":
+            return REFUTED_ON_TRUE
+        if normalized in {"UNATTESTED_AFTER_SEARCH", "UNVERIFIED_INSUFFICIENT_SEARCH"}:
+            return UNATTESTED_OR_UNVERIFIED_ON_TRUE
+        return 0
+
+    if normalized == "CONFIRMED":
+        return CONFIRMED_ON_FABRICATED
+    if normalized == "REFUTED_BY_CONTRADICTION":
+        return REFUTED_ON_FABRICATED
+    if normalized == "UNATTESTED_AFTER_SEARCH":
+        return UNATTESTED_ON_FABRICATED
+    return 0
+
+
+def score_fact_checks(
+    fact_checks: list[Mapping[str, Any]],
+    truth_by_claim: Mapping[str, bool],
+) -> int:
+    """Score fact-check rows by exact claim text."""
+    total = 0
+    for row in fact_checks:
+        claim = row.get("claim")
+        verdict = row.get("verdict")
+        if not isinstance(claim, str) or not isinstance(verdict, str):
+            continue
+        if claim not in truth_by_claim:
+            continue
+        total += score_verdict(verdict, claim_is_true=bool(truth_by_claim[claim]))
+    return total

--- a/scripts/audit/qg_schema.py
+++ b/scripts/audit/qg_schema.py
@@ -75,6 +75,19 @@ DISPOSITIONS = frozenset(
         "suppressed_fp",
     }
 )
+FACT_CHECK_VERDICTS = frozenset(
+    {
+        "CONFIRMED",
+        "REFUTED_BY_CONTRADICTION",
+        "UNATTESTED_AFTER_SEARCH",
+        "CONTESTED",
+        "UNVERIFIED_INSUFFICIENT_SEARCH",
+    }
+)
+MAX_REVIEWER_FACT_CHECKS = 40
+GROUNDING_REQUIRED_DIMENSIONS = frozenset({"seminar_sensitivity", "decolonization"})
+GROUNDING_REQUIRED_SEMINAR_CLASSES = frozenset({"calque", "false_friend"})
+GROUNDING_KEYS = frozenset({"tool", "query", "evidence_excerpt", "tool_call_id"})
 
 DEFAULT_ATTRIBUTION = {
     "corpus": None,
@@ -280,6 +293,7 @@ def build_finding(
     suggested_replacement: str | Sequence[str] | None = None,
     detector: Mapping[str, Any] | None = None,
     attribution: Mapping[str, Any] | None = None,
+    grounding: Mapping[str, Any] | None = None,
     sense_context: Mapping[str, Any] | None = None,
     metadata: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -316,6 +330,8 @@ def build_finding(
         finding["sense_context"] = dict(sense_context)
     if metadata:
         finding["metadata"] = dict(metadata)
+    if grounding:
+        finding["grounding"] = dict(grounding)
     finding["finding_id"] = make_finding_id(finding)
     validate_finding(finding)
     return finding
@@ -582,6 +598,102 @@ def validate_finding(finding: Mapping[str, Any]) -> None:
         raise ValueError("detector must be a mapping")
     if not isinstance(finding["attribution"], Mapping):
         raise ValueError("attribution must be a mapping")
+    grounding = finding.get("grounding")
+    if grounding is not None:
+        validate_grounding(grounding)
+
+
+def finding_requires_grounding(finding: Mapping[str, Any], policy_family: str | None) -> bool:
+    """Return True when the D1 grounding matrix requires this finding to cite tools."""
+    family = str(policy_family or "").strip().lower()
+    dimension = str(finding.get("dimension") or "")
+    issue_class = str(finding.get("issue_class") or "")
+    if dimension in GROUNDING_REQUIRED_DIMENSIONS:
+        return True
+    return family == "seminar" and issue_class in GROUNDING_REQUIRED_SEMINAR_CLASSES
+
+
+def validate_grounded_finding(finding: Mapping[str, Any], policy_family: str | None) -> None:
+    """Validate one reviewer finding plus the D1 grounding requirement."""
+    validate_finding(finding)
+    if finding_requires_grounding(finding, policy_family) and not finding.get("grounding"):
+        raise ValueError("finding requires grounding")
+
+
+def validate_grounding(grounding: Mapping[str, Any]) -> None:
+    """Validate the traceable reviewer grounding object."""
+    if not isinstance(grounding, Mapping):
+        raise ValueError("grounding must be a mapping")
+    missing = sorted(key for key in GROUNDING_KEYS if key not in grounding)
+    if missing:
+        raise ValueError(f"grounding missing required fields: {', '.join(missing)}")
+    for key in sorted(GROUNDING_KEYS):
+        value = grounding.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"grounding.{key} must be a non-empty string")
+
+
+def validate_fact_check(fact_check: Mapping[str, Any]) -> None:
+    """Validate one reviewer fact-check row."""
+    if not isinstance(fact_check, Mapping):
+        raise ValueError("fact_check must be a mapping")
+    claim = fact_check.get("claim")
+    if not isinstance(claim, str) or not claim.strip():
+        raise ValueError("fact_check.claim must be a non-empty string")
+    _require_member("fact_check.verdict", fact_check.get("verdict"), FACT_CHECK_VERDICTS)
+    grounding = fact_check.get("grounding")
+    if grounding is not None:
+        validate_grounding(grounding)
+    if fact_check.get("verdict") in {"CONFIRMED", "REFUTED_BY_CONTRADICTION", "CONTESTED"} and grounding is None:
+        raise ValueError("fact_check verdict requires grounding")
+    for bool_key in ("deep_read_attempted", "budget_exhausted"):
+        if bool_key in fact_check and not isinstance(fact_check[bool_key], bool):
+            raise ValueError(f"fact_check.{bool_key} must be a boolean")
+    searches = fact_check.get("searches")
+    if searches is not None:
+        _validate_string_list(searches, "fact_check.searches")
+
+
+def validate_evidence_gap(evidence_gap: Mapping[str, Any]) -> None:
+    """Validate one reviewer evidence-gap row."""
+    if not isinstance(evidence_gap, Mapping):
+        raise ValueError("evidence_gap must be a mapping")
+    for key in ("claim", "suspected_issue", "status", "reason"):
+        value = evidence_gap.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"evidence_gap.{key} must be a non-empty string")
+    _validate_string_list(evidence_gap.get("searches"), "evidence_gap.searches")
+
+
+def validate_reviewer_payload(payload: Mapping[str, Any], policy_family: str | None) -> None:
+    """Validate an LLM reviewer payload before cache write or cache reuse."""
+    if not isinstance(payload, Mapping):
+        raise ValueError("reviewer payload must be a mapping")
+    findings = payload.get("findings", [])
+    if not isinstance(findings, list):
+        raise ValueError("reviewer payload findings must be a list")
+    for finding in findings:
+        if not isinstance(finding, Mapping):
+            raise ValueError("reviewer payload findings entries must be mappings")
+        validate_grounded_finding(finding, policy_family)
+    fact_checks = payload.get("fact_checks", [])
+    if not isinstance(fact_checks, list):
+        raise ValueError("reviewer payload fact_checks must be a list")
+    if len(fact_checks) > MAX_REVIEWER_FACT_CHECKS:
+        raise ValueError(
+            f"reviewer payload fact_checks exceeds cap: {len(fact_checks)} > {MAX_REVIEWER_FACT_CHECKS}"
+        )
+    for fact_check in fact_checks:
+        if not isinstance(fact_check, Mapping):
+            raise ValueError("reviewer payload fact_checks entries must be mappings")
+        validate_fact_check(fact_check)
+    evidence_gaps = payload.get("evidence_gaps", [])
+    if not isinstance(evidence_gaps, list):
+        raise ValueError("reviewer payload evidence_gaps must be a list")
+    for evidence_gap in evidence_gaps:
+        if not isinstance(evidence_gap, Mapping):
+            raise ValueError("reviewer payload evidence_gaps entries must be mappings")
+        validate_evidence_gap(evidence_gap)
 
 
 def validate_record(record: Mapping[str, Any]) -> None:
@@ -613,3 +725,11 @@ def validate_record(record: Mapping[str, Any]) -> None:
 def _require_member(name: str, value: object, allowed: frozenset[str]) -> None:
     if not isinstance(value, str) or value not in allowed:
         raise ValueError(f"unsupported {name}: {value!r}")
+
+
+def _validate_string_list(value: object, name: str) -> None:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a list")
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise ValueError(f"{name} entries must be non-empty strings")

--- a/scripts/audit/qg_workflow.py
+++ b/scripts/audit/qg_workflow.py
@@ -709,19 +709,35 @@ def _run_tier2(
         path=store_path,
     )
     if cached is not None:
-        findings = _findings_from_payload(cached.payload)
-        return {
-            "findings": findings,
-            "result": {
-                **base_result,
-                "status": "cache_hit",
-                "findings": len(findings),
-                "cache_run_id": cached.run_id,
-            },
-            "llm_used": True,
-            "reviewer_model_id": reviewer_model_id,
-            "reviewer_family": reviewer_family,
+        cached_payload = dict(cached.payload)
+        cached_meta = {
+            "tool_call_count": cached.tool_call_count,
+            "tools_used": list(cached.tools_used),
+            "route_name": cached.route_name,
         }
+        try:
+            llm_reviewer.validate_reviewer_payload(cached_payload, policy_family)
+            cache_theatre = llm_reviewer_dispatch.tool_theatre_violation(
+                policy_family=policy_family,
+                payload=cached_payload,
+                dispatch_meta=cached_meta,
+            )
+        except ValueError:
+            cache_theatre = {"status": llm_reviewer_dispatch.INVALID_TOOL_THEATRE}
+        if cache_theatre is None:
+            findings = _findings_from_payload(cached_payload)
+            return {
+                "findings": findings,
+                "result": {
+                    **base_result,
+                    "status": "cache_hit",
+                    "findings": len(findings),
+                    "cache_run_id": cached.run_id,
+                },
+                "llm_used": True,
+                "reviewer_model_id": reviewer_model_id,
+                "reviewer_family": reviewer_family,
+            }
 
     stale_cache = _has_stale_cache(
         level=level,
@@ -804,118 +820,219 @@ def _run_tier2(
             "reviewer_family": reviewer_family,
         }
 
-    try:
-        raw_response = effective_reviewer(target, prompt)
-    except llm_reviewer_dispatch.ReviewerDispatchError as exc:
-        budget.record_spend(estimate)
-        return {
-            "findings": [],
-            "result": {
-                **base_result,
-                "status": "provider_error",
-                "reason": type(exc).__name__,
-                "message": str(exc),
-                "estimate": estimate,
-            },
-            "workflow_verdict": "PROVIDER_FAILURE",
-            "completion_status": "INCOMPLETE",
-            "reviewer_model_id": reviewer_model_id,
-            "reviewer_family": reviewer_family,
-        }
-    response_text, dispatch_meta = _coerce_reviewer_response(raw_response)
-    actual_model_id = str(dispatch_meta.get("reviewer_model_id") or reviewer_model_id)
-    actual_family = str(dispatch_meta.get("reviewer_family") or reviewer_family)
-    actual_route_name = str(dispatch_meta.get("route_name") or route_name)
-    observed_cost = _observed_cost(dispatch_meta)
-    budget.record_spend(estimate, observed_cost_usd=observed_cost)
-    if route is not None:
-        _record_daily_spend(
-            options=options,
-            level=level,
-            slug=slug,
-            route=route,
-            estimate=estimate,
-            observed_cost_usd=observed_cost,
+    attempt_prompt = prompt
+    theatre_retried = False
+    deep_read_retried = False
+    payload: dict[str, Any]
+    findings: list[dict[str, Any]]
+    dispatch_meta: dict[str, Any]
+    tier2_status = "ran"
+    workflow_override: str | None = None
+    while True:
+        try:
+            raw_response = effective_reviewer(target, attempt_prompt)
+        except llm_reviewer_dispatch.ReviewerDispatchError as exc:
+            budget.record_spend(estimate)
+            return {
+                "findings": [],
+                "result": {
+                    **base_result,
+                    "status": "provider_error",
+                    "reason": type(exc).__name__,
+                    "message": str(exc),
+                    "estimate": estimate,
+                },
+                "workflow_verdict": "PROVIDER_FAILURE",
+                "completion_status": "INCOMPLETE",
+                "reviewer_model_id": reviewer_model_id,
+                "reviewer_family": reviewer_family,
+            }
+        response_text, dispatch_meta = _coerce_reviewer_response(raw_response)
+        actual_model_id = str(dispatch_meta.get("reviewer_model_id") or reviewer_model_id)
+        actual_family = str(dispatch_meta.get("reviewer_family") or reviewer_family)
+        actual_route_name = str(dispatch_meta.get("route_name") or route_name)
+        observed_cost = _observed_cost(dispatch_meta)
+        budget.record_spend(estimate, observed_cost_usd=observed_cost)
+        if route is not None:
+            _record_daily_spend(
+                options=options,
+                level=level,
+                slug=slug,
+                route=route,
+                estimate=estimate,
+                observed_cost_usd=observed_cost,
+            )
+        if (
+            actual_model_id != reviewer_model_id
+            or actual_family != reviewer_family
+            # route_name keys the composite cache — a reviewer answering from the
+            # wrong route must not poison route-keyed rows (codex review of #4401;
+            # LiveReviewerDispatcher checks this itself, but _run_tier2 accepts
+            # arbitrary reviewer callables). Only enforceable when the workflow
+            # resolved an expected route (live mode); injected test reviewers with
+            # no resolved route (route_name=None) keep their reported name.
+            or (route_name is not None and actual_route_name != route_name)
+        ):
+            return {
+                "findings": [],
+                "result": {
+                    **base_result,
+                    "status": "provider_error",
+                    "reason": "reviewer_identity_mismatch",
+                    "actual_reviewer_model_id": actual_model_id,
+                    "actual_reviewer_family": actual_family,
+                    "actual_route_name": actual_route_name,
+                    "estimate": estimate,
+                },
+                "workflow_verdict": "PROVIDER_FAILURE",
+                "completion_status": "INCOMPLETE",
+                "reviewer_model_id": actual_model_id,
+                "reviewer_family": actual_family,
+            }
+        if _cost_overrun(estimate, observed_cost):
+            return {
+                "findings": [],
+                "result": {
+                    **base_result,
+                    "status": "cost_overrun",
+                    "estimate": estimate,
+                    "observed_cost_usd": observed_cost,
+                    "reason": "observed_cost_gt_125pct_estimate",
+                },
+                "workflow_verdict": "COST_OVERRUN",
+                "completion_status": "INCOMPLETE",
+                "reviewer_model_id": reviewer_model_id,
+                "reviewer_family": reviewer_family,
+            }
+        llm_reviewer_dispatch.enforce_tool_budget(dispatch_meta)
+        try:
+            parsed_payload = llm_reviewer.parse_and_evaluate_llm_response(
+                response_text,
+                module_md=texts.get("module.md", ""),
+                activities_yaml=texts.get("activities.yaml", ""),
+                vocabulary_yaml=texts.get("vocabulary.yaml", ""),
+                resources_yaml=texts.get("resources.yaml", ""),
+                return_payload=True,
+            )
+            if not isinstance(parsed_payload, Mapping):
+                raise ValueError("parsed reviewer payload must be a mapping")
+            payload = _payload_from_reviewer_payload(parsed_payload)
+            llm_reviewer.validate_reviewer_payload(payload, policy_family)
+        except ValueError as exc:
+            return {
+                "findings": [],
+                "result": {
+                    **base_result,
+                    "status": "schema_failure",
+                    "reason": str(exc),
+                    "estimate": estimate,
+                },
+                "workflow_verdict": "SCHEMA_FAILURE",
+                "completion_status": "INCOMPLETE",
+                "reviewer_model_id": reviewer_model_id,
+                "reviewer_family": reviewer_family,
+            }
+        findings = _findings_from_payload(payload)
+        if _parse_failed(findings):
+            return {
+                "findings": findings,
+                "result": {
+                    **base_result,
+                    "status": "parse_failure",
+                    "findings": len(findings),
+                    "estimate": estimate,
+                },
+                "workflow_verdict": "PARSE_FAILURE",
+                "completion_status": "INCOMPLETE",
+                "reviewer_model_id": reviewer_model_id,
+                "reviewer_family": reviewer_family,
+            }
+
+        theatre = llm_reviewer_dispatch.tool_theatre_violation(
+            policy_family=policy_family,
+            payload=payload,
+            dispatch_meta=dispatch_meta,
         )
-    if (
-        actual_model_id != reviewer_model_id
-        or actual_family != reviewer_family
-        # route_name keys the composite cache — a reviewer answering from the
-        # wrong route must not poison route-keyed rows (codex review of #4401;
-        # LiveReviewerDispatcher checks this itself, but _run_tier2 accepts
-        # arbitrary reviewer callables). Only enforceable when the workflow
-        # resolved an expected route (live mode); injected test reviewers with
-        # no resolved route (route_name=None) keep their reported name.
-        or (route_name is not None and actual_route_name != route_name)
-    ):
-        return {
-            "findings": [],
-            "result": {
-                **base_result,
-                "status": "provider_error",
-                "reason": "reviewer_identity_mismatch",
-                "actual_reviewer_model_id": actual_model_id,
-                "actual_reviewer_family": actual_family,
-                "actual_route_name": actual_route_name,
-                "estimate": estimate,
-            },
-            "workflow_verdict": "PROVIDER_FAILURE",
-            "completion_status": "INCOMPLETE",
-            "reviewer_model_id": actual_model_id,
-            "reviewer_family": actual_family,
-        }
-    if _cost_overrun(estimate, observed_cost):
-        return {
-            "findings": [],
-            "result": {
-                **base_result,
-                "status": "cost_overrun",
-                "estimate": estimate,
-                "observed_cost_usd": observed_cost,
-                "reason": "observed_cost_gt_125pct_estimate",
-            },
-            "workflow_verdict": "COST_OVERRUN",
-            "completion_status": "INCOMPLETE",
-            "reviewer_model_id": reviewer_model_id,
-            "reviewer_family": reviewer_family,
-        }
-    try:
-        findings = llm_reviewer.parse_and_evaluate_llm_response(
-            response_text,
-            module_md=texts.get("module.md", ""),
-            activities_yaml=texts.get("activities.yaml", ""),
-            vocabulary_yaml=texts.get("vocabulary.yaml", ""),
-            resources_yaml=texts.get("resources.yaml", ""),
+        if theatre is not None:
+            if not theatre_retried:
+                theatre_retried = True
+                attempt_prompt = llm_reviewer_dispatch.reviewer_retry_prompt(
+                    prompt,
+                    llm_reviewer_dispatch.INVALID_TOOL_THEATRE,
+                )
+                continue
+            return {
+                "findings": [],
+                "result": {
+                    **base_result,
+                    "status": llm_reviewer_dispatch.RETRY_EXHAUSTED,
+                    "reason": llm_reviewer_dispatch.INVALID_TOOL_THEATRE,
+                    "gate_reason": theatre.get("reason"),
+                    "estimate": estimate,
+                    "dispatch": dispatch_meta,
+                },
+                "workflow_verdict": llm_reviewer_dispatch.INVALID_TOOL_THEATRE,
+                "completion_status": "INCOMPLETE",
+                "llm_used": True,
+                "reviewer_model_id": reviewer_model_id,
+                "reviewer_family": reviewer_family,
+            }
+
+        if llm_reviewer_dispatch.deep_read_required(payload, dispatch_meta):
+            if not deep_read_retried:
+                deep_read_retried = True
+                attempt_prompt = llm_reviewer_dispatch.reviewer_retry_prompt(
+                    prompt,
+                    llm_reviewer_dispatch.DEEP_READ_REQUIRED,
+                )
+                continue
+            payload = llm_reviewer_dispatch.mark_deep_read_attempted(payload)
+            llm_reviewer.validate_reviewer_payload(payload, policy_family)
+
+        grounding_gate = llm_reviewer_dispatch.enforce_grounding_against_tool_events(
+            payload,
+            dispatch_meta,
+            policy_family=policy_family,
         )
-    except ValueError as exc:
-        return {
-            "findings": [],
-            "result": {
-                **base_result,
-                "status": "schema_failure",
-                "reason": str(exc),
-                "estimate": estimate,
-            },
-            "workflow_verdict": "SCHEMA_FAILURE",
-            "completion_status": "INCOMPLETE",
-            "reviewer_model_id": reviewer_model_id,
-            "reviewer_family": reviewer_family,
-        }
-    if _parse_failed(findings):
-        return {
-            "findings": findings,
-            "result": {
-                **base_result,
-                "status": "parse_failure",
-                "findings": len(findings),
-                "estimate": estimate,
-            },
-            "workflow_verdict": "PARSE_FAILURE",
-            "completion_status": "INCOMPLETE",
-            "reviewer_model_id": reviewer_model_id,
-            "reviewer_family": reviewer_family,
-        }
-    payload = _payload_from_findings(findings)
+        payload = grounding_gate.payload
+        sweep_incomplete = llm_reviewer_dispatch.factual_sweep_incomplete(
+            payload,
+            policy_family=policy_family,
+            invalid_fact_checks=grounding_gate.invalid_fact_checks,
+        )
+        if (
+            grounding_gate.required_ungrounded_findings
+            or grounding_gate.invalid_fact_checks
+            or sweep_incomplete
+        ):
+            tier2_status = (
+                llm_reviewer_dispatch.UNGROUNDED_FINDINGS
+                if grounding_gate.required_ungrounded_findings or grounding_gate.invalid_fact_checks
+                else "factual_sweep_incomplete"
+            )
+            workflow_override = "FAIL" if sweep_incomplete else "WARN"
+            severity = "critical" if sweep_incomplete else "warning"
+            findings = [
+                *_findings_from_payload(payload),
+                _reviewer_gate_finding(
+                    severity=severity,
+                    issue_id="LLM_REVIEWER_GROUNDING_GATE",
+                    message=(
+                        "Grounded reviewer gate found ungrounded evidence or an incomplete seminar "
+                        "fact-check sweep."
+                    ),
+                ),
+            ]
+            payload = _payload_from_findings(
+                findings,
+                fact_checks=payload.get("fact_checks", []),
+                evidence_gaps=payload.get("evidence_gaps", []),
+            )
+            llm_reviewer.validate_reviewer_payload(payload, policy_family)
+        else:
+            findings = _findings_from_payload(payload)
+        break
+
     llm_qg_store.record_llm_qg(
         level=level,
         slug=slug,
@@ -937,12 +1054,13 @@ def _run_tier2(
         "findings": findings,
         "result": {
             **base_result,
-            "status": "ran",
+            "status": tier2_status,
             "findings": len(findings),
             "estimate": estimate,
             "dispatch": dispatch_meta,
         },
         "llm_used": True,
+        "workflow_verdict": workflow_override,
         "reviewer_model_id": reviewer_model_id,
         "reviewer_family": reviewer_family,
     }
@@ -1165,7 +1283,11 @@ def _build_evidence_record(
     aggregate = _aggregate_from_dimensions(dimensions)
     schema_verdict = aggregate["verdict"]
     terminal_verdict = aggregate["terminal_verdict"]
-    if completion_status == "INCOMPLETE" and options.fail_closed_on_llm_skip:
+    infra_only_incomplete = workflow_verdict in {
+        llm_reviewer_dispatch.INVALID_TOOL_THEATRE,
+        llm_reviewer_dispatch.RETRY_EXHAUSTED,
+    }
+    if completion_status == "INCOMPLETE" and options.fail_closed_on_llm_skip and not infra_only_incomplete:
         schema_verdict = "FAIL"
         terminal_verdict = "FAIL"
     aggregate.update(
@@ -1271,14 +1393,38 @@ def _checker_runs(
     return runs
 
 
-def _payload_from_findings(findings: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+def _payload_from_findings(
+    findings: Sequence[Mapping[str, Any]],
+    *,
+    fact_checks: Sequence[Mapping[str, Any]] = (),
+    evidence_gaps: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
     dimensions = dimensions_from_findings(findings)
     return {
         "schema_version": qg_schema.SCHEMA_VERSION,
         "aggregate": _aggregate_from_dimensions(dimensions),
         "dimensions": dimensions,
         "findings": [dict(finding) for finding in findings],
+        "fact_checks": [dict(item) for item in fact_checks],
+        "evidence_gaps": [dict(item) for item in evidence_gaps],
     }
+
+
+def _payload_from_reviewer_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    findings = payload.get("findings", [])
+    if not isinstance(findings, list):
+        raise ValueError("reviewer payload findings must be a list")
+    fact_checks = payload.get("fact_checks", [])
+    evidence_gaps = payload.get("evidence_gaps", [])
+    return _payload_from_findings(
+        [dict(item) for item in findings if isinstance(item, Mapping)],
+        fact_checks=[dict(item) for item in fact_checks if isinstance(item, Mapping)]
+        if isinstance(fact_checks, list)
+        else (),
+        evidence_gaps=[dict(item) for item in evidence_gaps if isinstance(item, Mapping)]
+        if isinstance(evidence_gaps, list)
+        else (),
+    )
 
 
 def _findings_from_payload(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
@@ -1298,6 +1444,30 @@ def _findings_from_payload(payload: Mapping[str, Any]) -> list[dict[str, Any]]:
     for finding in out:
         qg_schema.validate_finding(finding)
     return out
+
+
+def _reviewer_gate_finding(*, severity: str, issue_id: str, message: str) -> dict[str, Any]:
+    return qg_schema.build_finding(
+        issue_id=issue_id,
+        issue_class="other",
+        dimension="mechanics",
+        severity=severity,
+        file="llm_response",
+        line=None,
+        span=None,
+        excerpt="grounded reviewer gate",
+        message=message,
+        confidence="deterministic",
+        disposition="defect",
+        detector={
+            "adapter": "llm_reviewer_dispatch",
+            "rule_id": issue_id,
+        },
+        attribution={
+            "corpus": "reviewer_tool_telemetry",
+            "evidence": "Deterministic grounded-reviewer gate",
+        },
+    )
 
 
 def _aggregate_from_dimensions(dimensions: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:

--- a/tests/audit/test_llm_reviewer.py
+++ b/tests/audit/test_llm_reviewer.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from scripts.audit import llm_reviewer, qg_schema
+import json
+
+from scripts.audit import llm_reviewer, qg_schema, qg_workflow
 
 # Ground truth bad content text for B1-27
 B1_27_BAD_TEXT = """# Вид у наказовому способі
@@ -213,3 +215,73 @@ def test_llm_response_parse_failure_emits_valid_finding() -> None:
     assert findings[0]["dimension"] == "mechanics"
     assert findings[0]["severity"] == "critical"
     qg_schema.validate_finding(findings[0])
+
+
+def test_reviewer_payload_round_trip_preserves_grounding_fact_checks_and_gaps() -> None:
+    module = """# Веснянки
+
+Веснянки — це весняні обрядові пісні.
+"""
+    response = json.dumps(
+        {
+            "findings": [
+                {
+                    "issue_id": "SEMINAR_FACTUAL_DETAIL",
+                    "issue_class": "other",
+                    "dimension": "seminar_sensitivity",
+                    "severity": "warning",
+                    "excerpt": "весняні обрядові пісні",
+                    "message": "Grounded seminar finding.",
+                    "grounding": {
+                        "tool": "sources_query_wikipedia",
+                        "query": "Веснянки",
+                        "evidence_excerpt": "весняні обрядові пісні",
+                        "tool_call_id": "call_1",
+                    },
+                }
+            ],
+            "fact_checks": [
+                {
+                    "claim": "Веснянки — це весняні обрядові пісні.",
+                    "verdict": "CONFIRMED",
+                    "grounding": {
+                        "tool": "sources_query_wikipedia",
+                        "query": "Веснянки",
+                        "evidence_excerpt": "весняні обрядові пісні",
+                        "tool_call_id": "call_1",
+                    },
+                    "deep_read_attempted": False,
+                    "budget_exhausted": False,
+                }
+            ],
+            "evidence_gaps": [
+                {
+                    "claim": "Гаї були прикрашені стрічками.",
+                    "suspected_issue": "Unattested ritual detail.",
+                    "searches": ["sources_search_text: веснянки гаї стрічками"],
+                    "status": "unresolved",
+                    "reason": "No attestation in required sources.",
+                }
+            ],
+        },
+        ensure_ascii=False,
+    )
+
+    parsed = llm_reviewer.parse_and_evaluate_llm_response(
+        response,
+        module_md=module,
+        return_payload=True,
+    )
+    assert isinstance(parsed, dict)
+    payload = qg_workflow._payload_from_reviewer_payload(parsed)
+    llm_reviewer.validate_reviewer_payload(payload, "seminar")
+
+    assert payload["findings"][0]["grounding"] == {
+        "tool": "sources_query_wikipedia",
+        "query": "Веснянки",
+        "evidence_excerpt": "весняні обрядові пісні",
+        "tool_call_id": "call_1",
+    }
+    assert payload["fact_checks"][0]["verdict"] == "CONFIRMED"
+    assert payload["fact_checks"][0]["grounding"]["tool_call_id"] == "call_1"
+    assert payload["evidence_gaps"][0]["searches"] == ["sources_search_text: веснянки гаї стрічками"]

--- a/tests/audit/test_qg_factcheck_scoring.py
+++ b/tests/audit/test_qg_factcheck_scoring.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from scripts.audit import qg_factcheck_scoring as scoring
+
+
+def test_locked_factcheck_scoring_constants() -> None:
+    assert scoring.score_verdict("CONFIRMED", claim_is_true=True) == 20
+    assert scoring.score_verdict("CONFIRMED", claim_is_true=False) == -100
+    assert scoring.score_verdict("REFUTED_BY_CONTRADICTION", claim_is_true=False) == 30
+    assert scoring.score_verdict("UNATTESTED_AFTER_SEARCH", claim_is_true=False) == 10
+    assert scoring.score_verdict("UNATTESTED_AFTER_SEARCH", claim_is_true=True) == -10
+    assert scoring.score_verdict("UNVERIFIED_INSUFFICIENT_SEARCH", claim_is_true=True) == -10
+    assert scoring.score_verdict("REFUTED_BY_CONTRADICTION", claim_is_true=True) == -50
+
+
+def test_scores_fact_check_rows_by_claim_truth_map() -> None:
+    fact_checks = [
+        {"claim": "true claim", "verdict": "CONFIRMED"},
+        {"claim": "fabricated claim", "verdict": "UNATTESTED_AFTER_SEARCH"},
+        {"claim": "ignored claim", "verdict": "CONFIRMED"},
+    ]
+
+    assert scoring.score_fact_checks(
+        fact_checks,
+        {"true claim": True, "fabricated claim": False},
+    ) == 30

--- a/tests/audit/test_qg_schema.py
+++ b/tests/audit/test_qg_schema.py
@@ -134,6 +134,78 @@ def test_semantic_false_friend_finding_carries_sense_context() -> None:
     }
 
 
+def test_grounded_finding_required_for_seminar_contact_classes() -> None:
+    finding = qg_schema.build_finding(
+        issue_id="SEMINAR_CALQUE",
+        issue_class="calque",
+        dimension="contact_calque",
+        severity="warning",
+        file="module.md",
+        line=3,
+        span={"start": 0, "end": 5},
+        excerpt="калька",
+        message="Seminar contact judgment needs evidence.",
+    )
+
+    with pytest.raises(ValueError, match="requires grounding"):
+        qg_schema.validate_grounded_finding(finding, "seminar")
+
+    finding["grounding"] = {
+        "tool": "sources_search_heritage",
+        "query": "калька",
+        "evidence_excerpt": "калька",
+        "tool_call_id": "call_1",
+    }
+    qg_schema.validate_grounded_finding(finding, "seminar")
+    qg_schema.validate_grounded_finding(finding, "b1_plus")
+
+
+def test_reviewer_payload_validates_fact_check_verdicts_and_length_cap() -> None:
+    payload = {
+        "findings": [],
+        "fact_checks": [
+            {
+                "claim": "Веснянки є весняними обрядовими піснями.",
+                "verdict": "CONFIRMED",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "Веснянки",
+                    "evidence_excerpt": "обрядових пісень",
+                    "tool_call_id": "call_1",
+                },
+            }
+        ],
+        "evidence_gaps": [
+            {
+                "claim": "Немає підтвердження.",
+                "suspected_issue": "Unattested ritual detail.",
+                "searches": ["sources_search_text: веснянки гаї"],
+                "status": "unresolved",
+                "reason": "No attestation in required sources.",
+            }
+        ],
+    }
+    qg_schema.validate_reviewer_payload(payload, "seminar")
+
+    bad_verdict = {**payload, "fact_checks": [{**payload["fact_checks"][0], "verdict": "UNVERIFIED"}]}
+    with pytest.raises(ValueError, match=r"unsupported fact_check\.verdict"):
+        qg_schema.validate_reviewer_payload(bad_verdict, "seminar")
+
+    too_many = {
+        **payload,
+        "fact_checks": [
+            {
+                "claim": f"claim {idx}",
+                "verdict": "UNVERIFIED_INSUFFICIENT_SEARCH",
+                "budget_exhausted": True,
+            }
+            for idx in range(qg_schema.MAX_REVIEWER_FACT_CHECKS + 1)
+        ],
+    }
+    with pytest.raises(ValueError, match="exceeds cap"):
+        qg_schema.validate_reviewer_payload(too_many, "seminar")
+
+
 def test_evidence_record_validates_nested_findings_and_keeps_legacy_versions() -> None:
     finding = qg_schema.build_ua_gec_finding(
         error="на протязі",

--- a/tests/test_llm_reviewer_dispatch.py
+++ b/tests/test_llm_reviewer_dispatch.py
@@ -8,16 +8,22 @@ from unittest.mock import patch
 import pytest
 
 from scripts.ai_agent_bridge._opencode import OpencodeStreamParse
-from scripts.audit import llm_reviewer_dispatch, qg_workflow
+from scripts.audit import llm_qg_store, llm_reviewer_dispatch, qg_workflow
 
 _DISPATCH = "scripts.audit.llm_reviewer_dispatch"
 
 
-def _write_module(tmp_path: Path, *, level: str = "b1", slug: str = "sample") -> Path:
+def _write_module(
+    tmp_path: Path,
+    *,
+    level: str = "b1",
+    slug: str = "sample",
+    module_md: str | None = None,
+) -> Path:
     module_dir = tmp_path / level / slug
     module_dir.mkdir(parents=True)
     (module_dir / "module.md").write_text(
-        "# Модуль\n\nУчні читають український текст і виконують коротке завдання.\n",
+        module_md or "# Модуль\n\nУчні читають український текст і виконують коротке завдання.\n",
         encoding="utf-8",
     )
     (module_dir / "activities.yaml").write_text("[]\n", encoding="utf-8")
@@ -32,6 +38,16 @@ def _target(module_dir: Path, *, level: str = "b1") -> qg_workflow.ReviewTarget:
 
 def _tier(record: dict[str, Any], tier_number: int) -> dict[str, Any]:
     return next(tier for tier in record["qg_workflow"]["tiers"] if tier["tier"] == tier_number)
+
+
+def _issue_ids(record: dict[str, Any]) -> list[str]:
+    return [
+        str(finding["issue_id"])
+        for entry in record.get("dimensions", {}).values()
+        if isinstance(entry, dict)
+        for finding in entry.get("findings", [])
+        if isinstance(finding, dict)
+    ]
 
 
 def _canary_artifact(tmp_path: Path, *, level: str = "b1") -> Path:
@@ -64,6 +80,80 @@ def _dispatch_result(response: str, *, observed_cost_usd: float = 0.0) -> llm_re
         reviewer_family=route.reviewer_family,
         route_name=route.route_name,
         observed_cost_usd=observed_cost_usd,
+    )
+
+
+def _seminar_options() -> qg_workflow.WorkflowOptions:
+    return qg_workflow.WorkflowOptions(
+        enable_llm=True,
+        reviewer_model_id="test-reviewer",
+        reviewer_family="test-family",
+    )
+
+
+def _sources_event(
+    *,
+    query: str = "Веснянки",
+    mode: str = "section",
+    output: str = "Веснянки — це весняні обрядові пісні.",
+    call_id: str = "call_1",
+    tool: str = "sources_query_wikipedia",
+) -> dict[str, Any]:
+    return {
+        "tool": tool,
+        "input": {"query": query, "mode": mode},
+        "status": "completed",
+        "tool_call_id": call_id,
+        "output": output,
+    }
+
+
+def _seminar_result(
+    response: str,
+    events: tuple[dict[str, Any], ...],
+    *,
+    tool_call_count: int | None = None,
+) -> llm_reviewer_dispatch.DispatchResult:
+    return llm_reviewer_dispatch.DispatchResult(
+        response_text=response,
+        reviewer_model_id="test-reviewer",
+        reviewer_family="test-family",
+        route_name="opencode_frontier",
+        tool_call_count=len(events) if tool_call_count is None else tool_call_count,
+        tools_used=tuple(dict.fromkeys(str(event["tool"]) for event in events)),
+        tool_events=events,
+    )
+
+
+def _fact_response(
+    *,
+    verdict: str = "CONFIRMED",
+    claim: str = "Веснянки — це весняні обрядові пісні.",
+    grounding_query: str = "Веснянки",
+    evidence_excerpt: str = "весняні обрядові пісні",
+    tool_call_id: str = "call_1",
+    findings: list[dict[str, Any]] | None = None,
+    extra_fact_fields: dict[str, Any] | None = None,
+) -> str:
+    fact_check: dict[str, Any] = {
+        "claim": claim,
+        "verdict": verdict,
+        **(extra_fact_fields or {}),
+    }
+    if verdict in {"CONFIRMED", "REFUTED_BY_CONTRADICTION", "CONTESTED", "UNATTESTED_AFTER_SEARCH"}:
+        fact_check["grounding"] = {
+            "tool": "sources_query_wikipedia",
+            "query": grounding_query,
+            "evidence_excerpt": evidence_excerpt,
+            "tool_call_id": tool_call_id,
+        }
+    return json.dumps(
+        {
+            "findings": findings or [],
+            "fact_checks": [fact_check],
+            "evidence_gaps": [],
+        },
+        ensure_ascii=False,
     )
 
 
@@ -228,6 +318,318 @@ def test_gemma_surface_route_does_not_require_mcp() -> None:
     invoke.assert_called_once()
     assert result.route_name == "gemma_surface"
     assert result.tool_call_count == 0
+
+
+def test_theatre_gate_retries_zero_tool_run_then_accepts_valid_retry(tmp_path: Path) -> None:
+    module_dir = _write_module(tmp_path, level="folk", slug="vesnianky")
+    calls: list[str] = []
+    valid_event = _sources_event(output="Веснянки — це весняні обрядові пісні.")
+
+    def reviewer(_target: qg_workflow.ReviewTarget, prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        calls.append(prompt)
+        if len(calls) == 1:
+            return _seminar_result(_fact_response(), (), tool_call_count=0)
+        return _seminar_result(_fact_response(), (valid_event,))
+
+    record = qg_workflow.review_module(
+        _target(module_dir, level="folk"),
+        options=_seminar_options(),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    assert _tier(record, 2)["status"] == "ran"
+    assert len(calls) == 2
+    assert "Tools Required" in calls[1]
+
+
+def test_theatre_gate_rejects_irrelevant_tool_only_run(tmp_path: Path) -> None:
+    module_dir = _write_module(tmp_path, level="folk", slug="vesnianky")
+    irrelevant = _sources_event(query="борщ", output="Борщ — страва.")
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        nonlocal calls
+        calls += 1
+        return _seminar_result(_fact_response(), (irrelevant,))
+
+    record = qg_workflow.review_module(
+        _target(module_dir, level="folk"),
+        options=_seminar_options(),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    tier = _tier(record, 2)
+    assert tier["status"] == llm_reviewer_dispatch.RETRY_EXHAUSTED
+    assert tier["reason"] == llm_reviewer_dispatch.INVALID_TOOL_THEATRE
+    assert record["completion_status"] == "INCOMPLETE"
+    assert record["terminal_verdict"] == "PASS"
+    assert calls == 2
+
+
+def test_theatre_gate_retry_then_invalid_zero_tool_path(tmp_path: Path) -> None:
+    module_dir = _write_module(tmp_path, level="folk", slug="vesnianky")
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        nonlocal calls
+        calls += 1
+        return _seminar_result(_fact_response(), (), tool_call_count=0)
+
+    record = qg_workflow.review_module(
+        _target(module_dir, level="folk"),
+        options=_seminar_options(),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    assert _tier(record, 2)["status"] == llm_reviewer_dispatch.RETRY_EXHAUSTED
+    assert record["completion_status"] == "INCOMPLETE"
+    assert calls == 2
+
+
+def test_deep_read_gate_retries_summary_only_unverified_then_accepts_attested(tmp_path: Path) -> None:
+    module_dir = _write_module(tmp_path, level="folk", slug="vesnianky")
+    calls: list[str] = []
+    summary_event = _sources_event(mode="summary", output="Короткий опис веснянок.")
+    section_event = _sources_event(mode="section", output="Веснянки — це весняні обрядові пісні.")
+
+    def reviewer(_target: qg_workflow.ReviewTarget, prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        calls.append(prompt)
+        if len(calls) == 1:
+            return _seminar_result(
+                _fact_response(verdict="UNVERIFIED_INSUFFICIENT_SEARCH"),
+                (summary_event,),
+            )
+        return _seminar_result(_fact_response(), (section_event,))
+
+    record = qg_workflow.review_module(
+        _target(module_dir, level="folk"),
+        options=_seminar_options(),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    assert _tier(record, 2)["status"] == "ran"
+    assert len(calls) == 2
+    assert "Deep Read Required" in calls[1]
+
+
+def test_budget_cap_raises_before_cache_write(tmp_path: Path) -> None:
+    module_dir = _write_module(tmp_path, level="folk", slug="vesnianky")
+    db_path = tmp_path / "qg.db"
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        event = _sources_event()
+        return _seminar_result(
+            _fact_response(),
+            (event,),
+            tool_call_count=llm_reviewer_dispatch.MAX_REVIEWER_TOOLS + 1,
+        )
+
+    with pytest.raises(llm_reviewer_dispatch.ReviewerDispatchError, match="hard cap"):
+        qg_workflow.review_module(
+            _target(module_dir, level="folk"),
+            options=_seminar_options(),
+            reviewer=reviewer,
+            store_path=db_path,
+        )
+
+    assert llm_qg_store.latest_llm_qg("folk", "vesnianky", path=db_path) is None
+
+
+def test_fake_grounding_excerpt_absent_from_telemetry_drops_required_finding(tmp_path: Path) -> None:
+    module_dir = _write_module(tmp_path, level="folk", slug="vesnianky")
+    event = _sources_event(output="Веснянки — це весняні обрядові пісні.")
+    finding = {
+        "issue_id": "SEMINAR_FACTUAL_DETAIL",
+        "issue_class": "other",
+        "dimension": "seminar_sensitivity",
+        "severity": "warning",
+        "excerpt": "український текст",
+        "message": "Grounding excerpt is fabricated.",
+        "grounding": {
+            "tool": "sources_query_wikipedia",
+            "query": "Веснянки",
+            "evidence_excerpt": "цього фрагмента немає в telemetry",
+            "tool_call_id": "call_1",
+        },
+    }
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        return _seminar_result(_fact_response(findings=[finding]), (event,))
+
+    record = qg_workflow.review_module(
+        _target(module_dir, level="folk"),
+        options=_seminar_options(),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    tier = _tier(record, 2)
+    assert tier["status"] == llm_reviewer_dispatch.UNGROUNDED_FINDINGS
+    issue_ids = _issue_ids(record)
+    assert "SEMINAR_FACTUAL_DETAIL" not in issue_ids
+    assert "LLM_REVIEWER_GROUNDING_GATE" in issue_ids
+    assert record["verdict"] == "WARN"
+    assert record["terminal_verdict"] == "PASS"
+
+
+def test_fake_grounding_query_without_matching_tool_use_drops_required_finding(tmp_path: Path) -> None:
+    module_dir = _write_module(tmp_path, level="folk", slug="vesnianky")
+    event = _sources_event(query="Веснянки", output="Веснянки — це весняні обрядові пісні.")
+    finding = {
+        "issue_id": "SEMINAR_FACTUAL_DETAIL",
+        "issue_class": "other",
+        "dimension": "seminar_sensitivity",
+        "severity": "warning",
+        "excerpt": "український текст",
+        "message": "Grounding query is not logged.",
+        "grounding": {
+            "tool": "sources_query_wikipedia",
+            "query": "гаї стрічками",
+            "evidence_excerpt": "весняні обрядові пісні",
+            "tool_call_id": "call_1",
+        },
+    }
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        return _seminar_result(_fact_response(findings=[finding]), (event,))
+
+    record = qg_workflow.review_module(
+        _target(module_dir, level="folk"),
+        options=_seminar_options(),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    assert _tier(record, 2)["status"] == llm_reviewer_dispatch.UNGROUNDED_FINDINGS
+    assert "SEMINAR_FACTUAL_DETAIL" not in _issue_ids(record)
+
+
+def test_offline_vesnianky_fixture_exercises_all_fact_check_verdicts(tmp_path: Path) -> None:
+    module_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="vesnianky",
+        module_md=(
+            "# Веснянки\n\n"
+            "Веснянки — це весняні обрядові пісні. Їхні мелодії нібито завжди світлі й піднесені. "
+            "Гаївка має спірну етимологію, а обряд зі стрічковими деревами не засвідчений.\n"
+        ),
+    )
+    events = (
+        _sources_event(
+            query="Веснянки",
+            output="Веснянки — це весняні обрядові пісні.",
+            call_id="call_confirmed",
+        ),
+        _sources_event(
+            query="Веснянки мелодика",
+            output="Мелодія веснянок часто побудована на повторенні однієї-двох поспівок.",
+            call_id="call_refuted",
+        ),
+        _sources_event(
+            query="веснянки гаї стрічками",
+            output="No results for: веснянки гаї стрічками",
+            call_id="call_unattested",
+            tool="sources_search_text",
+        ),
+        _sources_event(
+            query="гаївка етимологія",
+            output="ЕСУМ: походження слова неясне; подано кілька пояснень.",
+            call_id="call_contested",
+            tool="sources_search_esum",
+        ),
+        _sources_event(
+            query="веснянки психологічне відновлення",
+            output="No deep source found before budget expired.",
+            call_id="call_unverified",
+            tool="sources_search_literary",
+        ),
+    )
+    fact_checks = [
+        {
+            "claim": "Веснянки — це весняні обрядові пісні.",
+            "verdict": "CONFIRMED",
+            "grounding": {
+                "tool": "sources_query_wikipedia",
+                "query": "Веснянки",
+                "evidence_excerpt": "весняні обрядові пісні",
+                "tool_call_id": "call_confirmed",
+            },
+        },
+        {
+            "claim": "Мелодика веснянок завжди світла й піднесена.",
+            "verdict": "REFUTED_BY_CONTRADICTION",
+            "grounding": {
+                "tool": "sources_query_wikipedia",
+                "query": "Веснянки мелодика",
+                "evidence_excerpt": "повторенні однієї-двох поспівок",
+                "tool_call_id": "call_refuted",
+            },
+        },
+        {
+            "claim": "У ритуалі виставляли гаї як дерева зі стрічками.",
+            "verdict": "UNATTESTED_AFTER_SEARCH",
+            "grounding": {
+                "tool": "sources_search_text",
+                "query": "веснянки гаї стрічками",
+                "evidence_excerpt": "No results",
+                "tool_call_id": "call_unattested",
+            },
+            "deep_read_attempted": True,
+            "searches": [
+                "sources_query_wikipedia: Веснянки",
+                "sources_search_literary: веснянки гаї",
+                "sources_search_text: веснянки гаї стрічками",
+                "sources_search_grinchenko_1907: гаї",
+            ],
+        },
+        {
+            "claim": "Гаївка походить від слова гай.",
+            "verdict": "CONTESTED",
+            "grounding": {
+                "tool": "sources_search_esum",
+                "query": "гаївка етимологія",
+                "evidence_excerpt": "походження слова неясне",
+                "tool_call_id": "call_contested",
+            },
+        },
+        {
+            "claim": "Веснянки доводять психологічне відновлення людини.",
+            "verdict": "UNVERIFIED_INSUFFICIENT_SEARCH",
+            "budget_exhausted": True,
+            "deep_read_attempted": True,
+        },
+    ]
+    response = json.dumps({"findings": [], "fact_checks": fact_checks, "evidence_gaps": []}, ensure_ascii=False)
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        return _seminar_result(response, events)
+
+    db_path = tmp_path / "qg.db"
+    record = qg_workflow.review_module(
+        _target(module_dir, level="folk"),
+        options=_seminar_options(),
+        reviewer=reviewer,
+        store_path=db_path,
+    )
+
+    assert _tier(record, 2)["status"] == "factual_sweep_incomplete"
+    assert record["terminal_verdict"] == "FAIL"
+    assert _tier(record, 2)["dispatch"]["tool_call_count"] == 5
+    latest = llm_qg_store.latest_llm_qg("folk", "vesnianky", path=db_path)
+    assert latest is not None
+    verdicts = [row["verdict"] for row in latest.payload["fact_checks"]]
+    assert verdicts == [
+        "CONFIRMED",
+        "REFUTED_BY_CONTRADICTION",
+        "UNATTESTED_AFTER_SEARCH",
+        "CONTESTED",
+        "UNVERIFIED_INSUFFICIENT_SEARCH",
+    ]
 
 
 def test_http_endpoint_responds_true_on_streaming_timeout() -> None:

--- a/tests/test_opencode_stream_parse.py
+++ b/tests/test_opencode_stream_parse.py
@@ -38,14 +38,15 @@ def test_real_fixture_extracts_seven_tool_events() -> None:
     ]
 
 
-def test_each_tool_event_has_the_four_normalized_keys() -> None:
+def test_each_tool_event_has_the_five_normalized_keys() -> None:
     parse = _parse_opencode_stream(FIXTURE.read_text(encoding="utf-8"))
 
     for event in parse.tool_events:
-        assert set(event) == {"tool", "input", "status", "tool_call_id"}
+        assert set(event) == {"tool", "input", "status", "tool_call_id", "output"}
         assert event["status"] == "completed"
         assert isinstance(event["tool_call_id"], str) and event["tool_call_id"]
         assert isinstance(event["input"], dict)
+        assert isinstance(event["output"], str)
 
 
 def test_assistant_text_is_recovered_and_wrapper_matches() -> None:
@@ -91,6 +92,7 @@ def test_dedupes_repeated_tool_call_keeping_final_status() -> None:
 
     assert len(parse.tool_events) == 1
     assert parse.tool_events[0]["status"] == "completed"
+    assert parse.tool_events[0]["output"] is None
     assert parse.text == "done"
 
 

--- a/tests/test_qg_workflow.py
+++ b/tests/test_qg_workflow.py
@@ -70,6 +70,28 @@ def _reviewer_response(issue_id: str = "LLM_STYLE_REVIEW") -> str:
     )
 
 
+def _seminar_response() -> str:
+    return json.dumps(
+        {
+            "findings": [],
+            "fact_checks": [
+                {
+                    "claim": "Веснянки — це весняні обрядові пісні.",
+                    "verdict": "CONFIRMED",
+                    "grounding": {
+                        "tool": "sources_query_wikipedia",
+                        "query": "Веснянки",
+                        "evidence_excerpt": "весняні обрядові пісні",
+                        "tool_call_id": "call_1",
+                    },
+                }
+            ],
+            "evidence_gaps": [],
+        },
+        ensure_ascii=False,
+    )
+
+
 def _target(module_dir: Path, *, level: str = "b1", slug: str | None = None) -> qg_workflow.ReviewTarget:
     return qg_workflow.ReviewTarget(
         level=level,
@@ -107,9 +129,16 @@ def test_tier_order_and_tier0_hard_fail_short_circuits_llm(tmp_path: Path) -> No
 def test_tier2_policy_gate_reaches_seminar_and_skips_a1_a2(tmp_path: Path) -> None:
     calls: list[str] = []
 
-    def reviewer(target: qg_workflow.ReviewTarget, _prompt: str) -> str:
+    def reviewer(target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
         calls.append(target.level)
-        return '{"findings": []}'
+        return llm_reviewer_dispatch.DispatchResult(
+            response_text=_seminar_response(),
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+            route_name="opencode_frontier",
+            tool_call_count=1,
+            tools_used=("sources_query_wikipedia",),
+        )
 
     seminar_dir = _write_module(
         tmp_path,
@@ -122,7 +151,11 @@ def test_tier2_policy_gate_reaches_seminar_and_skips_a1_a2(tmp_path: Path) -> No
 
     seminar = qg_workflow.review_module(
         _target(seminar_dir, level="folk", slug="calm-seminar"),
-        options=qg_workflow.WorkflowOptions(enable_llm=True, reviewer_model_id="test-reviewer"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+        ),
         reviewer=reviewer,
         store_path=tmp_path / "seminar-qg.db",
     )
@@ -188,6 +221,82 @@ def test_composite_cache_invalidates_on_gate_version_bump(tmp_path: Path) -> Non
     assert calls == 2
 
 
+def test_cache_hit_revalidates_theatre_gate_on_stored_payload(tmp_path: Path) -> None:
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="cache-theatre",
+        module_md="# Семінар\n\nВеснянки — це весняні обрядові пісні.\n",
+    )
+    db_path = tmp_path / "qg.db"
+    prompt = llm_reviewer.build_reviewer_prompt(
+        level="folk",
+        slug="cache-theatre",
+        module_md=(seminar_dir / "module.md").read_text(encoding="utf-8"),
+        activities_yaml=(seminar_dir / "activities.yaml").read_text(encoding="utf-8"),
+        vocabulary_yaml=(seminar_dir / "vocabulary.yaml").read_text(encoding="utf-8"),
+        resources_yaml=(seminar_dir / "resources.yaml").read_text(encoding="utf-8"),
+    )
+    payload = qg_workflow._payload_from_findings(
+        [],
+        fact_checks=[
+            {
+                "claim": "Веснянки — це весняні обрядові пісні.",
+                "verdict": "CONFIRMED",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "Веснянки",
+                    "evidence_excerpt": "весняні обрядові пісні",
+                    "tool_call_id": "call_1",
+                },
+            }
+        ],
+    )
+    llm_qg_store.record_llm_qg(
+        level="folk",
+        slug="cache-theatre",
+        module_dir=seminar_dir,
+        payload=payload,
+        gate_version=qg_workflow.DEFAULT_GATE_VERSION,
+        prompt_hash=llm_qg_store.prompt_hash_for_text(prompt),
+        checker_version=CHECKER_VERSION,
+        level_policy_family="seminar",
+        reviewer_model="test-reviewer",
+        reviewer_family="test-family",
+        tool_call_count=0,
+        tools_used=(),
+        source="test",
+        path=db_path,
+    )
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        nonlocal calls
+        calls += 1
+        return llm_reviewer_dispatch.DispatchResult(
+            response_text=_seminar_response(),
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+            route_name="opencode_frontier",
+            tool_call_count=1,
+            tools_used=("sources_query_wikipedia",),
+        )
+
+    record = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="cache-theatre"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+        ),
+        reviewer=reviewer,
+        store_path=db_path,
+    )
+
+    assert _tier(record, 2)["status"] == "ran"
+    assert calls == 1
+
+
 def test_tier2_threads_tool_telemetry_into_store(tmp_path: Path) -> None:
     seminar_dir = _write_module(
         tmp_path,
@@ -199,7 +308,7 @@ def test_tier2_threads_tool_telemetry_into_store(tmp_path: Path) -> None:
 
     def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
         return llm_reviewer_dispatch.DispatchResult(
-            response_text='{"findings": []}',
+            response_text=_seminar_response(),
             reviewer_model_id="test-reviewer",
             reviewer_family="test-family",
             route_name="opencode_frontier",


### PR DESCRIPTION
## What

Implements #2156 PR-B scope:
- Adds the grounded evidence contract to `scripts/audit/prompts/reviewer_prompt.md` with fact-check verdict taxonomy, source protocols, citation admissibility, tool budget, and output shape.
- Adds additive grounding/fact-check/evidence-gap validation in `qg_schema.py` and threads preserved payload fields through `llm_reviewer.py` and `qg_workflow.py`.
- Adds deterministic reviewer gates for tool theatre, deep-read retry, tool budget cap, and anti-fabricated grounding using this run's captured tool events.
- Extends opencode tool telemetry with captured `output` bodies so grounding excerpts can be substring-verified.
- Adds locked step-3 bakeoff scoring constants in `scripts/audit/qg_factcheck_scoring.py`.
- Adds offline tests including the Веснянки fact-check fixture and every requested gate path.

No live reviewer proof/canary run is included; that remains out of scope for PR-B per the dispatch brief.

## Consumer Strictness Audit

Verdict: no strict consumers found for additive top-level or finding fields in `ua_contact_quality_evidence.v1`; schema identity remains unchanged.

Commands/results:
```text
rg -n "ua_contact_quality_evidence\.v1" .
./scripts/audit/qg_schema.py:17:19:SCHEMA_VERSION = "ua_contact_quality_evidence.v1"
./tests/audit/test_qg_schema.py:174:41:    assert record["schema_version"] == "ua_contact_quality_evidence.v1"
```

```text
rg -n "extra\s*=\s*['\"]?forbid|extra\s*=\s*Extra\.forbid|ConfigDict\([^\n]*extra\s*=\s*['\"]forbid|model_config\s*=.*extra" scripts tests
scripts/ai_agent_bridge/openai_proxy.py:46:5:    model_config = ConfigDict(extra="allow")
```

```text
git diff -U0 | rg "sys\.executable"
<no output>
```

Protected-file checks:
```text
git diff -- .python-version .yamllint .markdownlint.json
<no output>

git diff --name-only -- 'curriculum/l2-uk-en/**/status/*.json' 'curriculum/l2-uk-en/**/audit/*-review.md' 'curriculum/l2-uk-en/**/review/*-review.md' 'data/telemetry/**'
<no output>
```

Broad `rg "sys\.executable" scripts tests` still finds pre-existing unrelated test files, but this diff adds none.

## Verification

Per-file pytest final lines:
```text
tests/audit/test_qg_schema.py: ============================== 15 passed in 0.63s ==============================
tests/audit/test_llm_reviewer.py: =============================== 7 passed in 0.72s ===============================
tests/test_opencode_stream_parse.py: ============================== 8 passed in 0.21s ===============================
tests/test_llm_reviewer_dispatch.py: ============================== 28 passed in 0.86s ==============================
tests/test_qg_workflow.py: ============================== 10 passed in 0.79s ==============================
tests/audit/test_qg_factcheck_scoring.py: ============================== 2 passed in 0.48s ===============================
```

Post-rebase affected-suite run:
```text
.venv/bin/pytest tests/audit/test_qg_schema.py tests/audit/test_llm_reviewer.py tests/test_opencode_stream_parse.py tests/test_llm_reviewer_dispatch.py tests/test_qg_workflow.py tests/audit/test_qg_factcheck_scoring.py
============================== 70 passed in 0.93s ==============================
```

Touched-file ruff:
```text
.venv/bin/ruff check scripts/ai_agent_bridge/_opencode.py scripts/audit/llm_reviewer.py scripts/audit/llm_reviewer_dispatch.py scripts/audit/qg_schema.py scripts/audit/qg_workflow.py scripts/audit/qg_factcheck_scoring.py tests/audit/test_llm_reviewer.py tests/audit/test_qg_schema.py tests/audit/test_qg_factcheck_scoring.py tests/test_llm_reviewer_dispatch.py tests/test_opencode_stream_parse.py tests/test_qg_workflow.py
All checks passed!
```

Full repo ruff was also attempted, but it fails on pre-existing unrelated files under `docs/reports/` and `plans/` (`Found 28 errors`). I did not edit those unrelated files.

Prompt render:
```text
.venv/bin/python -c "from scripts.audit.llm_reviewer import build_reviewer_prompt; p=build_reviewer_prompt('folk','vesnianky','# Веснянки\n'); headers=['## 0. Grounded Evidence Contract','### Seminar Fact-Check Sweep','### Required Search Protocol','### Citation Admissibility','### Tool Budget','### Grounded Output Shape']; print('\n'.join(h for h in headers if h in p))"
## 0. Grounded Evidence Contract
### Seminar Fact-Check Sweep
### Required Search Protocol
### Citation Admissibility
### Tool Budget
### Grounded Output Shape
```

Round-trip integration assert list:
```python
assert payload["findings"][0]["grounding"] == {
    "tool": "sources_query_wikipedia",
    "query": "Веснянки",
    "evidence_excerpt": "весняні обрядові пісні",
    "tool_call_id": "call_1",
}
assert payload["fact_checks"][0]["verdict"] == "CONFIRMED"
assert payload["fact_checks"][0]["grounding"]["tool_call_id"] == "call_1"
assert payload["evidence_gaps"][0]["searches"] == ["sources_search_text: веснянки гаї стрічками"]
```

Other checks:
```text
git diff --cached --check
<no output>

.venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  136c1ffafb  PASS  X-Agent: codex/2156-prb

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.

git log -1 --oneline
136c1ffafb feat(audit): add grounded reviewer gates
```

## Notes

- The test/pre-commit path creates local `data/telemetry/llm_reviewer_spend.jsonl`; I removed it before commit/push and it is not in the diff.
- No auto-merge requested or performed.
