### PR TITLE
feat(bio): add repressed modernist Ukrainian readings

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/hryhorii-epik.yaml
+++ b/curriculum/l2-uk-en/plans/bio/hryhorii-epik.yaml
@@ -95,6 +95,31 @@ persona:
     Модератор семінару, який досліджує складну біографію письменника-комуніста без санітизації та без демонізації.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  learner_task: >-
+    Ознайомтеся зі статтею про Григорія Епіка. Простежте, як його письменницький шлях перетнувся зі сфабрикованою справою.
+  license: copyrighted
+  notes: >-
+    Енциклопедична стаття про життя та творчість прозаїка і сатирика з покоління Розстріляного відродження.
+  rights_note: Текст захищено авторським правом. Надається лише посилання на зовнішній ресурс.
+  role: primary
+  source_name: Енциклопедія сучасної України (ЕСУ)
+  source_type: article
+  source_url: https://esu.com.ua/article-17936
+- hosting: link-only
+  language: uk
+  learner_task: >-
+    Прочитайте статтю для кращого розуміння літературного середовища 1920-х років та місця Епіка в ньому.
+  license: creative-commons
+  notes: >-
+    Оглядова стаття, що містить додаткові факти біографії та аналіз прозового доробку.
+  rights_note: Матеріал поширюється за ліцензією CC BY-SA. Надається посилання на оригінал.
+  role: secondary
+  source_name: Вікіпедія
+  source_type: article
+  source_url: https://uk.wikipedia.org/wiki/%D0%95%D0%BF%D1%96%D0%BA_%D0%93%D1%80%D0%B8%D0%B3%D0%BE%D1%80%D1%96%D0%B9_%D0%94%D0%B0%D0%BD%D0%B8%D0%BB%D0%BE%D0%B2%D0%B8%D1%87
 references:
 - note: Енциклопедична стаття.
   path: https://esu.com.ua/article-17936
@@ -126,7 +151,7 @@ sequence: 208
 slug: hryhorii-epik
 subtitle: The Communist Novelist Destroyed by the Same System
 title: 'Григорій Епік: сатира, боротьбист і Сандармох'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: партія, до якої вступив Епік у 1919 році
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/hryhorii-epik.yaml
+++ b/curriculum/l2-uk-en/plans/bio/hryhorii-epik.yaml
@@ -111,15 +111,15 @@ readings:
 - hosting: link-only
   language: uk
   learner_task: >-
-    Прочитайте статтю для кращого розуміння літературного середовища 1920-х років та місця Епіка в ньому.
-  license: creative-commons
+    Відкрийте запис електронної бібліотеки НЛУ про Григорія Епіка. Зіставте бібліографічний корпус із плановим питанням про сатиру й радянський регістр.
+  license: copyrighted
   notes: >-
-    Оглядова стаття, що містить додаткові факти біографії та аналіз прозового доробку.
-  rights_note: Матеріал поширюється за ліцензією CC BY-SA. Надається посилання на оригінал.
-  role: secondary
-  source_name: Вікіпедія
-  source_type: article
-  source_url: https://uk.wikipedia.org/wiki/%D0%95%D0%BF%D1%96%D0%BA_%D0%93%D1%80%D0%B8%D0%B3%D0%BE%D1%80%D1%96%D0%B9_%D0%94%D0%B0%D0%BD%D0%B8%D0%BB%D0%BE%D0%B2%D0%B8%D1%87
+    Бібліотечний запис дає учням україномовну точку входу до корпусу творів, а не лише до мартирологічного сюжету.
+  rights_note: Текст захищено авторським правом. Надається лише посилання на зовнішній ресурс.
+  role: evidence
+  source_name: Національна бібліотека України імені Ярослава Мудрого
+  source_type: digital_library
+  source_url: https://elib.nlu.org.ua/view.html?id=7931
 references:
 - note: Енциклопедична стаття.
   path: https://esu.com.ua/article-17936
@@ -151,7 +151,7 @@ sequence: 208
 slug: hryhorii-epik
 subtitle: The Communist Novelist Destroyed by the Same System
 title: 'Григорій Епік: сатира, боротьбист і Сандармох'
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: партія, до якої вступив Епік у 1919 році
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/mykhailo-drai-khmara.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykhailo-drai-khmara.yaml
@@ -114,6 +114,31 @@ persona:
     тоталітарного знищення культури.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  learner_task: >-
