### PR TITLE
fix(audit): #4540 subscription bare cells — OAuth claude seat + neutral-cwd rules firewall

### DIFF
--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -579,7 +579,13 @@ def _neutral_runtime_cwd() -> Path:
     """
     global _NEUTRAL_RUNTIME_CWD
     if _NEUTRAL_RUNTIME_CWD is None or not _NEUTRAL_RUNTIME_CWD.exists():
-        _NEUTRAL_RUNTIME_CWD = Path(tempfile.mkdtemp(prefix="qg-bakeoff-bare-"))
+        candidate = Path(tempfile.mkdtemp(prefix="qg-bakeoff-bare-"))
+        repo_root = PROJECT_ROOT.resolve()
+        if candidate.resolve() == repo_root or candidate.resolve().is_relative_to(repo_root):
+            # TMPDIR pointed under the repo — the firewall would silently
+            # fail (codex review, #4577). Force a genuinely external dir.
+            candidate = Path(tempfile.mkdtemp(prefix="qg-bakeoff-bare-", dir="/tmp"))
+        _NEUTRAL_RUNTIME_CWD = candidate
     return _NEUTRAL_RUNTIME_CWD
 
 

--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -17,6 +17,7 @@ import os
 import re
 import shutil
 import sys
+import tempfile
 import time
 import unicodedata
 from collections import defaultdict
@@ -194,7 +195,13 @@ def _runtime_bridge_command(agent: str, model: str) -> tuple[str, ...]:
             "--hard-timeout",
             "1800",
             "--tool-config",
-            "use_bare=true,output_format=stream-json",
+            # use_bare=false is LOAD-BEARING: `claude --bare` skips the OAuth
+            # session entirely and requires ANTHROPIC_API_KEY — on the
+            # subscription machine it returns "Not logged in" (live-probed
+            # 2026-07-06, apiKeySource=none, error=authentication_failed).
+            # The subscription seat runs the standard -p path; the BARE part
+            # of the measurement is the prompt, not the CLI harness.
+            "use_bare=false,output_format=stream-json",
         )
     if agent == "codex":
         return (
@@ -266,7 +273,7 @@ _SUBSCRIPTION_BARE_IDENTITIES: dict[str, RouteIdentity] = {
         pricing_basis=_SUBSCRIPTION_PRICING_BASIS,
         resolved_model=CLAUDE_SUBSCRIPTION_BARE_MODEL_ID,
         runtime_agent="claude",
-        tool_config={"use_bare": True, "output_format": "stream-json"},
+        tool_config={"use_bare": False, "output_format": "stream-json"},
     ),
     "bare_runtime_gpt": RouteIdentity(
         transport="runtime-codex",
@@ -555,6 +562,27 @@ def invoke_bakeoff_route_bare(
     )
 
 
+_NEUTRAL_RUNTIME_CWD: Path | None = None
+
+
+def _neutral_runtime_cwd() -> Path:
+    """Out-of-repo cwd for subscription bare cells (standing-rules firewall).
+
+    Agent CLIs discover project standing rules by walking UP from cwd —
+    claude loads CLAUDE.md, codex loads AGENTS.md, gemini/agy loads GEMINI.md.
+    Running bare cells from PROJECT_ROOT silently injects those rules (VESUM
+    mandates, review protocols) into a measurement that promises a bare
+    prompt — exactly the framing the design v2 forbids. A per-process temp
+    dir outside the repo keeps the prompt bare. User-GLOBAL config
+    (~/.claude/CLAUDE.md etc.) may still load — that residue is part of what
+    measurement_tier=subscription_runtime_bare + the scorecard banner declare.
+    """
+    global _NEUTRAL_RUNTIME_CWD
+    if _NEUTRAL_RUNTIME_CWD is None or not _NEUTRAL_RUNTIME_CWD.exists():
+        _NEUTRAL_RUNTIME_CWD = Path(tempfile.mkdtemp(prefix="qg-bakeoff-bare-"))
+    return _NEUTRAL_RUNTIME_CWD
+
+
 def invoke_subscription_bare_route(
     route: llm_reviewer_dispatch.ReviewerRoute,
     prompt: str,
@@ -575,7 +603,7 @@ def invoke_subscription_bare_route(
             identity.runtime_agent or "",
             prompt,
             mode="read-only",
-            cwd=PROJECT_ROOT,
+            cwd=_neutral_runtime_cwd(),
             model=route.reviewer_model_id,
             task_id=task_id,
             session_id=None,
@@ -605,6 +633,10 @@ def invoke_subscription_bare_route(
             "cli_version": result.cli_version,
             "resolved_model": result.model,
             "returncode": result.returncode,
+            # Standing-rules firewall trail: bare cells run from an
+            # out-of-repo temp dir so project CLAUDE.md/AGENTS.md/GEMINI.md
+            # never reach the measured prompt.
+            "cwd_policy": "neutral-tmp",
         }
     )
     if result.rate_limited:

--- a/tests/audit/test_qg_bakeoff.py
+++ b/tests/audit/test_qg_bakeoff.py
@@ -1070,11 +1070,14 @@ def test_subscription_runtime_bare_invokes_agent_runtime_with_bare_claude_config
             "agent_name": "claude",
             "prompt": "bare prompt",
             "mode": "read-only",
-            "cwd": qg_bakeoff.PROJECT_ROOT,
+            "cwd": qg_bakeoff._neutral_runtime_cwd(),
             "model": qg_bakeoff.CLAUDE_SUBSCRIPTION_BARE_MODEL_ID,
             "task_id": "task-1",
             "session_id": None,
-            "tool_config": {"use_bare": True, "output_format": "stream-json"},
+            # use_bare=False is load-bearing: `claude --bare` bypasses the
+            # OAuth session and demands ANTHROPIC_API_KEY — on the
+            # subscription machine it fails "Not logged in" (2026-07-06 probe).
+            "tool_config": {"use_bare": False, "output_format": "stream-json"},
             "entrypoint": qg_bakeoff.BARE_RUNTIME_ENTRYPOINT,
             "hard_timeout": 1800,
             "stall_timeout": 600,
@@ -1082,6 +1085,52 @@ def test_subscription_runtime_bare_invokes_agent_runtime_with_bare_claude_config
     ]
     assert result.usage and result.usage["cli_version"] == "claude-code 2.2.0"
     assert result.usage["resolved_model"] == "claude-opus-resolved"
+    assert result.usage["cwd_policy"] == "neutral-tmp"
+
+
+def test_subscription_runtime_bare_cwd_is_outside_the_repo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Standing-rules firewall: bare cells must NEVER run from inside the repo.
+
+    Agent CLIs walk up from cwd to load CLAUDE.md / AGENTS.md / GEMINI.md —
+    a cwd under PROJECT_ROOT injects project standing rules into a
+    measurement that promises a bare prompt (caught live 2026-07-06: the
+    gpt/gemini cells ran with repo rules in context).
+    """
+    seen_cwds: list[Path] = []
+
+    def fake_invoke(agent_name: str, prompt: str, **kwargs: Any) -> SimpleNamespace:
+        seen_cwds.append(Path(kwargs["cwd"]))
+        return SimpleNamespace(
+            ok=True,
+            response=json.dumps({"fact_checks": []}),
+            rate_limited=False,
+            returncode=0,
+            stderr_excerpt=None,
+            usage_record={},
+            cli_version="x",
+            agent=agent_name,
+            model="m",
+            tool_calls=[],
+            tool_calls_total=0,
+        )
+
+    monkeypatch.setattr("scripts.agent_runtime.runner.invoke", fake_invoke)
+    for pin in (
+        qg_bakeoff.CLAUDE_SUBSCRIPTION_BARE_MODEL_ID,
+        qg_bakeoff.GPT_SUBSCRIPTION_BARE_MODEL_ID,
+        qg_bakeoff.GEMINI_SUBSCRIPTION_BARE_MODEL_ID,
+    ):
+        route = qg_bakeoff.route_for_matrix_pin(pin, arm=qg_bakeoff.BARE_ARM)
+        qg_bakeoff.invoke_subscription_bare_route(route, "bare prompt", f"task-{pin}")
+
+    assert len(seen_cwds) == 3
+    repo_root = qg_bakeoff.PROJECT_ROOT.resolve()
+    for cwd in seen_cwds:
+        resolved = cwd.resolve()
+        assert resolved != repo_root
+        assert not resolved.is_relative_to(repo_root)
 
 
 def test_subscription_runtime_bare_artifact_identity_and_filename(tmp_path: Path) -> None:


