### PR TITLE
feat(bio): add ukrainian readings for national canon

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/hanna-barvinok.yaml
+++ b/curriculum/l2-uk-en/plans/bio/hanna-barvinok.yaml
@@ -94,7 +94,15 @@ sequence: 63
 slug: hanna-barvinok
 subtitle: A Woman's Voice in the Shadow of an Icon
 title: 'Ганна Барвінок: Письменниця і етнографка'
-version: '4.0'
+readings:
+- hosting: excerpt-only
+  language: uk
+  source_name: "Вікіпедія"
+  source_url: "https://uk.wikipedia.org/wiki/Ганна_Барвінок"
+  task: "Аналіз ролі в збереженні спадщини П. Куліша та власної творчості"
+  title: "Ганна Барвінок"
+  type: encyclopedia
+version: '4.1'
 vocabulary_hints:
 - definition: жінка, що професійно займається літературною творчістю
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/hanna-barvinok.yaml
+++ b/curriculum/l2-uk-en/plans/bio/hanna-barvinok.yaml
@@ -95,14 +95,14 @@ slug: hanna-barvinok
 subtitle: A Woman's Voice in the Shadow of an Icon
 title: 'Ганна Барвінок: Письменниця і етнографка'
 readings:
-- hosting: excerpt-only
+- hosting: link-only
   language: uk
-  source_name: "Вікіпедія"
-  source_url: "https://uk.wikipedia.org/wiki/Ганна_Барвінок"
+  source_name: "Енциклопедія історії України"
+  source_url: "https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Barvinok_H&Z21ID="
   task: "Аналіз ролі в збереженні спадщини П. Куліша та власної творчості"
   title: "Ганна Барвінок"
   type: encyclopedia
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: жінка, що професійно займається літературною творчістю
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/ivan-nechuy-levytskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-nechuy-levytskyi.yaml
@@ -110,14 +110,14 @@ slug: ivan-nechuy-levytskyi
 subtitle: 'Ivan Nechuy-Levytskyi: Master of Ukrainian Realism'
 title: 'Іван Нечуй-Левицький: Майстер українського реалізму'
 readings:
-- hosting: excerpt-only
+- hosting: link-only
   language: uk
-  source_name: "Вікіпедія"
-  source_url: "https://uk.wikipedia.org/wiki/Нечуй-Левицький_Іван_Семенович"
+  source_name: "Велика українська енциклопедія"
+  source_url: "https://vue.gov.ua/%D0%9D%D0%B5%D1%87%D1%83%D0%B9-%D0%9B%D0%B5%D0%B2%D0%B8%D1%86%D1%8C%D0%BA%D0%B8%D0%B9%2C_%D0%86%D0%B2%D0%B0%D0%BD_%D0%A1%D0%B5%D0%BC%D0%B5%D0%BD%D0%BE%D0%B2%D0%B8%D1%87"
   task: "Ознайомлення з біографічними відомостями та творчим доробком"
   title: "Нечуй-Левицький Іван Семенович"
   type: encyclopedia
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: літературний напрям, що ставить за мету правдиве, об'єктивне зображення дійсності
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/ivan-nechuy-levytskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-nechuy-levytskyi.yaml
@@ -109,7 +109,15 @@ sequence: 66
 slug: ivan-nechuy-levytskyi
 subtitle: 'Ivan Nechuy-Levytskyi: Master of Ukrainian Realism'
 title: 'Іван Нечуй-Левицький: Майстер українського реалізму'
-version: '4.0'
+readings:
+- hosting: excerpt-only
+  language: uk
+  source_name: "Вікіпедія"
+  source_url: "https://uk.wikipedia.org/wiki/Нечуй-Левицький_Іван_Семенович"
+  task: "Ознайомлення з біографічними відомостями та творчим доробком"
+  title: "Нечуй-Левицький Іван Семенович"
+  type: encyclopedia
+version: '4.1'
 vocabulary_hints:
 - definition: літературний напрям, що ставить за мету правдиве, об'єктивне зображення дійсності
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/marko-vovchok.yaml
+++ b/curriculum/l2-uk-en/plans/bio/marko-vovchok.yaml
@@ -98,7 +98,15 @@ sequence: 64
 slug: marko-vovchok
 subtitle: From Russian Noblewoman to the Voice of Ukrainian Serfs
 title: 'Марко Вовчок: Голос пригноблених'
