### PR TITLE
feat(bio): add ukrainian readings for cossack and civic batch

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/dmytro-vyshnevetsky.yaml
+++ b/curriculum/l2-uk-en/plans/bio/dmytro-vyshnevetsky.yaml
@@ -80,19 +80,19 @@ persona:
 phase: BIO
 readings:
 - title: "Вишневецький Дмитро Іванович"
-  source_name: "Енциклопедія історії України"
-  source_url: "https://www.history.org.ua/?termin=Vyshnevetskyi_D"
+  source: "Енциклопедія історії України"
+  url: "https://www.history.org.ua/?termin=Vyshnevetskyi_D"
   language: uk
-  type: "encyclopedia_entry"
-  clearance: "public_domain"
-  notes: "Аналіз реальної політичної і військової діяльності засновника Хортицької фортеці."
+  type: encyclopedia
+  hosting: link-only
+  task: "Прочитайте про діяльність Вишневецького на Хортиці та спробуйте визначити його мотиви."
 - title: "Пісня про Байду"
-  source_name: "Українські народні думи та пісні"
-  source_url: "https://litopys.org.ua/dumy/dum44.htm"
+  source: "Ізборник"
+  url: "https://litopys.org.ua/dumy/dum44.htm"
   language: uk
-  type: "folk_song"
-  clearance: "public_domain"
-  notes: "Фольклорне джерело для порівняння міфу з історичними реаліями."
+  type: primary_text
+  hosting: excerpt-only
+  task: "Проаналізуйте фольклорний образ Байди: які риси характеру підкреслює народна пісня?"
 references:
 - title: Dmytro Vyshnevetsky
   note: Compiled research notes on Vyshnevetsky, covering both historical facts and folkloric interpretations.
@@ -112,7 +112,7 @@ sequence: 16
 slug: dmytro-vyshnevetsky
 subtitle: 'Dmytro Vyshnevetsky: Baida — The First Hetman'
 title: 'Дмитро Вишневецький: Байда — Перший Гетьман'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: укріплений військовий табір козаків, адміністративний і військовий центр
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/marko-kropyvnytskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/marko-kropyvnytskyi.yaml
@@ -79,6 +79,21 @@ persona:
   role: Модератор семінару, що ставить під сумнів усталені міфи про «батька театру» і показує його як складну, авторитарну, але геніальну постать
   voice: Theatre-Historian-Realist
 phase: BIO.2
+readings:
+- title: "Кропивницький Марко Лукич"
+  source: "Енциклопедія історії України"
+  url: "https://www.history.org.ua/?termin=Kropyvnytsky_M"
+  language: uk
+  type: encyclopedia
+  hosting: link-only
+  task: "Прочитайте статтю і зверніть увагу на організаційну роль Кропивницького у створенні професійного театру."
+- title: "Марко Кропивницький"
+  source: "Велика українська енциклопедія"
+  url: "https://vue.gov.ua/Кропивницький,_Марко_Лукич"
+  language: uk
+  type: encyclopedia
+  hosting: link-only
+  task: "Знайдіть інформацію про режисерські новації Кропивницького та його роботу з акторами."
 references:
 - title: Marko Kropyvnytskyi
   note: Базова біографія, перелік творів, дані про Театр корифеїв. Зібрано з uk.wikipedia.org та академічних джерел.
@@ -98,7 +113,7 @@ sequence: 67
 slug: marko-kropyvnytskyi
 subtitle: The Man Who Was the Theatre
 title: 'Марко Кропивницький: Батько чи Диктатор Театру?'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: провідний діяч у певній галузі мистецтва або науки; засновник нового напряму
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/mykhailo-drahomanov.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykhailo-drahomanov.yaml
@@ -80,6 +80,21 @@ persona:
   role: Модератор семінару, який ставить під сумнів канонічний образ Драгоманова, змушуючи студентів бачити не ікону, а живу людину з її протиріччями та помилками.
   voice: Drahomanov-Skeptic
 phase: BIO
