### PR TITLE
fix(ci): #4404 — E2E webServer boots prebuilt astro preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -927,6 +927,10 @@ jobs:
       working-directory: site
       run: npx playwright install --with-deps chromium
 
+    - name: Build site for Playwright preview
+      working-directory: site
+      run: npm run build
+
     - name: Run Playwright E2E
       working-directory: site
       run: npx playwright test

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -17,10 +17,10 @@ export default defineConfig({
     trace: 'retain-on-failure',
   },
   webServer: {
-    command: `npm run build && npm run preview -- --host ${host} --port ${PORT}`,
+    command: `npm run preview -- --host ${host} --port ${PORT}`,
     url: baseURL,
     reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
+    timeout: 180_000,
   },
   projects: [
     {


### PR DESCRIPTION
## Root cause

Playwright E2E was already aimed at `astro preview`, but `site/playwright.config.ts` still put `npm run build` inside `config.webServer.command`. That means the webServer timeout covered hydration, Atlas DB generation, and static generation for thousands of pages, so boot time still scaled with MDX/content volume and could hit the 120s cap before any test ran.

## Chosen fix

Use a prebuilt server for E2E: CI now runs `npm run build` as an explicit `frontend-e2e` step, and Playwright's `webServer` starts only `npm run preview -- --host 127.0.0.1 --port 4321`. There is no existing uploaded build artifact in this workflow to reuse, so the E2E job builds locally before the Playwright step. I kept a modest `webServer.timeout` raise to 180s as a cold-runner belt, but preview startup no longer includes the MDX compile. The existing E2E specs exercise production routes and browser interactions, not HMR, dev toolbar, or dev-only routes.

Closes #4404

## Evidence

### Build completed

```text
command: npm run build
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4404-e2e-webserver-boot-r2/site
raw output:
19:34:11 [build] ✓ Completed in 1m 17s.
19:34:11 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
19:34:11 [build] 6197 page(s) built in 1m 18s
19:34:11 [build] Complete!
```

### E2E boots locally

```text
command: npm run preview -- --host 127.0.0.1 --port 4321
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4404-e2e-webserver-boot-r2/site
raw output:
astro  v6.4.8 ready in 13 ms
┃ Local    http://127.0.0.1:4321/
```

### Smoke test passes

```text
command: npx playwright test e2e/atlas-practice.spec.ts --grep '/lexicon/ loads without console errors'
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4404-e2e-webserver-boot-r2/site
raw output:
Running 1 test using 1 worker
  ✓  1 …as-practice.spec.ts:79:3 › /lexicon/ loads without console errors (1.4s)
  1 passed (25.2s)
```

### Lint / config checks clean

```text
command: npx tsc --noEmit --pretty false --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --types node playwright.config.ts && echo 'playwright.config.ts typecheck clean'
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4404-e2e-webserver-boot-r2/site
raw output:
playwright.config.ts typecheck clean
```

```text
command: git diff --check && echo 'git diff --check clean'
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4404-e2e-webserver-boot-r2
raw output:
git diff --check clean
```

### Commit landed

```text
command: git log -1 --oneline
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4404-e2e-webserver-boot-r2
raw output:
8462e2a9f5 fix(ci): #4404 — E2E webServer boots prebuilt astro preview (boot no longer scales with MDX volume)
```

🤖 Generated with [Codex](https://codex.openai.com)
