### PR TITLE
data(atlas): review-approve teacher-lesson vocab rows 279-298 (17 approve + 1 hold, fifteenth ledger)

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-05-fifteenth-approved-teacher-lesson-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-05-fifteenth-approved-teacher-lesson-ledger-batch.yaml
@@ -1,0 +1,253 @@
+---
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: source-inventory-fifteenth-approved-teacher-lesson-ledger-batch-2026-07-05
+batch_label: fifteenth-approved-teacher-lesson-ledger-batch
+reviewer: content-review
+reviewed_at: '2026-07-05'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  total_queue_rows: 298
+  approved_in_queue: 17
+  promotion_batch_size: 17
+production_outputs_updated: []
+decisions:
+- lemma: пацієнт
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: patient
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a0e0920262b53f32
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 279
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: олень
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: deer
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 04c9752b88660622
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 280
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: вистачати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to be enough, to be sufficient
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 2b175e6ee3136292
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 281
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: їстівний
+  decision: approve_for_publish
+  approved_pos: adj
+  approved_gloss: edible
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 42870c45bec65c58
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 282
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: сміятися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to laugh (at)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 8c9bd110a56b9581
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 283
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: гостринка
+  decision: needs_more_evidence
+  sense_note: 'needs_more_evidence (2026-07-05, fable/track-driver): genuine colloquial
+    derivative of «гострий» (''a touch of spiciness''), NOT a russianism (russian_shadow
+    0.25 noise-level), but unpublishable today — absent from VESUM AND zero heritage
+    attestation (no Грінченко, no ЕСУМ, no СУМ-20 via search_heritage). Would fail
+    the lemma_in_vesum publish gate; no citable definition to render. Revisit if a
+    dictionary source attests it.'
+  source_inventory:
+    key: f03873bf9104bdf4
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 284
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - 'VESUM verify_words: NOT FOUND'
+  - 'search_heritage: no evidence rows'
+  - 'russian_shadow: 0.25 sub-threshold (not a russianism)'
+- lemma: благодійний
+  decision: approve_for_publish
+  approved_pos: adj
+  approved_gloss: charity (adj)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: a414d83bcdd5ff48
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 285
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: копчений
+  decision: approve_for_publish
+  approved_pos: adj
+  approved_gloss: smoked
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d53e10fa350b75ea
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 286
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: глибина
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: depth
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: ace5ebedeecf2077
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 288
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: чистити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to clean, to peel, to brush clean (imperfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 87fb22370839e9d5
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 289
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: почистити
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to clean, to peel, to brush clean (perfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: d74ac09f8bfc2f64
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 290
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: проваритися
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to be boiled (perfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 48cd4e309d30150e
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 291
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: помішувати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to stir (imperfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: fd916bc4b6bf0be1
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 292
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: помішати
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to stir (perfective)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 47f32d83df9bd7ab
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 293
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: пригоріти
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to burn, to stick to the bottom
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: c5bc88cd2bd70414
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 294
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: конфорка
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: burner
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 3bc0c6ff74159d19
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 295
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: полягти
+  decision: approve_for_publish
+  approved_pos: verb
+  approved_gloss: to die (in war as a soldier)
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: eb6b36ce4ecc4716
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 296
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table
+- lemma: повітря
+  decision: approve_for_publish
+  approved_pos: noun
+  approved_gloss: air
+  sense_note: private teacher-lesson explicit vocabulary table
+  source_inventory:
+    key: 57ffa736af76f7fd
+    path: data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+    locator: explicit vocabulary table row 298
+    source_id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+  evidence_refs:
+  - private teacher-lesson explicit vocabulary table

--- a/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
+++ b/data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml
@@ -1,0 +1,105 @@
+---
+version: 1
+kind: atlas_source_inventory
+sources:
+  - id: private-teacher-lesson-vocabulary-table-1-rows-279-298
+    source_family: teacher_lesson
+    extraction_mode: curated_headword
+    title: Private teacher lesson vocabulary - explicit table rows 279-298
+    locator: local-only explicit vocabulary table rows 279-298
+    notes: >-
+      Derived headword metadata only; raw private lesson material is local-only
+      and not committed. Daily Word, Practice, and cloze remain frozen without
+      explicit surface_admission. Rows 287 and 297 are multi-word idiom/collocation
+      entries deferred pending a collocation intake convention.
+    headwords:
+      - lemma: пацієнт
+        pos: noun
+        gloss: patient
+        locator: explicit vocabulary table row 279
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: олень
+        pos: noun
+        gloss: deer
+        locator: explicit vocabulary table row 280
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: вистачати
+        pos: verb
+        gloss: to be enough, to be sufficient
+        locator: explicit vocabulary table row 281
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: їстівний
+        pos: adj
+        gloss: edible
+        locator: explicit vocabulary table row 282
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: сміятися
+        pos: verb
+        gloss: to laugh (at)
+        locator: explicit vocabulary table row 283
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: гостринка
+        pos: noun
+        gloss: a spicy thing, spice
+        locator: explicit vocabulary table row 284
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: благодійний
+        pos: adj
+        gloss: charity (adj)
+        locator: explicit vocabulary table row 285
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: копчений
+        pos: adj
+        gloss: smoked
+        locator: explicit vocabulary table row 286
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: глибина
+        pos: noun
+        gloss: depth
+        locator: explicit vocabulary table row 288
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: чистити
+        pos: verb
+        gloss: to clean, to peel, to brush clean (imperfective)
+        locator: explicit vocabulary table row 289
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: почистити
+        pos: verb
+        gloss: to clean, to peel, to brush clean (perfective)
+        locator: explicit vocabulary table row 290
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: проваритися
+        pos: verb
+        gloss: to be boiled (perfective)
+        locator: explicit vocabulary table row 291
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: помішувати
+        pos: verb
+        gloss: to stir (imperfective)
+        locator: explicit vocabulary table row 292
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: помішати
+        pos: verb
+        gloss: to stir (perfective)
+        locator: explicit vocabulary table row 293
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: пригоріти
+        pos: verb
+        gloss: to burn, to stick to the bottom
+        locator: explicit vocabulary table row 294
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: конфорка
+        pos: noun
+        gloss: burner
+        locator: explicit vocabulary table row 295
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: полягти
+        pos: verb
+        gloss: to die (in war as a soldier)
+        locator: explicit vocabulary table row 296
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.
+      - lemma: повітря
+        pos: noun
+        gloss: air
+        locator: explicit vocabulary table row 298
+        context: Reviewed headword metadata derived from an explicit private lesson vocabulary table.

--- a/scripts/audit/generate_source_inventory_review_candidates.py
+++ b/scripts/audit/generate_source_inventory_review_candidates.py
@@ -32,6 +32,7 @@ COMMITTED_SOURCE_INVENTORIES: tuple[Path, ...] = (
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-219-238.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-239-258.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-259-278.yaml",
+    PROJECT_ROOT / "data/lexicon/source-inventory/private-teacher-lesson-vocabulary-table-1-rows-279-298.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-family-numerals.yaml",
     PROJECT_ROOT / "data/lexicon/source-inventory/vashulenko-grade3-headwords.yaml",
 )


### PR DESCRIPTION
## What

15th review-only teacher-lesson window (rows 279-298). Extraction+inventory by agy dispatch (died pre-commit; artifacts verified + committed by the driver); review + ledger by the track driver. Review-only — publish rides the manifest recipe separately.

- inventory: 18 headwords · **deferred (multiword):** «Зводити з розуму» — appears TWICE in the source (rows 287 AND 297), both deferred pending the collocation convention
- source typo normalized: «Паціент» (row 279) → «пацієнт» (VESUM-confirmed)
- row 288 «глибина» duplicates window-14 row 269 — kept (per-locator provenance; dedup at promotion, existing-entry bucket)
- ledger: **17 × approve_for_publish, 1 × needs_more_evidence**

## ⚠️ Hold (not reject): «гостринка» (row 284)

Genuine colloquial derivative of «гострий» — **NOT a russianism** (shadow 0.25 noise) — but unpublishable today: VESUM-absent AND zero heritage attestation (no Грінченко / ЕСУМ / СУМ-20 via search_heritage) → would fail `lemma_in_vesum`, no citable definition. `needs_more_evidence`; revisit if a dictionary attests it.

## Evidence (#M-4, raw)

- Source verify: re-extracted docx data-rows 279-298, diffed vs inventory — 18/18 exact (+2 deferred idiom occurrences)
- VESUM: `Found: 17/18` (конфорка IS attested — clean loanword; the 1 not-found is the hold)
- russian_shadow: `0.0` on all 17 approved
- Ledger: `files=1 rows=18 decisions={'approve_for_publish': 17, 'needs_more_evidence': 1}`; aggregate `files=21 rows=455 {'approve_for_publish': 451, 'needs_more_evidence': 1, 'reject': 3}`
- Candidates (**first window through the #4417 screen — full stack validated**): 17/17 approved = auto_merge; гостринка → needs_review (`missing dictionary definition`, grow's own gate); screen demoted благополуччя (`lemma_in_vesum:…`); щитовидка/місцезнаходження → needs_review (`heritage_status flags russian_shadow`). Three overlapping layers, each catching its class.
- Tests: `32 passed in 3.02s` · Lint: `All checks passed!` · pre-commit full suite: `✅`

Part of #4160/#4220 · umbrella #4387. Next window: rows 299-318.

🤖 Generated with [Claude Code](https://claude.com/claude-code)