### PR TITLE
feat(bio): add learner readings for diaspora modernism batch 45

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/ihor-kostetskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ihor-kostetskyi.yaml
@@ -133,6 +133,17 @@ persona:
     спрощень і без замовчування складних воєнних обставин.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  rights_note: "Educational use / Public access"
+  source_name: "Костецький Ігор (Енциклопедія Сучасної України)"
+  source_url: "https://esu.com.ua/article-4000"
+- hosting: link-only
+  language: uk
+  rights_note: "Educational use / Public access"
+  source_name: "Костецький, Ігор (Велика українська енциклопедія)"
+  source_url: "https://vue.gov.ua/Костецький,_Ігор"
 references:
 - note: Основна англомовна енциклопедична стаття про життя, МУР і видавничу працю.
   path: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CO%5CKostetskyIhor.htm
@@ -159,7 +170,7 @@ sequence: 234
 slug: ihor-kostetskyi
 subtitle: Український модерніст, який обрав Україну у вигнанні
 title: 'Ігор Костецький: Модернізм, МУР і вибір українства'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: свідомий вибір належності до певної спільноти, культури або традиції
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/leonid-mosendz.yaml
+++ b/curriculum/l2-uk-en/plans/bio/leonid-mosendz.yaml
@@ -115,6 +115,17 @@ persona:
     до зради й не романтизуючи радянське знищення.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  rights_note: "Educational use / Public access"
+  source_name: "Мосендз Леонід Маркович (Енциклопедія історії України)"
+  source_url: "http://history.org.ua/?termin=Mosendz_L_M"
+- hosting: link-only
+  language: uk
+  rights_note: "Creative Commons Attribution-ShareAlike"
+  source_name: "Леонід Мосендз (Вікіпедія)"
+  source_url: "https://uk.wikipedia.org/wiki/Мосендз_Леонід_Маркович"
 references:
 - note: Енциклопедична стаття; контекст УНР і творчості.
   path: http://history.org.ua/?termin=Mosendz_L_M
@@ -139,7 +150,7 @@ sequence: 230
 slug: leonid-mosendz
 subtitle: The UNR Officer, Chemist, and Prague-School Storyteller
 title: 'Леонід Мосендз: Зодіяк і лицар Празької школи'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: українське літературне й ідейне коло еміграції в Чехословаччині міжвоєння, пов'язане з *Вісником*
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/natalia-livytska-kholodna.yaml
+++ b/curriculum/l2-uk-en/plans/bio/natalia-livytska-kholodna.yaml
@@ -70,6 +70,17 @@ persona:
   role: Модератор семінару, який досліджує жіночий голос Празької школи та механізми радянського стирання еміграційно-державної традиції.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  rights_note: "Creative Commons Attribution-ShareAlike"
+  source_name: "Лівицька-Холодна Наталя Андріївна (Вікіпедія)"
+  source_url: "https://uk.wikipedia.org/wiki/Лівицька-Холодна_Наталя_Андріївна"
+- hosting: link-only
+  language: uk
+  rights_note: "Educational use / Public access"
+  source_name: "Наталя Лівицька-Холодна (УкрЛіб)"
+  source_url: "https://www.ukrlib.com.ua/bio/author.php?id=302"
 references:
 - author: Р. М. Коваль
   note: Стаття в Енциклопедії Сучасної України (esu.com.ua) про життя та творчість поетки.
@@ -96,7 +107,7 @@ sequence: 229
 slug: natalia-livytska-kholodna
 subtitle: The Last Great Voice of the Prague School
 title: 'Наталя Лівицька-Холодна: «Червоне й чорне» доньки УНР'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: вимушене переселення за межі батьківщини; спільнота переселенців
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/oksana-liaturynska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oksana-liaturynska.yaml
@@ -120,6 +120,17 @@ persona:
     еміграцію до зради й не пом'якшуючи названі злочини НКВД.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  rights_note: "Creative Commons Attribution-ShareAlike"