-version: '4.0'
+readings:
+- hosting: excerpt-only
+  language: uk
+  source_name: "Вікіпедія"
+  source_url: "https://uk.wikipedia.org/wiki/Марко_Вовчок"
+  task: "Огляд життєвого шляху та впливу на українську літературу"
+  title: "Марко Вовчок"
+  type: encyclopedia
+version: '4.1'
 vocabulary_hints:
 - definition: вигадане ім'я, яке автор використовує замість справжнього
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/marko-vovchok.yaml
+++ b/curriculum/l2-uk-en/plans/bio/marko-vovchok.yaml
@@ -99,14 +99,14 @@ slug: marko-vovchok
 subtitle: From Russian Noblewoman to the Voice of Ukrainian Serfs
 title: 'Марко Вовчок: Голос пригноблених'
 readings:
-- hosting: excerpt-only
+- hosting: link-only
   language: uk
-  source_name: "Вікіпедія"
-  source_url: "https://uk.wikipedia.org/wiki/Марко_Вовчок"
+  source_name: "Енциклопедія історії України"
+  source_url: "https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Vovchok_M&Z21ID="
   task: "Огляд життєвого шляху та впливу на українську літературу"
   title: "Марко Вовчок"
   type: encyclopedia
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: вигадане ім'я, яке автор використовує замість справжнього
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/oleksander-potebnya.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oleksander-potebnya.yaml
@@ -107,14 +107,14 @@ slug: oleksander-potebnya
 subtitle: 'The Ukrainian Humboldt: A Biography of Mind'
 title: 'Олександр Потебня: Філософ мови'
 readings:
-- hosting: excerpt-only
+- hosting: link-only
   language: uk
-  source_name: "Вікіпедія"
-  source_url: "https://uk.wikipedia.org/wiki/Потебня_Олександр_Опанасович"
+  source_name: "Енциклопедія історії України"
+  source_url: "https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=DOP&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Potebnia_O&Z21ID="
   task: "Ознайомлення з філософськими та лінгвістичними поглядами вченого"
   title: "Потебня Олександр Опанасович"
   type: encyclopedia
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: фахівець, що вивчає мову, її структуру та функціонування
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/oleksander-potebnya.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oleksander-potebnya.yaml
@@ -106,7 +106,15 @@ sequence: 65
 slug: oleksander-potebnya
 subtitle: 'The Ukrainian Humboldt: A Biography of Mind'
 title: 'Олександр Потебня: Філософ мови'
-version: '4.0'
+readings:
+- hosting: excerpt-only
+  language: uk
+  source_name: "Вікіпедія"
+  source_url: "https://uk.wikipedia.org/wiki/Потебня_Олександр_Опанасович"
+  task: "Ознайомлення з філософськими та лінгвістичними поглядами вченого"
+  title: "Потебня Олександр Опанасович"
+  type: encyclopedia
+version: '4.1'
 vocabulary_hints:
 - definition: фахівець, що вивчає мову, її структуру та функціонування
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/panteleimon-kulish.yaml
+++ b/curriculum/l2-uk-en/plans/bio/panteleimon-kulish.yaml
@@ -102,14 +102,14 @@ slug: panteleimon-kulish
 subtitle: 'Panteleimon Kulish: The European on the Farmstead'
 title: 'Пантелеймон Куліш: Європеєць на Хуторі'
 readings:
-- hosting: excerpt-only
+- hosting: link-only
   language: uk
