### PR TITLE
docs(audit): #2156 step-3 scorecard — harness lift +180…+310 across the cheap tier

### DIFF
--- a/audit/2026-07-05-qg-bakeoff/SCORECARD.md
+++ b/audit/2026-07-05-qg-bakeoff/SCORECARD.md
@@ -1,0 +1,80 @@
+# QG Bakeoff Scorecard
+
+Generated: 2026-07-05T22:29:21.234824Z
+
+Fractions are exact. `low-N` marks denominators below 10.
+
+## Runs
+
+| model | passage | arm | model judgment | live admissible | missing | U honesty | M alignment | true unsupported | invalid | inadmissible | tools | wall_s |
+| --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: |
+| openrouter/deepseek/deepseek-v4-flash | koliadky | bare | 40 | 40 | 2 | 1/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 37.915 |
+| openrouter/deepseek/deepseek-v4-flash | koliadky | tooled | 30 | 30 | 5 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 8 | 0 | 35 | 238.279 |
+| openrouter/deepseek/deepseek-v4-flash | kupalski | bare | 80 | 80 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 28.244 |
+| openrouter/deepseek/deepseek-v4-flash | kupalski | tooled | 60 | 60 | 4 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 3 | 0 | 34 | 182.667 |
+| openrouter/deepseek/deepseek-v4-flash | vesnianky | bare | -140 | -140 | 6 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 1 | 41.443 |
+| openrouter/deepseek/deepseek-v4-flash | vesnianky | tooled | -20 | -20 | 5 | 0/1 low-N | 0/1 low-N | 1/6 low-N | 5 | 0 | 15 | 140.463 |
+| openrouter/deepseek/deepseek-v4-flash | zhnyvarski | bare | -10 | -10 | 2 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 47.69 |
+| openrouter/deepseek/deepseek-v4-flash | zhnyvarski | tooled | 150 | 150 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 9 | 0 | 26 | 157.747 |
+| openrouter/deepseek/deepseek-v4-pro | koliadky | bare | 80 | 80 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 144.703 |
+| openrouter/deepseek/deepseek-v4-pro | koliadky | tooled | 70 | 70 | 4 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 4 | 0 | 17 | 206.013 |
+| openrouter/deepseek/deepseek-v4-pro | kupalski | bare | 50 | 50 | 2 | 0/1 low-N | 1/2 low-N | 2/6 low-N | 0 | 0 | 0 | 53.854 |
+| openrouter/deepseek/deepseek-v4-pro | kupalski | tooled | 150 | 150 | 1 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 12 | 0 | 15 | 215.682 |
+| openrouter/deepseek/deepseek-v4-pro | vesnianky | bare | -50 | -50 | 3 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 37.351 |
+| openrouter/deepseek/deepseek-v4-pro | vesnianky | tooled | -50 | -50 | 3 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 10 | 0 | 10 | 164.376 |
+| openrouter/deepseek/deepseek-v4-pro | zhnyvarski | bare | 30 | 30 | 1 | 0/1 low-N | 2/2 low-N | 4/6 low-N | 0 | 0 | 0 | 101.766 |
+| openrouter/deepseek/deepseek-v4-pro | zhnyvarski | tooled | 120 | 120 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 3 | 0 | 16 | 267.781 |
+| openrouter/google/gemma-4-31b-it | koliadky | bare | -20 | -20 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 40.363 |
+| openrouter/google/gemma-4-31b-it | koliadky | tooled | 60 | 60 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 7 | 0 | 4 | 43.402 |
+| openrouter/google/gemma-4-31b-it | kupalski | bare | -20 | -20 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 19.368 |
+| openrouter/google/gemma-4-31b-it | kupalski | tooled | 0 | 0 | 0 | 1/1 low-N | 0/2 low-N | 1/6 low-N | 6 | 0 | 4 | 16.499 |
+| openrouter/google/gemma-4-31b-it | vesnianky | bare | -50 | -50 | 3 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 47.969 |
+| openrouter/google/gemma-4-31b-it | vesnianky | tooled | 30 | 30 | 0 | 1/1 low-N | 0/1 low-N | 0/6 low-N | 2 | 0 | 4 | 25.968 |
+| openrouter/google/gemma-4-31b-it | zhnyvarski | bare | 20 | 20 | 0 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 8.473 |
+| openrouter/google/gemma-4-31b-it | zhnyvarski | tooled | 150 | 150 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 8 | 0 | 5 | 137.964 |
+
+## Totals With Anchor
+
+| model | arm | passages | model judgment | live admissible | U honesty | M alignment headline | true unsupported | missing | invalid | inadmissible | tools | wall_s |
+| --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
+| openrouter/deepseek/deepseek-v4-flash | bare | 4 | -30 | -30 | 1/4 low-N | 2/7 low-N | 2/24 | 12 | 0 | 0 | 1 | 155.292 |
+| openrouter/deepseek/deepseek-v4-flash | tooled | 4 | 220 | 220 | 2/4 low-N | 3/7 low-N | 1/24 | 14 | 25 | 0 | 110 | 719.156 |
+| openrouter/deepseek/deepseek-v4-pro | bare | 4 | 110 | 110 | 0/4 low-N | 4/7 low-N | 7/24 | 8 | 0 | 0 | 0 | 337.674 |
+| openrouter/deepseek/deepseek-v4-pro | tooled | 4 | 290 | 290 | 2/4 low-N | 4/7 low-N | 0/24 | 9 | 29 | 0 | 58 | 853.852 |
+| openrouter/google/gemma-4-31b-it | bare | 4 | -70 | -70 | 0/4 low-N | 2/7 low-N | 2/24 | 7 | 0 | 0 | 0 | 116.173 |
+| openrouter/google/gemma-4-31b-it | tooled | 4 | 240 | 240 | 3/4 low-N | 4/7 low-N | 1/24 | 0 | 23 | 0 | 17 | 223.833 |
+
+## Harness Lift With Anchor
+
+Lift = tooled model judgment − bare model judgment (positive = the harness helps),
+over PAIRED passages only (both arms on disk for that model+passage).
+M alignment is the discriminating fraction; low-N marks denominators below 10.
+
+| model | paired passages | tooled model judgment | bare model judgment | harness_lift | tooled M alignment | bare M alignment |
+| --- | ---: | ---: | ---: | ---: | --- | --- |
+| openrouter/deepseek/deepseek-v4-flash | 4 | 220 | -30 | 250 | 3/7 low-N | 2/7 low-N |
+| openrouter/deepseek/deepseek-v4-pro | 4 | 290 | 110 | 180 | 4/7 low-N | 4/7 low-N |
+| openrouter/google/gemma-4-31b-it | 4 | 240 | -70 | 310 | 4/7 low-N | 2/7 low-N |
+
+## Totals Without Anchor
+
+| model | arm | passages | model judgment | live admissible | U honesty | M alignment headline | true unsupported | missing | invalid | inadmissible | tools | wall_s |
+| --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
+| openrouter/deepseek/deepseek-v4-flash | bare | 3 | 110 | 110 | 1/3 low-N | 2/6 low-N | 2/18 | 6 | 0 | 0 | 0 | 113.849 |
+| openrouter/deepseek/deepseek-v4-flash | tooled | 3 | 240 | 240 | 2/3 low-N | 3/6 low-N | 0/18 | 9 | 20 | 0 | 95 | 578.693 |
+| openrouter/deepseek/deepseek-v4-pro | bare | 3 | 160 | 160 | 0/3 low-N | 4/6 low-N | 7/18 | 5 | 0 | 0 | 0 | 300.323 |
+| openrouter/deepseek/deepseek-v4-pro | tooled | 3 | 340 | 340 | 2/3 low-N | 4/6 low-N | 0/18 | 6 | 19 | 0 | 48 | 689.476 |
+| openrouter/google/gemma-4-31b-it | bare | 3 | -20 | -20 | 0/3 low-N | 2/6 low-N | 2/18 | 4 | 0 | 0 | 0 | 68.204 |
+| openrouter/google/gemma-4-31b-it | tooled | 3 | 210 | 210 | 2/3 low-N | 4/6 low-N | 1/18 | 0 | 21 | 0 | 13 | 197.865 |
+
+## Harness Lift Without Anchor
+
+Lift = tooled model judgment − bare model judgment (positive = the harness helps),
+over PAIRED passages only (both arms on disk for that model+passage).
+M alignment is the discriminating fraction; low-N marks denominators below 10.
+
+| model | paired passages | tooled model judgment | bare model judgment | harness_lift | tooled M alignment | bare M alignment |
+| --- | ---: | ---: | ---: | ---: | --- | --- |
+| openrouter/deepseek/deepseek-v4-flash | 3 | 240 | 110 | 130 | 3/6 low-N | 2/6 low-N |
+| openrouter/deepseek/deepseek-v4-pro | 3 | 340 | 160 | 180 | 4/6 low-N | 4/6 low-N |
+| openrouter/google/gemma-4-31b-it | 3 | 210 | -20 | 230 | 4/6 low-N | 2/6 low-N |

