### PR TITLE
fix(runtime): git shim fork bomb — pre-filter guard spawn + recursion sentinel

### DIFF
--- a/scripts/agent_runtime/shims/git
+++ b/scripts/agent_runtime/shims/git
@@ -130,7 +130,18 @@ sys.exit(1)
 ' "$repo_root" "$@"
 }
 
-if [[ "${AGENT_NO_MERGE:-}" == "1" ]] && _blocks_branch_switch "$@"; then
+# INCIDENT 2026-07-05 (fork bomb): _blocks_branch_switch spawns a python guard whose
+# worktree_containment._run_git calls bare "git" -> PATH resolves back to THIS shim ->
+# guard again -> infinite bash+python chains until the per-user process limit (observed:
+# ~2,200 stuck processes, machine-wide fork failures). Two independent breakers:
+#   1. Bash-side pre-filter: the guard only concerns checkout/switch — never spawn the
+#      python (which itself runs git) for any other subcommand.
+#   2. AGENT_GIT_SHIM_GUARD_ACTIVE sentinel: any git call nested under the guard skips
+#      the guard block entirely, so even a checkout/switch issued from inside the
+#      guard's own subtree cannot recurse. The push-deny above stays active regardless.
+if [[ "${AGENT_NO_MERGE:-}" == "1" && "${AGENT_GIT_SHIM_GUARD_ACTIVE:-}" != "1" ]] \
+   && [[ "${1:-}" == "checkout" || "${1:-}" == "switch" ]] \
+   && AGENT_GIT_SHIM_GUARD_ACTIVE=1 _blocks_branch_switch "$@"; then
   cat >&2 <<EOF
 error: agent cannot switch branches in the primary checkout.
        Create and cd into a dispatch worktree (.worktrees/dispatch/<agent>/<task>/) before switching branches.

--- a/scripts/agent_runtime/shims/git
+++ b/scripts/agent_runtime/shims/git
@@ -136,17 +136,25 @@ sys.exit(1)
 # ~2,200 stuck processes, machine-wide fork failures). Two independent breakers:
 #   1. Bash-side pre-filter: the guard only concerns checkout/switch — never spawn the
 #      python (which itself runs git) for any other subcommand.
-#   2. AGENT_GIT_SHIM_GUARD_ACTIVE sentinel: any git call nested under the guard skips
-#      the guard block entirely, so even a checkout/switch issued from inside the
-#      guard's own subtree cannot recurse. The push-deny above stays active regardless.
-if [[ "${AGENT_NO_MERGE:-}" == "1" && "${AGENT_GIT_SHIM_GUARD_ACTIVE:-}" != "1" ]] \
-   && [[ "${1:-}" == "checkout" || "${1:-}" == "switch" ]] \
-   && AGENT_GIT_SHIM_GUARD_ACTIVE=1 _blocks_branch_switch "$@"; then
-  cat >&2 <<EOF
+#   2. AGENT_GIT_SHIM_GUARD_ACTIVE sentinel, FAIL-CLOSED (codex review msg 2014): the
+#      guard's subtree only ever runs read-only plumbing (rev-parse/show-ref/ls-files),
+#      which the pre-filter passes through. A checkout/switch arriving WITH the sentinel
+#      set is therefore either recursion or spoofing — both are DENIED outright, without
+#      spawning the guard python. Spoofing the sentinel strengthens the block; it cannot
+#      bypass it. The push-deny above stays active regardless.
+if [[ "${AGENT_NO_MERGE:-}" == "1" ]] && [[ "${1:-}" == "checkout" || "${1:-}" == "switch" ]]; then
+  if [[ "${AGENT_GIT_SHIM_GUARD_ACTIVE:-}" == "1" ]]; then
+    cat >&2 <<EOF
+error: branch switch denied inside the containment guard's own subtree (fail-closed sentinel).
+EOF
+    exit 1
+  elif AGENT_GIT_SHIM_GUARD_ACTIVE=1 _blocks_branch_switch "$@"; then
+    cat >&2 <<EOF
 error: agent cannot switch branches in the primary checkout.
        Create and cd into a dispatch worktree (.worktrees/dispatch/<agent>/<task>/) before switching branches.
 EOF
