### PR TITLE
feat(guardrails): #4444 centralize main-checkout vs worktree containment predicate

### DIFF
--- a/scripts/guardrails/__init__.py
+++ b/scripts/guardrails/__init__.py
@@ -1,0 +1,7 @@
+"""Shared guardrail primitives for agent runtime containment.
+
+Modules here answer cross-cutting safety questions that several enforcement
+layers (provider hooks, the runtime git shim, pre-dispatch checks, Monitor API
+health) must answer identically. Keeping the logic in one place stops
+containment bugs from drifting between reimplementations (issue #4444).
+"""

--- a/scripts/guardrails/worktree_containment.py
+++ b/scripts/guardrails/worktree_containment.py
@@ -1,0 +1,423 @@
+"""Centralized main-checkout vs worktree containment predicate (issue #4444).
+
+Several proposed guardrails need the same answer: is a target path inside the
+protected *primary checkout*, inside an added *worktree*, gitignored *runtime
+state*, or *outside* the repo entirely? If each hook / runtime path / git shim
+reimplements that logic, containment bugs drift apart. This module is the single
+source of truth those layers import instead of duplicating prefix checks.
+
+Design notes
+------------
+* **Canonicalize first.** Every path is resolved to a real absolute path with
+  ``Path.resolve()`` (symlinks followed, ``..`` segments collapsed) *before* any
+  containment comparison. Non-existent leaves resolve lexically against their
+  nearest existing ancestor, so a path about to be created classifies the same
+  as one that already exists.
+* **Ask git, not the filesystem.** The primary root is resolved via
+  ``git rev-parse --git-common-dir`` (the shared object store lives at
+  ``<main_root>/.git``), which is robust from the main checkout, a subdirectory,
+  a ``.worktrees/**`` dispatch worktree, or an unrelated added worktree — all
+  resolve to the *same* primary root. Tracked/ignored status comes from
+  ``git ls-files`` and ``git check-ignore`` semantics, never raw string
+  matching, so ``.gitignore`` edits never desync this module.
+
+Public API
+----------
+* :func:`resolve_main_root` — primary checkout root that owns the shared ``.git``
+* :func:`classify_repo_path` — :data:`PathClass` for any path
+* :func:`is_primary_checkout` — is a cwd/path the protected primary checkout?
+* :func:`is_tracked` / :func:`is_ignored` — git plumbing predicates
+* :func:`evaluate_write` / :func:`is_write_allowed` — write-guard decision
+
+Downstream guardrail issues (#4448 hooks, #4449 monitor, #4450 git shim) import
+these helpers rather than re-deriving containment.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+__all__ = [
+    "PROTECTED_BRANCHES",
+    "NotAGitRepositoryError",
+    "PathClass",
+    "WriteDecision",
+    "canonicalize",
+    "classify_repo_path",
+    "current_branch",
+    "evaluate_write",
+    "is_dispatch_worktree",
+    "is_ignored",
+    "is_primary_checkout",
+    "is_protected_branch",
+    "is_tracked",
+    "is_write_allowed",
+    "registered_worktrees",
+    "resolve_main_root",
+]
+
+# A path is exactly one of these relative to the primary checkout:
+#   primary_checkout  – inside the protected main checkout (NOT under .worktrees)
+#   dispatch_worktree – inside <main>/.worktrees/dispatch/<agent>/<task>/...
+#   other_worktree    – any other registered worktree (flat .worktrees/* or an
+#                       externally-located worktree sharing the same .git store)
+#   outside_repo      – not inside the primary checkout or any known worktree
+PathClass = Literal[
+    "primary_checkout",
+    "dispatch_worktree",
+    "other_worktree",
+    "outside_repo",
+]
+
+# Branches on which the primary checkout must stay clean. Consumers gate their
+# enforcement on this (hooks/#4448, monitor/#4449, git shim/#4450 all speak of
+# "a protected branch"); containment classification itself is branch-agnostic.
+PROTECTED_BRANCHES: frozenset[str] = frozenset({"main", "master"})
+
+# Git env vars that redirect discovery away from ``-C <dir>``. Stripping them
+# lets a caller running inside a hook (which may export GIT_DIR/GIT_WORK_TREE)
+# still resolve the repo implied by the directory we pass. Mirrors
+# delegate.py::_GIT_ENV_DENYLIST.
+_GIT_ENV_DENYLIST = frozenset({
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_COMMON_DIR",
+})
+
+
+@dataclass(frozen=True)
+class WriteDecision:
+    """Outcome of a write-guard evaluation.
+
+    ``allowed`` is the boolean decision. ``reason`` is a stable snake_case code
+    (safe to branch on). ``path_class`` is the underlying classification.
+    ``message`` is operator/agent-facing guidance (populated on denial).
+    """
+
+    allowed: bool
+    reason: str
+    path_class: PathClass
+    message: str = ""
+
+
+# ---------------------------------------------------------------------------
+# git helpers
+# ---------------------------------------------------------------------------
+
+def _sanitized_git_env() -> dict[str, str]:
+    """Drop repo-redirecting Git env so ``-C <dir>`` resolves that repo."""
+    return {k: v for k, v in os.environ.items() if k not in _GIT_ENV_DENYLIST}
+
+
+def _run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run a read-only git command scoped to ``cwd`` with sanitized env."""
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_sanitized_git_env(),
+    )
+
+
+def _git_dir_for(path: Path) -> Path:
+    """Directory to hand to ``git -C`` for ``path`` (its parent if a file)."""
+    real = canonicalize(path)
+    return real if real.is_dir() else real.parent
+
+
+# ---------------------------------------------------------------------------
+# canonicalization + root resolution
+# ---------------------------------------------------------------------------
+
+def canonicalize(path: Path | str) -> Path:
+    """Resolve ``path`` to a real absolute path.
+
+    Follows symlinks and collapses ``..`` for the portion that exists; any
+    non-existent leaf is appended lexically (``..`` still collapsed). This is
+    what lets a not-yet-created file be classified the same as an existing one,
+    and neutralizes both symlink escapes and ``..`` escapes before containment
+    checks (``Path.resolve`` is non-strict on Python 3.6+).
+    """
+    return Path(path).expanduser().resolve()
+
+
+class NotAGitRepositoryError(RuntimeError):
+    """Raised by :func:`resolve_main_root` when ``start`` is not in a repo."""
+
+
+def _resolve_main_root_or_none(start: Path) -> Path | None:
+    """Primary checkout root for ``start``, or None if it is not in a repo.
+
+    Prefers ``git rev-parse --git-common-dir`` (the common dir is
+    ``<main_root>/.git``); if git is unavailable it falls back to walking
+    ``.git`` links on disk. Returns None — never a fabricated root — when
+    nothing git-owned is found, so out-of-repo paths classify honestly.
+    """
+    start_dir = _git_dir_for(start)
+
+    proc = _run_git(start_dir, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    if proc.returncode == 0:
+        common = proc.stdout.strip()
+        if common:
+            common_dir = canonicalize(Path(common))
+            # A non-bare repo's common dir is ``<main_root>/.git``.
+            if common_dir.name == ".git":
+                return common_dir.parent
+            # Bare repo / unusual layout: the working root is the toplevel.
+            top = _run_git(start_dir, "rev-parse", "--show-toplevel")
+            if top.returncode == 0 and top.stdout.strip():
+                return canonicalize(Path(top.stdout.strip()))
+
+    return _fs_main_root(start_dir)
+
+
+def resolve_main_root(start: Path | str | None = None) -> Path:
+    """Return the primary checkout root that owns the shared ``.git`` store.
+
+    Robust from anywhere in the tree: the main checkout, a subdirectory, a
+    ``.worktrees/**`` dispatch worktree, or an externally-located added
+    worktree all resolve to the *same* root. ``start`` defaults to the process
+    cwd. Raises :class:`NotAGitRepositoryError` if ``start`` is not inside a
+    git repository — soft callers should use :func:`classify_repo_path`,
+    :func:`is_primary_checkout`, or the internal helper instead.
+    """
+    origin = Path(start) if start is not None else Path.cwd()
+    root = _resolve_main_root_or_none(origin)
+    if root is None:
+        raise NotAGitRepositoryError(f"{origin} is not inside a git repository")
+    return root
+
+
+def _fs_main_root(start_dir: Path) -> Path | None:
+    """Filesystem fallback when git is unavailable.
+
+    Walks upward from ``start_dir`` for a ``.git`` entry. A ``.git`` *directory*
+    marks a primary checkout. A ``.git`` *file* points at a worktree gitdir; if
+    that lives under ``<root>/.git/worktrees/<name>`` the primary root is that
+    outer ``<root>``. Returns None when no ``.git`` is found upward.
+    """
+    for candidate in (start_dir, *start_dir.parents):
+        git_path = candidate / ".git"
+        if git_path.is_dir():
+            return candidate
+        if git_path.is_file():
+            try:
+                first = git_path.read_text().splitlines()[0]
+            except (IndexError, OSError):
+                continue
+            prefix = "gitdir:"
+            if not first.startswith(prefix):
+                continue
+            git_dir = Path(first[len(prefix):].strip())
+            if not git_dir.is_absolute():
+                git_dir = candidate / git_dir
+            git_dir = canonicalize(git_dir)
+            if git_dir.parent.name == "worktrees" and git_dir.parent.parent.name == ".git":
+                return git_dir.parent.parent.parent
+            return candidate
+    return None
+
+
+def registered_worktrees(main_root: Path) -> list[Path]:
+    """Canonical paths of every worktree registered with ``main_root``.
+
+    Includes the primary checkout itself (first entry). Empty list if git is
+    unavailable; callers fall back to structural ``.worktrees/**`` checks.
+    """
+    proc = _run_git(main_root, "worktree", "list", "--porcelain")
+    if proc.returncode != 0:
+        return []
+    roots: list[Path] = []
+    for line in proc.stdout.splitlines():
+        if line.startswith("worktree "):
+            roots.append(canonicalize(Path(line[len("worktree "):].strip())))
+    return roots
+
+
+# ---------------------------------------------------------------------------
+# containment classification
+# ---------------------------------------------------------------------------
+
+def _is_within(path: Path, base: Path) -> bool:
+    """True if ``path`` is ``base`` or nested under it (both pre-canonicalized)."""
+    return path == base or path.is_relative_to(base)
+
+
+def classify_repo_path(path: Path | str, cwd: Path | str | None = None) -> PathClass:
+    """Classify ``path`` relative to the primary checkout.
+
+    ``cwd`` (defaulting to the process cwd) only anchors *which* repo we resolve
+    the primary root from; the classification is about ``path`` itself. Returns
+    one of :data:`PathClass`.
+    """
+    target = canonicalize(path)
+    anchor = canonicalize(cwd) if cwd is not None else Path.cwd().resolve()
+    main_root = _resolve_main_root_or_none(anchor)
+    if main_root is None:
+        # The anchor is not in any repo (e.g. classifying a bare tmp path with
+        # a non-repo cwd). Fall back to resolving from the target itself.
+        main_root = _resolve_main_root_or_none(target)
+        if main_root is None:
+            return "outside_repo"
+    worktrees_dir = main_root / ".worktrees"
+
+    # The ``.worktrees/**`` subtree is classified structurally so a dispatch
+    # directory an agent is about to create (not yet a registered worktree)
+    # still reads as an allowed dispatch location.
+    if _is_within(target, worktrees_dir):
+        rel = target.relative_to(worktrees_dir)
+        if rel.parts and rel.parts[0] == "dispatch":
+            return "dispatch_worktree"
+        return "other_worktree"
+
+    # Any other registered worktree sharing this .git store — e.g. an
+    # externally-located worktree under ~/.codex/worktrees/... — is isolated
+    # from the primary checkout and therefore an allowed write location.
+    for worktree in registered_worktrees(main_root):
+        if worktree == main_root:
+            continue
+        if _is_within(target, worktree):
+            return "other_worktree"
+
+    if _is_within(target, main_root):
+        return "primary_checkout"
+
+    return "outside_repo"
+
+
+def is_primary_checkout(path_or_cwd: Path | str | None = None) -> bool:
+    """True if ``path_or_cwd`` (default: process cwd) is the primary checkout."""
+    target = Path(path_or_cwd) if path_or_cwd is not None else Path.cwd()
+    return classify_repo_path(target, cwd=target) == "primary_checkout"
+
+
+def is_dispatch_worktree(path_or_cwd: Path | str | None = None) -> bool:
+    """True if ``path_or_cwd`` is inside a ``.worktrees/dispatch/**`` worktree."""
+    target = Path(path_or_cwd) if path_or_cwd is not None else Path.cwd()
+    return classify_repo_path(target, cwd=target) == "dispatch_worktree"
+
+
+# ---------------------------------------------------------------------------
+# tracked / ignored plumbing
+# ---------------------------------------------------------------------------
+
+def _relpath_in_root(path: Path, main_root: Path) -> str | None:
+    """``path`` expressed relative to ``main_root``, or None if not contained.
+
+    A relative pathspec avoids /var vs /private/var canonicalization skew
+    between what git reports and what we resolve.
+    """
+    real = canonicalize(path)
+    try:
+        return str(real.relative_to(main_root))
+    except ValueError:
+        return None
+
+
+def is_tracked(path: Path | str, main_root: Path | None = None) -> bool:
+    """True if ``path`` is a file tracked in the primary checkout's index."""
+    root = canonicalize(main_root) if main_root is not None else _resolve_main_root_or_none(Path(path))
+    if root is None:
+        return False
+    rel = _relpath_in_root(Path(path), root)
+    if rel is None:
+        return False
+    proc = _run_git(root, "ls-files", "--error-unmatch", "--", rel)
+    return proc.returncode == 0
+
+
+def is_ignored(path: Path | str, main_root: Path | None = None) -> bool:
+    """True if ``path`` matches a gitignore rule in the primary checkout."""
+    root = canonicalize(main_root) if main_root is not None else _resolve_main_root_or_none(Path(path))
+    if root is None:
+        return False
+    rel = _relpath_in_root(Path(path), root)
+    if rel is None:
+        return False
+    # -q: quiet, exit 0 == ignored, 1 == not ignored, 128 == error.
+    proc = _run_git(root, "check-ignore", "-q", "--", rel)
+    return proc.returncode == 0
+
+
+def current_branch(root: Path | str | None = None) -> str | None:
+    """Current branch name of the checkout at ``root``, or None if detached."""
+    start = _git_dir_for(Path(root) if root is not None else Path.cwd())
+    proc = _run_git(start, "symbolic-ref", "--quiet", "--short", "HEAD")
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def is_protected_branch(root: Path | str | None = None) -> bool:
+    """True if the checkout at ``root`` is on a :data:`PROTECTED_BRANCHES` branch."""
+    branch = current_branch(root)
+    return branch is not None and branch in PROTECTED_BRANCHES
+
+
+# ---------------------------------------------------------------------------
+# write-guard decision
+# ---------------------------------------------------------------------------
+
+_WORKTREE_HINT = (
+    "Primary checkout is protected. Create and cd into a dispatch worktree "
+    "(.worktrees/dispatch/<agent>/<task>/) before writing."
+)
+
+
+def evaluate_write(path: Path | str, cwd: Path | str | None = None) -> WriteDecision:
+    """Decide whether a write to ``path`` is allowed, with full detail.
+
+    Writes are allowed everywhere except tracked or untracked-and-not-ignored
+    files inside the primary checkout — both would dirty the protected tree.
+    Gitignored local/runtime state inside the primary checkout is allowed.
+    """
+    path_class = classify_repo_path(path, cwd=cwd)
+
+    if path_class != "primary_checkout":
+        # Worktrees (dispatch or otherwise) and out-of-repo paths are isolated
+        # from the protected tree.
+        return WriteDecision(allowed=True, reason=path_class, path_class=path_class)
+
+    # class == primary_checkout guarantees the target resolved under a real
+    # primary root; resolve it once and reuse for both plumbing calls.
+    anchor = canonicalize(cwd) if cwd is not None else canonicalize(path)
+    main_root = _resolve_main_root_or_none(anchor) or _resolve_main_root_or_none(canonicalize(path))
+    if is_tracked(path, main_root):
+        return WriteDecision(
+            allowed=False,
+            reason="tracked_primary_checkout",
+            path_class=path_class,
+            message=_WORKTREE_HINT,
+        )
+    if is_ignored(path, main_root):
+        return WriteDecision(
+            allowed=True,
+            reason="gitignored_local_state",
+            path_class=path_class,
+        )
+    # Untracked and not ignored: creating/writing this dirties the primary
+    # working tree with a new file. Blocked with a distinct reason so a
+    # consumer that only cares about tracked files (e.g. #4448) can branch.
+    return WriteDecision(
+        allowed=False,
+        reason="untracked_primary_checkout",
+        path_class=path_class,
+        message=_WORKTREE_HINT,
+    )
+
+
+def is_write_allowed(path: Path | str, cwd: Path | str | None = None) -> tuple[bool, str]:
+    """``(allowed, reason)`` for a write to ``path`` — see :func:`evaluate_write`."""
+    decision = evaluate_write(path, cwd=cwd)
+    return decision.allowed, decision.reason

--- a/tests/test_worktree_containment.py
+++ b/tests/test_worktree_containment.py
@@ -1,0 +1,278 @@
+"""Tests for the centralized worktree containment predicate (issue #4444).
+
+These build *real* git repositories and worktrees in ``tmp_path`` rather than
+faking ``.git`` files, because the module deliberately relies on git plumbing
+(``rev-parse --git-common-dir``, ``ls-files``, ``check-ignore``,
+``worktree list``) rather than string prefixes.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from scripts.guardrails import worktree_containment as wc
+
+
+def _clean_env() -> dict[str, str]:
+    """Env with git-redirect vars stripped.
+
+    Under ``pre-commit`` / a git hook the process inherits ``GIT_DIR``,
+    ``GIT_WORK_TREE``, ``GIT_INDEX_FILE``, etc. pointing at the repo being
+    committed. Those would hijack the throwaway repos this test builds (``-C``
+    alone does not override them), so we scrub them for every git subprocess —
+    the same denylist the module applies internally.
+    """
+    return {k: v for k, v in os.environ.items() if k not in wc._GIT_ENV_DENYLIST}
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True, capture_output=True, text=True, env=_clean_env(),
+    )
+
+
+@dataclass(frozen=True)
+class Layout:
+    main: Path              # primary checkout root
+    dispatch_wt: Path       # .worktrees/dispatch/claude/task-1 (registered)
+    flat_wt: Path           # .worktrees/legacy (registered, non-dispatch)
+    external_wt: Path       # <tmp>/external-wt (registered, outside .worktrees)
+    outside: Path           # <tmp>/outside (plain dir, not a repo)
+
+
+@pytest.fixture
+def layout(tmp_path: Path) -> Layout:
+    main = tmp_path / "main"
+    main.mkdir()
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(main)],
+        check=True, capture_output=True, text=True, env=_clean_env(),
+    )
+    _git(main, "config", "user.email", "test@example.com")
+    _git(main, "config", "user.name", "Test")
+
+    # Tracked content + gitignore rules covering runtime/local state.
+    (main / ".gitignore").write_text(".worktrees/\nbuild/\n*.log\nlocal_state/\n")
+    (main / "tracked.txt").write_text("tracked\n")
+    (main / "pkg").mkdir()
+    (main / "pkg" / "module.py").write_text("x = 1\n")
+    _git(main, "add", "-A")
+    _git(main, "commit", "-q", "-m", "init")
+
+    # Real registered worktrees: a dispatch one, a flat non-dispatch one under
+    # .worktrees, and an externally-located one sharing the same .git store.
+    dispatch_wt = main / ".worktrees" / "dispatch" / "claude" / "task-1"
+    _git(main, "worktree", "add", "-q", "-b", "claude/task-1", str(dispatch_wt))
+    flat_wt = main / ".worktrees" / "legacy"
+    _git(main, "worktree", "add", "-q", "-b", "legacy", str(flat_wt))
+    external_wt = tmp_path / "external-wt"
+    _git(main, "worktree", "add", "-q", "-b", "ext", str(external_wt))
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    return Layout(
+        main=wc.canonicalize(main),
+        dispatch_wt=wc.canonicalize(dispatch_wt),
+        flat_wt=wc.canonicalize(flat_wt),
+        external_wt=wc.canonicalize(external_wt),
+        outside=wc.canonicalize(outside),
+    )
+
+
+# ---------------------------------------------------------------------------
+# resolve_main_root — same primary root from anywhere
+# ---------------------------------------------------------------------------
+
+def test_resolve_main_root_is_stable_from_every_vantage(layout: Layout):
+    assert wc.resolve_main_root(layout.main) == layout.main
+    assert wc.resolve_main_root(layout.main / "pkg") == layout.main
+    # From an added worktree we still resolve the SAME primary root (AC).
+    assert wc.resolve_main_root(layout.dispatch_wt) == layout.main
+    assert wc.resolve_main_root(layout.dispatch_wt / "pkg") == layout.main
+    assert wc.resolve_main_root(layout.external_wt) == layout.main
+
+
+def test_resolve_main_root_raises_outside_repo(layout: Layout):
+    with pytest.raises(wc.NotAGitRepositoryError):
+        wc.resolve_main_root(layout.outside)
+
+
+# ---------------------------------------------------------------------------
+# classify_repo_path
+# ---------------------------------------------------------------------------
+
+def test_tracked_file_in_primary_checkout_is_protected(layout: Layout):
+    tracked = layout.main / "tracked.txt"
+    assert wc.classify_repo_path(tracked, cwd=layout.main) == "primary_checkout"
+    assert wc.is_tracked(tracked, layout.main) is True
+    allowed, reason = wc.is_write_allowed(tracked, cwd=layout.main)
+    assert allowed is False
+    assert reason == "tracked_primary_checkout"
+    decision = wc.evaluate_write(tracked, cwd=layout.main)
+    assert decision.message  # actionable guidance is populated on denial
+    assert ".worktrees/dispatch" in decision.message
+
+
+def test_gitignored_local_state_is_allowed(layout: Layout):
+    ignored = layout.main / "build" / "out.txt"
+    assert wc.classify_repo_path(ignored, cwd=layout.main) == "primary_checkout"
+    assert wc.is_ignored(ignored, layout.main) is True
+    assert wc.is_tracked(ignored, layout.main) is False
+    allowed, reason = wc.is_write_allowed(ignored, cwd=layout.main)
+    assert allowed is True
+    assert reason == "gitignored_local_state"
+
+
+def test_untracked_non_ignored_in_primary_checkout_is_blocked(layout: Layout):
+    scratch = layout.main / "scratch_new.txt"
+    assert wc.classify_repo_path(scratch, cwd=layout.main) == "primary_checkout"
+    assert wc.is_tracked(scratch, layout.main) is False
+    assert wc.is_ignored(scratch, layout.main) is False
+    allowed, reason = wc.is_write_allowed(scratch, cwd=layout.main)
+    assert allowed is False
+    assert reason == "untracked_primary_checkout"
+
+
+def test_dispatch_worktree_path_is_allowed(layout: Layout):
+    target = layout.dispatch_wt / "pkg" / "module.py"
+    assert wc.classify_repo_path(target, cwd=layout.main) == "dispatch_worktree"
+    assert wc.is_dispatch_worktree(target) is True
+    allowed, reason = wc.is_write_allowed(target, cwd=layout.main)
+    assert allowed is True
+    assert reason == "dispatch_worktree"
+
+
+def test_dispatch_path_allowed_even_before_worktree_exists(layout: Layout):
+    # An agent is about to create .worktrees/dispatch/agy/future/ — structural
+    # classification must already treat it as an allowed dispatch location.
+    future = layout.main / ".worktrees" / "dispatch" / "agy" / "future" / "new.py"
+    assert wc.classify_repo_path(future, cwd=layout.main) == "dispatch_worktree"
+    assert wc.is_write_allowed(future, cwd=layout.main)[0] is True
+
+
+def test_non_dispatch_worktree_paths_are_other_worktree(layout: Layout):
+    flat = layout.flat_wt / "tracked.txt"
+    ext = layout.external_wt / "tracked.txt"
+    assert wc.classify_repo_path(flat, cwd=layout.main) == "other_worktree"
+    assert wc.classify_repo_path(ext, cwd=layout.main) == "other_worktree"
+    assert wc.is_write_allowed(flat, cwd=layout.main) == (True, "other_worktree")
+    assert wc.is_write_allowed(ext, cwd=layout.main) == (True, "other_worktree")
+
+
+def test_outside_repo_path(layout: Layout):
+    target = layout.outside / "note.txt"
+    assert wc.classify_repo_path(target, cwd=layout.main) == "outside_repo"
+    assert wc.is_write_allowed(target, cwd=layout.main) == (True, "outside_repo")
+
+
+# ---------------------------------------------------------------------------
+# canonicalization: symlink + ".." escapes
+# ---------------------------------------------------------------------------
+
+def test_symlink_escape_is_classified_by_real_target(layout: Layout, tmp_path: Path):
+    outside_target = tmp_path / "escape_target"
+    outside_target.mkdir()
+    link = layout.main / "escape"
+    link.symlink_to(outside_target)
+    # Path is lexically "inside" main, but the symlink lands outside the repo.
+    escaped = link / "secret.txt"
+    assert wc.classify_repo_path(escaped, cwd=layout.main) == "outside_repo"
+
+
+def test_symlink_staying_inside_is_primary_checkout(layout: Layout):
+    link = layout.main / "inward"
+    link.symlink_to(layout.main / "pkg")
+    target = link / "module.py"
+    assert wc.classify_repo_path(target, cwd=layout.main) == "primary_checkout"
+    # And it resolves to the tracked file, so writes are blocked.
+    assert wc.is_write_allowed(target, cwd=layout.main)[0] is False
+
+
+def test_dotdot_escape_is_classified_outside(layout: Layout):
+    escaped = layout.main / "pkg" / ".." / ".." / "outside" / "x.txt"
+    assert wc.classify_repo_path(escaped, cwd=layout.main) == "outside_repo"
+
+
+def test_dotdot_staying_inside_resolves_to_primary_checkout(layout: Layout):
+    inside = layout.main / "pkg" / ".." / "tracked.txt"
+    assert wc.classify_repo_path(inside, cwd=layout.main) == "primary_checkout"
+    assert wc.is_write_allowed(inside, cwd=layout.main)[1] == "tracked_primary_checkout"
+
+
+# ---------------------------------------------------------------------------
+# missing-path parent resolution
+# ---------------------------------------------------------------------------
+
+def test_missing_path_under_untracked_dir_is_blocked(layout: Layout):
+    # Parent dir does not exist yet; must still classify + decide.
+    missing = layout.main / "newpkg" / "deeply" / "new_module.py"
+    assert wc.classify_repo_path(missing, cwd=layout.main) == "primary_checkout"
+    assert wc.is_write_allowed(missing, cwd=layout.main) == (
+        False,
+        "untracked_primary_checkout",
+    )
+
+
+def test_missing_path_under_ignored_dir_is_allowed(layout: Layout):
+    missing = layout.main / "build" / "sub" / "artifact.log"
+    assert wc.is_ignored(missing, layout.main) is True
+    assert wc.is_write_allowed(missing, cwd=layout.main) == (
+        True,
+        "gitignored_local_state",
+    )
+
+
+# ---------------------------------------------------------------------------
+# is_primary_checkout / branch helpers
+# ---------------------------------------------------------------------------
+
+def test_is_primary_checkout_matrix(layout: Layout):
+    assert wc.is_primary_checkout(layout.main) is True
+    assert wc.is_primary_checkout(layout.main / "pkg") is True
+    assert wc.is_primary_checkout(layout.dispatch_wt) is False
+    assert wc.is_primary_checkout(layout.external_wt) is False
+    assert wc.is_primary_checkout(layout.outside) is False
+
+
+def test_branch_helpers(layout: Layout):
+    assert wc.current_branch(layout.main) == "main"
+    assert wc.is_protected_branch(layout.main) is True
+    # Dispatch worktree sits on an agent branch, never protected.
+    assert wc.current_branch(layout.dispatch_wt) == "claude/task-1"
+    assert wc.is_protected_branch(layout.dispatch_wt) is False
+
+
+# ---------------------------------------------------------------------------
+# read-only invocation must not mutate anything
+# ---------------------------------------------------------------------------
+
+def test_read_only_operations_do_not_dirty_the_checkout(layout: Layout):
+    before = _git(layout.main, "status", "--porcelain").stdout
+    # Exercise the full surface from the repo root.
+    wc.classify_repo_path(layout.main / "tracked.txt", cwd=layout.main)
+    wc.is_write_allowed(layout.main / "tracked.txt", cwd=layout.main)
+    wc.is_primary_checkout(layout.main)
+    wc.registered_worktrees(layout.main)
+    after = _git(layout.main, "status", "--porcelain").stdout
+    assert before == after
+
+
+def test_module_is_robust_to_hostile_git_env(layout: Layout, monkeypatch):
+    # Consumers (#4448 hooks, #4450 git shim) run inside git hooks where GIT_DIR
+    # etc. point elsewhere. The module must scrub them, so resolution/decisions
+    # stay correct regardless of the ambient (redirecting) git environment.
+    monkeypatch.setenv("GIT_DIR", str(layout.external_wt / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(layout.external_wt))
+    assert wc.resolve_main_root(layout.main / "pkg") == layout.main
+    assert wc.classify_repo_path(layout.main / "tracked.txt", cwd=layout.main) == "primary_checkout"
+    assert wc.is_write_allowed(layout.main / "tracked.txt", cwd=layout.main) == (
+        False,
+        "tracked_primary_checkout",
+    )


### PR DESCRIPTION
## What

Implements #4444 — a single shared module, `scripts/guardrails/worktree_containment.py`, that answers the one question every proposed guardrail needs: is a target path inside the protected **primary checkout**, inside an added **worktree**, gitignored **runtime state**, or **outside** the repo? Centralizing it stops containment bugs from drifting between reimplementations.

## Public API

- `resolve_main_root(start)` — robust primary-root resolution via `git rev-parse --git-common-dir`. Returns the **same** root from the main checkout, a subdir, a `.worktrees/**` dispatch worktree, or an externally-located added worktree. Raises `NotAGitRepositoryError` outside a repo.
- `classify_repo_path(path, cwd=None)` → `primary_checkout` | `dispatch_worktree` | `other_worktree` | `outside_repo`. Canonicalizes symlinks and `..` **before** any containment comparison.
- `is_primary_checkout(...)` / `is_dispatch_worktree(...)` predicates.
- `is_tracked(...)` / `is_ignored(...)` — `git ls-files` / `git check-ignore` plumbing, never raw prefix checks, so `.gitignore` edits can't desync the module.
- `evaluate_write(...)` / `is_write_allowed(...)` → `(allowed, reason)`. Allows worktree, out-of-repo, and gitignored local-state writes; blocks tracked **and** untracked-non-ignored primary-checkout writes (both dirty the protected tree), with distinct reason codes so a tracked-only consumer (#4448) can branch on `reason`.
- `current_branch(...)` / `is_protected_branch(...)` — the "protected branch" gate every consumer references.

## Design notes

- **Canonicalize first**, so a not-yet-created file classifies the same as an existing one, and symlink / `..` escapes are neutralized before comparison.
- **Ask git, not the filesystem**, for both root resolution and tracked/ignored status.
- **Hook-safe**: every git subprocess strips repo-redirecting env vars (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, ...), so the predicate stays correct when called from inside a git hook — the exact environment #4448/#4450 enforce in. (This bit me during the pre-commit run and is now covered by a test.)

## Scope

Predicate + tests only. No dependent-issue enforcement behavior (#4448/#4449/#4450) is implemented here; those import this module. Read-only operations from repo root are never blocked — the module only returns classifications/decisions.

## Tests (`tests/test_worktree_containment.py`, 19 cases)

Build **real** git repos + worktrees in `tmp_path` and cover: tracked-file protection, gitignored local state, dispatch / non-dispatch / external worktrees, outside-repo, symlink + `..` escapes (both directions), missing-path parent resolution, read-only non-mutation, stable root from an added worktree, and hostile-git-env robustness.

## Verification

- `.venv/bin/python -m pytest tests/test_worktree_containment.py -q` → **19 passed** (also green under simulated `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` hook env)
- `.venv/bin/ruff check` → clean
- `git diff --check` → clean
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` → PASS

Refs #4444

🤖 Generated with [Claude Code](https://claude.com/claude-code)