--- a/docs/projects/ua-eval-harness/model-evidence.md
+++ b/docs/projects/ua-eval-harness/model-evidence.md
@@ -170,3 +170,52 @@ UNATTESTED one and emitted a critical finding — but still rationalized the oth
 irrelevant real quote. Whether a stronger tooled model closes that alignment gap (and whether tooling
 lifts cheap→frontier on exactly this axis) is the step-3 bakeoff's central measurement, scored with the
 locked asymmetric constants (`qg_factcheck_scoring.py`: CONFIRMED-on-fabricated = −100 fatal).
+
+## Step-3 bakeoff — tooled vs bare harness lift (2026-07-05, #2156 step 3)
+
+The central measurement: same models, same 4 fabrication-seeded seminar passages (веснянки anchor +
+kupalski/zhnyvarski/koliadky, 35 claims: 24 true · 7 class-M w/ real distractor quotes · 4 class-U
+zero-attestation), two arms — **tooled** (sources-MCP grounding + theatre/budget/deep-read/grounding/
+admissibility gates, `qg_workflow.v3`) vs **bare** (identical verdict taxonomy sliced verbatim from the
+live reviewer prompt, NO tools, NO gates — parametric knowledge only). Scored with the locked asymmetric
+constants (`qg_factcheck_scoring.py`; CONFIRMED-on-fabricated = −100 fatal; missing = −10), claim-id
+matching per the #4485 verdict-not-echo matcher. Full data:
+`audit/2026-07-05-qg-bakeoff/SCORECARD.md` (24 artifacts, all cells `ran`).
+
+### Harness lift (model-judgment points, 4 paired passages, with anchor)
+
+| model | bare | tooled | **lift** | bare M alignment | tooled M alignment | bare U honesty | tooled U honesty |
+|---|---:|---:|---:|---|---|---|---|
+| gemma-4-31b-it (cheapest) | **−70** | 240 | **+310** | 2/7 | 4/7 | 0/4 | 3/4 |
+| deepseek-v4-flash | −30 | 220 | **+250** | 2/7 | 3/7 | 1/4 | 2/4 |
+| deepseek-v4-pro | 110 | 290 | **+180** | 4/7 | 4/7 | 0/4 | 2/4 |
+
+(Without-anchor split: +230 / +130 / +180 — same ordering. All fractions low-N; 4 passages.)
+
+### Findings
+
+1. **Every model is negative-to-mediocre bare.** Judging folk-culture claims from parametric knowledge,
+   all three confirm fabrications (gemma −70, flash −30; even pro's +110 is a third of its tooled score).
+   This is the quantified version of the step-1/D6 finding: surface-fluent ≠ factually grounded.
+2. **The harness lifts hardest where the model is cheapest** — gemma +310 > flash +250 > pro +180.
+   Stronger parametric knowledge shrinks the gap but nowhere near closes it: the BEST bare score (pro,
+   110) is below the WORST tooled score (flash, 220).
+3. **Bare honesty collapses.** Class-U (zero-attestation) claims: bare models guess instead of
+   withholding (gemma 0/4, pro 0/4 honest) despite the bare prompt explicitly licensing
+   `UNVERIFIED_INSUFFICIENT_SEARCH`. With tools, honest-withhold becomes the majority behavior.
+   Corollary: deepseek-pro bare marks 7/24 TRUE claims unverifiable — honest but useless without
+   retrieval.
+4. **Cost note:** bare cells run in ~10–145 s vs tooled 16–268 s; the entire 12-cell bare arm cost
+   pennies (OpenRouter gemma paid pin + deepseek API). The lift is not bought with latency — tooled
+   gemma is still the fastest tooled seat (224 s total for 4 passages).
+
+**Implications.** (a) UNLP claim quantified: tool-grounding + deterministic gates close most of the
+cheap-model factuality gap on seminar fact-checking — +180…+310 judgment points on a 4-passage matrix,
+scored fatal-asymmetric. (b) Hramatka/teacher-service: NO bare model is shippable for factual review —
+the harness is the product, and tooled gemma (near-frontier lift at the lowest cost + fastest wall
+clock) remains the default pin pending the frontier columns. (c) The tooled-frontier columns stay EMPTY
+by design: subscription families are guard-refused over OpenRouter (`routing_guard`, #4473/#4500);
+frontier bare/tooled cells need the subscription-lane `BareRunner`/rollout-telemetry adapters
+(follow-up). Frontier variants served by subscription lanes differ from OpenRouter pins
+(e.g. `gemini-3.1-pro-high` ≠ `google/gemini-3.1-pro-preview`) — analyze as transport+variant
+substitution, never conflate.

--- a/docs/projects/ua-eval-harness/model-evidence.md
+++ b/docs/projects/ua-eval-harness/model-evidence.md
@@ -190,7 +190,7 @@ matching per the #4485 verdict-not-echo matcher. Full data:
 | deepseek-v4-flash | −30 | 220 | **+250** | 2/7 | 3/7 | 1/4 | 2/4 |
 | deepseek-v4-pro | 110 | 290 | **+180** | 4/7 | 4/7 | 0/4 | 2/4 |
 
-(Without-anchor split: +230 / +130 / +180 — same ordering. All fractions low-N; 4 passages.)
+(Without-anchor split, 3 passages: +230 / +130 / +180 — same ordering. All fractions low-N; the full matrix is 4 passages.)
 
 ### Findings
 
@@ -202,7 +202,7 @@ matching per the #4485 verdict-not-echo matcher. Full data:
    110) is below the WORST tooled score (flash, 220).
 3. **Bare honesty collapses.** Class-U (zero-attestation) claims: bare models guess instead of
    withholding (gemma 0/4, pro 0/4 honest) despite the bare prompt explicitly licensing
-   `UNVERIFIED_INSUFFICIENT_SEARCH`. With tools, honest-withhold becomes the majority behavior.
+   `UNVERIFIED_INSUFFICIENT_SEARCH`. With tools, honest-withhold becomes the dominant shift (gemma 3/4; flash and pro reach 2/4 from 1/4 and 0/4; 7/12 combined).
    Corollary: deepseek-pro bare marks 7/24 TRUE claims unverifiable — honest but useless without
    retrieval.
 4. **Cost note:** bare cells run in ~10–145 s vs tooled 16–268 s; the entire 12-cell bare arm cost

--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -920,6 +920,15 @@ def model_pins_from_args(values: Sequence[str] | None) -> list[str]:
             pins.extend(piece.strip() for piece in value.split(",") if piece.strip())
         if not pins:
             raise BakeoffConfigError("--models was provided but no model pins were parsed")
+        # Fail fast on malformed pins (live burn 2026-07-05: a space-separated
+        # --models string parsed as ONE mega-pin and ran 4 garbage cells
+        # instead of erroring). Pins are comma-separated; whitespace inside a
+        # pin is always a caller mistake.
+        malformed = [pin for pin in pins if any(ch.isspace() for ch in pin)]
+        if malformed:
+            raise BakeoffConfigError(
+                f"model pins must not contain whitespace (use commas to separate): {malformed!r}"
+            )
         return pins
     unresolved = [candidate.label for candidate in DEFAULT_CANDIDATE_MODELS if candidate.unresolved]
     if unresolved:

--- a/tests/audit/test_qg_bakeoff.py
+++ b/tests/audit/test_qg_bakeoff.py
@@ -285,6 +285,14 @@ def test_negative_verdict_on_shared_sentence_does_not_refute_true_subclaim() -> 
     )
 
 
