### PR TITLE
feat(delegate): require verified worktree cwd for write-capable dispatch (#4445)

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -11,8 +11,9 @@ controls how long to wait.
 CLI:
 
     # Fire a task. Returns immediately with the task-id.
+    # Write-capable modes (workspace-write / danger) require a dispatch worktree.
     delegate.py dispatch --agent codex --task-id my-task \
-        --prompt "do the thing" [--mode workspace-write] [--model gpt-5.5]
+        --prompt "do the thing" [--mode workspace-write --worktree] [--model gpt-5.5]
         [--allow-merge]
 
     # Check status without blocking.
@@ -373,6 +374,134 @@ def _classify_worktree_layout(path: Path | str | None) -> str | None:
         if len(parts) >= 2:
             return "flat"
     return None
+
+
+# ---------------------------------------------------------------------------
+# Write-capable-mode worktree guard (#4445)
+# ---------------------------------------------------------------------------
+#
+# ``workspace-write`` and ``danger`` let the delegated worker mutate files. Both
+# MUST run inside an isolated dispatch worktree so those writes never dirty the
+# protected primary checkout — the operator contract must not rely on a model
+# *remembering* the worktree rule. ``read-only`` dispatches are exempt: repo-root
+# preflight and creating a worktree from the primary checkout stay allowed.
+
+_WRITE_CAPABLE_MODES = frozenset({"workspace-write", "danger"})
+
+_WRITE_WORKTREE_HINT = (
+    "Write-capable dispatch must run inside a dispatch worktree, never the "
+    "primary checkout. Preferred: pass bare `--worktree` to auto-create "
+    ".worktrees/dispatch/<agent>/<task>/. Alternatively point `--cwd` at an "
+    "existing added worktree there."
+)
+
+
+def _load_worktree_containment():
+    """Import the shared containment predicate (#4444), ensuring repo root on path.
+
+    Mirrors the import guard used for :mod:`scripts.orchestration.reap_worktrees`
+    below: running ``scripts/delegate.py`` directly puts ``scripts/`` (not the
+    repo root) on ``sys.path``, so the ``scripts.*`` package needs its parent.
+    """
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+    from scripts.guardrails import worktree_containment
+    return worktree_containment
+
+
+def _resolve_cwd_path(raw: str) -> Path:
+    """Resolve a ``--cwd`` argument the way the spawned worker will see it.
+
+    A relative ``--cwd`` is handed to the worker subprocess verbatim and thus
+    resolved against the dispatch process cwd, so classify it the same way.
+    """
+    p = Path(raw).expanduser()
+    if not p.is_absolute():
+        p = Path.cwd() / p
+    return p.resolve()
+
+
+def _is_verified_added_worktree(path: Path) -> bool:
+    """True if ``path`` resolves inside a git-registered worktree that is not the
+    primary checkout.
+
+    "Verified" means the containing worktree appears in ``git worktree list``. A
+    bare directory that only *looks* like ``.worktrees/**`` but was never
+    ``git worktree add``-ed does NOT qualify — the worker would otherwise run
+    outside any real worktree while believing it was isolated.
+    """
+    wc = _load_worktree_containment()
+    target = wc.canonicalize(path)
+    start = target if target.exists() else target.parent
+    try:
+        main_root = wc.resolve_main_root(start)
+    except wc.NotAGitRepositoryError:
+        return False
+    for worktree in wc.registered_worktrees(main_root):
+        if worktree == main_root:
+            continue
+        if target == worktree or target.is_relative_to(worktree):
+            return True
+    return False
+
+
+def _resolve_write_cwd_error(
+    *, mode: str, worktree_arg: str | None, cwd_arg: str | None,
+) -> str | None:
+    """Reject a write-capable dispatch that would run outside a verified worktree.
+
+    Returns an operator-facing error string, or None when the dispatch is safe.
+    Evaluated before any side effects (log files, ``git worktree add``) so a
+    rejection leaves no worktree/branch residue behind.
+
+    Policy (issue #4445):
+
+    * ``--worktree`` (bare/``auto``) is the recommended path and always lands in
+      ``.worktrees/dispatch/<agent>/<task>/`` — :func:`_ensure_worktree` creates
+      or validates it. An explicit ``--worktree PATH`` is rejected only when it
+      *is* the primary checkout.
+    * ``--cwd`` is allowed only when it resolves to a verified added worktree,
+      never the primary checkout or a bare in-repo directory.
+    * With neither flag the worker would default to the primary checkout, so a
+      write-capable dispatch is rejected outright.
+    """
+    if mode not in _WRITE_CAPABLE_MODES:
+        return None
+
+    wc = _load_worktree_containment()
+
+    if worktree_arg:
+        # Bare ``--worktree`` (the sentinel ``auto``) auto-derives the dispatch
+        # subtree — always isolated, nothing to verify up front.
+        if worktree_arg == "auto":
+            return None
+        candidate = _normalize_worktree_path(worktree_arg)
+        if wc.is_primary_checkout(candidate):
+            return (
+                f"❌ --worktree {worktree_arg!r} points at the primary checkout; "
+                f"write-capable dispatch may not run there.\n   {_WRITE_WORKTREE_HINT}"
+            )
+        return None
+
+    if cwd_arg:
+        candidate = _resolve_cwd_path(cwd_arg)
+        if wc.is_primary_checkout(candidate):
+            return (
+                f"❌ --cwd {cwd_arg!r} resolves inside the primary checkout; "
+                f"write-capable dispatch may not run there.\n   {_WRITE_WORKTREE_HINT}"
+            )
+        if not _is_verified_added_worktree(candidate):
+            return (
+                f"❌ --cwd {cwd_arg!r} is not a verified git worktree; "
+                f"write-capable dispatch requires an added worktree under "
+                f".worktrees/dispatch/<agent>/<task>/.\n   {_WRITE_WORKTREE_HINT}"
+            )
+        return None
+
+    return (
+        f"❌ --mode {mode} requires an isolated worktree; without --worktree/--cwd "
+        f"the worker would run in the primary checkout.\n   {_WRITE_WORKTREE_HINT}"
+    )
 
 
 def _fetch_base(base: str) -> bool:
@@ -1416,19 +1545,25 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     max_budget_usd = getattr(args, "max_budget_usd", None)
     keep_worktree = bool(getattr(args, "keep_worktree", False))
 
-    if args.mode == "danger" and not worktree_arg:
-        print(
-            "❌ --mode danger requires --worktree to keep delegated writes out "
-            "of the main checkout.",
-            file=sys.stderr,
-        )
-        return 2
     if args.cwd and worktree_arg:
         print(
             "❌ --cwd and --worktree are mutually exclusive. Use --worktree for "
             "delegated write isolation.",
             file=sys.stderr,
         )
+        return 2
+
+    # Write-capable modes (workspace-write / danger) must resolve to a verified
+    # added worktree — never the primary checkout (#4445). Read-only dispatches
+    # stay exempt so repo-root preflight keeps working. Evaluated before any
+    # side effects so a rejection leaves no worktree/branch/log residue.
+    write_cwd_error = _resolve_write_cwd_error(
+        mode=args.mode,
+        worktree_arg=worktree_arg,
+        cwd_arg=args.cwd,
+    )
+    if write_cwd_error:
+        print(write_cwd_error, file=sys.stderr)
         return 2
 
     # Refuse to clobber a task that's still alive — whether it's in
@@ -2069,8 +2204,9 @@ def build_parser() -> argparse.ArgumentParser:
         ),
         epilog=(
             "Examples:\n"
-            "  .venv/bin/python scripts/delegate.py dispatch --agent codex --task-id review-123 --prompt-file prompt.md --mode workspace-write --cwd .\n"
-            "  .venv/bin/python scripts/delegate.py dispatch --agent codex --task-id pr-123 --prompt-file brief.md --mode danger --worktree .worktrees/codex-pr-123\n"
+            "  .venv/bin/python scripts/delegate.py dispatch --agent codex --task-id review-123 --prompt-file prompt.md --mode read-only\n"
+            "  .venv/bin/python scripts/delegate.py dispatch --agent codex --task-id fix-123 --prompt-file brief.md --mode workspace-write --worktree\n"
+            "  .venv/bin/python scripts/delegate.py dispatch --agent codex --task-id pr-123 --prompt-file brief.md --mode danger --worktree\n"
             "  .venv/bin/python scripts/delegate.py dispatch --agent claude --task-id review-456 --prompt-file brief.md --max-budget-usd 0.50\n"
             "  .venv/bin/python scripts/delegate.py status-or-fail review-123\n"
             "  .venv/bin/python scripts/delegate.py wait review-123 --timeout 600\n"
@@ -2112,7 +2248,9 @@ def build_parser() -> argparse.ArgumentParser:
     d.add_argument("--prompt-file", help="Read the prompt body from this file path.")
     d.add_argument("--mode", default="read-only",
                    choices=["read-only", "workspace-write", "danger"],
-                   help="Runtime mode (default: read-only). Use danger only with --worktree.")
+                   help="Runtime mode (default: read-only). workspace-write and danger "
+                        "require a verified dispatch worktree (bare --worktree, or --cwd "
+                        "pointing at an existing added worktree); read-only may run from repo root.")
     d.add_argument("--model", default=None,
                    help="Optional model override, e.g. gpt-5.5 or gemini-3.1-pro-preview.")
     d.add_argument(
@@ -2130,18 +2268,20 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     d.add_argument("--cwd", default=None,
-                   help="Working directory for the worker (default: repo root)")
+                   help="Working directory for the worker (default: repo root). "
+                        "For workspace-write/danger it must be a verified added "
+                        "worktree, never the primary checkout — prefer --worktree.")
     d.add_argument(
         "--worktree",
         nargs="?",
         const="auto",
         default=None,
         help=(
-            "Run inside this git worktree (created on demand, required for "
-            "--mode danger). Pass `--worktree PATH` to use a specific path "
-            "(back-compat with existing `.worktrees/{agent}-{task}/` "
-            "layout), or `--worktree` alone to auto-derive the new default "
-            "`.worktrees/dispatch/{agent}/{task}/`."
+            "Run inside this git worktree (created on demand). Required for "
+            "write-capable modes (workspace-write, danger). Pass `--worktree` "
+            "alone (recommended) to auto-derive `.worktrees/dispatch/{agent}/"
+            "{task}/`, or `--worktree PATH` to reuse a specific added worktree "
+            "(validated against the expected dispatch branch before reuse)."
         ),
     )
     d.add_argument(

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2249,6 +2249,303 @@ def test_new_dispatch_uses_dispatch_subtree(tmp_tasks_dir, monkeypatch, capsys):
     assert state["worktree_layout"] == "dispatch"
 
 
+# ---------------------------------------------------------------------------
+# Write-capable-mode worktree guard (#4445)
+#
+# workspace-write / danger must resolve to a *verified added worktree*, never
+# the primary checkout — enforcement lives in delegate, not a model's memory.
+# read-only repo-root preflight and worktree creation from the primary checkout
+# stay allowed.
+# ---------------------------------------------------------------------------
+
+
+def _init_repo_with_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    """Build a real primary checkout + one registered dispatch worktree.
+
+    Returns ``(main, dispatch_wt)`` as resolved absolute paths. Uses git
+    plumbing rather than fake ``.git`` files because the containment predicate
+    the guard relies on asks git (``worktree list``/``rev-parse``), not string
+    prefixes. The dispatch worktree sits on branch ``codex/task-1``.
+    """
+    env = delegate._sanitized_git_env()
+
+    def _git(cwd: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(cwd), *args],
+            check=True, capture_output=True, text=True, env=env,
+        )
+
+    main = tmp_path / "main"
+    main.mkdir()
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(main)],
+        check=True, capture_output=True, text=True, env=env,
+    )
+    _git(main, "config", "user.email", "test@example.com")
+    _git(main, "config", "user.name", "Test")
+    (main / ".gitignore").write_text(".worktrees/\n")
+    (main / "tracked.txt").write_text("x\n")
+    _git(main, "add", "-A")
+    _git(main, "commit", "-q", "-m", "init")
+
+    dispatch_wt = main / ".worktrees" / "dispatch" / "codex" / "task-1"
+    _git(main, "worktree", "add", "-q", "-b", "codex/task-1", str(dispatch_wt))
+
+    return main.resolve(), dispatch_wt.resolve()
+
+
+class _GuardFakeStdin:
+    def write(self, _data):
+        pass
+
+    def close(self):
+        pass
+
+
+class _GuardFakeProc:
+    pid = 44551
+    stdin = _GuardFakeStdin()
+
+
+def _patch_worker_popen(monkeypatch):
+    """Fake the worker spawn while letting real ``git`` still run.
+
+    ``delegate.subprocess`` and ``worktree_containment.subprocess`` are the same
+    module object, so a blanket ``Popen`` patch would also break the containment
+    guard's git plumbing (``subprocess.run`` uses ``Popen`` internally). Route
+    ``git`` invocations to the real Popen and fake only the ``.venv`` worker.
+    """
+    real_popen = delegate.subprocess.Popen
+
+    def fake_popen(cmd, *a, **k):
+        if cmd and str(cmd[0]) == "git":
+            return real_popen(cmd, *a, **k)
+        return _GuardFakeProc()
+
+    monkeypatch.setattr(delegate.subprocess, "Popen", fake_popen)
+
+
+def _write_args(**overrides):
+    """Namespace for a cmd_dispatch call, defaulting to a write-capable mode."""
+    import argparse
+
+    base = {
+        "agent": "codex",
+        "task_id": "wt-guard",
+        "prompt": "do it",
+        "prompt_file": None,
+        "mode": "workspace-write",
+        "model": None,
+        "cwd": None,
+        "worktree": None,
+        "base": "main",
+        "hard_timeout": 3600,
+        "allow_merge": False,
+    }
+    base.update(overrides)
+    return argparse.Namespace(**base)
+
+
+# --- _resolve_write_cwd_error unit tests (deterministic policy) -------------
+
+
+def test_write_guard_allows_read_only_repo_root():
+    assert delegate._resolve_write_cwd_error(
+        mode="read-only", worktree_arg=None, cwd_arg=None,
+    ) is None
+
+
+def test_write_guard_allows_bare_worktree_for_both_write_modes():
+    for mode in ("workspace-write", "danger"):
+        assert delegate._resolve_write_cwd_error(
+            mode=mode, worktree_arg="auto", cwd_arg=None,
+        ) is None
+
+
+def test_write_guard_rejects_write_mode_without_isolation():
+    for mode in ("workspace-write", "danger"):
+        err = delegate._resolve_write_cwd_error(
+            mode=mode, worktree_arg=None, cwd_arg=None,
+        )
+        assert err is not None
+        assert "worktree" in err
+
+
+def test_write_guard_rejects_cwd_primary_checkout(tmp_path):
+    main, _ = _init_repo_with_worktree(tmp_path)
+    err = delegate._resolve_write_cwd_error(
+        mode="workspace-write", worktree_arg=None, cwd_arg=str(main),
+    )
+    assert err is not None
+    assert "primary checkout" in err
+
+
+def test_write_guard_rejects_cwd_in_repo_outside_worktrees(tmp_path):
+    main, _ = _init_repo_with_worktree(tmp_path)
+    subdir = main / "pkg"
+    subdir.mkdir()
+    err = delegate._resolve_write_cwd_error(
+        mode="danger", worktree_arg=None, cwd_arg=str(subdir),
+    )
+    assert err is not None
+    assert "primary checkout" in err
+
+
+def test_write_guard_accepts_cwd_added_worktree(tmp_path):
+    _, dispatch_wt = _init_repo_with_worktree(tmp_path)
+    assert delegate._resolve_write_cwd_error(
+        mode="workspace-write", worktree_arg=None, cwd_arg=str(dispatch_wt),
+    ) is None
+    # A subdirectory inside the verified worktree is equally fine.
+    sub = dispatch_wt / "nested"
+    sub.mkdir()
+    assert delegate._resolve_write_cwd_error(
+        mode="danger", worktree_arg=None, cwd_arg=str(sub),
+    ) is None
+
+
+def test_write_guard_rejects_cwd_unregistered_worktree_dir(tmp_path):
+    """A directory that only *looks* like .worktrees/** but was never
+    `git worktree add`-ed is not a verified worktree."""
+    main, _ = _init_repo_with_worktree(tmp_path)
+    ghost = main / ".worktrees" / "dispatch" / "codex" / "ghost"
+    ghost.mkdir(parents=True)
+    err = delegate._resolve_write_cwd_error(
+        mode="workspace-write", worktree_arg=None, cwd_arg=str(ghost),
+    )
+    assert err is not None
+    assert "verified git worktree" in err
+
+
+def test_write_guard_rejects_explicit_worktree_pointing_at_primary(tmp_path):
+    main, _ = _init_repo_with_worktree(tmp_path)
+    err = delegate._resolve_write_cwd_error(
+        mode="danger", worktree_arg=str(main), cwd_arg=None,
+    )
+    assert err is not None
+    assert "primary checkout" in err
+
+
+# --- cmd_dispatch end-to-end tests ------------------------------------------
+
+
+def test_dispatch_read_only_allows_repo_root(tmp_tasks_dir, monkeypatch):
+    """Read-only preflight from the primary checkout stays allowed."""
+    monkeypatch.setattr(delegate.subprocess, "Popen", lambda *a, **k: _GuardFakeProc())
+    args = _write_args(task_id="ro-root", mode="read-only", cwd=None, worktree=None)
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 0
+    state = delegate._read_state(delegate._state_path("ro-root"))
+    assert state is not None
+    assert state["cwd"] == str(delegate._REPO_ROOT)
+
+
+def test_dispatch_rejects_workspace_write_without_worktree(tmp_tasks_dir, capsys):
+    args = _write_args(task_id="ww-no-wt", mode="workspace-write", cwd=None, worktree=None)
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 2
+    assert delegate._read_state(delegate._state_path("ww-no-wt")) is None
+    assert "worktree" in capsys.readouterr().err
+
+
+def test_dispatch_rejects_workspace_write_cwd_primary_checkout(
+    tmp_tasks_dir, tmp_path, capsys,
+):
+    main, _ = _init_repo_with_worktree(tmp_path)
+    args = _write_args(
+        task_id="ww-cwd-main", mode="workspace-write", cwd=str(main), worktree=None,
+    )
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 2
+    assert delegate._read_state(delegate._state_path("ww-cwd-main")) is None
+    assert "primary checkout" in capsys.readouterr().err
+
+
+def test_dispatch_accepts_workspace_write_cwd_added_worktree(
+    tmp_tasks_dir, tmp_path, monkeypatch,
+):
+    _, dispatch_wt = _init_repo_with_worktree(tmp_path)
+    _patch_worker_popen(monkeypatch)
+    args = _write_args(
+        task_id="ww-cwd-wt", mode="workspace-write", cwd=str(dispatch_wt), worktree=None,
+    )
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 0
+    state = delegate._read_state(delegate._state_path("ww-cwd-wt"))
+    assert state is not None
+    assert Path(state["cwd"]) == dispatch_wt
+
+
+def test_dispatch_accepts_bare_worktree_for_workspace_write(
+    tmp_tasks_dir, monkeypatch,
+):
+    _, fake_run = _make_run_stub()
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+    monkeypatch.setattr(delegate.subprocess, "Popen", lambda *a, **k: _GuardFakeProc())
+    args = _write_args(
+        task_id="ww-bare", mode="workspace-write", cwd=None, worktree="auto",
+    )
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 0
+    state = delegate._read_state(delegate._state_path("ww-bare"))
+    assert state is not None
+    wt = Path(state["worktree_path"])
+    assert wt.parts[-4:] == (".worktrees", "dispatch", "codex", "ww-bare")
+
+
+def test_dispatch_accepts_explicit_added_worktree(tmp_tasks_dir, tmp_path, monkeypatch):
+    """An explicit --worktree pointing at a real registered dispatch worktree
+    is reused, not rejected."""
+    main, dispatch_wt = _init_repo_with_worktree(tmp_path)
+    # _ensure_worktree's reuse validation shells out to git without sanitizing
+    # the environment, so under a git hook (pre-commit/pre-push) an inherited
+    # GIT_DIR/GIT_WORK_TREE would hijack `cwd=<worktree>` and report the outer
+    # repo's branch. Strip those so the throwaway worktree resolves correctly.
+    _sanitize_git_env_for_test(monkeypatch)
+    # Route delegate's worktree machinery at the throwaway repo so reuse
+    # validation and provisioning never touch the real checkout or network.
+    monkeypatch.setattr(delegate, "_REPO_ROOT", main)
+    _patch_worker_popen(monkeypatch)
+    args = _write_args(
+        agent="codex",
+        task_id="task-1",
+        mode="workspace-write",
+        cwd=None,
+        worktree=str(dispatch_wt),
+        base="main",
+    )
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 0
+    state = delegate._read_state(delegate._state_path("task-1"))
+    assert state is not None
+    assert state["worktree_reused"] is True
+    assert Path(state["cwd"]) == dispatch_wt
+
+
+def test_dispatch_help_omits_deprecated_cwd_dot_example():
+    """Issue #4445: help/examples must not advertise `--cwd .` or a flat
+    worktree layout for write-capable work."""
+    help_text = delegate.build_parser().format_help()
+    assert "--cwd ." not in help_text
+    assert "--mode workspace-write --cwd" not in help_text
+    # The flat `.worktrees/<agent>-<task>` example is gone; bare --worktree
+    # is the advertised write-capable path.
+    assert ".worktrees/codex-pr-123" not in help_text
+    assert "--mode workspace-write --worktree" in help_text
+
+
 def test_list_and_status_walk_both_layouts(tmp_tasks_dir, tmp_path, capsys, monkeypatch):
     """Fix 4 (#1476): both the deprecated flat layout and the new dispatch
     subtree layout must surface in `list`, and flat-layout tasks emit


### PR DESCRIPTION
Resolves #4445.

## Problem
`scripts/delegate.py` rejected `--mode danger` without `--worktree`, but `workspace-write` could still run with `--cwd` defaulting to the **primary checkout**, and the help even advertised `--mode workspace-write --cwd .`. That let write-capable dispatches dirty the protected main checkout and made the operator contract depend on a model *remembering* the worktree rule.

## Change
Enforcement now lives in `delegate`, reusing the shared containment predicate from #4444 (`scripts.guardrails.worktree_containment`) instead of reimplementing path classification.

- **Both write-capable modes** (`workspace-write` **and** `danger`) must resolve to a verified added worktree, gated in `cmd_dispatch` **before any side effects** (`_resolve_write_cwd_error`), so a rejection leaves no worktree/branch/log residue.
- **Bare `--worktree`** (auto-derive `.worktrees/dispatch/<agent>/<task>/`) stays the recommended path. Explicit `--worktree PATH` is rejected only when it *is* the primary checkout; reuse validation stays in `_ensure_worktree`.
- **`--cwd`** is accepted for write modes only when it resolves to a git-**registered** ("verified added") worktree. The primary checkout, in-repo subdirs, and bare `.worktrees/**` dirs that were never `git worktree add`-ed are rejected, with a message pointing at `.worktrees/dispatch/<agent>/<task>/` and bare `--worktree`.
- **Read-only** repo-root preflight and **worktree creation from the primary checkout** remain allowed (the bootstrap path called out in the issue comment).
- Removed the deprecated `--cwd .` / flat-layout write examples from the help epilog and arg help.

## Acceptance criteria coverage
- [x] `workspace-write`/`danger` require a verified added worktree cwd; bare `--worktree` auto-derive remains recommended.
- [x] Read-only mode still runs from repo root.
- [x] Creating a worktree from the primary checkout still works.
- [x] Reject write-capable execution whose final worker cwd is the primary checkout.
- [x] Help no longer shows `--cwd .` or flat write layout.
- [x] Reuses the #4444 containment predicate (no reimplemented classification).

## Tests (`tests/test_delegate.py`)
Unit (`_resolve_write_cwd_error`) + end-to-end (`cmd_dispatch`): read-only repo-root allowed, `workspace-write`/`danger` without isolation rejected, `--cwd <primary>`/in-repo-subdir rejected, `--cwd <added-worktree>` accepted, unregistered `.worktrees/**` dir rejected, bare and explicit registered worktrees accepted, and help omits `--cwd .`.

## Verification
- `.venv/bin/python -m pytest tests/test_delegate.py` → 92 passed (pre-commit).
- New tests re-run green under a simulated git-hook env (`GIT_DIR`/`GIT_WORK_TREE` set).
- `git diff --check` clean; `scripts/audit/lint_agent_trailer.py` PASS.

Scoped to delegate policy; #4446/#4449 not implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)