### PR TITLE
feat(bio): add literary memory Ukrainian readings

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/anatolii-dimarov.yaml
+++ b/curriculum/l2-uk-en/plans/bio/anatolii-dimarov.yaml
@@ -100,18 +100,30 @@ references:
   work: Проєкт «Незламні»
 readings:
 - language: uk
-  notes: 'Матеріали "Локальної історії" про творчість Анатолія Дімарова як живого свідка катастроф XX століття, з акцентом на його роман "І будуть люди".'
-  source_name: Локальна історія
-  source_url: https://localhistory.org.ua/texts/statti/i-budut-liudi-chy-zmozhe-serial-stati-dlia-ukrayintsiv-tym-chym-ie-chornobil-dlia-svitu/
+  source_type: reference
+  role: orientation
+  source_name: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-26462
+  license: copyrighted
+  rights_note: ЕСУ захищена авторським правом; використовувати як link-only джерело.
+  hosting: link-only
+  learner_task: Виписати основні факти біографії, творчі етапи й ознаки офіційного визнання Дімарова.
+  notes: Академічна українська довідка про Анатолія Дімарова як письменника і громадського діяча.
 - language: uk
-  notes: 'Стаття на "Читомо" про цензурування творів Дімарова в радянські часи та історію публікації повних текстів його епопей.'
-  source_name: Читомо
-  source_url: https://chytomo.com/anatolij-dimarov-ta-joho-vyruba-cenzuroju-proza/
+  source_type: interview
+  role: context
+  source_name: Локальна історія
+  source_url: https://localhistory.org.ua/texts/interviu/nam-dorikaiut-shcho-geroyi-khodiat-u-chistenkomu-odiazi-rezhiser-serialu-i-budut-liudi/
+  license: copyrighted
+  rights_note: Матеріал "Локальної історії" захищений авторським правом; не копіювати повний текст.
+  hosting: link-only
+  learner_task: Прочитати про екранізацію "І будуть люди" і визначити, як адаптація повертає цензуровану історію родинної пам'яті.
+  notes: Українське інтерв'ю про нове прочитання роману Дімарова та відновлення частин, вирізаних радянською цензурою.
 sequence: 202
 slug: anatolii-dimarov
 subtitle: A Chronicle of a Man Who Outlived Three Regimes
 title: 'Анатолій Дімаров: Прожити й розповісти'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: насильницьке позбавлення селян власності та їх виселення радянською владою
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/anatolii-dimarov.yaml
+++ b/curriculum/l2-uk-en/plans/bio/anatolii-dimarov.yaml
@@ -98,11 +98,20 @@ references:
   note: Контекстуалізація постаті Дімарова як одного з символів української стійкості.
   type: primary
   work: Проєкт «Незламні»
+readings:
+- language: uk
+  notes: 'Матеріали "Локальної історії" про творчість Анатолія Дімарова як живого свідка катастроф XX століття, з акцентом на його роман "І будуть люди".'
+  source_name: Локальна історія
+  source_url: https://localhistory.org.ua/texts/statti/i-budut-liudi-chy-zmozhe-serial-stati-dlia-ukrayintsiv-tym-chym-ie-chornobil-dlia-svitu/
+- language: uk
+  notes: 'Стаття на "Читомо" про цензурування творів Дімарова в радянські часи та історію публікації повних текстів його епопей.'
+  source_name: Читомо
+  source_url: https://chytomo.com/anatolij-dimarov-ta-joho-vyruba-cenzuroju-proza/
 sequence: 202
 slug: anatolii-dimarov
 subtitle: A Chronicle of a Man Who Outlived Three Regimes
 title: 'Анатолій Дімаров: Прожити й розповісти'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: насильницьке позбавлення селян власності та їх виселення радянською владою
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/iryna-vilde.yaml
+++ b/curriculum/l2-uk-en/plans/bio/iryna-vilde.yaml
@@ -98,18 +98,30 @@ references:
   work: Ірина Вільде. Штрихи до портрета
 readings:
 - language: uk
