### PR TITLE
docs(gemini): bind operator contract digest into GEMINI.md

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -10,6 +10,18 @@ We are building the world's first comprehensive Ukrainian language curriculum. T
 ## Project policy — non-commercial, permanent
 This project will not be commercialized. It is and will remain a free, open-source educational resource. Decision recorded 2026-04-19. Dependencies under non-commercial licenses (CC BY-NC, etc.) are acceptable.
 
+## Operator Contract (binding — read before acting)
+
+The operator's working contract is `agents_extensions/shared/rules/operator-expectations.md`
+(digest also in `AGENTS.md` § Operator Contract; deploy copy `.gemini/rules/`). Its items are
+the tie-breakers. Core: quality over shortcuts · root-cause fixes · git/PR hygiene with
+`X-Agent` trailers · use the whole fleet, review gate = independent CROSS-FAMILY reviewer
+(discussion ≠ review) · route by model × harness fit · handle limits, NOTE substitutions ·
+no claims without tool-backed proof (Ukrainian word/stress/morphology facts VESUM/`sources`-
+verified, never guessed) · clean code + current docs · **max UA immersion EXCEPT A1** (its
+English scaffolding is by design; from A2 never raise English) · drive, don't defer · repo
+hard gates bind.
+
 ## Your Role
 You are **Gemini (Yellow Team)** — the content builder. You research, write content, and create activities. Claude (Blue Team) reviews work and maintains infrastructure. **An LLM must NEVER review its own work as an approval gate.** If Claude is unavailable, use another independent non-Codex review route from `AGENTS.md`; do not substitute self-review.
 

--- a/tests/test_operator_contract_wiring.py
+++ b/tests/test_operator_contract_wiring.py
@@ -52,6 +52,14 @@ def test_agents_md_carries_binding_digest() -> None:
     assert "EXCEPT A1" in body, "digest lost the A1 immersion exception"
 
 
+def test_gemini_md_carries_binding_digest() -> None:
+    """agy/gemini one-shots boot from GEMINI.md, not AGENTS.md — proven by the
+    2026-07-05 live canary (agy answered NOT LOADED before this digest)."""
+    body = (REPO / "GEMINI.md").read_text(encoding="utf-8")
+    assert "operator-expectations.md" in body, "GEMINI.md lost the contract pointer"
+    assert "EXCEPT A1" in body, "GEMINI.md digest lost the A1 immersion exception"
+
+
 def test_deploy_lock_step_lists_include_contract() -> None:
     """deploy excludes x drift-checker x idempotency fixtures must move
     together (learned the hard way in #4412 round 3)."""


### PR DESCRIPTION
Closes the one canary FAIL from the #4422 propagation test.

## Live canary matrix (no-tools probe, bridge thread `contract-canary` msgs 1893-1902)
| Lane | Boot path | Result |
|---|---|---|
| codex | AGENTS.md digest | ✅ PASS — named the contract + A1 exception |
| cursor | AGENTS.md digest | ✅ PASS |
| hermes (default model) | AGENTS.md (slot 5) + SOUL.md | ✅ PASS — cited 'full UA immersion applies from A2 onward' |
| pool (opencode) | AGENTS.md digest | ✅ PASS |
| agy | **GEMINI.md** — had no digest | ❌ NOT LOADED → **this PR** |

GEMINI.md gets the same digest section; `test_operator_contract_wiring.py` extended to pin it (6 tests). agy will be re-canaried after merge — result posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)