### PR TITLE
Add Ukrainian-only readings for Rus medieval BIOs

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/danylo-halytskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/danylo-halytskyi.yaml
@@ -89,6 +89,7 @@ readings:
   hosting: link-only
   cefr_min: C1
   learner_task: 'Ознайомитись з етапами правління та політичною стратегією короля.'
+  caveats: 'Довідкова стаття корисна для хронології; інтерпретацію коронації, дипломатії та війни треба звіряти з літописними уривками.'
 - title: 'Галицько-Волинський літопис (про Данила)'
   language: uk
   genre: chronicle
@@ -99,6 +100,7 @@ readings:
   hosting: excerpt-only
   cefr_min: C1
   learner_task: 'Проаналізувати опис коронації та взаємин з Ордою.'
+  caveats: 'Середньовічний літопис у модерному виданні; використовувати уривки з поясненням жанру, редакційної традиції та політичної риторики.'
 - title: 'Данило Романович (Вікіпедія)'
   language: uk
   genre: encyclopedia
@@ -109,6 +111,7 @@ readings:
   hosting: link-only
   cefr_min: B2
   learner_task: 'Перевірити основні віхи державотворення.'
+  caveats: 'Орієнтаційне читання; перевіряти титули, дати та оцінки за ЕІУ й літописними джерелами.'
 references:
 - title: Danylo Halytskyi
   note: Compiled from Hrushevsky, Plokhy, Hrytsak — key facts and interpretations
@@ -128,7 +131,7 @@ sequence: 10
 slug: danylo-halytskyi
 subtitle: The King Who Chose the West
 title: 'Данило Галицький: Король Русі'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: урочиста церемонія покладання корони на монарха, що символізує початок його правління
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/danylo-halytskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/danylo-halytskyi.yaml
@@ -78,6 +78,37 @@ persona:
   role: Літописець, що бачив і тріумф коронації, і приниження в Орді. Розповідає історію без прикрас, з болем і гордістю.
   voice: RoyalChronicler-Realist
 phase: BIO.1
+readings:
+- title: 'Данило Галицький: Енциклопедія історії України'
+  language: uk
+  genre: encyclopedia
+  source_type: reference
+  role: context
+  source_url: 'http://history.org.ua/?termin=Danylo_Halyckyj'
+  license: copyright
+  hosting: link-only
+  cefr_min: C1
+  learner_task: 'Ознайомитись з етапами правління та політичною стратегією короля.'
+- title: 'Галицько-Волинський літопис (про Данила)'
+  language: uk
+  genre: chronicle
+  source_type: primary
+  role: source-analysis
+  source_url: 'http://litopys.org.ua/litop/lit.htm'
+  license: public-domain
+  hosting: excerpt-only
+  cefr_min: C1
+  learner_task: 'Проаналізувати опис коронації та взаємин з Ордою.'
+- title: 'Данило Романович (Вікіпедія)'
+  language: uk
+  genre: encyclopedia
+  source_type: reference
+  role: context
+  source_url: 'https://uk.wikipedia.org/wiki/Данило_Романович'
+  license: CC-BY-SA
+  hosting: link-only
+  cefr_min: B2
+  learner_task: 'Перевірити основні віхи державотворення.'
 references:
 - title: Danylo Halytskyi
   note: Compiled from Hrushevsky, Plokhy, Hrytsak — key facts and interpretations
@@ -97,7 +128,7 @@ sequence: 10
 slug: danylo-halytskyi
 subtitle: The King Who Chose the West
 title: 'Данило Галицький: Король Русі'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: урочиста церемонія покладання корони на монарха, що символізує початок його правління
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/lev-danylovych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/lev-danylovych.yaml
@@ -80,6 +80,37 @@ persona:
   role: Модератор семінару, який спонукає студентів відійти від чорно-білих оцінок і побачити в Леві Даниловичі складну історичну постать, що діяла в екстремальних умовах.
   voice: Nuanced-Historian
 phase: BIO.2
