### PR TITLE
fix(audit): bakeoff scorer reads original_verdict on admissibility downgrades

### DIFF
--- a/scripts/audit/qg_factcheck_scoring.py
+++ b/scripts/audit/qg_factcheck_scoring.py
@@ -42,11 +42,20 @@ def score_fact_checks(
     fact_checks: list[Mapping[str, Any]],
     truth_by_claim: Mapping[str, bool],
 ) -> int:
-    """Score fact-check rows by exact claim text."""
+    """Score fact-check rows by exact claim text.
+
+    Scores the MODEL's raw judgment: when the admissibility gate downgraded a
+    positive verdict (#4416 / PR #4429 sets ``admissibility_downgraded`` and
+    preserves ``original_verdict``), score the original verdict — otherwise a
+    gate-downgraded CONFIRMED-on-fabricated would score 0 instead of the fatal
+    −100 the bakeoff exists to measure.
+    """
     total = 0
     for row in fact_checks:
         claim = row.get("claim")
         verdict = row.get("verdict")
+        if row.get("admissibility_downgraded") is True and isinstance(row.get("original_verdict"), str):
+            verdict = row["original_verdict"]
         if not isinstance(claim, str) or not isinstance(verdict, str):
             continue
         if claim not in truth_by_claim:

--- a/tests/audit/test_qg_factcheck_scoring.py
+++ b/tests/audit/test_qg_factcheck_scoring.py
@@ -24,3 +24,25 @@ def test_scores_fact_check_rows_by_claim_truth_map() -> None:
         fact_checks,
         {"true claim": True, "fabricated claim": False},
     ) == 30
+
+
+def test_admissibility_downgraded_rows_score_the_original_verdict() -> None:
+    """Gate downgrade (#4429) must not mask the model's raw judgment (−100 class)."""
+    fact_checks = [
+        {
+            "claim": "fabricated claim",
+            "verdict": "UNVERIFIED_INSUFFICIENT_SEARCH",
+            "original_verdict": "CONFIRMED",
+            "admissibility_downgraded": True,
+        },
+        {
+            # Model-emitted UNVERIFIED without the downgrade flag scores as-is.
+            "claim": "true claim",
+            "verdict": "UNVERIFIED_INSUFFICIENT_SEARCH",
+        },
+    ]
+
+    assert scoring.score_fact_checks(
+        fact_checks,
+        {"fabricated claim": False, "true claim": True},
+    ) == -110


### PR DESCRIPTION
Follow-through on PR #4429 / #4416: the admissibility gate deterministically downgrades inadmissible positive verdicts to `UNVERIFIED_INSUFFICIENT_SEARCH`. The #2156 step-3 bakeoff scorer (`qg_factcheck_scoring`) must measure the MODEL's raw judgment, not the gate's remediation — so `score_fact_checks` now prefers `original_verdict` when `admissibility_downgraded` is set. Without this, a CONFIRMED-on-fabricated that the gate caught would score 0 instead of −100, inverting the bakeoff's central asymmetry.

- Locked constants untouched.
- Regression test: downgraded row scores −100 via original_verdict; a model-emitted `UNVERIFIED_INSUFFICIENT_SEARCH` without the flag still scores as-is (−10 on true).

Verify: `pytest tests/audit/test_qg_factcheck_scoring.py -q` → 3 passed; ruff clean.

Addresses #2156 (step-3 bakeoff prep). Relates #4416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)