### PR TITLE
feat(hooks): block provider write tools dirtying the primary checkout (#4448)

### DIFF
--- a/agents_extensions/codex/hooks.json
+++ b/agents_extensions/codex/hooks.json
@@ -52,6 +52,23 @@
             "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-secret-print.py\"",
             "timeout": 5,
             "statusMessage": "Checking secret-print safety"
+          },
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-primary-checkout-write.py\"",
+            "timeout": 5,
+            "statusMessage": "Checking primary-checkout write safety"
+          }
+        ]
+      },
+      {
+        "matcher": "^(Write|Edit|MultiEdit|apply_patch)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$(git rev-parse --show-toplevel)/.venv/bin/python\" \"$(git rev-parse --show-toplevel)/.codex/hooks/guard-primary-checkout-write.py\"",
+            "timeout": 5,
+            "statusMessage": "Checking primary-checkout write safety"
           }
         ]
       }

--- a/agents_extensions/shared/hooks/guard-primary-checkout-write.py
+++ b/agents_extensions/shared/hooks/guard-primary-checkout-write.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""PreToolUse guard — block write tools from dirtying the primary checkout.
+
+The branch-switch guard (``guard-branch-switch-in-main.py``) stops an agent from
+*switching branches* in the primary checkout, but a direct write tool can dirty
+tracked files from repo root without ever running a git command. That was the
+observed Codex failure chain (issue #4448): the agent investigated from repo
+root and then edited from the same cwd.
+
+This hook closes that gap for providers whose PreToolUse hooks expose structured
+write payloads. It reads the hook payload on stdin and blocks a write when its
+target resolves to a protected file inside the primary checkout while that
+checkout sits on a protected branch (``main`` / ``master``). Everything else —
+writes into a ``.worktrees/**`` dispatch worktree, any other registered
+worktree, gitignored local/runtime state, or paths outside the repo — is
+allowed. Read-only commands (``git status``, ``git log``, ``rg``, ``cat`` …) are
+never touched because they expose no write target.
+
+Containment is **not** re-derived here: every decision defers to
+``scripts.guardrails.worktree_containment`` (issue #4444), the single source of
+truth shared with the monitor (#4449) and git shim (#4450). This hook only maps
+each provider payload onto the target path(s) that module classifies.
+
+Covered write surfaces
+----------------------
+* ``Write`` / ``Edit`` / ``MultiEdit`` — ``tool_input.file_path``.
+* ``apply_patch`` and Codex ``Edit`` / ``Write`` aliases — file paths parsed from
+  the ``*** Add/Update/Delete File:`` / ``*** Move to:`` headers of the patch
+  body (issue #4447 verified Codex CLI fires PreToolUse for ``apply_patch``).
+* ``Bash`` — write-capable redirection (``>``, ``>>``, ``&>``), ``tee``, and
+  in-place editors (``sed -i`` / ``perl -i``). Quote-aware tokenization keeps a
+  ``>`` inside a quoted string (e.g. a commit message) from reading as a
+  redirect.
+
+Coverage limitations (documented, by design)
+--------------------------------------------
+* Bash write detection is heuristic. Arbitrary write vectors — ``dd of=``,
+  ``cp``/``mv`` destinations, ``python -c "open(...,'w')"``, ``$EDITOR`` — are
+  **not** parsed. Those paths rely on physical worktree isolation plus the
+  monitor tripwire (#4449) and git shim (#4450).
+* Codex Desktop direct-edit interception is unverified (#4447). Where a provider
+  does not emit a hookable write event, this hook cannot enforce that path; the
+  enforcement layer is #4445/#4446/#4449 instead. See
+  ``docs/runbooks/codex-hooks.md``.
+
+The hook fails **open**: any parse/import/git error exits 0 (allow). It is a
+safety net, not a chokepoint — physical isolation is the real guarantee.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# shared containment predicate (issue #4444) — imported, never re-derived
+# ---------------------------------------------------------------------------
+
+
+def _load_containment():
+    """Import ``scripts.guardrails.worktree_containment`` from any launch dir.
+
+    The hook runs from a deployed copy (``<root>/.{claude,codex,agent}/hooks/``)
+    or from source (``agents_extensions/shared/hooks/``); in both the repo root
+    that owns ``scripts/`` is an ancestor. Walk upward for it and put it on
+    ``sys.path``. Returns ``None`` if it cannot be found/imported so the caller
+    fails open rather than blocking every write on an import error.
+    """
+    here = Path(__file__).resolve()
+    for candidate in (here.parent, *here.parents):
+        if (candidate / "scripts" / "guardrails" / "worktree_containment.py").exists():
+            if str(candidate) not in sys.path:
+                sys.path.insert(0, str(candidate))
+            break
+    try:
+        from scripts.guardrails import worktree_containment as wc
+    except Exception:  # pragma: no cover - defensive fail-open
+        return None
+    return wc
+
+
+# ---------------------------------------------------------------------------
+# payload plumbing
+# ---------------------------------------------------------------------------
+
+
+def _read_payload() -> dict:
+    try:
+        return json.loads(sys.stdin.read() or "{}")
+    except (json.JSONDecodeError, ValueError):
+        return {}
+
+
+def _tool_name(payload: dict) -> str:
+    return str(
+        payload.get("tool_name") or payload.get("tool") or payload.get("name") or ""
+    )
+
+
+def _tool_input(payload: dict) -> dict:
+    for key in ("tool_input", "arguments", "input", "params"):
+        value = payload.get(key)
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def _payload_cwd(payload: dict) -> str:
+    cwd = payload.get("cwd") or payload.get("working_directory")
+    return str(cwd) if cwd else os.getcwd()
+
+
+# ---------------------------------------------------------------------------
+# target extraction — structured write tools
+# ---------------------------------------------------------------------------
+
+# Headers in an apply_patch body that name a file the patch writes to. The path
+# is the remainder of the line. ``Move from`` is a delete of the old location,
+# ``Move to`` a create of the new one — both dirty the tree, so both count.
+_APPLY_PATCH_HEADERS = (
+    "*** Add File:",
+    "*** Update File:",
+    "*** Delete File:",
+    "*** Move to:",
+    "*** Move from:",
+)
+
+
+def _apply_patch_targets(patch_text: str) -> list[str]:
+    """File paths a ``*** Begin Patch`` body writes to, in order of appearance."""
+    targets: list[str] = []
+    for raw in patch_text.splitlines():
+        line = raw.strip()
+        for header in _APPLY_PATCH_HEADERS:
+            if line.startswith(header):
+                path = line[len(header):].strip()
+                if path:
+                    targets.append(path)
+                break
+    return targets
+
+
+def _strings_in(value: object) -> list[str]:
+    """Every string reachable inside a (possibly nested) tool_input value."""
+    out: list[str] = []
+    if isinstance(value, str):
+        out.append(value)
+    elif isinstance(value, dict):
+        for item in value.values():
+            out.extend(_strings_in(item))
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            out.extend(_strings_in(item))
+    return out
+
+
+def write_tool_targets(tool_input: dict) -> list[str]:
+    """Candidate target paths for a structured write tool.
+
+    ``Write``/``Edit``/``MultiEdit`` expose ``file_path`` directly.
+    ``apply_patch`` (and Codex ``Edit``/``Write`` aliases) carry the patch body
+    somewhere in ``tool_input``; scan every string for apply_patch headers and,
+    failing that, honor an explicit ``file_path``/``path`` key.
+    """
+    targets: list[str] = []
+
+    # Direct single-file path keys used by Write/Edit/MultiEdit (and some
+    # provider aliases). ``file_path`` is canonical; the rest are defensive.
+    for key in ("file_path", "path", "filepath", "target_file", "notebook_path"):
+        value = tool_input.get(key)
+        if isinstance(value, str) and value:
+            targets.append(value)
+
+    # apply_patch / patch-style payloads: parse file headers from any string.
+    for text in _strings_in(tool_input):
+        if "*** Begin Patch" in text or any(h in text for h in _APPLY_PATCH_HEADERS):
+            targets.extend(_apply_patch_targets(text))
+
+    # De-dup while preserving order.
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for path in targets:
+        if path not in seen:
+            seen.add(path)
+            ordered.append(path)
+    return ordered
+
+
+# ---------------------------------------------------------------------------
+# target extraction — write-capable Bash
+# ---------------------------------------------------------------------------
+
+# Control operators that separate one logical command from the next.
+_CONTROL_OPS = frozenset({"&&", "||", ";", "|", "&", "(", ")", "\n"})
+
+# Redirection operators that create/append to a *file* (as opposed to ``>&``
+# which duplicates a file descriptor). ``&>`` / ``&>>`` redirect both streams.
+_FILE_REDIRECTS = frozenset({">", ">>", ">|", "&>", "&>>"})
+
+
+def _tokenize(command: str) -> list[str]:
+    """Quote-aware tokens with redirection/control operators kept separate.
+
+    ``punctuation_chars`` makes shlex split ``();<>|&`` runs into their own
+    tokens while still respecting quotes, so ``echo a>b`` yields
+    ``['echo','a','>','b']`` but ``echo "a>b"`` keeps ``a>b`` intact — the whole
+    reason this is Python and not a grep.
+    """
+    try:
+        lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        return list(lexer)
+    except ValueError:
+        # Unbalanced quotes / un-tokenizable — fail open (the shell will reject
+        # the malformed command itself).
+        return []
+
+
+def _segments(tokens: list[str]) -> list[list[str]]:
+    """Split a token stream into per-command segments on control operators."""
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for tok in tokens:
+        if tok in _CONTROL_OPS:
+            if current:
+                segments.append(current)
+                current = []
+        else:
+            current.append(tok)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def _redirect_targets(tokens: list[str]) -> list[str]:
+    """Files named as the destination of a ``>``/``>>``/``&>`` redirection."""
+    targets: list[str] = []
+    for i, tok in enumerate(tokens):
+        if tok in _FILE_REDIRECTS and i + 1 < len(tokens):
+            dest = tokens[i + 1]
+            # ``>&1`` / ``> &2`` duplicate a descriptor, and a bare number is a
+            # descriptor too — neither is a file write.
+            if dest.startswith("&") or dest.isdigit():
+                continue
+            targets.append(dest)
+    return targets
+
+
+def _command_word(segment: list[str]) -> tuple[str, int]:
+    """First real command word of a segment and its index, skipping wrappers.
+
+    Skips leading ``VAR=val`` assignments and common wrappers (``sudo``,
+    ``env``, ``time``, ``nohup``, ``command``) so ``sudo tee x`` still reads as
+    a ``tee``.
+    """
+    i = 0
+    while i < len(segment):
+        tok = segment[i]
+        if "=" in tok and not tok.startswith("-") and tok.split("=", 1)[0].isidentifier():
+            i += 1  # leading environment assignment
+            continue
+        if tok in {"sudo", "env", "time", "nohup", "command", "builtin", "exec"}:
+            i += 1
+            continue
+        break
+    if i >= len(segment):
+        return "", i
+    return Path(segment[i]).name, i
+
+
+def _tee_targets(segment: list[str], cmd_index: int) -> list[str]:
+    """Non-flag operands of a ``tee`` invocation (its output files)."""
+    targets: list[str] = []
+    for tok in segment[cmd_index + 1:]:
+        if tok.startswith("-"):
+            continue  # -a / --append / -i / -p
+        targets.append(tok)
+    return targets
+
+
+def _inplace_edit_targets(segment: list[str], cmd_index: int) -> list[str]:
+    """File operands of an in-place ``sed -i`` / ``perl -i`` invocation.
+
+    Only fires when an in-place flag is present. The editor's *script* is
+    excluded so it is never mistaken for a file path: with an explicit
+    ``-e``/``-f`` script every positional is a file; otherwise the first
+    positional is the script and the rest are files.
+    """
+    args = segment[cmd_index + 1:]
+    has_inplace = False
+    has_explicit_script = False
+    files: list[str] = []
+    skip_next = False
+    first_positional_seen = False
+
+    for tok in args:
+        if skip_next:
+            skip_next = False
+            has_explicit_script = True  # value of -e/-f was the script, not a file
+            continue
+        if tok.startswith("--"):
+            long = tok[2:]
+            if long.startswith("in-place"):  # --in-place / --in-place=.bak
+                has_inplace = True
+            if long in ("expression", "file"):
+                skip_next = True
+            continue
+        if tok.startswith("-") and len(tok) > 1:
+            # Short-flag cluster (``-i``, ``-i.bak``, ``-Ei``, perl ``-pi``).
+            # Among sed/perl short switches only ``-i`` carries an ``i``.
+            if "i" in tok[1:]:
+                has_inplace = True
+            if tok in ("-e", "-f"):
+                skip_next = True
+            continue
+        # Positional token.
+        if not has_explicit_script and not first_positional_seen:
+            first_positional_seen = True  # inline script (no -e); never a file
+            continue
+        files.append(tok)
+
+    return files if has_inplace else []
+
+
+def bash_write_targets(command: str) -> list[str]:
+    """Best-effort list of files a Bash command would create/modify.
+
+    Covers redirection, ``tee``, and ``sed -i``/``perl -i``. Other write
+    vectors are intentionally out of scope (see module docstring); they rely on
+    physical worktree isolation and the monitor/git-shim layers.
+    """
+    targets: list[str] = []
+    for segment in _segments(_tokenize(command)):
+        if not segment:
+            continue
+        targets.extend(_redirect_targets(segment))
+        cmd, idx = _command_word(segment)
+        if cmd == "tee":
+            targets.extend(_tee_targets(segment, idx))
+        elif cmd in ("sed", "perl"):
+            targets.extend(_inplace_edit_targets(segment, idx))
+    return targets
+
+
+# ---------------------------------------------------------------------------
+# decision
+# ---------------------------------------------------------------------------
+
+
+def _resolve(path_str: str, cwd: str) -> Path:
+    """Resolve a possibly-relative target against the payload cwd."""
+    path = Path(path_str).expanduser()
+    if not path.is_absolute():
+        path = Path(cwd) / path
+    return path
+
+
+def main() -> int:
+    payload = _read_payload()
+    tool_name = _tool_name(payload)
+    if not tool_name:
+        return 0
+
+    wc = _load_containment()
+    if wc is None:
+        return 0  # can't classify without the shared predicate → allow
+
+    tool_input = _tool_input(payload)
+    cwd = _payload_cwd(payload)
+
+    if tool_name == "Bash":
+        command = str(tool_input.get("command") or "")
+        if not command.strip():
+            return 0
+        raw_targets = bash_write_targets(command)
+    else:
+        raw_targets = write_tool_targets(tool_input)
+
+    if not raw_targets:
+        return 0
+
+    # Enforce only while the primary checkout sits on a protected branch. If the
+    # human has deliberately checked the primary tree onto a feature branch, git
+    # can't resolve it, or any classification errors, this hook stays out of the
+    # way (fail open) — physical worktree isolation is the real guarantee.
+    try:
+        main_root = wc.resolve_main_root(cwd)
+        if not wc.is_protected_branch(main_root):
+            return 0
+        decisions = [
+            (raw, wc.evaluate_write(_resolve(raw, cwd), cwd=cwd)) for raw in raw_targets
+        ]
+    except Exception:  # pragma: no cover - defensive fail-open
+        return 0
+
+    for raw, decision in decisions:
+        if not decision.allowed:
+            sys.stderr.write(
+                f"BLOCKED by guard-primary-checkout-write: {tool_name} would write "
+                f"'{raw}' inside the protected primary checkout ({main_root}) "
+                f"[{decision.reason}].\n\n"
+                "The primary checkout must stay clean on `main`. Do all write "
+                "work in a dispatch worktree instead:\n\n"
+                "  git worktree add .worktrees/dispatch/<agent>/<task> "
+                "-b <agent>/<task>\n"
+                "  cd .worktrees/dispatch/<agent>/<task>\n"
+                "  # ...edits, commits, push, PR...\n\n"
+                f"{decision.message}\n"
+                "Hook source: agents_extensions/shared/hooks/"
+                "guard-primary-checkout-write.py\n"
+            )
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents_extensions/shared/settings.json
+++ b/agents_extensions/shared/settings.json
@@ -668,6 +668,21 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-secret-print.py",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-primary-checkout-write.py",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-primary-checkout-write.py",
+            "timeout": 5
           }
         ]
       }

--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -14,6 +14,56 @@ Codex hook facts verified from the current OpenAI Codex manual on 2026-07-05:
 - Hook command trust is separate from project trust. For automation that already
   vets the hook source, use `--dangerously-bypass-hook-trust`.
 
+## Primary-checkout write guard (#4448)
+
+`guard-primary-checkout-write.py` is a `PreToolUse` guard that blocks a write
+tool from dirtying tracked files in the *primary checkout* while it sits on a
+protected branch (`main`/`master`). It is wired into both providers:
+
+- Claude (`agents_extensions/shared/settings.json`): the `Bash` matcher plus a
+  `Write|Edit|MultiEdit` matcher.
+- Codex (`agents_extensions/codex/hooks.json`): the `^Bash$` matcher plus a
+  `^(Write|Edit|MultiEdit|apply_patch)$` matcher.
+
+Every containment decision is delegated to
+`scripts.guardrails.worktree_containment` (#4444); the hook only maps each
+provider payload onto the target path(s) that module classifies. Writes into a
+`.worktrees/**` dispatch worktree, any other registered worktree, gitignored
+local/runtime state, or paths outside the repo are allowed. On a block the hook
+exits 2 and tells the agent to create/`cd` into
+`.worktrees/dispatch/<agent>/<task>/`.
+
+### Covered write surfaces
+
+- `Write` / `Edit` / `MultiEdit` — `tool_input.file_path`.
+- `apply_patch` and Codex `Edit`/`Write` aliases — file paths parsed from the
+  `*** Add/Update/Delete File:` / `*** Move to:` patch headers. #4447 verified
+  Codex CLI fires `PreToolUse` for `apply_patch` (see the empirical result
+  below), so the guard can enforce that path for the CLI.
+- `Bash` — write-capable redirection (`>`, `>>`, `&>`), `tee`, and in-place
+  editors (`sed -i` / `perl -i`). Read-only preflight (`git status`, `git log`,
+  `rg`, `cat`, …) exposes no write target and is never blocked.
+
+### Coverage limitations (by design)
+
+- Bash write detection is heuristic. Arbitrary write vectors — `dd of=`,
+  `cp`/`mv` destinations, `python -c "open(...,'w')"`, `$EDITOR` — are **not**
+  parsed. Those paths rely on physical worktree isolation plus the monitor
+  tripwire (#4449) and git shim (#4450), not on this hook.
+- The guard is **not** the primary Codex enforcement layer for surfaces Codex
+  does not expose as hookable. #4447 confirmed Codex **CLI** `apply_patch`/`Bash`
+  interception, but Codex **Desktop** direct-edit interception is unverified. If
+  Desktop (or any provider) does not emit a hookable `Bash`/`apply_patch`/`Edit`/
+  `Write` event, this hook cannot enforce that path — #4445/#4446/#4449 carry it
+  instead.
+- Enforcement is scoped to protected branches. If the primary checkout is
+  deliberately on a feature branch, or git cannot resolve the branch, the hook
+  stays out of the way (fail open). It is a safety net; physical isolation is the
+  real guarantee.
+
+Tests: `tests/test_guard_primary_checkout_write.py` (pure payload extraction plus
+end-to-end block/allow against a real repo with a dispatch worktree).
+
 ## CLI probe
 
 Run the probe from the repository root:

--- a/tests/test_guard_primary_checkout_write.py
+++ b/tests/test_guard_primary_checkout_write.py
@@ -1,0 +1,272 @@
+"""Tests for the primary-checkout write guard hook (issue #4448).
+
+Two layers:
+
+* **Pure extraction** — ``bash_write_targets`` / ``write_tool_targets`` are
+  driven directly with strings/dicts (no git), covering redirection, ``tee``,
+  in-place edits, quoted false-positives, and the Write/Edit/apply_patch
+  payload shapes.
+* **End-to-end decision** — the hook is run as a subprocess with a JSON payload
+  on stdin against a *real* git repo (primary checkout on ``main`` + a
+  registered ``.worktrees/dispatch/**`` worktree + gitignored state), asserting
+  the exit code and worktree-hint message. The decision itself is delegated to
+  ``scripts.guardrails.worktree_containment`` (#4444); these tests prove the
+  provider payloads map onto it correctly.
+
+The hook filename has hyphens, so pure-function tests load it via importlib.
+Only module-level defs run on import (``main`` is ``__main__``-guarded).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK_PATH = REPO_ROOT / "agents_extensions/shared" / "hooks" / "guard-primary-checkout-write.py"
+
+# Git env vars that would hijack the throwaway repos below (inherited under
+# pre-commit / a git hook). Mirrors the module's own denylist.
+_GIT_ENV = {
+    "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_NAMESPACE", "GIT_CEILING_DIRECTORIES",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM", "GIT_COMMON_DIR",
+}
+
+
+def _load_hook():
+    spec = importlib.util.spec_from_file_location("guard_primary_checkout_write", HOOK_PATH)
+    assert spec and spec.loader, f"could not load hook at {HOOK_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+hook = _load_hook()
+
+
+# ===========================================================================
+# Pure extraction — Bash
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "command, expected",
+    [
+        # Read-only preflight commands expose no write target.
+        ("git status", []),
+        ("git log --oneline -5", []),
+        ("rg pattern scripts/", []),
+        ("cat curriculum/x.md", []),
+        ("git diff && git status", []),
+        # Redirection variants.
+        ("echo hi > out.txt", ["out.txt"]),
+        ("printf x >> a.log", ["a.log"]),
+        ("echo x &> both.txt", ["both.txt"]),
+        ("echo x 2>err.txt", ["err.txt"]),
+        ("build > /dev/null", ["/dev/null"]),
+        # tee (with wrapper + append flag).
+        ("cat a | tee out.txt", ["out.txt"]),
+        ("cat a | tee -a log.txt", ["log.txt"]),
+        ("sudo tee /etc/hosts", ["/etc/hosts"]),
+        # In-place editors — script excluded, files kept.
+        ('sed -i "s/x/y/" real.py', ["real.py"]),
+        ('sed -i.bak -e "s/a/b/" f1 f2', ["f1", "f2"]),
+        ('perl -pi -e "s/x/y/" z.txt', ["z.txt"]),
+        # Leading env assignment before the command word.
+        ("VAR=1 tee out2.txt", ["out2.txt"]),
+    ],
+)
+def test_bash_write_targets(command, expected):
+    assert hook.bash_write_targets(command) == expected
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        # A redirect char inside a quoted string is NOT a redirection.
+        'git commit -m "fix > thing"',
+        "echo 'a > b'",
+        # fd duplication is not a file write.
+        "echo x 2>&1",
+        # sed without an in-place flag does not write a file.
+        'sed "s/x/y/" real.py',
+    ],
+)
+def test_bash_no_false_positive_write(command):
+    assert hook.bash_write_targets(command) == []
+
+
+# ===========================================================================
+# Pure extraction — structured write tools
+# ===========================================================================
+
+
+def test_write_tool_targets_file_path():
+    assert hook.write_tool_targets({"file_path": "/repo/x.py", "content": "hi"}) == ["/repo/x.py"]
+    assert hook.write_tool_targets({"file_path": "rel/y.md"}) == ["rel/y.md"]
+
+
+def test_write_tool_targets_apply_patch():
+    patch = (
+        "*** Begin Patch\n"
+        "*** Add File: scripts/new.py\n+print(1)\n"
+        "*** Update File: docs/z.md\n"
+        "*** Delete File: old/gone.txt\n"
+        "*** End Patch\n"
+    )
+    assert hook.write_tool_targets({"input": patch}) == [
+        "scripts/new.py",
+        "docs/z.md",
+        "old/gone.txt",
+    ]
+
+
+def test_write_tool_targets_apply_patch_move():
+    patch = "*** Begin Patch\n*** Move to: dst/here.py\n*** Move from: src/there.py\n*** End Patch\n"
+    assert hook.write_tool_targets({"patch": patch}) == ["dst/here.py", "src/there.py"]
+
+
+# ===========================================================================
+# End-to-end decision against a real repo + worktree
+# ===========================================================================
+
+
+def _clean_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if k not in _GIT_ENV}
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True, capture_output=True, text=True, env=_clean_env(),
+    )
+
+
+def _python() -> str:
+    venv = REPO_ROOT / ".venv" / "bin" / "python"
+    return str(venv) if venv.exists() else "python3"
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """Primary checkout on ``main`` + a dispatch worktree + gitignored state."""
+    main = tmp_path / "main"
+    main.mkdir()
+    _git(main, "init", "-q", "-b", "main")
+    _git(main, "config", "user.email", "test@example.com")
+    _git(main, "config", "user.name", "Test")
+
+    (main / "curriculum").mkdir()
+    (main / "curriculum" / "tracked.md").write_text("original\n", encoding="utf-8")
+    (main / ".gitignore").write_text("local_state/\n*.local\n", encoding="utf-8")
+    _git(main, "add", "curriculum/tracked.md", ".gitignore")
+    _git(main, "commit", "-q", "-m", "init")
+
+    _git(main, "worktree", "add", "-q",
+         ".worktrees/dispatch/claude/task-1", "-b", "claude/task-1")
+    return main
+
+
+def _run(repo: Path, payload: dict) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [_python(), str(HOOK_PATH)],
+        input=json.dumps(payload),
+        cwd=repo, check=False, capture_output=True, text=True, env=_clean_env(),
+    )
+
+
+def _write_payload(repo: Path, tool: str, rel: str) -> dict:
+    return {"tool_name": tool, "cwd": str(repo), "tool_input": {"file_path": str(repo / rel)}}
+
+
+def test_tracked_primary_file_write_blocked(repo: Path):
+    result = _run(repo, _write_payload(repo, "Write", "curriculum/tracked.md"))
+    assert result.returncode == 2, result.stderr
+    assert ".worktrees/dispatch/" in result.stderr
+
+
+def test_untracked_new_primary_file_write_blocked(repo: Path):
+    # A brand-new tracked-to-be file in the primary checkout also dirties it.
+    result = _run(repo, _write_payload(repo, "Write", "curriculum/brand-new.md"))
+    assert result.returncode == 2, result.stderr
+
+
+def test_gitignored_local_state_write_allowed(repo: Path):
+    result = _run(repo, _write_payload(repo, "Write", "local_state/scratch.json"))
+    assert result.returncode == 0, result.stderr
+
+
+def test_dispatch_worktree_write_allowed(repo: Path):
+    payload = _write_payload(repo, "Edit", ".worktrees/dispatch/claude/task-1/curriculum/tracked.md")
+    result = _run(repo, payload)
+    assert result.returncode == 0, result.stderr
+
+
+def test_read_only_bash_allowed(repo: Path):
+    for command in ("git status", "cat curriculum/tracked.md", "git log --oneline"):
+        payload = {"tool_name": "Bash", "cwd": str(repo), "tool_input": {"command": command}}
+        result = _run(repo, payload)
+        assert result.returncode == 0, f"{command!r}: {result.stderr}"
+
+
+def test_write_capable_bash_redirect_blocked(repo: Path):
+    payload = {
+        "tool_name": "Bash", "cwd": str(repo),
+        "tool_input": {"command": "echo tampered > curriculum/tracked.md"},
+    }
+    result = _run(repo, payload)
+    assert result.returncode == 2, result.stderr
+    assert ".worktrees/dispatch/" in result.stderr
+
+
+def test_write_capable_bash_tee_blocked(repo: Path):
+    payload = {
+        "tool_name": "Bash", "cwd": str(repo),
+        "tool_input": {"command": "echo x | tee curriculum/tracked.md"},
+    }
+    result = _run(repo, payload)
+    assert result.returncode == 2, result.stderr
+
+
+def test_bash_redirect_to_gitignored_allowed(repo: Path):
+    payload = {
+        "tool_name": "Bash", "cwd": str(repo),
+        "tool_input": {"command": "echo x > local_state/out.log"},
+    }
+    result = _run(repo, payload)
+    assert result.returncode == 0, result.stderr
+
+
+def test_apply_patch_tracked_file_blocked(repo: Path):
+    patch = "*** Begin Patch\n*** Update File: curriculum/tracked.md\n@@\n-original\n+tampered\n*** End Patch\n"
+    payload = {"tool_name": "apply_patch", "cwd": str(repo), "tool_input": {"input": patch}}
+    result = _run(repo, payload)
+    assert result.returncode == 2, result.stderr
+    assert ".worktrees/dispatch/" in result.stderr
+
+
+def test_not_enforced_off_protected_branch(repo: Path):
+    # If the primary checkout is deliberately on a feature branch, the guard
+    # stays out of the way — enforcement is scoped to protected branches.
+    _git(repo, "checkout", "-q", "-b", "maintenance")
+    result = _run(repo, _write_payload(repo, "Write", "curriculum/tracked.md"))
+    assert result.returncode == 0, result.stderr
+
+
+def test_bash_write_from_worktree_targeting_main_blocked(repo: Path):
+    # An agent working in the dispatch worktree that reaches back into the
+    # primary checkout via an absolute path is still blocked (containment is by
+    # resolved real path, not by cwd).
+    worktree = repo / ".worktrees/dispatch/claude/task-1"
+    payload = {
+        "tool_name": "Bash", "cwd": str(worktree),
+        "tool_input": {"command": f"echo x > {repo / 'curriculum' / 'tracked.md'}"},
+    }
+    result = _run(repo, payload)
+    assert result.returncode == 2, result.stderr


### PR DESCRIPTION
## Summary

Closes #4448. Existing hooks guard branch switching, but a direct write tool can dirty tracked files in the primary checkout from repo root without any git command — the observed Codex failure chain (investigate from repo root, then edit from the same cwd).

This adds `guard-primary-checkout-write.py`, a `PreToolUse` guard wired into both providers that blocks a write when its target resolves to a protected file inside the primary checkout **while that checkout sits on a protected branch** (`main`/`master`). Everything else — dispatch-worktree writes, other registered worktrees, gitignored local/runtime state, out-of-repo paths, and read-only preflight commands — is allowed. On a block it exits 2 and tells the agent to create/`cd` into `.worktrees/dispatch/<agent>/<task>/`.

Every containment decision is delegated to `scripts.guardrails.worktree_containment` (#4444) — no path logic is re-derived here. The hook only maps each provider payload onto the target path(s) that module classifies.

## Changes

- **`agents_extensions/shared/hooks/guard-primary-checkout-write.py`** — the guard. Extracts targets from `Write`/`Edit`/`MultiEdit` (`file_path`), `apply_patch`/Codex aliases (`*** Add/Update/Delete File:` / `*** Move to:` headers), and write-capable Bash (redirection `>`/`>>`/`&>`, `tee`, `sed -i`/`perl -i`) via a quote-aware tokenizer. Fails open on any import/git/parse error.
- **`agents_extensions/shared/settings.json`** (Claude) — added to the `Bash` matcher + new `Write|Edit|MultiEdit` matcher.
- **`agents_extensions/codex/hooks.json`** (Codex) — added to `^Bash$` + new `^(Write|Edit|MultiEdit|apply_patch)$` matcher.
- **`docs/runbooks/codex-hooks.md`** — documents covered surfaces, coverage limitations, and the relationship to the #4447 Codex hook probe.
- **`tests/test_guard_primary_checkout_write.py`** — 35 tests.

## Coverage limitations (documented, by design)

- **Bash write detection is heuristic.** `dd of=`, `cp`/`mv` destinations, `python -c "open(...,'w')"`, `$EDITOR` are **not** parsed — those rely on physical worktree isolation plus the monitor tripwire (#4449) and git shim (#4450).
- **Not the primary Codex enforcement layer where Codex isn't hookable.** #4447 verified Codex **CLI** `apply_patch`/`Bash` interception (exit 2 blocks), but Codex **Desktop** direct-edit interception is unverified. Where a provider emits no hookable write event, #4445/#4446/#4449 carry that path.
- **Scoped to protected branches** — if the primary checkout is deliberately on a feature branch (or git can't resolve it), the hook stays out of the way. Safety net, not chokepoint; physical isolation is the real guarantee.

Out of scope: the #4450 git shim is intentionally not implemented here.

## Verification

- `pytest tests/test_guard_primary_checkout_write.py` — **35 passed** (pure payload extraction + end-to-end block/allow against a real repo with a dispatch worktree: tracked-block, untracked-new-block, gitignored-allow, dispatch-allow, read-only-Bash-allow, redirect-block, tee-block, apply_patch-block, off-branch-allow, worktree→main-via-absolute-path-block).
- `pytest tests/test_worktree_containment.py tests/test_guard_branch_switch_in_main.py tests/test_deploy_script_idempotency.py` — all green (no regressions).
- `scripts/deploy_prompts.sh --dry-run` — orphan guard green, exit 0.
- `ruff check`, `git diff --check`, `markdownlint` — clean.
- `scripts/audit/lint_agent_trailer.py` — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
