### PR TITLE
chore(gitignore): textbook_chunks pattern must match the symlink (dir-only slash)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,7 +218,7 @@ data/textbooks/
 data/qdrant/
 data/qdrant_db/
 data/textbook_images/
-data/textbook_chunks/
+data/textbook_chunks
 data/literary_texts/*.bin
 data/literary_texts/*.npy
 data/vesum/


### PR DESCRIPTION
`data/textbook_chunks` became a symlink into the Drive data dir during #4593 wave-1 (same architecture as `data/textbooks`). The existing `.gitignore` entry has a trailing slash — directory-only, doesn't match symlinks — so the link shows as untracked and trips dirty-tree checks for every session. One-character fix; same class as the `node_modules` ELOOP autopsy lesson.

🤖 Generated with [Claude Code](https://claude.com/claude-code)