### PR TITLE
feat(audit): #4370 E6 — Tier-2 circuit breaker, quota preflight, disarm runbook

### DIFF
--- a/docs/projects/ua-eval-harness/tier2-disarm.md
+++ b/docs/projects/ua-eval-harness/tier2-disarm.md
@@ -1,0 +1,58 @@
+# Tier-2 Disarm Procedure
+
+This is the only documented rollback for live Tier-2 after arming.
+
+Use it when the live reviewer lane fails canaries, the E6 circuit opens, provider
+behavior drifts, or the operator stops the broad batch.
+
+## Required Steps
+
+1. Restore the E0 sentinel in a reviewed commit:
+   - `DEFAULT_REVIEWER_MODEL_ID = "llm-reviewer-disabled-until-4370"`
+   - `WorkflowOptions.enable_llm` default remains `False`
+2. Freeze the spend ledger before more live calls:
+   - stop the current batch;
+   - copy the current ledger path and timestamp into the operator artifact;
+   - do not append new live rows until the lane is re-armed by reviewed commit.
+3. Invalidate current `gate_version` cache rows.
+4. Leave flags/code disarmed until the canary evidence is green again and the
+   user approves the next broad live batch.
+
+## Cache Invalidation
+
+Default command:
+
+```bash
+.venv/bin/python scripts/audit/qg_tier2_disarm.py --execute --gate-version qg_workflow.v3
+```
+
+Optional explicit DB:
+
+```bash
+.venv/bin/python scripts/audit/qg_tier2_disarm.py --execute --gate-version qg_workflow.v3 --db data/telemetry/llm_qg.db
+```
+
+Exact SQL executed by the helper:
+
+```sql
+DELETE FROM llm_qg_runs WHERE gate_version = ?;
+```
+
+The helper enables SQLite foreign keys, so matching `llm_qg_findings` rows are
+cascade-deleted with their parent runs. It never changes flags or source code.
+
+## Circuit State
+
+The E6 circuit sidecar is local telemetry state. Inspect it at:
+
+```bash
+cat data/telemetry/llm_qg_live_circuit.json
+```
+
+After the provider lane is fixed or rerouted, clear only the circuit state:
+
+```bash
+.venv/bin/python scripts/audit/qg_workflow.py --reset-circuit
+```
+
+Use `--qg-circuit-state PATH` when operating on a non-default sidecar.

--- a/scripts/audit/llm_qg_store.py
+++ b/scripts/audit/llm_qg_store.py
@@ -27,6 +27,20 @@ from scripts.api.resilience import connect_sqlite
 
 DEFAULT_DB_PATH = PROJECT_ROOT / "data" / "telemetry" / "llm_qg.db"
 DB_ENV_VAR = "LEARN_UKRAINIAN_LLM_QG_DB"
+DEFAULT_CIRCUIT_STATE_PATH = PROJECT_ROOT / "data" / "telemetry" / "llm_qg_live_circuit.json"
+CIRCUIT_ENV_VAR = "LEARN_UKRAINIAN_LLM_QG_CIRCUIT"
+CIRCUIT_SCHEMA_VERSION = "llm_qg_live_circuit.v1"
+CIRCUIT_WINDOW_SIZE = 30
+CIRCUIT_FAILURE_RATE_THRESHOLD = 0.15
+CIRCUIT_TERMINAL_FAILURE_STATUSES = frozenset(
+    {
+        "provider_error",
+        "parse_failure",
+        "schema_failure",
+        "RETRY_EXHAUSTED",
+        "timeout",
+    }
+)
 CONTENT_FILES = ("module.md", "activities.yaml", "vocabulary.yaml", "resources.yaml")
 EVIDENCE_SCHEMA_VERSION = "llm_qg_evidence.v1"
 SUPPORTED_EVIDENCE_GATE_VERSIONS = frozenset({"v7.llm_qg.1"})
@@ -67,12 +81,23 @@ def db_path(path: Path | None = None) -> Path:
     return Path(os.environ.get(DB_ENV_VAR, str(DEFAULT_DB_PATH)))
 
 
+def circuit_state_path(path: Path | None = None) -> Path:
+    """Return the configured live Tier-2 circuit state path."""
+    if path is not None:
+        return path
+    return Path(os.environ.get(CIRCUIT_ENV_VAR, str(DEFAULT_CIRCUIT_STATE_PATH)))
+
+
 def _now_z() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
 def _json_dumps(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _json_pretty(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True)
 
 
 def _sha256_bytes(data: bytes) -> str:
@@ -186,6 +211,153 @@ def init_db(path: Path | None = None) -> Path:
         )
         conn.commit()
     return resolved
