### PR TITLE
feat(agent-runtime): #4583 grok failover chain (xai → openrouter, probe-validated)

### DIFF
--- a/scripts/config/agent_runtime_failover.yaml
+++ b/scripts/config/agent_runtime_failover.yaml
@@ -47,3 +47,15 @@ chains:
         model: deepseek/deepseek-v4-pro
       - provider: openrouter
         model: deepseek/deepseek-v4-flash
+  grok:
+    cooldown_ttl_s: 300
+    routes:
+      # Primary: xai subscription seat (hermes oauth). Model inherits the
+      # dispatch request (grok-4.3 default).
+      - provider: xai
+      # Same-family fallback via OpenRouter, pay-per-token (1.25/2.50 USD
+      # per 1M, verified 2026-07-06). Only fires while the subscription
+      # seat faults; grok-lane volume is low-frequency review work, so a
+      # fault-window rotation costs cents (#4583 cost check on the issue).
+      - provider: openrouter
+        model: x-ai/grok-4.3

--- a/tests/agent_runtime/test_runner_failover.py
+++ b/tests/agent_runtime/test_runner_failover.py
@@ -517,3 +517,26 @@ def test_chain_route_missing_model_after_index_zero_warns_and_drops(
 
     assert chain is None  # single usable route -> feature disabled
     assert any("deepseek[1] dropped" in rec.getMessage() for rec in caplog.records)
+
+
+def test_shipped_grok_chain_is_grok_family_only():
+    """#4583: grok lane fails over inside the x-ai family via openrouter.
+    Route 0 inherits the dispatch-requested model (xai subscription seat)."""
+    from agent_runtime.failover import (
+        default_failover_config_path,
+        load_failover_chain,
+    )
+
+    chain = load_failover_chain(
+        "grok",
+        effective_model="grok-4.3",
+        path=default_failover_config_path(),
+    )
+
+    assert chain is not None, "shipped config must define the grok chain"
+    assert [route.provider for route in chain.routes] == ["xai", "openrouter"]
+    assert chain.routes[0].model == "grok-4.3"
+    assert chain.routes[1].model.startswith("x-ai/"), (
+        f"fallback left the grok family: {chain.routes[1].model}"
+    )
+    assert chain.cooldown_ttl_s == 300


### PR DESCRIPTION
Second #4501 runner-level chain, per #4583 AC1.

## Chain
`grok`: route 0 = xai subscription seat (model inherits dispatch request) → route 1 = `openrouter x-ai/grok-4.3`. Family-pure; pin-test added mirroring the deepseek one.

## Cost gate (resolved on the issue)
Fallback is pay-per-token: $1.25/$2.50 per 1M (live openrouter catalog 2026-07-06). It fires only while the already-paid subscription seat faults; grok-lane volume is low-frequency review work → cents per fault window, no quota window to trip.

## Live forced-failure validation
Isolated HERMES_HOME with corrupted xai-oauth credential (pool entry), isolated cooldown DB, worktree config:
- Run 1: route 0 auth failure → rotation → `ok=true`, substitution surfaced in marker/result/usage/telemetry (`source=agent-runtime-failover:auth`). **Also re-validates the #4580 classifier fixes against an oauth-type credential.**
- Run 2: cooling route skipped (`source=agent-runtime-failover:cooldown`).
- Probe home deleted after.

## agy lane: evaluated, declined for v1
agy chains can only express model downgrades (pro→flash — provider is informational for that adapter). Content lanes must not auto-downgrade output quality on a telemetry marker alone; dispatch-layer substitution (`agent_fallback_substitutions.yaml`) already covers agy limits with operator-visible routing. Recorded on #4583.

Tests: 126 passed locally (full agent_runtime suite incl. new pin-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)