### PR TITLE
docs(agents): bind operator contract into AGENTS.md + wiring guard tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,27 @@
 
 ---
 
+## Operator Contract (binding for ALL agents — read before acting)
+
+The operator's working contract is `agents_extensions/shared/rules/operator-expectations.md`
+(deploy copies: `.codex/rules/` · `.agent/rules/` · `.gemini/rules/`; served FIRST at
+`GET http://localhost:8765/api/rules`). Its items are the tie-breakers when instructions
+conflict. Digest — read the full file for the binding wording:
+**1** Quality: no shortcuts, no threshold-lowering, no "for now" · **2** Best practices +
+root-cause fixes · **3** Git/GitHub hygiene: worktrees, PRs only, post-merge cleanup,
+`X-Agent` trailer · **4** Use the whole fleet; the review gate needs an independent
+**cross-family** reviewer (discussion/panels do NOT satisfy it) · **5** Route by
+model × harness fit (`model-assignment.md` § Harness vs model) · **6** Limits are normal:
+substitute lanes and NOTE the substitution in the artifact · **7** No claims without
+tool-backed proof; Ukrainian word/stress/morphology facts VESUM/`sources`-verified, never
+guessed · **8** Clean code, current docs; prune stale context when touched · **9** Max UA
+immersion EXCEPT A1 (its English scaffolding is by design; from A2 never raise English) ·
+**10** Drive, don't defer: execute determinable next actions, report past-tense ·
+**11** Repo hard gates (worktree layout, `.venv/bin/python`, artifact hygiene, no secrets)
+bind as part of this contract.
+
+---
+
 ## Global Codex Operating Rules
 
 - Start every task at the repository root and run `git status --short --branch` before editing.

--- a/tests/test_operator_contract_wiring.py
+++ b/tests/test_operator_contract_wiring.py
@@ -1,0 +1,68 @@
+"""Wiring guard for the operator-expectations contract (PR #4412 follow-up).
+
+The contract is only useful if every agent boot path actually reaches it.
+These tests pin the wiring so a refactor can't silently orphan the file:
+
+- Claude / API cold-start  -> RULE_SOURCES[0] (served first at /api/rules)
+- Codex / cursor / opencode / hermes slot-5 -> AGENTS.md digest section
+- Deploy targets           -> excluded from .claude autoload, present in
+                              .codex/.agent/.gemini rules (lock-step lists)
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+CONTRACT = REPO / "agents_extensions/shared/rules/operator-expectations.md"
+CONTRACT_REL = "agents_extensions/shared/rules/operator-expectations.md"
+
+
+def test_contract_file_exists_with_all_eleven_items() -> None:
+    body = CONTRACT.read_text(encoding="utf-8")
+    for n in range(1, 12):
+        assert re.search(rf"^{n}\. \*\*", body, re.MULTILINE), f"contract item {n} missing"
+    assert "tie-breakers" in body
+    assert "A1 is the deliberate exception" in body, "A1 immersion exception clause missing"
+    assert "OUTSIDE your own model family" in body, "cross-family review clause missing"
+
+
+def test_contract_served_first_by_rules_api() -> None:
+    import sys
+
+    sys.path.insert(0, str(REPO / "scripts"))
+    from api.rules_router import RULE_SOURCES
+
+    assert RULE_SOURCES[0] == CONTRACT_REL, (
+        "operator-expectations must be the FIRST file served by /api/rules "
+        f"(got {RULE_SOURCES[0]!r})"
+    )
+
+
+def test_agents_md_carries_binding_digest() -> None:
+    """Codex, cursor, opencode-hosted models, and hermes (slot 5) boot from
+    AGENTS.md — the contract must be referenced AND digested there, because a
+    bare pointer is skippable while an inline digest is not."""
+    body = (REPO / "AGENTS.md").read_text(encoding="utf-8")
+    assert "operator-expectations.md" in body, "AGENTS.md lost the contract pointer"
+    assert "Operator Contract" in body, "AGENTS.md lost the contract digest section"
+    # Spot-check the two most operator-sensitive digest items survived edits.
+    assert "cross-family" in body, "digest lost the cross-family review clause"
+    assert "EXCEPT A1" in body, "digest lost the A1 immersion exception"
+
+
+def test_deploy_lock_step_lists_include_contract() -> None:
+    """deploy excludes x drift-checker x idempotency fixtures must move
+    together (learned the hard way in #4412 round 3)."""
+    deploy = (REPO / "scripts/deploy_prompts.sh").read_text(encoding="utf-8")
+    checker = (REPO / "scripts/check_rules_deployment.sh").read_text(encoding="utf-8")
+    assert 'rules/operator-expectations.md' in deploy, "deploy autoload-exclude missing"
+    assert 'rules/operator-expectations.md' in checker, "drift-checker exclude missing"
+
+
+def test_offline_fallback_lists_contract() -> None:
+    body = (REPO / "agents_extensions/shared/rules/_load-via-api.md").read_text(
+        encoding="utf-8"
+    )
+    assert CONTRACT_REL in body, "offline fallback list lost the contract"


### PR DESCRIPTION
Follow-up to #4412 per operator ask: *make sure codex and ALL agents use the contract — and test it*.

## Boot-path coverage after this PR
| Agent / harness | Boot path | Contract reaches it via |
|---|---|---|
| Claude interactive + headless | /api/rules cold-start (+ _load-via-api autoload pointer) | RULE_SOURCES[0] (#4412) |
| Codex (native CLI + dispatch) | AGENTS.md | **NEW inline digest section** |
| cursor | AGENTS.md | NEW digest |
| opencode-hosted (pool/glm/gemma/deepseek) | AGENTS.md at repo cwd | NEW digest |
| hermes-hosted (deepseek/grok/qwen/gpt-5.5) | context slot 5 = AGENTS.md at cwd (+ SOUL.md slot 1) | NEW digest (+ SOUL.md update, machine-local) |
| agy / gemini | .gemini/rules deploy copy + AGENTS.md | deploy (#4412) + NEW digest |

## Test layers
1. **Static (this PR, CI-enforced)**: `tests/test_operator_contract_wiring.py` — 11 items present, A1-exception + cross-family clauses, RULE_SOURCES[0], AGENTS.md digest, deploy/drift-checker lock-step lists, offline fallback.
2. **Behavioral (post-merge)**: live no-tools canary probe per lane — each agent asked to state the contract + the A1 exception from loaded context only; results will be posted on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)