### PR TITLE
fix(audit): #4416 P1 — segment-wise grounding match + positive-verdict admissibility

### DIFF
--- a/scripts/ai_agent_bridge/_opencode.py
+++ b/scripts/ai_agent_bridge/_opencode.py
@@ -494,6 +494,8 @@ def _extract_tool_event(event: dict) -> dict | None:
     Handles the observed opencode shape (top-level ``type == "tool_use"`` with a
     nested ``part`` whose ``state`` carries ``input``/``status``/``output`` and
     whose ``callID`` is the tool-call id) while tolerating flatter/older shapes.
+    Structured outputs are serialized to JSON text; ``None`` is kept only when
+    opencode genuinely emitted no output.
     """
     part = event.get("part")
     if not isinstance(part, dict):
@@ -504,6 +506,14 @@ def _extract_tool_event(event: dict) -> dict | None:
     state = part.get("state") if isinstance(part.get("state"), dict) else {}
     tool_input = state.get("input", part.get("input"))
     output = state.get("output", part.get("output"))
+    if output is None:
+        output_text = None
+    elif isinstance(output, str):
+        output_text = output
+    elif isinstance(output, (dict, list)):
+        output_text = json.dumps(output, ensure_ascii=False, default=str)
+    else:
+        output_text = str(output)
     status = state.get("status") or part.get("status") or event.get("status")
     tool_call_id = part.get("callID") or part.get("tool_call_id") or part.get("id") or event.get("callID")
     return {
@@ -511,7 +521,7 @@ def _extract_tool_event(event: dict) -> dict | None:
         "input": tool_input,
         "status": status if isinstance(status, str) else None,
         "tool_call_id": tool_call_id if isinstance(tool_call_id, str) else None,
-        "output": output if isinstance(output, str) else None,
+        "output": output_text,
     }
 
 

--- a/scripts/audit/llm_reviewer_dispatch.py
+++ b/scripts/audit/llm_reviewer_dispatch.py
@@ -1172,6 +1172,13 @@ def _is_wiki_event(event: Mapping[str, Any]) -> bool:
 
 
 def _positive_verdict_summary_only(fact_check: Mapping[str, Any], events: Sequence[Mapping[str, Any]]) -> bool:
+    """True when a positive verdict's grounding is backed only by shallow wiki access.
+
+    Fail-closed on wiki mode (cursor review of #4429): any matching wiki event
+    whose mode is NOT a deep-read mode (``summary``, ``search``, missing/empty,
+    unknown labels) counts as shallow — otherwise a summary-grade CONFIRMED
+    slips through admissibility whenever telemetry omits the mode.
+    """
     verdict = str(fact_check.get("verdict") or "")
     if verdict not in _POSITIVE_FACT_CHECK_VERDICTS:
         return False
@@ -1179,7 +1186,11 @@ def _positive_verdict_summary_only(fact_check: Mapping[str, Any], events: Sequen
     if not isinstance(grounding, Mapping):
         return False
     matches = _grounding_matching_events(grounding, events)
-    return bool(matches) and all(_is_wiki_event(event) and _event_mode(event) == "summary" for event in matches)
+    return (
+        bool(matches)
+        and all(_is_wiki_event(event) for event in matches)
+        and not any(_event_mode(event) in _DEEP_READ_WIKI_MODES for event in matches)
+    )
 
 
 def _grounding_matches_events(

--- a/scripts/audit/llm_reviewer_dispatch.py
+++ b/scripts/audit/llm_reviewer_dispatch.py
@@ -14,6 +14,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import unicodedata
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import suppress
 from dataclasses import asdict, dataclass
@@ -66,6 +67,8 @@ _COAUTHOR_RE = re.compile(r"^Co-Authored-By:\s*([^<\n]+)", re.IGNORECASE | re.MU
 _SOURCE_TOOL_PREFIXES = ("sources_", "mcp__sources")
 _WIKI_TOOL_MARKERS = ("wikipedia", "wiki")
 _DEEP_READ_WIKI_MODES = {"section", "sections", "extract", "article", "page"}
+_POSITIVE_FACT_CHECK_VERDICTS = frozenset({"CONFIRMED", "REFUTED_BY_CONTRADICTION", "CONTESTED"})
+_ELLIPSIS_RE = re.compile(r"\[…\]|\[\.\.\.\]|…|\.{3,}")
 
 _THEATRE_RETRY_REMINDER = """
 
@@ -82,7 +85,7 @@ _DEEP_READ_RETRY_REMINDER = """
 
 ## Reviewer Retry: Deep Read Required
 
-The prior response used only wiki summary-mode access for an unattested or unverified claim. Re-run the relevant wiki query in section/extract mode before deciding the verdict, then return only the required JSON object.
+The prior response used wiki summary-mode evidence where summary-only evidence is inadmissible for any verdict. Re-run the relevant wiki query in section/extract mode before deciding the verdict, then return only the required JSON object.
 """
 
 
@@ -192,6 +195,7 @@ class GroundingGateResult:
     ungrounded_findings: int = 0
     required_ungrounded_findings: int = 0
     invalid_fact_checks: int = 0
+    inadmissible_positive_verdicts: int = 0
 
 
 ProviderRunner = Callable[[ReviewerRoute, str, str], DispatchResult | str]
@@ -967,6 +971,11 @@ def deep_read_required(payload: Mapping[str, Any], dispatch_meta: Mapping[str, A
     for fact_check in fact_checks:
         if not isinstance(fact_check, Mapping):
             continue
+        if (
+            fact_check.get("deep_read_attempted") is not True
+            and _positive_verdict_summary_only(fact_check, events)
+        ):
+            return True
         verdict = str(fact_check.get("verdict") or "")
         if not verdict.startswith(("UNATTESTED", "UNVERIFIED")):
             continue
@@ -990,16 +999,19 @@ def deep_read_required(payload: Mapping[str, Any], dispatch_meta: Mapping[str, A
 
 
 def mark_deep_read_attempted(payload: Mapping[str, Any]) -> dict[str, Any]:
-    """Mark unattested/unverified fact checks as having received the forced retry."""
+    """Mark all fact checks as having received the shared forced deep-read retry.
+
+    The flag is only consumed by :func:`deep_read_required`, and the workflow has
+    one shared retry budget, so marking every fact-check records that this
+    reviewer response was evaluated after the forced retry opportunity.
+    """
     out = dict(payload)
     marked: list[dict[str, Any]] = []
     for fact_check in payload.get("fact_checks", []):
         if not isinstance(fact_check, Mapping):
             continue
         item = dict(fact_check)
-        verdict = str(item.get("verdict") or "")
-        if verdict.startswith(("UNATTESTED", "UNVERIFIED")):
-            item["deep_read_attempted"] = True
+        item["deep_read_attempted"] = True
         marked.append(item)
     out["fact_checks"] = marked
     return out
@@ -1032,20 +1044,34 @@ def enforce_grounding_against_tool_events(
         kept_findings.append(item)
 
     invalid_fact_checks = 0
-    for fact_check in payload.get("fact_checks", []):
+    inadmissible_positive_verdicts = 0
+    checked_fact_checks: list[dict[str, Any]] = []
+    raw_fact_checks = payload.get("fact_checks", [])
+    for fact_check in raw_fact_checks if isinstance(raw_fact_checks, list) else []:
         if not isinstance(fact_check, Mapping):
             continue
-        grounding = fact_check.get("grounding")
+        item = dict(fact_check)
+        grounding = item.get("grounding")
         if isinstance(grounding, Mapping) and not _grounding_matches_events(grounding, events):
             invalid_fact_checks += 1
+        elif item.get("deep_read_attempted") is True and _positive_verdict_summary_only(item, events):
+            original_verdict = str(item.get("verdict") or "")
+            item["original_verdict"] = original_verdict
+            item["verdict"] = "UNVERIFIED_INSUFFICIENT_SEARCH"
+            item["admissibility_downgraded"] = True
+            inadmissible_positive_verdicts += 1
+        checked_fact_checks.append(item)
 
     out = dict(payload)
     out["findings"] = kept_findings
+    if isinstance(raw_fact_checks, list):
+        out["fact_checks"] = checked_fact_checks
     return GroundingGateResult(
         payload=out,
         ungrounded_findings=ungrounded,
         required_ungrounded_findings=required_ungrounded,
         invalid_fact_checks=invalid_fact_checks,
+        inadmissible_positive_verdicts=inadmissible_positive_verdicts,
     )
 
 
@@ -1145,6 +1171,17 @@ def _is_wiki_event(event: Mapping[str, Any]) -> bool:
     return any(marker in tool for marker in _WIKI_TOOL_MARKERS)
 
 
+def _positive_verdict_summary_only(fact_check: Mapping[str, Any], events: Sequence[Mapping[str, Any]]) -> bool:
+    verdict = str(fact_check.get("verdict") or "")
+    if verdict not in _POSITIVE_FACT_CHECK_VERDICTS:
+        return False
+    grounding = fact_check.get("grounding")
+    if not isinstance(grounding, Mapping):
+        return False
+    matches = _grounding_matching_events(grounding, events)
+    return bool(matches) and all(_is_wiki_event(event) and _event_mode(event) == "summary" for event in matches)
+
+
 def _grounding_matches_events(
     grounding: Mapping[str, Any],
     events: Sequence[Mapping[str, Any]],
@@ -1152,27 +1189,82 @@ def _grounding_matches_events(
     """True when the grounding is backed by a captured tool event.
 
     Match semantics (live-proof fix, 2026-07-05): tool name + query must match
-    a captured event AND the excerpt must be a substring of that event's
-    captured output. ``tool_call_id`` is ADVISORY — the transport-level id
+    a captured event AND the normalized excerpt must be present in that event's
+    captured output. Abridged excerpts with ellipsis markers match only when all
+    retained normalized segments appear in order in the SAME event output, with
+    short-glue and evidence-mass guards. ``tool_call_id`` is ADVISORY — the transport-level id
     (e.g. ``chatcmpl-tool-…``) is never shown to the model, so requiring
     equality failed every legitimate grounding in the live «Веснянки» proof
     while adding nothing against fabrication (a fabricated excerpt still has
-    to appear verbatim in a real captured output for a query really made).
+    to appear in a real captured output for a query really made).
     """
+    return bool(_grounding_matching_events(grounding, events))
+
+
+def _grounding_matching_events(
+    grounding: Mapping[str, Any],
+    events: Sequence[Mapping[str, Any]],
+) -> tuple[Mapping[str, Any], ...]:
+    """Return captured events whose tool/query/output back this grounding."""
     query = str(grounding.get("query") or "").strip()
     excerpt = str(grounding.get("evidence_excerpt") or "").strip()
     if not query or not excerpt:
-        return False
+        return ()
     tool = str(grounding.get("tool") or "").strip()
+    matches: list[Mapping[str, Any]] = []
     for event in events:
         if tool and str(event.get("tool") or "").strip() != tool:
             continue
         if not _event_input_matches_query(event, query):
             continue
-        output = event.get("output")
-        if isinstance(output, str) and excerpt in output:
-            return True
-    return False
+        output = _event_output_text(event)
+        if output is not None and _output_contains_excerpt(output, excerpt):
+            matches.append(event)
+    return tuple(matches)
+
+
+def _event_output_text(event: Mapping[str, Any]) -> str | None:
+    output = event.get("output")
+    if output is None:
+        return None
+    if isinstance(output, str):
+        return output
+    if isinstance(output, (Mapping, list)):
+        return json.dumps(output, ensure_ascii=False, default=str)
+    return str(output)
+
+
+def _output_contains_excerpt(output: str, excerpt: str) -> bool:
+    normalized_output = _normalize_for_match(output)
+    if not _ELLIPSIS_RE.search(excerpt):
+        normalized_excerpt = _normalize_for_match(excerpt)
+        return bool(normalized_output and normalized_excerpt and normalized_excerpt in normalized_output)
+
+    segments = [segment for segment in _excerpt_segments(excerpt) if len(segment) >= 4]
+    if not segments:
+        return False
+    evidence_mass = sum(len(segment.replace(" ", "")) for segment in segments)
+    if evidence_mass < 12:
+        return False
+
+    cursor = 0
+    for segment in segments:
+        index = normalized_output.find(segment, cursor)
+        if index == -1:
+            return False
+        cursor = index + len(segment)
+    return True
+
+
+def _normalize_for_match(text: str) -> str:
+    normalized = unicodedata.normalize("NFKC", text)
+    normalized = normalized.replace("\u0301", "").replace("\u0341", "")
+    normalized = re.sub(r"\s+", " ", normalized)
+    return normalized.casefold().strip()
+
+
+def _excerpt_segments(excerpt: str) -> list[str]:
+    return [segment for part in _ELLIPSIS_RE.split(excerpt) if (segment := _normalize_for_match(part))]
 
 
 def _event_input_matches_query(event: Mapping[str, Any], query: str) -> bool:

--- a/scripts/audit/qg_schema.py
+++ b/scripts/audit/qg_schema.py
@@ -641,12 +641,14 @@ def validate_fact_check(fact_check: Mapping[str, Any]) -> None:
     if not isinstance(claim, str) or not claim.strip():
         raise ValueError("fact_check.claim must be a non-empty string")
     _require_member("fact_check.verdict", fact_check.get("verdict"), FACT_CHECK_VERDICTS)
+    if "original_verdict" in fact_check:
+        _require_member("fact_check.original_verdict", fact_check.get("original_verdict"), FACT_CHECK_VERDICTS)
     grounding = fact_check.get("grounding")
     if grounding is not None:
         validate_grounding(grounding)
     if fact_check.get("verdict") in {"CONFIRMED", "REFUTED_BY_CONTRADICTION", "CONTESTED"} and grounding is None:
         raise ValueError("fact_check verdict requires grounding")
-    for bool_key in ("deep_read_attempted", "budget_exhausted"):
+    for bool_key in ("deep_read_attempted", "budget_exhausted", "admissibility_downgraded"):
         if bool_key in fact_check and not isinstance(fact_check[bool_key], bool):
             raise ValueError(f"fact_check.{bool_key} must be a boolean")
     searches = fact_check.get("searches")

--- a/scripts/audit/qg_workflow.py
+++ b/scripts/audit/qg_workflow.py
@@ -44,9 +44,9 @@ from scripts.audit.qg_adapters import (
     dimensions_from_findings,
 )
 
-# v2 (#2156): seminar/factual now routes through the tooled opencode transport;
-# bump invalidates every ungrounded v1 llm_qg.db row so it re-runs with tools.
-DEFAULT_GATE_VERSION = "qg_workflow.v2"
+# v3 (#4416): grounding/admissibility gates changed; cache hits only re-check
+# theatre, so pre-fix rows must miss the composite cache and re-run with tools.
+DEFAULT_GATE_VERSION = "qg_workflow.v3"
 DEFAULT_REVIEWER_MODEL_ID = "llm-reviewer-disabled-until-4370"
 DEFAULT_REVIEWER_FAMILY = "qg_workflow"
 LLM_POLICY_FAMILIES = frozenset({"b1_plus", "seminar"})
@@ -1000,27 +1000,42 @@ def _run_tier2(
             policy_family=policy_family,
             invalid_fact_checks=grounding_gate.invalid_fact_checks,
         )
+        if grounding_gate.inadmissible_positive_verdicts:
+            payload["inadmissible_positive_verdicts"] = grounding_gate.inadmissible_positive_verdicts
         if (
             grounding_gate.required_ungrounded_findings
             or grounding_gate.invalid_fact_checks
+            or grounding_gate.inadmissible_positive_verdicts
             or sweep_incomplete
         ):
-            tier2_status = (
-                llm_reviewer_dispatch.UNGROUNDED_FINDINGS
-                if grounding_gate.required_ungrounded_findings or grounding_gate.invalid_fact_checks
-                else "factual_sweep_incomplete"
-            )
+            if (
+                grounding_gate.inadmissible_positive_verdicts
+                and not grounding_gate.invalid_fact_checks
+                and not grounding_gate.required_ungrounded_findings
+            ):
+                tier2_status = "inadmissible_citations"
+            elif grounding_gate.required_ungrounded_findings or grounding_gate.invalid_fact_checks:
+                tier2_status = llm_reviewer_dispatch.UNGROUNDED_FINDINGS
+            else:
+                tier2_status = "factual_sweep_incomplete"
             workflow_override = "FAIL" if sweep_incomplete else "WARN"
             severity = "critical" if sweep_incomplete else "warning"
+            message = "Grounded reviewer gate found ungrounded evidence or an incomplete seminar fact-check sweep."
+            if (
+                grounding_gate.inadmissible_positive_verdicts
+                and not grounding_gate.invalid_fact_checks
+                and not grounding_gate.required_ungrounded_findings
+            ):
+                message = (
+                    "reviewer confirmed/refuted claims on summary-only wiki evidence after the forced "
+                    "deep-read retry — factual sweep uncertified"
+                )
             findings = [
                 *_findings_from_payload(payload),
                 _reviewer_gate_finding(
                     severity=severity,
                     issue_id="LLM_REVIEWER_GROUNDING_GATE",
-                    message=(
-                        "Grounded reviewer gate found ungrounded evidence or an incomplete seminar "
-                        "fact-check sweep."
-                    ),
+                    message=message,
                 ),
             ]
             payload = _payload_from_findings(
@@ -1028,6 +1043,8 @@ def _run_tier2(
                 fact_checks=payload.get("fact_checks", []),
                 evidence_gaps=payload.get("evidence_gaps", []),
             )
+            if grounding_gate.inadmissible_positive_verdicts:
+                payload["inadmissible_positive_verdicts"] = grounding_gate.inadmissible_positive_verdicts
             llm_reviewer.validate_reviewer_payload(payload, policy_family)
         else:
             findings = _findings_from_payload(payload)
@@ -1058,6 +1075,8 @@ def _run_tier2(
             "findings": len(findings),
             "estimate": estimate,
             "dispatch": dispatch_meta,
+            "invalid_fact_checks": grounding_gate.invalid_fact_checks,
+            "inadmissible_positive_verdicts": grounding_gate.inadmissible_positive_verdicts,
         },
         "llm_used": True,
         "workflow_verdict": workflow_override,

--- a/tests/test_llm_reviewer_dispatch.py
+++ b/tests/test_llm_reviewer_dispatch.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 
 import pytest
 
-from scripts.ai_agent_bridge._opencode import OpencodeStreamParse
-from scripts.audit import llm_qg_store, llm_reviewer_dispatch, qg_workflow
+from scripts.ai_agent_bridge._opencode import OpencodeStreamParse, _extract_tool_event
+from scripts.audit import llm_qg_store, llm_reviewer_dispatch, qg_schema, qg_workflow
 
 _DISPATCH = "scripts.audit.llm_reviewer_dispatch"
 
@@ -931,3 +931,269 @@ def test_grounding_matches_despite_model_invented_call_id() -> None:
     # and a query never actually made still fails
     ghost_query = dict(grounding, query="мелодика веснянок")
     assert llm_reviewer_dispatch._grounding_matches_events(ghost_query, events) is False
+
+
+@pytest.mark.parametrize("ellipsis", ["…", "..."])
+def test_grounding_matches_ellipsized_excerpt_segments_in_order(ellipsis: str) -> None:
+    events = (
+        _sources_event(
+            output=(
+                "# Веснянки\n"
+                "Весня́нки — назва старовинних слов'янських обрядових пісень, "
+                "що виконуються навесні."
+            ),
+        ),
+    )
+    grounding = {
+        "tool": "sources_query_wikipedia",
+        "query": "Веснянки",
+        "evidence_excerpt": f"Веснянки {ellipsis} слов'янських обрядових пісень",
+        "tool_call_id": "model-invented",
+    }
+
+    assert llm_reviewer_dispatch._grounding_matches_events(grounding, events) is True
+
+
+def test_grounding_rejects_out_of_order_ellipsized_segments() -> None:
+    events = (
+        _sources_event(
+            output="Веснянки — назва старовинних слов'янських обрядових пісень.",
+        ),
+    )
+    grounding = {
+        "tool": "sources_query_wikipedia",
+        "query": "Веснянки",
+        "evidence_excerpt": "слов'янських обрядових пісень … Веснянки",
+        "tool_call_id": "call_1",
+    }
+
+    assert llm_reviewer_dispatch._grounding_matches_events(grounding, events) is False
+
+
+def test_grounding_rejects_ellipsized_segments_spanning_events() -> None:
+    events = (
+        _sources_event(output="Веснянки — назва старовинних пісень.", call_id="call_1"),
+        _sources_event(output="Обрядових пісень багато виконують навесні.", call_id="call_2"),
+    )
+    grounding = {
+        "tool": "sources_query_wikipedia",
+        "query": "Веснянки",
+        "evidence_excerpt": "Веснянки … обрядових пісень",
+        "tool_call_id": "call_1",
+    }
+
+    assert llm_reviewer_dispatch._grounding_matches_events(grounding, events) is False
+
+
+def test_grounding_normalizes_nfkc_whitespace_case_and_ukrainian_stress_only() -> None:
+    events = (_sources_event(output="Весня́нки\u00a0— НАЗВА старовинних пісень."),)
+    grounding = {
+        "tool": "sources_query_wikipedia",
+        "query": "Веснянки",
+        "evidence_excerpt": "веснянки — назва",
+        "tool_call_id": "call_1",
+    }
+
+    assert llm_reviewer_dispatch._grounding_matches_events(grounding, events) is True
+    assert llm_reviewer_dispatch._normalize_for_match("й ї") == "й ї"
+
+
+def test_grounding_rejects_fabricated_segment_among_real_segments() -> None:
+    events = (_sources_event(output="Веснянки — назва старовинних обрядових пісень."),)
+    grounding = {
+        "tool": "sources_query_wikipedia",
+        "query": "Веснянки",
+        "evidence_excerpt": "Веснянки … стрічкові гаї … обрядових пісень",
+        "tool_call_id": "call_1",
+    }
+
+    assert llm_reviewer_dispatch._grounding_matches_events(grounding, events) is False
+
+
+def test_grounding_rejects_ellipsized_excerpt_with_only_short_glue_segments() -> None:
+    events = (_sources_event(output="а в і"),)
+    grounding = {
+        "tool": "sources_query_wikipedia",
+        "query": "Веснянки",
+        "evidence_excerpt": "а…в…і",
+        "tool_call_id": "call_1",
+    }
+
+    assert llm_reviewer_dispatch._grounding_matches_events(grounding, events) is False
+
+
+def test_grounding_matches_dict_shaped_event_output_after_stringify() -> None:
+    events = (
+        _sources_event(
+            output={
+                "title": "Веснянки",
+                "body": "Веснянки — це весняні обрядові пісні.",
+            },
+        ),
+    )
+    grounding = {
+        "tool": "sources_query_wikipedia",
+        "query": "Веснянки",
+        "evidence_excerpt": "весняні обрядові пісні",
+        "tool_call_id": "call_1",
+    }
+
+    assert llm_reviewer_dispatch._grounding_matches_events(grounding, events) is True
+
+
+def test_extract_tool_event_preserves_dict_output_as_json_text() -> None:
+    extracted = _extract_tool_event(
+        {
+            "type": "tool_use",
+            "part": {
+                "tool": "sources_query_wikipedia",
+                "callID": "call_1",
+                "state": {
+                    "status": "completed",
+                    "input": {"query": "Веснянки", "mode": "summary"},
+                    "output": {"title": "Веснянки", "body": ["весняні обрядові пісні"]},
+                },
+            },
+        }
+    )
+
+    assert extracted is not None
+    assert isinstance(extracted["output"], str)
+    assert json.loads(extracted["output"]) == {"title": "Веснянки", "body": ["весняні обрядові пісні"]}
+
+
+def test_positive_verdict_summary_only_grounding_forces_deep_read_retry() -> None:
+    payload = json.loads(_fact_response())
+    summary_event = _sources_event(mode="summary", output="Веснянки — це весняні обрядові пісні.")
+
+    assert llm_reviewer_dispatch.deep_read_required(payload, {"tool_events": [summary_event]}) is True
+
+    payload["fact_checks"][0]["deep_read_attempted"] = True
+    assert llm_reviewer_dispatch.deep_read_required(payload, {"tool_events": [summary_event]}) is False
+
+
+def test_summary_only_positive_verdict_downgrades_after_deep_read_attempt() -> None:
+    payload = json.loads(_fact_response(extra_fact_fields={"deep_read_attempted": True}))
+    summary_event = _sources_event(mode="summary", output="Веснянки — це весняні обрядові пісні.")
+
+    result = llm_reviewer_dispatch.enforce_grounding_against_tool_events(
+        payload,
+        {"tool_events": [summary_event]},
+        policy_family="seminar",
+    )
+
+    fact_check = result.payload["fact_checks"][0]
+    assert fact_check["verdict"] == "UNVERIFIED_INSUFFICIENT_SEARCH"
+    assert fact_check["original_verdict"] == "CONFIRMED"
+    assert fact_check["admissibility_downgraded"] is True
+    assert result.inadmissible_positive_verdicts == 1
+    assert result.invalid_fact_checks == 0
+    assert llm_reviewer_dispatch.factual_sweep_incomplete(
+        result.payload,
+        policy_family="seminar",
+        invalid_fact_checks=result.invalid_fact_checks,
+    )
+    qg_schema.validate_reviewer_payload(result.payload, "seminar")
+
+
+def test_deep_read_wiki_positive_verdict_remains_admissible() -> None:
+    payload = json.loads(_fact_response(extra_fact_fields={"deep_read_attempted": True}))
+    section_event = _sources_event(mode="section", output="Веснянки — це весняні обрядові пісні.")
+
+    result = llm_reviewer_dispatch.enforce_grounding_against_tool_events(
+        payload,
+        {"tool_events": [section_event]},
+        policy_family="seminar",
+    )
+
+    assert result.payload["fact_checks"][0]["verdict"] == "CONFIRMED"
+    assert result.inadmissible_positive_verdicts == 0
+
+
+def test_positive_verdict_matching_summary_and_deep_events_is_admissible() -> None:
+    payload = json.loads(_fact_response(extra_fact_fields={"deep_read_attempted": True}))
+    summary_event = _sources_event(mode="summary", output="Веснянки — це весняні обрядові пісні.")
+    section_event = _sources_event(
+        mode="section",
+        output="У розділі сказано: Веснянки — це весняні обрядові пісні.",
+        call_id="call_2",
+    )
+
+    result = llm_reviewer_dispatch.enforce_grounding_against_tool_events(
+        payload,
+        {"tool_events": [summary_event, section_event]},
+        policy_family="seminar",
+    )
+
+    assert result.payload["fact_checks"][0]["verdict"] == "CONFIRMED"
+    assert result.inadmissible_positive_verdicts == 0
+
+
+def test_neighboring_deep_read_event_does_not_rescue_summary_grounded_verdict() -> None:
+    payload = json.loads(_fact_response(extra_fact_fields={"deep_read_attempted": True}))
+    summary_event = _sources_event(mode="summary", output="Веснянки — це весняні обрядові пісні.")
+    other_section = _sources_event(
+        query="Гаївка",
+        mode="section",
+        output="Гаївка має окрему історію опису.",
+        call_id="call_2",
+    )
+
+    result = llm_reviewer_dispatch.enforce_grounding_against_tool_events(
+        payload,
+        {"tool_events": [summary_event, other_section]},
+        policy_family="seminar",
+    )
+
+    assert result.payload["fact_checks"][0]["verdict"] == "UNVERIFIED_INSUFFICIENT_SEARCH"
+    assert result.inadmissible_positive_verdicts == 1
+
+
+def test_non_wiki_positive_grounding_is_not_summary_admissibility_failure() -> None:
+    payload = json.loads(
+        _fact_response(
+            grounding_query="Веснянки література",
+            evidence_excerpt="весняні обрядові пісні",
+            extra_fact_fields={"deep_read_attempted": True},
+        )
+    )
+    payload["fact_checks"][0]["grounding"]["tool"] = "sources_search_literary"
+    literary_event = _sources_event(
+        query="Веснянки література",
+        output="Веснянки — це весняні обрядові пісні.",
+        tool="sources_search_literary",
+    )
+
+    result = llm_reviewer_dispatch.enforce_grounding_against_tool_events(
+        payload,
+        {"tool_events": [literary_event]},
+        policy_family="seminar",
+    )
+
+    assert result.payload["fact_checks"][0]["verdict"] == "CONFIRMED"
+    assert result.inadmissible_positive_verdicts == 0
+
+
+def test_refuted_by_contradiction_summary_only_grounding_downgrades() -> None:
+    payload = json.loads(
+        _fact_response(
+            verdict="REFUTED_BY_CONTRADICTION",
+            claim="Мелодика веснянок завжди світла й піднесена.",
+            evidence_excerpt="повторенні однієї-двох поспівок",
+            extra_fact_fields={"deep_read_attempted": True},
+        )
+    )
+    summary_event = _sources_event(
+        mode="summary",
+        output="Мелодія веснянок часто побудована на повторенні однієї-двох поспівок.",
+    )
+
+    result = llm_reviewer_dispatch.enforce_grounding_against_tool_events(
+        payload,
+        {"tool_events": [summary_event]},
+        policy_family="seminar",
+    )
+
+    assert result.payload["fact_checks"][0]["verdict"] == "UNVERIFIED_INSUFFICIENT_SEARCH"
+    assert result.payload["fact_checks"][0]["original_verdict"] == "REFUTED_BY_CONTRADICTION"
+    assert result.inadmissible_positive_verdicts == 1

--- a/tests/test_llm_reviewer_dispatch.py
+++ b/tests/test_llm_reviewer_dispatch.py
@@ -1197,3 +1197,58 @@ def test_refuted_by_contradiction_summary_only_grounding_downgrades() -> None:
     assert result.payload["fact_checks"][0]["verdict"] == "UNVERIFIED_INSUFFICIENT_SEARCH"
     assert result.payload["fact_checks"][0]["original_verdict"] == "REFUTED_BY_CONTRADICTION"
     assert result.inadmissible_positive_verdicts == 1
+
+
+@pytest.mark.parametrize("shallow_mode", ["search", "", "snippet"])
+def test_non_deep_wiki_mode_positive_verdict_is_inadmissible(shallow_mode: str) -> None:
+    """Missing/unknown wiki modes must fail CLOSED, not certify (cursor review of #4429).
+
+    ``all(mode == "summary")`` failed open: one matching wiki event with
+    ``mode=""``/``"search"`` let a shallow-grounded CONFIRMED through both the
+    retry and the downgrade. Shallow = wiki-only matches with NO deep-read mode.
+    """
+    payload = json.loads(_fact_response())
+    shallow_event = _sources_event(mode=shallow_mode, output="Веснянки — це весняні обрядові пісні.")
+
+    assert llm_reviewer_dispatch.deep_read_required(payload, {"tool_events": [shallow_event]}) is True
+
+    attempted = json.loads(_fact_response(extra_fact_fields={"deep_read_attempted": True}))
+    result = llm_reviewer_dispatch.enforce_grounding_against_tool_events(
+        attempted,
+        {"tool_events": [shallow_event]},
+        policy_family="seminar",
+    )
+    fact_check = result.payload["fact_checks"][0]
+    assert fact_check["verdict"] == "UNVERIFIED_INSUFFICIENT_SEARCH"
+    assert fact_check["original_verdict"] == "CONFIRMED"
+    assert result.inadmissible_positive_verdicts == 1
+
+
+def test_contested_summary_only_grounding_downgrades() -> None:
+    payload = json.loads(
+        _fact_response(
+            verdict="CONTESTED",
+            extra_fact_fields={"deep_read_attempted": True},
+        )
+    )
+    summary_event = _sources_event(mode="summary", output="Веснянки — це весняні обрядові пісні.")
+
+    result = llm_reviewer_dispatch.enforce_grounding_against_tool_events(
+        payload,
+        {"tool_events": [summary_event]},
+        policy_family="seminar",
+    )
+
+    fact_check = result.payload["fact_checks"][0]
+    assert fact_check["verdict"] == "UNVERIFIED_INSUFFICIENT_SEARCH"
+    assert fact_check["original_verdict"] == "CONTESTED"
+    assert result.inadmissible_positive_verdicts == 1
+
+
+def test_ellipsized_evidence_mass_boundary_twelve_nonspace_chars() -> None:
+    """Retained-segment nonspace mass: 11 chars fails closed, 12 passes."""
+    output = "абвгд еєжзиі клмнопрст"
+    # Two retained segments (5 + 7 = 12 nonspace chars) in order → match.
+    assert llm_reviewer_dispatch._output_contains_excerpt(output, "абвгд…клмнопр") is True
+    # 5 + 6 = 11 nonspace chars → evidence-mass guard fails closed.
+    assert llm_reviewer_dispatch._output_contains_excerpt(output, "абвгд…клмноп") is False

--- a/tests/test_qg_workflow.py
+++ b/tests/test_qg_workflow.py
@@ -92,6 +92,39 @@ def _seminar_response() -> str:
     )
 
 
+def _wiki_event(
+    *,
+    query: str = "Веснянки",
+    mode: str = "summary",
+    output: str = "Веснянки — це весняні обрядові пісні.",
+    call_id: str = "call_1",
+) -> dict[str, Any]:
+    return {
+        "tool": "sources_query_wikipedia",
+        "input": {"query": query, "mode": mode},
+        "status": "completed",
+        "tool_call_id": call_id,
+        "output": output,
+    }
+
+
+def _seminar_dispatch(
+    *,
+    response_text: str | None = None,
+    events: tuple[dict[str, Any], ...] = (),
+    tool_call_count: int | None = None,
+) -> llm_reviewer_dispatch.DispatchResult:
+    return llm_reviewer_dispatch.DispatchResult(
+        response_text=response_text or _seminar_response(),
+        reviewer_model_id="test-reviewer",
+        reviewer_family="test-family",
+        route_name="opencode_frontier",
+        tool_call_count=len(events) if tool_call_count is None else tool_call_count,
+        tools_used=tuple(dict.fromkeys(str(event["tool"]) for event in events)),
+        tool_events=events,
+    )
+
+
 def _target(module_dir: Path, *, level: str = "b1", slug: str | None = None) -> qg_workflow.ReviewTarget:
     return qg_workflow.ReviewTarget(
         level=level,
@@ -221,6 +254,48 @@ def test_composite_cache_invalidates_on_gate_version_bump(tmp_path: Path) -> Non
     assert calls == 2
 
 
+def test_default_gate_version_v3_invalidates_v2_cache_rows(tmp_path: Path) -> None:
+    assert qg_workflow.DEFAULT_GATE_VERSION == "qg_workflow.v3"
+    module_dir = _write_module(tmp_path)
+    db_path = tmp_path / "qg.db"
+    prompt = llm_reviewer.build_reviewer_prompt(
+        level="b1",
+        slug="clean-module",
+        module_md=(module_dir / "module.md").read_text(encoding="utf-8"),
+        activities_yaml=(module_dir / "activities.yaml").read_text(encoding="utf-8"),
+        vocabulary_yaml=(module_dir / "vocabulary.yaml").read_text(encoding="utf-8"),
+        resources_yaml=(module_dir / "resources.yaml").read_text(encoding="utf-8"),
+    )
+    llm_qg_store.record_llm_qg(
+        level="b1",
+        slug="clean-module",
+        module_dir=module_dir,
+        payload=qg_workflow._payload_from_findings([]),
+        gate_version="qg_workflow.v2",
+        prompt_hash=llm_qg_store.prompt_hash_for_text(prompt),
+        checker_version=CHECKER_VERSION,
+        level_policy_family="b1_plus",
+        reviewer_model="test-reviewer",
+        path=db_path,
+    )
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> str:
+        nonlocal calls
+        calls += 1
+        return _reviewer_response()
+
+    record = qg_workflow.review_module(
+        _target(module_dir),
+        options=qg_workflow.WorkflowOptions(enable_llm=True, reviewer_model_id="test-reviewer"),
+        reviewer=reviewer,
+        store_path=db_path,
+    )
+
+    assert _tier(record, 2)["status"] == "ran"
+    assert calls == 1
+
+
 def test_cache_hit_revalidates_theatre_gate_on_stored_payload(tmp_path: Path) -> None:
     seminar_dir = _write_module(
         tmp_path,
@@ -332,6 +407,147 @@ def test_tier2_threads_tool_telemetry_into_store(tmp_path: Path) -> None:
     assert stored is not None
     assert stored.tool_call_count == 6
     assert stored.tools_used == ("sources_query_wikipedia", "sources_search_heritage")
+
+
+def test_summary_only_positive_verdict_after_retry_fails_inadmissible_citations(tmp_path: Path) -> None:
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="summary-only-positive",
+        module_md="# Семінар\n\nВеснянки — це весняні обрядові пісні.\n",
+    )
+    summary_event = _wiki_event(mode="summary")
+    calls: list[str] = []
+
+    def reviewer(_target: qg_workflow.ReviewTarget, prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        calls.append(prompt)
+        return _seminar_dispatch(events=(summary_event,))
+
+    db_path = tmp_path / "qg.db"
+    record = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="summary-only-positive"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+        ),
+        reviewer=reviewer,
+        store_path=db_path,
+    )
+
+    tier = _tier(record, 2)
+    assert tier["status"] == "inadmissible_citations"
+    assert tier["inadmissible_positive_verdicts"] == 1
+    assert tier["invalid_fact_checks"] == 0
+    assert record["workflow_verdict"] == "FAIL"
+    assert record["terminal_verdict"] == "FAIL"
+    assert len(calls) == 2
+    assert "Deep Read Required" in calls[1]
+
+    gate_findings = [
+        finding
+        for dimension in record["dimensions"].values()
+        for finding in dimension["findings"]
+        if finding["issue_id"] == "LLM_REVIEWER_GROUNDING_GATE"
+    ]
+    assert gate_findings[0]["message"] == (
+        "reviewer confirmed/refuted claims on summary-only wiki evidence after the forced "
+        "deep-read retry — factual sweep uncertified"
+    )
+    stored = llm_qg_store.latest_llm_qg("folk", "summary-only-positive", path=db_path)
+    assert stored is not None
+    assert stored.payload["inadmissible_positive_verdicts"] == 1
+    fact_check = stored.payload["fact_checks"][0]
+    assert fact_check["verdict"] == "UNVERIFIED_INSUFFICIENT_SEARCH"
+    assert fact_check["original_verdict"] == "CONFIRMED"
+    assert fact_check["admissibility_downgraded"] is True
+
+
+def test_required_ungrounded_finding_status_precedes_inadmissible_citations(tmp_path: Path) -> None:
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="ungrounded-plus-summary",
+        module_md="# Семінар\n\nВеснянки — це весняні обрядові пісні.\n",
+    )
+    summary_event = _wiki_event(mode="summary")
+    required_finding = {
+        "issue_id": "SEMINAR_FACTUAL_DETAIL",
+        "issue_class": "other",
+        "dimension": "seminar_sensitivity",
+        "severity": "warning",
+        "excerpt": "Веснянки",
+        "message": "Fabricated grounding should keep the ungrounded status.",
+        "grounding": {
+            "tool": "sources_query_wikipedia",
+            "query": "Веснянки",
+            "evidence_excerpt": "вигаданий фрагмент",
+            "tool_call_id": "call_1",
+        },
+    }
+    response = json.dumps(
+        {
+            "findings": [required_finding],
+            "fact_checks": json.loads(_seminar_response())["fact_checks"],
+            "evidence_gaps": [],
+        },
+        ensure_ascii=False,
+    )
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        nonlocal calls
+        calls += 1
+        return _seminar_dispatch(response_text=response, events=(summary_event,))
+
+    record = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="ungrounded-plus-summary"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+        ),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    tier = _tier(record, 2)
+    assert tier["status"] == llm_reviewer_dispatch.UNGROUNDED_FINDINGS
+    assert tier["inadmissible_positive_verdicts"] == 1
+    assert calls == 2
+
+
+def test_tier2_theatre_then_deep_read_retry_stays_within_three_calls(tmp_path: Path) -> None:
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="retry-budget",
+        module_md="# Семінар\n\nВеснянки — це весняні обрядові пісні.\n",
+    )
+    summary_event = _wiki_event(mode="summary")
+    calls: list[str] = []
+
+    def reviewer(_target: qg_workflow.ReviewTarget, prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        calls.append(prompt)
+        if len(calls) == 1:
+            return _seminar_dispatch(tool_call_count=0)
+        return _seminar_dispatch(events=(summary_event,))
+
+    record = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="retry-budget"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+        ),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    assert _tier(record, 2)["status"] == "inadmissible_citations"
+    assert len(calls) == 3
+    assert "Tools Required" in calls[1]
+    assert "Deep Read Required" in calls[2]
 
 
 def test_budget_exhaustion_emits_skipped_budget_and_incomplete(tmp_path: Path) -> None:


### PR DESCRIPTION
## What / why

Addresses #4416 items 1+3. Issue #4416 stays open for the remaining P2 work.

This fixes two P1 deterministic reviewer-gate defects from the live «Веснянки» proof:

- Segment-wise normalized grounding matching now accepts legitimate abridged excerpts with ellipses while still requiring all retained segments to appear in order in the same captured event output.
- Positive verdicts backed only by wiki summary-mode evidence now force the existing deep-read retry and downgrade to `UNVERIFIED_INSUFFICIENT_SEARCH` after retry if still inadmissible.

## Fixes

- Preserves structured opencode tool outputs by serializing dict/list outputs instead of dropping them to `None`.
- Adds `_normalize_for_match`, `_excerpt_segments`, and shared `_grounding_matching_events` so grounding checks and admissibility checks use the same matched events.
- Adds `inadmissible_positive_verdicts` to the grounding gate result and workflow tier result; the count is also stored in the JSON payload, with no DB migration in this PR.
- Bumps `DEFAULT_GATE_VERSION` to `qg_workflow.v3` so pre-fix cache rows miss the composite key.
- Preserves `original_verdict` and `admissibility_downgraded` through schema validation.

## Review

Cross-family read-only AGY/Gemini review was run for `review-4416-p1-gates`. One status-priority finding was accepted and fixed; the suggestion to downgrade before `deep_read_attempted` was rejected because the dispatch brief explicitly scopes terminal downgrade to post-retry fact checks.

## Test evidence

cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4416-p1-gates`

`/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_llm_reviewer_dispatch.py tests/test_qg_workflow.py tests/test_llm_qg_api.py -x -q`

```text
============================== 64 passed in 1.12s ==============================
```

`/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/audit/llm_reviewer_dispatch.py scripts/audit/qg_workflow.py scripts/ai_agent_bridge/_opencode.py tests/test_llm_reviewer_dispatch.py`

```text
All checks passed!
```

Additional touched-file lint guard:

`/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/audit/qg_schema.py tests/test_qg_workflow.py`

```text
All checks passed!
```

Trailer lint:

`/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

```text
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```
