### PR TITLE
BIO Ukrainian-only readings batch 49

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/hryhir-tiutiunnyk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/hryhir-tiutiunnyk.yaml
@@ -112,6 +112,22 @@ persona:
     радянських ярликів і не вигадує арешт.
   voice: Rural Novella Historian
 phase: BIO
+readings:
+- hosting: resource.history.org.ua
+  language: uk
+  note: Енциклопедична стаття про життя і творчість Тютюнника.
+  role: context
+  source: https://history.org.ua/?termin=Tiutiunnyk_H_M
+- hosting: uhb.chl.kiev.ua
+  language: uk
+  note: Довідка для дитячої літератури та бібліографія.
+  role: context
+  source: https://uhb.chl.kiev.ua/autors/338-hryhir-hryhorii-mykhailovych-tiutiunnyk
+- hosting: reading-needed
+  language: uk
+  note: 'reading-needed: verify stable ukrainian hosting for "Три зозулі з поклоном".'
+  role: reading-needed
+  source: 'reading-needed: hryhir-tiutiunnyk-primary'
 references:
 - note: Базова англомовна енциклопедична стаття про життя і творчість.
   path: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CT%5CI%5CTiutiunnykHryhir.htm
@@ -132,7 +148,7 @@ sequence: 258
 slug: hryhir-tiutiunnyk
 subtitle: Rural Novellas, Censorship Pressure, and No Fabricated Arrest
 title: 'Григір Тютюнник: новела почуття під тиском цензури'
-version: '1.0'
+version: '1.1'
 vocabulary_hints:
 - definition: короткий прозовий твір з щільною психологічною драмою
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/ivan-svitlychnyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-svitlychnyi.yaml
@@ -116,6 +116,22 @@ persona:
     документи судового переслідування.
   voice: Samvydav Network Historian
 phase: BIO
+readings:
+- hosting: museum-old.khpg.org
+  language: uk
+  note: Профіль у віртуальному музеї дисидентського руху; деталі суду й таборів.
+  role: context
+  source: https://museum-old.khpg.org/1113995279
+- hosting: nbuv.gov.ua
+  language: uk
+  note: Ювілейна довідка Національної бібліотеки України.
+  role: context
+  source: https://www.nbuv.gov.ua/node/4288
+- hosting: reading-needed
+  language: uk
+  note: 'reading-needed: verify stable ukrainian hosting for primary text "Серце для куль і для рим".'
+  role: reading-needed
+  source: 'reading-needed: ivan-svitlychnyi-primary'
 references:
 - note: Базова англомовна енциклопедична стаття про життя і діяльність.
   path: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CV%5CSvitlychnyIvan.htm
@@ -137,7 +153,7 @@ sequence: 257
 slug: ivan-svitlychnyi
 subtitle: Literary Critic, Samvydav Hub, and the Dobosh Case
 title: 'Іван Світличний: самвидав, табори й ціна слова'
-version: '1.0'
+version: '1.1'
 vocabulary_hints:
 - definition: самостійне або підпільне видання заборонених текстів
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/mykola-rudenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykola-rudenko.yaml
@@ -112,6 +112,17 @@ persona:
     судового переслідування.
   voice: Human Rights Historian
 phase: BIO
+readings:
+- hosting: museum.khpg.org
+  language: uk
+  note: Профіль у музеї-архіві дисидентського руху.
+  role: context
+  source: https://museum.khpg.org/1113912354
+- hosting: reading-needed
+  language: uk
+  note: 'reading-needed: verify stable ukrainian hosting for primary text "Енергія прогресу" або "Хрест".'
+  role: reading-needed
+  source: 'reading-needed: mykola-rudenko-primary'
 references:
 - note: Базова енциклопедична стаття про життя і діяльність.
   title: Руденко Микола Данилович (ЕІУ)
@@ -135,7 +146,7 @@ sequence: 256
 slug: mykola-rudenko
 subtitle: From Stalinist Loyalist to Founder of the Ukrainian Helsinki Group
 title: 'Микола Руденко: самвидав, УГГ і ціна правди'
-version: '1.0'
+version: '1.1'
 vocabulary_hints:
 - definition: людина, яка захищає права людини в умовах переслідування
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/oleksandr-kovinka.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oleksandr-kovinka.yaml
@@ -129,6 +129,17 @@ persona:
     митця.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: reading-needed
