### PR TITLE
test(audit): #4539 wave-3 bio-domain bakeoff fixtures

### DIFF
--- a/tests/fixtures/qg_bakeoff/ahatanhel-krymskyi.json
+++ b/tests/fixtures/qg_bakeoff/ahatanhel-krymskyi.json
@@ -1,0 +1,80 @@
+{
+  "slug": "ahatanhel-krymskyi",
+  "title": "Агатангел Кримський: академічна біографія і східні студії",
+  "verification_log": "BIO domain. All claims tool-verified 2026-07-06 by codex/4539-fixtures-bio-w3 via sources MCP. Sources: query_wikipedia('Кримський Агатангел Юхимович', summary/sections/section 1); search_literary('Агатангел Кримський біографія') -> wave8-ukr-lit-entsyklopediia fc2291b5_c3942, wave4-ukrainska-mova-encyclopedia 1af78606_c0008, wave7-popovych-narys-kultury 68ba0555_c0972. Class-U «Мирзівський звід тридцяти мов»: zero exact attestation verified by query_wikipedia search -> no results; verify_source_attribution(literary) -> discusses=false; search_literary returned only generic звід/мов component noise, no named manuscript.",
+  "passage_md": "У біографічному семінарі Агатангел Кримський постає як учений, чия особиста траєкторія поєднала українську гуманітаристику й орієнталістику. Саме тому джерела варто читати як карту установ, мовних компетенцій і політичного тиску, а не як набір меморіальних формул. Агатангел Кримський народився 3 (15) січня 1871 року у Володимирі-Волинському. Він закінчив Колегію Павла Ґалаґана 1889 року, а після московського навчання 1892 року закінчив Лазаревський інститут східних мов. Далі, 1896 року закінчив Московський університет. У 1896—1898 роках перебував у науковому відрядженні в Єгипті та Марокко.\n\nПісля повернення Кримський працював у Лазаревському інституті, і з 1900 року був професором Лазаревського інституту східних мов. 1918 року переїхав до Львова, де став неодмінним секретарем Наукового товариства імені Шевченка. В академічний період він організовував мовознавчі комісії, а протягом 1921—1929 років був директором Інституту української наукової мови. Для перевірки таких біографій особливо важливо не змішувати реальні посади з пізнішими символічними назвами. Пізніша пам'ять про вченого іноді змішує реальні архіви з легендою: у київському архіві виявили рукопис «Мирзівський звід тридцяти мов», начебто укладений Кримським для студентів-сходознавців.",
+  "claims": [
+    {
+      "claim_id": "kry-t1",
+      "claim": "Агатангел Кримський народився 3 (15) січня 1871 року у Володимирі-Волинському",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "wave8-ukr-lit-entsyklopediia fc2291b5_c3942: «3(15).І 1871, м. Володимир-Волинський... — 25.I 1942, Кустанай»; uk.wikipedia «Кримський Агатангел Юхимович» §Життєпис corroborates."
+    },
+    {
+      "claim_id": "kry-t2",
+      "claim": "закінчив Колегію Павла Ґалаґана 1889 року",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "wave4-ukrainska-mova-encyclopedia 1af78606_c0008: «Закін. 1889 Колегію Павла Ґалаґана в Києві»; fc2291b5_c3942 gives the same college sequence."
+    },
+    {
+      "claim_id": "kry-t3",
+      "claim": "1892 року закінчив Лазаревський інститут східних мов",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "wave8-ukr-lit-entsyklopediia fc2291b5_c3942: «Закін. 1892 Лазарев. ін-т сх. мов (Москва)»; 1af78606_c0008 corroborates."
+    },
+    {
+      "claim_id": "kry-t4",
+      "claim": "1896 року закінчив Московський університет",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "wave8-ukr-lit-entsyklopediia fc2291b5_c3942: «і 1896 — Моск. ун-т»; wave4-ukrainska-mova-encyclopedia 1af78606_c0008 corroborates."
+    },
+    {
+      "claim_id": "kry-m1",
+      "claim": "У 1896—1898 роках перебував у науковому відрядженні в Єгипті та Марокко",
+      "is_true": false,
+      "fabrication_class": "M",
+      "distractor_evidence": "wave8-ukr-lit-entsyklopediia fc2291b5_c3942 — the REAL passage: «У 1896 — 98 перебував у наук. відрядженні в Сирії та Лівані». wave4-ukrainska-mova-encyclopedia 1af78606_c0008 repeats «у Лівані та Сирії». The dates and travel-frame are real; the Egypt/Morocco destinations are fabricated.",
+      "verified_by": "Real destinations = Syria and Lebanon (fc2291b5_c3942; 1af78606_c0008). Egypt/Morocco are a wrong-place inversion."
+    },
+    {
+      "claim_id": "kry-t5",
+      "claim": "з 1900 року був професором Лазаревського інституту східних мов",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "wave8-ukr-lit-entsyklopediia fc2291b5_c3942: «У 1898 — 1918 працював у Лазарев. ін-ті сх. мов (з 1900 — професор)»."
+    },
+    {
+      "claim_id": "kry-m2",
+      "claim": "1918 року переїхав до Львова, де став неодмінним секретарем Наукового товариства імені Шевченка",
+      "is_true": false,
+      "fabrication_class": "M",
+      "distractor_evidence": "wave4-ukrainska-mova-encyclopedia 1af78606_c0008 — the REAL passage: «1918 переїхав до Києва, де взяв діяльну участь в організації УАН (1918). До 1928 — її неодмінний секретар». The move-to-city and secretary role are real, but they belong to Kyiv/UAN, not Lviv/NTSH.",
+      "verified_by": "Real: Kyiv and Ukrainian Academy of Sciences secretary (1af78606_c0008; fc2291b5_c3942; uk.wikipedia §Життєпис). Lviv/NTSH is fabricated."
+    },
+    {
+      "claim_id": "kry-t6",
+      "claim": "протягом 1921—1929 років був директором Інституту української наукової мови",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "wave8-ukr-lit-entsyklopediia fc2291b5_c3942: «У 1921 — 29 — директор Ін-ту укр. наук. мови»; 1af78606_c0008 corroborates."
+    },
+    {
+      "claim_id": "kry-u1",
+      "claim": "у київському архіві виявили рукопис «Мирзівський звід тридцяти мов»",
+      "is_true": false,
+      "fabrication_class": "U",
+      "distractor_evidence": null,
+      "verified_by": "INVENTED manuscript title. Zero exact attestation verified 2026-07-06: query_wikipedia search(«Мирзівський звід тридцяти мов») -> no results; verify_source_attribution(literary, «Мирзівський звід тридцяти мов») -> discusses=false; search_literary(«Мирзівський звід тридцяти мов») returned generic звід/мов chunks only, no named Krymsky manuscript."
+    }
+  ]
+}