### PR DESCRIPTION
Two live-matrix defects the stubbed tests could not catch (both artifact-proven, addresses #4540):

1. **claude seat 4/4 transport-failed**: `--bare` bypasses the OAuth session and requires `ANTHROPIC_API_KEY` — on the subscription machine every cell died "Not logged in" (probe: `apiKeySource=none`, `error=authentication_failed`). The design-v2 H6 assumption (force `use_bare=True`) was inverted — the adapter's auto-decide had it right. Now `use_bare=False`: the subscription seat runs the standard `-p` path; the BARE in the measurement is the **prompt**, not the CLI harness.
2. **Standing-rules contamination**: all seats ran `cwd=PROJECT_ROOT` — agent CLIs walk up from cwd and load CLAUDE.md/AGENTS.md/GEMINI.md, injecting project rules (VESUM mandates etc.) into a bare-prompt measurement. New `_neutral_runtime_cwd()` (out-of-repo temp dir), `cwd_policy=neutral-tmp` recorded in artifacts, regression test asserting no bare cell ever runs under the repo root. The 8 gpt/gemini cells that "ran" pre-fix are contaminated and will be re-run.

Live-verified post-fix: claude vesnianky cell ran end-to-end from the neutral cwd (`status=ran`, mj=20, real verdicts, `cwd_policy=neutral-tmp` in artifact).

44/44 targeted tests green. After merge: delete the 12 pre-fix runtime artifacts, re-run the frontier bare matrix, `--rescore`, scorecard PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)