### PR TITLE
fix(audit): bakeoff claim matching measures verdicts, not echo fidelity

### DIFF
--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -404,13 +404,23 @@ def _match_rows_to_claims(
 
     Matching, in precedence order per fixture claim:
     1. exact normalized equality (the anchor-fixture path, unchanged);
-    2. containment: normalized fixture claim is a substring of ONE model row's
+    2. containment: normalized fixture claim is a substring of a model row's
        normalized claim (models quote whole sentences; fixture claims are
-       sub-spans). A single model row MAY cover multiple fixture claims — that
-       is semantically fair: confirming a sentence that contains a fabricated
-       sub-claim IS confirming the fabrication (the shared-sentence M-traps).
+       sub-spans). Among multiple containing rows the TIGHTEST (shortest) row
+       wins — first-row-wins was row-order dependent and could score a broad
+       row's verdict over a more specific one (codex review, PR #4485).
+       A single model row MAY cover multiple fixture claims, but broad-row
+       verdict transfer is polarity-guarded: confirming a sentence that
+       contains a fabricated sub-claim IS confirming the fabrication (the
+       shared-sentence M-traps), and any verdict on a span containing a
+       fabrication is a judgment ABOUT that fabrication — but a NEGATIVE
+       verdict on a compound sentence usually targets the fabricated part,
+       so it must NOT transfer to a TRUE sub-claim the model never separately
+       judged (it would score refuted-true −50 for a verdict the model never
+       issued; the claim counts missing −10 instead).
     3. reverse containment (model row quotes a sub-span of the fixture claim),