--- a/tests/fixtures/qg_bakeoff/franko-ivan.json
+++ b/tests/fixtures/qg_bakeoff/franko-ivan.json
@@ -1,0 +1,80 @@
+{
+  "slug": "franko-ivan",
+  "title": "Іван Франко: освіта, політика і наукова праця",
+  "verification_log": "BIO domain. All claims tool-verified 2026-07-06 by codex/4539-fixtures-bio-w3 via sources MCP. Sources: query_wikipedia('Франко Іван Якович', summary/sections/section 1); search_literary('ФРАНКО Іван Якович народився Нагуєвичі') -> wave7-krypyakevych-istkult 48346587_c0579, wave8-fdm-biobibliohrafichnyi 479cf43d_c0172, wave7-popovych-narys-kultury 68ba0555_c0784; search_literary('Іван Франко 1906 почесний доктор Харківського університету') -> 68ba0555_c0785. Class-U «Золотий молот Каменяра»: zero exact award attestation verified by query_wikipedia search -> no results; verify_source_attribution(literary) -> discusses=false; search_literary returned only generic молот/Каменяр component noise.",
+  "passage_md": "Іван Франко в біографічному корпусі важливий не лише як письменник, а і як організатор інтелектуального життя Галичини. Його життєпис потребує уважного розрізнення партійної, університетської й науково-товариської сфер, бо саме там легко виникають привабливі хронологічні зсуви. Іван Франко народився 27 серпня 1856 року в селі Нагуєвичі і був сином сільського коваля. Після гімназії 1875 року вступив на філософський факультет Львівського університету. За громадсько-політичну діяльність Франко чотири рази був ув'язнений австрійською владою. У галицьких організаціях його роль була різною: 1890 року став першим головою Наукового товариства імені Шевченка.\n\nУ науковій біографії істотний віденський епізод: 1893 року у Віденському університеті захистив дисертацію і здобув учений ступінь доктора філософії. Пізніше, 1906 року він став почесним доктором Харківського технологічного інституту. Вершинним досягненням Франка — поета і мислителя — стала поема «Мойсей» 1905 року. Такі формули часто стоять поряд із ювілейними ритуалами, де факт і символ легко міняються місцями. Під час ювілейного вечора члени львівської громади нібито вручили йому нагороду «Золотий молот Каменяра», яку пізніші перекази трактували як знак праці й непоступливості.",
+  "claims": [
+    {
+      "claim_id": "fra-t1",
+      "claim": "Іван Франко народився 27 серпня 1856 року в селі Нагуєвичі",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "uk.wikipedia «Франко Іван Якович» §Життєпис: «Іван Франко народився 27 серпня 1856 року... села Нагуєвичі»; wave7-krypyakevych-istkult 48346587_c0579 corroborates."
+    },
+    {
+      "claim_id": "fra-t2",
+      "claim": "був сином сільського коваля",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "wave7-krypyakevych-istkult 48346587_c0579: «Був сином селянина-коваля»; wave8-fdm-biobibliohrafichnyi 479cf43d_c0172 corroborates «в родині коваля»."
+    },
+    {
+      "claim_id": "fra-t3",
+      "claim": "1875 року вступив на філософський факультет Львівського університету",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "uk.wikipedia «Франко Іван Якович» §Життєпис: «1875 року... вступив на філософський факультет Львівського університету»; 479cf43d_c0172 corroborates."
+    },
+    {
+      "claim_id": "fra-t4",
+      "claim": "Франко чотири рази був ув'язнений австрійською владою",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "uk.wikipedia «Франко Іван Якович» §Життєпис: «Франко 4 рази був ув'язнений австрійською владою (у 1877, 1880, 1889 і 1892)»."
+    },
+    {
+      "claim_id": "fra-m1",
+      "claim": "1890 року став першим головою Наукового товариства імені Шевченка",
+      "is_true": false,
+      "fabrication_class": "M",
+      "distractor_evidence": "uk.wikipedia «Франко Іван Якович» §Життєпис — the REAL adjacent facts: «1890 року став одним із засновників і першим головою... Русько-української радикальної партії» and «1899 року... став дійсним членом Наукового товариства ім. Шевченка». The party-chair fact and NTSH fact are real; combining them into first chair of NTSH is fabricated.",
+      "verified_by": "Real: first head of RURP in 1890; NTSH member from 1899, not first head (uk.wikipedia §Життєпис; wave7-popovych-narys-kultury 68ba0555_c0803 on NTSH roles)."
+    },
+    {
+      "claim_id": "fra-t5",
+      "claim": "1893 року у Віденському університеті захистив дисертацію і здобув учений ступінь доктора філософії",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "uk.wikipedia «Франко Іван Якович» §Життєпис: «1893 року у Віденському університеті... захистив дисертацію... і здобув учений ступінь доктора філософії»."
+    },
+    {
+      "claim_id": "fra-m2",
+      "claim": "1906 року він став почесним доктором Харківського технологічного інституту",
+      "is_true": false,
+      "fabrication_class": "M",
+      "distractor_evidence": "wave7-popovych-narys-kultury 68ba0555_c0785 — the REAL passage: «1906 р. він став почесним доктором російської словесності Харківського університету». The year and honorary-doctor frame are real; the institution is fabricated as the Kharkiv Technological Institute.",
+      "verified_by": "Real: honorary doctor of Kharkiv University, not Kharkiv Technological Institute (68ba0555_c0785; uk.wikipedia §Життєпис)."
+    },
+    {
+      "claim_id": "fra-t6",
+      "claim": "Вершинним досягненням Франка — поета і мислителя — стала поема «Мойсей» 1905 року",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "wave8-fdm-biobibliohrafichnyi 479cf43d_c0172: «Вершинним досягненням Ф. — поета і мислителя — стала поема \"Мойсей\" (1905)»."
+    },
+    {
+      "claim_id": "fra-u1",
+      "claim": "члени львівської громади нібито вручили йому нагороду «Золотий молот Каменяра»",
+      "is_true": false,
+      "fabrication_class": "U",
+      "distractor_evidence": null,
+      "verified_by": "INVENTED award. Zero exact attestation verified 2026-07-06: query_wikipedia search(«Золотий молот Каменяра») -> no results; verify_source_attribution(literary, «Золотий молот Каменяра») -> discusses=false; search_literary returned only generic молот/Каменяр component hits, no award."
+    }
+  ]
+}