-  source_name: "Вікіпедія"
-  source_url: "https://uk.wikipedia.org/wiki/Куліш_Пантелеймон_Олександрович"
-  task: "Ознайомлення з життєписом та етнографічною спадщиною"
+  source_name: "Енциклопедія історії України"
+  source_url: "https://www.history.org.ua/?termin=Kulish_P_O"
+  task: "Ознайомлення з життєписом, правописною та видавничою спадщиною"
   title: "Куліш Пантелеймон Олександрович"
   type: encyclopedia
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: гостра публічна суперечка з наукових, політичних, літературних питань
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/panteleimon-kulish.yaml
+++ b/curriculum/l2-uk-en/plans/bio/panteleimon-kulish.yaml
@@ -101,7 +101,15 @@ sequence: 62
 slug: panteleimon-kulish
 subtitle: 'Panteleimon Kulish: The European on the Farmstead'
 title: 'Пантелеймон Куліш: Європеєць на Хуторі'
-version: '4.0'
+readings:
+- hosting: excerpt-only
+  language: uk
+  source_name: "Вікіпедія"
+  source_url: "https://uk.wikipedia.org/wiki/Куліш_Пантелеймон_Олександрович"
+  task: "Ознайомлення з життєписом та етнографічною спадщиною"
+  title: "Куліш Пантелеймон Олександрович"
+  type: encyclopedia
+version: '4.1'
 vocabulary_hints:
 - definition: гостра публічна суперечка з наукових, політичних, літературних питань
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml
@@ -105,7 +105,15 @@ sequence: 61
 slug: taras-shevchenko
 subtitle: Від кріпака до символу нації — анатомія українського пророка
 title: 'Тарас Шевченко: Національний Пророк'
-version: '4.0'
+readings:
+- hosting: excerpt-only
+  language: uk
+  source_name: "Ізборник"
+  source_url: "http://litopys.org.ua/shevchenko/shev.htm"
+  task: "Огляд ключових етапів життя за хронологією"
+  title: "Тарас Шевченко: Біографія"
+  type: biography
+version: '4.1'
 vocabulary_hints:
 - definition: особисто залежний від пана селянин, фактично раб
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/taras-shevchenko.yaml
@@ -106,14 +106,14 @@ slug: taras-shevchenko
 subtitle: Від кріпака до символу нації — анатомія українського пророка
 title: 'Тарас Шевченко: Національний Пророк'
 readings:
-- hosting: excerpt-only
+- hosting: link-only
   language: uk
-  source_name: "Ізборник"
-  source_url: "http://litopys.org.ua/shevchenko/shev.htm"
-  task: "Огляд ключових етапів життя за хронологією"
-  title: "Тарас Шевченко: Біографія"
-  type: biography
-version: '4.1'
+  source_name: "Велика українська енциклопедія"
+  source_url: "https://vue.gov.ua/%D0%A8%D0%B5%D0%B2%D1%87%D0%B5%D0%BD%D0%BA%D0%BE%2C_%D0%A2%D0%B0%D1%80%D0%B0%D1%81_%D0%93%D1%80%D0%B8%D0%B3%D0%BE%D1%80%D0%BE%D0%B2%D0%B8%D1%87"
+  task: "Огляд ключових етапів життя та антиімперського значення спадщини"
+  title: "Шевченко, Тарас Григорович"
+  type: encyclopedia
+version: '4.2'
 vocabulary_hints:
 - definition: особисто залежний від пана селянин, фактично раб
   pos: ч.


### PR DESCRIPTION
Adds Ukrainian-only learner reading packets for the national-canon BIO batch: taras-shevchenko, panteleimon-kulish, hanna-barvinok, marko-vovchok, oleksander-potebnya, and ivan-nechuy-levytskyi.

Scope: exactly six plan YAML files under curriculum/l2-uk-en/plans/bio. No wiki source registries, generated artifacts, status/audit files, telemetry, or linter config files are included.

Source routing: AGY/Gemini initially added the batch; orchestrator upgraded weak Wikipedia fallbacks to Ukrainian institutional encyclopedia sources where available and bumped versions to 4.2.

Verification run locally:
- YAML/readings validation for all six files
- git diff --check
- scripts/audit/lint_agent_trailer.py

LLM-QG and Gemma were not used. Independent non-AGY review is still required before merge.