### PR TITLE
feat(agent-runtime): runner-level provider failover

### DIFF
--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -133,6 +133,56 @@ points:
   and raises `RateLimitedError` before burning a quota slot on a
   known-rate-limited call.
 
+## Runner-level provider failover (#4497)
+
+Provider failover is optional and configured per runtime lane in
+`scripts/config/agent_runtime_failover.yaml`. The default file has
+`chains: {}`; absent lane chain means `runner.invoke()` keeps the previous
+single-route behavior exactly.
+
+Configured chains are ordered route lists:
+
+```yaml
+chains:
+  deepseek:
+    cooldown_ttl_s: 300
+    routes:
+      - provider: deepseek
+        model: deepseek-v4-pro
+      - provider: openrouter
+        model: qwen/qwen3.6-plus
+```
+
+On eligible failures only, the runner marks the failed provider/model/profile
+route in a SQLite cooldown store at
+`batch_state/agent_runtime_failover_cooldowns.sqlite3` and reinvokes the same
+adapter with the next route. Parallel dispatches share that cooldown state.
+The next dispatch starts at the first non-cooling route, so a recently dead
+primary is not re-probed immediately.
+
+Eligible trigger classes are deliberately narrow: 401/403 auth failure,
+429/quota exhaustion, 5xx/overloaded, transport failures such as connection
+refused/reset/read timeout, and parsed-but-empty responses. Content-policy
+refusals and 4xx request-format errors do not fail over.
+
+Every runner-level switch emits the same substitution-shaped payload used by
+Hermes fallback surfacing: `requested_provider`, `requested_model`,
+`actual_provider`, `actual_model`, `substituted`, `source`, and `marker`.
+The payload flows into the usage record, delegate state, telemetry event, and
+a loud stderr/logger marker (`AGENT_RUNTIME_FAILOVER_SUBSTITUTION`). Silent
+provider/model substitution is forbidden.
+
+v1 adapter coverage:
+
+| Lane | Route override support |
+|---|---|
+| `deepseek`, `qwen`, `grok` | Hermes provider + model via runner route metadata and `--provider` when forced. |
+| `agy` | Model override through the existing `--model` mapping; provider is informational unless encoded by the CLI model label. |
+| Other adapters | Model-only chains work when the adapter's existing `model` argument can express the route. |
+
+The runner rejects zai/GLM failover targets before launch using the shared
+local-only route guard.
+
 ## Dispatch worktree layout (#1476)
 
 `delegate.py dispatch --worktree ...` creates the dispatched agent a

--- a/scripts/agent_runtime/adapters/hermes_common.py
+++ b/scripts/agent_runtime/adapters/hermes_common.py
@@ -11,6 +11,11 @@ from typing import Any
 
 import yaml
 
+from ..routes import (
+    RUNTIME_ROUTE_TOOL_CONFIG_KEY,
+    forbidden_glm_error,
+    is_forbidden_glm_route,
+)
 from .base import InvocationPlan
 
 _ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
@@ -51,8 +56,6 @@ _FALLBACK_EMPTY_LOG_RE = re.compile(
     r"(?P<actual_model>\S+)\s+on\s+(?P<actual_provider>\S+)",
     re.IGNORECASE,
 )
-_FORBIDDEN_GLM_MODEL_RE = re.compile(r"(^|[/_.:-])glm($|[/_.:-]|\d)", re.IGNORECASE)
-
 HERMES_SUBSTITUTION_MARKER = "HERMES_FALLBACK_SUBSTITUTION"
 HERMES_GLM_FORBIDDEN_MARKER = "HERMES_GLM_FORBIDDEN"
 
@@ -151,30 +154,21 @@ def _normalize_route_part(value: Any) -> str:
     return str(value or "").strip()
 
 
-def is_forbidden_glm_route(provider: Any, model: Any) -> bool:
-    """Return True for local-only zai/GLM routes forbidden in automation."""
-    provider_text = _normalize_route_part(provider).lower()
-    model_text = _normalize_route_part(model).lower()
-    if provider_text in {"zai", "z-ai", "glm"}:
-        return True
-    if model_text.startswith(("zai/", "z-ai/")):
-        return True
-    return bool(_FORBIDDEN_GLM_MODEL_RE.search(model_text))
-
-
-def forbidden_glm_error(
+def resolve_hermes_requested_route(
     *,
-    provider: Any,
-    model: Any,
-    source: str,
-) -> str:
-    """Build the explicit hard-fail text for forbidden zai/GLM routes."""
-    return (
-        f"{HERMES_GLM_FORBIDDEN_MARKER}: automated Hermes run refused "
-        f"local-only zai/GLM route from {source}: "
-        f"provider={_normalize_route_part(provider)!r} "
-        f"model={_normalize_route_part(model)!r}"
-    )
+    tool_config: dict | None,
+    default_provider: str,
+    requested_model: str,
+    provider_forced: bool = False,
+) -> tuple[str, str, bool]:
+    """Apply a runner-level provider/model override for Hermes lanes."""
+    raw_route = (tool_config or {}).get(RUNTIME_ROUTE_TOOL_CONFIG_KEY)
+    if not isinstance(raw_route, dict):
+        return default_provider, requested_model, provider_forced
+
+    provider = _normalize_route_part(raw_route.get("provider")) or default_provider
+    route_model = _normalize_route_part(raw_route.get("model")) or requested_model
+    return provider, route_model, True
 
 
 def _fallback_entries(config: dict[str, Any]) -> list[dict[str, Any]]:

--- a/scripts/agent_runtime/adapters/hermes_deepseek.py
+++ b/scripts/agent_runtime/adapters/hermes_deepseek.py
@@ -35,6 +35,7 @@ from .base import InvocationPlan
 from .hermes_common import (
     build_hermes_invocation_context,
     build_hermes_parse_fields,
+    resolve_hermes_requested_route,
     sources_mcp_registered,
     top_level_agent_effort,
     translate_mcp_prefix_for_hermes,
@@ -94,10 +95,16 @@ class HermesDeepSeekAdapter:
             )
 
         requested_model = model or self.default_model
+        requested_provider, requested_model, provider_forced = resolve_hermes_requested_route(
+            tool_config=tool_config,
+            default_provider="deepseek",
+            requested_model=requested_model,
+        )
         context = build_hermes_invocation_context(
             tool_config=tool_config,
-            requested_provider="deepseek",
+            requested_provider=requested_provider,
             requested_model=requested_model,
+            provider_forced=provider_forced,
         )
         config = context.config
         configured_effort = top_level_agent_effort(config)
@@ -124,8 +131,11 @@ class HermesDeepSeekAdapter:
 
         hermes_bin = shutil.which("hermes") or "hermes"
         hermes_prompt = translate_mcp_prefix_for_hermes(prompt)
