### PR TITLE
fix(audit): resolve wiki root per track from TRACK_WRITE_DOMAIN

### DIFF
--- a/scripts/audit/track_deterministic_audit.py
+++ b/scripts/audit/track_deterministic_audit.py
@@ -35,6 +35,7 @@ from audit.check_no_internal_ids import (
 from audit.checks.yaml_schema_validation import validate_activity_yaml_file
 from audit.content_surface_gates import scan_module_surface
 from manifest_utils import get_modules_for_level
+from wiki.config import TRACK_WRITE_DOMAIN
 
 CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
 SITE_DOCS_ROOT = PROJECT_ROOT / "site" / "src" / "content" / "docs"
@@ -192,6 +193,13 @@ def parse_slug_filter(values: list[str] | None) -> set[str] | None:
 def module_paths(track: str, module: Any) -> ModulePaths:
     slug = module.slug
     module_dir = CURRICULUM_ROOT / track / slug
+    if track in TRACK_WRITE_DOMAIN:
+        wiki_root = PROJECT_ROOT / "wiki" / TRACK_WRITE_DOMAIN[track]
+    else:
+        # Fallback for tracks NOT in TRACK_WRITE_DOMAIN (seminars use per-slug _get_domain() logic in scripts/wiki/compile.py):
+        # keep current grammar/{track} behavior UNCHANGED but leave a short comment noting seminar tracks need per-slug domain
+        # resolution at their deterministic-audit rollout.
+        wiki_root = WIKI_GRAMMAR_ROOT / track
     return ModulePaths(
         track=track,
         module_num=int(module.local_num),
@@ -203,8 +211,8 @@ def module_paths(track: str, module: Any) -> ModulePaths:
         activities=module_dir / "activities.yaml",
         vocabulary=module_dir / "vocabulary.yaml",
         resources=module_dir / "resources.yaml",
-        wiki=WIKI_GRAMMAR_ROOT / track / f"{slug}.md",
-        wiki_sources=WIKI_GRAMMAR_ROOT / track / f"{slug}.sources.yaml",
+        wiki=wiki_root / f"{slug}.md",
+        wiki_sources=wiki_root / f"{slug}.sources.yaml",
         site_mdx=SITE_DOCS_ROOT / track / f"{slug}.mdx",
     )
 

--- a/tests/audit/test_track_deterministic_audit.py
+++ b/tests/audit/test_track_deterministic_audit.py
@@ -166,3 +166,23 @@ def test_internal_leakage_skips_resource_provenance_key(tmp_path, monkeypatch) -
     assert not any(f.line == 4 for f in leaks), "packet_chunk_id: key line should not be flagged"
     # ...but the notes prose that MENTIONS chunk_id still leaks (renders in Resources tab).
     assert any(f.line == 5 for f in leaks), "notes prose mentioning chunk_id must still be flagged"
+
+
+def test_module_paths_wiki_resolution() -> None:
+    # 1. A1 should point under pedagogy/a1
+    a1_module = DummyModule("greeting", "Greeting", "a1", 1)
+    a1_paths = audit.module_paths("a1", a1_module)
+    assert "wiki/pedagogy/a1/greeting.md" in a1_paths.wiki.as_posix()
+    assert "wiki/pedagogy/a1/greeting.sources.yaml" in a1_paths.wiki_sources.as_posix()
+
+    # 2. B1 should point under grammar/b1
+    b1_module = DummyModule("aspect", "Aspect", "b1", 1)
+    b1_paths = audit.module_paths("b1", b1_module)
+    assert "wiki/grammar/b1/aspect.md" in b1_paths.wiki.as_posix()
+    assert "wiki/grammar/b1/aspect.sources.yaml" in b1_paths.wiki_sources.as_posix()
+
+    # 3. Unmapped track should fall back to grammar/track
+    unmapped_module = DummyModule("topic", "Topic", "unknown-track", 1)
+    unmapped_paths = audit.module_paths("unknown-track", unmapped_module)
+    assert "wiki/grammar/unknown-track/topic.md" in unmapped_paths.wiki.as_posix()
+    assert "wiki/grammar/unknown-track/topic.sources.yaml" in unmapped_paths.wiki_sources.as_posix()


### PR DESCRIPTION
## Root Cause
`scripts/audit/track_deterministic_audit.py` hardcoded `WIKI_GRAMMAR_ROOT = PROJECT_ROOT / 'wiki' / 'grammar'` and built `wiki` and `wiki_sources` paths assuming all tracks live there. A1's wiki artifacts, however, live at `wiki/pedagogy/a1/` by design (configured in `scripts/wiki/config.py::TRACK_WRITE_DOMAIN`). This led to 110 false positive findings for A1 since its wiki files could not be found under the hardcoded `wiki/grammar/a1` path.

## Fix
We imported `TRACK_WRITE_DOMAIN` from `wiki.config` and updated `module_paths()` to dynamically resolve each track's wiki directory from it, while keeping a fallback to `WIKI_GRAMMAR_ROOT / track` for unmapped tracks (such as seminar tracks).

Refs #4305

---
Generated by Antigravity.