### PR TITLE
feat(bio): add national movement learner readings

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/ahatanhel-krymskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ahatanhel-krymskyi.yaml
@@ -93,11 +93,11 @@ readings:
 - hosting: link-only
   language: uk
   role: Історія інституції, яку очолював Кримський.
-  source: Вікіпедія
-  task: Прочитайте про створення Інституту української наукової мови.
+  source: Енциклопедія історії України
+  task: Прочитайте енциклопедичну довідку про інституцію, яку очолював Кримський.
   title: Інститут української наукової мови
   type: encyclopedia
-  url: https://uk.wikipedia.org/wiki/%D0%86%D0%BD%D1%81%D1%82%D0%B8%D1%82%D1%83%D1%82_%D1%83%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D1%81%D1%8C%D0%BA%D0%BE%D1%97_%D0%BD%D0%B0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D1%97_%D0%BC%D0%BE%D0%B2%D0%B8
+  url: https://history.org.ua/?termin=Inst_ukr_naukovoi_movy
 references:
 - title: Кримський Агатангел Юхимович
   note: Comprehensive biography covering life, scholarship, and tragic fate
@@ -117,7 +117,7 @@ sequence: 93
 slug: ahatanhel-krymskyi
 subtitle: 'Ahatanhel Krymskyi: Polyglot and Martyr of Science'
 title: 'Агатангел Кримський: Поліглот і мученик науки'
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: людина, що володіє багатьма мовами
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/ahatanhel-krymskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ahatanhel-krymskyi.yaml
@@ -89,7 +89,7 @@ readings:
   task: Ознайомтеся з біографією видатного поліглота.
   title: Кримський Агатангел Юхимович
   type: encyclopedia
-  url: https://uk.wikipedia.org/wiki/Кримський_Агатангел_Юхимович
+  url: https://uk.wikipedia.org/wiki/%D0%9A%D1%80%D0%B8%D0%BC%D1%81%D1%8C%D0%BA%D0%B8%D0%B9_%D0%90%D0%B3%D0%B0%D1%82%D0%B0%D0%BD%D0%B3%D0%B5%D0%BB_%D0%AE%D1%85%D0%B8%D0%BC%D0%BE%D0%B2%D0%B8%D1%87
 - hosting: link-only
   language: uk
   role: Історія інституції, яку очолював Кримський.
@@ -97,7 +97,7 @@ readings:
   task: Прочитайте про створення Інституту української наукової мови.
   title: Інститут української наукової мови
   type: encyclopedia
-  url: https://uk.wikipedia.org/wiki/Інститут_української_наукової_мови
+  url: https://uk.wikipedia.org/wiki/%D0%86%D0%BD%D1%81%D1%82%D0%B8%D1%82%D1%83%D1%82_%D1%83%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D1%81%D1%8C%D0%BA%D0%BE%D1%97_%D0%BD%D0%B0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D1%97_%D0%BC%D0%BE%D0%B2%D0%B8
 references:
 - title: Кримський Агатангел Юхимович
   note: Comprehensive biography covering life, scholarship, and tragic fate
@@ -117,7 +117,7 @@ sequence: 93
 slug: ahatanhel-krymskyi
 subtitle: 'Ahatanhel Krymskyi: Polyglot and Martyr of Science'
 title: 'Агатангел Кримський: Поліглот і мученик науки'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: людина, що володіє багатьма мовами
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/ahatanhel-krymskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ahatanhel-krymskyi.yaml
@@ -81,6 +81,23 @@ persona:
   role: Модератор семінару, який розглядає біографію Кримського не як житіє святого, а як складну історичну драму, де наукові амбіції стикаються з політичними реаліями
   voice: Academic-Historian
 phase: BIO.3
