### PR TITLE
chore(atlas): #4571 pointer → first immutable versioned practice-deck asset

### DIFF
--- a/site/src/data/lexicon-practice-deck.pointer.json
+++ b/site/src/data/lexicon-practice-deck.pointer.json
@@ -1,404 +1,404 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck.json.gz",
-  "release_tag": "atlas-practice-deck",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-e73283406da45cb2.json.gz",
   "deck_version": "atlas-practice-v1-e73283406da45cb2",
-  "package_schema_version": 1,
-  "gz_sha256": "df06abc238c438fc5a91c6662af1050fc0cb51ce5929f28dad24f180d665ea20",
-  "package_sha256": "454731e0cf8fa87abc1af993d317a4480675700b2ec1e88e2834846a6bc9e86e",
-  "gz_bytes": 607318,
-  "package_bytes": 14410746,
   "file_count": 45,
   "files": [
     {
-      "path": "practice-index.A1.json",
+      "bytes": 318383,
+      "counts": {
+        "cloze": 22,
+        "clozeCoverage": 0.0191,
+        "clozeEligibleLexemes": 22,
+        "lexemes": 1150
+      },
       "kind": "index",
       "level": "A1",
+      "path": "practice-index.A1.json",
       "schema": "atlas-practice-index",
-      "bytes": 318383,
-      "sha256": "1336eb7b5d226519d0610904c29549f5b5e14d7c5f0ca3ace10d0a0bee2239c9",
-      "counts": {
-        "lexemes": 1150,
-        "cloze": 22,
-        "clozeEligibleLexemes": 22,
-        "clozeCoverage": 0.0191
-      }
+      "sha256": "1336eb7b5d226519d0610904c29549f5b5e14d7c5f0ca3ace10d0a0bee2239c9"
     },
     {
-      "path": "practice-lexemes.A1.json",
+      "bytes": 562939,
       "kind": "lexemes",
       "level": "A1",
+      "path": "practice-lexemes.A1.json",
       "schema": "atlas-practice-lexemes",
-      "bytes": 562939,
       "sha256": "c529a29b5db8b949fbf7ed82423e7fac9f6bffac539deeefc5d5cddcdf9e82d5"
     },
     {
-      "path": "practice-cloze.A1.json",
+      "bytes": 44922,
       "kind": "cloze",
       "level": "A1",
+      "path": "practice-cloze.A1.json",
       "schema": "atlas-practice-cloze",
-      "bytes": 44922,
       "sha256": "f363b95a2d9241615752216b4ffd833ceeb8da3ce0c8fe06e7d2a615889ae49a"
     },
     {
-      "path": "practice-stress.A1.json",
+      "bytes": 382927,
       "kind": "stress",
       "level": "A1",
+      "path": "practice-stress.A1.json",
       "schema": "atlas-practice-stress",
-      "bytes": 382927,
       "sha256": "4420c84332cfed6100c207844560b44b99be7f8fa807c5fc5ac112ad2963b273"
     },
     {
-      "path": "practice-classify.A1.json",
+      "bytes": 437057,
       "kind": "classify",
       "level": "A1",
+      "path": "practice-classify.A1.json",
       "schema": "atlas-practice-classify",
-      "bytes": 437057,
       "sha256": "e85f18f9abca5db86ce8042eabd7a43ff01e51a5e9490fb6251159485a17d613"
     },
     {
-      "path": "practice-paradigm.A1.json",
+      "bytes": 533851,
       "kind": "paradigm",
       "level": "A1",
+      "path": "practice-paradigm.A1.json",
       "schema": "atlas-practice-paradigm",
-      "bytes": 533851,
       "sha256": "5a1e2269988313552da3d7640e7f875c06e5d65f5ef5fd95daca98036f15e512"
     },
     {
-      "path": "practice-synonym.A1.json",
+      "bytes": 317,
       "kind": "synonym",
       "level": "A1",
+      "path": "practice-synonym.A1.json",
       "schema": "atlas-practice-synonym",
-      "bytes": 317,
       "sha256": "579a8ef1b805ecc24658fd40178a95787e743e98d42f9c0eeb2a22307e40f4f0"
     },
     {
-      "path": "practice-heritage.A1.json",
+      "bytes": 319,
       "kind": "heritage",
       "level": "A1",
+      "path": "practice-heritage.A1.json",
       "schema": "atlas-practice-heritage",
-      "bytes": 319,
       "sha256": "110f6418cf0d93676f45caf215df717db8ccf7b8cf5d082c3cba7ed43b650e9b"
     },
     {
-      "path": "practice-paronym.A1.json",
+      "bytes": 317,
       "kind": "paronym",
       "level": "A1",
+      "path": "practice-paronym.A1.json",
       "schema": "atlas-practice-paronym",
-      "bytes": 317,
       "sha256": "4c80ce8e514fc83719a35f02499d02fc2dcaea7c196a21e2a00048f02fa080c7"
     },
     {
-      "path": "practice-index.A2.json",
+      "bytes": 281496,
+      "counts": {
+        "cloze": 0,
+        "clozeCoverage": 0.0,
+        "clozeEligibleLexemes": 0,
+        "lexemes": 967
+      },
       "kind": "index",
       "level": "A2",
+      "path": "practice-index.A2.json",
       "schema": "atlas-practice-index",
-      "bytes": 281496,
-      "sha256": "2c499923a6287fe5f8ccb94939a4bc1ee7f4b52d97f399ff51290065f249fdd9",
-      "counts": {
-        "lexemes": 967,
-        "cloze": 0,
-        "clozeEligibleLexemes": 0,
-        "clozeCoverage": 0.0
-      }
+      "sha256": "2c499923a6287fe5f8ccb94939a4bc1ee7f4b52d97f399ff51290065f249fdd9"
     },
     {
-      "path": "practice-lexemes.A2.json",
+      "bytes": 474613,
       "kind": "lexemes",
       "level": "A2",
+      "path": "practice-lexemes.A2.json",
       "schema": "atlas-practice-lexemes",
-      "bytes": 474613,
       "sha256": "a40617e593223ec96d482f41f1e019ed760c43daf1153a45f5a76277145c738e"
     },
     {
-      "path": "practice-cloze.A2.json",
+      "bytes": 313,
       "kind": "cloze",
       "level": "A2",
+      "path": "practice-cloze.A2.json",
       "schema": "atlas-practice-cloze",
-      "bytes": 313,
       "sha256": "64d8472078f065e98cab8b9087cbb798e85942c5f91d24fd713c7761af3a30b7"
     },
     {
-      "path": "practice-stress.A2.json",
+      "bytes": 395787,
       "kind": "stress",
       "level": "A2",
+      "path": "practice-stress.A2.json",
       "schema": "atlas-practice-stress",
-      "bytes": 395787,
       "sha256": "61a149a1e4243ba96f966a3fc8f514ce6a465a5f8fc442798c7093d6419c4d8e"
     },
     {
-      "path": "practice-classify.A2.json",
+      "bytes": 1121136,
       "kind": "classify",
       "level": "A2",
+      "path": "practice-classify.A2.json",
       "schema": "atlas-practice-classify",
-      "bytes": 1121136,
       "sha256": "acf25389512b16e92b3ea5275e75faddd73431308569a57c7c1d9220c790f630"
     },
     {
-      "path": "practice-paradigm.A2.json",
+      "bytes": 420424,
       "kind": "paradigm",
       "level": "A2",
+      "path": "practice-paradigm.A2.json",
       "schema": "atlas-practice-paradigm",
-      "bytes": 420424,
       "sha256": "b82777e07dff7ee5540676d0023031ebbbd7418fe322427aad38de56c32ca1e0"
     },
     {
-      "path": "practice-synonym.A2.json",
+      "bytes": 317,
       "kind": "synonym",
       "level": "A2",
+      "path": "practice-synonym.A2.json",
       "schema": "atlas-practice-synonym",
-      "bytes": 317,
       "sha256": "a01c52164ab0bb34a03ea00889a86eac49831461441180ed89121a927dee9440"
     },
     {
-      "path": "practice-heritage.A2.json",
+      "bytes": 319,
       "kind": "heritage",
       "level": "A2",
+      "path": "practice-heritage.A2.json",
       "schema": "atlas-practice-heritage",
-      "bytes": 319,
       "sha256": "1e1f663ab09477c577e5cb8db4569abdd0c5e1a74eb419fb4b4a440cd9754d5b"
     },
     {
-      "path": "practice-paronym.A2.json",
+      "bytes": 317,
       "kind": "paronym",
       "level": "A2",
+      "path": "practice-paronym.A2.json",
       "schema": "atlas-practice-paronym",
-      "bytes": 317,
       "sha256": "68aed49eacd561fb63ce42d2e52fc94ea7a1ddedf58c31de89b36abbba856aad"
     },
     {
-      "path": "practice-index.B1.json",
+      "bytes": 434504,
+      "counts": {
+        "cloze": 0,
+        "clozeCoverage": 0.0,
+        "clozeEligibleLexemes": 0,
+        "lexemes": 1485
+      },
       "kind": "index",
       "level": "B1",
+      "path": "practice-index.B1.json",
       "schema": "atlas-practice-index",
-      "bytes": 434504,
-      "sha256": "aaaab72f864127d5237232e8f23cbd9505f13ab7cf2f02aabdd3ca06e70dac03",
-      "counts": {
-        "lexemes": 1485,
-        "cloze": 0,
-        "clozeEligibleLexemes": 0,
-        "clozeCoverage": 0.0
-      }
+      "sha256": "aaaab72f864127d5237232e8f23cbd9505f13ab7cf2f02aabdd3ca06e70dac03"
     },
     {
-      "path": "practice-lexemes.B1.json",
+      "bytes": 748382,
       "kind": "lexemes",
       "level": "B1",
+      "path": "practice-lexemes.B1.json",
       "schema": "atlas-practice-lexemes",
-      "bytes": 748382,
       "sha256": "cb96913244fd066e5a853c264876662803cfce0243a9e20e31fd5db8e38c98d6"
     },
     {
-      "path": "practice-cloze.B1.json",
+      "bytes": 313,
       "kind": "cloze",
       "level": "B1",
+      "path": "practice-cloze.B1.json",
       "schema": "atlas-practice-cloze",
-      "bytes": 313,
       "sha256": "62d8110278845efb0eea456b852e20ff2881d0f431896d43b8fdc2dec824f6d6"
     },
     {
-      "path": "practice-stress.B1.json",
+      "bytes": 447184,
       "kind": "stress",
       "level": "B1",
+      "path": "practice-stress.B1.json",
       "schema": "atlas-practice-stress",
-      "bytes": 447184,
       "sha256": "6a7b54783de1c5095721ee9abeb2cfe50ef93a0dfa5e263c95c5995b3a7be209"
     },
     {
-      "path": "practice-classify.B1.json",
+      "bytes": 1449662,
       "kind": "classify",
       "level": "B1",
+      "path": "practice-classify.B1.json",
       "schema": "atlas-practice-classify",
-      "bytes": 1449662,
       "sha256": "646c20785b606ac4caf0f8234a2d562f6216d702ad725f76f44517b2261b65f5"
     },
     {
-      "path": "practice-paradigm.B1.json",
+      "bytes": 583013,
       "kind": "paradigm",
       "level": "B1",
+      "path": "practice-paradigm.B1.json",
       "schema": "atlas-practice-paradigm",
-      "bytes": 583013,
       "sha256": "07f06503063b33bca0016285f91e9d99ffde34dfad79f21eaaff8fc9249613e4"
     },
     {
-      "path": "practice-synonym.B1.json",
+      "bytes": 222118,
       "kind": "synonym",
       "level": "B1",
+      "path": "practice-synonym.B1.json",
       "schema": "atlas-practice-synonym",
-      "bytes": 222118,
       "sha256": "98e243fa33cba480689c0b4cdd64d4c1a8fdcad676c4c96919f88feb26102e7b"
     },
     {
-      "path": "practice-heritage.B1.json",
+      "bytes": 319,
       "kind": "heritage",
       "level": "B1",
+      "path": "practice-heritage.B1.json",
       "schema": "atlas-practice-heritage",
-      "bytes": 319,
       "sha256": "31de256bb59385b755cb578ef937cfb055b52a9e5dca9e5f23ff43ac8cb13388"
     },
     {
-      "path": "practice-paronym.B1.json",
+      "bytes": 317,
       "kind": "paronym",
       "level": "B1",
+      "path": "practice-paronym.B1.json",
       "schema": "atlas-practice-paronym",
-      "bytes": 317,
       "sha256": "103b0971bd37602c20deb270b08d25f70d18d6c5cd6325983028253e941a01b2"
     },
     {
-      "path": "practice-index.B2.json",
+      "bytes": 254520,
+      "counts": {
+        "cloze": 0,
+        "clozeCoverage": 0.0,
+        "clozeEligibleLexemes": 0,
+        "lexemes": 853
+      },
       "kind": "index",
       "level": "B2",
+      "path": "practice-index.B2.json",
       "schema": "atlas-practice-index",
-      "bytes": 254520,
-      "sha256": "56e02e67e4eee654593a1607be095a1fcd177cd5849542481d08bf634c5e5d85",
-      "counts": {
-        "lexemes": 853,
-        "cloze": 0,
-        "clozeEligibleLexemes": 0,
-        "clozeCoverage": 0.0
-      }
+      "sha256": "56e02e67e4eee654593a1607be095a1fcd177cd5849542481d08bf634c5e5d85"
     },
     {
-      "path": "practice-lexemes.B2.json",
+      "bytes": 443931,
       "kind": "lexemes",
       "level": "B2",
+      "path": "practice-lexemes.B2.json",
       "schema": "atlas-practice-lexemes",
-      "bytes": 443931,
       "sha256": "8ea88edb0b443774e7e387d68f04940a533bd252024a4e810c122e5f3e8ddc67"
     },
     {
-      "path": "practice-cloze.B2.json",
+      "bytes": 313,
       "kind": "cloze",
       "level": "B2",
+      "path": "practice-cloze.B2.json",
       "schema": "atlas-practice-cloze",
-      "bytes": 313,
       "sha256": "6a869af2b9fa972ab35da1f18e917a705cbd7c0992a837c87be472613a54bc0f"
     },
     {
-      "path": "practice-stress.B2.json",
+      "bytes": 301091,
       "kind": "stress",
       "level": "B2",
+      "path": "practice-stress.B2.json",
       "schema": "atlas-practice-stress",
-      "bytes": 301091,
       "sha256": "c161ba2c3c08c7c730b90e8c0cd59853515165a1b5c102f1769d66d3f1547a9a"
     },
     {
-      "path": "practice-classify.B2.json",
+      "bytes": 901024,
       "kind": "classify",
       "level": "B2",
+      "path": "practice-classify.B2.json",
       "schema": "atlas-practice-classify",
-      "bytes": 901024,
       "sha256": "6e76af262ac982841a9e9e67eb1d4774581cef013d2fe29a781807422ef63c66"
     },
     {
-      "path": "practice-paradigm.B2.json",
+      "bytes": 400063,
       "kind": "paradigm",
       "level": "B2",
+      "path": "practice-paradigm.B2.json",
       "schema": "atlas-practice-paradigm",
-      "bytes": 400063,
       "sha256": "391581a72e28957ebe5895f8c11d3554db5039cfe171fefa2647ad9937a20dc7"
     },
     {
-      "path": "practice-synonym.B2.json",
+      "bytes": 80470,
       "kind": "synonym",
       "level": "B2",
+      "path": "practice-synonym.B2.json",
       "schema": "atlas-practice-synonym",
-      "bytes": 80470,
       "sha256": "c8b930b89b9cd70871708bf288cba4190ac99cc98a6f181a7e47183fb227ca4a"
     },
     {
-      "path": "practice-heritage.B2.json",
+      "bytes": 319,
       "kind": "heritage",
       "level": "B2",
+      "path": "practice-heritage.B2.json",
       "schema": "atlas-practice-heritage",
-      "bytes": 319,
       "sha256": "f3175eb169b33cbe865adae223d4a2e7bd98e2f9fbac4e2365db90bd1e4d7529"
     },
     {
-      "path": "practice-paronym.B2.json",
+      "bytes": 317,
       "kind": "paronym",
       "level": "B2",
+      "path": "practice-paronym.B2.json",
       "schema": "atlas-practice-paronym",
-      "bytes": 317,
       "sha256": "b457d05d0d6124424db77fe1977d965d6d6c7b30bc34b57c7d193740922ab46c"
     },
     {
-      "path": "practice-index.C1.json",
+      "bytes": 122018,
+      "counts": {
+        "cloze": 0,
+        "clozeCoverage": 0.0,
+        "clozeEligibleLexemes": 0,
+        "lexemes": 403
+      },
       "kind": "index",
       "level": "C1",
+      "path": "practice-index.C1.json",
       "schema": "atlas-practice-index",
-      "bytes": 122018,
-      "sha256": "f4547994ca221e649a67e453b4038123d7c4aced9ab5084799f4a088d964e782",
-      "counts": {
-        "lexemes": 403,
-        "cloze": 0,
-        "clozeEligibleLexemes": 0,
-        "clozeCoverage": 0.0
-      }
+      "sha256": "f4547994ca221e649a67e453b4038123d7c4aced9ab5084799f4a088d964e782"
     },
     {
-      "path": "practice-lexemes.C1.json",
+      "bytes": 229361,
       "kind": "lexemes",
       "level": "C1",
+      "path": "practice-lexemes.C1.json",
       "schema": "atlas-practice-lexemes",
-      "bytes": 229361,
       "sha256": "ee377f032c541ea6d4f434046e5f0e6b44b267577e591fde121d4dfccad23ed6"
     },
     {
-      "path": "practice-cloze.C1.json",
+      "bytes": 313,
       "kind": "cloze",
       "level": "C1",
+      "path": "practice-cloze.C1.json",
       "schema": "atlas-practice-cloze",
-      "bytes": 313,
       "sha256": "0874bf1acf147e21550574b8017df3d7835acb96635ef23757497b3ecff8a104"
     },
     {
-      "path": "practice-stress.C1.json",
+      "bytes": 200434,
       "kind": "stress",
       "level": "C1",
+      "path": "practice-stress.C1.json",
       "schema": "atlas-practice-stress",
-      "bytes": 200434,
       "sha256": "f917c48b680b55d84e12a65a66fd30d94a15b91c9e531f8bcd7476bb73a07a1f"
     },
     {
-      "path": "practice-classify.C1.json",
+      "bytes": 585487,
       "kind": "classify",
       "level": "C1",
+      "path": "practice-classify.C1.json",
       "schema": "atlas-practice-classify",
-      "bytes": 585487,
       "sha256": "e66ea6d4a602e63f2a839d18870e039fbf0ee0c6958cb61d7a250d88575f1d59"
     },
     {
-      "path": "practice-paradigm.C1.json",
+      "bytes": 342080,
       "kind": "paradigm",
       "level": "C1",
+      "path": "practice-paradigm.C1.json",
       "schema": "atlas-practice-paradigm",
-      "bytes": 342080,
       "sha256": "46b461a2a4e107797e49c5dd793fe1c85f424377e21c88766bc1e34788782315"
     },
     {
-      "path": "practice-synonym.C1.json",
+      "bytes": 29287,
       "kind": "synonym",
       "level": "C1",
+      "path": "practice-synonym.C1.json",
       "schema": "atlas-practice-synonym",
-      "bytes": 29287,
       "sha256": "ed1892e9977bac02a3d1ec3d7a2842733692f65462e32e059d8836d69f51e432"
     },
     {
-      "path": "practice-heritage.C1.json",
+      "bytes": 319,
       "kind": "heritage",
       "level": "C1",
+      "path": "practice-heritage.C1.json",
       "schema": "atlas-practice-heritage",
-      "bytes": 319,
       "sha256": "524aef220f53f0c7ee07e3b1021c152e72e96dcc3d1ab85883ecb75ed7222811"
     },
     {
-      "path": "practice-paronym.C1.json",
+      "bytes": 317,
       "kind": "paronym",
       "level": "C1",
+      "path": "practice-paronym.C1.json",
       "schema": "atlas-practice-paronym",
-      "bytes": 317,
       "sha256": "889dddeefdb3fc5623b1bd22a930567cedf8ee53f94378807cee76c3e24a2142"
     }
   ],
-  "note": "Pins GitHub Release asset practice deck for #3796; hydrate it build/test time instead of committing shards."
+  "gz_bytes": 607318,
+  "gz_sha256": "df06abc238c438fc5a91c6662af1050fc0cb51ce5929f28dad24f180d665ea20",
+  "note": "Pins GitHub Release asset practice deck for #3796; hydrate it build/test time instead of committing shards.",
+  "package_bytes": 14410746,
+  "package_schema_version": 1,
+  "package_sha256": "454731e0cf8fa87abc1af993d317a4480675700b2ec1e88e2834846a6bc9e86e",
+  "release_tag": "atlas-practice-deck"
 }


### PR DESCRIPTION
Post-#4575 driver step: first real versioned publish, every step live-verified (canonical sha == pointer; immutable upload clobber=False; live versioned bytes byte-identical). Pointer now pins the content-addressed asset. Closes #4571. Frontend CI (hydrate against the versioned URL) is the end-to-end verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)