### PR TITLE
feat(bio): add learner readings for literary transition batch 42

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/antin-krushelnytskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/antin-krushelnytskyi.yaml
@@ -127,6 +127,20 @@ persona:
     аналізом радянської репресивної процедури.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- source: "ЕСУ"
+  title: "Крушельницький Антін"
+  url: "https://esu.com.ua/article-221"
+  language: "uk"
+  hosting: "link-only"
+  rights_note: "Copyrighted, link only"
+- source: "Вінницький державний педагогічний університет"
+  title: "Крушельницький Антін Владиславович"
+  url: "https://vspu.edu.ua/faculty/filolog/ukr/persons/kryshelnuckii-antin.html"
+  language: "uk"
+  hosting: "link-only"
+  rights_note: "Copyrighted, link only"
+
 references:
 - note: Основна українська енциклопедична стаття про Антіна Крушельницького.
   path: https://esu.com.ua/article-221
@@ -157,7 +171,7 @@ sequence: 213
 slug: antin-krushelnytskyi
 subtitle: The Galician Educator and Family Patriarch Destroyed at Sandarmokh
 title: "Антін Крушельницький: Галицька культурна родина під ударом терору"
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: фахівець і громадський діяч, пов'язаний з освітою, вихованням і навчанням
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/marko-voronyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/marko-voronyi.yaml
@@ -124,6 +124,20 @@ persona:
     голос автора, і точну хронологію репресій.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- source: "ЕСУ"
+  title: "Вороний Марко Миколайович"
+  url: "https://esu.com.ua/article-29782"
+  language: "uk"
+  hosting: "link-only"
+  rights_note: "Copyrighted, link only"
+- source: "Музей-заповідник М. Коцюбинського"
+  title: "Співець трагічної епохи..."
+  url: "https://kotsubinsky.org/news/spivec_tragichnoji_epokhi_do_115_richchja_z_dnja_narodzhennja_marka_voronogo_18_03_1904_3_11_1937/2019-03-18-1381"
+  language: "uk"
+  hosting: "link-only"
+  rights_note: "Copyrighted, link only"
+
 references:
 - note: Основна українська енциклопедична стаття про Марка Вороного.
   path: https://esu.com.ua/article-29782
@@ -150,7 +164,7 @@ sequence: 211
 slug: marko-voronyi
 subtitle: The Second-Generation Poet in the Solovki-Sandarmokh Mechanism
 title: "Марко Вороний: Власний голос у знищеній літературній родині"
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: ім'я, яким автор підписує твори замість або поруч зі справжнім іменем
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/mykola-kostomarov.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykola-kostomarov.yaml
@@ -126,6 +126,26 @@ persona:
     репресію, відрізняючи засвідчені джерелами факти від пізнішого міфу.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- source: "Енциклопедія історії України"
+  title: "Костомаров Микола Іванович"
+  url: "https://www.history.org.ua/?termin=Kostomarov_M"
+  language: "uk"
+  hosting: "link-only"
+  rights_note: "Copyrighted, link only"
+- source: "Вікіджерела"
+  title: "Книги битія українського народу"
+  url: "https://uk.wikisource.org/wiki/Книги_битія_українського_народу"
+  language: "uk"
+  hosting: "link-only"
+  rights_note: "Public domain text, hosted externally"
+- source: "Вікіджерела"
+  title: "Дві руські народності"
+  url: "https://uk.wikisource.org/wiki/Дві_руські_народності"
+  language: "uk"
+  hosting: "link-only"
+  rights_note: "Public domain text, hosted externally"
+
 references:
 - note: Стаття про життя, братство та репресію; джерело розбіжності щодо дати народження.
   path: https://www.history.org.ua/?termin=Kostomarov_M
@@ -150,7 +170,7 @@ sequence: 216
 slug: mykola-kostomarov
 subtitle: The Historian and Brotherhood Founder Imprisoned for Imagining a Free Ukraine
 title: 'Микола Костомаров: Братство, "Книги битія" та імперська фортеця'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: добровільне об'єднання людей задля спільної мети; Кирило-Мефодіївське братство
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/myroslav-irchan.yaml
+++ b/curriculum/l2-uk-en/plans/bio/myroslav-irchan.yaml
@@ -124,6 +124,14 @@ persona:
     видань і політичних виборів, не підміняючи її радянськими ярликами.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- source: "ЕСУ"
