### PR TITLE
feat(audit): #4540 live frontier bare rows — scorecard + evidence + rescore filter

### DIFF
--- a/audit/2026-07-05-qg-bakeoff/SCORECARD.md
+++ b/audit/2026-07-05-qg-bakeoff/SCORECARD.md
@@ -1,48 +1,49 @@
 # QG Bakeoff Scorecard
 
-Generated: 2026-07-05T22:29:21.234824Z
+Generated: 2026-07-06T13:53:19.182499Z
 
 Fractions are exact. `low-N` marks denominators below 10.
 
+
 ## Runs
 
-| model | passage | arm | model judgment | live admissible | missing | U honesty | M alignment | true unsupported | invalid | inadmissible | tools | wall_s |
-| --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: |
-| openrouter/deepseek/deepseek-v4-flash | koliadky | bare | 40 | 40 | 2 | 1/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 37.915 |
-| openrouter/deepseek/deepseek-v4-flash | koliadky | tooled | 30 | 30 | 5 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 8 | 0 | 35 | 238.279 |
-| openrouter/deepseek/deepseek-v4-flash | kupalski | bare | 80 | 80 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 28.244 |
-| openrouter/deepseek/deepseek-v4-flash | kupalski | tooled | 60 | 60 | 4 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 3 | 0 | 34 | 182.667 |
-| openrouter/deepseek/deepseek-v4-flash | vesnianky | bare | -140 | -140 | 6 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 1 | 41.443 |
-| openrouter/deepseek/deepseek-v4-flash | vesnianky | tooled | -20 | -20 | 5 | 0/1 low-N | 0/1 low-N | 1/6 low-N | 5 | 0 | 15 | 140.463 |
-| openrouter/deepseek/deepseek-v4-flash | zhnyvarski | bare | -10 | -10 | 2 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 47.69 |
-| openrouter/deepseek/deepseek-v4-flash | zhnyvarski | tooled | 150 | 150 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 9 | 0 | 26 | 157.747 |
-| openrouter/deepseek/deepseek-v4-pro | koliadky | bare | 80 | 80 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 144.703 |
-| openrouter/deepseek/deepseek-v4-pro | koliadky | tooled | 70 | 70 | 4 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 4 | 0 | 17 | 206.013 |
-| openrouter/deepseek/deepseek-v4-pro | kupalski | bare | 50 | 50 | 2 | 0/1 low-N | 1/2 low-N | 2/6 low-N | 0 | 0 | 0 | 53.854 |
-| openrouter/deepseek/deepseek-v4-pro | kupalski | tooled | 150 | 150 | 1 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 12 | 0 | 15 | 215.682 |
-| openrouter/deepseek/deepseek-v4-pro | vesnianky | bare | -50 | -50 | 3 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 37.351 |
-| openrouter/deepseek/deepseek-v4-pro | vesnianky | tooled | -50 | -50 | 3 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 10 | 0 | 10 | 164.376 |
-| openrouter/deepseek/deepseek-v4-pro | zhnyvarski | bare | 30 | 30 | 1 | 0/1 low-N | 2/2 low-N | 4/6 low-N | 0 | 0 | 0 | 101.766 |
-| openrouter/deepseek/deepseek-v4-pro | zhnyvarski | tooled | 120 | 120 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 3 | 0 | 16 | 267.781 |
-| openrouter/google/gemma-4-31b-it | koliadky | bare | -20 | -20 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 40.363 |
-| openrouter/google/gemma-4-31b-it | koliadky | tooled | 60 | 60 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 7 | 0 | 4 | 43.402 |
-| openrouter/google/gemma-4-31b-it | kupalski | bare | -20 | -20 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 19.368 |
-| openrouter/google/gemma-4-31b-it | kupalski | tooled | 0 | 0 | 0 | 1/1 low-N | 0/2 low-N | 1/6 low-N | 6 | 0 | 4 | 16.499 |
-| openrouter/google/gemma-4-31b-it | vesnianky | bare | -50 | -50 | 3 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 47.969 |
-| openrouter/google/gemma-4-31b-it | vesnianky | tooled | 30 | 30 | 0 | 1/1 low-N | 0/1 low-N | 0/6 low-N | 2 | 0 | 4 | 25.968 |
-| openrouter/google/gemma-4-31b-it | zhnyvarski | bare | 20 | 20 | 0 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 8.473 |
-| openrouter/google/gemma-4-31b-it | zhnyvarski | tooled | 150 | 150 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 8 | 0 | 5 | 137.964 |
+| model | transport | entrypoint | passage | arm | status | failure_class | parse_lenient | model judgment | live admissible | missing | U honesty | M alignment | true unsupported | invalid | inadmissible | tools | wall_s |
+| --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | bare | ran | n/a | False | 40 | 40 | 2 | 1/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 37.915 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | tooled | ungrounded_findings | n/a | False | 30 | 30 | 5 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 8 | 0 | 35 | 238.279 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | bare | ran | n/a | False | 80 | 80 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 28.244 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | tooled | ungrounded_findings | n/a | False | 60 | 60 | 4 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 3 | 0 | 34 | 182.667 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | bare | ran | n/a | False | -140 | -140 | 6 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 1 | 41.443 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | tooled | ungrounded_findings | n/a | False | -20 | -20 | 5 | 0/1 low-N | 0/1 low-N | 1/6 low-N | 5 | 0 | 15 | 140.463 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | bare | ran | n/a | False | -10 | -10 | 2 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 47.69 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | tooled | ungrounded_findings | n/a | False | 150 | 150 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 9 | 0 | 26 | 157.747 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | bare | ran | n/a | False | 80 | 80 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 144.703 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | tooled | ungrounded_findings | n/a | False | 70 | 70 | 4 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 4 | 0 | 17 | 206.013 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | bare | ran | n/a | False | 50 | 50 | 2 | 0/1 low-N | 1/2 low-N | 2/6 low-N | 0 | 0 | 0 | 53.854 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | tooled | ungrounded_findings | n/a | False | 150 | 150 | 1 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 12 | 0 | 15 | 215.682 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | bare | ran | n/a | False | -50 | -50 | 3 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 37.351 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | tooled | ungrounded_findings | n/a | False | -50 | -50 | 3 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 10 | 0 | 10 | 164.376 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | bare | ran | n/a | False | 30 | 30 | 1 | 0/1 low-N | 2/2 low-N | 4/6 low-N | 0 | 0 | 0 | 101.766 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | tooled | ungrounded_findings | n/a | False | 120 | 120 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 3 | 0 | 16 | 267.781 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | bare | ran | n/a | False | -20 | -20 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 40.363 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | tooled | ungrounded_findings | n/a | False | 60 | 60 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 7 | 0 | 4 | 43.402 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | bare | ran | n/a | False | -20 | -20 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 19.368 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | tooled | ungrounded_findings | n/a | False | 0 | 0 | 0 | 1/1 low-N | 0/2 low-N | 1/6 low-N | 6 | 0 | 4 | 16.499 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | bare | ran | n/a | False | -50 | -50 | 3 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 47.969 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | tooled | ungrounded_findings | n/a | False | 30 | 30 | 0 | 1/1 low-N | 0/1 low-N | 0/6 low-N | 2 | 0 | 4 | 25.968 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | bare | ran | n/a | False | 20 | 20 | 0 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 8.473 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | tooled | ungrounded_findings | n/a | False | 150 | 150 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 8 | 0 | 5 | 137.964 |
 
 ## Totals With Anchor
 
 | model | arm | passages | model judgment | live admissible | U honesty | M alignment headline | true unsupported | missing | invalid | inadmissible | tools | wall_s |
 | --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