+readings:
+- hosting: link-only
+  language: uk
+  role: Основна біографічна стаття про Агатангела Кримського.
+  source: Вікіпедія
+  task: Ознайомтеся з біографією видатного поліглота.
+  title: Кримський Агатангел Юхимович
+  type: encyclopedia
+  url: https://uk.wikipedia.org/wiki/Кримський_Агатангел_Юхимович
+- hosting: link-only
+  language: uk
+  role: Історія інституції, яку очолював Кримський.
+  source: Вікіпедія
+  task: Прочитайте про створення Інституту української наукової мови.
+  title: Інститут української наукової мови
+  type: encyclopedia
+  url: https://uk.wikipedia.org/wiki/Інститут_української_наукової_мови
 references:
 - title: Кримський Агатангел Юхимович
   note: Comprehensive biography covering life, scholarship, and tragic fate
@@ -100,7 +117,7 @@ sequence: 93
 slug: ahatanhel-krymskyi
 subtitle: 'Ahatanhel Krymskyi: Polyglot and Martyr of Science'
 title: 'Агатангел Кримський: Поліглот і мученик науки'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: людина, що володіє багатьма мовами
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/liudmyla-starytska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/liudmyla-starytska.yaml
@@ -78,6 +78,23 @@ persona:
   role: Історик-архівіст, що працює з протоколами допитів СВУ, намагаючись відділити правду від брехні
   voice: Tragic-Realist
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  role: Біографія Людмили Старицької-Черняхівської.
+  source: Вікіпедія
+  task: Ознайомтеся з творчим та життєвим шляхом письменниці.
+  title: Людмила Старицька-Черняхівська
+  type: encyclopedia
+  url: https://uk.wikipedia.org/wiki/Людмила_Старицька-Черняхівська
+- hosting: link-only
+  language: uk
+  role: Історичне тло репресій проти української інтелігенції.
+  source: Вікіпедія
+  task: Дослідіть історичний контекст репресій, що призвели до її загибелі.
+  title: Справа Спілки визволення України
+  type: encyclopedia
+  url: https://uk.wikipedia.org/wiki/Справа_Спілки_визволення_України
 references:
 - title: Людмила Старицька-Черняхівська (Wikipedia UA)
   name: Людмила Старицька-Черняхівська (Wikipedia UA)
@@ -103,7 +120,7 @@ sequence: 89
 slug: liudmyla-starytska
 subtitle: 'Playwright Between Two Worlds: National Stage and Imperial Prison'
 title: 'Людмила Старицька-Черняхівська: Драматургиня'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: найвидатніший діяч у певній галузі, основоположник (вживається щодо батька)
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/liudmyla-starytska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/liudmyla-starytska.yaml
@@ -86,26 +86,26 @@ readings:
   task: Ознайомтеся з творчим та життєвим шляхом письменниці.
   title: Людмила Старицька-Черняхівська
   type: encyclopedia
-  url: https://uk.wikipedia.org/wiki/Людмила_Старицька-Черняхівська
+  url: https://uk.wikipedia.org/wiki/%D0%9B%D1%8E%D0%B4%D0%BC%D0%B8%D0%BB%D0%B0_%D0%A1%D1%82%D0%B0%D1%80%D0%B8%D1%86%D1%8C%D0%BA%D0%B0-%D0%A7%D0%B5%D1%80%D0%BD%D1%8F%D1%85%D1%96%D0%B2%D1%81%D1%8C%D0%BA%D0%B0
 - hosting: link-only
   language: uk
   role: Історичне тло репресій проти української інтелігенції.
   source: Вікіпедія
   task: Дослідіть історичний контекст репресій, що призвели до її загибелі.
-  title: Справа Спілки визволення України
+  title: Процес Спілки визволення України
   type: encyclopedia
-  url: https://uk.wikipedia.org/wiki/Справа_Спілки_визволення_України
+  url: https://uk.wikipedia.org/wiki/%D0%9F%D1%80%D0%BE%D1%86%D0%B5%D1%81_%D0%A1%D0%BF%D1%96%D0%BB%D0%BA%D0%B8_%D0%B2%D0%B8%D0%B7%D0%B2%D0%BE%D0%BB%D0%B5%D0%BD%D0%BD%D1%8F_%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D0%B8
 references:
 - title: Людмила Старицька-Черняхівська (Wikipedia UA)
   name: Людмила Старицька-Черняхівська (Wikipedia UA)
   notes: Біографія, літературна та громадська діяльність
   type: primary
