### PR TITLE
feat(agent-runtime): first #4501 failover chain (deepseek lane) + hermes fault-detection fixes

### DIFF
--- a/scripts/agent_runtime/adapters/hermes_common.py
+++ b/scripts/agent_runtime/adapters/hermes_common.py
@@ -56,6 +56,14 @@ _FALLBACK_EMPTY_LOG_RE = re.compile(
     r"(?P<actual_model>\S+)\s+on\s+(?P<actual_provider>\S+)",
     re.IGNORECASE,
 )
+# Hermes surfaces provider API failures as the FINAL assistant message on
+# stdout with returncode 0, formatted "HTTP {status}: {message}" or
+# "HTTP {status} — {title} — Ray {id}" (hermes-agent run_agent.py
+# _describe_api_error paths). Such a line is a failed invocation, not
+# content: without detection it parses ok=True, ships the error string as
+# the response, and the runner failover classifier never runs (probe
+# finding 2026-07-06, forced 401 → route 0 reported "ok").
+_INBAND_HTTP_ERROR_RE = re.compile(r"^HTTP\s+(?P<status>[45]\d{2})\b")
 HERMES_SUBSTITUTION_MARKER = "HERMES_FALLBACK_SUBSTITUTION"
 HERMES_GLM_FORBIDDEN_MARKER = "HERMES_GLM_FORBIDDEN"
 
@@ -429,6 +437,23 @@ def hermes_glm_guard_error(substitution: dict[str, Any] | None) -> str | None:
     )
 
 
