### PR TITLE
feat(audit): #4370 E2/E4 no-bare hardening + measured cost factors

### DIFF
--- a/scripts/audit/llm_reviewer_dispatch.py
+++ b/scripts/audit/llm_reviewer_dispatch.py
@@ -69,6 +69,15 @@ _WIKI_TOOL_MARKERS = ("wikipedia", "wiki")
 _DEEP_READ_WIKI_MODES = {"section", "sections", "extract", "article", "page"}
 _POSITIVE_FACT_CHECK_VERDICTS = frozenset({"CONFIRMED", "REFUTED_BY_CONTRADICTION", "CONTESTED"})
 _ELLIPSIS_RE = re.compile(r"\[…\]|\[\.\.\.\]|…|\.{3,}")
+SCORECARD_COST_BASIS_PATH = "audit/2026-07-05-qg-bakeoff/SCORECARD.md"
+SCORECARD_COST_BASIS_GENERATED_AT = "2026-07-05T22:29:21.234824Z"
+SCORECARD_COST_BASIS = (
+    "measured tooled medians from "
+    f"{SCORECARD_COST_BASIS_PATH} (Generated: {SCORECARD_COST_BASIS_GENERATED_AT}); "
+    "tool_calls/passage median: gemma=4.0, ds-pro=15.5, ds-flash=30.0; "
+    "wall_s observed range=16.499-267.781; soft tool anomaly band=>1.5x observed max; "
+    f"hard tool cap={MAX_REVIEWER_TOOLS}"
+)
 
 _THEATRE_RETRY_REMINDER = """
 
@@ -120,11 +129,45 @@ class ReviewerRoute:
     purpose: str
     input_usd_per_mtok: float
     output_usd_per_mtok: float
+    requires_mcp: bool = False
 
     def asdict(self) -> dict[str, Any]:
         return {
             **asdict(self),
             "bridge_command": list(self.bridge_command),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class MeasuredCostProfile:
+    """Scorecard-measured reviewer cost factors for one model class."""
+
+    label: str
+    input_usd_per_mtok: float
+    output_usd_per_mtok: float
+    observed_tool_call_min: int
+    observed_tool_call_median: float
+    observed_tool_call_max: int
+    observed_wall_s_min: float
+    observed_wall_s_median: float
+    observed_wall_s_max: float
+    pricing_basis: str
+
+    @property
+    def tool_call_anomaly_threshold(self) -> float:
+        return self.observed_tool_call_max * 1.5
+
+    def estimate_fields(self) -> dict[str, Any]:
+        return {
+            "measured_cost_profile": self.label,
+            "estimated_tool_call_median": self.observed_tool_call_median,
+            "observed_tool_call_min": self.observed_tool_call_min,
+            "observed_tool_call_max": self.observed_tool_call_max,
+            "tool_call_anomaly_threshold": self.tool_call_anomaly_threshold,
+            "estimated_wall_s_median": self.observed_wall_s_median,
+            "observed_wall_s_min": self.observed_wall_s_min,
+            "observed_wall_s_max": self.observed_wall_s_max,
+            "pricing_basis": self.pricing_basis,
         }
 
 
@@ -234,6 +277,7 @@ FRONTIER_OPENCODE_ROUTE = ReviewerRoute(
     purpose="Seminar/factual/contested-gold review, grounded via sources MCP over opencode",
     input_usd_per_mtok=0.12,
     output_usd_per_mtok=0.35,
+    requires_mcp=True,
 )
 CLAUDE_SPOT_AUDIT_ROUTE = ReviewerRoute(
     route_name="claude_spot_audit",
@@ -250,6 +294,45 @@ ROUTES: tuple[ReviewerRoute, ...] = (
     FRONTIER_OPENCODE_ROUTE,
     CLAUDE_SPOT_AUDIT_ROUTE,
 )
+
+_MEASURED_COST_PROFILES: dict[str, MeasuredCostProfile] = {
+    "openrouter/google/gemma-4-31b-it": MeasuredCostProfile(
+        label="gemma-4-31b-it",
+        input_usd_per_mtok=0.12,
+        output_usd_per_mtok=0.35,
+        observed_tool_call_min=4,
+        observed_tool_call_median=4.0,
+        observed_tool_call_max=5,
+        observed_wall_s_min=16.499,
+        observed_wall_s_median=34.685,
+        observed_wall_s_max=137.964,
+        pricing_basis="OpenRouter gemma-4-31b-it pin",
+    ),
+    "openrouter/deepseek/deepseek-v4-pro": MeasuredCostProfile(
+        label="deepseek-v4-pro",
+        input_usd_per_mtok=0.435,
+        output_usd_per_mtok=0.87,
+        observed_tool_call_min=10,
+        observed_tool_call_median=15.5,
+        observed_tool_call_max=17,
+        observed_wall_s_min=164.376,
+        observed_wall_s_median=210.8475,
+        observed_wall_s_max=267.781,
+        pricing_basis="DeepSeek API deepseek-v4-pro cache-miss pricing",
+    ),
+    "openrouter/deepseek/deepseek-v4-flash": MeasuredCostProfile(
+        label="deepseek-v4-flash",
+        input_usd_per_mtok=0.14,
+        output_usd_per_mtok=0.28,
+        observed_tool_call_min=15,
+        observed_tool_call_median=30.0,
+        observed_tool_call_max=35,
+        observed_wall_s_min=140.463,
+        observed_wall_s_median=170.207,
+        observed_wall_s_max=238.279,
+        pricing_basis="DeepSeek API deepseek-v4-flash cache-miss pricing",
+    ),
+}
 
 
 def normalize_family(raw: Any) -> str | None:
@@ -294,6 +377,16 @@ def route_for_review(
         # D0). FRONTIER_FACTUAL_ROUTE stays defined for fallback/reference.
         return FRONTIER_OPENCODE_ROUTE
     return GEMMA_SURFACE_ROUTE
+
+
+def assert_mcp_required_for_policy(*, policy_family: str, route: ReviewerRoute) -> None:
+    """Fail closed if a grounded policy resolves to a prompt-only route."""
+
+    if policy_family.strip().lower() == "seminar" and not route.requires_mcp:
+        raise ReviewerRouteError(
+            "seminar live Tier-2 route must require the sources MCP; "
+            f"route={route.route_name!r} reviewer_model_id={route.reviewer_model_id!r}"
+        )
 
 
 def assert_route_allowed(route: ReviewerRoute) -> None:
@@ -351,6 +444,47 @@ def estimate_tokens(text: str) -> int:
     return max(1, round(len(text.encode("utf-8")) / _TOKEN_DIVISOR))
 
 
+def measured_cost_profile_for_model(model_id: str) -> MeasuredCostProfile | None:
+    """Return the scorecard-measured cost profile for a reviewer model id."""
+
+    lowered = model_id.strip().lower()
+    if lowered in _MEASURED_COST_PROFILES:
+        return _MEASURED_COST_PROFILES[lowered]
+    for key, profile in _MEASURED_COST_PROFILES.items():
+        if key.rsplit("/", 1)[-1] in lowered:
+            return profile
+    return None
+
+
+def measured_cost_profile_for_policy(policy_family: str) -> MeasuredCostProfile:
+    """Return the production scorecard profile used by the current policy route."""
+
+    if policy_family.strip().lower() == "seminar":
+        return _MEASURED_COST_PROFILES[FRONTIER_OPENCODE_MODEL_ID]
+    return _MEASURED_COST_PROFILES[GEMMA_MODEL_ID]
+
+
+def measured_estimated_cost_usd(
+    *,
+    prompt_tokens: int,
+    completion_tokens: int,
+    profile: MeasuredCostProfile,
+) -> float:
+    """Estimate token spend using measured model-class pricing."""
+
+    cost = (
+        prompt_tokens * profile.input_usd_per_mtok
+        + completion_tokens * profile.output_usd_per_mtok
+    ) / 1_000_000
+    return round(cost, 6)
+
+
+def measured_cost_basis(profile: MeasuredCostProfile) -> str:
+    """Return the audit basis string attached to every measured estimate."""
+
+    return f"{SCORECARD_COST_BASIS}; profile={profile.label}; pricing={profile.pricing_basis}"
+
+
 def estimate_route_cost(
     prompt: str,
     route: ReviewerRoute,
@@ -362,10 +496,23 @@ def estimate_route_cost(
 
     prompt_tokens = estimate_tokens(prompt)
     estimated_completion_tokens = completion_tokens or (900 if policy_family == "seminar" else 600)
-    cost = (
-        prompt_tokens * route.input_usd_per_mtok
-        + estimated_completion_tokens * route.output_usd_per_mtok
-    ) / 1_000_000
+    profile = measured_cost_profile_for_model(route.reviewer_model_id)
+    if profile is None:
+        cost = (
+            prompt_tokens * route.input_usd_per_mtok
+            + estimated_completion_tokens * route.output_usd_per_mtok
+        ) / 1_000_000
+        estimated_cost_usd = round(cost, 6)
+        measured_fields: dict[str, Any] = {}
+        basis = "route-specific prompt byte estimate; no scorecard profile for reviewer model"
+    else:
+        estimated_cost_usd = measured_estimated_cost_usd(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=estimated_completion_tokens,
+            profile=profile,
+        )
+        measured_fields = profile.estimate_fields()
+        basis = measured_cost_basis(profile)
     return {
         "policy_family": policy_family,
         "route_name": route.route_name,
@@ -374,8 +521,9 @@ def estimate_route_cost(
         "estimated_prompt_tokens": prompt_tokens,
         "estimated_completion_tokens": estimated_completion_tokens,
         "estimated_total_tokens": prompt_tokens + estimated_completion_tokens,
-        "estimated_cost_usd": round(cost, 6),
-        "basis": "route-specific prompt byte estimate; calibrate before broad spend",
+        "estimated_cost_usd": estimated_cost_usd,
+        **measured_fields,
+        "basis": basis,
     }
 
 
@@ -464,7 +612,14 @@ def invoke_bridge_route(route: ReviewerRoute, prompt: str, task_id: str) -> Disp
         # Seminar/factual review MUST be grounded — fail-fast if the sources MCP
         # is not configured + reachable (design D0; step-1 lesson). Browsing +
         # dense tool sweeps run long, so allow a wider timeout than gemma.
-        return _invoke_opencode_reviewer(prompt, route, default_timeout_s=1800, require_mcp=True)
+        if not route.requires_mcp:
+            raise ReviewerRouteError("opencode frontier route must require the sources MCP")
+        return _invoke_opencode_reviewer(
+            prompt,
+            route,
+            default_timeout_s=1800,
+            require_mcp=route.requires_mcp,
+        )
     if route.route_name == FRONTIER_FACTUAL_ROUTE.route_name:
         return _invoke_output_path_bridge(
             route,
@@ -938,6 +1093,31 @@ def enforce_tool_budget(dispatch_meta: Mapping[str, Any]) -> None:
         raise ReviewerDispatchError(
             f"reviewer used {count} tools; hard cap is {MAX_REVIEWER_TOOLS}"
         )
+
+
+def tool_call_anomaly_warning(
+    dispatch_meta: Mapping[str, Any],
+    estimate: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Return a soft telemetry warning when tool use exceeds measured norms."""
+
+    try:
+        threshold = float(estimate.get("tool_call_anomaly_threshold"))
+        observed_max = int(estimate.get("observed_tool_call_max"))
+    except (TypeError, ValueError):
+        return None
+    count = tool_call_count_from_dispatch_meta(dispatch_meta)
+    if count <= threshold:
+        return None
+    return {
+        "kind": "tool_call_anomaly",
+        "severity": "warning",
+        "observed_tool_call_count": count,
+        "observed_tool_call_max": observed_max,
+        "tool_call_anomaly_threshold": threshold,
+        "measured_cost_profile": estimate.get("measured_cost_profile"),
+        "basis": estimate.get("basis"),
+    }
 
 
 def tool_theatre_violation(

--- a/scripts/audit/qg_workflow.py
+++ b/scripts/audit/qg_workflow.py
@@ -698,6 +698,7 @@ def _run_tier2(
             target=target,
             level=level,
             slug=slug,
+            policy_family=policy_family,
             route=route,
             options=options,
         )
@@ -961,6 +962,9 @@ def _run_tier2(
                 "reviewer_family": reviewer_family,
             }
         llm_reviewer_dispatch.enforce_tool_budget(dispatch_meta)
+        telemetry_warning = llm_reviewer_dispatch.tool_call_anomaly_warning(dispatch_meta, estimate)
+        if telemetry_warning is not None:
+            dispatch_meta = {**dispatch_meta, "telemetry_warning": telemetry_warning}
         try:
             parsed_payload = llm_reviewer.parse_and_evaluate_llm_response(
                 response_text,
@@ -1106,6 +1110,7 @@ def _live_reviewer_block(
     target: ReviewTarget,
     level: str,
     slug: str,
+    policy_family: str,
     route: llm_reviewer_dispatch.ReviewerRoute | None,
     options: WorkflowOptions,
 ) -> dict[str, Any] | None:
@@ -1114,6 +1119,10 @@ def _live_reviewer_block(
     if options.dry_run:
         return None
     try:
+        llm_reviewer_dispatch.assert_mcp_required_for_policy(
+            policy_family=policy_family,
+            route=route,
+        )
         lineage = llm_reviewer_dispatch.resolve_author_lineage(
             level=level,
             slug=slug,
@@ -1380,15 +1389,20 @@ def estimate_llm_cost(prompt: str, policy_family: str) -> dict[str, Any]:
 
     prompt_tokens = max(1, len(prompt.encode("utf-8")) // 4)
     completion_tokens = 900 if policy_family == "seminar" else 600
-    per_1k = 0.012 if policy_family == "seminar" else 0.008 if policy_family == "b1_plus" else 0.004
+    profile = llm_reviewer_dispatch.measured_cost_profile_for_policy(policy_family)
     total_tokens = prompt_tokens + completion_tokens
     return {
         "policy_family": policy_family,
         "estimated_prompt_tokens": prompt_tokens,
         "estimated_completion_tokens": completion_tokens,
         "estimated_total_tokens": total_tokens,
-        "estimated_cost_usd": round(total_tokens / 1000.0 * per_1k, 6),
-        "basis": "prompt byte estimate; replace with telemetry median when available",
+        "estimated_cost_usd": llm_reviewer_dispatch.measured_estimated_cost_usd(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            profile=profile,
+        ),
+        **profile.estimate_fields(),
+        "basis": llm_reviewer_dispatch.measured_cost_basis(profile),
     }
 
 

--- a/tests/test_llm_reviewer_dispatch.py
+++ b/tests/test_llm_reviewer_dispatch.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import ast
 import json
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -164,13 +166,57 @@ def test_routing_b1_surface_uses_gemma_and_seminar_uses_tooled_opencode() -> Non
 
     assert b1_route.bridge_command[0] == "ask-gemma"
     assert b1_route.reviewer_model_id == "openrouter/google/gemma-4-31b-it"
+    assert b1_route.requires_mcp is False
     # #2156: seminar/factual now flows through the tooled opencode route, not agy.
     assert seminar_route is llm_reviewer_dispatch.FRONTIER_OPENCODE_ROUTE
     assert seminar_route.route_name == "opencode_frontier"
     assert seminar_route.bridge_command[:2] == ("ask-opencode", "--model")
+    assert seminar_route.requires_mcp is True
     assert factual_route is llm_reviewer_dispatch.FRONTIER_OPENCODE_ROUTE
     # The old agy route stays defined for fallback/reference (not returned).
     assert llm_reviewer_dispatch.FRONTIER_FACTUAL_ROUTE.reviewer_model_id == "gemini-3.1-pro-high"
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected_profile", "median_tools", "max_tools", "median_wall_s"),
+    [
+        ("openrouter/google/gemma-4-31b-it", "gemma-4-31b-it", 4.0, 5, 34.685),
+        ("openrouter/deepseek/deepseek-v4-pro", "deepseek-v4-pro", 15.5, 17, 210.8475),
+        ("openrouter/deepseek/deepseek-v4-flash", "deepseek-v4-flash", 30.0, 35, 170.207),
+    ],
+)
+def test_estimates_attach_scorecard_measured_cost_profiles(
+    model_id: str,
+    expected_profile: str,
+    median_tools: float,
+    max_tools: int,
+    median_wall_s: float,
+) -> None:
+    route = replace(llm_reviewer_dispatch.FRONTIER_OPENCODE_ROUTE, reviewer_model_id=model_id)
+
+    estimate = llm_reviewer_dispatch.estimate_route_cost(
+        "Перевірте фактичні твердження.",
+        route,
+        policy_family="seminar",
+    )
+
+    assert estimate["measured_cost_profile"] == expected_profile
+    assert estimate["estimated_tool_call_median"] == median_tools
+    assert estimate["observed_tool_call_max"] == max_tools
+    assert estimate["tool_call_anomaly_threshold"] == max_tools * 1.5
+    assert estimate["estimated_wall_s_median"] == median_wall_s
+    assert llm_reviewer_dispatch.SCORECARD_COST_BASIS_PATH in estimate["basis"]
+    assert llm_reviewer_dispatch.SCORECARD_COST_BASIS_GENERATED_AT in estimate["basis"]
+    assert estimate["estimated_cost_usd"] > 0
+
+
+def test_qg_workflow_legacy_estimate_uses_scorecard_basis() -> None:
+    estimate = qg_workflow.estimate_llm_cost("Перевірте фактичні твердження.", "seminar")
+
+    assert estimate["measured_cost_profile"] == "gemma-4-31b-it"
+    assert estimate["estimated_tool_call_median"] == 4.0
+    assert llm_reviewer_dispatch.SCORECARD_COST_BASIS_PATH in estimate["basis"]
+    assert "replace with telemetry median" not in estimate["basis"]
 
 
 def test_self_review_hard_fails() -> None:
@@ -658,6 +704,31 @@ def test_offline_vesnianky_fixture_exercises_all_fact_check_verdicts(tmp_path: P
     ]
 
 
+def test_tool_call_anomaly_is_soft_telemetry_warning(tmp_path: Path) -> None:
+    module_dir = _write_module(tmp_path, level="folk", slug="vesnianky")
+    event = _sources_event(output="Веснянки — це весняні обрядові пісні.")
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        return _seminar_result(_fact_response(), (event,), tool_call_count=13)
+
+    record = qg_workflow.review_module(
+        _target(module_dir, level="folk"),
+        options=_seminar_options(),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    tier = _tier(record, 2)
+    assert tier["status"] == "ran"
+    warning = tier["dispatch"]["telemetry_warning"]
+    assert warning["kind"] == "tool_call_anomaly"
+    assert warning["severity"] == "warning"
+    assert warning["observed_tool_call_count"] == 13
+    assert warning["observed_tool_call_max"] == 5
+    assert warning["measured_cost_profile"] == "gemma-4-31b-it"
+    assert record["completion_status"] == "COMPLETE"
+
+
 def test_http_endpoint_responds_true_on_streaming_timeout() -> None:
     # curl on a streaming MCP endpoint exits 28 but still emits %{http_code}=200;
     # liveness must key on the code, not curl's exit status.
@@ -718,6 +789,45 @@ def test_live_single_call_requires_exact_canary(tmp_path: Path) -> None:
 
     assert _tier(record, 2)["status"] == "skipped_canary_required"
     assert record["completion_status"] == "INCOMPLETE"
+    assert calls == 0
+
+
+def test_live_seminar_route_hard_fails_if_mcp_not_required(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_dir = _write_module(tmp_path, level="folk", slug="vesnianky")
+    prompt_only_route = replace(llm_reviewer_dispatch.FRONTIER_OPENCODE_ROUTE, requires_mcp=False)
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        nonlocal calls
+        calls += 1
+        return _seminar_result(_fact_response(), (_sources_event(),))
+
+    monkeypatch.setattr(
+        llm_reviewer_dispatch,
+        "route_for_review",
+        lambda **_kwargs: prompt_only_route,
+    )
+    record = qg_workflow.review_module(
+        _target(module_dir, level="folk"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            live_reviewer=True,
+            author_family="openai",
+            max_cost_usd=1.0,
+            daily_spend_path=tmp_path / "spend.jsonl",
+        ),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    tier = _tier(record, 2)
+    assert tier["status"] == "provider_error"
+    assert tier["reason"] == "disallowed_reviewer_route"
+    assert "sources MCP" in tier["message"]
+    assert record["workflow_verdict"] == "INCOMPLETE"
     assert calls == 0
 
 
@@ -978,6 +1088,58 @@ def test_grounding_matches_ellipsized_excerpt_segments_in_order(ellipsis: str) -
     }
 
     assert llm_reviewer_dispatch._grounding_matches_events(grounding, events) is True
+
+
+def _ast_call_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _ast_string(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def test_no_production_entrypoint_constructs_bare_bakeoff_arm() -> None:
+    root = Path(__file__).resolve().parents[1]
+    bare_entrypoints = {
+        "BARE_ARM",
+        "BOTH_ARM",
+        "build_bare_factcheck_prompt",
+        "invoke_bakeoff_route_bare",
+        "run_one_bare",
+    }
+    violations: list[str] = []
+    source_paths = [
+        *sorted((root / "scripts" / "build").rglob("*.py")),
+        *sorted((root / "scripts" / "audit").rglob("*.py")),
+    ]
+    for path in source_paths:
+        if path.name == "qg_bakeoff.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module in {
+                "scripts.audit.qg_bakeoff",
+                "audit.qg_bakeoff",
+                "qg_bakeoff",
+            }:
+                for alias in node.names:
+                    if alias.name in bare_entrypoints:
+                        violations.append(f"{path.relative_to(root)} imports {alias.name}")
+            elif isinstance(node, ast.Call):
+                call_name = _ast_call_name(node.func)
+                if call_name in bare_entrypoints:
+                    violations.append(f"{path.relative_to(root)} calls {call_name}")
+                for keyword in node.keywords:
+                    if keyword.arg == "arm" and _ast_string(keyword.value) in {"bare", "both"}:
+                        violations.append(f"{path.relative_to(root)} passes arm={_ast_string(keyword.value)!r}")
+
+    assert violations == []
 
 
 def test_grounding_rejects_out_of_order_ellipsized_segments() -> None:


### PR DESCRIPTION
Addresses #4370.

## Summary
- Require live seminar Tier-2 routes to declare `requires_mcp=True` before dispatch, so prompt-only seminar fallback fails closed.
- Replace placeholder QG LLM cost basis with scorecard-measured model profiles from `audit/2026-07-05-qg-bakeoff/SCORECARD.md` (`Generated: 2026-07-05T22:29:21.234824Z`) and add soft telemetry warnings for >1.5x observed tool-call maxima while preserving the hard 40-tool cap.
- Add an AST source-scan regression test proving production `scripts/build` and `scripts/audit` entrypoints do not construct the bakeoff bare arm outside `qg_bakeoff.py`.

## Verification
- `.venv/bin/ruff check scripts/audit/qg_workflow.py scripts/audit/llm_reviewer_dispatch.py tests/test_llm_reviewer_dispatch.py`
- `.venv/bin/pytest tests/test_llm_reviewer_dispatch.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- push hooks: ruff, gitleaks, trailer warning hook

## Independent review
- AGY/Gemini task `review-4370-e2-e4-hardening` returned one finding about possible `route=None` in `_live_reviewer_block`; inspected as false positive because the function returns before the assertion when `route is None`.

No merge by dispatch instruction.