-  notes: 'Есе на "Локальній історії" про суперечливі життєві вибори та жіночу незалежність Ірини Вільде, що руйнує стереотипи про радянську конформістку.'
-  source_name: Локальна історія
-  source_url: https://localhistory.org.ua/texts/statti/irina-vilde-ne-khtila-b-buti-khoroshim-khlopchikom/
+  source_type: reference
+  role: orientation
+  source_name: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-34550
+  license: copyrighted
+  rights_note: ЕСУ захищена авторським правом; використовувати як link-only джерело.
+  hosting: link-only
+  learner_task: Зібрати базову хронологію життя Ірини Вільде та позначити, які факти потрібні для розмови про виживання під різними режимами.
+  notes: Академічна українська довідка про біографію, освіту, творчість і громадську діяльність письменниці.
 - language: uk
-  notes: 'Аналітична стаття на "Читомо" про літературний феномен "Сестер Річинських" та особистісні компроміси письменниці.'
+  source_type: article
+  role: reading
   source_name: Читомо
-  source_url: https://chytomo.com/dzerkalo-zhyttia-iryny-vilde-z-nadhrobnym-vinkom/
+  source_url: https://chytomo.com/sestry-richynski-iak-hra-prestoliv-shcho-spilnoho-u-vilde-i-martina/
+  license: copyrighted
+  rights_note: Матеріал Читомо захищений авторським правом; не копіювати повний текст.
+  hosting: link-only
+  learner_task: Прочитати як літературну рамку до "Сестер Річинських" і виписати, як авторка пояснює масштаб роману та родинної саги.
+  notes: Українська стаття про роман "Сестри Річинські" як великий галицький родинний наратив.
 sequence: 199
 slug: iryna-vilde
 subtitle: 'Iryna Vilde: A Butterfly on Pins'
 title: 'Ірина Вільде: Метелик на шпильках'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: жінка, яка професійно займається літературною творчістю
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/iryna-vilde.yaml
+++ b/curriculum/l2-uk-en/plans/bio/iryna-vilde.yaml
@@ -96,11 +96,20 @@ references:
   note: Біографічне дослідження, що аналізує складні життєві вибори письменниці.
   type: primary
   work: Ірина Вільде. Штрихи до портрета
+readings:
+- language: uk
+  notes: 'Есе на "Локальній історії" про суперечливі життєві вибори та жіночу незалежність Ірини Вільде, що руйнує стереотипи про радянську конформістку.'
+  source_name: Локальна історія
+  source_url: https://localhistory.org.ua/texts/statti/irina-vilde-ne-khtila-b-buti-khoroshim-khlopchikom/
+- language: uk
+  notes: 'Аналітична стаття на "Читомо" про літературний феномен "Сестер Річинських" та особистісні компроміси письменниці.'
+  source_name: Читомо
+  source_url: https://chytomo.com/dzerkalo-zhyttia-iryny-vilde-z-nadhrobnym-vinkom/
 sequence: 199
 slug: iryna-vilde
 subtitle: 'Iryna Vilde: A Butterfly on Pins'
 title: 'Ірина Вільде: Метелик на шпильках'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: жінка, яка професійно займається літературною творчістю
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/moisei-fishbein.yaml
+++ b/curriculum/l2-uk-en/plans/bio/moisei-fishbein.yaml
@@ -99,18 +99,30 @@ references:
   work: Премія імені Василя Стуса
 readings:
 - language: uk
-  notes: 'Матеріал від PEN Ukraine про роль Мойсея Фішбейна як "пророка українською" та його внесок в українсько-єврейський діалог.'
+  source_type: interview
+  role: reading
   source_name: Український ПЕН
-  source_url: https://pen.org.ua/in-memoriam-mojsej-fishbejn
+  source_url: https://pen.org.ua/mojsej-fishbejn-chuty-v-movi-gospodnyu-symfoniyu-j-nesty-tsyu-symfoniyu-inshym
+  license: copyrighted
+  rights_note: Матеріал Українського ПЕН захищений авторським правом; використовувати як link-only джерело.
+  hosting: link-only
+  learner_task: Прочитати розмову про українську мову Фішбейна і сформулювати, як він пов'язує переклад, віру та громадянську позицію.
+  notes: Українська PEN-розмова з біографічним блоком про еміграцію, повернення і перекладацьку працю Фішбейна.
 - language: uk
