### PR TITLE
feat(bio): add cultural movement learner readings

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml
@@ -79,6 +79,23 @@ persona:
   role: Модератор дискусії, що ставить під сумнів очевидні істини про «користь» стандартизації та показує її людську ціну.
   voice: Lexicography-Historian
 phase: BIO
+readings:
+- title: Грінченко Борис Дмитрович
+  language: uk
+  source: Енциклопедія історії України (ЕІУ)
+  url: http://www.history.org.ua/?termin=Hrinchenko_B_D
+  type: encyclopedia
+  role: reference
+  hosting: link-only
+  task: Ознайомитися з основними етапами створення «Словника української мови».
+- title: Словник української мови (онлайн-версія)
+  language: uk
+  source: Hrinchenko.com
+  url: https://hrinchenko.com/
+  type: reference
+  role: analysis
+  hosting: link-only
+  task: Проаналізувати лексикографічні принципи Грінченка та словникові статті.
 references:
 - title: Borys Hrinchenko
   note: Compiled from primary and secondary sources on Hrinchenko's life and the history of Ukrainian lexicography.
@@ -96,7 +113,7 @@ sequence: 78
 slug: borys-hrinchenko
 subtitle: 'Borys Hrinchenko: Guardian of the Ukrainian Word'
 title: 'Борис Грінченко: Вартовий українського слова'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: фахівець, що займається створенням словників
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/borys-hrinchenko.yaml
@@ -83,7 +83,7 @@ readings:
 - title: Грінченко Борис Дмитрович
   language: uk
   source: Енциклопедія історії України (ЕІУ)
-  url: http://www.history.org.ua/?termin=Hrinchenko_B_D
+  url: https://history.org.ua/?termin=Hrinchenko_B_D
   type: encyclopedia
   role: reference
   hosting: link-only
@@ -113,7 +113,7 @@ sequence: 78
 slug: borys-hrinchenko
 subtitle: 'Borys Hrinchenko: Guardian of the Ukrainian Word'
 title: 'Борис Грінченко: Вартовий українського слова'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: фахівець, що займається створенням словників
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/ivan-franko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-franko.yaml
@@ -81,6 +81,23 @@ persona:
   role: Модератор семінару, що ставить під сумнів усталені міфи про «Вічного Каменяра» та шукає живу людину за пам'ятником
   voice: Franko-Skeptic
 phase: BIO
+readings:
+- title: Франко Іван Якович
+  language: uk
+  source: Енциклопедія історії України (ЕІУ)
+  url: http://www.history.org.ua/?termin=Franko_I_Ya
+  type: encyclopedia
+  role: reference
+  hosting: link-only
+  task: Ознайомитися з фактами біографії та проаналізувати його політичну та літературну діяльність.
+- title: Що таке поступ?
+  language: uk
+  source: Ізборник (Зібрання творів)
+  url: http://litopys.org.ua/
+  type: primary
+  role: analysis
+  hosting: excerpt-only
+  task: Прочитати фрагменти трактату та обговорити еволюцію поглядів Франка.
 references:
 - title: Ivan Franko
   note: Compiled research notes, primary source quotes, and critical interpretations for this module.
@@ -105,7 +122,7 @@ sequence: 76
 slug: ivan-franko
 subtitle: 'Titan of Labor: A Critical Biography'
 title: 'Іван Франко: Каменяр'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: 'у переносному значенні: людина, що важкою працею прокладає шлях для інших; піонер, новатор'
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/ivan-franko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-franko.yaml
@@ -85,15 +85,15 @@ readings:
 - title: Франко Іван Якович
   language: uk
   source: Енциклопедія історії України (ЕІУ)
-  url: http://www.history.org.ua/?termin=Franko_I_Ya
+  url: https://history.org.ua/?termin=Franko_I_Ya
   type: encyclopedia
   role: reference
   hosting: link-only
   task: Ознайомитися з фактами біографії та проаналізувати його політичну та літературну діяльність.
 - title: Що таке поступ?
   language: uk
-  source: Ізборник (Зібрання творів)
-  url: http://litopys.org.ua/
+  source: Діаспоріана
+  url: https://diasporiana.org.ua/ideologiya/12272-franko-i-shho-take-postup/
   type: primary
   role: analysis
   hosting: excerpt-only
@@ -122,7 +122,7 @@ sequence: 76
 slug: ivan-franko
 subtitle: 'Titan of Labor: A Critical Biography'
 title: 'Іван Франко: Каменяр'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: 'у переносному значенні: людина, що важкою працею прокладає шлях для інших; піонер, новатор'
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/olha-kobylianska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/olha-kobylianska.yaml
@@ -85,15 +85,15 @@ readings:
 - title: Кобилянська Ольга Юліанівна
   language: uk
   source: Енциклопедія історії України (ЕІУ)
