### PR TITLE
feat(delegate): block dirty primary write dispatches (#4449)

### DIFF
--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -275,6 +275,8 @@ def _run_command(args: list[str], *, timeout: float = 2.0) -> subprocess.Complet
 
 
 def _collect_git_orient_data() -> dict:
+    from scripts.guardrails import worktree_containment
+
     branch_proc = _run_command(["git", "branch", "--show-current"])
     head_proc = _run_command(["git", "rev-parse", "--short=9", "HEAD"])
     ahead_proc = _run_command(["git", "rev-list", "--count", "origin/main..HEAD"])
@@ -301,12 +303,15 @@ def _collect_git_orient_data() -> dict:
             ahead_value = int(ahead_proc.stdout.strip() or "0")
         except ValueError:
             ahead_value = 0
+    primary_status = worktree_containment.primary_checkout_dirty_status(PROJECT_ROOT)
 
     return {
         "branch": branch_proc.stdout.strip(),
         "head": head_proc.stdout.strip(),
         "ahead_of_origin": ahead_value,
         "recent_commits": recent_commits,
+        "primary_checkout_dirty": primary_status["dirty"],
+        "primary_checkout": primary_status,
     }
 
 

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -303,7 +303,23 @@ def _collect_git_orient_data() -> dict:
             ahead_value = int(ahead_proc.stdout.strip() or "0")
         except ValueError:
             ahead_value = 0
-    primary_status = worktree_containment.primary_checkout_dirty_status(PROJECT_ROOT)
+    try:
+        primary_status = worktree_containment.primary_checkout_dirty_status(PROJECT_ROOT)
+    except Exception as exc:
+        branch = branch_proc.stdout.strip()
+        primary_status = {
+            "main_root": str(PROJECT_ROOT),
+            "branch": branch,
+            "protected_branch": branch in worktree_containment.PROTECTED_BRANCHES,
+            "dirty": False,
+            "dirty_count": 0,
+            "tracked_dirty_count": 0,
+            "untracked_dirty_count": 0,
+            "entries": [],
+            "checked_cwd": str(PROJECT_ROOT),
+            "checked_command": "git status --porcelain=v1 -z --untracked-files=all",
+            "error": str(exc),
+        }
 
     return {
         "branch": branch_proc.stdout.strip(),

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -504,6 +504,49 @@ def _resolve_write_cwd_error(
     )
 
 
+def _format_dirty_entries(entries: list[dict[str, str]], *, limit: int = 10) -> str:
+    shown = [f"{entry.get('xy', '').strip() or '??'} {entry.get('path', '')}" for entry in entries[:limit]]
+    if len(entries) > limit:
+        shown.append(f"... and {len(entries) - limit} more")
+    return ", ".join(shown) if shown else "(none)"
+
+
+def _resolve_dirty_primary_checkout_error(*, mode: str) -> str | None:
+    """Reject write-capable dispatch when the protected primary checkout is dirty.
+
+    This is separate from the #4445 isolation check: even a correctly isolated
+    new worktree should not be dispatched while main/master already has tracked
+    or untracked non-ignored dirt, because the next worker inherits polluted
+    operator state. Read-only dispatches stay allowed for preflight and diagnosis.
+    """
+    if mode not in _WRITE_CAPABLE_MODES:
+        return None
+
+    wc = _load_worktree_containment()
+    try:
+        status = wc.primary_checkout_dirty_status(_REPO_ROOT)
+    except Exception as exc:
+        return (
+            "❌ could not verify primary checkout cleanliness before "
+            f"write-capable dispatch: {type(exc).__name__}: {exc}"
+        )
+
+    if not status.get("protected_branch") or not status.get("dirty"):
+        return None
+
+    entries = status.get("entries") or []
+    return (
+        "❌ primary checkout is dirty; refusing write-capable dispatch before "
+        "creating branch/worktree residue.\n"
+        f"   cwd: {status.get('checked_cwd')}\n"
+        f"   command: {status.get('checked_command')}\n"
+        f"   branch: {status.get('branch')}\n"
+        f"   dirty files: {_format_dirty_entries(entries)}\n"
+        "   Clean/stash the primary checkout, or keep only gitignored local "
+        "runtime state, then retry."
+    )
+
+
 def _fetch_base(base: str) -> bool:
     """Fetch ``origin/{base}``. Returns True iff the remote ref is resolvable."""
     proc = subprocess.run(
@@ -1564,6 +1607,11 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     )
     if write_cwd_error:
         print(write_cwd_error, file=sys.stderr)
+        return 2
+
+    dirty_primary_error = _resolve_dirty_primary_checkout_error(mode=args.mode)
+    if dirty_primary_error:
+        print(dirty_primary_error, file=sys.stderr)
         return 2
 
     # Refuse to clobber a task that's still alive — whether it's in

--- a/scripts/guardrails/worktree_containment.py
+++ b/scripts/guardrails/worktree_containment.py
@@ -56,6 +56,7 @@ __all__ = [
     "is_protected_branch",
     "is_tracked",
     "is_write_allowed",
+    "primary_checkout_dirty_status",
     "registered_worktrees",
     "resolve_main_root",
 ]
@@ -363,6 +364,71 @@ def is_protected_branch(root: Path | str | None = None) -> bool:
     """True if the checkout at ``root`` is on a :data:`PROTECTED_BRANCHES` branch."""
     branch = current_branch(root)
     return branch is not None and branch in PROTECTED_BRANCHES
+
+
+def _parse_status_porcelain_z(stdout: str) -> list[dict[str, str]]:
+    """Parse ``git status --porcelain=v1 -z`` entries.
+
+    Ignored files are absent because callers do not pass ``--ignored``. Rename
+    and copy entries carry a second NUL-delimited source path; we skip that
+    extra token because the destination path is sufficient for the dirty-main
+    tripwire.
+    """
+    entries: list[dict[str, str]] = []
+    parts = stdout.split("\0")
+    index = 0
+    while index < len(parts):
+        raw = parts[index]
+        index += 1
+        if not raw:
+            continue
+        xy = raw[:2]
+        path = raw[3:] if len(raw) > 3 else ""
+        entries.append({
+            "xy": xy,
+            "path": path,
+            "kind": "untracked" if xy == "??" else "tracked",
+        })
+        if xy[:1] in {"R", "C"} or xy[1:2] in {"R", "C"}:
+            index += 1
+    return entries
+
+
+def primary_checkout_dirty_status(start: Path | str | None = None) -> dict:
+    """Return dirty-state detail for the protected primary checkout.
+
+    The check intentionally uses git status plumbing from the primary checkout
+    root and omits ignored files, so gitignored local runtime state does not
+    count as dirty. Tracked modifications/deletions and untracked non-ignored
+    files both count because either would pollute the primary checkout for the
+    next dispatched writer.
+    """
+    main_root = resolve_main_root(start)
+    branch = current_branch(main_root)
+    command = ("git", "status", "--porcelain=v1", "-z", "--untracked-files=all")
+    proc = _run_git(main_root, *command[1:])
+    if proc.returncode != 0:
+        detail = proc.stderr.strip() or proc.stdout.strip() or "git status failed"
+        raise RuntimeError(
+            f"could not inspect primary checkout dirty state "
+            f"(cwd={main_root}, command={' '.join(command)}): {detail}"
+        )
+
+    entries = _parse_status_porcelain_z(proc.stdout or "")
+    tracked_count = sum(1 for entry in entries if entry["kind"] == "tracked")
+    untracked_count = sum(1 for entry in entries if entry["kind"] == "untracked")
+    return {
+        "main_root": str(main_root),
+        "branch": branch,
+        "protected_branch": branch in PROTECTED_BRANCHES if branch else False,
+        "dirty": bool(entries),
+        "dirty_count": len(entries),
+        "tracked_dirty_count": tracked_count,
+        "untracked_dirty_count": untracked_count,
+        "entries": entries,
+        "checked_cwd": str(main_root),
+        "checked_command": " ".join(command),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2283,7 +2283,7 @@ def _init_repo_with_worktree(tmp_path: Path) -> tuple[Path, Path]:
     )
     _git(main, "config", "user.email", "test@example.com")
     _git(main, "config", "user.name", "Test")
-    (main / ".gitignore").write_text(".worktrees/\n")
+    (main / ".gitignore").write_text(".worktrees/\nlocal_state/\n")
     (main / "tracked.txt").write_text("x\n")
     _git(main, "add", "-A")
     _git(main, "commit", "-q", "-m", "init")
@@ -2426,6 +2426,53 @@ def test_write_guard_rejects_explicit_worktree_pointing_at_primary(tmp_path):
     assert "primary checkout" in err
 
 
+def _primary_dirty_status(main: Path) -> dict:
+    return delegate._load_worktree_containment().primary_checkout_dirty_status(main)
+
+
+def test_primary_dirty_status_clean_main(tmp_path):
+    main, _ = _init_repo_with_worktree(tmp_path)
+
+    status = _primary_dirty_status(main)
+
+    assert status["dirty"] is False
+    assert status["dirty_count"] == 0
+
+
+def test_primary_dirty_status_tracks_modified_file(tmp_path):
+    main, _ = _init_repo_with_worktree(tmp_path)
+    (main / "tracked.txt").write_text("dirty\n")
+
+    status = _primary_dirty_status(main)
+
+    assert status["dirty"] is True
+    assert status["tracked_dirty_count"] == 1
+    assert status["entries"] == [{"xy": " M", "path": "tracked.txt", "kind": "tracked"}]
+
+
+def test_primary_dirty_status_tracks_untracked_nonignored_file(tmp_path):
+    main, _ = _init_repo_with_worktree(tmp_path)
+    (main / "scratch.txt").write_text("new\n")
+
+    status = _primary_dirty_status(main)
+
+    assert status["dirty"] is True
+    assert status["untracked_dirty_count"] == 1
+    assert status["entries"] == [{"xy": "??", "path": "scratch.txt", "kind": "untracked"}]
+
+
+def test_primary_dirty_status_ignores_gitignored_local_state(tmp_path):
+    main, _ = _init_repo_with_worktree(tmp_path)
+    local_state = main / "local_state" / "cache.json"
+    local_state.parent.mkdir()
+    local_state.write_text("{}\n")
+
+    status = _primary_dirty_status(main)
+
+    assert status["dirty"] is False
+    assert status["dirty_count"] == 0
+
+
 # --- cmd_dispatch end-to-end tests ------------------------------------------
 
 
@@ -2440,6 +2487,56 @@ def test_dispatch_read_only_allows_repo_root(tmp_tasks_dir, monkeypatch):
     state = delegate._read_state(delegate._state_path("ro-root"))
     assert state is not None
     assert state["cwd"] == str(delegate._REPO_ROOT)
+
+
+def test_dispatch_read_only_allows_dirty_primary_checkout(
+    tmp_tasks_dir, tmp_path, monkeypatch,
+):
+    """Read-only preflight still runs so agents can inspect and report dirt."""
+    main, _ = _init_repo_with_worktree(tmp_path)
+    (main / "tracked.txt").write_text("dirty\n")
+    monkeypatch.setattr(delegate, "_REPO_ROOT", main)
+    monkeypatch.setattr(delegate.subprocess, "Popen", lambda *a, **k: _GuardFakeProc())
+    args = _write_args(task_id="ro-dirty-main", mode="read-only", cwd=None, worktree=None)
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 0
+    state = delegate._read_state(delegate._state_path("ro-dirty-main"))
+    assert state is not None
+    assert state["cwd"] == str(main)
+
+
+def test_dispatch_rejects_write_capable_when_primary_checkout_dirty(
+    tmp_tasks_dir, tmp_path, monkeypatch, capsys,
+):
+    main, _ = _init_repo_with_worktree(tmp_path)
+    (main / "tracked.txt").write_text("dirty\n")
+    monkeypatch.setattr(delegate, "_REPO_ROOT", main)
+    args = _write_args(
+        task_id="dirty-main",
+        mode="workspace-write",
+        cwd=None,
+        worktree="auto",
+    )
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 2
+    assert delegate._read_state(delegate._state_path("dirty-main")) is None
+    err = capsys.readouterr().err
+    assert "primary checkout is dirty" in err
+    assert "git status --porcelain=v1 -z --untracked-files=all" in err
+    assert "tracked.txt" in err
+    assert not (main / ".worktrees" / "dispatch" / "codex" / "dirty-main").exists()
+    branch_proc = subprocess.run(
+        ["git", "-C", str(main), "branch", "--list", "codex/dirty-main"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=delegate._sanitized_git_env(),
+    )
+    assert branch_proc.stdout.strip() == ""
 
 
 def test_dispatch_rejects_workspace_write_without_worktree(tmp_tasks_dir, capsys):
@@ -2470,7 +2567,8 @@ def test_dispatch_rejects_workspace_write_cwd_primary_checkout(
 def test_dispatch_accepts_workspace_write_cwd_added_worktree(
     tmp_tasks_dir, tmp_path, monkeypatch,
 ):
-    _, dispatch_wt = _init_repo_with_worktree(tmp_path)
+    main, dispatch_wt = _init_repo_with_worktree(tmp_path)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", main)
     _patch_worker_popen(monkeypatch)
     args = _write_args(
         task_id="ww-cwd-wt", mode="workspace-write", cwd=str(dispatch_wt), worktree=None,

--- a/tests/test_orient_api.py
+++ b/tests/test_orient_api.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
+import subprocess
 import time
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -53,6 +56,42 @@ def _patch_orient_sources(monkeypatch) -> None:
     monkeypatch.setattr(api_main, "_collect_session_hints_orient_data", lambda: [{"file": "docs/session-state/example.md", "first_line": "# Example"}])
 
 
+def _clean_git_env() -> dict[str, str]:
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_") and not key.startswith("PRE_COMMIT")
+    }
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_clean_git_env(),
+    )
+
+
+def _init_orient_git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main", str(repo)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_clean_git_env(),
+    )
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "tracked.txt").write_text("clean\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
 def test_orient_returns_all_top_level_keys(monkeypatch):
     _patch_orient_sources(monkeypatch)
 
@@ -73,6 +112,26 @@ def test_orient_returns_all_top_level_keys(monkeypatch):
         "session_hints",
     }
     assert expected <= set(data)
+
+
+def test_orient_git_exposes_primary_checkout_dirty_signal(monkeypatch, tmp_path):
+    original_git_collector = api_main._collect_git_orient_data
+    repo = _init_orient_git_repo(tmp_path)
+    (repo / "tracked.txt").write_text("dirty\n", encoding="utf-8")
+    _patch_orient_sources(monkeypatch)
+    monkeypatch.setattr(api_main, "PROJECT_ROOT", repo)
+    monkeypatch.setattr(api_main, "_collect_git_orient_data", original_git_collector)
+
+    response = client.get("/api/orient?fresh=true")
+
+    assert response.status_code == 200
+    git_info = response.json()["git"]
+    assert git_info["primary_checkout_dirty"] is True
+    assert git_info["primary_checkout"]["checked_cwd"] == str(repo)
+    assert git_info["primary_checkout"]["tracked_dirty_count"] == 1
+    assert git_info["primary_checkout"]["entries"] == [
+        {"xy": " M", "path": "tracked.txt", "kind": "tracked"}
+    ]
 
 
 def test_health_includes_core_bare_canary():

--- a/tests/test_orient_api.py
+++ b/tests/test_orient_api.py
@@ -134,6 +134,35 @@ def test_orient_git_exposes_primary_checkout_dirty_signal(monkeypatch, tmp_path)
     ]
 
 
