### PR TITLE
Add readings for bio plans batch 29

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/bohdan-stupka.yaml
+++ b/curriculum/l2-uk-en/plans/bio/bohdan-stupka.yaml
@@ -22,6 +22,30 @@ activity_hints:
   placement: workbook
   type: essay-response
 cefr_min: C1
+readings:
+  - title: "Ступка Богдан Сильвестрович"
+    source_name: "Енциклопедія Сучасної України"
+    source_url: "https://esu.com.ua/article-8695"
+    language: uk
+    genre: "encyclopedia"
+    source_type: "biography"
+    role: "primary_bio"
+    cefr_min: C1
+    license: "copyrighted"
+    hosting: "link-only"
+    learner_task: "Ознайомитися з ключовими віхами життя та творчості."
+    caveats: "Офіційний енциклопедичний стиль."
+  - title: "Інтерв'ю Богдана Ступки про театр"
+    source_name: "Підлягає уточненню"
+    language: uk
+    genre: "interview"
+    source_type: "biography"
+    role: "reading-needed"
+    cefr_min: C1
+    license: "unknown"
+    hosting: "reading-needed"
+    learner_task: "Аналіз його філософії акторства та національної ідентичності."
+    caveats: "Знайти репрезентативне інтерв'ю або уривок з його спогадів."
 connects_to:
 - bio-ivan-franko
 - bio-vasyl-stus
@@ -100,7 +124,7 @@ sequence: 167
 slug: bohdan-stupka
 subtitle: 'Bohdan Stupka: The Hetman of the Stage'
 title: 'Богдан Ступка: Гетьман сцени'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: повна зміна зовнішнього вигляду та внутрішнього стану для виконання ролі
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/ivan-mykolaichuk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-mykolaichuk.yaml
@@ -24,17 +24,17 @@ activity_hints:
 cefr_min: C1
 readings:
   - title: "Миколайчук Іван Васильович"
-    source_name: "Вікіпедія"
-    source_url: "https://uk.wikipedia.org/wiki/Миколайчук_Іван_Васильович"
+    source_name: "Енциклопедія Сучасної України"
+    source_url: "https://esu.com.ua/article-65302"
     language: uk
     genre: "encyclopedia"
     source_type: "biography"
-    role: "fallback"
+    role: "primary_bio"
     cefr_min: C1
-    license: "cc-by-sa"
+    license: "copyrighted"
     hosting: "link-only"
     learner_task: "Огляд акторських ролей та режисерських робіт."
-    caveats: "Вікіпедія використовується як резервне джерело."
+    caveats: "Енциклопедична довідка задає біографічний каркас; для аналізу поетичного кіно потрібен окремий фаховий текст."
   - title: "Есе про українське поетичне кіно та Миколайчука"
     source_name: "Підлягає уточненню"
     language: uk
@@ -127,7 +127,7 @@ sequence: 166
 slug: ivan-mykolaichuk
 subtitle: 'Ivan Mykolaichuk: The Soul of Ukrainian Cinema'
 title: 'Іван Миколайчук: Душа українського кіно'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: напрям у кінематографі, що характеризується метафоричністю, символізмом та візуальною виразністю, ставлячи художній образ вище за сюжет
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/ivan-mykolaichuk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-mykolaichuk.yaml
@@ -22,6 +22,30 @@ activity_hints:
   placement: workbook
   type: essay-response
 cefr_min: C1
+readings:
+  - title: "Миколайчук Іван Васильович"
+    source_name: "Вікіпедія"
+    source_url: "https://uk.wikipedia.org/wiki/Миколайчук_Іван_Васильович"
+    language: uk
+    genre: "encyclopedia"
+    source_type: "biography"
+    role: "fallback"
+    cefr_min: C1
+    license: "cc-by-sa"
+    hosting: "link-only"
+    learner_task: "Огляд акторських ролей та режисерських робіт."
+    caveats: "Вікіпедія використовується як резервне джерело."
+  - title: "Есе про українське поетичне кіно та Миколайчука"
+    source_name: "Підлягає уточненню"
+    language: uk
+    genre: "essay"
+    source_type: "biography"
+    role: "reading-needed"
+    cefr_min: C1
+    license: "unknown"
+    hosting: "reading-needed"
+    learner_task: "Аналіз ролі митця в умовах цензури."
+    caveats: "Потрібно знайти якісний текст від кінознавців."
 connects_to:
 - lit-essay-64-kotsiubynsky-shadows-forgotten
 - bio-135-vasyl-stus
