### PR TITLE
fix(agent-runtime): agy passes print timeout aligned with dispatch guard

### DIFF
--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -88,6 +88,12 @@ _SAVED_OUTPUT_POINTER_RE = re.compile(
     re.IGNORECASE,
 )
 _MAX_INLINE_TOOL_RESULT_BYTES = 1_000_000
+# Delegate's default hard_timeout is 7200s. Agy's print-mode default is 5m0s,
+# which is tighter than the runner guards; keep the CLI's own print wait aligned
+# with the delegate default until build_invocation can receive the actual
+# per-dispatch hard_timeout. TODO(#4441): plumb hard_timeout through the adapter
+# ABI if a future shared contract revision carries runner guard values.
+_AGY_PRINT_TIMEOUT = "120m"
 
 # Canonical model display strings accepted by ``agy --model`` (verbatim from
 # ``agy models``). A caller may pass a slug (``gemini-3.1-pro-high``) or the
@@ -190,6 +196,8 @@ class AgyAdapter:
             "-p",
             prompt,
             "--dangerously-skip-permissions",
+            "--print-timeout",
+            _AGY_PRINT_TIMEOUT,
             "--log-file",
             str(log_path),
         ]

--- a/tests/agent_runtime/adapters/test_agy_adapter.py
+++ b/tests/agent_runtime/adapters/test_agy_adapter.py
@@ -235,6 +235,17 @@ def _model_after_flag(plan) -> str | None:
     return plan.cmd[plan.cmd.index("--model") + 1]
 
 
+def _value_after_flag(plan, flag: str) -> str | None:
+    if flag not in plan.cmd:
+        return None
+    return plan.cmd[plan.cmd.index(flag) + 1]
+
+
+def test_build_invocation_sets_print_timeout(tmp_path: Path) -> None:
+    plan = _build(tmp_path, model=None)
+    assert _value_after_flag(plan, "--print-timeout") == agy_module._AGY_PRINT_TIMEOUT
+
+
 def test_build_invocation_maps_model_slug(tmp_path: Path) -> None:
     # A runtime slug is mapped to agy's --model display string. agy accepts the
     # display label (verified 2026-06-05) but NOT the bare slug, so the adapter


### PR DESCRIPTION
## Summary
- Fixes #4441 by adding `--print-timeout 120m` to `AgyAdapter.build_invocation`, matching delegate's default `hard_timeout=7200` guard instead of agy's CLI default `5m0s`.
- Adds a focused unit test asserting the built agy command includes the timeout flag and expected value.

## Root Cause
#4441 diagnosed that agy's print-mode CLI default is `5m0s`, while delegate/runtime guards permit longer work. Because `build_invocation` does not receive `hard_timeout` and plumbing it would require changing the shared adapter ABI/call sites, this PR uses `_AGY_PRINT_TIMEOUT = "120m"` with a TODO for future hard-timeout plumbing.

## Sibling Audit
Grep audit of `codex.py`, `cursor.py`, `gemini.py`, `grok_build.py`, and `hermes_*.py` found no sibling adapter-side CLI internal timeout flags/defaults tighter than runner guards. Findings only covered runtime guard references, max-budget warning text, and comments about hard-timeout recovery.

## Evidence

### agy help timeout line
```
command: agy --help 2>&1 | rg -n "print-timeout"
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/agy-print-timeout-fix
raw output:
13:5:  --print-timeout                 Timeout for print mode wait (default 5m0s)
```

### pytest summary
```
command: .venv/bin/python -m pytest tests/ -k "agy or agent_runtime"
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/agy-print-timeout-fix
raw output:
========= 347 passed, 9455 deselected, 3 warnings in 64.10s (0:01:04) ==========
```

### ruff final line
```
command: .venv/bin/ruff check scripts/agent_runtime/adapters/agy.py tests/agent_runtime/adapters/test_agy_adapter.py
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/agy-print-timeout-fix
raw output:
All checks passed!
```

### git log
```
command: git log -1 --oneline
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/agy-print-timeout-fix
raw output:
992eb038dc fix(agent-runtime): agy passes --print-timeout aligned with dispatch hard-timeout (#4441)
```

### PR URL
```
command: gh pr view 4454 --json url
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/agy-print-timeout-fix
raw output:
{"url":"https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/4454"}
```

## Independent Review
AGY / Gemini 3.1 Pro High review returned: `NO FINDINGS`.

Closes #4441

Generated with Codex.
