### PR TITLE
feat(bio): add science and repression learner readings

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/dmytro-falkivskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/dmytro-falkivskyi.yaml
@@ -148,6 +148,10 @@ persona:
     митця, який був водночас виконавцем і жертвою радянського терору.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- title: "Фальківський Дмитро Никанорович"
+  url: "https://uk.wikipedia.org/wiki/Фальківський_Дмитро_Никанорович"
+  note: "Оглядова стаття у Вікіпедії, яка розглядає його поетичну спадщину, участь у революції та страту."
 references:
 - note: Англомовна енциклопедична стаття про життя, чекістське минуле й страту поета.
   path: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CF%5CA%5CFalkivskyDmytro.htm
@@ -180,7 +184,7 @@ sequence: 132
 slug: dmytro-falkivskyi
 subtitle: The Poet of Polissia Devoured by the Terror He Once Served
 title: 'Дмитро Фальківський: Очерет за колиску і куля терору'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: оновлений символізм 1920-х — тяжіння до музичності, натяку й настрою; пізній стиль Фальківського
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/dmytro-falkivskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/dmytro-falkivskyi.yaml
@@ -150,8 +150,11 @@ persona:
 phase: BIO
 readings:
 - title: "Фальківський Дмитро Никанорович"
-  url: "https://uk.wikipedia.org/wiki/Фальківський_Дмитро_Никанорович"
-  note: "Оглядова стаття у Вікіпедії, яка розглядає його поетичну спадщину, участь у революції та страту."
+  url: "https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=ELIB&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Falkivskyj_D&Z21ID="
+  note: "Енциклопедія історії України. Академічна довідка про життя, творчість, чекістське минуле та розстріл поета."
+- title: "Народився Дмитро Фальківський (Левчук)"
+  url: "https://www.nbuv.gov.ua/node/4387"
+  note: "Національна бібліотека України імені В. І. Вернадського. Україніка в датах із бібліографічними посиланнями."
 references:
 - note: Англомовна енциклопедична стаття про життя, чекістське минуле й страту поета.
   path: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CF%5CA%5CFalkivskyDmytro.htm
@@ -159,7 +162,12 @@ references:
   type: reference
 - author: Герасимова Г. П.
   note: Енциклопедія історії України, Інститут історії України НАН України, 2013 (т. 10, с. 261).
+  path: https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=ELIB&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Falkivskyj_D&Z21ID=
   title: Фальківський Дмитро Никанорович (ЕІУ)
+  type: reference
+- note: НБУВ, Україніка в датах; коротка біографія з переліком творів і пов'язаних матеріалів е-бібліотеки.
+  path: https://www.nbuv.gov.ua/node/4387
+  title: Народився Дмитро Фальківський (Левчук), український письменник, сценарист, перекладач
   type: reference
 - note: Стартова навігація; дати народження і смерті звірені з ЕІУ та IEU.
   path: https://uk.wikipedia.org/wiki/Фальківський_Дмитро_Никанорович
@@ -184,7 +192,7 @@ sequence: 132
 slug: dmytro-falkivskyi
 subtitle: The Poet of Polissia Devoured by the Terror He Once Served
 title: 'Дмитро Фальківський: Очерет за колиску і куля терору'
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: оновлений символізм 1920-х — тяжіння до музичності, натяку й настрою; пізній стиль Фальківського
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/hryhorii-kosynka.yaml
+++ b/curriculum/l2-uk-en/plans/bio/hryhorii-kosynka.yaml
@@ -148,6 +148,13 @@ persona:
     і механізмом тоталітарного терору.
   voice: Literary Historian
 phase: BIO
+readings:
+- title: "Косинка Григорій Михайлович"
+  url: "https://esu.com.ua/article-3797"
+  note: "Стаття в Енциклопедії Сучасної України, що висвітлює життя та творчий шлях новеліста."
+- title: "1899 — народився Григорій Стрілець, письменник"
+  url: "https://uinp.gov.ua/istorychnyy-kalendar/lystopad/29/1899-narodyvsya-grygoriy-strilec-pysmennyk"
+  note: "Матеріал Українського інституту національної пам'яті про Григорія Косинку."
 references:
 - note: Стаття про життя та творчість письменника (автор — М. К. Наєнко).
   path: https://esu.com.ua/article-3797
