### PR TITLE
bio: add learner readings for Hetmanate autonomy batch 09

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/danylo-apostol.yaml
+++ b/curriculum/l2-uk-en/plans/bio/danylo-apostol.yaml
@@ -79,6 +79,14 @@ persona:
   role: Аналітик державних інституцій Гетьманщини, що оцінює спадщину Апостола через призму інституційної стійкості та компромісів.
   voice: Institutional-Historian
 phase: BIO.3
+readings:
+- hosting: link-only
+  language: uk
+  note: Біографічна довідка про гетьмана Данила Апостола, його реформи та політичний курс.
+  source_name: Енциклопедія історії України (Інститут історії України НАНУ)
+  source_type: encyclopedia
+  source_url: http://www.history.org.ua/?termin=Apostol_D
+  title: Апостол Данило Павлович
 references:
 - title: Danylo Apostol
   note: Compiled from Horobets, Smoliy — Apostol's reforms and legacy
@@ -98,7 +106,7 @@ sequence: 52
 slug: danylo-apostol
 subtitle: 'The Hetmanate''s Pragmatist: Reform and Compromise'
 title: 'Данило Апостол: Останній обраний гетьман'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: затверджений імператором Петром II документ, що регламентував становище Гетьманщини та повноваження гетьмана
   pos: ч. (мн.)

--- a/curriculum/l2-uk-en/plans/bio/kost-hordiyenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/kost-hordiyenko.yaml
@@ -78,6 +78,14 @@ persona:
   role: Модератор семінару, що ставить під сумнів романтичні міфи та фокусується на політичних розрахунках, ціні рішень та довгострокових наслідках.
   voice: Historical-Realist
 phase: BIO.3
+readings:
+- hosting: link-only
+  language: uk
+  note: Базова енциклопедична стаття про життєвий шлях, союз із Карлом XII та Іваном Мазепою.
+  source_name: Енциклопедія історії України (Інститут історії України НАНУ)
+  source_type: encyclopedia
+  source_url: http://www.history.org.ua/?termin=Hordiienko_K
+  title: Гордієнко Кость
 references:
 - title: Kost Hordiyenko
   note: Internal wiki compilation on Hordiyenko, his alliance, and the 1710 Constitution.
@@ -97,7 +105,7 @@ sequence: 49
 slug: kost-hordiyenko
 subtitle: The Koshovyi Otaman Who Defied an Empire
 title: 'Кость Гордієнко: Останній Лицар Запорожжя'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: найвища виборна посада у Запорозькій Січі, голова козацького уряду
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/kyrylo-rozumovskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/kyrylo-rozumovskyi.yaml
@@ -82,6 +82,21 @@ persona:
   role: Історик-джерелознавець, що відрізняє джерельну біографію Розумовського від ярликів «вірний вельможа» й «трагічний останній гетьман», тримаючи видимими і його реформи, і станові привілеї, і примусове скасування уряду
   voice: Source-Critical Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  note: Детальна енциклопедична довідка про останнього гетьмана, його судові, економічні та адміністративні реформи.
+  source_name: Енциклопедія історії України (Інститут історії України НАНУ)
+  source_type: encyclopedia
+  source_url: http://www.history.org.ua/?termin=Rozumovskyj_K
+  title: Розумовський Кирило Григорович
+- hosting: link-only
+  language: uk
+  note: Огляд Глухівських рад та чолобитних 1763 року щодо спадковості гетьманства.
+  source_name: Енциклопедія історії України (Інститут історії України НАНУ)
+  source_type: encyclopedia
+  source_url: http://www.history.org.ua/?termin=Glukhivski_rady
+  title: Глухівські ради 1750, 1763
 references:
 - note: 'Стаття ЕІУ (О. Путро): народження й смерть, Лемеші, рід, придворне піднесення, європейська освіта, граф/сенатор/президент академії, гетьманство 1750 року, обмеження 1754-1761 років, реформи, чолобитна 1763 року, усунення 1764 року, пізнє життя в Батурині'
   path: https://www.history.org.ua/?termin=Rozumovskyj_K
