### PR TITLE
refactor(corpus): author map single source of truth (dual-map drift killed)

### DIFF
--- a/scripts/ingest/incremental_textbook_ingest.py
+++ b/scripts/ingest/incremental_textbook_ingest.py
@@ -29,33 +29,13 @@ PROJECT_ROOT = SCRIPT_PATH.parents[2]
 sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
 
 from wiki.build_sources_db import _build_textbook_row
+from wiki.textbook_subjects import AUTHOR_UK_BY_TRANSLIT
 
 CHUNKS_DIR = PROJECT_ROOT / "data" / "textbook_chunks"
 DEFAULT_DB = PROJECT_ROOT / "data" / "sources.db"
 
-# Canonical Cyrillic author forms, title-probed from source pages during
-# wave-1 acquisition (#4593, 2026-07-06). Keep in sync with the migration
-# mapping in scripts/migrations/2026-05-15-add-author-uk-to-textbooks.py.
-AUTHOR_UK: dict[str, str] = {
-    "ryvkind": "Ривкінд",
-    "ister": "Істер",
-    "merzliak": "Мерзляк",
-    "zadorozhnyi": "Задорожний",
-    "bariakhtar": "Бар'яхтар",
-    "hryhorovych": "Григорович",
-    "popel": "Попель",
-    "anderson": "Андерсон",
-    # #4593 batch-2 authors (title-probed 2026-07-06)
-    "pryshliak": "Пришляк",
-    "krupska": "Крупська",
-    "lukianchykov": "Лук'янчиков",
-    "narovlianskyi": "Наровлянський",
-    "fuka": "Фука",
-    "komarovska": "Комаровська",
-    "masol": "Масол",
-    "zapotockyi": "Запотоцький",
-    "hilberh": "Гільберг",
-}
+# Author map: single source of truth in wiki.textbook_subjects (PR #4650).
+AUTHOR_UK = AUTHOR_UK_BY_TRANSLIT
 
 WAVE1_SLUGS: tuple[str, ...] = (
     "5-klas-informatyka-ryvkind-2022",

--- a/scripts/migrations/2026-05-15-add-author-uk-to-textbooks.py
+++ b/scripts/migrations/2026-05-15-add-author-uk-to-textbooks.py
@@ -31,8 +31,14 @@ from __future__ import annotations
 
 import argparse
 import sqlite3
+import sys
+from pathlib import Path as _P
+
+sys.path.insert(0, str(_P(__file__).resolve().parents[2] / 'scripts'))
 from dataclasses import dataclass, field
 from pathlib import Path
+
+from wiki.textbook_subjects import AUTHOR_UK_BY_TRANSLIT
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_DB = PROJECT_ROOT / "data" / "sources.db"
@@ -51,72 +57,10 @@ class MigrationStatus:
 # (plus the 6 entries added in PR #2013 and additional corpus authors
 # discovered via SELECT DISTINCT author FROM textbooks). Latin keys are
 # matched verbatim against textbooks.author.
-_LATIN_TO_UK: dict[str, str] = {
-    # Core mova/lit textbook authors (originally in TRANSLITS)
-    "karaman": "Караман",
-    "zakhariychuk": "Захарійчук",
-    "zaharijchuk": "Захарійчук",
-    "zahariichuk": "Захарійчук",
-    "kravcova": "Кравцова",
-    "kravtsova": "Кравцова",
-    "avramenko": "Авраменко",
-    "glazova": "Глазова",
-    "hlazova": "Глазова",
-    "zabolotnyi": "Заболотний",
-    "zabolotnij": "Заболотний",
-    "zakharchuk": "Захарчук",
-    "vashulenko": "Вашуленко",
-    "bolshakova": "Большакова",
-    "mishhenko": "Міщенко",
-    "mishchenko": "Міщенко",
-    "litvinova": "Літвінова",
-    "golub": "Голуб",
-    "varzatska": "Варзацька",
-    "ponomarova": "Пономарова",
-    # Additional textbook authors present in the corpus
-    "borzenko": "Борзенко",
-    "burnejko": "Бурнейко",
-    "galimov": "Галімов",
-    "gisem": "Гісем",
-    # Хлібовська: front-matter of 7-klas/8-klas/11-klas history textbooks
-    # confirms Х (Kh), not Г — the Latin transliteration here is unusual
-    # (h→Х instead of the more common h→Г). Verified via in-corpus
-    # textbook front-matter (2026-05-15 audit).
-    "hlibovska": "Хлібовська",
-    "kovalenko": "Коваленко",
-    "onatiy": "Онатій",
-    "pometun": "Пометун",
-    "savchenko": "Савченко",
-    "savchuk": "Савчук",
-    "schupak": "Щупак",
-    "shchupak": "Щупак",
-    "voron": "Ворон",
-    # #4593 wave-1 STEM authors (title-probed from source pages 2026-07-06)
-    "ryvkind": "Ривкінд",
-    "ister": "Істер",
-    "merzliak": "Мерзляк",
-    "zadorozhnyi": "Задорожний",
-    "bariakhtar": "Бар'яхтар",
-    "hryhorovych": "Григорович",
-    "popel": "Попель",
-    "anderson": "Андерсон",
-    "pryshliak": "Пришляк",
-    "krupska": "Крупська",
-    "lukianchykov": "Лук'янчиков",
-    "narovlianskyi": "Наровлянський",
-    "fuka": "Фука",
-    "komarovska": "Комаровська",
-    "masol": "Масол",
-    "zapotockyi": "Запотоцький",
-    "hilberh": "Гільберг",
-    # Non-textbook author-name strings already stored in Latin/English on
-    # ingestion (literary works, podcast, style-guide author). Map them
-    # to Cyrillic so author_uk is uniformly Cyrillic when populated.
-    "Anna Ohoiko": "Анна Огоїко",
-    "Borys Antonenko-Davydovych": "Борис Антоненко-Давидович",
-    "Mykola Pohribnyi": "Микола Погрібний",
-    "Ukrainian Lessons Podcast": "Ukrainian Lessons Podcast",
-}
+# Mapping moved to scripts/wiki/textbook_subjects.py::AUTHOR_UK_BY_TRANSLIT
+# (single source of truth; PR #4650). Kept as an alias for this module's
+# internal call sites and any external importers.
+_LATIN_TO_UK: dict[str, str] = AUTHOR_UK_BY_TRANSLIT
 
 
 def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:

--- a/scripts/wiki/textbook_subjects.py
+++ b/scripts/wiki/textbook_subjects.py
@@ -252,3 +252,76 @@ def subject_for_source_file(source_file: str) -> str | None:
         if any(token in key for token in tokens):
             return subject
     return None
+
+# Canonical Cyrillic author forms keyed by the Latin transliteration used
+# in source_file slugs. SINGLE SOURCE OF TRUTH (PR #4650 refactor): the
+# 2026-05-15 author_uk migration and scripts/ingest/incremental_textbook_ingest.py
+# both import THIS map — never grow a parallel copy again (the dual-map drift
+# bit the batch-2 ingest: 'gisem' existed here-adjacent but not in the tool's
+# local dict). Every value must be title-probed or front-matter-verified.
+AUTHOR_UK_BY_TRANSLIT: dict[str, str] = {
+    # Core mova/lit textbook authors (originally in TRANSLITS)
+    "karaman": "Караман",
+    "zakhariychuk": "Захарійчук",
+    "zaharijchuk": "Захарійчук",
+    "zahariichuk": "Захарійчук",
+    "kravcova": "Кравцова",
+    "kravtsova": "Кравцова",
+    "avramenko": "Авраменко",
+    "glazova": "Глазова",
+    "hlazova": "Глазова",
+    "zabolotnyi": "Заболотний",
+    "zabolotnij": "Заболотний",
+    "zakharchuk": "Захарчук",
+    "vashulenko": "Вашуленко",
+    "bolshakova": "Большакова",
+    "mishhenko": "Міщенко",
+    "mishchenko": "Міщенко",
+    "litvinova": "Літвінова",
+    "golub": "Голуб",
+    "varzatska": "Варзацька",
+    "ponomarova": "Пономарова",
+    # Additional textbook authors present in the corpus
+    "borzenko": "Борзенко",
+    "burnejko": "Бурнейко",
+    "galimov": "Галімов",
+    "gisem": "Гісем",
+    # Хлібовська: front-matter of 7-klas/8-klas/11-klas history textbooks
+    # confirms Х (Kh), not Г — the Latin transliteration here is unusual
+    # (h→Х instead of the more common h→Г). Verified via in-corpus
+    # textbook front-matter (2026-05-15 audit).
+    "hlibovska": "Хлібовська",
+    "kovalenko": "Коваленко",
+    "onatiy": "Онатій",
+    "pometun": "Пометун",
+    "savchenko": "Савченко",
+    "savchuk": "Савчук",
+    "schupak": "Щупак",
+    "shchupak": "Щупак",
+    "voron": "Ворон",
+    # #4593 wave-1 STEM authors (title-probed from source pages 2026-07-06)
+    "ryvkind": "Ривкінд",
+    "ister": "Істер",
+    "merzliak": "Мерзляк",
+    "zadorozhnyi": "Задорожний",
+    "bariakhtar": "Бар'яхтар",
+    "hryhorovych": "Григорович",
+    "popel": "Попель",
+    "anderson": "Андерсон",
+    "pryshliak": "Пришляк",
+    "krupska": "Крупська",
+    "lukianchykov": "Лук'янчиков",
+    "narovlianskyi": "Наровлянський",
+    "fuka": "Фука",
+    "komarovska": "Комаровська",
+    "masol": "Масол",
+    "zapotockyi": "Запотоцький",
+    "hilberh": "Гільберг",
+    # Non-textbook author-name strings already stored in Latin/English on
+    # ingestion (literary works, podcast, style-guide author). Map them
+    # to Cyrillic so author_uk is uniformly Cyrillic when populated.
+    "Anna Ohoiko": "Анна Огоїко",
+    "Borys Antonenko-Davydovych": "Борис Антоненко-Давидович",
+    "Mykola Pohribnyi": "Микола Погрібний",
+    "Ukrainian Lessons Podcast": "Ukrainian Lessons Podcast",
+}

--- a/tests/test_textbook_subjects.py
+++ b/tests/test_textbook_subjects.py
@@ -219,3 +219,15 @@ def test_batch2_slugs_resolve_to_new_canonical_subjects() -> None:
     for slug, expected in BATCH2_SOURCE_FILES.items():
         assert subject_for_source_file(slug) == expected, slug
         assert expected in CANONICAL_TEXTBOOK_SUBJECTS
+
+
+def test_author_map_single_source_and_batch2_authors_present() -> None:
+    """PR #4650: the dual-map drift class is dead — migration and ingest tool
+    must alias the canonical map, and every batch-1/2 slug author resolves."""
+    from scripts.ingest.incremental_textbook_ingest import AUTHOR_UK, WAVE1_SLUGS
+    from scripts.wiki.textbook_subjects import AUTHOR_UK_BY_TRANSLIT
+
+    assert AUTHOR_UK == AUTHOR_UK_BY_TRANSLIT
+    for slug in list(WAVE1_SLUGS) + list(BATCH2_SOURCE_FILES):
+        author = slug.split("-")[-2]
+        assert author in AUTHOR_UK_BY_TRANSLIT, slug


### PR DESCRIPTION
Batch-2 ingest dry-run was correctly REFUSED by the author_uk strictness gate: 'gisem' was in the migration's map but not the ingest tool's parallel dict — the dual-map design drifting exactly as dual maps do. Root fix instead of a third patch: canonical map moved to `wiki.textbook_subjects.AUTHOR_UK_BY_TRANSLIT`; migration + ingest tool alias it; pin-test asserts equality and that every batch-1/2 slug author resolves. Zero DB writes happened (fail-fast worked as designed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)