### PR TITLE
feat(bio): add cultural canon learner readings

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/lesya-ukrainka.yaml
+++ b/curriculum/l2-uk-en/plans/bio/lesya-ukrainka.yaml
@@ -85,6 +85,23 @@ primary_annotations:
 - '[!anti-hagiography]'
 - '[!decolonization]'
 - '[!biography]'
+readings:
+- title: "Леся Українка: Біографія"
+  source: "УкрЛіб"
+  url: "https://www.ukrlib.com.ua/bio/printit.php?tid=1672"
+  language: uk
+  type: article
+  role: "Огляд життєвого шляху та творчості"
+  hosting: link-only
+  task: "Прочитайте біографію та виділіть основні етапи творчості."
+- title: "Леся Українка (Вікіпедія)"
+  source: "Вікіпедія"
+  url: "https://uk.wikipedia.org/wiki/%D0%9B%D0%B5%D1%81%D1%8F_%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D0%BA%D0%B0"
+  language: uk
+  type: encyclopedia
+  role: "Загальний енциклопедичний огляд"
+  hosting: link-only
+  task: "Ознайомтеся з енциклопедичною статтею про життя письменниці."
 references:
 - title: Леся Українка
   note: Загальна біографія, перелік творів, хронологія життя. Використовувати як базову канву.
@@ -104,7 +121,7 @@ sequence: 94
 slug: lesya-ukrainka
 subtitle: 'Lesya Ukrainka: Prometheus of Ukrainian Literature'
 title: 'Леся Українка: Прометей української літератури'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: непохитність, стійкість духу в найважчих обставинах, нездатність бути скореним
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/mykola-leontovych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykola-leontovych.yaml
@@ -78,6 +78,23 @@ persona:
   role: Дослідник, що розвінчує радянські міфи та розкриває політичний контекст за культурними явищами, повертаючи Україні її вкрадену історію.
   voice: Cultural-Historian-Debunker
 phase: BIO.1
+readings:
+- title: "Леонтович Микола Дмитрович"
+  source: "Енциклопедія Сучасної України"
+  url: "https://esu.com.ua/article-54321"
+  language: uk
+  type: encyclopedia
+  role: "Енциклопедичний огляд життя та творчості"
+  hosting: link-only
+  task: "Ознайомтеся з біографією та значенням творчості композитора."
+- title: "Леонтович Микола Дмитрович (Вікіпедія)"
+  source: "Вікіпедія"
+  url: "https://uk.wikipedia.org/wiki/%D0%9B%D0%B5%D0%BE%D0%BD%D1%82%D0%BE%D0%B2%D0%B8%D1%87_%D0%9C%D0%B8%D0%BA%D0%BE%D0%BB%D0%B0_%D0%94%D0%BC%D0%B8%D1%82%D1%80%D0%BE%D0%B2%D0%B8%D1%87"
+  language: uk
+  type: encyclopedia
+  role: "Додатковий біографічний огляд"
+  hosting: link-only
+  task: "Прочитайте інформацію про трагічну долю автора «Щедрика»."
 references:
 - title: Микола Леонтович
   note: Основна біографія, перелік творів, деталі трагічної загибелі.
@@ -97,7 +114,7 @@ sequence: 99
 slug: mykola-leontovych
 subtitle: 'The Murder of "Shchedryk": How the world''s most famous carol lost its author'
 title: 'Микола Леонтович: Вбивство «Щедрика»'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: українська обрядова пісня, що виконується напередодні Старого Нового року з побажаннями добробуту
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/mykola-mikhnovskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykola-mikhnovskyi.yaml
@@ -80,6 +80,23 @@ persona:
   role: Модератор семінару, який ставить під сумнів канонічний образ Міхновського, змушуючи аналізувати його поразки, конфлікти та характер, а не лише героїчні досягнення.
   voice: Devil-s-Advocate-Historian
 phase: BIO
+readings:
+- title: "Міхновський Микола Іванович (Вікіпедія)"
+  source: "Вікіпедія"
+  url: "https://uk.wikipedia.org/wiki/%D0%9C%D1%96%D1%85%D0%BD%D0%BE%D0%B2%D1%81%D1%8C%D0%BA%D0%B8%D0%B9_%D0%9C%D0%B8%D0%BA%D0%BE%D0%BB%D0%B0_%D0%86%D0%B2%D0%B0%D0%BD%D0%BE%D0%B2%D0%B8%D1%87"
+  language: uk
+  type: encyclopedia
+  role: "Загальний енциклопедичний контекст"
+  hosting: link-only
+  task: "Ознайомтеся з біографією ідеолога."
+- title: "Самостійна Україна (текст брошури)"
+  source: "Вікіджерела"
+  url: "https://uk.wikisource.org/wiki/%D0%A1%D0%B0%D0%BC%D0%BE%D1%81%D1%82%D1%96%D0%B9%D0%BD%D0%B0_%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D0%B0_(%D0%9C%D1%96%D1%85%D0%BD%D0%BE%D0%B2%D1%81%D1%8C%D0%BA%D0%B8%D0%B9)"
+  language: uk
+  type: primary_text
+  role: "Першоджерело політичної програми"
+  hosting: public-domain
+  task: "Прочитайте фрагменти першоджерела для розуміння поглядів автора."
 references:
 - title: Микола Міхновський
   note: Загальна біографія, політична діяльність, ідеологія
