### PR TITLE
feat(bio): add war-remembrance learner reading packets

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/andrii-chaikovskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/andrii-chaikovskyi.yaml
@@ -82,6 +82,25 @@ persona:
   role: Спеціаліст з історії галицької державності, який розглядає біографію Чайковського як case study про можливості та трагедії української інтелігенції на зламі епох.
   voice: Senior Historian
 phase: BIO
+readings:
+- caveats: Академічний матеріал з детальним аналізом життя та творчості.
+  hosting: external
+  language: uk
+  role: Контекст
+  source_name: Локальна історія
+  source_type: Стаття
+  task: Прочитати про вплив Чайковського на галицьке суспільство та його літературний доробок.
+  title: Андрій Чайковський. Адвокат і письменник, який створив міф про козаків
+  url: https://localhistory.org.ua/texts/statti/andrii-chaikovskii-advokat-i-pismennik-iakii-stvoriv-mif-pro-kozakiv/
+- caveats: Енциклопедична стаття з основними фактами.
+  hosting: external
+  language: uk
+  role: Контекст
+  source_name: Енциклопедія Сучасної України
+  source_type: Енциклопедія
+  task: Ознайомитися з хронологією життя та державницькою діяльністю письменника.
+  title: Чайковський Андрій Якович
+  url: https://esu.com.ua/article-37142
 references:
 - title: Andrii Chaikovskyi
   note: Compiled from Wikipedia UA, biography sites, and analysis of his major works.
@@ -101,7 +120,7 @@ sequence: 198
 slug: andrii-chaikovskyi
 subtitle: The Nation's Advocate
 title: 'Андрій Чайковський: Адвокат нації'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: процес створення та зміцнення інститутів незалежної держави
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/andriy-pilshchykov.yaml
+++ b/curriculum/l2-uk-en/plans/bio/andriy-pilshchykov.yaml
@@ -79,6 +79,25 @@ persona:
   role: Модератор семінару, що аналізує не лише біографію, а й вплив однієї людини на стратегію та міжнародні відносини в умовах війни
   voice: Aviation Analyst
 phase: BIO
+readings:
+- caveats: Стаття-спогад з детальним аналізом його зусиль щодо F-16.
+  hosting: external
+  language: uk
+  role: Контекст
+  source_name: Українська правда
+  source_type: Стаття
+  task: Дізнатися про роль Андрія Пільщикова в лобіюванні західних винищувачів для України.
+  title: Джус і його мрія
+  url: https://www.pravda.com.ua/articles/2023/08/29/7417537/
+- caveats: Некролог від профільного видання.
+  hosting: external
+  language: uk
+  role: Контекст
+  source_name: Мілітарний
+  source_type: Стаття
+  task: Ознайомитися з професійним шляхом та досягненнями пілота.
+  title: 'Андрій Пільщиков: як загинув та ким був пілот на позивний "Juice"'
+  url: https://mil.in.ua/uk/news/zahynuv-pilot-andriy-pilshchykov-na-pozyvnyy-juice/
 references:
 - title: Андрій Пільщиков (Wikipedia UA)
   name: Андрій Пільщиков (Wikipedia UA)
@@ -97,7 +116,7 @@ sequence: 195
 slug: andriy-pilshchykov
 subtitle: 'Andriy "Juice" Pilshchykov: Defender of the Sky and Voice of Aviation'
 title: 'Андрій «Juice» Пільщиков: Захисник неба та голос авіації'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: бойовий літак, призначений для знищення повітряних цілей
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/dmytro-kotsyubailo.yaml
+++ b/curriculum/l2-uk-en/plans/bio/dmytro-kotsyubailo.yaml
@@ -78,6 +78,25 @@ persona:
   role: Модератор семінару, що досліджує феномен сучасного українського героїзму, уникаючи плаского захоплення та шукаючи складність, ціну та значення за яскравим символом.
   voice: Nuanced-Historian
 phase: BIO