--- a/tests/fixtures/qg_bakeoff/lesya-ukrainka.json
+++ b/tests/fixtures/qg_bakeoff/lesya-ukrainka.json
@@ -1,0 +1,80 @@
+{
+  "slug": "lesya-ukrainka",
+  "title": "Леся Українка: родина, політика і пізня творчість",
+  "verification_log": "BIO domain. All claims tool-verified 2026-07-06 by codex/4539-fixtures-bio-w3 via sources MCP. Sources: query_wikipedia('Леся Українка', summary/sections/section 1); search_literary('Леся Українка біографія') -> wave7-popovych-narys-kultury 68ba0555_c0833; search_literary('Леся Українка Ганкевич Політика і етика 1903') -> 68ba0555_c0834; search_literary('Леся Українка Драгоманов Софія помер на її руках') -> 68ba0555_c0833. Class-U «Софійський зошит Плеяди»: zero exact manuscript attestation verified by query_wikipedia search -> no results; verify_source_attribution(literary) -> discusses=false; search_literary returned only generic Софійський/Плеяда component noise, no named manuscript.",
+  "passage_md": "У біографічному читанні Леся Українка постає не як ізольована поетеса, а як діячка широкого родинного й політичного кола. Такий ракурс вимагає уважно відрізняти родинну пам'ять, політичну публіцистику і пізніший культ письменниці. Лариса Петрівна Косач, за чоловіком — Квітка, прожила 1871—1913 роки. Вона була племінницею, вихованкою і однодумницею Михайла Драгоманова, а Ольга Петрівна Косач, відома як Олена Пчілка, зробила власний внесок у культуру України. Драгоманов помер у Києві після її повернення з Софії.\n\nНа зламі століть її творча біографія перетиналася з громадською роботою: у 1896—1898 роках Леся Українка стала співзасновницею групи «Українська соціал-демократія». 1903 року Леся Українка написала відповідь Сергію Єфремову на статтю «Політика і етика». В особистій драмі 18 (31) січня 1901 року біля ліжка помираючого Сергія Мержинського з-під її пера вийшла поема «Одержима». 7 серпня 1907 року вона офіційно оформила шлюб із Климентом Квіткою. Саме поруч із такими перевіреними датами правдоподібно звучать, але мають відсіюватися, архівні легенди. Пізніший родинний переказ твердив, що родина зберігала рукопис «Софійський зошит Плеяди» як програму її політичного гуртка.",
+  "claims": [
+    {
+      "claim_id": "les-t1",
+      "claim": "Лариса Петрівна Косач, за чоловіком — Квітка, прожила 1871—1913 роки",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "wave7-popovych-narys-kultury 68ba0555_c0833: «Лариса Петрівна Косач, за чоловіком — Квітка (1871 — 1913 рр.)»; uk.wikipedia summary corroborates the article identity."
+    },
+    {
+      "claim_id": "les-t2",
+      "claim": "була племінницею, вихованкою і однодумницею Михайла Драгоманова",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "wave7-popovych-narys-kultury 68ba0555_c0833: «Вона була племінницею, вихованкою і однодумцем Михайла Драгоманова»; uk.wikipedia §Життєпис confirms Drahomanov's formative role."
+    },
+    {
+      "claim_id": "les-t3",
+      "claim": "Ольга Петрівна Косач, відома як Олена Пчілка, зробила власний внесок у культуру України",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "wave7-popovych-narys-kultury 68ba0555_c0833: «Свій внесок в культуру України зробили мати Лесі Українки Ольга Петрівна Косач... письменниця („Олена Пчілка“)»."
+    },
+    {
+      "claim_id": "les-m1",
+      "claim": "Драгоманов помер у Києві після її повернення з Софії",
+      "is_true": false,
+      "fabrication_class": "M",
+      "distractor_evidence": "wave7-popovych-narys-kultury 68ba0555_c0833 — the REAL passage: «Драгоманов і помер на її руках — дізнавшись про діагноз лікарів, Леся Українка терміново виїхала до Софії й прожила там цілий рік». The death/Sofia frame is real; the Kyiv-after-return twist is fabricated.",
+      "verified_by": "Real: Drahomanov died on her hands in Sofia, not in Kyiv after her return (68ba0555_c0833)."
+    },
+    {
+      "claim_id": "les-t4",
+      "claim": "у 1896—1898 роках Леся Українка стала співзасновницею групи «Українська соціал-демократія»",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "uk.wikipedia «Леся Українка» §Життєпис: «У 1896—1898 рр. Леся Українка стала співзасновницею... групи „Українська соціал-демократія“»."
+    },
+    {
+      "claim_id": "les-m2",
+      "claim": "1903 року Леся Українка написала відповідь Сергію Єфремову на статтю «Політика і етика»",
+      "is_true": false,
+      "fabrication_class": "M",
+      "distractor_evidence": "wave7-popovych-narys-kultury 68ba0555_c0834 — the REAL passage: «1903 р. Леся Українка написала відповідь М. Ганкевичу, який у статті „Політика і етика“ твердив...». Сергій Єфремов is genuinely discussed nearby in the same chunk, but the addressee of the 1903 response was Микола Ганкевич.",
+      "verified_by": "Real: response to M. Hankevych, not Serhii Yefremov (68ba0555_c0834)."
+    },
+    {
+      "claim_id": "les-t5",
+      "claim": "18 (31) січня 1901 року біля ліжка помираючого Сергія Мержинського з-під її пера вийшла поема «Одержима»",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "uk.wikipedia «Леся Українка» §Життєпис: «18 (31) січня 1901 року за одну ніч біля ліжка помираючого Мержинського з-під пера Лесі Українки вийшла поема „Одержима“»."
+    },
+    {
+      "claim_id": "les-t6",
+      "claim": "7 серпня 1907 року вона офіційно оформила шлюб із Климентом Квіткою",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "uk.wikipedia «Леся Українка» §Життєпис: «7 серпня 1907 р. вони офіційно оформили шлюб... із Климентом Квіткою»."
+    },
+    {
+      "claim_id": "les-u1",
+      "claim": "родина зберігала рукопис «Софійський зошит Плеяди» як програму її політичного гуртка",
+      "is_true": false,
+      "fabrication_class": "U",
+      "distractor_evidence": null,
+      "verified_by": "INVENTED manuscript. Zero exact attestation verified 2026-07-06: query_wikipedia search(«Софійський зошит Плеяди») -> no results; verify_source_attribution(literary, «Софійський зошит Плеяди») -> discusses=false; search_literary returned unrelated Софійський/Плеяда component hits, no manuscript."
+    }
+  ]
+}

