### PR TITLE
fix(delegate): normalize origin-prefixed --base refs (fetch, stale-check, worktree add)

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -548,9 +548,18 @@ def _resolve_dirty_primary_checkout_error(*, mode: str) -> str | None:
 
 
 def _fetch_base(base: str) -> bool:
-    """Fetch ``origin/{base}``. Returns True iff the remote ref is resolvable."""
+    """Fetch ``origin/{base}``. Returns True iff the remote ref is resolvable.
+
+    ``base`` may be a plain branch name (``main``) or an origin-prefixed ref
+    (``origin/main`` — the form the dispatch runbooks mandate). The remote
+    refspec is always the plain branch: ``git fetch origin origin/main`` asks
+    the remote for a ref literally named ``origin/main``, which does not
+    exist, so the fetch fails and callers silently fall back to the local
+    (possibly stale) remote-tracking ref.
+    """
+    branch = _base_branch_name(base)
     proc = subprocess.run(
-        ["git", "fetch", "origin", base],
+        ["git", "fetch", "origin", branch],
         cwd=_REPO_ROOT,
         capture_output=True,
         text=True,
@@ -559,7 +568,7 @@ def _fetch_base(base: str) -> bool:
     if proc.returncode != 0:
         return False
     verify = subprocess.run(
-        ["git", "rev-parse", "--verify", f"origin/{base}"],
+        ["git", "rev-parse", "--verify", f"origin/{branch}"],
         cwd=_REPO_ROOT,
         capture_output=True,
         text=True,
@@ -1008,10 +1017,13 @@ def _validate_existing_worktree(
 
     # 3. Stale-base check. Refresh origin/{base} first; ignore fetch failure
     # (we'll use whatever ref is locally available and warn instead of hard-
-    # failing offline).
+    # failing offline). Normalize so an origin-prefixed ``base`` (the form
+    # the dispatch runbooks mandate) never yields ``origin/origin/main`` —
+    # that unresolvable ref made this whole check a silent no-op.
+    origin_ref = _origin_base_ref(base)
     _fetch_base(base)
     count_proc = subprocess.run(
-        ["git", "rev-list", "--count", f"HEAD..origin/{base}"],
+        ["git", "rev-list", "--count", f"HEAD..{origin_ref}"],
         cwd=path,
         capture_output=True,
         text=True,
@@ -1028,12 +1040,12 @@ def _validate_existing_worktree(
         return False
 
     print(
-        f"⚠️  worktree {path} is {behind} commit(s) behind origin/{base}; "
+        f"⚠️  worktree {path} is {behind} commit(s) behind {origin_ref}; "
         f"attempting fast-forward rebase",
         file=sys.stderr,
     )
     rebase_proc = subprocess.run(
-        ["git", "rebase", f"origin/{base}"],
+        ["git", "rebase", origin_ref],
         cwd=path,
         capture_output=True,
         text=True,
@@ -1046,7 +1058,7 @@ def _validate_existing_worktree(
             cwd=path, capture_output=True, text=True, check=False,
         )
         raise WorktreeStaleBase(
-            f"worktree at {path} is {behind} commit(s) behind origin/{base} "
+            f"worktree at {path} is {behind} commit(s) behind {origin_ref} "
             f"and rebase failed. Resolve manually or remove:\n"
             f"    git worktree remove {path}"
         )
@@ -1162,14 +1174,18 @@ def _ensure_worktree(
     # Fix 1 (#1476): fetch origin/{base} and branch from the remote ref,
     # not the local one. Local `main` drifts the moment a PR merges while
     # a dispatch is queued — this is the stale-base footgun Codex
-    # diagnosed in bridge msg #431 (2026-04-23).
+    # diagnosed in bridge msg #431 (2026-04-23). Normalize so an
+    # origin-prefixed ``base`` (``--base origin/main``, the mandated form)
+    # fetches ``main`` and branches from ``origin/main`` — not the
+    # unresolvable ``origin/origin/main``.
+    origin_ref = _origin_base_ref(base)
     if _fetch_base(base):
-        worktree_base_ref = f"origin/{base}"
+        worktree_base_ref = origin_ref
     else:
         print(
-            f"⚠️  `git fetch origin {base}` failed or origin/{base} is "
-            f"unresolvable; falling back to local {base}. This worktree "
-            f"may be branched from a stale tip.",
+            f"⚠️  `git fetch origin {_base_branch_name(base)}` failed or "
+            f"{origin_ref} is unresolvable; falling back to local {base}. "
+            f"This worktree may be branched from a stale tip.",
             file=sys.stderr,
         )
         worktree_base_ref = base

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -1659,6 +1659,101 @@ def test_dispatch_creates_worktree_and_records_it(tmp_tasks_dir, tmp_path, monke
     assert "issue-1383-smoke" in captured.out
 
 
+def test_fetch_base_strips_origin_prefix(monkeypatch):
+    """`--base origin/main` (the mandated runbook form) must fetch refspec `main`.
+
+    `git fetch origin origin/main` asks the remote for a ref literally named
+    ``origin/main`` — nonexistent — so the fetch failed and every conforming
+    dispatch silently fell back to the local (possibly stale) tracking ref.
+    """
+    calls, fake_run = _make_run_stub()
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    assert delegate._fetch_base("origin/main") is True
+
+    fetch_cmd = next(c for c in calls if c[:2] == ["git", "fetch"])
+    assert fetch_cmd == ["git", "fetch", "origin", "main"]
+    verify_cmd = next(
+        c for c in calls if c[:2] == ["git", "rev-parse"] and "--verify" in c
+    )
+    assert verify_cmd[-1] == "origin/main"
+
+
+def test_fetch_base_plain_branch_unchanged(monkeypatch):
+    calls, fake_run = _make_run_stub()
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    assert delegate._fetch_base("main") is True
+
+    fetch_cmd = next(c for c in calls if c[:2] == ["git", "fetch"])
+    assert fetch_cmd == ["git", "fetch", "origin", "main"]
+
+
+def test_dispatch_origin_prefixed_base_branches_from_remote_ref(
+    tmp_tasks_dir, tmp_path, monkeypatch, capsys
+):
+    """base="origin/main" must produce `worktree add ... origin/main`,
+    never the unresolvable `origin/origin/main`."""
+    import argparse
+
+    class _FakeStdin:
+        def write(self, _data):
+            pass
+
+        def close(self):
+            pass
+
+    class _FakeProc:
+        pid = 24681
+        stdin = _FakeStdin()
+
+    calls, fake_run = _make_run_stub(rev_parse_head_sha="feedc0de")
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+    monkeypatch.setattr(delegate.subprocess, "Popen", lambda *a, **k: _FakeProc())
+
+    args = argparse.Namespace(
+        agent="codex",
+        task_id="origin-base-smoke",
+        prompt="Implement the fix",
+        prompt_file=None,
+        mode="danger",
+        model=None,
+        cwd=None,
+        worktree=str(tmp_path / ".worktrees" / "codex-origin-base"),
+        base="origin/main",
+        hard_timeout=3600,
+    )
+
+    rc = delegate.cmd_dispatch(args)
+
+    assert rc == 0
+    fetch_cmd = next(c for c in calls if c[:2] == ["git", "fetch"])
+    assert fetch_cmd == ["git", "fetch", "origin", "main"]
+    add_cmd = next(c for c in calls if c[:3] == ["git", "worktree", "add"])
+    assert add_cmd[-1] == "origin/main", (
+        f"worktree must be created from origin/main, got base={add_cmd[-1]!r}"
+    )
+
+
+def test_validate_existing_worktree_origin_prefixed_base(monkeypatch, tmp_path):
+    """The stale-base check must compare against origin/main, not
+    origin/origin/main (which made the check a silent no-op)."""
+    calls, fake_run = _make_run_stub(rev_list_count="2", abbrev_ref="codex/x")
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    rebased = delegate._validate_existing_worktree(
+        path=tmp_path, expected_branch="codex/x", base="origin/main"
+    )
+
+    assert rebased is True
+    rev_list_cmd = next(c for c in calls if c[:2] == ["git", "rev-list"])
+    assert rev_list_cmd[-1] == "HEAD..origin/main"
+    rebase_cmd = next(
+        c for c in calls if c[:2] == ["git", "rebase"] and "--abort" not in c
+    )
+    assert rebase_cmd[-1] == "origin/main"
+
+
 def test_dispatch_defaults_worker_env_to_no_merge(tmp_tasks_dir, monkeypatch):
     import argparse
 


### PR DESCRIPTION
## Root cause

`--base origin/main` — **the form the dispatch runbooks/agent defs mandate** — hit three broken interpolations in `scripts/delegate.py`:

1. **`_fetch_base`** ran `git fetch origin origin/main`: a remote refspec literally named `origin/main` doesn't exist, so the freshness fetch **always failed** and dispatch silently fell back to the local (possibly stale) tracking ref — the exact stale-tip/re-collision class the #1476 fix introduced this fetch to prevent. Observed live on dispatch `4507-enrich-like-perf` (2026-07-05): `⚠️ git fetch origin origin/main failed … falling back to local origin/main`.
2. Had the fetch succeeded, the creation path would have branched from `origin/origin/main` and **hard-failed** at `git worktree add`.
3. **`_validate_existing_worktree`** compared `HEAD..origin/origin/main` — unresolvable → `return False` — turning the reused-worktree stale-base check into a **silent no-op**.

## Fix

Route all three sites through the pre-existing normalizers `_base_branch_name` / `_origin_base_ref` (they existed but weren't used here). Plain `main` behavior byte-identical.

## Evidence (#M-4)

- Tests: `102 passed in 6.71s` (4 new — exact git argv asserted for both base forms: fetch refspec, worktree-add base ref, rev-list range, rebase target).
- Lint: `ruff check` → `All checks passed!`
- Live probe in this worktree: `delegate._fetch_base('origin/main')` → `True` (was `False` — reproduced pre-fix via the dispatch warning above).

Cross-family review being requested via pool lane; **NO auto-merge** — main orchestrator promotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)