### PR TITLE
[codex] feat(atlas): PR-1 ssg-db-read — Astro builds lexicon pages from atlas.db

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -834,6 +834,15 @@ jobs:
           cache: 'npm'
           cache-dependency-path: site/package-lock.json
 
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: '.python-version'
+
+      - name: Create Python venv
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+
       - name: Restore Atlas lexicon manifest cache
         id: atlas-manifest-cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -843,7 +852,7 @@ jobs:
 
       - name: Verify Atlas manifest matches pointer (rehydrate if stale)
         run: |
-          python3 -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
+          .venv/bin/python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
 
       - name: Save Atlas lexicon manifest cache
         if: steps.atlas-manifest-cache.outputs.cache-hit != 'true'
@@ -883,6 +892,15 @@ jobs:
         cache: 'npm'
         cache-dependency-path: site/package-lock.json
 
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version-file: '.python-version'
+
+    - name: Create Python venv
+      run: |
+        python -m venv .venv
+        .venv/bin/python -m pip install --upgrade pip
+
     - name: Restore Atlas lexicon manifest cache
       id: atlas-manifest-cache
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -892,7 +910,7 @@ jobs:
 
     - name: Verify Atlas manifest matches pointer (rehydrate if stale)
       run: |
-        python3 -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
+        .venv/bin/python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
 
     - name: Save Atlas lexicon manifest cache
       if: steps.atlas-manifest-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -48,6 +48,17 @@ jobs:
           cache: 'npm'
           cache-dependency-path: site/package-lock.json
 
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: '.python-version'
+
+      - name: Create Python venv
+        working-directory: .
+        run: |
+          python -m venv .venv
+          .venv/bin/python -m pip install --upgrade pip
+
       - name: Restore Atlas lexicon manifest cache
         id: atlas-manifest-cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -58,7 +69,7 @@ jobs:
       - name: Verify Atlas manifest matches pointer (rehydrate if stale)
         working-directory: .
         run: |
-          python3 -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
+          .venv/bin/python -c "import sys; sys.path.insert(0, 'scripts'); from lexicon.manifest_io import load_manifest; load_manifest(); print('Atlas manifest verified against pointer')"
 
       - name: Save Atlas lexicon manifest cache
         if: steps.atlas-manifest-cache.outputs.cache-hit != 'true'

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -446,7 +446,9 @@ Additional audit guardrails:
 - `scripts/audit/atlas_source_census.py` - aggregate-only Word Atlas source intake census; public reports must not include raw source text, private paths, or candidate lemma lists
 - `scripts/audit/atlas_entry_model_census.py` - aggregate-only Word Atlas entry-model census; separates reviewed article entries by `entry_type` from alias/form records
 - `scripts/audit/atlas_source_entry_count.py` - aggregate-only Word Atlas source-corpus entry-demand census by finalized entry-model bucket; public reports must not include source text, private paths, filenames, or candidate lists
+- `scripts/atlas/atlas_db.py` - rebuild `data/atlas.db` from the hydrated Atlas manifest, materialize the Astro article payload projection, and validate alias targets
 - `scripts/atlas/fill_local.py` - Phase-1 offline local enrichment writer for `data/atlas.db`; reads local dictionary/cache data only and reports per-section before/after coverage
+- `site/scripts/benchmark-atlas-db.mjs` - benchmark Atlas DB build, preload, and getStaticPaths mapping at current and synthetic sizes
 - `scripts/audit/curriculum_qg_harness.py` - deterministic Ukrainian curriculum QG fixture harness; use it to calibrate B1-27, A1/A2 scaffolding, B1+ leakage, and seminar-register checks before changing QG behavior
 
 ### Build pipeline entry point