+    Ознайомтеся з біографічною статтею про Михайла Драй-Хмару. Зверніть увагу на його науковий доробок та обставини знищення.
+  license: copyrighted
+  notes: >-
+    Енциклопедична стаття про життя та творчість видатного поета-неокласика.
+  rights_note: Текст захищено авторським правом. Надається лише посилання на зовнішній ресурс.
+  role: primary
+  source_name: Енциклопедія сучасної України (ЕСУ)
+  source_type: article
+  source_url: https://esu.com.ua/article-21682
+- hosting: link-only
+  language: uk
+  learner_task: >-
+    Прочитайте статтю в Енциклопедії історії України, щоб зрозуміти ширший історичний та політичний контекст життя Драй-Хмари.
+  license: copyrighted
+  notes: >-
+    Академічна стаття про Михайла Драй-Хмару від Інституту історії України НАНУ.
+  rights_note: Текст захищено авторським правом. Надається лише посилання на зовнішній ресурс.
+  role: secondary
+  source_name: Енциклопедія історії України (ЕІУ)
+  source_type: article
+  source_url: https://www.history.org.ua/?termin=Dray_Khmara_M
 references:
 - note: Стаття про життя та науковий доробок поета.
   path: https://esu.com.ua/article-21682
@@ -140,7 +165,7 @@ sequence: 205
 slug: mykhailo-drai-khmara
 subtitle: The Neoclassicist Poet and Scholar Consumed by the Terror
 title: 'Михайло Драй-Хмара: Ґроно п''ятірне та доля неокласика'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: молодий пагін рослини; у назві збірки Драй-Хмари — метафора проростання нової поетичної мови
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/mykhailo-yalovyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykhailo-yalovyi.yaml
@@ -120,6 +120,31 @@ persona:
     перетворення культурної мережі на кримінальну справу.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  learner_task: >-
+    Прочитайте статтю про Михайла Ялового (Юліана Шпола). Зверніть увагу на його роль як першого президента ВАПЛІТЕ та механізм сфабрикованої справи проти нього.
+  license: copyrighted
+  notes: >-
+    Біографічна довідка про організатора літературного життя 1920-х років та жертву сталінського терору.
+  rights_note: Текст захищено авторським правом. Надається лише посилання на зовнішній ресурс.
+  role: primary
+  source_name: Національна бібліотека України імені В. І. Вернадського (НБУВ)
+  source_type: article
+  source_url: https://www.nbuv.gov.ua/node/4119
+- hosting: link-only
+  language: uk
+  learner_task: >-
+    Ознайомтеся з оглядовою статтею про життя та творчість Ялового, його зв'язок із Миколою Хвильовим та Розстріляним відродженням.
+  license: creative-commons
+  notes: >-
+    Детальна оглядова стаття про життєвий і творчий шлях письменника.
+  rights_note: Матеріал поширюється за ліцензією CC BY-SA. Надається посилання на оригінал.
+  role: secondary
+  source_name: Вікіпедія
+  source_type: article
+  source_url: https://uk.wikipedia.org/wiki/%D0%AF%D0%BB%D0%BE%D0%B2%D0%B8%D0%B9_%D0%9C%D0%B8%D1%85%D0%B0%D0%B9%D0%BB%D0%BE_%D0%9E%D0%BC%D0%B5%D0%BB%D1%8F%D0%BD%D0%BE%D0%B2%D0%B8%D1%87
 references:
 - note: Англомовна енциклопедична стаття про ВАПЛІТЕ, арешт і розстріл.
   path: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CY%5CA%5CYalovyMykhailo.htm
@@ -150,7 +175,7 @@ sequence: 207
 slug: mykhailo-yalovyi
 subtitle: The VAPLITE President Whose Arrest Signaled the End
 title: 'Михайло Яловий: ВАПЛІТЕ, сатира та справа УВО'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: Вільна Академія Пролетарської Літератури — провідна літературна організація 1920-х років
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/mykhailo-yalovyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykhailo-yalovyi.yaml
@@ -136,15 +136,15 @@ readings:
 - hosting: link-only
   language: uk
   learner_task: >-
-    Ознайомтеся з оглядовою статтею про життя та творчість Ялового, його зв'язок із Миколою Хвильовим та Розстріляним відродженням.
-  license: creative-commons
+    Знайдіть ім'я Михайла Ялового у списку УІНП про розстріляних у Сандармоху. Зафіксуйте дату страти й поясніть, чому це джерело важливе для перевірки біографії.
+  license: copyrighted
   notes: >-
