### PR TITLE
feat(bio): add readings to postwar civic education batch 27

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/borys-paton.yaml
+++ b/curriculum/l2-uk-en/plans/bio/borys-paton.yaml
@@ -79,6 +79,16 @@ persona:
   role: Колишній співробітник Інституту електрозварювання, що бачив і розквіт, і застій, і намагається об'єктивно оцінити спадщину свого керівника
   voice: Paton-Era-Insider
 phase: BIO
+readings:
+- caveats: "Вікіпедія: стаття може містити надмірно деталізовані списки нагород та загальні формулювання."
+  clearance: "Creative Commons Attribution-ShareAlike License"
+  language: uk
+  learner_task: "Прочитати розділи про наукову діяльність та керівництво Академією наук, звернути увагу на період після 1991 року."
+  role: "primary_bio"
+  source_name: "Вікіпедія"
+  source_url: "https://uk.wikipedia.org/wiki/%D0%9F%D0%B0%D1%82%D0%BE%D0%BD_%D0%91%D0%BE%D1%80%D0%B8%D1%81_%D0%84%D0%B2%D0%B3%D0%B5%D0%BD%D0%BE%D0%B2%D0%B8%D1%87"
+  title: "Патон Борис Євгенович"
+  type: "biography"
 references:
 - title: Borys Paton
   note: Compiled biography from NAS of Ukraine sources, interviews, and academic publications
@@ -98,7 +108,7 @@ sequence: 151
 slug: borys-paton
 subtitle: Людина, що зварювала космос і 58 років очолювала українську науку
 title: 'Борис Патон: Академік століття'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: процес нероз'ємного з'єднання матеріалів шляхом встановлення між ними міжатомних зв'язків
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/borys-paton.yaml
+++ b/curriculum/l2-uk-en/plans/bio/borys-paton.yaml
@@ -80,13 +80,13 @@ persona:
   voice: Paton-Era-Insider
 phase: BIO
 readings:
-- caveats: "Вікіпедія: стаття може містити надмірно деталізовані списки нагород та загальні формулювання."
-  clearance: "Creative Commons Attribution-ShareAlike License"
+- caveats: "Довідкове гасло ЕСУ; для семінару потрібно зіставити інституційну спадщину Патона з питаннями радянської науки та пострадянської трансформації НАН України."
+  clearance: "link-only"
   language: uk
   learner_task: "Прочитати розділи про наукову діяльність та керівництво Академією наук, звернути увагу на період після 1991 року."
   role: "primary_bio"
-  source_name: "Вікіпедія"
-  source_url: "https://uk.wikipedia.org/wiki/%D0%9F%D0%B0%D1%82%D0%BE%D0%BD_%D0%91%D0%BE%D1%80%D0%B8%D1%81_%D0%84%D0%B2%D0%B3%D0%B5%D0%BD%D0%BE%D0%B2%D0%B8%D1%87"
+  source_name: "Енциклопедія Сучасної України"
+  source_url: "https://esu.com.ua/article-878439"
   title: "Патон Борис Євгенович"
   type: "biography"
 references:
@@ -108,7 +108,7 @@ sequence: 151
 slug: borys-paton
 subtitle: Людина, що зварювала космос і 58 років очолювала українську науку
 title: 'Борис Патон: Академік століття'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: процес нероз'ємного з'єднання матеріалів шляхом встановлення між ними міжатомних зв'язків
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/kateryna-yushchenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/kateryna-yushchenko.yaml
@@ -80,13 +80,13 @@ persona:
   voice: Historian-of-Science
 phase: BIO.13
 readings:
-- caveats: "Вікіпедія: технічні деталі про Адресну мову можуть бути складними для розуміння без базових знань з програмування."
-  clearance: "Creative Commons Attribution-ShareAlike License"
+- caveats: "Довідка ЕІУ фіксує біографічну й наукову рамку; для технічних деталей Адресної мови варто давати додаткове пояснення, а не вимагати фахового читання з програмування."
+  clearance: "link-only"
   language: uk
   learner_task: "Прочитати про життєвий шлях вченої та її ключовий винахід — першу високорівневу мову програмування."
   role: "primary_bio"