+readings:
+- title: "Драгоманов Михайло Петрович"
+  source: "Енциклопедія історії України"
+  url: "https://www.history.org.ua/?termin=Dragomanov_M"
+  language: uk
+  type: encyclopedia
+  hosting: link-only
+  task: "Знайдіть інформацію про еміграційний період життя Драгоманова. Як він продовжував впливати на український рух із-за кордону?"
+- title: "Михайло Драгоманов"
+  source: "Велика українська енциклопедія"
+  url: "https://vue.gov.ua/Драгоманов,_Михайло_Петрович"
+  language: uk
+  type: encyclopedia
+  hosting: link-only
+  task: "Прочитайте про основні політичні погляди мислителя. Що означала його концепція федералізму?"
 references:
 - title: Mykhailo Drahomanov
   note: Біографія, політичні погляди, вплив на культуру, зібрані з відкритих джерел (Wikipedia, праці істориків).
@@ -99,7 +114,7 @@ sequence: 69
 slug: mykhailo-drahomanov
 subtitle: 'Mykhailo Drahomanov: Architect of a European Ukraine'
 title: 'Михайло Драгоманов: Архітектор європейської України'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: політична концепція, що обстоює об'єднання окремих державних утворень в єдину федеративну державу з високим ступенем їхньої самостійності
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/mykhailo-starytsky.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykhailo-starytsky.yaml
@@ -78,6 +78,21 @@ persona:
   role: Модератор семінару, що ставить під сумнів усталені міфи про «батька театру» і показує його як прагматичного менеджера в екстремальних умовах
   voice: Starytsky-Skeptic
 phase: BIO
+readings:
+- title: "Старицький Михайло Петрович"
+  source: "Енциклопедія історії України"
+  url: "https://www.history.org.ua/?termin=Starytskyj_M"
+  language: uk
+  type: encyclopedia
+  hosting: link-only
+  task: "Прочитайте про внесок Старицького у формування репертуару українського театру."
+- title: "«За двома зайцями»"
+  source: "УкрЛіб"
+  url: "https://www.ukrlib.com.ua/books/printit.php?tid=1086"
+  language: uk
+  type: primary_text
+  hosting: excerpt-only
+  task: "Ознайомтеся з уривком п'єси. Як драматург використовує мовну характеристику (суржик) для створення комічного ефекту?"
 references:
 - title: Mykhailo Starytsky
   note: Основа біографії, з якої витягнуто ключові факти та дати.
@@ -92,7 +107,7 @@ sequence: 68
 slug: mykhailo-starytsky
 subtitle: Як збудувати національну сцену всупереч імперії
 title: 'Михайло Старицький: Корифей українського театру'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: провідний, видатний діяч у певній галузі науки, мистецтва, літератури
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/pavlo-pavliuk-but.yaml
+++ b/curriculum/l2-uk-en/plans/bio/pavlo-pavliuk-but.yaml
@@ -81,26 +81,26 @@ persona:
 phase: BIO
 readings:
 - title: "Бут (Павлюк) Павло Михнович"
-  source_name: "Енциклопедія історії України"
-  source_url: "https://www.history.org.ua/?termin=But_P"
+  source: "Енциклопедія історії України"
+  url: "https://www.history.org.ua/?termin=But_P"
   language: uk
-  type: "encyclopedia_entry"
-  clearance: "public_domain"
-  notes: "Енциклопедична довідка про обрання Павлюка та його походи."
+  type: encyclopedia
+  hosting: link-only
+  task: "Прочитайте довідку та виділіть ключові етапи військової кар'єри Павлюка."
 - title: "Павлюка повстання 1637"
-  source_name: "Енциклопедія історії України"
-  source_url: "https://www.history.org.ua/?termin=Pavliuka_povstannia_1637"
+  source: "Енциклопедія історії України"
+  url: "https://www.history.org.ua/?termin=Pavliuka_povstannia_1637"
   language: uk
-  type: "encyclopedia_entry"
-  clearance: "public_domain"
-  notes: "Детальний опис перебігу повстання, битви під Кумейками та конфлікту з реєстровими козаками."
+  type: encyclopedia
+  hosting: link-only
+  task: "Знайдіть, які саме вимоги висували повстанці у своїх універсалах."
 - title: "Кумейки, битва 1637"
-  source_name: "Енциклопедія історії України"
-  source_url: "https://www.history.org.ua/?termin=Kumeiki_Bitva_1637"
+  source: "Енциклопедія історії України"
+  url: "https://www.history.org.ua/?termin=Kumeiki_Bitva_1637"
   language: uk