-  url: http://www.history.org.ua/?termin=Kobylianska_O
+  url: https://history.org.ua/?termin=Kobylianska_O
   type: encyclopedia
   role: reference
   hosting: link-only
   task: Ознайомитися з біографією письменниці та її роллю в українському модернізмі.
-- title: Людина / Царівна (фрагменти)
+- title: Царівна (фрагменти)
   language: uk
-  source: Ізборник
-  url: http://litopys.org.ua/
+  source: УкрЛіб
+  url: https://www.ukrlib.com.ua/books/printit.php?tid=1027
   type: primary
   role: analysis
   hosting: excerpt-only
@@ -117,7 +117,7 @@ sequence: 79
 slug: olha-kobylianska
 subtitle: 'The Eagle of Bukovyna: Modernist and Feminist'
 title: 'Ольга Кобилянська: Модерністка і феміністка'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: загальний напрям у мистецтві та літературі кінця XIX – початку XX ст., що характеризується розривом із традиціями та пошуком нових форм
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/olha-kobylianska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/olha-kobylianska.yaml
@@ -93,7 +93,7 @@ readings:
 - title: Царівна (фрагменти)
   language: uk
   source: УкрЛіб
-  url: https://www.ukrlib.com.ua/books/printit.php?tid=1027
+  url: https://www.ukrlib.com.ua/books/printit.php?tid=462
   type: primary
   role: analysis
   hosting: excerpt-only
@@ -117,7 +117,7 @@ sequence: 79
 slug: olha-kobylianska
 subtitle: 'The Eagle of Bukovyna: Modernist and Feminist'
 title: 'Ольга Кобилянська: Модерністка і феміністка'
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: загальний напрям у мистецтві та літературі кінця XIX – початку XX ст., що характеризується розривом із традиціями та пошуком нових форм
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/olha-kobylianska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/olha-kobylianska.yaml
@@ -81,6 +81,23 @@ persona:
   role: Задає незручні питання, руйнує «бронзовий» образ, показуючи живу, суперечливу людину замість ікони.
   voice: Критичний біограф
 phase: BIO
+readings:
+- title: Кобилянська Ольга Юліанівна
+  language: uk
+  source: Енциклопедія історії України (ЕІУ)
+  url: http://www.history.org.ua/?termin=Kobylianska_O
+  type: encyclopedia
+  role: reference
+  hosting: link-only
+  task: Ознайомитися з біографією письменниці та її роллю в українському модернізмі.
+- title: Людина / Царівна (фрагменти)
+  language: uk
+  source: Ізборник
+  url: http://litopys.org.ua/
+  type: primary
+  role: analysis
+  hosting: excerpt-only
+  task: Прочитати фрагменти творів для розуміння ідей емансипації та ніцшеанства.
 references:
 - title: Olha Kobylianska
   note: Загальна біографія, список творів, ключові дати. Основа для семінару.
@@ -100,7 +117,7 @@ sequence: 79
 slug: olha-kobylianska
 subtitle: 'The Eagle of Bukovyna: Modernist and Feminist'
 title: 'Ольга Кобилянська: Модерністка і феміністка'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: загальний напрям у мистецтві та літературі кінця XIX – початку XX ст., що характеризується розривом із традиціями та пошуком нових форм
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/volodymyr-samiilenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/volodymyr-samiilenko.yaml
@@ -78,6 +78,23 @@ persona:
   role: Модератор семінару, що ставить під сумнів канон, шукає недооцінені постаті та їхні справжні, часто неочевидні, внески
   voice: Історик літератури, що спеціалізується на «другому ряді» класиків
 phase: BIO
+readings:
+- title: 1864 — народився Володимир Самійленко
+  language: uk
+  source: Український інститут національної пам’яті (УІНП)
+  url: https://uinp.gov.ua/istorychnyy-kalendar/lyutyy/3/1864-narodyvsya-volodymyr-samiylenko
+  type: article
+  role: reference
+  hosting: link-only
+  task: Ознайомитися з біографією Самійленка та його національною позицією.
+- title: Самійленко Володимир Іванович
+  language: uk
+  source: Енциклопедія історії України (ЕІУ)
+  url: http://www.history.org.ua/?termin=Samijlenko_V
+  type: encyclopedia
+  role: reference
+  hosting: link-only
+  task: Дослідити роль письменника у протистоянні русифікації.
 references:
 - title: Volodymyr Samiilenko
   note: Compiled research notes on Samiilenko, his works, and historical context
