### PR TITLE
feat(practice): #4383 PR-B — wave-1 decks + validators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,6 +238,12 @@ site/src/data/lexicon-practice-deck.json.gz
 site/public/lexicon/practice-index.*.json
 site/public/lexicon/practice-lexemes.*.json
 site/public/lexicon/practice-cloze.*.json
+site/public/lexicon/practice-stress.*.json
+site/public/lexicon/practice-classify.*.json
+site/public/lexicon/practice-paradigm.*.json
+site/public/lexicon/practice-synonym.*.json
+site/public/lexicon/practice-heritage.*.json
+site/public/lexicon/practice-paronym.*.json
 /testbed/*
 !/testbed/reference/
 data/sum11/

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: d0f207de135b5b4219091d5b6c64ffaf7f359a5642c807fc5082bbfe7bf2ff3b
+  components_sha256: d26ff768762dc73193d8249c7398bbbf752b8351ef2dacc1a2dc760e680582e8
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/scripts/audit/check_static_practice_assets.py
+++ b/scripts/audit/check_static_practice_assets.py
@@ -16,8 +16,18 @@ from pathlib import Path
 from typing import Any
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+AUDIT_DIR = PROJECT_ROOT / "scripts" / "audit"
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
+if str(AUDIT_DIR) not in sys.path:
+    sys.path.insert(0, str(AUDIT_DIR))
+
+from generate_practice_deck import (
+    validate_classify_item,
+    validate_classify_session_cap,
+    validate_paradigm_item,
+    validate_synonym_item,
+)
 
 from scripts.practice_deck.io import ensure_practice_deck_hydrated
 
@@ -45,7 +55,24 @@ EXPECTED_SCHEMAS = {
     "index": "atlas-practice-index",
     "lexemes": "atlas-practice-lexemes",
     "cloze": "atlas-practice-cloze",
+    "stress": "atlas-practice-stress",
+    "classify": "atlas-practice-classify",
+    "paradigm": "atlas-practice-paradigm",
+    "synonym": "atlas-practice-synonym",
+    "heritage": "atlas-practice-heritage",
+    "paronym": "atlas-practice-paronym",
 }
+MODE_BODY_KEYS = {
+    "cloze": "cloze",
+    "stress": "stress",
+    "classify": "classify",
+    "paradigm": "paradigm",
+    "synonym": "synonym",
+    "heritage": "heritage",
+    "paronym": "paronym",
+}
+DRILL_MODES = ("stress", "classify", "paradigm", "synonym", "heritage", "paronym")
+MODE_SHARD_KINDS = ("cloze", *DRILL_MODES)
 
 
 def _read_json(path: Path, errors: list[str]) -> Any:
@@ -286,7 +313,10 @@ def _check_level(
     paths = {
         "index": practice_dir / f"practice-index.{level}.json",
         "lexemes": practice_dir / f"practice-lexemes.{level}.json",
-        "cloze": practice_dir / f"practice-cloze.{level}.json",
+        **{
+            kind: practice_dir / f"practice-{kind}.{level}.json"
+            for kind in MODE_SHARD_KINDS
+        },
     }
     shards = {
         kind: _check_shard_meta(
@@ -302,6 +332,10 @@ def _check_level(
     index_items = shards["index"].get("items")
     lexemes = shards["lexemes"].get("lexemes")
     cloze_items = shards["cloze"].get("cloze")
+    mode_items = {
+        kind: shards[kind].get(MODE_BODY_KEYS[kind])
+        for kind in DRILL_MODES
+    }
     if not isinstance(index_items, list):
         errors.append(f"{paths['index']}: items must be a list")
         index_items = []
@@ -311,6 +345,10 @@ def _check_level(
     if not isinstance(cloze_items, list):
         errors.append(f"{paths['cloze']}: cloze must be a list")
         cloze_items = []
+    for kind in DRILL_MODES:
+        if not isinstance(mode_items[kind], list):
+            errors.append(f"{paths[kind]}: {MODE_BODY_KEYS[kind]} must be a list")
+            mode_items[kind] = []
 
     if len(index_items) < min_lexemes:
         errors.append(f"{paths['index']}: {len(index_items)} items, expected at least {min_lexemes}")
@@ -378,6 +416,38 @@ def _check_level(
             reviewed=reviewed,
             errors=errors,
         )
+    for kind, rows in mode_items.items():
+        assert isinstance(rows, list)
+        for index, item in enumerate(rows):
+            prefix = f"{paths[kind]}: {MODE_BODY_KEYS[kind]}[{index}]"
+            if not isinstance(item, dict):
+                errors.append(f"{prefix} must be an object")
+                continue
+            lemma_id = item.get("lemmaId")
+            if not _has_text(lemma_id):
+                errors.append(f"{prefix} missing lemmaId")
+            elif str(lemma_id) not in lexeme_by_id:
+                errors.append(f"{prefix} lemmaId {lemma_id!r} missing from {level} lexeme shard")
+        if kind == "classify":
+            classify_rows = [item for item in rows if isinstance(item, dict)]
+            for index, item in enumerate(classify_rows):
+                errors.extend(
+                    f"{paths[kind]}: classify[{index}] {error}"
+                    for error in validate_classify_item(item)
+                )
+            errors.extend(f"{paths[kind]}: {error}" for error in validate_classify_session_cap(classify_rows))
+        elif kind == "synonym":
+            for index, item in enumerate(item for item in rows if isinstance(item, dict)):
+                errors.extend(
+                    f"{paths[kind]}: synonym[{index}] {error}"
+                    for error in validate_synonym_item(item)
+                )
+        elif kind == "paradigm":
+            for index, item in enumerate(item for item in rows if isinstance(item, dict)):
+                errors.extend(
+                    f"{paths[kind]}: paradigm[{index}] {error}"
+                    for error in validate_paradigm_item(item)
+                )
 
     counts = shards["index"].get("counts")
     if not isinstance(counts, dict):
@@ -394,11 +464,36 @@ def _check_level(
     for key, expected in expected_counts.items():
         if counts.get(key) != expected:
             errors.append(f"{paths['index']}: counts.{key} {counts.get(key)!r} != {expected!r}")
+    mode_counts = counts.get("modeCounts")
+    mode_coverage = counts.get("modeCoverage")
+    if not isinstance(mode_counts, dict):
+        errors.append(f"{paths['index']}: missing counts.modeCounts")
+        mode_counts = {}
+    if not isinstance(mode_coverage, dict):
+        errors.append(f"{paths['index']}: missing counts.modeCoverage")
+        mode_coverage = {}
+    for kind in MODE_SHARD_KINDS:
+        rows = cloze_items if kind == "cloze" else mode_items[kind]
+        assert isinstance(rows, list)
+        expected_count = len(rows)
+        expected_mode_coverage = (
+            round(len({item.get("lemmaId") for item in rows if isinstance(item, dict)}) / len(lexemes), 4)
+            if lexemes
+            else 0.0
+        )
+        if mode_counts.get(kind) != expected_count:
+            errors.append(f"{paths['index']}: counts.modeCounts.{kind} {mode_counts.get(kind)!r} != {expected_count!r}")
+        if mode_coverage.get(kind) != expected_mode_coverage:
+            errors.append(
+                f"{paths['index']}: counts.modeCoverage.{kind} "
+                f"{mode_coverage.get(kind)!r} != {expected_mode_coverage!r}"
+            )
 
     return {
         "index": len(index_items),
         "lexemes": len(lexemes),
         "cloze": len(cloze_items),
+        **{kind: len(rows) for kind, rows in mode_items.items() if isinstance(rows, list)},
         "deck_versions": sorted(versions),
     }
 
@@ -464,9 +559,10 @@ def _print_summary(summary: dict[str, Any]) -> None:
     print(f"Deck versions: {', '.join(summary['deck_versions']) or 'none'}")
     print(f"Reviewed cloze source allowlist rows: {summary['reviewed_sources']}")
     for level, row in summary["practice"].items():
+        mode_counts = " ".join(f"{mode}={row.get(mode, 0)}" for mode in DRILL_MODES)
         print(
             f"  {level}: index={row['index']} lexemes={row['lexemes']} "
-            f"cloze={row['cloze']}"
+            f"cloze={row['cloze']} {mode_counts}"
         )
 
 

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -13,7 +13,10 @@ import hashlib
 import json
 import random
 import re
+import sqlite3
 import sys
+import unicodedata
+from collections import Counter
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
@@ -28,6 +31,7 @@ if str(AUDIT_DIR) not in sys.path:
 from lexeme_filter import SURFACE_CLOZE, is_practice_eligible, is_surface_admitted
 
 DEFAULT_MANIFEST = Path("site/src/data/lexicon-manifest.json")
+DEFAULT_ATLAS_DB = Path("data/atlas.db")
 # Deck shards are served as literal static files from public/ (not via dynamic .json.ts
 # endpoints) so the fetch URL resolves identically in dev and prod — astro's
 # `trailingSlash: 'always'` otherwise serves a dynamic endpoint only at the trailing-slash
@@ -38,14 +42,43 @@ DEFAULT_CLOZE_SOURCES = Path("site/src/data/lexicon-practice-cloze-sources.json"
 # Keep the default above the current all-eligible deck size. A lower default
 # silently contracts the committed practice surface during routine cloze regen.
 DEFAULT_TARGET = 6000
-DEFAULT_RAW_LIMIT = 550_000
-DEFAULT_GZIP_LIMIT = 140_000
+DEFAULT_RAW_LIMIT = 1_600_000
+DEFAULT_GZIP_LIMIT = 180_000
 SCHEMA_VERSION = 1
 CEFR_ORDER = ("A1", "A2", "B1", "B2", "C1", "C2")
 CEFR_RANK = {level: index for index, level in enumerate(CEFR_ORDER)}
+PUBLISHED_LEVELS = ("A1", "A2", "B1", "B2", "C1")
+DRILL_MODES = ("stress", "classify", "paradigm", "synonym", "heritage", "paronym")
+MODE_SHARD_KEYS = ("cloze", *DRILL_MODES)
+MODE_SCHEMAS = {
+    "cloze": "atlas-practice-cloze",
+    "stress": "atlas-practice-stress",
+    "classify": "atlas-practice-classify",
+    "paradigm": "atlas-practice-paradigm",
+    "synonym": "atlas-practice-synonym",
+    "heritage": "atlas-practice-heritage",
+    "paronym": "atlas-practice-paronym",
+}
+MODE_BODY_KEYS = {
+    "cloze": "cloze",
+    "stress": "stress",
+    "classify": "classify",
+    "paradigm": "paradigm",
+    "synonym": "synonym",
+    "heritage": "heritage",
+    "paronym": "paronym",
+}
+THIN_WARN_THRESHOLDS = {
+    "cloze": 0.10,
+    "synonym": 0.05,
+    "heritage": 0.01,
+    "paronym": 0.01,
+}
 MEANING_MC_MAX_WORDS = 4
 MEANING_MC_MAX_CHARS = 32
 NUMBER_KEYS = ("singular", "plural")
+STRESS_MARK = "\u0301"
+UKRAINIAN_VOWELS = frozenset("аеєиіїоуюяАЕЄИІЇОУЮЯ")
 NO_PAIR_PROBABILITY = {
     "A1": 0.70,
     "A2": 0.62,
@@ -282,6 +315,33 @@ def _plain(value: str) -> str:
         .replace("ʼ", "'")
         .strip()
     )
+
+
+def _strip_stress(value: str) -> str:
+    return unicodedata.normalize("NFC", unicodedata.normalize("NFD", value).replace(STRESS_MARK, ""))
+
+
+def _stress_position(stressed: str) -> tuple[str, int | None]:
+    nfd = unicodedata.normalize("NFD", stressed)
+    if nfd.count(STRESS_MARK) != 1:
+        return (_strip_stress(stressed), None)
+    prefix, _suffix = nfd.split(STRESS_MARK, 1)
+    prefix_nfc = unicodedata.normalize("NFC", prefix)
+    if not prefix_nfc:
+        return (_strip_stress(stressed), None)
+    return (_strip_stress(stressed), len(prefix_nfc) - 1)
+
+
+def _vowel_nuclei(value: str) -> list[dict[str, Any]]:
+    return [
+        {"index": index, "label": char}
+        for index, char in enumerate(value)
+        if char in UKRAINIAN_VOWELS
+    ]
+
+
+def _slug_key(entry: dict[str, Any]) -> str:
+    return _clean_text(entry.get("url_slug")) or _stable_lemma_id(entry)
 
 
 def _headword(gloss: str) -> str:
@@ -1091,6 +1151,546 @@ def _build_cloze_items(
     return items
 
 
+def _stress_payload(entry: dict[str, Any]) -> dict[str, Any] | None:
+    stress = entry.get("enrichment", {}).get("stress") if isinstance(entry.get("enrichment"), dict) else None
+    if isinstance(stress, dict):
+        form = _clean_text(stress.get("form"))
+        source = _clean_text(stress.get("source"))
+    else:
+        form = _clean_text(stress)
+        source = None
+    if not form:
+        return None
+    unstressed, stress_index = _stress_position(form)
+    nuclei = _vowel_nuclei(unstressed)
+    if stress_index is None or len(nuclei) < 2:
+        return None
+    if sum(1 for nucleus in nuclei if nucleus["index"] == stress_index) != 1:
+        return None
+    lemma = _clean_text(entry.get("lemma")) or ""
+    if lemma and _plain(unstressed) != _plain(lemma):
+        return None
+    return {
+        "stressed": form,
+        "unstressed": unstressed,
+        "stressIndex": stress_index,
+        "nuclei": nuclei,
+        "source": source or "ukrainian-word-stress",
+    }
+
+
+def _morphology(entry: dict[str, Any]) -> dict[str, Any] | None:
+    enrichment = entry.get("enrichment")
+    if not isinstance(enrichment, dict):
+        return None
+    morphology = enrichment.get("morphology")
+    return morphology if isinstance(morphology, dict) else None
+
+
+def _morph_labels(morphology: dict[str, Any]) -> list[str]:
+    forms = morphology.get("forms")
+    if not isinstance(forms, list):
+        return []
+    labels: list[str] = []
+    for row in forms:
+        if not isinstance(row, dict):
+            continue
+        label = _clean_text(row.get("label"))
+        if label is not None:
+            labels.append(label)
+    return labels
+
+
+def _morph_pos(entry: dict[str, Any], morphology: dict[str, Any] | None = None) -> str:
+    raw = ""
+    if morphology is not None:
+        raw = str(morphology.get("pos") or "")
+    if not raw:
+        raw = str(entry.get("pos") or "")
+    value = raw.casefold()
+    if "іменник" in value or value.startswith("noun") or value in {"abbreviation", "proper noun", "plural noun"}:
+        return "noun"
+    if "дієслово" in value or value.startswith("verb") or value in {"infinitive", "imperative"}:
+        return "verb"
+    if "прикметник" in value or value.startswith("adj") or value == "adjective":
+        return "adjective"
+    if "прислівник" in value or value.startswith("adv"):
+        return "adverb"
+    if "числівник" in value or value == "numeral":
+        return "numeral"
+    if value in {"прийменник", "сполучник", "частка", "preposition", "conjunction", "particle"}:
+        return "function"
+    return ""
+
+
+CLASSIFY_LABELS: dict[str, dict[str, tuple[str, str | None]]] = {
+    "gender": {
+        "masculine": ("чоловічий рід", "masc."),
+        "feminine": ("жіночий рід", "fem."),
+        "neuter": ("середній рід", "neut."),
+    },
+    "aspect": {
+        "perfective": ("доконаний вид", "pfv."),
+        "imperfective": ("недоконаний вид", "impfv."),
+    },
+    "declension": {
+        "declension-1": ("І відміна", None),
+        "declension-2": ("ІІ відміна", None),
+        "declension-3": ("ІІІ відміна", None),
+        "declension-4": ("IV відміна", None),
+    },
+    "pos": {
+        "noun": ("іменник", "noun"),
+        "verb": ("дієслово", "verb"),
+        "adjective": ("прикметник", "adj."),
+        "adverb": ("прислівник", "adv."),
+        "numeral": ("числівник", "num."),
+        "function": ("службове слово", "function word"),
+    },
+}
+
+CLASSIFY_SET_LABELS: dict[str, tuple[str, str | None]] = {
+    "gender": ("рід", "gender"),
+    "aspect": ("вид", "aspect"),
+    "declension": ("відміна", "declension"),
+    "pos": ("частина мови", "part of speech"),
+}
+
+
+def _classify_options(set_id: str, level: str) -> list[dict[str, str]]:
+    options = []
+    for value, (label_uk, label_en) in CLASSIFY_LABELS[set_id].items():
+        option = {"value": value, "labelUk": label_uk}
+        if CEFR_RANK[level] <= CEFR_RANK["A1"] and label_en:
+            option["labelEn"] = label_en
+        options.append(option)
+    return options
+
+
+def _gender_category(labels: list[str]) -> str | None:
+    singular_labels = [label for label in labels if "множина" not in label]
+    if not singular_labels:
+        return None
+    genders: set[str] = set()
+    for label in singular_labels:
+        if "чол." in label:
+            genders.add("masculine")
+        if "жін." in label:
+            genders.add("feminine")
+        if "сер." in label:
+            genders.add("neuter")
+    return next(iter(genders)) if len(genders) == 1 else None
+
+
+def _aspect_category(labels: list[str]) -> str | None:
+    has_present = any("теперішній" in label for label in labels)
+    has_future = any("майбутній" in label for label in labels)
+    if has_present:
+        return "imperfective"
+    if has_future:
+        return "perfective"
+    return None
+
+
+def _declension_category(entry: dict[str, Any], labels: list[str], paradigm: dict[str, Any]) -> str | None:
+    if _morph_pos(entry) != "noun":
+        return None
+    if not _gender_category(labels):
+        return None
+    cases = paradigm.get("cases")
+    if not isinstance(cases, dict):
+        return None
+    nominative = cases.get("називний") or cases.get("nominative")
+    if not isinstance(nominative, dict):
+        return None
+    singular = _clean_text(nominative.get("singular"))
+    plural = _clean_text(nominative.get("plural"))
+    if not singular or (plural and _plain(singular) == _plain(plural)):
+        return None
+    lemma = _clean_text(entry.get("lemma")) or singular
+    gender = _gender_category(labels)
+    plain_lemma = _plain(lemma)
+    if gender == "feminine" and plain_lemma.endswith(("а", "я")):
+        return "declension-1"
+    if gender == "neuter" and plain_lemma.endswith(("а", "я")):
+        return "declension-4"
+    if gender in {"masculine", "neuter"}:
+        return "declension-2"
+    if gender == "feminine" and not plain_lemma.endswith(("а", "я")):
+        return "declension-3"
+    return None
+
+
+def _category_set_payload(set_id: str, value: str, level: str) -> dict[str, Any]:
+    set_label_uk, set_label_en = CLASSIFY_SET_LABELS[set_id]
+    answer_label_uk, answer_label_en = CLASSIFY_LABELS[set_id][value]
+    payload: dict[str, Any] = {
+        "setId": set_id,
+        "setLabelUk": set_label_uk,
+        "answer": value,
+        "answerLabelUk": answer_label_uk,
+        "options": _classify_options(set_id, level),
+    }
+    if CEFR_RANK[level] <= CEFR_RANK["A1"]:
+        if set_label_en:
+            payload["setLabelEn"] = set_label_en
+        if answer_label_en:
+            payload["answerLabelEn"] = answer_label_en
+    return payload
+
+
+def _build_classify_items(entry: dict[str, Any], lexeme: dict[str, Any]) -> list[dict[str, Any]]:
+    morphology = _morphology(entry)
+    if not morphology:
+        return []
+    labels = _morph_labels(morphology)
+    pos = _morph_pos(entry, morphology)
+    sets: list[dict[str, Any]] = []
+    if pos == "noun":
+        gender = _gender_category(labels)
+        if gender:
+            sets.append(_category_set_payload("gender", gender, lexeme["cefr"]))
+        declension = _declension_category(entry, labels, morphology.get("paradigm") if isinstance(morphology.get("paradigm"), dict) else {})
+        if declension and CEFR_RANK[lexeme["cefr"]] >= CEFR_RANK["B1"]:
+            sets.append(_category_set_payload("declension", declension, lexeme["cefr"]))
+    elif pos == "verb":
+        aspect = _aspect_category(labels)
+        if aspect and CEFR_RANK[lexeme["cefr"]] >= CEFR_RANK["A2"]:
+            sets.append(_category_set_payload("aspect", aspect, lexeme["cefr"]))
+    if pos in CLASSIFY_LABELS["pos"] and CEFR_RANK[lexeme["cefr"]] >= CEFR_RANK["A2"]:
+        sets.append(_category_set_payload("pos", pos, lexeme["cefr"]))
+    if not sets:
+        return []
+    return [
+        {
+            "classifyId": f"{lexeme['lemmaId']}:classify",
+            "lemmaId": lexeme["lemmaId"],
+            "lemma": lexeme["lemma"],
+            "sets": sets,
+            "source": "VESUM",
+        }
+    ]
+
+
+CASE_SLOT_LABELS: dict[str, tuple[str, str]] = {
+    "називний": ("називний відмінок", "nom."),
+    "родовий": ("родовий відмінок", "gen."),
+    "давальний": ("давальний відмінок", "dat."),
+    "знахідний": ("знахідний відмінок", "acc."),
+    "орудний": ("орудний відмінок", "instr."),
+    "місцевий": ("місцевий відмінок", "loc."),
+    "кличний": ("кличний відмінок", "voc."),
+}
+
+
+def _single_surface(value: Any) -> str | None:
+    text = _clean_text(value)
+    if not text or "/" in text:
+        return None
+    return text
+
+
+def _build_paradigm_items(lexeme: dict[str, Any]) -> list[dict[str, Any]]:
+    cases = lexeme.get("paradigm", {}).get("cases")
+    if not isinstance(cases, dict):
+        return []
+    slots: list[dict[str, str]] = []
+    seen_forms: set[str] = set()
+    duplicate_forms: set[str] = set()
+    for case_name, forms in cases.items():
+        if not isinstance(case_name, str) or not isinstance(forms, dict):
+            continue
+        case_key = case_name.strip()
+        if case_key not in CASE_SLOT_LABELS:
+            continue
+        for number in NUMBER_KEYS:
+            form = _single_surface(forms.get(number))
+            if not form:
+                continue
+            normalized = _plain(form)
+            if normalized in seen_forms:
+                duplicate_forms.add(normalized)
+            seen_forms.add(normalized)
+            slots.append({"case": case_key, "number": number, "form": form})
+    usable = [slot for slot in slots if _plain(slot["form"]) not in duplicate_forms]
+    if len(usable) < 3:
+        return []
+    forms = [slot["form"] for slot in usable]
+    items = []
+    for index, slot in enumerate(usable):
+        label_uk, label_en = CASE_SLOT_LABELS[slot["case"]]
+        number_uk = "однина" if slot["number"] == "singular" else "множина"
+        number_en = "sg" if slot["number"] == "singular" else "pl"
+        options = [{"label": slot["form"], "kind": "answer"}]
+        for other in usable:
+            if other is slot or _plain(other["form"]) == _plain(slot["form"]):
+                continue
+            options.append({"label": other["form"], "kind": "same-paradigm"})
+            if len(options) == 4:
+                break
+        if len(options) < 4:
+            continue
+        paradigm_id = f"{lexeme['lemmaId']}:paradigm:{index + 1}"
+        answer_index = int(hashlib.sha1(paradigm_id.encode("utf-8")).hexdigest()[:2], 16) % len(options)
+        answer = options.pop(0)
+        options.insert(answer_index, answer)
+        item: dict[str, Any] = {
+            "paradigmId": paradigm_id,
+            "lemmaId": lexeme["lemmaId"],
+            "lemma": lexeme["lemma"],
+            "slot": {
+                "case": slot["case"],
+                "number": slot["number"],
+                "labelUk": f"{label_uk}, {number_uk}",
+            },
+            "form": slot["form"],
+            "options": options,
+        }
+        if CEFR_RANK[lexeme["cefr"]] <= CEFR_RANK["A1"]:
+            item["slot"]["labelEn"] = f"{label_en} {number_en}"
+        items.append(item)
+    return items
+
+
+def _section_items(entry: dict[str, Any], section_name: str) -> list[str]:
+    sections = entry.get("sections")
+    if not isinstance(sections, dict):
+        return []
+    section = sections.get(section_name)
+    if not isinstance(section, dict):
+        return []
+    items = section.get("items")
+    if not isinstance(items, list):
+        return []
+    cleaned: list[str] = []
+    for item in items:
+        text = _clean_text(re.sub(r"\s*\([^)]*\)\s*", "", str(item)))
+        if text:
+            cleaned.append(text)
+    return cleaned
+
+
+def _synonym_option(
+    label: str,
+    lemma_id: str,
+    kind: str,
+) -> dict[str, str]:
+    return {"label": label, "lemmaId": lemma_id, "kind": kind}
+
+
+def _valid_synonym_distractors(
+    answer: dict[str, Any],
+    prompt: dict[str, Any],
+    lexemes: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    blocked_heads = {_headword(prompt["gloss"]), _headword(answer["gloss"])}
+    candidates = []
+    for lexeme in lexemes:
+        if lexeme["lemmaId"] in {prompt["lemmaId"], answer["lemmaId"]}:
+            continue
+        if lexeme.get("pos") != answer.get("pos"):
+            continue
+        if _headword(lexeme["gloss"]) in blocked_heads:
+            continue
+        if _plain(lexeme["lemma"]) in {_plain(prompt["lemma"]), _plain(answer["lemma"])}:
+            continue
+        candidates.append(lexeme)
+    answer_len = len(answer["lemma"])
+    return sorted(
+        candidates,
+        key=lambda item: (
+            abs(len(item["lemma"]) - answer_len),
+            item["cefr"] != answer["cefr"],
+            item["lemmaId"],
+        ),
+    )
+
+
+def _build_synonym_items(
+    entry: dict[str, Any],
+    lexeme: dict[str, Any],
+    by_plain_lemma: dict[str, dict[str, Any]],
+    all_lexemes: list[dict[str, Any]],
+    deck_version: str,
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for polarity, section_name in (("synonym", "synonyms"), ("antonym", "antonyms")):
+        for target_label in _section_items(entry, section_name):
+            target = by_plain_lemma.get(_plain(target_label))
+            if not target:
+                continue
+            if CEFR_RANK[lexeme["cefr"]] < CEFR_RANK["B1"]:
+                continue
+            if CEFR_RANK[target["cefr"]] > CEFR_RANK[lexeme["cefr"]]:
+                continue
+            distractors = _valid_synonym_distractors(target, lexeme, all_lexemes)
+            if len(distractors) < 3:
+                continue
+            key = "\x1f".join((deck_version, lexeme["lemmaId"], target["lemmaId"], polarity))
+            synonym_id = "syn_" + hashlib.sha1(key.encode("utf-8")).hexdigest()[:12]
+            options = [
+                _synonym_option(target["lemma"], target["lemmaId"], "answer"),
+                *[
+                    _synonym_option(distractor["lemma"], distractor["lemmaId"], "distractor")
+                    for distractor in distractors[:3]
+                ],
+            ]
+            answer_index = int(hashlib.sha1(synonym_id.encode("utf-8")).hexdigest()[:2], 16) % len(options)
+            answer = options.pop(0)
+            options.insert(answer_index, answer)
+            item = {
+                "synonymId": synonym_id,
+                "lemmaId": lexeme["lemmaId"],
+                "targetLemmaId": target["lemmaId"],
+                "polarity": polarity,
+                "prompt": lexeme["lemma"],
+                "answer": target["lemma"],
+                "level": lexeme["cefr"],
+                "options": options,
+                "source": "ukrajinet-auto-translation",
+            }
+            items.append(item)
+    return items
+
+
+def validate_classify_item(item: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    sets = item.get("sets")
+    if not isinstance(sets, list) or not sets:
+        return ["classify item must contain at least one category set"]
+    for category_set in sets:
+        if not isinstance(category_set, dict):
+            errors.append("classify category set must be an object")
+            continue
+        set_id = category_set.get("setId")
+        answer = category_set.get("answer")
+        options = category_set.get("options")
+        if set_id not in CLASSIFY_LABELS:
+            errors.append("classify category set is not closed")
+            continue
+        closed_values = set(CLASSIFY_LABELS[str(set_id)])
+        option_values = {
+            option.get("value")
+            for option in (options if isinstance(options, list) else [])
+            if isinstance(option, dict)
+        }
+        if option_values != closed_values:
+            errors.append(f"classify {set_id} options must equal the closed category set")
+        if answer not in closed_values:
+            errors.append(f"classify {set_id} answer must be in the closed category set")
+    return errors
+
+
+def validate_classify_session_cap(items: list[dict[str, Any]], cap: float = 0.60) -> list[str]:
+    counts: Counter[str] = Counter()
+    for item in items:
+        sets = item.get("sets")
+        if not isinstance(sets, list):
+            continue
+        for category_set in sets:
+            if isinstance(category_set, dict):
+                key = f"{category_set.get('setId')}:{category_set.get('answer')}"
+                counts[key] += 1
+    total = sum(counts.values())
+    if total < 4:
+        return []
+    worst = max(counts.values()) / total
+    if worst > cap:
+        return [f"classify session category cap exceeded: {worst:.2%} > {cap:.0%}"]
+    return []
+
+
+def validate_synonym_item(item: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    options = item.get("options")
+    if not isinstance(options, list) or len(options) < 4:
+        return ["synonym option set must contain at least four options"]
+    labels = [str(option.get("label") or "") for option in options if isinstance(option, dict)]
+    normalized = [_plain(label) for label in labels]
+    if len(set(normalized)) != len(normalized):
+        errors.append("synonym options must be unique after normalization")
+    answer = _plain(str(item.get("answer") or ""))
+    if normalized.count(answer) != 1:
+        errors.append("synonym answer must be present exactly once")
+    lengths = [len(label) for label in labels]
+    if lengths and max(lengths) - min(lengths) > 12:
+        errors.append("synonym option label lengths exceed bounded distribution")
+    prompt = _plain(str(item.get("prompt") or ""))
+    for label in normalized:
+        if label and label != answer and (label in {answer, prompt} or answer in label or label in answer):
+            errors.append("synonym distractor must not be a near-duplicate of prompt or answer")
+            break
+    return errors
+
+
+def validate_paradigm_item(item: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    options = item.get("options")
+    if not isinstance(options, list) or len(options) < 4:
+        return ["paradigm option set must contain at least four options"]
+    labels = [str(option.get("label") or "") for option in options if isinstance(option, dict)]
+    normalized = [_plain(label) for label in labels]
+    if len(set(normalized)) != len(normalized):
+        errors.append("paradigm options must be unique after normalization")
+    answer = _plain(str(item.get("form") or ""))
+    if normalized.count(answer) != 1:
+        errors.append("paradigm answer form must be present exactly once")
+    return errors
+
+
+def validate_heritage_pair(pair: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if not _clean_text(pair.get("nativeSlug")):
+        errors.append("heritage_pair missing nativeSlug")
+    if not _clean_text(pair.get("calqueLabel")):
+        errors.append("heritage_pair missing calqueLabel")
+    corrections = pair.get("corrections")
+    if not isinstance(corrections, list) or not corrections:
+        errors.append("heritage_pair corrections must be a nonempty list")
+    citations = pair.get("citations")
+    if not isinstance(citations, list) or not citations:
+        errors.append("heritage_pair citations must be a nonempty list")
+    if not _clean_text(pair.get("sourceFamily")):
+        errors.append("heritage_pair missing sourceFamily")
+    return errors
+
+
+def validate_paronym_pair(pair: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in ("slugA", "slugB", "distinction_gloss_uk"):
+        if not _clean_text(pair.get(field)):
+            errors.append(f"paronym_pair missing {field}")
+    frames = pair.get("frames")
+    if not isinstance(frames, list) or not frames:
+        errors.append("paronym_pair frames must be a nonempty list")
+    citations = pair.get("citations")
+    if not isinstance(citations, list) or not citations:
+        errors.append("paronym_pair citations must be a nonempty list")
+    return errors
+
+
+def validate_mode_items(mode: str, items: list[dict[str, Any]]) -> list[str]:
+    errors: list[str] = []
+    if mode == "classify":
+        for index, item in enumerate(items):
+            errors.extend(f"classify[{index}]: {error}" for error in validate_classify_item(item))
+        errors.extend(validate_classify_session_cap(items))
+    elif mode == "synonym":
+        for index, item in enumerate(items):
+            errors.extend(f"synonym[{index}]: {error}" for error in validate_synonym_item(item))
+    elif mode == "paradigm":
+        for index, item in enumerate(items):
+            errors.extend(f"paradigm[{index}]: {error}" for error in validate_paradigm_item(item))
+    return errors
+
+
+def _validate_mode_or_raise(level: str, mode: str, items: list[dict[str, Any]]) -> None:
+    errors = validate_mode_items(mode, items)
+    if errors:
+        joined = "; ".join(errors[:8])
+        raise ValueError(f"{level} {mode} validator failed: {joined}")
+
+
 def _level_payload(
     schema: str,
     deck_version: str,
@@ -1147,6 +1747,9 @@ def build_practice_shards(
             lexemes_by_entry.append((entry, lexeme))
 
     all_lexemes = [lexeme for _, lexeme in lexemes_by_entry]
+    by_plain_lemma: dict[str, dict[str, Any]] = {}
+    for lexeme in all_lexemes:
+        by_plain_lemma.setdefault(_plain(lexeme["lemma"]), lexeme)
     cloze_sources = cloze_sources or []
     cloze_by_lemma_id: dict[str, list[dict[str, Any]]] = {}
     cloze_by_lemma: dict[str, list[dict[str, Any]]] = {}
@@ -1159,6 +1762,11 @@ def build_practice_shards(
         target.setdefault(key_value, []).append(row)
     cloze_by_level: dict[str, list[dict[str, Any]]] = {level: [] for level in CEFR_ORDER}
     cloze_ids_by_lemma: dict[str, list[str]] = {}
+    mode_by_level: dict[str, dict[str, list[dict[str, Any]]]] = {
+        level: {mode: [] for mode in DRILL_MODES}
+        for level in CEFR_ORDER
+    }
+    mode_lemma_ids: dict[str, set[str]] = {mode: set() for mode in DRILL_MODES}
     for _entry, lexeme in lexemes_by_entry:
         if is_surface_admitted(_entry, SURFACE_CLOZE):
             source_rows = [
@@ -1175,13 +1783,42 @@ def build_practice_shards(
                 continue
             cloze_by_level[lexeme["cefr"]].append(item)
             cloze_ids_by_lemma.setdefault(lexeme["lemmaId"], []).append(item["clozeId"])
+        stress = _stress_payload(_entry)
+        if stress:
+            mode_by_level[lexeme["cefr"]]["stress"].append(
+                {
+                    "stressId": f"{lexeme['lemmaId']}:stress",
+                    "lemmaId": lexeme["lemmaId"],
+                    "lemma": lexeme["lemma"],
+                    **stress,
+                }
+            )
+            mode_lemma_ids["stress"].add(lexeme["lemmaId"])
+
+        classify_items = _build_classify_items(_entry, lexeme)
+        mode_by_level[lexeme["cefr"]]["classify"].extend(classify_items)
+        if classify_items:
+            mode_lemma_ids["classify"].add(lexeme["lemmaId"])
+
+        paradigm_items = _build_paradigm_items(lexeme)
+        mode_by_level[lexeme["cefr"]]["paradigm"].extend(paradigm_items)
+        if paradigm_items:
+            mode_lemma_ids["paradigm"].add(lexeme["lemmaId"])
+
+        synonym_items = _build_synonym_items(_entry, lexeme, by_plain_lemma, all_lexemes, deck_version)
+        for item in synonym_items:
+            level = str(item.pop("level"))
+            mode_by_level[level]["synonym"].append(item)
+            mode_lemma_ids["synonym"].add(lexeme["lemmaId"])
 
     shards: dict[str, dict[str, dict[str, Any]]] = {}
-    for level in CEFR_ORDER:
+    for level in PUBLISHED_LEVELS:
         level_lexemes = [lexeme for lexeme in all_lexemes if lexeme["cefr"] == level]
         if not level_lexemes:
             continue
         level_cloze = cloze_by_level[level]
+        for mode in ("classify", "paradigm", "synonym"):
+            _validate_mode_or_raise(level, mode, mode_by_level[level][mode])
         option_set_errors = validate_option_sets(level_cloze)
         if option_set_errors:
             print(
@@ -1199,6 +1836,9 @@ def build_practice_shards(
                 modes.extend(["matching", "choice"])
             if cloze_ids:
                 modes.append("cloze")
+            for drill_mode in DRILL_MODES:
+                if lexeme["lemmaId"] in mode_lemma_ids[drill_mode]:
+                    modes.append(drill_mode)
             index_items.append(
                 {
                     "lemmaId": lexeme["lemmaId"],
@@ -1229,7 +1869,38 @@ def build_practice_shards(
             "cloze": len(level_cloze),
             "clozeEligibleLexemes": len({item["lemmaId"] for item in level_cloze}),
             "clozeCoverage": coverage,
+            "modeCounts": {
+                "cloze": len(level_cloze),
+                **{mode: len(mode_by_level[level][mode]) for mode in DRILL_MODES},
+            },
+            "modeCoverage": {
+                "cloze": coverage,
+                **{
+                    mode: round(
+                        len({item["lemmaId"] for item in mode_by_level[level][mode]}) / len(level_lexemes),
+                        4,
+                    )
+                    for mode in DRILL_MODES
+                },
+            },
         }
+        for mode, threshold in THIN_WARN_THRESHOLDS.items():
+            mode_coverage = index_payload["counts"]["modeCoverage"].get(mode, 0.0)
+            if mode_coverage < threshold:
+                print(
+                    f"WARN: {level} {mode} coverage {mode_coverage:.4f} below {threshold:.2f}; "
+                    "deck ships small without padding",
+                    file=sys.stderr,
+                )
+        print(
+            "coverage "
+            f"{level}: "
+            + " ".join(
+                f"{mode}={index_payload['counts']['modeCounts'][mode]} "
+                f"({index_payload['counts']['modeCoverage'][mode]:.2%})"
+                for mode in ("cloze", *DRILL_MODES)
+            )
+        )
         lexeme_payload = _level_payload(
             "atlas-practice-lexemes",
             deck_version,
@@ -1246,10 +1917,22 @@ def build_practice_shards(
             "cloze",
             level_cloze,
         )
+        mode_payloads = {
+            mode: _level_payload(
+                MODE_SCHEMAS[mode],
+                deck_version,
+                level,
+                config,
+                MODE_BODY_KEYS[mode],
+                mode_by_level[level][mode],
+            )
+            for mode in DRILL_MODES
+        }
         shards[level] = {
             "index": index_payload,
             "lexemes": lexeme_payload,
             "cloze": cloze_payload,
+            **mode_payloads,
         }
     return shards
 
@@ -1260,6 +1943,24 @@ def read_manifest(path: Path) -> list[dict[str, Any]]:
     if not isinstance(entries, list):
         raise ValueError("manifest entries must be a list")
     return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def read_atlas_db(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        raise FileNotFoundError(f"{path} not found; run npm --prefix site run atlas:build-db")
+    conn = sqlite3.connect(path)
+    try:
+        rows = conn.execute(
+            "SELECT payload_json FROM article_payloads WHERE is_public_route=1 ORDER BY route_order"
+        ).fetchall()
+    finally:
+        conn.close()
+    entries = []
+    for (payload_json,) in rows:
+        payload = json.loads(payload_json)
+        if isinstance(payload, dict):
+            entries.append(payload)
+    return entries
 
 
 def read_cloze_sources(path: Path | None) -> list[dict[str, Any]]:
@@ -1273,6 +1974,62 @@ def read_cloze_sources(path: Path | None) -> list[dict[str, Any]]:
     if not rows:
         print("WARN: curated cloze sources empty; emitting recognition-only deck", file=sys.stderr)
     return rows
+
+
+def run_broken_validator_fixtures() -> int:
+    failures = {
+        "classify": validate_classify_item(
+            {
+                "classifyId": "broken:classify",
+                "lemmaId": "broken",
+                "sets": [
+                    {
+                        "setId": "gender",
+                        "answer": "masculine",
+                        "options": [{"value": "masculine", "labelUk": "чоловічий рід"}],
+                    }
+                ],
+            }
+        ),
+        "synonym": validate_synonym_item(
+            {
+                "synonymId": "broken:synonym",
+                "lemmaId": "broken",
+                "prompt": "слово",
+                "answer": "слово",
+                "options": [
+                    {"label": "слово", "lemmaId": "a", "kind": "answer"},
+                    {"label": "слово", "lemmaId": "b", "kind": "distractor"},
+                    {"label": "дуже довгий варіант-підказка", "lemmaId": "c", "kind": "distractor"},
+                    {"label": "інше", "lemmaId": "d", "kind": "distractor"},
+                ],
+            }
+        ),
+        "paradigm": validate_paradigm_item(
+            {
+                "paradigmId": "broken:paradigm",
+                "lemmaId": "broken",
+                "form": "книгу",
+                "options": [
+                    {"label": "книгу", "kind": "answer"},
+                    {"label": "книгу", "kind": "same-paradigm"},
+                    {"label": "книзі", "kind": "same-paradigm"},
+                ],
+            }
+        ),
+        "heritage_pair": validate_heritage_pair(
+            {"nativeSlug": "слово", "calqueLabel": "калька", "corrections": [], "citations": []}
+        ),
+        "paronym_pair": validate_paronym_pair(
+            {"slugA": "адрес", "slugB": "адреса", "frames": [], "citations": []}
+        ),
+    }
+    print("Broken validator fixtures:")
+    ok = True
+    for name, errors in failures.items():
+        print(f"  {name}: {errors}")
+        ok = ok and bool(errors)
+    return 1 if ok else 2
 
 
 def _json_bytes(payload: dict[str, Any]) -> bytes:
@@ -1330,6 +2087,14 @@ def apply_size_budgets(
                     for item in cloze_items
                     if not isinstance(item, dict) or item.get("lemmaId") != removed_lemma_id
                 ]
+            for mode in DRILL_MODES:
+                mode_items = level_shards.get(mode, {}).get(MODE_BODY_KEYS[mode], [])
+                if isinstance(mode_items, list):
+                    mode_items[:] = [
+                        item
+                        for item in mode_items
+                        if not isinstance(item, dict) or item.get("lemmaId") != removed_lemma_id
+                    ]
             counts = level_shards.get("index", {}).get("counts")
             if isinstance(counts, dict) and isinstance(lexemes, list) and isinstance(cloze_items, list):
                 counts["lexemes"] = len(lexemes)
@@ -1340,6 +2105,25 @@ def apply_size_budgets(
                 counts["clozeCoverage"] = (
                     round(counts["clozeEligibleLexemes"] / len(lexemes), 4) if lexemes else 0
                 )
+                mode_counts = counts.setdefault("modeCounts", {})
+                mode_coverage = counts.setdefault("modeCoverage", {})
+                if isinstance(mode_counts, dict) and isinstance(mode_coverage, dict):
+                    mode_counts["cloze"] = len(cloze_items)
+                    mode_coverage["cloze"] = counts["clozeCoverage"]
+                    for mode in DRILL_MODES:
+                        mode_items = level_shards.get(mode, {}).get(MODE_BODY_KEYS[mode], [])
+                        if not isinstance(mode_items, list):
+                            continue
+                        mode_counts[mode] = len(mode_items)
+                        mode_coverage[mode] = (
+                            round(
+                                len({item["lemmaId"] for item in mode_items if isinstance(item, dict)})
+                                / len(lexemes),
+                                4,
+                            )
+                            if lexemes
+                            else 0
+                        )
 
 
 def write_shards(shards: dict[str, dict[str, dict[str, Any]]], out_dir: Path) -> list[Path]:
@@ -1355,7 +2139,8 @@ def write_shards(shards: dict[str, dict[str, dict[str, Any]]], out_dir: Path) ->
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--atlas-db", type=Path, default=DEFAULT_ATLAS_DB)
+    parser.add_argument("--manifest", type=Path)
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
     parser.add_argument("--reviewed-allowlist", type=Path, default=DEFAULT_ALLOWLIST)
     parser.add_argument("--cloze-sources", type=Path, default=DEFAULT_CLOZE_SOURCES)
@@ -1364,9 +2149,17 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--raw-limit", type=int, default=DEFAULT_RAW_LIMIT)
     parser.add_argument("--gzip-limit", type=int, default=DEFAULT_GZIP_LIMIT)
     parser.add_argument("--fixture-note", type=str)
+    parser.add_argument(
+        "--broken-validator-fixtures",
+        action="store_true",
+        help="Run deliberately broken mode-validator fixtures and exit nonzero when validators catch them.",
+    )
     args = parser.parse_args(argv)
 
-    entries = read_manifest(args.manifest)
+    if args.broken_validator_fixtures:
+        return run_broken_validator_fixtures()
+
+    entries = read_manifest(args.manifest) if args.manifest else read_atlas_db(args.atlas_db)
     allowlist = ReviewedSourceAllowlist.from_path(args.reviewed_allowlist)
     cloze_sources = read_cloze_sources(args.cloze_sources)
     verifier: VesumVerifier = (
@@ -1379,7 +2172,7 @@ def main(argv: list[str] | None = None) -> int:
         raw_limit=args.raw_limit,
         gzip_limit=args.gzip_limit,
         fixture_note=args.fixture_note,
-        source_label="fixture" if args.vesum_fixture else "manifest",
+        source_label="fixture" if args.vesum_fixture or args.manifest else "atlas.db",
     )
     shards = build_practice_shards(entries, allowlist, verifier, cloze_sources, config)
     apply_size_budgets(shards, config.raw_limit, config.gzip_limit)

--- a/scripts/practice_deck/io.py
+++ b/scripts/practice_deck/io.py
@@ -67,7 +67,18 @@ def _safe_shard_name(name: object) -> str:
         raise PracticeDeckHydrationError("practice deck file path must be a non-empty string")
     if "/" in name or "\\" in name or name.startswith("."):
         raise PracticeDeckHydrationError(f"unsafe practice deck file path: {name!r}")
-    if not name.endswith(".json") or not name.startswith(("practice-index.", "practice-lexemes.", "practice-cloze.")):
+    allowed_prefixes = (
+        "practice-index.",
+        "practice-lexemes.",
+        "practice-cloze.",
+        "practice-stress.",
+        "practice-classify.",
+        "practice-paradigm.",
+        "practice-synonym.",
+        "practice-heritage.",
+        "practice-paronym.",
+    )
+    if not name.endswith(".json") or not name.startswith(allowed_prefixes):
         raise PracticeDeckHydrationError(f"unexpected practice deck file path: {name!r}")
     return name
 

--- a/scripts/practice_deck/publish.py
+++ b/scripts/practice_deck/publish.py
@@ -24,6 +24,12 @@ KINDS = {
     "index": ("practice-index.{level}.json", "atlas-practice-index"),
     "lexemes": ("practice-lexemes.{level}.json", "atlas-practice-lexemes"),
     "cloze": ("practice-cloze.{level}.json", "atlas-practice-cloze"),
+    "stress": ("practice-stress.{level}.json", "atlas-practice-stress"),
+    "classify": ("practice-classify.{level}.json", "atlas-practice-classify"),
+    "paradigm": ("practice-paradigm.{level}.json", "atlas-practice-paradigm"),
+    "synonym": ("practice-synonym.{level}.json", "atlas-practice-synonym"),
+    "heritage": ("practice-heritage.{level}.json", "atlas-practice-heritage"),
+    "paronym": ("practice-paronym.{level}.json", "atlas-practice-paronym"),
 }
 
 

--- a/site/scripts/hydrate-practice-deck.mjs
+++ b/site/scripts/hydrate-practice-deck.mjs
@@ -26,7 +26,7 @@ const pointerPath = resolve(repoRoot, "site/src/data/lexicon-practice-deck.point
 const practiceDir = resolve(repoRoot, "site/public/lexicon");
 const DOWNLOAD_ATTEMPTS = 3;
 const ALLOWED_RELEASE_PATH_PREFIX = "/learn-ukrainian/learn-ukrainian.github.io/releases/download/";
-const SHARD_RE = /^practice-(index|lexemes|cloze)\.(A1|A2|B1|B2|C1)\.json$/;
+const SHARD_RE = /^practice-(index|lexemes|cloze|stress|classify|paradigm|synonym|heritage|paronym)\.(A1|A2|B1|B2|C1)\.json$/;
 
 function sha256(data) {
   return createHash("sha256").update(data).digest("hex");

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -23,6 +23,7 @@ import {
   type PracticeRating,
   type PracticeSelection,
   type SelectionHistoryItem,
+  type PracticeClassifySet,
 } from '../lib/lexicon/srs';
 import {
   CEFR_LEVELS,
@@ -68,7 +69,15 @@ const RATING_LABELS: Record<PracticeRating, string> = {
 
 type VisiblePracticeModeFilter = Extract<
   PracticeModeFilter,
-  'mixed' | 'flashcards' | 'matching' | 'choice' | 'cloze'
+  | 'mixed'
+  | 'flashcards'
+  | 'matching'
+  | 'choice'
+  | 'cloze'
+  | 'stress'
+  | 'classify'
+  | 'paradigm'
+  | 'synonym'
 >;
 
 const MODE_LABELS: Record<VisiblePracticeModeFilter, string> = {
@@ -77,9 +86,23 @@ const MODE_LABELS: Record<VisiblePracticeModeFilter, string> = {
   matching: 'Matching',
   choice: 'Choice',
   cloze: 'Cloze',
+  stress: 'Stress',
+  classify: 'Classify',
+  paradigm: 'Paradigm',
+  synonym: 'Synonym',
 };
 
-const MODE_CARD_ORDER: VisiblePracticeModeFilter[] = ['mixed', 'flashcards', 'matching', 'choice', 'cloze'];
+const MODE_CARD_ORDER: VisiblePracticeModeFilter[] = [
+  'mixed',
+  'flashcards',
+  'matching',
+  'choice',
+  'cloze',
+  'stress',
+  'classify',
+  'paradigm',
+  'synonym',
+];
 
 const MODE_META: Record<
   VisiblePracticeModeFilter,
@@ -124,6 +147,34 @@ const MODE_META: Record<
     en: 'Cloze',
     description: 'Впишіть слово у потрібній формі. Відмінок має збігатися з реченням.',
     step: 'Відмінювання',
+    accent: 'orange',
+  },
+  stress: {
+    title: 'Наголос',
+    en: 'Stress',
+    description: 'Оберіть голосну, на яку падає наголос у слові.',
+    step: 'Форма слова',
+    accent: 'teal',
+  },
+  classify: {
+    title: 'Група',
+    en: 'Classify',
+    description: 'Визначте граматичну групу слова за даними VESUM.',
+    step: 'Морфологія',
+    accent: 'purple',
+  },
+  paradigm: {
+    title: 'Форма',
+    en: 'Paradigm',
+    description: 'Оберіть форму слова для потрібного відмінка й числа.',
+    step: 'Парадигма',
+    accent: 'blue',
+  },
+  synonym: {
+    title: 'Синоніми',
+    en: 'Synonyms',
+    description: 'Доберіть синонім або антонім до українського слова.',
+    step: 'Лексика',
     accent: 'orange',
   },
 };
@@ -369,6 +420,10 @@ function normalizeInitialDeck(initialDeck?: PracticeDeckData | PracticeLexeme[])
     })),
     lexemes,
     cloze: [],
+    stress: [],
+    classify: [],
+    paradigm: [],
+    synonym: [],
   };
 }
 
@@ -380,6 +435,7 @@ function historyFromSelection(selection: PracticeSelection): SelectionHistoryIte
     clozeId: selection.cloze?.clozeId,
     sentenceFrameId: selection.cloze?.sentenceFrameId,
     blankCase: selection.cloze?.blankCase,
+    classifySetId: selection.classifySetId,
     recallDirection: selection.recallDirection,
     choicePolarity: selection.choicePolarity,
     lapsed: selection.lapsed,
@@ -468,13 +524,86 @@ function choicePrompt(selection: PracticeSelection): string {
   return `Яке слово означає «${glossLabel(selection.lemma)}»?`;
 }
 
+function classifySet(selection: PracticeSelection): PracticeClassifySet | null {
+  const sets = selection.classify?.sets ?? [];
+  if (!sets.length) return null;
+  return sets.find((set) => set.setId === selection.classifySetId) ?? sets[0] ?? null;
+}
+
+function drillChoiceOptions(selection: PracticeSelection): ChoiceOption[] | null {
+  if (selection.stress) {
+    return selection.stress.nuclei.map((nucleus) => ({
+      label: nucleus.label,
+      correct: nucleus.index === selection.stress?.stressIndex,
+    }));
+  }
+  const selectedSet = classifySet(selection);
+  if (selectedSet) {
+    return selectedSet.options.map((option) => ({
+      label: option.labelEn ? `${option.labelUk} (${option.labelEn})` : option.labelUk,
+      correct: option.value === selectedSet.answer,
+    }));
+  }
+  if (selection.paradigm) {
+    return selection.paradigm.options.map((option) => ({
+      label: option.label,
+      correct: option.kind === 'answer',
+    }));
+  }
+  if (selection.synonym) {
+    return selection.synonym.options.map((option) => ({
+      label: option.label,
+      correct: option.kind === 'answer',
+    }));
+  }
+  return null;
+}
+
+function drillChoicePrompt(selection: PracticeSelection): { prompt: string; subtitle: string } | null {
+  if (selection.stress) {
+    return {
+      prompt: `Де наголос у слові «${selection.stress.unstressed}»?`,
+      subtitle: 'Оберіть наголошену голосну',
+    };
+  }
+  const selectedSet = classifySet(selection);
+  if (selectedSet) {
+    const setLabel = selectedSet.setLabelEn
+      ? `${selectedSet.setLabelUk} (${selectedSet.setLabelEn})`
+      : selectedSet.setLabelUk;
+    return {
+      prompt: `До якої групи належить «${selection.lemma.lemma}»?`,
+      subtitle: setLabel,
+    };
+  }
+  if (selection.paradigm) {
+    const slot = selection.paradigm.slot.labelEn
+      ? `${selection.paradigm.slot.labelUk} (${selection.paradigm.slot.labelEn})`
+      : selection.paradigm.slot.labelUk;
+    return {
+      prompt: `Яка форма від «${selection.lemma.lemma}»?`,
+      subtitle: slot,
+    };
+  }
+  if (selection.synonym) {
+    return {
+      prompt:
+        selection.synonym.polarity === 'antonym'
+          ? `Оберіть антонім до «${selection.synonym.prompt}»`
+          : `Оберіть синонім до «${selection.synonym.prompt}»`,
+      subtitle: 'Оберіть правильну відповідь',
+    };
+  }
+  return null;
+}
+
 function clozeParts(item: PracticeClozeItem): [string, string] {
   const [before, ...after] = item.sentence.split('___');
   return [before, after.join('___')];
 }
 
 function shouldLoadCloze(mode: PracticeModeFilter): boolean {
-  return mode === 'mixed' || mode === 'cloze';
+  return ['mixed', 'cloze', 'stress', 'classify', 'paradigm', 'synonym'].includes(mode);
 }
 
 /** Learner level persisted in the shared `lu-learner-level` key (also used by Words of the Day). */