-  notes: 'Стаття-спогад на "Історичній правді" про громадянську позицію поета та його боротьбу з імперськими антисемітськими міфами.'
-  source_name: Історична правда
-  source_url: https://www.istpravda.com.ua/articles/2020/05/27/157588/
+  source_type: article
+  role: context
+  source_name: Радіо Свобода
+  source_url: https://www.radiosvoboda.org/a/moysey-fishbeyn-upa/31587500.html
+  license: copyrighted
+  rights_note: Матеріал Радіо Свобода захищений авторським правом; не хостити повний текст.
+  hosting: link-only
+  learner_task: Виписати аргументи про поєднання єврейської ідентичності, української мови та політичної солідарності.
+  notes: Українська стаття до 75-річчя поета про його український вибір, єврейське походження та ставлення до УПА.
 sequence: 200
 slug: moisei-fishbein
 subtitle: The Jewish Intellectual Who Chose the Ukrainian Language
 title: 'Мойсей Фішбейн: Пророк українською'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: свідоме рішення особистості використовувати певну мову в житті та творчості, часто як політичний акт
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/moisei-fishbein.yaml
+++ b/curriculum/l2-uk-en/plans/bio/moisei-fishbein.yaml
@@ -97,11 +97,20 @@ references:
   note: Контекст премії, що підкреслює інтелектуальну мужність Фішбейна
   type: reference
   work: Премія імені Василя Стуса
+readings:
+- language: uk
+  notes: 'Матеріал від PEN Ukraine про роль Мойсея Фішбейна як "пророка українською" та його внесок в українсько-єврейський діалог.'
+  source_name: Український ПЕН
+  source_url: https://pen.org.ua/in-memoriam-mojsej-fishbejn
+- language: uk
+  notes: 'Стаття-спогад на "Історичній правді" про громадянську позицію поета та його боротьбу з імперськими антисемітськими міфами.'
+  source_name: Історична правда
+  source_url: https://www.istpravda.com.ua/articles/2020/05/27/157588/
 sequence: 200
 slug: moisei-fishbein
 subtitle: The Jewish Intellectual Who Chose the Ukrainian Language
 title: 'Мойсей Фішбейн: Пророк українською'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: свідоме рішення особистості використовувати певну мову в житті та творчості, часто як політичний акт
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/mykhail-semenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykhail-semenko.yaml
@@ -154,18 +154,30 @@ references:
   work: Арії трьох П'єро
 readings:
 - language: uk
-  notes: 'Матеріали на "Історичній правді" про фабрикацію кримінальної справи проти Михайля Семенка та його страту радянським режимом.'
-  source_name: Історична правда
-  source_url: https://www.istpravda.com.ua/articles/2020/10/24/158319/
+  source_type: reference
+  role: orientation
+  source_name: Український інститут національної пам'яті
+  source_url: https://uinp.gov.ua/istorychnyy-kalendar/gruden/31/1892-narodyvsya-poet-myhayl-semenko
+  license: copyrighted
+  rights_note: Матеріал УІНП захищений авторським правом; використовувати як link-only джерело.
+  hosting: link-only
+  learner_task: Зібрати біографічні факти про Семенка і визначити, як УІНП пов'язує його з Розстріляним відродженням.
+  notes: Українська довідка УІНП про народження, футуризм і репресовану біографію Михайля Семенка.
 - language: uk
-  notes: 'Аналітична стаття про епатажний український футуризм, "спалення Кобзаря" як деколоніальний жест та роль Семенка в авангарді.'
   source_name: Локальна історія
-  source_url: https://localhistory.org.ua/texts/statti/mikhail-semenko-i-futuryzm/
+  source_type: article
+  role: reading
+  source_url: https://localhistory.org.ua/texts/statti/chomu-semenko-paliv-shevchenkiv-kobzar/
+  license: copyrighted
+  rights_note: Матеріал "Локальної історії" захищений авторським правом; використовувати як link-only джерело.
+  hosting: link-only
+  learner_task: Проаналізувати "спалення Кобзаря" як провокацію футуризму і порівняти її з деколоніальним читанням канону.
+  notes: Українська стаття Ярини Цимбал про Семенка, футуризм, епатаж і повернення авангарду до літературної пам'яті.
 sequence: 203
 slug: mykhail-semenko
 subtitle: The Futurist Visionary Who Reimagined Ukrainian Poetry
 title: 'Михайль Семенко: Засновник українського авангарду'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: >-
     авангардний напрям у мистецтві початку XX століття, що проголошував культ

--- a/curriculum/l2-uk-en/plans/bio/mykhail-semenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykhail-semenko.yaml
@@ -152,11 +152,20 @@ references:
   title: Арії трьох П'єро
   type: primary
   work: Арії трьох П'єро