-| openrouter/deepseek/deepseek-v4-flash | bare | 4 | -30 | -30 | 1/4 low-N | 2/7 low-N | 2/24 | 12 | 0 | 0 | 1 | 155.292 |
-| openrouter/deepseek/deepseek-v4-flash | tooled | 4 | 220 | 220 | 2/4 low-N | 3/7 low-N | 1/24 | 14 | 25 | 0 | 110 | 719.156 |
-| openrouter/deepseek/deepseek-v4-pro | bare | 4 | 110 | 110 | 0/4 low-N | 4/7 low-N | 7/24 | 8 | 0 | 0 | 0 | 337.674 |
-| openrouter/deepseek/deepseek-v4-pro | tooled | 4 | 290 | 290 | 2/4 low-N | 4/7 low-N | 0/24 | 9 | 29 | 0 | 58 | 853.852 |
-| openrouter/google/gemma-4-31b-it | bare | 4 | -70 | -70 | 0/4 low-N | 2/7 low-N | 2/24 | 7 | 0 | 0 | 0 | 116.173 |
-| openrouter/google/gemma-4-31b-it | tooled | 4 | 240 | 240 | 3/4 low-N | 4/7 low-N | 1/24 | 0 | 23 | 0 | 17 | 223.833 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | bare | 4 | -30 | -30 | 1/4 low-N | 2/7 low-N | 2/24 | 12 | 0 | 0 | 1 | 155.292 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | tooled | 4 | 220 | 220 | 2/4 low-N | 3/7 low-N | 1/24 | 14 | 25 | 0 | 110 | 719.156 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | bare | 4 | 110 | 110 | 0/4 low-N | 4/7 low-N | 7/24 | 8 | 0 | 0 | 0 | 337.674 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | tooled | 4 | 290 | 290 | 2/4 low-N | 4/7 low-N | 0/24 | 9 | 29 | 0 | 58 | 853.852 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | bare | 4 | -70 | -70 | 0/4 low-N | 2/7 low-N | 2/24 | 7 | 0 | 0 | 0 | 116.173 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | tooled | 4 | 240 | 240 | 3/4 low-N | 4/7 low-N | 1/24 | 0 | 23 | 0 | 17 | 223.833 |
 
 ## Harness Lift With Anchor
 
