### PR TITLE
fix(deploy): declare .agent/dispatch-briefs/ as runtime orphan (unblocks agents:deploy)

### DIFF
--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -73,7 +73,12 @@ ORPHAN_PATHS_CLAUDE="scheduled_tasks.lock worktrees *-epic"
 #          source-tracked. Without these patterns a single in-flight brief aborts the
 #          ENTIRE deploy (every target), so committed source prompt fixes silently never
 #          reach .claude/ + .codex/ + .agent/ runtime — agents keep running stale prompts (#3456).
-ORPHAN_PATHS_AGENT="wake cache prompts tmp *-thread-bootstrap.md *-handoff.md *-thread-lease.json *-brief.md dispatch-*.md"
+# dispatch-briefs/ — the DIRECTORY successor to the top-level dispatch-*.md scatter:
+#          orchestrators now collect per-dispatch briefs under .agent/dispatch-briefs/
+#          (e.g. 4497-runner-failover.md). The dispatch-*.md FILE glob does not match a
+#          directory, so without this entry the first collected brief aborts every
+#          deploy — the #3456 failure class again, one level down.
+ORPHAN_PATHS_AGENT="wake cache prompts tmp *-thread-bootstrap.md *-handoff.md *-thread-lease.json *-brief.md dispatch-*.md dispatch-briefs"
 ORPHAN_PATHS_AGENTS=""
 # agents/curriculum-orchestrator.toml and agents/curriculum-writer.toml —
 # Codex agent definitions with no source equivalent.

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -224,6 +224,12 @@ def test_agent_transient_briefs_are_preserved(tmp_path: Path) -> None:
     brief.write_text("transient dispatch brief\n", encoding="utf-8")
     dispatch = agent_dir / "dispatch-3098-slice3.md"
     dispatch.write_text("transient dispatch prompt\n", encoding="utf-8")
+    # Regression (2026-07-05): briefs now also collect under the dispatch-briefs/
+    # DIRECTORY, which the dispatch-*.md FILE glob does not match — an undeclared
+    # dir aborted every deploy until declared in ORPHAN_PATHS_AGENT.
+    collected = agent_dir / "dispatch-briefs" / "4497-runner-failover.md"
+    collected.parent.mkdir(parents=True)
+    collected.write_text("collected dispatch brief\n", encoding="utf-8")
 
     deploy_result = _run(repo, DEPLOY_SCRIPT)
     assert deploy_result.returncode == 0, (
@@ -233,6 +239,7 @@ def test_agent_transient_briefs_are_preserved(tmp_path: Path) -> None:
     # rsync --delete must preserve the declared transient scratch.
     assert brief.exists(), "atlas-3150-brief.md was wiped by rsync --delete"
     assert dispatch.exists(), "dispatch-3098-slice3.md was wiped by rsync --delete"
+    assert collected.exists(), "dispatch-briefs/ brief was wiped by rsync --delete"
 
 
 def test_claude_epic_dirs_are_preserved(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`npm run agents:deploy` aborts on this machine:

```
⚠️  agents_extensions/shared → .agent: undeclared orphan 'dispatch-briefs' in destination
❌ Deploy aborted: undeclared orphan paths would be deleted.
```

Orchestrators now collect per-dispatch briefs under the `.agent/dispatch-briefs/` **directory** (live runtime state — briefs for in-flight dispatches, e.g. `4497-runner-failover.md` written minutes before this fix). `ORPHAN_PATHS_AGENT` declares the legacy top-level `dispatch-*.md` **file** glob, which does not match a directory — so the guard (correctly) refused to let `rsync --delete` wipe live state, and every deploy on the machine aborts. Same failure class as #3456, one level down.

## Fix

- Declare `dispatch-briefs` in `ORPHAN_PATHS_AGENT` (runtime scratch, same category as `prompts/`, `tmp/`, `dispatch-*.md`), with a comment explaining why.
- Extend the #3456 regression test (`test_agent_transient_briefs_are_preserved`) to place a brief under `dispatch-briefs/` and assert the deploy succeeds AND the file survives `rsync --delete`.

## Verification

- `tests/test_deploy_script_idempotency.py` — 10/10 pass (extended test fails on the old script, passes on the new).
- ruff clean.
- Will verify end-to-end `npm run agents:deploy` on main after merge (the aborting machine is this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)