### PR TITLE
bio: add learner readings for Cossack Ruin batch 06

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml
+++ b/curriculum/l2-uk-en/plans/bio/bohdan-khmelnytskyy.yaml
@@ -78,6 +78,21 @@ persona:
   role: Модератор семінару з військово-політичної історії, що аналізує рішення Хмельницького з точки зору ризиків та вигод, а не моральних оцінок.
   voice: Strategic-Realist
 phase: BIO.4
+readings:
+- title: 'Богдан Хмельницький'
+  source: 'Енциклопедія історії України'
+  url: 'http://resource.history.org.ua/cgi-bin/eiu/history.exe?Z21ID=&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Khmelnytsky_B'
+  type: reference
+  language: uk
+  hosting: link-only
+  note: 'Оглядова стаття про життя та діяльність гетьмана.'
+- title: 'Документи Богдана Хмельницького'
+  source: 'Ізборник'
+  url: 'http://izbornyk.org.ua/'
+  type: primary
+  language: uk
+  hosting: link-only
+  note: 'Першоджерела: тексти універсалів та листів гетьмана.'
 references:
 - title: Bohdan Khmelnytskyy
   note: 'Internal wiki entry compiled from academic sources: Смолій, Плохій, Грушевський.'
@@ -97,7 +112,7 @@ sequence: 32
 slug: bohdan-khmelnytskyy
 subtitle: 'Bohdan Khmelnytsky: The Hetman State-Builder'
 title: 'Богдан Хмельницький: Гетьман-державотворець'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: здатність бути самостійним, активним діячем в історії, а не об'єктом впливу інших сил
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/dmytro-hunia.yaml
+++ b/curriculum/l2-uk-en/plans/bio/dmytro-hunia.yaml
@@ -79,6 +79,21 @@ persona:
   role: Історик-джерелознавець, що читає оборону над Старцем як поєднання військового вміння, постачання й переговорів, а не як двобій героя й боягуза
   voice: Source-Critical Historian
 phase: BIO
+readings:
+- title: 'Гуня Дмитро Тимошевич'
+  source: 'Енциклопедія історії України'
+  url: 'https://www.history.org.ua/?termin=Gunya_D'
+  type: reference
+  language: uk
+  hosting: link-only
+  note: 'Енциклопедична довідка про участь Гуні у повстаннях та обороні Січі.'
+- title: 'Старець, битва над затокою 1638'
+  source: 'Енциклопедія історії України'
+  url: 'https://www.history.org.ua/?termin=Starets_1638'
+  type: reference
+  language: uk
+  hosting: link-only
+  note: 'Детальний опис фінальної битви та відходу Гуні.'
 references:
 - note: 'Стаття ЕІУ (В. Щербак): невідомі роки життя, рештки з-під Кумейок, оборона Січі, Старець, Дон'
   path: https://www.history.org.ua/?termin=Gunya_D
@@ -105,7 +120,7 @@ sequence: 31
 slug: dmytro-hunia
 subtitle: 'Dmytro Hunia: The Defense at the Starets'
 title: 'Дмитро Гуня: Оборона над Старцем'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: виборний очільник війська; джерела називають Гуню «старшим над військом»
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/ivan-bohun.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-bohun.yaml
@@ -79,6 +79,21 @@ persona:
   role: Історик-джерелознавець, що відрізняє джерельну біографію Богуна від героїчної легенди, тримаючи видимими і його опір, і його участь у фракційній війні
   voice: Source-Critical Historian
 phase: BIO
+readings:
+- title: 'Богун Іван'
+  source: 'Енциклопедія історії України'
+  url: 'https://www.history.org.ua/?termin=Bogun_I'
+  type: reference
+  language: uk
+  hosting: link-only
+  note: 'Енциклопедична довідка про життєвий шлях і військову діяльність Івана Богуна.'
+- title: 'Берестецька битва 1651 р.'
+  source: 'Енциклопедія історії України'
+  url: 'https://www.history.org.ua/?termin=Berestetska_bytva_1651'
+  type: reference
+  language: uk
+  hosting: link-only
+  note: 'Стаття про битву під Берестечком та роль Богуна у виведенні козацьких сил.'
 references:
 - note: 'Стаття ЕІУ (О. Гуржій): уряд полковника, Вінниця, Берестечко, Монастирище, відмова від присяги, страта 1664 року'
   path: https://www.history.org.ua/?termin=Bogun_I
@@ -105,7 +120,7 @@ sequence: 33
 slug: ivan-bohun
 subtitle: 'Ivan Bohun: Resistance and the Making of a Legend'
 title: 'Іван Богун: Опір і пам''ять'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: командир козацького полку; Богун очолював Кальницький (Вінницький) полк
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-vyhovskyi.yaml
@@ -77,6 +77,21 @@ persona:
   role: Модератор семінару, що змушує оцінювати політичні рішення не за намірами, а за наслідками. Провокує на аналіз ціни кожного вибору.
   voice: Realpolitik-Historian
 phase: BIO.2
