### PR TITLE
feat(audit): promote wiki + wiki_sources to required for a1 (#4305)

### DIFF
--- a/scripts/audit/track_deterministic_audit_config.yaml
+++ b/scripts/audit/track_deterministic_audit_config.yaml
@@ -29,6 +29,22 @@ defaults:
     optional_missing: info
 
 tracks:
+  a1:
+    profile: core
+    required_files:
+      - plan
+      - module_md
+      - activities
+      - vocabulary
+      - site_mdx
+      - wiki
+      - wiki_sources
+    optional_files:
+      - resources
+    notes:
+      - "A1 is the published entry-point track: wiki + wiki_sources promoted to"
+      - "required per #4305 user decision 2026-07-06 (55/55 compiled at promotion;"
+      - "B2 precedent). optional_missing stays info per the same decision."
   b2:
     profile: core
     required_files:

--- a/tests/audit/test_track_deterministic_audit.py
+++ b/tests/audit/test_track_deterministic_audit.py
@@ -186,3 +186,19 @@ def test_module_paths_wiki_resolution() -> None:
     unmapped_paths = audit.module_paths("unknown-track", unmapped_module)
     assert "wiki/grammar/unknown-track/topic.md" in unmapped_paths.wiki.as_posix()
     assert "wiki/grammar/unknown-track/topic.sources.yaml" in unmapped_paths.wiki_sources.as_posix()
+
+
+def test_a1_config_requires_wiki_like_b2() -> None:
+    """#4305 user decision 2026-07-06: A1 (published entry-point track)
+    promotes wiki + wiki_sources to required, mirroring B2; resources stays
+    optional and optional_missing stays info-level."""
+    import yaml
+    from audit.track_deterministic_audit import DEFAULT_CONFIG, merged_track_config
+
+    config = yaml.safe_load(DEFAULT_CONFIG.read_text(encoding="utf-8"))
+    for track in ("a1", "b2"):
+        merged = merged_track_config(config, track)
+        assert "wiki" in merged["required_files"], track
+        assert "wiki_sources" in merged["required_files"], track
+        assert "resources" in merged["optional_files"], track
+        assert merged["severity"]["optional_missing"] == "info", track


### PR DESCRIPTION
Executes the #4305 user decision (2026-07-06), both parts:

1. **`optional_missing` stays `info`** — no config change needed (it's the default); recorded here and on the issue. Rationale: the 110-finding class was 100% audit false positive (fixed #4433); zero evidence optional inventory/resources ever goes missing.
2. **A1 promotes `wiki` + `wiki_sources` to required** — mirrors the B2 precedent. A1 is the published entry-point track; a silently missing wiki page there hurts real learners. Zero-cost: 55/55 A1 wiki compiled at promotion.

Verification (local, post-change): `track_deterministic_audit --track a1` → 0 findings (auto-fixable 0, remediation 0); `--track b2` unchanged; audit suite 7/7 incl. new pin-test asserting the merged config for both tracks.

Closes #4305. Umbrella #4300 closes with it (last open item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)