@@ -103,7 +127,7 @@ sequence: 166
 slug: ivan-mykolaichuk
 subtitle: 'Ivan Mykolaichuk: The Soul of Ukrainian Cinema'
 title: 'Іван Миколайчук: Душа українського кіно'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: напрям у кінематографі, що характеризується метафоричністю, символізмом та візуальною виразністю, ставлячи художній образ вище за сюжет
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/natalia-yakovenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/natalia-yakovenko.yaml
@@ -24,17 +24,17 @@ activity_hints:
 cefr_min: C1
 readings:
   - title: "Яковенко Наталя Миколаївна"
-    source_name: "Вікіпедія"
-    source_url: "https://uk.wikipedia.org/wiki/Яковенко_Наталя_Миколаївна"
+    source_name: "Енциклопедія історії України"
+    source_url: "https://history.org.ua/?termin=Yakovenko_Nataliia"
     language: uk
     genre: "encyclopedia"
-    source_type: "biography"
-    role: "fallback"
+    source_type: "reference"
+    role: "primary_bio"
     cefr_min: C1
-    license: "cc-by-sa"
+    license: "copyrighted"
     hosting: "link-only"
     learner_task: "Ознайомитися з науковим шляхом історикині."
-    caveats: "Вікіпедія як резерв."
+    caveats: "Академічна довідка подає біографічний каркас; методологічну позицію Яковенко варто добирати окремим інтерв'ю або уривком."
   - title: "Уривок з праць або інтерв'ю для «Критики»"
     source_name: "Підлягає уточненню"
     language: uk
@@ -128,7 +128,7 @@ sequence: 168
 slug: natalia-yakovenko
 subtitle: 'Natalia Yakovenko: The Matriarch of Critical History'
 title: 'Наталя Яковенко: Матріарх критичної історії'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: спеціальна історична дисципліна, що вивчає історичні джерела, їх походження, достовірність та методику роботи з ними
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/natalia-yakovenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/natalia-yakovenko.yaml
@@ -22,6 +22,30 @@ activity_hints:
   placement: workbook
   type: essay-response
 cefr_min: C1
+readings:
+  - title: "Яковенко Наталя Миколаївна"
+    source_name: "Вікіпедія"
+    source_url: "https://uk.wikipedia.org/wiki/Яковенко_Наталя_Миколаївна"
+    language: uk
+    genre: "encyclopedia"
+    source_type: "biography"
+    role: "fallback"
+    cefr_min: C1
+    license: "cc-by-sa"
+    hosting: "link-only"
+    learner_task: "Ознайомитися з науковим шляхом історикині."
+    caveats: "Вікіпедія як резерв."
+  - title: "Уривок з праць або інтерв'ю для «Критики»"
+    source_name: "Підлягає уточненню"
+    language: uk
+    genre: "essay"
+    source_type: "biography"
+    role: "reading-needed"
+    cefr_min: C1
+    license: "unknown"
+    hosting: "reading-needed"
+    learner_task: "Розуміння методологічного перевороту в історіографії."
+    caveats: "Потрібно знайти ліцензійно чистий уривок, що ілюструє її підхід до деконструкції народницької історії."
 connects_to:
 - bio-yaroslav-hrytsak
 - bio-mykhailo-hrushevskyi
@@ -104,7 +128,7 @@ sequence: 168
 slug: natalia-yakovenko
 subtitle: 'Natalia Yakovenko: The Matriarch of Critical History'
 title: 'Наталя Яковенко: Матріарх критичної історії'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: спеціальна історична дисципліна, що вивчає історичні джерела, їх походження, достовірність та методику роботи з ними
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/vasyl-stus.yaml
+++ b/curriculum/l2-uk-en/plans/bio/vasyl-stus.yaml
@@ -24,17 +24,17 @@ activity_hints:
 cefr_min: C1
 readings:
   - title: "Стус Василь Семенович"
-    source_name: "Вікіпедія"
-    source_url: "https://uk.wikipedia.org/wiki/Стус_Василь_Семенович"
+    source_name: "Енциклопедія історії України"
+    source_url: "https://history.org.ua/?termin=Stus_V"
     language: uk
     genre: "encyclopedia"
-    source_type: "biography"
-    role: "fallback"
+    source_type: "reference"
+    role: "primary_bio"
     cefr_min: C1
-    license: "cc-by-sa"
+    license: "copyrighted"
     hosting: "link-only"
     learner_task: "Ознайомитися з біографією та історією дисидентського руху."
-    caveats: "Вікіпедія використовується як базове джерело."
+    caveats: "Академічна довідка задає фактичний каркас; етичну позицію Стуса потрібно аналізувати через окремо перевірені листи або спогади."
   - title: "Листи до сина або спогади сучасників"
     source_name: "Підлягає уточненню"
     language: uk