+def _inband_provider_error(response: str) -> tuple[str, str] | None:
+    """Return ``(error_line, status)`` when stdout is an in-band HTTP error.
+
+    Deliberately conservative to avoid eating legitimate content: the whole
+    stripped response must be ONE line, at most 600 chars (hermes truncates
+    the provider message to ≤500), and start with ``HTTP 4xx``/``HTTP 5xx``.
+    A multi-line answer that merely discusses an HTTP status stays ok=True.
+    """
+    candidate = response.strip()
+    if not candidate or "\n" in candidate or len(candidate) > 600:
+        return None
+    match = _INBAND_HTTP_ERROR_RE.match(candidate)
+    if match is None:
+        return None
+    return candidate, match.group("status")
+
+
 def build_hermes_parse_fields(
     *,
     stdout: str,
@@ -455,6 +480,17 @@ def build_hermes_parse_fields(
             response="",
             stderr_excerpt=guard_error[:500],
             rate_limited=False,
+            substitution=substitution,
+        )
+
+    inband_error = _inband_provider_error(response) if returncode == 0 else None
+    if inband_error is not None:
+        error_text, status = inband_error
+        return HermesParseFields(
+            ok=False,
+            response="",
+            stderr_excerpt=error_text[:500],
+            rate_limited=rate_limited or status == "429",
             substitution=substitution,
         )
 

--- a/scripts/agent_runtime/adapters/hermes_common.py
+++ b/scripts/agent_runtime/adapters/hermes_common.py
@@ -483,7 +483,10 @@ def build_hermes_parse_fields(
             substitution=substitution,
         )
 
-    inband_error = _inband_provider_error(response) if returncode == 0 else None
+    # Not gated on returncode: the shape constraints are conservative on
+    # their own, and hermes pairing the stdout error line with a nonzero
+    # exit must not bypass detection (review D1, PR #4580).
+    inband_error = _inband_provider_error(response)
     if inband_error is not None:
         error_text, status = inband_error
         return HermesParseFields(

--- a/scripts/agent_runtime/failover.py
+++ b/scripts/agent_runtime/failover.py
@@ -31,9 +31,16 @@ _RATE_LIMIT_RE = re.compile(
     r"resource_exhausted|\bHTTP 429\b|\bstatus 429\b|\b429\b",
     re.IGNORECASE,
 )
+# Credential-absence phrasings included: hermes refuses to start a provider
+# whose key is missing/disabled with "Provider '<name>' is set in config.yaml
+# but no API key was found ..." (live-captured 2026-07-06). Rotating to the
+# next route on a dead credential is the point of the chain, so these
+# classify as auth.
 _AUTH_RE = re.compile(
     r"\b(?:401|403)\b|unauthorized|forbidden|invalid api key|"
-    r"authentication failed|auth(?:orization)? failed",
+    r"authentication failed|auth(?:orization)? failed|"
+    r"no api key(?: was)? (?:found|set|configured)|missing api key|"
+    r"no credentials? (?:found|set|configured|available)",
     re.IGNORECASE,
 )
 _OVERLOADED_RE = re.compile(

--- a/scripts/agent_runtime/failover.py
+++ b/scripts/agent_runtime/failover.py
@@ -35,7 +35,10 @@ _RATE_LIMIT_RE = re.compile(
 # whose key is missing/disabled with "Provider '<name>' is set in config.yaml
 # but no API key was found ..." (live-captured 2026-07-06). Rotating to the
 # next route on a dead credential is the point of the chain, so these
-# classify as auth.
+# classify as auth. Judgment call: the phrasings are broad enough that a
+# provider passing through a verbose downstream error body could false-match;
+# accepted because the classifier only ever sees text from an already-failed
+# attempt, so the cost of a false positive is one extra route rotation.
 _AUTH_RE = re.compile(
     r"\b(?:401|403)\b|unauthorized|forbidden|invalid api key|"
     r"authentication failed|auth(?:orization)? failed|"
@@ -183,6 +186,17 @@ def load_failover_chain(
         profile_raw = raw_route.get("profile")
         profile = str(profile_raw).strip() if profile_raw is not None else None
         if not provider or not model:
+            # Fail-safe by design (malformed config must never break
+            # dispatches), but LOUD: a dropped route can silently disable
+            # the whole chain via the len<2 check below (review D4,
+            # PR #4580). Only route 0 may omit model (inherits request).
+            logging.getLogger(__name__).warning(
+                "runner failover chain %s[%d] dropped: missing %s "
+                "(routes after index 0 must set an explicit model)",
+                agent_name,
+                index,
+                "provider" if not provider else "model",
+            )
             continue
         if is_forbidden_glm_route(provider, model):
             raise ValueError(

--- a/scripts/config/agent_runtime_failover.yaml
+++ b/scripts/config/agent_runtime_failover.yaml
@@ -1,22 +1,49 @@
 # Runner-level agent provider failover chains.
 #
-# Default is intentionally empty: absent lane chain means runner.invoke() keeps
-# its previous single-route behavior exactly. Populate per-lane chains only for
-# adapters that can express the requested route via model/provider override.
+# An absent lane chain means runner.invoke() keeps its previous single-route
+# behavior exactly. Populate per-lane chains only for adapters that can
+# express the requested route via model/provider override.
 #
 # Shape:
 # chains:
-#   deepseek:
+#   <lane>:
 #     cooldown_ttl_s: 300
 #     routes:
-#       - provider: deepseek
-#         model: deepseek-v4-pro
-#       - provider: openrouter
-#         model: qwen/qwen3.6-plus
+#       - provider: <primary>     # model omitted on route 0 = inherit the
+#       - provider: <fallback>    #   dispatch-requested model
+#         model: <provider-scoped model slug>
+#
+# Rules:
+# - Keep fallback routes in the SAME model family as the lane. Reviewer-seat
+#   independence and per-task routing assume the family
+#   (agents_extensions/shared/rules/model-assignment.md). qwen is
+#   cost-excluded as a fallback target; zai/GLM is rejected at chain load
+#   (LOCAL-ONLY guard).
+# - Failovers are never silent: the runner emits the
+#   AGENT_RUNTIME_FAILOVER_SUBSTITUTION marker and persists the substitution
+#   in the usage record + telemetry event.
+# - After editing a chain, re-validate with a live forced-failure probe
+#   (scripts/agent_runtime/probe_fallback.py) against an isolated
+#   HERMES_HOME, with AGENT_RUNTIME_FAILOVER_CONFIG and
+#   AGENT_RUNTIME_FAILOVER_COOLDOWN_DB pointed at throwaway copies — never
+#   the live cooldown DB.
 #
 # v1 coverage:
 # - Hermes-backed lanes (deepseek, qwen, grok): provider + model override.
 # - agy: model override; provider is informational unless encoded by the CLI
 #   model label.
 # - Other adapters: chain only if their existing model flag can express it.
-chains: {}
+chains:
+  deepseek:
+    cooldown_ttl_s: 300
+    routes:
+      # Primary: native DeepSeek API. Model inherits the dispatch request
+      # (deepseek-v4-pro content/review, deepseek-v4-flash code review).
+      - provider: deepseek
+      # Same-family fallbacks via OpenRouter (slugs verified against the
+      # live OpenRouter catalog 2026-07-06). Pro before flash: quality over
+      # cost on the degraded path.
+      - provider: openrouter
+        model: deepseek/deepseek-v4-pro
+      - provider: openrouter
+        model: deepseek/deepseek-v4-flash

--- a/tests/agent_runtime/adapters/test_hermes_deepseek_adapter.py
+++ b/tests/agent_runtime/adapters/test_hermes_deepseek_adapter.py
@@ -243,3 +243,76 @@ def test_registry_lists_deepseek_with_hermes_adapter():
     assert entry["default_model"] == "deepseek-v4-pro"
     assert entry["adapter"].endswith(":HermesDeepSeekAdapter")
     assert entry["resume_policy"] == "never"
+
+
+def test_deepseek_adapter_inband_http_error_is_not_ok():
+    """Hermes surfaces provider failures as final stdout with returncode 0.
+
+    Live-probed 2026-07-06: a forced bad key yields stdout
+    "HTTP 401: Authentication Fails, ..." and rc=0. That is a failed
+    invocation — never content — and the error must land in stderr_excerpt
+    so the runner failover classifier can route it.
+    """
+    result = HermesDeepSeekAdapter().parse_response(
+        stdout="HTTP 401: Authentication Fails, Your api key: ****robe is invalid",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is False
+    assert result.response == ""
+    assert "HTTP 401" in (result.stderr_excerpt or "")
+    assert result.rate_limited is False
+
+
+def test_deepseek_adapter_inband_429_sets_rate_limited():
+    result = HermesDeepSeekAdapter().parse_response(
+        stdout="HTTP 429: Too Many Requests",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is False
+    assert result.rate_limited is True
+
+
+def test_deepseek_adapter_inband_5xx_is_not_ok():
+    result = HermesDeepSeekAdapter().parse_response(
+        stdout="HTTP 503 — Service Unavailable — Ray 8c1a2b3d4e5f6789",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is False
+    assert "HTTP 503" in (result.stderr_excerpt or "")
+
+
+def test_deepseek_adapter_multiline_response_mentioning_http_error_stays_ok():
+    """Legit content that merely discusses an HTTP status must not be eaten."""
+    stdout = (
+        "HTTP 401 means the request lacked valid credentials.\n"
+        "Use www-authenticate to negotiate the scheme."
+    )
+    result = HermesDeepSeekAdapter().parse_response(
+        stdout=stdout,
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is True
+    assert result.response == stdout
+
+
+def test_deepseek_adapter_single_line_non_error_response_stays_ok():
+    result = HermesDeepSeekAdapter().parse_response(
+        stdout="Verdict: HTTP 404 handling in routes.py is correct.",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is True

--- a/tests/agent_runtime/adapters/test_hermes_deepseek_adapter.py
+++ b/tests/agent_runtime/adapters/test_hermes_deepseek_adapter.py
@@ -316,3 +316,43 @@ def test_deepseek_adapter_single_line_non_error_response_stays_ok():
     )
 
     assert result.ok is True
+
+
+def test_deepseek_adapter_inband_error_detected_on_nonzero_returncode():
+    """Detection must not depend on returncode (review D1, PR #4580)."""
+    result = HermesDeepSeekAdapter().parse_response(
+        stdout="HTTP 401: Authentication Fails, Your api key: ****robe is invalid",
+        stderr="",
+        returncode=1,
+        output_file=None,
+    )
+
+    assert result.ok is False
+    assert "HTTP 401" in (result.stderr_excerpt or "")
+
+
+def test_deepseek_adapter_inband_ansi_wrapped_error_is_detected():
+    """strip_ansi runs before detection — a colorized error line still fails."""
+    result = HermesDeepSeekAdapter().parse_response(
+        stdout="\x1b[31mHTTP 401: Authentication Fails\x1b[0m",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is False
+    assert "HTTP 401" in (result.stderr_excerpt or "")
+
+
+def test_deepseek_adapter_inband_400_parses_as_failure():
+    """A 400 is still a failed invocation (never content) even though the
+    failover classifier deliberately refuses to rotate on it."""
+    result = HermesDeepSeekAdapter().parse_response(
+        stdout="HTTP 400: Invalid request: unknown parameter 'foo'",
+        stderr="",
+        returncode=0,
+        output_file=None,
+    )
+
+    assert result.ok is False
+    assert "HTTP 400" in (result.stderr_excerpt or "")

--- a/tests/agent_runtime/test_runner_failover.py
+++ b/tests/agent_runtime/test_runner_failover.py
@@ -471,3 +471,49 @@ def test_classifier_routes_inband_http_401_stdout_to_auth():
     )
 
     assert trigger == "auth"
+
+
+def test_classifier_refuses_to_rotate_on_inband_400():
+    """Review D2 (PR #4580): a request-format error would fail identically on
+    every route — the gate must return None so the chain is not burned."""
+    from agent_runtime.failover import classify_failover_trigger
+
+    trigger = classify_failover_trigger(
+        parse=ParseResult(
+            ok=False,
+            response="",
+            stderr_excerpt="HTTP 400: Invalid request: unknown parameter 'foo'",
+        ),
+        returncode=0,
+        kill_reason=None,
+        stdout_text="",
+        stderr_text="",
+    )
+
+    assert trigger is None
+
+
+def test_chain_route_missing_model_after_index_zero_warns_and_drops(
+    tmp_path, caplog
+):
+    """Review D4 (PR #4580): fail-safe stays (no raise), but loudly."""
+    import logging
+
+    from agent_runtime.failover import load_failover_chain
+
+    config = tmp_path / "failover.yaml"
+    config.write_text(
+        "chains:\n"
+        "  deepseek:\n"
+        "    routes:\n"
+        "      - provider: deepseek\n"
+        "      - provider: openrouter\n",  # missing model -> dropped
+        encoding="utf-8",
+    )
+    with caplog.at_level(logging.WARNING):
+        chain = load_failover_chain(
+            "deepseek", effective_model="deepseek-v4-pro", path=config
+        )
+
+    assert chain is None  # single usable route -> feature disabled
+    assert any("deepseek[1] dropped" in rec.getMessage() for rec in caplog.records)

--- a/tests/agent_runtime/test_runner_failover.py
+++ b/tests/agent_runtime/test_runner_failover.py
@@ -397,3 +397,77 @@ def test_runner_failover_rejects_forbidden_glm_target(tmp_path, monkeypatch):
 
     with pytest.raises(ValueError, match="HERMES_GLM_FORBIDDEN"):
         runner_mod.invoke("failover-test", "hello", mode="read-only", cwd=tmp_path)
+
+
+def test_shipped_deepseek_chain_is_deepseek_family_only():
+    """Pin the shipped config: deepseek lane fails over inside its own family.
+
+    Guards the two banned drift directions for fallback targets: qwen
+    (cost-excluded) and zai/GLM (LOCAL-ONLY; the loader raises on it anyway).
+    Route 0 must inherit the dispatch-requested model so both pro and flash
+    dispatches keep their primary identity.
+    """
+    from agent_runtime.failover import (
+        default_failover_config_path,
+        load_failover_chain,
+    )
+
+    chain = load_failover_chain(
+        "deepseek",
+        effective_model="deepseek-v4-flash",
+        path=default_failover_config_path(),
+    )
+
+    assert chain is not None, "shipped config must define the deepseek chain"
+    assert [route.provider for route in chain.routes] == [
+        "deepseek",
+        "openrouter",
+        "openrouter",
+    ]
+    assert chain.routes[0].model == "deepseek-v4-flash"
+    for route in chain.routes[1:]:
+        assert route.model.startswith("deepseek/"), (
+            f"fallback route {route.index} left the deepseek family: "
+            f"{route.provider}/{route.model}"
+        )
+    assert chain.cooldown_ttl_s == 300
+
+
+def test_classifier_routes_hermes_credential_startup_failure_to_auth():
+    """Live-captured 2026-07-06: a dead/missing credential fails hermes at
+    startup with prose that previously matched NO trigger class, so the chain
+    never rotated. Credential rotation is the point — must classify as auth."""
+    from agent_runtime.failover import classify_failover_trigger
+
+    stderr = (
+        "hermes -z: agent failed: Provider 'deepseek' is set in config.yaml "
+        "but no API key was found. Set the DEEPSEEK_API_KEY environment "
+        "variable, or switch to a different provider with `hermes model`."
+    )
+    trigger = classify_failover_trigger(
+        parse=ParseResult(ok=False, response="", stderr_excerpt=stderr[:500]),
+        returncode=1,
+        kill_reason=None,
+        stdout_text="",
+        stderr_text=stderr,
+    )
+
+    assert trigger == "auth"
+
+
+def test_classifier_routes_inband_http_401_stdout_to_auth():
+    """Companion to the hermes_common in-band fix: once parse marks the
+    single-line 'HTTP 401: ...' stdout as not-ok, the classifier must see
+    auth in the excerpt."""
+    from agent_runtime.failover import classify_failover_trigger
+
+    excerpt = "HTTP 401: Authentication Fails, Your api key: ****robe is invalid"
+    trigger = classify_failover_trigger(
+        parse=ParseResult(ok=False, response="", stderr_excerpt=excerpt),
+        returncode=0,
+        kill_reason=None,
+        stdout_text="",
+        stderr_text="",
+    )
+
+    assert trigger == "auth"


### PR DESCRIPTION
## What

Populates the first runner-level failover chain (#4501 follow-up) and fixes two live-probed fault-detection gaps that made ANY hermes-lane chain untriggerable.

### 1. Chain population — `scripts/config/agent_runtime_failover.yaml`
- `deepseek` lane: native deepseek (route 0 inherits the dispatch-requested model) → `openrouter deepseek/deepseek-v4-pro` → `openrouter deepseek/deepseek-v4-flash` (slugs verified against the live OpenRouter catalog 2026-07-06).
- Fixes the YAML example nit: the old sample taught a **qwen** fallback target (cost-excluded). Family-purity rules now documented in the header; zai/GLM already rejected at chain load.
- Pin-test loads the shipped config: chain shape, route-0 model inheritance, deepseek-family-only fallbacks.

### 2. Hermes in-band HTTP errors parsed as success (bug, all 3 hermes lanes)
hermes surfaces provider API failures as the **final assistant message on stdout with rc=0** (`HTTP 401: Authentication Fails, ...` — hermes-agent `run_agent.py` `_describe_api_error`). `build_hermes_parse_fields` marked these `ok=True`: the error string shipped as dispatch *content* and the failover classifier never ran. Now a single-line `HTTP 4xx/5xx`-prefixed stdout parses `ok=False` with the error in `stderr_excerpt` (429 also sets `rate_limited`). Conservative shape — one line, ≤600 chars, anchored prefix — so legit content discussing HTTP statuses is untouched. Note this bug also affected **non-failover** dispatches: an in-band 401/429/5xx was previously recorded `outcome=ok` with the error text as the deliverable.

### 3. Dead-credential startup failures matched no trigger class (bug)
`hermes -z: agent failed: Provider 'deepseek' is set in config.yaml but no API key was found...` classified as **None** → chain never rotated credentials, though credential rotation is a headline #4497 use-case. `_AUTH_RE` now covers credential-absence phrasings; the live-captured string is pinned in tests.

## Live forced-failure validation (probe methodology)

Isolated `HERMES_HOME` + isolated cooldown DB + deliberately dead deepseek credential, real invocations through `scripts/agent_runtime/probe_fallback.py`:

- **Run 1** — route 0 auth failure → cooldown recorded (isolated DB only; default path untouched) → rotated to `openrouter/deepseek/deepseek-v4-pro` → `ok=true`, substitution surfaced in stderr marker + result + usage record + telemetry event (`source=agent-runtime-failover:auth`).
- **Run 2** — cooling route skipped, direct fallback routing (`source=agent-runtime-failover:cooldown`).
- Probe home deleted after (holds credential copies).

## Tests

- `tests/agent_runtime/` + delegate suites: **237 passed** locally.
- New: 5 in-band-error parse tests (401/429/5xx/two false-positive guards), 2 classifier tests pinning both live-captured fault strings, 1 shipped-config pin test.

## Notes

- No live behavior change until merge: the runtime reads this config from the main checkout, where `chains: {}` until now.
- Routing note: fixes authored inline by the orchestrator (small, root-cause, discovered mid-validation); cross-family review requested via the deepseek lane.

Closes the 'populate first chain' item from #4501/#4497.

🤖 Generated with [Claude Code](https://claude.com/claude-code)