### PR TITLE
feat(bio): add ukrainian readings for cultural institutions

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/ivan-puliui.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-puliui.yaml
@@ -74,6 +74,14 @@ persona:
   role: Арбітр у науковому дебаті, що виважує докази пріоритету та реалії наукової політики XIX ст.
   voice: Science-Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  source: Велика українська енциклопедія
+  task: Ознайомтеся з біографією винахідника та його внеском у відкриття рентгенівських променів.
+  title: Пулюй, Іван Павлович
+  type: article
+  url: https://vue.gov.ua/Пулюй,_Іван_Павлович
 references:
 - title: Ivan Puliui
   note: Compiled from Wikipedia, puliui.org.ua, historical physics journals
@@ -98,7 +106,7 @@ sequence: 71
 slug: ivan-puliui
 subtitle: The Physicist Who Saw the Invisible and Translated the Sacred
 title: 'Іван Пулюй: Світло і тінь першовідкривача'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: першість у якому-небудь відкритті, винаході; переважне право або значення
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/mariya-pavlova.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mariya-pavlova.yaml
@@ -82,11 +82,11 @@ phase: BIO
 readings:
 - hosting: link-only
   language: uk
-  source: Вікіпедія
-  task: "Прочитайте про першу жінку-палеонтолога (Примітка: використано Вікіпедію як резервне джерело)."
+  source: Енциклопедія Сучасної України
+  task: "Прочитайте академічну довідку про палеонтологічну працю Павлової та її шлях у науку."
   title: Павлова Марія Василівна
   type: article
-  url: https://uk.wikipedia.org/wiki/Павлова_Марія_Василівна
+  url: https://esu.com.ua/article-879600
 references:
 - title: Mariya Pavlova
   note: Compiled research notes for the module, including timelines and key publications.
@@ -106,7 +106,7 @@ sequence: 73
 slug: mariya-pavlova
 subtitle: 'Mariya Pavlova: The Woman Who Read Bones'
 title: 'Марія Павлова: Жінка, що читала кістки'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: наука, що вивчає вимерлі організми, їхні сліди та скам'янілі рештки
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/mariya-pavlova.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mariya-pavlova.yaml
@@ -79,6 +79,14 @@ persona:
   role: Модератор семінару, що проблематизує усталені біографії, виявляє приховані конфлікти та змушує бачити за "іконою" складну людську долю.
   voice: Nuanced-Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  source: Вікіпедія
+  task: "Прочитайте про першу жінку-палеонтолога (Примітка: використано Вікіпедію як резервне джерело)."
+  title: Павлова Марія Василівна
+  type: article
+  url: https://uk.wikipedia.org/wiki/Павлова_Марія_Василівна
 references:
 - title: Mariya Pavlova
   note: Compiled research notes for the module, including timelines and key publications.
@@ -98,7 +106,7 @@ sequence: 73
 slug: mariya-pavlova
 subtitle: 'Mariya Pavlova: The Woman Who Read Bones'
 title: 'Марія Павлова: Жінка, що читала кістки'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: наука, що вивчає вимерлі організми, їхні сліди та скам'янілі рештки
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/mariya-zankovetska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mariya-zankovetska.yaml
@@ -83,11 +83,11 @@ phase: BIO.2
 readings:
 - hosting: link-only
   language: uk
-  source: Вікіпедія
-  task: "Ознайомтеся з театральною діяльністю видатної української актриси (Примітка: використано Вікіпедію як резервне джерело)."
+  source: Енциклопедія Сучасної України
+  task: "Ознайомтеся з театральною діяльністю Заньковецької та її роллю в українській сцені."
   title: Заньковецька Марія Костянтинівна
   type: article
-  url: https://uk.wikipedia.org/wiki/Заньковецька_Марія_Костянтинівна
+  url: https://esu.com.ua/article-14895
 references:
 - title: Mariya Zankovetska
   note: 'Збірна довідка: біографія, театральна кар''єра, відмова від імператорської сцени, вплив на культуру.'
@@ -106,7 +106,7 @@ sequence: 74
 slug: mariya-zankovetska
 subtitle: The First Lady of the Ukrainian Stage
 title: 'Марія Заньковецька: Перша леді сцени'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: тип ролей, що відповідають сценічним даним актора
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/mariya-zankovetska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mariya-zankovetska.yaml
@@ -80,6 +80,14 @@ persona:
   role: Модератор семінару, що ставить під сумнів глянцевий образ «королеви сцени» і показує ціну її вибору.
   voice: Senior-Biographer-Skeptic
 phase: BIO.2
+readings:
+- hosting: link-only
+  language: uk
+  source: Вікіпедія
+  task: "Ознайомтеся з театральною діяльністю видатної української актриси (Примітка: використано Вікіпедію як резервне джерело)."
+  title: Заньковецька Марія Костянтинівна
+  type: article
+  url: https://uk.wikipedia.org/wiki/Заньковецька_Марія_Костянтинівна
 references:
 - title: Mariya Zankovetska
   note: 'Збірна довідка: біографія, театральна кар''єра, відмова від імператорської сцени, вплив на культуру.'
