### PR TITLE
fix(gitignore): cover -multirun bakeoff out-dirs (#4539 follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,9 @@ curriculum/l2-uk-direct/_orchestration/
 /*.write.jsonl
 
 # QG bakeoff live payloads are local run artifacts; SCORECARD.md remains committable.
-audit/*-qg-bakeoff/*.json
+# The trailing * also covers the -multirun out-dirs the #4539 harness derives
+# (audit/<date>-qg-bakeoff-multirun/) — see default_output_dir(multi_run=True).
+audit/*-qg-bakeoff*/*.json
 
 
 # Python


### PR DESCRIPTION
One-line pattern widen: `audit/*-qg-bakeoff/*.json` → `audit/*-qg-bakeoff*/*.json`.

#4613 shipped `default_output_dir(multi_run=True)` deriving `audit/<date>-qg-bakeoff-multirun/`, which the committed pattern does not match — the D7 matrix run (306 artifacts) would have polluted the primary checkout as untracked files. Verified with `git check-ignore`: multirun + legacy dirs both ignored; SCORECARD.md stays committable.

Driver-inline (≤5 LOC). 
🤖 Generated with [Claude Code](https://claude.com/claude-code)