+readings:
+- title: 'Лев Данилович: Енциклопедія історії України'
+  language: uk
+  genre: encyclopedia
+  source_type: reference
+  role: context
+  source_url: 'http://history.org.ua/?termin=Lev_Danylovych'
+  license: copyright
+  hosting: link-only
+  cefr_min: C1
+  learner_task: 'Вивчити політичну спадщину та містобудівну діяльність князя.'
+- title: 'Галицько-Волинський літопис (діяльність Лева)'
+  language: uk
+  genre: chronicle
+  source_type: primary
+  role: source-analysis
+  source_url: 'http://litopys.org.ua/litop/lit.htm'
+  license: public-domain
+  hosting: excerpt-only
+  cefr_min: C1
+  learner_task: 'Порівняти літописні оцінки політики Лева з діями Данила.'
+- title: 'Лев I Данилович (Вікіпедія)'
+  language: uk
+  genre: encyclopedia
+  source_type: reference
+  role: context
+  source_url: 'https://uk.wikipedia.org/wiki/Лев_I_Данилович'
+  license: CC-BY-SA
+  hosting: link-only
+  cefr_min: B2
+  learner_task: 'Ознайомитись із роллю Лева в розвитку Львова.'
 references:
 - title: Lev Danylovych
   note: Compiled research based on Hrushevsky, primary chronicles, and modern analysis.
@@ -99,7 +130,7 @@ sequence: 11
 slug: lev-danylovych
 subtitle: 'Lev Danylovych: Builder of Lviv'
 title: 'Лев Данилович: Будівничий Львова'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: головне місто держави, де перебувають вищі органи влади й управління
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/lev-danylovych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/lev-danylovych.yaml
@@ -91,6 +91,7 @@ readings:
   hosting: link-only
   cefr_min: C1
   learner_task: 'Вивчити політичну спадщину та містобудівну діяльність князя.'
+  caveats: 'Довідкова стаття стисло подає правління; твердження про столицю, дипломатію та спадщину звіряти з літописними уривками.'
 - title: 'Галицько-Волинський літопис (діяльність Лева)'
   language: uk
   genre: chronicle
@@ -101,6 +102,7 @@ readings:
   hosting: excerpt-only
   cefr_min: C1
   learner_task: 'Порівняти літописні оцінки політики Лева з діями Данила.'
+  caveats: 'Літописний текст потребує джерелознавчого коментаря; використовувати короткі уривки з поясненням жанру й редакційної перспективи.'
 - title: 'Лев I Данилович (Вікіпедія)'
   language: uk
   genre: encyclopedia
@@ -111,6 +113,7 @@ readings:
   hosting: link-only
   cefr_min: B2
   learner_task: 'Ознайомитись із роллю Лева в розвитку Львова.'
+  caveats: 'Орієнтаційне читання; спірні дати й топонімічні твердження перевіряти за ЕІУ та академічними джерелами.'
 references:
 - title: Lev Danylovych
   note: Compiled research based on Hrushevsky, primary chronicles, and modern analysis.
@@ -130,7 +133,7 @@ sequence: 11
 slug: lev-danylovych
 subtitle: 'Lev Danylovych: Builder of Lviv'
 title: 'Лев Данилович: Будівничий Львова'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: головне місто держави, де перебувають вищі органи влади й управління
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/mykhailo-chernihivskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykhailo-chernihivskyi.yaml
@@ -92,17 +92,18 @@ readings:
   hosting: link-only
   cefr_min: C1
   learner_task: 'Ознайомитись з родоводом та політичною діяльністю князя.'
+  caveats: 'Довідкова стаття задає біографічний каркас; агіографічні мотиви мучеництва треба аналізувати окремо від політичної реконструкції.'
 - title: 'Сказання про вбивство в Орді князя Михайла Чернігівського і його боярина Федора'
   language: uk
   genre: hagiography
   source_type: primary
   role: source-analysis