@@ -95,7 +112,7 @@ sequence: 81
 slug: volodymyr-samiilenko
 subtitle: 'Volodymyr Samiilenko: Poet, Satirist, and Language Builder'
 title: 'Володимир Самійленко: Поет, сатирик і будівничий мови'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: гостре, викривальне осміяння суспільних вад, негативних явищ чи конкретних осіб
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/volodymyr-samiilenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/volodymyr-samiilenko.yaml
@@ -90,7 +90,7 @@ readings:
 - title: Самійленко Володимир Іванович
   language: uk
   source: Енциклопедія історії України (ЕІУ)
-  url: http://www.history.org.ua/?termin=Samijlenko_V
+  url: https://history.org.ua/?termin=Samijlenko_V
   type: encyclopedia
   role: reference
   hosting: link-only
@@ -112,7 +112,7 @@ sequence: 81
 slug: volodymyr-samiilenko
 subtitle: 'Volodymyr Samiilenko: Poet, Satirist, and Language Builder'
 title: 'Володимир Самійленко: Поет, сатирик і будівничий мови'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: гостре, викривальне осміяння суспільних вад, негативних явищ чи конкретних осіб
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/volodymyr-vernadskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/volodymyr-vernadskyi.yaml
@@ -77,6 +77,23 @@ persona:
   role: Модератор семінару, що ставить незручні питання, вимагає дивитися за межі офіційної біографії та аналізувати моральні дилеми вченого.
   voice: Critical Biographer
 phase: BIO
+readings:
+- title: Вернадський Володимир Іванович
+  language: uk
+  source: Енциклопедія історії України (ЕІУ)
+  url: http://www.history.org.ua/?termin=Vernadsky_V
+  type: encyclopedia
+  role: reference
+  hosting: link-only
+  task: Ознайомитися з фактами біографії та проаналізувати його діяльність в УАН.
+- title: Щоденники (фрагменти)
+  language: uk
+  source: Національна бібліотека України імені В. І. Вернадського (НБУВ)
+  url: http://www.nbuv.gov.ua/
+  type: primary
+  role: reflection
+  hosting: reading-needed
+  task: Проаналізувати особисті записи про Україну та наукові компроміси.
 references:
 - title: Volodymyr Vernadskyi
   note: Compiled research notes, key debates, and primary source excerpts.
@@ -97,7 +114,7 @@ sequence: 80
 slug: volodymyr-vernadskyi
 subtitle: 'Volodymyr Vernadsky: The Noosphere and Compromise'
 title: 'Володимир Вернадський: Ноосфера та компроміс'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: сукупність частин земної оболонки (літо-, гідро- й атмосфери), яка заселена живими організмами та перетворена ними
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/volodymyr-vernadskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/volodymyr-vernadskyi.yaml
@@ -86,14 +86,14 @@ readings:
   role: reference
   hosting: link-only
   task: Ознайомитися з фактами біографії та проаналізувати його діяльність в УАН.
-- title: Щоденники (фрагменти)
+- title: 1917 рік у щоденникових записах В. І. Вернадського
   language: uk
-  source: НБУВ — електронна колекція В. І. Вернадського
-  url: https://nbuv.gov.ua/vernadsky/
-  type: primary
+  source: Наукова періодика України (НБУВ)
+  url: https://nbuv.gov.ua/UJRN/Uxxs_2013_18_12
+  type: article
   role: reflection
-  hosting: reading-needed
-  task: Проаналізувати особисті записи про Україну та наукові компроміси.
+  hosting: link-only
+  task: Проаналізувати щоденникові записи про 1917 рік та наукові компроміси.
 references:
 - title: Volodymyr Vernadskyi
   note: Compiled research notes, key debates, and primary source excerpts.
@@ -114,7 +114,7 @@ sequence: 80
 slug: volodymyr-vernadskyi
 subtitle: 'Volodymyr Vernadsky: The Noosphere and Compromise'
 title: 'Володимир Вернадський: Ноосфера та компроміс'
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: сукупність частин земної оболонки (літо-, гідро- й атмосфери), яка заселена живими організмами та перетворена ними
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/volodymyr-vernadskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/volodymyr-vernadskyi.yaml
@@ -81,15 +81,15 @@ readings:
 - title: Вернадський Володимир Іванович
   language: uk
   source: Енциклопедія історії України (ЕІУ)
-  url: http://www.history.org.ua/?termin=Vernadsky_V
+  url: https://history.org.ua/?termin=Vernadsky_V
   type: encyclopedia
   role: reference
   hosting: link-only
   task: Ознайомитися з фактами біографії та проаналізувати його діяльність в УАН.
 - title: Щоденники (фрагменти)
   language: uk