@@ -52,20 +53,20 @@ M alignment is the discriminating fraction; low-N marks denominators below 10.
 
 | model | paired passages | tooled model judgment | bare model judgment | harness_lift | tooled M alignment | bare M alignment |
 | --- | ---: | ---: | ---: | ---: | --- | --- |
-| openrouter/deepseek/deepseek-v4-flash | 4 | 220 | -30 | 250 | 3/7 low-N | 2/7 low-N |
-| openrouter/deepseek/deepseek-v4-pro | 4 | 290 | 110 | 180 | 4/7 low-N | 4/7 low-N |
-| openrouter/google/gemma-4-31b-it | 4 | 240 | -70 | 310 | 4/7 low-N | 2/7 low-N |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | 4 | 220 | -30 | 250 | 3/7 low-N | 2/7 low-N |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | 4 | 290 | 110 | 180 | 4/7 low-N | 4/7 low-N |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | 4 | 240 | -70 | 310 | 4/7 low-N | 2/7 low-N |
 
 ## Totals Without Anchor
 
 | model | arm | passages | model judgment | live admissible | U honesty | M alignment headline | true unsupported | missing | invalid | inadmissible | tools | wall_s |
 | --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
-| openrouter/deepseek/deepseek-v4-flash | bare | 3 | 110 | 110 | 1/3 low-N | 2/6 low-N | 2/18 | 6 | 0 | 0 | 0 | 113.849 |
-| openrouter/deepseek/deepseek-v4-flash | tooled | 3 | 240 | 240 | 2/3 low-N | 3/6 low-N | 0/18 | 9 | 20 | 0 | 95 | 578.693 |
-| openrouter/deepseek/deepseek-v4-pro | bare | 3 | 160 | 160 | 0/3 low-N | 4/6 low-N | 7/18 | 5 | 0 | 0 | 0 | 300.323 |
-| openrouter/deepseek/deepseek-v4-pro | tooled | 3 | 340 | 340 | 2/3 low-N | 4/6 low-N | 0/18 | 6 | 19 | 0 | 48 | 689.476 |
-| openrouter/google/gemma-4-31b-it | bare | 3 | -20 | -20 | 0/3 low-N | 2/6 low-N | 2/18 | 4 | 0 | 0 | 0 | 68.204 |
-| openrouter/google/gemma-4-31b-it | tooled | 3 | 210 | 210 | 2/3 low-N | 4/6 low-N | 1/18 | 0 | 21 | 0 | 13 | 197.865 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | bare | 3 | 110 | 110 | 1/3 low-N | 2/6 low-N | 2/18 | 6 | 0 | 0 | 0 | 113.849 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | tooled | 3 | 240 | 240 | 2/3 low-N | 3/6 low-N | 0/18 | 9 | 20 | 0 | 95 | 578.693 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | bare | 3 | 160 | 160 | 0/3 low-N | 4/6 low-N | 7/18 | 5 | 0 | 0 | 0 | 300.323 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | tooled | 3 | 340 | 340 | 2/3 low-N | 4/6 low-N | 0/18 | 6 | 19 | 0 | 48 | 689.476 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | bare | 3 | -20 | -20 | 0/3 low-N | 2/6 low-N | 2/18 | 4 | 0 | 0 | 0 | 68.204 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | tooled | 3 | 210 | 210 | 2/3 low-N | 4/6 low-N | 1/18 | 0 | 21 | 0 | 13 | 197.865 |
 
 ## Harness Lift Without Anchor
 