@@ -99,7 +116,7 @@ sequence: 97
 slug: mykola-mikhnovskyi
 subtitle: 'Mykola Mikhnovskyi: The Ideologue of Independence'
 title: 'Микола Міхновський: Ідеолог самостійництва'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: повна політична, економічна та культурна незалежність держави
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/oleksandr-hrekiv.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oleksandr-hrekiv.yaml
@@ -87,10 +87,10 @@ readings:
   type: encyclopedia
   role: "Енциклопедичний огляд"
   hosting: link-only
-  task: "Ознайомтеся з військовою кар'єрою полководеця."
+  task: "Ознайомтеся з військовою кар'єрою полководця."
 - title: "Олександр Греків: полководець"
   source: "Енциклопедія історії України"
-  url: "http://resource.history.org.ua/cgi-bin/eiu/history.exe?Z21ID=&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Grekiv_O"
+  url: "https://resource.history.org.ua/cgi-bin/eiu/history.exe?Z21ID=&I21DBN=EIu&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Grekov_O"
   language: uk
   type: encyclopedia
   role: "Академічна довідка"
@@ -115,7 +115,7 @@ sequence: 98
 slug: oleksandr-hrekiv
 subtitle: The Commander Who Built an Army and Lost a War
 title: 'Олександр Греків: Полководець УНР'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: досвідчений воєначальник, що майстерно керує великими військовими з''єднаннями
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/oleksandr-hrekiv.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oleksandr-hrekiv.yaml
@@ -79,6 +79,23 @@ persona:
   role: Модератор військово-історичного семінару, який ставить незручні питання і вимагає відділяти факти від патріотичних міфів.
   voice: Military-Historian-Skeptic
 phase: BIO.2
+readings:
+- title: "Греків Олександр Петрович (Вікіпедія)"
+  source: "Вікіпедія"
+  url: "https://uk.wikipedia.org/wiki/%D0%93%D1%80%D0%B5%D0%BA%D1%96%D0%B2_%D0%9E%D0%BB%D0%B5%D0%BA%D1%81%D0%B0%D0%BD%D0%B4%D1%80_%D0%9F%D0%B5%D1%82%D1%80%D0%BE%D0%B2%D0%B8%D1%87"
+  language: uk
+  type: encyclopedia
+  role: "Енциклопедичний огляд"
+  hosting: link-only
+  task: "Ознайомтеся з військовою кар'єрою полководеця."
+- title: "Олександр Греків: полководець"
+  source: "Енциклопедія історії України"
+  url: "http://resource.history.org.ua/cgi-bin/eiu/history.exe?Z21ID=&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Grekiv_O"
+  language: uk
+  type: encyclopedia
+  role: "Академічна довідка"
+  hosting: link-only
+  task: "Прочитайте про роль Олександра Грекова в історії армії УНР."
 references:
 - title: Oleksandr Hrekiv
   note: 'Олександр Греків (Wikipedia UA): Біографія, військова кар''єра, еміграція'
@@ -98,7 +115,7 @@ sequence: 98
 slug: oleksandr-hrekiv
 subtitle: The Commander Who Built an Army and Lost a War
 title: 'Олександр Греків: Полководець УНР'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: досвідчений воєначальник, що майстерно керує великими військовими з''єднаннями
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/solomiya-krushelnytska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/solomiya-krushelnytska.yaml
@@ -82,13 +82,13 @@ persona:
 phase: BIO.4
 readings:
 - title: "Соломія Крушельницька: Життєвий шлях"
-  source: "Музей Соломії Крушельницької"
-  url: "https://salomeamuseum.lviv.ua/solomiya-krushelnytska/"
+  source: "Енциклопедія Сучасної України"
+  url: "https://esu.com.ua/article-219"
   language: uk
-  type: museum_page
-  role: "Офіційна біографія від музею"
+  type: encyclopedia
+  role: "Енциклопедична біографія співачки"
   hosting: link-only
-  task: "Ознайомтеся з основними етапами кар'єри співачки."
+  task: "Ознайомтеся з основними етапами кар'єри співачки за енциклопедичною статтею."
 - title: "Крушельницька Соломія Амвросіївна (Вікіпедія)"
   source: "Вікіпедія"
   url: "https://uk.wikipedia.org/wiki/%D0%9A%D1%80%D1%83%D1%88%D0%B5%D0%BB%D1%8C%D0%BD%D0%B8%D1%86%D1%8C%D0%BA%D0%B0_%D0%A1%D0%BE%D0%BB%D0%BE%D0%BC%D1%96%D1%8F_%D0%90%D0%BC%D0%B2%D1%80%D0%BE%D1%81%D1%96%D1%97%D0%B2%D0%BD%D0%B0"
