### PR TITLE
BIO Ukrainian-only readings batch 47

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/bohdan-rubchak.yaml
+++ b/curriculum/l2-uk-en/plans/bio/bohdan-rubchak.yaml
@@ -108,6 +108,19 @@ persona:
     вільної української науки, уникаючи як радянського стирання, так і глорифікації.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: istpravda.com.ua
+  language: uk
+  note: Короткий некролог із викладом біографічних фактів та значення постаті.
+  role: biography-overview
+  source: 'In memoriam. Помер Богдан Рубчак (Історична правда)'
+  url: https://www.istpravda.com.ua/short/2018/09/24/152978/
+- hosting: ukrlit.net
+  language: uk
+  note: Оглядова стаття про поетику та наукову спадщину Рубчака, придатна для читання уривками.
+  role: literary-analysis
+  source: 'Поезія української діаспори: Богдан Рубчак (ukrlit.net)'
+  url: https://ukrlit.net/info/diaspora/27.html
 references:
 - note: Internet Encyclopedia of Ukraine; біографія, дати, доробок.
   path: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CU%5CRubchakBohdan.htm
@@ -138,7 +151,7 @@ sequence: 241
 slug: bohdan-rubchak
 subtitle: The Poet-Scholar Who Theorised Ukrainian Modernism in Exile
 title: 'Богдан Рубчак: Поет і вчений Нью-Йоркської групи'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: сукупність мистецьких напрямів XX століття, що поривали з традиційними формами на
     користь експерименту

--- a/curriculum/l2-uk-en/plans/bio/dmytro-chyzhevskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/dmytro-chyzhevskyi.yaml
@@ -108,6 +108,18 @@ persona:
     і бездумної глорифікації.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: history.org.ua
+  language: uk
+  note: Фундаментальна стаття про життя і діяльність ученого (Енциклопедія історії України).
+  role: encyclopedia
+  source: 'Чижевський Дмитро Іванович (ЕІУ)'
+  url: http://history.org.ua/?termin=Chyzhevskyj_D
+- hosting: reading-needed
+  language: uk
+  note: Уривок із праці «Український літературний барок» або спогадів про нього для прямого читання.
+  role: primary-excerpt
+  source: 'reading-needed: уривок з праць або листів Д. Чижевського'
 references:
 - title: Chyzhevsky, Dmytro
   note: Основна англомовна енциклопедична стаття про життя та науковий доробок.
@@ -131,7 +143,7 @@ sequence: 244
 slug: dmytro-chyzhevskyi
 subtitle: The Emigré Scholar Who Returned Ukrainian Literature to Europe
 title: 'Дмитро Чижевський: Філософ українського бароко'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: стиль у європейському мистецтві кінця XVI — середини XVIII століття, якому властиві складність,
     контрастність та теоцентризм

--- a/curriculum/l2-uk-en/plans/bio/oleksa-voropai.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oleksa-voropai.yaml
@@ -76,6 +76,29 @@ persona:
     Модератор семінару, який досліджує інтелектуальну історію, уникаючи як радянського стирання, так і бездумної глорифікації.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: esu.com.ua
+  language: uk
+  note: Короткий життєпис етнографа та огляд його основних праць.
+  role: encyclopedia
+  source: 'Воропай Олекса (ЕСУ)'
+  url: https://esu.com.ua/article-29877
+- hosting: vue.gov.ua
+  language: uk
+  note: Велика енциклопедична стаття (Велика українська енциклопедія) про життєвий шлях.
+  role: encyclopedia
+  source: 'Воропай, Олекса Іванович (ВУЕ)'
+  url: https://vue.gov.ua/Воропай,_Олекса_Іванович
+- hosting: reading-needed
+  language: uk
+  note: Біографічний нарис про життя і діяльність О. Воропая у Великій Британії.
+  role: biography-overview
+  source: 'reading-needed: Олекса Воропай (Українці у Сполученому Королівстві)'
+- hosting: reading-needed
+  language: uk
+  note: Уривок із переднього слова до книги «Звичаї нашого народу» для аналізу ідей про мову та звичаї.
+  role: primary-excerpt
+  source: 'reading-needed: передмова до книги «Звичаї нашого народу»'
 references:
 - note: Канонічна стаття ВУЕ.
   path: https://vue.gov.ua/Воропай,_Олекса_Іванович
@@ -102,7 +125,7 @@ sequence: 246
 slug: oleksa-voropai
 subtitle: The Ethnographer Who Preserved Ukrainian Village Life in Exile
 title: 'Олекса Воропай: Звичаї нашого народу у еміграції'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: народний обряд або звичай
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/omelian-pritsak.yaml
+++ b/curriculum/l2-uk-en/plans/bio/omelian-pritsak.yaml
@@ -77,6 +77,23 @@ persona:
     Модератор семінару, який досліджує інтелектуальну історію, уникаючи як радянського стирання, так і бездумної глорифікації.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: esu.com.ua