@@ -617,7 +619,9 @@ Use this before content generation to verify plan files still match `scripts/aud
 | `scripts/audit/atlas_source_census.py` | Build aggregate-safe Word Atlas source planning counts | `.venv/bin/python scripts/audit/atlas_source_census.py --markdown-out docs/runbooks/word-atlas-source-census-planning.md` |
 | `scripts/audit/atlas_entry_model_census.py` | Count reviewed Atlas entries by finalized `entry_type` bucket | `.venv/bin/python scripts/audit/atlas_entry_model_census.py --format markdown` |
 | `scripts/audit/atlas_source_entry_count.py` | Estimate aggregate source-corpus Atlas entry backlog by finalized bucket | `.venv/bin/python scripts/audit/atlas_source_entry_count.py --include-ohoiko-private --markdown-out docs/runbooks/word-atlas-source-entry-count.md` |
+| `scripts/atlas/atlas_db.py` | Rebuild `data/atlas.db`, materialize article payloads, and validate public alias targets | `.venv/bin/python -m scripts.atlas.atlas_db --db data/atlas.db` |
 | `scripts/atlas/fill_local.py` | Fill `data/atlas.db` with Phase-1 local Atlas enrichment rows | `.venv/bin/python -m scripts.atlas.fill_local --db data/atlas.db --report-json /tmp/atlas-fill-local-report.json` |
+| `site/scripts/benchmark-atlas-db.mjs` | Benchmark Atlas DB build, preloaded payload read, and getStaticPaths mapping | `npm --prefix site run atlas:perf` |
 | `scripts/audit/curriculum_qg_harness.py` | Run calibrated Ukrainian QG fixtures or scan one module into compact evidence | `.venv/bin/python scripts/audit/curriculum_qg_harness.py --fixtures tests/fixtures/curriculum_qg/fixtures.yaml` |
 | `scripts/audit/ingest_ua_gec_gold.py` | Curate the small attributed UA-GEC gold fixture for the #2156 eval harness | `.venv/bin/python scripts/audit/ingest_ua_gec_gold.py --dry-run` |
 | `scripts/audit/module_quality_audit.py` | Report surface and LLM-QG/compact evidence coverage by level | `.venv/bin/python scripts/audit/module_quality_audit.py --level b1 --format summary` |

--- a/scripts/atlas/atlas_db.py
+++ b/scripts/atlas/atlas_db.py
@@ -5,6 +5,16 @@ The JSON manifest becomes a generated export of this DB, not the store.
 
 Migration is deterministic and idempotent: it rebuilds the DB from the current
 manifest. entry_type / alias / provenance are assigned by rule (no LLM).
+
+Compatibility projection contract for PR-1 SSG DB reads:
+``article_payloads.payload_json`` stores the exact public manifest entry object
+that ``site/src/lexicon/WordAtlasArticle.astro`` consumes today, keyed by the
+route slug and preserving manifest route order. This table is deliberately an
+opaque build-time projection, not the normalized entry-model schema: it includes
+current ``form_of`` routes until the alias/redirect split lands in PR-3, while
+the normalized ``articles`` table continues to treat ``form_of`` rows as alias
+records. Any field newly consumed by the Astro article must be present in this
+projection and covered by render-parity tests.
 """
 
 from __future__ import annotations
@@ -13,6 +23,7 @@ import argparse
 import json
 import re
 import sqlite3
+import sys
 import unicodedata
 from pathlib import Path
 from typing import Any
@@ -87,6 +98,16 @@ CREATE TABLE IF NOT EXISTS articles (
     created_at TEXT,
     updated_at TEXT
 );
+CREATE TABLE IF NOT EXISTS manifest_metadata (
+    key TEXT PRIMARY KEY,
+    value_json TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS article_payloads (
+    slug TEXT PRIMARY KEY,
+    route_order INTEGER NOT NULL,
+    payload_json TEXT NOT NULL,
+    is_public_route INTEGER NOT NULL CHECK (is_public_route IN (0, 1))
+);
 CREATE TABLE IF NOT EXISTS article_provenance (
     slug TEXT NOT NULL,
     source_family TEXT,
@@ -99,6 +120,7 @@ CREATE TABLE IF NOT EXISTS aliases (
     kind TEXT NOT NULL CHECK (kind IN ({_sql_enum(ALIAS_KINDS)})),
     source TEXT,
     target_slug TEXT NOT NULL,
+    visibility TEXT NOT NULL DEFAULT 'public' CHECK (visibility IN ({_sql_enum(VISIBILITIES)})),
     UNIQUE (alias, kind, target_slug)
 );
 CREATE TABLE IF NOT EXISTS related_entries (
@@ -122,6 +144,7 @@ CREATE TABLE IF NOT EXISTS enrichment (
 CREATE INDEX IF NOT EXISTS idx_aliases_target ON aliases(target_slug);
 CREATE INDEX IF NOT EXISTS idx_prov_slug ON article_provenance(slug);
 CREATE INDEX IF NOT EXISTS idx_enrichment_slug ON enrichment(slug);
+CREATE INDEX IF NOT EXISTS idx_article_payloads_route ON article_payloads(is_public_route, route_order);
 CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
     slug UNINDEXED, display_head, lemma, gloss, aliases
 );
@@ -166,6 +189,23 @@ def _iso(entry: dict[str, Any]) -> str | None:
     return entry.get("updated_at") or entry.get("created_at")
 
 
+def is_public_route_payload(entry: dict[str, Any]) -> bool:
+    """Mirror the current Astro word-page route filter for compatibility payloads."""
+    lemma = str(entry.get("lemma") or "").strip()
+    slug = str(entry.get("url_slug") or "").strip()
+    return bool(lemma and slug and entry.get("pos") != "grammar term")
+
+
+def _insert_manifest_metadata(cur: sqlite3.Cursor, manifest: dict[str, Any]) -> None:
+    for key in ("version", "generated_at"):
+        value = manifest.get(key)
+        if value is not None:
+            cur.execute(
+                "INSERT OR REPLACE INTO manifest_metadata(key, value_json) VALUES (?, ?)",
+                (key, json.dumps(value, ensure_ascii=False)),
+            )
+
+
 def migrate_manifest(manifest_path: Path, db_path: Path) -> dict[str, int]:
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     entries = manifest.get("entries", [])
@@ -175,37 +215,49 @@ def migrate_manifest(manifest_path: Path, db_path: Path) -> dict[str, int]:
     conn = sqlite3.connect(db_path)
     conn.executescript(SCHEMA)
     cur = conn.cursor()
+    _insert_manifest_metadata(cur, manifest)
 
-    counts = {"articles": 0, "aliases": 0, "provenance": 0, "enrichment": 0, "form_aliases": 0}
+    counts = {"articles": 0, "aliases": 0, "provenance": 0, "enrichment": 0, "form_aliases": 0, "payloads": 0}
     by_type: dict[str, int] = {}
 
     # first pass: gather article slugs so form_of aliases only resolve to real articles
-    article_slugs: set[str] = set()
+    article_visibility: dict[str, str] = {}
     for e in entries:
         if e.get("form_of"):
             continue
-        article_slugs.add(str(e.get("url_slug") or e.get("lemma")).strip())
+        slug = str(e.get("url_slug") or e.get("lemma")).strip()
+        if slug:
+            article_visibility[slug] = "private" if e.get("pos") == "grammar term" else "public"
 
     def _form_of_target(form_of: Any) -> str | None:
         if isinstance(form_of, dict):
             return str(form_of.get("url_slug") or form_of.get("lemma") or "").strip() or None
         return str(form_of).strip() or None
 
-    for e in entries:
+    for route_order, e in enumerate(entries):
         lemma = str(e.get("lemma") or "").strip()
         slug = str(e.get("url_slug") or lemma).strip()
         if not lemma or not slug:
             continue
         display_head = str(e.get("display_head") or lemma).strip()
 
+        if is_public_route_payload(e):
+            cur.execute(
+                """INSERT OR REPLACE INTO article_payloads
+                   (slug, route_order, payload_json, is_public_route)
+                   VALUES (?, ?, ?, 1)""",
+                (slug, route_order, json.dumps(e, ensure_ascii=False)),
+            )
+            counts["payloads"] += 1
+
         # form_of records -> alias rows, not articles (only if target is a real article)
         form_of = e.get("form_of")
         if form_of:
             target = _form_of_target(form_of)
-            if target and target in article_slugs:
+            if target and target in article_visibility:
                 cur.execute(
-                    "INSERT OR IGNORE INTO aliases(alias, kind, source, target_slug) VALUES (?,?,?,?)",
-                    (unstressed(lemma), "inflected_form", "manifest:form_of", target),
+                    "INSERT OR IGNORE INTO aliases(alias, kind, source, target_slug, visibility) VALUES (?,?,?,?,?)",
+                    (unstressed(lemma), "inflected_form", "manifest:form_of", target, article_visibility[target]),
                 )
                 counts["form_aliases"] += 1
             else:
@@ -260,7 +312,10 @@ def migrate_manifest(manifest_path: Path, db_path: Path) -> dict[str, int]:
         ]
         for a, k, s, t in alias_rows:
             if a and a != slug:
-                cur.execute("INSERT OR IGNORE INTO aliases(alias, kind, source, target_slug) VALUES (?,?,?,?)", (a, k, s, t))
+                cur.execute(
+                    "INSERT OR IGNORE INTO aliases(alias, kind, source, target_slug, visibility) VALUES (?,?,?,?,?)",
+                    (a, k, s, t, visibility),
+                )
                 counts["aliases"] += 1
 
         # enrichment sections (from enrichment + sections + top-level pronunciation/wiki/heritage)
@@ -300,15 +355,76 @@ def migrate_manifest(manifest_path: Path, db_path: Path) -> dict[str, int]:
     return counts
 
 
+def validate_alias_targets(db_path: Path) -> dict[str, int]:
+    """Validate every emitted alias resolves to an approved public article."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    failures = conn.execute(
+        """SELECT al.alias, al.kind, al.target_slug, a.review_state, a.visibility
+           FROM aliases al
+           LEFT JOIN articles a ON a.slug = al.target_slug
+           WHERE al.visibility = 'public'
+             AND (
+                a.slug IS NULL
+                OR a.review_state != 'approved'
+                OR a.visibility != 'public'
+             )
+           ORDER BY al.target_slug, al.kind, al.alias"""
+    ).fetchall()
+    counts = {
+        "public_aliases": int(conn.execute("SELECT COUNT(*) FROM aliases WHERE visibility='public'").fetchone()[0]),
+        "private_aliases": int(conn.execute("SELECT COUNT(*) FROM aliases WHERE visibility='private'").fetchone()[0]),
+        "distinct_public_targets": int(
+            conn.execute("SELECT COUNT(DISTINCT target_slug) FROM aliases WHERE visibility='public'").fetchone()[0]
+        ),
+        "approved_public_articles": int(
+            conn.execute("SELECT COUNT(*) FROM articles WHERE review_state='approved' AND visibility='public'").fetchone()[0]
+        ),
+        "failures": len(failures),
+    }
+    conn.close()
+
+    if failures:
+        for row in failures:
+            if row["review_state"] is None:
+                reason = "missing target article"
+            elif row["review_state"] != "approved":
+                reason = f"target review_state={row['review_state']!r}"
+            else:
+                reason = f"target visibility={row['visibility']!r}"
+            print(
+                "alias_target_integrity failure: "
+                f"alias={row['alias']!r} kind={row['kind']!r} target_slug={row['target_slug']!r} reason={reason}",
+                file=sys.stderr,
+            )
+        raise ValueError(f"{len(failures)} alias target(s) are not approved public articles")
+
+    print("atlas_db alias validation:", json.dumps(counts, ensure_ascii=False))
+    return counts
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description="Build/migrate the Word Atlas entry-model v1 SQLite DB.")
     ap.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     ap.add_argument("--db", type=Path, default=DEFAULT_DB)
+    ap.add_argument(
+        "--validate-aliases-only",
+        action="store_true",
+        help="Validate alias targets in an existing DB without rebuilding it.",
+    )
     args = ap.parse_args()
-    counts = migrate_manifest(args.manifest, args.db)
-    by_type = counts.pop("by_type", {})
-    print("atlas_db migrate:", json.dumps(counts, ensure_ascii=False))
-    print("by entry_type:", json.dumps(by_type, ensure_ascii=False))
+    try:
+        if args.validate_aliases_only:
+            validate_alias_targets(args.db)
+            return
+        counts = migrate_manifest(args.manifest, args.db)
+        by_type = counts.pop("by_type", {})
+        print("atlas_db migrate:", json.dumps(counts, ensure_ascii=False))
+        print("by entry_type:", json.dumps(by_type, ensure_ascii=False))
+        validate_alias_targets(args.db)
+    except ValueError as exc:
+        print(f"atlas_db validation failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
 
 
 if __name__ == "__main__":

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "astro": "^6.4.7",
+        "better-sqlite3": "^12.11.1",
         "playwright": "^1.60.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.7",
@@ -31,6 +32,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/better-sqlite3": "^7.6.13",
         "@vitest/coverage-v8": "^4.1.8",
         "happy-dom": "^20.10.6",
         "vitest": "^4.1.9"
@@ -2427,6 +2429,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -3943,6 +3955,26 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.38",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
@@ -3953,6 +3985,40 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.11.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/boolbase": {
@@ -3992,6 +4058,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-image-size": {
@@ -4101,6 +4191,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
@@ -4876,6 +4972,30 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/defu": {
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
@@ -5063,6 +5183,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -5283,6 +5412,15 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5338,6 +5476,12 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/flattie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
@@ -5367,6 +5511,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -5414,6 +5564,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
@@ -5783,6 +5939,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -5792,6 +5968,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -7322,6 +7510,18 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -7340,6 +7540,21 @@
       "bin": {
         "mini-svg-data-uri": "cli.js"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.8.0",
@@ -7392,6 +7607,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/neotraverse": {
       "version": "0.6.18",
       "resolved": "https://registry.npmjs.org/neotraverse/-/neotraverse-0.6.18.tgz",
@@ -7412,6 +7633,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-fetch-native": {
@@ -7482,6 +7715,15 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/oniguruma-parser": {
       "version": "0.12.2",
@@ -7745,6 +7987,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
@@ -7809,11 +8078,36 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/radix3": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
     },
     "node_modules/react": {
       "version": "19.2.7",
@@ -7851,6 +8145,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -8348,6 +8656,26 @@
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -8451,6 +8779,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -8551,6 +8924,15 @@
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -8602,6 +8984,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/style-to-js": {
@@ -8664,6 +9055,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.5.tgz",
+      "integrity": "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tiny-inflate": {
@@ -8767,6 +9186,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/typesafe-path": {
       "version": "0.2.2",
@@ -9111,6 +9542,12 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "14.0.0",
@@ -9649,6 +10086,12 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.21.0",

--- a/site/package.json
+++ b/site/package.json
@@ -3,7 +3,11 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
-    "hydrate": "node ./scripts/hydrate-manifest.mjs && node ./scripts/hydrate-practice-deck.mjs",
+    "atlas:build-db": "cd .. && .venv/bin/python -m scripts.atlas.atlas_db --db data/atlas.db",
+    "atlas:perf": "node ./scripts/benchmark-atlas-db.mjs",
+    "atlas:validate-aliases": "cd .. && .venv/bin/python -m scripts.atlas.atlas_db --db data/atlas.db --validate-aliases-only",
+    "hydrate": "node ./scripts/hydrate-manifest.mjs && npm run atlas:build-db && node ./scripts/hydrate-practice-deck.mjs",
+    "hydrate:manifest": "node ./scripts/hydrate-manifest.mjs && npm run atlas:build-db",
     "hydrate:practice": "node ./scripts/hydrate-practice-deck.mjs",
     "dev": "npm run hydrate && astro dev",
     "start": "npm run dev",
@@ -11,9 +15,9 @@
     "build:full": "npm run hydrate && BUILD_ETYMOLOGY_ROUTES=1 astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "test": "npm run hydrate:practice && vitest run",
-    "test:watch": "npm run hydrate:practice && vitest --watch",
-    "test:coverage": "npm run hydrate:practice && vitest run --coverage"
+    "test": "npm run hydrate && vitest run",
+    "test:watch": "npm run hydrate && vitest --watch",
+    "test:coverage": "npm run hydrate && vitest run --coverage"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.9",
@@ -24,6 +28,7 @@
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "astro": "^6.4.7",
+    "better-sqlite3": "^12.11.1",
     "playwright": "^1.60.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.7",
@@ -39,6 +44,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/better-sqlite3": "^7.6.13",
     "@vitest/coverage-v8": "^4.1.8",
     "happy-dom": "^20.10.6",
     "vitest": "^4.1.9"

--- a/site/scripts/benchmark-atlas-db.mjs
+++ b/site/scripts/benchmark-atlas-db.mjs
@@ -1,0 +1,178 @@
+/* eslint-env node */
+/* global console, process */
+
+import Database from 'better-sqlite3';
+import { createWriteStream } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '../..');
+const pythonPath = resolve(repoRoot, '.venv/bin/python');
+const currentManifestPath = resolve(repoRoot, 'site/src/data/lexicon-manifest.json');
+const currentPreloadLimitSeconds = Number(process.env.ATLAS_DB_CURRENT_PRELOAD_LIMIT_SECONDS ?? '30');
+const currentOnly = process.argv.includes('--current-only');
+
+function secondsSince(start) {
+  return (performance.now() - start) / 1000;
+}
+
+function runAtlasDb(manifestPath, dbPath) {
+  const start = performance.now();
+  const result = spawnSync(
+    pythonPath,
+    ['-m', 'scripts.atlas.atlas_db', '--manifest', manifestPath, '--db', dbPath],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      maxBuffer: 50 * 1024 * 1024,
+    },
+  );
+  if (result.status !== 0) {
+    process.stdout.write(result.stdout ?? '');
+    process.stderr.write(result.stderr ?? '');
+    throw new Error(`atlas_db failed for ${manifestPath}`);
+  }
+  return secondsSince(start);
+}
+
+function preloadPayloads(dbPath) {
+  const start = performance.now();
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  try {
+    const rows = db
+      .prepare(
+        `SELECT slug, payload_json
+         FROM article_payloads
+         WHERE is_public_route = 1
+         ORDER BY route_order`,
+      )
+      .all();
+    const bySlug = new Map();
+    for (const row of rows) {
+      bySlug.set(row.slug, JSON.parse(row.payload_json));
+    }
+    return { seconds: secondsSince(start), bySlug };
+  } finally {
+    db.close();
+  }
+}
+
+function measureGetStaticPaths(bySlug) {
+  const start = performance.now();
+  const paths = Array.from(bySlug.values()).map((entry) => ({
+    params: { lemma: entry.url_slug },
+    props: { entry },
+  }));
+  return { seconds: secondsSince(start), count: paths.length };
+}
+
+function writeChunk(stream, chunk) {
+  return new Promise((resolveWrite, rejectWrite) => {
+    if (stream.write(chunk)) {
+      resolveWrite();
+      return;
+    }
+    const onDrain = () => {
+      stream.off('error', onError);
+      resolveWrite();
+    };
+    const onError = (error) => {
+      stream.off('drain', onDrain);
+      rejectWrite(error);
+    };
+    stream.once('drain', onDrain);
+    stream.once('error', onError);
+  });
+}
+
+async function writeSyntheticManifest(manifestPath, rows) {
+  const stream = createWriteStream(manifestPath, { encoding: 'utf8' });
+  await writeChunk(
+    stream,
+    `{"version":"synthetic-${rows}","generated_at":"2026-07-05T00:00:00Z","entries":[`,
+  );
+  for (let index = 0; index < rows; index += 1) {
+    const slug = `atlasword-${index}`;
+    const entry = {
+      lemma: `atlasword${index}`,
+      url_slug: slug,
+      gloss: `synthetic entry ${index}`,
+      pos: 'noun',
+      primary_source: 'synthetic',
+      course_usage: [],
+      enrichment: {
+        cefr: { level: 'A1', source: 'synthetic' },
+      },
+    };
+    await writeChunk(stream, `${index === 0 ? '' : ','}${JSON.stringify(entry)}`);
+  }
+  await writeChunk(stream, ']}');
+  await new Promise((resolveFinish, rejectFinish) => {
+    stream.end(resolveFinish);
+    stream.once('error', rejectFinish);
+  });
+}
+
+async function benchmarkDataset(tempDir, label, manifestPath, rowCount) {
+  const dbPath = join(tempDir, `${label}.db`);
+  const dbBuildSeconds = runAtlasDb(manifestPath, dbPath);
+  const preload = preloadPayloads(dbPath);
+  const staticPaths = measureGetStaticPaths(preload.bySlug);
+  return {
+    dataset: label,
+    rows: rowCount ?? staticPaths.count,
+    dbBuildSeconds,
+    preloadSeconds: preload.seconds,
+    getStaticPathsSeconds: staticPaths.seconds,
+    paths: staticPaths.count,
+  };
+}
+
+function printTable(results) {
+  console.log('atlas_db perf benchmark:');
+  console.log('| dataset | rows | DB-build seconds | preload seconds | getStaticPaths seconds | paths |');
+  console.log('| --- | ---: | ---: | ---: | ---: | ---: |');
+  for (const result of results) {
+    console.log(
+      `| ${result.dataset} | ${result.rows} | ${result.dbBuildSeconds.toFixed(3)} | ` +
+        `${result.preloadSeconds.toFixed(3)} | ${result.getStaticPathsSeconds.toFixed(3)} | ${result.paths} |`,
+    );
+  }
+}
+
+async function main() {
+  const tempDir = await mkdtemp(join(tmpdir(), 'atlas-db-bench-'));
+  try {
+    const results = [await benchmarkDataset(tempDir, 'current', currentManifestPath)];
+    if (!currentOnly) {
+      for (const rows of [50000, 250000]) {
+        const manifestPath = join(tempDir, `synthetic-${rows}.json`);
+        await writeSyntheticManifest(manifestPath, rows);
+        results.push(await benchmarkDataset(tempDir, `${rows} synthetic`, manifestPath, rows));
+      }
+    }
+    printTable(results);
+    const current = results[0];
+    if (current.preloadSeconds > currentPreloadLimitSeconds) {
+      throw new Error(
+        `current preload ${current.preloadSeconds.toFixed(3)}s exceeds ${currentPreloadLimitSeconds}s`,
+      );
+    }
+    console.log(
+      `perf gate current preload ${current.preloadSeconds.toFixed(3)}s <= ` +
+        `${currentPreloadLimitSeconds}s OK`,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/site/src/lib/lexicon/atlasDb.ts
+++ b/site/src/lib/lexicon/atlasDb.ts
@@ -1,0 +1,110 @@
+import Database from 'better-sqlite3';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export interface CourseUsage {
+  track: string;
+  module_num: number;
+  slug: string;
+  context: string;
+}
+
+export interface LexiconEntry {
+  lemma: string;
+  url_slug: string;
+  gloss: string | null;
+  form_of?: { lemma: string; url_slug: string } | null;
+  pos?: string | null;
+  ipa?: string | null;
+  pronunciation?: { ipa: string; source: string } | null;
+  primary_source?: string;
+  course_usage?: CourseUsage[];
+  sections?: unknown;
+  enrichment?: unknown;
+  heritage_status?: unknown;
+  wiki_reference?: unknown;
+}
+
+interface PayloadRow {
+  slug: string;
+  payload_json: string;
+}
+
+interface MetadataRow {
+  key: string;
+  value_json: string;
+}
+
+export interface AtlasPayloadCache {
+  entries: LexiconEntry[];
+  bySlug: Map<string, LexiconEntry>;
+  generatedAt: string;
+  manifestVersion: string;
+}
+
+const defaultDbPath = resolve(process.cwd(), '../data/atlas.db');
+let cachedAtlasPayloads: AtlasPayloadCache | null = null;
+
+function atlasDbPath(): string {
+  return process.env.ATLAS_DB_PATH || defaultDbPath;
+}
+
+function parseMetadata(rows: MetadataRow[]): { generatedAt: string; manifestVersion: string } {
+  const metadata = new Map(rows.map((row) => [row.key, JSON.parse(row.value_json) as unknown]));
+  return {
+    generatedAt: String(metadata.get('generated_at') ?? ''),
+    manifestVersion: String(metadata.get('version') ?? ''),
+  };
+}
+
+export function resetAtlasPayloadCacheForTests(): void {
+  cachedAtlasPayloads = null;
+}
+
+export function getAtlasPayloadCache(): AtlasPayloadCache {
+  if (cachedAtlasPayloads) return cachedAtlasPayloads;
+
+  const dbPath = atlasDbPath();
+  if (!existsSync(dbPath)) {
+    throw new Error(
+      `Atlas DB not found at ${dbPath}. Run \`npm --prefix site run hydrate\` or ` +
+        `\`.venv/bin/python -m scripts.atlas.atlas_db --db data/atlas.db\` before building the site.`,
+    );
+  }
+
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  try {
+    const payloadRows = db
+      .prepare(
+        `SELECT slug, payload_json
+         FROM article_payloads
+         WHERE is_public_route = 1
+         ORDER BY route_order`,
+      )
+      .all() as PayloadRow[];
+    const metadataRows = db
+      .prepare(
+        `SELECT key, value_json
+         FROM manifest_metadata
+         WHERE key IN ('generated_at', 'version')`,
+      )
+      .all() as MetadataRow[];
+    const entries = payloadRows.map((row) => JSON.parse(row.payload_json) as LexiconEntry);
+    const bySlug = new Map<string, LexiconEntry>();
+    for (const entry of entries) {
+      bySlug.set(entry.url_slug, entry);
+    }
+    cachedAtlasPayloads = {
+      entries,
+      bySlug,
+      ...parseMetadata(metadataRows),
+    };
+    return cachedAtlasPayloads;
+  } finally {
+    db.close();
+  }
+}
+
+export function getLexiconEntryBySlug(slug: string): LexiconEntry | undefined {
+  return getAtlasPayloadCache().bySlug.get(slug);
+}