-  url: https://uk.wikipedia.org/wiki/Людмила_Старицька-Черняхівська
+  url: https://uk.wikipedia.org/wiki/%D0%9B%D1%8E%D0%B4%D0%BC%D0%B8%D0%BB%D0%B0_%D0%A1%D1%82%D0%B0%D1%80%D0%B8%D1%86%D1%8C%D0%BA%D0%B0-%D0%A7%D0%B5%D1%80%D0%BD%D1%8F%D1%85%D1%96%D0%B2%D1%81%D1%8C%D0%BA%D0%B0
 - title: Справа СВУ (Wikipedia UA)
   name: Справа СВУ (Wikipedia UA)
   notes: Сфабрикований процес та репресії проти української інтелігенції
   type: primary
-  url: https://uk.wikipedia.org/wiki/Справа_Спілки_визволення_України
+  url: https://uk.wikipedia.org/wiki/%D0%9F%D1%80%D0%BE%D1%86%D0%B5%D1%81_%D0%A1%D0%BF%D1%96%D0%BB%D0%BA%D0%B8_%D0%B2%D0%B8%D0%B7%D0%B2%D0%BE%D0%BB%D0%B5%D0%BD%D0%BD%D1%8F_%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D0%B8
 - title: Суди над «ворогами народу»
   author: Прімо, Я.
   note: Аналіз показових процесів у СРСР, включно з СВУ
@@ -115,12 +115,12 @@ references:
   name: Михайло Старицький (Wikipedia UA)
   notes: Батько — класик української літератури
   type: reference
-  url: https://uk.wikipedia.org/wiki/Михайло_Старицький
+  url: https://uk.wikipedia.org/wiki/%D0%9C%D0%B8%D1%85%D0%B0%D0%B9%D0%BB%D0%BE_%D0%A1%D1%82%D0%B0%D1%80%D0%B8%D1%86%D1%8C%D0%BA%D0%B8%D0%B9
 sequence: 89
 slug: liudmyla-starytska
 subtitle: 'Playwright Between Two Worlds: National Stage and Imperial Prison'
 title: 'Людмила Старицька-Черняхівська: Драматургиня'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: найвидатніший діяч у певній галузі, основоположник (вживається щодо батька)
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/mariia-voiakovska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mariia-voiakovska.yaml
@@ -76,6 +76,23 @@ persona:
   role: Кураторка, що повертає Марію Вояківську з тіні чоловіка, показуючи її як самостійну перекладачку, освітянку й громадську діячку на тлі галицького жіночого руху
   voice: Feminist-Historian
 phase: BIO.4
+readings:
+- hosting: link-only
+  language: uk
+  role: Офіційна біографічна довідка про Марію Грушевську.
+  source: Енциклопедія історії України
+  task: Ознайомтеся з енциклопедичною статтею про життя діячки.
+  title: Грушевська Марія Сильвестрівна
+  type: encyclopedia
+  url: http://ukr-revolution.history.org.ua/termin/grushevska_marija
+- hosting: link-only
+  language: uk
+  role: Додаткові відомості про її перекладацьку та громадську роботу.
+  source: Енциклопедія Сучасної України
+  task: Прочитайте статтю з Енциклопедії Сучасної України для ширшого контексту.
+  title: Грушевська Марія Сильвестрівна
+  type: encyclopedia
+  url: https://esu.com.ua/article-32108
 references:
 - author: Сергій Білокінь
   note: 'Енциклопедична біографія: походження з родини греко-католицького священика, освіта, громадська і перекладацька діяльність, доля родини.'
@@ -112,7 +129,7 @@ sequence: 90
 slug: mariia-voiakovska
 subtitle: The Galician Translator and Educator Beyond the Shadow of a Great Man
 title: 'Марія Вояківська-Грушевська: Більше, ніж тінь'