+        cmd = [hermes_bin, "-z", hermes_prompt, "-m", requested_model]
+        if provider_forced:
+            cmd.extend(["--provider", requested_provider])
         return InvocationPlan(
-            cmd=[hermes_bin, "-z", hermes_prompt, "-m", requested_model],
+            cmd=cmd,
             cwd=cwd,
             stdin_payload="",
             output_file=None,

--- a/scripts/agent_runtime/adapters/hermes_grok.py
+++ b/scripts/agent_runtime/adapters/hermes_grok.py
@@ -26,6 +26,7 @@ from .base import InvocationPlan
 from .hermes_common import (
     build_hermes_invocation_context,
     build_hermes_parse_fields,
+    resolve_hermes_requested_route,
     sources_mcp_registered,
     top_level_agent_effort,
     translate_mcp_prefix_for_hermes,
@@ -79,10 +80,16 @@ class HermesGrokAdapter:
             )
 
         requested_model = model or self.default_model
+        requested_provider, requested_model, provider_forced = resolve_hermes_requested_route(
+            tool_config=tool_config,
+            default_provider="xai",
+            requested_model=requested_model,
+        )
         context = build_hermes_invocation_context(
             tool_config=tool_config,
-            requested_provider="xai",
+            requested_provider=requested_provider,
             requested_model=requested_model,
+            provider_forced=provider_forced,
         )
         config = context.config
         configured_effort = top_level_agent_effort(config)
@@ -109,8 +116,11 @@ class HermesGrokAdapter:
 
         hermes_bin = shutil.which("hermes") or "hermes"
         hermes_prompt = translate_mcp_prefix_for_hermes(prompt)
+        cmd = [hermes_bin, "-z", hermes_prompt, "-m", requested_model]
+        if provider_forced:
+            cmd.extend(["--provider", requested_provider])
         return InvocationPlan(
-            cmd=[hermes_bin, "-z", hermes_prompt, "-m", requested_model],
+            cmd=cmd,
             cwd=cwd,
             stdin_payload="",
             output_file=None,

--- a/scripts/agent_runtime/adapters/hermes_qwen.py
+++ b/scripts/agent_runtime/adapters/hermes_qwen.py
@@ -42,6 +42,7 @@ from .base import InvocationPlan
 from .hermes_common import (
     build_hermes_invocation_context,
     build_hermes_parse_fields,
+    resolve_hermes_requested_route,
     sources_mcp_registered,
     top_level_agent_effort,
     translate_mcp_prefix_for_hermes,
@@ -101,11 +102,17 @@ class HermesQwenAdapter:
             )
 
         requested_model = model or self.default_model
-        context = build_hermes_invocation_context(
+        requested_provider, requested_model, provider_forced = resolve_hermes_requested_route(
             tool_config=tool_config,
-            requested_provider="openrouter",
+            default_provider="openrouter",
             requested_model=requested_model,
             provider_forced=True,
+        )
+        context = build_hermes_invocation_context(
+            tool_config=tool_config,
+            requested_provider=requested_provider,
+            requested_model=requested_model,
+            provider_forced=provider_forced,
         )
         config = context.config
         configured_effort = top_level_agent_effort(config)
@@ -143,13 +150,11 @@ class HermesQwenAdapter:
         # Investigated 2026-05-19: verified that the flag rescues k2.5, k2.6,
         # minimax-m2.7; qwen/* and other previously-working models continue
         # to work unchanged.
+        cmd = [hermes_bin, "-z", hermes_prompt, "-m", requested_model]
+        if provider_forced:
+            cmd.extend(["--provider", requested_provider])
         return InvocationPlan(
-            cmd=[
-                hermes_bin,
-                "-z", hermes_prompt,
-                "-m", requested_model,
-                "--provider", "openrouter",
-            ],
+            cmd=cmd,
             cwd=cwd,
             stdin_payload="",
             output_file=None,

--- a/scripts/agent_runtime/failover.py
+++ b/scripts/agent_runtime/failover.py
@@ -1,0 +1,416 @@
+"""Runner-level provider failover configuration, cooldowns, and classifiers."""
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import re
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .result import ParseResult
+from .routes import (
+    RUNTIME_ROUTE_TOOL_CONFIG_KEY,
+    forbidden_glm_error,
+    is_forbidden_glm_route,
+)
+
+RUNNER_FAILOVER_MARKER = "AGENT_RUNTIME_FAILOVER_SUBSTITUTION"
+FAILOVER_CONFIG_ENV = "AGENT_RUNTIME_FAILOVER_CONFIG"
+FAILOVER_COOLDOWN_DB_ENV = "AGENT_RUNTIME_FAILOVER_COOLDOWN_DB"
+DEFAULT_COOLDOWN_TTL_S = 5 * 60
+
+_RATE_LIMIT_RE = re.compile(
+    r"rate limit|rate_limit|quota exceeded|too many requests|"
+    r"resource_exhausted|\bHTTP 429\b|\bstatus 429\b|\b429\b",
+    re.IGNORECASE,
+)
+_AUTH_RE = re.compile(
+    r"\b(?:401|403)\b|unauthorized|forbidden|invalid api key|"
+    r"authentication failed|auth(?:orization)? failed",
+    re.IGNORECASE,
+)
+_OVERLOADED_RE = re.compile(
+    r"\b5\d{2}\b|server error|service unavailable|bad gateway|"
+    r"gateway timeout|overloaded|over capacity|upstream error",
+    re.IGNORECASE,
+)
+_TRANSPORT_RE = re.compile(
+    r"connection refused|connection reset|connection aborted|"
+    r"econnrefused|econnreset|etimedout|network is unreachable|"
+    r"read timeout|timed out|timeout while connecting|temporarily unavailable",
+    re.IGNORECASE,
+)
+_EMPTY_RESPONSE_RE = re.compile(
+    r"empty response|empty stream|no content|parsed but empty|"
+    r"no parsed response|zero-length response",
+    re.IGNORECASE,
+)
+_CONTENT_POLICY_RE = re.compile(
+    r"content[-_ ]?policy|content filter|safety filter|policy refusal|"
+    r"\brefusal\b|refused for safety|blocked by safety",
+    re.IGNORECASE,
+)
+_REQUEST_FORMAT_RE = re.compile(
+    r"\b400\b|bad request|invalid[_ -]?request|request format|"
+    r"unsupported parameter|unknown parameter|schema validation|"
+    r"malformed request|not found|\b404\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class FailoverRoute:
+    """One non-secret route identity from a per-lane failover chain."""
+
+    provider: str
+    model: str
+    profile: str | None = None
+    index: int = 0
+
+    def cooldown_key(self, *, agent_name: str) -> str:
+        return "|".join(
+            (
+                agent_name,
+                self.provider,
+                self.model,
+                self.profile or "",
+            )
+        )
+
+    def as_tool_config(self) -> dict[str, str]:
+        route = {
+            "provider": self.provider,
+            "model": self.model,
+        }
+        if self.profile:
+            route["profile"] = self.profile
+        return route
+
+
+@dataclass(frozen=True)
+class FailoverChain:
+    """Ordered routes and cooldown policy for one runtime lane."""
+
+    agent_name: str
+    routes: tuple[FailoverRoute, ...]
+    cooldown_ttl_s: int = DEFAULT_COOLDOWN_TTL_S
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def default_failover_config_path() -> Path:
+    return _repo_root() / "scripts" / "config" / "agent_runtime_failover.yaml"
+
+
+def default_cooldown_db_path() -> Path:
+    return _repo_root() / "batch_state" / "agent_runtime_failover_cooldowns.sqlite3"
+
+
+def _configured_path(env_name: str, default: Path) -> Path:
+    raw = os.environ.get(env_name)
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return default
+
+
+def load_failover_chain(
+    agent_name: str,
+    *,
+    effective_model: str,
+    path: Path | None = None,
+) -> FailoverChain | None:
+    """Return the configured failover chain for ``agent_name``, if any.
+
+    Missing config, missing lane, or fewer than two usable routes all mean
+    "feature disabled" so the runner keeps its pre-failover behavior exactly.
+    """
+    config_path = path or _configured_path(
+        FAILOVER_CONFIG_ENV,
+        default_failover_config_path(),
+    )
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    chains = data.get("chains")
+    if not isinstance(chains, dict):
+        return None
+    lane = chains.get(agent_name)
+    if lane is None:
+        return None
+
+    cooldown_ttl_s = DEFAULT_COOLDOWN_TTL_S
+    if isinstance(lane, dict):
+        raw_routes = lane.get("routes")
+        raw_ttl = lane.get("cooldown_ttl_s")
+        if isinstance(raw_ttl, int) and raw_ttl > 0:
+            cooldown_ttl_s = raw_ttl
+    elif isinstance(lane, list):
+        raw_routes = lane
+    else:
+        return None
+
+    if not isinstance(raw_routes, list):
+        return None
+
+    routes: list[FailoverRoute] = []
+    for index, raw_route in enumerate(raw_routes):
+        if not isinstance(raw_route, dict):
+            continue
+        provider = str(raw_route.get("provider") or agent_name).strip()
+        model = str(raw_route.get("model") or (effective_model if index == 0 else "")).strip()
+        profile_raw = raw_route.get("profile")
+        profile = str(profile_raw).strip() if profile_raw is not None else None
+        if not provider or not model:
+            continue
+        if is_forbidden_glm_route(provider, model):
+            raise ValueError(
+                forbidden_glm_error(
+                    provider=provider,
+                    model=model,
+                    source=f"runner failover chain {agent_name}[{index}]",
+                )
+            )
+        routes.append(
+            FailoverRoute(
+                provider=provider,
+                model=model,
+                profile=profile or None,
+                index=index,
+            )
+        )
+
+    if len(routes) < 2:
+        return None
+    return FailoverChain(
+        agent_name=agent_name,
+        routes=tuple(routes),
+        cooldown_ttl_s=cooldown_ttl_s,
+    )
+
+
+class FailoverCooldownStore:
+    """SQLite-backed route cooldown store shared by parallel dispatches."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self.path = path or _configured_path(
+            FAILOVER_COOLDOWN_DB_ENV,
+            default_cooldown_db_path(),
+        )
+
+    def _connect(self) -> sqlite3.Connection:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.path), timeout=10.0)
+        conn.execute("PRAGMA busy_timeout=5000")
+        with contextlib.suppress(sqlite3.DatabaseError):
+            conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS route_cooldowns (
+                route_key TEXT PRIMARY KEY,
+                agent TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                model TEXT NOT NULL,
+                profile TEXT,
+                trigger TEXT NOT NULL,
+                expires_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            )
+            """
+        )
+        return conn
+
+    def is_cooling(
+        self,
+        route: FailoverRoute,
+        *,
+        agent_name: str,
+        now: float | None = None,
+    ) -> bool:
+        now = time.time() if now is None else now
+        route_key = route.cooldown_key(agent_name=agent_name)
+        with self._connect() as conn:
+            conn.execute("DELETE FROM route_cooldowns WHERE expires_at <= ?", (now,))
+            row = conn.execute(
+                "SELECT expires_at FROM route_cooldowns WHERE route_key = ?",
+                (route_key,),
+            ).fetchone()
+        return bool(row and float(row[0]) > now)
+
+    def mark_cooldown(
+        self,
+        route: FailoverRoute,
+        *,
+        agent_name: str,
+        trigger: str,
+        ttl_s: int,
+        now: float | None = None,
+    ) -> None:
+        now = time.time() if now is None else now
+        expires_at = now + max(1, ttl_s)
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO route_cooldowns (
+                    route_key, agent, provider, model, profile,
+                    trigger, expires_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(route_key) DO UPDATE SET
+                    trigger = excluded.trigger,
+                    expires_at = excluded.expires_at,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    route.cooldown_key(agent_name=agent_name),
+                    agent_name,
+                    route.provider,
+                    route.model,
+                    route.profile,
+                    trigger,
+                    expires_at,
+                    now,
+                ),
+            )
+
+
+def ordered_available_routes(
+    chain: FailoverChain,
+    store: FailoverCooldownStore,
+) -> tuple[FailoverRoute, ...]:
+    """Return chain routes not currently cooling, preserving configured order."""
+    return tuple(
+        route
+        for route in chain.routes
+        if not store.is_cooling(route, agent_name=chain.agent_name)
+    )
+
+
+def classify_failover_trigger(
+    *,
+    parse: ParseResult,
+    returncode: int | None,
+    kill_reason: str | None,
+    stdout_text: str,
+    stderr_text: str,
+) -> str | None:
+    """Map one failed attempt to an eligible failover trigger, if any."""
+    text = "\n".join(
+        part
+        for part in (
+            parse.stderr_excerpt or "",
+            stderr_text or "",
+            stdout_text or "",
+        )
+        if part
+    )
+
+    if _CONTENT_POLICY_RE.search(text):
+        return None
+    if _REQUEST_FORMAT_RE.search(text) and not (
+        parse.rate_limited
+        or _RATE_LIMIT_RE.search(text)
+        or _AUTH_RE.search(text)
+        or _OVERLOADED_RE.search(text)
+    ):
+        return None
+
+    if parse.rate_limited or _RATE_LIMIT_RE.search(text):
+        return "rate_limited"
+    if _AUTH_RE.search(text):
+        return "auth"
+    if _OVERLOADED_RE.search(text):
+        return "overloaded"
+    if _TRANSPORT_RE.search(text):
+        return "transport"
+    if kill_reason in {"stdout_silence_timeout", "initial_response_timeout"}:
+        return "transport"
+    if _EMPTY_RESPONSE_RE.search(text):
+        return "empty_response"
+    if (
+        not parse.ok
+        and returncode == 0
+        and not (parse.response or "").strip()
+        and not text.strip()
+    ):
+        return "empty_response"
+    return None
+
+
+def tool_config_with_route(
+    tool_config: dict | None,
+    route: FailoverRoute,
+) -> dict:
+    """Clone tool_config and pin the adapter-visible runtime route."""
+    merged = dict(tool_config or {})
+    merged[RUNTIME_ROUTE_TOOL_CONFIG_KEY] = route.as_tool_config()
+    return merged
+
+
+def substitution_for_route(
+    *,
+    requested_route: FailoverRoute,
+    actual_route: FailoverRoute,
+    source: str,
+    adapter_substitution: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Build a runner substitution record, preserving adapter actual route."""
+    actual_provider = actual_route.provider
+    actual_model = actual_route.model
+    if isinstance(adapter_substitution, dict):
+        actual_provider = str(
+            adapter_substitution.get("actual_provider") or actual_provider
+        )
+        actual_model = str(adapter_substitution.get("actual_model") or actual_model)
+
+    substituted = (
+        actual_provider != requested_route.provider
+        or actual_model != requested_route.model
+    )
+    if not substituted:
+        return adapter_substitution
+
+    return {
+        "requested_provider": requested_route.provider,
+        "requested_model": requested_route.model,
+        "actual_provider": actual_provider,
+        "actual_model": actual_model,
+        "substituted": True,
+        "source": source,
+        "marker": RUNNER_FAILOVER_MARKER,
+    }
+
+
+def emit_runner_substitution_marker(
+    substitution: dict[str, Any] | None,
+    *,
+    logger: logging.Logger,
+) -> None:
+    """Emit the loud stderr/logger marker required for runner failover."""
+    if not substitution or not substitution.get("substituted"):
+        return
+    if substitution.get("marker") != RUNNER_FAILOVER_MARKER:
+        return
+    message = (
+        f"{RUNNER_FAILOVER_MARKER}: "
+        f"{substitution.get('requested_provider')}/"
+        f"{substitution.get('requested_model')} -> "
+        f"{substitution.get('actual_provider')}/"
+        f"{substitution.get('actual_model')} "
+        f"source={substitution.get('source')}"
+    )
+    logger.warning(message)
+    print(message, file=sys.stderr)

--- a/scripts/agent_runtime/routes.py
+++ b/scripts/agent_runtime/routes.py
@@ -1,0 +1,40 @@
+"""Shared route identity helpers for agent runtime adapters and runner."""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+RUNTIME_ROUTE_TOOL_CONFIG_KEY = "agent_runtime_route"
+HERMES_GLM_FORBIDDEN_MARKER = "HERMES_GLM_FORBIDDEN"
+
+_FORBIDDEN_GLM_MODEL_RE = re.compile(r"(^|[/_.:-])glm($|[/_.:-]|\d)", re.IGNORECASE)
+
+
+def normalize_route_part(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def is_forbidden_glm_route(provider: Any, model: Any) -> bool:
+    """Return True for local-only zai/GLM routes forbidden in automation."""
+    provider_text = normalize_route_part(provider).lower()
+    model_text = normalize_route_part(model).lower()
+    if provider_text in {"zai", "z-ai", "glm"}:
+        return True
+    if model_text.startswith(("zai/", "z-ai/")):
+        return True
+    return bool(_FORBIDDEN_GLM_MODEL_RE.search(model_text))
+
+
+def forbidden_glm_error(
+    *,
+    provider: Any,
+    model: Any,
+    source: str,
+) -> str:
+    """Build the explicit hard-fail text for forbidden zai/GLM routes."""
+    return (
+        f"{HERMES_GLM_FORBIDDEN_MARKER}: automated Hermes run refused "
+        f"local-only zai/GLM route from {source}: "
+        f"provider={normalize_route_part(provider)!r} "
+        f"model={normalize_route_part(model)!r}"
+    )

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import contextlib
 import importlib
+import logging
 import os
 import re
 import shutil
@@ -57,6 +58,17 @@ from .errors import (
     AgentUnavailableError,
     RateLimitedError,
 )
+from .failover import (
+    FailoverChain,
+    FailoverCooldownStore,
+    FailoverRoute,
+    classify_failover_trigger,
+    emit_runner_substitution_marker,
+    load_failover_chain,
+    ordered_available_routes,
+    substitution_for_route,
+    tool_config_with_route,
+)
 from .registry import AGENTS, get_agent_entry
 from .result import ParseResult, Result
 from .telemetry import InvocationTelemetry, resolve_invocation_telemetry
@@ -78,6 +90,7 @@ except ImportError:  # pragma: no cover - package import path
 # fast enough that stall detection fires within 1s of the threshold, slow
 # enough that we don't burn CPU in the wait loop.
 _POLL_INTERVAL_S = 1.0
+_logger = logging.getLogger(__name__)
 _STDIN_TEMP_PREFIX = "agent-runtime-stdin-"
 _SHIMS_DIR = Path(__file__).resolve().parent / "shims"
 _MCP_RUNTIME_INIT_TIMEOUT_S = 30.0
@@ -1703,6 +1716,306 @@ def _invoke_gemini_with_fallback(
     )
 
 
+def _write_rate_limited_short_circuit(
+    *,
+    agent_name: str,
+    entrypoint: str,
+    model: str,
+    mode: str,
+    task_id: str | None,
+    cwd: Path,
+    session_id: str | None,
+    prompt: str,
+    reason: str,
+) -> None:
+    record = _build_usage_record(
+        agent=agent_name,
+        entrypoint=entrypoint,
+        model=model,
+        mode=mode,
+        task_id=task_id,
+        cwd=cwd,
+        session_id=session_id,
+        duration_s=0.0,
+        input_chars=len(prompt),
+        output_chars=0,
+        returncode=None,
+        outcome="rate_limited",
+        rate_limited=True,
+        stalled=False,
+        stderr_excerpt=f"pre-call headroom check: {reason}",
+        tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
+    )
+    write_record(record)
+
+
+def _route_substitution_for_attempt(
+    *,
+    requested_route: FailoverRoute,
+    actual_route: FailoverRoute,
+    source_trigger: str,
+    adapter_substitution: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    return substitution_for_route(
+        requested_route=requested_route,
+        actual_route=actual_route,
+        source=f"agent-runtime-failover:{source_trigger}",
+        adapter_substitution=adapter_substitution,
+    )
+
+
+def _invoke_with_runner_failover(
+    *,
+    agent_name: str,
+    adapter: AgentAdapter,
+    chain: FailoverChain,
+    prompt: str,
+    mode: str,
+    cwd: Path,
+    task_id: str | None,
+    session_id: str | None,
+    tool_config: dict | None,
+    entrypoint: str,
+    hard_timeout: int,
+    stall_timeout: int,
+    stdout_silence_timeout: int | None,
+    initial_response_timeout: int | None,
+    event_sink: Callable[..., None] | None,
+    effort: str | None,
+) -> Result:
+    """Run one invocation through the configured runner-level failover chain."""
+    store = FailoverCooldownStore()
+    routes = ordered_available_routes(chain, store)
+    requested_route = chain.routes[0]
+    if not routes:
+        reason = "all configured runner failover routes are cooling"
+        _write_rate_limited_short_circuit(
+            agent_name=agent_name,
+            entrypoint=entrypoint,
+            model=requested_route.model,
+            mode=mode,
+            task_id=task_id,
+            cwd=cwd,
+            session_id=session_id,
+            prompt=prompt,
+            reason=reason,
+        )
+        raise RateLimitedError(agent_name, requested_route.model, reason)
+
+    overall_start = time.monotonic()
+    last_trigger = "requested"
+    last_headroom_failure: tuple[FailoverRoute, str] | None = None
+
+    for attempt_index, route in enumerate(routes):
+        headroom_ok, headroom_reason = has_headroom(agent_name, route.model)
+        has_next_route = attempt_index < len(routes) - 1
+        if not headroom_ok:
+            store.mark_cooldown(
+                route,
+                agent_name=agent_name,
+                trigger="rate_limited",
+                ttl_s=chain.cooldown_ttl_s,
+            )
+            last_headroom_failure = (route, headroom_reason)
+            last_trigger = "rate_limited"
+            if has_next_route:
+                continue
+            _write_rate_limited_short_circuit(
+                agent_name=agent_name,
+                entrypoint=entrypoint,
+                model=route.model,
+                mode=mode,
+                task_id=task_id,
+                cwd=cwd,
+                session_id=session_id,
+                prompt=prompt,
+                reason=headroom_reason,
+            )
+            raise RateLimitedError(agent_name, route.model, headroom_reason)
+
+        attempt_tool_config = tool_config_with_route(tool_config, route)
+        plan = adapter.build_invocation(
+            prompt=prompt,
+            mode=mode,
+            cwd=cwd,
+            model=route.model,
+            task_id=task_id,
+            session_id=session_id,
+            tool_config=attempt_tool_config,
+            effort=effort,
+        )
+
+        telemetry = resolve_invocation_telemetry(
+            agent_name=agent_name,
+            plan=plan,
+            requested_model=route.model,
+            requested_effort=effort,
+        )
+
+        execution = _execute_invocation_plan(
+            agent_name=agent_name,
+            adapter=adapter,
+            plan=plan,
+            prompt=prompt,
+            mode=mode,
+            cwd=cwd,
+            model=route.model,
+            task_id=task_id,
+            session_id=session_id,
+            entrypoint=entrypoint,
+            hard_timeout=hard_timeout,
+            stall_timeout=stall_timeout,
+            tool_config=attempt_tool_config,
+            event_sink=event_sink,
+            stdout_silence_timeout=stdout_silence_timeout,
+            initial_response_timeout=initial_response_timeout,
+        )
+        parse = execution.parse
+        trigger = None
+        if not parse.ok or execution.kill_reason:
+            trigger = classify_failover_trigger(
+                parse=parse,
+                returncode=execution.returncode,
+                kill_reason=execution.kill_reason,
+                stdout_text=execution.stdout_text,
+                stderr_text=execution.stderr_text,
+            )
+
+        if trigger:
+            store.mark_cooldown(
+                route,
+                agent_name=agent_name,
+                trigger=trigger,
+                ttl_s=chain.cooldown_ttl_s,
+            )
+            last_trigger = trigger
+            if has_next_route:
+                continue
+
+        if execution.kill_reason:
+            _raise_for_kill_reason(
+                agent_name=agent_name,
+                kill_reason=execution.kill_reason,
+                execution=execution,
+                prompt=prompt,
+                entrypoint=entrypoint,
+                model=route.model,
+                mode=mode,
+                task_id=task_id,
+                cwd=cwd,
+                session_id=session_id,
+                stdout_silence_timeout=stdout_silence_timeout,
+                initial_response_timeout=initial_response_timeout,
+                stall_timeout=stall_timeout,
+                hard_timeout=hard_timeout,
+                event_sink=event_sink,
+            )
+
+        if parse.rate_limited:
+            outcome = "rate_limited"
+        elif parse.ok:
+            outcome = "ok"
+        else:
+            outcome = "error"
+
+        source_trigger = last_trigger
+        if route != requested_route and source_trigger == "requested":
+            source_trigger = "cooldown"
+        substitution = _route_substitution_for_attempt(
+            requested_route=requested_route,
+            actual_route=route,
+            source_trigger=source_trigger,
+            adapter_substitution=parse.substitution,
+        )
+        emit_runner_substitution_marker(substitution, logger=_logger)
+
+        record_model = telemetry.model
+        if (
+            isinstance(substitution, dict)
+            and substitution.get("substituted")
+            and substitution.get("actual_model")
+        ):
+            record_model = str(substitution["actual_model"])[:200]
+
+        _emit_substitution_event(
+            agent_name=agent_name,
+            entrypoint=entrypoint,
+            task_id=task_id,
+            cwd=cwd,
+            model=record_model,
+            substitution=substitution,
+            event_sink=event_sink,
+        )
+
+        duration_s = time.monotonic() - overall_start
+        record = _build_usage_record(
+            agent=agent_name,
+            entrypoint=entrypoint,
+            model=record_model,
+            mode=mode,
+            task_id=task_id,
+            cwd=cwd,
+            session_id=session_id,
+            duration_s=duration_s,
+            input_chars=len(prompt),
+            output_chars=len(parse.response),
+            returncode=execution.returncode,
+            outcome=outcome,
+            rate_limited=parse.rate_limited,
+            stalled=False,
+            stderr_excerpt=parse.stderr_excerpt,
+            tokens=parse.tokens,
+            substitution=substitution,
+        )
+        write_record(record)
+
+        if parse.rate_limited:
+            raise RateLimitedError(
+                agent_name,
+                record_model,
+                reason=(parse.stderr_excerpt or "")[:200],
+            )
+
+        return Result(
+            ok=parse.ok,
+            agent=agent_name,
+            model=record_model,
+            mode=mode,
+            effort=telemetry.effort,
+            cli_version=telemetry.cli_version,
+            response=parse.response,
+            stderr_excerpt=parse.stderr_excerpt,
+            duration_s=duration_s,
+            session_id=parse.session_id,
+            rate_limited=parse.rate_limited,
+            stalled=False,
+            returncode=execution.returncode,
+            usage_record=record,
+            tool_calls=list(parse.tool_calls),
+            tool_calls_total=getattr(parse, "tool_calls_total", len(parse.tool_calls)),
+            substitution=substitution,
+        )
+
+    if last_headroom_failure is not None:
+        route, reason = last_headroom_failure
+        _write_rate_limited_short_circuit(
+            agent_name=agent_name,
+            entrypoint=entrypoint,
+            model=route.model,
+            mode=mode,
+            task_id=task_id,
+            cwd=cwd,
+            session_id=session_id,
+            prompt=prompt,
+            reason=reason,
+        )
+        raise RateLimitedError(agent_name, route.model, reason)
+
+    raise AgentUnavailableError(
+        f"Agent {agent_name!r} has an empty runner failover route set"
+    )
+
+
 def invoke(
     agent_name: str,
     prompt: str,
@@ -1812,29 +2125,45 @@ def invoke(
 
     # ---------- 5. Pre-call rate-limit check ----------
     effective_model = model or adapter.default_model
+    failover_chain = load_failover_chain(
+        agent_name,
+        effective_model=effective_model,
+    )
+    if failover_chain is not None:
+        return _invoke_with_runner_failover(
+            agent_name=agent_name,
+            adapter=adapter,
+            chain=failover_chain,
+            prompt=prompt,
+            mode=mode,
+            cwd=effective_cwd,
+            task_id=task_id,
+            session_id=session_id,
+            tool_config=tool_config,
+            entrypoint=entrypoint,
+            hard_timeout=hard_timeout,
+            stall_timeout=stall_timeout,
+            stdout_silence_timeout=stdout_silence_timeout,
+            initial_response_timeout=initial_response_timeout,
+            event_sink=event_sink,
+            effort=effort,
+        )
+
     ok, reason = has_headroom(agent_name, effective_model)
     if not ok:
         # Record the short-circuit for observability — the caller didn't
         # burn a quota slot, but we still want the usage log to show it.
-        record = _build_usage_record(
-            agent=agent_name,
+        _write_rate_limited_short_circuit(
+            agent_name=agent_name,
             entrypoint=entrypoint,
             model=effective_model,
             mode=mode,
             task_id=task_id,
             cwd=effective_cwd,
             session_id=session_id,
-            duration_s=0.0,
-            input_chars=len(prompt),
-            output_chars=0,
-            returncode=None,
-            outcome="rate_limited",
-            rate_limited=True,
-            stalled=False,
-            stderr_excerpt=f"pre-call headroom check: {reason}",
-            tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
+            prompt=prompt,
+            reason=reason,
         )
-        write_record(record)
         raise RateLimitedError(agent_name, effective_model, reason)
 
     if agent_name == "gemini":

--- a/scripts/config/agent_runtime_failover.yaml
+++ b/scripts/config/agent_runtime_failover.yaml
@@ -1,0 +1,22 @@
+# Runner-level agent provider failover chains.
+#
+# Default is intentionally empty: absent lane chain means runner.invoke() keeps
+# its previous single-route behavior exactly. Populate per-lane chains only for
+# adapters that can express the requested route via model/provider override.
+#
+# Shape:
+# chains:
+#   deepseek:
+#     cooldown_ttl_s: 300
+#     routes:
+#       - provider: deepseek
+#         model: deepseek-v4-pro
+#       - provider: openrouter
+#         model: qwen/qwen3.6-plus
+#
+# v1 coverage:
+# - Hermes-backed lanes (deepseek, qwen, grok): provider + model override.
+# - agy: model override; provider is informational unless encoded by the CLI
+#   model label.
+# - Other adapters: chain only if their existing model flag can express it.
+chains: {}

--- a/tests/agent_runtime/test_runner_failover.py
+++ b/tests/agent_runtime/test_runner_failover.py
@@ -1,0 +1,399 @@
+"""Runner-level failover tests for agent_runtime."""
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from agent_runtime import runner as runner_mod
+from agent_runtime.adapters.base import InvocationPlan
+from agent_runtime.errors import RateLimitedError
+from agent_runtime.failover import (
+    FAILOVER_CONFIG_ENV,
+    FAILOVER_COOLDOWN_DB_ENV,
+    RUNNER_FAILOVER_MARKER,
+)
+from agent_runtime.result import ParseResult
+from agent_runtime.routes import RUNTIME_ROUTE_TOOL_CONFIG_KEY
+
+
+class _FailoverTestAdapter:
+    name = "failover-test"
+    default_model = "primary-model"
+    supported_modes = frozenset({"read-only", "workspace-write", "danger"})
+
+    def __init__(self) -> None:
+        self.attempts: list[str] = []
+
+    def build_invocation(
+        self,
+        *,
+        prompt: str,
+        mode: str,
+        cwd: Path,
+        model: str | None,
+        task_id: str | None,
+        session_id: str | None,
+        tool_config: dict | None,
+        effort: str | None = None,
+    ) -> InvocationPlan:
+        _ = prompt
+        _ = mode
+        _ = task_id
+        _ = session_id
+        _ = effort
+        route = dict((tool_config or {}).get(RUNTIME_ROUTE_TOOL_CONFIG_KEY) or {})
+        route_model = str(route.get("model") or model or self.default_model)
+        self.attempts.append(route_model)
+        return InvocationPlan(
+            cmd=["fake-agent", route_model],
+            cwd=cwd,
+            metadata={"route": route},
+        )
+
+    def parse_response(
+        self,
+        *,
+        stdout: str,
+        stderr: str,
+        returncode: int,
+        output_file: Path | None,
+        plan: InvocationPlan | None = None,
+        call_start_time: float | None = None,
+    ) -> ParseResult:
+        _ = stdout
+        _ = stderr
+        _ = returncode
+        _ = output_file
+        _ = plan
+        _ = call_start_time
+        raise AssertionError("_execute_invocation_plan is stubbed in these tests")
+
+    def liveness_signal_paths(self, plan: InvocationPlan) -> tuple[Path, ...]:
+        _ = plan
+        return ()
+
+
+@pytest.fixture(autouse=True)
+def _clear_adapter_cache():
+    runner_mod._ADAPTER_CACHE.clear()
+    yield
+    runner_mod._ADAPTER_CACHE.clear()
+
+
+def _write_failover_config(tmp_path: Path, *, forbidden: bool = False) -> Path:
+    fallback_provider = "zai" if forbidden else "fallback-provider"
+    fallback_model = "glm-4.6" if forbidden else "fallback-model"
+    config_path = tmp_path / "agent_runtime_failover.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "chains:",
+                "  failover-test:",
+                "    cooldown_ttl_s: 600",
+                "    routes:",
+                "      - provider: primary-provider",
+                "        model: primary-model",
+                f"      - provider: {fallback_provider}",
+                f"        model: {fallback_model}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _install_fake_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    outcomes_by_model: dict[str, dict[str, Any]],
+    *,
+    forbidden_config: bool = False,
+) -> tuple[_FailoverTestAdapter, list[dict[str, Any]], list[tuple[str, dict[str, Any]]]]:
+    config_path = _write_failover_config(tmp_path, forbidden=forbidden_config)
+    monkeypatch.setenv(FAILOVER_CONFIG_ENV, str(config_path))
+    monkeypatch.setenv(
+        FAILOVER_COOLDOWN_DB_ENV,
+        str(tmp_path / "cooldowns.sqlite3"),
+    )
+
+    adapter = _FailoverTestAdapter()
+    runner_mod._ADAPTER_CACHE["failover-test"] = adapter
+
+    records: list[dict[str, Any]] = []
+    emitted_events: list[tuple[str, dict[str, Any]]] = []
+    fake_emit = types.ModuleType("telemetry.emit")
+    fake_emit.emit_event = (
+        lambda event_name, payload: emitted_events.append((event_name, payload))
+    )
+    monkeypatch.setitem(sys.modules, "telemetry.emit", fake_emit)
+    monkeypatch.setattr(runner_mod, "write_record", records.append)
+    monkeypatch.setattr(runner_mod, "has_headroom", lambda _agent, _model: (True, ""))
+    monkeypatch.setattr(
+        runner_mod,
+        "resolve_invocation_telemetry",
+        lambda agent_name, plan, requested_model, requested_effort: SimpleNamespace(
+            model=requested_model,
+            effort=requested_effort or "unknown",
+            cli_version=f"{agent_name}-test",
+        ),
+    )
+
+    def fake_execute(*, plan: InvocationPlan, **_kwargs: Any) -> runner_mod._ExecutionOutcome:
+        route = plan.metadata["route"]
+        outcome = outcomes_by_model[str(route["model"])]
+        return runner_mod._ExecutionOutcome(
+            parse=outcome["parse"],
+            duration_s=0.01,
+            returncode=outcome.get("returncode", 1),
+            kill_reason=outcome.get("kill_reason"),
+            stdout_text=outcome.get("stdout_text", ""),
+            stderr_text=outcome.get("stderr_text", ""),
+            liveness_paths=(),
+        )
+
+    monkeypatch.setattr(runner_mod, "_execute_invocation_plan", fake_execute)
+    return adapter, records, emitted_events
+
+
+_TRIGGER_CASES = [
+    (
+        "auth",
+        {
+            "parse": ParseResult(
+                ok=False,
+                response="",
+                stderr_excerpt="401 unauthorized after refresh attempt failed",
+            ),
+            "returncode": 1,
+            "stderr_text": "401 unauthorized after refresh attempt failed",
+        },
+    ),
+    (
+        "rate_limited",
+        {
+            "parse": ParseResult(
+                ok=False,
+                response="",
+                stderr_excerpt="quota exceeded",
+                rate_limited=True,
+            ),
+            "returncode": 1,
+            "stderr_text": "quota exceeded",
+        },
+    ),
+    (
+        "overloaded",
+        {
+            "parse": ParseResult(
+                ok=False,
+                response="",
+                stderr_excerpt="HTTP 503 overloaded",
+            ),
+            "returncode": 1,
+            "stderr_text": "HTTP 503 overloaded",
+        },
+    ),
+    (
+        "transport",
+        {
+            "parse": ParseResult(
+                ok=False,
+                response="",
+                stderr_excerpt="connection refused",
+            ),
+            "returncode": 1,
+            "stderr_text": "connection refused",
+        },
+    ),
+    (
+        "empty_response",
+        {
+            "parse": ParseResult(ok=False, response="", stderr_excerpt=None),
+            "returncode": 0,
+            "stderr_text": "",
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize(("trigger_name", "primary_failure"), _TRIGGER_CASES)
+def test_runner_failover_switches_for_eligible_trigger_classes(
+    tmp_path,
+    monkeypatch,
+    capsys,
+    trigger_name,
+    primary_failure,
+):
+    sink_events: list[tuple[str, dict[str, Any]]] = []
+    adapter, records, emitted_events = _install_fake_runtime(
+        monkeypatch,
+        tmp_path,
+        {
+            "primary-model": primary_failure,
+            "fallback-model": {
+                "parse": ParseResult(ok=True, response="fallback ok"),
+                "returncode": 0,
+            },
+        },
+    )
+
+    result = runner_mod.invoke(
+        "failover-test",
+        "hello",
+        mode="read-only",
+        cwd=tmp_path,
+        event_sink=lambda name, **fields: sink_events.append((name, fields)),
+    )
+
+    assert adapter.attempts == ["primary-model", "fallback-model"]
+    assert result.ok is True
+    assert result.response == "fallback ok"
+    assert result.substitution is not None
+    assert result.substitution["requested_provider"] == "primary-provider"
+    assert result.substitution["actual_provider"] == "fallback-provider"
+    assert result.substitution["marker"] == RUNNER_FAILOVER_MARKER
+    assert result.substitution["source"] == f"agent-runtime-failover:{trigger_name}"
+    assert records[0]["substitution"]["substituted"] is True
+    assert sink_events[0][0] == "agent_runtime_substitution"
+    assert emitted_events[0][0] == "agent_runtime_substitution"
+    assert RUNNER_FAILOVER_MARKER in capsys.readouterr().err
+
+
+def test_runner_failover_does_not_switch_for_content_policy(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    adapter, records, _emitted_events = _install_fake_runtime(
+        monkeypatch,
+        tmp_path,
+        {
+            "primary-model": {
+                "parse": ParseResult(
+                    ok=False,
+                    response="",
+                    stderr_excerpt="content policy refusal",
+                ),
+                "returncode": 1,
+                "stderr_text": "content policy refusal",
+            },
+            "fallback-model": {
+                "parse": ParseResult(ok=True, response="fallback ok"),
+                "returncode": 0,
+            },
+        },
+    )
+
+    result = runner_mod.invoke("failover-test", "hello", mode="read-only", cwd=tmp_path)
+
+    assert adapter.attempts == ["primary-model"]
+    assert result.ok is False
+    assert result.substitution is None
+    assert records[0]["outcome"] == "error"
+    assert "substitution" not in records[0]
+    assert RUNNER_FAILOVER_MARKER not in capsys.readouterr().err
+
+
+def test_runner_failover_cooldown_routes_next_dispatch_directly_to_fallback(
+    tmp_path,
+    monkeypatch,
+):
+    adapter, records, _emitted_events = _install_fake_runtime(
+        monkeypatch,
+        tmp_path,
+        {
+            "primary-model": {
+                "parse": ParseResult(
+                    ok=False,
+                    response="",
+                    stderr_excerpt="connection refused",
+                ),
+                "returncode": 1,
+                "stderr_text": "connection refused",
+            },
+            "fallback-model": {
+                "parse": ParseResult(ok=True, response="fallback ok"),
+                "returncode": 0,
+            },
+        },
+    )
+
+    first = runner_mod.invoke("failover-test", "hello", mode="read-only", cwd=tmp_path)
+    first_attempts = list(adapter.attempts)
+    adapter.attempts.clear()
+    second = runner_mod.invoke("failover-test", "hello", mode="read-only", cwd=tmp_path)
+
+    assert first.ok is True
+    assert first_attempts == ["primary-model", "fallback-model"]
+    assert second.ok is True
+    assert adapter.attempts == ["fallback-model"]
+    assert second.substitution is not None
+    assert second.substitution["source"] == "agent-runtime-failover:cooldown"
+    assert len(records) == 2
+
+
+def test_runner_failover_cools_final_failed_route_and_short_circuits_all_cooling(
+    tmp_path,
+    monkeypatch,
+):
+    adapter, records, _emitted_events = _install_fake_runtime(
+        monkeypatch,
+        tmp_path,
+        {
+            "primary-model": {
+                "parse": ParseResult(
+                    ok=False,
+                    response="",
+                    stderr_excerpt="connection refused",
+                ),
+                "returncode": 1,
+                "stderr_text": "connection refused",
+            },
+            "fallback-model": {
+                "parse": ParseResult(
+                    ok=False,
+                    response="",
+                    stderr_excerpt="HTTP 503 overloaded",
+                ),
+                "returncode": 1,
+                "stderr_text": "HTTP 503 overloaded",
+            },
+        },
+    )
+
+    first = runner_mod.invoke("failover-test", "hello", mode="read-only", cwd=tmp_path)
+    first_attempts = list(adapter.attempts)
+    adapter.attempts.clear()
+
+    with pytest.raises(RateLimitedError, match=r"all configured.*cooling"):
+        runner_mod.invoke("failover-test", "hello", mode="read-only", cwd=tmp_path)
+
+    assert first.ok is False
+    assert first_attempts == ["primary-model", "fallback-model"]
+    assert adapter.attempts == []
+    assert records[-1]["outcome"] == "rate_limited"
+
+
+def test_runner_failover_rejects_forbidden_glm_target(tmp_path, monkeypatch):
+    _adapter, _records, _emitted_events = _install_fake_runtime(
+        monkeypatch,
+        tmp_path,
+        {
+            "primary-model": {
+                "parse": ParseResult(ok=True, response="primary ok"),
+                "returncode": 0,
+            },
+        },
+        forbidden_config=True,
+    )
+
+    with pytest.raises(ValueError, match="HERMES_GLM_FORBIDDEN"):
+        runner_mod.invoke("failover-test", "hello", mode="read-only", cwd=tmp_path)


### PR DESCRIPTION
## Design recap

Implements #4497 in the runner layer: optional per-lane provider/model chains, SQLite cooldowns under `batch_state/`, narrow eligible trigger classification, and mandatory substitution surfacing through the existing result/usage/delegate/telemetry path.

I chose a sibling YAML config, `scripts/config/agent_runtime_failover.yaml`, instead of extending the budget substitution table. That keeps quota-routing policy separate from runtime retry behavior, and the default `chains: {}` preserves current behavior exactly for lanes without an explicit chain.

Failover triggers are limited to auth 401/403, 429/quota, 5xx/overloaded, transport failures, and parsed-empty responses. Content-policy refusals and request-format 4xx failures do not fail over. zai/GLM routes are rejected before launch via the shared route guard.

## Coverage matrix

| Lane | v1 support |
| --- | --- |
| `deepseek`, `qwen`, `grok` | Hermes provider + model override via runner route metadata; `--provider` is appended when the route is forced. |
| `agy` | Model override through existing `--model` mapping; provider is informational unless encoded by the CLI model label. |
| Other adapters | Model-only chains are possible when the adapter's existing `model` argument can express the route. No chain means old behavior. |

## Independent review

AGY/Gemini read-only review was run through the bridge. One valid cooldown finding was fixed by cooling the final failed route and short-circuiting when all routes are cooling; one Qwen provider-forcing finding was verified stale against the current diff.

## Evidence

### pytest selector

```text
command: .venv/bin/python -m pytest tests/ -k "agent_runtime or failover or fallback"
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4497-runner-failover
raw output:
========= 395 passed, 9536 deselected, 3 warnings in 102.62s (0:01:42) =========
```

### ruff

```text
command: .venv/bin/ruff check scripts/agent_runtime/routes.py scripts/agent_runtime/failover.py scripts/agent_runtime/runner.py scripts/agent_runtime/adapters/hermes_common.py scripts/agent_runtime/adapters/hermes_deepseek.py scripts/agent_runtime/adapters/hermes_qwen.py scripts/agent_runtime/adapters/hermes_grok.py tests/agent_runtime/test_runner_failover.py
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4497-runner-failover
raw output:
All checks passed!
```

### demo: unreachable primary completes via chain

```text
command: .venv/bin/python - <<'PY' ... PY
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4497-runner-failover
raw output:
AGENT_RUNTIME_FAILOVER_SUBSTITUTION: primary-provider/primary-model -> fallback-provider/fallback-model source=agent-runtime-failover:transport
AGENT_RUNTIME_FAILOVER_SUBSTITUTION: primary-provider/primary-model -> fallback-provider/fallback-model source=agent-runtime-failover:transport
{"attempts": ["primary-model", "fallback-model"], "ok": true, "response": "completed through fallback", "substitution": {"actual_model": "fallback-model", "actual_provider": "fallback-provider", "marker": "AGENT_RUNTIME_FAILOVER_SUBSTITUTION", "requested_model": "primary-model", "requested_provider": "primary-provider", "source": "agent-runtime-failover:transport", "substituted": true}, "usage_substitution": {"actual_model": "fallback-model", "actual_provider": "fallback-provider", "marker": "AGENT_RUNTIME_FAILOVER_SUBSTITUTION", "requested_model": "primary-model", "requested_provider": "primary-provider", "source": "agent-runtime-failover:transport", "substituted": true}}
```

### git log

```text
command: git log -1 --oneline
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4497-runner-failover
raw output:
56374c0ca3 feat(agent-runtime): runner-level provider failover — per-lane chains, cooldowns, mandatory substitution surfacing (#4497)
```

### PR URL

```text
command: gh pr view 4501 --json url
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4497-runner-failover
raw output:
{"url":"https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/4501"}
```

Closes #4497

Generated with Codex.