+def test_model_pins_reject_whitespace_mega_pin() -> None:
+    """A space-separated --models string must fail fast, not run garbage cells
+    (live burn 2026-07-05: one mega-pin ran 4 junk artifacts)."""
+    with pytest.raises(qg_bakeoff.BakeoffConfigError, match="whitespace"):
+        qg_bakeoff.model_pins_from_args(["pin/a pin/b pin/c"])
+    assert qg_bakeoff.model_pins_from_args(["pin/a,pin/b"]) == ["pin/a", "pin/b"]
+
+
 def test_resume_skips_existing_artifact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CI", raising=False)
     monkeypatch.setenv("QG_BAKEOFF", "1")


### PR DESCRIPTION
## The step-3 measurement, complete

12 tooled + 12 bare cells (gemma-4-31b, deepseek-flash, deepseek-pro × 4 fabrication-seeded seminar passages, 35 claims), rescored end-to-end with the #4485 verdict-not-echo matcher and the #4500 paired-cell lift. All cells `ran`; raw artifacts stay local by design (`audit/*-qg-bakeoff/*.json` gitignored — no raw model output in git); `SCORECARD.md` + `model-evidence.md` §step-3 are the durable record.

## Headline (model-judgment points, locked asymmetric constants)

| model | bare | tooled | lift |
|---|---:|---:|---:|
| gemma-4-31b-it | −70 | 240 | **+310** |
| deepseek-v4-flash | −30 | 220 | **+250** |
| deepseek-v4-pro | +110 | 290 | **+180** |

Every model confirms fabrications bare; best bare < worst tooled; class-U honesty collapses without tools. Full findings + Hramatka implications in the evidence doc.

## Also

`model_pins_from_args` fails fast on whitespace inside a pin (live burn this session: a space-separated `--models` string parsed as ONE mega-pin and ran 4 garbage cells) + regression test.

Feeds #4370 (exit-criteria extension) and the Hramatka model choice. Follow-ups: frontier bare/tooled columns via subscription-lane runners (BareRunner seam, #4500); #4364 with/without-contested reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)