-version: '5.0'
+version: '5.1'
 vocabulary_hints:
 - definition: жінка, що професійно перекладає тексти з однієї мови на іншу
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/mariia-voiakovska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mariia-voiakovska.yaml
@@ -80,11 +80,11 @@ readings:
 - hosting: link-only
   language: uk
   role: Офіційна біографічна довідка про Марію Грушевську.
-  source: Енциклопедія історії України
+  source: Енциклопедія історії української революції 1917–1921
   task: Ознайомтеся з енциклопедичною статтею про життя діячки.
   title: Грушевська Марія Сильвестрівна
   type: encyclopedia
-  url: http://ukr-revolution.history.org.ua/termin/grushevska_marija
+  url: https://ukr-revolution.history.org.ua/termin/grushevska_marija
 - hosting: link-only
   language: uk
   role: Додаткові відомості про її перекладацьку та громадську роботу.
@@ -129,7 +129,7 @@ sequence: 90
 slug: mariia-voiakovska
 subtitle: The Galician Translator and Educator Beyond the Shadow of a Great Man
 title: 'Марія Вояківська-Грушевська: Більше, ніж тінь'
-version: '5.1'
+version: '5.2'
 vocabulary_hints:
 - definition: жінка, що професійно перекладає тексти з однієї мови на іншу
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/mykola-vasylenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykola-vasylenko.yaml
@@ -89,15 +89,15 @@ readings:
   task: Ознайомтеся з основними етапами біографії Миколи Василенка.
   title: Микола Василенко
   type: encyclopedia
-  url: https://uk.wikipedia.org/wiki/Микола_Василенко
+  url: https://uk.wikipedia.org/wiki/%D0%9C%D0%B8%D0%BA%D0%BE%D0%BB%D0%B0_%D0%92%D0%B0%D1%81%D0%B8%D0%BB%D0%B5%D0%BD%D0%BA%D0%BE
 - hosting: link-only
   language: uk
   role: Контекст політичних репресій, жертвою яких став Василенко.
   source: Вікіпедія
   task: Прочитайте про сфабрикований судовий процес над українською інтелігенцією.
-  title: Справа «Спілки визволення України»
+  title: Процес Спілки визволення України
   type: encyclopedia
-  url: https://uk.wikipedia.org/wiki/Справа_«Спілки_визволення_України»
+  url: https://uk.wikipedia.org/wiki/%D0%9F%D1%80%D0%BE%D1%86%D0%B5%D1%81_%D0%A1%D0%BF%D1%96%D0%BB%D0%BA%D0%B8_%D0%B2%D0%B8%D0%B7%D0%B2%D0%BE%D0%BB%D0%B5%D0%BD%D0%BD%D1%8F_%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D0%B8
 references:
 - title: Микола Василенко
   note: Основна біографічна довідка, перелік праць, дані про державну та наукову діяльність.
@@ -119,7 +119,7 @@ sequence: 88
 slug: mykola-vasylenko
 subtitle: The Tragedy of a Statesman in a Stateless Era
 title: 'Микола Василенко: Юрист і державник'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: сукупність правових наук, наука про право; правознавство
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/mykola-vasylenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykola-vasylenko.yaml
@@ -81,6 +81,23 @@ persona:
   role: Аналітик, що показує трагедію державника в епоху бездержавності, фокусуючись на конфлікті між ідеалом правової держави та реальністю революцій і диктатур.
   voice: Legal-Historian-Turned-Statesman
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  role: Огляд життя та діяльності Миколи Василенка.
+  source: Вікіпедія
+  task: Ознайомтеся з основними етапами біографії Миколи Василенка.
+  title: Микола Василенко
+  type: encyclopedia
+  url: https://uk.wikipedia.org/wiki/Микола_Василенко
+- hosting: link-only
+  language: uk
+  role: Контекст політичних репресій, жертвою яких став Василенко.
+  source: Вікіпедія
+  task: Прочитайте про сфабрикований судовий процес над українською інтелігенцією.
+  title: Справа «Спілки визволення України»
+  type: encyclopedia
+  url: https://uk.wikipedia.org/wiki/Справа_«Спілки_визволення_України»
 references:
 - title: Микола Василенко
   note: Основна біографічна довідка, перелік праць, дані про державну та наукову діяльність.
