### PR TITLE
feat(atlas): #4571 content-addressed practice-deck release assets

### DIFF
--- a/scripts/practice_deck/io.py
+++ b/scripts/practice_deck/io.py
@@ -33,6 +33,11 @@ REQUIRED_POINTER_KEYS = (
 )
 DOWNLOAD_ATTEMPTS = 3
 ALLOWED_RELEASE_PATH_PREFIX = "/learn-ukrainian/learn-ukrainian.github.io/releases/download/"
+STALE_POINTER_HINT = (
+    "If your branch predates the latest practice deck publish, its committed pointer is stale — "
+    "update the branch from origin/main (gh pr update-branch <N> / git merge origin/main). "
+    "Re-downloading cannot fix a stale pointer."
+)
 
 
 class PracticeDeckHydrationError(RuntimeError):
@@ -170,6 +175,7 @@ def _download_gzip(pointer: dict[str, Any]) -> bytes:
         "gz sha256 mismatch: "
         f"expected {pointer['gz_sha256']}, got {actual_gz_sha} "
         f"after {DOWNLOAD_ATTEMPTS} download attempts. "
+        f"{STALE_POINTER_HINT} "
         f"Manual recovery command: {RECOVERY_COMMAND}"
     )
 
@@ -230,7 +236,8 @@ def _decode_package(data: bytes, pointer: dict[str, Any]) -> list[tuple[str, byt
     actual_sha = _sha256(data)
     if actual_sha != pointer["package_sha256"]:
         raise PracticeDeckHydrationError(
-            f"package sha mismatch: expected {pointer['package_sha256']}, got {actual_sha}"
+            f"package sha mismatch: expected {pointer['package_sha256']}, got {actual_sha}. "
+            f"{STALE_POINTER_HINT}"
         )
     package = json.loads(data.decode("utf-8"))
     if not isinstance(package, dict):

--- a/scripts/practice_deck/publish.py
+++ b/scripts/practice_deck/publish.py
@@ -8,6 +8,8 @@ import gzip
 import hashlib
 import json
 import subprocess
+import tempfile
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -16,6 +18,7 @@ ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_PRACTICE_DIR = ROOT / "site" / "public" / "lexicon"
 DEFAULT_POINTER = ROOT / "site" / "src" / "data" / "lexicon-practice-deck.pointer.json"
 DEFAULT_GZIP = ROOT / "site" / "src" / "data" / "lexicon-practice-deck.json.gz"
+DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
 DEFAULT_RELEASE_TAG = "atlas-practice-deck"
 DEFAULT_REPO = "learn-ukrainian/learn-ukrainian.github.io"
 ASSET_NAME = "lexicon-practice-deck.json.gz"
@@ -43,6 +46,29 @@ def _sha256(data: bytes) -> str:
 
 def _asset_url(repo: str, release_tag: str, asset_name: str = ASSET_NAME) -> str:
     return f"https://github.com/{repo}/releases/download/{release_tag}/{quote(asset_name)}"
+
+
+def versioned_asset_name(deck_version: str) -> str:
+    return f"lexicon-practice-deck-{deck_version}.json.gz"
+
+
+def expected_deck_version(manifest_path: Path) -> str:
+    if not manifest_path.exists():
+        raise PracticeDeckPublishError(
+            f"Manifest file {manifest_path} is missing. "
+            "Please build the manifest (e.g., run `make atlas`) first."
+        )
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        entries = manifest.get("entries") if isinstance(manifest, dict) else manifest
+        if not isinstance(entries, list):
+            raise PracticeDeckPublishError("manifest entries must be a list")
+        entries = [entry for entry in entries if isinstance(entry, dict)]
+        payload = json.dumps(entries, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        fingerprint = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+        return f"atlas-practice-v1-{fingerprint}"
+    except Exception as exc:
+        raise PracticeDeckPublishError(f"Failed to calculate expected deck version: {exc}") from exc
 
 
 def _read_json_bytes(path: Path) -> tuple[bytes, dict[str, Any]]:
@@ -127,7 +153,7 @@ def build_pointer(
     repo: str = DEFAULT_REPO,
 ) -> dict[str, Any]:
     return {
-        "asset_url": _asset_url(repo, release_tag),
+        "asset_url": _asset_url(repo, release_tag, versioned_asset_name(deck_version)),
         "release_tag": release_tag,
         "deck_version": deck_version,
         "package_schema_version": 1,
@@ -174,21 +200,103 @@ def ensure_release(release_tag: str, repo: str) -> None:
     )
 
 
-def upload_release_asset(gzip_path: Path, *, release_tag: str, repo: str) -> None:
+def upload_release_asset(
+    gzip_path: Path,
+    *,
+    asset_name: str = ASSET_NAME,
+    release_tag: str = DEFAULT_RELEASE_TAG,
+    repo: str = DEFAULT_REPO,
+    clobber: bool = True,
+) -> None:
     ensure_release(release_tag, repo)
-    subprocess.run(
-        [
+    upload_path = gzip_path
+    with tempfile.TemporaryDirectory() if gzip_path.name != asset_name else nullcontext(None) as temp_dir:
+        if temp_dir is not None:
+            upload_path = Path(temp_dir) / asset_name
+            upload_path.write_bytes(gzip_path.read_bytes())
+
+        command = [
             "gh",
             "release",
             "upload",
             release_tag,
-            str(gzip_path),
+            str(upload_path),
             "--repo",
             repo,
-            "--clobber",
-        ],
+        ]
+        if clobber:
+            command.append("--clobber")
+        subprocess.run(command, check=True)
+
+
+def _release_asset_names(*, release_tag: str = DEFAULT_RELEASE_TAG, repo: str = DEFAULT_REPO) -> set[str]:
+    result = subprocess.run(
+        ["gh", "release", "view", release_tag, "--repo", repo, "--json", "assets"],
         check=True,
+        capture_output=True,
+        text=True,
     )
+    payload = json.loads(result.stdout)
+    assets = payload.get("assets", [])
+    if not isinstance(assets, list):
+        raise PracticeDeckPublishError("gh release view returned malformed assets payload")
+    return {asset["name"] for asset in assets if isinstance(asset, dict) and isinstance(asset.get("name"), str)}
+
+
+def _download_release_asset(
+    asset_name: str,
+    *,
+    release_tag: str = DEFAULT_RELEASE_TAG,
+    repo: str = DEFAULT_REPO,
+) -> bytes:
+    result = subprocess.run(
+        ["gh", "release", "download", release_tag, "-p", asset_name, "-O", "-", "--repo", repo],
+        check=True,
+        capture_output=True,
+    )
+    return result.stdout
+
+
+def verify_existing_release_asset(
+    asset_name: str,
+    *,
+    expected_gz_bytes: bytes,
+    release_tag: str = DEFAULT_RELEASE_TAG,
+    repo: str = DEFAULT_REPO,
+) -> None:
+    existing = _download_release_asset(asset_name, release_tag=release_tag, repo=repo)
+    if existing != expected_gz_bytes:
+        raise PracticeDeckPublishError(
+            f"Existing Atlas practice deck release asset {asset_name} does not match local gzip bytes"
+        )
+
+
+def upload_practice_deck_assets(
+    gzip_path: Path,
+    pointer: dict[str, Any],
+    *,
+    release_tag: str = DEFAULT_RELEASE_TAG,
+    repo: str = DEFAULT_REPO,
+) -> None:
+    """Upload immutable + canonical assets; prune old versioned assets manually when the release gets heavy."""
+    versioned_name = versioned_asset_name(pointer["deck_version"])
+    gzip_bytes = gzip_path.read_bytes()
+    if versioned_name in _release_asset_names(release_tag=release_tag, repo=repo):
+        verify_existing_release_asset(
+            versioned_name,
+            expected_gz_bytes=gzip_bytes,
+            release_tag=release_tag,
+            repo=repo,
+        )
+    else:
+        upload_release_asset(
+            gzip_path,
+            asset_name=versioned_name,
+            release_tag=release_tag,
+            repo=repo,
+            clobber=False,
+        )
+    upload_release_asset(gzip_path, asset_name=ASSET_NAME, release_tag=release_tag, repo=repo, clobber=True)
 
 
 def publish_practice_deck(
@@ -196,11 +304,19 @@ def publish_practice_deck(
     practice_dir: Path = DEFAULT_PRACTICE_DIR,
     gzip_path: Path = DEFAULT_GZIP,
     pointer_path: Path = DEFAULT_POINTER,
+    manifest_path: Path = DEFAULT_MANIFEST,
     release_tag: str = DEFAULT_RELEASE_TAG,
     repo: str = DEFAULT_REPO,
     dry_run: bool = False,
 ) -> dict[str, Any]:
     deck_version, pointer_files, package_files = collect_shards(practice_dir)
+    expected_version = expected_deck_version(manifest_path)
+    if deck_version != expected_version:
+        raise PracticeDeckPublishError(
+            f"Practice deck version on disk {deck_version!r} does not match expected "
+            f"version {expected_version!r} from manifest. "
+            "Please rebuild the practice deck (e.g., run `make practice-deck`) before publishing."
+        )
     package_bytes = build_package(deck_version, package_files)
     gzip_bytes = gzip.compress(package_bytes, compresslevel=9, mtime=0)
     gzip_path.parent.mkdir(parents=True, exist_ok=True)
@@ -215,7 +331,7 @@ def publish_practice_deck(
     )
     if dry_run:
         return pointer
-    upload_release_asset(gzip_path, release_tag=release_tag, repo=repo)
+    upload_practice_deck_assets(gzip_path, pointer, release_tag=release_tag, repo=repo)
     write_pointer(pointer_path, pointer)
     return pointer
 
@@ -225,6 +341,7 @@ def main() -> int:
     parser.add_argument("--practice-dir", type=Path, default=DEFAULT_PRACTICE_DIR)
     parser.add_argument("--gzip", type=Path, default=DEFAULT_GZIP)
     parser.add_argument("--pointer", type=Path, default=DEFAULT_POINTER)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     parser.add_argument("--release-tag", default=DEFAULT_RELEASE_TAG)
     parser.add_argument("--repo", default=DEFAULT_REPO)
     parser.add_argument("--dry-run", action="store_true", help="Build metadata without uploading/writing pointer")
@@ -233,6 +350,7 @@ def main() -> int:
         practice_dir=args.practice_dir,
         gzip_path=args.gzip,
         pointer_path=args.pointer,
+        manifest_path=args.manifest,
         release_tag=args.release_tag,
         repo=args.repo,
         dry_run=args.dry_run,

--- a/site/scripts/hydrate-practice-deck.mjs
+++ b/site/scripts/hydrate-practice-deck.mjs
@@ -6,6 +6,8 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { gunzipSync } from "node:zlib";
 
 const RECOVERY_COMMAND = "node site/scripts/hydrate-practice-deck.mjs";
+const STALE_POINTER_HINT =
+  "If your branch predates the latest practice deck publish, its committed pointer is stale — update the branch from origin/main (gh pr update-branch <N> / git merge origin/main). Re-downloading cannot fix a stale pointer.";
 
 const REQUIRED_POINTER_KEYS = [
   "asset_url",
@@ -149,7 +151,7 @@ async function downloadGzip(pointer) {
     );
   }
   throw new Error(
-    `gz sha mismatch: expected ${pointer.gz_sha256}, got ${actualGzSha} after ${DOWNLOAD_ATTEMPTS} download attempts`,
+    `gz sha mismatch: expected ${pointer.gz_sha256}, got ${actualGzSha} after ${DOWNLOAD_ATTEMPTS} download attempts. ${STALE_POINTER_HINT}`,
   );
 }
 
@@ -169,7 +171,7 @@ function parsePackage(packageBytes, pointer) {
   }
   const actualPackageSha = sha256(packageBytes);
   if (actualPackageSha !== pointer.package_sha256) {
-    throw new Error(`package sha mismatch: expected ${pointer.package_sha256}, got ${actualPackageSha}`);
+    throw new Error(`package sha mismatch: expected ${pointer.package_sha256}, got ${actualPackageSha}. ${STALE_POINTER_HINT}`);
   }
   const packagePayload = JSON.parse(packageBytes.toString("utf8"));
   if (packagePayload.schema !== "atlas-practice-deck-package") {

--- a/site/tests/unit/hydrate-practice-deck.test.ts
+++ b/site/tests/unit/hydrate-practice-deck.test.ts
@@ -10,6 +10,8 @@ import {
 
 const ASSET_URL =
   'https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck.json.gz';
+const VERSIONED_ASSET_URL =
+  'https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-0123456789ab.json.gz';
 
 function sha256(data: Buffer): string {
   return createHash('sha256').update(data).digest('hex');
@@ -72,6 +74,16 @@ describe('hydrate practice deck release download', () => {
     );
   });
 
+  test('preserves the versioned filename when adding cache-busting query parameters', () => {
+    const { pointer } = packageFixture();
+    const pointerWithVersioned = { ...pointer, asset_url: VERSIONED_ASSET_URL };
+
+    expect(downloadUrl(pointerWithVersioned, 0)).toBe(VERSIONED_ASSET_URL);
+    expect(downloadUrl(pointerWithVersioned, 1)).toBe(
+      `${VERSIONED_ASSET_URL}?atlas_practice_deck_sha256=${pointer.gz_sha256}&atlas_practice_deck_attempt=1`,
+    );
+  });
+
   test('retries stale gzip responses with cache-busting URL', async () => {
     const { gzBytes, pointer } = packageFixture();
     const staleGzBytes = gzipSync(Buffer.from('{"old":true}'));
@@ -87,6 +99,16 @@ describe('hydrate practice deck release download', () => {
     );
   });
 
+  test('explains that re-downloading cannot fix a stale pointer after repeated sha mismatch', async () => {
+    const { pointer } = packageFixture();
+    const staleGzBytes = gzipSync(Buffer.from('{"old":true}'));
+    const fetchMock = vi.fn().mockResolvedValue(okResponse(staleGzBytes));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(downloadGzip(pointer)).rejects.toThrow('Re-downloading cannot fix a stale pointer.');
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   test('verifies package and shard hashes before writing', () => {
     const { packageBytes, pointer } = packageFixture();
 
@@ -95,6 +117,10 @@ describe('hydrate practice deck release download', () => {
     expect(files).toHaveLength(1);
     expect(files[0][0]).toBe('practice-index.A1.json');
     expect(files[0][1].toString('utf8')).toContain('"atlas-practice-index"');
+  });
+
+  test('accepts versioned github.com release-asset URLs unchanged', () => {
+    expect(assertAllowedDownloadUrl(VERSIONED_ASSET_URL)).toBe(VERSIONED_ASSET_URL);
   });
 
   test.each([

--- a/tests/test_practice_deck_io.py
+++ b/tests/test_practice_deck_io.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import gzip
+import hashlib
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.practice_deck import io as practice_deck_io
+
+
+def _json_bytes(payload: dict) -> bytes:
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _write_pointer(
+    pointer_path: Path,
+    *,
+    package_bytes: bytes,
+    gz_bytes: bytes,
+    gz_sha256: str | None = None,
+    package_sha256: str | None = None,
+    deck_version: str = "deck-v1",
+) -> None:
+    pointer_path.write_text(
+        json.dumps(
+            {
+                "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck.json.gz",
+                "release_tag": "atlas-practice-deck",
+                "deck_version": deck_version,
+                "package_schema_version": 1,
+                "gz_sha256": gz_sha256 or _sha256(gz_bytes),
+                "package_sha256": package_sha256 or _sha256(package_bytes),
+                "gz_bytes": len(gz_bytes),
+                "package_bytes": len(package_bytes),
+                "file_count": 1,
+                "files": [
+                    {
+                        "path": "practice-index.A1.json",
+                        "kind": "index",
+                        "level": "A1",
+                        "schema": "atlas-practice-index",
+                        "bytes": len(b"content-data"),
+                        "sha256": _sha256(b"content-data"),
+                    }
+                ],
+                "note": "test pointer",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _pin_defaults(monkeypatch: pytest.MonkeyPatch, practice_dir: Path, pointer_path: Path) -> None:
+    monkeypatch.setattr(practice_deck_io, "DEFAULT_PRACTICE_DIR", practice_dir)
+    monkeypatch.setattr(practice_deck_io, "DEFAULT_POINTER", pointer_path)
+
+
+def _request_url(request: object) -> str:
+    return getattr(request, "full_url", str(request))
+
+
+def test_ensure_practice_deck_hydrated_returns_matching_local(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    practice_dir = tmp_path / "lexicon"
+    pointer_path = tmp_path / "lexicon-practice-deck.pointer.json"
+
+    shard_path = practice_dir / "practice-index.A1.json"
+    shard_path.parent.mkdir(parents=True, exist_ok=True)
+    shard_path.write_bytes(b"content-data")
+
+    package = {
+        "schema": "atlas-practice-deck-package",
+        "schemaVersion": 1,
+        "deckVersion": "deck-v1",
+        "files": [{"path": "practice-index.A1.json", "content": "content-data"}],
+    }
+    package_bytes = _json_bytes(package)
+    gz_bytes = gzip.compress(package_bytes)
+
+    _write_pointer(pointer_path, package_bytes=package_bytes, gz_bytes=gz_bytes)
+    _pin_defaults(monkeypatch, practice_dir, pointer_path)
+
+    def fail_urlopen(*args, **kwargs):
+        raise AssertionError("matching local practice deck should not fetch")
+
+    monkeypatch.setattr(practice_deck_io.urllib.request, "urlopen", fail_urlopen)
+
+    assert practice_deck_io.ensure_practice_deck_hydrated(
+        practice_dir=practice_dir, pointer_path=pointer_path
+    ) is not None
+
+
+def test_ensure_practice_deck_hydrated_fetches_decompresses_and_writes_when_absent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    practice_dir = tmp_path / "lexicon"
+    pointer_path = tmp_path / "lexicon-practice-deck.pointer.json"
+
+    package = {
+        "schema": "atlas-practice-deck-package",
+        "schemaVersion": 1,
+        "deckVersion": "deck-v1",
+        "files": [{"path": "practice-index.A1.json", "content": "content-data"}],
+    }
+    package_bytes = _json_bytes(package)
+    gz_bytes = gzip.compress(package_bytes)
+
+    _write_pointer(pointer_path, package_bytes=package_bytes, gz_bytes=gz_bytes)
+    _pin_defaults(monkeypatch, practice_dir, pointer_path)
+
+    expected_url = "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck.json.gz"
+
+    def fake_urlopen(request: object, timeout: int):
+        assert _request_url(request) == expected_url
+        assert timeout == 60
+        return io.BytesIO(gz_bytes)
+
+    monkeypatch.setattr(practice_deck_io.urllib.request, "urlopen", fake_urlopen)
+
+    assert practice_deck_io.ensure_practice_deck_hydrated(
+        practice_dir=practice_dir, pointer_path=pointer_path
+    ) is not None
+    shard_path = practice_dir / "practice-index.A1.json"
+    assert shard_path.exists()
+    assert shard_path.read_bytes() == b"content-data"
+
+
+def test_ensure_practice_deck_hydrated_raises_on_gz_sha256_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    practice_dir = tmp_path / "lexicon"
+    pointer_path = tmp_path / "lexicon-practice-deck.pointer.json"
+
+    package = {
+        "schema": "atlas-practice-deck-package",
+        "schemaVersion": 1,
+        "deckVersion": "deck-v1",
+        "files": [{"path": "practice-index.A1.json", "content": "content-data"}],
+    }
+    package_bytes = _json_bytes(package)
+    gz_bytes = gzip.compress(package_bytes)
+
+    _write_pointer(pointer_path, package_bytes=package_bytes, gz_bytes=gz_bytes, gz_sha256="0" * 64)
+    _pin_defaults(monkeypatch, practice_dir, pointer_path)
+
+    def fake_urlopen(request: object, timeout: int):
+        return io.BytesIO(gz_bytes)
+
+    monkeypatch.setattr(practice_deck_io.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(RuntimeError, match="gz sha256 mismatch") as excinfo:
+        practice_deck_io.ensure_practice_deck_hydrated(
+            practice_dir=practice_dir, pointer_path=pointer_path
+        )
+
+    assert "Re-downloading cannot fix a stale pointer" in str(excinfo.value)
+    assert not (practice_dir / "practice-index.A1.json").exists()
+
+
+def test_ensure_practice_deck_hydrated_retries_gz_sha256_mismatch_with_cache_bust(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    practice_dir = tmp_path / "lexicon"
+    pointer_path = tmp_path / "lexicon-practice-deck.pointer.json"
+
+    package = {
+        "schema": "atlas-practice-deck-package",
+        "schemaVersion": 1,
+        "deckVersion": "deck-v1",
+        "files": [{"path": "practice-index.A1.json", "content": "content-data"}],
+    }
+    package_bytes = _json_bytes(package)
+    gz_bytes = gzip.compress(package_bytes)
+    stale_gz_bytes = gzip.compress(_json_bytes({"schema": "wrong"}))
+
+    _write_pointer(pointer_path, package_bytes=package_bytes, gz_bytes=gz_bytes)
+    _pin_defaults(monkeypatch, practice_dir, pointer_path)
+    urls: list[str] = []
+
+    def fake_urlopen(request: object, timeout: int):
+        assert timeout == 60
+        urls.append(_request_url(request))
+        return io.BytesIO(stale_gz_bytes if len(urls) == 1 else gz_bytes)
+
+    monkeypatch.setattr(practice_deck_io.urllib.request, "urlopen", fake_urlopen)
+
+    assert practice_deck_io.ensure_practice_deck_hydrated(
+        practice_dir=practice_dir, pointer_path=pointer_path
+    ) is not None
+    shard_path = practice_dir / "practice-index.A1.json"
+    assert shard_path.read_bytes() == b"content-data"
+    expected_base_url = "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck.json.gz"
+    assert urls == [
+        expected_base_url,
+        (
+            f"{expected_base_url}"
+            f"?atlas_practice_deck_sha256={_sha256(gz_bytes)}&atlas_practice_deck_attempt=1"
+        ),
+    ]

--- a/tests/test_publish_practice_deck.py
+++ b/tests/test_publish_practice_deck.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import gzip
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
 
 from scripts.practice_deck.publish import (
+    ASSET_NAME,
     KINDS,
     LEVELS,
     PracticeDeckPublishError,
@@ -75,12 +77,24 @@ def _write_practice_deck(practice_dir: Path, *, deck_version: str = "atlas-pract
 def test_publish_practice_deck_dry_run_builds_hash_pinned_package(tmp_path: Path) -> None:
     practice_dir = tmp_path / "lexicon"
     gzip_path = tmp_path / "lexicon-practice-deck.json.gz"
-    _write_practice_deck(practice_dir)
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    _write_json(manifest_path, {"entries": []})
 
-    pointer = publish_practice_deck(practice_dir=practice_dir, gzip_path=gzip_path, dry_run=True)
+    from scripts.practice_deck.publish import expected_deck_version, versioned_asset_name
+    expected_version = expected_deck_version(manifest_path)
+    _write_practice_deck(practice_dir, deck_version=expected_version)
 
-    assert pointer["deck_version"] == "atlas-practice-v1-test"
+    pointer = publish_practice_deck(
+        practice_dir=practice_dir,
+        gzip_path=gzip_path,
+        manifest_path=manifest_path,
+        dry_run=True,
+    )
+
+    assert pointer["deck_version"] == expected_version
     assert pointer["file_count"] == len(LEVELS) * len(KINDS)
+    expected_name = versioned_asset_name(expected_version)
+    assert pointer["asset_url"].endswith(f"/{expected_name}")
     assert gzip_path.exists()
     package = json.loads(gzip.decompress(gzip_path.read_bytes()).decode("utf-8"))
     assert package["schema"] == "atlas-practice-deck-package"
@@ -91,10 +105,114 @@ def test_publish_practice_deck_dry_run_builds_hash_pinned_package(tmp_path: Path
 
 def test_publish_practice_deck_rejects_version_mismatch(tmp_path: Path) -> None:
     practice_dir = tmp_path / "lexicon"
-    _write_practice_deck(practice_dir)
-    payload = json.loads((practice_dir / "practice-cloze.C1.json").read_text(encoding="utf-8"))
-    payload["deckVersion"] = "atlas-practice-v1-other"
-    _write_json(practice_dir / "practice-cloze.C1.json", payload)
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    _write_json(manifest_path, {"entries": []})
+    _write_practice_deck(practice_dir, deck_version="atlas-practice-v1-other")
 
-    with pytest.raises(PracticeDeckPublishError, match="deckVersion"):
-        publish_practice_deck(practice_dir=practice_dir, gzip_path=tmp_path / "deck.json.gz", dry_run=True)
+    with pytest.raises(PracticeDeckPublishError, match="does not match expected version"):
+        publish_practice_deck(
+            practice_dir=practice_dir,
+            gzip_path=tmp_path / "deck.json.gz",
+            manifest_path=manifest_path,
+            dry_run=True,
+        )
+
+
+def test_publish_practice_deck_uploads_versioned_and_canonical_assets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    practice_dir = tmp_path / "lexicon"
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    gzip_path = tmp_path / "lexicon-practice-deck.json.gz"
+    pointer_path = tmp_path / "lexicon-practice-deck.pointer.json"
+
+    _write_json(manifest_path, {"entries": []})
+
+    from scripts.practice_deck.publish import expected_deck_version, versioned_asset_name
+    expected_version = expected_deck_version(manifest_path)
+    _write_practice_deck(practice_dir, deck_version=expected_version)
+    expected_versioned_name = versioned_asset_name(expected_version)
+
+    upload_calls: list[list[str]] = []
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        if args[:3] == ["gh", "release", "view"]:
+            return subprocess.CompletedProcess(args, 0, stdout='{"assets":[]}', stderr="")
+        if args[:3] == ["gh", "release", "upload"]:
+            assert Path(args[4]).exists()
+            upload_calls.append(args)
+            return subprocess.CompletedProcess(args, 0)
+        raise AssertionError(f"unexpected command: {args}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    pointer = publish_practice_deck(
+        practice_dir=practice_dir,
+        gzip_path=gzip_path,
+        pointer_path=pointer_path,
+        manifest_path=manifest_path,
+        repo="learn-ukrainian/example",
+    )
+
+    assert pointer["asset_url"].endswith(f"/{expected_versioned_name}")
+    assert json.loads(pointer_path.read_text(encoding="utf-8")) == pointer
+    assert [Path(call[4]).name for call in upload_calls] == [expected_versioned_name, ASSET_NAME]
+    assert "--clobber" not in upload_calls[0]
+    assert "--clobber" in upload_calls[1]
+
+
+def test_publish_practice_deck_skips_existing_verified_versioned_asset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    practice_dir = tmp_path / "lexicon"
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    gzip_path = tmp_path / "lexicon-practice-deck.json.gz"
+    pointer_path = tmp_path / "lexicon-practice-deck.pointer.json"
+
+    _write_json(manifest_path, {"entries": []})
+
+    from scripts.practice_deck.publish import expected_deck_version, versioned_asset_name
+    expected_version = expected_deck_version(manifest_path)
+    _write_practice_deck(practice_dir, deck_version=expected_version)
+    expected_versioned_name = versioned_asset_name(expected_version)
+
+    upload_calls: list[list[str]] = []
+    download_calls: list[str] = []
+
+    def fake_run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess:
+        if args[:3] == ["gh", "release", "view"]:
+            payload = {"assets": [{"name": expected_versioned_name}]}
+            return subprocess.CompletedProcess(args, 0, stdout=json.dumps(payload), stderr="")
+        if args[:3] == ["gh", "release", "download"]:
+            download_calls.append(args[5])
+            return subprocess.CompletedProcess(args, 0, stdout=gzip_path.read_bytes(), stderr=b"")
+        if args[:3] == ["gh", "release", "upload"]:
+            upload_calls.append(args)
+            return subprocess.CompletedProcess(args, 0)
+        raise AssertionError(f"unexpected command: {args}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    # First compile gzip so it exists for download mock
+    publish_practice_deck(
+        practice_dir=practice_dir,
+        gzip_path=gzip_path,
+        pointer_path=pointer_path,
+        manifest_path=manifest_path,
+        repo="learn-ukrainian/example",
+        dry_run=True,
+    )
+
+    publish_practice_deck(
+        practice_dir=practice_dir,
+        gzip_path=gzip_path,
+        pointer_path=pointer_path,
+        manifest_path=manifest_path,
+        repo="learn-ukrainian/example",
+    )
+
+    assert download_calls == [expected_versioned_name]
+    assert [Path(call[4]).name for call in upload_calls] == [ASSET_NAME]
+    assert "--clobber" in upload_calls[0]


### PR DESCRIPTION
Port of the proven #4411 immutable content-addressed asset design to the practice deck.

Fixes #4571.

- Publish uploads immutable `lexicon-practice-deck-<hash>.json.gz`; pointer pins exact asset name + sha256; legacy fixed name kept as a transition compatibility copy.
- `hydrate-practice-deck.mjs` downloads by the pinned content-addressed name (legacy fallback only for pre-port pointers), sha256 + deckVersion verified.
- Stale-tree publish guard: rebuilding a deck whose hash differs from the tree's fails loudly — the #4551 clobber-race class is closed at the machinery level, not by convention.
- No real asset published in this PR — machinery + tests only; the driver does the first versioned publish after merge.

Authored by agy dispatch `4571-deck-versioned-assets` (report has command+cwd+raw-output triples: pytest 24 passed, vitest 11 passed, ruff clean). PR opened by driver (agy lane skips `gh pr create`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)