### PR TITLE
feat(bio): add war-memory learner reading packets

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/kateryna-handziuk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/kateryna-handziuk.yaml
@@ -79,6 +79,30 @@ persona:
   role: Ведучий розслідування, що розкриває зв'язки між локальною корупцією, бездіяльністю правоохоронних органів та долею однієї людини.
   voice: Investigative-Journalist
 phase: BIO
+readings:
+- title: Хто замовив Катю Гандзюк?
+  language: uk
+  genre: Аналітична стаття / Громадська ініціатива
+  source_type: secondary
+  role: orientation
+  source: Ініціатива "Хто замовив Катю Гандзюк?"
+  source_url: https://gandziuk.org
+  license: copyrighted
+  rights_note: Сайт ініціативи є агрегатором новин та розслідувань у справі.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: Ознайомитися з хронологією боротьби за справедливість на сайті ініціативи пам'яті Катерини Гандзюк.
+- title: "Безкарність вбиває. Ким була і за що боролась Катя Гандзюк"
+  language: uk
+  genre: Аналітична стаття
+  source_type: secondary
+  role: reading
+  source: Українська правда
+  license: copyrighted
+  rights_note: Матеріал УП є об'єктом авторського права. Потребує точного посилання.
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: Прочитати статтю-некролог або розслідування про діяльність Гандзюк і виписати основні причини її конфлікту з місцевими елітами.
 references:
 - title: Kateryna Handziuk
   note: Compiled from Wikipedia, news investigations (Slidstvo.Info), and reports from human rights organizations.
@@ -93,7 +117,7 @@ sequence: 191
 slug: kateryna-handziuk
 subtitle: The Activist Who Paid the Ultimate Price for Justice
 title: 'Катерина Гандзюк: Голос правди та боротьба проти свавілля'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: жінка, яка веде активну громадсько-політичну діяльність
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/oleg-sentsov.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oleg-sentsov.yaml
@@ -80,6 +80,31 @@ persona:
   role: Модератор дискусії, що ставить під сумнів однозначні оцінки та спонукає шукати складність за героїчним фасадом.
   voice: Critical-Biographer
 phase: BIO
+readings:
+- title: Олег Сенцов
+  language: uk
+  genre: Біографічна довідка
+  source_type: reference
+  role: orientation
+  source: Український ПЕН
+  source_url: https://pen.org.ua/members/sentsov-oleg
+  license: copyrighted
+  rights_note: Матеріали сайту PEN Ukraine захищені авторським правом. Використовувати як link-only джерело.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: Прочитати коротку довідку про творчість, громадську діяльність та ув'язнення режисера, виокремити етапи його спротиву.
+- title: "Олег Сенцов: «Моє завдання — не знімати кіно, а воювати»"
+  language: uk
+  genre: Інтерв'ю
+  source_type: primary
+  role: reading
+  source: Суспільне Культура
+  license: copyrighted
+  rights_note: Інтерв'ю та матеріали Суспільного захищені авторським правом.
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: Проаналізувати інтерв'ю Сенцова періоду повномасштабного вторгнення, звернувши увагу на його аргументацію щодо ролі митця під час війни.
+  caveats: Матеріал може містити жорстку риторику та описи бойових дій.
 references:
 - title: Wikipedia (UA)
   note: Базова хронологія життя та творчості, перелік нагород.
@@ -99,7 +124,7 @@ sequence: 188
 slug: oleg-sentsov
 subtitle: 'Oleh Sentsov: Director of His Own Fate and a Warrior'
 title: 'Олег Сенцов: Режисер власної долі та воїн'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: особа, позбавлена волі за політичні переконання або діяльність
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/oleksandra-matviichuk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oleksandra-matviichuk.yaml
@@ -80,6 +80,31 @@ persona:
   role: Модератор семінару, що розглядає правозахист не як абстрактне добро, а як складну, сповнену дилем і компромісів професійну діяльність.
   voice: Human-Rights-Analyst
 phase: BIO