-       guarded by a length floor so tiny fragments cannot claim-jack.
+       guarded by a length floor so tiny fragments cannot claim-jack; among
+       multiple candidates the LONGEST (most coverage) wins.
     Rows that match nothing stay unmatched (counted, visible in artifacts).
     """
     matched: dict[str, dict[str, Any]] = {}
@@ -423,19 +433,28 @@ def _match_rows_to_claims(
             continue
         # 1. exact
         hit = next((i for i, (nr, _r) in enumerate(norm_rows) if nr == want), None)
-        # 2. fixture-claim ⊆ model-row
+        # 2. fixture-claim ⊆ model-row: tightest containing row; only a
+        #    CONFIRMED judgment transfers from a broader span to a TRUE claim.
         if hit is None:
-            hit = next((i for i, (nr, _r) in enumerate(norm_rows) if nr and want in nr), None)
-        # 3. model-row ⊆ fixture-claim (length floor: ≥60% of the fixture claim)
+            candidates = [
+                i
+                for i, (nr, r) in enumerate(norm_rows)
+                if nr
+                and want in nr
+                and (not claim.is_true or _judgment_verdict(r) == "CONFIRMED")
+            ]
+            if candidates:
+                hit = min(candidates, key=lambda i: len(norm_rows[i][0]))
+        # 3. model-row ⊆ fixture-claim (length floor: ≥60% of the fixture
+        #    claim): longest contained row.
         if hit is None:
-            hit = next(
-                (
-                    i
-                    for i, (nr, _r) in enumerate(norm_rows)
-                    if nr and nr in want and len(nr) >= max(20, int(0.6 * len(want)))
-                ),
-                None,
-            )
+            candidates = [
+                i
+                for i, (nr, _r) in enumerate(norm_rows)
+                if nr and nr in want and len(nr) >= max(20, int(0.6 * len(want)))
+            ]
+            if candidates:
+                hit = max(candidates, key=lambda i: len(norm_rows[i][0]))
         if hit is not None:
             matched[claim.claim_id] = norm_rows[hit][1]
             used_rows.add(hit)

--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -171,6 +171,14 @@ def load_fixture(path: Path) -> BakeoffFixture:
             raise BakeoffConfigError(f"{path}: {claim_id}: false claims require fabrication_class")
         if fabrication_class == "M" and not (isinstance(distractor, str) and distractor.strip()):
             raise BakeoffConfigError(f"{path}: {claim_id}: class-M claims require distractor_evidence")
+        if _normalize_claim_loose(claim) not in _normalize_claim_loose(passage_md):
+            # Load-bearing (first scored matrix, 2026-07-05): models fact-check
+            # by quoting PASSAGE spans; paraphrased fixture claims can never
+            # match and score as "missing". Claims MUST be literal sub-spans.
+            raise BakeoffConfigError(
+                f"{path}: {claim_id}: claim text must be a literal sub-span of passage_md "
+                f"(loose-normalized) — paraphrases break claim matching"
+            )
         claims.append(
             FixtureClaim(
                 claim_id=claim_id,
@@ -370,20 +378,77 @@ def run_one(
     return BakeoffRun(artifact_path=artifact_path, artifact=artifact)
 
 
+
+_CLAIM_PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
+
+
+def _normalize_claim_loose(text: str) -> str:
+    """Claim matching only: punctuation-insensitive on top of the base norm.
+
+    Live finding: fixture claims end with «.» where the model's sentence-quote
+    continues with «,» — containment failed on the period alone.
+    """
+    return " ".join(_CLAIM_PUNCT_RE.sub(" ", _normalize_claim_text(text)).split())
+
+
+def _match_rows_to_claims(
+    rows: list[dict[str, Any]],
+    fixture: BakeoffFixture,
+) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]:
+    """Map model fact-check rows onto fixture claims (containment matching).
+
+    Live finding (first scored matrix, 2026-07-05): models quote PASSAGE
+    SENTENCES verbatim while fixture claims are trimmed sub-spans of those
+    sentences — exact-normalized matching left 22-30/35 claims "missing" and
+    the scorecard measured claim-echo fidelity instead of verdict quality.
+
+    Matching, in precedence order per fixture claim:
+    1. exact normalized equality (the anchor-fixture path, unchanged);
+    2. containment: normalized fixture claim is a substring of ONE model row's
+       normalized claim (models quote whole sentences; fixture claims are
+       sub-spans). A single model row MAY cover multiple fixture claims — that
+       is semantically fair: confirming a sentence that contains a fabricated
+       sub-claim IS confirming the fabrication (the shared-sentence M-traps).
+    3. reverse containment (model row quotes a sub-span of the fixture claim),
+       guarded by a length floor so tiny fragments cannot claim-jack.
+    Rows that match nothing stay unmatched (counted, visible in artifacts).
+    """
+    matched: dict[str, dict[str, Any]] = {}
+    used_rows: set[int] = set()
+    norm_rows = [(_normalize_claim_loose(str(r.get("claim") or "")), r) for r in rows]
+
+    for claim in fixture.claims:
+        want = _normalize_claim_loose(claim.claim)
+        if not want:
+            continue
+        # 1. exact
+        hit = next((i for i, (nr, _r) in enumerate(norm_rows) if nr == want), None)
+        # 2. fixture-claim ⊆ model-row
+        if hit is None:
+            hit = next((i for i, (nr, _r) in enumerate(norm_rows) if nr and want in nr), None)
+        # 3. model-row ⊆ fixture-claim (length floor: ≥60% of the fixture claim)
+        if hit is None:
+            hit = next(
+                (
+                    i
+                    for i, (nr, _r) in enumerate(norm_rows)
+                    if nr and nr in want and len(nr) >= max(20, int(0.6 * len(want)))
+                ),
+                None,
+            )
+        if hit is not None:
+            matched[claim.claim_id] = norm_rows[hit][1]
+            used_rows.add(hit)
+
+    unmatched = [r for i, (_nr, r) in enumerate(norm_rows) if i not in used_rows]
+    return matched, unmatched
+
+
 def score_payload(payload: Mapping[str, Any], fixture: BakeoffFixture) -> dict[str, Any]:
     """Score a gated payload against fixture truth, keyed by stable claim_id."""
     fact_checks = payload.get("fact_checks")
     rows = [dict(row) for row in fact_checks] if isinstance(fact_checks, list) else []
-    fixture_by_norm = {_normalize_claim_text(claim.claim): claim for claim in fixture.claims}
-    matched: dict[str, dict[str, Any]] = {}
-    unmatched_rows: list[dict[str, Any]] = []
-    for row in rows:
-        claim_text = row.get("claim")
-        fixture_claim = fixture_by_norm.get(_normalize_claim_text(str(claim_text or "")))
-        if fixture_claim is None or fixture_claim.claim_id in matched:
-            unmatched_rows.append(row)
-            continue
-        matched[fixture_claim.claim_id] = row
+    matched, unmatched_rows = _match_rows_to_claims(rows, fixture)
 
     truth_by_claim_id = {claim.claim_id: claim.is_true for claim in fixture.claims}
     scoring_rows: list[dict[str, Any]] = []
@@ -533,6 +598,37 @@ def pin_slug(pin: str) -> str:
     return slug or "model"
 
 
+
+def rescore_artifacts(output_dir: Path, fixtures_dir: Path = FIXTURE_DIR) -> int:
+    """Recompute scores for existing artifacts from their STORED payloads.
+
+    Zero model invocations — pure offline rescoring, for matcher/scoring
+    changes (e.g. the containment matcher). Rewrites each artifact's score
+    block and the scorecard.
+    """
+    fixtures = {f.slug: f for f in load_fixtures(fixtures_dir)}
+    artifacts: list[dict[str, Any]] = []
+    count = 0
+    for path in sorted(output_dir.glob("*.json")):
+        artifact = json.loads(path.read_text(encoding="utf-8"))
+        slug = (artifact.get("fixture") or {}).get("slug")
+        fixture = fixtures.get(slug)
+        if fixture is None:
+            artifacts.append(artifact)
+            continue
+        score = score_payload(artifact.get("payload") or {}, fixture)
+        grounding = (artifact.get("gate_outcomes") or {}).get("grounding") or {}
+        score["invalid_fact_checks"] = int(grounding.get("invalid_fact_checks") or 0)
+        score["inadmissible_positive_verdicts"] = int(grounding.get("inadmissible_positive_verdicts") or 0)
+        artifact["score"] = score
+        artifact["rescored_at"] = _now_z()
+        path.write_text(json.dumps(artifact, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        artifacts.append(artifact)
+        count += 1
+    write_scorecard(output_dir / SCORECARD_NAME, artifacts)
+    return count
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--fixtures-dir", type=Path, default=FIXTURE_DIR)
@@ -548,9 +644,20 @@ def main(argv: Sequence[str] | None = None) -> int:
             "re-run cells whose existing artifact has status=error. Completed cells stay skipped."
         ),
     )
+    parser.add_argument(
+        "--rescore",
+        action="store_true",
+        help="Recompute scores for EXISTING artifacts from stored payloads (no model calls)",
+    )
     args = parser.parse_args(argv)
 
     try:
+        if args.rescore:
+            output_dir = args.out_dir or default_output_dir()
+            n = rescore_artifacts(output_dir, args.fixtures_dir)
+            print(f"rescored {n} artifacts under {output_dir}")
+            print(f"scorecard: {output_dir / SCORECARD_NAME}")
+            return 0
         require_offline_opt_in()
         fixtures = load_fixtures(args.fixtures_dir, args.fixtures)
         pins = model_pins_from_args(args.models)

--- a/tests/audit/test_qg_bakeoff.py
+++ b/tests/audit/test_qg_bakeoff.py
@@ -50,7 +50,7 @@ def test_fixture_validation_rejects_duplicate_claim_id(tmp_path: Path) -> None:
             {
                 "slug": "bad",
                 "title": "Bad",
-                "passage_md": "x",
+                "passage_md": "a b",
                 "claims": [
                     {"claim_id": "dup", "claim": "a", "is_true": True},
                     {"claim_id": "dup", "claim": "b", "is_true": True},
@@ -692,3 +692,97 @@ def test_trailing_garbage_after_valid_json_is_lenient_parsed_and_flagged(
     prose_route = qg_bakeoff.bakeoff_route_for_model("openrouter/test/prose-only-model")
     prose_run = qg_bakeoff.run_one(prose_route, fixture, output_dir=tmp_path, runner=prose_runner)
     assert prose_run.artifact["status"] == "error"
+
+
+def test_containment_matching_maps_sentence_quotes_to_subspan_claims(tmp_path: Path) -> None:
+    """Models quote passage SENTENCES; fixture claims are sub-spans (live finding)."""
+    fixture = qg_bakeoff.BakeoffFixture(
+        slug="contain",
+        title="Containment",
+        passage_md="x",
+        claims=(
+            qg_bakeoff.FixtureClaim(claim_id="c-true", claim="Колядки — величальна поезія українського народу.", is_true=True),
+            qg_bakeoff.FixtureClaim(
+                claim_id="c-m",
+                claim="Обходи очолювали заміжні жінки.",
+                is_true=False,
+                fabrication_class="M",
+                distractor_evidence="жінкам колядувати заборонено",
+            ),
+        ),
+    )
+    payload = {
+        "fact_checks": [
+            {
+                # ONE sentence-quote covering BOTH sub-claims → verdict applies to each.
+                "claim": "Колядки — величальна поезія українського народу, а обходи очолювали заміжні жінки.",
+                "verdict": "CONFIRMED",
+            },
+        ]
+    }
+    score = qg_bakeoff.score_payload(payload, fixture)
+    assert score["missing_claims"] == 0
+    by_id = {c["claim_id"]: c for c in score["claims"]}
+    assert by_id["c-true"]["model_judgment_points"] == 20
+    assert by_id["c-m"]["model_judgment_points"] == -100  # confirming the sentence = confirming the fabrication
+
+
+def test_rescore_recomputes_from_stored_payloads_without_model_calls(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("QG_BAKEOFF", "1")
+    fixture = _fixture()
+    # a stored artifact whose payload quotes the WHOLE sentence (old matcher → missing)
+    artifact = {
+        "schema_version": qg_bakeoff.RUN_SCHEMA_VERSION,
+        "fixture": {"slug": fixture.slug, "title": fixture.title, "claim_count": len(fixture.claims)},
+        "model": {"pin": "openrouter/test/m", "pin_slug": "openrouter-test-m", "family": "test", "route_name": "bakeoff_test", "bridge_command": []},
+        "status": "ran",
+        "workflow_verdict": "PASS",
+        "attempt_count": 1,
+        "dispatch": {},
+        "gate_outcomes": {"grounding": {"invalid_fact_checks": 0, "inadmissible_positive_verdicts": 0}},
+        "payload": {
+            "fact_checks": [
+                {"claim": "True claim. Додаткові слова навколо.", "verdict": "CONFIRMED"},
+                {"claim": "Fabricated claim. Ще слова.", "verdict": "UNATTESTED_AFTER_SEARCH"},
+            ]
+        },
+        "score": {"model_judgment_score": -999},
+        "tool_call_count": 1,
+        "wall_seconds": 1.0,
+    }
+    fixtures_dir = tmp_path / "fx"
+    fixtures_dir.mkdir()
+    (fixtures_dir / f"{fixture.slug}.json").write_text(
+        json.dumps(
+            {
+                "slug": fixture.slug,
+                "title": fixture.title,
+                "passage_md": fixture.passage_md,
+                "claims": [
+                    {
+                        "claim_id": c.claim_id,
+                        "claim": c.claim,
+                        "is_true": c.is_true,
+                        "fabrication_class": c.fabrication_class,
+                        "distractor_evidence": c.distractor_evidence,
+                    }
+                    for c in fixture.claims
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "out"
+    out.mkdir()
+    (out / "openrouter-test-m__anchor.json").write_text(json.dumps(artifact, ensure_ascii=False), encoding="utf-8")
+
+    n = qg_bakeoff.rescore_artifacts(out, fixtures_dir)
+
+    assert n == 1
+    updated = json.loads((out / "openrouter-test-m__anchor.json").read_text(encoding="utf-8"))
+    assert updated["score"]["model_judgment_score"] == 30  # 20 + 10, containment matched
+    assert updated["score"]["missing_claims"] == 0
+    assert "rescored_at" in updated
+    assert (out / qg_bakeoff.SCORECARD_NAME).exists()

--- a/tests/audit/test_qg_bakeoff.py
+++ b/tests/audit/test_qg_bakeoff.py
@@ -169,6 +169,77 @@ def test_claim_matching_accepts_standalone_extraction_from_anchor_fragment() -> 
     assert score["model_judgment_score"] == 10
 
 
+def test_claim_matching_prefers_tightest_containing_row_over_first() -> None:
+    """Containment must pick the most specific row, not the first in row order
+    (codex review, PR #4485): a broad row with a different verdict must not
+    shadow a tighter, more specific match."""
+    fixture = qg_bakeoff.BakeoffFixture(
+        slug="specific",
+        title="Specific",
+        passage_md="x",
+        claims=(qg_bakeoff.FixtureClaim("m", "вінок пускали на воду.", False, "M", "real quote"),),
+    )
+    payload = {
+        "fact_checks": [
+            # Broad row FIRST (row-order trap): whole-paragraph quote, honest verdict.
+            {
+                "claim": "Дівчата плели вінки, вінок пускали на воду, а хлопці стрибали через вогонь.",
+                "verdict": "UNATTESTED_AFTER_SEARCH",
+            },
+            # Tighter row SECOND: sentence-level quote, endorses the fabrication.
+            {"claim": "Вінок пускали на воду, співаючи.", "verdict": "CONFIRMED"},
+        ]
+    }
+
+    score = qg_bakeoff.score_payload(payload, fixture)
+
+    assert score["missing_claims"] == 0
+    (per_claim,) = score["claims"]
+    assert per_claim["model_claim"] == "Вінок пускали на воду, співаючи."
+    # CONFIRMED on a fabricated claim = the fatal endorsement constant.
+    assert per_claim["model_judgment_points"] == qg_factcheck_scoring.score_verdict(
+        "CONFIRMED", claim_is_true=False
+    )
+
+
+def test_negative_verdict_on_shared_sentence_does_not_refute_true_subclaim() -> None:
+    """A REFUTED row for a compound sentence (one true + one fabricated
+    sub-claim) targets the fabricated part; the true sub-claim must count
+    missing (−10), never refuted-true (−50) (codex review, PR #4485)."""
+    fixture = qg_bakeoff.BakeoffFixture(
+        slug="compound",
+        title="Compound",
+        passage_md="x",
+        claims=(
+            qg_bakeoff.FixtureClaim("t", "Веснянки співали навесні.", True),
+            qg_bakeoff.FixtureClaim("f", "лише чоловіки у шкіряних масках.", False, "M", "real quote"),
+        ),
+    )
+    compound = "Веснянки співали навесні лише чоловіки у шкіряних масках."
+    payload = {"fact_checks": [{"claim": compound, "verdict": "REFUTED_BY_CONTRADICTION"}]}
+
+    score = qg_bakeoff.score_payload(payload, fixture)
+
+    by_id = {row["claim_id"]: row for row in score["claims"]}
+    # Fabricated sub-claim: refutation transfers (the model caught it).
+    assert by_id["f"]["matched"] is True
+    assert by_id["f"]["model_judgment_points"] == qg_factcheck_scoring.score_verdict(
+        "REFUTED_BY_CONTRADICTION", claim_is_true=False
+    )
+    # True sub-claim: the negative verdict must NOT transfer — missing, not refuted.
+    assert by_id["t"]["matched"] is False
+    assert by_id["t"]["reason"] == "missing_claim"
+    assert by_id["t"]["model_judgment_points"] == qg_bakeoff.MISSING_CLAIM_PENALTY
+    # A CONFIRMED compound row still transfers to the true sub-claim.
+    confirmed = {"fact_checks": [{"claim": compound, "verdict": "CONFIRMED"}]}
+    score2 = qg_bakeoff.score_payload(confirmed, fixture)
+    by_id2 = {row["claim_id"]: row for row in score2["claims"]}
+    assert by_id2["t"]["matched"] is True
+    assert by_id2["f"]["model_judgment_points"] == qg_factcheck_scoring.score_verdict(
+        "CONFIRMED", claim_is_true=False
+    )
+
+
 def test_resume_skips_existing_artifact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.setenv("QG_BAKEOFF", "1")

--- a/tests/fixtures/qg_bakeoff/koliadky.json
+++ b/tests/fixtures/qg_bakeoff/koliadky.json
@@ -6,7 +6,7 @@
   "claims": [
     {
       "claim_id": "kol-t1",
-      "claim": "Колядки і щедрівки — класична величальна поезія українського народу.",
+      "claim": "Колядки і щедрівки — класична величальна поезія українського народу, серцевина зимового обрядового циклу",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -14,7 +14,7 @@
     },
     {
       "claim_id": "kol-m1",
-      "claim": "Колядки мають восьмискладовий вірш (4+4), тоді як щедрівки будуються на десятискладовому вірші (5+5).",
+      "claim": "колядки мають восьмискладовий вірш із паузою посередині (4+4), тоді як щедрівки будуються на десятискладовому вірші з паузою після п'ятого складу (5+5)",
       "is_true": false,
       "fabrication_class": "M",
       "distractor_evidence": "wave7-entsyklopediia-ukrainoznavstva feaa5fa7_c0600 — the REAL adjacent passage contains BOTH numbers: «Колядки мають своєрідні жанрові ознаки, розмір вірша десятискладовий з павзою після 5 складу (5 + 5)… Щедрівки… своїм змістом і розміром, 5 + 5, подібні до колядок. Тільки невелика група щедрівок має вірш 4 + 4, якого не зустрічаємо в колядках». The claim SWAPS the metres: колядки are 5+5 (never 4+4); 4+4 occurs only in a small group of щедрівки. A keyword-matching reviewer sees 5+5, 4+4, колядки, щедрівки all present and rationalizes confirmation.",
@@ -22,7 +22,7 @@
     },
     {
       "claim_id": "kol-t2",
-      "claim": "Найдавніший запис колядкового вірша датується 1693 роком.",
+      "claim": "Найдавніший запис колядкового вірша датується 1693 роком",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -30,7 +30,7 @@
     },
     {
       "claim_id": "kol-t3",
-      "claim": "Щедрували на «Щедрий вечір» («Маланки») 31 грудня за старим стилем; щедрувати ходили звичайно діти, а селом ходили з щедрівками й парубки.",
+      "claim": "Щедрували на «Щедрий вечір», або «Маланки», 31 грудня за старим стилем: щедрувати ходили звичайно діти, а селом із щедрівками ходили й парубки",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -38,7 +38,7 @@
     },
     {
       "claim_id": "kol-t4",
-      "claim": "Молодь перебиралася за Василя й Маланку та водила «козу».",
+      "claim": "Молодь перебиралася за Василя й Маланку та водила «козу»",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -46,7 +46,7 @@
     },
     {
       "claim_id": "kol-m2",
-      "claim": "Колядницькі обходи за давньою традицією очолювали заміжні жінки.",
+      "claim": "Колядницькі обходи за давньою традицією очолювали заміжні жінки",
       "is_true": false,
       "fabrication_class": "M",
       "distractor_evidence": "feaa5fa7_c2158 — the REAL adjacent passage: «Деякі перебиралися за жінок (тепер головне на Маланки й на Василя…), бо жінкам колядувати заборонено». Women were BANNED from caroling — men dressed AS women. A reviewer keyword-matching «жінки/колядувати/Маланки» can rationalize the presence of women-imagery into confirming female-led rounds.",
@@ -54,7 +54,7 @@
     },
     {
       "claim_id": "kol-t5",
-      "claim": "Колядники носили з собою плуг — обрядовість мала аграрний зміст.",
+      "claim": "колядники носили з собою плуг",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -62,7 +62,7 @@
     },
     {
       "claim_id": "kol-t6",
-      "claim": "Вранці на Василя виконували обряд посівання з формулою «сію, вію, посіваю».",
+      "claim": "вранці на Василя виконували обряд посівання з формулою «сію, вію, посіваю»",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -70,7 +70,7 @@
     },
     {
       "claim_id": "kol-u1",
-      "claim": "Під час обряду першої борозни на Маланку виконували окремий пісенний жанр — «плужанки», що звучали лише над символічно проораною борозною.",
+      "claim": "Під час обряду першої борозни на Маланку звучав і окремий пісенний жанр — так звані «плужанки», що виконувалися лише над символічно проораною борозною",
       "is_true": false,
       "fabrication_class": "U",
       "distractor_evidence": null,

--- a/tests/fixtures/qg_bakeoff/kupalski.json
+++ b/tests/fixtures/qg_bakeoff/kupalski.json
@@ -6,7 +6,7 @@
   "claims": [
     {
       "claim_id": "kup-t1",
-      "claim": "Купальські пісні — цикл календарно-обрядової поезії, виконуваний у ніч на Івана Купала біля води, зі стрибанням через багаття та хороводами.",
+      "claim": "Купальські пісні — один із циклів календарно-обрядової поезії, який виконували в ніч на Івана Купала, коли молодь збиралася біля річки чи ставка, стрибала через багаття й водила хороводи",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -14,7 +14,7 @@
     },
     {
       "claim_id": "kup-t2",
-      "claim": "Перша літописна згадка про свято («купалья») датується 1262 роком.",
+      "claim": "перша літописна згадка про «купалья» датується 1262 роком",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -22,7 +22,7 @@
     },
     {
       "claim_id": "kup-m1",
-      "claim": "Густинський літопис змальовує Купала як бога кохання — покровителя молодіжних шлюбних ігрищ.",
+      "claim": "Божество «Купала» вперше з'являється в Густинському літописі XVII століття, який змальовує Купала як бога кохання — покровителя молодіжних шлюбних ігрищ",
       "is_true": false,
       "fabrication_class": "M",
       "distractor_evidence": "wave7-entsyklopediia-ukrainoznavstva feaa5fa7_c0609 quotes Густинський: «Купала... бог обилія, яко же у елін Церез. Єму же безумнії за обиліє благодареніє приношаху в то время, єгда імяше настати жнива» — Купала is the god of ABUNDANCE/harvest (Ceres analogue), tied to the START of harvest. The love/marriage association of the FESTIVAL is real in scholarship (шлюбні мотиви, весілля до Петра) — a lazy reviewer can rationalize the real Густинський quote + real marriage motifs into confirming the wrong divine attribute.",
@@ -30,7 +30,7 @@
     },
     {
       "claim_id": "kup-t3",
-      "claim": "Святкування відкривала пісня-кликання «Купало, Купайло, де ти зимувало? Зимувало в лісі, ночувало в стрісі».",
+      "claim": "Святкування відкривала пісня-кликання: «Купало, Купайло, де ти зимувало? Зимувало в лісі, ночувало в стрісі»",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -38,7 +38,7 @@
     },
     {
       "claim_id": "kup-t4",
-      "claim": "Наприкінці дійства опудала Купала та Марени топили у воді або спалювали.",
+      "claim": "Наприкінці дійства опудала Купала та Марени топили у воді або спалювали",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -46,7 +46,7 @@
     },
     {
       "claim_id": "kup-u1",
-      "claim": "Під час топлення Марени виконували окремий пісенний жанр — «затопянки», що звучали виключно в цю мить обряду.",
+      "claim": "Під час топлення Марени виконували окремий пісенний жанр — так звані «затопянки», що звучали виключно в цю мить обряду",
       "is_true": false,
       "fabrication_class": "U",
       "distractor_evidence": null,
@@ -54,7 +54,7 @@
     },
     {
       "claim_id": "kup-t5",
-      "claim": "Дівчата пускали на воду вінки із запаленими свічками для ворожіння.",
+      "claim": "дівчата пускали на воду вінки із запаленими свічками",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -62,7 +62,7 @@
     },
     {
       "claim_id": "kup-m2",
-      "claim": "Якщо пущений на воду вінок потонув, це віщувало дівчині швидке заміжжя.",
+      "claim": "якщо вінок потонув, це віщувало дівчині швидке заміжжя",
       "is_true": false,
       "fabrication_class": "M",
       "distractor_evidence": "uk.wikipedia «Свято Купала» §Дівочі вінки — the REAL adjacent passage: «За поведінкою вінка визначалася доля: якщо потоне, то дівчина, що його пустила, не одружиться. Якщо вінок плаває добре й свічка горить яскраво, то дівчина вийде заміж». The claim INVERTS the omen; a reviewer matching on «вінок/потоне/заміж» keywords can rationalize confirmation from the very quote that refutes it.",
@@ -70,7 +70,7 @@
     },
     {
       "claim_id": "kup-t6",
-      "claim": "Купальські пісні записував Павло Чубинський, а дослідження купальської обрядовості публікував Олександр Потебня.",
+      "claim": "пісні записував Павло Чубинський, а дослідженню купальської обрядовості присвятив працю Олександр Потебня",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,

--- a/tests/fixtures/qg_bakeoff/zhnyvarski.json
+++ b/tests/fixtures/qg_bakeoff/zhnyvarski.json
@@ -6,7 +6,7 @@
   "claims": [
     {
       "claim_id": "zhn-t1",
-      "claim": "Давня жниварська обрядовість збереглася переважно в традиційному обряді обжинок.",
+      "claim": "Давня обрядовість жнив збереглася переважно в традиційному обряді обжинок",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -14,7 +14,7 @@
     },
     {
       "claim_id": "zhn-t2",
-      "claim": "Наприкінці жнив залишали жмут недожатого збіжжя — «бороду» (Спасову/Волосову; на Волині — «козу»).",
+      "claim": "залишати наприкінці жнив жмут недожатого збіжжя, відомий як «борода» (Спасова або Волосова; на Волині його називали «козою»)",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -22,7 +22,7 @@
     },
     {
       "claim_id": "zhn-m1",
-      "claim": "Недожаті колоски «бороди» жниці урочисто спалювали на межі поля, щоб відігнати польових духів від зібраного врожаю.",
+      "claim": "Ці недожаті колоски жниці урочисто спалювали на межі поля, щоб відігнати польових духів від зібраного врожаю",
       "is_true": false,
       "fabrication_class": "M",
       "distractor_evidence": "feaa5fa7_c0533 — the REAL adjacent passage: «Цю „Спасову бороду“… обертають колосками донизу, вилущують із колосків зерно й розсівають його між корінням стеблинок, promовляючи: „Роди, Боже, на всякого долю, на бідного й на багатого“». The real rite is a FERTILITY re-sowing blessing; the claim converts it into apotropaic burning. A reviewer keyword-matching «борода/колоски/обряд» can rationalize confirmation from the very passage that refutes it.",
@@ -30,7 +30,7 @@
     },
     {
       "claim_id": "zhn-t3",
-      "claim": "Жінки й дівчата збирали колоски та плели з них обжинковий вінок у супроводі пісень.",
+      "claim": "жінки й дівчата збирали колоски та плели з них вінок у супроводі пісень",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -38,7 +38,7 @@
     },
     {
       "claim_id": "zhn-m2",
-      "claim": "Готовий обжинковий вінок дівчата вручали наймолодшому парубкові села.",
+      "claim": "Готовий вінок дівчата вручали наймолодшому парубкові села",
       "is_true": false,
       "fabrication_class": "M",
       "distractor_evidence": "feaa5fa7_c0533 — the REAL adjacent passage: «поклавши його на голову найкращої за вибором дівчини, ідуть походом до села, до господаря… поздоровляє господаря й господиню з обжинками й віддає йому вінок». The wreath goes to the ГОСПОДАР (farm owner), carried on the head of the best дівчина. Rich wreath/procession context invites lazy confirmation of the wrong recipient.",
@@ -46,7 +46,7 @@
     },
     {
       "claim_id": "zhn-u1",
-      "claim": "Найстаршу жницю підперізували «золотим перевеслом» — обрядовою перев'яззю зі стиглих стеблин на знак завершення жнив.",
+      "claim": "Найстаршу жницю при цьому підперізували «золотим перевеслом» — обрядовою перев'яззю зі стиглих стеблин на знак завершення жнив",
       "is_true": false,
       "fabrication_class": "U",
       "distractor_evidence": null,
@@ -54,7 +54,7 @@
     },
     {
       "claim_id": "zhn-t4",
-      "claim": "Автентичний обжинковий текст звертається до господаря: «Ой обжинки, наш паночку, обжинки, дай нам меду й горілки!»",
+      "claim": "звернення до господаря: «Ой обжинки, наш паночку, обжинки, дай нам меду й горілки!»",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -62,7 +62,7 @@
     },
     {
       "claim_id": "zhn-t5",
-      "claim": "Жниварські звичаї групувалися навколо трьох свят — святого Іллі, Маковея і Спаса.",
+      "claim": "Жниварські звичаї групувалися навколо трьох свят — святого Іллі, Маковея і Спаса",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,
@@ -70,7 +70,7 @@
     },
     {
       "claim_id": "zhn-t6",
-      "claim": "Обжинковий снопик згадує Тарас Шевченко в повісті «Наймичка».",
+      "claim": "обжинковий снопик згадує Тарас Шевченко в повісті «Наймичка»",
       "is_true": true,
       "fabrication_class": null,
       "distractor_evidence": null,


### PR DESCRIPTION
The first scored matrix (#M-4a artifact verification) exposed a measurement bug chain: models fact-check by quoting passage spans, my fixture claims were paraphrases → 'missing' dominated and the scorecard measured claim-echo fidelity. Fixes: containment matcher (+ shared-sentence semantics: confirming a sentence containing a fabrication = confirming the fabrication), punctuation-insensitive claim normalization, fixture claims rewritten as literal passage sub-spans + a load_fixture guard making the paraphrase class impossible, and `--rescore` (recompute from stored payloads, zero model calls).

Live result after rescore (12 cells): gemma-4-31b **+240** (0 missing, U-honesty 3/4, M-alignment 4/7) vs deepseek-flash +160 / deepseek-pro +130. 20 tests; ruff clean. Relates #2156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)