### PR TITLE
[codex] feat(corpus): #4593 subject column for textbooks

### DIFF
--- a/.mcp/servers/sources/server.py
+++ b/.mcp/servers/sources/server.py
@@ -43,6 +43,8 @@ for _path in (PROJECT_ROOT, SCRIPTS_DIR):
     if str(_path) not in sys.path:
         sys.path.insert(0, str(_path))
 
+from wiki.textbook_subjects import CANONICAL_TEXTBOOK_SUBJECTS
+
 try:
     from mcp.server import Server
     from mcp.server.stdio import stdio_server
@@ -135,7 +137,11 @@ async def list_tools() -> list[Tool]:
                     },
                     "subject": {
                         "type": "string",
-                        "description": "Filter by subject (e.g., 'ukrainska-mova', 'bukvar'). Optional."
+                        "description": (
+                            "Optional canonical textbook subject slug. "
+                            "Examples: 'ukrmova', 'ukrlit', 'istoriya', 'bukvar'."
+                        ),
+                        "enum": list(CANONICAL_TEXTBOOK_SUBJECTS),
                     },
                     "trust_tier": {
                         "type": "integer",
@@ -1286,10 +1292,11 @@ async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
 async def handle_search_text(args: dict) -> list[TextContent]:
     query = args["query"]
     limit = min(args.get("limit", 5), 20)
+    subject = args.get("subject")
 
     from wiki.sources_db import search_textbooks
     keywords = {w for w in query.lower().split() if len(w) >= 3}
-    hits = await asyncio.to_thread(search_textbooks, keywords, limit)
+    hits = await asyncio.to_thread(search_textbooks, keywords, limit, subject=subject)
 
     if not hits:
         return [TextContent(type="text", text="No results found.")]
@@ -1299,6 +1306,7 @@ async def handle_search_text(args: dict) -> list[TextContent]:
         lines.append(f"### Result {i}")
         lines.append(f"- **Section**: {hit.get('section_title', hit.get('title', ''))}")
         lines.append(f"- **Source**: Grade {hit.get('grade', '?')}, {hit.get('author', '?')}")
+        lines.append(f"- **Subject**: {hit.get('subject', '')}")
         lines.append(f"- **Chunk ID**: `{hit.get('chunk_id', '')}`")
         lines.append(f"- **Text**:\n{hit.get('text', '')}")
         lines.append("")

--- a/scripts/migrations/2026-07-06-add-subject-to-textbooks.py
+++ b/scripts/migrations/2026-07-06-add-subject-to-textbooks.py
@@ -1,0 +1,228 @@
+"""Add canonical ``subject`` column to ``textbooks`` and back-fill it.
+
+The textbook corpus historically encoded subject only in ``source_file``
+tokens such as ``ukrmova``, ``ukrlit``, ``istoriya``, and ``bukvar``.
+STEM ingestion needs a first-class filterable column so callers can query
+``search_text(subject=...)`` without brittle filename matching.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+DEFAULT_DB = PROJECT_ROOT / "data" / "sources.db"
+
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from wiki.textbook_subjects import subject_for_source_file
+
+
+class UnmappedTextbookSubjectsError(RuntimeError):
+    """Raised when any existing ``source_file`` cannot be assigned a subject."""
+
+    def __init__(self, source_files: list[str]) -> None:
+        self.source_files = sorted(source_files)
+        super().__init__(
+            "Unmapped textbooks.source_file values: "
+            + ", ".join(repr(value) for value in self.source_files)
+        )
+
+
+@dataclass
+class MigrationStatus:
+    column_added: bool = False
+    rows_updated: int = 0
+    total_rows: int = 0
+    populated_subject: int = 0
+    subject_counts: dict[str, int] = field(default_factory=dict)
+
+
+def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(row[1] == column for row in rows)
+
+
+def _ensure_column(conn: sqlite3.Connection, *, dry_run: bool) -> bool:
+    """Add ``subject`` column if missing. Returns True if it was/would be added."""
+    if _has_column(conn, "textbooks", "subject"):
+        return False
+    if not dry_run:
+        conn.execute("ALTER TABLE textbooks ADD COLUMN subject TEXT")
+    return True
+
+
+def _ensure_index(conn: sqlite3.Connection, *, dry_run: bool) -> None:
+    if not dry_run:
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_textbooks_subject ON textbooks(subject)"
+        )
+
+
+def _distinct_source_files(conn: sqlite3.Connection) -> list[str]:
+    rows = conn.execute(
+        """
+        SELECT DISTINCT source_file
+        FROM textbooks
+        ORDER BY source_file
+        """
+    ).fetchall()
+    return ["" if row[0] is None else str(row[0]) for row in rows]
+
+
+def _subject_map(conn: sqlite3.Connection) -> dict[str, str]:
+    mapped: dict[str, str] = {}
+    unmapped: list[str] = []
+    for source_file in _distinct_source_files(conn):
+        subject = subject_for_source_file(source_file)
+        if subject is None:
+            unmapped.append(source_file)
+        else:
+            mapped[source_file] = subject
+    if unmapped:
+        raise UnmappedTextbookSubjectsError(unmapped)
+    return mapped
+
+
+def _count_rows_for_source(
+    conn: sqlite3.Connection,
+    *,
+    source_file: str,
+    subject: str,
+    column_exists: bool,
+) -> int:
+    if column_exists:
+        sql = """
+            SELECT COUNT(*) FROM textbooks
+            WHERE source_file = ?
+              AND (subject IS NULL OR subject = '' OR subject != ?)
+        """
+        params = (source_file, subject)
+    else:
+        sql = "SELECT COUNT(*) FROM textbooks WHERE source_file = ?"
+        params = (source_file,)
+    return int(conn.execute(sql, params).fetchone()[0])
+
+
+def _backfill(
+    conn: sqlite3.Connection,
+    *,
+    dry_run: bool,
+    column_exists: bool,
+    subjects_by_source: dict[str, str],
+) -> tuple[int, dict[str, int]]:
+    updated_total = 0
+    subject_counts = dict.fromkeys(sorted(set(subjects_by_source.values())), 0)
+    for source_file, subject in subjects_by_source.items():
+        count_total = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM textbooks WHERE source_file = ?",
+                (source_file,),
+            ).fetchone()[0]
+        )
+        subject_counts[subject] += count_total
+
+        count_update = _count_rows_for_source(
+            conn,
+            source_file=source_file,
+            subject=subject,
+            column_exists=column_exists,
+        )
+        if count_update == 0:
+            continue
+        if not dry_run:
+            conn.execute(
+                """
+                UPDATE textbooks
+                SET subject = ?
+                WHERE source_file = ?
+                  AND (subject IS NULL OR subject = '' OR subject != ?)
+                """,
+                (subject, source_file, subject),
+            )
+        updated_total += count_update
+    return updated_total, subject_counts
+
+
+def apply(conn: sqlite3.Connection, *, dry_run: bool = False) -> MigrationStatus:
+    """Apply the migration idempotently."""
+    subjects_by_source = _subject_map(conn)
+    had_column_before = _has_column(conn, "textbooks", "subject")
+    column_added = _ensure_column(conn, dry_run=dry_run)
+    column_exists_for_count = had_column_before or (column_added and not dry_run)
+    rows_updated, subject_counts = _backfill(
+        conn,
+        dry_run=dry_run,
+        column_exists=column_exists_for_count,
+        subjects_by_source=subjects_by_source,
+    )
+    _ensure_index(conn, dry_run=dry_run)
+    if not dry_run:
+        conn.commit()
+
+    total_rows = int(conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0])
+    if column_exists_for_count:
+        populated_subject = int(
+            conn.execute(
+                """
+                SELECT COUNT(*) FROM textbooks
+                WHERE subject IS NOT NULL AND subject != ''
+                """
+            ).fetchone()[0]
+        )
+    else:
+        populated_subject = 0
+
+    return MigrationStatus(
+        column_added=column_added,
+        rows_updated=rows_updated,
+        total_rows=total_rows,
+        populated_subject=populated_subject,
+        subject_counts=subject_counts,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing.",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.db.exists():
+        raise SystemExit(f"Sources DB not found: {args.db}")
+
+    try:
+        with sqlite3.connect(str(args.db)) as conn:
+            status = apply(conn, dry_run=args.dry_run)
+    except UnmappedTextbookSubjectsError as exc:
+        print("ERROR: unmapped textbooks.source_file values:", file=sys.stderr)
+        for source_file in exc.source_files:
+            print(f"  - {source_file}", file=sys.stderr)
+        return 1
+
+    prefix = "[dry-run] " if args.dry_run else ""
+    print(f"{prefix}column_added={status.column_added}")
+    print(f"{prefix}rows_updated={status.rows_updated}")
+    print(
+        f"{prefix}populated_subject={status.populated_subject}/"
+        f"{status.total_rows} (rows with subject / total textbook rows)"
+    )
+    print(f"{prefix}subject_counts:")
+    for subject, count in sorted(status.subject_counts.items()):
+        print(f"{prefix}  {subject}: {count}")
+    print(f"{prefix}all distinct source_file values mapped to subjects.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rag/query.py
+++ b/scripts/rag/query.py
@@ -50,7 +50,7 @@ def _text_hit(row: dict[str, Any]) -> dict[str, Any]:
         "trust_tier": row.get("trust_tier", 0) or 0,
         "source_type": row.get("source_type", "textbook"),
         "source_file": row.get("source_file", ""),
-        "subject": row.get("subject", ""),
+        "subject": row.get("subject") or "",
     }
 
 

--- a/scripts/rag/query.py
+++ b/scripts/rag/query.py
@@ -50,6 +50,7 @@ def _text_hit(row: dict[str, Any]) -> dict[str, Any]:
         "trust_tier": row.get("trust_tier", 0) or 0,
         "source_type": row.get("source_type", "textbook"),
         "source_file": row.get("source_file", ""),
+        "subject": row.get("subject", ""),
     }
 
 
@@ -100,11 +101,16 @@ def search_text(
 ) -> list[dict[str, Any]]:
     """Search textbook chunks through SQLite FTS5."""
     del rerank
-    rows = sources_db.search_textbooks(_keywords(query), max_total=max(limit * 3, limit))
+    canonical_subject = sources_db.normalize_subject_slug(subject)
+    rows = sources_db.search_textbooks(
+        _keywords(query),
+        max_total=max(limit * 3, limit),
+        subject=canonical_subject,
+    )
     hits = [_text_hit(row) for row in rows]
     if grade is not None:
         hits = [hit for hit in hits if hit.get("grade") == grade]
-    if subject:
+    if subject and canonical_subject is None:
         subject_l = subject.lower()
         hits = [
             hit

--- a/scripts/wiki/build_sources_db.py
+++ b/scripts/wiki/build_sources_db.py
@@ -59,11 +59,13 @@ if __package__ in {None, ""}:
     from wiki.config import GDRIVE_DATA
     from wiki.extract_sections import DEFAULT_REPORT_PATH, extract_sections
     from wiki.sources import build_literary_row
+    from wiki.textbook_subjects import subject_for_source_file
     from wiki.ukrainian_wiki_corpus import ensure_ukrainian_wiki_manifest, ensure_ukrainian_wiki_schema
 else:
     from .config import GDRIVE_DATA
     from .extract_sections import DEFAULT_REPORT_PATH, extract_sections
     from .sources import build_literary_row
+    from .textbook_subjects import subject_for_source_file
     from .ukrainian_wiki_corpus import ensure_ukrainian_wiki_manifest, ensure_ukrainian_wiki_schema
 
 SCHEMA = """
@@ -75,6 +77,10 @@ CREATE TABLE IF NOT EXISTS textbooks (
     title TEXT NOT NULL DEFAULT '',
     text TEXT NOT NULL DEFAULT '',
     source_file TEXT NOT NULL DEFAULT '',
+    -- subject: canonical ASCII slug from scripts/wiki/textbook_subjects.py.
+    -- Used by search_text(subject=...) and back-filled by
+    -- scripts/migrations/2026-07-06-add-subject-to-textbooks.py.
+    subject TEXT DEFAULT '',
     grade TEXT DEFAULT '',
     author TEXT DEFAULT '',
     -- author_uk: canonical Cyrillic form of the author. Populated by
@@ -89,6 +95,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS textbooks_fts USING fts5(
 CREATE TRIGGER IF NOT EXISTS textbooks_ai AFTER INSERT ON textbooks BEGIN
     INSERT INTO textbooks_fts(rowid, title, text) VALUES (new.id, new.title, new.text);
 END;
+CREATE INDEX IF NOT EXISTS idx_textbooks_subject ON textbooks(subject);
 
 CREATE TABLE IF NOT EXISTS external_articles (
     id INTEGER PRIMARY KEY,
@@ -287,6 +294,13 @@ def _build_textbook_row(
     ``author_uk`` directly — silently inserting rows with empty
     ``author_uk`` would break textbook citation resolution.
     """
+    subject = subject_for_source_file(source_file)
+    if subject is None:
+        raise ValueError(
+            f"Textbook source_file={source_file!r} has no canonical subject "
+            "mapping. Add it to scripts/wiki/textbook_subjects.py before "
+            "ingesting."
+        )
     author = str(entry.get("author") or "").strip()
     author_uk = str(entry.get("author_uk") or "").strip()
     if author and not author_uk:
@@ -301,6 +315,7 @@ def _build_textbook_row(
         entry.get("section_title", ""),
         entry.get("text", ""),
         source_file,
+        subject,
         entry.get("grade", grade),
         author,
         author_uk,
@@ -625,9 +640,9 @@ def build(db_path: Path | None = None,
     # --- Textbook chunks ---
     print("\n📖 Textbooks")
     tb_sql = """INSERT INTO textbooks
-                (chunk_id, title, text, source_file, grade, author,
+                (chunk_id, title, text, source_file, subject, grade, author,
                  author_uk, char_count)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)"""
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"""
     if tb_dir.exists():
         for grade_dir in sorted(tb_dir.glob("grade-*")):
             grade = grade_dir.name

--- a/scripts/wiki/sources_db.py
+++ b/scripts/wiki/sources_db.py
@@ -38,6 +38,7 @@ from .channels import rank_external_hits
 from .chunking import chunk_text, policy_for
 from .dense_rerank import _get_tokenizer, rerank_candidates, rerank_sections
 from .query_builder import build_query_buckets
+from .textbook_subjects import normalize_subject_slug
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 SOURCES_DB_PATH = PROJECT_ROOT / "data" / "sources.db"
@@ -1186,6 +1187,7 @@ def search_textbooks(
     max_total: int = 40,
     *,
     track: str | None = None,
+    subject: str | None = None,
 ) -> list[dict]:
     """Deprecated chunk-level FTS5 textbook search kept for backward compatibility.
 
@@ -1193,12 +1195,24 @@ def search_textbooks(
     Requests extra rows from FTS5 to compensate for filtered-out noise.
 
     `track`: accepted for backward compatibility with existing callers;
-    the value is no longer consulted. This function is deprecated; use
+    the value is no longer consulted. `subject` filters against the
+    canonical `textbooks.subject` slug. This function is deprecated; use
     `search_sources` for new code.
     """
     _ = track  # accepted for backward compatibility; ignored
     extra_where = ""
     extra_params: tuple = ()
+    if subject:
+        normalized_subject = normalize_subject_slug(subject)
+        if normalized_subject is None:
+            return []
+        if "subject" not in _table_columns("textbooks"):
+            raise sqlite3.OperationalError(
+                "textbooks.subject column missing; run "
+                "scripts/migrations/2026-07-06-add-subject-to-textbooks.py"
+            )
+        extra_where = "AND s.subject = ?"
+        extra_params = (normalized_subject,)
     # Request 2x to compensate for filtered TOC/noise chunks
     rows = _fts_search(
         "textbooks_fts", "textbooks", ukr_keywords, max_total * 2,

--- a/scripts/wiki/textbook_subjects.py
+++ b/scripts/wiki/textbook_subjects.py
@@ -1,0 +1,242 @@
+"""Canonical subject slugs for rows in the ``textbooks`` corpus table."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CANONICAL_TEXTBOOK_SUBJECTS: tuple[str, ...] = (
+    "ukrmova",
+    "ukrlit",
+    "istoriya",
+    "bukvar",
+    "lexicon",
+    "informatyka",
+    "matematyka",
+    "algebra",
+    "heometriya",
+    "fizyka",
+    "khimiya",
+    "biolohiya",
+    "heohrafiya",
+)
+
+
+KNOWN_SOURCE_FILE_SUBJECTS: dict[str, str] = {
+    "1-klas-bukvar-bolshakova-2018-1": "bukvar",
+    "1-klas-bukvar-bolshakova-2018-2": "bukvar",
+    "1-klas-bukvar-zaharijchuk-2025-1": "bukvar",
+    "1-klas-bukvar-zaharijchuk-2025-2": "bukvar",
+    "10-klas-istorija-ukrajiny-gisem-2018": "istoriya",
+    "10-klas-ukrajinska-literatura-avramenko-2018": "ukrlit",
+    "10-klas-ukrajinska-mova-avramenko-2018": "ukrmova",
+    "10-klas-ukrajinska-mova-zabolotnij-2018": "ukrmova",
+    "10-klas-ukrlit-borzenko-2018-prof": "ukrlit",
+    "10-klas-ukrmova-glazova-2018": "ukrmova",
+    "10-klas-ukrmova-karaman-2018": "ukrmova",
+    "10-klas-ukrmova-zabolotnyi-2018": "ukrmova",
+    "11-klas-istoriya-ukr-galimov-2024": "istoriya",
+    "11-klas-istoriya-ukr-gisem-2024": "istoriya",
+    "11-klas-istoriya-ukr-hlibovska-2024": "istoriya",
+    "11-klas-ukrajinska-literatura-avramenko-2019": "ukrlit",
+    "11-klas-ukrajinska-mova-avramenko-2019": "ukrmova",
+    "11-klas-ukrajinska-mova-glazova-2019": "ukrmova",
+    "11-klas-ukrajinska-mova-voron-2019": "ukrmova",
+    "11-klas-ukrlit-borzenko-2019-prof": "ukrlit",
+    "11-klas-ukrmova-zabolotnyi-2019": "ukrmova",
+    "2-klas-ukrmova-bolshakova-2019-1": "ukrmova",
+    "2-klas-ukrmova-bolshakova-2019-2": "ukrmova",
+    "2-klas-ukrmova-kravcova-2019-1": "ukrmova",
+    "2-klas-ukrmova-kravcova-2019-2": "ukrmova",
+    "2-klas-ukrmova-vashulenko-2019-1": "ukrmova",
+    "2-klas-ukrmova-vashulenko-2019-2": "ukrmova",
+    "3-klas-ukrainska-mova-kravtsova-2020-1": "ukrmova",
+    "3-klas-ukrainska-mova-ponomarova-2020-1": "ukrmova",
+    "3-klas-ukrainska-mova-savchenko-2020-2": "ukrmova",
+    "3-klas-ukrainska-mova-savchuk-2020-2": "ukrmova",
+    "3-klas-ukrainska-mova-vashulenko-2020-1": "ukrmova",
+    "3-klas-ukrainska-mova-vashulenko-2020-2": "ukrmova",
+    "4-klas-ukrayinska-mova-kravtsova-2021-1": "ukrmova",
+    "4-klas-ukrayinska-mova-ponomarova-2021-1": "ukrmova",
+    "4-klas-ukrayinska-mova-savchenko-2021-2": "ukrmova",
+    "4-klas-ukrayinska-mova-varzatska-2021-1": "ukrmova",
+    "4-klas-ukrayinska-mova-zaharijchuk-2021-1": "ukrmova",
+    "4-klas-ukrmova-zaharijchuk": "ukrmova",
+    "5-klas-istoriya-schupak-2022": "istoriya",
+    "5-klas-ukrlit-avramenko-2022": "ukrlit",
+    "5-klas-ukrlit-zabolotnyi-2022": "ukrlit",
+    "5-klas-ukrmova-avramenko-2022": "ukrmova",
+    "5-klas-ukrmova-golub-2022": "ukrmova",
+    "5-klas-ukrmova-litvinova-2022": "ukrmova",
+    "5-klas-ukrmova-zabolotnyi-2023": "ukrmova",
+    "6-klas-istoriia-shchupak-2023": "istoriya",
+    "6-klas-istoriya-gisem-2023": "istoriya",
+    "6-klas-ukrlit-avramenko-2023": "ukrlit",
+    "6-klas-ukrlit-kovalenko-2023": "ukrlit",
+    "6-klas-ukrlit-zabolotnyi-2023": "ukrlit",
+    "6-klas-ukrmova-avramenko-2023": "ukrmova",
+    "6-klas-ukrmova-golub-2023": "ukrmova",
+    "6-klas-ukrmova-litvinova-2023": "ukrmova",
+    "6-klas-ukrmova-zabolotnyi-2020": "ukrmova",
+    "7-klas-istoria-ukr-galimov-2024": "istoriya",
+    "7-klas-istoria-ukr-hlibovska-2024": "istoriya",
+    "7-klas-istoria-ukr-pometun-2024": "istoriya",
+    "7-klas-ukrlit-avramenko-2024": "ukrlit",
+    "7-klas-ukrlit-mishhenko-2015": "ukrlit",
+    "7-klas-ukrlit-zabolotnyi-2024": "ukrlit",
+    "7-klas-ukrmova-avramenko-2024": "ukrmova",
+    "7-klas-ukrmova-litvinova-2024": "ukrmova",
+    "7-klas-ukrmova-zabolotnyi-2024": "ukrmova",
+    "8-klas-istoria-ukr-galimov-2025": "istoriya",
+    "8-klas-istoria-ukr-hlibovska-2025": "istoriya",
+    "8-klas-istoria-ukr-schupak-2025": "istoriya",
+    "8-klas-istoriya-ukr-gisem-2021": "istoriya",
+    "8-klas-ukrlit-avramenko-2025": "ukrlit",
+    "8-klas-ukrlit-zabolotnyi-2025": "ukrlit",
+    "8-klas-ukrmova-avramenko-2025": "ukrmova",
+    "8-klas-ukrmova-onatiy-2025": "ukrmova",
+    "8-klas-ukrmova-zabolotnyi-2025": "ukrmova",
+    "9-klas-istorija-ukrajini-burnejko-2017": "istoriya",
+    "9-klas-istorija-ukrajini-gisem-2017": "istoriya",
+    "9-klas-ukrajinska-literatura-avramenko-2017": "ukrlit",
+    "9-klas-ukrajinska-literatura-mishhenko-2017": "ukrlit",
+    "9-klas-ukrajinska-mova-avramenko-2017": "ukrmova",
+    "9-klas-ukrajinska-mova-voron-2017": "ukrmova",
+    "9-klas-ukrajinska-mova-zabolotnij-2017": "ukrmova",
+    "9-klas-ukrmova-zabolotnyi-2017": "ukrmova",
+    "anna-ohoiko-1000-words-2nd-ed": "lexicon",
+    "anna-ohoiko-500-verbs": "lexicon",
+    "antonenko-davydovych-yak-my-hovorymo": "lexicon",
+    "pohribnyi-ukrainska-literaturna-vymova-1992": "lexicon",
+    "ulp-1-00-lesson-notes": "lexicon",
+    "ulp-2-00-lesson-notes": "lexicon",
+    "ulp-3-00-lesson-notes": "lexicon",
+    "ulp-4-00-lesson-notes": "lexicon",
+    "ulp-5-00-lesson-notes": "lexicon",
+    "ulp-6-00-lesson-notes": "lexicon",
+}
+
+
+_SUBJECT_ALIASES: dict[str, str] = {
+    "ukrainska-mova": "ukrmova",
+    "ukrajinska-mova": "ukrmova",
+    "ukrayinska-mova": "ukrmova",
+    "ukr-mova": "ukrmova",
+    "mova": "ukrmova",
+    "ukrainska-literatura": "ukrlit",
+    "ukrajinska-literatura": "ukrlit",
+    "ukrayinska-literatura": "ukrlit",
+    "literatura": "ukrlit",
+    "history": "istoriya",
+    "istorija": "istoriya",
+    "istoria": "istoriya",
+    "istoriia": "istoriya",
+    "istoriya-ukr": "istoriya",
+    "istoria-ukr": "istoriya",
+    "vocab": "lexicon",
+    "vocabulary": "lexicon",
+    "wordlist": "lexicon",
+    "lesson-notes": "lexicon",
+    "geometriya": "heometriya",
+    "geometry": "heometriya",
+    "geografiya": "heohrafiya",
+    "geohrafiya": "heohrafiya",
+    "heohrafiia": "heohrafiya",
+    "geography": "heohrafiya",
+    "biolohiia": "biolohiya",
+    "biologia": "biolohiya",
+    "biology": "biolohiya",
+    "chemistry": "khimiya",
+    "physics": "fizyka",
+}
+
+
+_SUBJECT_TOKEN_PATTERNS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "lexicon",
+        (
+            "anna-ohoiko",
+            "1000-words",
+            "500-verbs",
+            "antonenko-davydovych",
+            "yak-my-hovorymo",
+            "pohribnyi",
+            "literaturna-vymova",
+            "lesson-notes",
+            "ulp-",
+        ),
+    ),
+    ("bukvar", ("bukvar",)),
+    (
+        "ukrlit",
+        (
+            "ukrlit",
+            "ukr-lit",
+            "ukrajinska-literatura",
+            "ukrayinska-literatura",
+            "ukrainska-literatura",
+            "ukrayinska-lit",
+        ),
+    ),
+    (
+        "ukrmova",
+        (
+            "ukrmova",
+            "ukr-mova",
+            "ukrajinska-mova",
+            "ukrayinska-mova",
+            "ukrainska-mova",
+        ),
+    ),
+    (
+        "istoriya",
+        (
+            "istoriya",
+            "istoriia",
+            "istorija",
+            "istoria",
+        ),
+    ),
+    ("informatyka", ("informatyka",)),
+    ("matematyka", ("matematyka",)),
+    ("algebra", ("algebra",)),
+    ("heometriya", ("heometriya", "geometriya", "geometry")),
+    ("fizyka", ("fizyka", "physics")),
+    ("khimiya", ("khimiya", "chemistry")),
+    ("biolohiya", ("biolohiya", "biolohiia", "biologia", "biology")),
+    (
+        "heohrafiya",
+        ("heohrafiya", "heohrafiia", "geohrafiya", "geografiya", "geography"),
+    ),
+)
+
+
+def _source_key(value: str) -> str:
+    stem = Path(str(value).strip()).name
+    for suffix in (".jsonl", ".pdf", ".txt"):
+        stem = stem.removesuffix(suffix)
+    return stem.casefold().replace("_", "-")
+
+
+def normalize_subject_slug(subject: str | None) -> str | None:
+    """Return a canonical subject slug for user/API input."""
+    if subject is None:
+        return None
+    key = _source_key(subject)
+    if not key:
+        return None
+    if key in CANONICAL_TEXTBOOK_SUBJECTS:
+        return key
+    return _SUBJECT_ALIASES.get(key)
+
+
+def subject_for_source_file(source_file: str) -> str | None:
+    """Infer a canonical subject slug from a ``textbooks.source_file`` value."""
+    key = _source_key(source_file)
+    if not key:
+        return None
+    if key in KNOWN_SOURCE_FILE_SUBJECTS:
+        return KNOWN_SOURCE_FILE_SUBJECTS[key]
+    for subject, tokens in _SUBJECT_TOKEN_PATTERNS:
+        if any(token in key for token in tokens):
+            return subject
+    return None

--- a/tests/test_mcp_sources_server.py
+++ b/tests/test_mcp_sources_server.py
@@ -78,6 +78,13 @@ class TestListTools:
         assert "word" in vw.inputSchema["required"]
         assert "word" in vw.inputSchema["properties"]
 
+    def test_search_text_subject_schema(self, server_module):
+        tools = _run(server_module.list_tools())
+        search_text = next(t for t in tools if t.name == "search_text")
+        subject = search_text.inputSchema["properties"]["subject"]
+        assert subject["enum"] == list(server_module.CANONICAL_TEXTBOOK_SUBJECTS)
+        assert "ukrmova" in subject["description"]
+
     def test_verify_words_schema(self, server_module):
         tools = _run(server_module.list_tools())
         vw = next(t for t in tools if t.name == "verify_words")
@@ -146,6 +153,30 @@ class TestCallToolDispatch:
             mock.return_value = [MagicMock(text="ok")]
             _run(server_module.call_tool("search_sources", {"query": "голосні звуки"}))
             mock.assert_called_once_with({"query": "голосні звуки"})
+
+    def test_search_text_handler_passes_subject_filter(self, server_module):
+        hit = {
+            "chunk_id": "chunk-1",
+            "title": "Родовий відмінок",
+            "section_title": "Родовий відмінок",
+            "grade": "5",
+            "author": "Авраменко",
+            "subject": "ukrmova",
+            "text": "Родовий відмінок у шкільному підручнику.",
+        }
+        with patch("wiki.sources_db.search_textbooks", return_value=[hit]) as mock:
+            result = _run(
+                server_module.handle_search_text(
+                    {"query": "родовий відмінок", "subject": "ukrmova", "limit": 3}
+                )
+            )
+
+        assert "Subject**: ukrmova" in result[0].text
+        mock.assert_called_once()
+        args, kwargs = mock.call_args
+        assert "родовий" in args[0]
+        assert args[1] == 3
+        assert kwargs["subject"] == "ukrmova"
 
     def test_search_grinchenko_1907_dispatches(self, server_module):
         with patch.object(server_module, "handle_dict_search", new_callable=AsyncMock) as mock:

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -14,9 +14,10 @@ def test_build_filter_returns_plain_descriptor():
 
 
 def test_search_text_maps_sqlite_rows(monkeypatch):
-    def fake_search_textbooks(keywords, max_total):
+    def fake_search_textbooks(keywords, max_total, *, subject=None):
         assert "мова" in keywords
         assert max_total == 6
+        assert subject == "ukrmova"
         return [
             {
                 "_kw_score": 4,
@@ -26,6 +27,7 @@ def test_search_text_maps_sqlite_rows(monkeypatch):
                 "grade": 3,
                 "author_uk": "Автор",
                 "source_file": "3-klas-mova.pdf",
+                "subject": "ukrmova",
             },
             {
                 "_kw_score": 1,
@@ -38,7 +40,7 @@ def test_search_text_maps_sqlite_rows(monkeypatch):
 
     monkeypatch.setattr(query.sources_db, "search_textbooks", fake_search_textbooks)
 
-    hits = query.search_text("мова", grade=3, limit=2)
+    hits = query.search_text("мова", grade=3, subject="ukrmova", limit=2)
 
     assert hits == [
         {
@@ -52,8 +54,40 @@ def test_search_text_maps_sqlite_rows(monkeypatch):
             "trust_tier": 0,
             "source_type": "textbook",
             "source_file": "3-klas-mova.pdf",
+            "subject": "ukrmova",
         }
     ]
+
+
+def test_search_text_preserves_legacy_subject_substring_filter(monkeypatch):
+    def fake_search_textbooks(keywords, max_total, *, subject=None):
+        assert "мова" in keywords
+        assert max_total == 6
+        assert subject is None
+        return [
+            {
+                "_kw_score": 3,
+                "chunk_id": "chunk-1",
+                "text": "Українська мова",
+                "title": "Title",
+                "section_title": "Апостроф",
+                "source_file": "3-klas-mova.pdf",
+            },
+            {
+                "_kw_score": 2,
+                "chunk_id": "chunk-2",
+                "text": "Other",
+                "title": "Other",
+                "section_title": "Інший розділ",
+                "source_file": "5-klas-ukrlit.pdf",
+            },
+        ]
+
+    monkeypatch.setattr(query.sources_db, "search_textbooks", fake_search_textbooks)
+
+    hits = query.search_text("мова", subject="апостроф", limit=2)
+
+    assert [hit["chunk_id"] for hit in hits] == ["chunk-1"]
 
 
 def test_search_literary_maps_and_filters(monkeypatch):

--- a/tests/test_sources_db.py
+++ b/tests/test_sources_db.py
@@ -56,7 +56,7 @@ def sample_data(tmp_path):
          "grade": "5", "author": "avramenko", "author_uk": "Авраменко",
          "token_count": 50},
     ]
-    with open(tb_dir / "5-klas-test.jsonl", "w") as f:
+    with open(tb_dir / "5-klas-ukrmova-avramenko-2022.jsonl", "w") as f:
         for c in chunks:
             f.write(json.dumps(c, ensure_ascii=False) + "\n")
 
@@ -133,6 +133,7 @@ class TestBuildSourcesDb:
         # Check each table has data
         assert conn.execute("SELECT COUNT(*) FROM external_articles").fetchone()[0] == 2
         assert conn.execute("SELECT COUNT(*) FROM textbooks").fetchone()[0] == 1
+        assert conn.execute("SELECT subject FROM textbooks").fetchone()[0] == "ukrmova"
         assert conn.execute("SELECT COUNT(*) FROM literary_texts").fetchone()[0] == 1
         assert conn.execute("SELECT COUNT(*) FROM sum11").fetchone()[0] == 1
         assert conn.execute("SELECT COUNT(*) FROM grinchenko").fetchone()[0] == 1
@@ -184,6 +185,27 @@ class TestSourcesDb:
         results = search_textbooks({"родовий", "відмінок"}, max_total=5)
         assert len(results) >= 1
         assert results[0]["source_type"] == "textbook"
+
+    def test_search_textbooks_subject_filter(self, sample_data, monkeypatch):
+        self._build_and_patch(sample_data, monkeypatch)
+        from wiki.sources_db import search_textbooks
+
+        results = search_textbooks(
+            {"родовий", "відмінок"},
+            max_total=5,
+            subject="ukrainska-mova",
+        )
+        assert len(results) >= 1
+        assert {row["subject"] for row in results} == {"ukrmova"}
+
+        assert (
+            search_textbooks(
+                {"родовий", "відмінок"},
+                max_total=5,
+                subject="ukrlit",
+            )
+            == []
+        )
 
     def test_search_external(self, sample_data, monkeypatch):
         self._build_and_patch(sample_data, monkeypatch)

--- a/tests/test_subject_migration.py
+++ b/tests/test_subject_migration.py
@@ -1,0 +1,145 @@
+"""Tests for ``2026-07-06-add-subject-to-textbooks`` migration."""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_migration():
+    repo = Path(__file__).resolve().parent.parent
+    src = repo / "scripts" / "migrations" / "2026-07-06-add-subject-to-textbooks.py"
+    spec = importlib.util.spec_from_file_location("_mig_subject_2026_07_06", src)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_pre_migration_db(path: Path) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE textbooks (
+            id INTEGER PRIMARY KEY,
+            chunk_id TEXT NOT NULL DEFAULT '',
+            title TEXT NOT NULL DEFAULT '',
+            text TEXT NOT NULL DEFAULT '',
+            source_file TEXT NOT NULL DEFAULT '',
+            grade TEXT DEFAULT '',
+            author TEXT DEFAULT '',
+            author_uk TEXT DEFAULT '',
+            char_count INTEGER DEFAULT 0
+        );
+        """
+    )
+    conn.executemany(
+        """
+        INSERT INTO textbooks (chunk_id, source_file, grade, author, author_uk)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        [
+            ("mova-1", "5-klas-ukrmova-avramenko-2022", "5", "avramenko", ""),
+            ("lit-1", "6-klas-ukrlit-avramenko-2023", "6", "avramenko", ""),
+            ("hist-1", "8-klas-istoria-ukr-schupak-2025", "8", "schupak", ""),
+            ("lex-1", "anna-ohoiko-500-verbs", "", "Anna Ohoiko", ""),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_subject_migration_adds_column_index_and_backfills(tmp_path: Path) -> None:
+    db = tmp_path / "sources.db"
+    _build_pre_migration_db(db)
+    mig = _load_migration()
+
+    with sqlite3.connect(str(db)) as conn:
+        status = mig.apply(conn, dry_run=False)
+
+    assert status.column_added is True
+    assert status.rows_updated == 4
+    assert status.subject_counts == {
+        "istoriya": 1,
+        "lexicon": 1,
+        "ukrlit": 1,
+        "ukrmova": 1,
+    }
+
+    with sqlite3.connect(str(db)) as conn:
+        rows = conn.execute(
+            "SELECT source_file, subject FROM textbooks ORDER BY source_file"
+        ).fetchall()
+        assert rows == [
+            ("5-klas-ukrmova-avramenko-2022", "ukrmova"),
+            ("6-klas-ukrlit-avramenko-2023", "ukrlit"),
+            ("8-klas-istoria-ukr-schupak-2025", "istoriya"),
+            ("anna-ohoiko-500-verbs", "lexicon"),
+        ]
+        index_names = {
+            row[1] for row in conn.execute("PRAGMA index_list(textbooks)").fetchall()
+        }
+        assert "idx_textbooks_subject" in index_names
+
+
+def test_subject_migration_is_idempotent(tmp_path: Path) -> None:
+    db = tmp_path / "sources.db"
+    _build_pre_migration_db(db)
+    mig = _load_migration()
+
+    with sqlite3.connect(str(db)) as conn:
+        first = mig.apply(conn, dry_run=False)
+    with sqlite3.connect(str(db)) as conn:
+        second = mig.apply(conn, dry_run=False)
+
+    assert first.column_added is True
+    assert second.column_added is False
+    assert second.rows_updated == 0
+    assert second.populated_subject == 4
+
+
+def test_subject_migration_dry_run_reports_counts_without_writing(
+    tmp_path: Path,
+) -> None:
+    db = tmp_path / "sources.db"
+    _build_pre_migration_db(db)
+    mig = _load_migration()
+
+    with sqlite3.connect(str(db)) as conn:
+        status = mig.apply(conn, dry_run=True)
+
+    assert status.column_added is True
+    assert status.rows_updated == 4
+    assert status.subject_counts["ukrmova"] == 1
+    with sqlite3.connect(str(db)) as conn:
+        columns = [
+            row[1] for row in conn.execute("PRAGMA table_info(textbooks)").fetchall()
+        ]
+    assert "subject" not in columns
+
+
+def test_subject_migration_errors_on_unmapped_source_file(tmp_path: Path) -> None:
+    db = tmp_path / "sources.db"
+    _build_pre_migration_db(db)
+    mig = _load_migration()
+
+    with sqlite3.connect(str(db)) as conn:
+        conn.execute(
+            "INSERT INTO textbooks (chunk_id, source_file) VALUES (?, ?)",
+            ("bad-1", "mystery-source-with-no-subject"),
+        )
+        conn.commit()
+        with pytest.raises(mig.UnmappedTextbookSubjectsError) as exc_info:
+            mig.apply(conn, dry_run=False)
+
+    assert exc_info.value.source_files == ["mystery-source-with-no-subject"]
+    with sqlite3.connect(str(db)) as conn:
+        columns = [
+            row[1] for row in conn.execute("PRAGMA table_info(textbooks)").fetchall()
+        ]
+    assert "subject" not in columns

--- a/tests/test_textbook_subjects.py
+++ b/tests/test_textbook_subjects.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from collections import Counter
+
+from scripts.wiki.textbook_subjects import (
+    KNOWN_SOURCE_FILE_SUBJECTS,
+    normalize_subject_slug,
+    subject_for_source_file,
+)
+
+# Quoted from the required read-only probe:
+# sqlite3 'file:/Users/krisztiankoos/projects/learn-ukrainian/data/sources.db?mode=ro' \
+#   "SELECT DISTINCT source_file FROM textbooks ORDER BY source_file;"
+CURRENT_TEXTBOOK_SOURCE_FILES = (
+    "1-klas-bukvar-bolshakova-2018-1",
+    "1-klas-bukvar-bolshakova-2018-2",
+    "1-klas-bukvar-zaharijchuk-2025-1",
+    "1-klas-bukvar-zaharijchuk-2025-2",
+    "10-klas-istorija-ukrajiny-gisem-2018",
+    "10-klas-ukrajinska-literatura-avramenko-2018",
+    "10-klas-ukrajinska-mova-avramenko-2018",
+    "10-klas-ukrajinska-mova-zabolotnij-2018",
+    "10-klas-ukrlit-borzenko-2018-prof",
+    "10-klas-ukrmova-glazova-2018",
+    "10-klas-ukrmova-karaman-2018",
+    "10-klas-ukrmova-zabolotnyi-2018",
+    "11-klas-istoriya-ukr-galimov-2024",
+    "11-klas-istoriya-ukr-gisem-2024",
+    "11-klas-istoriya-ukr-hlibovska-2024",
+    "11-klas-ukrajinska-literatura-avramenko-2019",
+    "11-klas-ukrajinska-mova-avramenko-2019",
+    "11-klas-ukrajinska-mova-glazova-2019",
+    "11-klas-ukrajinska-mova-voron-2019",
+    "11-klas-ukrlit-borzenko-2019-prof",
+    "11-klas-ukrmova-zabolotnyi-2019",
+    "2-klas-ukrmova-bolshakova-2019-1",
+    "2-klas-ukrmova-bolshakova-2019-2",
+    "2-klas-ukrmova-kravcova-2019-1",
+    "2-klas-ukrmova-kravcova-2019-2",
+    "2-klas-ukrmova-vashulenko-2019-1",
+    "2-klas-ukrmova-vashulenko-2019-2",
+    "3-klas-ukrainska-mova-kravtsova-2020-1",
+    "3-klas-ukrainska-mova-ponomarova-2020-1",
+    "3-klas-ukrainska-mova-savchenko-2020-2",
+    "3-klas-ukrainska-mova-savchuk-2020-2",
+    "3-klas-ukrainska-mova-vashulenko-2020-1",
+    "3-klas-ukrainska-mova-vashulenko-2020-2",
+    "4-klas-ukrayinska-mova-kravtsova-2021-1",
+    "4-klas-ukrayinska-mova-ponomarova-2021-1",
+    "4-klas-ukrayinska-mova-savchenko-2021-2",
+    "4-klas-ukrayinska-mova-varzatska-2021-1",
+    "4-klas-ukrayinska-mova-zaharijchuk-2021-1",
+    "4-klas-ukrmova-zaharijchuk",
+    "5-klas-istoriya-schupak-2022",
+    "5-klas-ukrlit-avramenko-2022",
+    "5-klas-ukrlit-zabolotnyi-2022",
+    "5-klas-ukrmova-avramenko-2022",
+    "5-klas-ukrmova-golub-2022",
+    "5-klas-ukrmova-litvinova-2022",
+    "5-klas-ukrmova-zabolotnyi-2023",
+    "6-klas-istoriia-shchupak-2023",
+    "6-klas-istoriya-gisem-2023",
+    "6-klas-ukrlit-avramenko-2023",
+    "6-klas-ukrlit-kovalenko-2023",
+    "6-klas-ukrlit-zabolotnyi-2023",
+    "6-klas-ukrmova-avramenko-2023",
+    "6-klas-ukrmova-golub-2023",
+    "6-klas-ukrmova-litvinova-2023",
+    "6-klas-ukrmova-zabolotnyi-2020",
+    "7-klas-istoria-ukr-galimov-2024",
+    "7-klas-istoria-ukr-hlibovska-2024",
+    "7-klas-istoria-ukr-pometun-2024",
+    "7-klas-ukrlit-avramenko-2024",
+    "7-klas-ukrlit-mishhenko-2015",
+    "7-klas-ukrlit-zabolotnyi-2024",
+    "7-klas-ukrmova-avramenko-2024",
+    "7-klas-ukrmova-litvinova-2024",
+    "7-klas-ukrmova-zabolotnyi-2024",
+    "8-klas-istoria-ukr-galimov-2025",
+    "8-klas-istoria-ukr-hlibovska-2025",
+    "8-klas-istoria-ukr-schupak-2025",
+    "8-klas-istoriya-ukr-gisem-2021",
+    "8-klas-ukrlit-avramenko-2025",
+    "8-klas-ukrlit-zabolotnyi-2025",
+    "8-klas-ukrmova-avramenko-2025",
+    "8-klas-ukrmova-onatiy-2025",
+    "8-klas-ukrmova-zabolotnyi-2025",
+    "9-klas-istorija-ukrajini-burnejko-2017",
+    "9-klas-istorija-ukrajini-gisem-2017",
+    "9-klas-ukrajinska-literatura-avramenko-2017",
+    "9-klas-ukrajinska-literatura-mishhenko-2017",
+    "9-klas-ukrajinska-mova-avramenko-2017",
+    "9-klas-ukrajinska-mova-voron-2017",
+    "9-klas-ukrajinska-mova-zabolotnij-2017",
+    "9-klas-ukrmova-zabolotnyi-2017",
+    "anna-ohoiko-1000-words-2nd-ed",
+    "anna-ohoiko-500-verbs",
+    "antonenko-davydovych-yak-my-hovorymo",
+    "pohribnyi-ukrainska-literaturna-vymova-1992",
+    "ulp-1-00-lesson-notes",
+    "ulp-2-00-lesson-notes",
+    "ulp-3-00-lesson-notes",
+    "ulp-4-00-lesson-notes",
+    "ulp-5-00-lesson-notes",
+    "ulp-6-00-lesson-notes",
+)
+
+
+def test_current_textbook_source_files_all_map_to_canonical_subjects() -> None:
+    assert len(CURRENT_TEXTBOOK_SOURCE_FILES) == 91
+    subjects = [subject_for_source_file(source) for source in CURRENT_TEXTBOOK_SOURCE_FILES]
+
+    assert None not in subjects
+    assert Counter(subjects) == {
+        "ukrmova": 45,
+        "ukrlit": 16,
+        "istoriya": 16,
+        "bukvar": 4,
+        "lexicon": 10,
+    }
+    assert set(CURRENT_TEXTBOOK_SOURCE_FILES) == set(KNOWN_SOURCE_FILE_SUBJECTS)
+
+
+def test_subject_aliases_normalize_to_canonical_slugs() -> None:
+    assert normalize_subject_slug("ukrainska-mova") == "ukrmova"
+    assert normalize_subject_slug("ukrajinska-literatura") == "ukrlit"
+    assert normalize_subject_slug("istoriia") == "istoriya"
+    assert normalize_subject_slug("vocabulary") == "lexicon"
+    assert normalize_subject_slug("unknown") is None
+
+
+def test_future_stem_source_files_map_by_token() -> None:
+    assert subject_for_source_file("5-klas-informatyka-example-2026") == "informatyka"
+    assert subject_for_source_file("7-klas-geometriya-example-2026") == "heometriya"
+    assert subject_for_source_file("8-klas-biolohiia-example-2026") == "biolohiya"


### PR DESCRIPTION
## Summary

- Add canonical `textbooks.subject` slugs and a dated migration that adds the column, creates `idx_textbooks_subject`, backfills from `source_file`, reports dry-run subject counts, and errors on unmapped sources.
- Teach `build_sources_db.py` to populate `subject` during future rebuilds via the same helper used by the migration.
- Add `subject` filtering to `wiki.sources_db.search_textbooks`, thread it through legacy `rag.query.search_text` and MCP `search_text`, and preserve the legacy non-canonical substring fallback in `rag.query.search_text`.
- Add tmp-DB tests for mapping coverage, migration idempotency/error handling, ingest subject population, search filtering, and MCP handler/schema wiring.

## Boundary

Did not run the migration against live `data/sources.db`. Tests use temporary SQLite databases only.

## Verification

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_textbook_subjects.py tests/test_subject_migration.py tests/test_sources_db.py::TestBuildSourcesDb::test_builds_all_tables tests/test_sources_db.py::TestSourcesDb::test_search_textbooks tests/test_sources_db.py::TestSourcesDb::test_search_textbooks_subject_filter tests/test_rag.py::test_search_text_maps_sqlite_rows tests/test_rag.py::test_search_text_preserves_legacy_subject_substring_filter tests/test_mcp_sources_server.py::TestListTools::test_search_text_subject_schema tests/test_mcp_sources_server.py::TestCallToolDispatch::test_search_text_handler_passes_subject_filter`
  - `============================== 14 passed in 0.87s ==============================`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/wiki/textbook_subjects.py scripts/migrations/2026-07-06-add-subject-to-textbooks.py scripts/wiki/build_sources_db.py scripts/wiki/sources_db.py scripts/rag/query.py .mcp/servers/sources/server.py tests/test_textbook_subjects.py tests/test_subject_migration.py tests/test_sources_db.py tests/test_rag.py tests/test_mcp_sources_server.py`
  - `All checks passed!`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`
  - `✅ All 1 non-skipped commit(s) carry an X-Agent trailer.`
- Pre-commit on amend ran affected `tests/test_rag.py`: `============================== 7 passed in 0.40s ===============================`
- Independent cross-family AGY review found one legacy wrapper compatibility issue; addressed by retaining non-canonical subject substring fallback and adding `test_search_text_preserves_legacy_subject_substring_filter`.
