### PR TITLE
bio: add readings for late-Soviet public voices batch 41

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/ivan-dziuba.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-dziuba.yaml
@@ -79,6 +79,17 @@ persona:
   role: Проводить семінар про складні моральні вибори в українській історії, змушуючи студентів уникати чорно-білих оцінок
   voice: Senior Biographer
 phase: BIO
+readings:
+- source_name: "«Інтернаціоналізм чи русифікація?» (вибрані розділи)"
+  source_url: ""
+  source_type: "primary-source"
+  role: "text-analysis"
+  learner_task: "Аналіз публіцистичної аргументації та політичного контексту твору"
+  license: "unknown"
+  rights_note: "Самвидав; перевірити сучасний статус авторських прав для легального розміщення уривків"
+  hosting: "reading-needed"
+  language: "uk"
+  cefr_min: C1
 references:
 - title: Ivan Dziuba
   note: Compiled from uk.wikipedia.org, dissertation abstracts, and critical reviews
@@ -103,7 +114,7 @@ sequence: 161
 slug: ivan-dziuba
 subtitle: The Dissident Who Weaponized Leninism
 title: 'Іван Дзюба: Інтернаціоналізм чи русифікація?'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: політична ідеологія, що проголошує рівність і дружбу всіх націй (у радянському контексті — часто ширма для русифікації)
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/lina-kostenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/lina-kostenko.yaml
@@ -80,6 +80,27 @@ persona:
   role: Модератор семінару, що ставить складні питання. Замість поклоніння іконі — пропонує глибокий аналіз її творчості та життєвого шляху, включно з суперечливими моментами.
   voice: Literary-Critic
 phase: BIO.13
+readings:
+- source_name: "Ліна Костенко: Біографія"
+  source_url: ""
+  source_type: "biography"
+  role: "background"
+  learner_task: "Читання життєпису, фокус на періоді 'шістдесятників' та творчому мовчанні"
+  license: "unknown"
+  rights_note: "Знайти надійне джерело (наприклад, Інститут національної пам'яті)"
+  hosting: "reading-needed"
+  language: "uk"
+  cefr_min: C1
+- source_name: "«Маруся Чурай» (уривки)"
+  source_url: ""
+  source_type: "primary-source"
+  role: "text-analysis"
+  learner_task: "Аналіз поетичних фрагментів, визначення історичного та культурного контексту"
+  license: "copyright"
+  rights_note: "Захищено авторським правом. Тільки навчальне цитування"
+  hosting: "reading-needed"
+  language: "uk"
+  cefr_min: C1
 references:
 - title: Маруся Чурай
   author: Ліна Костенко
@@ -104,7 +125,7 @@ sequence: 160
 slug: lina-kostenko
 subtitle: 'Lina Kostenko: The Conscience and Voice of an Epoch'
 title: 'Ліна Костенко: Совість і голос епохи'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: представник покоління радянської інтелігенції 1960-х років, що виступав за демократизацію та культурне відродження
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/liubomyr-huzar.yaml
+++ b/curriculum/l2-uk-en/plans/bio/liubomyr-huzar.yaml
@@ -79,6 +79,17 @@ persona:
   role: Модератор семінару, що аналізує суспільний вплив релігійного діяча, розрізняючи його теологічний, політичний та культурний внесок.
   voice: Secular-Historian-of-Religion
 phase: BIO.1
+readings:
+- source_name: "«Бути людиною» (вибрані есеї/проповіді)"
+  source_url: ""
+  source_type: "primary-source"
+  role: "text-analysis"
+  learner_task: "Читання та обговорення морально-етичних концепцій Любомира Гузара"
+  license: "copyright"
+  rights_note: "Захищено авторським правом. Тільки цитування в навчальних цілях"
+  hosting: "reading-needed"
+  language: "uk"
+  cefr_min: C1
 references:
 - title: Liubomyr Huzar
   note: Базова біографія, дати, ключові події. Скомпільовано з Wikipedia та офіційних джерел УГКЦ.
@@ -98,7 +109,7 @@ sequence: 162
 slug: liubomyr-huzar
 subtitle: 'Lyubomyr Huzar: The Moral Authority of a Nation'
 title: 'Любомир Гузар: Моральний авторитет нації'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: найвищий титул глави самостійної східної християнської церкви
   pos: ч.


### PR DESCRIPTION
Adds Ukrainian-only learner reading metadata for BIO plans: Lina Kostenko, Ivan Dziuba, and Liubomyr Huzar.

Policy compliance:
- Learner readings are top-level plan YAML `readings:` blocks.
- Sources are Ukrainian-only; explicit `reading-needed` exceptions are used where stable hostable URLs were not safely confirmed.
- No wiki/source packet files are changed.
- LLM-QG, Gemma, and OpenRouter were not used.

Worker validation reported: YAML parsing passed, `git diff --check` passed, diff scope limited to the three owned plan files, and commit includes `X-Agent: agy/bio-readings-late-soviet-public-batch-41-agy`.