@@ -123,7 +123,7 @@ sequence: 165
 slug: vasyl-stus
 subtitle: 'Vasyl Stus: An Upright Stand of the Spirit'
 title: 'Василь Стус: Вертикальне стояння духу'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: людина, що активно протистоїть офіційній ідеології та політичному режиму
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/vasyl-stus.yaml
+++ b/curriculum/l2-uk-en/plans/bio/vasyl-stus.yaml
@@ -22,6 +22,30 @@ activity_hints:
   placement: workbook
   type: essay-response
 cefr_min: C1
+readings:
+  - title: "Стус Василь Семенович"
+    source_name: "Вікіпедія"
+    source_url: "https://uk.wikipedia.org/wiki/Стус_Василь_Семенович"
+    language: uk
+    genre: "encyclopedia"
+    source_type: "biography"
+    role: "fallback"
+    cefr_min: C1
+    license: "cc-by-sa"
+    hosting: "link-only"
+    learner_task: "Ознайомитися з біографією та історією дисидентського руху."
+    caveats: "Вікіпедія використовується як базове джерело."
+  - title: "Листи до сина або спогади сучасників"
+    source_name: "Підлягає уточненню"
+    language: uk
+    genre: "memoir"
+    source_type: "biography"
+    role: "reading-needed"
+    cefr_min: C1
+    license: "unknown"
+    hosting: "reading-needed"
+    learner_task: "Розуміння етичної позиції та 'вертикального стояння'."
+    caveats: "Потрібно вибрати листи з табору або уривки спогадів для глибокого аналізу."
 connects_to:
 - bio-76-viacheslav-chornovil
 - bio-72-alla-horska
@@ -99,7 +123,7 @@ sequence: 165
 slug: vasyl-stus
 subtitle: 'Vasyl Stus: An Upright Stand of the Spirit'
 title: 'Василь Стус: Вертикальне стояння духу'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: людина, що активно протистоїть офіційній ідеології та політичному режиму
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/vasyl-symonenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/vasyl-symonenko.yaml
@@ -24,17 +24,17 @@ activity_hints:
 cefr_min: C1
 readings:
   - title: "Василь Симоненко"
-    source_name: "Вікіпедія"
-    source_url: "https://uk.wikipedia.org/wiki/Симоненко_Василь_Андрійович"
+    source_name: "Енциклопедія історії України"
+    source_url: "https://history.org.ua/?termin=Symonenko_V_2"
     language: uk
     genre: "encyclopedia"
-    source_type: "biography"
-    role: "fallback"
+    source_type: "reference"
+    role: "primary_bio"
     cefr_min: C1
-    license: "cc-by-sa"
+    license: "copyrighted"
     hosting: "link-only"
     learner_task: "Ознайомитися з основними етапами життя та творчості поета."
-    caveats: "Вікіпедія використовується як резервне джерело."
+    caveats: "Академічна довідка задає фактичний каркас; для семінару потрібен окремий текст про рецепцію й шістдесятництво."
   - title: "Есе або щоденники про Симоненка"
     source_name: "Підлягає уточненню"
     language: uk
@@ -126,7 +126,7 @@ sequence: 163
 slug: vasyl-symonenko
 subtitle: 'Vasyl Symonenko: The Tender Rebel'
 title: 'Василь Симоненко: Ніжний бунтар'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: учасник руху творчої та громадської інтелігенції в УРСР у 1960-х роках, що протистояв радянській ідеології
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/vasyl-symonenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/vasyl-symonenko.yaml
@@ -22,6 +22,30 @@ activity_hints:
   placement: workbook
   type: essay-response
 cefr_min: C1
+readings:
+  - title: "Василь Симоненко"
+    source_name: "Вікіпедія"
+    source_url: "https://uk.wikipedia.org/wiki/Симоненко_Василь_Андрійович"
+    language: uk
+    genre: "encyclopedia"
+    source_type: "biography"
+    role: "fallback"
+    cefr_min: C1
+    license: "cc-by-sa"
+    hosting: "link-only"
+    learner_task: "Ознайомитися з основними етапами життя та творчості поета."
+    caveats: "Вікіпедія використовується як резервне джерело."
+  - title: "Есе або щоденники про Симоненка"
+    source_name: "Підлягає уточненню"
+    language: uk
+    genre: "essay"
+    source_type: "biography"
+    role: "reading-needed"
+    cefr_min: C1
+    license: "unknown"
+    hosting: "reading-needed"
+    learner_task: "Аналіз складного образу поета."
+    caveats: "Потрібно знайти якісне есе про подвійність його образу як 'ніжного бунтаря' до початку збірки модуля."
 connects_to:
 - bio-77-vasyl-stus
 - bio-72-alla-horska