-    Детальна оглядова стаття про життєвий і творчий шлях письменника.
-  rights_note: Матеріал поширюється за ліцензією CC BY-SA. Надається посилання на оригінал.
-  role: secondary
-  source_name: Вікіпедія
-  source_type: article
-  source_url: https://uk.wikipedia.org/wiki/%D0%AF%D0%BB%D0%BE%D0%B2%D0%B8%D0%B9_%D0%9C%D0%B8%D1%85%D0%B0%D0%B9%D0%BB%D0%BE_%D0%9E%D0%BC%D0%B5%D0%BB%D1%8F%D0%BD%D0%BE%D0%B2%D0%B8%D1%87
+    Український меморіальний список допомагає перевірити сандармоський етап репресій без опори на вторинний огляд.
+  rights_note: Текст захищено авторським правом. Надається лише посилання на зовнішній ресурс.
+  role: evidence
+  source_name: Український інститут національної пам'яті
+  source_type: memorial_list
+  source_url: https://uinp.gov.ua/pres-centr/novyny/sogodni-po-vsomu-sviti-chytayut-imena-zhertv-sandarmohu-spysok-rozstrilyanyh-ukrayinciv
 references:
 - note: Англомовна енциклопедична стаття про ВАПЛІТЕ, арешт і розстріл.
   path: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CY%5CA%5CYalovyMykhailo.htm
@@ -175,7 +175,7 @@ sequence: 207
 slug: mykhailo-yalovyi
 subtitle: The VAPLITE President Whose Arrest Signaled the End
 title: 'Михайло Яловий: ВАПЛІТЕ, сатира та справа УВО'
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: Вільна Академія Пролетарської Літератури — провідна літературна організація 1920-х років
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/mykola-voronyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykola-voronyi.yaml
@@ -142,15 +142,15 @@ readings:
 - hosting: link-only
   language: uk
   learner_task: >-
-    Прочитайте статтю у Вікіпедії, щоб ознайомитися з додатковими фактами біографії Миколи Вороного та його роллю в українському модернізмі.
-  license: creative-commons
+    Прочитайте меморіальну довідку УІНП. Випишіть, як у ній подано арешт, заслання, повторний арешт і вирок особливої трійки.
+  license: copyrighted
   notes: >-
-    Оглядова стаття, що деталізує біографію та естетичні погляди Миколи Вороного.
-  rights_note: Матеріал поширюється за ліцензією CC BY-SA. Надається посилання на оригінал.
-  role: secondary
-  source_name: Вікіпедія
-  source_type: article
-  source_url: https://uk.wikipedia.org/wiki/%D0%92%D0%BE%D1%80%D0%BE%D0%BD%D0%B8%D0%B9_%D0%9C%D0%B8%D0%BA%D0%BE%D0%BB%D0%B0_%D0%9A%D1%96%D0%BD%D0%B4%D1%80%D0%B0%D1%82%D0%BE%D0%B2%D0%B8%D1%87
+    Меморіальний матеріал УІНП дає стислий україномовний контекст про репресії та повертає увагу до механізму державного терору.
+  rights_note: Текст захищено авторським правом. Надається лише посилання на зовнішній ресурс.
+  role: context
+  source_name: Український інститут національної пам'яті
+  source_type: memorial_note
+  source_url: https://www.uinp.gov.ua/istorychnyy-kalendar/gruden/6/narodyvsya-mykola-voronyy
 references:
 - note: Енциклопедична стаття про життя, творчість та репресії.
   path: https://esu.com.ua/article-29783
@@ -178,7 +178,7 @@ sequence: 206
 slug: mykola-voronyi
 subtitle: The Symbolist Poet Who Built a Bridge to Europe
 title: 'Микола Вороний: Символізм, театр і особлива трійка'
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: напрям у літературі кінця XIX — початку XX століття, що використовує символи, музичність і алегорії
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/mykola-voronyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykola-voronyi.yaml
@@ -126,6 +126,31 @@ persona:
     уникаючи як радянського стирання, так і спрощеної глорифікації.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  learner_task: >-
