### PR TITLE
bio: add learner readings for Cossack Ruin batch 07

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/ivan-briukhovetskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-briukhovetskyi.yaml
@@ -117,7 +117,7 @@ sequence: 40
 slug: ivan-briukhovetskyi
 subtitle: 'Ivan Briukhovetskyi: The Black Council and the Moscow Articles'
 title: 'Іван Брюховецький: Чорна рада і Московські статті'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: загальна козацька рада за участю поспільства («черні») під Ніжином 1663 року, на якій Брюховецького обрали гетьманом
   pos: ж.
@@ -147,3 +147,19 @@ vocabulary_hints:
   pos: ж.
   word: чернь
 word_target: 5000
+
+readings:
+- hosting: reading-needed
+  language: uk
+  rationale: "Детальний аналіз політичного шляху Брюховецького: від антистаршинської демагогії до радикального антимосковського повстання."
+  source: "Енциклопедія історії України"
+  title: "Брюховецький Іван Мартинович"
+  type: encyclopedia
+  url: "http://resource.history.org.ua/cgi-bin/eiu/history.exe?&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Briukhovetsky_I"
+- hosting: reading-needed
+  language: uk
+  rationale: "Розбір Московських статей 1665 року — угоди, яка підірвала автономію Гетьманщини та стала каталізатором соціального вибуху."
+  source: "Енциклопедія історії України"
+  title: "Московські статті 1665"
+  type: encyclopedia
+  url: "http://resource.history.org.ua/cgi-bin/eiu/history.exe?&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Moskovski_statti_1665"

--- a/curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-sirko.yaml
@@ -94,7 +94,7 @@ sequence: 41
 slug: ivan-sirko
 subtitle: 'Ivan Sirko: The Legendary Koshovyi Otaman'
 title: 'Іван Сірко: Легендарний кошовий отаман'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: у народних віруваннях — козак, що володіє надприродними здібностями, може обертатися на вовка, ловити кулі руками
   pos: ч.
@@ -118,3 +118,19 @@ vocabulary_hints:
   pos: ж.
   word: булава
 word_target: 5200
+
+readings:
+- hosting: reading-needed
+  language: uk
+  rationale: "Наукова деконструкція біографії Івана Сірка, його військових кампаній та часто деструктивного втручання в гетьманську політику."
+  source: "Енциклопедія історії України"
+  title: "Сірко Іван Дмитрович"
+  type: encyclopedia
+  url: "http://resource.history.org.ua/cgi-bin/eiu/history.exe?&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Sirko_I"
+- hosting: reading-needed
+  language: uk
+  rationale: "Огляд ролі Сірка у подіях 1668 року під час антимосковського повстання Брюховецького та проголошення Дорошенка гетьманом обох берегів Дніпра."
+  source: "Енциклопедія історії України"
+  title: "Антимосковське повстання 1668"
+  type: encyclopedia
+  url: "http://resource.history.org.ua/cgi-bin/eiu/history.exe?&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Antymoskovske_povstannia_1668"

--- a/curriculum/l2-uk-en/plans/bio/pavlo-teteria.yaml
+++ b/curriculum/l2-uk-en/plans/bio/pavlo-teteria.yaml
@@ -116,7 +116,7 @@ sequence: 39
 slug: pavlo-teteria
 subtitle: 'Pavlo Teteria: The Right-Bank Hetman and the Cost of Compromise'
 title: 'Павло Тетеря: Правобережний гетьман і ціна компромісу'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: керівник гетьманської канцелярії й дипломатії; посада, яку Тетеря обіймав в уряді Юрія Хмельницького
   pos: ч.
@@ -146,3 +146,19 @@ vocabulary_hints:
   pos: ч.
   word: ясир
 word_target: 5000
+
+readings:
+- hosting: reading-needed
+  language: uk
+  rationale: "Життєпис Павла Тетері: від впливового дипломата часів Хмельницького до суперечливого гетьмана Правобережжя."
+  source: "Енциклопедія історії України"
+  title: "Тетеря Павло Іванович"
+  type: encyclopedia
+  url: "http://resource.history.org.ua/cgi-bin/eiu/history.exe?&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Teteria_P"
+- hosting: external
+  language: uk
+  rationale: "Огляд літописних згадок про політичні кроки Тетері та його конфлікти."
+  source: "Літопис Самовидця"
+  title: "Літопис Самовидця (частина третя)"
+  type: primary-source
+  url: "http://litopys.org.ua/samovyd/sam03.htm"

--- a/curriculum/l2-uk-en/plans/bio/petro-doroshenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/petro-doroshenko.yaml
@@ -118,7 +118,7 @@ sequence: 42
 slug: petro-doroshenko
 subtitle: 'Petro Doroshenko: The Sun of the Ruin'
 title: 'Петро Дорошенко: Сонце Руїни'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: залежність меншої держави від сильнішої на умовах заступництва; Дорошенко шукав османського протекторату як третьої гарантії проти поділу
   pos: ч.