+readings:
+- title: Олександра Матвійчук
+  language: uk
+  genre: Біографічна довідка
+  source_type: reference
+  role: orientation
+  source: Український ПЕН
+  source_url: https://pen.org.ua/members/matvijchuk-oleksandra
+  license: copyrighted
+  rights_note: Матеріали сайту PEN Ukraine захищені авторським правом. Використовувати як link-only джерело.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: Ознайомитися з довідкою про правозахисну діяльність Олександри Матвійчук та Центру громадянських свобод.
+- title: Нобелівська лекція "Час взяти на себе відповідальність"
+  language: uk
+  genre: Публічна промова / Лекція
+  source_type: primary
+  role: reading
+  source: NobelPrize.org
+  source_url: https://www.nobelprize.org/prizes/peace/2022/matviichuk/lecture/
+  license: copyrighted
+  rights_note: Текст Нобелівської лекції захищено авторським правом Фундації Нобеля.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: Прочитати україномовну версію Нобелівської лекції та проаналізувати її головні тези про справедливість і права людини під час війни.
 references:
 - title: Олександра Матвійчук (Wikipedia UA)
   name: Олександра Матвійчук (Wikipedia UA)
@@ -100,7 +125,7 @@ sequence: 190
 slug: oleksandra-matviichuk
 subtitle: A Lawyer's Fight for Justice and the Voice of a Nobel Laureate
 title: 'Олександра Матвійчук: Право на справедливість та Нобелівський голос'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: жінка, що професійно займається захистом прав людини
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/victoria-amelina.yaml
+++ b/curriculum/l2-uk-en/plans/bio/victoria-amelina.yaml
@@ -77,6 +77,30 @@ persona:
   role: Модератор семінару, що балансує між аналізом літературної спадщини Амеліної та осмисленням її останньої правозахисної місії
   voice: Literary Analyst & Human Rights Advocate
 phase: Executed Renaissance 2.0
+readings:
+- title: Вікторія Амеліна
+  language: uk
+  genre: Біографічна довідка
+  source_type: reference
+  role: orientation
+  source: Український ПЕН
+  source_url: https://pen.org.ua/members/amelina-viktoriya
+  license: copyrighted
+  rights_note: Матеріали сайту PEN Ukraine захищені авторським правом. Використовувати як link-only джерело.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: Ознайомитися з профілем письменниці на сайті Українського ПЕН, звернувши увагу на її перехід від художньої літератури до правозахисної роботи.
+- title: Спецпроєкт "Слова і кулі" або інше інтерв'ю Вікторії Амеліної
+  language: uk
+  genre: Інтерв'ю / Есей
+  source_type: primary
+  role: reading
+  source: Читомо / Український ПЕН
+  license: copyrighted
+  rights_note: Текст захищено авторським правом. Точне посилання на статтю потребує уточнення.
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: Прочитати розмову або есей Вікторії Амеліної про роль письменника під час війни та концепцію "Нового Розстріляного Відродження".
 references:
 - title: Victoria Amelina
   note: Curated page with key biographical facts, links to works, and critical reception
@@ -96,7 +120,7 @@ sequence: 192
 slug: victoria-amelina
 subtitle: The Price of Testimony
 title: Вікторія Амеліна
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: здатність особистості, спільноти бути активним творцем власної історії та культури, а не пасивним об'єктом зовнішніх впливів
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/volodymyr-vakulenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/volodymyr-vakulenko.yaml
@@ -81,6 +81,32 @@ persona:
   role: Старший біограф, який намагається осмислити трагедію Вакуленка, поєднуючи особистий біль із суворим професійним аналізом
   voice: Senior-Biographer-Mourning
 phase: Executed Renaissance 2.0
