### PR TITLE
feat(audit): hermes nightly read-only audit-cron pilot — wrapper + /api/hermes-cron/latest (hermes P1-b)

### DIFF
--- a/agents_extensions/shared/prompts/hermes-nightly-audit.md
+++ b/agents_extensions/shared/prompts/hermes-nightly-audit.md
@@ -1,0 +1,13 @@
+# Nightly Audit Cron Job Prompt
+
+You are running as a nightly read-only automated cron job.
+
+## Instructions
+1. Run the nightly audit wrapper script:
+   ```bash
+   .venv/bin/python scripts/audit/hermes_nightly_audit.py
+   ```
+2. Read the script's stdout summary and print it.
+3. Do **NOTHING** else. Do not run any other tools, do not perform git commands, do not build levels, and do not modify the curriculum files.
+4. Do **NOT** write files outside the designated report path `batch_state/hermes_cron/`.
+5. Forbid the use of toolsets other than `terminal` and `file`.

--- a/scripts/api/hermes_cron_router.py
+++ b/scripts/api/hermes_cron_router.py
@@ -1,0 +1,45 @@
+"""FastAPI router for serving the latest nightly Hermes audit cron results."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import PlainTextResponse
+
+from .config import PROJECT_ROOT
+
+router = APIRouter(tags=["hermes-cron"])
+
+
+@router.get("/latest")
+async def get_latest(format: str | None = Query(None, description="Output format: 'json' or 'markdown'")):
+    """Get the latest nightly audit report."""
+    cron_dir = PROJECT_ROOT / "batch_state" / "hermes_cron"
+
+    if format == "markdown":
+        md_file = cron_dir / "latest.md"
+        if not md_file.exists():
+            raise HTTPException(status_code=404, detail="Latest nightly audit markdown report not found")
+        try:
+            content = md_file.read_text(encoding="utf-8")
+            return PlainTextResponse(
+                content=content,
+                media_type="text/markdown; charset=utf-8",
+            )
+        except Exception as e:
+            raise HTTPException(
+                status_code=500, detail=f"Failed to read latest nightly audit markdown report: {e}"
+            ) from e
+    else:
+        # Default is JSON
+        json_file = cron_dir / "latest.json"
+        if not json_file.exists():
+            raise HTTPException(status_code=404, detail="Latest nightly audit json report not found")
+        try:
+            return json.loads(json_file.read_text(encoding="utf-8"))
+        except Exception as e:
+            raise HTTPException(
+                status_code=500, detail=f"Failed to parse latest nightly audit json report: {e}"
+            ) from e

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -63,6 +63,7 @@ from .git_hygiene_router import router as git_hygiene_router
 from .gold_router import router as gold_router
 from .governance_router import collect_governance_summary
 from .governance_router import router as governance_router
+from .hermes_cron_router import router as hermes_cron_router
 from .images_router import router as images_router
 from .issues_router import router as issues_router
 from .rag_router import router as rag_router
@@ -146,6 +147,7 @@ app.include_router(discussions_router, prefix="/api/discussions", tags=["discuss
 app.include_router(git_hygiene_router, prefix="/api/git", tags=["git"])
 app.include_router(gold_router, prefix="/api/gold")
 app.include_router(governance_router, prefix="/api/state/governance", tags=["governance"])
+app.include_router(hermes_cron_router, prefix="/api/hermes-cron", tags=["hermes-cron"])
 app.include_router(build_events_router, prefix="/api/build/events")
 app.include_router(images_router, prefix="/api/images")
 app.include_router(issues_router, prefix="/api/issues", tags=["issues"])

--- a/scripts/api/route_contracts.py
+++ b/scripts/api/route_contracts.py
@@ -408,6 +408,16 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
         "keep",
     ),
     RouteContract(
+        "/api/hermes-cron/latest", "exact", "http",
+        "Latest nightly sweep audit results and insights.",
+        "batch_state/hermes_cron/latest.json and latest.md.",
+        "No route cache; reads from the latest generated nightly audit artifacts.",
+        ("agents", "docs"),
+        "None.",
+        "low",
+        "keep",
+    ),
+    RouteContract(
         "/api/issues/map", "exact", "http",
         "Open issue map grouped by category.",
         "gh issue list output.",

--- a/scripts/audit/hermes_nightly_audit.py
+++ b/scripts/audit/hermes_nightly_audit.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Run nightly deterministic curriculum track audits sequentially.
+
+This script runs the deterministic audit checks for tracks a1, a2, b1, b2 sequentially.
+It gathers findings, counts, severities, optionally appends a 'hermes insights' snapshot,
+and writes the aggregated results to both Markdown and JSON files in batch_state/hermes_cron/.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from collections import Counter
+from datetime import UTC, datetime, timezone
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def run_track_audit(track: str) -> dict:
+    """Run track_deterministic_audit.py for a single track and return its JSON output."""
+    script_path = PROJECT_ROOT / "scripts" / "audit" / "track_deterministic_audit.py"
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--track",
+        track,
+        "--format",
+        "json",
+        "--fail-on",
+        "never",
+    ]
+    try:
+        res = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return json.loads(res.stdout)
+    except subprocess.CalledProcessError as e:
+        # If it failed to run (e.g. exit code 1), check if we got JSON output anyway
+        try:
+            return json.loads(e.stdout)
+        except Exception:
+            return {
+                "track": track,
+                "summary": {
+                    "findings_total": 1,
+                    "findings_by_severity": {
+                        "blocker": 1,
+                        "high": 0,
+                        "medium": 0,
+                        "low": 0,
+                        "info": 0,
+                    },
+                    "modules_selected": 0,
+                    "modules_built": 0,
+                    "modules_not_built": 0,
+                    "skipped_checks": 0,
+                },
+                "findings": [
+                    {
+                        "track": track,
+                        "module_num": None,
+                        "slug": None,
+                        "category": "process",
+                        "severity": "blocker",
+                        "file": "scripts/audit/track_deterministic_audit.py",
+                        "line": None,
+                        "message": f"Audit process exited with error code {e.returncode}",
+                        "evidence": f"stdout: {e.stdout}\nstderr: {e.stderr}",
+                        "auto_fixable": False,
+                        "recommended_remediation_batch": "infrastructure",
+                    }
+                ],
+            }
+    except Exception as e:
+        return {
+            "track": track,
+            "summary": {
+                "findings_total": 1,
+                "findings_by_severity": {
+                    "blocker": 1,
+                    "high": 0,
+                    "medium": 0,
+                    "low": 0,
+                    "info": 0,
+                },
+                "modules_selected": 0,
+                "modules_built": 0,
+                "modules_not_built": 0,
+                "skipped_checks": 0,
+            },
+            "findings": [
+                {
+                    "track": track,
+                    "module_num": None,
+                    "slug": None,
+                    "category": "process",
+                    "severity": "blocker",
+                    "file": None,
+                    "line": None,
+                    "message": f"Failed to invoke audit runner: {e}",
+                    "evidence": str(e),
+                    "auto_fixable": False,
+                    "recommended_remediation_batch": "infrastructure",
+                }
+            ],
+        }
+
+
+def get_hermes_insights(insights_cmd: str = "hermes") -> str:
+    """Retrieve hermes insights snapshot if available, otherwise return 'insights unavailable'."""
+    try:
+        res = subprocess.run([insights_cmd, "insights"], capture_output=True, text=True, check=True)
+        return res.stdout
+    except Exception:
+        return "insights unavailable"
+
+
+def build_markdown_report(timestamp: str, track_results: dict[str, dict], insights: str) -> str:
+    """Assemble a beautifully formatted Markdown report of the sweep results."""
+    # Compute totals
+    total_findings = 0
+    total_by_severity = Counter()
+    total_modules_selected = 0
+    total_modules_built = 0
+    total_modules_not_built = 0
+
+    for _track, data in track_results.items():
+        summary = data.get("summary", {})
+        total_findings += summary.get("findings_total", 0)
+        total_modules_selected += summary.get("modules_selected", 0)
+        total_modules_built += summary.get("modules_built", 0)
+        total_modules_not_built += summary.get("modules_not_built", 0)
+        for sev, count in summary.get("findings_by_severity", {}).items():
+            total_by_severity[sev] += count
+
+    lines = [
+        "# Hermes Nightly Audit Report",
+        f"Generated at: `{timestamp}`",
+        "",
+        "## Summary of Findings",
+        "",
+        "| Severity | Count |",
+        "| :--- | :--- |",
+        f"| 🔴 Blocker | {total_by_severity['blocker']} |",
+        f"| 🟠 High | {total_by_severity['high']} |",
+        f"| 🟡 Medium | {total_by_severity['medium']} |",
+        f"| 🔵 Low | {total_by_severity['low']} |",
+        f"| ⚪ Info | {total_by_severity['info']} |",
+        f"| **Total Findings** | **{total_findings}** |",
+        "",
+        "## Track Details",
+        "",
+    ]
+
+    for track, data in track_results.items():
+        summary = data.get("summary", {})
+        lines.extend([
+            f"### Track `{track.upper()}`",
+            f"- **Modules**: Selected {summary.get('modules_selected', 0)} (Built: {summary.get('modules_built', 0)}, Not Built: {summary.get('modules_not_built', 0)})",
+            f"- **Findings**: Total {summary.get('findings_total', 0)}",
+            f"  - Blocker: {summary.get('findings_by_severity', {}).get('blocker', 0)}",
+            f"  - High: {summary.get('findings_by_severity', {}).get('high', 0)}",
+            f"  - Medium: {summary.get('findings_by_severity', {}).get('medium', 0)}",
+            f"  - Low: {summary.get('findings_by_severity', {}).get('low', 0)}",
+            f"  - Info: {summary.get('findings_by_severity', {}).get('info', 0)}",
+        ])
+
+        findings = data.get("findings", [])
+        if findings:
+            lines.append("  - **Top Findings**:")
+            # Display up to 10 findings for this track
+            for item in findings[:10]:
+                location = item.get("file") or "<repo>"
+                if item.get("line"):
+                    location = f"{location}:{item['line']}"
+                module = f"M{item.get('module_num', 0):02d} {item.get('slug', '')}" if item.get("module_num") else "track"
+                lines.append(f"    - `[{item.get('severity', 'info')}]` {module} ({item.get('category', '')}) `{location}`: {item.get('message', '')}")
+            if len(findings) > 10:
+                lines.append(f"    - ... and {len(findings) - 10} more findings")
+        else:
+            lines.append("  - No findings reported.")
+        lines.append("")
+
+    lines.extend([
+        "## Hermes Insights Snapshot",
+        "```",
+        insights.strip(),
+        "```",
+        "",
+    ])
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run nightly deterministic curriculum track audits sequentially and aggregate findings.\n"
+                    "Use this tool to verify repository structural health, case parity, and findings status.\n"
+                    "Do NOT use this tool for mutating curriculum data or running LLM tasks.",
+        epilog="Examples:\n"
+               "  .venv/bin/python scripts/audit/hermes_nightly_audit.py\n"
+               "  .venv/bin/python scripts/audit/hermes_nightly_audit.py --tracks a1\n"
+               "  .venv/bin/python scripts/audit/hermes_nightly_audit.py --tracks a1,a2 --insights-cmd /usr/local/bin/hermes\n\n"
+               "Outputs:\n"
+               "  batch_state/hermes_cron/audit_YYYYMMDD_HHMMSS.md   - Markdown report of findings and insights.\n"
+               "  batch_state/hermes_cron/audit_YYYYMMDD_HHMMSS.json - Machine-readable JSON sidecar.\n"
+               "  batch_state/hermes_cron/latest.md                  - Copy of the latest Markdown report.\n"
+               "  batch_state/hermes_cron/latest.json                - Copy of the latest JSON report.\n\n"
+               "Exit codes:\n"
+               "  0 - Sweep completed and reports written successfully.\n"
+               "  1 - Unexpected script execution failure.\n\n"
+               "Related:\n"
+               "  Prompt template: agents_extensions/shared/prompts/hermes-nightly-audit.md\n"
+               "  Monitor Router: scripts/api/hermes_cron_router.py\n"
+               "  Auditor script: scripts/audit/track_deterministic_audit.py\n"
+               "  Specification: docs/best-practices/hermes-usage.md",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--tracks",
+        default="a1,a2,b1,b2",
+        help="Comma-separated track IDs to audit (default: 'a1,a2,b1,b2'). Example: '--tracks a1,a2'.",
+    )
+    parser.add_argument(
+        "--insights-cmd",
+        default="hermes",
+        help="The command name or path to the hermes binary for retrieving insights (default: 'hermes').",
+    )
+
+    args = parser.parse_args()
+
+    track_list = [t.strip().lower() for t in args.tracks.split(",") if t.strip()]
+    if not track_list:
+        print("Error: No tracks specified to audit.", file=sys.stderr)
+        return 1
+
+    print(f"Starting sequential audit for tracks: {track_list}")
+    track_results = {}
+    for track in track_list:
+        print(f"Auditing track '{track}'...")
+        track_results[track] = run_track_audit(track)
+
+    print("Retrieving Hermes insights snapshot...")
+    insights = get_hermes_insights(args.insights_cmd)
+
+    now = datetime.now(UTC)
+    timestamp_str = now.strftime("%Y%m%d_%H%M%S")
+    iso_timestamp = now.isoformat().replace("+00:00", "Z")
+
+    # Compute overall totals for JSON
+    overall_by_severity = Counter()
+    total_findings = 0
+    for _track, data in track_results.items():
+        summary = data.get("summary", {})
+        total_findings += summary.get("findings_total", 0)
+        for sev, count in summary.get("findings_by_severity", {}).items():
+            overall_by_severity[sev] += count
+
+    json_data = {
+        "timestamp": iso_timestamp,
+        "summary": {
+            "findings_total": total_findings,
+            "findings_by_severity": dict(overall_by_severity),
+        },
+        "tracks": track_results,
+        "insights": insights,
+    }
+
+    markdown_report = build_markdown_report(iso_timestamp, track_results, insights)
+
+    # Write output to batch_state/hermes_cron/ (gitignored)
+    output_dir = PROJECT_ROOT / "batch_state" / "hermes_cron"
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+    except Exception as e:
+        print(f"Error: Failed to create output directory {output_dir}: {e}", file=sys.stderr)
+        return 1
+
+    md_path = output_dir / f"audit_{timestamp_str}.md"
+    json_path = output_dir / f"audit_{timestamp_str}.json"
+    latest_md_path = output_dir / "latest.md"
+    latest_json_path = output_dir / "latest.json"
+
+    try:
+        md_path.write_text(markdown_report, encoding="utf-8")
+        json_path.write_text(json.dumps(json_data, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        shutil.copy2(md_path, latest_md_path)
+        shutil.copy2(json_path, latest_json_path)
+
+        print(f"Reports successfully written to:\n  - {md_path}\n  - {json_path}\nAnd copied to latest links.")
+    except Exception as e:
+        print(f"Error writing reports: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/api/test_hermes_cron_router.py
+++ b/tests/api/test_hermes_cron_router.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+from scripts.api.main import app
+
+client = TestClient(app, raise_server_exceptions=False)
+
+
+def test_hermes_cron_router_returns_404_when_missing(tmp_path, monkeypatch):
+    from scripts.api import hermes_cron_router
+    monkeypatch.setattr(hermes_cron_router, "PROJECT_ROOT", tmp_path)
+
+    # Request JSON
+    resp_json = client.get("/api/hermes-cron/latest")
+    assert resp_json.status_code == 404
+    assert resp_json.json()["detail"] == "Latest nightly audit json report not found"
+
+    # Request markdown
+    resp_md = client.get("/api/hermes-cron/latest?format=markdown")
+    assert resp_md.status_code == 404
+    assert resp_md.json()["detail"] == "Latest nightly audit markdown report not found"
+
+
+def test_hermes_cron_router_returns_correct_content(tmp_path, monkeypatch):
+    from scripts.api import hermes_cron_router
+    monkeypatch.setattr(hermes_cron_router, "PROJECT_ROOT", tmp_path)
+
+    # Write fake reports to tmp_path/batch_state/hermes_cron/
+    cron_dir = tmp_path / "batch_state" / "hermes_cron"
+    cron_dir.mkdir(parents=True)
+
+    fake_json = {
+        "timestamp": "2026-07-05T19:33:21Z",
+        "summary": {"findings_total": 0},
+        "tracks": {},
+        "insights": "mocked",
+    }
+    (cron_dir / "latest.json").write_text(json.dumps(fake_json), encoding="utf-8")
+
+    fake_md = "# Hermes Nightly Audit Report\nNo findings."
+    (cron_dir / "latest.md").write_text(fake_md, encoding="utf-8")
+
+    # Request JSON (default)
+    resp_json = client.get("/api/hermes-cron/latest")
+    assert resp_json.status_code == 200
+    assert resp_json.json() == fake_json
+
+    # Request markdown
+    resp_md = client.get("/api/hermes-cron/latest?format=markdown")
+    assert resp_md.status_code == 200
+    assert resp_md.headers["content-type"] == "text/markdown; charset=utf-8"
+    assert resp_md.text == fake_md

--- a/tests/audit/test_hermes_nightly_audit.py
+++ b/tests/audit/test_hermes_nightly_audit.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from scripts.audit import hermes_nightly_audit as audit
+
+
+def test_build_markdown_report():
+    timestamp = "2026-07-05T19:33:21Z"
+    track_results = {
+        "a1": {
+            "summary": {
+                "findings_total": 2,
+                "findings_by_severity": {
+                    "blocker": 0,
+                    "high": 0,
+                    "medium": 0,
+                    "low": 0,
+                    "info": 2,
+                },
+                "modules_selected": 55,
+                "modules_built": 55,
+                "modules_not_built": 0,
+            },
+            "findings": [
+                {
+                    "severity": "info",
+                    "module_num": 1,
+                    "slug": "hello",
+                    "category": "inventory",
+                    "file": "wiki/grammar/a1/hello.md",
+                    "line": 10,
+                    "message": "Optional missing",
+                }
+            ],
+        }
+    }
+    insights = "Test insights output"
+    report = audit.build_markdown_report(timestamp, track_results, insights)
+
+    assert "# Hermes Nightly Audit Report" in report
+    assert "Generated at: `2026-07-05T19:33:21Z`" in report
+    assert "Test insights output" in report
+    assert "M01 hello" in report
+    assert "wiki/grammar/a1/hello.md:10" in report
+
+
+def test_get_hermes_insights():
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="Fake Insights Output")
+        assert audit.get_hermes_insights("hermes") == "Fake Insights Output"
+
+    with patch("subprocess.run", side_effect=Exception("not found")):
+        assert audit.get_hermes_insights("hermes") == "insights unavailable"
+
+
+def test_main_writes_only_to_designated_path(tmp_path, monkeypatch):
+    # Mock project root to point to tmp_path
+    monkeypatch.setattr(audit, "PROJECT_ROOT", tmp_path)
+
+    # Mock run_track_audit to avoid running actual subprocesses during unit tests
+    def dummy_run_track_audit(track):
+        return {
+            "summary": {
+                "findings_total": 0,
+                "findings_by_severity": {
+                    "blocker": 0,
+                    "high": 0,
+                    "medium": 0,
+                    "low": 0,
+                    "info": 0,
+                },
+                "modules_selected": 1,
+                "modules_built": 1,
+                "modules_not_built": 0,
+            },
+            "findings": [],
+        }
+
+    monkeypatch.setattr(audit, "run_track_audit", dummy_run_track_audit)
+    monkeypatch.setattr(audit, "get_hermes_insights", lambda cmd: "mocked insights")
+
+    # Mock CLI arguments
+    test_args = ["--tracks", "a1", "--insights-cmd", "hermes"]
+    with patch("sys.argv", ["scripts/audit/hermes_nightly_audit.py", *test_args]):
+        exit_code = audit.main()
+
+    assert exit_code == 0
+
+    # Assert reports are written under tmp_path / "batch_state" / "hermes_cron"
+    cron_dir = tmp_path / "batch_state" / "hermes_cron"
+    assert cron_dir.exists()
+
+    # Verify latest files exist
+    assert (cron_dir / "latest.md").exists()
+    assert (cron_dir / "latest.json").exists()
+
+    # Verify we also have timestamped files
+    files = list(cron_dir.glob("audit_*.md"))
+    assert len(files) == 1
+
+    # Assert NO writes outside batch_state/hermes_cron/
+    # All files inside tmp_path must be under batch_state/hermes_cron/
+    all_files = [p for p in tmp_path.glob("**/*") if p.is_file()]
+    for p in all_files:
+        assert p.relative_to(tmp_path).parts[0:2] == ("batch_state", "hermes_cron")


### PR DESCRIPTION
## What / why

Repo-side half of the approved P1 `hermes cron` row in `docs/best-practices/hermes-usage.md` § Automation adoption plan (user order 2026-07-05: use hermes features for automation). The nightly sweep is deterministic by design — no LLM in the loop:

- `scripts/audit/hermes_nightly_audit.py` — sequential `track_deterministic_audit` over a1,a2,b1,b2 + optional `hermes insights` snapshot → timestamped md+json reports + `latest.*` in gitignored `batch_state/hermes_cron/`; writes nothing outside that path.
- `scripts/api/hermes_cron_router.py` — `GET /api/hermes-cron/latest` (+`?format=markdown`), wired in `main.py` + `route_contracts.py`.
- `agents_extensions/shared/prompts/hermes-nightly-audit.md` — cron prompt: run wrapper, print summary, nothing else; toolsets restricted.
- Tests for wrapper + router.

Machine-local `hermes cron` registration + plan-row status flip follow post-merge (orchestrator).

## Provenance

Authored + committed by the **agy** dispatch (`hermes-p1b-cron-pilot`, trailer `X-Agent: agy` is genuine); the dispatch died at the agy CLI's 5m print-timeout (#4441) after committing but before push/PR. Orchestrator (Claude) finalized and independently verified.

## Verification evidence (orchestrator-run, in the dispatch worktree)

- `pytest tests/audit/test_hermes_nightly_audit.py tests/api/test_hermes_cron_router.py -q` → `5 passed in 0.53s`
- `ruff check` (wrapper, router, both tests) → `All checks passed!`
- E2E: `hermes_nightly_audit.py --tracks a1` → audit ran, insights snapshot retrieved, `audit_20260705_175008.{md,json}` + latest links written
- `git check-ignore -v batch_state/hermes_cron/latest.json` → `.gitignore:190:batch_state/` (report path gitignored)
- Worktree tree clean after E2E run (path containment holds)
- Code review: fixed report paths (no traversal), list-form subprocess (no shell), no LLM calls, router follows existing thin-router style + route contract registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)