+
+
+def live_tier2_circuit_status(path: Path | None = None) -> dict[str, Any]:
+    """Return deterministic live Tier-2 circuit state from the sidecar file."""
+    state = _read_circuit_state(path)
+    return _circuit_status_from_state(state)
+
+
+def live_tier2_circuit_open_message(path: Path | None = None) -> str:
+    """Return the operator-facing message for an open live Tier-2 circuit."""
+    status = live_tier2_circuit_status(path)
+    message = status.get("operator_message")
+    if isinstance(message, str) and message:
+        return message
+    return _circuit_open_message(status)
+
+
+def reset_live_tier2_circuit(path: Path | None = None) -> dict[str, Any]:
+    """Clear the live Tier-2 circuit until new live outcomes trip it again."""
+    resolved = circuit_state_path(path)
+    state = _empty_circuit_state()
+    now = _now_z()
+    state["reset_at"] = now
+    state["updated_at"] = now
+    _write_circuit_state(resolved, state)
+    return _circuit_status_from_state(state)
+
+
+def record_live_tier2_outcome(
+    *,
+    level: str,
+    slug: str,
+    gate_version: str,
+    reviewer_model: str | None,
+    reviewer_family: str | None,
+    route_name: str | None,
+    status: str,
+    reason: str | None = None,
+    path: Path | None = None,
+) -> dict[str, Any]:
+    """Persist one completed live Tier-2 passage outcome for circuit accounting."""
+    resolved = circuit_state_path(path)
+    state = _read_circuit_state(resolved)
+    outcome_status = status.strip()
+    now = _now_z()
+    outcome = {
+        "created_at": now,
+        "level": level.strip().lower(),
+        "slug": slug.strip(),
+        "gate_version": gate_version,
+        "reviewer_model": reviewer_model,
+        "reviewer_family": reviewer_family,
+        "route_name": route_name,
+        "status": outcome_status,
+        "reason": reason,
+        "terminal_failure": live_tier2_status_is_terminal_failure(outcome_status),
+    }
+    outcomes = [item for item in state.get("live_outcomes", []) if isinstance(item, Mapping)]
+    outcomes.append(outcome)
+    state["live_outcomes"] = outcomes[-CIRCUIT_WINDOW_SIZE:]
+    state["updated_at"] = now
+    status_payload = _circuit_status_from_state(state)
+    if status_payload["open"] and not state.get("opened_at"):
+        state["opened_at"] = now
+    state["operator_message"] = _circuit_open_message(status_payload) if status_payload["open"] else None
+    _write_circuit_state(resolved, state)
+    return _circuit_status_from_state(state)
+
+
+def live_tier2_status_is_terminal_failure(status: str) -> bool:
+    """Return True for infra/provider terminal failures that trip the circuit."""
+    return status.strip() in CIRCUIT_TERMINAL_FAILURE_STATUSES
+
+
+def _empty_circuit_state() -> dict[str, Any]:
+    return {
+        "schema_version": CIRCUIT_SCHEMA_VERSION,
+        "window_size": CIRCUIT_WINDOW_SIZE,
+        "failure_rate_threshold": CIRCUIT_FAILURE_RATE_THRESHOLD,
+        "opened_at": None,
+        "operator_message": None,
+        "live_outcomes": [],
+    }
+
+
+def _read_circuit_state(path: Path | None = None) -> dict[str, Any]:
+    resolved = circuit_state_path(path)
+    if not resolved.exists():
+        return _empty_circuit_state()
+    try:
+        loaded = json.loads(resolved.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return _empty_circuit_state()
+    if not isinstance(loaded, dict) or loaded.get("schema_version") != CIRCUIT_SCHEMA_VERSION:
+        return _empty_circuit_state()
+    state = _empty_circuit_state()
+    state.update(loaded)
+    outcomes = state.get("live_outcomes")
+    state["live_outcomes"] = outcomes if isinstance(outcomes, list) else []
+    return state
+
+
+def _write_circuit_state(path: Path, state: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_json_pretty(dict(state)) + "\n", encoding="utf-8")
+
+
+def _circuit_status_from_state(state: Mapping[str, Any]) -> dict[str, Any]:
+    raw_outcomes = state.get("live_outcomes")
+    outcomes = [item for item in raw_outcomes if isinstance(item, Mapping)] if isinstance(raw_outcomes, list) else []
+    window = outcomes[-CIRCUIT_WINDOW_SIZE:]
+    failure_count = sum(1 for item in window if item.get("terminal_failure") is True)
+    attempted = len(window)
+    failure_rate = (failure_count / attempted) if attempted else 0.0
+    threshold_exceeded = attempted >= CIRCUIT_WINDOW_SIZE and failure_rate > CIRCUIT_FAILURE_RATE_THRESHOLD
+    opened_at = state.get("opened_at") if isinstance(state.get("opened_at"), str) else None
+    is_open = bool(opened_at) or threshold_exceeded
+    status = {
+        "schema_version": CIRCUIT_SCHEMA_VERSION,
+        "open": is_open,
+        "opened_at": opened_at,
+        "window_size": CIRCUIT_WINDOW_SIZE,
+        "attempted": attempted,
+        "terminal_failures": failure_count,
+        "failure_rate": round(failure_rate, 6),
+        "failure_rate_threshold": CIRCUIT_FAILURE_RATE_THRESHOLD,
+        "operator_message": None,
+    }
+    if is_open:
+        status["operator_message"] = (
+            state.get("operator_message")
+            if isinstance(state.get("operator_message"), str) and state.get("operator_message")
+            else _circuit_open_message(status)
+        )
+    return status
+
+
+def _circuit_open_message(status: Mapping[str, Any]) -> str:
+    failures = int(status.get("terminal_failures") or 0)
+    attempted = int(status.get("attempted") or 0)
+    threshold = float(status.get("failure_rate_threshold") or CIRCUIT_FAILURE_RATE_THRESHOLD)
+    return (
+        "live Tier-2 circuit_open: "
+        f"{failures}/{attempted} recent live passages ended in terminal provider/parse/schema/"
+        f"timeout failures (> {threshold:.0%}). Fix or reroute the reviewer lane, then reset with "
+        ".venv/bin/python scripts/audit/qg_workflow.py --reset-circuit."
+    )
 
 
 def _ensure_composite_columns(conn: sqlite3.Connection) -> None:

--- a/scripts/audit/llm_reviewer_dispatch.py
+++ b/scripts/audit/llm_reviewer_dispatch.py
@@ -106,6 +106,14 @@ class ReviewerProviderError(ReviewerDispatchError):
     """Provider invocation failed before a parseable reviewer response."""
 
 
+class ReviewerPreflightError(ReviewerProviderError):
+    """Batch-level live transport preflight failed with a named reason."""
+
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
 class ReviewerLineageError(ReviewerDispatchError):
     """Module author lineage is unavailable in live mode."""
 
@@ -525,6 +533,84 @@ def estimate_route_cost(
         **measured_fields,
         "basis": basis,
     }
+
+
+def live_batch_preflight(routes: Sequence[ReviewerRoute], *, timeout_s: int = 10) -> dict[str, Any]:
+    """Verify the live Tier-2 transport before a broad batch spends quota."""
+    unique_routes = _unique_routes(routes)
+    if not unique_routes:
+        return {
+            "status": "skipped",
+            "reason": "no_live_routes",
+            "routes": [],
+        }
+    opencode = shutil.which("opencode")
+    if not opencode:
+        raise ReviewerPreflightError(
+            "opencode_unavailable",
+            "opencode CLI not found on PATH; live Tier-2 batch preflight cannot proceed",
+        )
+    for route in unique_routes:
+        try:
+            assert_route_allowed(route)
+            if route.requires_mcp:
+                _assert_sources_mcp_available()
+        except ReviewerRouteError as exc:
+            raise ReviewerPreflightError("route_disallowed", str(exc)) from exc
+        except ReviewerProviderError as exc:
+            raise ReviewerPreflightError("sources_mcp_unavailable", str(exc)) from exc
+    try:
+        proc = subprocess.run(
+            [opencode, "models"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ReviewerPreflightError("opencode_models_timeout", str(exc)) from exc
+    except OSError as exc:
+        raise ReviewerPreflightError("opencode_models_unavailable", str(exc)) from exc
+    if proc.returncode != 0:
+        message = (proc.stderr or proc.stdout or "opencode models failed").strip()
+        raise ReviewerPreflightError("opencode_models_failed", message[-1000:])
+    model_listing = f"{proc.stdout}\n{proc.stderr}"
+    missing = [
+        route.reviewer_model_id
+        for route in unique_routes
+        if not _model_list_contains(model_listing, route.reviewer_model_id)
+    ]
+    if missing:
+        raise ReviewerPreflightError(
+            "reviewer_model_unavailable",
+            "opencode models did not list required reviewer model(s): " + ", ".join(missing),
+        )
+    return {
+        "status": "passed",
+        "reason": None,
+        "routes": [route.route_name for route in unique_routes],
+        "reviewer_model_ids": [route.reviewer_model_id for route in unique_routes],
+        "sources_mcp_required": any(route.requires_mcp for route in unique_routes),
+    }
+
+
+def _unique_routes(routes: Sequence[ReviewerRoute]) -> list[ReviewerRoute]:
+    unique: list[ReviewerRoute] = []
+    seen: set[str] = set()
+    for route in routes:
+        key = f"{route.route_name}\0{route.reviewer_model_id}"
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(route)
+    return unique
+
+
+def _model_list_contains(model_listing: str, model_id: str) -> bool:
+    text = model_listing.lower()
+    clean = model_id.strip().lower()
+    tail = clean.rsplit("/", 1)[-1]
+    return clean in text or tail in text
 
 
 def prompt_template_hash() -> str:

--- a/scripts/audit/qg_tier2_disarm.py
+++ b/scripts/audit/qg_tier2_disarm.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Print or execute the Tier-2 disarm cache-invalidation checklist."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.api.resilience import connect_sqlite
+from scripts.audit import llm_qg_store, qg_workflow
+
+E0_SENTINEL_MODEL_ID = "llm-reviewer-disabled-until-4370"
+SQL_INVALIDATE_GATE_VERSION = "DELETE FROM llm_qg_runs WHERE gate_version = ?"
+
+
+def invalidate_gate_version_cache(*, db_path: Path | None, gate_version: str) -> int:
+    """Delete current gate-version cache rows and cascade their findings."""
+    resolved = llm_qg_store.init_db(db_path)
+    with closing(connect_sqlite(str(resolved))) as conn:
+        conn.execute("PRAGMA foreign_keys = ON")
+        cursor = conn.execute(SQL_INVALIDATE_GATE_VERSION, (gate_version,))
+        conn.commit()
+        return int(cursor.rowcount if cursor.rowcount is not None else 0)
+
+
+def checklist(*, db_path: Path | None, gate_version: str) -> dict[str, Any]:
+    resolved = llm_qg_store.db_path(db_path)
+    return {
+        "schema_version": "qg_tier2_disarm.v1",
+        "e0_sentinel_model_id": E0_SENTINEL_MODEL_ID,
+        "enable_llm_default": False,
+        "gate_version": gate_version,
+        "db_path": str(resolved),
+        "cache_invalidation_sql": SQL_INVALIDATE_GATE_VERSION + ";",
+        "cache_invalidation_command": (
+            ".venv/bin/python scripts/audit/qg_tier2_disarm.py --execute "
+            f"--gate-version {gate_version}"
+        ),
+        "steps": [
+            "Restore qg_workflow.DEFAULT_REVIEWER_MODEL_ID to the E0 sentinel in a reviewed commit.",
+            "Keep WorkflowOptions.enable_llm default set to false in that reviewed commit.",
+            "Freeze the local spend ledger and note the freeze in the operator artifact before more live runs.",
+            "Invalidate current gate_version cache rows with the SQL/command above.",
+        ],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, help="Optional LLM-QG SQLite cache path.")
+    parser.add_argument("--gate-version", default=qg_workflow.DEFAULT_GATE_VERSION)
+    parser.add_argument("--execute", action="store_true", help="Delete matching cache rows.")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    return parser
+
+
+def render_text(payload: dict[str, Any]) -> str:
+    lines = [
+        "Tier-2 disarm checklist",
+        f"- Restore DEFAULT_REVIEWER_MODEL_ID to {payload['e0_sentinel_model_id']}",
+        "- Keep WorkflowOptions.enable_llm default off",
+        "- Freeze the spend ledger and record the freeze note",
+        f"- Invalidate cache rows for gate_version={payload['gate_version']}",
+        f"  SQL: {payload['cache_invalidation_sql']}",
+        f"  Command: {payload['cache_invalidation_command']}",
+    ]
+    if "rows_deleted" in payload:
+        lines.append(f"- Rows deleted: {payload['rows_deleted']}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    payload = checklist(db_path=args.db, gate_version=args.gate_version)
+    if args.execute:
+        try:
+            payload["rows_deleted"] = invalidate_gate_version_cache(
+                db_path=args.db,
+                gate_version=args.gate_version,
+            )
+        except sqlite3.DatabaseError as exc:
+            print(f"error: {exc}")
+            return 2
+    output = (
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+        if args.format == "json"
+        else render_text(payload)
+    )
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/qg_workflow.py
+++ b/scripts/audit/qg_workflow.py
@@ -79,6 +79,7 @@ class WorkflowOptions:
     author_family: str | None = None
     canary_artifacts: Mapping[str, Path] | None = None
     daily_spend_path: Path | None = None
+    circuit_state_path: Path | None = None
     run_command: str | None = None
     enable_llm: bool = False
     force_llm: bool = False
@@ -250,6 +251,7 @@ def dry_run_modules(
         author_family=dry_options.author_family,
         canary_artifacts=dry_options.canary_artifacts,
         daily_spend_path=dry_options.daily_spend_path,
+        circuit_state_path=dry_options.circuit_state_path,
         run_command=dry_options.run_command,
         enable_llm=True,
         force_llm=dry_options.force_llm,
@@ -346,7 +348,23 @@ def review_modules(
 
     effective_options = options or WorkflowOptions()
     if effective_options.live_reviewer:
-        _validate_live_reviewer_preflight(targets, effective_options)
+        if (
+            not effective_options.dry_run
+            and _llm_enabled_for_any_target(targets, effective_options)
+            and llm_qg_store.live_tier2_circuit_status(effective_options.circuit_state_path)["open"]
+        ):
+            message = llm_qg_store.live_tier2_circuit_open_message(effective_options.circuit_state_path)
+            return [
+                _build_aborted_record(
+                    target,
+                    options=effective_options,
+                    reason="circuit_open",
+                    status="circuit_open",
+                    message=message,
+                )
+                for target in targets
+            ]
+        _validate_live_reviewer_preflight(targets, effective_options, reviewer=reviewer)
     elif (
         len(targets) > 1
         and _llm_enabled_for_any_target(targets, effective_options)
@@ -464,11 +482,45 @@ def _dry_run_gateable_artifact(
 def _validate_live_reviewer_preflight(
     targets: Sequence[ReviewTarget],
     options: WorkflowOptions,
+    *,
+    reviewer: Reviewer | None,
 ) -> None:
     if options.dry_run:
         return
     if _llm_enabled_for_any_target(targets, options) and options.max_cost_usd is None:
         raise ValueError("live Tier-2 runs require --max-cost-usd")
+    if reviewer is not None:
+        return
+    if len(targets) <= 1 or not _llm_enabled_for_any_target(targets, options):
+        return
+    routes = _live_preflight_routes(targets, options)
+    try:
+        llm_reviewer_dispatch.live_batch_preflight(routes)
+    except llm_reviewer_dispatch.ReviewerPreflightError as exc:
+        raise ValueError(f"live Tier-2 quota preflight failed: {exc.reason}: {exc}") from exc
+
+
+def _live_preflight_routes(
+    targets: Sequence[ReviewTarget],
+    options: WorkflowOptions,
+) -> list[llm_reviewer_dispatch.ReviewerRoute]:
+    routes: list[llm_reviewer_dispatch.ReviewerRoute] = []
+    for target in targets:
+        policy = policy_for_level(target.level)
+        if not (
+            policy.family in LLM_POLICY_FAMILIES
+            or options.force_llm
+            or options.calibration_sample
+        ):
+            continue
+        route = _tier2_route(
+            options=options,
+            policy_family=policy.family,
+            contested_gold_suppressed=False,
+        )
+        if route is not None:
+            routes.append(route)
+    return routes
 
 
 def _initial_daily_spend(options: WorkflowOptions) -> float:
@@ -498,6 +550,8 @@ def _batch_abort_reason(records: Sequence[Mapping[str, Any]]) -> str | None:
             return "lineage_required"
         if status == "skipped_canary_required":
             return "canary_required"
+        if status == "circuit_open":
+            return "circuit_open"
     if attempted and parse_failures / attempted > 0.05:
         return "parse_failure_rate"
     if attempted and provider_errors / attempted > 0.10:
@@ -510,6 +564,8 @@ def _build_aborted_record(
     *,
     options: WorkflowOptions,
     reason: str,
+    status: str = "aborted_batch",
+    message: str | None = None,
 ) -> dict[str, Any]:
     level = target.level.strip().lower()
     slug = target.slug.strip() or target.module_dir.name
@@ -538,7 +594,7 @@ def _build_aborted_record(
         {
             "tier": 2,
             "name": "llm_reviewer",
-            "status": "aborted_batch",
+            "status": status,
             "reason": reason,
             "llm_required_by_policy": policy.family in LLM_POLICY_FAMILIES,
             "policy_family": policy.family,
@@ -547,6 +603,8 @@ def _build_aborted_record(
             "findings": 0,
         },
     ]
+    if message:
+        tiers[2]["message"] = message
     return _build_evidence_record(
         level=level,
         slug=slug,
@@ -694,6 +752,21 @@ def _run_tier2(
         }
 
     if options.live_reviewer:
+        circuit_status = llm_qg_store.live_tier2_circuit_status(options.circuit_state_path)
+        if circuit_status["open"]:
+            return {
+                "findings": [],
+                "result": {
+                    **base_result,
+                    "status": "circuit_open",
+                    "reason": "circuit_open",
+                    "message": llm_qg_store.live_tier2_circuit_open_message(options.circuit_state_path),
+                },
+                "workflow_verdict": "INCOMPLETE",
+                "completion_status": "INCOMPLETE",
+                "reviewer_model_id": reviewer_model_id,
+                "reviewer_family": reviewer_family,
+            }
         blocked = _live_reviewer_block(
             target=target,
             level=level,
@@ -890,6 +963,16 @@ def _run_tier2(
             raw_response = effective_reviewer(target, attempt_prompt)
         except llm_reviewer_dispatch.ReviewerDispatchError as exc:
             budget.record_spend(estimate)
+            _record_live_tier2_outcome(
+                options=options,
+                level=level,
+                slug=slug,
+                reviewer_model_id=reviewer_model_id,
+                reviewer_family=reviewer_family,
+                route_name=route_name,
+                status="provider_error",
+                reason=type(exc).__name__,
+            )
             return {
                 "findings": [],
                 "result": {
@@ -930,6 +1013,16 @@ def _run_tier2(
             # no resolved route (route_name=None) keep their reported name.
             or (route_name is not None and actual_route_name != route_name)
         ):
+            _record_live_tier2_outcome(
+                options=options,
+                level=level,
+                slug=slug,
+                reviewer_model_id=actual_model_id,
+                reviewer_family=actual_family,
+                route_name=actual_route_name,
+                status="provider_error",
+                reason="reviewer_identity_mismatch",
+            )
             return {
                 "findings": [],
                 "result": {
@@ -947,6 +1040,16 @@ def _run_tier2(
                 "reviewer_family": actual_family,
             }
         if _cost_overrun(estimate, observed_cost):
+            _record_live_tier2_outcome(
+                options=options,
+                level=level,
+                slug=slug,
+                reviewer_model_id=reviewer_model_id,
+                reviewer_family=reviewer_family,
+                route_name=route_name,
+                status="cost_overrun",
+                reason="observed_cost_gt_125pct_estimate",
+            )
             return {
                 "findings": [],
                 "result": {
@@ -979,6 +1082,16 @@ def _run_tier2(
             payload = _payload_from_reviewer_payload(parsed_payload)
             llm_reviewer.validate_reviewer_payload(payload, policy_family)
         except ValueError as exc:
+            _record_live_tier2_outcome(
+                options=options,
+                level=level,
+                slug=slug,
+                reviewer_model_id=reviewer_model_id,
+                reviewer_family=reviewer_family,
+                route_name=route_name,
+                status="schema_failure",
+                reason=str(exc),
+            )
             return {
                 "findings": [],
                 "result": {
@@ -994,6 +1107,15 @@ def _run_tier2(
             }
         findings = _findings_from_payload(payload)
         if _parse_failed(findings):
+            _record_live_tier2_outcome(
+                options=options,
+                level=level,
+                slug=slug,
+                reviewer_model_id=reviewer_model_id,
+                reviewer_family=reviewer_family,
+                route_name=route_name,
+                status="parse_failure",
+            )
             return {
                 "findings": findings,
                 "result": {
@@ -1030,6 +1152,16 @@ def _run_tier2(
             )
             continue
         if gate_outcome.status == llm_reviewer_dispatch.RETRY_EXHAUSTED:
+            _record_live_tier2_outcome(
+                options=options,
+                level=level,
+                slug=slug,
+                reviewer_model_id=reviewer_model_id,
+                reviewer_family=reviewer_family,
+                route_name=route_name,
+                status=llm_reviewer_dispatch.RETRY_EXHAUSTED,
+                reason=llm_reviewer_dispatch.INVALID_TOOL_THEATRE,
+            )
             return {
                 "findings": [],
                 "result": {
@@ -1054,6 +1186,16 @@ def _run_tier2(
         grounding_gate = gate_outcome.grounding_gate or llm_reviewer_dispatch.GroundingGateResult(payload=payload)
         break
 
+    _record_live_tier2_outcome(
+        options=options,
+        level=level,
+        slug=slug,
+        reviewer_model_id=reviewer_model_id,
+        reviewer_family=reviewer_family,
+        route_name=route_name,
+        status=tier2_status,
+        reason=workflow_override,
+    )
     llm_qg_store.record_llm_qg(
         level=level,
         slug=slug,
@@ -1239,6 +1381,32 @@ def _record_daily_spend(
         route=route,
         estimated_cost_usd=float(estimate.get("estimated_cost_usd") or 0.0),
         observed_cost_usd=observed_cost_usd,
+    )
+
+
+def _record_live_tier2_outcome(
+    *,
+    options: WorkflowOptions,
+    level: str,
+    slug: str,
+    reviewer_model_id: str | None,
+    reviewer_family: str | None,
+    route_name: str | None,
+    status: str,
+    reason: str | None = None,
+) -> dict[str, Any] | None:
+    if not options.live_reviewer or options.dry_run:
+        return None
+    return llm_qg_store.record_live_tier2_outcome(
+        level=level,
+        slug=slug,
+        gate_version=options.gate_version,
+        reviewer_model=reviewer_model_id,
+        reviewer_family=reviewer_family,
+        route_name=route_name,
+        status=status,
+        reason=reason,
+        path=options.circuit_state_path,
     )
 
 
@@ -1740,6 +1908,7 @@ def calibrate_modules(
         author_family=options.author_family,
         canary_artifacts=options.canary_artifacts,
         daily_spend_path=options.daily_spend_path,
+        circuit_state_path=options.circuit_state_path,
         run_command=options.run_command,
         enable_llm=True,
         force_llm=True,
@@ -1843,6 +2012,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--max-daily-cost-usd", type=float, help="Per-day safety rail for this local run.")
     parser.add_argument("--max-module-cost-usd", type=float, help="Per-module pathological prompt cost cap.")
     parser.add_argument("--daily-spend-ledger", type=Path, help="Optional local JSONL spend ledger path.")
+    parser.add_argument("--qg-circuit-state", type=Path, help="Optional live Tier-2 circuit sidecar JSON path.")
+    parser.add_argument("--reset-circuit", action="store_true", help="Clear the live Tier-2 circuit sidecar and exit unless targets are also supplied.")
     parser.add_argument("--gate-version", default=DEFAULT_GATE_VERSION)
     parser.add_argument("--reviewer-model-id", default=DEFAULT_REVIEWER_MODEL_ID)
     parser.add_argument("--reviewer-family", default=DEFAULT_REVIEWER_FAMILY)
@@ -1866,6 +2037,21 @@ def main(argv: list[str] | None = None) -> int:
     argv_list = list(argv) if argv is not None else sys.argv[1:]
     args = build_parser().parse_args(argv_list)
     try:
+        if args.reset_circuit:
+            reset_payload = llm_qg_store.reset_live_tier2_circuit(args.qg_circuit_state)
+            has_targets = bool(args.target or args.module_dir)
+            if not has_targets:
+                output = (
+                    json.dumps(reset_payload, ensure_ascii=False, indent=2, sort_keys=True)
+                    if args.format == "json"
+                    else "live Tier-2 circuit reset"
+                )
+                if args.output:
+                    args.output.parent.mkdir(parents=True, exist_ok=True)
+                    args.output.write_text(output + "\n", encoding="utf-8")
+                else:
+                    print(output)
+                return 0
         targets = _targets_from_args(args)
         canary_artifacts = _canary_artifacts_from_args(args, targets)
         enable_llm = bool(
@@ -1899,6 +2085,7 @@ def main(argv: list[str] | None = None) -> int:
             author_family=args.author_family,
             canary_artifacts=canary_artifacts,
             daily_spend_path=args.daily_spend_ledger,
+            circuit_state_path=args.qg_circuit_state,
             run_command=_exact_run_command(argv_list),
             enable_llm=enable_llm,
             force_llm=args.force_llm,

--- a/tests/audit/test_qg_tier2_disarm.py
+++ b/tests/audit/test_qg_tier2_disarm.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.audit import llm_qg_store, qg_tier2_disarm, qg_workflow
+
+
+def _write_module(tmp_path: Path) -> Path:
+    module_dir = tmp_path / "b1" / "disarm-module"
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text("# Модуль\n\nКороткий текст.\n", encoding="utf-8")
+    (module_dir / "activities.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "vocabulary.yaml").write_text("[]\n", encoding="utf-8")
+    (module_dir / "resources.yaml").write_text("[]\n", encoding="utf-8")
+    return module_dir
+
+
+def test_disarm_helper_invalidates_only_requested_gate_version(tmp_path: Path) -> None:
+    module_dir = _write_module(tmp_path)
+    db_path = tmp_path / "qg.db"
+    payload = qg_workflow._payload_from_findings([])
+
+    llm_qg_store.record_llm_qg(
+        level="b1",
+        slug="disarm-module",
+        module_dir=module_dir,
+        payload=payload,
+        gate_version="qg_workflow.v2",
+        reviewer_model="test-reviewer",
+        path=db_path,
+    )
+    llm_qg_store.record_llm_qg(
+        level="b1",
+        slug="disarm-module",
+        module_dir=module_dir,
+        payload=payload,
+        gate_version=qg_workflow.DEFAULT_GATE_VERSION,
+        reviewer_model="test-reviewer",
+        path=db_path,
+    )
+
+    deleted = qg_tier2_disarm.invalidate_gate_version_cache(
+        db_path=db_path,
+        gate_version=qg_workflow.DEFAULT_GATE_VERSION,
+    )
+
+    assert deleted == 1
+    assert (
+        llm_qg_store.latest_llm_qg(
+            "b1",
+            "disarm-module",
+            gate_version=qg_workflow.DEFAULT_GATE_VERSION,
+            path=db_path,
+        )
+        is None
+    )
+    assert (
+        llm_qg_store.latest_llm_qg(
+            "b1",
+            "disarm-module",
+            gate_version="qg_workflow.v2",
+            path=db_path,
+        )
+        is not None
+    )

--- a/tests/test_qg_workflow.py
+++ b/tests/test_qg_workflow.py
@@ -4,7 +4,9 @@ import json
 import sqlite3
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
+import pytest
 import yaml
 
 from scripts.audit import llm_qg_store, llm_reviewer, llm_reviewer_dispatch, qg_schema, qg_workflow
@@ -999,6 +1001,8 @@ def test_tier2_rejects_route_name_mismatch(tmp_path: Path) -> None:
                 max_cost_usd=5.0,
                 reviewer_model_id=expected_route.reviewer_model_id,
                 reviewer_family=expected_route.reviewer_family,
+                daily_spend_path=tmp_path / "spend.jsonl",
+                circuit_state_path=tmp_path / "circuit.json",
             ),
             reviewer=reviewer,
             store_path=db_path,
@@ -1010,3 +1014,198 @@ def test_tier2_rejects_route_name_mismatch(tmp_path: Path) -> None:
     assert tier2["actual_route_name"] == "agy_frontier"
     # nothing persisted for the poisoned run
     assert llm_qg_store.latest_llm_qg("folk", "route-mismatch", path=db_path) is None
+
+
+def _record_circuit_window(path: Path, statuses: list[str]) -> dict[str, Any]:
+    status: dict[str, Any] = {}
+    for index, tier2_status in enumerate(statuses):
+        status = llm_qg_store.record_live_tier2_outcome(
+            level="folk",
+            slug=f"circuit-{index}",
+            gate_version=qg_workflow.DEFAULT_GATE_VERSION,
+            reviewer_model=llm_reviewer_dispatch.FRONTIER_OPENCODE_ROUTE.reviewer_model_id,
+            reviewer_family=llm_reviewer_dispatch.FRONTIER_OPENCODE_ROUTE.reviewer_family,
+            route_name=llm_reviewer_dispatch.FRONTIER_OPENCODE_ROUTE.route_name,
+            status=tier2_status,
+            path=path,
+        )
+    return status
+
+
+def test_live_tier2_circuit_trips_at_first_integer_over_threshold(tmp_path: Path) -> None:
+    circuit_path = tmp_path / "circuit.json"
+    closed = _record_circuit_window(
+        circuit_path,
+        ["ran"] * 25 + ["provider_error"] * 4 + ["ran"],
+    )
+
+    assert closed["attempted"] == 30
+    assert closed["terminal_failures"] == 4
+    assert closed["open"] is False
+
+    opened = llm_qg_store.record_live_tier2_outcome(
+        level="folk",
+        slug="circuit-open",
+        gate_version=qg_workflow.DEFAULT_GATE_VERSION,
+        reviewer_model=llm_reviewer_dispatch.FRONTIER_OPENCODE_ROUTE.reviewer_model_id,
+        reviewer_family=llm_reviewer_dispatch.FRONTIER_OPENCODE_ROUTE.reviewer_family,
+        route_name=llm_reviewer_dispatch.FRONTIER_OPENCODE_ROUTE.route_name,
+        status="provider_error",
+        path=circuit_path,
+    )
+
+    assert opened["attempted"] == 30
+    assert opened["terminal_failures"] == 5
+    assert opened["open"] is True
+    assert "circuit_open" in opened["operator_message"]
+
+
+def test_live_tier2_gate_downgrades_do_not_count_as_circuit_failures(tmp_path: Path) -> None:
+    circuit_path = tmp_path / "circuit.json"
+    status = _record_circuit_window(
+        circuit_path,
+        ["ran"] * 25 + [llm_reviewer_dispatch.UNGROUNDED_FINDINGS] * 5,
+    )
+
+    assert status["attempted"] == 30
+    assert status["terminal_failures"] == 0
+    assert status["open"] is False
+
+
+def test_circuit_open_refuses_live_dispatch(tmp_path: Path) -> None:
+    circuit_path = tmp_path / "circuit.json"
+    _record_circuit_window(circuit_path, ["ran"] * 25 + ["provider_error"] * 5)
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="blocked-live",
+        module_md="# Семінар\n\nВеснянки — це весняні обрядові пісні.\n",
+    )
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> str:
+        nonlocal calls
+        calls += 1
+        return _seminar_response()
+
+    record = qg_workflow.review_module(
+        _target(seminar_dir, level="folk", slug="blocked-live"),
+        options=qg_workflow.WorkflowOptions(
+            enable_llm=True,
+            live_reviewer=True,
+            max_cost_usd=5.0,
+            circuit_state_path=circuit_path,
+        ),
+        reviewer=reviewer,
+        store_path=tmp_path / "qg.db",
+    )
+
+    tier2 = _tier(record, 2)
+    assert tier2["status"] == "circuit_open"
+    assert tier2["reason"] == "circuit_open"
+    assert "circuit_open" in tier2["message"]
+    assert calls == 0
+
+
+def test_reset_circuit_allows_live_dispatch_after_operator_clear(tmp_path: Path) -> None:
+    circuit_path = tmp_path / "circuit.json"
+    _record_circuit_window(circuit_path, ["ran"] * 25 + ["provider_error"] * 5)
+    output = tmp_path / "reset.json"
+
+    code = qg_workflow.main(
+        [
+            "--reset-circuit",
+            "--qg-circuit-state",
+            str(circuit_path),
+            "--format",
+            "json",
+            "--output",
+            str(output),
+        ]
+    )
+
+    reset_payload = json.loads(output.read_text(encoding="utf-8"))
+    assert code == 0
+    assert reset_payload["open"] is False
+    assert llm_qg_store.live_tier2_circuit_status(circuit_path)["open"] is False
+
+    seminar_dir = _write_module(
+        tmp_path,
+        level="folk",
+        slug="reset-live",
+        module_md="# Семінар\n\nВеснянки — це весняні обрядові пісні.\n",
+    )
+    expected_route = llm_reviewer_dispatch.FRONTIER_OPENCODE_ROUTE
+    calls = 0
+
+    def reviewer(_target: qg_workflow.ReviewTarget, _prompt: str) -> llm_reviewer_dispatch.DispatchResult:
+        nonlocal calls
+        calls += 1
+        return llm_reviewer_dispatch.DispatchResult(
+            response_text=_seminar_response(),
+            reviewer_model_id=expected_route.reviewer_model_id,
+            reviewer_family=expected_route.reviewer_family,
+            route_name=expected_route.route_name,
+            tool_call_count=1,
+            tools_used=("sources_query_wikipedia",),
+            tool_events=(_wiki_event(mode="section"),),
+        )
+
+    with patch.object(qg_workflow, "_live_reviewer_block", return_value=None):
+        record = qg_workflow.review_module(
+            _target(seminar_dir, level="folk", slug="reset-live"),
+            options=qg_workflow.WorkflowOptions(
+                enable_llm=True,
+                live_reviewer=True,
+                max_cost_usd=5.0,
+                circuit_state_path=circuit_path,
+                daily_spend_path=tmp_path / "spend.jsonl",
+            ),
+            reviewer=reviewer,
+            store_path=tmp_path / "qg.db",
+        )
+
+    assert _tier(record, 2)["status"] == "ran"
+    assert calls == 1
+    assert llm_qg_store.live_tier2_circuit_status(circuit_path)["open"] is False
+
+
+def test_live_batch_preflight_failure_short_circuits_before_dispatch(
+    tmp_path: Path,
+    monkeypatch: Any,
+) -> None:
+    first = _write_module(
+        tmp_path,
+        level="folk",
+        slug="batch-one",
+        module_md="# Семінар\n\nУчасники аналізують джерела.\n",
+    )
+    second = _write_module(
+        tmp_path,
+        level="folk",
+        slug="batch-two",
+        module_md="# Семінар\n\nУчасники аналізують джерела.\n",
+    )
+
+    def fail_preflight(_routes: Any) -> None:
+        raise llm_reviewer_dispatch.ReviewerPreflightError(
+            "opencode_unavailable",
+            "opencode missing in test",
+        )
+
+    monkeypatch.setattr(llm_reviewer_dispatch, "live_batch_preflight", fail_preflight)
+
+    with pytest.raises(ValueError, match="opencode_unavailable"):
+        qg_workflow.review_modules(
+            [
+                _target(first, level="folk", slug="batch-one"),
+                _target(second, level="folk", slug="batch-two"),
+            ],
+            options=qg_workflow.WorkflowOptions(
+                enable_llm=True,
+                live_reviewer=True,
+                max_cost_usd=5.0,
+                circuit_state_path=tmp_path / "circuit.json",
+            ),
+            store_path=tmp_path / "qg.db",
+        )


### PR DESCRIPTION
Addresses #4370

## Summary
- Add an inspectable live Tier-2 circuit sidecar with manual reset support.
- Add batch-only live transport preflight for opencode, sources MCP, and model listing probes.
- Add the Tier-2 disarm runbook plus a helper that only invalidates current gate-version cache rows with --execute.

## Verification
- .venv/bin/python -m pytest tests/test_qg_workflow.py tests/audit/test_qg_tier2_disarm.py
- .venv/bin/ruff check scripts/audit/qg_workflow.py scripts/audit/llm_qg_store.py scripts/audit/llm_reviewer_dispatch.py scripts/audit/qg_tier2_disarm.py tests/test_qg_workflow.py tests/audit/test_qg_tier2_disarm.py
- node_modules/.bin/markdownlint-cli2 docs/projects/ua-eval-harness/tier2-disarm.md
- .venv/bin/python scripts/audit/lint_agent_trailer.py
- AGY independent review review-4370-e6-ops: APPROVED, no blocking findings