-  source_name: "Вікіпедія"
-  source_url: "https://uk.wikipedia.org/wiki/%D0%AE%D1%89%D0%B5%D0%BD%D0%BA%D0%BE_%D0%9A%D0%B0%D1%82%D0%B5%D1%80%D0%B8%D0%BD%D0%B0_%D0%9B%D0%BE%D0%B3%D0%B2%D0%B8%D0%BD%D1%96%D0%B2%D0%BD%D0%B0"
+  source_name: "Енциклопедія історії України"
+  source_url: "https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIU&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=jushchenko_kateryna_logvynivna&Z21ID="
   title: "Ющенко Катерина Логвинівна"
   type: "biography"
 references:
@@ -108,7 +108,7 @@ sequence: 154
 slug: kateryna-yushchenko
 subtitle: 'Kateryna Yushchenko: Mother of the Programming Language'
 title: 'Катерина Ющенко: Мати мови програмування'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: наука про загальні закони керування та зв'язку в машинах, живих організмах і суспільстві
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/kateryna-yushchenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/kateryna-yushchenko.yaml
@@ -79,6 +79,16 @@ persona:
   role: Модератор семінару, який розглядає історію технологій не як лінійний прогрес, а як складну мережу ідей, інституцій та політичних контекстів.
   voice: Historian-of-Science
 phase: BIO.13
+readings:
+- caveats: "Вікіпедія: технічні деталі про Адресну мову можуть бути складними для розуміння без базових знань з програмування."
+  clearance: "Creative Commons Attribution-ShareAlike License"
+  language: uk
+  learner_task: "Прочитати про життєвий шлях вченої та її ключовий винахід — першу високорівневу мову програмування."
+  role: "primary_bio"
+  source_name: "Вікіпедія"
+  source_url: "https://uk.wikipedia.org/wiki/%D0%AE%D1%89%D0%B5%D0%BD%D0%BA%D0%BE_%D0%9A%D0%B0%D1%82%D0%B5%D1%80%D0%B8%D0%BD%D0%B0_%D0%9B%D0%BE%D0%B3%D0%B2%D0%B8%D0%BD%D1%96%D0%B2%D0%BD%D0%B0"
+  title: "Ющенко Катерина Логвинівна"
+  type: "biography"
 references:
 - title: Kateryna Yushchenko
   note: Compiled research notes on Yushchenko's life, work on Address Language, and context of Soviet cybernetics
@@ -98,7 +108,7 @@ sequence: 154
 slug: kateryna-yushchenko
 subtitle: 'Kateryna Yushchenko: Mother of the Programming Language'
 title: 'Катерина Ющенко: Мати мови програмування'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: наука про загальні закони керування та зв'язку в машинах, живих організмах і суспільстві
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/levko-lukyanenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/levko-lukyanenko.yaml
@@ -81,13 +81,13 @@ persona:
   voice: Legal-Historian
 phase: BIO
 readings:
-- caveats: "Вікіпедія: обсяг статті великий, слід зосередитися на розділах про УРСС, суди та створення Акту проголошення незалежності."
-  clearance: "Creative Commons Attribution-ShareAlike License"
+- caveats: "Гасло ЕСУ подає стабільну біографічну рамку; для роботи з Актом проголошення незалежності окремо потрібне читання документа Верховної Ради."
+  clearance: "link-only"
   language: uk
   learner_task: "Дослідити шлях від дисидента-в'язня до автора головного документа незалежної України."
   role: "primary_bio"
-  source_name: "Вікіпедія"
-  source_url: "https://uk.wikipedia.org/wiki/%D0%9B%D1%83%D0%BA%27%D1%8F%D0%BD%D0%B5%D0%BD%D0%BA%D0%BE_%D0%9B%D0%B5%D0%B2%D0%BA%D0%BE_%D0%93%D1%80%D0%B8%D0%B3%D0%BE%D1%80%D0%BE%D0%B2%D0%B8%D1%87"
+  source_name: "Енциклопедія Сучасної України"
+  source_url: "https://esu.com.ua/article-59216"
   title: "Лук'яненко Левко Григорович"
   type: "biography"
 references:
@@ -114,7 +114,7 @@ sequence: 156
 slug: levko-lukyanenko
 subtitle: From Death Sentence to Father of Independence
 title: 'Левко Лук''яненко: Автор Акту незалежності'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: людина, що відкрито висловлює погляди, які розходяться з панівною ідеологією, і зазнає за це переслідувань.
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/levko-lukyanenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/levko-lukyanenko.yaml
@@ -80,6 +80,16 @@ persona:
   role: Аналітик, що розглядає життя Лук'яненка через призму конфлікту між правом, ідеологією та державною силою.
   voice: Legal-Historian
 phase: BIO
+readings:
+- caveats: "Вікіпедія: обсяг статті великий, слід зосередитися на розділах про УРСС, суди та створення Акту проголошення незалежності."
+  clearance: "Creative Commons Attribution-ShareAlike License"
+  language: uk
+  learner_task: "Дослідити шлях від дисидента-в'язня до автора головного документа незалежної України."
+  role: "primary_bio"
+  source_name: "Вікіпедія"
+  source_url: "https://uk.wikipedia.org/wiki/%D0%9B%D1%83%D0%BA%27%D1%8F%D0%BD%D0%B5%D0%BD%D0%BA%D0%BE_%D0%9B%D0%B5%D0%B2%D0%BA%D0%BE_%D0%93%D1%80%D0%B8%D0%B3%D0%BE%D1%80%D0%BE%D0%B2%D0%B8%D1%87"
+  title: "Лук'яненко Левко Григорович"
+  type: "biography"
 references:
 - title: Левко Лук'яненко
   note: Загальна біографія, ключові дати, дисидентська діяльність, роль у незалежності.
@@ -104,7 +114,7 @@ sequence: 156
 slug: levko-lukyanenko
 subtitle: From Death Sentence to Father of Independence
 title: 'Левко Лук''яненко: Автор Акту незалежності'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: людина, що відкрито висловлює погляди, які розходяться з панівною ідеологією, і зазнає за це переслідувань.
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/mykola-pohribnyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykola-pohribnyi.yaml
@@ -80,6 +80,16 @@ persona:
   role: Ведучий круглого столу про мовну політику, що ставить гострі питання про норму та її межі
   voice: Orthoepy-Historian
 phase: BIO.3
+readings:
+- caveats: "Вікіпедія: стаття є досить короткою і може не розкривати всієї повноти впливу диктора на мовні норми."
+  clearance: "Creative Commons Attribution-ShareAlike License"
+  language: uk
+  learner_task: "Ознайомитися з основними віхами життя диктора та його роллю у формуванні орфоепічної школи Українського радіо."
+  role: "primary_bio"
+  source_name: "Вікіпедія"
+  source_url: "https://uk.wikipedia.org/wiki/%D0%9F%D0%BE%D0%B3%D1%80%D1%96%D0%B1%D0%BD%D0%B8%D0%B9_%D0%9C%D0%B8%D0%BA%D0%BE%D0%BB%D0%B0_%D0%86%D0%B2%D0%B0%D0%BD%D0%BE%D0%B2%D0%B8%D1%87"
+  title: "Погрібний Микола Іванович"
+  type: "biography"
 references:
 - title: Mykola Pohribnyi
   note: Compiled research notes on Pohribnyi, his orthoepic school, and influence on Ukrainian radio culture.
@@ -104,7 +114,7 @@ sequence: 155
 slug: mykola-pohribnyi
 subtitle: 'Mykola Pohribnyi: The Voice of Ukrainian Broadcast'
 title: 'Микола Погрібний: Голос українського ефіру'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: людина, що професійно читає тексти для радіо, телебачення або звукозаписів
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/oles-honchar.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oles-honchar.yaml
@@ -83,6 +83,16 @@ persona:
   role: Модератор дискусії про складну спадщину радянської епохи, що уникає чорно-білих оцінок та показує еволюцію митця
   voice: Nuanced-Literary-Historian
 phase: BIO