-  exit 1
+    exit 1
+  fi
 fi
 
 real_git="$(_real_git)" || {

--- a/tests/test_git_shim_guard.py
+++ b/tests/test_git_shim_guard.py
@@ -96,18 +96,34 @@ def test_checkout_consults_guard(shim_fixture: dict[str, Path]) -> None:
     assert shim_fixture["log"].exists(), "guard python was NOT consulted for checkout"
 
 
-def test_sentinel_breaks_recursion(shim_fixture: dict[str, Path]) -> None:
-    """A nested call under the guard (sentinel set) must skip the guard entirely."""
+def test_sentinel_fails_closed_on_branch_switch(shim_fixture: dict[str, Path]) -> None:
+    """checkout/switch under the sentinel is DENIED without spawning the guard.
+
+    Fail-closed design (codex review msg 2014): the guard's subtree only runs
+    read-only plumbing, so a sentinel-bearing checkout/switch is recursion or
+    spoofing — both must be blocked, never allowed and never recursed into.
+    """
     result = _run_shim(
         shim_fixture,
         "checkout",
         "some-branch",
         extra_env={"AGENT_GIT_SHIM_GUARD_ACTIVE": "1"},
     )
-    assert not shim_fixture["log"].exists(), "sentinel did not suppress the guard — recursion possible"
-    # the underlying real git checkout fails (branch doesn't exist) but the shim
-    # itself must have exec'd through to real git rather than blocking:
-    assert "cannot switch branches" not in result.stderr
+    assert not shim_fixture["log"].exists(), "guard python spawned under sentinel — recursion possible"
+    assert result.returncode == 1
+    assert "fail-closed sentinel" in result.stderr
+
+
+def test_sentinel_passes_readonly_plumbing(shim_fixture: dict[str, Path]) -> None:
+    """Non-switch commands under the sentinel pass through without the guard."""
+    result = _run_shim(
+        shim_fixture,
+        "status",
+        "--porcelain",
+        extra_env={"AGENT_GIT_SHIM_GUARD_ACTIVE": "1"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert not shim_fixture["log"].exists()
 
 
 def test_push_deny_still_active_with_sentinel(shim_fixture: dict[str, Path]) -> None:

--- a/tests/test_git_shim_guard.py
+++ b/tests/test_git_shim_guard.py
@@ -1,0 +1,123 @@
+"""Regression tests for the agent git shim's branch-switch guard.
+
+INCIDENT 2026-07-05 (fork bomb): the shim spawned the worktree-containment
+python guard for EVERY git subcommand, and the guard's own ``_run_git`` calls
+bare ``git`` which PATH-resolves back to the shim — infinite bash+python
+recursion until the per-user process limit (~2,200 stuck processes observed,
+machine-wide fork failures).
+
+Contract under test (scripts/agent_runtime/shims/git):
+1. Non-checkout/switch subcommands NEVER spawn the python guard (bash pre-filter).
+2. checkout/switch DO consult the guard.
+3. With AGENT_GIT_SHIM_GUARD_ACTIVE=1 (set by the shim around the guard call),
+   even checkout/switch skip the guard — breaking any nested recursion.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SHIM_SOURCE = REPO_ROOT / "scripts" / "agent_runtime" / "shims" / "git"
+
+PYTHON_STUB = """#!/usr/bin/env bash
+# Records that the containment guard python was invoked, then declines to block.
+echo invoked >> "$(dirname "$0")/../guard-invocations.log"
+exit 1
+"""
+
+
+@pytest.fixture()
+def shim_fixture(tmp_path: Path) -> dict[str, Path]:
+    """Copy the shim into an isolated fake repo root with a stub guard python.
+
+    The shim derives repo_root from its own location (shim_dir/../../..), so a
+    copy rooted at tmp_path uses tmp_path/.venv/bin/python — our stub — instead
+    of the real containment guard.
+    """
+    shim_dir = tmp_path / "scripts" / "agent_runtime" / "shims"
+    shim_dir.mkdir(parents=True)
+    shim_copy = shim_dir / "git"
+    shutil.copy2(SHIM_SOURCE, shim_copy)
+
+    stub_dir = tmp_path / ".venv" / "bin"
+    stub_dir.mkdir(parents=True)
+    stub = stub_dir / "python"
+    stub.write_text(PYTHON_STUB, encoding="utf-8")
+    stub.chmod(0o755)
+
+    workdir = tmp_path / "repo"
+    workdir.mkdir()
+    # Clean env: when this test runs under a git hook (pre-commit), inherited
+    # GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE would redirect `git init` out of the
+    # fixture directory.
+    subprocess.run(
+        ["git", "init", "-q", str(workdir)],
+        check=True,
+        env={"PATH": "/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin", "HOME": str(tmp_path)},
+    )
+
+    return {"shim": shim_copy, "workdir": workdir, "log": tmp_path / ".venv" / "guard-invocations.log"}
+
+
+def _run_shim(fx: dict[str, Path], *args: str, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    env = {
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin",
+        "HOME": str(fx["workdir"]),
+        "AGENT_NO_MERGE": "1",
+    }
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [str(fx["shim"]), *args],
+        cwd=fx["workdir"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+
+def test_non_switch_subcommand_never_spawns_guard(shim_fixture: dict[str, Path]) -> None:
+    """`git status` through the shim must not fork the python guard (fork-bomb vector)."""
+    result = _run_shim(shim_fixture, "status", "--porcelain")
+    assert result.returncode == 0, result.stderr
+    assert not shim_fixture["log"].exists(), "guard python was spawned for a non-checkout subcommand"
+
+
+def test_checkout_consults_guard(shim_fixture: dict[str, Path]) -> None:
+    """checkout/switch still route through the containment guard."""
+    _run_shim(shim_fixture, "checkout", "some-branch")
+    assert shim_fixture["log"].exists(), "guard python was NOT consulted for checkout"
+
+
+def test_sentinel_breaks_recursion(shim_fixture: dict[str, Path]) -> None:
+    """A nested call under the guard (sentinel set) must skip the guard entirely."""
+    result = _run_shim(
+        shim_fixture,
+        "checkout",
+        "some-branch",
+        extra_env={"AGENT_GIT_SHIM_GUARD_ACTIVE": "1"},
+    )
+    assert not shim_fixture["log"].exists(), "sentinel did not suppress the guard — recursion possible"
+    # the underlying real git checkout fails (branch doesn't exist) but the shim
+    # itself must have exec'd through to real git rather than blocking:
+    assert "cannot switch branches" not in result.stderr
+
+
+def test_push_deny_still_active_with_sentinel(shim_fixture: dict[str, Path]) -> None:
+    """The push-to-main deny is bash-only and must survive the sentinel path."""
+    result = _run_shim(
+        shim_fixture,
+        "push",
+        "origin",
+        "main",
+        extra_env={"AGENT_GIT_SHIM_GUARD_ACTIVE": "1"},
+    )
+    assert result.returncode == 1
+    assert "cannot push directly to main" in result.stderr


### PR DESCRIPTION
## Incident (2026-07-05, machine-wide)
`e301b9616a`'s branch-switch guard spawns a python (`worktree_containment`) for **every** git subcommand, and the guard's `_run_git` calls bare `git` → PATH resolves back to the shim → guard → shim → **infinite bash+python recursion**. Observed: ~2,200 stuck processes, per-user process-table saturation (`ulimit -u` 2666), machine-wide fork failures (killed background tasks, agent silent-exits, failed CLI version probes). Chains regrew within minutes while the unfixed shim was deployed; recovery took operator root pkill + in-place hotfix of the deployed shim (already live — this PR is the durable version of exactly that hotfix + tests).

## Fix — two independent breakers
1. **Bash pre-filter**: only spawn the guard for `checkout`/`switch` — mirrors the python's own `git_args[0]` check (identical semantics), removes the python spawn for the ~95% non-switch case (~100-300ms per git call machine-wide), and breaks the recursion at depth 1.
2. **`AGENT_GIT_SHIM_GUARD_ACTIVE` sentinel** exported around the guard call: any git nested under the guard's subtree skips the guard block. The push-to-main deny stays active on the sentinel path (bash-only, recursion-free).

## Evidence
- `bash -n` clean; 4 new regression tests green (incl. under-pre-commit env isolation): non-switch never spawns guard / checkout consults guard / sentinel suppresses guard / push-deny survives sentinel
- Live smoke on the primary checkout: `status` 0.59s with zero guard spawns; `switch x` correctly **blocked** in 0.50s, no recursion
- Process table: 2747 → 524 after sweep + hotfix; guards 1006 → 4

## Flagged, not fixed here (for the #4446 lane)
- Pre-existing guard bypass: global options before the subcommand (`git -C . checkout x`) defeat both the original python check and this pre-filter identically
- Shared `.git/config` kept being re-armed `core.bare=true` during the incident (`claude/bakeoff-bare-arm` experiment) — breaks git/hooks in every other linked worktree (#2842 class); plus stray `[user] test@example.com` pollution in the shared config

🤖 Generated with [Claude Code](https://claude.com/claude-code)