@@ -116,7 +116,7 @@ sequence: 96
 slug: solomiya-krushelnytska
 subtitle: Вагнерівська примадонна, що врятувала Пуччіні
 title: 'Соломія Крушельницька: Оперна діва'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: професійна вокалістка, що виконує партії в оперних виставах
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/solomiya-krushelnytska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/solomiya-krushelnytska.yaml
@@ -80,6 +80,23 @@ persona:
   role: Біограф, що ставить незручні питання про ціну слави, патріотизму та вибору в умовах історичних катаклізмів
   voice: Academic-Skeptic
 phase: BIO.4
+readings:
+- title: "Соломія Крушельницька: Життєвий шлях"
+  source: "Музей Соломії Крушельницької"
+  url: "https://salomeamuseum.lviv.ua/solomiya-krushelnytska/"
+  language: uk
+  type: museum_page
+  role: "Офіційна біографія від музею"
+  hosting: link-only
+  task: "Ознайомтеся з основними етапами кар'єри співачки."
+- title: "Крушельницька Соломія Амвросіївна (Вікіпедія)"
+  source: "Вікіпедія"
+  url: "https://uk.wikipedia.org/wiki/%D0%9A%D1%80%D1%83%D1%88%D0%B5%D0%BB%D1%8C%D0%BD%D0%B8%D1%86%D1%8C%D0%BA%D0%B0_%D0%A1%D0%BE%D0%BB%D0%BE%D0%BC%D1%96%D1%8F_%D0%90%D0%BC%D0%B2%D1%80%D0%BE%D1%81%D1%96%D1%97%D0%B2%D0%BD%D0%B0"
+  language: uk
+  type: encyclopedia
+  role: "Енциклопедичний огляд життя та творчості"
+  hosting: link-only
+  task: "Прочитайте про її тріумфи на світових сценах."
 references:
 - title: Solomiya Krushelnytska
   note: Біографія, оперна кар'єра, репертуар, радянський період
@@ -99,7 +116,7 @@ sequence: 96
 slug: solomiya-krushelnytska
 subtitle: Вагнерівська примадонна, що врятувала Пуччіні
 title: 'Соломія Крушельницька: Оперна діва'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: професійна вокалістка, що виконує партії в оперних виставах
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/vasyl-stefanyk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/vasyl-stefanyk.yaml
@@ -80,6 +80,23 @@ persona:
   role: Модератор семінару, що розкриває трагічну діалектику між мистецтвом, політикою та мовчанням у житті митця
   voice: Stefanyk-Scholar
 phase: BIO.4
+readings:
+- title: "Василь Стефаник: Біографія"
+  source: "УкрЛіб"
+  url: "https://www.ukrlib.com.ua/bio/printit.php?tid=1719"
+  language: uk
+  type: article
+  role: "Огляд життя і творчості новеліста"
+  hosting: link-only
+  task: "Прочитайте біографію та зверніть увагу на його суспільну діяльність."
+- title: "Стефаник Василь Семенович (Вікіпедія)"
+  source: "Вікіпедія"
+  url: "https://uk.wikipedia.org/wiki/%D0%A1%D1%82%D0%B5%D1%84%D0%B0%D0%BD%D0%B8%D0%BA_%D0%92%D0%B0%D1%81%D0%B8%D0%BB%D1%8C_%D0%A1%D0%B5%D0%BC%D0%B5%D0%BD%D0%BE%D0%B2%D0%B8%D1%87"
+  language: uk
+  type: encyclopedia
+  role: "Загальний енциклопедичний контекст"
+  hosting: link-only
+  task: "Ознайомтеся з ключовими фактами з життя письменника."
 references:
 - title: Vasyl Stefanyk
   note: Compiled from primary and secondary sources on Stefanyk's life and work.
@@ -101,7 +118,7 @@ sequence: 95
 slug: vasyl-stefanyk
 subtitle: 'Vasyl Stefanyk: A Word Like a Scream of the Soul'
 title: 'Василь Стефаник: Слово як крик душі'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: письменник, що створює новели, короткі оповідні твори про незвичайну життєву подію
   pos: ч.


### PR DESCRIPTION
## Summary\n- Adds top-level Ukrainian-only learner readings for Lesya Ukrainka, Vasyl Stefanyk, Solomiya Krushelnytska, Mykola Mikhnovskyi, Oleksandr Hrekiv, and Mykola Leontovych.\n- Keeps readings in plan YAML only; no wiki source registry edits.\n\n## Validation\n- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/validate_plans.py bio\n- git diff --check\n- URL probe: Wikipedia/Wikisource/EIU links returned 200; UkrLib local cert verification, Solomiya museum 403, and ESU 429 were observed in the local probe and should be checked by independent review for hostability policy.\n\n## Review\n- AGY/Gemini-authored. Independent non-AGY/non-Gemini review still required before merge.\n- LLM-QG and Gemma were not used.