-  source: Національна бібліотека України імені В. І. Вернадського (НБУВ)
-  url: http://www.nbuv.gov.ua/
+  source: НБУВ — електронна колекція В. І. Вернадського
+  url: https://nbuv.gov.ua/vernadsky/
   type: primary
   role: reflection
   hosting: reading-needed
@@ -108,13 +108,13 @@ references:
   author: С.М. Гірік
   note: Стаття в Енциклопедії історії України для верифікації біографічних фактів.
   type: primary
-  url: http://www.history.org.ua/?termin=Vernadsky_V
+  url: https://history.org.ua/?termin=Vernadsky_V
   work: Вернадський Володимир Іванович
 sequence: 80
 slug: volodymyr-vernadskyi
 subtitle: 'Volodymyr Vernadsky: The Noosphere and Compromise'
 title: 'Володимир Вернадський: Ноосфера та компроміс'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: сукупність частин земної оболонки (літо-, гідро- й атмосфери), яка заселена живими організмами та перетворена ними
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/yevhen-chykalenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yevhen-chykalenko.yaml
@@ -83,22 +83,22 @@ readings:
 - title: Чикаленко Євген Харлампійович
   language: uk
   source: Енциклопедія історії України (ЕІУ)
-  url: http://www.history.org.ua/?termin=Chykalenko_Y
+  url: https://history.org.ua/?termin=Chykalenko_Y
   type: encyclopedia
   role: reference
   hosting: link-only
   task: Дослідити внесок Чикаленка у розвиток українського руху та періодичної преси.
-- title: Спогади та Щоденник (фрагменти)
+- title: Спогади (1861-1907)
   language: uk
-  source: Чтиво
-  url: https://chtyvo.org.ua/
+  source: Діаспоріана
+  url: https://diasporiana.org.ua/memuari/1755-chikalenko-ye-spogadi-1861-1907/
   type: primary
   role: reflection
   hosting: excerpt-only
-  task: Ознайомитися з фрагментами щоденників для розуміння мотивації мецената.
+  task: Ознайомитися з фрагментами спогадів для розуміння мотивації мецената.
 references:
 - title: Yevhen Chykalenko
-  note: Опрацьована та доповнена біографічна довідка з uk.wikipedia.org
+  note: Compiled research notes on Chykalenko's publishing, patronage, and Ukrainian civic networks.
   path: wiki/bio/yevhen-chykalenko.md
   type: wiki
 - title: Щоденник (1907-1917)
@@ -120,7 +120,7 @@ sequence: 77
 slug: yevhen-chykalenko
 subtitle: Людина, яка платила за Україну
 title: 'Євген Чикаленко: Меценат і видавець'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: особа, що безкорисливо підтримує розвиток культури, науки, мистецтва, часто з власних коштів
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/yevhen-chykalenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yevhen-chykalenko.yaml
@@ -79,6 +79,23 @@ persona:
   role: 'Модератор семінару, який постійно ставить незручне питання: "А хто за все це платить?"'
   voice: Pragmatic-Accountant
 phase: BIO
+readings:
+- title: Чикаленко Євген Харлампійович
+  language: uk
+  source: Енциклопедія історії України (ЕІУ)
+  url: http://www.history.org.ua/?termin=Chykalenko_Y
+  type: encyclopedia
+  role: reference
+  hosting: link-only
+  task: Дослідити внесок Чикаленка у розвиток українського руху та періодичної преси.
+- title: Спогади та Щоденник (фрагменти)
+  language: uk
+  source: Чтиво
+  url: https://chtyvo.org.ua/
+  type: primary
+  role: reflection
+  hosting: excerpt-only
+  task: Ознайомитися з фрагментами щоденників для розуміння мотивації мецената.
 references:
 - title: Yevhen Chykalenko
   note: Опрацьована та доповнена біографічна довідка з uk.wikipedia.org
@@ -103,7 +120,7 @@ sequence: 77
 slug: yevhen-chykalenko
 subtitle: Людина, яка платила за Україну
 title: 'Євген Чикаленко: Меценат і видавець'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: особа, що безкорисливо підтримує розвиток культури, науки, мистецтва, часто з власних коштів
   pos: ч.


### PR DESCRIPTION
## Summary
- Add Ukrainian-only learner reading blocks for Franko, Chykalenko, Hrinchenko, Kobylianska, Vernadskyi, and Samiilenko.
- Tighten batch sources to exact Ukrainian pages where possible and replace generic Litopys/Chytvo/NBUV roots.
- Keep learner readings in plan-level `readings:` blocks; no wiki source YAML changes.

## Verification
- `git diff --check`
- URL hostability spot-checks returned HTTP 200 for replacement URLs
- YAML parse check for the six reading blocks
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/validate_plans.py bio`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`

LLM-QG and Gemma were not used.