### PR TITLE
BIO Ukrainian-only readings batch 46

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/bohdan-boichuk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/bohdan-boichuk.yaml
@@ -142,7 +142,7 @@ sequence: 238
 slug: bohdan-boichuk
 subtitle: The Émigré Modernist Who Co-Founded the New York Group
 title: 'Богдан Бойчук: Творче заперечення Нью-Йоркської групи'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: вимушене або добровільне переселення за межі батьківщини; середовище українців,
     що жили й творили поза УРСР
@@ -171,3 +171,22 @@ vocabulary_hints:
   pos: ж.
   word: деколонізація
 word_target: 5200
+readings:
+- hosting: esu.com.ua
+  language: uk
+  note: Енциклопедична довідка про життєвий шлях і творчість поета-модерніста.
+  role: biography
+  source: https://esu.com.ua/search_articles.php?id=36186
+  title: Бойчук Богдан Миколайович
+- hosting: chytomo.com
+  language: uk
+  note: Оглядовий матеріал (некролог) про значення Бойчука для Нью-Йоркської групи.
+  role: overview
+  source: https://chytomo.com/bohdan-bojchuk-2/
+  title: Богдан Бойчук. Один із чільних поетів Нью-Йоркської групи
+- hosting: reading-needed
+  language: uk
+  note: Дебютна збірка Бойчука для вивчення його поетики болю та екзистенціалізму.
+  role: primary
+  source: 'reading-needed: Богдан Бойчук "Час болю"'
+  title: Час болю

--- a/curriculum/l2-uk-en/plans/bio/dokiia-humenna.yaml
+++ b/curriculum/l2-uk-en/plans/bio/dokiia-humenna.yaml
@@ -164,7 +164,7 @@ sequence: 235
 slug: dokiia-humenna
 subtitle: Документальна пам'ять села, Києва і діаспори
 title: 'Докія Гуменна: Заборонена правда українського села'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: літературне письмо, що спирається на свідчення, спостереження й фактичний матеріал
   pos: ж.
@@ -190,3 +190,22 @@ vocabulary_hints:
   pos: ж.
   word: діаспора
 word_target: 5200
+readings:
+- hosting: esu.com.ua
+  language: uk
+  note: Енциклопедичний огляд життя та доробку Докії Гуменної з української перспективи.
+  role: biography
+  source: https://esu.com.ua/article-24663
+  title: Гуменна Докія Кузьмівна
+- hosting: diasporiana.org.ua
+  language: uk
+  note: Автобіографічна проза. Читати фрагменти для розуміння її рефлексій про минуле.
+  role: primary
+  source: https://diasporiana.org.ua/proza/7593-gumenna-d-dar-evdoteyi-t-1/
+  title: Дар Евдотеї (Том 1)
+- hosting: ukrlib.com.ua
+  language: uk
+  note: Роман-хроніка окупаційного Києва.
+  role: primary
+  source: https://www.ukrlib.com.ua/books/printit.php?tid=14190
+  title: Хрещатий Яр

--- a/curriculum/l2-uk-en/plans/bio/emma-andiievska.yaml
+++ b/curriculum/l2-uk-en/plans/bio/emma-andiievska.yaml
@@ -139,7 +139,7 @@ sequence: 240
 slug: emma-andiievska
 subtitle: The Surrealist of Donetsk Who Chose Ukrainian
 title: 'Емма Андієвська: Сюрреалізм і «мова моєї душі»'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: мистецький напрям XX століття, що відтворює образи сну, марення та підсвідомого;
     основа поетики Андієвської
@@ -167,3 +167,22 @@ vocabulary_hints:
   pos: ж.
   word: діаспора
 word_target: 5200
+readings:
+- hosting: esu.com.ua
+  language: uk
+  note: Базова енциклопедична інформація про сюрреалістку Нью-Йоркської групи.
+  role: biography
+  source: https://esu.com.ua/article-44101
+  title: Андієвська Емма
+- hosting: ukrainer.net
+  language: uk
+  note: Мультимедійний матеріал про ідентичність Емми Андієвської та її українську мову.
+  role: cultural-context
+  source: https://www.ukrainer.net/emma-andiievska/
+  title: Хто така Емма Андієвська?
+- hosting: reading-needed
+  language: uk
+  note: Збірка поезій 1958 року.
+  role: primary
+  source: 'reading-needed: Емма Андієвська "Народження ідола"'
+  title: Народження ідола

