### PR TITLE
feat(atlas): candidates-stage lemma-validity screen (defense-in-depth from #4415)

### DIFF
--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -73,6 +73,7 @@ def generate_review_candidates(
             out=temp_out,
         )
         validate_source_provenance(payload)
+        screen_auto_merge_lemma_validity(payload)
     finally:
         temp_out.unlink(missing_ok=True)
 
@@ -87,6 +88,81 @@ def generate_review_candidates(
     }
     grow.write_candidates(payload, output_path)
     return payload
+
+
+_USE_DEFAULT_LOOKUP = object()
+
+
+def screen_auto_merge_lemma_validity(
+    payload: dict[str, Any],
+    *,
+    vesum: Any = _USE_DEFAULT_LOOKUP,
+    heritage: Any = _USE_DEFAULT_LOOKUP,
+) -> list[str]:
+    """Demote VESUM-absent ``auto_merge`` candidates to ``needs_review``.
+
+    Defense-in-depth from the 14th-window lesson (PR #4415): the candidates stage
+    auto-merged «благополуччя», which is absent from VESUM and would only have been
+    caught by the ledger reject / the publish-time ``lemma_in_vesum`` self-check.
+    Reuses the conformance gate's policy verbatim — multi-word/proper-noun/deliberate-
+    warning exemptions, Грінченко/ЕСУМ heritage fallback, curated modern-technical
+    allowlist, and silent skip when ``data/vesum.db`` is unavailable (CI parity with
+    the gate itself). Returns the demoted lemmas.
+    """
+    from scripts.audit import validate_atlas_conformance as conformance
+
+    if vesum is _USE_DEFAULT_LOOKUP:
+        vesum = conformance.DEFAULT_VESUM if conformance.DEFAULT_VESUM.exists() else None
+    if heritage is _USE_DEFAULT_LOOKUP:
+        heritage = conformance.DEFAULT_SOURCES_DB if conformance.DEFAULT_SOURCES_DB.exists() else None
+    lookup = conformance._coerce_vesum_lookup(vesum)
+    heritage_lookup = conformance._coerce_heritage_lookup(heritage)
+    should_close_lookup = (
+        isinstance(lookup, conformance.VesumLemmaLookup) and lookup is not vesum
+    )
+    should_close_heritage = (
+        isinstance(heritage_lookup, conformance.HeritageLemmaLookup)
+        and heritage_lookup is not heritage
+    )
+    demoted: list[str] = []
+    try:
+        kept: list[dict[str, Any]] = []
+        for entry in payload.get("auto_merge", []):
+            if not isinstance(entry, dict):
+                kept.append(entry)
+                continue
+            lemma = str(entry.get("lemma") or "").strip()
+            violations: list[conformance.Violation] = []
+            conformance._check_lemma_in_vesum(
+                entry, lemma, lookup, violations, heritage=heritage_lookup
+            )
+            if violations:
+                payload.setdefault("needs_review", []).append(
+                    {
+                        "entry": entry,
+                        "reason": f"lemma_in_vesum:{violations[0].detail}",
+                    }
+                )
+                demoted.append(lemma)
+            else:
+                kept.append(entry)
+        payload["auto_merge"] = kept
+    finally:
+        if should_close_lookup:
+            lookup.close()
+        if should_close_heritage:
+            heritage_lookup.close()
+
+    counts = payload.get("counts")
+    if isinstance(counts, dict) and demoted:
+        counts["auto_merge"] = len(payload.get("auto_merge", []))
+        counts["needs_review"] = len(payload.get("needs_review", []))
+    if demoted:
+        print(
+            "lemma-validity screen demoted "
+            f"{len(demoted)} auto_merge candidate(s) to needs_review: {', '.join(sorted(demoted))}"
+        )
+    return demoted
 
 
 def validate_source_provenance(payload: dict[str, Any]) -> None:

--- a/tests/test_source_inventory_review_candidates.py
+++ b/tests/test_source_inventory_review_candidates.py
@@ -52,6 +52,9 @@ def test_review_candidates_use_committed_inventories_and_keep_provenance(
     expected_pos = {candidate.pos for candidate in expected_candidates if candidate.pos}
 
     monkeypatch.setattr(review.grow, "_source_connection", lambda path: nullcontext(object()))
+    # Hermetic scope = inventory→candidates plumbing; the lemma-validity screen has its own
+    # dedicated tests below and consults real dbs when present, so stub it here.
+    monkeypatch.setattr(review, "screen_auto_merge_lemma_validity", lambda payload, **kw: [])
     monkeypatch.setattr(review.grow, "_preserve_wiki_reference_cache", lambda: nullcontext())
     monkeypatch.setattr(review.grow.enrich_manifest, "_load_kaikki_lookup", lambda: {})
     monkeypatch.setattr(review.grow.enrich_manifest, "_sum11_has_flag_columns", lambda conn: False)
@@ -503,3 +506,65 @@ def test_review_workflow_rejects_live_atlas_output_directory() -> None:
 def test_review_workflow_rejects_static_lexicon_outputs(static_output: Path) -> None:
     with pytest.raises(SourceInventoryError, match="site/public/lexicon"):
         review.resolve_review_output_path(static_output)
+
+
+class _FakeVesumLookup:
+    """Stub with the VesumLemmaLookup surface used by _check_lemma_in_vesum."""
+
+    def __init__(self, known: set[str]):
+        self._known = {k.casefold() for k in known}
+
+    def has_lemma(self, lemma: str) -> bool:
+        return lemma.casefold() in self._known
+
+    def close(self) -> None:  # pragma: no cover - symmetry with the real lookup
+        pass
+
+
+def test_lemma_validity_screen_demotes_vesum_absent_auto_merge() -> None:
+    """PR #4415 lesson: VESUM-absent lemmas must not stay auto_merge (благополуччя class)."""
+    payload: dict[str, Any] = {
+        "counts": {"auto_merge": 2, "needs_review": 0},
+        "auto_merge": [
+            {"lemma": "добробут", "source_provenance": ["x"]},
+            {"lemma": "благополуччя", "source_provenance": ["x"]},
+        ],
+        "needs_review": [],
+    }
+    demoted = review.screen_auto_merge_lemma_validity(
+        payload, vesum=_FakeVesumLookup({"добробут"}), heritage=None
+    )
+    assert demoted == ["благополуччя"]
+    assert [e["lemma"] for e in payload["auto_merge"]] == ["добробут"]
+    assert len(payload["needs_review"]) == 1
+    wrapped = payload["needs_review"][0]
+    assert wrapped["entry"]["lemma"] == "благополуччя"
+    assert wrapped["reason"].startswith("lemma_in_vesum:")
+    assert payload["counts"] == {"auto_merge": 1, "needs_review": 1}
+
+
+def test_lemma_validity_screen_skips_when_vesum_unavailable() -> None:
+    """No db ⇒ no demotions — CI parity with the conformance gate's degradation."""
+    payload: dict[str, Any] = {
+        "counts": {"auto_merge": 1, "needs_review": 0},
+        "auto_merge": [{"lemma": "неіснуючеслово", "source_provenance": ["x"]}],
+        "needs_review": [],
+    }
+    demoted = review.screen_auto_merge_lemma_validity(payload, vesum=None, heritage=None)
+    assert demoted == []
+    assert len(payload["auto_merge"]) == 1
+
+
+def test_lemma_validity_screen_exempts_genuine_multiword() -> None:
+    """Multi-word phrases are legitimately VESUM-absent — never demoted for absence."""
+    payload: dict[str, Any] = {
+        "counts": {"auto_merge": 1, "needs_review": 0},
+        "auto_merge": [
+            {"lemma": "мікрохвильова піч", "source_provenance": ["x"]},
+        ],
+        "needs_review": [],
+    }
+    review.screen_auto_merge_lemma_validity(
+        payload, vesum=_FakeVesumLookup({"мікрохвильова", "піч"}), heritage=None
+    )
+    assert [e["lemma"] for e in payload["auto_merge"]] == ["мікрохвильова піч"]


### PR DESCRIPTION
## What

`generate_source_inventory_review_candidates` gains `screen_auto_merge_lemma_validity`: a post-pass demoting VESUM-absent `auto_merge` candidates to `needs_review` (reason `lemma_in_vesum:<detail>`), wired into `generate_review_candidates` after provenance validation.

## Why

14th-window lesson (PR #4415): «благополуччя» — VESUM-absent, heritage-unattested — sailed through candidates as `auto_merge`; only the review ledger (and the publish-time `lemma_in_vesum` self-check) stood in the way. The candidates report is what reviewers triage FROM, so the screen belongs there.

## Design

Reuses the conformance gate's policy **verbatim** (`validate_atlas_conformance._check_lemma_in_vesum`): multi-word / proper-noun / deliberate-warning exemptions, Грінченко/ЕСУМ heritage fallback, curated modern-technical allowlist, silent skip when `data/vesum.db` is absent (CI parity with the gate's own degradation). Explicit `_USE_DEFAULT_LOOKUP` sentinel so tests can express "explicitly no db" vs "use defaults".

Expected live effect: the two historical rejects still present in old committed inventories (щитовидка, місцезнаходження) now land in `needs_review` at candidates stage instead of `auto_merge` — verified during development (the pre-commit run with real dbs demoted exactly {благополуччя, місцезнаходження, щитовидка}).

## Evidence (#M-4, raw)

- Tests: `30 passed in 0.67s` at commit time (3 new: demote / explicit-no-db skip / multiword exemption; hermetic legacy test stubs the screen — it consults real dbs when present)
- Lint: `All checks passed!`
- Real-data end-to-end (local vesum.db + sources.db): `demoted: ['благополуччя']`, kept `['добробут', 'мілина']`, reason `lemma_in_vesum:single-word entry is absent from VESUM and unattested in the heritage corpus (Грінченко/ЕСУМ)`
- No-db degradation verified live (without symlinked dbs the screen demotes nothing — matches the gate's CI behavior)

Part of #4160/#4220 · umbrella #4387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)