### PR TITLE
feat(corpus): #4593 batch-2 subject mappings (astronomy/economics/law/civic/defense/arts/geography)

### DIFF
--- a/scripts/ingest/incremental_textbook_ingest.py
+++ b/scripts/ingest/incremental_textbook_ingest.py
@@ -45,6 +45,16 @@ AUTHOR_UK: dict[str, str] = {
     "hryhorovych": "Григорович",
     "popel": "Попель",
     "anderson": "Андерсон",
+    # #4593 batch-2 authors (title-probed 2026-07-06)
+    "pryshliak": "Пришляк",
+    "krupska": "Крупська",
+    "lukianchykov": "Лук'янчиков",
+    "narovlianskyi": "Наровлянський",
+    "fuka": "Фука",
+    "komarovska": "Комаровська",
+    "masol": "Масол",
+    "zapotockyi": "Запотоцький",
+    "hilberh": "Гільберг",
 }
 
 WAVE1_SLUGS: tuple[str, ...] = (

--- a/scripts/migrations/2026-05-15-add-author-uk-to-textbooks.py
+++ b/scripts/migrations/2026-05-15-add-author-uk-to-textbooks.py
@@ -100,6 +100,15 @@ _LATIN_TO_UK: dict[str, str] = {
     "hryhorovych": "Григорович",
     "popel": "Попель",
     "anderson": "Андерсон",
+    "pryshliak": "Пришляк",
+    "krupska": "Крупська",
+    "lukianchykov": "Лук'янчиков",
+    "narovlianskyi": "Наровлянський",
+    "fuka": "Фука",
+    "komarovska": "Комаровська",
+    "masol": "Масол",
+    "zapotockyi": "Запотоцький",
+    "hilberh": "Гільберг",
     # Non-textbook author-name strings already stored in Latin/English on
     # ingestion (literary works, podcast, style-guide author). Map them
     # to Cyrillic so author_uk is uniformly Cyrillic when populated.

--- a/scripts/wiki/textbook_subjects.py
+++ b/scripts/wiki/textbook_subjects.py
@@ -18,6 +18,12 @@ CANONICAL_TEXTBOOK_SUBJECTS: tuple[str, ...] = (
     "khimiya",
     "biolohiya",
     "heohrafiya",
+    "astronomiya",
+    "ekonomika",
+    "pravoznavstvo",
+    "hromadianska",
+    "zakhyst",
+    "mystetstvo",
 )
 
 
@@ -151,6 +157,12 @@ _SUBJECT_ALIASES: dict[str, str] = {
 
 
 _SUBJECT_TOKEN_PATTERNS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("astronomiya", ("astronomiya", "astronomiia", "astronomija")),
+    ("ekonomika", ("ekonomika", "ekonomka")),
+    ("pravoznavstvo", ("pravoznavstvo",)),
+    ("hromadianska", ("hromadianska", "gromadianska", "gromadjanska")),
+    ("zakhyst", ("zakhyst", "zahyst")),
+    ("mystetstvo", ("mystetstvo", "mystectvo", "mistectvo")),
     (
         "lexicon",
         (

--- a/tests/test_textbook_subjects.py
+++ b/tests/test_textbook_subjects.py
@@ -192,3 +192,30 @@ def test_wave1_stem_url_config_slugs_map_to_canonical_subjects() -> None:
     for slug, expected_subject in WAVE1_STEM_TEXTBOOK_SOURCE_FILES.items():
         subject_token = slug.split("-klas-", maxsplit=1)[1].split("-", maxsplit=1)[0]
         assert normalize_subject_slug(subject_token) == expected_subject
+
+
+BATCH2_SOURCE_FILES: dict[str, str] = {
+    "11-klas-astronomiya-pryshliak-2019": "astronomiya",
+    "10-klas-ekonomika-krupska-2018": "ekonomika",
+    "10-klas-pravoznavstvo-lukianchykov-2018": "pravoznavstvo",
+    "11-klas-pravoznavstvo-narovlianskyi-2019": "pravoznavstvo",
+    "10-klas-hromadianska-gisem-2018": "hromadianska",
+    "10-klas-zakhyst-fuka-2023": "zakhyst",
+    "8-klas-mystetstvo-komarovska-2025": "mystetstvo",
+    "9-klas-mystetstvo-masol-2017": "mystetstvo",
+    "6-klas-heohrafiya-zapotockyi-2023": "heohrafiya",
+    "7-klas-heohrafiya-hilberh-2024": "heohrafiya",
+    "8-klas-heohrafiya-hilberh-2025": "heohrafiya",
+}
+
+
+def test_batch2_slugs_resolve_to_new_canonical_subjects() -> None:
+    """#4593 batch 2: applied-register subjects (gap-audit rank-1 consumers)."""
+    from scripts.wiki.textbook_subjects import (
+        CANONICAL_TEXTBOOK_SUBJECTS,
+        subject_for_source_file,
+    )
+
+    for slug, expected in BATCH2_SOURCE_FILES.items():
+        assert subject_for_source_file(slug) == expected, slug
+        assert expected in CANONICAL_TEXTBOOK_SUBJECTS


### PR DESCRIPTION
Prerequisite for the batch-2 ingest (11 books, user-directed 2026-07-06): 6 new canonical subjects, token patterns, 9 title-probed Cyrillic authors in both the ingest tool and migration maps, pin-test asserting all 11 slugs resolve. Selection rationale + probes on #4593. Radionova econ-11 dropped (year unverifiable → tier rule). Same pipeline as wave 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)