--- a/curriculum/l2-uk-en/plans/bio/mykhailo-orest.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykhailo-orest.yaml
@@ -166,7 +166,7 @@ sequence: 237
 slug: mykhailo-orest
 subtitle: Поет і архівіст розстріляного неокласицизму
 title: 'Михайло Орест: Держава слова після терору'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: мистецька течія, що спирається на класичну форму, дисципліну і європейську культурну пам'ять
   pos: ч.
@@ -190,3 +190,22 @@ vocabulary_hints:
   pos: с.
   word: перепоховання
 word_target: 5200
+readings:
+- hosting: esu.com.ua
+  language: uk
+  note: Оглядова стаття про життя та творчість Михайла Ореста.
+  role: biography
+  source: https://esu.com.ua/article-75699
+  title: Орест Михайло
+- hosting: tyktor.media
+  language: uk
+  note: Аналітична стаття про роль Ореста як самостійного поета та збереження спадщини брата.
+  role: analysis
+  source: https://tyktor.media/ktytor/mykhajlo-orest/
+  title: Михайло Орест. Недооцінений талант у тіні брата Миколи Зерова
+- hosting: diasporiana.org.ua
+  language: uk
+  note: Поетична збірка для ознайомлення з його неокласичною поетикою.
+  role: primary
+  source: https://diasporiana.org.ua/poeziya/19619-orest-m-derzhava-slova/
+  title: Держава слова

--- a/curriculum/l2-uk-en/plans/bio/yurii-kosach.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yurii-kosach.yaml
@@ -169,7 +169,7 @@ sequence: 236
 slug: yurii-kosach
 subtitle: Суперечлива спадщина МУРівського модерніста
 title: 'Юрій Косач: Модернізм, вигнання і прорадянський поворот'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: таємна політична або військова діяльність, заборонена владою
   pos: с.
@@ -193,3 +193,22 @@ vocabulary_hints:
   pos: ж.
   word: відповідальність
 word_target: 5200
+readings:
+- hosting: esu.com.ua
+  language: uk
+  note: Енциклопедична стаття про Юрія Косача, його родину та життєвий шлях.
+  role: biography
+  source: https://esu.com.ua/article-5498
+  title: Косач Юрій Миколайович
+- hosting: history.org.ua
+  language: uk
+  note: Історичний огляд діяльності Косача від Енциклопедії історії України.
+  role: history
+  source: http://history.org.ua/?termin=Kosach_Yu
+  title: Косач Юрій Миколайович
+- hosting: litgazeta.com.ua
+  language: uk
+  note: Повість про модерністське відчуття вигнанця.
+  role: primary
+  source: https://litgazeta.com.ua/chytaty-onlayn/kosach-urij-enej-ta-zitta-inshih/
+  title: Еней і життя інших

--- a/curriculum/l2-uk-en/plans/bio/yurii-tarnavskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yurii-tarnavskyi.yaml
@@ -141,7 +141,7 @@ sequence: 239
 slug: yurii-tarnavskyi
 subtitle: The Architect of Ukraine's Depoeticised Verse in Exile
 title: 'Юрій Тарнавський: Депоетизований вірш Нью-Йоркської групи'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: вільний вірш без сталого розміру та рими; основна форма поетики Тарнавського
   pos: ч.
@@ -169,3 +169,22 @@ vocabulary_hints:
   pos: ж.
   word: діаспора
 word_target: 5200
+readings:
+- hosting: suspilne.media
+  language: uk
+  note: Оглядова стаття та некролог про Юрія Тарнавського від суспільного мовника.
+  role: biography
+  source: https://suspilne.media/1141186-pomer-pismennik-urij-tarnavskij/
+  title: Помер письменник Юрій Тарнавський
+- hosting: ukrlit.net
+  language: uk
+  note: Лекційний матеріал та огляд поезії Нью-Йоркської групи.
+  role: analysis
+  source: https://ukrlit.net/info/outside/15.html
+  title: Поезія української діаспори (Тарнавський)
+- hosting: reading-needed
+  language: uk
+  note: Програмна збірка-маніфест "депоетизованого" вірша.
+  role: primary
+  source: 'reading-needed: Юрій Тарнавський "Поезії про ніщо і інші поезії на цю саму тему"'
+  title: Поезії про ніщо і інші поезії на цю саму тему


### PR DESCRIPTION
Adds Ukrainian-only reading packets to diaspora literature plans. Changed slugs: dokiia-humenna, yurii-kosach, mykhailo-orest, bohdan-boichuk, yurii-tarnavskyi, emma-andiievska. All sources are either stable Ukrainian URLs (ESU, UkrLib, Diasporiana, etc.) or explicitly marked reading-needed. LLM-QG and Gemma/OpenRouter were NOT used.