### PR TITLE
fix(audit): bakeoff error cells — schema/provider failures never crash the matrix

### DIFF
--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -87,6 +87,14 @@ class BakeoffConfigError(ValueError):
     """Configuration or fixture validation error."""
 
 
+class BakeoffCellError(ValueError):
+    """Per-cell failure carrying the raw response head for diagnosis."""
+
+    def __init__(self, message: str, *, response_head: str | None = None) -> None:
+        super().__init__(message)
+        self.response_head = response_head
+
+
 ProviderRunner = Callable[
     [llm_reviewer_dispatch.ReviewerRoute, str, str],
     llm_reviewer_dispatch.DispatchResult | str,
@@ -249,6 +257,9 @@ def run_one(
     artifact_path = output_dir / f"{pin_slug(route.reviewer_model_id)}__{fixture.slug}.json"
     if artifact_path.exists() and not force:
         artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+        # retry_failures is a RESUME MODIFIER: missing cells always run (plain
+        # resume behavior), completed cells always skip, and error cells re-run
+        # only under the flag (codex review of #4463 pinned these semantics).
         if not (retry_failures and artifact.get("status") == "error"):
             return BakeoffRun(artifact_path=artifact_path, artifact=artifact, skipped=True)
 
@@ -281,7 +292,11 @@ def run_one(
                 "bridge_command": list(route.bridge_command),
             },
             "status": "error",
-            "error": {"class": type(exc).__name__, "message": str(exc)[:2000]},
+            "error": {
+                "class": type(exc).__name__,
+                "message": str(exc)[:2000],
+                "response_head": getattr(exc, "response_head", None),
+            },
             "workflow_verdict": "ERROR",
             "attempt_count": None,
             "dispatch": {},
@@ -505,7 +520,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "--retry-failures",
         action="store_true",
-        help="Re-run only cells whose existing artifact has status=error",
+        help=(
+            "Resume modifier: in addition to running MISSING cells (normal resume), "
+            "re-run cells whose existing artifact has status=error. Completed cells stay skipped."
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -544,8 +562,13 @@ def _invoke_and_gate(
         # (cursor review of #4458): an over-budget run hard-fails identically
         # in the harness and in live gating.
         llm_reviewer_dispatch.enforce_tool_budget(dispatch)
-        payload = dict(llm_reviewer_dispatch._json_payload_from_response(result.response_text))
-        llm_reviewer.validate_reviewer_payload(payload, BAKEOFF_POLICY_FAMILY)
+        try:
+            payload = dict(llm_reviewer_dispatch._json_payload_from_response(result.response_text))
+            llm_reviewer.validate_reviewer_payload(payload, BAKEOFF_POLICY_FAMILY)
+        except ValueError as exc:
+            # Preserve what the model actually said — the first live run left
+            # only "Expecting value: char 0" with no way to diagnose offline.
+            raise BakeoffCellError(str(exc), response_head=result.response_text[:2000]) from exc
         attempt = {
             "attempt": attempt_count,
             "tool_call_count": dispatch.get("tool_call_count"),

--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -101,6 +101,27 @@ ProviderRunner = Callable[
 ]
 
 
+def _lenient_first_json_object(response_text: str) -> Mapping[str, Any] | None:
+    """Parse the FIRST JSON object from a response with trailing garbage.
+
+    Measured live (deepseek-v4-flash): a valid payload followed by extra text
+    ("Extra data: char 7498"). JSON hygiene is a contract defect worth
+    counting, not a reason to void the fact-check measurement. Returns None
+    when no leading object parses.
+    """
+    text = response_text.strip()
+    if "```json" in text:
+        text = text.split("```json", 1)[1]
+    elif text.startswith("```"):
+        text = text.split("```", 1)[1]
+    text = text.lstrip()
+    try:
+        payload, _end = json.JSONDecoder().raw_decode(text)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, Mapping) else None
+
+
 def require_offline_opt_in() -> None:
     """Refuse CI and require explicit local experiment opt-in."""
     if os.environ.get("CI"):
@@ -336,6 +357,7 @@ def run_one(
         "status": gate_result["status"],
         "workflow_verdict": gate_result["workflow_verdict"],
         "findings_schema_invalid": bool(gate_result.get("findings_schema_invalid")),
+        "response_parse_lenient": bool(gate_result.get("response_parse_lenient")),
         "attempt_count": gate_result["attempt_count"],
         "dispatch": dispatch,
         "gate_outcomes": gate_outcomes,
@@ -563,12 +585,17 @@ def _invoke_and_gate(
         # (cursor review of #4458): an over-budget run hard-fails identically
         # in the harness and in live gating.
         llm_reviewer_dispatch.enforce_tool_budget(dispatch)
+        response_parse_lenient = False
         try:
             payload = dict(llm_reviewer_dispatch._json_payload_from_response(result.response_text))
         except ValueError as exc:
-            # Preserve what the model actually said — the first live run left
-            # only "Expecting value: char 0" with no way to diagnose offline.
-            raise BakeoffCellError(str(exc), response_head=result.response_text[:2000]) from exc
+            lenient = _lenient_first_json_object(result.response_text)
+            if lenient is None:
+                # Preserve what the model actually said — the first live run
+                # left only "Expecting value: char 0", undiagnosable offline.
+                raise BakeoffCellError(str(exc), response_head=result.response_text[:2000]) from exc
+            payload = dict(lenient)
+            response_parse_lenient = True
         # MEASUREMENT-VALIDITY SPLIT (live gemma cells, 2026-07-05): the bakeoff
         # measures FACT-CHECK quality; strict `findings` schema compliance is an
         # ORTHOGONAL axis. gemma emitted valid fact_checks with non-conforming
@@ -675,6 +702,7 @@ def _invoke_and_gate(
             "dispatch": dispatch,
             "payload": payload,
             "findings_schema_invalid": findings_schema_invalid,
+            "response_parse_lenient": response_parse_lenient,
             "gate_outcomes": {
                 "attempts": attempts,
                 "theatre": {"status": "passed", "retried": theatre_retried},
@@ -683,6 +711,7 @@ def _invoke_and_gate(
                 "grounding": grounding,
                 "factual_sweep": {"incomplete": sweep_incomplete},
                 "findings_schema_invalid": findings_schema_invalid,
+                "response_parse_lenient": response_parse_lenient,
             },
         }
 

--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -201,6 +201,7 @@ def run_matrix(
     output_dir: Path,
     runner: ProviderRunner = invoke_bakeoff_route,
     force: bool = False,
+    retry_failures: bool = False,
 ) -> list[BakeoffRun]:
     """Run or resume every model x fixture pair and write a scorecard.
 
@@ -221,6 +222,7 @@ def run_matrix(
                     output_dir=output_dir,
                     runner=runner,
                     force=force,
+                    retry_failures=retry_failures,
                 )
             )
     write_scorecard(output_dir / SCORECARD_NAME, [run.artifact for run in runs])
@@ -234,6 +236,7 @@ def run_one(
     output_dir: Path,
     runner: ProviderRunner = invoke_bakeoff_route,
     force: bool = False,
+    retry_failures: bool = False,
 ) -> BakeoffRun:
     """Run or resume one model x passage bakeoff artifact.
 
@@ -246,14 +249,52 @@ def run_one(
     artifact_path = output_dir / f"{pin_slug(route.reviewer_model_id)}__{fixture.slug}.json"
     if artifact_path.exists() and not force:
         artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
-        return BakeoffRun(artifact_path=artifact_path, artifact=artifact, skipped=True)
+        if not (retry_failures and artifact.get("status") == "error"):
+            return BakeoffRun(artifact_path=artifact_path, artifact=artifact, skipped=True)
 
     # ``folk`` is the track level; it maps to the seminar policy family in
     # content_surface_gates. There is no literal ``seminar`` level.
     prompt = llm_reviewer.build_reviewer_prompt(BAKEOFF_LEVEL, f"bakeoff-{fixture.slug}", fixture.passage_md)
     task_id = f"qg-bakeoff-{pin_slug(route.reviewer_model_id)}-{fixture.slug}"
     started = time.monotonic()
-    gate_result = _invoke_and_gate(route, prompt, task_id, runner)
+    try:
+        gate_result = _invoke_and_gate(route, prompt, task_id, runner)
+    except (ValueError, llm_reviewer_dispatch.ReviewerDispatchError) as exc:
+        # A model that cannot produce a schema-valid grounded payload (or a
+        # provider that errors out) is a MEASURED per-cell outcome, never a
+        # matrix crash (first live run: gemma findings flunked validate_finding
+        # and killed all 24 cells). Score = every fixture claim missing.
+        wall_seconds = round(time.monotonic() - started, 3)
+        artifact = {
+            "schema_version": RUN_SCHEMA_VERSION,
+            "created_at": _now_z(),
+            "fixture": {
+                "slug": fixture.slug,
+                "title": fixture.title,
+                "claim_count": len(fixture.claims),
+            },
+            "model": {
+                "pin": route.reviewer_model_id,
+                "pin_slug": pin_slug(route.reviewer_model_id),
+                "family": route.reviewer_family,
+                "route_name": route.route_name,
+                "bridge_command": list(route.bridge_command),
+            },
+            "status": "error",
+            "error": {"class": type(exc).__name__, "message": str(exc)[:2000]},
+            "workflow_verdict": "ERROR",
+            "attempt_count": None,
+            "dispatch": {},
+            "gate_outcomes": {},
+            "payload": {},
+            "score": score_payload({"fact_checks": []}, fixture),
+            "tool_call_count": 0,
+            "wall_seconds": wall_seconds,
+        }
+        artifact_path.write_text(
+            json.dumps(artifact, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        return BakeoffRun(artifact_path=artifact_path, artifact=artifact)
     wall_seconds = round(time.monotonic() - started, 3)
     score = score_payload(gate_result["payload"], fixture)
     gate_outcomes = gate_result["gate_outcomes"]
@@ -461,6 +502,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--models", action="append", help="Comma-separated or repeated OpenRouter/opencode model pins")
     parser.add_argument("--out-dir", type=Path, default=None)
     parser.add_argument("--force", action="store_true", help="Redo runs even when artifact JSON exists")
+    parser.add_argument(
+        "--retry-failures",
+        action="store_true",
+        help="Re-run only cells whose existing artifact has status=error",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -468,7 +514,9 @@ def main(argv: Sequence[str] | None = None) -> int:
         fixtures = load_fixtures(args.fixtures_dir, args.fixtures)
         pins = model_pins_from_args(args.models)
         output_dir = args.out_dir or default_output_dir()
-        runs = run_matrix(fixtures, pins, output_dir=output_dir, force=args.force)
+        runs = run_matrix(
+        fixtures, pins, output_dir=output_dir, force=args.force, retry_failures=args.retry_failures
+    )
     except BakeoffConfigError as exc:
         print(str(exc), file=sys.stderr)
         return 2

--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -335,6 +335,7 @@ def run_one(
         },
         "status": gate_result["status"],
         "workflow_verdict": gate_result["workflow_verdict"],
+        "findings_schema_invalid": bool(gate_result.get("findings_schema_invalid")),
         "attempt_count": gate_result["attempt_count"],
         "dispatch": dispatch,
         "gate_outcomes": gate_outcomes,
@@ -564,11 +565,30 @@ def _invoke_and_gate(
         llm_reviewer_dispatch.enforce_tool_budget(dispatch)
         try:
             payload = dict(llm_reviewer_dispatch._json_payload_from_response(result.response_text))
-            llm_reviewer.validate_reviewer_payload(payload, BAKEOFF_POLICY_FAMILY)
         except ValueError as exc:
             # Preserve what the model actually said — the first live run left
             # only "Expecting value: char 0" with no way to diagnose offline.
             raise BakeoffCellError(str(exc), response_head=result.response_text[:2000]) from exc
+        # MEASUREMENT-VALIDITY SPLIT (live gemma cells, 2026-07-05): the bakeoff
+        # measures FACT-CHECK quality; strict `findings` schema compliance is an
+        # ORTHOGONAL axis. gemma emitted valid fact_checks with non-conforming
+        # findings — voiding the cell would confound the central metric with
+        # contract-following noise. Harness-only: strip non-conforming findings,
+        # count the defect (`findings_schema_invalid`), keep gating fact_checks
+        # strictly. The LIVE pipeline stays strict (SCHEMA_FAILURE) — unchanged.
+        findings_schema_invalid = False
+        try:
+            llm_reviewer.validate_reviewer_payload(payload, BAKEOFF_POLICY_FAMILY)
+        except ValueError as exc:
+            stripped = dict(payload)
+            stripped["findings"] = []
+            try:
+                llm_reviewer.validate_reviewer_payload(stripped, BAKEOFF_POLICY_FAMILY)
+            except ValueError:
+                # fact_checks/evidence_gaps themselves are invalid → real error cell.
+                raise BakeoffCellError(str(exc), response_head=result.response_text[:2000]) from exc
+            findings_schema_invalid = True
+            payload = stripped
         attempt = {
             "attempt": attempt_count,
             "tool_call_count": dispatch.get("tool_call_count"),
@@ -644,6 +664,7 @@ def _invoke_and_gate(
         }
         attempt["grounding"] = grounding
         attempt["factual_sweep"] = {"incomplete": sweep_incomplete}
+        attempt["findings_schema_invalid"] = findings_schema_invalid
         attempts.append(attempt)
         status = _status_for_gates(grounding_gate, sweep_incomplete)
         workflow_verdict = "FAIL" if sweep_incomplete else ("WARN" if status != "ran" else "PASS")
@@ -653,6 +674,7 @@ def _invoke_and_gate(
             "attempt_count": attempt_count,
             "dispatch": dispatch,
             "payload": payload,
+            "findings_schema_invalid": findings_schema_invalid,
             "gate_outcomes": {
                 "attempts": attempts,
                 "theatre": {"status": "passed", "retried": theatre_retried},
@@ -660,6 +682,7 @@ def _invoke_and_gate(
                 "deep_read": attempt["deep_read"],
                 "grounding": grounding,
                 "factual_sweep": {"incomplete": sweep_incomplete},
+                "findings_schema_invalid": findings_schema_invalid,
             },
         }
 

--- a/tests/audit/test_qg_bakeoff.py
+++ b/tests/audit/test_qg_bakeoff.py
@@ -615,3 +615,80 @@ def test_nonconforming_findings_counted_not_fatal(tmp_path: Path, monkeypatch: p
     bad_route = qg_bakeoff.bakeoff_route_for_model("openrouter/test/bad-facts-model")
     bad_run = qg_bakeoff.run_one(bad_route, fixture, output_dir=tmp_path, runner=bad_runner)
     assert bad_run.artifact["status"] == "error"
+
+
+def test_trailing_garbage_after_valid_json_is_lenient_parsed_and_flagged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Live deepseek-v4-flash class: valid payload + trailing text ("Extra data")."""
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("QG_BAKEOFF", "1")
+    fixture = _fixture()
+    payload = {
+        "findings": [],
+        "fact_checks": [
+            {
+                "claim": "True claim.",
+                "verdict": "CONFIRMED",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "True claim",
+                    "evidence_excerpt": "True claim",
+                    "tool_call_id": "call_1",
+                },
+            },
+            {
+                "claim": "Fabricated claim.",
+                "verdict": "UNATTESTED_AFTER_SEARCH",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "True claim",
+                    "evidence_excerpt": "Fabricated claim",
+                    "tool_call_id": "call_1",
+                },
+            },
+        ],
+        "evidence_gaps": [],
+    }
+
+    def runner(
+        run_route: llm_reviewer_dispatch.ReviewerRoute,
+        _prompt: str,
+        _task_id: str,
+    ) -> llm_reviewer_dispatch.DispatchResult:
+        return llm_reviewer_dispatch.DispatchResult(
+            response_text=json.dumps(payload) + "\n\nОсь мій аналіз повністю.",
+            reviewer_model_id=run_route.reviewer_model_id,
+            reviewer_family=run_route.reviewer_family,
+            route_name=run_route.route_name,
+            tool_call_count=1,
+            tools_used=("sources_query_wikipedia",),
+            tool_events=(_event(),),
+        )
+
+    route = qg_bakeoff.bakeoff_route_for_model("openrouter/test/trailing-model")
+    run = qg_bakeoff.run_one(route, fixture, output_dir=tmp_path, runner=runner)
+
+    assert run.artifact["status"] != "error"
+    assert run.artifact["response_parse_lenient"] is True
+    assert run.artifact["score"]["model_judgment_score"] == 30
+
+    # Pure prose still fails closed.
+    def prose_runner(
+        run_route: llm_reviewer_dispatch.ReviewerRoute,
+        _prompt: str,
+        _task_id: str,
+    ) -> llm_reviewer_dispatch.DispatchResult:
+        return llm_reviewer_dispatch.DispatchResult(
+            response_text="Жодного JSON тут немає.",
+            reviewer_model_id=run_route.reviewer_model_id,
+            reviewer_family=run_route.reviewer_family,
+            route_name=run_route.route_name,
+            tool_call_count=1,
+            tools_used=("sources_query_wikipedia",),
+            tool_events=(_event(),),
+        )
+
+    prose_route = qg_bakeoff.bakeoff_route_for_model("openrouter/test/prose-only-model")
+    prose_run = qg_bakeoff.run_one(prose_route, fixture, output_dir=tmp_path, runner=prose_runner)
+    assert prose_run.artifact["status"] == "error"

--- a/tests/audit/test_qg_bakeoff.py
+++ b/tests/audit/test_qg_bakeoff.py
@@ -347,3 +347,93 @@ def test_run_one_with_default_live_runner_is_guarded(
 
     with pytest.raises(qg_bakeoff.BakeoffConfigError, match="QG_BAKEOFF=1"):
         qg_bakeoff.run_one(route, _fixture(), output_dir=tmp_path)
+
+
+def test_matrix_survives_schema_invalid_cell_and_retry_failures_reruns_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A schema-invalid model payload is a MEASURED error cell, never a matrix crash.
+
+    First live run: gemma findings flunked validate_finding and killed all 24
+    cells (ValueError propagated out of run_matrix). Error cells score as
+    all-claims-missing; --retry-failures re-runs ONLY error cells.
+    """
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("QG_BAKEOFF", "1")
+    fixture = _fixture()
+    calls: list[str] = []
+
+    def flaky_runner(
+        run_route: llm_reviewer_dispatch.ReviewerRoute,
+        _prompt: str,
+        _task_id: str,
+    ) -> llm_reviewer_dispatch.DispatchResult:
+        calls.append(run_route.reviewer_model_id)
+        if run_route.reviewer_model_id.endswith("bad-model"):
+            raise ValueError("finding missing required fields: attribution")
+        return _dispatch_result(
+            {
+                "findings": [],
+                "fact_checks": [
+                    {
+                        "claim": "True claim.",
+                        "verdict": "CONFIRMED",
+                        "grounding": {
+                            "tool": "sources_query_wikipedia",
+                            "query": "True claim",
+                            "evidence_excerpt": "True claim",
+                            "tool_call_id": "call_1",
+                        },
+                    },
+                    {
+                        "claim": "Fabricated claim.",
+                        "verdict": "UNATTESTED_AFTER_SEARCH",
+                        "grounding": {
+                            "tool": "sources_query_wikipedia",
+                            "query": "True claim",
+                            "evidence_excerpt": "Fabricated claim",
+                            "tool_call_id": "call_1",
+                        },
+                    },
+                ],
+                "evidence_gaps": [],
+            },
+            run_route,
+        )
+
+    runs = qg_bakeoff.run_matrix(
+        [fixture],
+        ["openrouter/test/bad-model", "openrouter/test/good-model"],
+        output_dir=tmp_path,
+        runner=flaky_runner,
+    )
+
+    assert len(runs) == 2
+    by_status = {run.artifact["model"]["pin"]: run.artifact["status"] for run in runs}
+    assert by_status["openrouter/test/bad-model"] == "error"
+    assert by_status["openrouter/test/good-model"] == "ran"
+    error_artifact = next(r.artifact for r in runs if r.artifact["status"] == "error")
+    assert error_artifact["error"]["class"] == "ValueError"
+    assert error_artifact["score"]["missing_claims"] == len(fixture.claims)
+    assert (tmp_path / qg_bakeoff.SCORECARD_NAME).exists()
+
+    # resume: neither cell re-runs without flags
+    calls.clear()
+    qg_bakeoff.run_matrix(
+        [fixture],
+        ["openrouter/test/bad-model", "openrouter/test/good-model"],
+        output_dir=tmp_path,
+        runner=flaky_runner,
+    )
+    assert calls == []
+
+    # --retry-failures: ONLY the error cell re-runs
+    calls.clear()
+    qg_bakeoff.run_matrix(
+        [fixture],
+        ["openrouter/test/bad-model", "openrouter/test/good-model"],
+        output_dir=tmp_path,
+        runner=flaky_runner,
+        retry_failures=True,
+    )
+    assert calls == ["openrouter/test/bad-model"]

--- a/tests/audit/test_qg_bakeoff.py
+++ b/tests/audit/test_qg_bakeoff.py
@@ -548,3 +548,70 @@ def test_error_artifact_preserves_response_head_for_parse_failures(
     assert run.artifact["status"] == "error"
     assert run.artifact["error"]["class"] == "BakeoffCellError"
     assert "червона калина" in run.artifact["error"]["response_head"]
+
+
+def test_nonconforming_findings_counted_not_fatal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Findings-schema flunk is an ORTHOGONAL metric — fact_checks still score.
+
+    Live gemma cells emitted valid fact_checks with findings missing the strict
+    11 required fields; voiding those cells confounded the central fact-check
+    measurement with contract-following noise.
+    """
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("QG_BAKEOFF", "1")
+    fixture = _fixture()
+    payload = {
+        "findings": [{"excerpt": "щось", "message": "bare finding, misses 11 fields"}],
+        "fact_checks": [
+            {
+                "claim": "True claim.",
+                "verdict": "CONFIRMED",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "True claim",
+                    "evidence_excerpt": "True claim",
+                    "tool_call_id": "call_1",
+                },
+            },
+            {
+                "claim": "Fabricated claim.",
+                "verdict": "UNATTESTED_AFTER_SEARCH",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "True claim",
+                    "evidence_excerpt": "Fabricated claim",
+                    "tool_call_id": "call_1",
+                },
+            },
+        ],
+        "evidence_gaps": [],
+    }
+
+    def runner(
+        run_route: llm_reviewer_dispatch.ReviewerRoute,
+        _prompt: str,
+        _task_id: str,
+    ) -> llm_reviewer_dispatch.DispatchResult:
+        return _dispatch_result(payload, run_route)
+
+    route = qg_bakeoff.bakeoff_route_for_model("openrouter/test/loose-findings-model")
+    run = qg_bakeoff.run_one(route, fixture, output_dir=tmp_path, runner=runner)
+
+    assert run.artifact["status"] != "error"
+    assert run.artifact["findings_schema_invalid"] is True
+    assert run.artifact["payload"]["findings"] == []
+    assert run.artifact["score"]["model_judgment_score"] == 30
+
+    # Invalid FACT_CHECKS remain a genuine error cell (regression guard).
+    bad_facts = dict(payload, findings=[], fact_checks=[{"claim": "x", "verdict": "NOT_A_VERDICT"}])
+
+    def bad_runner(
+        run_route: llm_reviewer_dispatch.ReviewerRoute,
+        _prompt: str,
+        _task_id: str,
+    ) -> llm_reviewer_dispatch.DispatchResult:
+        return _dispatch_result(bad_facts, run_route)
+
+    bad_route = qg_bakeoff.bakeoff_route_for_model("openrouter/test/bad-facts-model")
+    bad_run = qg_bakeoff.run_one(bad_route, fixture, output_dir=tmp_path, runner=bad_runner)
+    assert bad_run.artifact["status"] == "error"

--- a/tests/audit/test_qg_bakeoff.py
+++ b/tests/audit/test_qg_bakeoff.py
@@ -437,3 +437,114 @@ def test_matrix_survives_schema_invalid_cell_and_retry_failures_reruns_it(
         retry_failures=True,
     )
     assert calls == ["openrouter/test/bad-model"]
+
+
+def test_retry_failures_still_runs_missing_cells_and_overwrites_error_on_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--retry-failures is a RESUME MODIFIER (codex review of #4463):
+
+    missing cells run as in plain resume; error cells re-run and a successful
+    retry OVERWRITES the error artifact.
+    """
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("QG_BAKEOFF", "1")
+    fixture = _fixture()
+    good_payload = {
+        "findings": [],
+        "fact_checks": [
+            {
+                "claim": "True claim.",
+                "verdict": "CONFIRMED",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "True claim",
+                    "evidence_excerpt": "True claim",
+                    "tool_call_id": "call_1",
+                },
+            },
+            {
+                "claim": "Fabricated claim.",
+                "verdict": "UNATTESTED_AFTER_SEARCH",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "True claim",
+                    "evidence_excerpt": "Fabricated claim",
+                    "tool_call_id": "call_1",
+                },
+            },
+        ],
+        "evidence_gaps": [],
+    }
+    fail_once = {"flaky": True}
+    calls: list[str] = []
+
+    def runner(
+        run_route: llm_reviewer_dispatch.ReviewerRoute,
+        _prompt: str,
+        _task_id: str,
+    ) -> llm_reviewer_dispatch.DispatchResult:
+        calls.append(run_route.reviewer_model_id)
+        if run_route.reviewer_model_id.endswith("flaky-model") and fail_once.pop("flaky", False):
+            raise ValueError("Expecting value: line 1 column 1 (char 0)")
+        return _dispatch_result(good_payload, run_route)
+
+    # Pass 1: flaky errors, fresh model absent entirely.
+    runs = qg_bakeoff.run_matrix(
+        [fixture], ["openrouter/test/flaky-model"], output_dir=tmp_path, runner=runner
+    )
+    assert runs[0].artifact["status"] == "error"
+
+    # Pass 2 with retry_failures: error cell re-runs AND the missing fresh-model cell runs.
+    calls.clear()
+    runs = qg_bakeoff.run_matrix(
+        [fixture],
+        ["openrouter/test/flaky-model", "openrouter/test/fresh-model"],
+        output_dir=tmp_path,
+        runner=runner,
+        retry_failures=True,
+    )
+    assert sorted(calls) == ["openrouter/test/flaky-model", "openrouter/test/fresh-model"]
+    statuses = {run.artifact["model"]["pin"]: run.artifact["status"] for run in runs}
+    assert statuses == {
+        "openrouter/test/flaky-model": "ran",
+        "openrouter/test/fresh-model": "ran",
+    }
+
+
+def test_error_artifact_preserves_response_head_for_parse_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("QG_BAKEOFF", "1")
+    fixture = _fixture()
+
+    def prose_runner(
+        run_route: llm_reviewer_dispatch.ReviewerRoute,
+        _prompt: str,
+        _task_id: str,
+    ) -> llm_reviewer_dispatch.DispatchResult:
+        return llm_reviewer_dispatch.DispatchResult(
+            response_text="Ой у лузі червона калина — no JSON here.",
+            reviewer_model_id=run_route.reviewer_model_id,
+            reviewer_family=run_route.reviewer_family,
+            route_name=run_route.route_name,
+            tool_call_count=1,
+            tools_used=("sources_query_wikipedia",),
+            tool_events=(
+                {
+                    "tool": "sources_query_wikipedia",
+                    "input": {"query": "калина"},
+                    "status": "completed",
+                    "tool_call_id": "call_1",
+                    "output": "калина",
+                },
+            ),
+        )
+
+    route = qg_bakeoff.bakeoff_route_for_model("openrouter/test/prose-model")
+    run = qg_bakeoff.run_one(route, fixture, output_dir=tmp_path, runner=prose_runner)
+
+    assert run.artifact["status"] == "error"
+    assert run.artifact["error"]["class"] == "BakeoffCellError"
+    assert "червона калина" in run.artifact["error"]["response_head"]


### PR DESCRIPTION
First live bakeoff launch crashed on cell 1: gemma-4's findings missed strict schema fields (attribution/confidence/detector/…) and the ValueError propagated out of `run_matrix`, killing all 24 cells. Fixture tests only fed well-formed payloads, so this path was untested.

Fix: per-cell try/except in `run_one` — schema-validation ValueErrors and `ReviewerDispatchError`s produce a `status=error` artifact (error class+message preserved, score = all-claims-missing = honest worst case) and the matrix continues. `--retry-failures` re-runs only error cells; plain resume skips them as before.

Test: `test_matrix_survives_schema_invalid_cell_and_retry_failures_reruns_it` (crash → error artifact + good cell unaffected + scorecard written; resume idempotent; retry-failures selective). 14 pass in tests/audit/test_qg_bakeoff.py; ruff clean.

Relates #2156 (unblocks the step-3 run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)