+readings:
+- caveats: Велика стаття з детальним описом бойового шляху.
+  hosting: external
+  language: uk
+  role: Контекст
+  source_name: Історична правда
+  source_type: Стаття
+  task: Дослідити шлях Дмитра Коцюбайла від учасника Революції Гідності до командира батальйону.
+  title: Да Вінчі. Історія Героя
+  url: https://www.istpravda.com.ua/articles/2023/03/9/162788/
+- caveats: Некролог з основними біографічними відомостями.
+  hosting: external
+  language: uk
+  role: Контекст
+  source_name: Суспільне Новини
+  source_type: Стаття
+  task: Ознайомитися з реакцією суспільства на загибель Да Вінчі.
+  title: На війні загинув командир "Вовків Да Вінчі" Дмитро Коцюбайло
+  url: https://suspilne.media/407338-na-vijni-zaginuv-komandir-vovkiv-da-vinci-dmitro-kocubajlo/
 references:
 - title: Дмитро Коцюбайло (Да Вінчі) в програмі «Рандеву з Яніною Соколовою»
   name: Дмитро Коцюбайло (Да Вінчі) в програмі «Рандеву з Яніною Соколовою»
@@ -103,7 +122,7 @@ sequence: 196
 slug: dmytro-kotsyubailo
 subtitle: 'Dmytro "Da Vinci" Kotsiubailo: Symbol of the Volunteer Generation'
 title: 'Дмитро «Да Вінчі» Коцюбайло: Символ покоління добровольців'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: особа, яка за власним бажанням, без примусу, зголосилася до військової служби або іншої суспільно важливої діяльності
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/illia-chernilevskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/illia-chernilevskyi.yaml
@@ -81,6 +81,25 @@ persona:
 phase: Executed Renaissance 2.0
 prerequisites:
 - maksym-kryvtsov
+readings:
+- caveats: Некролог з деталями загибелі.
+  hosting: external
+  language: uk
+  role: Контекст
+  source_name: Український ПЕН
+  source_type: Стаття
+  task: Ознайомитися з біографічними даними та творчим шляхом митця.
+  title: На війні загинув поет, перекладач та музикант Ілля Чернілевський
+  url: https://pen.org.ua/na-vijni-zagynuv-poet-perekladach-ta-muzykant-illya-chernilevskyj
+- caveats: Стаття містить огляд перекладацької та акторської роботи.
+  hosting: external
+  language: uk
+  role: Контекст
+  source_name: Суспільне Культура
+  source_type: Стаття
+  task: Дізнатися про внесок Іллі Чернілевського в український дубляж та культуру.
+  title: На війні загинув український поет та музикант Ілля Чернілевський
+  url: https://suspilne.media/culture/237937-na-vijni-zaginuv-ukrainskij-poet-ta-muzikant-illa-cernilevskij/
 references:
 - title: Illia Chernilevskyi
   note: Зібрані факти біографії, посилання на публікації, інтерв'ю та основні твори.
@@ -95,7 +114,7 @@ sequence: 194
 slug: illia-chernilevskyi
 subtitle: Голос страченого покоління Z
 title: Ілля Чернілевський
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: здатність бути активним діячем, а не пасивним об'єктом історії; право на власну волю та позицію
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/maksym-kryvtsov.yaml
+++ b/curriculum/l2-uk-en/plans/bio/maksym-kryvtsov.yaml
@@ -89,6 +89,25 @@ persona:
   role: Модератор семінару, який знав Максима особисто, але намагається зберегти критичну дистанцію, щоб проаналізувати його спадщину, а не просто оплакати втрату.
   voice: Grieving-but-Critical-Contemporary
 phase: BIO.4
