### PR TITLE
data(atlas): review-approve teacher-lesson vocab rows 259-278 (19 headwords + 1 reject, fourteenth ledger)

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-05-fourteenth-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-05-fourteenth-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,280 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-fourteenth-approved-teacher-lesson-ledger-batch-2026-07-05
+batch_label: fourteenth-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-05'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  total_queue_rows: 278
+  approved_in_queue: 19
+  promotion_batch_size: 19
+production_outputs_updated: []
+decisions:
+- lemma: відмінний
+  decision: approve_for_publish
+  approved_pos: adj
+  approved_gloss: excellent
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 9d2c99e5dcac6a03
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 259
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: буря
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: storm
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 84b83a02163266fe
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 260
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: бруд
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: dirt
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: deae593890c8ad5c
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 261
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: співбесіда
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: job interview
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: f8142e35f5eb0e20
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 262
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: колода
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: deck
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 44f5ab2c56e84a4b
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 264
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: виконувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to complete (imperfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: dd1f3f911b36c810
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 265
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: виконати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to complete (perfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 7bd3289aaca1603e
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 266
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: мілкий
+  decision: approve_for_publish
+  approved_pos: adj
+  approved_gloss: shallow
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d82d627b05c97519
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 267
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: мілина
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: shallow water
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d10deebd08b91c75
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 268
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: глибина
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: depth
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d33b004d0e3be5f0
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 269
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: звільнювати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to fire, to sack (imperfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 8df4a2d8b8beca89
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 270
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: звільнити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to fire, to sack (perfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: e2849c2d5b85d9c6
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 271
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: звільнятися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to quit a job (imperfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 524d4757d843b9ae
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 272
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: звільнитися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to quit a job (perfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 139be2aaaa7474ad
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 273
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: огидний
+  decision: approve_for_publish
+  approved_pos: adj
+  approved_gloss: disgusting
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 8efabf4f04f7b683
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 274
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: огида
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: disgust
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: e52c4ab8465fdfca
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 275
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: дитячий
+  decision: approve_for_publish
+  approved_pos: adj
+  approved_gloss: childish
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 89ab1a48fb0edf0f
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 276
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: вагітний
+  decision: approve_for_publish
+  approved_pos: adj
+  approved_gloss: pregnant
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 24b8f42993a93a96
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 277
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: благополуччя
+  decision: reject
+  sense_note: 'REJECTED on review (2026-07-05, fable/track-driver): NOT in VESUM (would
+    fail the lemma_in_vesum publish gate — щитовидка precedent); no Грінченко pre-Soviet
+    attestation; the only heritage hit is СУМ-20 modern, whose own definition glosses
+    it as «добробут» — the native word, present as the second lemma of the same source
+    row (278) and approved. Widely treated as a calque of Russian «благополучие»;
+    decolonization bar per the місцезнаходження precedent (СУМ-20-''authentic'' alone
+    does not clear it). Prefer: добробут.'
+  source_inventory:
+    key: 386b0c931cac3aa5
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 278
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - 'VESUM verify_words: NOT FOUND'
+  - 'search_heritage: no Грінченко; СУМ-20 only (defines via добробут)'
+  - 'russian_shadow: 0.57 sub-threshold'
+- lemma: добробут
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: wellbeing
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d72f70ce5f0848e2
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+    locator: explicit vocabulary table row 278
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table

--- a/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
+++ b/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml
@@ -1,0 +1,115 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: private-teacher-lesson-vocabulary-table-1-rows-259-278
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Private teacher lesson vocabulary - explicit table rows 259-278
+    locator: local-only explicit vocabulary table rows 259-278
+    notes: >-
+      Derived headword metadata only; raw private lesson material is local-only
+      and not committed. Daily Word, Practice, and cloze remain frozen without
+      explicit surface_admission. Rows 259 and 263 are multi-word idiom/collocation
+      entries deferred pending a collocation intake convention.
+    headwords:
+      - lemma: відмінний
+        pos: adj
+        gloss: excellent
+        locator: explicit vocabulary table row 259
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: буря
+        pos: noun
+        gloss: storm
+        locator: explicit vocabulary table row 260
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: бруд
+        pos: noun
+        gloss: dirt
+        locator: explicit vocabulary table row 261
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: співбесіда
+        pos: noun
+        gloss: job interview
+        locator: explicit vocabulary table row 262
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: колода
+        pos: noun
+        gloss: deck
+        locator: explicit vocabulary table row 264
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: виконувати
+        pos: verb
+        gloss: to complete (imperfective)
+        locator: explicit vocabulary table row 265
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: виконати
+        pos: verb
+        gloss: to complete (perfective)
+        locator: explicit vocabulary table row 266
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: мілкий
+        pos: adj
+        gloss: shallow
+        locator: explicit vocabulary table row 267
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: мілина
+        pos: noun
+        gloss: shallow water
+        locator: explicit vocabulary table row 268
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: глибина
+        pos: noun
+        gloss: depth
+        locator: explicit vocabulary table row 269
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: звільнювати
+        pos: verb
+        gloss: to fire, to sack (imperfective)
+        locator: explicit vocabulary table row 270
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: звільнити
+        pos: verb
+        gloss: to fire, to sack (perfective)
+        locator: explicit vocabulary table row 271
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: звільнятися
+        pos: verb
+        gloss: to quit a job (imperfective)
+        locator: explicit vocabulary table row 272
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: звільнитися
+        pos: verb
+        gloss: to quit a job (perfective)
+        locator: explicit vocabulary table row 273
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: огидний
+        pos: adj
+        gloss: disgusting
+        locator: explicit vocabulary table row 274
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: огида
+        pos: noun
+        gloss: disgust
+        locator: explicit vocabulary table row 275
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: дитячий
+        pos: adj
+        gloss: childish
+        locator: explicit vocabulary table row 276
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вагітний
+        pos: adj
+        gloss: pregnant
+        locator: explicit vocabulary table row 277
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: благополуччя
+        pos: noun
+        gloss: wellbeing
+        locator: explicit vocabulary table row 278
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: добробут
+        pos: noun
+        gloss: wellbeing
+        locator: explicit vocabulary table row 278
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -31,6 +31,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-199-218.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )


### PR DESCRIPTION
## What

14th review-only teacher-lesson window (table rows 259-278). Extraction+inventory by agy dispatch (`be1f3e9c5a`, extraction-only lane shape); review + ledger by the track driver (`aa5d84953d`). Review-only — publish rides the manifest recipe separately.

- inventory: 20 headwords (rows 260-262, 264-278 + `відмінний` from mixed row 259 + both lemmas of row 278)
- **Deferred (multiword):** row 259 phrase «На високому рівні», row 263 «Не лізь поперед батька в пекло…» (idiom, pending collocation convention)
- ledger: **19 × approve_for_publish, 1 × reject**
- registry: inventory added to `COMMITTED_SOURCE_INVENTORIES`

## ⚠️ Reject: «благополуччя» (row 278; decolonization precedent applied)

Evidence (raw, tool-backed):
- VESUM `verify_words`: **NOT FOUND** (19/20 found; would fail the `lemma_in_vesum` publish gate — щитовидка precedent)
- `search_heritage`: **no Грінченко**; only СУМ-20 modern attestation — whose own definition glosses it as «добробут»; the ЕСУМ "hit" is a different headword (false positive)
- `russian_shadow`: 0.57 sub-threshold — widely treated as calque of рос. «благополучие»
- **Native alternative approved in the same source row: «добробут»** (VESUM 2 matches, shadow 0.0)

Follows the місцезнаходження precedent: СУМ-20-"authentic" alone doesn't clear the decolonization bar.

## Evidence (#M-4, raw)

- Source verify: re-extracted docx table#0 data-rows 259-278, diffed vs inventory — 20/20 exact (incl. the row-278 double lemma and both deferrals)
- VESUM: `Found: 19/20` (all POS match; the 1 not-found is the reject)
- russian_shadow: `0.0` on all 19 approved
- Ledger: `files=1 rows=20 decisions={'approve_for_publish': 19, 'reject': 1}`; aggregate `files=20 rows=437 decisions={'approve_for_publish': 434, 'reject': 3}`
- Candidates: `{'total_delta': 432, 'processed': 432, 'auto_merge': 388, 'needs_review': 44}` — my 19 approved: 19/19 auto_merge
- Tests: `32 passed in 2.52s` · Lint: `All checks passed!`

## Follow-up noted (defense-in-depth gap)

`generate_source_inventory_review_candidates` auto_merges VESUM-absent lemmas (благополуччя passed candidates; only the publish self-check would catch it). The ledger reject is the effective gate today; a candidates-stage VESUM screen ships as a separate small PR.

Part of #4160 / #4220 · umbrella #4387. Next window: rows 279-298.

🤖 Generated with [Claude Code](https://claude.com/claude-code)