--- a/tests/fixtures/qg_bakeoff/skovoroda-hryhorii.json
+++ b/tests/fixtures/qg_bakeoff/skovoroda-hryhorii.json
@@ -1,0 +1,80 @@
+{
+  "slug": "skovoroda-hryhorii",
+  "title": "Григорій Сковорода: навчання, колегіуми і мандрівка",
+  "verification_log": "BIO domain. All claims tool-verified 2026-07-06 by codex/4539-fixtures-bio-w3 via sources MCP. Sources: query_wikipedia('Сковорода Григорій Савич', summary/sections/section 1); search_literary('Сковорода 1759 Харківський колегіум 1769 странницький період') -> ukrlib-skovoroda ad3fc8fc_c0000, wave5-skovoroda-tvory 5c054efc_c0008 and 5c054efc_c0602; search_literary('НАЧАЛЬНАЯ ДВЕРЬ КО ХРИСТІАНСКОМУ ДОБРОНРАВІЮ 1766 Сковорода') -> wave5-skovoroda-tvory 5c054efc_c0614 and 5c054efc_c0157. Class-U «Каврайський кодекс сродної праці»: zero exact manuscript attestation verified by query_wikipedia search -> no results; verify_source_attribution(literary) -> discusses=false; search_literary returned generic сродна праця scholarship only, no named Kavraiskyi codex.",
+  "passage_md": "У біографічному нарисі Григорій Сковорода постає не лише автором афоризмів, а й педагогом, що не раз змінював інституційне середовище. Для семінару важливо простежити не абстрактну легенду про мандрівного філософа, а конкретну послідовність навчання, служби й викладання. Григорій Сковорода народився 3 грудня 1722 року в Чорнухах на Полтавщині. У 1741 році пройшов конкурсний відбір до придворної капели, а наприкінці серпня 1744 року повернувся до Києво-Могилянської академії. У 1753 році він прибув у село Каврай, де був домашнім учителем у родині Томари.\n\nОсвітня кар'єра Сковороди часто описується через колегіуми. 1759 року Сковороду запросили викладати поетику до Києво-Могилянської академії. Після перерви 1 вересня 1762 року Сковорода почав викладати синтаксиму і грецьку мову. У 1766 році написав трактат «Вступні двері до християнської добронравності». Після 1769 року він розпочав професорський період у Харківському університеті. На межі біографії й рецепції особливо легко сплутати справжні рукописи з красивими назвами. У пізніх спогадах учні переписували «Каврайський кодекс сродної праці», нібито ранній конспект його етики покликання.",
+  "claims": [
+    {
+      "claim_id": "sko-t1",
+      "claim": "Григорій Сковорода народився 3 грудня 1722 року в Чорнухах на Полтавщині",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "ukrlib-skovoroda 69e15fe1_c0000: «Григорій Савич Сковорода народився 3 грудня 1722 р. в селі Чорнухах на Полтавщині»; uk.wikipedia §Життєпис corroborates Chornukhy."
+    },
+    {
+      "claim_id": "sko-t2",
+      "claim": "У 1741 році пройшов конкурсний відбір до придворної капели",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "uk.wikipedia «Сковорода Григорій Савич» §Життєпис: «У 1741 році... пройшов конкурсний відбір до придворної капели»."
+    },
+    {
+      "claim_id": "sko-t3",
+      "claim": "наприкінці серпня 1744 року повернувся до Києво-Могилянської академії",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "uk.wikipedia «Сковорода Григорій Савич» §Життєпис: «Наприкінці серпня 1744 року... повернувся до Києво-Могилянської академії»."
+    },
+    {
+      "claim_id": "sko-t4",
+      "claim": "У 1753 році він прибув у село Каврай",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "uk.wikipedia «Сковорода Григорій Савич» §Життєпис: «Восени 1753 року Сковорода прибув у село Каврай»; ukrlib-skovoroda ad3fc8fc_c0000 corroborates Kavraї/Tomara period."
+    },
+    {
+      "claim_id": "sko-m1",
+      "claim": "1759 року Сковороду запросили викладати поетику до Києво-Могилянської академії",
+      "is_true": false,
+      "fabrication_class": "M",
+      "distractor_evidence": "ukrlib-skovoroda ad3fc8fc_c0000 — the REAL passage: «1759 р. — Григорія Сковороду запрошено на посаду вчителя поезії до Харківського колегіуму». The year and teaching-poetics frame are real; the institution is fabricated.",
+      "verified_by": "Real institution = Kharkiv Collegium, not Kyiv-Mohyla Academy (ad3fc8fc_c0000; uk.wikipedia §Харківський колегіум)."
+    },
+    {
+      "claim_id": "sko-t5",
+      "claim": "1 вересня 1762 року Сковорода почав викладати синтаксиму і грецьку мову",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "uk.wikipedia «Сковорода Григорій Савич» §Життєпис: «1 вересня 1762 року Сковорода почав викладати в класі синтаксими, також вів... курс грецької мови»."
+    },
+    {
+      "claim_id": "sko-t6",
+      "claim": "У 1766 році написав трактат «Вступні двері до християнської добронравності»",
+      "is_true": true,
+      "fabrication_class": null,
+      "distractor_evidence": null,
+      "verified_by": "wave5-skovoroda-tvory 5c054efc_c0157: «НАЧАЛЬНАЯ ДВЕРЬ КО ХРИСТІАНСКОМУ ДОБРОНРАВІЮ» and «Написана в 1766 году»; textbook_sections S4936 normalizes the title as «Вступні двері до християнської добронравності»."
+    },
+    {
+      "claim_id": "sko-m2",
+      "claim": "Після 1769 року він розпочав професорський період у Харківському університеті",
+      "is_true": false,
+      "fabrication_class": "M",
+      "distractor_evidence": "uk.wikipedia «Сковорода Григорій Савич» §Життєпис — the REAL passage: after leaving the Kharkiv Collegium in 1769, «Відтепер Сковорода обрав новий... стиль життя, а саме — мандрівку». wave5-skovoroda-tvory 5c054efc_c0008: «Останні 25 років свого життя Сковорода провів у мандрах по Україні». The post-1769 period is real, but it is a wandering period, not a Kharkiv University professorship.",
+      "verified_by": "Real: post-1769 wandering life after Kharkiv Collegium, not professor at Kharkiv University (uk.wikipedia §Життєпис; 5c054efc_c0008)."
+    },
+    {
+      "claim_id": "sko-u1",
+      "claim": "учні переписували «Каврайський кодекс сродної праці»",
+      "is_true": false,
+      "fabrication_class": "U",
+      "distractor_evidence": null,
+      "verified_by": "INVENTED manuscript title. Zero exact attestation verified 2026-07-06: query_wikipedia search(«Каврайський кодекс сродної праці») -> no results; verify_source_attribution(literary, «Каврайський кодекс сродної праці») -> discusses=false; search_literary returned generic scholarship on «сродна праця», no Kavraiskyi codex."
+    }
+  ]
+}