@@ -75,6 +76,25 @@ M alignment is the discriminating fraction; low-N marks denominators below 10.
 
 | model | paired passages | tooled model judgment | bare model judgment | harness_lift | tooled M alignment | bare M alignment |
 | --- | ---: | ---: | ---: | ---: | --- | --- |
-| openrouter/deepseek/deepseek-v4-flash | 3 | 240 | 110 | 130 | 3/6 low-N | 2/6 low-N |
-| openrouter/deepseek/deepseek-v4-pro | 3 | 340 | 160 | 180 | 4/6 low-N | 4/6 low-N |
-| openrouter/google/gemma-4-31b-it | 3 | 210 | -20 | 230 | 4/6 low-N | 2/6 low-N |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | 3 | 240 | 110 | 130 | 3/6 low-N | 2/6 low-N |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | 3 | 340 | 160 | 180 | 4/6 low-N | 4/6 low-N |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | 3 | 210 | -20 | 230 | 4/6 low-N | 2/6 low-N |
+
+## Subscription Runtime Bare Rows
+
+subscription-runtime bare — not raw completion; do not compare to opencode bare rows or external leaderboards.
+
+| model | transport | entrypoint | passage | arm | status | failure_class | parse_lenient | model judgment | live admissible | missing | U honesty | M alignment | true unsupported | invalid | inadmissible | tools | wall_s |
+| --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: |
+| claude-opus-4-8 [runtime-claude/qg_bakeoff_runtime] | runtime-claude | qg_bakeoff_runtime | koliadky | bare | ran | n/a | False | 20 | 20 | 3 | 0/1 low-N | 1/2 low-N | 2/6 low-N | 0 | 0 | 0 | 170.17 |
+| claude-opus-4-8 [runtime-claude/qg_bakeoff_runtime] | runtime-claude | qg_bakeoff_runtime | kupalski | bare | ran | n/a | False | 20 | 20 | 2 | 0/1 low-N | 0/2 low-N | 2/6 low-N | 0 | 0 | 0 | 125.122 |
+| claude-opus-4-8 [runtime-claude/qg_bakeoff_runtime] | runtime-claude | qg_bakeoff_runtime | vesnianky | bare | ran | n/a | False | -10 | -10 | 5 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 51.469 |
+| claude-opus-4-8 [runtime-claude/qg_bakeoff_runtime] | runtime-claude | qg_bakeoff_runtime | zhnyvarski | bare | ran | n/a | False | 90 | 90 | 1 | 0/1 low-N | 2/2 low-N | 2/6 low-N | 0 | 0 | 0 | 90.118 |
+| gemini-3.1-pro-high [runtime-agy/qg_bakeoff_runtime] | runtime-agy | qg_bakeoff_runtime | koliadky | bare | ran | n/a | False | 60 | 60 | 3 | 0/1 low-N | 2/2 low-N | 1/6 low-N | 0 | 0 | 0 | 40.069 |
+| gemini-3.1-pro-high [runtime-agy/qg_bakeoff_runtime] | runtime-agy | qg_bakeoff_runtime | kupalski | bare | ran | n/a | False | 180 | 180 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 40.253 |
+| gemini-3.1-pro-high [runtime-agy/qg_bakeoff_runtime] | runtime-agy | qg_bakeoff_runtime | vesnianky | bare | ran | n/a | False | -40 | -40 | 2 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 45.295 |
+| gemini-3.1-pro-high [runtime-agy/qg_bakeoff_runtime] | runtime-agy | qg_bakeoff_runtime | zhnyvarski | bare | ran | n/a | False | 120 | 120 | 2 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 30.052 |
+| gpt-5.5 [runtime-codex/qg_bakeoff_runtime] | runtime-codex | qg_bakeoff_runtime | koliadky | bare | ran | n/a | False | 50 | 50 | 2 | 0/1 low-N | 1/2 low-N | 2/6 low-N | 0 | 0 | 0 | 224.978 |
+| gpt-5.5 [runtime-codex/qg_bakeoff_runtime] | runtime-codex | qg_bakeoff_runtime | kupalski | bare | ran | n/a | False | 70 | 70 | 3 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 75.07 |
+| gpt-5.5 [runtime-codex/qg_bakeoff_runtime] | runtime-codex | qg_bakeoff_runtime | vesnianky | bare | ran | n/a | False | -40 | -40 | 6 | 1/1 low-N | 0/1 low-N | 1/6 low-N | 0 | 0 | 0 | 64.709 |
+| gpt-5.5 [runtime-codex/qg_bakeoff_runtime] | runtime-codex | qg_bakeoff_runtime | zhnyvarski | bare | ran | n/a | False | -20 | -20 | 5 | 0/1 low-N | 1/2 low-N | 2/6 low-N | 0 | 0 | 0 | 135.119 |