@@ -179,7 +186,7 @@ sequence: 134
 slug: hryhorii-kosynka
 subtitle: 'Hryhorii Kosynka: The Executed Master of the Ukrainian Short Story'
 title: 'Григорій Косинка: Розстріляний майстер української новели'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: невеликий за обсягом прозовий твір про одну незвичайну подію з гострим, часто несподіваним фіналом
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/kateryna-bilokur.yaml
+++ b/curriculum/l2-uk-en/plans/bio/kateryna-bilokur.yaml
@@ -80,6 +80,10 @@ persona:
   role: Куратор виставки, що ставить під сумнів офіційні біографії та шукає людську драму за іконічними образами
   voice: Art-Historian-Skeptic
 phase: BIO
+readings:
+- title: "Білокур Катерина Василівна"
+  url: "https://uk.wikipedia.org/wiki/Білокур_Катерина_Василівна"
+  note: "Оглядова стаття у Вікіпедії про видатну українську художницю наївного мистецтва."
 references:
 - title: Білокур Катерина Василівна
   author: Вікіпедія
@@ -95,7 +99,7 @@ sequence: 135
 slug: kateryna-bilokur
 subtitle: 'Kateryna Bilokur: The Genius of Naïve Art'
 title: 'Катерина Білокур: Геній наївного мистецтва'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: напрям у мистецтві, для якого характерна творчість художників-самоуків, що не здобули формальної освіти
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/klavdiya-latysheva.yaml
+++ b/curriculum/l2-uk-en/plans/bio/klavdiya-latysheva.yaml
@@ -153,7 +153,7 @@ readings:
   url: "https://esu.com.ua/article-53414"
   note: "Енциклопедія Сучасної України. Біографічна стаття про першу в Україні математикиню, яка захистила кандидатську дисертацію."
 - title: "Клавдія Латишева: Математикиня, що подолала систему"
-  url: "https://stemisfem.org/latisheva"
+  url: "https://stemisfem.org/node/447"
   note: "Проєкт «Наука — це вона» (STEM is FEM). Сучасна рецепція життєвого шляху вченої."
 - title: "Латишева Клавдія Яківна"
   url: "https://uk.wikipedia.org/wiki/Латишева_Клавдія_Яківна"
@@ -178,14 +178,14 @@ references:
 - note: >-
     Сучасна рецепція й деколоніальне повернення імені — проєкт «Наука — це вона»
     (2021), 12 видатних українських жінок-учених.
-  path: https://stemisfem.org/latisheva
+  path: https://stemisfem.org/node/447
   title: 'Клавдія Латишева — STEM is FEM («Наука — це вона»)'
   type: reference
 sequence: 130
 slug: klavdiya-latysheva
 subtitle: 'Klavdiya Latysheva: The Mathematician Behind the Method'
 title: 'Клавдія Латишева: Перша математикиня та її метод'
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: жінка, яка професійно займається математикою
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/klavdiya-latysheva.yaml
+++ b/curriculum/l2-uk-en/plans/bio/klavdiya-latysheva.yaml
@@ -148,6 +148,16 @@ persona:
     неіснуючих репресій.
   voice: History-of-Science Scholar
 phase: BIO
+readings:
+- title: "Латишева Клавдія Яківна"
+  url: "https://esu.com.ua/article-53414"
+  note: "Енциклопедія Сучасної України. Біографічна стаття про першу в Україні математикиню, яка захистила кандидатську дисертацію."
+- title: "Клавдія Латишева: Математикиня, що подолала систему"
+  url: "https://stemisfem.org/latisheva"
+  note: "Проєкт «Наука — це вона» (STEM is FEM). Сучасна рецепція життєвого шляху вченої."
+- title: "Латишева Клавдія Яківна"
+  url: "https://uk.wikipedia.org/wiki/Латишева_Клавдія_Яківна"
+  note: "Оглядова стаття у Вікіпедії з докладнішою бібліографією."
 references:
 - note: >-
     Авторитетна стаття: дати, ступені, деканство (1952–54), кафедра (1953–56),
@@ -175,7 +185,7 @@ sequence: 130
 slug: klavdiya-latysheva
 subtitle: 'Klavdiya Latysheva: The Mathematician Behind the Method'
 title: 'Клавдія Латишева: Перша математикиня та її метод'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: жінка, яка професійно займається математикою
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/yevhen-pluzhnyk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yevhen-pluzhnyk.yaml
@@ -138,14 +138,14 @@ persona:
 phase: BIO
 readings:
 - title: "Плужник Євген Павлович"