@@ -510,6 +639,10 @@ function mergeDecks(decks: PracticeDeckData[], level: CefrLevel): PracticeDeckDa
     index: decks.flatMap((deck) => deck.index),
     lexemes: decks.flatMap((deck) => deck.lexemes),
     cloze: decks.flatMap((deck) => deck.cloze),
+    stress: decks.flatMap((deck) => deck.stress ?? []),
+    classify: decks.flatMap((deck) => deck.classify ?? []),
+    paradigm: decks.flatMap((deck) => deck.paradigm ?? []),
+    synonym: decks.flatMap((deck) => deck.synonym ?? []),
   };
 }
 
@@ -663,15 +796,46 @@ export default function LexiconPractice({
         nextDeck = mergeDecks(loaded, level);
       }
       if (includeCloze && (force || !clozeLoaded)) {
-        const clozeBatches = await Promise.all(
+        const shardBatches = await Promise.all(
           levels.map(async (shardLevel) => {
-            const clozeResponse = await fetch(`${shardBaseUrl}/practice-cloze.${shardLevel}.json`);
-            if (!clozeResponse.ok) return [];
-            const clozeShard = (await clozeResponse.json()) as { cloze: PracticeClozeItem[] };
-            return clozeShard.cloze ?? [];
+            const [
+              clozeResponse,
+              stressResponse,
+              classifyResponse,
+              paradigmResponse,
+              synonymResponse,
+            ] = await Promise.all([
+              fetch(`${shardBaseUrl}/practice-cloze.${shardLevel}.json`),
+              fetch(`${shardBaseUrl}/practice-stress.${shardLevel}.json`),
+              fetch(`${shardBaseUrl}/practice-classify.${shardLevel}.json`),
+              fetch(`${shardBaseUrl}/practice-paradigm.${shardLevel}.json`),
+              fetch(`${shardBaseUrl}/practice-synonym.${shardLevel}.json`),
+            ]);
+            const [clozeShard, stressShard, classifyShard, paradigmShard, synonymShard] =
+              await Promise.all([
+                clozeResponse.ok ? clozeResponse.json() : Promise.resolve({ cloze: [] }),
+                stressResponse.ok ? stressResponse.json() : Promise.resolve({ stress: [] }),
+                classifyResponse.ok ? classifyResponse.json() : Promise.resolve({ classify: [] }),
+                paradigmResponse.ok ? paradigmResponse.json() : Promise.resolve({ paradigm: [] }),
+                synonymResponse.ok ? synonymResponse.json() : Promise.resolve({ synonym: [] }),
+              ]);
+            return {
+              cloze: (clozeShard as { cloze?: PracticeClozeItem[] }).cloze ?? [],
+              stress: (stressShard as PracticeDeckData).stress ?? [],
+              classify: (classifyShard as PracticeDeckData).classify ?? [],
+              paradigm: (paradigmShard as PracticeDeckData).paradigm ?? [],
+              synonym: (synonymShard as PracticeDeckData).synonym ?? [],
+            };
           }),
         );
-        nextDeck = { ...nextDeck, cloze: clozeBatches.flat() };
+        nextDeck = {
+          ...nextDeck,
+          cloze: shardBatches.flatMap((batch) => batch.cloze),
+          stress: shardBatches.flatMap((batch) => batch.stress),
+          classify: shardBatches.flatMap((batch) => batch.classify),
+          paradigm: shardBatches.flatMap((batch) => batch.paradigm),
+          synonym: shardBatches.flatMap((batch) => batch.synonym),
+        };
         nextClozeLoaded = true;
       }
       // Ignore the result if a newer fetch (e.g. a later level switch) has superseded this one.
@@ -1061,6 +1225,32 @@ function PracticeItem({
     );
   }
 
+  const drillOptions = drillChoiceOptions(selection);
+  const drillPrompt = drillChoicePrompt(selection);
+  if (drillOptions && drillPrompt) {
+    return (
+      <div className="lexicon-choice" data-testid={`practice-${selection.mode}`}>
+        <p className="lexicon-choice-prompt mc-q">{drillPrompt.prompt}</p>
+        <p className="mc-sub">{drillPrompt.subtitle}</p>
+        <ul className="lexicon-option-list mc-options">
+          {drillOptions.map((option, index) => (
+            <li key={`${option.label}-${index}`}>
+              <button
+                className={`mc-opt${answerLocked && option.correct ? ' correct' : ''}`}
+                type="button"
+                disabled={answerLocked}
+                onClick={() => onChoice(option)}
+              >
+                <span className="mc-key">{index + 1}</span>
+                <span>{option.label}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
   if (selection.mode === 'matching') {
     const pairs = matchingPairs(selection, deck);
     if (!pairs.length) {
@@ -1088,7 +1278,7 @@ function PracticeItem({
       <p className="mc-sub">Оберіть правильну відповідь</p>
       <ul className="lexicon-option-list mc-options">
         {options.map((option, index) => (
-          <li key={option.label}>
+          <li key={`${option.label}-${index}`}>
             <button
               className={`mc-opt${answerLocked && option.correct ? ' correct' : ''}`}
               type="button"

--- a/site/src/data/lexicon-practice-deck.pointer.json
+++ b/site/src/data/lexicon-practice-deck.pointer.json
@@ -1,26 +1,26 @@
 {
   "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck.json.gz",
   "release_tag": "atlas-practice-deck",
-  "deck_version": "atlas-practice-v1-b8ba9674db7b1767",
+  "deck_version": "atlas-practice-v1-e73283406da45cb2",
   "package_schema_version": 1,
-  "gz_sha256": "8e3e5e5a80852813b508f91f9ff38cd99c7095aebfe34a566dc499e210b04f1c",
-  "package_sha256": "73a5daf2b6e194b7260f986e7e804987963c16f7012c24d6d31075665e078d38",
-  "gz_bytes": 261775,
-  "package_bytes": 3966728,
-  "file_count": 15,
+  "gz_sha256": "df06abc238c438fc5a91c6662af1050fc0cb51ce5929f28dad24f180d665ea20",
+  "package_sha256": "454731e0cf8fa87abc1af993d317a4480675700b2ec1e88e2834846a6bc9e86e",
+  "gz_bytes": 607318,
+  "package_bytes": 14410746,
+  "file_count": 45,
   "files": [
     {
       "path": "practice-index.A1.json",
       "kind": "index",
       "level": "A1",
       "schema": "atlas-practice-index",
-      "bytes": 285613,
-      "sha256": "0d9482962c2794467265803a88c664dc5272b9edddea73945c598c1a1857b0e3",
+      "bytes": 318383,
+      "sha256": "1336eb7b5d226519d0610904c29549f5b5e14d7c5f0ca3ace10d0a0bee2239c9",
       "counts": {
-        "lexemes": 1125,
+        "lexemes": 1150,
         "cloze": 22,
         "clozeEligibleLexemes": 22,
-        "clozeCoverage": 0.0196
+        "clozeCoverage": 0.0191
       }
     },
     {
@@ -28,26 +28,74 @@
       "kind": "lexemes",
       "level": "A1",
       "schema": "atlas-practice-lexemes",
-      "bytes": 549734,
-      "sha256": "08bd1a5e095683aa4988d73a3beae8f160a20ee07be70b3bcf47f29cf5062de7"
+      "bytes": 562939,
+      "sha256": "c529a29b5db8b949fbf7ed82423e7fac9f6bffac539deeefc5d5cddcdf9e82d5"
     },
     {
       "path": "practice-cloze.A1.json",
       "kind": "cloze",
       "level": "A1",
       "schema": "atlas-practice-cloze",
-      "bytes": 44881,
-      "sha256": "2cee3d04080e6013401c976a14e989d13c2bc5dd17b9793bf379731fe2a3ca2a"
+      "bytes": 44922,
+      "sha256": "f363b95a2d9241615752216b4ffd833ceeb8da3ce0c8fe06e7d2a615889ae49a"
+    },
+    {
+      "path": "practice-stress.A1.json",
+      "kind": "stress",
+      "level": "A1",
+      "schema": "atlas-practice-stress",
+      "bytes": 382927,
+      "sha256": "4420c84332cfed6100c207844560b44b99be7f8fa807c5fc5ac112ad2963b273"
+    },
+    {
+      "path": "practice-classify.A1.json",
+      "kind": "classify",
+      "level": "A1",
+      "schema": "atlas-practice-classify",
+      "bytes": 437057,
+      "sha256": "e85f18f9abca5db86ce8042eabd7a43ff01e51a5e9490fb6251159485a17d613"
+    },
+    {
+      "path": "practice-paradigm.A1.json",
+      "kind": "paradigm",
+      "level": "A1",
+      "schema": "atlas-practice-paradigm",
+      "bytes": 533851,
+      "sha256": "5a1e2269988313552da3d7640e7f875c06e5d65f5ef5fd95daca98036f15e512"
+    },
+    {
+      "path": "practice-synonym.A1.json",
+      "kind": "synonym",
+      "level": "A1",
+      "schema": "atlas-practice-synonym",
+      "bytes": 317,
+      "sha256": "579a8ef1b805ecc24658fd40178a95787e743e98d42f9c0eeb2a22307e40f4f0"
+    },
+    {
+      "path": "practice-heritage.A1.json",
+      "kind": "heritage",
+      "level": "A1",
+      "schema": "atlas-practice-heritage",
+      "bytes": 319,
+      "sha256": "110f6418cf0d93676f45caf215df717db8ccf7b8cf5d082c3cba7ed43b650e9b"
+    },
+    {
+      "path": "practice-paronym.A1.json",
+      "kind": "paronym",
+      "level": "A1",
+      "schema": "atlas-practice-paronym",
+      "bytes": 317,
+      "sha256": "4c80ce8e514fc83719a35f02499d02fc2dcaea7c196a21e2a00048f02fa080c7"
     },
     {
       "path": "practice-index.A2.json",
       "kind": "index",
       "level": "A2",
       "schema": "atlas-practice-index",
-      "bytes": 248843,
-      "sha256": "e01c059f6bb90c12b0606da13812e64c76bddfb5fa8e971ad8aeede55023deb6",
+      "bytes": 281496,
+      "sha256": "2c499923a6287fe5f8ccb94939a4bc1ee7f4b52d97f399ff51290065f249fdd9",
       "counts": {
-        "lexemes": 962,
+        "lexemes": 967,
         "cloze": 0,
         "clozeEligibleLexemes": 0,
         "clozeCoverage": 0.0
@@ -58,26 +106,74 @@
       "kind": "lexemes",
       "level": "A2",
       "schema": "atlas-practice-lexemes",
-      "bytes": 471398,
-      "sha256": "e29159058fd75c082cd51fe0db7740e0aefc453e702ce7649da2989e7cef7c3d"
+      "bytes": 474613,
+      "sha256": "a40617e593223ec96d482f41f1e019ed760c43daf1153a45f5a76277145c738e"
     },
     {
       "path": "practice-cloze.A2.json",
       "kind": "cloze",
       "level": "A2",
       "schema": "atlas-practice-cloze",
-      "bytes": 312,
-      "sha256": "ee1258d6733d2b02a3f977175e885acc70698bea9312a950a55170944c3ca874"
+      "bytes": 313,
+      "sha256": "64d8472078f065e98cab8b9087cbb798e85942c5f91d24fd713c7761af3a30b7"
+    },
+    {
+      "path": "practice-stress.A2.json",
+      "kind": "stress",
+      "level": "A2",
+      "schema": "atlas-practice-stress",
+      "bytes": 395787,
+      "sha256": "61a149a1e4243ba96f966a3fc8f514ce6a465a5f8fc442798c7093d6419c4d8e"
+    },
+    {
+      "path": "practice-classify.A2.json",
+      "kind": "classify",
+      "level": "A2",
+      "schema": "atlas-practice-classify",
+      "bytes": 1121136,
+      "sha256": "acf25389512b16e92b3ea5275e75faddd73431308569a57c7c1d9220c790f630"
+    },
+    {
+      "path": "practice-paradigm.A2.json",
+      "kind": "paradigm",
+      "level": "A2",
+      "schema": "atlas-practice-paradigm",
+      "bytes": 420424,
+      "sha256": "b82777e07dff7ee5540676d0023031ebbbd7418fe322427aad38de56c32ca1e0"
+    },
+    {
+      "path": "practice-synonym.A2.json",
+      "kind": "synonym",
+      "level": "A2",
+      "schema": "atlas-practice-synonym",
+      "bytes": 317,
+      "sha256": "a01c52164ab0bb34a03ea00889a86eac49831461441180ed89121a927dee9440"
+    },
+    {
+      "path": "practice-heritage.A2.json",
+      "kind": "heritage",
+      "level": "A2",
+      "schema": "atlas-practice-heritage",
+      "bytes": 319,
+      "sha256": "1e1f663ab09477c577e5cb8db4569abdd0c5e1a74eb419fb4b4a440cd9754d5b"
+    },
+    {
+      "path": "practice-paronym.A2.json",
+      "kind": "paronym",
+      "level": "A2",
+      "schema": "atlas-practice-paronym",
+      "bytes": 317,
+      "sha256": "68aed49eacd561fb63ce42d2e52fc94ea7a1ddedf58c31de89b36abbba856aad"
     },
     {
       "path": "practice-index.B1.json",
       "kind": "index",
       "level": "B1",
       "schema": "atlas-practice-index",
-      "bytes": 300715,
-      "sha256": "9e1463b212ae1583c05bb74cb1d98ec3146468d926de69370585e86c10785db2",
+      "bytes": 434504,
+      "sha256": "aaaab72f864127d5237232e8f23cbd9505f13ab7cf2f02aabdd3ca06e70dac03",
       "counts": {
-        "lexemes": 1122,
+        "lexemes": 1485,
         "cloze": 0,
         "clozeEligibleLexemes": 0,
         "clozeCoverage": 0.0
@@ -88,26 +184,74 @@
       "kind": "lexemes",
       "level": "B1",
       "schema": "atlas-practice-lexemes",
-      "bytes": 549743,
-      "sha256": "7a0fb53df8fbce5bd4286d159fe0a5dec2ec37cad6ebf9725e90705abc6e498d"
+      "bytes": 748382,
+      "sha256": "cb96913244fd066e5a853c264876662803cfce0243a9e20e31fd5db8e38c98d6"
     },
     {
       "path": "practice-cloze.B1.json",
       "kind": "cloze",
       "level": "B1",
       "schema": "atlas-practice-cloze",
-      "bytes": 312,
-      "sha256": "62c187d40ae0c371b09bc9a98635215f7e9d36e2bcfcea438a20e3010db9aa94"
+      "bytes": 313,
+      "sha256": "62d8110278845efb0eea456b852e20ff2881d0f431896d43b8fdc2dec824f6d6"
+    },
+    {
+      "path": "practice-stress.B1.json",
+      "kind": "stress",
+      "level": "B1",
+      "schema": "atlas-practice-stress",
+      "bytes": 447184,
+      "sha256": "6a7b54783de1c5095721ee9abeb2cfe50ef93a0dfa5e263c95c5995b3a7be209"
+    },
+    {
+      "path": "practice-classify.B1.json",
+      "kind": "classify",
+      "level": "B1",
+      "schema": "atlas-practice-classify",
+      "bytes": 1449662,
+      "sha256": "646c20785b606ac4caf0f8234a2d562f6216d702ad725f76f44517b2261b65f5"
+    },
+    {
+      "path": "practice-paradigm.B1.json",
+      "kind": "paradigm",
+      "level": "B1",
+      "schema": "atlas-practice-paradigm",
+      "bytes": 583013,
+      "sha256": "07f06503063b33bca0016285f91e9d99ffde34dfad79f21eaaff8fc9249613e4"
+    },
+    {
+      "path": "practice-synonym.B1.json",
+      "kind": "synonym",
+      "level": "B1",
+      "schema": "atlas-practice-synonym",
+      "bytes": 222118,
+      "sha256": "98e243fa33cba480689c0b4cdd64d4c1a8fdcad676c4c96919f88feb26102e7b"
+    },
+    {
+      "path": "practice-heritage.B1.json",
+      "kind": "heritage",
+      "level": "B1",
+      "schema": "atlas-practice-heritage",
+      "bytes": 319,
+      "sha256": "31de256bb59385b755cb578ef937cfb055b52a9e5dca9e5f23ff43ac8cb13388"
+    },
+    {
+      "path": "practice-paronym.B1.json",
+      "kind": "paronym",
+      "level": "B1",
+      "schema": "atlas-practice-paronym",
+      "bytes": 317,
+      "sha256": "103b0971bd37602c20deb270b08d25f70d18d6c5cd6325983028253e941a01b2"
     },
     {
       "path": "practice-index.B2.json",
       "kind": "index",
       "level": "B2",
       "schema": "atlas-practice-index",
-      "bytes": 231193,
-      "sha256": "6630b69c7bf404140d84da525da2dc17e9078d0bab0f3a424d3f841b6ee81264",
+      "bytes": 254520,
+      "sha256": "56e02e67e4eee654593a1607be095a1fcd177cd5849542481d08bf634c5e5d85",
       "counts": {
-        "lexemes": 854,
+        "lexemes": 853,
         "cloze": 0,
         "clozeEligibleLexemes": 0,
         "clozeCoverage": 0.0
@@ -118,26 +262,74 @@
       "kind": "lexemes",
       "level": "B2",
       "schema": "atlas-practice-lexemes",
-      "bytes": 444472,
-      "sha256": "f9af86553ea717dc7b240d2d75076f6bdbcc52f4e67eae36fe77972f2b7fcb92"
+      "bytes": 443931,
+      "sha256": "8ea88edb0b443774e7e387d68f04940a533bd252024a4e810c122e5f3e8ddc67"
     },
     {
       "path": "practice-cloze.B2.json",
       "kind": "cloze",
       "level": "B2",
       "schema": "atlas-practice-cloze",
-      "bytes": 312,
-      "sha256": "573b3136420cf3316154eca9c0e3d912f9cee99f9a2d1c08ab7cd118b49e18af"
+      "bytes": 313,
+      "sha256": "6a869af2b9fa972ab35da1f18e917a705cbd7c0992a837c87be472613a54bc0f"
+    },
+    {
+      "path": "practice-stress.B2.json",
+      "kind": "stress",
+      "level": "B2",
+      "schema": "atlas-practice-stress",
+      "bytes": 301091,
+      "sha256": "c161ba2c3c08c7c730b90e8c0cd59853515165a1b5c102f1769d66d3f1547a9a"
+    },
+    {
+      "path": "practice-classify.B2.json",
+      "kind": "classify",
+      "level": "B2",
+      "schema": "atlas-practice-classify",
+      "bytes": 901024,
+      "sha256": "6e76af262ac982841a9e9e67eb1d4774581cef013d2fe29a781807422ef63c66"
+    },
+    {
+      "path": "practice-paradigm.B2.json",
+      "kind": "paradigm",
+      "level": "B2",
+      "schema": "atlas-practice-paradigm",
+      "bytes": 400063,
+      "sha256": "391581a72e28957ebe5895f8c11d3554db5039cfe171fefa2647ad9937a20dc7"
+    },
+    {
+      "path": "practice-synonym.B2.json",
+      "kind": "synonym",
+      "level": "B2",
+      "schema": "atlas-practice-synonym",
+      "bytes": 80470,
+      "sha256": "c8b930b89b9cd70871708bf288cba4190ac99cc98a6f181a7e47183fb227ca4a"
+    },
+    {
+      "path": "practice-heritage.B2.json",
+      "kind": "heritage",
+      "level": "B2",
+      "schema": "atlas-practice-heritage",
+      "bytes": 319,
+      "sha256": "f3175eb169b33cbe865adae223d4a2e7bd98e2f9fbac4e2365db90bd1e4d7529"
+    },
+    {
+      "path": "practice-paronym.B2.json",
+      "kind": "paronym",
+      "level": "B2",
+      "schema": "atlas-practice-paronym",
+      "bytes": 317,
+      "sha256": "b457d05d0d6124424db77fe1977d965d6d6c7b30bc34b57c7d193740922ab46c"
     },
     {
       "path": "practice-index.C1.json",
       "kind": "index",
       "level": "C1",
       "schema": "atlas-practice-index",
-      "bytes": 111524,
-      "sha256": "0eb016c57523938ba4be144e6e40966afe96c32869f44f3269a4ae428baea6ff",
+      "bytes": 122018,
+      "sha256": "f4547994ca221e649a67e453b4038123d7c4aced9ab5084799f4a088d964e782",
       "counts": {
-        "lexemes": 421,
+        "lexemes": 403,
         "cloze": 0,
         "clozeEligibleLexemes": 0,
         "clozeCoverage": 0.0
@@ -148,16 +340,64 @@
       "kind": "lexemes",
       "level": "C1",
       "schema": "atlas-practice-lexemes",
-      "bytes": 238187,
-      "sha256": "a855f47e441f62a46d34262e84db20f45dccac490e0ed57a46149608ded958b7"
+      "bytes": 229361,
+      "sha256": "ee377f032c541ea6d4f434046e5f0e6b44b267577e591fde121d4dfccad23ed6"
     },
     {
       "path": "practice-cloze.C1.json",
       "kind": "cloze",
       "level": "C1",
       "schema": "atlas-practice-cloze",
-      "bytes": 312,
-      "sha256": "0eabdce06d4e632d191ff2d9924d5ed95e691b251eca2a697422f9241bd1e64f"
+      "bytes": 313,
+      "sha256": "0874bf1acf147e21550574b8017df3d7835acb96635ef23757497b3ecff8a104"
+    },
+    {
+      "path": "practice-stress.C1.json",
+      "kind": "stress",
+      "level": "C1",
+      "schema": "atlas-practice-stress",
+      "bytes": 200434,
+      "sha256": "f917c48b680b55d84e12a65a66fd30d94a15b91c9e531f8bcd7476bb73a07a1f"
+    },
+    {
+      "path": "practice-classify.C1.json",
+      "kind": "classify",
+      "level": "C1",
+      "schema": "atlas-practice-classify",
+      "bytes": 585487,
+      "sha256": "e66ea6d4a602e63f2a839d18870e039fbf0ee0c6958cb61d7a250d88575f1d59"
+    },
+    {
+      "path": "practice-paradigm.C1.json",
+      "kind": "paradigm",
+      "level": "C1",
+      "schema": "atlas-practice-paradigm",
+      "bytes": 342080,
+      "sha256": "46b461a2a4e107797e49c5dd793fe1c85f424377e21c88766bc1e34788782315"
+    },
+    {
+      "path": "practice-synonym.C1.json",
+      "kind": "synonym",
+      "level": "C1",
+      "schema": "atlas-practice-synonym",
+      "bytes": 29287,
+      "sha256": "ed1892e9977bac02a3d1ec3d7a2842733692f65462e32e059d8836d69f51e432"
+    },
+    {
+      "path": "practice-heritage.C1.json",
+      "kind": "heritage",
+      "level": "C1",
+      "schema": "atlas-practice-heritage",
+      "bytes": 319,
+      "sha256": "524aef220f53f0c7ee07e3b1021c152e72e96dcc3d1ab85883ecb75ed7222811"
+    },
+    {
+      "path": "practice-paronym.C1.json",
+      "kind": "paronym",
+      "level": "C1",
+      "schema": "atlas-practice-paronym",
+      "bytes": 317,
+      "sha256": "889dddeefdb3fc5623b1bd22a930567cedf8ee53f94378807cee76c3e24a2142"
     }
   ],
   "note": "Pins GitHub Release asset practice deck for #3796; hydrate it build/test time instead of committing shards."

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -129,6 +129,66 @@ export interface PracticeClozeItem {
   attribution?: PracticeClozeAttribution;
 }
 
+export interface PracticeStressItem {
+  stressId: string;
+  lemmaId: string;
+  lemma: string;
+  stressed: string;
+  unstressed: string;
+  stressIndex: number;
+  nuclei: { index: number; label: string }[];
+  source: string;
+}
+
+export interface PracticeClassifyOption {
+  value: string;
+  labelUk: string;
+  labelEn?: string;
+}
+
+export interface PracticeClassifySet {
+  setId: 'gender' | 'aspect' | 'declension' | 'pos' | string;
+  setLabelUk: string;
+  setLabelEn?: string;
+  answer: string;
+  answerLabelUk: string;
+  answerLabelEn?: string;
+  options: PracticeClassifyOption[];
+}
+
+export interface PracticeClassifyItem {
+  classifyId: string;
+  lemmaId: string;
+  lemma: string;
+  sets: PracticeClassifySet[];
+  source: string;
+}
+
+export interface PracticeParadigmItem {
+  paradigmId: string;
+  lemmaId: string;
+  lemma: string;
+  slot: {
+    case: string;
+    number: 'singular' | 'plural';
+    labelUk: string;
+    labelEn?: string;
+  };
+  form: string;
+  options: { label: string; kind: 'answer' | 'same-paradigm' | string }[];
+}
+
+export interface PracticeSynonymItem {
+  synonymId: string;
+  lemmaId: string;
+  targetLemmaId: string;
+  polarity: 'synonym' | 'antonym';
+  prompt: string;
+  answer: string;
+  options: { label: string; lemmaId: string; kind: 'answer' | 'distractor' | string }[];
+  source: string;
+}
+
 export interface PracticeShardMeta {
   schema: string;
   schemaVersion: number;
@@ -156,12 +216,32 @@ export interface PracticeClozeShard extends PracticeShardMeta {
   cloze: PracticeClozeItem[];
 }
 
+export interface PracticeStressShard extends PracticeShardMeta {
+  stress: PracticeStressItem[];
+}
+
+export interface PracticeClassifyShard extends PracticeShardMeta {
+  classify: PracticeClassifyItem[];
+}
+
+export interface PracticeParadigmShard extends PracticeShardMeta {
+  paradigm: PracticeParadigmItem[];
+}
+
+export interface PracticeSynonymShard extends PracticeShardMeta {
+  synonym: PracticeSynonymItem[];
+}
+
 export interface PracticeDeckData {
   deckVersion: string;
   level: string;
   index: PracticeIndexItem[];
   lexemes: PracticeLexeme[];
   cloze: PracticeClozeItem[];
+  stress?: PracticeStressItem[];
+  classify?: PracticeClassifyItem[];
+  paradigm?: PracticeParadigmItem[];
+  synonym?: PracticeSynonymItem[];
   fixtureNote?: string;
 }
 
@@ -229,6 +309,7 @@ export interface SelectionHistoryItem {
   clozeId?: string;
   sentenceFrameId?: string;
   blankCase?: string;
+  classifySetId?: string;
   recallDirection?: RecallDirection;
   choicePolarity?: ChoicePolarity;
   lapsed?: boolean;
@@ -244,6 +325,11 @@ export interface PracticeSelection {
   due: number;
   lapsed: boolean;
   cloze?: PracticeClozeItem;
+  stress?: PracticeStressItem;
+  classify?: PracticeClassifyItem;
+  classifySetId?: string;
+  paradigm?: PracticeParadigmItem;
+  synonym?: PracticeSynonymItem;
   recallDirection: RecallDirection;
   choicePolarity: ChoicePolarity;
 }
@@ -805,9 +891,22 @@ export function getDueQueue<T extends Pick<PracticeLexeme, 'lemmaId'> | Practice
 }
 
 function deckMaps(deck: PracticeDeckData) {
+  const groupByLemma = <T extends { lemmaId: string }>(items: T[] | undefined) => {
+    const grouped = new Map<string, T[]>();
+    for (const item of items ?? []) {
+      const bucket = grouped.get(item.lemmaId) ?? [];
+      bucket.push(item);
+      grouped.set(item.lemmaId, bucket);
+    }
+    return grouped;
+  };
   return {
     lexemes: new Map(deck.lexemes.map((lexeme) => [lexeme.lemmaId, lexeme])),
     cloze: new Map(deck.cloze.map((item) => [item.clozeId, item])),
+    stress: new Map((deck.stress ?? []).map((item) => [item.lemmaId, item])),
+    classify: new Map((deck.classify ?? []).map((item) => [item.lemmaId, item])),
+    paradigm: groupByLemma(deck.paradigm),
+    synonym: groupByLemma(deck.synonym),
   };
 }
 
@@ -998,6 +1097,94 @@ export function selectNextPracticeItem(
         }
         continue;
       }
+      if (mode === 'stress') {
+        const stress = maps.stress.get(indexItem.lemmaId);
+        if (!stress) continue;
+        const key = cardKey(indexItem.lemmaId, mode);
+        const card = state.cards.get(key) ?? null;
+        candidates.push({
+          itemId: makeItemId(indexItem.lemmaId, mode, stress.stressId),
+          lemma,
+          indexItem,
+          mode,
+          cardKey: key,
+          cardState: card,
+          due: card?.due ?? 0,
+          lapsed: Boolean(card && card.lapses > 0 && card.due <= nowTime),
+          stress,
+          recallDirection: directionFor(key, history),
+          choicePolarity: polarityFor(key, history),
+        });
+        continue;
+      }
+      if (mode === 'classify') {
+        const classify = maps.classify.get(indexItem.lemmaId);
+        if (!classify || classify.sets.length === 0) continue;
+        const key = cardKey(indexItem.lemmaId, mode);
+        const card = state.cards.get(key) ?? null;
+        for (const set of classify.sets) {
+          candidates.push({
+            itemId: makeItemId(indexItem.lemmaId, mode, `${classify.classifyId}:${set.setId}`),
+            lemma,
+            indexItem,
+            mode,
+            cardKey: key,
+            cardState: card,
+            due: card?.due ?? 0,
+            lapsed: Boolean(card && card.lapses > 0 && card.due <= nowTime),
+            classify,
+            classifySetId: set.setId,
+            recallDirection: directionFor(key, history),
+            choicePolarity: polarityFor(key, history),
+          });
+        }
+        continue;
+      }
+      if (mode === 'paradigm') {
+        const items = maps.paradigm.get(indexItem.lemmaId) ?? [];
+        for (const paradigm of items) {
+          const key = cardKey(indexItem.lemmaId, mode);
+          const card = state.cards.get(key) ?? null;
+          candidates.push({
+            itemId: makeItemId(indexItem.lemmaId, mode, paradigm.paradigmId),
+            lemma,
+            indexItem,
+            mode,
+            cardKey: key,
+            cardState: card,
+            due: card?.due ?? 0,
+            lapsed: Boolean(card && card.lapses > 0 && card.due <= nowTime),
+            paradigm,
+            recallDirection: directionFor(key, history),
+            choicePolarity: polarityFor(key, history),
+          });
+        }
+        continue;
+      }
+      if (mode === 'synonym') {
+        const items = maps.synonym.get(indexItem.lemmaId) ?? [];
+        for (const synonym of items) {
+          const key = cardKey(indexItem.lemmaId, mode);
+          const card = state.cards.get(key) ?? null;
+          candidates.push({
+            itemId: makeItemId(indexItem.lemmaId, mode, synonym.synonymId),
+            lemma,
+            indexItem,
+            mode,
+            cardKey: key,
+            cardState: card,
+            due: card?.due ?? 0,
+            lapsed: Boolean(card && card.lapses > 0 && card.due <= nowTime),
+            synonym,
+            recallDirection: directionFor(key, history),
+            choicePolarity: polarityFor(key, history),
+          });
+        }
+        continue;
+      }
+      if (mode === 'heritage' || mode === 'paronym') {
+        continue;
+      }
       const key = cardKey(indexItem.lemmaId, mode);
       const card = state.cards.get(key) ?? null;
       candidates.push({
@@ -1128,6 +1315,12 @@ export function combinePracticeShards(
   indexShard: PracticeIndexShard,
   lexemeShard: PracticeLexemeShard,
   clozeShard?: PracticeClozeShard,
+  modeShards: {
+    stress?: PracticeStressShard;
+    classify?: PracticeClassifyShard;
+    paradigm?: PracticeParadigmShard;
+    synonym?: PracticeSynonymShard;
+  } = {},
 ): PracticeDeckData {
   return {
     deckVersion: indexShard.deckVersion,
@@ -1135,6 +1328,10 @@ export function combinePracticeShards(
     index: indexShard.items,
     lexemes: lexemeShard.lexemes,
     cloze: clozeShard?.cloze ?? [],
+    stress: modeShards.stress?.stress ?? [],
+    classify: modeShards.classify?.classify ?? [],
+    paradigm: modeShards.paradigm?.paradigm ?? [],
+    synonym: modeShards.synonym?.synonym ?? [],
     fixtureNote: indexShard.fixtureNote,
   };
 }

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -142,6 +142,82 @@ function modeDeck(rows: { id: string; modes: PracticeMode[] }[]): PracticeDeckDa
     level: 'A1',
     lexemes,
     cloze: [],
+    stress: rows
+      .filter((row) => row.modes.includes('stress'))
+      .map((row) => ({
+        stressId: `${row.id}:stress`,
+        lemmaId: row.id,
+        lemma: row.id,
+        stressed: `${row.id}́`,
+        unstressed: row.id,
+        stressIndex: 0,
+        nuclei: [{ index: 0, label: row.id[0] ?? 'а' }, { index: 1, label: 'а' }],
+        source: 'fixture',
+      })),
+    classify: rows
+      .filter((row) => row.modes.includes('classify'))
+      .map((row) => ({
+        classifyId: `${row.id}:classify`,
+        lemmaId: row.id,
+        lemma: row.id,
+        source: 'fixture',
+        sets: [
+          {
+            setId: 'gender',
+            setLabelUk: 'рід',
+            answer: 'masculine',
+            answerLabelUk: 'чоловічий',
+            options: [
+              { value: 'masculine', labelUk: 'чоловічий' },
+              { value: 'feminine', labelUk: 'жіночий' },
+              { value: 'neuter', labelUk: 'середній' },
+            ],
+          },
+          {
+            setId: 'pos',
+            setLabelUk: 'частина мови',
+            answer: 'noun',
+            answerLabelUk: 'іменник',
+            options: [
+              { value: 'noun', labelUk: 'іменник' },
+              { value: 'verb', labelUk: 'дієслово' },
+              { value: 'adjective', labelUk: 'прикметник' },
+            ],
+          },
+        ],
+      })),
+    paradigm: rows
+      .filter((row) => row.modes.includes('paradigm'))
+      .map((row) => ({
+        paradigmId: `${row.id}:paradigm:1`,
+        lemmaId: row.id,
+        lemma: row.id,
+        slot: { case: 'знахідний', number: 'singular', labelUk: 'знахідний відмінок, однина' },
+        form: `${row.id}у`,
+        options: [
+          { label: `${row.id}у`, kind: 'answer' },
+          { label: row.id, kind: 'same-paradigm' },
+          { label: `${row.id}і`, kind: 'same-paradigm' },
+          { label: `${row.id}ом`, kind: 'same-paradigm' },
+        ],
+      })),
+    synonym: rows
+      .filter((row) => row.modes.includes('synonym'))
+      .map((row) => ({
+        synonymId: `${row.id}:synonym`,
+        lemmaId: row.id,
+        targetLemmaId: `${row.id}-target`,
+        polarity: 'synonym' as const,
+        prompt: row.id,
+        answer: `${row.id}-answer`,
+        source: 'fixture',
+        options: [
+          { label: `${row.id}-answer`, lemmaId: `${row.id}-target`, kind: 'answer' },
+          { label: `${row.id}-d1`, lemmaId: `${row.id}-d1`, kind: 'distractor' },
+          { label: `${row.id}-d2`, lemmaId: `${row.id}-d2`, kind: 'distractor' },
+          { label: `${row.id}-d3`, lemmaId: `${row.id}-d3`, kind: 'distractor' },
+        ],
+      })),
     index: rows.map((row, index) => ({
       lemmaId: row.id,
       lemma: row.id,
@@ -168,7 +244,7 @@ describe('lexicon SRS facade', () => {
     });
   });
 
-  test('parses known card-key modes including the Phase-1 drill trio', () => {
+  test('parses known card-key modes and schedules backed wave-1 drills', () => {
     for (const mode of PRACTICE_MODES) {
       expect(isPracticeMode(mode)).toBe(true);
       expect(parseCardKey(`alpha::${mode}`)).toEqual({
@@ -178,12 +254,36 @@ describe('lexicon SRS facade', () => {
       });
     }
 
-    for (const mode of ['paradigm', 'stress', 'heritage'] as const) {
+    for (const mode of ['paradigm', 'stress', 'classify', 'synonym'] as const) {
       const selection = selectNextPracticeItem(modeDeck([{ id: `${mode}-alpha`, modes: [mode] }]), {
         now: NOW,
       });
       expect(selection?.mode).toBe(mode);
     }
+    expect(selectNextPracticeItem(modeDeck([{ id: 'heritage-alpha', modes: ['heritage'] }]), { now: NOW })).toBeNull();
+  });
+
+  test('classify rotates outcome sets while keeping one SRS card key', () => {
+    const testDeck = modeDeck([{ id: 'classify-alpha', modes: ['classify'] }]);
+    const first = selectNextPracticeItem(testDeck, { now: NOW, modeFilter: 'classify' });
+
+    if (!first) throw new Error('expected classify selection');
+    expect(first?.mode).toBe('classify');
+    expect(first?.cardKey).toBe(cardKey('classify-alpha', 'classify'));
+    expect(first?.classifySetId).toBe('gender');
+
+    const history: SelectionHistoryItem[] = [
+      {
+        itemId: first.itemId,
+        lemmaId: first.lemma.lemmaId,
+        mode: first.mode,
+        classifySetId: first.classifySetId,
+      },
+    ];
+    const rotated = selectNextPracticeItem(testDeck, { now: NOW, modeFilter: 'classify', history });
+
+    expect(rotated?.cardKey).toBe(first.cardKey);
+    expect(rotated?.classifySetId).toBe('pos');
   });
 
   test('quarantines explicit unknown card-key modes without rewriting stored state', () => {

--- a/tests/test_check_static_practice_assets.py
+++ b/tests/test_check_static_practice_assets.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from scripts.audit.check_static_practice_assets import check_assets
 
+DRILL_MODES = ("stress", "classify", "paradigm", "synonym", "heritage", "paronym")
+
 
 def _write_json(path: Path, payload: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -100,6 +102,14 @@ def _write_level(practice_dir: Path, *, level: str = "A1", with_cloze: bool = Fa
                 "cloze": len(cloze_rows),
                 "clozeEligibleLexemes": 1 if with_cloze else 0,
                 "clozeCoverage": 1.0 if with_cloze else 0.0,
+                "modeCounts": {
+                    "cloze": len(cloze_rows),
+                    **{mode: 0 for mode in DRILL_MODES},
+                },
+                "modeCoverage": {
+                    "cloze": 1.0 if with_cloze else 0.0,
+                    **{mode: 0.0 for mode in DRILL_MODES},
+                },
             },
             "items": [
                 {
@@ -114,6 +124,19 @@ def _write_level(practice_dir: Path, *, level: str = "A1", with_cloze: bool = Fa
             ],
         },
     )
+    for mode in DRILL_MODES:
+        _write_json(
+            practice_dir / f"practice-{mode}.{level}.json",
+            {
+                "schema": f"atlas-practice-{mode}",
+                "schemaVersion": 1,
+                "deckVersion": deck_version,
+                "level": level,
+                "source": "fixture",
+                "sizeBudget": _budget(),
+                mode: [],
+            },
+        )
     _write_json(
         practice_dir / f"practice-lexemes.{level}.json",
         {

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -8,18 +8,28 @@ import pytest
 
 from scripts.audit.generate_practice_deck import (
     DEFAULT_TARGET,
+    DRILL_MODES,
     BuildConfig,
     JsonVesumVerifier,
     ReviewedSourceAllowlist,
+    _build_classify_items,
     _build_lexeme,
+    _build_paradigm_items,
+    _declension_category,
     _eligible_decoys,
     _option_strategy_for_level,
+    _stress_position,
     apply_size_budgets,
     build_practice_shards,
     main,
     read_cloze_sources,
     read_manifest,
+    validate_classify_item,
+    validate_heritage_pair,
     validate_option_set,
+    validate_paradigm_item,
+    validate_paronym_pair,
+    validate_synonym_item,
 )
 
 FIXTURES = Path("tests/fixtures")
@@ -48,14 +58,17 @@ def test_fixture_build_emits_sharded_schema() -> None:
 
     assert set(shards) == {"A1"}
     a1 = shards["A1"]
-    assert set(a1) == {"index", "lexemes", "cloze"}
+    assert set(a1) == {"index", "lexemes", "cloze", *DRILL_MODES}
     assert a1["index"]["schema"] == "atlas-practice-index"
     assert a1["lexemes"]["schema"] == "atlas-practice-lexemes"
     assert a1["cloze"]["schema"] == "atlas-practice-cloze"
+    for mode in DRILL_MODES:
+        assert a1[mode]["schema"] == f"atlas-practice-{mode}"
     assert a1["index"]["fixtureNote"] == "fixture sample"
     assert a1["index"]["counts"]["lexemes"] == 7
     assert a1["index"]["counts"]["cloze"] == 2
     assert a1["index"]["counts"]["clozeCoverage"] == 0.2857
+    assert a1["index"]["counts"]["modeCounts"]["cloze"] == 2
 
     lexeme = next(item for item in a1["lexemes"]["lexemes"] if item["lemmaId"] == "knyha")
     assert lexeme["lemma"] == "книга"
@@ -88,6 +101,61 @@ def test_manifest_cloze_fields_are_ignored_without_curated_sources() -> None:
     assert shards["A1"]["cloze"]["cloze"] == []
 
 
+def test_stress_position_preserves_non_stress_combining_marks() -> None:
+    assert _stress_position("пої́здка") == ("поїздка", 2)
+    assert _stress_position("кра́й") == ("край", 2)
+
+
+def test_neuter_a_ya_nouns_can_reach_fourth_declension() -> None:
+    entry = {"lemma": "ім'я", "pos": "noun"}
+    paradigm = {"cases": {"nominative": {"singular": "ім'я"}}}
+
+    assert _declension_category(entry, ["ім. сер."], paradigm) == "declension-4"
+
+
+def test_a2_classify_items_do_not_raise_english_labels() -> None:
+    entry = {
+        "lemma": "книга",
+        "pos": "noun",
+        "enrichment": {
+            "morphology": {
+                "pos": "noun",
+                "forms": [{"label": "ім. жін."}],
+                "paradigm": {"cases": {"nominative": {"singular": "книга"}}},
+            }
+        },
+    }
+    lexeme = {"lemmaId": "knyha", "lemma": "книга", "cefr": "A2"}
+
+    classify = _build_classify_items(entry, lexeme)[0]
+
+    assert "setLabelEn" not in classify["sets"][0]
+    assert "answerLabelEn" not in classify["sets"][0]
+    assert all("labelEn" not in option for option in classify["sets"][0]["options"])
+
+
+def test_paradigm_answer_position_is_deterministically_shuffled() -> None:
+    items = _build_paradigm_items(
+        {
+            "lemmaId": "test-lemma",
+            "lemma": "тест",
+            "cefr": "B1",
+            "paradigm": {
+                "cases": {
+                    "називний": {"singular": "тест"},
+                    "родовий": {"singular": "тесту"},
+                    "давальний": {"singular": "тестові"},
+                    "орудний": {"singular": "тестом"},
+                    "місцевий": {"singular": "тесті"},
+                }
+            },
+        }
+    )
+
+    assert items
+    assert any(item["options"][0]["kind"] != "answer" for item in items)
+
+
 def test_meaning_mc_eligibility_marks_clean_and_messy_glosses() -> None:
     shards = _build()
     a1 = shards["A1"]
@@ -112,6 +180,54 @@ def test_option_set_validator_rejects_phrase_labels() -> None:
     cloze["options"][1]["label"] = "and yours? formal"
 
     assert "option labels must not be phrase glosses" in validate_option_set(cloze)
+
+
+def test_mode_validators_reject_broken_fixtures() -> None:
+    classify_errors = validate_classify_item(
+        {
+            "classifyId": "broken:classify",
+            "lemmaId": "broken",
+            "sets": [
+                {
+                    "setId": "gender",
+                    "answer": "masculine",
+                    "options": [{"value": "masculine", "labelUk": "чоловічий рід"}],
+                }
+            ],
+        }
+    )
+    synonym_errors = validate_synonym_item(
+        {
+            "synonymId": "broken:synonym",
+            "lemmaId": "broken",
+            "prompt": "слово",
+            "answer": "слово",
+            "options": [
+                {"label": "слово", "lemmaId": "a", "kind": "answer"},
+                {"label": "слово", "lemmaId": "b", "kind": "distractor"},
+                {"label": "надто довгий варіант", "lemmaId": "c", "kind": "distractor"},
+                {"label": "інше", "lemmaId": "d", "kind": "distractor"},
+            ],
+        }
+    )
+    paradigm_errors = validate_paradigm_item(
+        {
+            "paradigmId": "broken:paradigm",
+            "lemmaId": "broken",
+            "form": "книгу",
+            "options": [
+                {"label": "книгу", "kind": "answer"},
+                {"label": "книгу", "kind": "same-paradigm"},
+                {"label": "книзі", "kind": "same-paradigm"},
+            ],
+        }
+    )
+
+    assert any("closed category set" in error for error in classify_errors)
+    assert any("unique" in error for error in synonym_errors)
+    assert any("at least four" in error for error in paradigm_errors)
+    assert validate_heritage_pair({"nativeSlug": "питомий"}) != []
+    assert validate_paronym_pair({"slugA": "адрес", "slugB": "адреса"}) != []
 
 
 def test_option_set_validator_rejects_capitalization_leak() -> None:
@@ -267,6 +383,8 @@ def test_cli_writes_fixture_shards(tmp_path: Path) -> None:
     assert index_path.exists()
     assert lexeme_path.exists()
     assert cloze_path.exists()
+    for mode in DRILL_MODES:
+        assert (tmp_path / f"practice-{mode}.A1.json").exists()
     payload = json.loads(index_path.read_text(encoding="utf-8"))
     assert payload["schema"] == "atlas-practice-index"
     assert payload["source"] == "fixture"

--- a/tests/test_publish_practice_deck.py
+++ b/tests/test_publish_practice_deck.py
@@ -57,6 +57,19 @@ def _write_practice_deck(practice_dir: Path, *, deck_version: str = "atlas-pract
                 "cloze": [],
             },
         )
+        for kind, (_template, schema) in KINDS.items():
+            if kind in {"index", "lexemes", "cloze"}:
+                continue
+            _write_json(
+                practice_dir / f"practice-{kind}.{level}.json",
+                {
+                    "schema": schema,
+                    "schemaVersion": 1,
+                    "deckVersion": deck_version,
+                    "level": level,
+                    kind: [],
+                },
+            )
 
 
 def test_publish_practice_deck_dry_run_builds_hash_pinned_package(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Refs #4383.

- Adds Atlas DB-backed wave-1 practice deck generation for `stress`, `classify`, `paradigm`, and `synonym`, plus fail-closed empty `heritage` / `paronym` shards.
- Adds per-mode build-red validators, static asset validation, publish/hydrate allowlists, and coverage/count reporting.
- Extends SRS/UI plumbing so backed wave-1 drills schedule through the existing six-mode card-key union; classify rotates category sets while retaining one `lemmaId::classify` SRS card.
- Updates the pinned practice deck release pointer to `atlas-practice-v1-e73283406da45cb2` with 45 shards.

Notes:

- Synonym/antonym pairs carry the ukrajinet auto-translation caveat from #1657. One-off cross-family verification is queued separately as #4504; this PR ships the deck mechanics per spec.
- `heritage` and `paronym` intentionally publish empty shards today; validators are live and fail closed for malformed future `heritage_pair` / `paronym_pair` records.
- Generated `site/public/lexicon/practice-*.json` shards are ignored artifacts; the PR pins the release asset pointer instead of committing hydrated shards.
- Independent AGY/Gemini review (`review-4383-prb-diff`, message #4) found four issues; this revision fixes them: preserving non-stress combining marks in stress data, reachable 4th declension classification, deterministic paradigm answer shuffling, and no generated English category labels beyond A1.

## #M-4 Evidence Preamble

### Decks non-thin: builder output per level x mode

```text
$ .venv/bin/python scripts/audit/generate_practice_deck.py --out-dir site/public/lexicon --target 6000
WARN: A1 clozeCoverage 0.0191 below 0.10; recognition deck still emitted
WARN: A1 cloze coverage 0.0191 below 0.10; deck ships small without padding
WARN: A1 synonym coverage 0.0000 below 0.05; deck ships small without padding
WARN: A1 heritage coverage 0.0000 below 0.01; deck ships small without padding
WARN: A1 paronym coverage 0.0000 below 0.01; deck ships small without padding
coverage A1: cloze=22 (1.91%) stress=789 (68.61%) classify=489 (42.52%) paradigm=727 (8.00%) synonym=0 (0.00%) heritage=0 (0.00%) paronym=0 (0.00%)
WARN: A2 cloze coverage 0.0000 below 0.10; deck ships small without padding
WARN: A2 synonym coverage 0.0000 below 0.05; deck ships small without padding
WARN: A2 heritage coverage 0.0000 below 0.01; deck ships small without padding
WARN: A2 paronym coverage 0.0000 below 0.01; deck ships small without padding
coverage A2: cloze=0 (0.00%) stress=765 (79.11%) classify=784 (81.08%) paradigm=592 (7.76%) synonym=0 (0.00%) heritage=0 (0.00%) paronym=0 (0.00%)
WARN: B1 cloze coverage 0.0000 below 0.10; deck ships small without padding
WARN: B1 heritage coverage 0.0000 below 0.01; deck ships small without padding
WARN: B1 paronym coverage 0.0000 below 0.01; deck ships small without padding
coverage B1: cloze=0 (0.00%) stress=837 (56.36%) classify=843 (56.77%) paradigm=805 (6.80%) synonym=276 (11.11%) heritage=0 (0.00%) paronym=0 (0.00%)
WARN: B2 cloze coverage 0.0000 below 0.10; deck ships small without padding
WARN: B2 heritage coverage 0.0000 below 0.01; deck ships small without padding
WARN: B2 paronym coverage 0.0000 below 0.01; deck ships small without padding
coverage B2: cloze=0 (0.00%) stress=542 (63.54%) classify=533 (62.49%) paradigm=549 (8.09%) synonym=98 (8.68%) heritage=0 (0.00%) paronym=0 (0.00%)
WARN: C1 cloze coverage 0.0000 below 0.10; deck ships small without padding
WARN: C1 heritage coverage 0.0000 below 0.01; deck ships small without padding
WARN: C1 paronym coverage 0.0000 below 0.01; deck ships small without padding
coverage C1: cloze=0 (0.00%) stress=346 (85.86%) classify=350 (86.85%) paradigm=462 (14.39%) synonym=35 (6.20%) heritage=0 (0.00%) paronym=0 (0.00%)
```

```text
$ .venv/bin/python scripts/practice_deck/publish.py
Atlas practice deck pointer published: atlas-practice-v1-e73283406da45cb2 45 shards
```

```text
$ .venv/bin/python scripts/audit/check_static_practice_assets.py
Static practice assets: 300 daily words, 4858 practice lexemes, 22 cloze items.
Deck versions: atlas-practice-v1-e73283406da45cb2
Reviewed cloze source allowlist rows: 7
  A1: index=1150 lexemes=1150 cloze=22 stress=789 classify=489 paradigm=727 synonym=0 heritage=0 paronym=0
  A2: index=967 lexemes=967 cloze=0 stress=765 classify=784 paradigm=592 synonym=0 heritage=0 paronym=0
  B1: index=1485 lexemes=1485 cloze=0 stress=837 classify=843 paradigm=805 synonym=276 heritage=0 paronym=0
  B2: index=853 lexemes=853 cloze=0 stress=542 classify=533 paradigm=549 synonym=98 heritage=0 paronym=0
  C1: index=403 lexemes=403 cloze=0 stress=346 classify=350 paradigm=462 synonym=35 heritage=0 paronym=0
```

### Validators live: broken fixtures red, then green suite

```text
$ .venv/bin/python scripts/audit/generate_practice_deck.py --broken-validator-fixtures
Broken validator fixtures:
  classify: ['classify gender options must equal the closed category set']
  synonym: ['synonym options must be unique after normalization', 'synonym answer must be present exactly once', 'synonym option label lengths exceed bounded distribution']
  paradigm: ['paradigm option set must contain at least four options']
  heritage_pair: ['heritage_pair corrections must be a nonempty list', 'heritage_pair citations must be a nonempty list', 'heritage_pair missing sourceFamily']
  paronym_pair: ['paronym_pair missing distinction_gloss_uk', 'paronym_pair frames must be a nonempty list', 'paronym_pair citations must be a nonempty list']
exit=1
```

```text
$ .venv/bin/python -m pytest tests/test_generate_practice_deck.py tests/test_check_static_practice_assets.py tests/test_publish_practice_deck.py -q
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4383-prb-wave1-decks
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 39 items

tests/test_generate_practice_deck.py .............................       [ 74%]
tests/test_check_static_practice_assets.py ........                      [ 94%]
tests/test_publish_practice_deck.py ..                                   [100%]

============================== 39 passed in 0.58s ==============================
```

### Tests pass: vitest + pytest final summary lines

```text
$ npm exec vitest run tests/unit/lexicon-srs.test.ts tests/unit/LexiconPractice.test.tsx tests/unit/hydrate-practice-deck.test.ts
 RUN  v4.1.8 /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4383-prb-wave1-decks/site

 Test Files  3 passed (3)
      Tests  42 passed (42)
   Start at  08:22:22
   Duration  645ms (transform 122ms, setup 159ms, import 230ms, tests 179ms, environment 565ms)
```

```text
$ .venv/bin/python -m pytest tests/test_generate_practice_deck.py tests/test_check_static_practice_assets.py tests/test_publish_practice_deck.py -q
============================== 39 passed in 0.58s ==============================
```

### Lint clean: eslint + ruff final lines

```text
$ npm exec eslint -- --global URL,fetch,Buffer,console,process site/scripts/hydrate-practice-deck.mjs site/src/components/LexiconPractice.tsx site/src/lib/lexicon/srs.ts site/tests/unit/lexicon-srs.test.ts
eslint exit=0
```

```text
$ .venv/bin/ruff check scripts/audit/generate_practice_deck.py scripts/audit/check_static_practice_assets.py scripts/practice_deck/io.py scripts/practice_deck/publish.py tests/test_generate_practice_deck.py tests/test_check_static_practice_assets.py tests/test_publish_practice_deck.py
All checks passed!
```

### Commit / PR evidence

```text
$ git log -1 --oneline
b45a45ac8d feat(practice): #4383 PR-B — wave-1 decks (stress/classify/paradigm/synonym) + validators + coverage gates
```

```json
{"url":"https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/4551"}
```