@@ -151,3 +151,19 @@ vocabulary_hints:
   pos: ж.
   word: Руїна
 word_target: 5000
+
+readings:
+- hosting: reading-needed
+  language: uk
+  rationale: "Комплексний життєпис Петра Дорошенка, його амбітної програми 'Сонце Руїни' та її трагічного краху."
+  source: "Енциклопедія історії України"
+  title: "Дорошенко Петро Дорофійович"
+  type: encyclopedia
+  url: "http://resource.history.org.ua/cgi-bin/eiu/history.exe?&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Doroshenko_P"
+- hosting: reading-needed
+  language: uk
+  rationale: "Аналіз Корсунської угоди, що закріпила перехід Правобережної Гетьманщини під протекторат Османської імперії."
+  source: "Енциклопедія історії України"
+  title: "Корсунська угода 1669"
+  type: encyclopedia
+  url: "http://resource.history.org.ua/cgi-bin/eiu/history.exe?&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Korsunska_ugoda_1669"

--- a/curriculum/l2-uk-en/plans/bio/yakym-somko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yakym-somko.yaml
@@ -118,7 +118,7 @@ sequence: 37
 slug: yakym-somko
 subtitle: 'Yakym Somko: Acting Hetman and the Black Council'
 title: 'Яким Сомко: Наказний гетьман і Чорна рада'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: тимчасовий/виконувач гетьманських обов'язків; титул Сомка на Лівобережжі у 1660–1663 роках
   pos: ч.
@@ -148,3 +148,19 @@ vocabulary_hints:
   pos: ж.
   word: зрада
 word_target: 5000
+
+readings:
+- hosting: reading-needed
+  language: uk
+  rationale: "Фундаментальна академічна довідка про життєпис, походження та політичну кар'єру Якима Сомка на посаді наказного гетьмана."
+  source: "Енциклопедія історії України"
+  title: "Сомко Яким Семенович"
+  type: encyclopedia
+  url: "http://resource.history.org.ua/cgi-bin/eiu/history.exe?&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Somko_Y"
+- hosting: reading-needed
+  language: uk
+  rationale: "Детальний розбір механіки Ніжинської ради, обставин страти Сомка та впливу царської присутності на ці події."
+  source: "Енциклопедія історії України"
+  title: "Чорна рада 1663"
+  type: encyclopedia
+  url: "http://resource.history.org.ua/cgi-bin/eiu/history.exe?&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Chorna_rada_1663"

--- a/curriculum/l2-uk-en/plans/bio/yurii-khmelnytskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yurii-khmelnytskyi.yaml
@@ -117,7 +117,7 @@ sequence: 38
 slug: yurii-khmelnytskyi
 subtitle: 'Yurii Khmelnytskyi: The Burden of a Name'
 title: 'Юрій Хмельницький: Тягар імені'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: син гетьмана, династичний спадкоємець булави; статус, що надав Юрієві символічну легітимність без реальної влади
   pos: ч.
@@ -147,3 +147,19 @@ vocabulary_hints:
   pos: ж.
   word: Руїна
 word_target: 5000
+
+readings:
+- hosting: reading-needed
+  language: uk
+  rationale: "Академічна біографія Юрія Хмельницького. Важлива для розуміння трагедії 'гетьманича', який став заручником власного імені та зовнішніх впливів."
+  source: "Енциклопедія історії України"
+  title: "Хмельницький Юрій Богданович"
+  type: encyclopedia
+  url: "http://resource.history.org.ua/cgi-bin/eiu/history.exe?&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Khmelnytsky_Ju"
+- hosting: reading-needed
+  language: uk
+  rationale: "Аналіз ключового договору, який ознаменував розрив Юрія Хмельницького з Москвою та спробу відновити Гадяцькі домовленості."
+  source: "Енциклопедія історії України"
+  title: "Слободищенський трактат 1660"
+  type: encyclopedia
+  url: "http://resource.history.org.ua/cgi-bin/eiu/history.exe?&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Slobodyshchenskyj_traktat"


### PR DESCRIPTION
## Summary
- Add Ukrainian-only learner `readings:` packets for six Cossack/Ruin BIO plans: `yakym-somko`, `yurii-khmelnytskyi`, `pavlo-teteria`, `ivan-briukhovetskyi`, `ivan-sirko`, `petro-doroshenko`.
- Keep changes scoped to plan YAML only with version bumps.
- Leave `wiki/figures/*.sources.yaml` untouched; learner readings remain plan-level per #4400.

## Verification
- Worker parsed all six YAML files with `.venv/bin/python` + PyYAML.
- Orchestrator verified branch diff scope and `X-Agent` trailer.

## Review
- AGY/Gemini-authored; needs independent non-AGY review before merge.
- LLM-QG and Gemma/OpenRouter were not used.

Refs #4431, #4400, #4215