-  source_url: 'http://litopys.org.ua/'
-  license: public-domain
+  source: 'internal:wave7-istkult-t2-xiii-xvii#484d0ffb_c0578'
+  license: copyright
   hosting: excerpt-only
   cefr_min: C1
   learner_task: 'Критично оцінити агіографічне джерело.'
-  caveats: 'Потребує адаптації мови для рівня C1.'
+  caveats: 'Внутрішній корпусний фрагмент подає жанровий контекст житія; використовувати як керовану цитату або короткий уривок, не як самостійно хостований повний текст.'
 - title: 'Михайло Всеволодович (Вікіпедія)'
   language: uk
   genre: encyclopedia
@@ -113,6 +114,7 @@ readings:
   hosting: link-only
   cefr_min: B2
   learner_task: 'Вивчити дати та ключові події життя.'
+  caveats: 'Орієнтаційне читання; перевіряти факти за ЕІУ та першоджерельними матеріалами, особливо щодо культу мучеництва.'
 references:
 - title: Михайло Всеволодович
   note: Загальна біографія, дати та родовід
@@ -137,7 +139,7 @@ sequence: 9
 slug: mykhailo-chernihivskyi
 subtitle: 'Mykhailo of Chernihiv: The Martyr Prince'
 title: 'Михайло Чернігівський: Князь-мученик'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: смерть, прийнята за віру; свідома жертва життям заради вищих переконань
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/mykhailo-chernihivskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykhailo-chernihivskyi.yaml
@@ -81,6 +81,38 @@ persona:
   role: Модератор семінару, що відділяє житіє від життя, а святого від князя, проблематизуючи офіційні наративи
   voice: Hagiography-Skeptic
 phase: BIO
+readings:
+- title: 'Михайло Всеволодович: Енциклопедія історії України'
+  language: uk
+  genre: encyclopedia
+  source_type: reference
+  role: context
+  source_url: 'http://history.org.ua/?termin=Mykhajlo_Vsevolodovych'
+  license: copyright
+  hosting: link-only
+  cefr_min: C1
+  learner_task: 'Ознайомитись з родоводом та політичною діяльністю князя.'
+- title: 'Сказання про вбивство в Орді князя Михайла Чернігівського і його боярина Федора'
+  language: uk
+  genre: hagiography
+  source_type: primary
+  role: source-analysis
+  source_url: 'http://litopys.org.ua/'
+  license: public-domain
+  hosting: excerpt-only
+  cefr_min: C1
+  learner_task: 'Критично оцінити агіографічне джерело.'
+  caveats: 'Потребує адаптації мови для рівня C1.'
+- title: 'Михайло Всеволодович (Вікіпедія)'
+  language: uk
+  genre: encyclopedia
+  source_type: reference
+  role: context
+  source_url: 'https://uk.wikipedia.org/wiki/Михайло_Всеволодович'
+  license: CC-BY-SA
+  hosting: link-only
+  cefr_min: B2
+  learner_task: 'Вивчити дати та ключові події життя.'
 references:
 - title: Михайло Всеволодович
   note: Загальна біографія, дати та родовід
@@ -105,7 +137,7 @@ sequence: 9
 slug: mykhailo-chernihivskyi
 subtitle: 'Mykhailo of Chernihiv: The Martyr Prince'
 title: 'Михайло Чернігівський: Князь-мученик'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: смерть, прийнята за віру; свідома жертва життям заради вищих переконань
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/mykhailo-chernihivskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykhailo-chernihivskyi.yaml
@@ -93,17 +93,29 @@ readings:
   cefr_min: C1
   learner_task: 'Ознайомитись з родоводом та політичною діяльністю князя.'
   caveats: 'Довідкова стаття задає біографічний каркас; агіографічні мотиви мучеництва треба аналізувати окремо від політичної реконструкції.'
-- title: 'Сказання про вбивство в Орді князя Михайла Чернігівського і його боярина Федора'
+- title: 'Житіє Михайла Чернігівського в історико-культурному викладі'
   language: uk