+readings:
+- language: uk
+  notes: 'Матеріали на "Історичній правді" про фабрикацію кримінальної справи проти Михайля Семенка та його страту радянським режимом.'
+  source_name: Історична правда
+  source_url: https://www.istpravda.com.ua/articles/2020/10/24/158319/
+- language: uk
+  notes: 'Аналітична стаття про епатажний український футуризм, "спалення Кобзаря" як деколоніальний жест та роль Семенка в авангарді.'
+  source_name: Локальна історія
+  source_url: https://localhistory.org.ua/texts/statti/mikhail-semenko-i-futuryzm/
 sequence: 203
 slug: mykhail-semenko
 subtitle: The Futurist Visionary Who Reimagined Ukrainian Poetry
 title: 'Михайль Семенко: Засновник українського авангарду'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: >-
     авангардний напрям у мистецтві початку XX століття, що проголошував культ

--- a/curriculum/l2-uk-en/plans/bio/oleh-olzhych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oleh-olzhych.yaml
@@ -99,11 +99,20 @@ references:
   note: Академічне дослідження постаті Ольжича в контексті його оточення
   type: primary
   work: 'Олег Ольжич і Олена Теліга: Нариси про життя і творчість'
+readings:
+- language: uk
+  notes: 'Стаття на "Історичній правді" про життя та діяльність поета як символа національного героїзму, що тривалий час був під радянським "табу".'
+  source_name: Історична правда
+  source_url: https://www.istpravda.com.ua/articles/2012/07/21/90100/
+- language: uk
+  notes: 'Матеріал на "Локальній історії" з фокусом на останні роки життя Ольжича, обставини його арешту ґестапо та загибель у концтаборі.'
+  source_name: Локальна історія
+  source_url: https://localhistory.org.ua/texts/statti/zagibel-olzhicha/
 sequence: 201
 slug: oleh-olzhych
 subtitle: 'Oleh Olzhych: A stone from God''s sling'
 title: 'Олег Ольжич: Камінь з Божої пращі'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: учасник таємної організації, що бореться проти окупаційної влади
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/oleh-olzhych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oleh-olzhych.yaml
@@ -101,18 +101,30 @@ references:
   work: 'Олег Ольжич і Олена Теліга: Нариси про життя і творчість'
 readings:
 - language: uk
-  notes: 'Стаття на "Історичній правді" про життя та діяльність поета як символа національного героїзму, що тривалий час був під радянським "табу".'
-  source_name: Історична правда
-  source_url: https://www.istpravda.com.ua/articles/2012/07/21/90100/
+  source_type: reference
+  role: orientation
+  source_name: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-76571
+  license: copyrighted
+  rights_note: ЕСУ захищена авторським правом; використовувати як link-only джерело.
+  hosting: link-only
+  learner_task: Скласти коротку карту трьох імен Ольжича — наукового, літературного та підпільного.
+  notes: Академічна українська довідка про Ольжича як поета, археолога, публіциста і діяча ОУН.
 - language: uk
-  notes: 'Матеріал на "Локальній історії" з фокусом на останні роки життя Ольжича, обставини його арешту ґестапо та загибель у концтаборі.'
+  source_type: article
+  role: reading
   source_name: Локальна історія
-  source_url: https://localhistory.org.ua/texts/statti/zagibel-olzhicha/
+  source_url: https://localhistory.org.ua/texts/chitanka/tilki-iedinogo-olega-olzhicha-zamorduvali-dopovid-pro-zhittia-poeta/
+  license: copyrighted
+  rights_note: Матеріал "Локальної історії" захищений авторським правом; використовувати як link-only джерело.
+  hosting: link-only
+  learner_task: Простежити, як текст описує арешт, Заксенгаузен і післявоєнну пам'ять без радянських замовчувань.
+  notes: Український матеріал про останні місяці життя Ольжича, його арешт ґестапо і загибель у Заксенгаузені.
 sequence: 201
 slug: oleh-olzhych
 subtitle: 'Oleh Olzhych: A stone from God''s sling'
 title: 'Олег Ольжич: Камінь з Божої пращі'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: учасник таємної організації, що бореться проти окупаційної влади
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/volodymyr-svidzinskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/volodymyr-svidzinskyi.yaml
@@ -131,18 +131,30 @@ references:
   work: Медобір
 readings:
 - language: uk