### PR DESCRIPTION
Addresses #4539

## Summary

Adds four BIO-domain qg bakeoff fixtures:

- `tests/fixtures/qg_bakeoff/ahatanhel-krymskyi.json`
- `tests/fixtures/qg_bakeoff/franko-ivan.json`
- `tests/fixtures/qg_bakeoff/lesya-ukrainka.json`
- `tests/fixtures/qg_bakeoff/skovoroda-hryhorii.json`

Each fixture has a 150-250 word Ukrainian seminar-register passage and 9 literal passage-substring claims: 6 true, 2 class-M, and 1 class-U. Class-M distractors use real retrieved evidence with a plausible fabricated twist; class-U traps are invented names with zero-attestation checks recorded in each fixture.

## Provenance Notes

- `ahatanhel-krymskyi`: true BIO claims verified with `query_wikipedia('Кримський Агатангел Юхимович')` plus `search_literary('Агатангел Кримський біографія')` / Syria-Lebanon / 1918 Kyiv queries returning `wave8-ukr-lit-entsyklopediia fc2291b5_c3942`, `wave4-ukrainska-mova-encyclopedia 1af78606_c0008`, and `wave7-popovych-narys-kultury 68ba0555_c0972`. M traps invert Syria/Lebanon -> Egypt/Morocco and Kyiv/UAN secretary -> Lviv/NTSH secretary. U trap `Мирзівський звід тридцяти мов` has zero exact attestation by Wikipedia search, literary attribution verification, and literary search.
- `franko-ivan`: true BIO claims verified with `query_wikipedia('Франко Іван Якович')`, `search_literary('ФРАНКО Іван Якович народився Нагуєвичі')`, and honorary-doctor queries returning `wave7-krypyakevych-istkult 48346587_c0579`, `wave8-fdm-biobibliohrafichnyi 479cf43d_c0172`, `wave7-popovych-narys-kultury 68ba0555_c0784`, and `68ba0555_c0785`. M traps invert first RURP chair/NTSH membership into first NTSH chair, and Kharkiv University honorary doctorate into Kharkiv Technological Institute. U trap `Золотий молот Каменяра` has zero exact attestation.
- `lesya-ukrainka`: true BIO claims verified with `query_wikipedia('Леся Українка')` and `search_literary` queries returning `wave7-popovych-narys-kultury 68ba0555_c0833` and `68ba0555_c0834`. M traps invert Drahomanov's Sofia death-on-her-hands into Kyiv-after-return, and M. Hankevych response into a Serhii Yefremov response. U trap `Софійський зошит Плеяди` has zero exact attestation.
- `skovoroda-hryhorii`: true BIO claims verified with `query_wikipedia('Сковорода Григорій Савич')`, `search_literary('Сковорода 1759 Харківський колегіум 1769 странницький період')`, and `search_literary('НАЧАЛЬНАЯ ДВЕРЬ КО ХРИСТІАНСКОМУ ДОБРОНРАВІЮ 1766 Сковорода')`, returning `ukrlib-skovoroda ad3fc8fc_c0000`, `wave5-skovoroda-tvory 5c054efc_c0008`, `5c054efc_c0602`, `5c054efc_c0614`, and `5c054efc_c0157`; the Ukrainian normalized title also checked against textbook section `S4936`. M traps invert Kharkiv Collegium -> Kyiv-Mohyla Academy and post-1769 wandering -> Kharkiv University professorship. U trap `Каврайський кодекс сродної праці` has zero exact attestation.

