### PR TITLE
fix(agent-runtime): isolate write-capable spawns to worktrees by construction (#4446)

### DIFF
--- a/docs/runbooks/codex-hooks.md
+++ b/docs/runbooks/codex-hooks.md
@@ -64,6 +64,72 @@ exits 2 and tells the agent to create/`cd` into
 Tests: `tests/test_guard_primary_checkout_write.py` (pure payload extraction plus
 end-to-end block/allow against a real repo with a dispatch worktree).
 
+## Runtime write-cwd guard (#4446)
+
+The hook above is a *provider-side* control that only fires for surfaces a
+provider exposes as hookable. #4446 adds the complementary *runtime-side*
+control: `agent_runtime.runner.invoke` — the single chokepoint every
+orchestrated agent subprocess funnels through — refuses, **by construction**, to
+spawn a write-capable child (`workspace-write`/`danger`) whose `cwd` is a primary
+checkout sitting on a protected branch. No command-string intent parsing is
+involved; the decision is a pure containment classification.
+
+- **Reuses #4444.** The guard classifies `cwd` via
+  `scripts.guardrails.worktree_containment` (`classify_repo_path` +
+  `is_protected_branch`). Dispatch worktrees, any other registered worktree, and
+  out-of-repo paths all pass; only a primary checkout on `main`/`master` is
+  refused. A cheap in-tree pre-filter (`_RUNNER_REPO_TREE`) skips the git plumbing
+  for cwds outside this checkout's own file tree.
+- **Fails closed.** If the containment predicate cannot be imported, a
+  write-capable spawn is refused rather than allowed — an isolation we cannot
+  prove is treated as absent.
+- **Env cannot re-point the child.** `env_sanitize.build_agent_env` uses a strict
+  allowlist, so `GIT_WORK_TREE`/`GIT_DIR`/`GIT_INDEX_FILE`/`PWD`/`OLDPWD` are
+  dropped from the child env — a spawned agent cannot escape its worktree `cwd`
+  via inherited git-discovery or shell state
+  (`tests/test_env_sanitize.py::test_workdir_repointing_git_env_is_scrubbed`).
+
+### Relationship to #4445 and the branch scoping
+
+- **#4445 (delegate)** is the stricter, dispatch-specific CLI-arg preflight: it
+  requires a worktree for *every* delegate write dispatch, branch-agnostic. The
+  runtime guard is the *universal minimum* backstopping all callers, not a
+  duplicate of that policy.
+- The runtime guard is **protected-branch-scoped**, matching the hook (#4448),
+  monitor tripwire (#4449), and git shim (#4450): the hazard is dirtying `main`.
+  A primary checkout deliberately on a feature branch is a developer workspace
+  and is allowed.
+
+### Bridge write-mode alignment
+
+The read-only Q&A bridges (`ask-codex`, `ask-agy`, `grok`) inspect from the repo
+root under `read-only` and are unaffected. The Gemini bridge previously ran
+**every** invocation `workspace-write` (`--approval-mode=yolo`) from the primary
+checkout — so an `ask-gemini` query could silently mutate tracked files. #4446
+decouples the runtime write-mode from the CLI approval flag: only `--allow-write`
+callers (curriculum writers) get `workspace-write`; plain Q&A/review now runs
+`read-only`. Genuine write-intent invocations must therefore run from an isolated
+worktree, enforced by the guard above.
+
+### Scope boundaries (do not overclaim)
+
+- **Covered by construction:** orchestrated write-capable subprocesses launched
+  through `runner.invoke` — delegate dispatches, bridge write lanes, V7 pipeline
+  writers. These physically cannot spawn in a protected primary checkout.
+- **Not covered here:** direct interactive **Codex Desktop** (or any provider's
+  direct-edit UI) that never routes through `runner.invoke`. Those depend on the
+  provider hook (#4448), the operator self-check, and the monitor tripwire
+  (#4449) — not on this runtime guard.
+- **Known residual:** `v7_build.py --writer gemini-tools` pins the writer `cwd`
+  to the repo root (gemini-tools loads `.gemini/settings.json` from there); on a
+  primary checkout that is on `main` the guard refuses it. Run such builds from a
+  feature branch or migrate gemini-tools MCP discovery off the repo root. The
+  legacy v6 `scripts/pipeline/core.py` gemini writer is likewise guard-gated.
+
+Tests: `tests/test_agent_runtime.py` (`test_write_guard_*`,
+`test_invoke_codex_write_lane_*`) and `tests/test_gemini_bridge.py`
+(`test_run_gemini_sync_derives_runtime_mode_from_allow_write`).
+
 ## CLI probe
 
 Run the probe from the repository root:

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -80,6 +80,10 @@ except ImportError:  # pragma: no cover - package import path
 _POLL_INTERVAL_S = 1.0
 _STDIN_TEMP_PREFIX = "agent-runtime-stdin-"
 _SHIMS_DIR = Path(__file__).resolve().parent / "shims"
+# Repo root that owns this runner (scripts/agent_runtime/runner.py → parents[2]).
+# Used by the #4446 write-cwd guard as a cheap pre-filter: only a cwd inside this
+# checkout's own file tree can be its protected primary checkout.
+_RUNNER_REPO_TREE = Path(__file__).resolve().parents[2]
 _MCP_RUNTIME_INIT_TIMEOUT_S = 30.0
 _MCP_TOOL_EVENT_RE = re.compile(
     r"\bmcp:\s+(?P<server>[A-Za-z0-9_.-]+)/(?P<tool>[A-Za-z0-9_.-]+)\s+"
@@ -1703,6 +1707,89 @@ def _invoke_gemini_with_fallback(
     )
 
 
+# ---------------------------------------------------------------------------
+# Write-capable cwd isolation (#4446)
+# ---------------------------------------------------------------------------
+#
+# Write-capable modes (``workspace-write`` / ``danger``) let the spawned CLI
+# mutate files via apply_patch / Edit / Bash. Provider hooks (#4448) can miss
+# those edit surfaces, so isolation must be correct *by construction*: this
+# runner — the single chokepoint every orchestrated invocation funnels through —
+# refuses to spawn a write-capable child in a *primary checkout that sits on a
+# protected branch*, regardless of how the caller assembled ``cwd``. That is the
+# real "never dirty main" hazard #4446 targets, and it aligns the runtime layer
+# with the protected-branch scoping of the hook (#4448), monitor tripwire
+# (#4449), and git shim (#4450). It backstops delegate's stricter CLI-arg
+# preflight (#4445), which additionally requires a worktree for *every* delegate
+# write dispatch irrespective of branch — this guard is the universal minimum,
+# not a duplicate of that policy. Read-only invocations and worktrees (dispatch
+# or otherwise) are always allowed; inspecting from the repo root is legitimate.
+
+_WRITE_CAPABLE_MODES = frozenset({"workspace-write", "danger"})
+
+_WRITE_CWD_HINT = (
+    "Write-capable invocations must run inside a dispatch worktree "
+    "(.worktrees/dispatch/<agent>/<task>/), never a primary checkout that is on "
+    "a protected branch (main/master)."
+)
+
+
+def _load_worktree_containment():
+    """Import the shared containment predicate (#4444).
+
+    Mirrors the dual-candidate import in :func:`_load_adapter`: the ``scripts.*``
+    name resolves when the repo root is on ``sys.path`` (``python -m ...`` /
+    pytest), while the delegate worker and build entrypoints put only
+    ``scripts/`` on the path, where the ``scripts.``-stripped name resolves.
+    Returns ``None`` only if neither import succeeds (a broken deployment).
+    """
+    for candidate in (
+        "scripts.guardrails.worktree_containment",
+        "guardrails.worktree_containment",
+    ):
+        try:
+            return importlib.import_module(candidate)
+        except ImportError:
+            continue
+    return None
+
+
+def _ensure_write_cwd_isolated(cwd: Path, *, mode: str, agent_name: str) -> None:
+    """Refuse a write-capable spawn whose cwd is a protected primary checkout.
+
+    Raises ``ValueError`` when ``cwd`` classifies as ``primary_checkout`` (#4444)
+    *and* that checkout is on a protected branch, or when the containment
+    predicate cannot be imported (fail closed — a write-capable spawn we cannot
+    prove is isolated is exactly what this guard exists to prevent). Dispatch
+    worktrees, any other registered worktree, out-of-repo paths, and primary
+    checkouts deliberately on a feature branch all pass.
+    """
+    wc = _load_worktree_containment()
+    if wc is None:
+        raise ValueError(
+            f"cannot verify worktree isolation for write-capable mode={mode!r} "
+            f"(agent {agent_name!r}): the containment predicate "
+            f"(scripts.guardrails.worktree_containment, #4444) failed to import. "
+            f"Refusing to spawn. {_WRITE_CWD_HINT}"
+        )
+    resolved = wc.canonicalize(cwd)
+    # Cheap containment gate: only a cwd inside this checkout's own file tree can
+    # be its primary checkout root. Out-of-tree cwds (temp dirs, externally
+    # located worktrees) are isolated from the primary checkout by definition, so
+    # skip the git-plumbing classify — and its subprocess — entirely for them.
+    if not resolved.is_relative_to(_RUNNER_REPO_TREE):
+        return
+    if wc.classify_repo_path(resolved, cwd=resolved) != "primary_checkout":
+        return
+    if not wc.is_protected_branch(resolved):
+        return
+    raise ValueError(
+        f"cwd {str(cwd)!r} is the primary checkout on a protected branch; "
+        f"write-capable mode={mode!r} for agent {agent_name!r} may not spawn "
+        f"there. {_WRITE_CWD_HINT}"
+    )
+
+
 def invoke(
     agent_name: str,
     prompt: str,
@@ -1797,12 +1884,17 @@ def invoke(
         )
 
     # ---------- 3. Validate cwd for write modes ----------
-    if mode in ("workspace-write", "danger") and cwd is None:
-        raise ValueError(
-            f"cwd is mandatory for mode={mode!r}. Write-capable invocations "
-            f"must pin their working directory to prevent cross-worktree "
-            f"contamination."
-        )
+    if mode in _WRITE_CAPABLE_MODES:
+        if cwd is None:
+            raise ValueError(
+                f"cwd is mandatory for mode={mode!r}. Write-capable invocations "
+                f"must pin their working directory to prevent cross-worktree "
+                f"contamination."
+            )
+        # #4446: enforce worktree isolation by construction at the spawn
+        # chokepoint — a write-capable child may never run in a protected
+        # primary checkout, regardless of how the caller assembled cwd.
+        _ensure_write_cwd_isolated(cwd, mode=mode, agent_name=agent_name)
     effective_cwd = cwd or Path.cwd()
     current_run_id()
     current_session_id()

--- a/scripts/ai_agent_bridge/_gemini.py
+++ b/scripts/ai_agent_bridge/_gemini.py
@@ -315,7 +315,7 @@ def _run_gemini_sync(msg: dict, message_id: int, model: str, prompt: str,
             result = _run_gemini_attempt(msg, message_id, current_model, requested_model, prompt,
                                          timeout_val, stdout_only, output_path, skip_github,
                                          attempt, max_retries, base_delay, rate_limit_state,
-                                         auth_mode)
+                                         auth_mode, allow_write)
             if isinstance(result, dict) and result.get("action") == "fallback":
                 current_model = str(result["model"])
                 continue
@@ -337,7 +337,7 @@ def _run_gemini_sync(msg: dict, message_id: int, model: str, prompt: str,
 
 def _run_gemini_attempt(msg, message_id, model, requested_model, prompt, timeout_val,
                         stdout_only, output_path, skip_github, attempt, max_retries,
-                        base_delay, rate_limit_state, auth_mode):
+                        base_delay, rate_limit_state, auth_mode, allow_write=False):
     """Run a single Gemini CLI attempt via agent_runtime.
 
     Returns None to retry, False to stop, or (response, sent).
@@ -362,15 +362,22 @@ def _run_gemini_attempt(msg, message_id, model, requested_model, prompt, timeout
     if output_path:
         pre_snapshot = _git_status_snapshot()
 
-    # Gemini bridge is always write-enabled (--approval-mode=yolo) — preserving
-    # legacy behavior. Tool config is None because the bridge doesn't restrict
-    # MCP tools the way dispatch.py does.
+    # Runtime write-mode tracks write *intent*, decoupled from the CLI approval
+    # flag (#4446): only ``--allow-write`` callers (curriculum writers) need
+    # ``workspace-write`` (→ gemini ``--approval-mode=yolo``); plain Q&A / review
+    # runs ``read-only`` like the codex/agy bridges, so an ``ask-gemini`` query
+    # can no longer silently mutate the primary checkout. The runner's #4446
+    # guard rejects a write-capable spawn in a protected primary checkout, so
+    # write-intent invocations must run from an isolated worktree.
+    # Tool config is None because the bridge doesn't restrict MCP tools the way
+    # dispatch.py does.
+    runtime_mode = "workspace-write" if allow_write else "read-only"
     tool_config = {"auth_mode": auth_mode} if auth_mode else None
     try:
         result = runtime_invoke(
             "gemini",
             prompt,
-            mode="workspace-write",
+            mode=runtime_mode,
             cwd=REPO_ROOT,
             model=model,
             task_id=msg.get("task_id"),

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -112,6 +112,7 @@ from agent_runtime.errors import (
 from agent_runtime.registry import AGENTS, get_agent_entry
 from agent_runtime.runner import (
     _enforce_resume_policy,
+    _ensure_write_cwd_isolated,
     _is_temp_file,
     _kill_process_tree,
     _load_adapter,
@@ -1571,6 +1572,116 @@ def test_invoke_requires_cwd_for_write_mode():
 def test_invoke_requires_cwd_for_danger_mode():
     with pytest.raises(ValueError, match="cwd is mandatory"):
         invoke("codex", "hello", mode="danger", cwd=None)
+
+
+# ---------------------------------------------------------------------------
+# #4446 — write-capable spawns must never land in a protected primary checkout
+# ---------------------------------------------------------------------------
+#
+# These build a *real* git repo + dispatch worktree in tmp_path (the containment
+# predicate is git-plumbing, not string prefixes) and point the runner's cheap
+# in-tree pre-filter (``_RUNNER_REPO_TREE``) at that repo so the guard actually
+# classifies it instead of short-circuiting on "not this checkout".
+
+def _git_wt(repo, *args):
+    env = {k: v for k, v in os.environ.items()
+           if k not in {"GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE",
+                        "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+                        "GIT_NAMESPACE", "GIT_CEILING_DIRECTORIES",
+                        "GIT_DISCOVERY_ACROSS_FILESYSTEM", "GIT_COMMON_DIR"}}
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          check=True, capture_output=True, text=True, env=env)
+
+
+@pytest.fixture
+def write_guard_repo(tmp_path, monkeypatch):
+    """A primary checkout on ``main`` with a registered dispatch worktree.
+
+    Points ``_RUNNER_REPO_TREE`` at it so the guard evaluates containment here.
+    """
+    main = tmp_path / "main"
+    main.mkdir()
+    _git_wt(main.parent, "init", "-q", "-b", "main", str(main))
+    _git_wt(main, "config", "user.email", "t@example.com")
+    _git_wt(main, "config", "user.name", "T")
+    (main / "tracked.txt").write_text("x\n")
+    _git_wt(main, "add", "-A")
+    _git_wt(main, "commit", "-q", "-m", "init")
+    dispatch_wt = main / ".worktrees" / "dispatch" / "codex" / "task-1"
+    _git_wt(main, "worktree", "add", "-q", "-b", "codex/task-1", str(dispatch_wt))
+
+    from agent_runtime import runner as runner_mod
+    monkeypatch.setattr(runner_mod, "_RUNNER_REPO_TREE", main.resolve())
+    return SimpleNamespace(main=main.resolve(), dispatch_wt=dispatch_wt.resolve())
+
+
+@pytest.mark.parametrize("mode", ["workspace-write", "danger"])
+def test_write_guard_rejects_primary_checkout_on_protected_branch(write_guard_repo, mode):
+    with pytest.raises(ValueError, match="primary checkout on a protected branch"):
+        _ensure_write_cwd_isolated(write_guard_repo.main, mode=mode, agent_name="codex")
+
+
+def test_write_guard_allows_dispatch_worktree(write_guard_repo):
+    # Must not raise: an isolated dispatch worktree is the sanctioned location.
+    _ensure_write_cwd_isolated(
+        write_guard_repo.dispatch_wt, mode="danger", agent_name="codex"
+    )
+
+
+def test_write_guard_allows_primary_checkout_on_feature_branch(write_guard_repo):
+    # Branch-scoped like #4448/#4449/#4450: a deliberately-checked-out feature
+    # branch in the primary checkout is a developer workspace, not a hazard.
+    _git_wt(write_guard_repo.main, "checkout", "-q", "-b", "feature/x")
+    _ensure_write_cwd_isolated(
+        write_guard_repo.main, mode="workspace-write", agent_name="codex"
+    )
+
+
+def test_write_guard_allows_out_of_tree_cwd(tmp_path):
+    # No monkeypatch of _RUNNER_REPO_TREE: a cwd outside this checkout's tree is
+    # isolated by definition and must skip the git-plumbing classify entirely.
+    outside = tmp_path / "somewhere-else"
+    outside.mkdir()
+    _ensure_write_cwd_isolated(outside, mode="danger", agent_name="codex")
+
+
+def test_write_guard_fails_closed_when_containment_unavailable(tmp_path, monkeypatch):
+    from agent_runtime import runner as runner_mod
+    monkeypatch.setattr(runner_mod, "_load_worktree_containment", lambda: None)
+    with pytest.raises(ValueError, match="failed to import"):
+        _ensure_write_cwd_isolated(tmp_path, mode="danger", agent_name="codex")
+
+
+def test_invoke_codex_write_lane_rejects_primary_checkout_cwd(write_guard_repo):
+    """End-to-end: a write-capable Codex invoke in the protected primary checkout
+    is refused at the chokepoint — the subprocess is never spawned there.
+
+    ``_spawn_subprocess`` is the seam (not ``subprocess.Popen``) so the guard's
+    real git classify runs while the agent spawn stays observable.
+    """
+    with patch("agent_runtime.runner._spawn_subprocess") as mock_spawn:
+        with pytest.raises(ValueError, match="primary checkout on a protected branch"):
+            invoke("codex", "hello", mode="danger", cwd=write_guard_repo.main)
+    mock_spawn.assert_not_called()
+
+
+def test_invoke_codex_write_lane_spawns_in_dispatch_worktree(write_guard_repo):
+    """End-to-end: a write-capable Codex invoke with a dispatch-worktree cwd
+    passes the guard and the spawn receives that worktree as cwd (never the main
+    checkout)."""
+    from agent_runtime.errors import AgentUnavailableError
+    with patch("agent_runtime.runner.has_headroom", return_value=(True, "")), \
+         patch("agent_runtime.runner.write_record"), \
+         patch(
+             "agent_runtime.runner._spawn_subprocess",
+             side_effect=FileNotFoundError("no codex binary"),
+         ) as mock_spawn, \
+         pytest.raises(AgentUnavailableError):
+        invoke("codex", "hello", mode="workspace-write", cwd=write_guard_repo.dispatch_wt)
+    mock_spawn.assert_called_once()
+    spawn_cwd = Path(mock_spawn.call_args.kwargs["cwd"]).resolve()
+    assert spawn_cwd == write_guard_repo.dispatch_wt
+    assert spawn_cwd != write_guard_repo.main
 
 
 def test_codex_adapter_dispatch_ignores_session_id_via_runner_policy(tmp_path):

--- a/tests/test_env_sanitize.py
+++ b/tests/test_env_sanitize.py
@@ -99,3 +99,26 @@ def test_git_global_config_sandboxed_system_left_intact() -> None:
     # System config deliberately NOT disabled — credential.helper must survive.
     assert "GIT_CONFIG_NOSYSTEM" not in env
     assert "GIT_CONFIG_SYSTEM" not in env
+
+
+def test_workdir_repointing_git_env_is_scrubbed() -> None:
+    """#4446: the child env must not carry vars that re-point its working root
+    back to the primary checkout. The strict allowlist drops GIT_WORK_TREE /
+    GIT_DIR / GIT_INDEX_FILE and PWD / OLDPWD, so a write-capable child cannot
+    escape its worktree cwd via inherited git-discovery or shell state."""
+    hostile = {
+        "PATH": "/usr/bin",
+        "HOME": "/Users/example",
+        "GIT_WORK_TREE": "/repo/primary",
+        "GIT_DIR": "/repo/primary/.git",
+        "GIT_INDEX_FILE": "/repo/primary/.git/index",
+        "GIT_COMMON_DIR": "/repo/primary/.git",
+        "PWD": "/repo/primary",
+        "OLDPWD": "/repo/primary/sub",
+    }
+    with patch.dict("os.environ", hostile, clear=True):
+        env = build_agent_env(provider="codex")
+
+    for leaked in ("GIT_WORK_TREE", "GIT_DIR", "GIT_INDEX_FILE",
+                   "GIT_COMMON_DIR", "PWD", "OLDPWD"):
+        assert leaked not in env, f"{leaked} must be scrubbed from the child env"

--- a/tests/test_gemini_bridge.py
+++ b/tests/test_gemini_bridge.py
@@ -175,6 +175,48 @@ def test_run_gemini_sync_passes_auth_mode_to_runtime(
     assert mock_invoke.call_args.kwargs["tool_config"] == {"auth_mode": "subscription"}
 
 
+def _ok_result() -> Result:
+    return Result(
+        ok=True, agent="gemini", model=PRO_MODEL, mode="read-only",
+        response="reply", stderr_excerpt=None, duration_s=0.1, session_id=None,
+        rate_limited=False, stalled=False, returncode=0, usage_record={},
+    )
+
+
+@pytest.mark.parametrize(
+    "allow_write, expected_mode",
+    [(False, "read-only"), (True, "workspace-write")],
+)
+@patch("ai_agent_bridge._gemini._route_gemini_response")
+@patch("ai_agent_bridge._gemini.acknowledge")
+@patch("ai_agent_bridge._gemini.runtime_invoke")
+def test_run_gemini_sync_derives_runtime_mode_from_allow_write(
+    mock_invoke, _ack, _route, bridge_db, allow_write, expected_mode,
+):
+    """#4446: the runtime write-mode tracks write *intent* (``--allow-write``),
+    not the CLI approval flag — plain Q&A runs ``read-only`` so an ``ask-gemini``
+    query can no longer silently mutate the primary checkout."""
+    message_id = send_message(
+        "Please review this", task_id="issue-4446", msg_type="query",
+        from_llm="claude", to_llm="gemini", to_model=PRO_MODEL, quiet=True,
+    )
+    msg = {"id": message_id, "task_id": "issue-4446", "from": "claude",
+           "to": "gemini", "type": "query", "content": "x", "data": None}
+    mock_invoke.return_value = _ok_result()
+
+    with patch("ai_agent_bridge._gemini._is_task_locked", return_value=False), \
+         patch("ai_agent_bridge._gemini._write_pid_file"), \
+         patch("ai_agent_bridge._gemini._remove_pid_file"), \
+         patch("ai_agent_bridge._gemini.atexit.register"):
+        _run_gemini_sync(
+            msg, message_id, PRO_MODEL, "bridge prompt", no_timeout=False,
+            stdout_only=True, output_path=None, allow_write=allow_write,
+            skip_github=True, auth_mode=None,
+        )
+
+    assert mock_invoke.call_args.kwargs["mode"] == expected_mode
+
+
 def test_handle_ask_gemini_routes_to_agy(monkeypatch):
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
Resolves #4446.

## Problem
Write-capable agent subprocesses could be spawned with `cwd` = the primary
checkout, so an `apply_patch`/Edit/Bash from the child (which provider hooks may
not intercept) could dirty the protected tree. The safety invariant needed to be
correct **by construction**, not dependent on command-string intent parsing.

## What changed

**1. Runtime chokepoint guard (`agent_runtime.runner.invoke`)**
`invoke` is the single point every orchestrated agent subprocess funnels through.
It now refuses to spawn a write-capable child (`workspace-write`/`danger`) whose
`cwd` is a **primary checkout on a protected branch** — reusing the #4444
containment predicate (`classify_repo_path` + `is_protected_branch`). Dispatch
worktrees, any other registered worktree, out-of-repo paths, and feature-branch
checkouts all pass. A cheap in-tree pre-filter (`_RUNNER_REPO_TREE`) skips the
git plumbing for out-of-tree cwds. **Fails closed** if containment can't import.

This makes isolation correct by construction for every caller (delegate, bridge,
V7 writers). It backstops delegate's stricter CLI-arg preflight (#4445) — which
requires a worktree for *every* delegate write dispatch regardless of branch —
and aligns the runtime layer with the protected-branch scoping of the hook
(#4448), monitor tripwire (#4449), and git shim (#4450). Not a duplicate of
#4445/#4449.

**2. Gemini bridge over-grant fix (`ai_agent_bridge/_gemini.py`)**
The bridge previously ran **every** invocation `workspace-write`
(`--approval-mode=yolo`) from the primary checkout, so an `ask-gemini` query
could silently mutate tracked files. Runtime write-mode now tracks write
*intent*: only `--allow-write` callers get `workspace-write`; plain Q&A/review
runs `read-only` (matching `ask-codex`/`ask-agy`).

**3. Env can't re-point the child workdir**
`env_sanitize.build_agent_env`'s strict allowlist already drops
`GIT_WORK_TREE`/`GIT_DIR`/`GIT_INDEX_FILE`/`PWD`/`OLDPWD`; a regression test
locks that invariant.

**4. Docs** — scope boundaries in `docs/runbooks/codex-hooks.md`.

## Scope boundaries (not overclaimed)
- **Covered by construction:** orchestrated write-capable subprocesses via
  `runner.invoke` (delegate, bridge write lanes, V7 writers).
- **Not covered here:** direct interactive **Codex Desktop** / provider
  direct-edit UIs that never route through `runner.invoke` — those depend on the
  hook (#4448), operator self-check, and monitor tripwire (#4449).
- **Known residual (documented):** `v7_build.py --writer gemini-tools` pins the
  writer cwd to the repo root; on `main` the guard refuses it (run from a feature
  branch). Legacy v6 `pipeline/core.py` gemini writer is likewise guard-gated.

## Acceptance criteria
- [x] Write-capable wrapper/dispatch paths create or require a dispatch worktree
      before spawning (delegate #4445 creates; runtime guard requires).
- [x] Spawned subprocess cwd is the verified worktree (test asserts Popen/spawn
      receives the dispatch-worktree cwd, never the main checkout).
- [x] Tests: write-capable Codex lane gets a worktree cwd and is rejected on a
      primary-checkout cwd.
- [x] Read-only wrappers still inspect from repo root.
- [x] Env/config can't re-point workdir back to the primary checkout.
- [x] No duplicate #4445/#4449 behavior.

## Verification
- `tests/test_agent_runtime.py` — `test_write_guard_*`,
  `test_invoke_codex_write_lane_*` (real git repo + dispatch worktree).
- `tests/test_gemini_bridge.py` —
  `test_run_gemini_sync_derives_runtime_mode_from_allow_write`.
- `tests/test_env_sanitize.py` — `test_workdir_repointing_git_env_is_scrubbed`.
- Full run: 310 passed across `tests/test_agent_runtime.py`,
  `tests/test_gemini_bridge.py`, `tests/test_env_sanitize.py`,
  `tests/agent_runtime/`, `tests/test_worktree_containment.py` (integrated with
  #4497 runner failover after merging origin/main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)