### PR TITLE
fix(bridge): #4473 regression — relative routing_guard import unbreaks opencode lanes for script-path invocation

### DIFF
--- a/scripts/ai_agent_bridge/_opencode.py
+++ b/scripts/ai_agent_bridge/_opencode.py
@@ -397,7 +397,12 @@ def _run_opencode(
     :func:`_invoke_opencode_detailed` (text + tool telemetry) so the argv
     construction, timeout, and error handling live in exactly one place.
     """
-    from scripts.ai_agent_bridge.routing_guard import assert_model_routing_allowed
+    # Relative import: script-path invocation (python scripts/ai_agent_bridge/
+    # __main__.py, the documented form) puts scripts/ on sys.path, so the
+    # package is `ai_agent_bridge` — an absolute `scripts.` self-import breaks
+    # every opencode-routed lane there (#4473 regression; _hermes.py already
+    # uses the relative form).
+    from .routing_guard import assert_model_routing_allowed
 
     assert_model_routing_allowed(model, context="opencode transport (_run_opencode)")
     opencode_bin = shutil.which("opencode")

--- a/tests/test_ask_opencode.py
+++ b/tests/test_ask_opencode.py
@@ -46,3 +46,59 @@ def test_invoke_opencode_raises_when_binary_missing():
     with patch("scripts.ai_agent_bridge._opencode.shutil.which", return_value=None):
         with pytest.raises(SystemExit, match="opencode CLI not found"):
             _invoke_opencode("hello", "openrouter/google/gemma-4-31b-it")
+
+
+def test_no_absolute_scripts_self_imports_in_bridge_package():
+    """Script-path invocation (`python scripts/ai_agent_bridge/__main__.py`,
+    the documented CLI form) puts scripts/ — not the repo root — on sys.path,
+    so the package is importable only as `ai_agent_bridge`. An absolute
+    `scripts.ai_agent_bridge` self-import inside the package therefore breaks
+    every lane whose module does it (#4473's lazy routing_guard import in
+    _opencode.py killed pool/glm/gemma for script-path callers)."""
+    import re
+    from pathlib import Path
+
+    pkg = Path(__file__).resolve().parent.parent / "scripts" / "ai_agent_bridge"
+    offenders = []
+    for path in sorted(pkg.rglob("*.py")):
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if re.match(r"\s*(from|import)\s+scripts\.ai_agent_bridge", line):
+                offenders.append(f"{path.name}:{lineno}")
+    assert offenders == [], (
+        f"absolute scripts.* self-imports break script-path invocation: {offenders}"
+    )
+
+
+def test_run_opencode_lazy_import_resolves_under_script_path_invocation():
+    """End-to-end repro of the #4473 regression: load the package exactly the
+    way the documented CLI form does (ONLY scripts/ on sys.path, repo root
+    absent) and drive _run_opencode far enough to execute its lazy
+    routing_guard import. Pre-fix: ModuleNotFoundError. Post-fix: the import
+    resolves and the stubbed missing-binary SystemExit fires."""
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parent.parent
+    probe = (
+        "import sys\n"
+        "sys.path[:] = [p for p in sys.path if p not in ('', '.')]\n"
+        f"sys.path.insert(0, {str(repo_root / 'scripts')!r})\n"
+        "from ai_agent_bridge import _opencode\n"
+        "import shutil\n"
+        "shutil.which = lambda _n: None\n"
+        "try:\n"
+        "    _opencode._run_opencode('hi', 'openrouter/google/gemma-4-31b-it')\n"
+        "except SystemExit:\n"
+        "    print('LAZY-IMPORT-OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        cwd=str(repo_root / "tests"),  # anywhere that is NOT the repo root
+        timeout=60,
+    )
+    assert "LAZY-IMPORT-OK" in result.stdout, (
+        f"stdout={result.stdout!r} stderr={result.stderr[-800:]!r}"
+    )


### PR DESCRIPTION
## Root cause
#4473 added a lazy `from scripts.ai_agent_bridge.routing_guard import …` inside `_run_opencode`. The **documented** bridge invocation (`python scripts/ai_agent_bridge/__main__.py …`, per CLAUDE.md) puts `scripts/` on sys.path — the package loads as `ai_agent_bridge`, the absolute `scripts.` self-import can never resolve, and every opencode-routed lane (pool / glm / gemma) dies with `ModuleNotFoundError`. CI never caught it because pytest runs with the repo root importable. Hit live twice this session (task `review-4512-union-commit` r1/r2).

## Fix
The relative import `_hermes.py` already uses (`from .routing_guard import …`) — works in both invocation modes.

## Evidence (#M-4)
- New subprocess repro test loads the package script-style (repo root stripped from sys.path) and drives the lazy import: **fails pre-fix** (`ModuleNotFoundError`), passes post-fix — verified both ways via stash.
- New package-wide guard: no `scripts.ai_agent_bridge` self-imports anywhere in the package (kills the regression class).
- `tests/test_ask_opencode.py`: 6 passed. `ruff`: clean.

Workaround meanwhile: `python -m scripts.ai_agent_bridge …` from the repo root.

**NO auto-merge** — main promotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)