Full per-claim source refs are embedded in each fixture's `verified_by` fields and each fixture-level `verification_log`.

## Verification

Command:

```bash
.venv/bin/python - <<'PY'
# JSON parse, 150-250 word checks, 9 claim checks, literal-span checks, load_fixtures()
PY
```

Cwd:

```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4539-fixtures-bio-w3
```

Raw output:

```text
ahatanhel-krymskyi.json: words=165 claims=9 true=6 M=2 U=1 missing=[]
franko-ivan.json: words=166 claims=9 true=6 M=2 U=1 missing=[]
lesya-ukrainka.json: words=164 claims=9 true=6 M=2 U=1 missing=[]
skovoroda-hryhorii.json: words=157 claims=9 true=6 M=2 U=1 missing=[]
load_fixtures_count=13
```

Command:

```bash
.venv/bin/pytest -q tests/audit/test_qg_bakeoff.py tests/audit/test_qg_tier2_canary_check.py
```

Cwd:

```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4539-fixtures-bio-w3
```

Raw output:

```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4539-fixtures-bio-w3
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 54 items

tests/audit/test_qg_bakeoff.py ......................................... [ 75%]
....                                                                     [ 83%]
tests/audit/test_qg_tier2_canary_check.py .........                      [100%]

============================== 54 passed in 0.81s ==============================
```

