### PR TITLE
fix(atlas): #4515 — thin-page cap enforced at publish time; per-PR richness gate becomes advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,10 +226,15 @@ jobs:
       - name: Block thin/un-enriched Atlas manifest (#3658)
         run: .venv/bin/python scripts/audit/check_atlas_manifest_enrichment.py
 
-      # Learner-facing static Atlas gate (#3930): no missing English anchors in
-      # search suggestions, and the current thin-page count must not regress
-      # above the release-asset baseline until #3931/#3933/#3934 reduce it.
-      - name: Gate Atlas POC richness and learner anchors (#3930)
+      # Learner-facing static Atlas gate (#3930). ADVISORY since #4515: the
+      # thin-page count is a property of the LIVE release asset, not this PR's
+      # diff — regressions can only enter at publish time, where
+      # scripts/lexicon/publish_manifest.py enforces the same cap
+      # (DEFAULT_MAX_POC_THIN_PAGES in audit_atlas_poc_richness.py) as a hard
+      # ManifestPublishError. Blocking here failed unrelated PRs after the
+      # fact (#4514/#4512, 2026-07-06). Kept for visibility only.
+      - name: Gate Atlas POC richness and learner anchors (#3930, advisory since #4515)
+        continue-on-error: true
         run: |
           .venv/bin/python scripts/audit/audit_atlas_poc_richness.py \
             --max-search-no-visible-gloss 0 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,13 +226,14 @@ jobs:
       - name: Block thin/un-enriched Atlas manifest (#3658)
         run: .venv/bin/python scripts/audit/check_atlas_manifest_enrichment.py
 
-      # Learner-facing static Atlas gate (#3930). ADVISORY since #4515: the
-      # thin-page count is a property of the LIVE release asset, not this PR's
-      # diff — regressions can only enter at publish time, where
-      # scripts/lexicon/publish_manifest.py enforces the same cap
+      # Learner-facing static Atlas gate (#3930). ADVISORY since #4515: all
+      # three caps (gloss, anchor, thin pages) audit the LIVE release asset,
+      # not this PR's diff — regressions can only enter at publish time, where
+      # scripts/lexicon/publish_manifest.py enforces the thin-page cap
       # (DEFAULT_MAX_POC_THIN_PAGES in audit_atlas_poc_richness.py) as a hard
-      # ManifestPublishError. Blocking here failed unrelated PRs after the
-      # fact (#4514/#4512, 2026-07-06). Kept for visibility only.
+      # ManifestPublishError; anchor/gloss caps are held at 0 by the same
+      # publish flow. Blocking here failed unrelated PRs after the fact
+      # (#4514/#4512, 2026-07-06). Kept for visibility only.
       - name: Gate Atlas POC richness and learner anchors (#3930, advisory since #4515)
         continue-on-error: true
         run: |

--- a/scripts/audit/audit_atlas_poc_richness.py
+++ b/scripts/audit/audit_atlas_poc_richness.py
@@ -21,6 +21,12 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
 
+# #4515: the BINDING thin-page cap. Enforced hard at publish time
+# (scripts/lexicon/publish_manifest.py) — the per-PR CI step reports the same
+# number advisorily. Raising this value is threshold-lowering and needs an
+# operator decision; the aligned fix is enriching thin pages before publish.
+DEFAULT_MAX_POC_THIN_PAGES = 900
+
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))

--- a/scripts/lexicon/publish_manifest.py
+++ b/scripts/lexicon/publish_manifest.py
@@ -304,9 +304,10 @@ def assert_manifest_richness_publishable(
         raise ManifestPublishError(
             f"publish blocked (#4515): manifest at {manifest_path} has {thin} thin "
             f"POC pages (> cap {cap}). Enrich the thin entries before publishing "
-            f"(list them: scripts/audit/audit_atlas_poc_richness.py --format json; "
-            f"fill via enrich_entry / the fill recipe), then re-run. The cap has "
-            f"no publish-time override by design."
+            f"(entry list: scripts/audit/audit_atlas_poc_richness.py --format tsv; "
+            f"machine-readable: --format json --limit 2000; fill via enrich_entry / "
+            f"the fill recipe), then re-run. The cap has no publish-time override "
+            f"by design."
         )
     return summary
 

--- a/scripts/lexicon/publish_manifest.py
+++ b/scripts/lexicon/publish_manifest.py
@@ -277,6 +277,40 @@ def upload_manifest_assets(
     upload_release_asset(gzip_path, asset_name=ASSET_NAME, release_tag=release_tag, repo=repo, clobber=True)
 
 
+def assert_manifest_richness_publishable(
+    manifest_path: Path,
+    *,
+    max_poc_thin_pages: int | None = None,
+) -> dict[str, Any]:
+    """#4515: thin-page regressions can only ENTER at publish time — so the
+    binding cap lives here, not in per-PR CI (which audits the live asset and
+    therefore fails unrelated PRs after the fact; that step is now advisory).
+
+    Raises :class:`ManifestPublishError` with an actionable message when the
+    manifest about to be published carries more thin POC pages than the cap.
+    Runs on dry-run too (preflight should fail the same way the real publish
+    would). There is deliberately NO CLI override — enrich, don't bypass.
+    """
+    from scripts.audit.audit_atlas_poc_richness import (
+        DEFAULT_MAX_POC_THIN_PAGES,
+        audit_manifest,
+    )
+
+    cap = DEFAULT_MAX_POC_THIN_PAGES if max_poc_thin_pages is None else max_poc_thin_pages
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    summary = audit_manifest(manifest)
+    thin = int(summary["poc_thin_pages"])
+    if thin > cap:
+        raise ManifestPublishError(
+            f"publish blocked (#4515): manifest at {manifest_path} has {thin} thin "
+            f"POC pages (> cap {cap}). Enrich the thin entries before publishing "
+            f"(list them: scripts/audit/audit_atlas_poc_richness.py --format json; "
+            f"fill via enrich_entry / the fill recipe), then re-run. The cap has "
+            f"no publish-time override by design."
+        )
+    return summary
+
+
 def publish_manifest(
     *,
     manifest_path: Path = DEFAULT_MANIFEST,
@@ -287,6 +321,7 @@ def publish_manifest(
     repo: str = DEFAULT_REPO,
     dry_run: bool = False,
 ) -> dict[str, Any]:
+    assert_manifest_richness_publishable(manifest_path)
     gzip_manifest(manifest_path, gzip_path)
     pointer = build_pointer_payload(
         manifest_path=manifest_path,

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "49ad543e4e7494f65fb5d89360d595cee4774b6f835e664c3b2d4c11a388ab4b",
+  "fingerprint": "8a91f88c717d7df91eb01176a0db353d3f0dafb8f3fe8c8120b46da39fe88a67",
   "inputs": {
     "lexicon_code": [
       {
@@ -96,7 +96,7 @@
       },
       {
         "path": "scripts/lexicon/publish_manifest.py",
-        "sha256": "9f2bf3446fdce1ce40feb5e9a7045a807a24e832bfb55c05705b87c2ad98479d"
+        "sha256": "0c365639dabd855e3eac29484f8350e0221da07f55836c9a61711af52850ef16"
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "972bff251ba7354a0d49cc20adf472ca294a7a8b16445494125f97f198480290",
+  "fingerprint": "49ad543e4e7494f65fb5d89360d595cee4774b6f835e664c3b2d4c11a388ab4b",
   "inputs": {
     "lexicon_code": [
       {
@@ -96,7 +96,7 @@
       },
       {
         "path": "scripts/lexicon/publish_manifest.py",
-        "sha256": "42f9ba38f59c9a5bb8a96227ae12278bda434df44a2c08b006c3f0deb85855f8"
+        "sha256": "9f2bf3446fdce1ce40feb5e9a7045a807a24e832bfb55c05705b87c2ad98479d"
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",

--- a/tests/test_publish_manifest.py
+++ b/tests/test_publish_manifest.py
@@ -168,3 +168,49 @@ def test_pointer_freshness_guard_fails_on_stale_pointer_fixture() -> None:
 
     with pytest.raises(ManifestPublishError, match="fingerprint is stale"):
         validate_pointer_freshness(pointer, fingerprint)
+
+
+def test_richness_gate_blocks_publish_above_cap(tmp_path: Path, monkeypatch) -> None:
+    """#4515: the binding thin-page cap lives at publish time. A manifest whose
+    audit exceeds the cap must raise ManifestPublishError before any gzip/
+    upload/pointer work happens — on dry-run too (preflight parity)."""
+    import scripts.audit.audit_atlas_poc_richness as richness
+    from scripts.lexicon.publish_manifest import assert_manifest_richness_publishable
+
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    _write_json(manifest_path, {"version": "0.1", "entries": []})
+
+    monkeypatch.setattr(richness, "audit_manifest", lambda m: {"poc_thin_pages": 901})
+
+    with pytest.raises(ManifestPublishError, match=r"publish blocked \(#4515\).*901"):
+        assert_manifest_richness_publishable(manifest_path, max_poc_thin_pages=900)
+
+    # Wired into publish_manifest itself (cap from DEFAULT_MAX_POC_THIN_PAGES=900),
+    # and dry_run does NOT bypass it.
+    gzip_calls: list[Path] = []
+    monkeypatch.setattr(
+        "scripts.lexicon.publish_manifest.gzip_manifest",
+        lambda mp, gp: gzip_calls.append(mp),
+    )
+    with pytest.raises(ManifestPublishError, match=r"publish blocked \(#4515\)"):
+        publish_manifest(
+            manifest_path=manifest_path,
+            gzip_path=tmp_path / "m.json.gz",
+            pointer_path=tmp_path / "pointer.json",
+            fingerprint_path=tmp_path / "fp.json",
+            repo="learn-ukrainian/example",
+            dry_run=True,
+        )
+    assert gzip_calls == [], "gate must fire before any packaging work"
+
+
+def test_richness_gate_passes_at_cap_and_reports_summary(tmp_path: Path, monkeypatch) -> None:
+    import scripts.audit.audit_atlas_poc_richness as richness
+    from scripts.lexicon.publish_manifest import assert_manifest_richness_publishable
+
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    _write_json(manifest_path, {"version": "0.1", "entries": []})
+
+    monkeypatch.setattr(richness, "audit_manifest", lambda m: {"poc_thin_pages": 900})
+    summary = assert_manifest_richness_publishable(manifest_path, max_poc_thin_pages=900)
+    assert summary["poc_thin_pages"] == 900


### PR DESCRIPTION
Half of the user-approved #4515 plan (the enforcement move — option B). The content half (fill thin pages back under 900 — option A) runs separately; probe in flight.

## Why
Thin pages can only increase when a manifest is **published**, but the #3930 cap ran as blocking CI on every `scripts/lexicon`-touching PR and audited the **live release asset** — so after #4432's +270 publish crossed the cap, unrelated PRs (#4514, #4512) went red with zero connection to their diffs.

## What
- `publish_manifest()` now runs `assert_manifest_richness_publishable()` **before any packaging**, dry-run included; above the cap it raises `ManifestPublishError` with an actionable enrich-first message. **No publish-time override by design.**
- Cap has ONE binding source: `DEFAULT_MAX_POC_THIN_PAGES` in the audit module (still 900 — this PR does NOT touch the threshold).
- The per-PR CI step keeps running for visibility, `continue-on-error: true`.

## Evidence (#M-4)
- `tests/test_publish_manifest.py`: **6 passed** (blocks above cap before gzip/upload; dry-run parity; passes at cap).
- Live bite-check, no mocks: gate run against today's real manifest → `publish blocked (#4515): … 950 thin POC pages (> cap 900)` — exactly the state it must catch.
- `ruff`: clean. ci.yml change is comments + `continue-on-error` on a fixed command (no new interpolation).
- Fingerprint sidecar delta = pre-commit freshness hook (fires on scripts/lexicon changes).

**NO auto-merge** — main promotes. Cross-family review requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)