### PR TITLE
feat(audit): #4539 multi-run harness extension (3 runs/cell + domain split)

### DIFF
--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -25,6 +25,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, date, datetime
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -64,11 +65,36 @@ _FAILURE_CLASSES = {
     FAILURE_CLASS_OPS_QUOTA,
     FAILURE_CLASS_MODEL_FAILURE,
 }
+_RUN_SUFFIX_RE = re.compile(r"__r([1-9][0-9]*)$")
 # Verbatim reuse markers: the bare prompt slices the LIVE verdict taxonomy out of
 # the reviewer template so the fact-check verdict set can never fork from tooled.
 _TAXONOMY_START = "Each fact check MUST use exactly one verdict from this taxonomy:"
 _TAXONOMY_END = "Few-shot anchors:"
 _LEADING_CLAIM_FILLER_RE = re.compile(r"^(?:або|чи)\s+", re.IGNORECASE)
+
+DOMAIN_BY_SLUG: Mapping[str, str] = MappingProxyType(
+    {
+        "vesnianky": "folk",
+        "kupalski": "folk",
+        "zhnyvarski": "folk",
+        "koliadky": "folk",
+        "holosinnia": "folk",
+        "rusalii": "folk",
+        "vesilnyi-obriad": "folk",
+        "andriivski-vechornytsi": "folk",
+        "khmelnytskyi-1648": "history",
+        "khreshchennia-rusi": "history",
+        "yaroslav-sofiya": "history",
+        "zaporozka-sich": "history",
+        # The almanac fixture is routed to history because the measurement
+        # target is publication context and cultural-national movement history.
+        "rusalka-dnistrova": "history",
+        "ahatanhel-krymskyi": "bio",
+        "franko-ivan": "bio",
+        "lesya-ukrainka": "bio",
+        "skovoroda-hryhorii": "bio",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -446,6 +472,69 @@ def _transport_slug(transport: str) -> str:
     return pin_slug(transport)
 
 
+def _validate_run_index(run_index: int) -> int:
+    if isinstance(run_index, bool) or not isinstance(run_index, int) or run_index < 1:
+        raise BakeoffConfigError(f"run_index must be an integer >= 1; got {run_index!r}")
+    return run_index
+
+
+def _artifact_run_index(artifact: Mapping[str, Any]) -> int:
+    """Return the artifact's authoritative 1-based run index.
+
+    ``run_index`` is additive for ``qg_bakeoff_run.v2``: legacy artifacts omit
+    it and are therefore run 1. Invalid explicit values fail closed because
+    aggregation and canary refusal depend on this field not being ambiguous.
+    """
+    raw = artifact.get("run_index", 1)
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw < 1:
+        raise BakeoffConfigError(f"artifact run_index must be an integer >= 1; got {raw!r}")
+    return raw
+
+
+def _artifact_filename_run_index(path: Path) -> int:
+    match = _RUN_SUFFIX_RE.search(path.stem)
+    if match is None:
+        return 1
+    return int(match.group(1))
+
+
+def _assert_artifact_filename_matches_run_index(path: Path, artifact: Mapping[str, Any]) -> None:
+    field_run_index = _artifact_run_index(artifact)
+    filename_run_index = _artifact_filename_run_index(path)
+    if field_run_index != filename_run_index:
+        raise BakeoffConfigError(
+            f"{path}: artifact run_index={field_run_index} does not match "
+            f"filename run index={filename_run_index}"
+        )
+
+
+def _cell_artifact_path(
+    output_dir: Path,
+    route: llm_reviewer_dispatch.ReviewerRoute,
+    fixture: BakeoffFixture,
+    arm: str,
+    run_index: int = 1,
+) -> Path:
+    """Build the unique artifact path for one model/passage/arm/run cell."""
+    run_index = _validate_run_index(run_index)
+    if arm not in (TOOLED_ARM, BARE_ARM):
+        raise BakeoffConfigError(f"cell artifact arm must be {TOOLED_ARM!r} or {BARE_ARM!r}; got {arm!r}")
+    stem = f"{pin_slug(route.reviewer_model_id)}__{fixture.slug}"
+    if arm == BARE_ARM:
+        stem += f"__bare__{_transport_slug(_route_transport(route))}"
+    if run_index > 1:
+        stem += f"__r{run_index}"
+    return output_dir / f"{stem}.json"
+
+
+def domain_for_slug(slug: str) -> str:
+    """Return the locked bakeoff domain for a fixture slug, failing closed."""
+    try:
+        return DOMAIN_BY_SLUG[slug]
+    except KeyError as exc:
+        raise BakeoffConfigError(f"missing DOMAIN_BY_SLUG mapping for fixture slug: {slug!r}") from exc
+
+
 def _is_subscription_bare_route(route: llm_reviewer_dispatch.ReviewerRoute) -> bool:
     return route.route_name in _SUBSCRIPTION_BARE_IDENTITIES
 
@@ -813,6 +902,7 @@ def run_matrix(
     arm: str = TOOLED_ARM,
     force: bool = False,
     retry_failures: bool = False,
+    runs: int = 1,
 ) -> list[BakeoffRun]:
     """Run or resume every model x fixture pair for the requested arm(s).
 
@@ -827,6 +917,7 @@ def run_matrix(
     CI-refusal / ``QG_BAKEOFF=1`` opt-in that ``main()`` enforces.
     """
     require_offline_opt_in()
+    runs = _validate_run_index(runs)
     if arm not in _ARM_CHOICES:
         raise BakeoffConfigError(f"arm must be one of {list(_ARM_CHOICES)}; got {arm!r}")
     routes = [route_for_matrix_pin(pin, arm=arm) for pin in model_pins]
@@ -841,38 +932,41 @@ def run_matrix(
         if _is_subscription_bare_route(route):
             continue
         assert_model_routing_allowed(route.reviewer_model_id, context="qg_bakeoff matrix pin")
-    if bare_runner is invoke_bakeoff_route_bare:
-        preflight_subscription_bare_routes(routes)
     output_dir.mkdir(parents=True, exist_ok=True)
     run_tooled = arm in (TOOLED_ARM, BOTH_ARM)
     run_bare = arm in (BARE_ARM, BOTH_ARM)
-    runs: list[BakeoffRun] = []
-    for route in routes:
-        for fixture in fixtures:
-            if run_tooled:
-                runs.append(
-                    run_one(
-                        route,
-                        fixture,
-                        output_dir=output_dir,
-                        runner=runner,
-                        force=force,
-                        retry_failures=retry_failures,
+    matrix_runs: list[BakeoffRun] = []
+    for run_index in range(1, runs + 1):
+        if run_bare and bare_runner is invoke_bakeoff_route_bare:
+            preflight_subscription_bare_routes(routes)
+        for route in routes:
+            for fixture in fixtures:
+                if run_tooled:
+                    matrix_runs.append(
+                        run_one(
+                            route,
+                            fixture,
+                            output_dir=output_dir,
+                            runner=runner,
+                            force=force,
+                            retry_failures=retry_failures,
+                            run_index=run_index,
+                        )
                     )
-                )
-            if run_bare:
-                runs.append(
-                    run_one_bare(
-                        route,
-                        fixture,
-                        output_dir=output_dir,
-                        runner=bare_runner,
-                        force=force,
-                        retry_failures=retry_failures,
+                if run_bare:
+                    matrix_runs.append(
+                        run_one_bare(
+                            route,
+                            fixture,
+                            output_dir=output_dir,
+                            runner=bare_runner,
+                            force=force,
+                            retry_failures=retry_failures,
+                            run_index=run_index,
+                        )
                     )
-                )
     write_scorecard(output_dir / SCORECARD_NAME, _load_all_artifacts(output_dir))
-    return runs
+    return matrix_runs
 
 
 def _is_bakeoff_cell(artifact: Mapping[str, Any]) -> bool:
@@ -897,6 +991,7 @@ def _load_all_artifacts(output_dir: Path) -> list[dict[str, Any]]:
             continue
         if not _is_bakeoff_cell(artifact):
             continue
+        _assert_artifact_filename_matches_run_index(path, artifact)
         artifacts.append(artifact)
     return artifacts
 
@@ -970,6 +1065,7 @@ def _error_artifact(
     wall_seconds: float,
     *,
     arm: str,
+    run_index: int = 1,
     attempt_count: int = 1,
     transport_retry: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -983,6 +1079,7 @@ def _error_artifact(
     return {
         "schema_version": RUN_SCHEMA_VERSION,
         "arm": arm,
+        "run_index": _validate_run_index(run_index),
         "created_at": _now_z(),
         "fixture": _fixture_block(fixture),
         "model": _model_block(route),
@@ -1014,6 +1111,7 @@ def run_one(
     runner: ProviderRunner = invoke_bakeoff_route,
     force: bool = False,
     retry_failures: bool = False,
+    run_index: int = 1,
 ) -> BakeoffRun:
     """Run or resume one model x passage TOOLED bakeoff artifact.
 
@@ -1023,9 +1121,12 @@ def run_one(
     """
     if runner is invoke_bakeoff_route:
         require_offline_opt_in()
-    artifact_path = output_dir / f"{pin_slug(route.reviewer_model_id)}__{fixture.slug}.json"
+    run_index = _validate_run_index(run_index)
+    artifact_path = _cell_artifact_path(output_dir, route, fixture, TOOLED_ARM, run_index)
     if artifact_path.exists() and not force:
         artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+        _assert_artifact_filename_matches_run_index(artifact_path, artifact)
+        _assert_resume_transport_matches(artifact, route, artifact_path)
         # retry_failures is a RESUME MODIFIER: missing cells always run (plain
         # resume behavior), completed cells always skip, and error cells re-run
         # only under the flag (codex review of #4463 pinned these semantics).
@@ -1036,6 +1137,8 @@ def run_one(
     # content_surface_gates. There is no literal ``seminar`` level.
     prompt = llm_reviewer.build_reviewer_prompt(BAKEOFF_LEVEL, f"bakeoff-{fixture.slug}", fixture.passage_md)
     task_id = f"qg-bakeoff-{pin_slug(route.reviewer_model_id)}-{fixture.slug}"
+    if run_index > 1:
+        task_id = f"{task_id}-r{run_index}"
     started = time.monotonic()
     try:
         gate_result = _invoke_and_gate(route, prompt, task_id, runner)
@@ -1045,7 +1148,7 @@ def run_one(
         # matrix crash (first live run: gemma findings flunked validate_finding
         # and killed all 24 cells). Score = every fixture claim missing.
         wall_seconds = round(time.monotonic() - started, 3)
-        artifact = _error_artifact(route, fixture, exc, wall_seconds, arm=TOOLED_ARM)
+        artifact = _error_artifact(route, fixture, exc, wall_seconds, arm=TOOLED_ARM, run_index=run_index)
         artifact_path.write_text(
             json.dumps(artifact, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
@@ -1061,6 +1164,7 @@ def run_one(
     artifact = {
         "schema_version": RUN_SCHEMA_VERSION,
         "arm": TOOLED_ARM,
+        "run_index": run_index,
         "created_at": _now_z(),
         "fixture": _fixture_block(fixture),
         "model": _model_block(route, dispatch),
@@ -1086,11 +1190,9 @@ def _bare_artifact_path(
     output_dir: Path,
     route: llm_reviewer_dispatch.ReviewerRoute,
     fixture: BakeoffFixture,
+    run_index: int = 1,
 ) -> Path:
-    return output_dir / (
-        f"{pin_slug(route.reviewer_model_id)}__{fixture.slug}__bare__"
-        f"{_transport_slug(_route_transport(route))}.json"
-    )
+    return _cell_artifact_path(output_dir, route, fixture, BARE_ARM, run_index)
 
 
 def _assert_resume_transport_matches(
@@ -1102,7 +1204,7 @@ def _assert_resume_transport_matches(
     route_transport = _route_transport(route)
     if artifact_transport != route_transport:
         raise BakeoffConfigError(
-            f"{artifact_path}: existing bare artifact transport={artifact_transport!r} "
+            f"{artifact_path}: existing artifact transport={artifact_transport!r} "
             f"does not match route transport={route_transport!r}; use --force with a clean "
             "artifact path instead of silently overwriting a different transport"
         )
@@ -1144,6 +1246,7 @@ def run_one_bare(
     runner: BareRunner = invoke_bakeoff_route_bare,
     force: bool = False,
     retry_failures: bool = False,
+    run_index: int = 1,
 ) -> BakeoffRun:
     """Run or resume one model x passage BARE (tool-free control) artifact.
 
@@ -1155,15 +1258,19 @@ def run_one_bare(
     """
     if runner is invoke_bakeoff_route_bare:
         require_offline_opt_in()
-    artifact_path = _bare_artifact_path(output_dir, route, fixture)
+    run_index = _validate_run_index(run_index)
+    artifact_path = _bare_artifact_path(output_dir, route, fixture, run_index)
     if artifact_path.exists() and not force:
         artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+        _assert_artifact_filename_matches_run_index(artifact_path, artifact)
         _assert_resume_transport_matches(artifact, route, artifact_path)
         if not (retry_failures and artifact.get("status") == "error"):
             return BakeoffRun(artifact_path=artifact_path, artifact=artifact, skipped=True)
 
     prompt = build_bare_factcheck_prompt(fixture.title, fixture.passage_md)
     task_id = f"qg-bakeoff-bare-{pin_slug(route.reviewer_model_id)}-{fixture.slug}"
+    if run_index > 1:
+        task_id = f"{task_id}-r{run_index}"
     started = time.monotonic()
     attempt_count = 1
     transport_retry = {"attempted": False, "reason": None}
@@ -1178,6 +1285,7 @@ def run_one_bare(
             exc,
             wall_seconds,
             arm=BARE_ARM,
+            run_index=run_index,
             attempt_count=int(getattr(exc, "attempt_count", attempt_count) or attempt_count),
             transport_retry=getattr(exc, "transport_retry", transport_retry),
         )
@@ -1195,6 +1303,7 @@ def run_one_bare(
     artifact = {
         "schema_version": RUN_SCHEMA_VERSION,
         "arm": BARE_ARM,
+        "run_index": run_index,
         "created_at": _now_z(),
         "fixture": _fixture_block(fixture),
         "model": _model_block(route, dispatch),
@@ -1394,6 +1503,8 @@ def write_scorecard(path: Path, artifacts: Sequence[Mapping[str, Any]]) -> None:
     regular_artifacts = [a for a in artifacts if not _is_subscription_runtime_artifact(a)]
     subscription_artifacts = [a for a in artifacts if _is_subscription_runtime_artifact(a)]
     judgment_artifacts = [a for a in regular_artifacts if not _is_ops_quota_artifact(a)]
+    all_judgment_artifacts = [a for a in artifacts if not _is_ops_quota_artifact(a)]
+    multi_run = _max_run_index(artifacts) > 1
     lines = [
         "# QG Bakeoff Scorecard",
         "",
@@ -1402,7 +1513,7 @@ def write_scorecard(path: Path, artifacts: Sequence[Mapping[str, Any]]) -> None:
         "Fractions are exact. `low-N` marks denominators below 10.",
         "",
     ]
-    lines.extend(_runs_table_section("Runs", regular_artifacts))
+    lines.extend(_runs_table_section("Runs", regular_artifacts, show_run=multi_run))
     lines.extend(_ops_quota_section(regular_artifacts))
     lines.extend(_totals_and_lift_section("With Anchor", judgment_artifacts))
     lines.extend(
@@ -1411,6 +1522,9 @@ def write_scorecard(path: Path, artifacts: Sequence[Mapping[str, Any]]) -> None:
             [a for a in judgment_artifacts if _fixture_slug(a) != ANCHOR_SLUG],
         )
     )
+    if multi_run:
+        lines.extend(_run_variance_section(all_judgment_artifacts, scheduled_runs=_max_run_index(artifacts)))
+        lines.extend(_domain_totals_section(all_judgment_artifacts))
     if subscription_artifacts:
         lines.extend(
             [
@@ -1421,48 +1535,68 @@ def write_scorecard(path: Path, artifacts: Sequence[Mapping[str, Any]]) -> None:
                 "",
             ]
         )
-        lines.extend(_runs_table(subscription_artifacts))
+        lines.extend(_runs_table(subscription_artifacts, show_run=multi_run))
         lines.extend(_ops_quota_section(subscription_artifacts))
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def _runs_table_section(title: str, artifacts: Sequence[Mapping[str, Any]]) -> list[str]:
-    return ["", f"## {title}", "", *_runs_table(artifacts)]
+def _runs_table_section(title: str, artifacts: Sequence[Mapping[str, Any]], *, show_run: bool = False) -> list[str]:
+    return ["", f"## {title}", "", *_runs_table(artifacts, show_run=show_run)]
 
 
-def _runs_table(artifacts: Sequence[Mapping[str, Any]]) -> list[str]:
-    lines = [
-        "| model | transport | entrypoint | passage | arm | status | failure_class | parse_lenient | model judgment | live admissible | missing | U honesty | M alignment | true unsupported | invalid | inadmissible | tools | wall_s |",
-        "| --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: |",
-    ]
+def _runs_table(artifacts: Sequence[Mapping[str, Any]], *, show_run: bool = False) -> list[str]:
+    if show_run:
+        lines = [
+            "| model | transport | entrypoint | passage | arm | run | status | failure_class | parse_lenient | model judgment | live admissible | missing | U honesty | M alignment | true unsupported | invalid | inadmissible | tools | wall_s |",
+            "| --- | --- | --- | --- | --- | ---: | --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: |",
+        ]
+    else:
+        lines = [
+            "| model | transport | entrypoint | passage | arm | status | failure_class | parse_lenient | model judgment | live admissible | missing | U honesty | M alignment | true unsupported | invalid | inadmissible | tools | wall_s |",
+            "| --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: |",
+        ]
     if not artifacts:
-        lines.append("| n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | 0 | 0 | 0 | 0/0 low-N | 0/0 low-N | 0/0 low-N | 0 | 0 | 0 | 0 |")
+        if show_run:
+            lines.append("| n/a | n/a | n/a | n/a | n/a | 0 | n/a | n/a | n/a | 0 | 0 | 0 | 0/0 low-N | 0/0 low-N | 0/0 low-N | 0 | 0 | 0 | 0 |")
+        else:
+            lines.append("| n/a | n/a | n/a | n/a | n/a | n/a | n/a | n/a | 0 | 0 | 0 | 0/0 low-N | 0/0 low-N | 0/0 low-N | 0 | 0 | 0 | 0 |")
         return lines
     for artifact in sorted(artifacts, key=_artifact_sort_key):
         score = _score(artifact)
         fractions = score.get("fractions", {})
-        lines.append(
-            "| {model} | {transport} | {entrypoint} | {passage} | {arm} | {status} | {failure_class} | {parse_lenient} | {model_score} | {live_score} | {missing} | {u} | {m} | {true_bad} | {invalid} | {inadmissible} | {tools} | {wall} |".format(
-                model=_model_label(artifact),
-                transport=_artifact_transport(artifact),
-                entrypoint=_artifact_entrypoint(artifact),
-                passage=_fixture_slug(artifact),
-                arm=_artifact_arm(artifact),
-                status=artifact.get("status", "unknown"),
-                failure_class=artifact.get("failure_class") or "n/a",
-                parse_lenient=bool(artifact.get("response_parse_lenient")),
-                model_score=score.get("model_judgment_score", 0),
-                live_score=score.get("live_admissible_score", 0),
-                missing=score.get("missing_claims", 0),
-                u=_fraction_label(fractions.get("class_u_honesty")),
-                m=_fraction_label(fractions.get("class_m_alignment")),
-                true_bad=_fraction_label(fractions.get("false_unsupported_on_true")),
-                invalid=score.get("invalid_fact_checks", 0),
-                inadmissible=score.get("inadmissible_positive_verdicts", 0),
-                tools=artifact.get("tool_call_count", 0),
-                wall=artifact.get("wall_seconds", 0),
+        values = {
+            "model": _model_label(artifact),
+            "transport": _artifact_transport(artifact),
+            "entrypoint": _artifact_entrypoint(artifact),
+            "passage": _fixture_slug(artifact),
+            "arm": _artifact_arm(artifact),
+            "run": _artifact_run_index(artifact),
+            "status": artifact.get("status", "unknown"),
+            "failure_class": artifact.get("failure_class") or "n/a",
+            "parse_lenient": bool(artifact.get("response_parse_lenient")),
+            "model_score": score.get("model_judgment_score", 0),
+            "live_score": score.get("live_admissible_score", 0),
+            "missing": score.get("missing_claims", 0),
+            "u": _fraction_label(fractions.get("class_u_honesty")),
+            "m": _fraction_label(fractions.get("class_m_alignment")),
+            "true_bad": _fraction_label(fractions.get("false_unsupported_on_true")),
+            "invalid": score.get("invalid_fact_checks", 0),
+            "inadmissible": score.get("inadmissible_positive_verdicts", 0),
+            "tools": artifact.get("tool_call_count", 0),
+            "wall": artifact.get("wall_seconds", 0),
+        }
+        if show_run:
+            lines.append(
+                "| {model} | {transport} | {entrypoint} | {passage} | {arm} | {run} | {status} | {failure_class} | {parse_lenient} | {model_score} | {live_score} | {missing} | {u} | {m} | {true_bad} | {invalid} | {inadmissible} | {tools} | {wall} |".format(
+                    **values
+                )
             )
-        )
+        else:
+            lines.append(
+                "| {model} | {transport} | {entrypoint} | {passage} | {arm} | {status} | {failure_class} | {parse_lenient} | {model_score} | {live_score} | {missing} | {u} | {m} | {true_bad} | {invalid} | {inadmissible} | {tools} | {wall} |".format(
+                    **values
+                )
+            )
     return lines
 
 
@@ -1495,9 +1629,10 @@ def _ops_quota_section(artifacts: Sequence[Mapping[str, Any]]) -> list[str]:
     return lines
 
 
-def default_output_dir(day: date | None = None) -> Path:
+def default_output_dir(day: date | None = None, *, multi_run: bool = False) -> Path:
     effective = day or datetime.now(UTC).date()
-    return DEFAULT_OUTPUT_ROOT / f"{effective.isoformat()}-qg-bakeoff"
+    suffix = "-qg-bakeoff-multirun" if multi_run else "-qg-bakeoff"
+    return DEFAULT_OUTPUT_ROOT / f"{effective.isoformat()}{suffix}"
 
 
 def model_pins_from_args(values: Sequence[str] | None) -> list[str]:
@@ -1548,6 +1683,7 @@ def rescore_artifacts(output_dir: Path, fixtures_dir: Path = FIXTURE_DIR) -> int
             # See _is_bakeoff_cell — foreign JSONs (canary verdicts etc.)
             # must never be rescored or rendered as cells.
             continue
+        _assert_artifact_filename_matches_run_index(path, artifact)
         # Backfill ``arm`` for backward compat: pre-arm tooled artifacts have no
         # field (→ "tooled"); a ``__bare`` filename identifies a bare artifact even
         # if it somehow lacks the field. Rescore covers BOTH arms — the bare grounding
@@ -1603,6 +1739,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             "re-run cells whose existing artifact has status=error. Completed cells stay skipped."
         ),
     )
+    parser.add_argument("--runs", type=int, default=1, help="Repeat every requested cell N times (default: 1)")
     parser.add_argument(
         "--rescore",
         action="store_true",
@@ -1617,10 +1754,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(f"rescored {n} artifacts under {output_dir}")
             print(f"scorecard: {output_dir / SCORECARD_NAME}")
             return 0
+        runs_requested = _validate_run_index(args.runs)
         require_offline_opt_in()
         fixtures = load_fixtures(args.fixtures_dir, args.fixtures)
         pins = model_pins_from_args(args.models)
-        output_dir = args.out_dir or default_output_dir()
+        output_dir = args.out_dir or default_output_dir(multi_run=runs_requested > 1)
         runs = run_matrix(
             fixtures,
             pins,
@@ -1628,6 +1766,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             arm=args.arm,
             force=args.force,
             retry_failures=args.retry_failures,
+            runs=runs_requested,
         )
     except BakeoffConfigError as exc:
         print(str(exc), file=sys.stderr)
@@ -1844,6 +1983,26 @@ def _fabrication_success(verdict: str) -> bool:
     return qg_factcheck_scoring.score_verdict(verdict, claim_is_true=False) > 0
 
 
+def _claim_stability_class(claim: Mapping[str, Any]) -> str:
+    """Classify one scored claim for run-to-run stability.
+
+    The classes are intentionally coarse and paper-facing:
+    ``true-confirmed`` when a true claim is judged ``CONFIRMED``;
+    ``fabrication-caught`` when a false claim receives any verdict that scores
+    positively for a fabrication; ``missed`` when the fixture claim was not
+    matched; and ``other`` for admissibility edges such as UNATTESTED on a
+    true claim or any remaining non-headline outcome.
+    """
+    if claim.get("matched") is False:
+        return "missed"
+    verdict = str(claim.get("model_judgment_verdict") or _judgment_verdict(claim)).strip().upper()
+    if claim.get("is_true") is True and verdict == "CONFIRMED":
+        return "true-confirmed"
+    if claim.get("is_true") is False and _fabrication_success(verdict):
+        return "fabrication-caught"
+    return "other"
+
+
 def _fraction(numerator: int, denominator: int) -> dict[str, Any]:
     return {
         "numerator": numerator,
@@ -1860,9 +2019,198 @@ def _fraction_label(value: Any) -> str:
     return f"{value.get('text', '0/0')}{suffix}"
 
 
+_TOTAL_NUMERIC_KEYS = (
+    "model_judgment_score",
+    "live_admissible_score",
+    "missing_claims",
+    "invalid_fact_checks",
+    "inadmissible_positive_verdicts",
+    "tool_call_count",
+    "wall_seconds",
+)
+
+
+def _max_run_index(artifacts: Sequence[Mapping[str, Any]]) -> int:
+    if not artifacts:
+        return 1
+    return max(_artifact_run_index(artifact) for artifact in artifacts)
+
+
+def _empty_total_row() -> dict[str, Any]:
+    return {
+        "passages": 0,
+        "model_judgment_score": 0,
+        "live_admissible_score": 0,
+        "class_u_good": 0,
+        "class_u_total": 0,
+        "class_m_good": 0,
+        "class_m_total": 0,
+        "true_unsupported": 0,
+        "true_total": 0,
+        "missing_claims": 0,
+        "invalid_fact_checks": 0,
+        "inadmissible_positive_verdicts": 0,
+        "tool_call_count": 0,
+        "wall_seconds": 0.0,
+    }
+
+
+def _unique_judgment_cells(
+    artifacts: Sequence[Mapping[str, Any]],
+) -> dict[tuple[tuple[str, str, str], str, str, int], Mapping[str, Any]]:
+    cells: dict[tuple[tuple[str, str, str], str, str, int], Mapping[str, Any]] = {}
+    for artifact in artifacts:
+        if _is_ops_quota_artifact(artifact):
+            continue
+        key = (_model_key(artifact), _fixture_slug(artifact), _artifact_arm(artifact), _artifact_run_index(artifact))
+        cells[key] = artifact
+    return cells
+
+
+def _add_artifact_to_total(row: dict[str, Any], artifact: Mapping[str, Any]) -> None:
+    score = _score(artifact)
+    row["passages"] += 1
+    row["model_judgment_score"] += int(score.get("model_judgment_score") or 0)
+    row["live_admissible_score"] += int(score.get("live_admissible_score") or 0)
+    row["missing_claims"] += int(score.get("missing_claims") or 0)
+    row["invalid_fact_checks"] += int(score.get("invalid_fact_checks") or 0)
+    row["inadmissible_positive_verdicts"] += int(score.get("inadmissible_positive_verdicts") or 0)
+    row["tool_call_count"] += int(artifact.get("tool_call_count") or 0)
+    row["wall_seconds"] += float(artifact.get("wall_seconds") or 0.0)
+    raw_fractions = score.get("fractions")
+    fractions = raw_fractions if isinstance(raw_fractions, Mapping) else {}
+    _add_fraction(row, "class_u", fractions.get("class_u_honesty"))
+    _add_fraction(row, "class_m", fractions.get("class_m_alignment"))
+    _add_fraction(
+        row,
+        "true",
+        fractions.get("false_unsupported_on_true"),
+        good_key="true_unsupported",
+        total_key="true_total",
+    )
+
+
+def _mean(values: Sequence[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _sample_sd(values: Sequence[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    center = _mean(values)
+    return (sum((value - center) ** 2 for value in values) / (len(values) - 1)) ** 0.5
+
+
+def _stats(values: Sequence[float]) -> dict[str, Any]:
+    vals = list(values)
+    if not vals:
+        return {"mean": 0.0, "sd": 0.0, "min": 0.0, "max": 0.0, "n": 0, "values": []}
+    return {
+        "mean": _mean(vals),
+        "sd": _sample_sd(vals),
+        "min": min(vals),
+        "max": max(vals),
+        "n": len(vals),
+        "values": vals,
+    }
+
+
+def _run_fraction_rate(row: Mapping[str, Any], good_key: str, total_key: str) -> float | None:
+    denominator = int(row.get(total_key) or 0)
+    if denominator <= 0:
+        return None
+    return int(row.get(good_key) or 0) / denominator
+
+
+def _fraction_rate_summary(rows: Sequence[Mapping[str, Any]], good_key: str, total_key: str) -> dict[str, Any]:
+    rates: list[float] = []
+    denominators: list[int] = []
+    for row in rows:
+        denominator = int(row.get(total_key) or 0)
+        denominators.append(denominator)
+        rate = _run_fraction_rate(row, good_key, total_key)
+        if rate is not None:
+            rates.append(rate)
+    summary = _stats(rates)
+    summary["denominators"] = denominators
+    summary["low_n"] = any(denominator < 10 for denominator in denominators)
+    return summary
+
+
+def _format_number(value: float) -> str:
+    if abs(value - round(value)) < 1e-9:
+        return str(round(value))
+    return f"{value:.3f}".rstrip("0").rstrip(".")
+
+
+def _stats_label(value: Any) -> str:
+    if not isinstance(value, Mapping):
+        return _format_number(float(value or 0))
+    return "{mean} ± {sd} [{lo}..{hi}]".format(
+        mean=_format_number(float(value.get("mean") or 0.0)),
+        sd=_format_number(float(value.get("sd") or 0.0)),
+        lo=_format_number(float(value.get("min") or 0.0)),
+        hi=_format_number(float(value.get("max") or 0.0)),
+    )
+
+
+def _fraction_summary_label(value: Any) -> str:
+    if not isinstance(value, Mapping) or int(value.get("n") or 0) == 0:
+        return "0/0 low-N"
+    suffix = " low-N" if value.get("low_n") else ""
+    return f"{_stats_label(value)}{suffix}"
+
+
+def _summarize_run_rows(rows: Sequence[Mapping[str, Any]], run_indices: Sequence[int]) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "multi_run": True,
+        "runs": len(rows),
+        "run_indices": list(run_indices),
+        "passages_per_run": [int(row.get("passages") or 0) for row in rows],
+    }
+    summary["passages"] = _stats([float(row.get("passages") or 0) for row in rows])
+    for key in _TOTAL_NUMERIC_KEYS:
+        summary[key] = _stats([float(row.get(key) or 0) for row in rows])
+    summary["class_u_honesty"] = _fraction_rate_summary(rows, "class_u_good", "class_u_total")
+    summary["class_m_alignment"] = _fraction_rate_summary(rows, "class_m_good", "class_m_total")
+    summary["false_unsupported_on_true"] = _fraction_rate_summary(rows, "true_unsupported", "true_total")
+    return summary
+
+
 def _totals_and_lift_section(title: str, artifacts: Sequence[Mapping[str, Any]]) -> list[str]:
     """Per-(model, arm) totals table + the harness-lift table for one anchor split."""
     totals = _aggregate_by_model_arm(artifacts)
+    if _max_run_index(artifacts) > 1:
+        lines = [
+            "",
+            f"## Totals {title}",
+            "",
+            "| model | arm | runs | passages/run | model judgment | live admissible | U honesty | M alignment headline | true unsupported | missing | invalid | inadmissible | tools | wall_s |",
+            "| --- | --- | ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+        ]
+        for (model_key, arm), row in sorted(totals.items()):
+            model = f"{model_key[0]} [{model_key[1]}/{model_key[2]}]"
+            passages = "/".join(str(value) for value in row["passages_per_run"]) or "0"
+            lines.append(
+                "| {model} | {arm} | {runs} | {passages} | {model_score} | {live_score} | {u} | {m} | {true_bad} | {missing} | {invalid} | {inadmissible} | {tools} | {wall} |".format(
+                    model=model,
+                    arm=arm,
+                    runs=row["runs"],
+                    passages=passages,
+                    model_score=_stats_label(row["model_judgment_score"]),
+                    live_score=_stats_label(row["live_admissible_score"]),
+                    u=_fraction_summary_label(row["class_u_honesty"]),
+                    m=_fraction_summary_label(row["class_m_alignment"]),
+                    true_bad=_fraction_summary_label(row["false_unsupported_on_true"]),
+                    missing=_stats_label(row["missing_claims"]),
+                    invalid=_stats_label(row["invalid_fact_checks"]),
+                    inadmissible=_stats_label(row["inadmissible_positive_verdicts"]),
+                    tools=_stats_label(row["tool_call_count"]),
+                    wall=_stats_label(row["wall_seconds"]),
+                )
+            )
+        lines.extend(_harness_lift_section(title, artifacts))
+        return lines
     lines = [
         "",
         f"## Totals {title}",
@@ -1907,6 +2255,8 @@ def _harness_lift_section(
     artifacts do not. A model with zero paired fixtures shows ``n/a`` — never a
     fabricated number.
     """
+    if _max_run_index(artifacts) > 1:
+        return _harness_lift_section_multirun(title, artifacts)
     cells: dict[tuple[str, str, str], dict[str, dict[str, Mapping[str, Any]]]] = defaultdict(lambda: defaultdict(dict))
     for artifact in artifacts:
         if _is_ops_quota_artifact(artifact):
@@ -1967,6 +2317,329 @@ def _harness_lift_section(
     return lines
 
 
+def _score_number(artifact: Mapping[str, Any], key: str) -> float:
+    return float(_score(artifact).get(key) or 0.0)
+
+
+def _score_fraction_rate(artifact: Mapping[str, Any], key: str) -> float | None:
+    fractions = _score(artifact).get("fractions")
+    fraction = fractions.get(key) if isinstance(fractions, Mapping) else None
+    if not isinstance(fraction, Mapping):
+        return None
+    denominator = int(fraction.get("denominator") or 0)
+    if denominator <= 0:
+        return None
+    return int(fraction.get("numerator") or 0) / denominator
+
+
+def _arm_mean_for_fixture(
+    runs: Mapping[int, Mapping[str, Any]],
+    key: str,
+) -> float:
+    return _mean([_score_number(artifact, key) for _run, artifact in sorted(runs.items())])
+
+
+def _arm_fraction_mean_for_fixture(
+    runs: Mapping[int, Mapping[str, Any]],
+    key: str,
+) -> float | None:
+    rates = [
+        rate
+        for _run, artifact in sorted(runs.items())
+        if (rate := _score_fraction_rate(artifact, key)) is not None
+    ]
+    return _mean(rates) if rates else None
+
+
+def _harness_lift_section_multirun(
+    title: str,
+    artifacts: Sequence[Mapping[str, Any]],
+) -> list[str]:
+    scheduled_runs = _max_run_index(artifacts)
+    cells: dict[
+        tuple[str, str, str],
+        dict[str, dict[str, dict[int, Mapping[str, Any]]]],
+    ] = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
+    for artifact in artifacts:
+        if _is_ops_quota_artifact(artifact):
+            continue
+        cells[_model_key(artifact)][_fixture_slug(artifact)][_artifact_arm(artifact)][
+            _artifact_run_index(artifact)
+        ] = artifact
+
+    lines = [
+        "",
+        f"## Harness Lift {title}",
+        "",
+        "Lift = tooled model judgment mean − bare model judgment mean (positive = the harness helps),",
+        "over PAIRED passages only. For repeat runs each arm is averaged within a passage first;",
+        "run indexes are not paired across arms. Ranges are across paired passage lifts.",
+        f"Observed run ceiling: {scheduled_runs}.",
+        "",
+        "| model | paired passages | run coverage | tooled model judgment | bare model judgment | harness_lift | tooled M alignment | bare M alignment |",
+        "| --- | ---: | --- | --- | --- | --- | --- | --- |",
+    ]
+    for model_key in sorted(cells):
+        paired = sorted(
+            slug
+            for slug, arms in cells[model_key].items()
+            if TOOLED_ARM in arms and BARE_ARM in arms
+        )
+        model_label = f"{model_key[0]} [{model_key[1]}/{model_key[2]}]"
+        if not paired:
+            lines.append(f"| {model_label} | 0 | n/a | n/a | n/a | n/a | n/a | n/a |")
+            continue
+        tooled_means: list[float] = []
+        bare_means: list[float] = []
+        lifts: list[float] = []
+        tooled_m: list[float] = []
+        bare_m: list[float] = []
+        run_counts: list[int] = []
+        for slug in paired:
+            arms = cells[model_key][slug]
+            run_counts.extend([len(arms[TOOLED_ARM]), len(arms[BARE_ARM])])
+            tooled_mean = _arm_mean_for_fixture(arms[TOOLED_ARM], "model_judgment_score")
+            bare_mean = _arm_mean_for_fixture(arms[BARE_ARM], "model_judgment_score")
+            tooled_means.append(tooled_mean)
+            bare_means.append(bare_mean)
+            lifts.append(tooled_mean - bare_mean)
+            tooled_rate = _arm_fraction_mean_for_fixture(arms[TOOLED_ARM], "class_m_alignment")
+            bare_rate = _arm_fraction_mean_for_fixture(arms[BARE_ARM], "class_m_alignment")
+            if tooled_rate is not None:
+                tooled_m.append(tooled_rate)
+            if bare_rate is not None:
+                bare_m.append(bare_rate)
+        coverage = f"{min(run_counts)}..{max(run_counts)}/{scheduled_runs}" if run_counts else "0"
+        lines.append(
+            "| {model} | {paired} | {coverage} | {tooled} | {bare} | {lift} | {tooled_m} | {bare_m} |".format(
+                model=model_label,
+                paired=len(paired),
+                coverage=coverage,
+                tooled=_stats_label(_stats(tooled_means)),
+                bare=_stats_label(_stats(bare_means)),
+                lift=_stats_label(_stats(lifts)),
+                tooled_m=_fraction_summary_label(_stats(tooled_m) | {"low_n": True}),
+                bare_m=_fraction_summary_label(_stats(bare_m) | {"low_n": True}),
+            )
+        )
+    return lines
+
+
+def _claim_classes_by_id(artifact: Mapping[str, Any]) -> dict[str, str]:
+    claims = _score(artifact).get("claims")
+    if not isinstance(claims, list):
+        return {}
+    classes: dict[str, str] = {}
+    for index, claim in enumerate(claims):
+        if not isinstance(claim, Mapping):
+            continue
+        claim_id = str(claim.get("claim_id") or f"claim-{index}")
+        classes[claim_id] = _claim_stability_class(claim)
+    return classes
+
+
+def _cell_stability(
+    runs: Mapping[int, Mapping[str, Any]],
+    *,
+    scheduled_runs: int,
+) -> tuple[float | None, list[str]]:
+    flags: list[str] = []
+    run_indices = set(runs)
+    if run_indices != set(range(1, scheduled_runs + 1)):
+        flags.append("partial")
+    if any(artifact.get("status") == "error" for artifact in runs.values()):
+        flags.append("error")
+    parse_values = {bool(artifact.get("response_parse_lenient")) for artifact in runs.values()}
+    if len(parse_values) > 1:
+        flags.append("parse-lenient-variance")
+    if "partial" in flags or "error" in flags:
+        return None, flags
+    per_run_classes = {run: _claim_classes_by_id(artifact) for run, artifact in runs.items()}
+    claim_ids = sorted({claim_id for classes in per_run_classes.values() for claim_id in classes})
+    if not claim_ids:
+        return None, flags
+    stable = 0
+    for claim_id in claim_ids:
+        classes = {per_run_classes[run].get(claim_id, "missed") for run in range(1, scheduled_runs + 1)}
+        stable += int(len(classes) == 1)
+    return stable / len(claim_ids), flags
+
+
+def _run_variance_section(
+    artifacts: Sequence[Mapping[str, Any]],
+    *,
+    scheduled_runs: int,
+) -> list[str]:
+    cells = _unique_judgment_cells(artifacts)
+    per_run: dict[tuple[tuple[str, str, str], str, int], dict[str, Any]] = defaultdict(_empty_total_row)
+    grouped_cells: dict[
+        tuple[tuple[str, str, str], str, str],
+        dict[int, Mapping[str, Any]],
+    ] = defaultdict(dict)
+    for (_model_key_value, slug, arm, run_index), artifact in cells.items():
+        model_key = _model_key(artifact)
+        _add_artifact_to_total(per_run[(model_key, arm, run_index)], artifact)
+        grouped_cells[(model_key, slug, arm)][run_index] = artifact
+
+    lines = [
+        "",
+        "## Run Variance",
+        "",
+        "Run-level fractions are computed inside each run before mean/sd/range summaries; pooled numerators are not used.",
+        "Cells whose `response_parse_lenient` flag differs across runs are flagged because parser leniency can inflate apparent class instability.",
+        "Partial cells are excluded from arm-level stability. Error cells are flagged separately and never counted stable.",
+        "",
+        "### Per-Run Totals",
+        "",
+        "| model | arm | run | passages | errors | model judgment | live admissible | missing | U honesty | M alignment |",
+        "| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |",
+    ]
+    for (model_key, arm, run_index), row in sorted(per_run.items()):
+        model = f"{model_key[0]} [{model_key[1]}/{model_key[2]}]"
+        run_artifacts = [
+            artifact
+            for key, artifact in cells.items()
+            if key[0] == model_key and key[2] == arm and key[3] == run_index
+        ]
+        errors = sum(1 for artifact in run_artifacts if artifact.get("status") == "error")
+        lines.append(
+            "| {model} | {arm} | {run} | {passages} | {errors} | {model_score} | {live_score} | {missing} | {u} | {m} |".format(
+                model=model,
+                arm=arm,
+                run=run_index,
+                passages=row["passages"],
+                errors=errors,
+                model_score=row["model_judgment_score"],
+                live_score=row["live_admissible_score"],
+                missing=row["missing_claims"],
+                u=_fraction_label(_fraction(row["class_u_good"], row["class_u_total"])),
+                m=_fraction_label(_fraction(row["class_m_good"], row["class_m_total"])),
+            )
+        )
+
+    stability: dict[tuple[tuple[str, str, str], str], dict[str, Any]] = defaultdict(
+        lambda: {
+            "complete": 0,
+            "partial": 0,
+            "error": 0,
+            "parse_lenient_variance": 0,
+            "values": [],
+        }
+    )
+    flagged_rows: list[tuple[tuple[str, str, str], str, str, str, str]] = []
+    for (model_key, slug, arm), runs in sorted(grouped_cells.items()):
+        value, flags = _cell_stability(runs, scheduled_runs=scheduled_runs)
+        row = stability[(model_key, arm)]
+        if "partial" in flags:
+            row["partial"] += 1
+        if "error" in flags:
+            row["error"] += 1
+        if "parse-lenient-variance" in flags:
+            row["parse_lenient_variance"] += 1
+        if value is not None:
+            row["complete"] += 1
+            row["values"].append(value)
+        if flags:
+            flagged_rows.append((model_key, slug, arm, ",".join(str(run) for run in sorted(runs)), ", ".join(flags)))
+
+    lines.extend(
+        [
+            "",
+            "### Stability",
+            "",
+            "| model | arm | complete cells | partial cells | error cells | parse-lenient variance cells | stability |",
+            "| --- | --- | ---: | ---: | ---: | ---: | --- |",
+        ]
+    )
+    for (model_key, arm), row in sorted(stability.items()):
+        model = f"{model_key[0]} [{model_key[1]}/{model_key[2]}]"
+        lines.append(
+            "| {model} | {arm} | {complete} | {partial} | {error} | {parse_var} | {stability} |".format(
+                model=model,
+                arm=arm,
+                complete=row["complete"],
+                partial=row["partial"],
+                error=row["error"],
+                parse_var=row["parse_lenient_variance"],
+                stability=_stats_label(_stats(row["values"])) if row["values"] else "n/a",
+            )
+        )
+    if flagged_rows:
+        lines.extend(
+            [
+                "",
+                "### Flagged Cells",
+                "",
+                "| model | passage | arm | runs present | flags |",
+                "| --- | --- | --- | --- | --- |",
+            ]
+        )
+        for model_key, slug, arm, runs_present, flags in flagged_rows:
+            model = f"{model_key[0]} [{model_key[1]}/{model_key[2]}]"
+            lines.append(f"| {model} | {slug} | {arm} | {runs_present} | {flags} |")
+    return lines
+
+
+def _lift_stats_by_model(artifacts: Sequence[Mapping[str, Any]]) -> dict[tuple[str, str, str], dict[str, Any]]:
+    cells: dict[
+        tuple[str, str, str],
+        dict[str, dict[str, dict[int, Mapping[str, Any]]]],
+    ] = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
+    for artifact in artifacts:
+        if _is_ops_quota_artifact(artifact):
+            continue
+        cells[_model_key(artifact)][_fixture_slug(artifact)][_artifact_arm(artifact)][
+            _artifact_run_index(artifact)
+        ] = artifact
+    lifts: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for model_key, by_slug in cells.items():
+        values: list[float] = []
+        for arms in by_slug.values():
+            if TOOLED_ARM not in arms or BARE_ARM not in arms:
+                continue
+            values.append(
+                _arm_mean_for_fixture(arms[TOOLED_ARM], "model_judgment_score")
+                - _arm_mean_for_fixture(arms[BARE_ARM], "model_judgment_score")
+            )
+        if values:
+            lifts[model_key] = _stats(values)
+    return lifts
+
+
+def _domain_totals_section(artifacts: Sequence[Mapping[str, Any]]) -> list[str]:
+    by_domain: dict[str, list[Mapping[str, Any]]] = defaultdict(list)
+    for artifact in artifacts:
+        by_domain[domain_for_slug(_fixture_slug(artifact))].append(artifact)
+    lines = [
+        "",
+        "## Domain Totals",
+        "",
+        "| domain | model | arm | runs | passages/run | model judgment | U honesty | M alignment headline | harness_lift |",
+        "| --- | --- | --- | ---: | --- | --- | --- | --- | --- |",
+    ]
+    for domain in sorted(by_domain):
+        domain_artifacts = by_domain[domain]
+        totals = _aggregate_by_model_arm(domain_artifacts)
+        lifts = _lift_stats_by_model(domain_artifacts)
+        for (model_key, arm), row in sorted(totals.items()):
+            model = f"{model_key[0]} [{model_key[1]}/{model_key[2]}]"
+            if row.get("multi_run"):
+                runs = row["runs"]
+                passages = "/".join(str(value) for value in row["passages_per_run"]) or "0"
+                model_score = _stats_label(row["model_judgment_score"])
+                u = _fraction_summary_label(row["class_u_honesty"])
+                m = _fraction_summary_label(row["class_m_alignment"])
+            else:
+                runs = 1
+                passages = str(row["passages"])
+                model_score = str(row["model_judgment_score"])
+                u = _fraction_label(_fraction(row["class_u_good"], row["class_u_total"]))
+                m = _fraction_label(_fraction(row["class_m_good"], row["class_m_total"]))
+            lift = _stats_label(lifts[model_key]) if model_key in lifts else "n/a"
+            lines.append(f"| {domain} | {model} | {arm} | {runs} | {passages} | {model_score} | {u} | {m} | {lift} |")
+    return lines
+
+
 def _na(value: Any) -> str:
     return "n/a" if value is None else str(value)
 
@@ -1974,43 +2647,26 @@ def _na(value: Any) -> str:
 def _aggregate_by_model_arm(
     artifacts: Sequence[Mapping[str, Any]],
 ) -> dict[tuple[tuple[str, str, str], str], dict[str, Any]]:
-    totals: dict[tuple[tuple[str, str, str], str], dict[str, Any]] = defaultdict(
-        lambda: {
-            "passages": 0,
-            "model_judgment_score": 0,
-            "live_admissible_score": 0,
-            "class_u_good": 0,
-            "class_u_total": 0,
-            "class_m_good": 0,
-            "class_m_total": 0,
-            "true_unsupported": 0,
-            "true_total": 0,
-            "missing_claims": 0,
-            "invalid_fact_checks": 0,
-            "inadmissible_positive_verdicts": 0,
-            "tool_call_count": 0,
-            "wall_seconds": 0.0,
-        }
+    cells = _unique_judgment_cells(artifacts)
+    if _max_run_index(list(cells.values())) <= 1:
+        totals: dict[tuple[tuple[str, str, str], str], dict[str, Any]] = defaultdict(_empty_total_row)
+        for artifact in cells.values():
+            _add_artifact_to_total(totals[(_model_key(artifact), _artifact_arm(artifact))], artifact)
+        return dict(totals)
+
+    per_run: dict[tuple[tuple[str, str, str], str], dict[int, dict[str, Any]]] = defaultdict(
+        lambda: defaultdict(_empty_total_row)
     )
-    for artifact in artifacts:
-        if _is_ops_quota_artifact(artifact):
-            continue
-        row = totals[(_model_key(artifact), _artifact_arm(artifact))]
-        score = _score(artifact)
-        row["passages"] += 1
-        row["model_judgment_score"] += int(score.get("model_judgment_score") or 0)
-        row["live_admissible_score"] += int(score.get("live_admissible_score") or 0)
-        row["missing_claims"] += int(score.get("missing_claims") or 0)
-        row["invalid_fact_checks"] += int(score.get("invalid_fact_checks") or 0)
-        row["inadmissible_positive_verdicts"] += int(score.get("inadmissible_positive_verdicts") or 0)
-        row["tool_call_count"] += int(artifact.get("tool_call_count") or 0)
-        row["wall_seconds"] += float(artifact.get("wall_seconds") or 0.0)
-        raw_fractions = score.get("fractions")
-        fractions = raw_fractions if isinstance(raw_fractions, Mapping) else {}
-        _add_fraction(row, "class_u", fractions.get("class_u_honesty"))
-        _add_fraction(row, "class_m", fractions.get("class_m_alignment"))
-        _add_fraction(row, "true", fractions.get("false_unsupported_on_true"), good_key="true_unsupported", total_key="true_total")
-    return dict(totals)
+    for artifact in cells.values():
+        key = (_model_key(artifact), _artifact_arm(artifact))
+        run_index = _artifact_run_index(artifact)
+        _add_artifact_to_total(per_run[key][run_index], artifact)
+
+    totals: dict[tuple[tuple[str, str, str], str], dict[str, Any]] = {}
+    for key, rows_by_run in per_run.items():
+        run_indices = sorted(rows_by_run)
+        totals[key] = _summarize_run_rows([rows_by_run[index] for index in run_indices], run_indices)
+    return totals
 
 
 def _add_fraction(
@@ -2096,9 +2752,9 @@ def _artifact_arm(artifact: Mapping[str, Any]) -> str:
     return arm if isinstance(arm, str) and arm else TOOLED_ARM
 
 
-def _artifact_sort_key(artifact: Mapping[str, Any]) -> tuple[str, str, str, str, str]:
+def _artifact_sort_key(artifact: Mapping[str, Any]) -> tuple[str, str, str, str, str, int]:
     pin, transport, entrypoint = _model_key(artifact)
-    return (pin, transport, entrypoint, _fixture_slug(artifact), _artifact_arm(artifact))
+    return (pin, transport, entrypoint, _fixture_slug(artifact), _artifact_arm(artifact), _artifact_run_index(artifact))
 
 
 def _empty_grounding() -> dict[str, int]:

--- a/scripts/audit/qg_tier2_canary_check.py
+++ b/scripts/audit/qg_tier2_canary_check.py
@@ -28,6 +28,7 @@ CLASS_M_MIN_NUMERATOR = 4
 CLASS_M_EXPECTED_DENOMINATOR = 7
 CLASS_U_MIN_NUMERATOR = 3
 CLASS_U_EXPECTED_DENOMINATOR = 4
+MULTI_RUN_DIR_UNSUPPORTED = "multi_run_dir_unsupported"
 
 # The E3 arming canary is calibrated to a PINNED fixture set — the four folk-domain
 # anchor passages — NOT to whatever happens to live in qg_bakeoff.FIXTURE_DIR. That
@@ -102,6 +103,31 @@ def evaluate_canary_dir(
     allowlist = load_allowlist(allowlist_path)
     artifacts, load_failures = _load_tooled_artifacts(output_dir)
     failure_reasons = list(load_failures)
+    if MULTI_RUN_DIR_UNSUPPORTED in failure_reasons:
+        return {
+            "schema_version": VERDICT_SCHEMA_VERSION,
+            "created_at": _now_z(),
+            "verdict": "FAIL",
+            "passed": False,
+            "failure_reasons": [MULTI_RUN_DIR_UNSUPPORTED],
+            "summary": {
+                "artifact_count": 0,
+                "missing_claims": 0,
+                "class_m_alignment": _fraction(0, 0),
+                "class_u_honesty": _fraction(0, 0),
+                "class_u_confirmed": [],
+                "class_m_confirmed_unallowlisted": [],
+                "class_m_confirmed_allowlisted": [],
+            },
+            "provenance": _provenance(
+                fixtures=fixtures,
+                gate_version=gate_version,
+                pin=pin,
+                route_name=production_route_name,
+                bakeoff_route_name=expected_bakeoff_route,
+                run_date=run_date,
+            ),
+        }
 
     seen_slugs: set[str] = set()
     seen_cells: set[tuple[str, str]] = set()
@@ -283,10 +309,14 @@ def main(argv: Sequence[str] | None = None) -> int:
 def _load_tooled_artifacts(output_dir: Path) -> tuple[list[tuple[Path, dict[str, Any]]], list[str]]:
     artifacts: list[tuple[Path, dict[str, Any]]] = []
     failures: list[str] = []
+    multi_run_seen = False
     if not output_dir.exists():
         return artifacts, [f"output directory does not exist: {output_dir}"]
     for path in sorted(output_dir.glob("*.json")):
         if path.name == VERDICT_FILENAME:
+            continue
+        if qg_bakeoff._artifact_filename_run_index(path) > 1:
+            multi_run_seen = True
             continue
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
@@ -296,6 +326,21 @@ def _load_tooled_artifacts(output_dir: Path) -> tuple[list[tuple[Path, dict[str,
         if not isinstance(payload, dict):
             failures.append(f"{path.name}: artifact must be a JSON object")
             continue
+        if not qg_bakeoff._is_bakeoff_cell(payload):
+            continue
+        try:
+            artifact_run_index = qg_bakeoff._artifact_run_index(payload)
+        except qg_bakeoff.BakeoffConfigError as exc:
+            failures.append(str(exc))
+            continue
+        if artifact_run_index > 1:
+            multi_run_seen = True
+            continue
+        try:
+            qg_bakeoff._assert_artifact_filename_matches_run_index(path, payload)
+        except qg_bakeoff.BakeoffConfigError as exc:
+            failures.append(str(exc))
+            continue
         arm = payload.get("arm") or qg_bakeoff.TOOLED_ARM
         if arm == qg_bakeoff.BARE_ARM:
             continue
@@ -303,6 +348,8 @@ def _load_tooled_artifacts(output_dir: Path) -> tuple[list[tuple[Path, dict[str,
             failures.append(f"{path.name}: unsupported arm {arm!r}")
             continue
         artifacts.append((path, payload))
+    if multi_run_seen:
+        return [], [MULTI_RUN_DIR_UNSUPPORTED]
     return artifacts, failures
 
 

--- a/tests/audit/test_qg_tier2_canary_check.py
+++ b/tests/audit/test_qg_tier2_canary_check.py
@@ -228,6 +228,44 @@ def test_stray_non_canary_artifact_fails_closed(tmp_path: Path) -> None:
     )
 
 
+def test_multirun_dir_refused_with_explicit_reason(tmp_path: Path) -> None:
+    artifacts = _passing_artifacts()
+    artifacts[0]["run_index"] = 2
+
+    verdict = _verdict_for(tmp_path, artifacts)
+
+    assert verdict["passed"] is False
+    assert verdict["failure_reasons"] == [qg_tier2_canary_check.MULTI_RUN_DIR_UNSUPPORTED]
+
+
+def test_load_tooled_artifacts_skips_foreign_tooled_json(tmp_path: Path) -> None:
+    artifacts = _passing_artifacts()
+    _write_artifacts(tmp_path, artifacts)
+    (tmp_path / "foreign.json").write_text(
+        json.dumps({"arm": qg_bakeoff.TOOLED_ARM, "passed": True}),
+        encoding="utf-8",
+    )
+
+    verdict = qg_tier2_canary_check.evaluate_canary_dir(tmp_path, run_date="2026-07-06")
+
+    assert verdict["passed"] is True
+
+
+def test_duplicate_run1_artifacts_still_fail(tmp_path: Path) -> None:
+    artifacts = _passing_artifacts()
+    _write_artifacts(tmp_path, artifacts)
+    duplicate = copy.deepcopy(artifacts[0])
+    (tmp_path / "duplicate-run1.json").write_text(
+        json.dumps(duplicate, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    verdict = qg_tier2_canary_check.evaluate_canary_dir(tmp_path, run_date="2026-07-06")
+
+    assert verdict["passed"] is False
+    assert any("duplicate artifact cell" in reason for reason in verdict["failure_reasons"])
+
+
 def test_missing_fixture_artifact_fails(tmp_path: Path) -> None:
     artifacts = _passing_artifacts()[:-1]
 

--- a/tests/fixtures/qg_bakeoff_scorecards/legacy_scorecard.md
+++ b/tests/fixtures/qg_bakeoff_scorecards/legacy_scorecard.md
@@ -1,0 +1,44 @@
+# QG Bakeoff Scorecard
+
+Generated: 2026-07-06T00:00:00Z
+
+Fractions are exact. `low-N` marks denominators below 10.
+
+
+## Runs
+
+| model | transport | entrypoint | passage | arm | status | failure_class | parse_lenient | model judgment | live admissible | missing | U honesty | M alignment | true unsupported | invalid | inadmissible | tools | wall_s |
+| --- | --- | --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: |
+| openrouter/test/m [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | bare | ran | n/a | False | -80 | -80 | 0 | 0/0 low-N | 1/1 low-N | 0/1 low-N | 0 | 0 | 1 | 1.0 |
+| openrouter/test/m [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | tooled | ran | n/a | False | 30 | 30 | 0 | 0/0 low-N | 1/1 low-N | 0/1 low-N | 0 | 0 | 1 | 1.0 |
+
+## Totals With Anchor
+
+| model | arm | passages | model judgment | live admissible | U honesty | M alignment headline | true unsupported | missing | invalid | inadmissible | tools | wall_s |
+| --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
+| openrouter/test/m [opencode/qg_bakeoff_opencode] | bare | 1 | -80 | -80 | 0/0 low-N | 1/1 low-N | 0/1 low-N | 0 | 0 | 0 | 1 | 1.0 |
+| openrouter/test/m [opencode/qg_bakeoff_opencode] | tooled | 1 | 30 | 30 | 0/0 low-N | 1/1 low-N | 0/1 low-N | 0 | 0 | 0 | 1 | 1.0 |
+
+## Harness Lift With Anchor
+
+Lift = tooled model judgment − bare model judgment (positive = the harness helps),
+over PAIRED passages only (both arms on disk for that model+passage).
+M alignment is the discriminating fraction; low-N marks denominators below 10.
+
+| model | paired passages | tooled model judgment | bare model judgment | harness_lift | tooled M alignment | bare M alignment |
+| --- | ---: | ---: | ---: | ---: | --- | --- |
+| openrouter/test/m [opencode/qg_bakeoff_opencode] | 1 | 30 | -80 | 110 | 1/1 low-N | 1/1 low-N |
+
+## Totals Without Anchor
+
+| model | arm | passages | model judgment | live admissible | U honesty | M alignment headline | true unsupported | missing | invalid | inadmissible | tools | wall_s |
+| --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
+
+## Harness Lift Without Anchor
+
+Lift = tooled model judgment − bare model judgment (positive = the harness helps),
+over PAIRED passages only (both arms on disk for that model+passage).
+M alignment is the discriminating fraction; low-N marks denominators below 10.
+
+| model | paired passages | tooled model judgment | bare model judgment | harness_lift | tooled M alignment | bare M alignment |
+| --- | ---: | ---: | ---: | ---: | --- | --- |

--- a/tests/test_qg_bakeoff_multirun.py
+++ b/tests/test_qg_bakeoff_multirun.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.audit import llm_reviewer_dispatch, qg_bakeoff
+
+PIN = "openrouter/google/gemma-4-31b-it"
+
+
+def _fixture(slug: str = "vesnianky") -> qg_bakeoff.BakeoffFixture:
+    return qg_bakeoff.BakeoffFixture(
+        slug=slug,
+        title="Sample",
+        passage_md="True claim. Fabricated claim.",
+        claims=(
+            qg_bakeoff.FixtureClaim("c-true", "True claim.", True),
+            qg_bakeoff.FixtureClaim("c-false", "Fabricated claim.", False, "M", "real adjacent quote"),
+        ),
+    )
+
+
+def _event() -> dict[str, Any]:
+    return {
+        "tool": "sources_query_wikipedia",
+        "input": {"query": "True claim", "mode": "section"},
+        "status": "completed",
+        "tool_call_id": "call_1",
+        "output": "True claim. Fabricated claim.",
+    }
+
+
+def _tooled_result(route: llm_reviewer_dispatch.ReviewerRoute) -> llm_reviewer_dispatch.DispatchResult:
+    payload = {
+        "findings": [],
+        "fact_checks": [
+            {
+                "claim": "True claim.",
+                "verdict": "CONFIRMED",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "True claim",
+                    "evidence_excerpt": "True claim",
+                    "tool_call_id": "call_1",
+                },
+            },
+            {
+                "claim": "Fabricated claim.",
+                "verdict": "UNATTESTED_AFTER_SEARCH",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "True claim",
+                    "evidence_excerpt": "Fabricated claim",
+                    "tool_call_id": "call_1",
+                },
+            },
+        ],
+        "evidence_gaps": [],
+    }
+    return llm_reviewer_dispatch.DispatchResult(
+        response_text=json.dumps(payload),
+        reviewer_model_id=route.reviewer_model_id,
+        reviewer_family=route.reviewer_family,
+        route_name=route.route_name,
+        tool_call_count=1,
+        tools_used=("sources_query_wikipedia",),
+        tool_events=(_event(),),
+    )
+
+
+def _artifact(
+    *,
+    slug: str = "vesnianky",
+    arm: str = qg_bakeoff.TOOLED_ARM,
+    run_index: int = 1,
+    model: str = "openrouter/test/m",
+    mj: int = 30,
+    live: int | None = None,
+    status: str = "ran",
+    parse_lenient: bool = False,
+    transport: str = qg_bakeoff.OPENCODE_TRANSPORT,
+    entrypoint: str = qg_bakeoff.OPENCODE_ENTRYPOINT,
+    claims: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    live_score = mj if live is None else live
+    score_claims = claims if claims is not None else [
+        {
+            "claim_id": "c-true",
+            "matched": True,
+            "is_true": True,
+            "fabrication_class": None,
+            "model_judgment_verdict": "CONFIRMED",
+            "verdict": "CONFIRMED",
+        },
+        {
+            "claim_id": "c-false",
+            "matched": True,
+            "is_true": False,
+            "fabrication_class": "M",
+            "model_judgment_verdict": "UNATTESTED_AFTER_SEARCH",
+            "verdict": "UNATTESTED_AFTER_SEARCH",
+        },
+    ]
+    return {
+        "schema_version": qg_bakeoff.RUN_SCHEMA_VERSION,
+        "arm": arm,
+        "run_index": run_index,
+        "created_at": "2026-07-06T00:00:00Z",
+        "fixture": {"slug": slug, "title": "Sample", "claim_count": 2},
+        "model": {
+            "pin": model,
+            "pin_slug": qg_bakeoff.pin_slug(model),
+            "transport": transport,
+            "entrypoint": entrypoint,
+            "measurement_tier": qg_bakeoff.OPENCODE_MEASUREMENT_TIER,
+        },
+        "status": status,
+        "workflow_verdict": "PASS" if status == "ran" else "ERROR",
+        "findings_schema_invalid": False,
+        "response_parse_lenient": parse_lenient,
+        "attempt_count": 1,
+        "dispatch": {},
+        "gate_outcomes": {"grounding": {"invalid_fact_checks": 0, "inadmissible_positive_verdicts": 0}},
+        "payload": {},
+        "score": {
+            "model_judgment_score": mj,
+            "live_admissible_score": live_score,
+            "missing_claims": 0,
+            "invalid_fact_checks": 0,
+            "inadmissible_positive_verdicts": 0,
+            "claims": score_claims,
+            "fractions": {
+                "class_u_honesty": {"numerator": 0, "denominator": 0, "text": "0/0", "low_n": True},
+                "class_m_alignment": {"numerator": 1, "denominator": 1, "text": "1/1", "low_n": True},
+                "false_unsupported_on_true": {"numerator": 0, "denominator": 1, "text": "0/1", "low_n": True},
+            },
+        },
+        "tool_call_count": 1,
+        "wall_seconds": 1.0,
+    }
+
+
+def _write_artifact(path: Path, artifact: dict[str, Any]) -> None:
+    path.write_text(json.dumps(artifact, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def test_multirun_matrix_resume_retry_and_narrower_runs_leave_r3(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("QG_BAKEOFF", "1")
+    fixture = _fixture()
+    calls: list[str] = []
+
+    def runner(
+        route: llm_reviewer_dispatch.ReviewerRoute,
+        _prompt: str,
+        task_id: str,
+    ) -> llm_reviewer_dispatch.DispatchResult:
+        calls.append(task_id)
+        return _tooled_result(route)
+
+    runs = qg_bakeoff.run_matrix([fixture], [PIN], output_dir=tmp_path, runner=runner, runs=3)
+
+    assert len(runs) == 3
+    assert [run.artifact["run_index"] for run in runs] == [1, 2, 3]
+    names = sorted(path.name for path in tmp_path.glob("*.json"))
+    assert names == [
+        "openrouter-google-gemma-4-31b-it__vesnianky.json",
+        "openrouter-google-gemma-4-31b-it__vesnianky__r2.json",
+        "openrouter-google-gemma-4-31b-it__vesnianky__r3.json",
+    ]
+    assert calls == [
+        "qg-bakeoff-openrouter-google-gemma-4-31b-it-vesnianky",
+        "qg-bakeoff-openrouter-google-gemma-4-31b-it-vesnianky-r2",
+        "qg-bakeoff-openrouter-google-gemma-4-31b-it-vesnianky-r3",
+    ]
+
+    calls.clear()
+    resumed = qg_bakeoff.run_matrix([fixture], [PIN], output_dir=tmp_path, runner=runner, runs=3)
+    assert all(run.skipped for run in resumed)
+    assert calls == []
+
+    r2_path = tmp_path / "openrouter-google-gemma-4-31b-it__vesnianky__r2.json"
+    r2 = json.loads(r2_path.read_text(encoding="utf-8"))
+    r2["status"] = "error"
+    _write_artifact(r2_path, r2)
+    calls.clear()
+    qg_bakeoff.run_matrix(
+        [fixture],
+        [PIN],
+        output_dir=tmp_path,
+        runner=runner,
+        retry_failures=True,
+        runs=3,
+    )
+    assert calls == ["qg-bakeoff-openrouter-google-gemma-4-31b-it-vesnianky-r2"]
+
+    r3_path = tmp_path / "openrouter-google-gemma-4-31b-it__vesnianky__r3.json"
+    r3_before = r3_path.read_text(encoding="utf-8")
+    calls.clear()
+    qg_bakeoff.run_matrix([fixture], [PIN], output_dir=tmp_path, runner=runner, force=True, runs=2)
+    assert calls == [
+        "qg-bakeoff-openrouter-google-gemma-4-31b-it-vesnianky",
+        "qg-bakeoff-openrouter-google-gemma-4-31b-it-vesnianky-r2",
+    ]
+    assert r3_path.read_text(encoding="utf-8") == r3_before
+
+
+def test_cell_artifact_path_round_trips_all_arms_and_mismatch_fails(tmp_path: Path) -> None:
+    fixture = _fixture()
+    route = qg_bakeoff.bakeoff_route_for_model(PIN)
+    subscription = qg_bakeoff.route_for_matrix_pin(qg_bakeoff.GPT_SUBSCRIPTION_BARE_MODEL_ID, arm=qg_bakeoff.BARE_ARM)
+
+    assert qg_bakeoff.default_output_dir(date(2026, 7, 6), multi_run=True).name == "2026-07-06-qg-bakeoff-multirun"
+    assert qg_bakeoff._cell_artifact_path(tmp_path, route, fixture, qg_bakeoff.TOOLED_ARM).name == (
+        "openrouter-google-gemma-4-31b-it__vesnianky.json"
+    )
+    assert qg_bakeoff._cell_artifact_path(tmp_path, route, fixture, qg_bakeoff.TOOLED_ARM, 2).name == (
+        "openrouter-google-gemma-4-31b-it__vesnianky__r2.json"
+    )
+    assert qg_bakeoff._cell_artifact_path(tmp_path, route, fixture, qg_bakeoff.BARE_ARM, 3).name == (
+        "openrouter-google-gemma-4-31b-it__vesnianky__bare__opencode__r3.json"
+    )
+    assert qg_bakeoff._cell_artifact_path(tmp_path, subscription, fixture, qg_bakeoff.BARE_ARM, 2).name == (
+        "gpt-5-5__vesnianky__bare__runtime-codex__r2.json"
+    )
+
+    mismatched = tmp_path / "openrouter-test-m__vesnianky.json"
+    _write_artifact(mismatched, _artifact(run_index=2))
+    with pytest.raises(qg_bakeoff.BakeoffConfigError, match="run_index=2"):
+        qg_bakeoff._load_all_artifacts(tmp_path)
+
+
+def test_subscription_preflight_runs_at_each_sweep_boundary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("QG_BAKEOFF", "1")
+    fixture = _fixture()
+    route = qg_bakeoff.bakeoff_route_for_model(PIN)
+    for run_index in (1, 2, 3):
+        path = qg_bakeoff._cell_artifact_path(tmp_path, route, fixture, qg_bakeoff.BARE_ARM, run_index)
+        _write_artifact(path, _artifact(arm=qg_bakeoff.BARE_ARM, run_index=run_index, model=PIN))
+
+    calls: list[list[str]] = []
+
+    def preflight(routes: list[llm_reviewer_dispatch.ReviewerRoute]) -> dict[str, Any]:
+        calls.append([route.reviewer_model_id for route in routes])
+        return {"status": "passed", "routes": []}
+
+    monkeypatch.setattr(qg_bakeoff, "preflight_subscription_bare_routes", preflight)
+
+    runs = qg_bakeoff.run_matrix([fixture], [PIN], output_dir=tmp_path, arm=qg_bakeoff.BARE_ARM, runs=3)
+
+    assert all(run.skipped for run in runs)
+    assert calls == [[PIN], [PIN], [PIN]]
+
+
+def test_legacy_scorecard_renders_byte_identical_to_golden(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(qg_bakeoff, "_now_z", lambda: "2026-07-06T00:00:00Z")
+    out = tmp_path / "SCORECARD.md"
+    artifacts = [
+        {key: value for key, value in _artifact(mj=30).items() if key != "run_index"},
+        {key: value for key, value in _artifact(arm=qg_bakeoff.BARE_ARM, mj=-80).items() if key != "run_index"},
+    ]
+
+    qg_bakeoff.write_scorecard(out, artifacts)
+
+    golden = Path("tests/fixtures/qg_bakeoff_scorecards/legacy_scorecard.md").read_text(encoding="utf-8")
+    assert out.read_text(encoding="utf-8") == golden
+
+
+def test_variance_math_stability_flags_and_single_run_gate(tmp_path: Path) -> None:
+    assert qg_bakeoff._claim_stability_class(
+        {"matched": True, "is_true": True, "model_judgment_verdict": "CONFIRMED"}
+    ) == "true-confirmed"
+    assert qg_bakeoff._claim_stability_class(
+        {"matched": True, "is_true": False, "model_judgment_verdict": "REFUTED_BY_CONTRADICTION"}
+    ) == "fabrication-caught"
+    assert qg_bakeoff._claim_stability_class({"matched": False, "is_true": True}) == "missed"
+    assert qg_bakeoff._claim_stability_class(
+        {"matched": True, "is_true": True, "model_judgment_verdict": "UNATTESTED_AFTER_SEARCH"}
+    ) == "other"
+
+    single = tmp_path / "single.md"
+    qg_bakeoff.write_scorecard(single, [_artifact(run_index=1)])
+    assert "## Run Variance" not in single.read_text(encoding="utf-8")
+
+    flipped_claims = [
+        {
+            "claim_id": "c-true",
+            "matched": True,
+            "is_true": True,
+            "fabrication_class": None,
+            "model_judgment_verdict": "UNATTESTED_AFTER_SEARCH",
+            "verdict": "UNATTESTED_AFTER_SEARCH",
+        },
+        {
+            "claim_id": "c-false",
+            "matched": False,
+            "is_true": False,
+            "fabrication_class": "M",
+            "model_judgment_verdict": "",
+            "verdict": "",
+        },
+    ]
+    artifacts = [
+        _artifact(slug="vesnianky", run_index=1, mj=30),
+        _artifact(slug="vesnianky", run_index=2, mj=30, parse_lenient=True),
+        _artifact(slug="vesnianky", run_index=3, mj=-20, claims=flipped_claims),
+        _artifact(slug="kupalski", run_index=1, mj=10),
+        _artifact(slug="kupalski", run_index=2, mj=10),
+        _artifact(slug="koliadky", run_index=1, status="error", mj=-20),
+        _artifact(slug="koliadky", run_index=2, mj=30),
+        _artifact(slug="koliadky", run_index=3, mj=30),
+    ]
+    multirun = tmp_path / "multi.md"
+    qg_bakeoff.write_scorecard(multirun, artifacts)
+    text = multirun.read_text(encoding="utf-8")
+    assert "## Run Variance" in text
+    assert "partial" in text
+    assert "error" in text
+    assert "parse-lenient-variance" in text
+    assert "| openrouter/test/m [opencode/qg_bakeoff_opencode] | tooled | 1 | 1 | 1 | 1 |" in text
+
+
+def test_domain_mapping_complete_and_unknown_slug_fails(tmp_path: Path) -> None:
+    fixture_slugs = {path.stem for path in qg_bakeoff.FIXTURE_DIR.glob("*.json")}
+    assert set(qg_bakeoff.DOMAIN_BY_SLUG) == fixture_slugs
+
+    with pytest.raises(qg_bakeoff.BakeoffConfigError, match="DOMAIN_BY_SLUG"):
+        qg_bakeoff.write_scorecard(tmp_path / "score.md", [_artifact(slug="unknown", run_index=2)])
+
+
+def test_multirun_aggregate_and_harness_lift_do_not_triple_count() -> None:
+    artifacts = [
+        _artifact(run_index=1, mj=10),
+        _artifact(run_index=2, mj=20),
+        _artifact(run_index=3, mj=30),
+    ]
+    row = next(iter(qg_bakeoff._aggregate_by_model_arm(artifacts).values()))
+    assert row["passages_per_run"] == [1, 1, 1]
+    assert row["model_judgment_score"]["mean"] == 20
+
+    lift_artifacts = [
+        _artifact(slug="vesnianky", arm=qg_bakeoff.TOOLED_ARM, run_index=1, mj=30),
+        _artifact(slug="vesnianky", arm=qg_bakeoff.TOOLED_ARM, run_index=2, mj=50),
+        _artifact(slug="vesnianky", arm=qg_bakeoff.BARE_ARM, run_index=1, mj=-10),
+        _artifact(slug="vesnianky", arm=qg_bakeoff.BARE_ARM, run_index=2, mj=10),
+        _artifact(slug="kupalski", arm=qg_bakeoff.TOOLED_ARM, run_index=2, mj=999),
+    ]
+    lines = qg_bakeoff._harness_lift_section("Test", lift_artifacts)
+    row = next(line for line in lines if line.startswith("| openrouter/test/m"))
+    assert "| 1 |" in row
+    assert "40 ± 0 [40..40]" in row
+    assert "999" not in row
+
+
+def test_rescore_preserves_multirun_run_index(tmp_path: Path) -> None:
+    fixture = _fixture()
+    fixtures_dir = tmp_path / "fixtures"
+    fixtures_dir.mkdir()
+    (fixtures_dir / "vesnianky.json").write_text(
+        json.dumps(
+            {
+                "slug": fixture.slug,
+                "title": fixture.title,
+                "passage_md": fixture.passage_md,
+                "claims": [
+                    {
+                        "claim_id": claim.claim_id,
+                        "claim": claim.claim,
+                        "is_true": claim.is_true,
+                        "fabrication_class": claim.fabrication_class,
+                        "distractor_evidence": claim.distractor_evidence,
+                    }
+                    for claim in fixture.claims
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    artifact = _artifact(run_index=2, mj=-999)
+    artifact["payload"] = {
+        "fact_checks": [
+            {"claim": "True claim.", "verdict": "CONFIRMED"},
+            {"claim": "Fabricated claim.", "verdict": "UNATTESTED_AFTER_SEARCH"},
+        ]
+    }
+    path = tmp_path / "openrouter-test-m__vesnianky__r2.json"
+    _write_artifact(path, artifact)
+
+    assert qg_bakeoff.rescore_artifacts(tmp_path, fixtures_dir) == 1
+    updated = json.loads(path.read_text(encoding="utf-8"))
+    assert updated["run_index"] == 2
+    assert updated["score"]["model_judgment_score"] == 30
+
+
+def test_run_one_tooled_resume_transport_mismatch_hard_fails(tmp_path: Path) -> None:
+    fixture = _fixture()
+    route = qg_bakeoff.bakeoff_route_for_model(PIN)
+    path = qg_bakeoff._cell_artifact_path(tmp_path, route, fixture, qg_bakeoff.TOOLED_ARM)
+    artifact = _artifact(model=PIN, transport="runtime-codex")
+    _write_artifact(path, artifact)
+
+    def runner(*_args: Any, **_kwargs: Any) -> llm_reviewer_dispatch.DispatchResult:  # pragma: no cover
+        raise AssertionError("transport mismatch must fail before invocation")
+
+    with pytest.raises(qg_bakeoff.BakeoffConfigError, match="transport"):
+        qg_bakeoff.run_one(route, fixture, output_dir=tmp_path, runner=runner)


### PR DESCRIPTION
## Summary

- Adds `run_index` artifacts, shared cell artifact naming, `--runs`, multirun output-dir separation, and per-sweep subscription preflight.
- Rebuilds bakeoff scorecard aggregation for run-aware totals, harness lift, run variance, and per-domain totals.
- Makes the tier-2 canary refuse multi-run dirs and ignore foreign non-bakeoff JSON, with golden and regression coverage.

## Evidence (#M-4)

- tests pass
  - cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4539-multirun-harness`
  - command: `.venv/bin/python -m pytest tests/test_qg_bakeoff*.py tests/audit/ -k "bakeoff or canary"`
  - raw output: `===================== 71 passed, 636 deselected in 11.67s ======================`
- ruff clean
  - cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4539-multirun-harness`
  - command: `.venv/bin/ruff check scripts/audit/ tests/`
  - raw output: `All checks passed!`
- golden byte-compat holds
  - cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4539-multirun-harness`
  - command: `.venv/bin/python -m pytest tests/test_qg_bakeoff*.py tests/audit/ -k "bakeoff or canary"`
  - raw output: `tests/test_qg_bakeoff_multirun.py::test_legacy_scorecard_renders_byte_identical_to_golden PASSED [  5%]`
- commit landed
  - cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4539-multirun-harness`
  - command: `git log -1 --oneline`
  - raw output: `6a808dee1f feat(audit): #4539 multi-run harness — run_index, variance, domain split`
- PR opened
  - cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4539-multirun-harness`
  - command: `gh pr view --json url`
  - raw output: `{"url":"https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/4613"}`

Spec: design v3 (fleet-reviewed, driver holds the file)