Command:

```bash
.venv/bin/ruff check scripts/audit/qg_bakeoff.py scripts/audit/qg_tier2_canary_check.py tests/audit/test_qg_bakeoff.py tests/audit/test_qg_tier2_canary_check.py
```

Cwd:

```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4539-fixtures-bio-w3
```

Raw output:

```text
All checks passed!
```

Command:

```bash
git diff --check origin/main..HEAD
```

Cwd:

```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4539-fixtures-bio-w3
```

Raw output:

```text

```

Command:

```bash
.venv/bin/python scripts/audit/lint_agent_trailer.py
```

Cwd:

```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4539-fixtures-bio-w3
```

Raw output:

```text
Checking 1 commit(s) in origin/main..HEAD:

  c9d69d3aad  PASS  X-Agent: codex/4539-fixtures-bio-w3

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

## Independent Review

Initial AGY cross-family review found one blocker in `skovoroda-hryhorii.json:sko-t6` around the tract title/provenance. The commit was amended to use the corpus-backed/normalized title `Вступні двері до християнської добронравності` with `wave5-skovoroda-tvory 5c054efc_c0157` and textbook `S4936` refs.

Follow-up AGY raw result:

```text
No blocking findings. The corrected title and provenance for `skovoroda-hryhorii.json:sko-t6` (using the S4936 normalization for «Вступні двері до християнської добронравності») are verified and acceptable. All four fixtures have consistent mappings between the generated passages and the extracted claims, and there are no structural errors or unaddressed blockers in the diff.
```

## Merge Note

No merge from this task. Driver should spot-verify via sources MCP before merging.