-  genre: hagiography
-  source_type: primary
+  genre: scholarly excerpt
+  source_type: secondary
   role: source-analysis
   source: 'internal:wave7-istkult-t2-xiii-xvii#484d0ffb_c0578'
   license: copyright
   hosting: excerpt-only
   cefr_min: C1
-  learner_task: 'Критично оцінити агіографічне джерело.'
-  caveats: 'Внутрішній корпусний фрагмент подає жанровий контекст житія; використовувати як керовану цитату або короткий уривок, не як самостійно хостований повний текст.'
+  learner_task: 'Відділити цитовану агіографічну фразу від наукового коментаря й визначити, як створюється образ мученика.'
+  caveats: 'Внутрішній корпусний фрагмент з «Історії української культури» подає жанровий контекст і коротку цитату з житія; це не повний текст самого «Сказання».'
+  rights_note: 'Підставовий твір — «Історія української культури», т. 2; використовувати лише короткий контрольований уривок або переказ, не хостити повний текст.'
+- title: 'Плано Карпіні про страту руського князя в Орді'
+  language: uk
+  genre: travel account
+  source_type: primary
+  role: reading-needed
+  source: 'reading-needed: verify a Ukrainian-hosted translation excerpt from «Історія монголів» before module build'
+  license: unknown
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: 'Після верифікації українського уривка зіставити зовнішній опис Орди з агіографічною моделлю мучеництва.'
+  caveats: 'Не підміняти текст Плано Карпіні переказом із довідників; потрібні перевірка українського перекладу, прав і стабільного доступу.'
 - title: 'Михайло Всеволодович (Вікіпедія)'
   language: uk
   genre: encyclopedia
@@ -139,7 +151,7 @@ sequence: 9
 slug: mykhailo-chernihivskyi
 subtitle: 'Mykhailo of Chernihiv: The Martyr Prince'
 title: 'Михайло Чернігівський: Князь-мученик'
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: смерть, прийнята за віру; свідома жертва життям заради вищих переконань
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/nestor-litopysets.yaml
+++ b/curriculum/l2-uk-en/plans/bio/nestor-litopysets.yaml
@@ -90,6 +90,7 @@ readings:
   hosting: link-only
   cefr_min: C1
   learner_task: 'Ознайомитися з академічною біографією Нестора.'
+  caveats: 'Довідкова стаття задає біографічний контекст; авторство літопису й редакційні гіпотези потрібно перевіряти за джерелознавчими працями.'
 - title: 'Повість минулих літ (переклад В. Яременка)'
   language: uk
   genre: chronicle
@@ -100,6 +101,7 @@ readings:
   hosting: excerpt-only
   cefr_min: C1
   learner_task: 'Проаналізувати мову та стиль літопису.'
+  caveats: 'Середньовічний літопис у модерному перекладі; використовувати уривки з поясненням жанру, редакцій і політичного контексту.'
 - title: 'Житіє преподобного отця нашого Нестора'
   language: uk
   genre: hagiography
@@ -110,6 +112,7 @@ readings:
   hosting: link-only
   cefr_min: C1
   learner_task: 'Порівняти історичні факти з агіографічним описом.'
+  caveats: 'Агіографічний текст не є нейтральною біографією; читати як церковний жанр із власною риторикою святості.'
 - title: 'Нестор-літописець (ЕСУ)'
   language: uk
   genre: encyclopedia
@@ -120,6 +123,7 @@ readings:
   hosting: link-only
   cefr_min: B2
   learner_task: 'Перевірити основні факти з біографії.'
+  caveats: 'Коротка енциклопедична довідка; не замінює аналізу літописного тексту й історіографічної дискусії.'
 references:
 - title: Index
   note: Повість минулих літ в перекладі та з коментарями