+  source_name: "Лятуринська Оксана Михайлівна (Вікіпедія)"
+  source_url: "https://uk.wikipedia.org/wiki/Лятуринська_Оксана_Михайлівна"
+- hosting: link-only
+  language: uk
+  rights_note: "Educational use / Public access"
+  source_name: "Оксана Лятуринська (УкрЛіб)"
+  source_url: "https://www.ukrlib.com.ua/bio/author.php?id=233"
 references:
 - note: Англомовна енциклопедична стаття про життя та творчість.
   path: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CL%5CI%5CLiaturynskaOksana.htm
@@ -145,7 +156,7 @@ sequence: 231
 slug: oksana-liaturynska
 subtitle: The Prague Poet-Sculptor and the Family the NKVD Destroyed
 title: 'Оксана Лятуринська: Княжа емаль і згарище Лятуринщини'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: стислий, «вирізаний у камені» стиль мови; характерна риса поезії Лятуринської
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/vasyl-barka.yaml
+++ b/curriculum/l2-uk-en/plans/bio/vasyl-barka.yaml
@@ -115,6 +115,17 @@ persona:
     геноцидне формулювання й не зводячи Барку лише до «жертви».
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  rights_note: "Educational use / Public access"
+  source_name: "Барка Василь (Енциклопедія Сучасної України)"
+  source_url: "https://esu.com.ua/article-40577"
+- hosting: link-only
+  language: uk
+  rights_note: "Educational use / Public access"
+  source_name: "Василь Барка (УкрЛіб)"
+  source_url: "https://www.ukrlib.com.ua/bio/author.php?id=21"
 references:
 - note: Енциклопедична стаття про життя та доробок.
   path: https://esu.com.ua/article-40577
@@ -141,7 +152,7 @@ sequence: 232
 slug: vasyl-barka
 subtitle: The Holodomor Witness and Author of The Yellow Prince
 title: 'Василь Барка: Жовтий князь і свідчення геноциду'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: штучний голод 1932–1933 років як акт геноциду проти українського селянства
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/viktor-domontovych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/viktor-domontovych.yaml
@@ -123,6 +123,17 @@ persona:
     прасування й без діаспорного суду без доказів.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  rights_note: "Educational use / Public access"
+  source_name: "Петров Віктор Платонович (Енциклопедія історії України)"
+  source_url: "http://history.org.ua/?termin=Petrov_V_P"
+- hosting: link-only
+  language: uk
+  rights_note: "Educational use / Public access"
+  source_name: "Петров, Віктор Платонович (Велика українська енциклопедія)"
+  source_url: "https://vue.gov.ua/Петров,_Віктор_Платонович"
 references:
 - note: Англомовна енциклопедична стаття; еміграція 1944, МУН, зникнення 1949.
   path: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CP%5CE%5CPetrovViktor.htm
@@ -149,7 +160,7 @@ sequence: 233
 slug: viktor-domontovych
 subtitle: The Intellectual Novelist and the Open Dossier
 title: 'Віктор Домонтович: інтелектуальний роман і спірне повернення'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: прозовий жанр, що поєднує художній виклад із дослідженням реальної постаті
   pos: ж.


### PR DESCRIPTION
Adds Ukrainian-only learner reading metadata to the BIO diaspora/modernism batch:

- `natalia-livytska-kholodna`
- `leonid-mosendz`
- `oksana-liaturynska`
- `vasyl-barka`
- `viktor-domontovych`
- `ihor-kostetskyi`

Scope: top-level plan YAML `readings:` blocks only.

Local validation before PR:
- YAML reading-contract validation for owned files
- `git diff --check origin/main...HEAD`
- `lint_agent_trailer.py` passed in the worker

LLM-QG, Gemma/OpenRouter tests, wiki writers, module builders, and `module_quality_audit.py` were not used.