+def test_orient_git_survives_primary_checkout_probe_failure(monkeypatch, tmp_path):
+    original_git_collector = api_main._collect_git_orient_data
+    repo = _init_orient_git_repo(tmp_path)
+    _patch_orient_sources(monkeypatch)
+    monkeypatch.setattr(api_main, "PROJECT_ROOT", repo)
+    monkeypatch.setattr(api_main, "_collect_git_orient_data", original_git_collector)
+
+    from scripts.guardrails import worktree_containment
+
+    def broken_primary_status(_start):
+        raise RuntimeError("git status failed")
+
+    monkeypatch.setattr(
+        worktree_containment,
+        "primary_checkout_dirty_status",
+        broken_primary_status,
+    )
+
+    response = client.get("/api/orient?fresh=true")
+
+    assert response.status_code == 200
+    git_info = response.json()["git"]
+    assert git_info["branch"]
+    assert git_info["head"]
+    assert git_info["primary_checkout_dirty"] is False
+    assert git_info["primary_checkout"]["error"] == "git status failed"
+    assert git_info["primary_checkout"]["checked_cwd"] == str(repo)
+
+
 def test_health_includes_core_bare_canary():
     """#2842: the health section surfaces the git core.bare detection canary."""
     health = api_main._collect_health_orient_data()