@@ -138,7 +142,7 @@ sequence: 7
 slug: nestor-litopysets
 subtitle: 'Nestor the Chronicler: The Father of Ukrainian Historiography'
 title: 'Нестор Літописець: Батько української історіографії'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: укладач літопису, середньовічний історик
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/nestor-litopysets.yaml
+++ b/curriculum/l2-uk-en/plans/bio/nestor-litopysets.yaml
@@ -79,6 +79,47 @@ persona:
   role: Ведучий семінару з джерелознавства, що ставить під сумнів канонічні інтерпретації та шукає політичний підтекст.
   voice: Scholarly-Skeptic
 phase: BIO.1
+readings:
+- title: 'Нестор Літописець: Енциклопедія історії України'
+  language: uk
+  genre: encyclopedia
+  source_type: reference
+  role: context
+  source_url: 'http://history.org.ua/?termin=Nestor_Litopysec'
+  license: copyright
+  hosting: link-only
+  cefr_min: C1
+  learner_task: 'Ознайомитися з академічною біографією Нестора.'
+- title: 'Повість минулих літ (переклад В. Яременка)'
+  language: uk
+  genre: chronicle
+  source_type: primary
+  role: source-analysis
+  source_url: 'http://litopys.org.ua/povist/pov.htm'
+  license: public-domain
+  hosting: excerpt-only
+  cefr_min: C1
+  learner_task: 'Проаналізувати мову та стиль літопису.'
+- title: 'Житіє преподобного отця нашого Нестора'
+  language: uk
+  genre: hagiography
+  source_type: primary
+  role: context
+  source_url: 'http://litopys.org.ua/paterik/pater18.htm'
+  license: public-domain
+  hosting: link-only
+  cefr_min: C1
+  learner_task: 'Порівняти історичні факти з агіографічним описом.'
+- title: 'Нестор-літописець (ЕСУ)'
+  language: uk
+  genre: encyclopedia
+  source_type: reference
+  role: context
+  source_url: 'https://esu.com.ua/article-73138'
+  license: copyright
+  hosting: link-only
+  cefr_min: B2
+  learner_task: 'Перевірити основні факти з біографії.'
 references:
 - title: Index
   note: Повість минулих літ в перекладі та з коментарями
@@ -97,7 +138,7 @@ sequence: 7
 slug: nestor-litopysets
 subtitle: 'Nestor the Chronicler: The Father of Ukrainian Historiography'
 title: 'Нестор Літописець: Батько української історіографії'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: укладач літопису, середньовічний історик
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/roman-mstyslavych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/roman-mstyslavych.yaml
@@ -82,6 +82,37 @@ persona:
   role: Модератор семінару, що ставить під сумнів офіційну версію літописів, змушуючи розрізняти державну пропаганду та історичну реальність
   voice: Chronicle-Skeptic
 phase: BIO
+readings:
+- title: 'Роман Мстиславич: Енциклопедія історії України'
+  language: uk
+  genre: encyclopedia
+  source_type: reference
+  role: context
+  source_url: 'http://history.org.ua/?termin=Roman_Mstyslavych'
+  license: copyright
+  hosting: link-only
+  cefr_min: C1
+  learner_task: 'Вивчити основні віхи життя та державотворення князя.'
+- title: 'Галицько-Волинський літопис'
+  language: uk
+  genre: chronicle
+  source_type: primary
+  role: source-analysis
+  source_url: 'http://litopys.org.ua/litop/lit.htm'
+  license: public-domain
+  hosting: excerpt-only
+  cefr_min: C1
+  learner_task: 'Проаналізувати фрагменти, що стосуються правління Романа Мстиславича.'
+- title: 'Галицько-Волинське князівство (Вікіпедія)'
+  language: uk
+  genre: encyclopedia
+  source_type: reference
+  role: context
+  source_url: 'https://uk.wikipedia.org/wiki/Галицько-Волинське_князівство'
+  license: CC-BY-SA
+  hosting: link-only
+  cefr_min: B2
+  learner_task: 'Зрозуміти геополітичний контекст утворення держави.'
 references:
 - title: Роман Мстиславич (Wikipedia UA)
   note: Biography, military campaigns, unification of principalities