--- a/site/src/pages/lexicon/[lemma].astro
+++ b/site/src/pages/lexicon/[lemma].astro
@@ -4,40 +4,13 @@
  */
 import CourseLayout from "../../layouts/CourseLayout.astro";
 import WordAtlasArticle from "../../lexicon/WordAtlasArticle.astro";
-import manifest from "../../data/lexicon-manifest.json";
+import { getAtlasPayloadCache, type LexiconEntry } from "../../lib/lexicon/atlasDb";
 
-interface LexiconEntry {
-  lemma: string;
-  url_slug: string;
-  gloss: string | null;
-  pos?: string | null;
-  form_of?: { lemma: string; url_slug: string } | null;
-}
-
-interface LexiconManifest {
-  version: string;
-  generated_at: string;
-  entries: LexiconEntry[];
-}
-
-// Grammar metaterms (pos === "grammar term", e.g. "singularia tantum") are not lemmas:
-// keep them out of word-page routes AND the cross-link set passed to WordAtlasArticle.
-// Mirrors scripts/audit/lexeme_filter.py::is_lexeme_entry (used by the search index +
-// daily pool), so all Atlas surfaces agree on what counts as a headword.
-function isLexemeEntry(entry: LexiconEntry): boolean {
-  return Boolean(entry.lemma) && Boolean(entry.url_slug) && entry.pos !== "grammar term";
-}
-
-const data = manifest as LexiconManifest;
-const lexemeEntries = data.entries.filter(isLexemeEntry);
+const atlasPayloads = getAtlasPayloadCache();
+const lexemeEntries = atlasPayloads.entries;
 
 export async function getStaticPaths() {
-  // Astro runs getStaticPaths in an isolated scope — it cannot see the module-scope
-  // isLexemeEntry above, so the same predicate is inlined here (keep them in sync).
-  const isLexeme = (entry: LexiconEntry) =>
-    Boolean(entry.lemma) && Boolean(entry.url_slug) && entry.pos !== "grammar term";
-  return (manifest as LexiconManifest).entries
-    .filter(isLexeme)
+  return getAtlasPayloadCache().entries
     .map((entry) => ({
       params: { lemma: entry.url_slug },
       props: { entry },
@@ -64,7 +37,7 @@ const frontmatter = {
   <WordAtlasArticle
     entry={entry}
     allEntries={lexemeEntries}
-    generatedAt={data.generated_at}
-    manifestVersion={data.version}
+    generatedAt={atlasPayloads.generatedAt}
+    manifestVersion={atlasPayloads.manifestVersion}
   />
 </CourseLayout>

--- a/site/tests/unit/atlas-db-read.test.ts
+++ b/site/tests/unit/atlas-db-read.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment node
+
+import Database from 'better-sqlite3';
+import { getContainerRenderer } from '@astrojs/react';
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { loadRenderers } from 'astro:container';
+import { describe, expect, test } from 'vitest';
+import { resolve } from 'node:path';
+import manifest from '@site/src/data/lexicon-manifest.json';
+import {
+  getAtlasPayloadCache,
+  resetAtlasPayloadCacheForTests,
+  type LexiconEntry,
+} from '@site/src/lib/lexicon/atlasDb';
+
+interface LexiconManifest {
+  version: string;
+  generated_at: string;
+  entries: LexiconEntry[];
+}
+
+interface EntryTypeRow {
+  entry_type: string;
+  slug: string;
+}
+
+type AstroComponent = Parameters<InstanceType<typeof AstroContainer>['renderToString']>[0];
+
+interface AstroComponentModule {
+  default: AstroComponent;
+}
+
+const data = manifest as LexiconManifest;
+const atlasDbPath = resolve(process.cwd(), '../data/atlas.db');
+const requiredFixtureSlugs = [
+  'прапор',
+  'файний',
+  'будь-ласка',
+  'доконаний-вид',
+  'ілля',
+  'іване',
+];
+
+function isCurrentRouteEntry(entry: LexiconEntry): boolean {
+  return Boolean(entry.lemma) && Boolean(entry.url_slug) && entry.pos !== 'grammar term';
+}
+
+function manifestRouteEntries(): LexiconEntry[] {
+  return data.entries.filter(isCurrentRouteEntry);
+}
+
+function readEntryTypeFixtures(): EntryTypeRow[] {
+  const db = new Database(atlasDbPath, { readonly: true, fileMustExist: true });
+  try {
+    return db
+      .prepare(
+        `SELECT entry_type, MIN(slug) AS slug
+         FROM articles
+         WHERE review_state = 'approved'
+           AND visibility = 'public'
+         GROUP BY entry_type
+         ORDER BY entry_type`,
+      )
+      .all() as EntryTypeRow[];
+  } finally {
+    db.close();
+  }
+}
+
+function firstDifference(left: string, right: string): string {
+  const limit = Math.min(left.length, right.length);
+  for (let index = 0; index < limit; index += 1) {
+    if (left[index] !== right[index]) {
+      return `first difference at ${index}: manifest=${JSON.stringify(left.slice(index, index + 120))} db=${JSON.stringify(right.slice(index, index + 120))}`;
+    }
+  }
+  return `length differs: manifest=${left.length} db=${right.length}`;
+}
+
+describe('Atlas DB SSG read parity', () => {
+  test('preloaded DB payloads preserve the current manifest route surface', async () => {
+    resetAtlasPayloadCacheForTests();
+    const cache = getAtlasPayloadCache();
+    const manifestEntries = manifestRouteEntries();
+
+    expect(cache.entries.map((entry) => entry.url_slug)).toEqual(
+      manifestEntries.map((entry) => entry.url_slug),
+    );
+    expect(cache.generatedAt).toBe(data.generated_at);
+    expect(cache.manifestVersion).toBe(data.version);
+
+    const paths = cache.entries.map((entry) => ({
+      params: { lemma: entry.url_slug },
+      props: { entry },
+    }));
+    expect(paths.map((path) => path.params.lemma)).toEqual(cache.entries.map((entry) => entry.url_slug));
+  });
+
+  test('renders DB payload HTML byte-identical to manifest payload HTML for parity fixtures', async () => {
+    resetAtlasPayloadCacheForTests();
+    const cache = getAtlasPayloadCache();
+    const manifestEntries = manifestRouteEntries();
+    const manifestBySlug = new Map(manifestEntries.map((entry) => [entry.url_slug, entry]));
+    const fixtureSlugs = Array.from(
+      new Set([...requiredFixtureSlugs, ...readEntryTypeFixtures().map((row) => row.slug)]),
+    );
+    const { default: WordAtlasArticle } = (await import(
+      '@site/src/lexicon/WordAtlasArticle.astro'
+    )) as AstroComponentModule;
+    const renderers = await loadRenderers([getContainerRenderer()]);
+    const container = await AstroContainer.create({ renderers });
+    let differing = 0;
+
+    for (const slug of fixtureSlugs) {
+      const manifestEntry = manifestBySlug.get(slug);
+      const dbEntry = cache.bySlug.get(slug);
+      expect(manifestEntry, `manifest fixture missing: ${slug}`).toBeDefined();
+      expect(dbEntry, `DB fixture missing: ${slug}`).toBeDefined();
+      expect(dbEntry).toEqual(manifestEntry);
+
+      const manifestHtml = await container.renderToString(WordAtlasArticle, {
+        props: {
+          entry: manifestEntry,
+          allEntries: manifestEntries,
+          generatedAt: data.generated_at,
+          manifestVersion: data.version,
+        },
+      });
+      const dbHtml = await container.renderToString(WordAtlasArticle, {
+        props: {
+          entry: dbEntry,
+          allEntries: cache.entries,
+          generatedAt: cache.generatedAt,
+          manifestVersion: cache.manifestVersion,
+        },
+      });
+
+      if (manifestHtml !== dbHtml) {
+        differing += 1;
+        throw new Error(`golden diff not empty for ${slug}: ${firstDifference(manifestHtml, dbHtml)}`);
+      }
+    }
+
+    process.stdout.write(`atlas render parity golden diff: fixtures=${fixtureSlugs.length} differing=${differing}\n`);
+    expect(differing).toBe(0);
+  });
+});

--- a/tests/test_atlas_db.py
+++ b/tests/test_atlas_db.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import sqlite3
 
+import pytest
+
 from scripts.atlas import atlas_db
 
 
@@ -57,6 +59,21 @@ def test_migration_shapes_and_gates(tmp_path):
     assert q("SELECT COUNT(*) FROM enrichment WHERE slug='прапор'")[0][0] >= 3
     assert q("SELECT COUNT(*) FROM articles_fts")[0][0] == 3
     assert q("SELECT slug FROM articles_fts WHERE articles_fts MATCH 'прапор'")[0][0] == "прапор"
+
+    # Compatibility projection keeps the exact current Astro route surface:
+    # form_of rows still render until PR-3 redirects them, but grammar terms do not.
+    payload_slugs = [row[0] for row in q("SELECT slug FROM article_payloads ORDER BY route_order")]
+    assert payload_slugs == ["прапор", "іван", "іване", "гхост", "сліпа-зона"]
+    payload = json.loads(q("SELECT payload_json FROM article_payloads WHERE slug='іване'")[0][0])
+    assert payload["form_of"] == {"lemma": "Іван", "url_slug": "іван"}
+
+    metadata = dict(q("SELECT key, value_json FROM manifest_metadata"))
+    assert metadata == {}
+
+    validation = atlas_db.validate_alias_targets(db)
+    assert validation["failures"] == 0
+    assert validation["public_aliases"] >= 1
+    assert validation["private_aliases"] == 0
     conn.close()
 
 
@@ -65,6 +82,26 @@ def test_alias_helpers():
     assert atlas_db.transliterate("розвідка") == "rozvidka"
     assert atlas_db.classify_entry_type({"lemma": "сліпа зона"}) == "multiword_term"
     assert atlas_db.classify_entry_type({"lemma": "розвідка"}) == "lemma"
+
+
+def test_alias_validator_reports_actionable_failures(tmp_path, capsys):
+    db = tmp_path / "atlas.db"
+    atlas_db.migrate_manifest(_manifest(tmp_path), db)
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO aliases(alias, kind, source, target_slug) VALUES (?,?,?,?)",
+        ("orphan-alias", "spelling_variant", "test", "missing-slug"),
+    )
+    conn.commit()
+    conn.close()
+
+    with pytest.raises(ValueError, match="alias target"):
+        atlas_db.validate_alias_targets(db)
+
+    captured = capsys.readouterr()
+    assert "alias_target_integrity failure:" in captured.err
+    assert "alias='orphan-alias'" in captured.err
+    assert "target_slug='missing-slug'" in captured.err
 
 
 def test_hardening_gates(tmp_path):
@@ -89,6 +126,7 @@ def test_hardening_gates(tmp_path):
     # metaterm is private, real word is public
     rows = dict(conn.execute("SELECT slug, visibility FROM articles").fetchall())
     assert rows == {"pluralia-tantum": "private", "кава": "public"}
+    assert conn.execute("SELECT COUNT(*) FROM article_payloads").fetchone()[0] == 1
 
     # timestamps not conflated; display_head kept verbatim (incl. stress mark)
     head, created, updated = conn.execute(
@@ -99,8 +137,6 @@ def test_hardening_gates(tmp_path):
 
     # CHECK constraints are load-bearing: invalid enum values are REJECTED by
     # the storage layer (a filler bug cannot silently write them)
-    import pytest
-
     for stmt, params in [
         ("INSERT INTO articles(slug, display_head, lemma, entry_type, review_state, visibility) VALUES (?,?,?,?,?,?)",
          ("x", "x", "x", "grammar term", "approved", "public")),  # not an entry-model type


### PR DESCRIPTION
## What

- Build `data/atlas.db` after manifest hydration in local site scripts, CI frontend jobs, and Pages deploy.
- Materialize `article_payloads.payload_json` in `scripts.atlas.atlas_db` as the compatibility projection consumed by the current Astro article page, including current `form_of` routes for PR-1 render parity.
- Add `site/src/lib/lexicon/atlasDb.ts` with one read-only `better-sqlite3` preload pass and switch `/lexicon/[lemma]` page generation/data to the cached DB payload map.
- Add public-alias target validation, render-parity Vitest coverage, and a current/50k/250k DB-read performance benchmark.

## Why

This implements design §1 + §7 PR-1 (`ssg-db-read`) without changing the article template, route names, search split, redirect behavior, or counts API. The DB remains a derived, gitignored build artifact; the manifest pointer remains the transport for this PR.

Part of #4385 / umbrella #4387; implements design §1+§7-PR-1.

## Setup note

The worktree already had `.venv`, root `node_modules`, `sources.db`, and `vesum.db` symlinks. I added the missing `data/wiki_cache.db` symlink, then unlinked `site/node_modules` and did a real worktree-local install for the site package (`npm --prefix site install better-sqlite3`, then `npm --prefix site install -D @types/better-sqlite3`) so the main checkout's linked `site/node_modules` was not mutated.

## Raw evidence

### Render parity

Command: `npm exec vitest run tests/unit/atlas-db-read.test.ts` from `site/`

```text
atlas render parity golden diff: fixtures=8 differing=0

 Test Files  1 passed (1)
      Tests  2 passed (2)
   Start at  18:03:20
   Duration  2.63s (transform 992ms, setup 54ms, import 1.70s, tests 803ms, environment 0ms)
```

### Alias validation works

Command: `npm --prefix site run atlas:validate-aliases`

```text
atlas_db alias validation: {"public_aliases": 6916, "private_aliases": 18, "distinct_public_targets": 5171, "approved_public_articles": 5171, "failures": 0}
```

### Perf gate

Command: `npm --prefix site run atlas:perf`

```text
atlas_db perf benchmark:
| dataset | rows | DB-build seconds | preload seconds | getStaticPaths seconds | paths |
| --- | ---: | ---: | ---: | ---: | ---: |
| current | 5507 | 1.150 | 0.182 | 0.000 | 5507 |
| 50000 synthetic | 50000 | 1.692 | 0.059 | 0.002 | 50000 |
| 250000 synthetic | 250000 | 8.816 | 0.391 | 0.018 | 250000 |
perf gate current preload 0.182s <= 30s OK
```

### Tests pass / lint clean

Command: `.venv/bin/python -m pytest tests/test_atlas_db.py -v`

```text
tests/test_atlas_db.py::test_migration_shapes_and_gates PASSED           [ 25%]
tests/test_atlas_db.py::test_alias_helpers PASSED                        [ 50%]
tests/test_atlas_db.py::test_alias_validator_reports_actionable_failures PASSED [ 75%]
tests/test_atlas_db.py::test_hardening_gates PASSED                      [100%]

============================== 4 passed in 0.09s ===============================
```

Command: `npm --prefix site test`

```text
atlas render parity golden diff: fixtures=8 differing=0

 Test Files  32 passed (32)
      Tests  435 passed (435)
   Start at  18:05:46
   Duration  67.69s (transform 4.27s, setup 3.47s, import 12.26s, tests 72.99s, environment 18.63s)
```

Command: `.venv/bin/ruff check scripts/atlas/atlas_db.py tests/test_atlas_db.py`

```text
All checks passed!
```

Command: `npm exec eslint -- site/src/lib/lexicon/atlasDb.ts site/tests/unit/atlas-db-read.test.ts site/scripts/benchmark-atlas-db.mjs`

```text
eslint touched site files: OK
```

### Site builds

Command: `bash -o pipefail -c 'npm --prefix site run build 2>&1 | tail -n 40'`

```text
18:02:29   ├─ /folk/pysankarstvo/index.html (+6ms) 
18:02:29   ├─ /folk/rodynna-obriadovist-zvychai/index.html (+6ms) 
18:02:29   ├─ /folk/rodynno-pobutovi-pisni/index.html (+6ms) 
18:02:29   ├─ /folk/sotsialno-pobutovi-kazky/index.html (+5ms) 
18:02:29   ├─ /folk/striletski-povstanski-pisni/index.html (+5ms) 
18:02:29   ├─ /folk/suspilno-pobutovi-pisni/index.html (+5ms) 
18:02:29   ├─ /folk/vertep-narodna-drama/index.html (+6ms) 
18:02:29   ├─ /folk/vesilni-pisni/index.html (+6ms) 
18:02:29   ├─ /folk/vesnianky-hayivky/index.html (+5ms) 
18:02:29   ├─ /folk/zahadky/index.html (+6ms) 
18:02:29   ├─ /folk/zhnyvarski-obzhynkovi-pisni/index.html (+5ms) 
18:02:29 ✓ Completed in 12.40s.

18:02:29 [build] ✓ Completed in 47.64s.
18:02:29 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
18:02:29 [build] 5927 page(s) built in 49.24s
18:02:29 [build] Complete!
```

### Independent review

Command: `.venv/bin/python scripts/ai_agent_bridge/__main__.py ask-agy - --task-id review-atlas-ssg-pr1-db-read-followup --to-model gemini-3.1-pro-high --review`

```text
NO BLOCKERS.
```

Initial AGY review objected to `.venv/bin/python` in npm scripts; that finding was rejected because AGENTS.md explicitly requires `.venv/bin/python` and forbids replacing it with `python3`/ambient interpreters. The follow-up review, with that repo rule supplied, returned the `NO BLOCKERS` line above.

### Commit landed

Command: `git log -1 --oneline`

```text
c135e1a764 feat(atlas): PR-1 ssg-db-read — Astro builds lexicon pages from atlas.db (render parity)
```

### PR opened

Command: `gh pr view 4427 --json url`

```text
{"url":"https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/4427"}
```