+    Ознайомтеся зі статтею про життя та творчий шлях Миколи Вороного. Зверніть увагу на його театральну та громадську діяльність.
+  license: copyrighted
+  notes: >-
+    Енциклопедична стаття про ключові етапи життя видатного письменника і перекладача.
+  rights_note: Текст захищено авторським правом. Надається лише посилання на зовнішній ресурс.
+  role: primary
+  source_name: Енциклопедія сучасної України (ЕСУ)
+  source_type: article
+  source_url: https://esu.com.ua/article-29783
+- hosting: link-only
+  language: uk
+  learner_task: >-
+    Прочитайте статтю у Вікіпедії, щоб ознайомитися з додатковими фактами біографії Миколи Вороного та його роллю в українському модернізмі.
+  license: creative-commons
+  notes: >-
+    Оглядова стаття, що деталізує біографію та естетичні погляди Миколи Вороного.
+  rights_note: Матеріал поширюється за ліцензією CC BY-SA. Надається посилання на оригінал.
+  role: secondary
+  source_name: Вікіпедія
+  source_type: article
+  source_url: https://uk.wikipedia.org/wiki/%D0%92%D0%BE%D1%80%D0%BE%D0%BD%D0%B8%D0%B9_%D0%9C%D0%B8%D0%BA%D0%BE%D0%BB%D0%B0_%D0%9A%D1%96%D0%BD%D0%B4%D1%80%D0%B0%D1%82%D0%BE%D0%B2%D0%B8%D1%87
 references:
 - note: Енциклопедична стаття про життя, творчість та репресії.
   path: https://esu.com.ua/article-29783
@@ -153,7 +178,7 @@ sequence: 206
 slug: mykola-voronyi
 subtitle: The Symbolist Poet Who Built a Bridge to Europe
 title: 'Микола Вороний: Символізм, театр і особлива трійка'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: напрям у літературі кінця XIX — початку XX століття, що використовує символи, музичність і алегорії
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/oleksa-vlyzko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oleksa-vlyzko.yaml
@@ -138,15 +138,15 @@ readings:
 - hosting: link-only
   language: uk
   learner_task: >-
-    Прочитайте статтю про ранній старт поета, особливості його інвалідності та механізм сфабрикованої справи 1934 року.
-  license: creative-commons
+    Ознайомтеся з виставковою сторінкою НІБУ про Олексу Влизька. Оберіть один твір або біографічний факт, який допомагає читати його як автора, а не лише як жертву.
+  license: copyrighted
   notes: >-
-    Оглядова стаття з додатковими деталями про життєпис Олекси Влизька.
-  rights_note: Матеріал поширюється за ліцензією CC BY-SA. Надається посилання на оригінал.
-  role: secondary
-  source_name: Вікіпедія
-  source_type: article
-  source_url: https://uk.wikipedia.org/wiki/%D0%92%D0%BB%D0%B8%D0%B7%D1%8C%D0%BA%D0%BE_%D0%9E%D0%BB%D0%B5%D0%BA%D1%81%D0%B0_%D0%A4%D0%B5%D0%B4%D0%BE%D1%80%D0%BE%D0%B2%D0%B8%D1%87
+    Бібліотечна виставка дає україномовний контекст корпусу та пам'яті без опори на енциклопедичний переказ.
+  rights_note: Текст захищено авторським правом. Надається лише посилання на зовнішній ресурс.
+  role: context
+  source_name: Національна історична бібліотека України
+  source_type: exhibition
+  source_url: https://nibu.kyiv.ua/exhibitions/627/
 references:
 - note: Основна українська енциклопедична стаття; містить альтернативне датування смерті.
   path: https://esu.com.ua/article-35164
@@ -156,9 +156,9 @@ references:
   path: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CV%5CL%5CVlyzkoOleksa.htm
   title: Vlyzko, Oleksa (IEU)
   type: reference
-- note: Архівно-музейний матеріал про хвилю репресій після вбивства Кірова та справу Влизька.
-  path: https://old-csam.archives.gov.ua/ukr/holovna/
-  title: ЦДАМЛМ України — матеріал про репресійну хвилю 1934 року
+- note: Бібліотечна виставкова сторінка про Олексу Влизька та його книжки.
+  path: https://nibu.kyiv.ua/exhibitions/627/
+  title: Олекса Влизько (НІБУ)
   type: reference
 - author: Олекса Влизько
   note: Морська збірка 1930 року; використовується для аналізу індустріально-морської образності.
