### PR TITLE
feat(audit): #4630 lm_eval-compatible results emitter

### DIFF
--- a/docs/projects/ua-eval-harness/lm-eval-emitter.md
+++ b/docs/projects/ua-eval-harness/lm-eval-emitter.md
@@ -1,0 +1,15 @@
+# lm_eval emitter for qg_bakeoff
+
+`scripts/audit/qg_bakeoff.py --emit-lm-eval <dir>` writes `eval-results/<model>/results_<created_at>.json`.
+The timestamp is copied from artifact `created_at`; missing legacy timestamps become `results_unknown.json`.
+Each JSON has `config_general.model_name` set to the qg_bakeoff model pin.
+`qg_factuality_model_judgment.score` maps to the scorecard model judgment aggregate.
+`qg_factuality_u_honesty.score` maps to the U-fabrication honesty rate.
+`qg_factuality_m_alignment.score` maps to the M-fabrication alignment rate.
+`qg_factuality_harness_lift.score` maps to tooled minus bare model judgment on paired cells only.
+Multi-run exports use the same run-aware means printed in the scorecard.
+Low-N flags, run counts, arm identity, transport, and entrypoint live under each task's `qg_meta`.
+Legacy/missing fields set `qg_meta.partial=true` with `partial_reasons` instead of blocking export.
+A leaderboard maintainer can copy each model directory under their `eval-results/` tree.
+Their loader should read `results.<task>.<metric>` floats and ignore `qg_meta` for ranking.
+Keep qg_bakeoff as a factuality track, and regenerate after rescoring or new matrix runs.

--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -42,6 +42,11 @@ ANCHOR_SLUG = "vesnianky"
 MISSING_CLAIM_PENALTY = -10
 BAKEOFF_LEVEL = "folk"
 BAKEOFF_POLICY_FAMILY = "seminar"
+LM_EVAL_RESULTS_PREFIX = "results_"
+LM_EVAL_TASK_MODEL_JUDGMENT = "qg_factuality_model_judgment"
+LM_EVAL_TASK_U_HONESTY = "qg_factuality_u_honesty"
+LM_EVAL_TASK_M_ALIGNMENT = "qg_factuality_m_alignment"
+LM_EVAL_TASK_HARNESS_LIFT = "qg_factuality_harness_lift"
 # Arms of the bakeoff. TOOLED = the shipped grounded+gated reviewer path;
 # BARE = the tool-free control (model judges from its own knowledge, no gates)
 # so tooled − bare per model quantifies the harness lift (#2156 step 3).
@@ -1666,7 +1671,6 @@ def pin_slug(pin: str) -> str:
     return slug or "model"
 
 