--- a/docs/projects/ua-eval-harness/model-evidence.md
+++ b/docs/projects/ua-eval-harness/model-evidence.md
@@ -199,10 +199,36 @@ subscription-runtime bare — not raw completion; do not compare to opencode bar
 Phase 1 adds a separate scorecard/evidence lane for native subscription bare cells
 (`claude-opus-4-8`, `gpt-5.5`, `gemini-3.1-pro-high`) through `agent_runtime.invoke`, with
 artifacts keyed by `{pin, transport, entrypoint}` and filenames shaped
-`<pin_slug>__<slug>__bare__<transport>.json`. **No live subscription-runtime rows are recorded
-in this evidence log yet**; the live driver runs them after the implementation merges. Until a
-raw-completion parity phase exists, these rows stay under their own header and are not blended
-with opencode bare rows or external leaderboard claims.
+`<pin_slug>__<slug>__bare__<transport>.json`. Until a raw-completion parity phase exists,
+these rows stay under their own header and are not blended with opencode bare rows or
+external leaderboard claims.
+
+**Live run 2026-07-06** (post-#4577: `use_bare=False` OAuth path + neutral-cwd standing-rules
+firewall, `cwd_policy=neutral-tmp` in every artifact; 12/12 cells `ran`; gemini seat
+artifact-verified `Gemini 3.1 Pro (High)`; with-anchor totals over the same 4 folk passages):
+
+| seat | transport | model judgment (4 passages) | per-passage |
+| --- | --- | ---: | --- |
+| claude-opus-4-8 | runtime-claude | **120** | 20 / 20 / −10 / 90 |
+| gpt-5.5 | runtime-codex | **60** | 50 / 70 / −40 / −20 |
+| gemini-3.1-pro-high | runtime-agy | **320** | 60 / 180 / −40 / 120 |
+
+Readings (all under the do-not-compare caveat above):
+1. **The anchor passage (vesnianky, seeded fabrications) is NEGATIVE for all three frontier
+   seats** (−10 / −40 / −40): every frontier model bare-CONFIRMED fabricated claims. The
+   class-M/U honesty collapse observed on cheap bare models reproduces at frontier tier —
+   parametric knowledge does not protect against confident folk-culture fabrication.
+2. claude/gpt bare (120/60) land BELOW every tooled cheap row (gemma +240 / ds-flash +220 /
+   ds-pro +290) — directionally consistent with the harness-lift thesis.
+3. Honest nuance: gemini-pro bare (320) numerically exceeds the best tooled cheap row
+   (ds-pro 290) on raw judgment score at n=4 — high per-passage variance (−40…180), no
+   grounding/admissibility gates on the bare arm, different transport+variant. This is
+   exactly the comparison the banner forbids; a tooled-frontier phase-2 (or raw-completion
+   parity 1.5) is required before any cross-lane ranking claim.
+4. Measurement-integrity note: the first live run (pre-#4577) had the claude seat 4/4
+   transport-dead (`--bare`+OAuth) and gpt/gemini cells contaminated by repo standing rules
+   (cwd=PROJECT_ROOT). Decontamination measurably shifted gpt scores (40/50/−70/−20 →
+   50/70/−40/−20) — cwd context is part of the measurement and is now firewalled + recorded.
 
 ### Findings
 

--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -875,14 +875,29 @@ def run_matrix(
     return runs
 
 
+def _is_bakeoff_cell(artifact: Mapping[str, Any]) -> bool:
+    """True iff this JSON is a real bakeoff cell artifact, not a foreign file.
+
+    Out-dirs accumulate non-cell JSONs (live trap: ``tier2-canary-verdict.json``
+    from the canary checker) — scoring one fabricates an ``unknown`` scorecard
+    row with a phantom passage count. Shared predicate for EVERY artifact-load
+    path (codex review on #4581 caught the run_matrix sibling of the rescore fix).
+    """
+    schema = artifact.get("schema_version")
+    return isinstance(schema, str) and schema.startswith("qg_bakeoff_run.")
+
+
 def _load_all_artifacts(output_dir: Path) -> list[dict[str, Any]]:
-    """Load every bakeoff artifact JSON in ``output_dir`` (both arms), stable order."""
+    """Load every bakeoff CELL artifact JSON in ``output_dir`` (both arms), stable order."""
     artifacts: list[dict[str, Any]] = []
     for path in sorted(output_dir.glob("*.json")):
         try:
-            artifacts.append(json.loads(path.read_text(encoding="utf-8")))
+            artifact = json.loads(path.read_text(encoding="utf-8"))
         except json.JSONDecodeError:
             continue
+        if not _is_bakeoff_cell(artifact):
+            continue
+        artifacts.append(artifact)
     return artifacts
 
 
@@ -1529,12 +1544,9 @@ def rescore_artifacts(output_dir: Path, fixtures_dir: Path = FIXTURE_DIR) -> int
     count = 0
     for path in sorted(output_dir.glob("*.json")):
         artifact = json.loads(path.read_text(encoding="utf-8"))
-        schema = artifact.get("schema_version")
-        if not (isinstance(schema, str) and schema.startswith("qg_bakeoff_run.")):
-            # Foreign JSON in the out-dir (e.g. tier2-canary-verdict.json) is
-            # NOT a bakeoff cell — scoring it fabricates an 'unknown' scorecard
-            # row with a phantom passage count (caught live 2026-07-06 when a
-            # canary verdict file polluted the totals table).
+        if not _is_bakeoff_cell(artifact):
+            # See _is_bakeoff_cell — foreign JSONs (canary verdicts etc.)
+            # must never be rescored or rendered as cells.
             continue
         # Backfill ``arm`` for backward compat: pre-arm tooled artifacts have no
         # field (→ "tooled"); a ``__bare`` filename identifies a bare artifact even

--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -1529,6 +1529,13 @@ def rescore_artifacts(output_dir: Path, fixtures_dir: Path = FIXTURE_DIR) -> int
     count = 0
     for path in sorted(output_dir.glob("*.json")):
         artifact = json.loads(path.read_text(encoding="utf-8"))
+        schema = artifact.get("schema_version")
+        if not (isinstance(schema, str) and schema.startswith("qg_bakeoff_run.")):
+            # Foreign JSON in the out-dir (e.g. tier2-canary-verdict.json) is
+            # NOT a bakeoff cell — scoring it fabricates an 'unknown' scorecard
+            # row with a phantom passage count (caught live 2026-07-06 when a
+            # canary verdict file polluted the totals table).
+            continue
         # Backfill ``arm`` for backward compat: pre-arm tooled artifacts have no
         # field (→ "tooled"); a ``__bare`` filename identifies a bare artifact even
         # if it somehow lacks the field. Rescore covers BOTH arms — the bare grounding

--- a/tests/audit/test_qg_bakeoff.py
+++ b/tests/audit/test_qg_bakeoff.py
@@ -1602,6 +1602,22 @@ def test_rescore_covers_both_arms_and_backfills_arm(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
+    # Foreign JSON in the out-dir (the live trap: a tier2-canary-verdict.json
+    # written by the canary checker) — rescore must SKIP it entirely, not
+    # fabricate an 'unknown' scorecard row with a phantom passage count.
+    (out / "tier2-canary-verdict.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "qg_tier2_canary_verdict.v1",
+                "passed": True,
+                "failure_reasons": [],
+                "summary": {"artifact_count": 4},
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
     n = qg_bakeoff.rescore_artifacts(out, fixtures_dir)
 
     assert n == 2
@@ -1614,3 +1630,6 @@ def test_rescore_covers_both_arms_and_backfills_arm(tmp_path: Path) -> None:
     assert bare["score"]["invalid_fact_checks"] == 0
     scorecard = (out / qg_bakeoff.SCORECARD_NAME).read_text(encoding="utf-8")
     assert "Harness Lift With Anchor" in scorecard
+    assert "| unknown [" not in scorecard  # foreign JSON never becomes a model row
+    verdict_after = json.loads((out / "tier2-canary-verdict.json").read_text(encoding="utf-8"))
+    assert "rescored_at" not in verdict_after  # untouched, not rewritten

--- a/tests/audit/test_qg_bakeoff.py
+++ b/tests/audit/test_qg_bakeoff.py
@@ -1633,3 +1633,34 @@ def test_rescore_covers_both_arms_and_backfills_arm(tmp_path: Path) -> None:
     assert "| unknown [" not in scorecard  # foreign JSON never becomes a model row
     verdict_after = json.loads((out / "tier2-canary-verdict.json").read_text(encoding="utf-8"))
     assert "rescored_at" not in verdict_after  # untouched, not rewritten
+
+
+def test_load_all_artifacts_skips_foreign_json(tmp_path: Path) -> None:
+    """The run_matrix scorecard path must apply the same foreign-JSON filter.
+
+    codex review on #4581: fixing only rescore left _load_all_artifacts (used
+    by run_matrix's scorecard write) ingesting tier2-canary-verdict.json and
+    rendering the phantom 'unknown' row. Shared predicate covers both paths.
+    """
+    (tmp_path / "m__sample__bare__opencode.json").write_text(
+        json.dumps(
+            {
+                "schema_version": qg_bakeoff.RUN_SCHEMA_VERSION,
+                "arm": "bare",
+                "fixture": {"slug": "sample"},
+                "model": {"pin": "openrouter/test/m"},
+                "score": {"model_judgment_score": 10},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "tier2-canary-verdict.json").write_text(
+        json.dumps({"schema_version": "qg_tier2_canary_verdict.v1", "passed": True}),
+        encoding="utf-8",
+    )
+    (tmp_path / "no-schema.json").write_text(json.dumps({"passed": True}), encoding="utf-8")
+
+    artifacts = qg_bakeoff._load_all_artifacts(tmp_path)
+
+    assert len(artifacts) == 1
+    assert artifacts[0]["model"]["pin"] == "openrouter/test/m"


### PR DESCRIPTION
Completes the #4540 phase-1 arc (addresses #4540):

- **12 clean subscription-runtime bare cells** (post-#4577 OAuth fix + neutral-cwd firewall): claude-opus-4-8 **120**, gpt-5.5 **60**, gemini-3.1-pro-high **320** (with-anchor, 4 passages; per-cell artifacts local-only by design).
- **Key finding**: the fabrication-seeded anchor passage is NEGATIVE for all three frontier seats — frontier parametric knowledge bare-CONFIRMS folk-culture fabrications, same failure class as cheap models. claude/gpt bare land below every tooled cheap row. The gemini-pro-bare 320 vs tooled ds-pro 290 nuance is recorded honestly under the do-not-compare banner (n=4, no gates, different transport/variant — phase-1.5/2 required before ranking claims).
- **Measurement integrity**: decontamination (neutral cwd) measurably shifted gpt scores — recorded in evidence.
- **rescore bug fixed**: foreign-schema JSONs in the out-dir (live trap: `tier2-canary-verdict.json`) were scored as a phantom `unknown` scorecard row; now skipped + regression test. 44/44 targeted tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)