### PR TITLE
fix(codex): deploy project hooks config

### DIFF
--- a/agents_extensions/codex/hooks.json
+++ b/agents_extensions/codex/hooks.json
@@ -1,0 +1,122 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/session-setup.sh\"",
+            "timeout": 10,
+            "statusMessage": "Checking learn-ukrainian session state"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/enforce-venv.sh\"",
+            "timeout": 3,
+            "statusMessage": "Checking Bash Python interpreter"
+          },
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/heal-core-bare.py\"",
+            "timeout": 3,
+            "statusMessage": "Checking git worktree health"
+          },
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-branch-switch-in-main.py\"",
+            "timeout": 3,
+            "statusMessage": "Checking branch-switch safety"
+          },
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-admin-merge.py\"",
+            "timeout": 30,
+            "statusMessage": "Checking admin merge safety"
+          },
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-push-pytest.py\"",
+            "timeout": 10,
+            "statusMessage": "Checking push safety"
+          },
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-secret-print.py\"",
+            "timeout": 5,
+            "statusMessage": "Checking secret-print safety"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^(Bash|apply_patch|Edit|Write)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/tool-timing.sh\"",
+            "timeout": 1,
+            "statusMessage": "Recording tool timing"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/context-monitor.sh\"",
+            "timeout": 5,
+            "statusMessage": "Checking context budget"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/stamp-pytest.sh\"",
+            "timeout": 3,
+            "statusMessage": "Stamping pytest telemetry"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/check-gemini-inbox.sh\"",
+            "timeout": 5,
+            "statusMessage": "Checking cross-agent inbox"
+          }
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "manual|auto",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/post-compact.sh\"",
+            "timeout": 10,
+            "statusMessage": "Refreshing compacted context"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/goal-driver-stop.sh\"",
+            "timeout": 5,
+            "statusMessage": "Checking goal-driver state"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -1,0 +1,89 @@
+# Codex hooks deployment and probe
+
+Issue #4447 established `.codex/hooks.json` as a deployed runtime config, not a
+hand-edited destination file. The source of truth is
+`agents_extensions/codex/hooks.json`; run `npm run agents:deploy` to refresh the
+ignored `.codex/` target.
+
+Codex hook facts verified from the current OpenAI Codex manual on 2026-07-05:
+
+- Project-local `.codex/hooks.json` is loaded only for trusted project layers.
+- `PreToolUse` and `PostToolUse` match on tool name.
+- Current matcher support includes `Bash`, `apply_patch`, and the `Edit`/`Write`
+  aliases for apply-patch edit paths.
+- Hook command trust is separate from project trust. For automation that already
+  vets the hook source, use `--dangerously-bypass-hook-trust`.
+
+## CLI probe
+
+Run the probe from the repository root:
+
+```bash
+.venv/bin/python scripts/agent_runtime/codex_hook_probe.py --keep-workdir
+```
+
+The probe creates a temporary Git repo under `/private/tmp`, installs a minimal
+project `.codex/hooks.json`, and runs nested `codex exec` cases for:
+
+- Bash write allowed
+- Bash write denied by a `PreToolUse` hook exiting 2
+- apply_patch write allowed
+- apply_patch write denied by a `PreToolUse` hook exiting 2
+
+The JSON output includes the exact nested `codex exec` commands, hook payload
+logs, tool names seen by hooks, return codes, and whether the target file was
+created. Treat `expected_file_exists: false` in a deny case, together with a
+matching hook tool name, as evidence that the path is blockable.
+
+Use this command for a cheap harness-only check that does not call Codex:
+
+```bash
+.venv/bin/python scripts/agent_runtime/codex_hook_probe.py --self-test
+```
+
+## Desktop/direct edit probe
+
+Codex Desktop direct-edit behavior is not invokable from the CLI probe. Verify it
+manually after `npm run agents:deploy`:
+
+1. Open this repository in Codex Desktop from the trusted worktree.
+2. Open `/hooks` and confirm the project `.codex/hooks.json` entries are listed
+   and trusted, or start with `--dangerously-bypass-hook-trust` from CLI only.
+3. Ask Desktop to run a shell write such as
+   `printf 'desktop shell hook probe\n' > desktop-shell-probe.txt`.
+4. Ask Desktop to edit a file without a shell command, using Desktop's normal
+   direct edit/apply flow.
+5. Compare hook labels/log output with the CLI probe results.
+
+If Desktop or direct edit writes do not emit `Bash`, `apply_patch`, `Edit`, or
+`Write` hook events, project hooks cannot enforce that path. Leave tracked-file
+write enforcement to #4445/#4446/#4448/#4449 instead of claiming hook coverage.
+
+## Empirical CLI result, 2026-07-05
+
+Environment:
+
+- cwd:
+  `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4447-codex-hooks-deploy`
+- Codex CLI: `codex-cli 0.142.5`
+- Command:
+  `.venv/bin/python scripts/agent_runtime/codex_hook_probe.py --keep-workdir --timeout 240`
+- Probe repo:
+  `/private/tmp/codex-hook-probe-9w43s82u/codex-hook-probe-repo`
+
+| Case | Prompt summary | Hook tool names | Target file | Result |
+| --- | --- | --- | --- | --- |
+| Bash allow | `printf 'codex shell hook probe\n' > shell-write.txt` | `Bash`, `Bash` | `shell-write.txt` exists | Intercepted and allowed |
+| Bash deny | `printf 'codex shell hook deny probe\n' > shell-denied.txt` | `Bash` | `shell-denied.txt` absent | Intercepted and blocked by exit 2 |
+| apply_patch allow | Create `apply-patch-write.txt` with apply_patch only | `apply_patch`, `apply_patch` | `apply-patch-write.txt` exists | Intercepted and allowed |
+| apply_patch deny | Create `apply-patch-denied.txt` with apply_patch only | `apply_patch` | `apply-patch-denied.txt` absent | Intercepted and blocked by exit 2 |
+
+Observed block messages included:
+
+- `Command blocked by PreToolUse hook: codex-hook-probe denying Bash`
+- `Command blocked by PreToolUse hook: codex-hook-probe denying apply_patch`
+
+Conclusion for this CLI build: project `PreToolUse` hooks can intercept and
+block both Bash writes and Codex CLI apply_patch writes. This does not prove
+Codex Desktop direct-edit interception; Desktop must still be checked with the
+manual steps above.