-
 def rescore_artifacts(output_dir: Path, fixtures_dir: Path = FIXTURE_DIR) -> int:
     """Recompute scores for existing artifacts from their STORED payloads.
 
@@ -1707,6 +1711,310 @@ def rescore_artifacts(output_dir: Path, fixtures_dir: Path = FIXTURE_DIR) -> int
     return count
 
 
+def emit_lm_eval_results_from_dir(output_dir: Path, emit_dir: Path) -> list[Path]:
+    """Emit lang-uk/lm_eval-shaped result files from artifacts already on disk."""
+    return emit_lm_eval_results(_load_all_artifacts(output_dir), emit_dir)
+
+
+def emit_lm_eval_results(artifacts: Sequence[Mapping[str, Any]], emit_dir: Path) -> list[Path]:
+    """Write one ``results_<created_at>.json`` file per measured model identity."""
+    emit_dir.mkdir(parents=True, exist_ok=True)
+    grouped: dict[tuple[str, str, str], list[Mapping[str, Any]]] = defaultdict(list)
+    for artifact in artifacts:
+        if _is_ops_quota_artifact(artifact):
+            continue
+        grouped[_model_key(artifact)].append(artifact)
+
+    pin_counts: dict[str, int] = defaultdict(int)
+    for pin, _transport, _entrypoint in grouped:
+        pin_counts[pin] += 1
+
+    written: list[Path] = []
+    for model_key, model_artifacts in sorted(grouped.items()):
+        payload = _lm_eval_payload_for_model(model_key, model_artifacts)
+        stamp = _lm_eval_filename_stamp(model_artifacts)
+        model_dir = emit_dir / _lm_eval_model_dir_name(
+            model_key,
+            duplicate_pin=pin_counts[model_key[0]] > 1,
+        )
+        model_dir.mkdir(parents=True, exist_ok=True)
+        path = model_dir / f"{LM_EVAL_RESULTS_PREFIX}{stamp}.json"
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        written.append(path)
+    return written
+
+
+def _lm_eval_payload_for_model(
+    model_key: tuple[str, str, str],
+    artifacts: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    pin, transport, entrypoint = model_key
+    totals = _aggregate_by_model_arm(artifacts)
+    available_arms = sorted({arm for key, arm in totals if key == model_key})
+    primary_arm = (
+        TOOLED_ARM
+        if (model_key, TOOLED_ARM) in totals
+        else (available_arms[0] if available_arms else TOOLED_ARM)
+    )
+    row = totals.get((model_key, primary_arm), _empty_total_row())
+    primary_artifacts = [
+        artifact
+        for artifact in artifacts
+        if _model_key(artifact) == model_key and _artifact_arm(artifact) == primary_arm
+    ]
+    partial_reasons = _partial_reasons(primary_artifacts)
+    task_meta = _lm_eval_task_meta(
+        model_key,
+        primary_arm,
+        row,
+        available_arms=available_arms,
+        partial_reasons=partial_reasons,
+    )
+    results: dict[str, dict[str, Any]] = {
+        LM_EVAL_TASK_MODEL_JUDGMENT: {
+            "score": _row_numeric_metric(row, "model_judgment_score"),
+            "qg_meta": task_meta | {"metric": "model_judgment_score"},
+        },
+        LM_EVAL_TASK_U_HONESTY: {
+            "score": _row_fraction_metric(row, "class_u"),
+            "qg_meta": task_meta
+            | {
+                "metric": "class_u_honesty",
+                "fraction": _row_fraction_meta(row, "class_u"),
+            },
+        },
+        LM_EVAL_TASK_M_ALIGNMENT: {
+            "score": _row_fraction_metric(row, "class_m"),
+            "qg_meta": task_meta
+            | {
+                "metric": "class_m_alignment",
+                "fraction": _row_fraction_meta(row, "class_m"),
+            },
+        },
+    }
+    lift = _lm_eval_harness_lift_for_model(model_key, artifacts)
+    if lift is not None:
+        results[LM_EVAL_TASK_HARNESS_LIFT] = {
+            "score": lift["score"],
+            "qg_meta": {
+                "metric": "harness_lift",
+                "arm": BOTH_ARM,
+                "available_arms": available_arms,
+                "primary_arm": TOOLED_ARM,
+                "comparison_arm": BARE_ARM,
+                "runs": lift["runs"],
+                "run_indices": lift["run_indices"],
+                "paired_passages": lift["paired_passages"],
+                "low_n": lift["paired_passages"] < 10,
+                "partial": bool(lift["partial_reasons"]),
+                "partial_reasons": lift["partial_reasons"],
+                "transport": transport,
+                "entrypoint": entrypoint,
+                "model_pin": pin,
+                "anchor_included": True,
+            },
+        }
+    return {
+        "config_general": {"model_name": pin},
+        "results": results,
+        "qg_meta": {
+            "schema_version": RUN_SCHEMA_VERSION,
+            "source": "qg_bakeoff",
+            "model_pin": pin,
+            "transport": transport,
+            "entrypoint": entrypoint,
+            "available_arms": available_arms,
+            "created_at": _lm_eval_filename_stamp(artifacts),
+            "partial": bool(_partial_reasons(artifacts)),
+        },
+    }
+
+
+def _lm_eval_model_dir_name(model_key: tuple[str, str, str], *, duplicate_pin: bool = False) -> str:
+    pin, transport, entrypoint = model_key
+    if duplicate_pin:
+        return f"{pin_slug(pin)}__{pin_slug(transport)}__{pin_slug(entrypoint)}"
+    return pin_slug(pin)
+
+
+def _lm_eval_filename_stamp(artifacts: Sequence[Mapping[str, Any]]) -> str:
+    stamps = [
+        str(artifact.get("created_at")).strip()
+        for artifact in artifacts
+        if isinstance(artifact.get("created_at"), str) and str(artifact.get("created_at")).strip()
+    ]
+    return max(stamps) if stamps else "unknown"
+
+
+def _lm_eval_task_meta(
+    model_key: tuple[str, str, str],
+    arm: str,
+    row: Mapping[str, Any],
+    *,
+    available_arms: Sequence[str],
+    partial_reasons: Sequence[str],
+) -> dict[str, Any]:
+    pin, transport, entrypoint = model_key
+    runs = int(row.get("runs") or 1)
+    run_indices = list(row.get("run_indices") or range(1, runs + 1))
+    passages = row.get("passages_per_run") if row.get("multi_run") else [int(row.get("passages") or 0)]
+    return {
+        "arm": arm,
+        "available_arms": list(available_arms),
+        "runs": runs,
+        "run_indices": run_indices,
+        "passages_per_run": passages,
+        "low_n": _row_any_low_n(row),
+        "partial": bool(partial_reasons),
+        "partial_reasons": list(partial_reasons),
+        "transport": transport,
+        "entrypoint": entrypoint,
+        "model_pin": pin,
+        "anchor_included": True,
+    }
+
+
+def _row_numeric_metric(row: Mapping[str, Any], key: str) -> float:
+    value = row.get(key)
+    if isinstance(value, Mapping):
+        return float(value.get("mean") or 0.0)
+    return float(value or 0.0)
+
+
+def _row_fraction_metric(row: Mapping[str, Any], prefix: str) -> float:
+    if row.get("multi_run"):
+        value = row.get(f"{prefix}_honesty" if prefix == "class_u" else f"{prefix}_alignment")
+        return float(value.get("mean") or 0.0) if isinstance(value, Mapping) else 0.0
+    denominator = int(row.get(f"{prefix}_total") or 0)
+    if denominator <= 0:
+        return 0.0
+    return int(row.get(f"{prefix}_good") or 0) / denominator
+
+
+def _row_fraction_meta(row: Mapping[str, Any], prefix: str) -> dict[str, Any]:
+    if row.get("multi_run"):
+        value = row.get(f"{prefix}_honesty" if prefix == "class_u" else f"{prefix}_alignment")
+        if isinstance(value, Mapping):
+            return {
+                "denominators": list(value.get("denominators") or []),
+                "low_n": bool(value.get("low_n")),
+            }
+        return {"denominators": [], "low_n": True}
+    numerator = int(row.get(f"{prefix}_good") or 0)
+    denominator = int(row.get(f"{prefix}_total") or 0)
+    return {
+        "numerator": numerator,
+        "denominator": denominator,
+        "text": f"{numerator}/{denominator}",
+        "low_n": denominator < 10,
+    }
+
+
+def _row_any_low_n(row: Mapping[str, Any]) -> bool:
+    if row.get("multi_run"):
+        return any(
+            bool(value.get("low_n"))
+            for key in ("class_u_honesty", "class_m_alignment", "false_unsupported_on_true")
+            if isinstance((value := row.get(key)), Mapping)
+        )
+    return any(int(row.get(key) or 0) < 10 for key in ("class_u_total", "class_m_total", "true_total"))
+
+
+def _partial_reasons(artifacts: Sequence[Mapping[str, Any]]) -> list[str]:
+    reasons: set[str] = set()
+    for artifact in artifacts:
+        if "created_at" not in artifact:
+            reasons.add("missing_created_at")
+        if "arm" not in artifact:
+            reasons.add("missing_arm")
+        if "run_index" not in artifact:
+            reasons.add("missing_run_index")
+        if not isinstance(artifact.get("fixture"), Mapping):
+            reasons.add("missing_fixture")
+        model = artifact.get("model")
+        if not isinstance(model, Mapping):
+            reasons.add("missing_model")
+        else:
+            if not isinstance(model.get("pin"), str):
+                reasons.add("missing_model_pin")
+            if not isinstance(model.get("transport"), str):
+                reasons.add("missing_transport")
+            if not isinstance(model.get("entrypoint"), str):
+                reasons.add("missing_entrypoint")
+        score = artifact.get("score")
+        if not isinstance(score, Mapping):
+            reasons.add("missing_score")
+            continue
+        for key in ("model_judgment_score", "fractions"):
+            if key not in score:
+                reasons.add(f"missing_score_{key}")
+        fractions = score.get("fractions")
+        if not isinstance(fractions, Mapping):
+            reasons.add("missing_score_fractions")
+            continue
+        for key in ("class_u_honesty", "class_m_alignment"):
+            if key not in fractions:
+                reasons.add(f"missing_fraction_{key}")
+    return sorted(reasons)
+
+
+def _lm_eval_harness_lift_for_model(
+    model_key: tuple[str, str, str],
+    artifacts: Sequence[Mapping[str, Any]],
+) -> dict[str, Any] | None:
+    cells: dict[str, dict[str, dict[int, Mapping[str, Any]]]] = defaultdict(lambda: defaultdict(dict))
+    for artifact in artifacts:
+        if _is_ops_quota_artifact(artifact) or _model_key(artifact) != model_key:
+            continue
+        cells[_fixture_slug(artifact)][_artifact_arm(artifact)][_artifact_run_index(artifact)] = artifact
+    paired = sorted(slug for slug, arms in cells.items() if TOOLED_ARM in arms and BARE_ARM in arms)
+    if not paired:
+        return None
+    paired_artifacts = [
+        artifact
+        for slug in paired
+        for arm in (TOOLED_ARM, BARE_ARM)
+        for artifact in cells[slug][arm].values()
+    ]
+    partial_reasons = _partial_reasons(paired_artifacts)
+    scheduled_runs = _max_run_index(
+        [artifact for arms in cells.values() for runs in arms.values() for artifact in runs.values()]
+    )
+    if scheduled_runs > 1:
+        lifts = [
+            _arm_mean_for_fixture(cells[slug][TOOLED_ARM], "model_judgment_score")
+            - _arm_mean_for_fixture(cells[slug][BARE_ARM], "model_judgment_score")
+            for slug in paired
+        ]
+        run_indices = sorted(
+            {run for slug in paired for arm in (TOOLED_ARM, BARE_ARM) for run in cells[slug][arm]}
+        )
+        return {
+            "score": _mean(lifts),
+            "runs": max((len(cells[slug][arm]) for slug in paired for arm in (TOOLED_ARM, BARE_ARM)), default=1),
+            "run_indices": run_indices,
+            "paired_passages": len(paired),
+            "partial_reasons": partial_reasons,
+        }
+    tooled = sum(
+        int(_score(cells[slug][TOOLED_ARM][1]).get("model_judgment_score") or 0)
+        for slug in paired
+        if 1 in cells[slug][TOOLED_ARM]
+    )
+    bare = sum(
+        int(_score(cells[slug][BARE_ARM][1]).get("model_judgment_score") or 0)
+        for slug in paired
+        if 1 in cells[slug][BARE_ARM]
+    )
+    return {
+        "score": float(tooled - bare),
+        "runs": 1,
+        "run_indices": [1],
+        "paired_passages": len(paired),
+        "partial_reasons": partial_reasons,
+    }
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--fixtures-dir", type=Path, default=FIXTURE_DIR)
@@ -1745,14 +2053,24 @@ def main(argv: Sequence[str] | None = None) -> int:
         action="store_true",
         help="Recompute scores for EXISTING artifacts from stored payloads (no model calls)",
     )
+    parser.add_argument(
+        "--emit-lm-eval",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Write lang-uk/lm_eval-shaped results_<created_at>.json files from artifacts on disk",
+    )
     args = parser.parse_args(argv)
 
     try:
         if args.rescore:
             output_dir = args.out_dir or default_output_dir()
             n = rescore_artifacts(output_dir, args.fixtures_dir)
+            emitted = emit_lm_eval_results_from_dir(output_dir, args.emit_lm_eval) if args.emit_lm_eval else []
             print(f"rescored {n} artifacts under {output_dir}")
             print(f"scorecard: {output_dir / SCORECARD_NAME}")
+            if args.emit_lm_eval:
+                print(f"lm-eval results: {len(emitted)} files under {args.emit_lm_eval}")
             return 0
         runs_requested = _validate_run_index(args.runs)
         require_offline_opt_in()
@@ -1768,11 +2086,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             retry_failures=args.retry_failures,
             runs=runs_requested,
         )
+        emitted = emit_lm_eval_results_from_dir(output_dir, args.emit_lm_eval) if args.emit_lm_eval else []
     except BakeoffConfigError as exc:
         print(str(exc), file=sys.stderr)
         return 2
     print(f"wrote {len(runs)} bakeoff artifacts under {output_dir}")
     print(f"scorecard: {output_dir / SCORECARD_NAME}")
+    if args.emit_lm_eval:
+        print(f"lm-eval results: {len(emitted)} files under {args.emit_lm_eval}")
     return 0
 
 

--- a/tests/test_qg_bakeoff_emitter.py
+++ b/tests/test_qg_bakeoff_emitter.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts.audit import llm_reviewer_dispatch, qg_bakeoff
+
+PIN = "openrouter/test/emitter-model"
+CREATED_AT = "2026-07-06T12:34:56Z"
+
+
+def _fixture() -> qg_bakeoff.BakeoffFixture:
+    return qg_bakeoff.BakeoffFixture(
+        slug="emitter",
+        title="Emitter",
+        passage_md="True claim. U fabricated claim. M fabricated claim.",
+        claims=(
+            qg_bakeoff.FixtureClaim("true", "True claim.", True),
+            qg_bakeoff.FixtureClaim("u", "U fabricated claim.", False, "U"),
+            qg_bakeoff.FixtureClaim("m", "M fabricated claim.", False, "M", "real adjacent quote"),
+        ),
+    )
+
+
+def _write_fixture(fixtures_dir: Path, fixture: qg_bakeoff.BakeoffFixture) -> None:
+    fixtures_dir.mkdir()
+    (fixtures_dir / f"{fixture.slug}.json").write_text(
+        json.dumps(
+            {
+                "slug": fixture.slug,
+                "title": fixture.title,
+                "passage_md": fixture.passage_md,
+                "claims": [
+                    {
+                        "claim_id": claim.claim_id,
+                        "claim": claim.claim,
+                        "is_true": claim.is_true,
+                        "fabrication_class": claim.fabrication_class,
+                        "distractor_evidence": claim.distractor_evidence,
+                    }
+                    for claim in fixture.claims
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _event() -> dict[str, Any]:
+    return {
+        "tool": "sources_query_wikipedia",
+        "input": {"query": "fixture", "mode": "section"},
+        "status": "completed",
+        "tool_call_id": "call_1",
+        "output": "True claim. U fabricated claim. M fabricated claim.",
+    }
+
+
+def _dispatch_result(
+    payload: dict[str, Any],
+    route: llm_reviewer_dispatch.ReviewerRoute,
+    *,
+    tool_call_count: int,
+) -> llm_reviewer_dispatch.DispatchResult:
+    return llm_reviewer_dispatch.DispatchResult(
+        response_text=json.dumps(payload, ensure_ascii=False),
+        reviewer_model_id=route.reviewer_model_id,
+        reviewer_family=route.reviewer_family,
+        route_name=route.route_name,
+        tool_call_count=tool_call_count,
+        tools_used=("sources_query_wikipedia",) if tool_call_count else (),
+        tool_events=(_event(),) if tool_call_count else (),
+    )
+
+
+def _tooled_runner(
+    route: llm_reviewer_dispatch.ReviewerRoute,
+    _prompt: str,
+    _task_id: str,
+) -> llm_reviewer_dispatch.DispatchResult:
+    payload = {
+        "findings": [],
+        "fact_checks": [
+            {
+                "claim": "True claim.",
+                "verdict": "CONFIRMED",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "fixture",
+                    "evidence_excerpt": "True claim.",
+                    "tool_call_id": "call_1",
+                },
+            },
+            {
+                "claim": "U fabricated claim.",
+                "verdict": "UNATTESTED_AFTER_SEARCH",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "fixture",
+                    "evidence_excerpt": "U fabricated claim.",
+                    "tool_call_id": "call_1",
+                },
+            },
+            {
+                "claim": "M fabricated claim.",
+                "verdict": "UNATTESTED_AFTER_SEARCH",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "fixture",
+                    "evidence_excerpt": "M fabricated claim.",
+                    "tool_call_id": "call_1",
+                },
+            },
+        ],
+        "evidence_gaps": [],
+    }
+    return _dispatch_result(payload, route, tool_call_count=1)
+
+
+def _bare_runner(
+    route: llm_reviewer_dispatch.ReviewerRoute,
+    _prompt: str,
+    _task_id: str,
+) -> llm_reviewer_dispatch.DispatchResult:
+    payload = {
+        "findings": [],
+        "fact_checks": [
+            {"claim": "True claim.", "verdict": "CONFIRMED"},
+            {"claim": "U fabricated claim.", "verdict": "CONFIRMED"},
+            {"claim": "M fabricated claim.", "verdict": "CONFIRMED"},
+        ],
+        "evidence_gaps": [],
+    }
+    return _dispatch_result(payload, route, tool_call_count=0)
+
+
+def _load_lang_uk_leaderboard_records(path: Path) -> list[dict[str, Any]]:
+    """Minimal lang-uk loader contract: model_name plus float metrics per task."""
+    data = json.loads(path.read_text(encoding="utf-8"))
+    config_general = data["config_general"]
+    assert isinstance(config_general["model_name"], str)
+    results = data["results"]
+    assert isinstance(results, dict)
+
+    records: list[dict[str, Any]] = []
+    for task_name, metrics in results.items():
+        assert isinstance(task_name, str)
+        assert isinstance(metrics, dict)
+        for metric_name, value in metrics.items():
+            if metric_name == "qg_meta":
+                assert isinstance(value, dict)
+                continue
+            assert isinstance(value, int | float)
+            assert not isinstance(value, bool)
+            records.append(
+                {
+                    "model_name": config_general["model_name"],
+                    "task": task_name,
+                    "metric": metric_name,
+                    "value": float(value),
+                }
+            )
+    return records
+
+
+def test_emitter_round_trips_through_vendored_lang_uk_aggregation_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("CI", raising=False)
+    monkeypatch.setenv("QG_BAKEOFF", "1")
+    monkeypatch.setattr(qg_bakeoff, "_now_z", lambda: CREATED_AT)
+    fixture = _fixture()
+    fixtures_dir = tmp_path / "fixtures"
+    output_dir = tmp_path / "artifacts"
+    emit_dir = tmp_path / "eval-results"
+    _write_fixture(fixtures_dir, fixture)
+
+    qg_bakeoff.run_matrix(
+        [fixture],
+        [PIN],
+        output_dir=output_dir,
+        runner=_tooled_runner,
+        bare_runner=_bare_runner,
+        arm=qg_bakeoff.BOTH_ARM,
+    )
+
+    assert qg_bakeoff.main(
+        [
+            "--rescore",
+            "--out-dir",
+            str(output_dir),
+            "--fixtures-dir",
+            str(fixtures_dir),
+            "--emit-lm-eval",
+            str(emit_dir),
+        ]
+    ) == 0
+
+    result_path = emit_dir / qg_bakeoff.pin_slug(PIN) / f"results_{CREATED_AT}.json"
+    rows = _load_lang_uk_leaderboard_records(result_path)
+    by_task = {row["task"]: row["value"] for row in rows}
+    assert set(by_task) == {
+        qg_bakeoff.LM_EVAL_TASK_MODEL_JUDGMENT,
+        qg_bakeoff.LM_EVAL_TASK_U_HONESTY,
+        qg_bakeoff.LM_EVAL_TASK_M_ALIGNMENT,
+        qg_bakeoff.LM_EVAL_TASK_HARNESS_LIFT,
+    }
+
+    artifacts = qg_bakeoff._load_all_artifacts(output_dir)
+    model_key = (PIN, qg_bakeoff.OPENCODE_TRANSPORT, qg_bakeoff.OPENCODE_ENTRYPOINT)
+    totals = qg_bakeoff._aggregate_by_model_arm(artifacts)
+    tooled = totals[(model_key, qg_bakeoff.TOOLED_ARM)]
+    bare = totals[(model_key, qg_bakeoff.BARE_ARM)]
+    assert by_task[qg_bakeoff.LM_EVAL_TASK_MODEL_JUDGMENT] == float(tooled["model_judgment_score"])
+    assert by_task[qg_bakeoff.LM_EVAL_TASK_U_HONESTY] == 1.0
+    assert by_task[qg_bakeoff.LM_EVAL_TASK_M_ALIGNMENT] == 1.0
+    assert by_task[qg_bakeoff.LM_EVAL_TASK_HARNESS_LIFT] == float(
+        tooled["model_judgment_score"] - bare["model_judgment_score"]
+    )
+
+    data = json.loads(result_path.read_text(encoding="utf-8"))
+    meta = data["results"][qg_bakeoff.LM_EVAL_TASK_M_ALIGNMENT]["qg_meta"]
+    assert meta["arm"] == qg_bakeoff.TOOLED_ARM
+    assert meta["runs"] == 1
+    assert meta["low_n"] is True
+    assert meta["partial"] is False
+    assert meta["transport"] == qg_bakeoff.OPENCODE_TRANSPORT
+    assert meta["entrypoint"] == qg_bakeoff.OPENCODE_ENTRYPOINT
+
+
+def test_emitter_marks_legacy_partial_without_wall_clock(tmp_path: Path) -> None:
+    output_dir = tmp_path / "artifacts"
+    emit_dir = tmp_path / "eval-results"
+    output_dir.mkdir()
+    artifact = {
+        "schema_version": qg_bakeoff.RUN_SCHEMA_VERSION,
+        "fixture": {"slug": "legacy"},
+        "model": {"pin": "openrouter/test/legacy"},
+        "status": "ran",
+    }
+    (output_dir / "openrouter-test-legacy__legacy.json").write_text(
+        json.dumps(artifact, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    [result_path] = qg_bakeoff.emit_lm_eval_results_from_dir(output_dir, emit_dir)
+
+    assert result_path.name == "results_unknown.json"
+    rows = _load_lang_uk_leaderboard_records(result_path)
+    by_task = {row["task"]: row["value"] for row in rows}
+    assert qg_bakeoff.LM_EVAL_TASK_HARNESS_LIFT not in by_task
+    assert by_task[qg_bakeoff.LM_EVAL_TASK_MODEL_JUDGMENT] == 0.0
+
+    data = json.loads(result_path.read_text(encoding="utf-8"))
+    meta = data["results"][qg_bakeoff.LM_EVAL_TASK_MODEL_JUDGMENT]["qg_meta"]
+    assert meta["partial"] is True
+    assert "missing_created_at" in meta["partial_reasons"]
+    assert "missing_score" in meta["partial_reasons"]


### PR DESCRIPTION
## Summary
- Adds `--emit-lm-eval <dir>` to export qg_bakeoff artifacts as lang-uk/lm_eval-shaped `results_<created_at>.json` files.
- Maps model judgment, U honesty, M alignment, and paired harness lift into task-keyed float metrics with qg metadata.
- Adds offline round-trip coverage plus a 15-line maintainer doc.

## Evidence
### Emitter pytest
cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4630-lmeval-emitter`
command:
```bash
.venv/bin/python -m pytest tests/test_qg_bakeoff*.py -k emitter -q
```
raw output:
```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4630-lmeval-emitter
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 11 items / 9 deselected / 2 selected

tests/test_qg_bakeoff_emitter.py ..                                      [100%]

======================= 2 passed, 9 deselected in 0.48s ========================
```

### Full bakeoff suite
cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4630-lmeval-emitter`
command:
```bash
.venv/bin/python -m pytest tests/test_qg_bakeoff*.py tests/audit/test_qg_bakeoff.py -q
```
raw output:
```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4630-lmeval-emitter
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collected 57 items

tests/test_qg_bakeoff_emitter.py ..                                      [  3%]
tests/test_qg_bakeoff_multirun.py .........                              [ 19%]
tests/audit/test_qg_bakeoff.py ......................................... [ 91%]
.....                                                                    [100%]

============================== 57 passed in 0.61s ==============================
```

### Ruff
cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4630-lmeval-emitter`
command:
```bash
.venv/bin/ruff check scripts/audit/ tests/
```
raw output:
```text
All checks passed!
```

### Round-trip proof
cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4630-lmeval-emitter`
command:
```bash
.venv/bin/python -m pytest tests/test_qg_bakeoff_emitter.py::test_emitter_round_trips_through_vendored_lang_uk_aggregation_shape -vv
```
raw output:
```text
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.0.2, pluggy-1.6.0 -- /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4630-lmeval-emitter/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4630-lmeval-emitter
configfile: pyproject.toml
plugins: anyio-4.12.1, cov-7.1.0, xdist-3.8.0, timeout-2.4.0
collecting ... collected 1 item

tests/test_qg_bakeoff_emitter.py::test_emitter_round_trips_through_vendored_lang_uk_aggregation_shape PASSED [100%]

============================== 1 passed in 0.51s ===============================
```

### Commit
cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4630-lmeval-emitter`
command:
```bash
git log -1 --oneline
```
raw output:
```text
a6e94d126e feat(audit): #4630 lm_eval-compatible results emitter
```

### PR
cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4630-lmeval-emitter`
command:
```bash
gh pr view --json url
```
raw output:
```text
{"url":"https://github.com/learn-ukrainian/learn-ukrainian.github.io/pull/4645"}
```