### PR TITLE
bio: add reading packets for postwar science/memory batch 26

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/bohdan-ihor-antonych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/bohdan-ihor-antonych.yaml
@@ -79,6 +79,15 @@ persona:
   role: Модератор семінару, що ставить під сумнів усталені кліше про "співучого лемка" і розкриває інтелектуальну складність його метафізики та болісні конфлікти ідентичності.
   voice: Poet-Philosopher-Skeptic
 phase: BIO.4
+readings:
+- clearance: public
+  language: uk
+  rationale: Базовий життєпис для розуміння формування поета та його місця в українській літературі
+  role: Primary biography
+  source_name: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-42956
+  title: Антонич Богдан-Ігор
+  type: biography
 references:
 - title: Антонич Богдан Ігор
   note: Comprehensive biography of the Lemko-born modernist poet
@@ -98,7 +107,7 @@ sequence: 145
 slug: bohdan-ihor-antonych
 subtitle: 'Bohdan-Ihor Antonych: The Green Gospel'
 title: 'Богдан-Ігор Антонич: Зелена Євангелія'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: до християнські вірування, засновані на обожненні сил природи; у Антонича — філософська система
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/mariia-prymachenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mariia-prymachenko.yaml
@@ -81,6 +81,15 @@ persona:
   role: Куратор виставки, що ставить під сумнів усталені кліше та запрошує до критичного переосмислення феномену Примаченко
   voice: Art-Historian-Skeptic
 phase: BIO.4
+readings:
+- clearance: public
+  language: uk
+  rationale: Ознайомлення з біографією та унікальним стилем народної художниці
+  role: Primary biography
+  source_name: Велика українська енциклопедія
+  source_url: https://vue.gov.ua/%D0%9F%D1%80%D0%B8%D0%BC%D0%B0%D1%87%D0%B5%D0%BD%D0%BA%D0%BE,_%D0%9C%D0%B0%D1%80%D1%96%D1%8F_%D0%9E%D0%BA%D1%81%D0%B5%D0%BD%D1%82%D1%96%D1%97%D0%B2%D0%BD%D0%B0
+  title: Примаченко Марія Оксентіївна
+  type: biography
 references:
 - title: Марія Примаченко
   note: Загальна біографія, перелік робіт, хронологія
@@ -103,7 +112,7 @@ sequence: 146
 slug: mariia-prymachenko
 subtitle: The World of Fantastic Beasts and a Symbol of Resistance
 title: 'Марія Примаченко: Світ фантастичних звірів та символ спротиву'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: напрям в мистецтві, що характеризується спрощеними, майже дитячими формами та відсутністю академічної школи
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/mykhailo-yangel.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykhailo-yangel.yaml
@@ -79,6 +79,15 @@ persona:
   role: Модератор семінару, що ставить під сумнів офіційну історію ракетобудування та розкриває її людський вимір.
   voice: Critical-Historian
 phase: BIO
+readings:
+- clearance: public
+  language: uk
+  rationale: Життєпис видатного конструктора ракетно-космічної техніки
+  role: Primary biography
+  source_name: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-77810
+  title: Янгель Михайло Кузьмич
+  type: biography
 references:
 - title: КБ «Південне» — Історія
   name: КБ «Південне» — Історія
@@ -99,7 +108,7 @@ sequence: 147
 slug: mykhailo-yangel
 subtitle: 'Mykhailo Yangel: Creator of the Missile Shield and Space Power'
 title: 'Михайло Янгель: Творець ракетного щита та космічної міці'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: галузь важкого машинобудування, що розробляє та виробляє ракети, ракетні комплекси та космічну техніку.
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/mykola-amosov.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykola-amosov.yaml
@@ -77,6 +77,15 @@ persona:
   role: Модератор семінару, що ставить гострі питання про ціну прогресу, етику вченого та межі втручання в людський організм.
   voice: Bioethics-Committee-Chair
 phase: BIO
+readings:
+- clearance: public
+  language: uk
+  rationale: Базова біографія для вивчення внеску Амосова в кардіохірургію та науку
+  role: Primary biography
+  source_name: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-44017
+  title: Амосов Микола Михайлович
+  type: biography
 references:
 - title: Mykola Amosov
   note: Compiled research notes on Amosov's life, work, and philosophical ideas.
@@ -101,7 +110,7 @@ sequence: 149
 slug: mykola-amosov
 subtitle: 'Mykola Amosov: Surgeon and Philosopher of Health'
 title: 'Микола Амосов: Хірург і філософ здоров''я'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: галузь хірургії, що займається лікуванням захворювань серця та судин оперативними методами
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/petro-vesklyarov.yaml
+++ b/curriculum/l2-uk-en/plans/bio/petro-vesklyarov.yaml
@@ -80,6 +80,15 @@ persona:
   role: Дослідник, що аналізує телевізійні феномени як дзеркало суспільних настроїв та прихованих культурних кодів
   voice: TV Historian & Cultural Anthropologist
 phase: BIO.12
+readings:
+- clearance: public
+  language: uk
+  rationale: Огляд життя та творчості культового українського актора та телеведучого
+  role: Primary biography
+  source_name: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-33779
+  title: Вескляров Петро Юхимович
+  type: biography
 references:
 - title: Вескляров Петро Юхимович
   note: Основна біографічна довідка
@@ -99,7 +108,7 @@ sequence: 148
 slug: petro-vesklyarov
 subtitle: 'Did Panas: The Nation''s Storyteller'
 title: 'Дід Панас: Казкар нації'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: людина, що веде телевізійні програми
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/vasyl-kuk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/vasyl-kuk.yaml
@@ -78,6 +78,15 @@ persona:
   role: Прокурор на суді історії, що ставить незручні питання і вимагає доказів, а не віри.
   voice: Inquisitorial Analyst
 phase: BIO.4
+readings:
+- clearance: public
+  language: uk
+  rationale: Енциклопедичний життєпис останнього Головнокомандувача УПА
+  role: Primary biography
+  source_name: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-51093
+  title: Кук Василь Степанович
+  type: biography
 references:
 - title: '"Останній командир УПА. Життя і боротьба Василя Кука"'
   author: Аліна Понипаляк
@@ -97,7 +106,7 @@ sequence: 150
 slug: vasyl-kuk
 subtitle: The Last Commander's Dilemma
 title: 'Василь Кук: Останній командир'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: найвища військова посада, особа, що очолює всі збройні сили
   pos: ч.


### PR DESCRIPTION
Part of #4400, addresses #4431.

Added Ukrainian-only learner readings for the following BIO plans:
- `bohdan-ihor-antonych`
- `mariia-prymachenko`
- `mykhailo-yangel`
- `petro-vesklyarov`
- `mykola-amosov`
- `vasyl-kuk`

**Source Choices:**
High-quality institutional sources were used, primarily the **Енциклопедія Сучасної України (ЕСУ)** for 5 of the figures, and **Велика українська енциклопедія (ВУЕ)** for Maria Prymachenko, providing stable direct URLs and highly credible encyclopedic text for learners.

**Note:** LLM-QG / Gemma were NOT used for this batch.