### PR DESCRIPTION
## Summary

Resolves #4449.

Adds a dirty-primary-checkout tripwire that surfaces primary checkout dirtiness in Monitor health and blocks write-capable dispatches before creating new worktree/branch residue when the primary checkout is dirty.

## Changes

- `scripts/guardrails/worktree_containment.py`: adds primary checkout dirtiness helpers based on Git status plumbing and existing containment/write-decision semantics.
- `scripts/delegate.py`: blocks `workspace-write`/`danger` dispatches when the primary checkout has blocking dirtiness, while preserving read-only dispatches.
- `scripts/api/main.py`: exposes primary checkout dirty state in Monitor health.
- `tests/test_delegate.py` and `tests/test_orient_api.py`: cover clean/dirty tracked, untracked non-ignored, gitignored local state, read-only allow, and write-capable reject cases.

## Verification

- `.venv/bin/python -m pytest tests/test_delegate.py tests/test_orient_api.py tests/test_worktree_containment.py -q` -> 132 passed
- pre-commit during commit passed affected tests, ruff, and gitleaks
- `git diff --check origin/main..HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py origin/main..HEAD`

## Notes

The original dispatch completed the commit but could not push/create the PR because the host temporarily refused new process creation. Codex orchestrator finished push/PR creation after verifying the branch.

X-Agent: codex/4449-monitor-dirty-main-tripwire