@@ -102,7 +119,7 @@ sequence: 88
 slug: mykola-vasylenko
 subtitle: The Tragedy of a Statesman in a Stateless Era
 title: 'Микола Василенко: Юрист і державник'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: сукупність правових наук, наука про право; правознавство
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/yevhen-paton.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yevhen-paton.yaml
@@ -86,20 +86,20 @@ phase: BIO.2
 readings:
 - hosting: link-only
   language: uk
-  role: Загальна біографія та ключові досягнення інженера.
-  source: Вікіпедія
-  task: Ознайомтеся з життєписом видатного інженера-мостобудівника.
-  title: Патон Євген Оскарович
-  type: encyclopedia
-  url: https://uk.wikipedia.org/wiki/%D0%9F%D0%B0%D1%82%D0%BE%D0%BD_%D0%84%D0%B2%D0%B3%D0%B5%D0%BD_%D0%9E%D1%81%D0%BA%D0%B0%D1%80%D0%BE%D0%B2%D0%B8%D1%87
+  role: Офіційна біографічна довідка про засновника інституту.
+  source: Інститут електрозварювання ім. Є. О. Патона НАН України
+  task: Ознайомтеся з офіційним нарисом про засновника інституту.
+  title: 'Засновник: Євген Оскарович Патон'
+  type: article
+  url: https://paton.org.ua/institut/istoriya/pro-zasnovnika/
 - hosting: link-only
   language: uk
-  role: Історія та сучасний стан інституту, заснованого Патоном.
-  source: Вікіпедія
-  task: Дізнайтеся про створення та діяльність Інституту електрозварювання.
-  title: Інститут електрозварювання імені Є. О. Патона НАН України
-  type: encyclopedia
-  url: https://uk.wikipedia.org/wiki/%D0%86%D0%BD%D1%81%D1%82%D0%B8%D1%82%D1%83%D1%82_%D0%B5%D0%BB%D0%B5%D0%BA%D1%82%D1%80%D0%BE%D0%B7%D0%B2%D0%B0%D1%80%D1%8E%D0%B2%D0%B0%D0%BD%D0%BD%D1%8F_%D1%96%D0%BC%D0%B5%D0%BD%D1%96_%D0%84._%D0%9E._%D0%9F%D0%B0%D1%82%D0%BE%D0%BD%D0%B0_%D0%9D%D0%90%D0%9D_%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D0%B8
+  role: Історія інституції, яку заснував і очолював Патон.
+  source: Інститут електрозварювання ім. Є. О. Патона НАН України
+  task: Прочитайте про створення та розвиток Інституту електрозварювання.
+  title: Історія Інституту електрозварювання ім. Є. О. Патона
+  type: article
+  url: https://paton.org.ua/institut/istoriya/
 references:
 - title: Патон Євген Оскарович
   note: Загальна біографія, дати, ключові досягнення
@@ -117,7 +117,7 @@ sequence: 91
 slug: yevhen-paton
 subtitle: 'Yevhen Paton: The Engineer Who United Ukraine'
 title: 'Євген Патон: Інженер, що з''єднав Україну'
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: галузь інженерії, що займається проектуванням, будівництвом та експлуатацією мостів
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/yevhen-paton.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yevhen-paton.yaml
@@ -91,15 +91,15 @@ readings:
   task: Ознайомтеся з життєписом видатного інженера-мостобудівника.
   title: Патон Євген Оскарович
   type: encyclopedia
