### PR TITLE
docs(agents): curriculum-orchestrator loads session from .agent/claude-thread-handoff.md

### DIFF
--- a/agents_extensions/shared/agents/curriculum-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-orchestrator.md
@@ -35,7 +35,11 @@ initialPrompt: |
      - `curl -s --max-time 2 'http://localhost:8765/api/session/current?agent=orchestrator'` only if session hash changed
      - `curl -s --max-time 2 http://localhost:8765/api/orient`
      - `curl -s --max-time 2 'http://localhost:8765/api/comms/inbox?agent=claude'`
-  3. Read `docs/session-state/current.orchestrator.md` for the detailed handoff; `current.md` is only the router.
+  3. **Load the session from `.agent/claude-thread-handoff.md` FIRST** — the gitignored local
+   driver handoff is the freshest session state (done/in-flight/queue/hygiene; driver handoffs
+   are out of git per user policy 2026-06-23). Then read `docs/session-state/current.orchestrator.md`
+   for the durable cross-agent handoff; `current.md` is only the router. If the thread handoff is
+   missing or stale (older than current.orchestrator.md), say so and use the durable one.
   4. Check `docs/decisions/pending/`; pending decisions block only their declared Scope.
   5. Then begin work. If Monitor API times out, say "API down, falling back" and read
      `docs/session-state/current.md` router -> matching `current.<agent>.md` -> `memory/MEMORY.md` -> `CLAUDE.md`.
@@ -136,8 +140,9 @@ review, orchestration, precise dispatch briefs.
   driver's machine, e.g. `.claude/bio-epic/CLAUDE-DRIVER-HANDOFF.md` (user policy 2026-06-23 — driver
   handoffs are out of git/PRs). You (main) do NOT read it; track drivers report to you via TRACK-UPDATE
   pings + their PR descriptions.
-- Main orchestrator source of truth: `docs/session-state/current.md` router plus
-  `docs/session-state/current.orchestrator.md`.
+- Main orchestrator source of truth: session layer = `.agent/claude-thread-handoff.md`
+  (gitignored LOCAL driver handoff — load first, write at session end); durable cross-agent
+  layer = `docs/session-state/current.md` router plus `docs/session-state/current.orchestrator.md`.
 - Track pings use:
   `TRACK-UPDATE track=<track> pr=<number|none> state=<blocked|ready|in-flight>
   owner=<agent> needs=<main-review|merge|codex-help|decision|none>


### PR DESCRIPTION
Per operator ask: the curriculum-orchestrator agent definition must load its session from the thread handoff.

- Cold-start step 3: **load `.agent/claude-thread-handoff.md` FIRST** (gitignored local driver handoff — freshest state), then `docs/session-state/current.orchestrator.md` as the durable cross-agent layer; staleness tie-break documented.
- Main-orchestrator SSOT declaration updated to name both layers explicitly.
- Matches the SessionStart hook (which already points new threads at the same file) — the agent def and the hook now agree.

Verified: lint_prompts + deploy idempotency 77 passed; deploy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)