+readings:
+- title: 'Виговський Іван Остапович'
+  source: 'Енциклопедія історії України'
+  url: 'https://www.history.org.ua/?termin=Vyhovskyj_I'
+  type: reference
+  language: uk
+  hosting: link-only
+  note: 'Оглядова стаття про життя та діяльність гетьмана.'
+- title: 'Гадяцький договір 1658'
+  source: 'Енциклопедія історії України'
+  url: 'https://www.history.org.ua/?termin=Gadiatsky_dogovir_1658'
+  type: reference
+  language: uk
+  hosting: link-only
+  note: 'Детальний розбір змісту та значення угоди.'
 references:
 - title: Іван Виговський
   author: Смолій В.А., Степанков В.С.
@@ -100,7 +115,7 @@ sequence: 35
 slug: ivan-vyhovskyi
 subtitle: 'Ivan Vyhovskyi: Architect of the Hadiach Union'
 title: 'Іван Виговський: Архітектор Гадяцької унії'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: договір 1658 р., що передбачав створення Великого князівства Руського як третьої частини Речі Посполитої
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/martyn-pushkar.yaml
+++ b/curriculum/l2-uk-en/plans/bio/martyn-pushkar.yaml
@@ -81,6 +81,21 @@ persona:
   role: Історик-джерелознавець, що читає Пушкаря крізь ворожі й прихильні джерела й не робить із нього ні московського ставленика, ні бездоганного оборонця прав
   voice: Source-Critical Historian
 phase: BIO
+readings:
+- title: 'Пушкар Мартин'
+  source: 'Енциклопедія історії України'
+  url: 'https://www.history.org.ua/?termin=Pushkar_M'
+  type: reference
+  language: uk
+  hosting: link-only
+  note: 'Енциклопедична довідка про полтавського полковника.'
+- title: 'Пушкаря і Барабаша повстання 1658'
+  source: 'Енциклопедія історії України'
+  url: 'https://www.history.org.ua/?termin=Pushkaria_Barabasha_1657'
+  type: reference
+  language: uk
+  hosting: link-only
+  note: 'Детальний опис повстання та його наслідків.'
 references:
 - note: 'Стаття ЕІУ (В. Горобець): невідомий рік народження, рід Пушкарів-Ресинських, полтавський полковник, наказне командування під Берестечком, підтримка Виговського і перехід в опозицію, смерть під Полтавою'
   path: https://www.history.org.ua/?termin=Pushkar_M
@@ -116,7 +131,7 @@ sequence: 34
 slug: martyn-pushkar
 subtitle: 'Martyn Pushkar: The Poltava Colonel and the First Rupture of the Ruin'
 title: 'Мартин Пушкар: Полтавський полковник і перший розкол Руїни'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: лівобережна військово-адміністративна одиниця Гетьманщини; полтавський полк Пушкар очолив 1648 року
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/yuriy-nemyrych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yuriy-nemyrych.yaml
@@ -81,6 +81,14 @@ persona:
   role: Модератор семінару, що розглядає Немирича не як "пророка", а як трагічну фігуру, чиї аристократичні ідеали були несумісні з реаліями козацької революції.
   voice: Lypynsky-School-Historian
 phase: BIO
+readings:
+- title: 'Немирич Юрій Стефанович'
+  source: 'Енциклопедія історії України'
+  url: 'https://www.history.org.ua/?termin=Nemyrych_Yu'
+  type: reference
+  language: uk
+  hosting: link-only
+  note: 'Енциклопедична стаття про політичну та інтелектуальну діяльність Юрія Немирича.'
 references:
 - title: Yuriy Nemyrych
   note: Compiled from Hrushevsky, Lypynsky, Plokhy — primary source analysis, historiography
@@ -100,7 +108,7 @@ sequence: 36
 slug: yuriy-nemyrych
 subtitle: 'Yuriy Nemyrych: The Architect of an Unbuilt State'
 title: 'Юрій Немирич: Архітектор незбудованої держави'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: Пропонована козацькою старшиною назва для третьої, рівноправної Речі Посполитій, частини федерації за Гадяцьким договором.
   pos: с.


### PR DESCRIPTION
## Summary
- Add Ukrainian-only learner `readings:` packets for six Cossack/Ruin BIO plans: `dmytro-hunia`, `bohdan-khmelnytskyy`, `ivan-bohun`, `martyn-pushkar`, `ivan-vyhovskyi`, `yuriy-nemyrych`.
- Keep changes scoped to plan YAML only with version bumps.
- Leave `wiki/figures/*.sources.yaml` untouched; learner readings remain plan-level per #4400.

## Verification
- Worker parsed all six YAML files with `.venv/bin/python` + PyYAML.
- Orchestrator verified branch diff scope and `X-Agent` trailer.

## Review
- AGY/Gemini-authored; needs independent non-AGY review before merge.
- LLM-QG and Gemma/OpenRouter were not used.

Refs #4431, #4400, #4215
