### PR TITLE
bio: add learner readings for Cossack revolt batch 05c

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/mykhailo-doroshenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykhailo-doroshenko.yaml
@@ -79,6 +79,21 @@ persona:
   role: Історик, що показує подвійне лезо реєстру й козацько-кримську дипломатію без сортування «герой чи колаборант».
   voice: Critical-Historian
 phase: BIO
+readings:
+- title: "Дорошенко Михайло"
+  source_name: "Енциклопедія історії України"
+  source_url: "https://www.history.org.ua/?termin=Doroshenko_M"
+  language: uk
+  type: reference
+  hosting: reading-needed
+  rationale: "Адаптація енциклопедичної статті про Михайла Дорошенка для читання, зосереджена на подвійному лезі реєстру та його участі в кримських походах."
+- title: "Куруківська угода 1625"
+  source_name: "Енциклопедія історії України"
+  source_url: "https://www.history.org.ua/?termin=KurukiVska_Ugoda_1625"
+  language: uk
+  type: reference
+  hosting: link-only
+  rationale: "Оригінальний історичний огляд умов договору для поглибленого читання й аналізу обмежень козацьких вольностей."
 references:
 - author: В. О. Щербак
   note: 'Базові факти: невідоме народження, смерть 1628, реєстрове гетьманство 1625–1628, засновник роду Дорошенків, контекст Сагайдачного й Хотина, Жмайло/Куруків, перемога під Білою Церквою, кримський похід і смерть на Альмі.'
@@ -112,7 +127,7 @@ sequence: 26
 slug: mykhailo-doroshenko
 subtitle: 'Mykhailo Doroshenko: The Register as Both Recognition and Control'
 title: 'Михайло Дорошенко: реєстр як визнання і як контроль'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: козаки, внесені державою до офіційного списку на службу й платню
   pos: мн.

--- a/curriculum/l2-uk-en/plans/bio/sylvestr-kosiv.yaml
+++ b/curriculum/l2-uk-en/plans/bio/sylvestr-kosiv.yaml
@@ -80,6 +80,14 @@ persona:
   role: Модератор, що ставить під сумнів офіційну церковну історію, шукаючи політичні та економічні мотиви за духовними деклараціями
   voice: Ecclesiastical-Historian-Skeptic
 phase: BIO.1
+readings:
+- title: "Косів Сильвестр"
+  source_name: "Енциклопедія історії України"
+  source_url: "http://www.history.org.ua/?termin=Kosiv_S"
+  language: uk
+  type: reference
+  hosting: reading-needed
+  rationale: "Енциклопедична стаття про життєпис митрополита, що потребує адаптації для студентів рівня C1, зосереджена на його політичному балансуванні та відмові від присяги."
 references:
 - title: Sylvestr Kosiv
   note: Compiled from Wikipedia UA, Hrushevsky, Plokhy
@@ -104,7 +112,7 @@ sequence: 25
 slug: sylvestr-kosiv
 subtitle: 'Sylvestr Kosiv: Metropolitan in a Turbulent Era'
 title: 'Сильвестр Косів: Митрополит у буремну епоху'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: вищий духовний сан єпископа, глава автокефальної або автономної православної церкви
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/taras-fedorovych-triasylo.yaml
+++ b/curriculum/l2-uk-en/plans/bio/taras-fedorovych-triasylo.yaml
@@ -79,6 +79,21 @@ persona:
   role: Історик, що відділяє документального Тараса Федоровича від романтичного імені пам'яті «Трясило».
   voice: Anti-Hagiographer
 phase: BIO
+readings:
+- title: "Федорович Тарас"
+  source_name: "Енциклопедія історії України"
+  source_url: "https://www.history.org.ua/?termin=Fedorovych_Taras"
+  language: uk
+  type: reference
+  hosting: reading-needed
+  rationale: "Енциклопедичний текст для читання, що висвітлює біографію нереєстрового гетьмана та його роль у повстанні 1630 року, адаптований для студентів."
+- title: "Федоровича повстання 1630"
+  source_name: "Енциклопедія історії України"
+  source_url: "https://www.history.org.ua/?termin=Fedorovycha_povstannia"
+  language: uk
+  type: reference
+  hosting: link-only
+  rationale: "Детальний опис причин та ходу повстання для поглибленого читання й розуміння реєстрового тиску."
 references:
 - author: Д. Я. Вортман
   note: 'Базові факти: невідомі дати, спірне походження, пізнє прізвисько «Трясило», вибори нереєстровими козаками, кримський похід 1629, відкрита фаза повстання 1630, усунення в травні, кар''єра 1631–1636, застереження про Тараса Чорного.'
@@ -118,7 +133,7 @@ sequence: 27
 slug: taras-fedorovych-triasylo
 subtitle: 'Taras Fedorovych: The Rebel Whom Memory Renamed Triasylo'
 title: 'Тарас Федорович: повстанець, якого пам''ять перейменувала на Трясила'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: масовий збройний виступ проти наявної влади
   pos: с.


### PR DESCRIPTION
Adds Ukrainian-only learner reading packets to three BIO plan YAML files for the Cossack revolt / early Hetmanate sequence.

Owned files:
- curriculum/l2-uk-en/plans/bio/sylvestr-kosiv.yaml
- curriculum/l2-uk-en/plans/bio/mykhailo-doroshenko.yaml
- curriculum/l2-uk-en/plans/bio/taras-fedorovych-triasylo.yaml

Notes:
- Plan-level `readings:` blocks only; no wiki/source YAML edits.
- LLM-QG and Gemma were not used.
- AGY/Gemini authored; requires independent non-AGY review before merge.