+readings:
+- title: Вакуленко-К. Володимир
+  language: uk
+  genre: Біографічна довідка
+  source_type: reference
+  role: orientation
+  source: Український ПЕН
+  source_url: https://pen.org.ua/members/vakulenko-k-volodymyr
+  license: copyrighted
+  rights_note: Матеріали сайту PEN Ukraine захищені авторським правом. Використовувати як link-only джерело.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: Ознайомитися з офіційною біографічною довідкою Українського ПЕН, виписати ключові факти літературної та громадської діяльності Вакуленка до окупації.
+- title: "Я перетворююсь... Щоденник окупації. Вибрані вірші"
+  language: uk
+  genre: Щоденник / Поезія
+  source_type: primary
+  role: reading
+  source: Vivat
+  source_url: https://vivat.com.ua/product/ya-peretvoryuyus-shchodennyk-okupatsiyi-vybrani-virshi
+  license: copyrighted
+  rights_note: Текст щоденника та віршів захищено авторським правом. Хостинг повної версії заборонений.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: Ознайомитися з анотацією до книги та прочитати доступні фрагменти щоденника окупації для аналізу мови свідка та письменника під час війни.
+  caveats: Містить чутливий контент, описи життя в окупації та психологічного тиску.
 references:
 - title: Я перетворююсь. Щоденник окупації. Вибрані вірші
   author: Володимир Вакуленко
@@ -100,7 +126,7 @@ sequence: 187
 slug: volodymyr-vakulenko
 subtitle: Голос, який не змогли змусити замовкнути
 title: Володимир Вакуленко
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: здатність бути самостійним, незалежним у своїх діях та думках; риса, притаманна активному творцю, а не пасивній жертві
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/yuriy-ruf.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yuriy-ruf.yaml
@@ -80,6 +80,30 @@ persona:
   role: Історик і ветеран, який фіксує народження нового пантеону героїв, відмовляючись від напівтонів, бо на війні їх не існує.
   voice: Uncompromising-Chronicler
 phase: Executed Renaissance 2.0
+readings:
+- title: Юрій Руф
+  language: uk
+  genre: Енциклопедична стаття / Біографічна довідка
+  source_type: reference
+  role: orientation
+  source: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-77631
+  license: copyrighted
+  rights_note: Текст ЕСУ є довідковим матеріалом. Хостити повну статтю заборонено.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: Ознайомитися з офіційною біографічною довідкою з Енциклопедії Сучасної України.
+- title: Документальний матеріал "Руф. Присутній"
+  language: uk
+  genre: Документальний матеріал
+  source_type: secondary
+  role: reading
+  source: Меморіал / Суспільне
+  license: copyrighted
+  rights_note: Потребує пошуку конкретного лінку на відео чи статтю платформи Меморіал або Суспільного.
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: Проаналізувати життєвий шлях Юрія Руфа за документальними матеріалами та спогадами сучасників.
 references:
 - title: Yuriy Ruf
   note: Базова компіляція фактів з відкритих джерел (Вікіпедія, інтерв'ю, некрологи).
@@ -99,7 +123,7 @@ sequence: 189
 slug: yuriy-ruf
 subtitle: 'Yuriy Ruf: A Poet on the Battlefield'
 title: 'Юрій Руф: Поет на полі бою'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: здатність бути активним діячем, а не пасивним об'єктом історії; право на власну волю та рішення
   pos: ж.


### PR DESCRIPTION
## Summary

Adds plan-level Ukrainian-only learner `readings:` packets for six contemporary war-memory / civil-society BIO figures:

- `volodymyr-vakulenko`
- `oleg-sentsov`
- `yuriy-ruf`
- `oleksandra-matviichuk`
- `kateryna-handziuk`
- `victoria-amelina`

All changes are limited to the six owned plan YAML files. `wiki/figures/*.sources.yaml` remains untouched.

## Gates

- `git diff --name-only origin/main...HEAD`
- `git diff --check origin/main...HEAD`
- `.venv/bin/python scripts/validate_plan_config.py bio`
- `.venv/bin/python scripts/validate_plans.py bio`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- focused readings parser: 12 reading items, all `language: uk`, each with an HTTPS URL or explicit `hosting: reading-needed`

## Notes

- AGY/Gemini-authored; Codex amended the commit metadata only to add the required `X-Agent` trailer after rebase.
- LLM-QG, Gemma/OpenRouter, `run_llm_qg_parity.py`, and `scripts/audit/module_quality_audit.py` were not used.
- Requires independent non-AGY/non-Gemini review before merge.