### PR TITLE
feat(practice): #4505 PR-2 heritage pair loader

### DIFF
--- a/scripts/audit/check_static_practice_assets.py
+++ b/scripts/audit/check_static_practice_assets.py
@@ -25,6 +25,7 @@ if str(AUDIT_DIR) not in sys.path:
 from generate_practice_deck import (
     validate_classify_item,
     validate_classify_session_cap,
+    validate_heritage_item,
     validate_paradigm_item,
     validate_synonym_item,
 )
@@ -441,6 +442,12 @@ def _check_level(
                 errors.extend(
                     f"{paths[kind]}: synonym[{index}] {error}"
                     for error in validate_synonym_item(item)
+                )
+        elif kind == "heritage":
+            for index, item in enumerate(item for item in rows if isinstance(item, dict)):
+                errors.extend(
+                    f"{paths[kind]}: heritage[{index}] {error}"
+                    for error in validate_heritage_item(item)
                 )
         elif kind == "paradigm":
             for index, item in enumerate(item for item in rows if isinstance(item, dict)):

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -91,9 +91,10 @@ NO_PAIR_PROBABILITY = {
 HERITAGE_KINDS = frozenset({"lexical", "sense_restricted"})
 HERITAGE_DEFAULT_AVAILABILITY = "B1"
 HERITAGE_OPTION_LEAK_PATTERN = re.compile(
-    r"(?:⚠|кальк|calque|русизм|russianism|суржик)",
+    r"(?:⚠|кальк|calque|русизм|russianism|суржик|рос\.)",
     re.IGNORECASE,
 )
+HERITAGE_PUBLIC_OPTION_KEYS = frozenset({"label"})
 
 CASE_LABELS_UA = {
     "nominative": "називний",
@@ -1602,20 +1603,10 @@ def _valid_heritage_frames(pair: dict[str, Any]) -> list[dict[str, Any]]:
 def _heritage_pair_native_lexeme(
     pair: dict[str, Any],
     lexemes_by_id: dict[str, dict[str, Any]],
-    by_plain_lemma: dict[str, dict[str, Any]],
 ) -> dict[str, Any] | None:
     native_slug = _clean_text(pair.get("nativeSlug"))
     if native_slug and native_slug in lexemes_by_id:
         return lexemes_by_id[native_slug]
-    native_lemma = _clean_text(pair.get("nativeLemma"))
-    if native_lemma:
-        lexeme = by_plain_lemma.get(_plain(native_lemma))
-        if lexeme:
-            return lexeme
-    for correction in _clean_text_list(pair.get("corrections")):
-        lexeme = by_plain_lemma.get(_plain(correction))
-        if lexeme:
-            return lexeme
     return None
 
 
@@ -1693,11 +1684,23 @@ def _shuffle_heritage_options(heritage_id: str, options: list[dict[str, str]]) -
     )
 
 
+def _strip_heritage_option_metadata(item: dict[str, Any]) -> dict[str, Any]:
+    stripped = {**item}
+    stripped["options"] = [
+        {"label": str(option.get("label") or "")}
+        for option in item.get("options", [])
+        if isinstance(option, dict)
+    ]
+    return stripped
+
+
 def _build_heritage_items(
     pair: dict[str, Any],
     lexeme: dict[str, Any],
     all_lexemes: list[dict[str, Any]],
     deck_version: str,
+    *,
+    public_options: bool = True,
 ) -> list[dict[str, Any]]:
     frames = _valid_heritage_frames(pair)
     if not frames:
@@ -1750,7 +1753,7 @@ def _build_heritage_items(
         if item["kind"] == "sense_restricted":
             item["calqueSense"] = _clean_text(pair.get("calqueSense")) or ""
             item["authenticSense"] = _clean_text(pair.get("authenticSense")) or ""
-        items.append(item)
+        items.append(_strip_heritage_option_metadata(item) if public_options else item)
     return items
 
 
@@ -1824,7 +1827,7 @@ def validate_synonym_item(item: dict[str, Any]) -> list[str]:
     return errors
 
 
-def validate_heritage_item(item: dict[str, Any]) -> list[str]:
+def validate_heritage_item(item: dict[str, Any], *, internal_options: bool = False) -> list[str]:
     errors: list[str] = []
     for field in ("heritageId", "lemmaId", "srsKey", "prompt", "answer", "calque", "rationale"):
         if not _clean_text(item.get(field)):
@@ -1844,6 +1847,15 @@ def validate_heritage_item(item: dict[str, Any]) -> list[str]:
     labels = [str(option.get("label") or "") for option in option_objects]
     if any(HERITAGE_OPTION_LEAK_PATTERN.search(label) for label in labels):
         errors.append("heritage options must not visually mark the calque pre-answer")
+    if not internal_options:
+        for option in option_objects:
+            leaked_keys = sorted(set(option) - HERITAGE_PUBLIC_OPTION_KEYS)
+            if leaked_keys:
+                errors.append(
+                    "heritage options must expose only label; "
+                    f"remove leaked option keys {leaked_keys}"
+                )
+                break
     normalized = [_plain(label) for label in labels]
     if len(set(normalized)) != len(normalized):
         errors.append("heritage options must be unique after normalization")
@@ -1853,27 +1865,28 @@ def validate_heritage_item(item: dict[str, Any]) -> list[str]:
         errors.append("heritage answer must be present exactly once")
     if normalized.count(calque) != 1:
         errors.append("heritage calque must be present exactly once")
-    kinds = Counter(str(option.get("kind") or "") for option in option_objects)
-    if kinds.get("answer") != 1:
-        errors.append("heritage options must contain exactly one answer")
-    if kinds.get("calque") != 1:
-        errors.append("heritage options must contain exactly one calque")
-    if kinds.get("distractor") != 2:
-        errors.append("heritage options must contain exactly two distractors")
     lengths = [len(label) for label in labels]
     if lengths and max(lengths) - min(lengths) > 12:
         errors.append("heritage option label lengths exceed bounded distribution")
-    pos_values = {
-        str(option.get("pos") or "")
-        for option in option_objects
-        if option.get("kind") != "calque" and option.get("pos")
-    }
-    if len(pos_values) > 1:
-        errors.append("heritage distractors must stay within one POS bucket")
-    for option in option_objects:
-        if option.get("kind") not in {"answer", "calque", "distractor"}:
-            errors.append("heritage option kind is not recognized")
-            break
+    if internal_options:
+        kinds = Counter(str(option.get("kind") or "") for option in option_objects)
+        if kinds.get("answer") != 1:
+            errors.append("heritage options must contain exactly one answer")
+        if kinds.get("calque") != 1:
+            errors.append("heritage options must contain exactly one calque")
+        if kinds.get("distractor") != 2:
+            errors.append("heritage options must contain exactly two distractors")
+        pos_values = {
+            str(option.get("pos") or "")
+            for option in option_objects
+            if option.get("kind") != "calque" and option.get("pos")
+        }
+        if len(pos_values) > 1:
+            errors.append("heritage distractors must stay within one POS bucket")
+        for option in option_objects:
+            if option.get("kind") not in {"answer", "calque", "distractor"}:
+                errors.append("heritage option kind is not recognized")
+                break
     return errors
 
 
@@ -2105,7 +2118,7 @@ def build_practice_shards(
         if not frames:
             heritage_frame_debt += 1
             continue
-        native_lexeme = _heritage_pair_native_lexeme(pair, lexemes_by_id, by_plain_lemma)
+        native_lexeme = _heritage_pair_native_lexeme(pair, lexemes_by_id)
         if not native_lexeme:
             native_slug = _clean_text(pair.get("nativeSlug")) or "<missing>"
             print(
@@ -2114,7 +2127,13 @@ def build_practice_shards(
                 file=sys.stderr,
             )
             continue
-        for item in _build_heritage_items(pair, native_lexeme, all_lexemes, deck_version):
+        for item in _build_heritage_items(
+            pair,
+            native_lexeme,
+            all_lexemes,
+            deck_version,
+            public_options=False,
+        ):
             level = str(item.get("cefr") or "")
             if level not in mode_by_level:
                 print(
@@ -2122,14 +2141,22 @@ def build_practice_shards(
                     file=sys.stderr,
                 )
                 continue
-            item_errors = validate_heritage_item(item)
+            item_errors = validate_heritage_item(item, internal_options=True)
             if item_errors:
                 print(
                     f"WARN: heritage_pair[{index}] item dropped: {'; '.join(item_errors)}",
                     file=sys.stderr,
                 )
                 continue
-            mode_by_level[level]["heritage"].append(item)
+            public_item = _strip_heritage_option_metadata(item)
+            public_errors = validate_heritage_item(public_item)
+            if public_errors:
+                print(
+                    f"WARN: heritage_pair[{index}] item dropped: {'; '.join(public_errors)}",
+                    file=sys.stderr,
+                )
+                continue
+            mode_by_level[level]["heritage"].append(public_item)
             mode_lemma_ids[level]["heritage"].add(native_lexeme["lemmaId"])
     if heritage_frame_debt:
         print(

--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -39,6 +39,7 @@ DEFAULT_ATLAS_DB = Path("data/atlas.db")
 DEFAULT_OUT_DIR = Path("site/public/lexicon")
 DEFAULT_ALLOWLIST = Path("site/src/data/lexicon-practice-reviewed-sources.json")
 DEFAULT_CLOZE_SOURCES = Path("site/src/data/lexicon-practice-cloze-sources.json")
+DEFAULT_HERITAGE_PAIRS = Path("data/lexicon/heritage_pairs.yaml")
 # Keep the default above the current all-eligible deck size. A lower default
 # silently contracts the committed practice surface during routine cloze regen.
 DEFAULT_TARGET = 6000
@@ -87,6 +88,12 @@ NO_PAIR_PROBABILITY = {
     "C1": 0.45,
     "C2": 0.45,
 }
+HERITAGE_KINDS = frozenset({"lexical", "sense_restricted"})
+HERITAGE_DEFAULT_AVAILABILITY = "B1"
+HERITAGE_OPTION_LEAK_PATTERN = re.compile(
+    r"(?:⚠|кальк|calque|русизм|russianism|суржик)",
+    re.IGNORECASE,
+)
 
 CASE_LABELS_UA = {
     "nominative": "називний",
@@ -1553,6 +1560,200 @@ def _build_synonym_items(
     return items
 
 
+def _clean_text_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [text for item in value if (text := _clean_text(item))]
+
+
+def _heritage_availability_level(pair: dict[str, Any]) -> str:
+    return _normalize_cefr(pair.get("cefrAvailability")) or HERITAGE_DEFAULT_AVAILABILITY
+
+
+def _heritage_frame_errors(frame: Any, kind: str) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(frame, dict):
+        return ["heritage_pair frame must be an object"]
+    sentence = _clean_text(frame.get("sentence_with_slot"))
+    if not sentence:
+        errors.append("heritage_pair frame missing sentence_with_slot")
+    elif sentence.count("___") != 1:
+        errors.append("heritage_pair frame sentence_with_slot must contain exactly one ___ slot")
+    for field in ("answer_form", "calque_form", "origin"):
+        if not _clean_text(frame.get(field)):
+            errors.append(f"heritage_pair frame missing {field}")
+    if kind == "sense_restricted" and frame.get("disambiguated") is not True:
+        errors.append("sense_restricted heritage_pair frames require disambiguated: true")
+    return errors
+
+
+def _valid_heritage_frames(pair: dict[str, Any]) -> list[dict[str, Any]]:
+    kind = _clean_text(pair.get("kind")) or ""
+    frames = pair.get("frames")
+    if not isinstance(frames, list):
+        return []
+    return [
+        frame
+        for frame in frames
+        if isinstance(frame, dict) and not _heritage_frame_errors(frame, kind)
+    ]
+
+
+def _heritage_pair_native_lexeme(
+    pair: dict[str, Any],
+    lexemes_by_id: dict[str, dict[str, Any]],
+    by_plain_lemma: dict[str, dict[str, Any]],
+) -> dict[str, Any] | None:
+    native_slug = _clean_text(pair.get("nativeSlug"))
+    if native_slug and native_slug in lexemes_by_id:
+        return lexemes_by_id[native_slug]
+    native_lemma = _clean_text(pair.get("nativeLemma"))
+    if native_lemma:
+        lexeme = by_plain_lemma.get(_plain(native_lemma))
+        if lexeme:
+            return lexeme
+    for correction in _clean_text_list(pair.get("corrections")):
+        lexeme = by_plain_lemma.get(_plain(correction))
+        if lexeme:
+            return lexeme
+    return None
+
+
+def _heritage_option(
+    label: str,
+    kind: str,
+    lemma_id: str | None = None,
+    pos: str | None = None,
+) -> dict[str, str]:
+    option = {"label": label, "kind": kind}
+    if lemma_id:
+        option["lemmaId"] = lemma_id
+    if pos:
+        option["pos"] = pos
+    return option
+
+
+def _valid_heritage_distractors(
+    answer: dict[str, Any],
+    frame: dict[str, Any],
+    pair: dict[str, Any],
+    lexemes: list[dict[str, Any]],
+    level: str,
+) -> list[dict[str, Any]]:
+    answer_form = _clean_text(frame.get("answer_form")) or answer["lemma"]
+    calque_form = _clean_text(frame.get("calque_form")) or ""
+    blocked = {
+        _plain(answer["lemma"]),
+        _plain(answer_form),
+        _plain(calque_form),
+        _plain(_clean_text(pair.get("calqueLabel")) or ""),
+        *{_plain(value) for value in _clean_text_list(pair.get("corrections"))},
+        *{_plain(value) for value in _clean_text_list(pair.get("calqueSurfaces"))},
+    }
+    candidates = []
+    base_labels = [answer_form, calque_form]
+    for lexeme in lexemes:
+        if lexeme["lemmaId"] == answer["lemmaId"]:
+            continue
+        if lexeme.get("pos") != answer.get("pos"):
+            continue
+        if CEFR_RANK[lexeme["cefr"]] > CEFR_RANK[level]:
+            continue
+        label = lexeme["lemma"]
+        if _plain(label) in blocked:
+            continue
+        labels = [*base_labels, label]
+        if max(len(item) for item in labels) - min(len(item) for item in labels) > 12:
+            continue
+        candidates.append(lexeme)
+    answer_len = len(answer_form)
+    return sorted(
+        candidates,
+        key=lambda item: (
+            abs(len(item["lemma"]) - answer_len),
+            item["cefr"] != answer["cefr"],
+            item["lemmaId"],
+        ),
+    )
+
+
+def _shuffle_heritage_options(heritage_id: str, options: list[dict[str, str]]) -> list[dict[str, str]]:
+    return sorted(
+        options,
+        key=lambda option: hashlib.sha1(
+            "\x1f".join(
+                (
+                    heritage_id,
+                    option.get("kind", ""),
+                    option.get("label", ""),
+                    option.get("lemmaId", ""),
+                )
+            ).encode("utf-8")
+        ).hexdigest(),
+    )
+
+
+def _build_heritage_items(
+    pair: dict[str, Any],
+    lexeme: dict[str, Any],
+    all_lexemes: list[dict[str, Any]],
+    deck_version: str,
+) -> list[dict[str, Any]]:
+    frames = _valid_heritage_frames(pair)
+    if not frames:
+        return []
+    level = _heritage_availability_level(pair)
+    items: list[dict[str, Any]] = []
+    for index, frame in enumerate(frames, start=1):
+        answer_form = _clean_text(frame.get("answer_form"))
+        calque_form = _clean_text(frame.get("calque_form"))
+        sentence = _clean_text(frame.get("sentence_with_slot"))
+        origin = _clean_text(frame.get("origin"))
+        rationale = _clean_text(pair.get("rationale")) or ""
+        citations = _clean_text_list(pair.get("citations"))
+        if not all((answer_form, calque_form, sentence, origin, rationale, citations)):
+            continue
+        distractors = _valid_heritage_distractors(lexeme, frame, pair, all_lexemes, level)
+        if len(distractors) < 2:
+            continue
+        key = "\x1f".join((deck_version, lexeme["lemmaId"], sentence, answer_form, calque_form, origin))
+        heritage_id = "her_" + hashlib.sha1(key.encode("utf-8")).hexdigest()[:12]
+        options = [
+            _heritage_option(answer_form, "answer", lexeme["lemmaId"], lexeme.get("pos")),
+            _heritage_option(calque_form, "calque"),
+            *[
+                _heritage_option(distractor["lemma"], "distractor", distractor["lemmaId"], distractor.get("pos"))
+                for distractor in distractors[:2]
+            ],
+        ]
+        item: dict[str, Any] = {
+            "heritageId": heritage_id,
+            "lemmaId": lexeme["lemmaId"],
+            # §9.5: SRS identity is the native lemma, not each sentence frame.
+            "srsKey": f"{lexeme['lemmaId']}::heritage",
+            "lemma": lexeme["lemma"],
+            "nativeLemma": _clean_text(pair.get("nativeLemma")) or lexeme["lemma"],
+            "calqueLabel": _clean_text(pair.get("calqueLabel")) or calque_form,
+            "kind": _clean_text(pair.get("kind")) or "lexical",
+            "prompt": sentence,
+            "answer": answer_form,
+            "calque": calque_form,
+            "origin": origin,
+            "frameIndex": index,
+            "cefr": level,
+            "options": _shuffle_heritage_options(heritage_id, options),
+            "rationale": rationale,
+            "citations": citations,
+            "corrections": _clean_text_list(pair.get("corrections")),
+            "sourceFamily": _clean_text(pair.get("sourceFamily")) or "",
+        }
+        if item["kind"] == "sense_restricted":
+            item["calqueSense"] = _clean_text(pair.get("calqueSense")) or ""
+            item["authenticSense"] = _clean_text(pair.get("authenticSense")) or ""
+        items.append(item)
+    return items
+
+
 def validate_classify_item(item: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     sets = item.get("sets")
@@ -1623,6 +1824,59 @@ def validate_synonym_item(item: dict[str, Any]) -> list[str]:
     return errors
 
 
+def validate_heritage_item(item: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    for field in ("heritageId", "lemmaId", "srsKey", "prompt", "answer", "calque", "rationale"):
+        if not _clean_text(item.get(field)):
+            errors.append(f"heritage item missing {field}")
+    prompt = _clean_text(item.get("prompt"))
+    if prompt and prompt.count("___") != 1:
+        errors.append("heritage prompt must contain exactly one ___ slot")
+    citations = item.get("citations")
+    if not _clean_text_list(citations):
+        errors.append("heritage citations must be a nonempty list")
+    options = item.get("options")
+    if not isinstance(options, list) or len(options) != 4:
+        return [*errors, "heritage option set must contain exactly four options"]
+    option_objects = [option for option in options if isinstance(option, dict)]
+    if len(option_objects) != len(options):
+        errors.append("heritage options must be objects")
+    labels = [str(option.get("label") or "") for option in option_objects]
+    if any(HERITAGE_OPTION_LEAK_PATTERN.search(label) for label in labels):
+        errors.append("heritage options must not visually mark the calque pre-answer")
+    normalized = [_plain(label) for label in labels]
+    if len(set(normalized)) != len(normalized):
+        errors.append("heritage options must be unique after normalization")
+    answer = _plain(str(item.get("answer") or ""))
+    calque = _plain(str(item.get("calque") or ""))
+    if normalized.count(answer) != 1:
+        errors.append("heritage answer must be present exactly once")
+    if normalized.count(calque) != 1:
+        errors.append("heritage calque must be present exactly once")
+    kinds = Counter(str(option.get("kind") or "") for option in option_objects)
+    if kinds.get("answer") != 1:
+        errors.append("heritage options must contain exactly one answer")
+    if kinds.get("calque") != 1:
+        errors.append("heritage options must contain exactly one calque")
+    if kinds.get("distractor") != 2:
+        errors.append("heritage options must contain exactly two distractors")
+    lengths = [len(label) for label in labels]
+    if lengths and max(lengths) - min(lengths) > 12:
+        errors.append("heritage option label lengths exceed bounded distribution")
+    pos_values = {
+        str(option.get("pos") or "")
+        for option in option_objects
+        if option.get("kind") != "calque" and option.get("pos")
+    }
+    if len(pos_values) > 1:
+        errors.append("heritage distractors must stay within one POS bucket")
+    for option in option_objects:
+        if option.get("kind") not in {"answer", "calque", "distractor"}:
+            errors.append("heritage option kind is not recognized")
+            break
+    return errors
+
+
 def validate_paradigm_item(item: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     options = item.get("options")
@@ -1644,14 +1898,33 @@ def validate_heritage_pair(pair: dict[str, Any]) -> list[str]:
         errors.append("heritage_pair missing nativeSlug")
     if not _clean_text(pair.get("calqueLabel")):
         errors.append("heritage_pair missing calqueLabel")
-    corrections = pair.get("corrections")
-    if not isinstance(corrections, list) or not corrections:
+    if not _clean_text_list(pair.get("corrections")):
         errors.append("heritage_pair corrections must be a nonempty list")
-    citations = pair.get("citations")
-    if not isinstance(citations, list) or not citations:
+    if not _clean_text_list(pair.get("citations")):
         errors.append("heritage_pair citations must be a nonempty list")
     if not _clean_text(pair.get("sourceFamily")):
         errors.append("heritage_pair missing sourceFamily")
+    if not _clean_text(pair.get("rationale")):
+        errors.append("heritage_pair missing rationale")
+    kind = _clean_text(pair.get("kind"))
+    if kind not in HERITAGE_KINDS:
+        errors.append("heritage_pair kind must be lexical or sense_restricted")
+    if kind == "sense_restricted":
+        if not _clean_text(pair.get("calqueSense")):
+            errors.append("sense_restricted heritage_pair missing calqueSense")
+        if not _clean_text(pair.get("authenticSense")):
+            errors.append("sense_restricted heritage_pair missing authenticSense")
+    availability = _clean_text(pair.get("cefrAvailability"))
+    if availability and _normalize_cefr(availability) not in {"A2", "B1"}:
+        errors.append("heritage_pair cefrAvailability must be a2 or b1")
+    frames = pair.get("frames")
+    if frames is None:
+        return errors
+    if not isinstance(frames, list):
+        errors.append("heritage_pair frames must be a list")
+        return errors
+    for index, frame in enumerate(frames):
+        errors.extend(f"heritage_pair frames[{index}]: {error}" for error in _heritage_frame_errors(frame, kind or ""))
     return errors
 
 
@@ -1678,6 +1951,9 @@ def validate_mode_items(mode: str, items: list[dict[str, Any]]) -> list[str]:
     elif mode == "synonym":
         for index, item in enumerate(items):
             errors.extend(f"synonym[{index}]: {error}" for error in validate_synonym_item(item))
+    elif mode == "heritage":
+        for index, item in enumerate(items):
+            errors.extend(f"heritage[{index}]: {error}" for error in validate_heritage_item(item))
     elif mode == "paradigm":
         for index, item in enumerate(items):
             errors.extend(f"paradigm[{index}]: {error}" for error in validate_paradigm_item(item))
@@ -1718,6 +1994,7 @@ def build_practice_shards(
     verifier: VesumVerifier,
     cloze_sources: list[dict[str, Any]] | None = None,
     config: BuildConfig | None = None,
+    heritage_pairs: list[dict[str, Any]] | None = None,
 ) -> dict[str, dict[str, dict[str, Any]]]:
     if isinstance(cloze_sources, BuildConfig) and config is None:
         config = cloze_sources
@@ -1747,6 +2024,7 @@ def build_practice_shards(
             lexemes_by_entry.append((entry, lexeme))
 
     all_lexemes = [lexeme for _, lexeme in lexemes_by_entry]
+    lexemes_by_id = {lexeme["lemmaId"]: lexeme for lexeme in all_lexemes}
     by_plain_lemma: dict[str, dict[str, Any]] = {}
     for lexeme in all_lexemes:
         by_plain_lemma.setdefault(_plain(lexeme["lemma"]), lexeme)
@@ -1766,7 +2044,10 @@ def build_practice_shards(
         level: {mode: [] for mode in DRILL_MODES}
         for level in CEFR_ORDER
     }
-    mode_lemma_ids: dict[str, set[str]] = {mode: set() for mode in DRILL_MODES}
+    mode_lemma_ids: dict[str, dict[str, set[str]]] = {
+        level: {mode: set() for mode in DRILL_MODES}
+        for level in CEFR_ORDER
+    }
     for _entry, lexeme in lexemes_by_entry:
         if is_surface_admitted(_entry, SURFACE_CLOZE):
             source_rows = [
@@ -1793,23 +2074,68 @@ def build_practice_shards(
                     **stress,
                 }
             )
-            mode_lemma_ids["stress"].add(lexeme["lemmaId"])
+            mode_lemma_ids[lexeme["cefr"]]["stress"].add(lexeme["lemmaId"])
 
         classify_items = _build_classify_items(_entry, lexeme)
         mode_by_level[lexeme["cefr"]]["classify"].extend(classify_items)
         if classify_items:
-            mode_lemma_ids["classify"].add(lexeme["lemmaId"])
+            mode_lemma_ids[lexeme["cefr"]]["classify"].add(lexeme["lemmaId"])
 
         paradigm_items = _build_paradigm_items(lexeme)
         mode_by_level[lexeme["cefr"]]["paradigm"].extend(paradigm_items)
         if paradigm_items:
-            mode_lemma_ids["paradigm"].add(lexeme["lemmaId"])
+            mode_lemma_ids[lexeme["cefr"]]["paradigm"].add(lexeme["lemmaId"])
 
         synonym_items = _build_synonym_items(_entry, lexeme, by_plain_lemma, all_lexemes, deck_version)
         for item in synonym_items:
             level = str(item.pop("level"))
             mode_by_level[level]["synonym"].append(item)
-            mode_lemma_ids["synonym"].add(lexeme["lemmaId"])
+            mode_lemma_ids[level]["synonym"].add(lexeme["lemmaId"])
+
+    heritage_frame_debt = 0
+    for index, pair in enumerate(heritage_pairs or []):
+        pair_errors = validate_heritage_pair(pair)
+        if pair_errors:
+            print(
+                f"WARN: heritage_pair[{index}] dropped: {'; '.join(pair_errors)}",
+                file=sys.stderr,
+            )
+            continue
+        frames = _valid_heritage_frames(pair)
+        if not frames:
+            heritage_frame_debt += 1
+            continue
+        native_lexeme = _heritage_pair_native_lexeme(pair, lexemes_by_id, by_plain_lemma)
+        if not native_lexeme:
+            native_slug = _clean_text(pair.get("nativeSlug")) or "<missing>"
+            print(
+                f"WARN: heritage_pair[{index}] nativeSlug {native_slug!r} not in practice lexemes; "
+                "emitted 0 items",
+                file=sys.stderr,
+            )
+            continue
+        for item in _build_heritage_items(pair, native_lexeme, all_lexemes, deck_version):
+            level = str(item.get("cefr") or "")
+            if level not in mode_by_level:
+                print(
+                    f"WARN: heritage_pair[{index}] unavailable CEFR level {level!r}; emitted 0 items",
+                    file=sys.stderr,
+                )
+                continue
+            item_errors = validate_heritage_item(item)
+            if item_errors:
+                print(
+                    f"WARN: heritage_pair[{index}] item dropped: {'; '.join(item_errors)}",
+                    file=sys.stderr,
+                )
+                continue
+            mode_by_level[level]["heritage"].append(item)
+            mode_lemma_ids[level]["heritage"].add(native_lexeme["lemmaId"])
+    if heritage_frame_debt:
+        print(
+            f"heritage frame coverage: {heritage_frame_debt} records without frames — emitted 0 items for them",
+            file=sys.stderr,
+        )
 
     shards: dict[str, dict[str, dict[str, Any]]] = {}
     for level in PUBLISHED_LEVELS:
@@ -1817,7 +2143,7 @@ def build_practice_shards(
         if not level_lexemes:
             continue
         level_cloze = cloze_by_level[level]
-        for mode in ("classify", "paradigm", "synonym"):
+        for mode in ("classify", "paradigm", "synonym", "heritage"):
             _validate_mode_or_raise(level, mode, mode_by_level[level][mode])
         option_set_errors = validate_option_sets(level_cloze)
         if option_set_errors:
@@ -1837,7 +2163,7 @@ def build_practice_shards(
             if cloze_ids:
                 modes.append("cloze")
             for drill_mode in DRILL_MODES:
-                if lexeme["lemmaId"] in mode_lemma_ids[drill_mode]:
+                if lexeme["lemmaId"] in mode_lemma_ids[level][drill_mode]:
                     modes.append(drill_mode)
             index_items.append(
                 {
@@ -1976,6 +2302,22 @@ def read_cloze_sources(path: Path | None) -> list[dict[str, Any]]:
     return rows
 
 
+def read_heritage_pairs(path: Path | None) -> list[dict[str, Any]]:
+    if path is None or not path.exists():
+        print("WARN: no curated heritage pairs found; emitting empty heritage deck", file=sys.stderr)
+        return []
+    import yaml
+
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or []
+    pairs = payload.get("pairs") if isinstance(payload, dict) else payload
+    if not isinstance(pairs, list):
+        raise ValueError("heritage pairs must be a list or an object with pairs list")
+    rows = [row for row in pairs if isinstance(row, dict)]
+    if not rows:
+        print("WARN: curated heritage pairs empty; emitting empty heritage deck", file=sys.stderr)
+    return rows
+
+
 def run_broken_validator_fixtures() -> int:
     failures = {
         "classify": validate_classify_item(
@@ -2018,7 +2360,25 @@ def run_broken_validator_fixtures() -> int:
             }
         ),
         "heritage_pair": validate_heritage_pair(
-            {"nativeSlug": "слово", "calqueLabel": "калька", "corrections": [], "citations": []}
+            {
+                "nativeSlug": "slovo",
+                "calqueLabel": "калька",
+                "kind": "sense_restricted",
+                "corrections": ["слово"],
+                "citations": ["fixture:broken"],
+                "sourceFamily": "fixture",
+                "rationale": "fixture broken v5.1 case",
+                "calqueSense": "",
+                "authenticSense": "",
+                "frames": [
+                    {
+                        "sentence_with_slot": "___ і ще ___",
+                        "answer_form": "слово",
+                        "calque_form": "калька",
+                        "origin": "fixture",
+                    }
+                ],
+            }
         ),
         "paronym_pair": validate_paronym_pair(
             {"slugA": "адрес", "slugB": "адреса", "frames": [], "citations": []}
@@ -2144,6 +2504,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
     parser.add_argument("--reviewed-allowlist", type=Path, default=DEFAULT_ALLOWLIST)
     parser.add_argument("--cloze-sources", type=Path, default=DEFAULT_CLOZE_SOURCES)
+    parser.add_argument("--heritage-pairs", type=Path, default=DEFAULT_HERITAGE_PAIRS)
     parser.add_argument("--vesum-fixture", type=Path)
     parser.add_argument("--target", type=int, default=DEFAULT_TARGET)
     parser.add_argument("--raw-limit", type=int, default=DEFAULT_RAW_LIMIT)
@@ -2162,6 +2523,7 @@ def main(argv: list[str] | None = None) -> int:
     entries = read_manifest(args.manifest) if args.manifest else read_atlas_db(args.atlas_db)
     allowlist = ReviewedSourceAllowlist.from_path(args.reviewed_allowlist)
     cloze_sources = read_cloze_sources(args.cloze_sources)
+    heritage_pairs = read_heritage_pairs(args.heritage_pairs)
     verifier: VesumVerifier = (
         JsonVesumVerifier.from_path(args.vesum_fixture)
         if args.vesum_fixture
@@ -2174,7 +2536,7 @@ def main(argv: list[str] | None = None) -> int:
         fixture_note=args.fixture_note,
         source_label="fixture" if args.vesum_fixture or args.manifest else "atlas.db",
     )
-    shards = build_practice_shards(entries, allowlist, verifier, cloze_sources, config)
+    shards = build_practice_shards(entries, allowlist, verifier, cloze_sources, config, heritage_pairs)
     apply_size_budgets(shards, config.raw_limit, config.gzip_limit)
     written = write_shards(shards, args.out_dir)
     for path in written:

--- a/tests/fixtures/lexicon-practice-heritage-pairs.yaml
+++ b/tests/fixtures/lexicon-practice-heritage-pairs.yaml
@@ -1,0 +1,20 @@
+schema_version: 1
+pairs:
+  - nativeSlug: knyha
+    nativeLemma: книга
+    calqueLabel: кніга
+    calqueSurfaces:
+      - кніга
+    kind: lexical
+    corrections:
+      - книга
+    rationale: fixture rationale with cited correction
+    citations:
+      - fixture:heritage
+    sourceFamily: fixture
+    cefrAvailability: a2
+    frames:
+      - sentence_with_slot: Я читаю ___.
+        answer_form: книгу
+        calque_form: кнігу
+        origin: fixture-frame

--- a/tests/test_check_static_practice_assets.py
+++ b/tests/test_check_static_practice_assets.py
@@ -176,6 +176,41 @@ def _write_level(practice_dir: Path, *, level: str = "A1", with_cloze: bool = Fa
     )
 
 
+def _add_heritage_item(practice_dir: Path, *, options: list[dict[str, object]], level: str = "A1") -> None:
+    heritage_path = practice_dir / f"practice-heritage.{level}.json"
+    heritage_payload = json.loads(heritage_path.read_text(encoding="utf-8"))
+    heritage_payload["heritage"] = [
+        {
+            "heritageId": "her_fixture",
+            "lemmaId": "dim",
+            "srsKey": "dim::heritage",
+            "lemma": "дім",
+            "nativeLemma": "дім",
+            "calqueLabel": "дом",
+            "kind": "lexical",
+            "prompt": "Я бачу ___.",
+            "answer": "дім",
+            "calque": "дом",
+            "origin": "fixture",
+            "frameIndex": 1,
+            "cefr": level,
+            "options": options,
+            "rationale": "fixture rationale",
+            "citations": ["fixture:heritage"],
+            "corrections": ["дім"],
+            "sourceFamily": "fixture",
+        }
+    ]
+    _write_json(heritage_path, heritage_payload)
+
+    index_path = practice_dir / f"practice-index.{level}.json"
+    index_payload = json.loads(index_path.read_text(encoding="utf-8"))
+    index_payload["items"][0]["modes"].append("heritage")
+    index_payload["counts"]["modeCounts"]["heritage"] = 1
+    index_payload["counts"]["modeCoverage"]["heritage"] = 1.0
+    _write_json(index_path, index_payload)
+
+
 def _fixture_paths(tmp_path: Path) -> tuple[Path, Path, Path]:
     daily_pool = tmp_path / "lexicon-daily-pool.json"
     practice_dir = tmp_path / "lexicon"
@@ -247,6 +282,31 @@ def test_check_assets_accepts_allowlisted_cloze(tmp_path: Path) -> None:
     assert summary["ok"] is True
     assert summary["reviewed_sources"] == 1
     assert summary["total_cloze"] == 1
+
+
+def test_check_assets_rejects_heritage_option_metadata_leaks(tmp_path: Path) -> None:
+    daily_pool, practice_dir, reviewed_sources = _fixture_paths(tmp_path)
+    _add_heritage_item(
+        practice_dir,
+        options=[
+            {"label": "дім", "kind": "answer", "lemmaId": "dim", "pos": "noun"},
+            {"label": "дом", "kind": "calque"},
+            {"label": "сад", "kind": "distractor", "lemmaId": "sad", "pos": "noun"},
+            {"label": "ліс", "kind": "distractor", "lemmaId": "lis", "pos": "noun"},
+        ],
+    )
+
+    summary = check_assets(
+        daily_pool=daily_pool,
+        practice_dir=practice_dir,
+        reviewed_sources=reviewed_sources,
+        levels=("A1",),
+        min_daily_pool_size=2,
+        min_practice_lexemes_per_level=1,
+    )
+
+    assert summary["ok"] is False
+    assert any("heritage options must expose only label" in error for error in summary["errors"])
 
 
 def test_check_assets_reports_bad_daily_pool_rows(tmp_path: Path) -> None:

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -13,6 +13,7 @@ from scripts.audit.generate_practice_deck import (
     JsonVesumVerifier,
     ReviewedSourceAllowlist,
     _build_classify_items,
+    _build_heritage_items,
     _build_lexeme,
     _build_paradigm_items,
     _declension_category,
@@ -23,8 +24,10 @@ from scripts.audit.generate_practice_deck import (
     build_practice_shards,
     main,
     read_cloze_sources,
+    read_heritage_pairs,
     read_manifest,
     validate_classify_item,
+    validate_heritage_item,
     validate_heritage_pair,
     validate_option_set,
     validate_paradigm_item,
@@ -37,6 +40,7 @@ MANIFEST = FIXTURES / "lexicon-practice-manifest.json"
 ALLOWLIST = FIXTURES / "lexicon-practice-reviewed-allowlist.json"
 VESUM = FIXTURES / "lexicon-practice-vesum.json"
 CLOZE_SOURCES = FIXTURES / "lexicon-practice-cloze-sources.json"
+HERITAGE_PAIRS = FIXTURES / "lexicon-practice-heritage-pairs.yaml"
 
 
 def test_default_target_preserves_committed_practice_surface() -> None:
@@ -50,6 +54,16 @@ def _build(config: BuildConfig | None = None, cloze_sources_path: Path | None = 
     verifier = JsonVesumVerifier.from_path(VESUM)
     cloze_sources = read_cloze_sources(cloze_sources_path) if cloze_sources_path else []
     return build_practice_shards(entries, allowlist, verifier, cloze_sources, config or BuildConfig())
+
+
+def _fixture_lexemes() -> list[dict[str, object]]:
+    verifier = JsonVesumVerifier.from_path(VESUM)
+    lexemes = [_build_lexeme(entry, verifier) for entry in read_manifest(MANIFEST)]
+    return [lexeme for lexeme in lexemes if lexeme]
+
+
+def _fixture_heritage_pair() -> dict[str, object]:
+    return read_heritage_pairs(HERITAGE_PAIRS)[0]
 
 
 def test_fixture_build_emits_sharded_schema() -> None:
@@ -99,6 +113,156 @@ def test_manifest_cloze_fields_are_ignored_without_curated_sources() -> None:
     assert shards["A1"]["index"]["counts"]["lexemes"] == 7
     assert shards["A1"]["index"]["counts"]["cloze"] == 0
     assert shards["A1"]["cloze"]["cloze"] == []
+
+
+def test_read_heritage_pairs_missing_file_warns(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rows = read_heritage_pairs(tmp_path / "missing-heritage.yaml")
+
+    captured = capsys.readouterr()
+    assert rows == []
+    assert "WARN: no curated heritage pairs found; emitting empty heritage deck" in captured.err
+
+
+def test_read_heritage_pairs_empty_file_warns(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    path = tmp_path / "empty-heritage.yaml"
+    path.write_text("", encoding="utf-8")
+
+    rows = read_heritage_pairs(path)
+
+    captured = capsys.readouterr()
+    assert rows == []
+    assert "WARN: curated heritage pairs empty; emitting empty heritage deck" in captured.err
+
+
+def test_heritage_pair_v51_validator_accepts_framed_lexical_pair() -> None:
+    pair = _fixture_heritage_pair()
+
+    assert validate_heritage_pair(pair) == []
+
+
+def test_heritage_pair_v51_validator_rejects_missing_senses_and_bad_frames() -> None:
+    missing_senses = {
+        **_fixture_heritage_pair(),
+        "kind": "sense_restricted",
+        "calqueSense": "",
+        "authenticSense": "",
+        "frames": [
+            {
+                "sentence_with_slot": "Я читаю ___.",
+                "answer_form": "книгу",
+                "calque_form": "кнігу",
+                "origin": "fixture-frame",
+                "disambiguated": True,
+            }
+        ],
+    }
+    no_disambiguation = {
+        **missing_senses,
+        "calqueSense": "calque sense",
+        "authenticSense": "authentic sense",
+        "frames": [
+            {
+                "sentence_with_slot": "Я читаю ___.",
+                "answer_form": "книгу",
+                "calque_form": "кнігу",
+                "origin": "fixture-frame",
+            }
+        ],
+    }
+    multi_slot = {
+        **_fixture_heritage_pair(),
+        "frames": [
+            {
+                "sentence_with_slot": "___ і ще ___",
+                "answer_form": "книгу",
+                "calque_form": "кнігу",
+                "origin": "fixture-frame",
+            }
+        ],
+    }
+
+    assert any("missing calqueSense" in error for error in validate_heritage_pair(missing_senses))
+    assert any("missing authenticSense" in error for error in validate_heritage_pair(missing_senses))
+    assert any("disambiguated: true" in error for error in validate_heritage_pair(no_disambiguation))
+    assert any("exactly one ___ slot" in error for error in validate_heritage_pair(multi_slot))
+
+
+def test_heritage_builder_fails_closed_without_frames(capsys: pytest.CaptureFixture[str]) -> None:
+    pair = _fixture_heritage_pair()
+    pair.pop("frames")
+    lexemes = _fixture_lexemes()
+
+    assert validate_heritage_pair(pair) == []
+    assert _build_heritage_items(pair, lexemes[0], lexemes, "deck-v1") == []
+
+    shards = build_practice_shards(
+        read_manifest(MANIFEST),
+        ReviewedSourceAllowlist.from_path(ALLOWLIST),
+        JsonVesumVerifier.from_path(VESUM),
+        read_cloze_sources(CLOZE_SOURCES),
+        BuildConfig(),
+        [pair],
+    )
+    captured = capsys.readouterr()
+
+    assert shards["A1"]["heritage"]["heritage"] == []
+    assert "1 records without frames — emitted 0 items for them" in captured.err
+
+
+def test_heritage_items_wire_mode_counts_and_index_modes() -> None:
+    entries = json.loads(json.dumps(read_manifest(MANIFEST)))
+    for entry in entries:
+        entry["enrichment"]["cefr"]["level"] = "A2"
+        entry["course_usage"][0]["track"] = "a2"
+    entries[3]["pos"] = "verb"
+    entries[4]["pos"] = "adjective"
+
+    shards = build_practice_shards(
+        entries,
+        ReviewedSourceAllowlist.from_path(ALLOWLIST),
+        JsonVesumVerifier.from_path(VESUM),
+        read_cloze_sources(CLOZE_SOURCES),
+        BuildConfig(),
+        [_fixture_heritage_pair()],
+    )
+    a2 = shards["A2"]
+    heritage = a2["heritage"]["heritage"]
+    index_item = next(item for item in a2["index"]["items"] if item["lemmaId"] == "knyha")
+
+    assert len(heritage) == 1
+    assert heritage[0]["lemmaId"] == "knyha"
+    assert a2["index"]["counts"]["modeCounts"]["heritage"] == 1
+    assert a2["index"]["counts"]["modeCoverage"]["heritage"] == 0.1429
+    assert "heritage" in index_item["modes"]
+
+
+def test_heritage_item_options_are_valid_and_do_not_mark_calque() -> None:
+    pair = _fixture_heritage_pair()
+    lexemes = _fixture_lexemes()
+    item = _build_heritage_items(pair, lexemes[0], lexemes, "deck-v1")[0]
+
+    assert validate_heritage_item(item) == []
+
+    marked = json.loads(json.dumps(item))
+    for option in marked["options"]:
+        if option["kind"] == "calque":
+            option["label"] = f"⚠ {option['label']}"
+            break
+
+    assert "heritage options must not visually mark the calque pre-answer" in validate_heritage_item(marked)
+
+
+def test_heritage_item_ids_and_options_are_deterministic() -> None:
+    pair = _fixture_heritage_pair()
+    lexemes = _fixture_lexemes()
+
+    first = _build_heritage_items(pair, lexemes[0], lexemes, "deck-v1")[0]
+    second = _build_heritage_items(pair, lexemes[0], lexemes, "deck-v1")[0]
+    changed_version = _build_heritage_items(pair, lexemes[0], lexemes, "deck-v2")[0]
+
+    assert first["heritageId"] == second["heritageId"]
+    assert first["options"] == second["options"]
+    assert first["heritageId"] != changed_version["heritageId"]
 
 
 def test_stress_position_preserves_non_stress_combining_marks() -> None:

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -231,6 +231,7 @@ def test_heritage_items_wire_mode_counts_and_index_modes() -> None:
 
     assert len(heritage) == 1
     assert heritage[0]["lemmaId"] == "knyha"
+    assert all(set(option) == {"label"} for option in heritage[0]["options"])
     assert a2["index"]["counts"]["modeCounts"]["heritage"] == 1
     assert a2["index"]["counts"]["modeCoverage"]["heritage"] == 0.1429
     assert "heritage" in index_item["modes"]
@@ -240,16 +241,48 @@ def test_heritage_item_options_are_valid_and_do_not_mark_calque() -> None:
     pair = _fixture_heritage_pair()
     lexemes = _fixture_lexemes()
     item = _build_heritage_items(pair, lexemes[0], lexemes, "deck-v1")[0]
+    internal_item = _build_heritage_items(
+        pair,
+        lexemes[0],
+        lexemes,
+        "deck-v1",
+        public_options=False,
+    )[0]
 
     assert validate_heritage_item(item) == []
+    assert validate_heritage_item(internal_item, internal_options=True) == []
+    assert all(set(option) == {"label"} for option in item["options"])
+    assert all("kind" in option for option in internal_item["options"])
 
     marked = json.loads(json.dumps(item))
     for option in marked["options"]:
-        if option["kind"] == "calque":
-            option["label"] = f"⚠ {option['label']}"
+        if option["label"] == marked["calque"]:
+            option["label"] = f"рос. {option['label']}"
             break
 
     assert "heritage options must not visually mark the calque pre-answer" in validate_heritage_item(marked)
+
+
+def test_heritage_pair_native_slug_must_resolve_without_native_lemma_fallback(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    pair = _fixture_heritage_pair()
+    pair["nativeSlug"] = "missing-slug"
+    pair["nativeLemma"] = "книга"
+    pair["corrections"] = ["книга"]
+
+    shards = build_practice_shards(
+        read_manifest(MANIFEST),
+        ReviewedSourceAllowlist.from_path(ALLOWLIST),
+        JsonVesumVerifier.from_path(VESUM),
+        read_cloze_sources(CLOZE_SOURCES),
+        BuildConfig(),
+        [pair],
+    )
+    captured = capsys.readouterr()
+
+    assert all(level["heritage"]["heritage"] == [] for level in shards.values())
+    assert "nativeSlug 'missing-slug' not in practice lexemes; emitted 0 items" in captured.err
 
 
 def test_heritage_item_ids_and_options_are_deterministic() -> None:


### PR DESCRIPTION
## Summary

- Adds `read_heritage_pairs()` plus `--heritage-pairs` for `data/lexicon/heritage_pairs.yaml`.
- Implements v5.1 heritage-pair validation, framed heritage item construction, deterministic IDs/options, and fail-closed frame debt reporting.
- Adds heritage option validation to the generator and static asset audit.
- Adds fixture coverage for missing/empty loaders, v5.1 reject cases, no-frame fail-closed behavior, mode counts/index wiring, option leakage, and deterministic IDs.

## Dependency

Depends on PR #4596 for `data/lexicon/heritage_pairs.yaml`. This PR intentionally does not include that data file.

Current dependency-branch observation differs from the task brief count (`56`):

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4505-pr2-heritage-loader-r2
command: git fetch origin claude/4505-heritage-pairs && .venv/bin/python - <<'PY' ... validate_heritage_pair ... PY
output: pairs=73 invalid=0 frames=0
```

No implementation ambiguity came from the count drift: the current records validate against the implemented v5.1 contract and have no frames yet, so they emit zero heritage items and are reported as frame debt when consumed.

## Review Gate

Cross-family read-only review via AGY (`gemini-3.1-pro-high`) completed. Actionable findings fixed: deterministic full option shuffle, item-validation warning path, empty YAML handling, and lazy YAML import for static-audit imports. One finding requested per-frame SRS keys; that was not applied because §9.5 explicitly sets SRS identity to native lemma + heritage.

## Validation

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4505-pr2-heritage-loader-r2
command: .venv/bin/python -m pytest tests/test_generate_practice_deck.py tests/test_check_static_practice_assets.py -q
output: ============================== 45 passed in 0.55s ==============================
```

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4505-pr2-heritage-loader-r2
command: .venv/bin/ruff check scripts/audit/generate_practice_deck.py
output: All checks passed!
```

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4505-pr2-heritage-loader-r2
command: git log -1 --oneline
output: eead1ae4f5 feat(practice): #4505 PR-2 heritage pair loader
```
