### PR TITLE
BIO Ukrainian-only readings batch 48

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/maksym-rylskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/maksym-rylskyi.yaml
@@ -143,6 +143,17 @@ persona:
     нагляд без замовчування вимушених компромісів.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: reading-needed
+  language: uk
+  note: Біографічний або історичний контекст потребує стабільного посилання (наприклад, стаття в ЕІУ).
+  role: reading-needed
+  source: 'reading-needed: контекст (біографія)'
+- hosting: reading-needed
+  language: uk
+  note: Первинний текст (напр., неокласичні поезії) потребує перевірки на вільні ліцензії та стабільний хостинг.
+  role: reading-needed
+  source: 'reading-needed: первинний текст'
 references:
 - title: Рильський Максим Тадейович
   note: Енциклопедія Сучасної України; основні факти життя, освіти й доробку.
@@ -169,7 +180,7 @@ sequence: 248
 slug: maksym-rylskyi
 subtitle: The Neoclassicist Who Preserved Balance Under Surveillance
 title: 'Максим Рильський: Неокласик під справою "Ставка"'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: >-
     напрям української поезії 1920-х років, що поєднував класичну форму,

--- a/curriculum/l2-uk-en/plans/bio/mykola-bazhan.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykola-bazhan.yaml
@@ -130,6 +130,16 @@ persona:
     спрощеного засудження.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- language: uk
+  note: Енциклопедія Сучасної України; стаття про життя, творчість та архівні матеріали. Джерело стабільне.
+  role: context
+  source: 'https://esu.com.ua/article-38786'
+- hosting: reading-needed
+  language: uk
+  note: Первинний текст (напр., поезія з ранніх збірок) потребує перевірки на вільні ліцензії.
+  role: reading-needed
+  source: 'reading-needed: первинний текст'
 references:
 - note: Основна стаття про життя, творчість та архівні матеріали про справу НКВС.
   path: https://esu.com.ua/article-38786
@@ -157,7 +167,7 @@ sequence: 252
 slug: mykola-bazhan
 subtitle: The Avant-Garde Poet Broken and Co-opted by the Regime
 title: 'Микола Бажан: Будівлі духу й покара славою'
-version: '1.0'
+version: '1.1'
 vocabulary_hints:
 - definition: митець, що творить поезію
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/ostap-vyshnia.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ostap-vyshnia.yaml
@@ -131,6 +131,16 @@ persona:
     демонізації.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- language: uk
+  note: Енциклопедія Сучасної України; основна стаття про життя та творчість письменника. Джерело стабільне.
+  role: context
+  source: 'https://esu.com.ua/article-34351'
+- hosting: reading-needed
+  language: uk
+  note: Первинний текст (напр., "Моя автобіографія" або усмішки) потребує перевірки на вільні ліцензії.
+  role: reading-needed
+  source: 'reading-needed: первинний текст'
 references:
 - note: Основна стаття про життя та творчість письменника.
   path: https://esu.com.ua/article-34351
@@ -157,7 +167,7 @@ sequence: 251
 slug: ostap-vyshnia
 subtitle: The King of Satire Broken and Weaponized by the Terror
 title: 'Остап Вишня: Усмішка крізь сльози'
-version: '1.0'
+version: '1.1'
 vocabulary_hints:
 - definition: короткий гумористично-сатиричний прозовий твір; жанр, який Остап Вишня запровадив замість іншомовного «фейлетон»
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/pavlo-tychyna.yaml
+++ b/curriculum/l2-uk-en/plans/bio/pavlo-tychyna.yaml
@@ -147,6 +147,17 @@ persona:
     кооптацію культури і відповідальність митця під примусом.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: reading-needed
+  language: uk
+  note: Біографічний або історичний контекст потребує стабільного посилання (наприклад, стаття в ЕІУ).
+  role: reading-needed
+  source: 'reading-needed: контекст (біографія)'
+- hosting: reading-needed
+  language: uk
+  note: Первинний текст (напр., вірш "Ви знаєте, як липа шелестить") потребує перевірки на вільні ліцензії та стабільний хостинг.
+  role: reading-needed
+  source: 'reading-needed: первинний текст'
 references:
 - title: Тичина Павло Григорович
   note: Енциклопедія Сучасної України; основні факти життя, освіти й доробку.
@@ -173,7 +184,7 @@ sequence: 247
 slug: pavlo-tychyna
 subtitle: The Poet Broken by Glory
 title: 'Павло Тичина: "Соняшні кларнети" і покара славою'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: сукупність мистецьких течій кінця XIX і початку XX століття, що шукали нових форм для сучасного досвіду
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/volodymyr-sosiura.yaml
+++ b/curriculum/l2-uk-en/plans/bio/volodymyr-sosiura.yaml
@@ -143,6 +143,16 @@ persona:
     радянську цензуру з увагою до біографічної суперечності.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- language: uk
+  note: Енциклопедія Сучасної України; стаття про життя та творчість. Джерело стабільне.
+  role: context
+  source: 'https://esu.com.ua/article-889403'
+- hosting: reading-needed
+  language: uk
+  note: Первинний текст (напр., вірш "Любіть Україну!") потребує перевірки на вільні ліцензії та стабільний хостинг.
+  role: reading-needed
+  source: 'reading-needed: первинний текст'
 references:
 - note: Основна енциклопедична стаття про життя, твори, архіви та пізні видання.
   path: https://esu.com.ua/article-889403
@@ -170,7 +180,7 @@ sequence: 249
 slug: volodymyr-sosiura
 subtitle: The Lyric Poet Accused for Loving Ukraine
 title: 'Володимир Сосюра: "Любіть Україну!" під цензурою'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: рід поезії, у якому переважає особисте почуття, переживання й внутрішній голос
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/yurii-yanovskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yurii-yanovskyi.yaml
@@ -148,6 +148,16 @@ persona:
     прозі та насильницьке редагування літературної пам'яті.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- language: uk
+  note: Енциклопедія історії України; біографічна стаття. Джерело стабільне.
+  role: context
+  source: 'http://www.history.org.ua/?termin=Yanovsky_Yu_I'
+- hosting: reading-needed
+  language: uk
+  note: Первинний текст (напр., уривки з "Вершників" або "Майстра корабля") потребує перевірки на вільні ліцензії.
+  role: reading-needed
+  source: 'reading-needed: первинний текст'
 references:
 - note: Енциклопедія історії України; основна стаття з біографічними фактами й уточненням місця народження.
   path: http://www.history.org.ua/?termin=Yanovsky_Yu_I
@@ -177,7 +187,7 @@ sequence: 250
 slug: yurii-yanovskyi
 subtitle: The Neoromantic Broken by Censorship
 title: 'Юрій Яновський: "Жива вода" під батогом цензури'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: мистецький напрям, що оновлює романтичну піднесеність, міф і сильний образ у модерній формі
   pos: ч.


### PR DESCRIPTION
Adds Ukrainian-only learner reading packets for Pavlo Tychyna, Maksym Rylskyi, Volodymyr Sosiura, Yurii Yanovskyi, Ostap Vyshnia, and Mykola Bazhan.

Scope:
- Top-level plan YAML readings blocks only.
- Six owned BIO plan files.
- No wiki/source packets, generated status/audit/review artifacts, linter configs, telemetry, LLM-QG, or Gemma.

Worker verification reported:
- git diff --check
- YAML parse of edited plans
- Owned-file diff check

Required before merge:
- GitHub checks green.
- Independent non-AGY/non-Gemini review.

X-Agent: agy/bio-readings-soviet-canon-batch-48-agy