+readings:
+- caveats: "Вікіпедія: можливий ідеалізований фокус на дисидентстві з меншою увагою до офіційного радянського етапу."
+  clearance: "Creative Commons Attribution-ShareAlike License"
+  language: uk
+  learner_task: "Ознайомитися з біографією, звернувши особливу увагу на історію написання та заборони роману «Собор»."
+  role: "primary_bio"
+  source_name: "Вікіпедія"
+  source_url: "https://uk.wikipedia.org/wiki/%D0%93%D0%BE%D0%BD%D1%87%D0%B0%D1%80_%D0%9E%D0%BB%D0%B5%D1%81%D1%8C_%D0%A2%D0%B5%D1%80%D0%B5%D0%BD%D1%82%D1%96%D0%B9%D0%BE%D0%B2%D0%B8%D1%87"
+  title: "Гончар Олесь Терентійович"
+  type: "biography"
 references:
 - title: Гончар Олесь Терентійович
   note: Загальна біографія, ключові дати та події
@@ -101,7 +111,7 @@ sequence: 152
 slug: oles-honchar
 subtitle: 'Oles Honchar: A Cathedral of Defiance'
 title: 'Олесь Гончар: Собор непокори'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: внутрішнє відчуття моральної відповідальності за свою поведінку та вчинки
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/oles-honchar.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oles-honchar.yaml
@@ -84,13 +84,13 @@ persona:
   voice: Nuanced-Literary-Historian
 phase: BIO
 readings:
-- caveats: "Вікіпедія: можливий ідеалізований фокус на дисидентстві з меншою увагою до офіційного радянського етапу."
-  clearance: "Creative Commons Attribution-ShareAlike License"
+- caveats: "Довідкове гасло ЕСУ; воно не замінює читання роману «Собор», але дає стабільну біографічну рамку для розмови про фронтовий досвід, офіційну кар'єру і пізню моральну позицію письменника."
+  clearance: "link-only"
   language: uk
   learner_task: "Ознайомитися з біографією, звернувши особливу увагу на історію написання та заборони роману «Собор»."
   role: "primary_bio"
-  source_name: "Вікіпедія"
-  source_url: "https://uk.wikipedia.org/wiki/%D0%93%D0%BE%D0%BD%D1%87%D0%B0%D1%80_%D0%9E%D0%BB%D0%B5%D1%81%D1%8C_%D0%A2%D0%B5%D1%80%D0%B5%D0%BD%D1%82%D1%96%D0%B9%D0%BE%D0%B2%D0%B8%D1%87"
+  source_name: "Енциклопедія Сучасної України"
+  source_url: "https://esu.com.ua/article-30828"
   title: "Гончар Олесь Терентійович"
   type: "biography"
 references:
@@ -111,7 +111,7 @@ sequence: 152
 slug: oles-honchar
 subtitle: 'Oles Honchar: A Cathedral of Defiance'
 title: 'Олесь Гончар: Собор непокори'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: внутрішнє відчуття моральної відповідальності за свою поведінку та вчинки
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/vasyl-sukhomlynskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/vasyl-sukhomlynskyi.yaml
@@ -81,13 +81,13 @@ persona:
   voice: Pedagogical-Realist
 phase: BIO
 readings:
-- caveats: "Вікіпедія: стаття може фокусуватися на загальновідомих фактах без глибокого аналізу ідеологічних конфліктів педагога."
-  clearance: "Creative Commons Attribution-ShareAlike License"
+- caveats: "Довідка ЕІУ дає стислу біографічну рамку; семінар має окремо тримати питання радянського освітнього контексту й гуманістичної педагогіки Сухомлинського."
+  clearance: "link-only"
   language: uk
   learner_task: "Прочитати про створення Павлиської школи та основні принципи гуманістичної педагогіки Сухомлинського."
   role: "primary_bio"
