### PR TITLE
fix(corpus): 2017-era dollar-as-hyphen repair in textbook extraction (#4593)

### DIFF
--- a/scripts/rag/extract_text.py
+++ b/scripts/rag/extract_text.py
@@ -101,6 +101,20 @@ def _repair_cp1251_mojibake(text: str) -> str:
     return "".join(result)
 
 
+_DOLLAR_HYPHEN_RE = re.compile(r"([а-яіїєґА-ЯІЇЄҐ])\$([а-яіїєґА-ЯІЇЄҐ])")
+
+
+def _repair_dollar_hyphen(text: str) -> str:
+    """Fix 2017-era font mapping where '$' stands in for a compound hyphen.
+
+    Live-measured on 9-klas-khimiya-popel-2017 (#4593 wave 1): 22 intra-word
+    occurrences like "фізико$хімічні"/"гідроксид$іонів" — the PDF font maps
+    the discretionary/compound hyphen glyph to '$'. Only rewrites '$' BETWEEN
+    Cyrillic letters, so prices and code snippets are untouched.
+    """
+    return _DOLLAR_HYPHEN_RE.sub(r"\1-\2", text)
+
+
 def extract_text_fast(pdf_path: Path) -> str:
     """Extract text from digital PDF using pymupdf (fast, no OCR)."""
     import pymupdf
@@ -111,6 +125,7 @@ def extract_text_fast(pdf_path: Path) -> str:
         text = doc[i].get_text()
         if text.strip():
             text = _repair_cp1251_mojibake(text.strip())
+            text = _repair_dollar_hyphen(text)
             pages.append(f"## Сторінка {i + 1}\n\n{text}")
     doc.close()
     return "\n\n".join(pages)

--- a/tests/test_chunk_quality.py
+++ b/tests/test_chunk_quality.py
@@ -73,3 +73,14 @@ def test_ukrainian_apostrophe_forms_are_not_noise():
 
     prose = "Мʼяч підстрибнув, і об'єкт зупинився — учні записали висновок…"
     assert symbol_noise_density(prose) == 0.0
+
+
+def test_dollar_hyphen_repair_fixes_compound_words_only():
+    """2017-era font quirk: '$' between Cyrillic letters is a hyphen glyph."""
+    from scripts.rag.extract_text import _repair_dollar_hyphen
+
+    assert _repair_dollar_hyphen("гідроксид$іонів") == "гідроксид-іонів"
+    assert _repair_dollar_hyphen("фізико$хімічні") == "фізико-хімічні"
+    # prices / code stay untouched
+    assert _repair_dollar_hyphen("ціна 100$ за рік") == "ціна 100$ за рік"
+    assert _repair_dollar_hyphen("var x = a$b") == "var x = a$b"


### PR DESCRIPTION
Pilot QA on the first wave-1 extraction (khimiya-popel-2017: 241 chunks, 0 noise-dropped) surfaced a 2017-era font artifact: 22 intra-word `$` occurrences where the compound-hyphen glyph maps to `$` (`фізико$хімічні`, `гідроксид$іонів`). Repair rewrites `$` only between Cyrillic letters — prices and code untouched (tested both ways). Zero occurrences in the existing 25.7K-chunk corpus, so no retro sweep needed; the 2017-era wave-1 books extract clean after this.

Also verified during pilot QA: mid-word line-break hyphenation is an existing corpus-wide extraction trait (identical in long-ingested books) — deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)