+readings:
+- caveats: Містить емоційно важкі деталі війни та загибелі.
+  hosting: external
+  language: uk
+  role: Контекст
+  source_name: Читомо
+  source_type: Стаття
+  task: Ознайомитися з біографічними фактами та відгуками спільноти про поета.
+  title: На війні загинув поет Максим Кривцов
+  url: https://www.chytomo.com/na-vijni-zahynuv-poet-maksym-kryvtsov/
+- caveats: Короткий некролог.
+  hosting: external
+  language: uk
+  role: Контекст
+  source_name: Український ПЕН
+  source_type: Стаття
+  task: Прочитати про військовий шлях та літературну спадщину Кривцова.
+  title: На фронті загинув поет та військовий Максим Кривцов
+  url: https://pen.org.ua/na-fronti-zagynuv-poet-ta-vijskovyj-maksym-kryvtsov
 references:
 - title: Maksym Kryvtsov
   note: Compiled from public interviews, poems from "Вірші з бійниці", posts by friends and family.
@@ -107,7 +126,7 @@ sequence: 193
 slug: maksym-kryvtsov
 subtitle: Поет і воїн. Трагедія «Розстріляного Відродження 2.0»
 title: Максим «Далі» Кривцов
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: здатність бути активним діячем, творцем власної долі та історії, а не пасивним об'єктом зовнішніх впливів
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/roman-ratushny.yaml
+++ b/curriculum/l2-uk-en/plans/bio/roman-ratushny.yaml
@@ -94,6 +94,25 @@ persona:
   role: Модератор дискусії, який спонукає студентів бачити не ікону, а складну особистість в історичному контексті
   voice: Критичний біограф
 phase: BIO.4
+readings:
+- caveats: Стаття містить детальний огляд його громадської діяльності.
+  hosting: external
+  language: uk
+  role: Контекст
+  source_name: Українська правда
+  source_type: Стаття
+  task: Дізнатися про боротьбу за Протасів Яр та становлення Романа як громадського діяча.
+  title: Роман Ратушний. Історія київського активіста
+  url: https://www.pravda.com.ua/articles/2022/06/18/7353272/
+- caveats: Короткий новинний формат з реакцією спільноти.
+  hosting: external
+  language: uk
+  role: Контекст
+  source_name: Суспільне Новини
+  source_type: Стаття
+  task: Ознайомитися з фактами військового шляху Ратушного в 93-й ОМБр.
+  title: Загинув лідер ГО "Захистимо Протасів Яр", розвідник 93-ї ОМБр Роман Ратушний
+  url: https://suspilne.media/250269-zaginuv-lider-go-zahistimo-protasiv-ar-rozvidnik-93-i-ombr-holodnij-ar-roman-ratusnij/
 references:
 - note: Загальна біографічна довідка, хронологія подій
   title: Роман Ратушний (Wikipedia UA)
@@ -110,7 +129,7 @@ sequence: 197
 slug: roman-ratushny
 subtitle: 'The Voice of Protasiy Yar: From Activist to Soldier'
 title: 'Роман Ратушний: Громадянин, активіст, воїн'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: здатність людини чи спільноти бути активним, свідомим і вільним діячем, творцем свого життя та історії
   pos: ж.


### PR DESCRIPTION
Adds Ukrainian-only plan-level learner reading packets for six BIO modules: Maksym Kryvtsov, Illia Chernilevskyi, Andriy Pilshchykov, Dmytro Kotsyubailo, Roman Ratushny, and Andrii Chaikovskyi.\n\nScope:\n- Only six owned BIO plan YAML files changed.\n- No wiki/source-packet, module, activity, vocabulary, resource, status, audit, review, telemetry, or config changes.\n\nVerification:\n- git diff --check origin/main...HEAD\n- .venv/bin/python scripts/validate_plan_config.py bio\n- .venv/bin/python scripts/validate_plans.py bio\n- .venv/bin/python scripts/audit/lint_agent_trailer.py\n- Focused reading parser: 12 items, all language: uk, all URL-backed, no inline excerpt/text/content fields.\n\nLLM-QG and Gemma/OpenRouter were not used.\n\nX-Agent: agy/bio-readings-war-remembrance-batch-35-agy