-  notes: 'Матеріал на "Читомо" про унікальну позицію Свідзінського як поета, що обрав "внутрішню еміграцію" та зберіг творчу незалежність.'
-  source_name: Читомо
-  source_url: https://chytomo.com/volodymyr-svidzinskyj-dyskurs-movchannia/
+  source_type: reference
+  role: orientation
+  source_name: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-888174
+  license: copyrighted
+  rights_note: ЕСУ захищена авторським правом; використовувати як link-only джерело.
+  hosting: link-only
+  learner_task: Виписати факти про освіту, перекладацьку працю, арешт і загибель Свідзінського.
+  notes: Академічна українська довідка Елеонори Соловей про поета, перекладача і його посмертну рецепцію.
 - language: uk
-  notes: 'Розбір поезії Свідзінського на "Локальній історії", фокус на метафізичному катастрофізмі та трагічній загибелі від рук НКВС.'
-  source_name: Локальна історія
-  source_url: https://localhistory.org.ua/texts/statti/volodymyr-svidzinskyi-katastrofizm/
+  source_type: scholarly_pdf
+  role: evidence
+  source_name: Слово і Час / Харківська організація НСПУ
+  source_url: https://kharkiv-nspu.org.ua/wp-content/uploads/2016/11/%D0%A1%D1%96%D0%A7-%D0%A1%D0%BB%D1%96%D0%B4%D1%87%D0%B0-%D1%81%D0%BF%D1%80%D0%B0%D0%B2%D0%B0.pdf
+  license: copyrighted
+  rights_note: Наукова стаття у PDF захищена авторським правом; використовувати тільки посилання і короткі навчальні цитати.
+  hosting: link-only
+  learner_task: Прочитати фрагменти про слідчу справу і пояснити, як архівні документи спростовують радянську дезінформацію.
+  notes: Українська наукова стаття Елеонори Соловей про слідчу справу Свідзінського та обставини репресії.
 sequence: 204
 slug: volodymyr-svidzinskyi
 subtitle: The Poet of Silence Burned Alive by the NKVD
 title: 'Володимир Свідзінський: Внутрішня еміграція і знищення поета'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: метафоричне визначення стану людини в тоталітарному суспільстві, коли вона
     відмежовується від публічного життя та офіційної ідеології

--- a/curriculum/l2-uk-en/plans/bio/volodymyr-svidzinskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/volodymyr-svidzinskyi.yaml
@@ -129,11 +129,20 @@ references:
   note: Посмертна збірка поезій, що зберегла найкращі зразки його "тихої" лірики.
   type: primary
   work: Медобір
+readings:
+- language: uk
+  notes: 'Матеріал на "Читомо" про унікальну позицію Свідзінського як поета, що обрав "внутрішню еміграцію" та зберіг творчу незалежність.'
+  source_name: Читомо
+  source_url: https://chytomo.com/volodymyr-svidzinskyj-dyskurs-movchannia/
+- language: uk
+  notes: 'Розбір поезії Свідзінського на "Локальній історії", фокус на метафізичному катастрофізмі та трагічній загибелі від рук НКВС.'
+  source_name: Локальна історія
+  source_url: https://localhistory.org.ua/texts/statti/volodymyr-svidzinskyi-katastrofizm/
 sequence: 204
 slug: volodymyr-svidzinskyi
 subtitle: The Poet of Silence Burned Alive by the NKVD
 title: 'Володимир Свідзінський: Внутрішня еміграція і знищення поета'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: метафоричне визначення стану людини в тоталітарному суспільстві, коли вона
     відмежовується від публічного життя та офіційної ідеології


### PR DESCRIPTION
## Summary
- adds Ukrainian-only learner reading packets for Iryna Vilde, Moisei Fishbein, Oleh Olzhych, Anatolii Dimarov, Mykhail Semenko, and Volodymyr Svidzinskyi
- repairs the initial worker's dead URLs with verified Ukrainian sources and explicit link-only rights/hosting metadata
- keeps learner readings in plan-level `readings:` blocks only; no wiki/source/module surfaces changed

## Verification
- `git diff --check origin/main...HEAD`
- `.venv/bin/python scripts/validate_plan_config.py bio`
- `.venv/bin/python scripts/validate_plans.py bio`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- URL probe for all 12 `source_url` values: HTTP 200

LLM-QG and Gemma/OpenRouter were not used.