-  url: https://uk.wikipedia.org/wiki/Патон_Євген_Оскарович
+  url: https://uk.wikipedia.org/wiki/%D0%9F%D0%B0%D1%82%D0%BE%D0%BD_%D0%84%D0%B2%D0%B3%D0%B5%D0%BD_%D0%9E%D1%81%D0%BA%D0%B0%D1%80%D0%BE%D0%B2%D0%B8%D1%87
 - hosting: link-only
   language: uk
   role: Історія та сучасний стан інституту, заснованого Патоном.
   source: Вікіпедія
   task: Дізнайтеся про створення та діяльність Інституту електрозварювання.
-  title: Інститут електрозварювання імені Є. О. Патона
+  title: Інститут електрозварювання імені Є. О. Патона НАН України
   type: encyclopedia
-  url: https://uk.wikipedia.org/wiki/Інститут_електрозварювання_імені_Є._О._Патона
+  url: https://uk.wikipedia.org/wiki/%D0%86%D0%BD%D1%81%D1%82%D0%B8%D1%82%D1%83%D1%82_%D0%B5%D0%BB%D0%B5%D0%BA%D1%82%D1%80%D0%BE%D0%B7%D0%B2%D0%B0%D1%80%D1%8E%D0%B2%D0%B0%D0%BD%D0%BD%D1%8F_%D1%96%D0%BC%D0%B5%D0%BD%D1%96_%D0%84._%D0%9E._%D0%9F%D0%B0%D1%82%D0%BE%D0%BD%D0%B0_%D0%9D%D0%90%D0%9D_%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D0%B8
 references:
 - title: Патон Євген Оскарович
   note: Загальна біографія, дати, ключові досягнення
@@ -117,7 +117,7 @@ sequence: 91
 slug: yevhen-paton
 subtitle: 'Yevhen Paton: The Engineer Who United Ukraine'
 title: 'Євген Патон: Інженер, що з''єднав Україну'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: галузь інженерії, що займається проектуванням, будівництвом та експлуатацією мостів
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/yevhen-paton.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yevhen-paton.yaml
@@ -83,6 +83,23 @@ persona:
   role: Модератор семінару, який ставить під сумнів героїчний наратив про "великого інженера", змушуючи аналізувати політичний контекст, моральні компроміси та людську ціну технологічного прогресу.
   voice: Critical-Historian-of-Technology
 phase: BIO.2
+readings:
+- hosting: link-only
+  language: uk
+  role: Загальна біографія та ключові досягнення інженера.
+  source: Вікіпедія
+  task: Ознайомтеся з життєписом видатного інженера-мостобудівника.
+  title: Патон Євген Оскарович
+  type: encyclopedia
+  url: https://uk.wikipedia.org/wiki/Патон_Євген_Оскарович
+- hosting: link-only
+  language: uk
+  role: Історія та сучасний стан інституту, заснованого Патоном.
+  source: Вікіпедія
+  task: Дізнайтеся про створення та діяльність Інституту електрозварювання.
+  title: Інститут електрозварювання імені Є. О. Патона
+  type: encyclopedia
+  url: https://uk.wikipedia.org/wiki/Інститут_електрозварювання_імені_Є._О._Патона
 references:
 - title: Патон Євген Оскарович
   note: Загальна біографія, дати, ключові досягнення
@@ -100,7 +117,7 @@ sequence: 91
 slug: yevhen-paton
 subtitle: 'Yevhen Paton: The Engineer Who United Ukraine'
 title: 'Євген Патон: Інженер, що з''єднав Україну'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: галузь інженерії, що займається проектуванням, будівництвом та експлуатацією мостів
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/yulian-bachynskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yulian-bachynskyi.yaml
@@ -76,6 +76,23 @@ pedagogy: CBI
 persona:
   role: Модератор дискусії, що ставить під сумнів усталені наративи і вимагає доказів. Чому саме Бачинський, а не хтось інший? Де його слабкі місця?
   voice: Critical-Historian