@@ -98,7 +106,7 @@ sequence: 74
 slug: mariya-zankovetska
 subtitle: The First Lady of the Ukrainian Stage
 title: 'Марія Заньковецька: Перша леді сцени'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: тип ролей, що відповідають сценічним даним актора
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykola-lysenko.yaml
@@ -88,6 +88,14 @@ persona:
   role: Модератор дискусії про межі національного в мистецтві, що ставить під сумнів усталені епітети на кшталт "батько нації"
   voice: Critical-Musicologist
 phase: BIO.4
+readings:
+- hosting: link-only
+  language: uk
+  source: Велика українська енциклопедія
+  task: Прочитайте біографічну статтю та зверніть увагу на його етнографічні експедиції.
+  title: Лисенко, Микола Віталійович
+  type: article
+  url: https://vue.gov.ua/Лисенко,_Микола_Віталійович
 references:
 - title: Mykola Lysenko
   note: Біографія, музична та громадська діяльність, зведення з академічних джерел
@@ -111,7 +119,7 @@ sequence: 70
 slug: mykola-lysenko
 subtitle: 'Mykola Lysenko: The Father of Ukrainian Music'
 title: 'Микола Лисенко: Батько української музики'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: людина, що створює музику; автор музичних творів
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/nataliya-kobrynska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/nataliya-kobrynska.yaml
@@ -80,6 +80,14 @@ persona:
   role: Модератор семінару, що ставить незручні питання про ціну та межі першої хвилі українського фемінізму, проблематизуючи постать «ікони».
   voice: Critical-Sympathizer
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  source: Вікіпедія
+  task: "Зверніть увагу на її роль у заснуванні жіночого руху в Галичині (Примітка: використано Вікіпедію як резервне джерело)."
+  title: Кобринська Наталія Іванівна
+  type: article
+  url: https://uk.wikipedia.org/wiki/Кобринська_Наталія_Іванівна
 references:
 - title: Nataliya Kobrynska
   note: Compiled research notes on Kobrynska, her works, correspondence with Franko, and historiography of the women's movement.
@@ -104,7 +112,7 @@ sequence: 75
 slug: nataliya-kobrynska
 subtitle: The Birth of Ukrainian Feminism
 title: 'Наталія Кобринська: Народження українського фемінізму'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: суспільно-політичний рух, метою якого є досягнення рівних прав для жінок
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/nataliya-kobrynska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/nataliya-kobrynska.yaml
@@ -83,11 +83,11 @@ phase: BIO
 readings:
 - hosting: link-only
   language: uk
-  source: Вікіпедія
-  task: "Зверніть увагу на її роль у заснуванні жіночого руху в Галичині (Примітка: використано Вікіпедію як резервне джерело)."
+  source: Енциклопедія Сучасної України
+  task: "Зверніть увагу на її роль у становленні жіночого руху та літературної модернізації."
   title: Кобринська Наталія Іванівна
   type: article
-  url: https://uk.wikipedia.org/wiki/Кобринська_Наталія_Іванівна
+  url: https://esu.com.ua/article-8894
 references:
 - title: Nataliya Kobrynska
   note: Compiled research notes on Kobrynska, her works, correspondence with Franko, and historiography of the women's movement.
@@ -112,7 +112,7 @@ sequence: 75
 slug: nataliya-kobrynska
 subtitle: The Birth of Ukrainian Feminism
 title: 'Наталія Кобринська: Народження українського фемінізму'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: суспільно-політичний рух, метою якого є досягнення рівних прав для жінок
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/olena-pchilka.yaml
+++ b/curriculum/l2-uk-en/plans/bio/olena-pchilka.yaml
@@ -80,6 +80,14 @@ persona:
   role: Модератор семінару — ставить незручні питання про ціну геніальності та роль жінки в історії
   voice: Feminist-Literary-Critic
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  source: Велика українська енциклопедія
+  task: Зверніть увагу на її етнографічну та видавничу діяльність.
+  title: Пчілка, Олена
+  type: article
+  url: https://vue.gov.ua/Пчілка,_Олена
 references:
 - title: Olena Pchilka
   note: Зібрана біографія, основні дати, ключові твори та конфлікти
@@ -103,7 +111,7 @@ sequence: 72
 slug: olena-pchilka
 subtitle: 'Olena Pchilka: The Matriarch of Ukrainian Modernism'
 title: 'Олена Пчілка: Матріарх українського модернізму'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: жінка, яка є головою роду, родини; шанована, впливова жінка
   pos: ч.


### PR DESCRIPTION
Draft PR for #4400 / #4431. Adds Ukrainian-only learner reading packets for six cultural/institutional BIO plans, with VUE/ESU sources and orchestrator source upgrades for Pavlova, Zankovetska, and Kobrynska. LLM-QG and Gemma were not used. Independent non-AGY review still required before merge.