-  type: "encyclopedia_entry"
-  clearance: "public_domain"
-  notes: "Опис битви під Кумейками: розгром козацького табору та брак підтримки."
+  type: encyclopedia
+  hosting: link-only
+  task: "Ознайомтеся з перебігом битви. Що стало головною причиною поразки козацького війська?"
 references:
 - note: 'Стаття ЕІУ (В. Щербак): походи, участь у повстанні Сулими 1635 року, обрання 1637, страта у Варшаві'
   path: https://www.history.org.ua/?termin=But_P
@@ -127,7 +127,7 @@ sequence: 29
 slug: pavlo-pavliuk-but
 subtitle: 'Pavlo Pavliuk (But): The 1637 Uprising'
 title: 'Павло Павлюк (Бут): Повстання 1637 року'
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: офіційний список козаків на службі корони; поза ним статус козака був напівлегальним
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/yakiv-ostrianyn.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yakiv-ostrianyn.yaml
@@ -81,26 +81,26 @@ persona:
 phase: BIO
 readings:
 - title: "Острянин Яків"
-  source_name: "Енциклопедія історії України"
-  source_url: "https://www.history.org.ua/?termin=Ostrianyn_Y"
+  source: "Енциклопедія історії України"
+  url: "https://www.history.org.ua/?termin=Ostrianyn_Y"
   language: uk
-  type: "encyclopedia_entry"
-  clearance: "public_domain"
-  notes: "Енциклопедична довідка про полковника, його роль у подіях 1638 року та перехід на Слобідську Україну."
+  type: encyclopedia
+  hosting: link-only
+  task: "Прочитайте біографічну статтю. Як пояснюється рішення Острянина перейти на територію Московського царства?"
 - title: "Говтва, битва 1638"
-  source_name: "Енциклопедія історії України"
-  source_url: "https://www.history.org.ua/?termin=Govtva_bytva_1638"
+  source: "Енциклопедія історії України"
+  url: "https://www.history.org.ua/?termin=Govtva_bytva_1638"
   language: uk
-  type: "encyclopedia_entry"
-  clearance: "public_domain"
-  notes: "Аналіз тактичної перемоги повстанців: географія, укріплення, застосування артилерії."
+  type: encyclopedia
+  hosting: link-only
+  task: "Проаналізуйте тактику козаків під Говтвою. Як вони використали рельєф місцевості?"
 - title: "Жовнинська битва 1638"
-  source_name: "Енциклопедія історії України"
-  source_url: "https://www.history.org.ua/?termin=Zhovnynska_bytva_1638"
+  source: "Енциклопедія історії України"
+  url: "https://www.history.org.ua/?termin=Zhovnynska_bytva_1638"
   language: uk
-  type: "encyclopedia_entry"
-  clearance: "public_domain"
-  notes: "Опис табору над Сулою, відходу Острянина та обрання Гуні."
+  type: encyclopedia
+  hosting: link-only
+  task: "Ознайомтеся з подіями Жовнинської битви. Оцініть наслідки відступу Острянина для загального перебігу повстання."
 references:
 - note: 'Стаття ЕІУ (В. Щербак): реєстровий полковник 1633 року, гетьман 1638 року, Говтва, Жовнин, Чугуїв'
   path: https://www.history.org.ua/?termin=Ostrianyn_Y
@@ -127,7 +127,7 @@ sequence: 30
 slug: yakiv-ostrianyn
 subtitle: 'Yakiv Ostrianyn: A Won Battle and a Lost Campaign'
 title: 'Яків Острянин: Перемога під Говтвою і поразка кампанії'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: командир козацького полку; Острянин почав як полковник реєстрового війська
   pos: ч.


### PR DESCRIPTION
Adds Ukrainian-only learner reading packets for six BIO plans: dmytro-vyshnevetsky, pavlo-pavliuk-but, yakiv-ostrianyn, marko-kropyvnytskyi, mykhailo-starytsky, and mykhailo-drahomanov.

Scope: exactly six plan YAML files under curriculum/l2-uk-en/plans/bio. No wiki source registries, generated artifacts, status/audit files, telemetry, or linter config files are included.

Verification run locally:
- YAML/readings validation for all six files
- git diff --check
- scripts/audit/lint_agent_trailer.py

LLM-QG and Gemma were not used. Independent non-AGY review is still required before merge.