@@ -122,7 +137,7 @@ sequence: 53
 slug: kyrylo-rozumovskyi
 subtitle: 'Kyrylo Rozumovskyi: The Hetmanate''s Last Mace'
 title: 'Кирило Розумовський: Остання булава Гетьманщини'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: гетьманський уряд як інституція; його відновили 1750 року й скасували 1764-го
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/pavlo-polubotok.yaml
+++ b/curriculum/l2-uk-en/plans/bio/pavlo-polubotok.yaml
@@ -79,6 +79,14 @@ persona:
   role: Модератор історичного трибуналу, що розглядає "справу Полуботка". Його завдання — через провокативні питання та зіткнення позицій з'ясувати не хто правий, а де правда.
   voice: Legal-Historian-Skeptic
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  note: Енциклопедична біографія наказного гетьмана, його протистояння з Малоросійською колегією та ув'язнення.
+  source_name: Енциклопедія історії України (Інститут історії України НАНУ)
+  source_type: encyclopedia
+  source_url: http://www.history.org.ua/?termin=Polubotok_P
+  title: Полуботок Павло Леонтійович
 references:
 - title: Павло Полуботок (Wikipedia UA)
   name: Павло Полуботок (Wikipedia UA)
@@ -99,7 +107,7 @@ sequence: 51
 slug: pavlo-polubotok
 subtitle: Символ опору чи прагматичний провал?
 title: 'Павло Полуботок: Мученик за автономію'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: особа, що тимчасово виконує обов''язки гетьмана
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/petro-kalnyshevskyy.yaml
+++ b/curriculum/l2-uk-en/plans/bio/petro-kalnyshevskyy.yaml
@@ -79,6 +79,14 @@ persona:
   role: Модератор семінару, що спонукає студентів аналізувати першоджерела та ставити під сумнів офіційні та героїзовані версії історії
   voice: Archivist-Skeptic
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  note: Енциклопедична стаття про останнього кошового отамана Запорозької Січі та його долю після її ліквідації.
+  source_name: Енциклопедія історії України (Інститут історії України НАНУ)
+  source_type: encyclopedia
+  source_url: http://www.history.org.ua/?termin=Kalnyshevskyj_P
+  title: Калнишевський Петро Іванович
 references:
 - title: Petro Kalnyshevskyy
   note: 'Збірна довідка: біографія, ліквідація Січі, ув''язнення, канонізація'
@@ -98,7 +106,7 @@ sequence: 54
 slug: petro-kalnyshevskyy
 subtitle: 'The Last Koshovyi: Prosperity, Surrender, and Martyrdom'
 title: 'Петро Калнишевський: Останній кошовий'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: найвища виборна посада у Запорозькій Січі, голова козацького уряду
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/pylyp-orlyk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/pylyp-orlyk.yaml
@@ -79,6 +79,21 @@ pedagogy: CBI
 persona:
   role: Модератор семінару, що ставить під сумнів офіційні наративи та змушує шукати глибші причини й наслідки
   voice: Senior-Biographer-Skeptic
+readings:
+- hosting: link-only
+  language: uk
+  note: Детальна стаття про життя, діяльність в еміграції та політичну спадщину гетьмана.
+  source_name: Енциклопедія історії України (Інститут історії України НАНУ)
+  source_type: encyclopedia
+  source_url: http://www.history.org.ua/?termin=Orlyk_P
+  title: Орлик Пилип Степанович
+- hosting: link-only
+  language: uk
+  note: Огляд конституційного проєкту та політичної угоди Пилипа Орлика зі старшиною.
+  source_name: Енциклопедія історії України (Інститут історії України НАНУ)
+  source_type: encyclopedia
+  source_url: http://www.history.org.ua/?termin=Pakty_i_konstytutsii_1710
+  title: Пакти і Конституції прав і вольностей Війська Запорозького 1710
 references:
 - title: Пилип Орлик
   note: Біографія, Конституція 1710 року, еміграція
@@ -97,7 +112,7 @@ sequence: 50
 slug: pylyp-orlyk
 subtitle: 'Pylyp Orlyk: Author of the First Ukrainian Constitution'
 title: 'Пилип Орлик: Автор першої української конституції'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: основний закон держави, що визначає її устрій, права та обов'язки громадян
   pos: ж.


### PR DESCRIPTION
## Summary
- Add Ukrainian-only plan-level learner readings for Kost Hordiyenko, Pylyp Orlyk, Pavlo Polubotok, Danylo Apostol, Kyrylo Rozumovskyi, and Petro Kalnyshevskyy.
- Keep learner readings in top-level plan YAML `readings:` blocks; no wiki citation YAML changes.
- Use link-only Ukrainian EIU/history.org.ua sources with explicit hostability metadata.

## Verification
- Parsed all six changed YAML files with `.venv/bin/python` and `yaml.safe_load`.
- Verified each reading has `language: uk` and explicit hosting metadata.
- Verified `git diff --name-only origin/main...HEAD` contains only the six owned plan YAML files.

LLM-QG and Gemma were not used.