@@ -102,7 +133,7 @@ sequence: 8
 slug: roman-mstyslavych
 subtitle: 'Roman the Great: Founder of the Galicia-Volhynia State'
 title: 'Роман Мстиславич: Засновник Галицько-Волинської держави'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: монарх з необмеженою верховною владою, автократ
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/roman-mstyslavych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/roman-mstyslavych.yaml
@@ -93,6 +93,7 @@ readings:
   hosting: link-only
   cefr_min: C1
   learner_task: 'Вивчити основні віхи життя та державотворення князя.'
+  caveats: 'Довідкова стаття стисло подає політичну кар''єру; причинно-наслідкові висновки треба звіряти з літописними уривками.'
 - title: 'Галицько-Волинський літопис'
   language: uk
   genre: chronicle
@@ -103,6 +104,7 @@ readings:
   hosting: excerpt-only
   cefr_min: C1
   learner_task: 'Проаналізувати фрагменти, що стосуються правління Романа Мстиславича.'
+  caveats: 'Середньовічний літопис у виданні для читання; використовувати вибрані уривки з поясненням редакції, жанру й датування.'
 - title: 'Галицько-Волинське князівство (Вікіпедія)'
   language: uk
   genre: encyclopedia
@@ -113,6 +115,7 @@ readings:
   hosting: link-only
   cefr_min: B2
   learner_task: 'Зрозуміти геополітичний контекст утворення держави.'
+  caveats: 'Орієнтаційне читання; фактичні твердження перевіряти за ЕІУ та першоджерельними уривками.'
 references:
 - title: Роман Мстиславич (Wikipedia UA)
   note: Biography, military campaigns, unification of principalities
@@ -133,7 +136,7 @@ sequence: 8
 slug: roman-mstyslavych
 subtitle: 'Roman the Great: Founder of the Galicia-Volhynia State'
 title: 'Роман Мстиславич: Засновник Галицько-Волинської держави'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: монарх з необмеженою верховною владою, автократ
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/yuriy-lvovych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yuriy-lvovych.yaml
@@ -94,6 +94,17 @@ readings:
   cefr_min: C1
   learner_task: 'Зрозуміти значення титулу Короля Русі та заснування митрополії.'
   caveats: 'Довідкова стаття задає хронологію й титулатуру; інтерпретації державної спадкоємності треба перевіряти за нумізматичними та літописними джерелами.'
+- title: 'Печатка Юрія I Львовича з титулом короля Русі'
+  language: uk
+  genre: seal
+  source_type: primary
+  role: reading-needed
+  source: 'reading-needed: verify a rights-clear Ukrainian-hosted facsimile or scholarly edition of the seal legend before module build'
+  license: unknown
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: 'Після верифікації джерела пояснити, як титул «король Русі» працює як документальний доказ державної традиції.'
+  caveats: 'Не підміняти печатку загальною статтею про Королівство Русі; потрібні перевірка зображення або видання легенди, прав і стабільного доступу.'
 - title: 'Королівство Русі (Вікіпедія)'
   language: uk
   genre: encyclopedia
@@ -136,7 +147,7 @@ sequence: 12
 slug: yuriy-lvovych
 subtitle: 'Yuriy I Lvovych: The Last King of Rus'''
 title: 'Юрій I Львович: Останній Король Русі'
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: пристрій для відбитку офіційного знака або сам відбиток, що підтверджує автентичність документа
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/yuriy-lvovych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yuriy-lvovych.yaml
@@ -93,6 +93,7 @@ readings:
   hosting: link-only
   cefr_min: C1
   learner_task: 'Зрозуміти значення титулу Короля Русі та заснування митрополії.'
+  caveats: 'Довідкова стаття задає хронологію й титулатуру; інтерпретації державної спадкоємності треба перевіряти за нумізматичними та літописними джерелами.'
 - title: 'Королівство Русі (Вікіпедія)'
   language: uk
   genre: encyclopedia
