### PR TITLE
fix(bridge): route check-model through AGY instead of retired gemini-cli

### DIFF
--- a/scripts/ai_agent_bridge/__init__.py
+++ b/scripts/ai_agent_bridge/__init__.py
@@ -41,6 +41,7 @@ from ._config import (
     _MODEL_CACHE,
     _MODEL_CACHE_TTL,
     _PARENT_ENV,
+    AGY_CLI,
     CLAUDE_CMD,
     CODEX_CLI,
     DB_PATH,
@@ -75,6 +76,7 @@ from ._model import _detect_model_error, check_model
 from ._prompts import build_claude_prompt, build_codex_prompt, build_gemini_prompt
 
 __all__ = [
+    "AGY_CLI",
     "CLAUDE_CMD",
     "CODEX_CLI",
     "DB_PATH",

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -852,8 +852,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
 
     # check-model
-    check_model_parser = subparsers.add_parser("check-model", help="Check if a Gemini model is available")
-    check_model_parser.add_argument("model", help="Model name")
+    check_model_parser = subparsers.add_parser(
+        "check-model",
+        help="Check if an AGY model is available (slug or display label)",
+    )
+    check_model_parser.add_argument("model", help="AGY model slug or display label")
 
     # cleanup
     cleanup_parser = subparsers.add_parser("cleanup", help="Clean stuck broker state and old acknowledged rows")

--- a/scripts/ai_agent_bridge/_config.py
+++ b/scripts/ai_agent_bridge/_config.py
@@ -29,6 +29,7 @@ PID_DIR = Path(
 # Use npx to run Claude Code — avoids bugs in the globally installed version.
 # Returns a list: ["npx", "@anthropic-ai/claude-code"] to use as cmd prefix.
 CLAUDE_CMD = ["npx", "@anthropic-ai/claude-code@latest"]
+AGY_CLI = shutil.which("agy") or str(Path.home() / ".local/bin/agy")
 GEMINI_CLI = shutil.which("gemini") or "gemini"
 CODEX_CLI = shutil.which("codex") or "codex"
 GEMINI_DEFAULT_MODEL = os.environ.get("AB_GEMINI_MODEL", "")

--- a/scripts/ai_agent_bridge/_model.py
+++ b/scripts/ai_agent_bridge/_model.py
@@ -1,21 +1,56 @@
 """Model availability checking."""
 
+import os
 import subprocess
 from pathlib import Path
 
-from ._config import _MODEL_CACHE, _MODEL_CACHE_TTL, _PARENT_ENV, GEMINI_CLI
+from agent_runtime.adapters.agy import (
+    _AGY_MODEL_BY_NORMALIZED,
+    AgyAdapter,
+    _normalize_model,
+)
+
+from ._config import _MODEL_CACHE, _MODEL_CACHE_TTL, _PARENT_ENV, AGY_CLI
 
 GROK_BUILD_DEFAULT_MODEL = "grok-build"
 GROK_BUILD_DEFAULT_EFFORT = "high"
 
+DEFAULT_CHECK_MODEL_TIMEOUT = int(os.environ.get("AB_CHECK_MODEL_TIMEOUT", "90"))
 
-def check_model(model: str, timeout: int = 15, force: bool = False) -> bool:
-    """Check if a Gemini model is available by sending a trivial prompt.
+_AGY_ADAPTER = AgyAdapter()
+_REPO_ROOT = Path(__file__).parent.parent.parent
+
+
+def _resolve_requested_agy_model(model: str) -> str | None:
+    """Map *model* to an AGY display label without default-model fallback."""
+    return _AGY_MODEL_BY_NORMALIZED.get(_normalize_model(model))
+
+
+def _build_agy_probe_plan(model: str, task_id: str = "check-model"):
+    """Build an agy print-mode probe for *model* (slug or display name)."""
+    if not _resolve_requested_agy_model(model):
+        return None
+    return _AGY_ADAPTER.build_invocation(
+        prompt="Reply with exactly: MODEL_OK",
+        mode="danger",
+        cwd=_REPO_ROOT,
+        model=model,
+        task_id=task_id,
+        session_id=None,
+        tool_config=None,
+    )
+
+
+def check_model(model: str, timeout: int | None = None, force: bool = False) -> bool:
+    """Check if an AGY model is available by sending a trivial prompt.
 
     Results are cached for 1 hour to avoid burning API quota.
     Returns True if the model responds, False if unavailable or errors.
     """
     import time as _time
+
+    if timeout is None:
+        timeout = DEFAULT_CHECK_MODEL_TIMEOUT
 
     # Check cache first (saves an API call)
     if not force and model in _MODEL_CACHE:
@@ -26,12 +61,26 @@ def check_model(model: str, timeout: int = 15, force: bool = False) -> bool:
             print(f"🔍 Model '{model}': {status} (cached {int(age)}s ago)")
             return available
 
+    plan = _build_agy_probe_plan(model)
+    if plan is None:
+        print(
+            f"❌ Model '{model}' is not a recognized AGY model. "
+            "Run `agy models` for supported display labels."
+        )
+        _MODEL_CACHE[model] = (False, _time.time())
+        return False
+
+    env = dict(_PARENT_ENV)
+    env.update(plan.env_overrides)
+
     try:
         result = subprocess.run(
-            [GEMINI_CLI, "-m", model, "-p", "Reply with exactly: MODEL_OK"],
-            capture_output=True, text=True, timeout=timeout,
-            cwd=str(Path(__file__).parent.parent.parent),
-            env=_PARENT_ENV,
+            plan.cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=str(_REPO_ROOT),
+            env=env,
         )
         if result.returncode == 0 and "MODEL_OK" in result.stdout:
             _MODEL_CACHE[model] = (True, _time.time())
@@ -44,7 +93,7 @@ def check_model(model: str, timeout: int = 15, force: bool = False) -> bool:
         _MODEL_CACHE[model] = (False, _time.time())
         return False
     except FileNotFoundError:
-        print(f"❌ Gemini CLI not found at: {GEMINI_CLI}")
+        print(f"❌ AGY CLI not found at: {AGY_CLI}")
         return False
 
 
@@ -60,7 +109,7 @@ def _handle_model_check_failure(result, model: str, _time):
 
 
 def _detect_model_error(stderr: str, model: str) -> str | None:
-    """Detect model-specific errors from Gemini CLI stderr.
+    """Detect model-specific errors from AGY stderr.
 
     Returns a user-friendly error message, or None if not a model error.
     """

--- a/scripts/ai_agent_bridge/openai_proxy.py
+++ b/scripts/ai_agent_bridge/openai_proxy.py
@@ -26,7 +26,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
-from ._config import _PARENT_ENV, CLAUDE_CMD, CODEX_CLI, GEMINI_CLI, REPO_ROOT
+from ._config import _PARENT_ENV, AGY_CLI, CLAUDE_CMD, CODEX_CLI, GEMINI_CLI, REPO_ROOT
 
 _DEFAULT_BACKEND_TIMEOUT_S = 120
 _HERMES_STDIN_MODULE = "scripts.ai_agent_bridge._hermes_stdin"
@@ -317,7 +317,8 @@ def _probe_codex() -> tuple[bool, str]:
 
 
 def _probe_gemini() -> tuple[bool, str]:
-    return _probe_cli([GEMINI_CLI, "--version"])
+    """Health probe for the Gemini-family route (AGY CLI, not retired gemini-cli)."""
+    return _probe_cli([AGY_CLI, "--version"])
 
 
 def _probe_claude() -> tuple[bool, str]:

--- a/tests/test_coverage_bridge_audit.py
+++ b/tests/test_coverage_bridge_audit.py
@@ -37,10 +37,11 @@ class TestConfig:
         assert "pids" in str(PID_DIR)
 
     def test_cli_paths_are_correct_types(self):
-        from scripts.ai_agent_bridge._config import CLAUDE_CMD, GEMINI_CLI
+        from scripts.ai_agent_bridge._config import AGY_CLI, CLAUDE_CMD, GEMINI_CLI
         assert isinstance(CLAUDE_CMD, list)
         assert CLAUDE_CMD[0] == "npx"
         assert "@anthropic-ai/claude-code" in CLAUDE_CMD[1]
+        assert isinstance(AGY_CLI, str)
         assert isinstance(GEMINI_CLI, str)
 
     def test_parent_env_has_gemini_session(self):
@@ -672,34 +673,57 @@ class TestModel:
 
         from scripts.ai_agent_bridge._config import _MODEL_CACHE
         from scripts.ai_agent_bridge._model import check_model
-        _MODEL_CACHE["old-model"] = (True, time.time() - 7200)  # 2 hours old
+        _MODEL_CACHE["gemini-3.5-flash-high"] = (True, time.time() - 7200)  # 2 hours old
         try:
             with patch("subprocess.run", side_effect=FileNotFoundError):
-                result = check_model("old-model")
+                result = check_model("gemini-3.5-flash-high")
             assert result is False
         finally:
-            _MODEL_CACHE.pop("old-model", None)
+            _MODEL_CACHE.pop("gemini-3.5-flash-high", None)
 
     def test_check_model_timeout(self, capsys):
         import subprocess
 
         from scripts.ai_agent_bridge._config import _MODEL_CACHE
         from scripts.ai_agent_bridge._model import check_model
-        _MODEL_CACHE.pop("timeout-model", None)
-        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 15)):
-            result = check_model("timeout-model")
+        _MODEL_CACHE.pop("gemini-3.5-flash-high", None)
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("cmd", 90)):
+            result = check_model("gemini-3.5-flash-high")
         assert result is False
         assert "timed out" in capsys.readouterr().out