@@ -174,7 +174,7 @@ sequence: 210
 slug: oleksa-vlyzko
 subtitle: The Young Maritime Modernist Destroyed in the 1934 Terror Wave
 title: "Олекса Влизько: Морська модерність і прискорений терор"
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: втрата слуху; у біографії Влизька — факт дитячої хвороби, який не слід подавати як сентиментальну легенду
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/oleksa-vlyzko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oleksa-vlyzko.yaml
@@ -122,6 +122,31 @@ persona:
     мартиролог, і водночас точно називає механізми радянського терору.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  learner_task: >-
+    Ознайомтеся з біографічною статтею про Олексу Влизька. Проаналізуйте, як морська та подорожня тематика відобразилася у його поезії.
+  license: copyrighted
+  notes: >-
+    Енциклопедична стаття про наймолодшого представника «Розстріляного відродження».
+  rights_note: Текст захищено авторським правом. Надається лише посилання на зовнішній ресурс.
+  role: primary
+  source_name: Енциклопедія сучасної України (ЕСУ)
+  source_type: article
+  source_url: https://esu.com.ua/article-35164
+- hosting: link-only
+  language: uk
+  learner_task: >-
+    Прочитайте статтю про ранній старт поета, особливості його інвалідності та механізм сфабрикованої справи 1934 року.
+  license: creative-commons
+  notes: >-
+    Оглядова стаття з додатковими деталями про життєпис Олекси Влизька.
+  rights_note: Матеріал поширюється за ліцензією CC BY-SA. Надається посилання на оригінал.
+  role: secondary
+  source_name: Вікіпедія
+  source_type: article
+  source_url: https://uk.wikipedia.org/wiki/%D0%92%D0%BB%D0%B8%D0%B7%D1%8C%D0%BA%D0%BE_%D0%9E%D0%BB%D0%B5%D0%BA%D1%81%D0%B0_%D0%A4%D0%B5%D0%B4%D0%BE%D1%80%D0%BE%D0%B2%D0%B8%D1%87
 references:
 - note: Основна українська енциклопедична стаття; містить альтернативне датування смерті.
   path: https://esu.com.ua/article-35164
@@ -149,7 +174,7 @@ sequence: 210
 slug: oleksa-vlyzko
 subtitle: The Young Maritime Modernist Destroyed in the 1934 Terror Wave
 title: "Олекса Влизько: Морська модерність і прискорений терор"
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: втрата слуху; у біографії Влизька — факт дитячої хвороби, який не слід подавати як сентиментальну легенду
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/valerian-polishchuk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/valerian-polishchuk.yaml
@@ -110,15 +110,15 @@ readings:
 - hosting: link-only
   language: uk
   learner_task: >-
-    Прочитайте статтю про творчий та життєвий шлях Валер'яна Поліщука, а також про механізм його репресії та фальсифікації дати смерті.
-  license: creative-commons
+    Прочитайте статтю «Читомо» про Валер'яна Поліщука. Випишіть один приклад, який ускладнює простий мартирологічний портрет автора.
+  license: copyrighted
   notes: >-
-    Оглядова стаття, що описує індустріальну лірику та обставини загибелі митця.
-  rights_note: Матеріал поширюється за ліцензією CC BY-SA. Надається посилання на оригінал.
-  role: secondary
-  source_name: Вікіпедія
+    Журнальний україномовний матеріал підтримує антиагіографічне читання та не підміняє біографію лише датою розстрілу.
+  rights_note: Текст захищено авторським правом. Надається лише посилання на зовнішній ресурс.
+  role: reading
+  source_name: Читомо
   source_type: article
-  source_url: https://uk.wikipedia.org/wiki/%D0%9F%D0%BE%D0%BB%D1%96%D1%89%D1%83%D0%BA_%D0%92%D0%B0%D0%BB%D0%B5%D1%80%27%D1%8F%D0%BD_%D0%9B%D1%8C%D0%B2%D0%BE%D0%B2%D0%B8%D1%87
+  source_url: https://archive.chytomo.com/uncategorized/pershij-ukraiinskij-poet-shho-postrazhdav-za-pornografiyu
 references:
 - note: Енциклопедична стаття.
   path: https://esu.com.ua/article-881253
@@ -128,9 +128,9 @@ references:
   path: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CP%5CO%5CPolishchukValeriian.htm
   title: Polishchuk, Valeriian (IEU)
   type: reference