@@ -103,6 +104,7 @@ readings:
   hosting: link-only
   cefr_min: B2
   learner_task: 'Дослідити геополітичний статус Королівства в часи Юрія І.'
+  caveats: 'Орієнтаційне читання; стаття про політичну формацію не замінює біографічного джерела про самого Юрія.'
 - title: 'Галицька митрополія (Вікіпедія)'
   language: uk
   genre: encyclopedia
@@ -113,6 +115,7 @@ readings:
   hosting: link-only
   cefr_min: B2
   learner_task: 'Ознайомитись з церковною незалежністю держави.'
+  caveats: 'Орієнтаційне читання про інституційний контекст; перевіряти зв''язок із Юрієм за спеціальними довідковими джерелами.'
 references:
 - title: Юрій I Львович (Wikipedia UA)
   name: Юрій I Львович (Wikipedia UA)
@@ -133,7 +136,7 @@ sequence: 12
 slug: yuriy-lvovych
 subtitle: 'Yuriy I Lvovych: The Last King of Rus'''
 title: 'Юрій I Львович: Останній Король Русі'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: пристрій для відбитку офіційного знака або сам відбиток, що підтверджує автентичність документа
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/yuriy-lvovych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yuriy-lvovych.yaml
@@ -82,6 +82,37 @@ persona:
   role: Модератор семінару, що руйнує чорно-білі оцінки та змушує студентів бачити складність і парадокси історії
   voice: Nuanced-Historian
 phase: BIO.2
+readings:
+- title: 'Юрій I Львович: Енциклопедія історії України'
+  language: uk
+  genre: encyclopedia
+  source_type: reference
+  role: context
+  source_url: 'http://history.org.ua/?termin=Yuriy_Lvovych'
+  license: copyright
+  hosting: link-only
+  cefr_min: C1
+  learner_task: 'Зрозуміти значення титулу Короля Русі та заснування митрополії.'
+- title: 'Королівство Русі (Вікіпедія)'
+  language: uk
+  genre: encyclopedia
+  source_type: reference
+  role: context
+  source_url: 'https://uk.wikipedia.org/wiki/Королівство_Русі'
+  license: CC-BY-SA
+  hosting: link-only
+  cefr_min: B2
+  learner_task: 'Дослідити геополітичний статус Королівства в часи Юрія І.'
+- title: 'Галицька митрополія (Вікіпедія)'
+  language: uk
+  genre: encyclopedia
+  source_type: reference
+  role: context
+  source_url: 'https://uk.wikipedia.org/wiki/Галицька_митрополія'
+  license: CC-BY-SA
+  hosting: link-only
+  cefr_min: B2
+  learner_task: 'Ознайомитись з церковною незалежністю держави.'
 references:
 - title: Юрій I Львович (Wikipedia UA)
   name: Юрій I Львович (Wikipedia UA)
@@ -102,7 +133,7 @@ sequence: 12
 slug: yuriy-lvovych
 subtitle: 'Yuriy I Lvovych: The Last King of Rus'''
 title: 'Юрій I Львович: Останній Король Русі'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: пристрій для відбитку офіційного знака або сам відбиток, що підтверджує автентичність документа
   pos: ж.


### PR DESCRIPTION
Adds top-level Ukrainian-only learner reading packets for six Rus/medieval BIO plans: Nestor Litopysets, Roman Mstyslavych, Mykhailo Chernihivskyi, Danylo Halytskyi, Lev Danylovych, and Yuriy Lvovych.\n\nSource strategy: Ukrainian-only primary/near-primary and context sources, with Litopys/Izbornyk, Ukrainian encyclopedia/institutional sources, and fallback Ukrainian Wikipedia where appropriate. Includes hostability/copyright notes in plan-level readings metadata.\n\nLLM-QG/Gemma: not used.\n\nRefs #4400. Refs #4431.\n\nX-Agent: agy/bio-readings-rus-medieval-batch-02-agy