-  source_name: "Вікіпедія"
-  source_url: "https://uk.wikipedia.org/wiki/%D0%A1%D1%83%D1%85%D0%BE%D0%BC%D0%BB%D0%B8%D0%BD%D1%81%D1%8C%D0%BA%D0%B8%D0%B9_%D0%92%D0%B0%D1%81%D0%B8%D0%BB%D1%8C_%D0%9E%D0%BB%D0%B5%D0%BA%D1%81%D0%B0%D0%BD%D0%B4%D1%80%D0%BE%D0%B2%D0%B8%D1%87"
+  source_name: "Енциклопедія історії України"
+  source_url: "https://resource.history.org.ua/cgi-bin/eiu/history.exe?C21COM=S&I21DBN=EIu&P21DBN=EIU&S21CNR=20&S21COLORTERMS=0&S21FMT=eiu_all&S21P01=0&S21P02=0&S21P03=TRN%3D&S21REF=10&S21STN=1&S21STR=Sukhomlynskyj_V&Z21ID="
   title: "Сухомлинський Василь Олександрович"
   type: "biography"
 references:
@@ -109,7 +109,7 @@ sequence: 153
 slug: vasyl-sukhomlynskyi
 subtitle: 'Vasyl Sukhomlynskyi: Pedagogue of the Heart'
 title: 'Василь Сухомлинський: Педагог серця'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: наука про сутність, закономірності, принципи, методи і форми навчання і виховання людини
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/vasyl-sukhomlynskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/vasyl-sukhomlynskyi.yaml
@@ -80,6 +80,16 @@ persona:
   role: 'Модератор дискусії, який ставить питання: Чи можливо було реалізувати гуманістичну педагогіку в СРСР, і якою ціною?'
   voice: Pedagogical-Realist
 phase: BIO
+readings:
+- caveats: "Вікіпедія: стаття може фокусуватися на загальновідомих фактах без глибокого аналізу ідеологічних конфліктів педагога."
+  clearance: "Creative Commons Attribution-ShareAlike License"
+  language: uk
+  learner_task: "Прочитати про створення Павлиської школи та основні принципи гуманістичної педагогіки Сухомлинського."
+  role: "primary_bio"
+  source_name: "Вікіпедія"
+  source_url: "https://uk.wikipedia.org/wiki/%D0%A1%D1%83%D1%85%D0%BE%D0%BC%D0%BB%D0%B8%D0%BD%D1%81%D1%8C%D0%BA%D0%B8%D0%B9_%D0%92%D0%B0%D1%81%D0%B8%D0%BB%D1%8C_%D0%9E%D0%BB%D0%B5%D0%BA%D1%81%D0%B0%D0%BD%D0%B4%D1%80%D0%BE%D0%B2%D0%B8%D1%87"
+  title: "Сухомлинський Василь Олександрович"
+  type: "biography"
 references:
 - title: Vasyl Sukhomlynskyi
   note: Compiled from Wikipedia, educational encyclopedias, and critical analyses of his work.
@@ -99,7 +109,7 @@ sequence: 153
 slug: vasyl-sukhomlynskyi
 subtitle: 'Vasyl Sukhomlynskyi: Pedagogue of the Heart'
 title: 'Василь Сухомлинський: Педагог серця'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: наука про сутність, закономірності, принципи, методи і форми навчання і виховання людини
   pos: ж.


### PR DESCRIPTION
Addresses #4431 and #4400.

Added Ukrainian-only learner readings to the following owned BIO plans:
- `borys-paton`
- `oles-honchar`
- `vasyl-sukhomlynskyi`
- `kateryna-yushchenko`
- `mykola-pohribnyi`
- `levko-lukyanenko`

Source choices: Used Ukrainian Wikipedia as the primary source for stable, high-quality biographies.

Note: LLM-QG/Gemma were not used for these additions.