+  language: uk
+  note: 'reading-needed: verify ESU URL for Kovinka or another stable bio source.'
+  role: reading-needed
+  source: 'reading-needed: oleksandr-kovinka-context'
+- hosting: reading-needed
+  language: uk
+  note: 'reading-needed: verify stable ukrainian hosting for primary text "Як мене купали й сповивали".'
+  role: reading-needed
+  source: 'reading-needed: oleksandr-kovinka-primary'
 references:
 - note: Основна стаття про життя, репресії та творчість письменника.
   title: Ковінька Олександр Іванович (Енциклопедія Сучасної України)
@@ -154,7 +165,7 @@ sequence: 254
 slug: oleksandr-kovinka
 subtitle: The Humorist Who Survived Twenty-One Years in the Camps
 title: 'Олександр Ковінька: Гумор, що пережив Магадан'
-version: '1.0'
+version: '1.1'
 vocabulary_hints:
 - definition: невеликий гумористичний прозовий твір з добродушним, м'яким сміхом
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/yevhen-hutsalo.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yevhen-hutsalo.yaml
@@ -111,6 +111,17 @@ persona:
     радянських ярликів і шкільних спрощень.
   voice: Rural Prose Historian
 phase: BIO
+readings:
+- hosting: esu.com.ua
+  language: uk
+  note: Базова енциклопедична стаття про Гуцала (ЕСУ).
+  role: context
+  source: https://esu.com.ua/article-25016
+- hosting: reading-needed
+  language: uk
+  note: 'reading-needed: verify stable ukrainian hosting for excerpt of "Лось" or "Ментальність орди".'
+  role: reading-needed
+  source: 'reading-needed: yevhen-hutsalo-primary'
 references:
 - note: Дати, бібліографія, нагороди, освіта.
   path: https://esu.com.ua/article-25016
@@ -130,7 +141,7 @@ sequence: 255
 slug: yevhen-hutsalo
 subtitle: Lyrical Prose and Soviet Framing Without Imprisonment
 title: 'Євген Гуцало: сільська пам''ять і тихий тиск системи'
-version: '1.0'
+version: '1.1'
 vocabulary_hints:
 - definition: територія або установа, де охороняють природу й тваринний світ
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/zinaida-tulub.yaml
+++ b/curriculum/l2-uk-en/plans/bio/zinaida-tulub.yaml
@@ -130,6 +130,17 @@ persona:
     російському привласненню.
   voice: Intellectual Historian
 phase: BIO
+readings:
+- hosting: resource.history.org.ua
+  language: uk
+  note: Енциклопедична стаття про життя та репресії письменниці.
+  role: context
+  source: https://history.org.ua/?termin=Tulub_Z
+- hosting: reading-needed
+  language: uk
+  note: 'reading-needed: verify stable ukrainian hosting for primary text "Людолови" (або "В степу безкраїм за Уралом").'
+  role: reading-needed
+  source: 'reading-needed: zinaida-tulub-primary'
 references:
 - author: Г. Герасимова
   note: Енциклопедична стаття про життя та репресії письменниці.
@@ -156,7 +167,7 @@ sequence: 253
 slug: zinaida-tulub
 subtitle: The Historical Novelist Devoured by the Gulag
 title: 'Зінаїда Тулуб: Людолови історії'
-version: '1.0'
+version: '1.1'
 vocabulary_hints:
 - definition: великий за обсягом епічний прозовий твір зі складним сюжетом і багатьма персонажами
   pos: ч.


### PR DESCRIPTION
Adds Ukrainian-only learner reading packets for Zinaida Tulub, Oleksandr Kovinka, Yevhen Hutsalo, Mykola Rudenko, Ivan Svitlychnyi, and Hryhir Tiutiunnyk.

Scope:
- Top-level plan YAML readings blocks only.
- Six owned BIO plan files.
- No wiki/source packets, generated status/audit/review artifacts, linter configs, telemetry, LLM-QG, or Gemma.

Worker verification reported:
- git diff --check
- YAML parse of edited plans
- Owned-file diff check

Required before merge:
- GitHub checks green.
- Independent non-AGY/non-Gemini review.

X-Agent: agy/bio-readings-soviet-dissent-batch-49-agy