-        _MODEL_CACHE.pop("timeout-model", None)
+        _MODEL_CACHE.pop("gemini-3.5-flash-high", None)
 
     def test_check_model_file_not_found(self, capsys):
         from scripts.ai_agent_bridge._config import _MODEL_CACHE
         from scripts.ai_agent_bridge._model import check_model
-        _MODEL_CACHE.pop("missing-cli", None)
+        _MODEL_CACHE.pop("gemini-3.5-flash-high", None)
         with patch("subprocess.run", side_effect=FileNotFoundError):
-            result = check_model("missing-cli")
+            result = check_model("gemini-3.5-flash-high")
         assert result is False
-        _MODEL_CACHE.pop("missing-cli", None)
+        assert "AGY CLI not found" in capsys.readouterr().out
+        _MODEL_CACHE.pop("gemini-3.5-flash-high", None)
+
+    def test_check_model_unknown_slug(self, capsys):
+        from scripts.ai_agent_bridge._config import _MODEL_CACHE
+        from scripts.ai_agent_bridge._model import check_model
+        _MODEL_CACHE.pop("not-a-real-model", None)
+        result = check_model("not-a-real-model")
+        assert result is False
+        assert "not a recognized AGY model" in capsys.readouterr().out
+        _MODEL_CACHE.pop("not-a-real-model", None)
+
+    def test_check_model_success(self):
+        from scripts.ai_agent_bridge._config import _MODEL_CACHE
+        from scripts.ai_agent_bridge._model import check_model
+        _MODEL_CACHE.pop("gemini-3.5-flash-high", None)
+        mock_result = MagicMock(returncode=0, stdout="MODEL_OK", stderr="")
+        with patch("subprocess.run", return_value=mock_result) as run:
+            assert check_model("gemini-3.5-flash-high") is True
+        cmd = run.call_args.args[0]
+        assert "agy" in cmd[0] or cmd[0].endswith("/agy")
+        assert "--model" in cmd
+        assert "Gemini 3.5 Flash (High)" in cmd
+        _MODEL_CACHE.pop("gemini-3.5-flash-high", None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `ab check-model` now probes **AGY** (not the retired `gemini` CLI) using the same slug→display-label mapping as `ask-agy`
- Default probe timeout raised to **90s** (`AB_CHECK_MODEL_TIMEOUT` override); unknown slugs fail fast without default-model fallback
- OpenAI proxy `/healthz` gemini-family probe uses `agy --version`

## Context
Gemini CLI returns `IneligibleTierError` for individuals and was misleading operators into thinking AGY timed out when `check-model gemini-3.1-pro-high` failed on a 15s `gemini -m …` probe while `ask-agy` succeeded.

## Test plan
- [x] `pytest tests/test_coverage_bridge_audit.py::TestModel`
- [x] `pytest tests/ai_agent_bridge/test_openai_proxy_healthz.py`
- [x] Pre-commit ruff + affected pytest (195 tests)

## Follow-up (out of scope)
`openai_proxy._gemini_backend()` still invokes legacy `gemini` CLI for completions — separate migration if that surface is still in use.


Made with [Cursor](https://cursor.com)