### PR TITLE
fix(bridge): inject operator-contract digest into agy prompts + CLAUDE.md digest for headless Claude

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,21 @@
 
 ---
 
+## Operator Contract (binding — loads without tools)
+
+The operator's working contract is `agents_extensions/shared/rules/operator-expectations.md`
+(served FIRST at `GET /api/rules`; digests also in `AGENTS.md` and `GEMINI.md` § Operator
+Contract). Headless `claude -p` runs may not fetch the API — this digest keeps the contract
+in-context regardless: quality over shortcuts · root-cause fixes · git/PR hygiene +
+`X-Agent` trailers · whole-fleet utilization, review gate = independent CROSS-FAMILY
+reviewer (discussion ≠ review) · route by model × harness fit · handle limits, NOTE
+substitutions · tool-backed claims only (UK word/stress/morphology facts VESUM/`sources`-
+verified, never guessed) · clean code + current docs · **max UA immersion EXCEPT A1**
+(English scaffolding there is by design; from A2 never raise English) · drive, don't defer ·
+repo hard gates bind.
+
+---
+
 ## Best Practices Reference
 
 Detailed standards in `docs/best-practices/`. Read the relevant doc before working in that area.

--- a/scripts/ai_agent_bridge/_prompts.py
+++ b/scripts/ai_agent_bridge/_prompts.py
@@ -236,6 +236,13 @@ Violating this rule destroys the caller's work in progress. There is no exceptio
 """
 
 
+OPERATOR_CONTRACT_DIGEST = """Operator contract (binding; full text: agents_extensions/shared/rules/operator-expectations.md):
+quality over shortcuts - root-cause fixes - tool-backed claims only (Ukrainian word/stress/
+morphology facts VESUM/`sources`-verified, never guessed) - max UA immersion EXCEPT A1 (its
+English scaffolding is by design; from A2 never raise English) - reviews need an independent
+cross-family reviewer (discussion does not satisfy the gate) - note any lane substitution."""
+
+
 def build_agy_prompt(msg: dict, review: bool = False) -> str:
     """Build prompt for Agy (Antigravity CLI) invocation.
 
@@ -246,6 +253,8 @@ def build_agy_prompt(msg: dict, review: bool = False) -> str:
     standing rules here explicitly forbid those routes for bridge Q&A.
     """
     prompt = f"""You are Agy (Antigravity CLI, Gemini-3.5-Flash-High), receiving a message from {msg['from'].title()} via the message broker.
+
+{OPERATOR_CONTRACT_DIGEST}
 
 ---
 Task ID: {msg['task_id'] or 'none'}

--- a/tests/test_operator_contract_wiring.py
+++ b/tests/test_operator_contract_wiring.py
@@ -60,6 +60,30 @@ def test_gemini_md_carries_binding_digest() -> None:
     assert "EXCEPT A1" in body, "GEMINI.md digest lost the A1 immersion exception"
 
 
+def test_claude_md_carries_binding_digest() -> None:
+    """Headless `claude -p` boots from CLAUDE.md and may not fetch /api/rules
+    — the digest must live in the file itself."""
+    body = (REPO / "CLAUDE.md").read_text(encoding="utf-8")
+    assert "operator-expectations.md" in body
+    assert "EXCEPT A1" in body, "CLAUDE.md digest lost the A1 immersion exception"
+
+
+def test_agy_bridge_prompt_injects_contract_digest() -> None:
+    """The agy CLI loads NO repo context files in bridge one-shot mode
+    (canary-proven NOT LOADED twice on 2026-07-05, even after the GEMINI.md
+    digest) — the bridge prompt builder must inject the digest itself."""
+    import sys
+
+    sys.path.insert(0, str(REPO / "scripts"))
+    from ai_agent_bridge._prompts import build_agy_prompt
+
+    out = build_agy_prompt(
+        {"from": "claude", "task_id": "t", "type": "query", "content": "x", "data": None}
+    )
+    assert "operator-expectations.md" in out
+    assert "EXCEPT A1" in out
+
+
 def test_deploy_lock_step_lists_include_contract() -> None:
     """deploy excludes x drift-checker x idempotency fixtures must move
     together (learned the hard way in #4412 round 3)."""


### PR DESCRIPTION
Round-2 canary follow-up (#4422 → #4424 → this).

- **agy**: NOT LOADED persisted after the GEMINI.md digest → proven the Antigravity CLI loads no repo context in bridge one-shot mode. Fix at the ADAPTER layer: `build_agy_prompt` injects `OPERATOR_CONTRACT_DIGEST` (same pattern as hermes SOUL.md slot 1). Verified: builder output contains the digest.
- **headless Claude** (operator ask): `claude -p` boots from CLAUDE.md and may not fetch /api/rules — CLAUDE.md now carries the same compact digest, tools-free.
- `test_operator_contract_wiring.py` → **8 tests** pinning every boot surface: /api/rules order, AGENTS.md, GEMINI.md, CLAUDE.md, agy prompt-builder, deploy lock-step lists, offline fallback, 11 contract items.

Post-merge: re-canary agy + headless claude; final matrix on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)