+readings:
+- hosting: link-only
+  language: uk
+  role: Огляд життя і діяльності автора.
+  source: Вікіпедія
+  task: Прочитайте біографію Юліана Бачинського.
+  title: Бачинський Юліан Олександрович
+  type: encyclopedia
+  url: https://uk.wikipedia.org/wiki/Бачинський_Юліан_Олександрович
+- hosting: link-only
+  language: uk
+  role: Історія партії, співзасновником якої був Бачинський.
+  source: Вікіпедія
+  task: Ознайомтеся з політичним середовищем початку ХХ століття.
+  title: Русько-українська радикальна партія
+  type: encyclopedia
+  url: https://uk.wikipedia.org/wiki/Русько-українська_радикальна_партія
 references:
 - title: Yulian Bachynskyi
   note: Основна біографічна інформація, дати, ключові події
@@ -95,7 +112,7 @@ sequence: 92
 slug: yulian-bachynskyi
 subtitle: The Man Who Wrote the Book on Independence
 title: 'Юліан Бачинський: Теоретик незалежності'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: політичний термін, що означає «невизволені» або «неврятовані» території, які нація вважає своїми
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/yulian-bachynskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yulian-bachynskyi.yaml
@@ -84,7 +84,7 @@ readings:
   task: Прочитайте біографію Юліана Бачинського.
   title: Бачинський Юліан Олександрович
   type: encyclopedia
-  url: https://uk.wikipedia.org/wiki/Бачинський_Юліан_Олександрович
+  url: https://uk.wikipedia.org/wiki/%D0%91%D0%B0%D1%87%D0%B8%D0%BD%D1%81%D1%8C%D0%BA%D0%B8%D0%B9_%D0%AE%D0%BB%D1%96%D0%B0%D0%BD_%D0%9E%D0%BB%D0%B5%D0%BA%D1%81%D0%B0%D0%BD%D0%B4%D1%80%D0%BE%D0%B2%D0%B8%D1%87
 - hosting: link-only
   language: uk
   role: Історія партії, співзасновником якої був Бачинський.
@@ -92,7 +92,7 @@ readings:
   task: Ознайомтеся з політичним середовищем початку ХХ століття.
   title: Русько-українська радикальна партія
   type: encyclopedia
-  url: https://uk.wikipedia.org/wiki/Русько-українська_радикальна_партія
+  url: https://uk.wikipedia.org/wiki/%D0%A0%D1%83%D1%81%D1%8C%D0%BA%D0%BE-%D1%83%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D1%81%D1%8C%D0%BA%D0%B0_%D1%80%D0%B0%D0%B4%D0%B8%D0%BA%D0%B0%D0%BB%D1%8C%D0%BD%D0%B0_%D0%BF%D0%B0%D1%80%D1%82%D1%96%D1%8F
 references:
 - title: Yulian Bachynskyi
   note: Основна біографічна інформація, дати, ключові події
@@ -112,7 +112,7 @@ sequence: 92
 slug: yulian-bachynskyi
 subtitle: The Man Who Wrote the Book on Independence
 title: 'Юліан Бачинський: Теоретик незалежності'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: політичний термін, що означає «невизволені» або «неврятовані» території, які нація вважає своїми
   pos: ж.


### PR DESCRIPTION
## Summary\n- Adds top-level Ukrainian-only learner readings for Mykola Vasylenko, Liudmyla Starytska-Cherniakhivska, Mariia Voiakovska, Yevhen Paton, Yulian Bachynskyi, and Ahatanhel Krymskyi.\n- Keeps readings in plan YAML only; no wiki source registry edits.\n- Includes Codex orchestrator URL fixes for percent-encoded Wikipedia URLs and corrected live SVU/Paton institute pages.\n\n## Validation\n- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/validate_plans.py bio\n- git diff --check\n- URL probe: all checked reading URLs returned 200 except ESU rate-limited https://esu.com.ua/article-32108 with HTTP 429.\n\n## Review\n- AGY/Gemini-authored with Codex orchestration fix. Independent non-AGY/non-Gemini review still required before merge.\n- LLM-QG and Gemma were not used.