### PR TITLE
feat(bio): add reading packets for post-war culture batch 22

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/anatol-petrytskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/anatol-petrytskyi.yaml
@@ -105,6 +105,12 @@ persona:
     тоталітарній державі.
   voice: Art Historian
 phase: BIO
+readings:
+- author: Енциклопедія Сучасної України
+  description: Академічна біографія Анатоля Петрицького.
+  difficulty: B2
+  title: Петрицький Анатоль
+  url: https://esu.com.ua/article-884765
 references:
 - note: Академічна біографія в Енциклопедії Сучасної України.
   path: https://esu.com.ua/article-884765
@@ -137,7 +143,7 @@ sequence: 125
 slug: anatol-petrytskyi
 subtitle: The Avant-Garde Genius, the Erased Gallery, and the Price of Survival
 title: 'Анатоль Петрицький: Авангард, знищена галерея і ціна виживання'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: 'мистецтво художнього оформлення театральної вистави: декорації, костюми та простір сцени'
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/berta-rapoport.yaml
+++ b/curriculum/l2-uk-en/plans/bio/berta-rapoport.yaml
@@ -148,6 +148,12 @@ persona:
     радянської маргіналізації.
   voice: Maritime Historian
 phase: BIO
+readings:
+- author: Одеський мартиролог
+  description: Інституційний меморіальний запис про життя та кар'єру капітанки Берти Рапопорт.
+  difficulty: B2
+  title: Рапопорт Берта Яківна (1914–1967)
+  url: https://odessa-memory.info/ua/index.php?id=87
 references:
 - note: >-
     Інституційний меморіальний запис (Одеський мартиролог) — найсильніше доступне
@@ -173,7 +179,7 @@ sequence: 129
 slug: berta-rapoport
 subtitle: 'Berta Rapoport: One of the First Women Sea-Captains'
 title: 'Берта Рапопорт: Капітанка, яку море прийняло, а пам''ять забула'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: жінка, яка командує морським судном і відповідає за екіпаж та плавання
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/borys-liatoshynskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/borys-liatoshynskyi.yaml
@@ -79,6 +79,12 @@ persona:
   role: Куратор виставки, що ставить складні питання про ціну творчості в умовах диктатури, уникаючи простих оцінок «зрада/перемога».
   voice: Critical-Musicologist
 phase: BIO
+readings:
+- author: Енциклопедія Сучасної України
+  description: Академічна біографія Бориса Лятошинського.
+  difficulty: B2
+  title: Лятошинський Борис Миколайович
+  url: https://esu.com.ua/article-60072
 references:
 - title: Borys Liatoshynskyi
   note: Базова біографічна довідка, згенерована з Wikipedia та академічних джерел.
@@ -98,7 +104,7 @@ sequence: 126
 slug: borys-liatoshynskyi
 subtitle: Батько українського модернізму під тиском тоталітарної системи
 title: 'Борис Лятошинський: Симфоніст'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: монументальний, зазвичай чотиричастинний, твір для симфонічного оркестру
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/maik-yohansen.yaml
+++ b/curriculum/l2-uk-en/plans/bio/maik-yohansen.yaml
@@ -137,6 +137,12 @@ persona:
     механізми сталінського терору проти митців.
   voice: Literary Historian
 phase: BIO
+readings:
+- author: Енциклопедія Сучасної України
+  description: Академічна біографія Майка Йогансена.
+  difficulty: B2
+  title: Йогансен Майк (Михайло Гервасійович)
+  url: https://esu.com.ua/article-12974
 references:
 - note: Академічна біографічна стаття про життя й доробок письменника.
   path: https://esu.com.ua/article-12974
@@ -168,7 +174,7 @@ sequence: 127
 slug: maik-yohansen
 subtitle: 'Maik Yohansen: Avant-Garde Mystifier and Linguist of the Executed Renaissance'
 title: 'Майк Йогансен: Авангард, містифікація і розстріляне слово'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: мистецький напрям початку XX століття, що рвав із традицією й шукав радикально нових форм
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/oleksandr-dovzhenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oleksandr-dovzhenko.yaml
@@ -77,6 +77,12 @@ persona:
   role: Модератор кіносемінару, що відділяє міфи від фактів та аналізує складні моральні вибори митця
   voice: Критик-біограф
 phase: BIO
+readings:
+- author: Енциклопедія Сучасної України
+  description: Академічна біографія Олександра Довженка.
+  difficulty: B2
+  title: Довженко Олександр Петрович
+  url: https://esu.com.ua/article-20465
 references:
 - title: Oleksandr Dovzhenko
   note: Compiled from ЕІУ, Корнієнко, and Dovzhenko's own writings.
@@ -106,7 +112,7 @@ sequence: 124
 slug: oleksandr-dovzhenko
 subtitle: The Tragedy of a Genius
 title: 'Олександр Довженко: Трагедія генія'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: творець фільму, що керує творчим процесом
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/vasyl-vyshyvanyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/vasyl-vyshyvanyi.yaml
@@ -79,6 +79,12 @@ persona:
   role: Модератор семінару, що ставить під сумнів романтичні міфи та змушує студентів аналізувати мотивацію історичних постатей
   voice: Scholarly-Skeptical
 phase: BIO
+readings:
+- author: Енциклопедія Сучасної України
+  description: Академічна біографія Василя Вишиваного (Вільгельма Габсбурга).
+  difficulty: B2
+  title: Габсбург Вільгельм
+  url: https://esu.com.ua/article-27931
 references:
 - title: Vyshyvanyi Memoirs
   note: Фрагменти зі спогадів "Минають дні"
@@ -99,7 +105,7 @@ sequence: 128
 slug: vasyl-vyshyvanyi
 subtitle: Archduke Wilhelm von Habsburg, the Ukrainian Colonel
 title: 'Василь Вишиваний: Князь-українець'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: титул некоронованих членів австрійської імператорської династії Габсбургів
   pos: ч.


### PR DESCRIPTION
## Description

Adds Ukrainian-language reading packets to six BIO plans:
- `curriculum/l2-uk-en/plans/bio/oleksandr-dovzhenko.yaml`
- `curriculum/l2-uk-en/plans/bio/anatol-petrytskyi.yaml`
- `curriculum/l2-uk-en/plans/bio/borys-liatoshynskyi.yaml`
- `curriculum/l2-uk-en/plans/bio/maik-yohansen.yaml`
- `curriculum/l2-uk-en/plans/bio/vasyl-vyshyvanyi.yaml`
- `curriculum/l2-uk-en/plans/bio/berta-rapoport.yaml`

Validation passed via `validate_plans.py bio` and `git diff --check`.

**Note:** LLM-QG / Gemma were NOT used for this generation.