### PR TITLE
fix(audit): replay grounding/admissibility gates on cache hits

### DIFF
--- a/docs/projects/ua-eval-harness/README.md
+++ b/docs/projects/ua-eval-harness/README.md
@@ -55,6 +55,7 @@ These are NOT the harness, but they are the scorer-side foundation:
   deterministic, UA-GEC-fixture, and LLM-placeholder adapter layer.
 - [Cost-aware curriculum QG workflow](cost-aware-qg-workflow.md) documents the
   #4310 tiered, short-circuiting workflow and composite LLM cache key.
+  Tier-2 reviewer retries are capped at <=3 calls/module: initial + one theatre retry + one deep-read retry.
 - [Agent fleet evidence for #4307](agent-fleet-4307.md) records the concrete
   fleet lanes used for the schema slice and the observed strengths/weaknesses.
 - [Model evidence](model-evidence.md) — per-model probe results (Gemma 4 bakeoff,

--- a/scripts/audit/llm_qg_store.py
+++ b/scripts/audit/llm_qg_store.py
@@ -31,6 +31,7 @@ CONTENT_FILES = ("module.md", "activities.yaml", "vocabulary.yaml", "resources.y
 EVIDENCE_SCHEMA_VERSION = "llm_qg_evidence.v1"
 SUPPORTED_EVIDENCE_GATE_VERSIONS = frozenset({"v7.llm_qg.1"})
 DIMENSION_ORDER = ("pedagogical", "naturalness", "decolonization", "engagement", "tone")
+TOOL_EVENT_KEYS = ("tool", "input", "status", "tool_call_id", "output")
 
 
 @dataclass(frozen=True, slots=True)
@@ -53,6 +54,7 @@ class StoredQG:
     tool_call_count: int = 0
     tools_used: tuple[str, ...] = ()
     route_name: str | None = None
+    tool_events: tuple[dict[str, Any], ...] | None = None
 
     def is_current_for(self, module_dir: Path) -> bool:
         return self.content_sha == content_sha_for_module(module_dir)
@@ -197,6 +199,7 @@ def _ensure_composite_columns(conn: sqlite3.Connection) -> None:
         "route_name": "TEXT",
         "tool_call_count": "INTEGER",
         "tools_used_json": "TEXT",
+        "tool_events_json": "TEXT",
     }
     for name, column_type in additions.items():
         if name not in existing:
@@ -237,6 +240,16 @@ def _finding_category(item: dict[str, Any]) -> Any:
     )
 
 
+def _normalize_tool_events(tool_events: Sequence[Mapping[str, Any]]) -> tuple[dict[str, Any], ...]:
+    """Return the replayable subset of normalized dispatch tool events."""
+    normalized: list[dict[str, Any]] = []
+    for event in tool_events:
+        if not isinstance(event, Mapping):
+            continue
+        normalized.append({key: event.get(key) for key in TOOL_EVENT_KEYS})
+    return tuple(normalized)
+
+
 def record_llm_qg(
     *,
     level: str,
@@ -252,6 +265,7 @@ def record_llm_qg(
     route_name: str | None = None,
     tool_call_count: int = 0,
     tools_used: Sequence[str] = (),
+    tool_events: Sequence[Mapping[str, Any]] = (),
     source: str = "pipeline",
     run_id: str | None = None,
     path: Path | None = None,
@@ -267,6 +281,7 @@ def record_llm_qg(
     findings = _iter_findings(payload)
     tools_used_tuple = tuple(str(tool) for tool in tools_used)
     tool_call_count_int = int(tool_call_count)
+    normalized_tool_events = _normalize_tool_events(tool_events)
 
     with closing(connect_sqlite(str(resolved))) as conn:
         conn.execute("PRAGMA foreign_keys = ON")
@@ -277,11 +292,11 @@ def record_llm_qg(
                 run_id, created_at, level, slug, content_sha, gate_version,
                 prompt_hash, checker_version, level_policy_family,
                 reviewer_model, reviewer_family, route_name,
-                tool_call_count, tools_used_json,
+                tool_call_count, tools_used_json, tool_events_json,
                 source, verdict, terminal_verdict,
                 min_score, min_dim, payload_json
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(run_id) DO UPDATE SET
                 created_at = excluded.created_at,
                 level = excluded.level,
@@ -296,6 +311,7 @@ def record_llm_qg(
                 route_name = excluded.route_name,
                 tool_call_count = excluded.tool_call_count,
                 tools_used_json = excluded.tools_used_json,
+                tool_events_json = excluded.tool_events_json,
                 source = excluded.source,
                 verdict = excluded.verdict,
                 terminal_verdict = excluded.terminal_verdict,
@@ -318,6 +334,7 @@ def record_llm_qg(
                 route_name,
                 tool_call_count_int,
                 _json_dumps(list(tools_used_tuple)),
+                _json_dumps(list(normalized_tool_events)),
                 source,
                 aggregate.get("verdict"),
                 aggregate.get("terminal_verdict"),
@@ -366,6 +383,7 @@ def record_llm_qg(
         tool_call_count=tool_call_count_int,
         tools_used=tools_used_tuple,
         route_name=route_name,
+        tool_events=normalized_tool_events,
     )
 
 
@@ -390,6 +408,19 @@ def _tools_used_from_row(row: sqlite3.Row) -> tuple[str, ...]:
     return tuple(str(item) for item in loaded)
 
 
+def _tool_events_from_row(row: sqlite3.Row) -> tuple[dict[str, Any], ...] | None:
+    raw = _row_key(row, "tool_events_json")
+    if raw is None:
+        return None
+    try:
+        loaded = json.loads(str(raw))
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(loaded, list):
+        return None
+    return _normalize_tool_events(item for item in loaded if isinstance(item, Mapping))
+
+
 def _row_to_record(row: sqlite3.Row) -> StoredQG:
     raw_tool_count = _row_key(row, "tool_call_count")
     return StoredQG(
@@ -409,6 +440,7 @@ def _row_to_record(row: sqlite3.Row) -> StoredQG:
         tool_call_count=int(raw_tool_count) if raw_tool_count is not None else 0,
         tools_used=_tools_used_from_row(row),
         route_name=_row_key(row, "route_name"),
+        tool_events=_tool_events_from_row(row),
     )
 
 

--- a/scripts/audit/llm_reviewer_dispatch.py
+++ b/scripts/audit/llm_reviewer_dispatch.py
@@ -954,7 +954,7 @@ def tool_theatre_violation(
     if (
         isinstance(tools_used, Sequence)
         and not isinstance(tools_used, (str, bytes))
-        and any(_is_source_tool(str(tool)) for tool in tools_used)
+        and any(_source_tool_name_relevant(str(tool), claim_tokens) for tool in tools_used)
     ):
         return None
     return {"status": INVALID_TOOL_THEATRE, "reason": "no_relevant_source_tool_calls"}
@@ -1114,6 +1114,14 @@ def _source_event_relevant(event: Mapping[str, Any], claim_tokens: set[str]) -> 
     if not claim_tokens:
         return True
     return bool(claim_tokens.intersection(_event_query_tokens(event)))
+
+
+def _source_tool_name_relevant(tool: str, claim_tokens: set[str]) -> bool:
+    if not _is_source_tool(tool):
+        return False
+    if not claim_tokens:
+        return True
+    return bool(claim_tokens.intersection(_tokenize(tool)))
 
 
 def _payload_claim_tokens(payload: Mapping[str, Any]) -> set[str]:

--- a/scripts/audit/prompts/reviewer_prompt.md
+++ b/scripts/audit/prompts/reviewer_prompt.md
@@ -4,7 +4,7 @@
 
 For seminar content and fact-sensitive reviews, source grounding is REQUIRED for:
 * findings in `seminar_sensitivity` or `decolonization`;
-* calque, false-friend, russicism, or heritage-contact judgments on seminar content.
+* `calque` or `false_friend` judgments on seminar content.
 
 Style, register, tone, and naturalness judgments outside those factual/contact categories remain prompt-only judgments and do not require source grounding.
 

--- a/scripts/audit/qg_corpus_report.py
+++ b/scripts/audit/qg_corpus_report.py
@@ -519,6 +519,7 @@ def _completion_summary(
     completion_counts: Counter[str] = Counter()
     workflow_verdict_counts: Counter[str] = Counter()
     tier2_status_counts: Counter[str] = Counter()
+    cache_regate_counts: Counter[str] = Counter()
     provider_error = 0
     parse_failure = 0
     skipped_budget = 0
@@ -537,6 +538,9 @@ def _completion_summary(
         status = str(tier2.get("status") or "")
         if status:
             tier2_status_counts[status] += 1
+        cache_regate = str(tier2.get("cache_regate") or "")
+        if cache_regate:
+            cache_regate_counts[cache_regate] += 1
         if status == "provider_error" or workflow_verdict == "PROVIDER_FAILURE":
             provider_error += 1
         if status in {"parse_failure", "schema_failure"} or workflow_verdict in {"PARSE_FAILURE", "SCHEMA_FAILURE"}:
@@ -546,6 +550,7 @@ def _completion_summary(
         "completion_status_counts": dict(sorted(completion_counts.items())),
         "workflow_verdict_counts": dict(sorted(workflow_verdict_counts.items())),
         "tier2_status_counts": dict(sorted(tier2_status_counts.items())),
+        "cache_regate_counts": dict(sorted(cache_regate_counts.items())),
         "skipped_budget": skipped_budget,
         "incomplete": incomplete,
         "provider_error": provider_error,

--- a/scripts/audit/qg_schema.py
+++ b/scripts/audit/qg_schema.py
@@ -86,6 +86,9 @@ FACT_CHECK_VERDICTS = frozenset(
 )
 MAX_REVIEWER_FACT_CHECKS = 40
 GROUNDING_REQUIRED_DIMENSIONS = frozenset({"seminar_sensitivity", "decolonization"})
+# Keep in exact sync with scripts/audit/prompts/reviewer_prompt.md. The prompt's
+# earlier broader "russicism/contact" wording was narrowed because the schema
+# exposes no separate russicism or heritage-contact issue_class.
 GROUNDING_REQUIRED_SEMINAR_CLASSES = frozenset({"calque", "false_friend"})
 GROUNDING_KEYS = frozenset({"tool", "query", "evidence_excerpt", "tool_call_id"})
 

--- a/scripts/audit/qg_workflow.py
+++ b/scripts/audit/qg_workflow.py
@@ -4,7 +4,9 @@
 This composes the deterministic/lookup adapters and the gated LLM reviewer into
 one canonical ``qg_schema`` evidence record per module. Live reviewer dispatch
 is intentionally absent until #4370 calibrates the prompt and canary runbook;
-callers must inject a reviewer response or reuse a composite cache hit.
+callers must inject a reviewer response or reuse a composite cache hit. The
+live Tier-2 retry composition is capped at three reviewer calls per module:
+initial response, at most one theatre retry, and at most one deep-read retry.
 """
 
 from __future__ import annotations
@@ -116,6 +118,19 @@ class BudgetState:
         cost = float(observed_cost_usd if observed_cost_usd is not None else estimate.get("estimated_cost_usd") or 0.0)
         self.cost_usd += cost
         self.daily_cost_usd += cost
+
+
+@dataclass(frozen=True, slots=True)
+class _ReviewerGateOutcome:
+    """Deterministic post-response reviewer gate outcome."""
+
+    payload: dict[str, Any]
+    findings: list[dict[str, Any]]
+    status: str = "ran"
+    workflow_override: str | None = None
+    grounding_gate: llm_reviewer_dispatch.GroundingGateResult | None = None
+    retry_reason: str | None = None
+    gate_reason: str | None = None
 
 
 def review_module(
@@ -715,29 +730,70 @@ def _run_tier2(
             "tools_used": list(cached.tools_used),
             "route_name": cached.route_name,
         }
-        try:
-            llm_reviewer.validate_reviewer_payload(cached_payload, policy_family)
-            cache_theatre = llm_reviewer_dispatch.tool_theatre_violation(
-                policy_family=policy_family,
-                payload=cached_payload,
-                dispatch_meta=cached_meta,
-            )
-        except ValueError:
-            cache_theatre = {"status": llm_reviewer_dispatch.INVALID_TOOL_THEATRE}
-        if cache_theatre is None:
-            findings = _findings_from_payload(cached_payload)
-            return {
-                "findings": findings,
-                "result": {
-                    **base_result,
-                    "status": "cache_hit",
-                    "findings": len(findings),
-                    "cache_run_id": cached.run_id,
-                },
-                "llm_used": True,
-                "reviewer_model_id": reviewer_model_id,
-                "reviewer_family": reviewer_family,
-            }
+        if cached.tool_events is not None:
+            cached_meta["tool_events"] = [dict(event) for event in cached.tool_events]
+            try:
+                llm_reviewer.validate_reviewer_payload(cached_payload, policy_family)
+                cache_gate = _run_reviewer_gate_sequence(
+                    cached_payload,
+                    cached_meta,
+                    policy_family=policy_family,
+                    theatre_retry_available=True,
+                    deep_read_retry_available=True,
+                    retry_unavailable_fails=True,
+                )
+            except ValueError:
+                cache_gate = _ReviewerGateOutcome(
+                    payload=cached_payload,
+                    findings=[],
+                    retry_reason="schema_failure",
+                )
+            if cache_gate.retry_reason is None:
+                findings = cache_gate.findings
+                grounding_gate = cache_gate.grounding_gate or llm_reviewer_dispatch.GroundingGateResult(
+                    payload=cache_gate.payload
+                )
+                return {
+                    "findings": findings,
+                    "result": {
+                        **base_result,
+                        "status": "cache_hit" if cache_gate.status == "ran" else cache_gate.status,
+                        "findings": len(findings),
+                        "cache_run_id": cached.run_id,
+                        "cache_regate": "replayed",
+                        "invalid_fact_checks": grounding_gate.invalid_fact_checks,
+                        "inadmissible_positive_verdicts": grounding_gate.inadmissible_positive_verdicts,
+                    },
+                    "llm_used": True,
+                    "workflow_verdict": cache_gate.workflow_override,
+                    "reviewer_model_id": reviewer_model_id,
+                    "reviewer_family": reviewer_family,
+                }
+        else:
+            try:
+                llm_reviewer.validate_reviewer_payload(cached_payload, policy_family)
+                cache_theatre = llm_reviewer_dispatch.tool_theatre_violation(
+                    policy_family=policy_family,
+                    payload=cached_payload,
+                    dispatch_meta=cached_meta,
+                )
+            except ValueError:
+                cache_theatre = {"status": llm_reviewer_dispatch.INVALID_TOOL_THEATRE}
+            if cache_theatre is None:
+                findings = _findings_from_payload(cached_payload)
+                return {
+                    "findings": findings,
+                    "result": {
+                        **base_result,
+                        "status": "cache_hit",
+                        "findings": len(findings),
+                        "cache_run_id": cached.run_id,
+                        "cache_regate": "unavailable",
+                    },
+                    "llm_used": True,
+                    "reviewer_model_id": reviewer_model_id,
+                    "reviewer_family": reviewer_family,
+                }
 
     stale_cache = _has_stale_cache(
         level=level,
@@ -948,26 +1004,35 @@ def _run_tier2(
                 "reviewer_family": reviewer_family,
             }
 
-        theatre = llm_reviewer_dispatch.tool_theatre_violation(
+        gate_outcome = _run_reviewer_gate_sequence(
+            payload,
+            dispatch_meta,
             policy_family=policy_family,
-            payload=payload,
-            dispatch_meta=dispatch_meta,
+            theatre_retry_available=not theatre_retried,
+            deep_read_retry_available=not deep_read_retried,
         )
-        if theatre is not None:
-            if not theatre_retried:
-                theatre_retried = True
-                attempt_prompt = llm_reviewer_dispatch.reviewer_retry_prompt(
-                    prompt,
-                    llm_reviewer_dispatch.INVALID_TOOL_THEATRE,
-                )
-                continue
+        if gate_outcome.retry_reason == llm_reviewer_dispatch.INVALID_TOOL_THEATRE:
+            theatre_retried = True
+            attempt_prompt = llm_reviewer_dispatch.reviewer_retry_prompt(
+                prompt,
+                llm_reviewer_dispatch.INVALID_TOOL_THEATRE,
+            )
+            continue
+        if gate_outcome.retry_reason == llm_reviewer_dispatch.DEEP_READ_REQUIRED:
+            deep_read_retried = True
+            attempt_prompt = llm_reviewer_dispatch.reviewer_retry_prompt(
+                prompt,
+                llm_reviewer_dispatch.DEEP_READ_REQUIRED,
+            )
+            continue
+        if gate_outcome.status == llm_reviewer_dispatch.RETRY_EXHAUSTED:
             return {
                 "findings": [],
                 "result": {
                     **base_result,
                     "status": llm_reviewer_dispatch.RETRY_EXHAUSTED,
                     "reason": llm_reviewer_dispatch.INVALID_TOOL_THEATRE,
-                    "gate_reason": theatre.get("reason"),
+                    "gate_reason": gate_outcome.gate_reason,
                     "estimate": estimate,
                     "dispatch": dispatch_meta,
                 },
@@ -978,76 +1043,11 @@ def _run_tier2(
                 "reviewer_family": reviewer_family,
             }
 
-        if llm_reviewer_dispatch.deep_read_required(payload, dispatch_meta):
-            if not deep_read_retried:
-                deep_read_retried = True
-                attempt_prompt = llm_reviewer_dispatch.reviewer_retry_prompt(
-                    prompt,
-                    llm_reviewer_dispatch.DEEP_READ_REQUIRED,
-                )
-                continue
-            payload = llm_reviewer_dispatch.mark_deep_read_attempted(payload)
-            llm_reviewer.validate_reviewer_payload(payload, policy_family)
-
-        grounding_gate = llm_reviewer_dispatch.enforce_grounding_against_tool_events(
-            payload,
-            dispatch_meta,
-            policy_family=policy_family,
-        )
-        payload = grounding_gate.payload
-        sweep_incomplete = llm_reviewer_dispatch.factual_sweep_incomplete(
-            payload,
-            policy_family=policy_family,
-            invalid_fact_checks=grounding_gate.invalid_fact_checks,
-        )
-        if grounding_gate.inadmissible_positive_verdicts:
-            payload["inadmissible_positive_verdicts"] = grounding_gate.inadmissible_positive_verdicts
-        if (
-            grounding_gate.required_ungrounded_findings
-            or grounding_gate.invalid_fact_checks
-            or grounding_gate.inadmissible_positive_verdicts
-            or sweep_incomplete
-        ):
-            if (
-                grounding_gate.inadmissible_positive_verdicts
-                and not grounding_gate.invalid_fact_checks
-                and not grounding_gate.required_ungrounded_findings
-            ):
-                tier2_status = "inadmissible_citations"
-            elif grounding_gate.required_ungrounded_findings or grounding_gate.invalid_fact_checks:
-                tier2_status = llm_reviewer_dispatch.UNGROUNDED_FINDINGS
-            else:
-                tier2_status = "factual_sweep_incomplete"
-            workflow_override = "FAIL" if sweep_incomplete else "WARN"
-            severity = "critical" if sweep_incomplete else "warning"
-            message = "Grounded reviewer gate found ungrounded evidence or an incomplete seminar fact-check sweep."
-            if (
-                grounding_gate.inadmissible_positive_verdicts
-                and not grounding_gate.invalid_fact_checks
-                and not grounding_gate.required_ungrounded_findings
-            ):
-                message = (
-                    "reviewer confirmed/refuted claims on summary-only wiki evidence after the forced "
-                    "deep-read retry — factual sweep uncertified"
-                )
-            findings = [
-                *_findings_from_payload(payload),
-                _reviewer_gate_finding(
-                    severity=severity,
-                    issue_id="LLM_REVIEWER_GROUNDING_GATE",
-                    message=message,
-                ),
-            ]
-            payload = _payload_from_findings(
-                findings,
-                fact_checks=payload.get("fact_checks", []),
-                evidence_gaps=payload.get("evidence_gaps", []),
-            )
-            if grounding_gate.inadmissible_positive_verdicts:
-                payload["inadmissible_positive_verdicts"] = grounding_gate.inadmissible_positive_verdicts
-            llm_reviewer.validate_reviewer_payload(payload, policy_family)
-        else:
-            findings = _findings_from_payload(payload)
+        payload = gate_outcome.payload
+        findings = gate_outcome.findings
+        tier2_status = gate_outcome.status
+        workflow_override = gate_outcome.workflow_override
+        grounding_gate = gate_outcome.grounding_gate or llm_reviewer_dispatch.GroundingGateResult(payload=payload)
         break
 
     llm_qg_store.record_llm_qg(
@@ -1062,8 +1062,9 @@ def _run_tier2(
         reviewer_model=reviewer_model_id,
         reviewer_family=reviewer_family,
         route_name=route_name,
-        tool_call_count=int(dispatch_meta.get("tool_call_count") or 0),
+        tool_call_count=llm_reviewer_dispatch.tool_call_count_from_dispatch_meta(dispatch_meta),
         tools_used=[str(tool) for tool in (dispatch_meta.get("tools_used") or ())],
+        tool_events=llm_reviewer_dispatch.tool_events_from_dispatch_meta(dispatch_meta),
         source="qg_workflow",
         path=store_path,
     )
@@ -1234,6 +1235,120 @@ def _record_daily_spend(
 
 def _parse_failed(findings: Sequence[Mapping[str, Any]]) -> bool:
     return any(str(finding.get("issue_id")) == "LLM_RESPONSE_PARSE_FAILURE" for finding in findings)
+
+
+def _run_reviewer_gate_sequence(
+    payload: Mapping[str, Any],
+    dispatch_meta: Mapping[str, Any],
+    *,
+    policy_family: str,
+    theatre_retry_available: bool,
+    deep_read_retry_available: bool,
+    retry_unavailable_fails: bool = False,
+) -> _ReviewerGateOutcome:
+    """Apply the canonical theatre/deep-read/grounding/factual-sweep gates."""
+    working_payload = dict(payload)
+    theatre = llm_reviewer_dispatch.tool_theatre_violation(
+        policy_family=policy_family,
+        payload=working_payload,
+        dispatch_meta=dispatch_meta,
+    )
+    if theatre is not None:
+        if theatre_retry_available or retry_unavailable_fails:
+            return _ReviewerGateOutcome(
+                payload=working_payload,
+                findings=[],
+                retry_reason=llm_reviewer_dispatch.INVALID_TOOL_THEATRE,
+                gate_reason=str(theatre.get("reason") or ""),
+            )
+        return _ReviewerGateOutcome(
+            payload=working_payload,
+            findings=[],
+            status=llm_reviewer_dispatch.RETRY_EXHAUSTED,
+            workflow_override=llm_reviewer_dispatch.INVALID_TOOL_THEATRE,
+            gate_reason=str(theatre.get("reason") or ""),
+        )
+
+    if llm_reviewer_dispatch.deep_read_required(working_payload, dispatch_meta):
+        if deep_read_retry_available or retry_unavailable_fails:
+            return _ReviewerGateOutcome(
+                payload=working_payload,
+                findings=[],
+                retry_reason=llm_reviewer_dispatch.DEEP_READ_REQUIRED,
+            )
+        working_payload = llm_reviewer_dispatch.mark_deep_read_attempted(working_payload)
+        llm_reviewer.validate_reviewer_payload(working_payload, policy_family)
+
+    grounding_gate = llm_reviewer_dispatch.enforce_grounding_against_tool_events(
+        working_payload,
+        dispatch_meta,
+        policy_family=policy_family,
+    )
+    working_payload = grounding_gate.payload
+    sweep_incomplete = llm_reviewer_dispatch.factual_sweep_incomplete(
+        working_payload,
+        policy_family=policy_family,
+        invalid_fact_checks=grounding_gate.invalid_fact_checks,
+    )
+    if grounding_gate.inadmissible_positive_verdicts:
+        working_payload["inadmissible_positive_verdicts"] = grounding_gate.inadmissible_positive_verdicts
+    if (
+        grounding_gate.required_ungrounded_findings
+        or grounding_gate.invalid_fact_checks
+        or grounding_gate.inadmissible_positive_verdicts
+        or sweep_incomplete
+    ):
+        if (
+            grounding_gate.inadmissible_positive_verdicts
+            and not grounding_gate.invalid_fact_checks
+            and not grounding_gate.required_ungrounded_findings
+        ):
+            status = "inadmissible_citations"
+        elif grounding_gate.required_ungrounded_findings or grounding_gate.invalid_fact_checks:
+            status = llm_reviewer_dispatch.UNGROUNDED_FINDINGS
+        else:
+            status = "factual_sweep_incomplete"
+        workflow_override = "FAIL" if sweep_incomplete else "WARN"
+        severity = "critical" if sweep_incomplete else "warning"
+        message = "Grounded reviewer gate found ungrounded evidence or an incomplete seminar fact-check sweep."
+        if (
+            grounding_gate.inadmissible_positive_verdicts
+            and not grounding_gate.invalid_fact_checks
+            and not grounding_gate.required_ungrounded_findings
+        ):
+            message = (
+                "reviewer confirmed/refuted claims on summary-only wiki evidence after the forced "
+                "deep-read retry — factual sweep uncertified"
+            )
+        findings = [
+            *_findings_from_payload(working_payload),
+            _reviewer_gate_finding(
+                severity=severity,
+                issue_id="LLM_REVIEWER_GROUNDING_GATE",
+                message=message,
+            ),
+        ]
+        working_payload = _payload_from_findings(
+            findings,
+            fact_checks=working_payload.get("fact_checks", []),
+            evidence_gaps=working_payload.get("evidence_gaps", []),
+        )
+        if grounding_gate.inadmissible_positive_verdicts:
+            working_payload["inadmissible_positive_verdicts"] = grounding_gate.inadmissible_positive_verdicts
+        llm_reviewer.validate_reviewer_payload(working_payload, policy_family)
+        return _ReviewerGateOutcome(
+            payload=working_payload,
+            findings=findings,
+            status=status,
+            workflow_override=workflow_override,
+            grounding_gate=grounding_gate,
+        )
+
+    return _ReviewerGateOutcome(
+        payload=working_payload,
+        findings=_findings_from_payload(working_payload),
+        grounding_gate=grounding_gate,
+    )
 
 
 def _has_stale_cache(

--- a/tests/audit/test_llm_qg_store.py
+++ b/tests/audit/test_llm_qg_store.py
@@ -226,12 +226,20 @@ def test_legacy_db_without_tool_columns_migrates_on_read(tmp_path: Path) -> None
     assert record is not None
     assert record.tool_call_count == 0
     assert record.tools_used == ()
+    assert record.tool_events is None
     assert record.route_name is None
 
     cols = {row[1] for row in sqlite3.connect(db_path).execute("PRAGMA table_info(llm_qg_runs)")}
-    assert {"route_name", "tool_call_count", "tools_used_json"} <= cols
+    assert {"route_name", "tool_call_count", "tools_used_json", "tool_events_json"} <= cols
 
     # WRITE through the new code path on the migrated DB: also must not raise.
+    event = {
+        "tool": "sources_query_wikipedia",
+        "input": {"query": "Веснянки", "mode": "section"},
+        "status": "completed",
+        "tool_call_id": "call_1",
+        "output": "Веснянки — це весняні обрядові пісні.",
+    }
     stored = record_llm_qg(
         level="b1",
         slug="aspect-in-imperatives",
@@ -241,19 +249,30 @@ def test_legacy_db_without_tool_columns_migrates_on_read(tmp_path: Path) -> None
         route_name="opencode_frontier",
         tool_call_count=5,
         tools_used=["sources_query_wikipedia"],
+        tool_events=[event],
         path=db_path,
     )
     assert stored.tool_call_count == 5
     assert stored.tools_used == ("sources_query_wikipedia",)
+    assert stored.tool_events == (event,)
     reread = latest_llm_qg("b1", "aspect-in-imperatives", content_sha=stored.content_sha, path=db_path)
     assert reread is not None
     assert reread.tool_call_count == 5
     assert reread.tools_used == ("sources_query_wikipedia",)
+    assert reread.tool_events == (event,)
 
 
 def test_tool_telemetry_round_trips_through_store(tmp_path: Path) -> None:
     module_dir = _module(tmp_path)
     db_path = tmp_path / "qg.db"
+    event = {
+        "tool": "sources_search_heritage",
+        "input": {"query": "Веснянки"},
+        "status": "completed",
+        "tool_call_id": "call_1",
+        "output": {"rows": ["heritage result"]},
+        "ignored_extra": "not persisted",
+    }
     record_llm_qg(
         level="b1",
         slug="aspect-in-imperatives",
@@ -263,6 +282,7 @@ def test_tool_telemetry_round_trips_through_store(tmp_path: Path) -> None:
         route_name="opencode_frontier",
         tool_call_count=7,
         tools_used=("sources_search_heritage", "sources_query_wikipedia"),
+        tool_events=(event,),
         path=db_path,
     )
     record = latest_llm_qg("b1", "aspect-in-imperatives", path=db_path)
@@ -270,6 +290,15 @@ def test_tool_telemetry_round_trips_through_store(tmp_path: Path) -> None:
     assert record.tool_call_count == 7
     assert record.tools_used == ("sources_search_heritage", "sources_query_wikipedia")
     assert record.route_name == "opencode_frontier"
+    assert record.tool_events == (
+        {
+            "tool": "sources_search_heritage",
+            "input": {"query": "Веснянки"},
+            "status": "completed",
+            "tool_call_id": "call_1",
+            "output": {"rows": ["heritage result"]},
+        },
+    )
 
 
 def test_composite_cache_key_includes_route_name(tmp_path: Path) -> None:

--- a/tests/audit/test_qg_corpus_report.py
+++ b/tests/audit/test_qg_corpus_report.py
@@ -174,6 +174,7 @@ def test_workflow_records_count_failures_spend_and_warn_conversion(tmp_path: Pat
         completion_status="COMPLETE",
         estimated_cost=0.2,
         observed_cost=0.4,
+        cache_regate="replayed",
     )
     provider_record = _workflow_record(
         _module(tmp_path, slug="provider"),
@@ -204,6 +205,7 @@ def test_workflow_records_count_failures_spend_and_warn_conversion(tmp_path: Pat
     assert report["completion"]["provider_error"] == 1
     assert report["completion"]["parse_failure"] == 1
     assert report["completion"]["incomplete"] == 2
+    assert report["completion"]["cache_regate_counts"] == {"replayed": 1}
     assert report["spend"]["accepted_evidence"] == 1
     assert report["spend"]["observed_cost_usd"] == 0.5
     assert report["spend"]["spend_per_accepted_evidence_usd"] == 0.5
@@ -241,6 +243,7 @@ def _workflow_record(
     completion_status: str = "COMPLETE",
     estimated_cost: float | None = None,
     observed_cost: float | None = None,
+    cache_regate: str | None = None,
 ) -> dict[str, Any]:
     target = _target(module_dir, slug=slug)
     payload = _payload(*(findings or []))
@@ -254,6 +257,8 @@ def _workflow_record(
         tier2["estimate"] = {"estimated_cost_usd": estimated_cost}
     if observed_cost is not None:
         tier2["dispatch"] = {"observed_cost_usd": observed_cost}
+    if cache_regate is not None:
+        tier2["cache_regate"] = cache_regate
     return {
         "schema_version": qg_schema.SCHEMA_VERSION,
         "module_id": f"b1/{slug}",

--- a/tests/test_llm_reviewer_dispatch.py
+++ b/tests/test_llm_reviewer_dispatch.py
@@ -368,6 +368,32 @@ def test_theatre_gate_rejects_irrelevant_tool_only_run(tmp_path: Path) -> None:
     assert calls == 2
 
 
+def test_tools_used_only_theatre_fallback_requires_tool_name_relevance_for_claims() -> None:
+    payload = json.loads(_fact_response())
+    dispatch_meta = {
+        "route_name": "opencode_frontier",
+        "tool_call_count": 1,
+        "tools_used": ["sources_query_wikipedia"],
+    }
+
+    violation = llm_reviewer_dispatch.tool_theatre_violation(
+        policy_family="seminar",
+        payload=payload,
+        dispatch_meta=dispatch_meta,
+    )
+    no_claim_violation = llm_reviewer_dispatch.tool_theatre_violation(
+        policy_family="seminar",
+        payload={"findings": []},
+        dispatch_meta=dispatch_meta,
+    )
+
+    assert violation == {
+        "status": llm_reviewer_dispatch.INVALID_TOOL_THEATRE,
+        "reason": "no_relevant_source_tool_calls",
+    }
+    assert no_claim_violation is None
+
+
 def test_theatre_gate_retry_then_invalid_zero_tool_path(tmp_path: Path) -> None:
     module_dir = _write_module(tmp_path, level="folk", slug="vesnianky")
     calls = 0

--- a/tests/test_qg_workflow.py
+++ b/tests/test_qg_workflow.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 from typing import Any
 
@@ -171,6 +172,7 @@ def test_tier2_policy_gate_reaches_seminar_and_skips_a1_a2(tmp_path: Path) -> No
             route_name="opencode_frontier",
             tool_call_count=1,
             tools_used=("sources_query_wikipedia",),
+            tool_events=(_wiki_event(mode="section"),),
         )
 
     seminar_dir = _write_module(
@@ -355,6 +357,7 @@ def test_cache_hit_revalidates_theatre_gate_on_stored_payload(tmp_path: Path) ->
             route_name="opencode_frontier",
             tool_call_count=1,
             tools_used=("sources_query_wikipedia",),
+            tool_events=(_wiki_event(mode="section"),),
         )
 
     record = qg_workflow.review_module(
@@ -372,6 +375,274 @@ def test_cache_hit_revalidates_theatre_gate_on_stored_payload(tmp_path: Path) ->
     assert calls == 1
 
 
+def test_cache_hit_replays_grounding_gate_from_stored_tool_events(tmp_path: Path) -> None:
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="cache-grounding",
+        module_md="# Семінар\n\nВеснянки — це весняні обрядові пісні.\n",
+    )
+    db_path = tmp_path / "qg.db"
+    prompt = llm_reviewer.build_reviewer_prompt(
+        level="folk",
+        slug="cache-grounding",
+        module_md=(seminar_dir / "module.md").read_text(encoding="utf-8"),
+        activities_yaml=(seminar_dir / "activities.yaml").read_text(encoding="utf-8"),
+        vocabulary_yaml=(seminar_dir / "vocabulary.yaml").read_text(encoding="utf-8"),
+        resources_yaml=(seminar_dir / "resources.yaml").read_text(encoding="utf-8"),
+    )
+    fabricated_finding = qg_schema.build_finding(
+        issue_id="SEMINAR_FACTUAL_DETAIL",
+        issue_class="other",
+        dimension="seminar_sensitivity",
+        severity="warning",
+        file="module.md",
+        line=3,
+        span={"start": 0, "end": 8},
+        excerpt="Веснянки",
+        message="Fabricated grounding should fail cache replay.",
+        confidence="llm_judgment",
+        detector={"adapter": "llm_reviewer", "rule_id": "SEMINAR_FACTUAL_DETAIL"},
+        attribution={"corpus": "reviewer"},
+        grounding={
+            "tool": "sources_query_wikipedia",
+            "query": "Веснянки",
+            "evidence_excerpt": "вигаданий фрагмент",
+            "tool_call_id": "call_1",
+        },
+    )
+    payload = qg_workflow._payload_from_findings(
+        [fabricated_finding],
+        fact_checks=json.loads(_seminar_response())["fact_checks"],
+    )
+    llm_qg_store.record_llm_qg(
+        level="folk",
+        slug="cache-grounding",
+        module_dir=seminar_dir,
+        payload=payload,
+        gate_version=qg_workflow.DEFAULT_GATE_VERSION,
+        prompt_hash=llm_qg_store.prompt_hash_for_text(prompt),
+        checker_version=CHECKER_VERSION,
+        level_policy_family="seminar",
+        reviewer_model="test-reviewer",
+        reviewer_family="test-family",
+        route_name=None,
+        tool_call_count=1,
+        tools_used=("sources_query_wikipedia",),
+        tool_events=(_wiki_event(mode="section"),),
+        source="test",
+        path=db_path,
+    )
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> str:
+        nonlocal calls
+        calls += 1
+        return _seminar_response()
+
+    record = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="cache-grounding"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+        ),
+        reviewer=reviewer,
+        store_path=db_path,
+    )
+
+    issue_ids = [
+        finding["issue_id"]
+        for dimension in record["dimensions"].values()
+        for finding in dimension["findings"]
+    ]
+    tier2 = _tier(record, 2)
+    assert tier2["status"] == llm_reviewer_dispatch.UNGROUNDED_FINDINGS
+    assert tier2["cache_regate"] == "replayed"
+    assert "SEMINAR_FACTUAL_DETAIL" not in issue_ids
+    assert "LLM_REVIEWER_GROUNDING_GATE" in issue_ids
+    assert calls == 0
+
+
+def test_cache_hit_deep_read_retry_requirement_falls_through_to_live_run(tmp_path: Path) -> None:
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="cache-deep-read",
+        module_md="# Семінар\n\nВеснянки — це весняні обрядові пісні.\n",
+    )
+    db_path = tmp_path / "qg.db"
+    prompt = llm_reviewer.build_reviewer_prompt(
+        level="folk",
+        slug="cache-deep-read",
+        module_md=(seminar_dir / "module.md").read_text(encoding="utf-8"),
+        activities_yaml=(seminar_dir / "activities.yaml").read_text(encoding="utf-8"),
+        vocabulary_yaml=(seminar_dir / "vocabulary.yaml").read_text(encoding="utf-8"),
+        resources_yaml=(seminar_dir / "resources.yaml").read_text(encoding="utf-8"),
+    )
+    old = llm_qg_store.record_llm_qg(
+        level="folk",
+        slug="cache-deep-read",
+        module_dir=seminar_dir,
+        payload=qg_workflow._payload_from_reviewer_payload(json.loads(_seminar_response())),
+        gate_version=qg_workflow.DEFAULT_GATE_VERSION,
+        prompt_hash=llm_qg_store.prompt_hash_for_text(prompt),
+        checker_version=CHECKER_VERSION,
+        level_policy_family="seminar",
+        reviewer_model="test-reviewer",
+        reviewer_family="test-family",
+        route_name=None,
+        tool_call_count=1,
+        tools_used=("sources_query_wikipedia",),
+        tool_events=(_wiki_event(mode="summary"),),
+        source="test",
+        path=db_path,
+    )
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        nonlocal calls
+        calls += 1
+        return _seminar_dispatch(events=(_wiki_event(mode="section"),))
+
+    record = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="cache-deep-read"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+        ),
+        reviewer=reviewer,
+        store_path=db_path,
+    )
+
+    latest = llm_qg_store.latest_llm_qg("folk", "cache-deep-read", path=db_path)
+    assert _tier(record, 2)["status"] == "ran"
+    assert "cache_regate" not in _tier(record, 2)
+    assert calls == 1
+    assert latest is not None
+    assert latest.run_id != old.run_id
+
+
+def test_pre_change_cache_row_without_tool_events_is_marked_unavailable(tmp_path: Path) -> None:
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="legacy-cache",
+        module_md="# Семінар\n\nУчасники аналізують джерела спокійно й уважно.\n",
+    )
+    db_path = tmp_path / "qg.db"
+    prompt = llm_reviewer.build_reviewer_prompt(
+        level="folk",
+        slug="legacy-cache",
+        module_md=(seminar_dir / "module.md").read_text(encoding="utf-8"),
+        activities_yaml=(seminar_dir / "activities.yaml").read_text(encoding="utf-8"),
+        vocabulary_yaml=(seminar_dir / "vocabulary.yaml").read_text(encoding="utf-8"),
+        resources_yaml=(seminar_dir / "resources.yaml").read_text(encoding="utf-8"),
+    )
+    stored = llm_qg_store.record_llm_qg(
+        level="folk",
+        slug="legacy-cache",
+        module_dir=seminar_dir,
+        payload=qg_workflow._payload_from_findings([]),
+        gate_version=qg_workflow.DEFAULT_GATE_VERSION,
+        prompt_hash=llm_qg_store.prompt_hash_for_text(prompt),
+        checker_version=CHECKER_VERSION,
+        level_policy_family="seminar",
+        reviewer_model="test-reviewer",
+        reviewer_family="test-family",
+        route_name=None,
+        tool_call_count=1,
+        tools_used=("sources_query_wikipedia",),
+        tool_events=(_wiki_event(mode="section"),),
+        source="test",
+        path=db_path,
+    )
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("UPDATE llm_qg_runs SET tool_events_json = NULL WHERE run_id = ?", (stored.run_id,))
+
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> str:
+        nonlocal calls
+        calls += 1
+        return _seminar_response()
+
+    record = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="legacy-cache"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+        ),
+        reviewer=reviewer,
+        store_path=db_path,
+    )
+
+    tier2 = _tier(record, 2)
+    assert tier2["status"] == "cache_hit"
+    assert tier2["cache_regate"] == "unavailable"
+    assert calls == 0
+
+
+def test_live_and_cache_paths_use_shared_reviewer_gate_helper(tmp_path: Path, monkeypatch: Any) -> None:
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="shared-helper",
+        module_md="# Семінар\n\nВеснянки — це весняні обрядові пісні.\n",
+    )
+    db_path = tmp_path / "qg.db"
+    calls: list[bool] = []
+
+    def fake_gate(
+        payload: dict[str, Any],
+        dispatch_meta: dict[str, Any],
+        *,
+        policy_family: str,
+        theatre_retry_available: bool,
+        deep_read_retry_available: bool,
+        retry_unavailable_fails: bool = False,
+    ) -> qg_workflow._ReviewerGateOutcome:
+        calls.append(retry_unavailable_fails)
+        clean_payload = dict(payload)
+        return qg_workflow._ReviewerGateOutcome(
+            payload=clean_payload,
+            findings=[],
+            grounding_gate=llm_reviewer_dispatch.GroundingGateResult(payload=clean_payload),
+        )
+
+    monkeypatch.setattr(qg_workflow, "_run_reviewer_gate_sequence", fake_gate)
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        return _seminar_dispatch(events=(_wiki_event(mode="section"),))
+
+    first = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="shared-helper"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+        ),
+        reviewer=reviewer,
+        store_path=db_path,
+    )
+    second = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="shared-helper"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            reviewer_model_id="test-reviewer",
+            reviewer_family="test-family",
+        ),
+        reviewer=None,
+        store_path=db_path,
+    )
+
+    assert _tier(first, 2)["status"] == "ran"
+    assert _tier(second, 2)["status"] == "cache_hit"
+    assert calls == [False, True]
+
+
 def test_tier2_threads_tool_telemetry_into_store(tmp_path: Path) -> None:
     seminar_dir = _write_module(
         tmp_path,
@@ -380,6 +651,16 @@ def test_tier2_threads_tool_telemetry_into_store(tmp_path: Path) -> None:
         module_md="# Семінар\n\nУчасники аналізують джерела спокійно й уважно.\n",
     )
     db_path = tmp_path / "qg.db"
+    events = (
+        _wiki_event(mode="section"),
+        {
+            "tool": "sources_search_heritage",
+            "input": {"query": "Веснянки"},
+            "status": "completed",
+            "tool_call_id": "call_2",
+            "output": "Heritage result",
+        },
+    )
 
     def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
         return llm_reviewer_dispatch.DispatchResult(
@@ -389,6 +670,7 @@ def test_tier2_threads_tool_telemetry_into_store(tmp_path: Path) -> None:
             route_name="opencode_frontier",
             tool_call_count=6,
             tools_used=("sources_query_wikipedia", "sources_search_heritage"),
+            tool_events=events,
         )
 
     record = qg_workflow.review_module(
@@ -407,6 +689,7 @@ def test_tier2_threads_tool_telemetry_into_store(tmp_path: Path) -> None:
     assert stored is not None
     assert stored.tool_call_count == 6
     assert stored.tools_used == ("sources_query_wikipedia", "sources_search_heritage")
+    assert stored.tool_events == events
 
 
 def test_summary_only_positive_verdict_after_retry_fails_inadmissible_citations(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

- Persist normalized reviewer `tool_events` in `llm_qg_runs.tool_events_json` via the existing additive SQLite migration path.
- Factor the Tier-2 theatre/deep-read/grounding/admissibility/factual-sweep sequence into one shared helper used by both live reviewer responses and replayable cache hits.
- Mark cache re-gating as `cache_regate: replayed` for rows with stored events and `cache_regate: unavailable` for legacy rows without events; retry-required cache rows fall through to live execution without firing cache-hit retries.
- Align the seminar grounding prompt wording with the exact schema classes, add claim-token relevance to the `tools_used`-only theatre fallback, and count `cache_regate` values in the corpus report.

## Why

This closes the cache-hit hole from #4416 item 2 permanently: future deterministic gate changes can replay against stored tool outputs instead of relying only on cache-version invalidation. The shared helper is the root-cause guard against live/cache gate drift.

## Validation

- `.venv/bin/python -m pytest tests/test_qg_workflow.py tests/test_llm_reviewer_dispatch.py tests/test_llm_qg_api.py tests/audit/test_qg_bakeoff.py -q` — 87 passed.
- `.venv/bin/ruff check scripts/audit/qg_workflow.py scripts/audit/llm_qg_store.py scripts/audit/llm_reviewer_dispatch.py scripts/audit/qg_schema.py scripts/audit/qg_corpus_report.py tests/test_qg_workflow.py tests/test_llm_reviewer_dispatch.py tests/audit/test_llm_qg_store.py tests/audit/test_qg_corpus_report.py` — All checks passed.
- `git diff --check origin/main..HEAD` — no output.
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — PASS for `X-Agent: codex/4416-cache-regate`.
- Independent Agy/Gemini review (`review-4416-cache-regate`) — No findings.

Addresses #4416 items 2+4.