--- a/scripts/agent_runtime/codex_hook_probe.py
+++ b/scripts/agent_runtime/codex_hook_probe.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Empirically probe which Codex edit paths fire project hooks.
+
+The probe creates a temporary trusted Git repo under /private/tmp, installs a
+minimal .codex/hooks.json, and runs nested `codex exec` prompts that ask Codex
+to write through Bash and apply_patch. The hook records every payload it sees
+and can exit 2 for selected tools to test whether Codex blocks the operation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
+DEFAULT_TIMEOUT_SECONDS = 180
+TEMP_PARENT = Path("/private/tmp") if Path("/private/tmp").is_dir() else Path(tempfile.gettempdir())
+
+HOOK_SCRIPT = """#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _payload() -> dict:
+    try:
+        return json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError as exc:
+        return {"_decode_error": str(exc)}
+
+
+def _tool_name(payload: dict) -> str:
+    return str(payload.get("tool_name") or payload.get("tool") or payload.get("name") or "")
+
+
+payload = _payload()
+tool_name = _tool_name(payload)
+event = str(payload.get("hook_event_name") or payload.get("event") or "")
+log_path = Path(os.environ["CODEX_HOOK_PROBE_LOG"])
+record = {
+    "ts": datetime.now(timezone.utc).isoformat(),
+    "event": event,
+    "tool_name": tool_name,
+    "cwd": os.getcwd(),
+    "payload": payload,
+}
+with log_path.open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(record, sort_keys=True) + "\\n")
+
+deny_tools = {item for item in os.environ.get("CODEX_HOOK_PROBE_DENY_TOOLS", "").split(",") if item}
+if tool_name in deny_tools:
+    print(f"codex-hook-probe denying {tool_name}", file=sys.stderr)
+    raise SystemExit(2)
+
+raise SystemExit(0)
+"""
+
+
+def _hooks_json() -> dict[str, Any]:
+    hook_command = (
+        '"$(git rev-parse --show-toplevel)/.venv/bin/python" '
+        '"$(git rev-parse --show-toplevel)/.codex/hooks/probe-hook.py"'
+    )
+    return {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "^(Bash|apply_patch|Edit|Write)$",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": hook_command,
+                            "timeout": 5,
+                            "statusMessage": "Codex hook probe",
+                        }
+                    ],
+                }
+            ],
+            "PostToolUse": [
+                {
+                    "matcher": "^(Bash|apply_patch|Edit|Write)$",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": hook_command,
+                            "timeout": 5,
+                            "statusMessage": "Codex hook probe",
+                        }
+                    ],
+                }
+            ],
+        }
+    }
+
+
+@dataclass(frozen=True)
+class ProbeCase:
+    name: str
+    prompt: str
+    expected_file: str
+    deny_tools: tuple[str, ...] = ()
+
+
+PROBE_CASES = (
+    ProbeCase(
+        name="bash-write-allow",
+        prompt=(
+            "Use the Bash tool exactly once to run this command, then stop: "
+            "printf 'codex shell hook probe\\n' > shell-write.txt"
+        ),
+        expected_file="shell-write.txt",
+    ),
+    ProbeCase(
+        name="bash-write-deny",
+        prompt=(
+            "Use the Bash tool exactly once to run this command, then stop: "
+            "printf 'codex shell hook deny probe\\n' > shell-denied.txt"
+        ),
+        expected_file="shell-denied.txt",
+        deny_tools=("Bash",),
+    ),
+    ProbeCase(
+        name="apply-patch-allow",
+        prompt=(
+            "Use the apply_patch tool, not a shell command, to create "
+            "apply-patch-write.txt containing exactly: codex apply_patch hook probe"
+        ),
+        expected_file="apply-patch-write.txt",
+    ),
+    ProbeCase(
+        name="apply-patch-deny",
+        prompt=(
+            "Use the apply_patch tool, not a shell command, to create "
+            "apply-patch-denied.txt containing exactly: codex apply_patch denied"
+        ),
+        expected_file="apply-patch-denied.txt",
+        deny_tools=("apply_patch", "Edit", "Write"),
+    ),
+)
+
+
+def _run(command: list[str], cwd: Path, env: dict[str, str] | None = None, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _prepare_probe_repo(parent: Path) -> Path:
+    repo = parent / "codex-hook-probe-repo"
+    repo.mkdir()
+    git_init = _run(["git", "init"], cwd=repo)
+    if git_init.returncode != 0:
+        raise RuntimeError(f"git init failed:\n{git_init.stderr}")
+
+    venv_bin = repo / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    python_wrapper = venv_bin / "python"
+    python_wrapper.write_text(
+        "#!/usr/bin/env bash\n"
+        f"exec {shlex.quote(str(PROJECT_PYTHON))} \"$@\"\n",
+        encoding="utf-8",
+    )
+    python_wrapper.chmod(0o755)
+
+    hook_dir = repo / ".codex" / "hooks"
+    hook_dir.mkdir(parents=True)
+    hook_script = hook_dir / "probe-hook.py"
+    hook_script.write_text(HOOK_SCRIPT, encoding="utf-8")
+    hook_script.chmod(0o755)
+    (repo / ".codex" / "hooks.json").write_text(
+        json.dumps(_hooks_json(), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (repo / "README.md").write_text("# Codex hook probe\n", encoding="utf-8")
+    commit = _run(["git", "add", "README.md", ".codex/hooks.json", ".codex/hooks/probe-hook.py"], cwd=repo)
+    if commit.returncode != 0:
+        raise RuntimeError(f"git add failed:\n{commit.stderr}")
+    commit = _run(
+        [
+            "git",
+            "-c",
+            "user.name=Codex Hook Probe",
+            "-c",
+            "user.email=codex-hook-probe@example.invalid",
+            "commit",
+            "-m",
+            "init probe repo",
+        ],
+        cwd=repo,
+    )
+    if commit.returncode != 0:
+        raise RuntimeError(f"git commit failed:\n{commit.stderr}")
+    return repo
+
+
+def _load_events(log_path: Path) -> list[dict[str, Any]]:
+    if not log_path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _tool_names(events: list[dict[str, Any]]) -> list[str]:
+    return [
+        str(event.get("tool_name") or "")
+        for event in events
+        if event.get("tool_name")
+    ]
+
+
+def _run_case(repo: Path, case: ProbeCase, model: str | None, timeout: int) -> dict[str, Any]:
+    log_path = repo / f"{case.name}.jsonl"
+    env = os.environ.copy()
+    env["CODEX_HOOK_PROBE_LOG"] = str(log_path)
+    env["CODEX_HOOK_PROBE_DENY_TOOLS"] = ",".join(case.deny_tools)
+
+    output_file = repo / f"{case.name}-last-message.txt"
+    command = [
+        "codex",
+        "exec",
+        "--dangerously-bypass-hook-trust",
+        "--dangerously-bypass-approvals-and-sandbox",
+        "--cd",
+        str(repo),
+        "--json",
+        "--output-last-message",
+        str(output_file),
+    ]
+    if model:
+        command.extend(["--model", model])
+    command.append(case.prompt)
+
+    result = _run(command, cwd=repo, env=env, timeout=timeout)
+    events = _load_events(log_path)
+    expected_path = repo / case.expected_file
+    return {
+        "case": case.name,
+        "command": command,
+        "returncode": result.returncode,
+        "stdout_tail": "\n".join(result.stdout.splitlines()[-20:]),
+        "stderr_tail": "\n".join(result.stderr.splitlines()[-40:]),
+        "expected_file": case.expected_file,
+        "expected_file_exists": expected_path.exists(),
+        "denied_tools": list(case.deny_tools),
+        "hook_event_count": len(events),
+        "hook_tool_names": _tool_names(events),
+        "hook_log": str(log_path),
+    }
+
+
+def _summarize(results: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "codex_cli_version": _run(["codex", "--version"], cwd=REPO_ROOT).stdout.strip(),
+        "repo_root": str(REPO_ROOT),
+        "manual_source": "Codex manual Hooks section fetched via openai-docs skill",
+        "results": results,
+        "interpretation": {
+            "bash_write_intercepted": any(
+                "Bash" in result["hook_tool_names"] for result in results if result["case"].startswith("bash-write")
+            ),
+            "apply_patch_intercepted": any(
+                any(tool in {"apply_patch", "Edit", "Write"} for tool in result["hook_tool_names"])
+                for result in results
+                if result["case"].startswith("apply-patch")
+            ),
+            "direct_edit_desktop": "Not runnable from this CLI harness; verify with the manual Desktop steps in docs/runbooks/codex-hooks.md.",
+        },
+    }
+
+
+def _self_test() -> int:
+    with tempfile.TemporaryDirectory(prefix="codex-hook-probe-selftest-", dir=TEMP_PARENT) as tmp:
+        repo = _prepare_probe_repo(Path(tmp))
+        hooks = json.loads((repo / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+        command = hooks["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+        assert ".venv/bin/python" in command
+        assert "probe-hook.py" in command
+        assert (repo / ".codex" / "hooks" / "probe-hook.py").exists()
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default=os.environ.get("CODEX_HOOK_PROBE_MODEL"))
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument(
+        "--keep-workdir",
+        action="store_true",
+        help="Keep the temporary probe repo and include its path in the JSON output.",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Validate probe repo generation without invoking Codex.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test:
+        return _self_test()
+
+    if not PROJECT_PYTHON.exists():
+        raise SystemExit(f"missing project interpreter: {PROJECT_PYTHON}")
+    if not shutil.which("codex"):
+        raise SystemExit("codex CLI not found on PATH")
+
+    tmp_path = Path(tempfile.mkdtemp(prefix="codex-hook-probe-", dir=TEMP_PARENT))
+    try:
+        repo = _prepare_probe_repo(tmp_path)
+        results = [_run_case(repo, case, args.model, args.timeout) for case in PROBE_CASES]
+        summary = _summarize(results)
+        if args.keep_workdir:
+            summary["probe_repo"] = str(repo)
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    finally:
+        if not args.keep_workdir:
+            shutil.rmtree(tmp_path, ignore_errors=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_rules_deployment.sh
+++ b/scripts/check_rules_deployment.sh
@@ -91,8 +91,7 @@ check_pair \
     ".claude" \
     "scheduled_tasks.lock" \
     "worktrees" \
-    "folk-epic" \
-    "bio-epic" \
+    "*-epic" \
     "rules/critical-rules.md" \
     "rules/non-negotiable-rules.md" \
     "rules/workflow.md" \
@@ -108,7 +107,7 @@ check_pair \
     "prompts" \
     "tmp" \
     "*-thread-bootstrap.md" \
-    "*-thread-handoff.md" \
+    "*-handoff.md" \
     "*-thread-lease.json" \
     "*-brief.md" \
     "dispatch-*.md" || drift=1

--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -76,10 +76,13 @@ ORPHAN_PATHS_CLAUDE="scheduled_tasks.lock worktrees *-epic"
 ORPHAN_PATHS_AGENT="wake cache prompts tmp *-thread-bootstrap.md *-handoff.md *-thread-lease.json *-brief.md dispatch-*.md"
 ORPHAN_PATHS_AGENTS=""
 # agents/curriculum-orchestrator.toml and agents/curriculum-writer.toml —
-# Codex agent definitions with no shared equivalent.
-# memory/ — Codex-owned durable memory deployed from agents_extensions/codex/.
-# config.toml and hooks.json — Codex CLI configuration files managed directly by Codex.
-ORPHAN_PATHS_CODEX="agents/curriculum-orchestrator.toml agents/curriculum-writer.toml config.toml hooks.json memory"
+# Codex agent definitions with no source equivalent.
+# config.toml — Codex CLI configuration managed directly by Codex.
+ORPHAN_PATHS_CODEX="agents/curriculum-orchestrator.toml agents/curriculum-writer.toml config.toml"
+# Codex overlay paths are managed by agents_extensions/codex/, not by the shared
+# tree. Exclude them from the shared rsync/delete pass, then verify them with the
+# overlay drift check. hooks.json is intentionally here, not in ORPHAN_PATHS_CODEX.
+CODEX_OVERLAY_PATHS="hooks.json memory"
 # tmp/ — Gemini CLI runtime workspace (e.g. .gemini/tmp/learn-ukrainian/);
 #        local working state, NOT a deploy artifact. Preserve across rsync --delete.
 # config.yaml — repository-level Gemini Code Assist for GitHub configuration.
@@ -155,7 +158,7 @@ orphan_fail=false
 check_orphans "$SHARED_EXTENSIONS" ".claude" "$ORPHAN_PATHS_CLAUDE" "$SHARED_EXTENSIONS → .claude" || orphan_fail=true
 check_orphans "$SHARED_EXTENSIONS" ".agent" "$ORPHAN_PATHS_AGENT" "$SHARED_EXTENSIONS → .agent" || orphan_fail=true
 check_orphans "$SHARED_EXTENSIONS/skills" ".agents/skills" "$ORPHAN_PATHS_AGENTS" "$SHARED_EXTENSIONS/skills → .agents/skills" || orphan_fail=true
-check_orphans "$SHARED_EXTENSIONS" ".codex" "$ORPHAN_PATHS_CODEX" "$SHARED_EXTENSIONS → .codex" || orphan_fail=true
+check_orphans "$SHARED_EXTENSIONS" ".codex" "$ORPHAN_PATHS_CODEX $CODEX_OVERLAY_PATHS" "$SHARED_EXTENSIONS → .codex" || orphan_fail=true
 check_orphans "gemini_extensions" ".gemini" "$ORPHAN_PATHS_GEMINI" "gemini_extensions → .gemini" || orphan_fail=true
 check_orphans "$SHARED_EXTENSIONS/rules" ".gemini/rules" "" "$SHARED_EXTENSIONS/rules → .gemini/rules" || orphan_fail=true
 if [[ "$orphan_fail" == true ]]; then
@@ -255,7 +258,7 @@ diff_dirs \
     "$ORPHAN_PATHS_CLAUDE $CLAUDE_RULE_AUTOLOAD_EXCLUDE_PATHS"
 diff_dirs "$SHARED_EXTENSIONS" ".agent" "$SHARED_EXTENSIONS → .agent" "$ORPHAN_PATHS_AGENT"
 diff_dirs "$SHARED_EXTENSIONS/skills" ".agents/skills" "$SHARED_EXTENSIONS/skills → .agents/skills" "$ORPHAN_PATHS_AGENTS"
-diff_dirs "$SHARED_EXTENSIONS" ".codex" "$SHARED_EXTENSIONS → .codex" "$ORPHAN_PATHS_CODEX"
+diff_dirs "$SHARED_EXTENSIONS" ".codex" "$SHARED_EXTENSIONS → .codex" "$ORPHAN_PATHS_CODEX $CODEX_OVERLAY_PATHS"
 if [[ -d "$CODEX_EXTENSIONS" ]]; then
     diff_overlay_files "$CODEX_EXTENSIONS" ".codex" "$CODEX_EXTENSIONS → .codex"
 fi
@@ -280,7 +283,7 @@ rsync -av --delete $(build_excludes "$ORPHAN_PATHS_CLAUDE $CLAUDE_RULE_AUTOLOAD_
 # shellcheck disable=SC2046
 rsync -av --delete $(build_excludes "$ORPHAN_PATHS_AGENT") "$SHARED_EXTENSIONS/" .agent/
 # shellcheck disable=SC2046
-rsync -av --delete $(build_excludes "$ORPHAN_PATHS_CODEX") "$SHARED_EXTENSIONS/" .codex/
+rsync -av --delete $(build_excludes "$ORPHAN_PATHS_CODEX $CODEX_OVERLAY_PATHS") "$SHARED_EXTENSIONS/" .codex/
 if [[ -d "$CODEX_EXTENSIONS" ]]; then
     rsync -av "$CODEX_EXTENSIONS/" .codex/
 fi

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -13,6 +13,7 @@ DEPLOY_SCRIPT = Path("scripts/deploy_prompts.sh")
 CHECK_SCRIPT = Path("scripts/check_rules_deployment.sh")
 DRIFT_TARGET = Path(".claude/rules/pipeline.md")
 CODEX_HOOK_TARGET = Path(".codex/hooks/session-setup.sh")
+CODEX_HOOKS_CONFIG = Path(".codex/hooks.json")
 UNSCOPED_RULE_FILES = (
     "operator-expectations.md",
     "critical-rules.md",
@@ -102,6 +103,10 @@ def test_fresh_deploy_produces_synced_output(tmp_path: Path) -> None:
         f"stdout: {check_result.stdout}\nstderr: {check_result.stderr}"
     )
     assert (repo / CODEX_HOOK_TARGET).exists()
+    assert (repo / CODEX_HOOKS_CONFIG).exists()
+    assert (repo / CODEX_HOOKS_CONFIG).read_text(encoding="utf-8") == (
+        repo / "agents_extensions" / "codex" / "hooks.json"
+    ).read_text(encoding="utf-8")
     assert (repo / ".codex" / "memory" / "MEMORY.md").exists()
     assert (repo / ".gemini/config.yaml").exists()
     deployed_claude_rules = sorted(
@@ -131,6 +136,17 @@ def test_claude_rule_exclusion_list_covers_unscoped_files() -> None:
         assert f'"rules/{filename}"' in script
 
 
+def test_drift_checker_orphan_globs_match_deploy_script() -> None:
+    """The post-deploy drift checker must mirror deploy orphan globs."""
+    deploy = (REPO_ROOT / DEPLOY_SCRIPT).read_text(encoding="utf-8")
+    check = (REPO_ROOT / CHECK_SCRIPT).read_text(encoding="utf-8")
+
+    assert 'ORPHAN_PATHS_CLAUDE="scheduled_tasks.lock worktrees *-epic"' in deploy
+    assert '"*-epic" \\' in check
+    assert "*-handoff.md" in deploy
+    assert '"*-handoff.md" \\' in check
+
+
 def test_second_deploy_is_noop_for_codex_target(tmp_path: Path) -> None:
     """Two consecutive deploys should leave the Codex target unchanged."""
     repo = _init_checkout(tmp_path)
@@ -147,6 +163,35 @@ def test_second_deploy_is_noop_for_codex_target(tmp_path: Path) -> None:
     assert "agents_extensions/shared → .codex: no changes" in second_result.stdout
     assert "agents_extensions/codex → .codex: no changes" in second_result.stdout
     assert "No changes to deploy." in second_result.stdout
+
+
+def test_codex_hooks_json_is_managed_source_not_orphan() -> None:
+    """Codex hooks config must be deployed from agents_extensions/codex."""
+    deploy = (REPO_ROOT / DEPLOY_SCRIPT).read_text(encoding="utf-8")
+    check = (REPO_ROOT / CHECK_SCRIPT).read_text(encoding="utf-8")
+
+    assert (REPO_ROOT / "agents_extensions" / "codex" / "hooks.json").exists()
+    assert 'ORPHAN_PATHS_CODEX="agents/curriculum-orchestrator.toml agents/curriculum-writer.toml config.toml"' in deploy
+    assert 'CODEX_OVERLAY_PATHS="hooks.json memory"' in deploy
+    assert '"hooks.json" \\' in check
+
+
+def test_missing_codex_hooks_json_is_drift(tmp_path: Path) -> None:
+    """The drift checker must fail if runtime .codex/hooks.json disappears."""
+    repo = _init_checkout(tmp_path)
+
+    deploy_result = _run(repo, DEPLOY_SCRIPT)
+    assert deploy_result.returncode == 0, (
+        f"deploy failed:\nstdout: {deploy_result.stdout}\nstderr: {deploy_result.stderr}"
+    )
+
+    (repo / CODEX_HOOKS_CONFIG).unlink()
+
+    check_result = _run(repo, CHECK_SCRIPT)
+    combined_output = f"{check_result.stdout}\n{check_result.stderr}"
+    assert check_result.returncode != 0
+    assert "Deploy-script drift between agents_extensions/codex and .codex" in combined_output
+    assert "Missing deployed overlay file: .codex/hooks.json" in combined_output
 
 
 def test_codex_orphan_is_caught(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Refs #4447.

- Adds `agents_extensions/codex/hooks.json` as the source-controlled Codex hooks overlay and stops treating `.codex/hooks.json` as a destination-only orphan.
- Splits Codex deploy exclusions into true orphans vs overlay-managed paths so `hooks.json` is preserved by the shared rsync phase and verified by the overlay drift checker.
- Adds `scripts/agent_runtime/codex_hook_probe.py` and `docs/runbooks/codex-hooks.md` to empirically distinguish Bash and apply_patch hookability from Desktop/direct-edit behavior.
- Keeps tracked-file write-guard enforcement out of scope for #4448.

## Empirical hook result

Command run from this worktree:

```bash
.venv/bin/python scripts/agent_runtime/codex_hook_probe.py --keep-workdir --timeout 240
```

Observed with Codex CLI `0.142.5`:

- Bash allow: `Bash`, `Bash` hook events; target file created.
- Bash deny: `Bash` hook event; `PreToolUse` exit 2 blocked the write; target file absent.
- apply_patch allow: `apply_patch`, `apply_patch` hook events; target file created.
- apply_patch deny: `apply_patch` hook event; `PreToolUse` exit 2 blocked the write; target file absent.

Desktop/direct edit is documented as a manual verification gap in `docs/runbooks/codex-hooks.md`; this PR does not claim Desktop direct-edit enforcement.

## Verification

- `.venv/bin/python -m pytest tests/test_deploy_script_idempotency.py -q`
- `scripts/deploy_prompts.sh --dry-run`
- `scripts/deploy_prompts.sh`
- `scripts/check_rules_deployment.sh`
- `.venv/bin/python scripts/agent_runtime/codex_hook_probe.py --self-test`
- `.venv/bin/python scripts/agent_runtime/codex_hook_probe.py --keep-workdir --timeout 240`
- `.venv/bin/ruff check scripts/agent_runtime/codex_hook_probe.py tests/test_deploy_script_idempotency.py`
- `.venv/bin/python -m json.tool agents_extensions/codex/hooks.json >/dev/null`
- `bash -n scripts/deploy_prompts.sh scripts/check_rules_deployment.sh`
- `git diff --check`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Review

Independent cross-family review via AGY/Gemini (`review-4447-codex-hooks-deploy-followup`) found two deploy-checker glob mismatches; both are fixed in this PR and covered by `test_drift_checker_orphan_globs_match_deploy_script`.