-- note: Архівно-музейна довідка про репресованих письменників.
-  path: https://old-csam.archives.gov.ua/ukr/vchiteli/
-  title: Репресовані письменники (ЦДАМЛМ)
+- note: Журнальна стаття про складну рецепцію Валер'яна Поліщука.
+  path: https://archive.chytomo.com/uncategorized/pershij-ukraiinskij-poet-shho-postrazhdav-za-pornografiyu
+  title: Перший український поет, що постраждав за «порнографію» (Читомо)
   type: reference
 - note: Перехресна перевірка дати розстрілу.
   path: https://uinp.gov.ua/pres-centr/novyny/sogodni-po-vsomu-sviti-chytayut-imena-zhertv-sandarmohu-spysok-rozstrilyanyh-ukrayinciv
@@ -150,7 +150,7 @@ sequence: 209
 slug: valerian-polishchuk
 subtitle: The Constructivist Poet Erased Twice
 title: 'Валер''ян Поліщук: авангард, конструктивізм і Сандармох'
-version: '4.2'
+version: '4.3'
 vocabulary_hints:
 - definition: напрям у модерністській літературі 1920-х, що експериментує з мовою та формою
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/valerian-polishchuk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/valerian-polishchuk.yaml
@@ -94,6 +94,31 @@ persona:
     Модератор семінару, який досліджує український авангард та конструктивізм, уникаючи мокри та спрощеної глорифікації.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  learner_task: >-
+    Ознайомтеся зі статтею про Валер'яна Поліщука. Зверніть увагу на його роль як лідера та ідеолога літературної групи «Авангард».
+  license: copyrighted
+  notes: >-
+    Енциклопедична стаття про поета-конструктивіста та його модерністський доробок.
+  rights_note: Текст захищено авторським правом. Надається лише посилання на зовнішній ресурс.
+  role: primary
+  source_name: Енциклопедія сучасної України (ЕСУ)
+  source_type: article
+  source_url: https://esu.com.ua/article-881253
+- hosting: link-only
+  language: uk
+  learner_task: >-
+    Прочитайте статтю про творчий та життєвий шлях Валер'яна Поліщука, а також про механізм його репресії та фальсифікації дати смерті.
+  license: creative-commons
+  notes: >-
+    Оглядова стаття, що описує індустріальну лірику та обставини загибелі митця.
+  rights_note: Матеріал поширюється за ліцензією CC BY-SA. Надається посилання на оригінал.
+  role: secondary
+  source_name: Вікіпедія
+  source_type: article
+  source_url: https://uk.wikipedia.org/wiki/%D0%9F%D0%BE%D0%BB%D1%96%D1%89%D1%83%D0%BA_%D0%92%D0%B0%D0%BB%D0%B5%D1%80%27%D1%8F%D0%BD_%D0%9B%D1%8C%D0%B2%D0%BE%D0%B2%D0%B8%D1%87
 references:
 - note: Енциклопедична стаття.
   path: https://esu.com.ua/article-881253
@@ -125,7 +150,7 @@ sequence: 209
 slug: valerian-polishchuk
 subtitle: The Constructivist Poet Erased Twice
 title: 'Валер''ян Поліщук: авангард, конструктивізм і Сандармох'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: напрям у модерністській літературі 1920-х, що експериментує з мовою та формою
   pos: ч.


### PR DESCRIPTION
## Summary

Adds Ukrainian-only learner reading blocks for the repressed modernist batch:

- `mykhailo-drai-khmara`
- `mykola-voronyi`
- `mykhailo-yalovyi`
- `hryhorii-epik`
- `valerian-polishchuk`
- `oleksa-vlyzko`

The AGY/Gemini worker added the initial readings. The orchestrator replaced Wikipedia fallback readings with stronger Ukrainian institutional/library sources where available and removed dead archive reference links in the touched files.

## Verification

- `git diff --check origin/main..HEAD`
- `.venv/bin/python scripts/validate_plan_config.py bio`
- `.venv/bin/python scripts/validate_plans.py bio`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- Focused reading URL/schema probe: all 12 reading URLs returned HTTP 200; all readings have `language: uk`, hostability/copyright notes, learner tasks, and source metadata; no Wikipedia reading fallbacks remain.

LLM-QG and Gemma/OpenRouter tests were not used.