+  title: "Ірчан Мирослав"
+  url: "https://esu.com.ua/article-12635"
+  language: "uk"
+  hosting: "link-only"
+  rights_note: "Copyrighted, link only"
+
 references:
 - note: Основна українська енциклопедична стаття про Ірчана.
   path: https://esu.com.ua/article-12635
@@ -150,7 +158,7 @@ sequence: 212
 slug: myroslav-irchan
 subtitle: The Transnational Theater Organizer Reframed as an Enemy
 title: "Мирослав Ірчан: Театр, діаспора і шлях до Сандармоху"
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: ім'я, під яким автор публікується замість свого цивільного імені
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/pavlo-hrabovskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/pavlo-hrabovskyi.yaml
@@ -134,6 +134,26 @@ persona:
     російського імперського заслання, не зводячи поета до мученицького епізоду.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- source: "Енциклопедія історії України"
+  title: "Грабовський Павло Арсенович"
+  url: "https://www.history.org.ua/?termin=Grabovsky_P"
+  language: "uk"
+  hosting: "link-only"
+  rights_note: "Copyrighted, link only"
+- source: "ЕСУ"
+  title: "Грабовський Павло Арсенович"
+  url: "https://esu.com.ua/article-26782"
+  language: "uk"
+  hosting: "link-only"
+  rights_note: "Copyrighted, link only"
+- source: "Вікіджерела"
+  title: "Швачка (Пролїсок)"
+  url: "https://uk.wikisource.org/wiki/Пролїсок/Швачка"
+  language: "uk"
+  hosting: "link-only"
+  rights_note: "Public domain text, hosted externally"
+
 references:
 - note: Стаття про життя, репресії та літературний доробок поета.
   path: https://www.history.org.ua/?termin=Grabovsky_P
@@ -159,7 +179,7 @@ sequence: 215
 slug: pavlo-hrabovskyi
 subtitle: The Civic Poet and Translator Exiled to Siberia by the Empire
 title: 'Павло Грабовський: Поет неволі та галицького слова'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: примусове виселення у віддалену місцевість як вид адміністративного покарання
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/sofiia-nalepynska-boichuk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/sofiia-nalepynska-boichuk.yaml
@@ -136,6 +136,20 @@ persona:
     бездумної глорифікації.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- source: "ЕСУ"
+  title: "Налепинська-Бойчук Софія"
+  url: "https://esu.com.ua/article-70885"
+  language: "uk"
+  hosting: "link-only"
+  rights_note: "Copyrighted, link only"
+- source: "Локальна історія"
+  title: "Традиції нашого штрихарства"
+  url: "https://localhistory.org.ua/rubrics/painting/traditsiyi-nashogo-shtrikharstva-derevoriti-sofiyi-nalepinskoyi-boichuk/"
+  language: "uk"
+  hosting: "link-only"
+  rights_note: "Copyrighted, link only"
+
 references:
 - note: Основна стаття про життя та мистецький доробок художниці.
   path: https://esu.com.ua/article-70885
@@ -162,7 +176,7 @@ sequence: 214
 slug: sofiia-nalepynska-boichuk
 subtitle: The Boychukist Graphic Artist Erased by the Terror
 title: 'Софія Налепинська-Бойчук: Дереворит і доля бойчукістки'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: гравюра, відбита з рисунка, вирізаного на дерев'яній дошці; основна техніка Налепинської-Бойчук
   pos: ч.


### PR DESCRIPTION
Adds Ukrainian-only learner reading metadata to six BIO plan files: Marko Voronyi, Myroslav Irchan, Antin Krushelnytskyi, Sofiia Nalepynska-Boichuk, Pavlo Hrabovskyi, and Mykola Kostomarov.\n\nValidation reported by the AGY worker:\n- YAML parsing for owned files passed.\n- git diff --check passed.\n- lint_agent_trailer.py passed.\n- Scope limited to the six owned plan YAML files.\n\nIndependent cross-family review is still required before ready/merge. LLM-QG, Gemma, and OpenRouter were not used.