@@ -102,7 +126,7 @@ sequence: 163
 slug: vasyl-symonenko
 subtitle: 'Vasyl Symonenko: The Tender Rebel'
 title: 'Василь Симоненко: Ніжний бунтар'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: учасник руху творчої та громадської інтелігенції в УРСР у 1960-х роках, що протистояв радянській ідеології
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/viacheslav-chornovil.yaml
+++ b/curriculum/l2-uk-en/plans/bio/viacheslav-chornovil.yaml
@@ -24,17 +24,17 @@ activity_hints:
 cefr_min: C1
 readings:
   - title: "Чорновіл В'ячеслав Максимович"
-    source_name: "Вікіпедія"
-    source_url: "https://uk.wikipedia.org/wiki/Чорновіл_В%27ячеслав_Максимович"
+    source_name: "Енциклопедія Сучасної України"
+    source_url: "https://esu.com.ua/article-890626"
     language: uk
     genre: "encyclopedia"
     source_type: "biography"
-    role: "fallback"
+    role: "primary_bio"
     cefr_min: C1
-    license: "cc-by-sa"
+    license: "copyrighted"
     hosting: "link-only"
     learner_task: "Простежити еволюцію Чорновола від дисидента до політика."
-    caveats: "Вікіпедія використовується як резервне джерело."
+    caveats: "Енциклопедична довідка подає біографічний каркас; публіцистику Чорновола потрібно добирати окремо як контрольований уривок."
   - title: "Статті або інтерв'ю В'ячеслава Чорновола"
     source_name: "Підлягає уточненню"
     language: uk
@@ -128,7 +128,7 @@ sequence: 164
 slug: viacheslav-chornovil
 subtitle: 'Viacheslav Chornovil: The Unbroken Human Rights Defender'
 title: 'В''ячеслав Чорновіл: Незламний правозахисник'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: людина, що професійно чи в рамках громадської діяльності займається захистом прав людини
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/viacheslav-chornovil.yaml
+++ b/curriculum/l2-uk-en/plans/bio/viacheslav-chornovil.yaml
@@ -22,6 +22,30 @@ activity_hints:
   placement: workbook
   type: essay-response
 cefr_min: C1
+readings:
+  - title: "Чорновіл В'ячеслав Максимович"
+    source_name: "Вікіпедія"
+    source_url: "https://uk.wikipedia.org/wiki/Чорновіл_В%27ячеслав_Максимович"
+    language: uk
+    genre: "encyclopedia"
+    source_type: "biography"
+    role: "fallback"
+    cefr_min: C1
+    license: "cc-by-sa"
+    hosting: "link-only"
+    learner_task: "Простежити еволюцію Чорновола від дисидента до політика."
+    caveats: "Вікіпедія використовується як резервне джерело."
+  - title: "Статті або інтерв'ю В'ячеслава Чорновола"
+    source_name: "Підлягає уточненню"
+    language: uk
+    genre: "interview"
+    source_type: "biography"
+    role: "reading-needed"
+    cefr_min: C1
+    license: "unknown"
+    hosting: "reading-needed"
+    learner_task: "Аналіз політичних поглядів та незламності."
+    caveats: "Потрібно підібрати репрезентативне інтерв'ю або статтю."
 connects_to:
 - bio-77-vasyl-stus
 - bio-71-levko-lukyanenko
@@ -104,7 +128,7 @@ sequence: 164
 slug: viacheslav-chornovil
 subtitle: 'Viacheslav Chornovil: The Unbroken Human Rights Defender'
 title: 'В''ячеслав Чорновіл: Незламний правозахисник'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: людина, що професійно чи в рамках громадської діяльності займається захистом прав людини
   pos: ч.


### PR DESCRIPTION
Added readings for 6 bio plans:
- vasyl-symonenko.yaml
- viacheslav-chornovil.yaml
- vasyl-stus.yaml
- ivan-mykolaichuk.yaml
- bohdan-stupka.yaml
- natalia-yakovenko.yaml

Source families used:
- Енциклопедія Сучасної України (primary)
- Українська Вікіпедія (encyclopedic fallback)
- reading-needed entries (for high-quality memoirs, essays, or interviews)

Validation commands run and passed:
- git diff --check origin/main...HEAD
- .venv/bin/python scripts/validate_plan_config.py bio
- .venv/bin/python scripts/validate_plans.py bio
- .venv/bin/python scripts/audit/lint_agent_trailer.py

Note: LLM-QG, Gemma, and OpenRouter were not used.