+  language: uk
+  note: Енциклопедична стаття про кар'єру та науковий доробок історика.
+  role: encyclopedia
+  source: 'Пріцак Омелян Йосипович (ЕСУ)'
+  url: https://esu.com.ua/article-885199
+- hosting: reading-needed
+  language: uk
+  note: Розгорнута публіцистична стаття про створення Гарвардського інституту українознавства.
+  role: historical-longform
+  source: 'reading-needed: «Гарвардське диво» (babel.ua)'
+- hosting: reading-needed
+  language: uk
+  note: Біографічний нарис про складний шлях Пріцака та його роль у відновленні спадщини Кримського.
+  role: biography-overview
+  source: 'reading-needed: Омелян Пріцак — історик модерної України'
 references:
 - note: Енциклопедічна стаття ЕСУ.
   path: https://esu.com.ua/article-885199
@@ -111,7 +128,7 @@ sequence: 243
 slug: omelian-pritsak
 subtitle: The Harvard Historian Who Built Ukrainian Studies in America
 title: 'Омелян Пріцак: Гарвардське диво українських студій'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: галуз науки про Схід та Туркичних народів
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/vira-vovk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/vira-vovk.yaml
@@ -84,6 +84,24 @@ persona:
     Модератор семінару, який досліджує діаспорну поезію та переклад як інструмент культурної суб'єктності, уникаючи як радянського стирання, так і бездумної глорифікації.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: esu.com.ua
+  language: uk
+  note: Офіційна енциклопедична довідка про життєвий шлях і творчість.
+  role: encyclopedia
+  source: 'Вовк Віра (ЕСУ)'
+  url: https://esu.com.ua/article-35205
+- hosting: zbruc.eu
+  language: uk
+  note: Стаття з нагоди смерті письменниці з оцінкою її внеску в культуру.
+  role: obituary-reflection
+  source: 'Померла Віра Вовк (1926–2022) (Збруч)'
+  url: https://zbruc.eu/node/112524
+- hosting: reading-needed
+  language: uk
+  note: Розгорнута стаття-портрет про зв'язок поетки з Бразилією та Україною.
+  role: longform-profile
+  source: 'reading-needed: Віра Вовк (Читомо)'
 references:
 - note: Життєпис, членство в УВАН/НТШ, премії, переклади.
   path: https://esu.com.ua/article-35205
@@ -114,7 +132,7 @@ sequence: 242
 slug: vira-vovk
 subtitle: The Diaspora Poet-Translator Who Built Ukrainian Literature in Brazil
 title: 'Віра Вовк: Поезія та переклад між Бразилією і Україною'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: розселення народу за межами історичної батьківщини
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/yurii-lavrynenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yurii-lavrynenko.yaml
@@ -76,6 +76,24 @@ persona:
     Модератор семінару, який досліджує інтелектуальну історію, уникаючи як радянського стирання, так і бездумної глорифікації.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: esu.com.ua
+  language: uk
+  note: Академічна довідка про життєвий шлях критика та історію створення антології.
+  role: encyclopedia
+  source: 'Лавріненко Юрій Андріянович (ЕСУ)'
+  url: https://esu.com.ua/article-52788
+- hosting: nibu.kyiv.ua
+  language: uk
+  note: Матеріали виставки Національної історичної бібліотеки України, присвячені життю і діяльності.
+  role: exhibition-materials
+  source: 'Лавріненко Юрій Андріянович (НІБУ)'
+  url: https://nibu.kyiv.ua/exhibitions/839/
+- hosting: reading-needed
+  language: uk
+  note: Передмова або уривок з антології «Розстріляне відродження» для прямого читання.
+  role: primary-excerpt
+  source: 'reading-needed: уривок з передмови до антології «Розстріляне відродження»'
 references:
 - note: Канонічне ім'я, арешт 1933 року.
   path: https://esu.com.ua/article-52788
@@ -102,7 +120,7 @@ sequence: 245
 slug: yurii-lavrynenko
 subtitle: The Editor Who Named the Executed Renaissance
 title: 'Юрій Лавріненко: Антологія Розстріляного відродження'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: покоління 1920-х рр., знищене репресіями
   pos: ч.


### PR DESCRIPTION
Adds Ukrainian-only reading packets to six BIO diaspora scholarship plans.

Changed slugs:
- `bohdan-rubchak`
- `vira-vovk`
- `omelian-pritsak`
- `dmytro-chyzhevskyi`
- `yurii-lavrynenko`
- `oleksa-voropai`

Source/hosting posture:
- Uses Ukrainian-only `readings:` items in the top-level plan YAML blocks.
- Uses stable Ukrainian source URLs where available.
- Marks pedagogically useful but not-yet-hostable or not-yet-verified reading material as `reading-needed` instead of fabricating URLs.
- Leaves `wiki/figures/*.sources.yaml` untouched; those remain citation-only.

Deterministic worker checks reported:
- YAML parse passed with `.venv/bin/python`.
- Reading language/url validation passed.
- `git diff --check` passed.
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` passed.

LLM-QG and Gemma/OpenRouter were not used.
