### PR TITLE
fix(audit): grounding-gate call_id semantics + mandatory sweep coverage (#2156 live-proof fixes)

### DIFF
--- a/scripts/audit/llm_reviewer_dispatch.py
+++ b/scripts/audit/llm_reviewer_dispatch.py
@@ -1149,18 +1149,29 @@ def _grounding_matches_events(
     grounding: Mapping[str, Any],
     events: Sequence[Mapping[str, Any]],
 ) -> bool:
+    """True when the grounding is backed by a captured tool event.
+
+    Match semantics (live-proof fix, 2026-07-05): tool name + query must match
+    a captured event AND the excerpt must be a substring of that event's
+    captured output. ``tool_call_id`` is ADVISORY — the transport-level id
+    (e.g. ``chatcmpl-tool-…``) is never shown to the model, so requiring
+    equality failed every legitimate grounding in the live «Веснянки» proof
+    while adding nothing against fabrication (a fabricated excerpt still has
+    to appear verbatim in a real captured output for a query really made).
+    """
     query = str(grounding.get("query") or "").strip()
     excerpt = str(grounding.get("evidence_excerpt") or "").strip()
-    call_id = str(grounding.get("tool_call_id") or "").strip()
-    if not query or not excerpt or not call_id:
+    if not query or not excerpt:
         return False
+    tool = str(grounding.get("tool") or "").strip()
     for event in events:
-        if str(event.get("tool_call_id") or "") != call_id:
+        if tool and str(event.get("tool") or "").strip() != tool:
             continue
         if not _event_input_matches_query(event, query):
-            return False
+            continue
         output = event.get("output")
-        return isinstance(output, str) and excerpt in output
+        if isinstance(output, str) and excerpt in output:
+            return True
     return False
 
 

--- a/scripts/audit/prompts/reviewer_prompt.md
+++ b/scripts/audit/prompts/reviewer_prompt.md
@@ -10,6 +10,11 @@ Style, register, tone, and naturalness judgments outside those factual/contact c
 
 ### Seminar Fact-Check Sweep
 
+**Coverage is mandatory:** enumerate EVERY factual claim in the content — each factual sentence yields at
+least one `fact_checks` entry. Skipping a claim is a defect: an unchecked fabrication passes silently. If
+the tool budget cannot cover all claims, emit the remainder as `UNVERIFIED_INSUFFICIENT_SEARCH` with
+`budget_exhausted: true` — never silently omit them.
+
 For every seminar module, enumerate the factual claims in the learner-facing content, verify each claim, and return a top-level `fact_checks` list. Each fact check MUST use exactly one verdict from this taxonomy:
 
 * `CONFIRMED`: authoritative source text directly supports the claim.

--- a/tests/test_llm_reviewer_dispatch.py
+++ b/tests/test_llm_reviewer_dispatch.py
@@ -901,3 +901,33 @@ def test_project_config_discovered_walking_up_to_repo_root(tmp_path, monkeypatch
 
     merged = llm_reviewer_dispatch._load_opencode_config()
     assert merged["mcp"]["sources"]["url"] == "http://repo/mcp"
+
+
+def test_grounding_matches_despite_model_invented_call_id() -> None:
+    """Live «Веснянки» proof regression (2026-07-05): the transport tool_call_id
+    (chatcmpl-tool-…) is never shown to the model, which invents call_0/call_1.
+    Grounding validity = tool + query + excerpt ⊆ captured output; the id is
+    advisory. Requiring id equality failed EVERY legitimate grounding live."""
+    events = (
+        {
+            "tool": "sources_query_wikipedia",
+            "input": {"mode": "extract", "query": "Веснянки"},
+            "status": "completed",
+            "tool_call_id": "chatcmpl-tool-8aa58af0f4248afc",
+            "output": "# Веснянки\nВесня́нки — назва старовинних слов'янських обрядових пісень.",
+        },
+    )
+    grounding = {
+        "tool": "sources_query_wikipedia",
+        "query": "Веснянки",
+        "evidence_excerpt": "назва старовинних слов'янських обрядових пісень",
+        "tool_call_id": "call_0",  # model-invented — must NOT invalidate
+    }
+    assert llm_reviewer_dispatch._grounding_matches_events(grounding, events) is True
+
+    # fabrication still caught: excerpt absent from every captured output
+    fabricated = dict(grounding, evidence_excerpt="гаї — це прикрашені стрічками дерева")
+    assert llm_reviewer_dispatch._grounding_matches_events(fabricated, events) is False
+    # and a query never actually made still fails
+    ghost_query = dict(grounding, query="мелодика веснянок")
+    assert llm_reviewer_dispatch._grounding_matches_events(ghost_query, events) is False


### PR DESCRIPTION
The first LIVE «Веснянки» proof run through the merged PR-A+PR-B machinery (post #4414) surfaced two defects the offline fixtures structurally could not catch:

1. **Grounding gate false-negative on ALL legit groundings:** `_grounding_matches_events` required the model-emitted `tool_call_id` to equal the transport id (`chatcmpl-tool-…`) — never visible to the model. Live result: `invalid_fact_checks=3` on excerpts that were verbatim substrings of the captured outputs (verified: `excerpt in output: True`). Fix: match on tool + query + excerpt⊆captured-output; id stays advisory. Anti-fabrication is unchanged (fabricated excerpt / ghost query still rejected — regression test covers both negative paths).
2. **Silent claim omission:** the live sweep produced 4 fact_checks and skipped the melody fabrication entirely. The prompt's sweep contract now mandates full enumeration (every factual sentence → ≥1 entry; budget exhaustion → `UNVERIFIED_INSUFFICIENT_SEARCH`, never omission).

Live-proof positives for the record: route/telemetry/theatre/budget all functioned; the «гаї» fabrication got `UNATTESTED_AFTER_SEARCH` + an `evidence_gaps` entry; true claims CONFIRMED with section-depth wiki quotes; grinchenko in the search mix per protocol.

Verification: 61 tests pass (incl. the new live-regression test), ruff clean. Proof re-run follows this merge.

Part of #2156; relates #4416 (this elevates nothing there — the normalization item stays P2; literal matching was NOT the live failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)