-  url: "https://history.org.ua/?encyclop=&termin=Pluzhnyk_Y"
+  url: "https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=EIU1&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Pluzhnyk_Y&Z21ID="
   note: "Стаття в Енциклопедії історії України про життя, творчість та репресії поета."
 - title: "Євген Плужник — Історичний календар"
   url: "https://uinp.gov.ua/istorychnyy-kalendar/gruden/26/1001"
   note: "Біографічна довідка Українського інституту національної пам'яті."
 references:
 - note: Академічна біографія з життєвими датами, механізмом репресій та переліком творів.
-  path: http://history.org.ua/?encyclop=&termin=Pluzhnyk_Y
+  path: https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=EIU1&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Pluzhnyk_Y&Z21ID=
   title: Плужник Євген Павлович (ЕІУ)
   type: reference
 - note: Англомовна енциклопедична стаття (подає варіантну дату смерті 31 січня 1936).
@@ -174,7 +174,7 @@ sequence: 133
 slug: yevhen-pluzhnyk
 subtitle: The Poet of Quiet Sorrow Crushed by the Terror
 title: 'Євген Плужник: Поет тихої скорботи доби Розстріляного відродження'
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: напрям у мистецтві кінця ХІХ — початку ХХ ст., що передає миттєві враження, настрої та тонкі відтінки чуттів
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/yevhen-pluzhnyk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yevhen-pluzhnyk.yaml
@@ -136,6 +136,13 @@ persona:
     відродження та механізми сталінського терору проти культури.
   voice: Literary Historian
 phase: BIO
+readings:
+- title: "Плужник Євген Павлович"
+  url: "https://history.org.ua/?encyclop=&termin=Pluzhnyk_Y"
+  note: "Стаття в Енциклопедії історії України про життя, творчість та репресії поета."
+- title: "Євген Плужник — Історичний календар"
+  url: "https://uinp.gov.ua/istorychnyy-kalendar/gruden/26/1001"
+  note: "Біографічна довідка Українського інституту національної пам'яті."
 references:
 - note: Академічна біографія з життєвими датами, механізмом репресій та переліком творів.
   path: http://history.org.ua/?encyclop=&termin=Pluzhnyk_Y
@@ -167,7 +174,7 @@ sequence: 133
 slug: yevhen-pluzhnyk
 subtitle: The Poet of Quiet Sorrow Crushed by the Terror
 title: 'Євген Плужник: Поет тихої скорботи доби Розстріляного відродження'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: напрям у мистецтві кінця ХІХ — початку ХХ ст., що передає миттєві враження, настрої та тонкі відтінки чуттів
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/yuriy-kondratiuk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yuriy-kondratiuk.yaml
@@ -81,6 +81,10 @@ persona:
   role: Слідчий у справі «забутого генія», що ставить під сумнів офіційні версії та шукає приховані мотиви в історії науки.
   voice: Cold-War-Historian
 phase: BIO
+readings:
+- title: "Кондратюк Юрій Васильович"
+  url: "https://uk.wikipedia.org/wiki/Кондратюк_Юрій_Васильович"
+  note: "Оглядова стаття у Вікіпедії про піонера світової космонавтики та розробника «траси Кондратюка»."
 references:
 - title: Yuriy Kondratiuk
   note: Compiled from Wikipedia, academic sources on history of science.
@@ -100,7 +104,7 @@ sequence: 131
 slug: yuriy-kondratiuk
 subtitle: Геній, що проміняв ім'я на зірки
 title: 'Юрій Кондратюк: Пророк космічних трас'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: наука про польоти літальних апаратів у світовий простір, і мистецтво їхнього водіння
   pos: ж.


### PR DESCRIPTION
## Description

Adds Ukrainian-only learner reading packets to six BIO plans:
- `curriculum/l2-uk-en/plans/bio/klavdiya-latysheva.yaml`
- `curriculum/l2-uk-en/plans/bio/yuriy-kondratiuk.yaml`
- `curriculum/l2-uk-en/plans/bio/dmytro-falkivskyi.yaml`
- `curriculum/l2-uk-en/plans/bio/yevhen-pluzhnyk.yaml`
- `curriculum/l2-uk-en/plans/bio/hryhorii-kosynka.yaml`
- `curriculum/l2-uk-en/plans/bio/kateryna-bilokur.yaml`

Validation reported by worker:
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/validate_plans.py bio`
- `git diff --check`

Notes:
- LLM-QG and Gemma were not used.
- Learner readings are plan-level `readings:` only; no wiki source YAML edits.