### PR TITLE
[codex] fix(practice): #4651 selector perf + seeded ordering + level-biased intro

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: d26ff768762dc73193d8249c7398bbbf752b8351ef2dacc1a2dc760e680582e8
+  components_sha256: 7906551b36edb49559e7956c6a73b7de240b601aa9de6af9102d17a9207b39bd
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -914,7 +914,11 @@ components:
     placement: n/a
     props:
       required: []
-      optional: []
+      optional:
+      - name: nonce
+        type: string
+        description: nonce prop.
+        ukrainian_text: 'false'
     nested_types: {}
     example: {}
     deprecated: false

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import { realpathSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, URL } from 'node:url';
 import { unified } from '@astrojs/markdown-remark';
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
@@ -21,8 +21,10 @@ const starlightRoot = fileURLToPath(new URL('.', import.meta.url));
 const starlightNodeModules = realpathSync(fileURLToPath(new URL('./node_modules', import.meta.url)));
 // Folk un-hidden 2026-06-14 for the preview/seminar-test launch (reverses
 // orchestrator #3027). Empty = nothing suppressed from public routing.
+/** @type {string[]} */
 const hiddenPublicPaths = [];
 
+/** @param {string} page */
 const isHiddenPublicPage = (page) => {
   const pathname = page.startsWith('http') ? new URL(page).pathname : page;
   return hiddenPublicPaths.some(
@@ -38,6 +40,7 @@ const redirects = {
   '/lexicon/practice': '/words-of-the-day/practice/',
 };
 
+/** @param {string} page */
 const isRedirectSource = (page) => {
   const pathname = page.startsWith('http') ? new URL(page).pathname : page;
   return Object.keys(redirects).some(

--- a/site/src/components/HashTabSync.tsx
+++ b/site/src/components/HashTabSync.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-export interface HashTabSyncProps {}
+export interface HashTabSyncProps {
+  nonce?: string;
+}
 
 type StarlightTabsElement = HTMLElement & {
   switchTab?: (tab: Element, index: number, animate?: boolean) => void;
@@ -15,11 +17,11 @@ declare global {
 export function installHashTabSync() {
   if (typeof window === 'undefined' || typeof document === 'undefined') return;
 
-  let originalHtmlOverflowAnchor;
-  let originalBodyOverflowAnchor;
-  let restoreOverflowAnchorTimer;
+  let originalHtmlOverflowAnchor: string | undefined;
+  let originalBodyOverflowAnchor: string | undefined;
+  let restoreOverflowAnchorTimer: number | undefined;
 
-  function currentHashId() {
+  function currentHashId(): string {
     try {
       return decodeURIComponent(window.location.hash.slice(1));
     } catch {
@@ -29,11 +31,11 @@ export function installHashTabSync() {
 
   const requestedHashId = currentHashId();
 
-  function isInternalTabHash(id) {
+  function isInternalTabHash(id: string): boolean {
     return /^tab-panel-\\d+$/.test(id);
   }
 
-  function targetHashId() {
+  function targetHashId(): string {
     const id = currentHashId();
     if (isInternalTabHash(id) && requestedHashId && !isInternalTabHash(requestedHashId)) {
       return requestedHashId;
@@ -41,7 +43,7 @@ export function installHashTabSync() {
     return id;
   }
 
-  function restoreRequestedHash(id) {
+  function restoreRequestedHash(id: string): void {
     if (!id || currentHashId() === id || !window.history || !window.history.replaceState) return;
     window.history.replaceState(null, '', '#' + encodeURIComponent(id));
   }
@@ -63,7 +65,7 @@ export function installHashTabSync() {
     if (typeof tabs.switchTab === 'function') {
       tabs.switchTab(tab, index, false);
     } else {
-      tab.click();
+      (tab as HTMLAnchorElement).click();
     }
   }
 
@@ -131,6 +133,6 @@ export function installHashTabSync() {
 
 const hashTabSyncScript = `(${installHashTabSync.toString()})();`;
 
-export default function HashTabSync(_props: HashTabSyncProps) {
-  return <script dangerouslySetInnerHTML={{ __html: hashTabSyncScript }} />;
+export default function HashTabSync({ nonce }: HashTabSyncProps) {
+  return <script nonce={nonce} dangerouslySetInnerHTML={{ __html: hashTabSyncScript }} />;
 }

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -10,6 +10,7 @@ import {
   masteredCount,
   rateCard,
   selectNextPracticeItem,
+  seededAnswerIndex,
   uaPlural,
   validateClozeOptions,
   type ChoicePolarity,
@@ -59,6 +60,10 @@ interface ClozeFeedback {
 
 const STREAK_KEY = 'lu-lexicon-practice-streak';
 const MASTERED_THRESHOLD = 21;
+
+function makePracticeSessionSeed(): number {
+  return (Date.now() ^ Math.floor(Math.random() * 4294967296)) >>> 0;
+}
 
 const RATING_LABELS: Record<PracticeRating, string> = {
   again: 'Ще раз',
@@ -446,6 +451,7 @@ function orderedChoiceOptions(
   selection: PracticeSelection,
   deck: PracticeDeckData,
   polarity: ChoicePolarity,
+  sessionSeed: number,
 ): ChoiceOption[] {
   if (!isMeaningMcEligible(selection.lemma)) return [];
   const distractors = meaningDistractors(selection.lemma, deck, 3);
@@ -458,7 +464,7 @@ function orderedChoiceOptions(
       correct: false,
     })),
   ];
-  const answerIndex = selection.itemId.length % options.length;
+  const answerIndex = seededAnswerIndex(sessionSeed, selection.itemId, options.length);
   const [first] = options.splice(0, 1);
   options.splice(answerIndex, 0, first);
   return options;
@@ -660,6 +666,7 @@ export default function LexiconPractice({
     return Boolean(normalized && normalized.cloze.length > 0);
   });
   const [started, setStarted] = useState(autoStart);
+  const [sessionSeed, setSessionSeed] = useState(() => makePracticeSessionSeed());
   const [mode, setMode] = useState<PracticeModeFilter>(initialMode);
   const [learnerLevel, setLearnerLevel] = useState<CefrLevel>(() =>
     readLearnerLevel(normalizeCefrLevel(deckLevel)),
@@ -738,8 +745,9 @@ export default function LexiconPractice({
       history,
       modeFilter: mode,
       now: new Date(),
+      sessionSeed,
     });
-  }, [deck, history, mode, revision]);
+  }, [deck, history, mode, revision, sessionSeed]);
 
   useEffect(() => {
     setAnswerLocked(false);
@@ -854,6 +862,7 @@ export default function LexiconPractice({
   async function start(nextMode: PracticeModeFilter = mode) {
     setMode(nextMode);
     setStarted(true);
+    setSessionSeed(makePracticeSessionSeed());
     await ensureDeck(shouldLoadCloze(nextMode));
   }
 
@@ -1141,6 +1150,7 @@ export default function LexiconPractice({
             <PracticeItem
               selection={selection}
               deck={deck}
+              sessionSeed={sessionSeed}
               answerLocked={answerLocked}
               clozeInput={clozeInput}
               clozeFeedback={clozeFeedback}
@@ -1169,6 +1179,7 @@ export default function LexiconPractice({
 function PracticeItem({
   selection,
   deck,
+  sessionSeed,
   answerLocked,
   clozeInput,
   clozeFeedback,
@@ -1180,6 +1191,7 @@ function PracticeItem({
 }: {
   selection: PracticeSelection;
   deck: PracticeDeckData;
+  sessionSeed: number;
   answerLocked: boolean;
   clozeInput: string;
   clozeFeedback: ClozeFeedback | null;
@@ -1267,7 +1279,7 @@ function PracticeItem({
     );
   }
 
-  const options = orderedChoiceOptions(selection, deck, selection.choicePolarity);
+  const options = orderedChoiceOptions(selection, deck, selection.choicePolarity, sessionSeed);
   if (!options.length) {
     return <p className="lexicon-practice-muted">Зараз немає карток для вибору відповіді.</p>;
   }

--- a/site/src/env.d.ts
+++ b/site/src/env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="astro/client" />
+
+declare module '*.astro' {
+  const Component: unknown;
+  export default Component;
+}

--- a/site/src/lib/lexicon/practice-api-shard.ts
+++ b/site/src/lib/lexicon/practice-api-shard.ts
@@ -56,7 +56,7 @@ export function practiceShardResponse(
     });
   }
 
-  return new Response(readPracticeShardBytes(kind, level), {
+  return new Response(new Uint8Array(readPracticeShardBytes(kind, level)), {
     headers: PRACTICE_API_JSON_HEADERS,
   });
 }

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -342,6 +342,7 @@ export interface SelectPracticeOptions {
   clozeSoftCap?: number;
   dueWindowMs?: number;
   wordRepeatWindow?: number;
+  sessionSeed?: number;
 }
 
 interface PersistedSrsSchemaV3 {
@@ -381,6 +382,39 @@ const RATING_TO_FSRS: Record<PracticeRating, Grade> = {
   good: Rating.Good,
   easy: Rating.Easy,
 };
+
+function hashString(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function mulberry32(seed: number): () => number {
+  let value = seed >>> 0;
+  return () => {
+    value = (value + 0x6d2b79f5) >>> 0;
+    let result = Math.imul(value ^ (value >>> 15), 1 | value);
+    result ^= result + Math.imul(result ^ (result >>> 7), 61 | result);
+    return ((result ^ (result >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function seededPracticeHash(sessionSeed: number | undefined, value: string): number {
+  const seed = (Number.isFinite(sessionSeed) ? sessionSeed : 0) as number;
+  return Math.floor(mulberry32((seed >>> 0) ^ hashString(value))() * 4294967296);
+}
+
+export function seededAnswerIndex(
+  sessionSeed: number | undefined,
+  itemId: string,
+  optionCount: number,
+): number {
+  if (optionCount <= 0) return 0;
+  return seededPracticeHash(sessionSeed, `choice:${itemId}`) % optionCount;
+}
 
 const memoryStore = new Map<string, string>();
 const memoryStorage: StorageLike = {
@@ -890,7 +924,21 @@ export function getDueQueue<T extends Pick<PracticeLexeme, 'lemmaId'> | Practice
     });
 }
 
-function deckMaps(deck: PracticeDeckData) {
+interface DeckMaps {
+  lexemes: Map<string, PracticeLexeme>;
+  cloze: Map<string, PracticeClozeItem>;
+  stress: Map<string, PracticeStressItem>;
+  classify: Map<string, PracticeClassifyItem>;
+  paradigm: Map<string, PracticeParadigmItem[]>;
+  synonym: Map<string, PracticeSynonymItem[]>;
+}
+
+const deckMapsCache = new WeakMap<PracticeDeckData, DeckMaps>();
+const staticCandidateCache = new WeakMap<PracticeDeckData, Map<PracticeModeFilter, PracticeSelection[]>>();
+
+function deckMaps(deck: PracticeDeckData): DeckMaps {
+  const cached = deckMapsCache.get(deck);
+  if (cached) return cached;
   const groupByLemma = <T extends { lemmaId: string }>(items: T[] | undefined) => {
     const grouped = new Map<string, T[]>();
     for (const item of items ?? []) {
@@ -900,7 +948,7 @@ function deckMaps(deck: PracticeDeckData) {
     }
     return grouped;
   };
-  return {
+  const maps = {
     lexemes: new Map(deck.lexemes.map((lexeme) => [lexeme.lemmaId, lexeme])),
     cloze: new Map(deck.cloze.map((item) => [item.clozeId, item])),
     stress: new Map((deck.stress ?? []).map((item) => [item.lemmaId, item])),
@@ -908,6 +956,8 @@ function deckMaps(deck: PracticeDeckData) {
     paradigm: groupByLemma(deck.paradigm),
     synonym: groupByLemma(deck.synonym),
   };
+  deckMapsCache.set(deck, maps);
+  return maps;
 }
 
 function recognitionMastered(
@@ -925,71 +975,107 @@ function makeItemId(lemmaId: string, mode: PracticeMode, clozeId?: string): stri
   return clozeId ? `${lemmaId}:${mode}:${clozeId}` : `${lemmaId}:${mode}`;
 }
 
-function directionFor(candidateKey: string, history: SelectionHistoryItem[]): RecallDirection {
-  const last = [...history].reverse().find((item) => item.recallDirection)?.recallDirection;
+function lastRecallDirection(history: SelectionHistoryItem[]): RecallDirection | undefined {
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const direction = history[index].recallDirection;
+    if (direction) return direction;
+  }
+  return undefined;
+}
+
+function directionFor(candidateKey: string, last: RecallDirection | undefined): RecallDirection {
   if (last === 'uk-to-meaning') return 'meaning-to-uk';
   if (last === 'meaning-to-uk') return 'uk-to-meaning';
   return candidateKey.length % 2 === 0 ? 'uk-to-meaning' : 'meaning-to-uk';
 }
 
-function polarityFor(candidateKey: string, history: SelectionHistoryItem[]): ChoicePolarity {
-  const last = [...history].reverse().find((item) => item.choicePolarity)?.choicePolarity;
+function lastChoicePolarity(history: SelectionHistoryItem[]): ChoicePolarity | undefined {
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const polarity = history[index].choicePolarity;
+    if (polarity) return polarity;
+  }
+  return undefined;
+}
+
+function polarityFor(candidateKey: string, last: ChoicePolarity | undefined): ChoicePolarity {
   if (last === 'word-to-meaning') return 'meaning-to-word';
   if (last === 'meaning-to-word') return 'word-to-meaning';
   return candidateKey.length % 2 === 0 ? 'word-to-meaning' : 'meaning-to-word';
 }
 
 function sessionCounts(history: SelectionHistoryItem[]): Record<PracticeMode, number> {
-  return PRACTICE_MODES.reduce(
-    (counts, mode) => {
-      counts[mode] = history.filter((item) => item.mode === mode).length;
-      return counts;
-    },
-    {} as Record<PracticeMode, number>,
-  );
+  const counts = Object.fromEntries(PRACTICE_MODES.map((mode) => [mode, 0])) as Record<PracticeMode, number>;
+  for (const item of history) {
+    counts[item.mode] += 1;
+  }
+  return counts;
+}
+
+interface CandidatePenaltyContext {
+  counts: Record<PracticeMode, number>;
+  availableModes: Set<PracticeMode>;
+  recent: SelectionHistoryItem[];
+  lastThreeModes: Set<PracticeMode>;
+  candidateCases: Set<string>;
+  recentCases: Set<string>;
+  last: SelectionHistoryItem | undefined;
+  expectedModeCount: number;
+}
+
+function candidatePenaltyContext(
+  candidates: PracticeSelection[],
+  history: SelectionHistoryItem[],
+): CandidatePenaltyContext {
+  const availableModes = new Set<PracticeMode>();
+  const candidateCases = new Set<string>();
+  for (const candidate of candidates) {
+    availableModes.add(candidate.mode);
+    if (candidate.cloze) candidateCases.add(candidate.cloze.blankCase);
+  }
+  const recent = history.slice(-12);
+  const recentCases = new Set<string>();
+  for (const item of history.slice(-8)) {
+    if (item.mode === 'cloze' && item.blankCase) recentCases.add(item.blankCase);
+  }
+  const total = Math.max(1, history.length);
+  return {
+    counts: sessionCounts(history),
+    availableModes,
+    recent,
+    lastThreeModes: new Set(history.slice(-3).map((item) => item.mode)),
+    candidateCases,
+    recentCases,
+    last: history.at(-1),
+    expectedModeCount: total / Math.max(1, availableModes.size),
+  };
 }
 
 function candidatePenalty(
   candidate: PracticeSelection,
-  candidates: PracticeSelection[],
-  history: SelectionHistoryItem[],
+  context: CandidatePenaltyContext,
+  historyLength: number,
   clozeSoftCap: number,
   nowTime: number,
 ): number {
   if (candidate.lapsed) return -100_000;
   let penalty = 0;
-  const recent = history.slice(-12);
-  const lastThreeModes = history.slice(-3).map((item) => item.mode);
-  if (lastThreeModes.includes(candidate.mode)) penalty += 18;
-  const counts = sessionCounts(history);
-  const availableModes = new Set(candidates.map((item) => item.mode));
-  if (history.length < 8 && !counts[candidate.mode] && availableModes.size > 1) {
+  if (context.lastThreeModes.has(candidate.mode)) penalty += 18;
+  if (historyLength < 8 && !context.counts[candidate.mode] && context.availableModes.size > 1) {
     penalty -= 45;
   }
-  const total = Math.max(1, history.length);
-  const expected = total / Math.max(1, availableModes.size);
-  penalty -= Math.max(0, expected - counts[candidate.mode]) * 3;
+  penalty -= Math.max(0, context.expectedModeCount - context.counts[candidate.mode]) * 3;
 
-  if (candidate.mode === 'cloze' && recent.length >= 4) {
-    const clozeRatio = recent.filter((item) => item.mode === 'cloze').length / recent.length;
+  if (candidate.mode === 'cloze' && context.recent.length >= 4) {
+    const clozeRatio =
+      context.recent.filter((item) => item.mode === 'cloze').length / context.recent.length;
     if (clozeRatio >= clozeSoftCap && candidate.due > nowTime) penalty += 35;
   }
 
   if (candidate.cloze) {
-    const candidateCases = new Set(
-      candidates.filter((item) => item.cloze).map((item) => item.cloze?.blankCase),
-    );
-    const recentCases = new Set(
-      history
-        .slice(-8)
-        .filter((item) => item.mode === 'cloze' && item.blankCase)
-        .map((item) => item.blankCase),
-    );
-    if (candidateCases.size >= 3 && recentCases.size < 3) {
-      penalty += recentCases.has(candidate.cloze.blankCase) ? 16 : -12;
+    if (context.candidateCases.size >= 3 && context.recentCases.size < 3) {
+      penalty += context.recentCases.has(candidate.cloze.blankCase) ? 16 : -12;
     }
-    const last = history.at(-1);
-    if (last?.sentenceFrameId === candidate.cloze.sentenceFrameId) penalty += 60;
+    if (context.last?.sentenceFrameId === candidate.cloze.sentenceFrameId) penalty += 60;
   }
   return penalty;
 }
@@ -1020,8 +1106,13 @@ function applySpacingFilters(
 
 function urgencyBucket(candidate: PracticeSelection, nowTime: number): number {
   if (candidate.lapsed) return -1_000_000_000;
-  if (!candidate.cardState) return 0;
+  if (!candidate.cardState) return 1;
   return Math.floor((candidate.due - nowTime) / HOUR_MS);
+}
+
+function levelMatchBias(candidate: PracticeSelection, deckLevel: string): number {
+  if (candidate.cardState) return 0;
+  return candidate.indexItem.cefr === deckLevel ? 0 : 1;
 }
 
 function rankCandidates(
@@ -1029,22 +1120,215 @@ function rankCandidates(
   history: SelectionHistoryItem[],
   clozeSoftCap: number,
   nowTime: number,
+  deckLevel: string,
+  sessionSeed: number | undefined,
 ): PracticeSelection | null {
   // Urgency is the PRIMARY sort key (lapsed first, then most-overdue); the soft
   // anti-monotony penalty is only a TIEBREAK within the same urgency bucket. Adding the
   // penalty to the urgency score (as before) let a +18–60 penalty leak across hour-buckets
   // and overtake a genuinely-more-due card — variety must never delay a due/lapsed card.
+  const context = candidatePenaltyContext(pool, history);
+  const ranked = pool.map((candidate) => ({
+    candidate,
+    urgency: urgencyBucket(candidate, nowTime),
+    penalty: candidatePenalty(candidate, context, history.length, clozeSoftCap, nowTime),
+    levelBias: levelMatchBias(candidate, deckLevel),
+    seedHash: seededPracticeHash(sessionSeed, candidate.itemId),
+  }));
   return (
-    [...pool].sort((left, right) => {
+    ranked.sort((left, right) => {
       return (
-        urgencyBucket(left, nowTime) - urgencyBucket(right, nowTime) ||
-        candidatePenalty(left, pool, history, clozeSoftCap, nowTime) -
-          candidatePenalty(right, pool, history, clozeSoftCap, nowTime) ||
-        left.indexItem.newOrder - right.indexItem.newOrder ||
-        left.itemId.localeCompare(right.itemId)
+        left.urgency - right.urgency ||
+        left.penalty - right.penalty ||
+        left.levelBias - right.levelBias ||
+        left.seedHash - right.seedHash ||
+        left.candidate.itemId.localeCompare(right.candidate.itemId)
       );
-    })[0] ?? null
+    })[0]?.candidate ?? null
   );
+}
+
+function cachedSelection(
+  selection: Omit<PracticeSelection, 'cardState' | 'due' | 'lapsed' | 'recallDirection' | 'choicePolarity'>,
+): PracticeSelection {
+  return {
+    ...selection,
+    cardState: null,
+    due: 0,
+    lapsed: false,
+    recallDirection: 'uk-to-meaning',
+    choicePolarity: 'word-to-meaning',
+  };
+}
+
+function selectionSnapshot(selection: PracticeSelection): PracticeSelection {
+  return { ...selection };
+}
+
+function buildStaticCandidates(deck: PracticeDeckData, modeFilter: PracticeModeFilter): PracticeSelection[] {
+  const maps = deckMaps(deck);
+  const candidates: PracticeSelection[] = [];
+
+  for (const indexItem of deck.index) {
+    const lemma = maps.lexemes.get(indexItem.lemmaId);
+    if (!lemma) continue;
+    const modes = indexItem.modes.filter(
+      (mode): mode is PracticeMode =>
+        isPracticeMode(mode) && (modeFilter === 'mixed' || mode === modeFilter),
+    );
+    for (const mode of modes) {
+      if (mode === 'cloze') {
+        for (const clozeId of indexItem.clozeIds) {
+          const cloze = maps.cloze.get(clozeId);
+          if (!cloze) continue;
+          const key = cardKey(indexItem.lemmaId, 'cloze');
+          candidates.push(
+            cachedSelection({
+              itemId: makeItemId(indexItem.lemmaId, mode, clozeId),
+              lemma,
+              indexItem,
+              mode,
+              cardKey: key,
+              cloze,
+            }),
+          );
+        }
+        continue;
+      }
+      if (mode === 'stress') {
+        const stress = maps.stress.get(indexItem.lemmaId);
+        if (!stress) continue;
+        const key = cardKey(indexItem.lemmaId, mode);
+        candidates.push(
+          cachedSelection({
+            itemId: makeItemId(indexItem.lemmaId, mode, stress.stressId),
+            lemma,
+            indexItem,
+            mode,
+            cardKey: key,
+            stress,
+          }),
+        );
+        continue;
+      }
+      if (mode === 'classify') {
+        const classify = maps.classify.get(indexItem.lemmaId);
+        if (!classify || classify.sets.length === 0) continue;
+        const key = cardKey(indexItem.lemmaId, mode);
+        for (const set of classify.sets) {
+          candidates.push(
+            cachedSelection({
+              itemId: makeItemId(indexItem.lemmaId, mode, `${classify.classifyId}:${set.setId}`),
+              lemma,
+              indexItem,
+              mode,
+              cardKey: key,
+              classify,
+              classifySetId: set.setId,
+            }),
+          );
+        }
+        continue;
+      }
+      if (mode === 'paradigm') {
+        const items = maps.paradigm.get(indexItem.lemmaId) ?? [];
+        for (const paradigm of items) {
+          const key = cardKey(indexItem.lemmaId, mode);
+          candidates.push(
+            cachedSelection({
+              itemId: makeItemId(indexItem.lemmaId, mode, paradigm.paradigmId),
+              lemma,
+              indexItem,
+              mode,
+              cardKey: key,
+              paradigm,
+            }),
+          );
+        }
+        continue;
+      }
+      if (mode === 'synonym') {
+        const items = maps.synonym.get(indexItem.lemmaId) ?? [];
+        for (const synonym of items) {
+          const key = cardKey(indexItem.lemmaId, mode);
+          candidates.push(
+            cachedSelection({
+              itemId: makeItemId(indexItem.lemmaId, mode, synonym.synonymId),
+              lemma,
+              indexItem,
+              mode,
+              cardKey: key,
+              synonym,
+            }),
+          );
+        }
+        continue;
+      }
+      if (mode === 'heritage' || mode === 'paronym') {
+        continue;
+      }
+      const key = cardKey(indexItem.lemmaId, mode);
+      candidates.push(
+        cachedSelection({
+          itemId: makeItemId(indexItem.lemmaId, mode),
+          lemma,
+          indexItem,
+          mode,
+          cardKey: key,
+        }),
+      );
+    }
+  }
+
+  return candidates;
+}
+
+function staticCandidatesFor(deck: PracticeDeckData, modeFilter: PracticeModeFilter): PracticeSelection[] {
+  let byMode = staticCandidateCache.get(deck);
+  if (!byMode) {
+    byMode = new Map();
+    staticCandidateCache.set(deck, byMode);
+  }
+  const cached = byMode.get(modeFilter);
+  if (cached) return cached;
+  const candidates = buildStaticCandidates(deck, modeFilter);
+  byMode.set(modeFilter, candidates);
+  return candidates;
+}
+
+function refreshedCandidates(
+  deck: PracticeDeckData,
+  state: LoadedSrsState,
+  history: SelectionHistoryItem[],
+  modeFilter: PracticeModeFilter,
+  minRecognitionStability: number,
+  nowTime: number,
+): PracticeSelection[] {
+  const candidates: PracticeSelection[] = [];
+  const staticCandidates = staticCandidatesFor(deck, modeFilter);
+  const clozeRecognition = new Map<string, boolean>();
+  const recallDirection = lastRecallDirection(history);
+  const choicePolarity = lastChoicePolarity(history);
+
+  for (const candidate of staticCandidates) {
+    if (candidate.mode === 'cloze' && modeFilter !== 'cloze') {
+      let mastered = clozeRecognition.get(candidate.indexItem.lemmaId);
+      if (mastered === undefined) {
+        mastered = recognitionMastered(candidate.indexItem.lemmaId, state, minRecognitionStability);
+        clozeRecognition.set(candidate.indexItem.lemmaId, mastered);
+      }
+      if (!mastered) continue;
+    }
+    const card = state.cards.get(candidate.cardKey) ?? null;
+    candidate.cardState = card;
+    candidate.due = card?.due ?? 0;
+    candidate.lapsed = Boolean(card && card.lapses > 0 && card.due <= nowTime);
+    candidate.recallDirection = directionFor(candidate.cardKey, recallDirection);
+    candidate.choicePolarity = polarityFor(candidate.cardKey, choicePolarity);
+    candidates.push(candidate);
+  }
+
+  return candidates;
 }
 
 export function selectNextPracticeItem(
@@ -1058,149 +1342,18 @@ export function selectNextPracticeItem(
   const minRecognitionStability = options.minRecognitionStability ?? DEFAULT_RECOGNITION_STABILITY;
   const clozeSoftCap = options.clozeSoftCap ?? 0.25;
   const dueWindowMs = options.dueWindowMs ?? 0;
-  const wordRepeatWindow = Math.max(MIN_WORD_REPEAT_WINDOW, options.wordRepeatWindow ?? MIN_WORD_REPEAT_WINDOW);
-  const maps = deckMaps(deck);
-  const candidates: PracticeSelection[] = [];
-
-  for (const indexItem of deck.index) {
-    const lemma = maps.lexemes.get(indexItem.lemmaId);
-    if (!lemma) continue;
-    const modes = indexItem.modes.filter(
-      (mode): mode is PracticeMode =>
-        isPracticeMode(mode) && (modeFilter === 'mixed' || mode === modeFilter),
-    );
-    for (const mode of modes) {
-      if (mode === 'cloze') {
-        if (
-          modeFilter !== 'cloze' &&
-          !recognitionMastered(indexItem.lemmaId, state, minRecognitionStability)
-        )
-          continue;
-        for (const clozeId of indexItem.clozeIds) {
-          const cloze = maps.cloze.get(clozeId);
-          if (!cloze) continue;
-          const key = cardKey(indexItem.lemmaId, 'cloze');
-          const card = state.cards.get(key) ?? null;
-          candidates.push({
-            itemId: makeItemId(indexItem.lemmaId, mode, clozeId),
-            lemma,
-            indexItem,
-            mode,
-            cardKey: key,
-            cardState: card,
-            due: card?.due ?? 0,
-            lapsed: Boolean(card && card.lapses > 0 && card.due <= nowTime),
-            cloze,
-            recallDirection: directionFor(key, history),
-            choicePolarity: polarityFor(key, history),
-          });
-        }
-        continue;
-      }
-      if (mode === 'stress') {
-        const stress = maps.stress.get(indexItem.lemmaId);
-        if (!stress) continue;
-        const key = cardKey(indexItem.lemmaId, mode);
-        const card = state.cards.get(key) ?? null;
-        candidates.push({
-          itemId: makeItemId(indexItem.lemmaId, mode, stress.stressId),
-          lemma,
-          indexItem,
-          mode,
-          cardKey: key,
-          cardState: card,
-          due: card?.due ?? 0,
-          lapsed: Boolean(card && card.lapses > 0 && card.due <= nowTime),
-          stress,
-          recallDirection: directionFor(key, history),
-          choicePolarity: polarityFor(key, history),
-        });
-        continue;
-      }
-      if (mode === 'classify') {
-        const classify = maps.classify.get(indexItem.lemmaId);
-        if (!classify || classify.sets.length === 0) continue;
-        const key = cardKey(indexItem.lemmaId, mode);
-        const card = state.cards.get(key) ?? null;
-        for (const set of classify.sets) {
-          candidates.push({
-            itemId: makeItemId(indexItem.lemmaId, mode, `${classify.classifyId}:${set.setId}`),
-            lemma,
-            indexItem,
-            mode,
-            cardKey: key,
-            cardState: card,
-            due: card?.due ?? 0,
-            lapsed: Boolean(card && card.lapses > 0 && card.due <= nowTime),
-            classify,
-            classifySetId: set.setId,
-            recallDirection: directionFor(key, history),
-            choicePolarity: polarityFor(key, history),
-          });
-        }
-        continue;
-      }
-      if (mode === 'paradigm') {
-        const items = maps.paradigm.get(indexItem.lemmaId) ?? [];
-        for (const paradigm of items) {
-          const key = cardKey(indexItem.lemmaId, mode);
-          const card = state.cards.get(key) ?? null;
-          candidates.push({
-            itemId: makeItemId(indexItem.lemmaId, mode, paradigm.paradigmId),
-            lemma,
-            indexItem,
-            mode,
-            cardKey: key,
-            cardState: card,
-            due: card?.due ?? 0,
-            lapsed: Boolean(card && card.lapses > 0 && card.due <= nowTime),
-            paradigm,
-            recallDirection: directionFor(key, history),
-            choicePolarity: polarityFor(key, history),
-          });
-        }
-        continue;
-      }
-      if (mode === 'synonym') {
-        const items = maps.synonym.get(indexItem.lemmaId) ?? [];
-        for (const synonym of items) {
-          const key = cardKey(indexItem.lemmaId, mode);
-          const card = state.cards.get(key) ?? null;
-          candidates.push({
-            itemId: makeItemId(indexItem.lemmaId, mode, synonym.synonymId),
-            lemma,
-            indexItem,
-            mode,
-            cardKey: key,
-            cardState: card,
-            due: card?.due ?? 0,
-            lapsed: Boolean(card && card.lapses > 0 && card.due <= nowTime),
-            synonym,
-            recallDirection: directionFor(key, history),
-            choicePolarity: polarityFor(key, history),
-          });
-        }
-        continue;
-      }
-      if (mode === 'heritage' || mode === 'paronym') {
-        continue;
-      }
-      const key = cardKey(indexItem.lemmaId, mode);
-      const card = state.cards.get(key) ?? null;
-      candidates.push({
-        itemId: makeItemId(indexItem.lemmaId, mode),
-        lemma,
-        indexItem,
-        mode,
-        cardKey: key,
-        cardState: card,
-        due: card?.due ?? 0,
-        lapsed: Boolean(card && card.lapses > 0 && card.due <= nowTime),
-        recallDirection: directionFor(key, history),
-        choicePolarity: polarityFor(key, history),
-      });
-    }
-  }
+  const wordRepeatWindow = Math.max(
+    MIN_WORD_REPEAT_WINDOW,
+    options.wordRepeatWindow ?? MIN_WORD_REPEAT_WINDOW,
+  );
+  const candidates = refreshedCandidates(
+    deck,
+    state,
+    history,
+    modeFilter,
+    minRecognitionStability,
+    nowTime,
+  );
 
   const overduePool = candidates.filter((candidate) => candidate.due <= nowTime);
   const windowPool = candidates.filter(
@@ -1219,7 +1372,8 @@ export function selectNextPracticeItem(
   }
   if (!scheduledPool.length) return null;
 
-  return rankCandidates(scheduledPool, history, clozeSoftCap, nowTime);
+  const selection = rankCandidates(scheduledPool, history, clozeSoftCap, nowTime, deck.level, options.sessionSeed);
+  return selection ? selectionSnapshot(selection) : null;
 }
 
 export function czNorm(value: string): string {

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -9,6 +9,7 @@ import {
   saveState,
   type PracticeDeckData,
   type PracticeLexeme,
+  type PracticeMode,
 } from '@site/src/lib/lexicon/srs';
 import { LEARNER_LEVEL_STORAGE_KEY, type CefrLevel } from '@site/src/lib/lexicon/levels';
 
@@ -184,6 +185,20 @@ function sampleDeck(): PracticeDeckData {
   };
 }
 
+function sampleDeckWithOnlyMode(lemmaId: string, mode: PracticeMode): PracticeDeckData {
+  const baseDeck = sampleDeck();
+  return {
+    ...baseDeck,
+    index: baseDeck.index.map((item) => ({
+      ...item,
+      modes: item.lemmaId === lemmaId ? [mode] : [],
+      hasCloze: false,
+      clozeIds: [],
+    })),
+    cloze: [],
+  };
+}
+
 function wordToMeaningDeck(): PracticeDeckData {
   const lexemes = [
     lexeme('sady', 'сад', 'garden', {
@@ -238,7 +253,7 @@ function wordToMeaningDeck(): PracticeDeckData {
       lemma: entry.lemma,
       cefr: 'A1',
       modes:
-        entry.meaningMcEligible === false
+        entry.meaningMcEligible === false || entry.lemmaId === 'ityx'
           ? ['flashcards']
           : ['flashcards', 'matching', 'choice'],
       hasCloze: false,
@@ -350,7 +365,7 @@ describe('LexiconPractice', () => {
   test('flashcard rating persists mode-specific SRS progress', async () => {
     const user = userEvent.setup();
     const { container } = render(
-      <LexiconPractice initialDeck={sampleDeck()} autoStart initialMode="flashcards" />,
+      <LexiconPractice initialDeck={sampleDeckWithOnlyMode('knyha', 'flashcards')} autoStart initialMode="flashcards" />,
     );
 
     const flashcard = container.querySelector<HTMLElement>('[data-activity="flashcard"]');
@@ -368,7 +383,7 @@ describe('LexiconPractice', () => {
 
   test('choice mode records result and advances through selector', async () => {
     const user = userEvent.setup();
-    render(<LexiconPractice initialDeck={sampleDeck()} autoStart initialMode="choice" />);
+    render(<LexiconPractice initialDeck={sampleDeckWithOnlyMode('knyha', 'choice')} autoStart initialMode="choice" />);
 
     const choice = screen.getByTestId('practice-choice');
     expect(choice).toBeInTheDocument();
@@ -389,7 +404,7 @@ describe('LexiconPractice', () => {
     render(<LexiconPractice initialDeck={wordToMeaningDeck()} autoStart initialMode="choice" />);
     const choice = screen.getByTestId('practice-choice');
 
-    expect(screen.getByText('Що означає «сад»?')).toBeInTheDocument();
+    expect(screen.getByText(/^Що означає «(сад|дім|ліс|річка)»\?$/)).toBeInTheDocument();
     // The option label lives in its own span next to the "1-4" key span; read just the label.
     const labels = within(choice)
       .getAllByRole('button')

--- a/site/tests/unit/atlas-db-read.test.ts
+++ b/site/tests/unit/atlas-db-read.test.ts
@@ -1,9 +1,8 @@
 // @vitest-environment node
 
 import Database from 'better-sqlite3';
-import { getContainerRenderer } from '@astrojs/react/container-renderer';
+import reactRenderer from '@astrojs/react/server.js';
 import { experimental_AstroContainer as AstroContainer } from 'astro/container';
-import { loadRenderers } from 'astro:container';
 import { describe, expect, test } from 'vitest';
 import { resolve } from 'node:path';
 import manifest from '@site/src/data/lexicon-manifest.json';
@@ -24,7 +23,7 @@ interface EntryTypeRow {
   slug: string;
 }
 
-type AstroComponent = Parameters<InstanceType<typeof AstroContainer>['renderToString']>[0];
+type AstroComponent = Parameters<AstroContainer['renderToString']>[0];
 
 interface AstroComponentModule {
   default: AstroComponent;
@@ -107,8 +106,8 @@ describe('Atlas DB SSG read parity', () => {
     const { default: WordAtlasArticle } = (await import(
       '@site/src/lexicon/WordAtlasArticle.astro'
     )) as AstroComponentModule;
-    const renderers = await loadRenderers([getContainerRenderer()]);
-    const container = await AstroContainer.create({ renderers });
+    const container = await AstroContainer.create();
+    container.addServerRenderer({ renderer: reactRenderer });
     let differing = 0;
 
     for (const slug of fixtureSlugs) {

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -14,12 +14,14 @@ import {
   rateCard,
   saveState,
   selectNextPracticeItem,
+  seededAnswerIndex,
   uaPlural,
   validateClozeOptions,
   type PracticeClozeItem,
   type PracticeDeckData,
   type PracticeLexeme,
   type PracticeMode,
+  type PracticeSelection,
   type SelectionHistoryItem,
 } from '@site/src/lib/lexicon/srs';
 
@@ -42,7 +44,12 @@ function stateCard(overrides: Partial<ReturnType<typeof rateCard>> = {}) {
   };
 }
 
-function lexeme(lemmaId: string, lemma = lemmaId, gloss = `${lemmaId} gloss`): PracticeLexeme {
+function lexeme(
+  lemmaId: string,
+  lemma = lemmaId,
+  gloss = `${lemmaId} gloss`,
+  cefr = 'A1',
+): PracticeLexeme {
   return {
     lemmaId,
     lemma,
@@ -50,7 +57,7 @@ function lexeme(lemmaId: string, lemma = lemmaId, gloss = `${lemmaId} gloss`): P
     gloss,
     ipa: null,
     pos: 'noun',
-    cefr: 'A1',
+    cefr,
     heritage: null,
     severity: null,
     paradigm: {
@@ -228,6 +235,65 @@ function modeDeck(rows: { id: string; modes: PracticeMode[] }[]): PracticeDeckDa
       newOrder: index,
     })),
   };
+}
+
+function flashcardDeck(
+  rows: { id: string; cefr?: string }[],
+  level = 'A1',
+  deckVersion = 'test',
+): PracticeDeckData {
+  const lexemes = rows.map((row) => lexeme(row.id, row.id, `${row.id} gloss`, row.cefr ?? 'A1'));
+  return {
+    deckVersion,
+    level,
+    lexemes,
+    cloze: [],
+    stress: [],
+    classify: [],
+    paradigm: [],
+    synonym: [],
+    index: lexemes.map((entry, index) => ({
+      lemmaId: entry.lemmaId,
+      lemma: entry.lemma,
+      cefr: entry.cefr ?? 'A1',
+      modes: ['flashcards'],
+      hasCloze: false,
+      clozeIds: [],
+      newOrder: index,
+    })),
+  };
+}
+
+function selectionHistory(selection: PracticeSelection): SelectionHistoryItem {
+  return {
+    itemId: selection.itemId,
+    lemmaId: selection.lemma.lemmaId,
+    mode: selection.mode,
+    clozeId: selection.cloze?.clozeId,
+    sentenceFrameId: selection.cloze?.sentenceFrameId,
+    blankCase: selection.cloze?.blankCase,
+    classifySetId: selection.classifySetId,
+    recallDirection: selection.recallDirection,
+    choicePolarity: selection.choicePolarity,
+    lapsed: selection.lapsed,
+  };
+}
+
+function newCardSequence(testDeck: PracticeDeckData, seed: number, count: number): PracticeSelection[] {
+  const history: SelectionHistoryItem[] = [];
+  const selections: PracticeSelection[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const selection = selectNextPracticeItem(testDeck, {
+      now: NOW,
+      modeFilter: 'flashcards',
+      history,
+      sessionSeed: seed,
+    });
+    if (!selection) throw new Error(`expected selection ${index}`);
+    selections.push(selection);
+    history.push(selectionHistory(selection));
+  }
+  return selections;
 }
 
 beforeEach(() => {
@@ -590,6 +656,138 @@ describe('lexicon SRS facade', () => {
     expect(selection?.mode).toBe('matching');
   });
 
+  test('selector uses the session seed only as a stable tied-new-card tiebreak', () => {
+    const testDeck = flashcardDeck(
+      Array.from({ length: 30 }, (_, index) => ({ id: `seeded-${String(index).padStart(2, '0')}` })),
+    );
+
+    const firstRun = newCardSequence(testDeck, 12345, 10).map((selection) => selection.itemId);
+    const secondRun = newCardSequence(testDeck, 12345, 10).map((selection) => selection.itemId);
+    const differentSeedRun = newCardSequence(testDeck, 54321, 10).map((selection) => selection.itemId);
+
+    expect(secondRun).toEqual(firstRun);
+    expect(differentSeedRun).not.toEqual(firstRun);
+  });
+
+  test('selector returns immutable snapshots of cached candidates', () => {
+    const testDeck = flashcardDeck([{ id: 'snapshot' }]);
+    const first = selectNextPracticeItem(testDeck, {
+      now: NOW,
+      modeFilter: 'flashcards',
+      sessionSeed: 12345,
+    });
+    if (!first) throw new Error('expected first selection');
+    const firstPolarity = first.choicePolarity;
+
+    selectNextPracticeItem(testDeck, {
+      now: NOW,
+      modeFilter: 'flashcards',
+      history: [selectionHistory(first)],
+      sessionSeed: 12345,
+    });
+
+    expect(first.choicePolarity).toBe(firstPolarity);
+  });
+
+  test('due and lapsed cards beat tied new cards regardless of seed', () => {
+    const state = loadState(localStorage, NOW);
+    state.cards.set(cardKey('due-review', 'flashcards'), stateCard({ due: NOW.getTime() }));
+    const testDeck = flashcardDeck([
+      { id: 'fresh-a' },
+      { id: 'fresh-b' },
+      { id: 'due-review' },
+      { id: 'fresh-c' },
+    ]);
+
+    for (const seed of [1, 987654321]) {
+      const selection = selectNextPracticeItem(testDeck, {
+        now: NOW,
+        modeFilter: 'flashcards',
+        sessionSeed: seed,
+      });
+      expect(selection?.lemma.lemmaId).toBe('due-review');
+      expect(selection?.cardState).toBeTruthy();
+    }
+
+    state.cards.set(cardKey('lapsed-review', 'flashcards'), stateCard({ lapses: 1, due: NOW.getTime() - HOUR_MS }));
+    const lapsedDeck = flashcardDeck([
+      { id: 'fresh-a' },
+      { id: 'lapsed-review' },
+      { id: 'fresh-b' },
+    ]);
+    for (const seed of [1, 987654321]) {
+      const selection = selectNextPracticeItem(lapsedDeck, {
+        now: NOW,
+        modeFilter: 'flashcards',
+        sessionSeed: seed,
+      });
+      expect(selection?.lemma.lemmaId).toBe('lapsed-review');
+      expect(selection?.lapsed).toBe(true);
+    }
+  });
+
+  test('B1 decks introduce B1 new cards before same-urgency lower-level cards', () => {
+    const testDeck = flashcardDeck(
+      [
+        ...Array.from({ length: 10 }, (_, index) => ({ id: `a1-${index}`, cefr: 'A1' })),
+        ...Array.from({ length: 10 }, (_, index) => ({ id: `a2-${index}`, cefr: 'A2' })),
+        ...Array.from({ length: 10 }, (_, index) => ({ id: `b1-${index}`, cefr: 'B1' })),
+      ],
+      'B1',
+    );
+
+    const firstIntroductions = newCardSequence(testDeck, 20260706, 8);
+
+    expect(firstIntroductions.map((selection) => selection.indexItem.cefr)).toEqual(
+      Array.from({ length: 8 }, () => 'B1'),
+    );
+  });
+
+  test('seeded answer placement varies correct-answer positions across a session', () => {
+    const positions = new Set(
+      Array.from({ length: 20 }, (_, index) =>
+        seededAnswerIndex(20260706, `choice-fixture-${index}:choice`, 4),
+      ),
+    );
+
+    expect(positions.size).toBeGreaterThanOrEqual(3);
+    expect(seededAnswerIndex(111, 'choice-fixture-0:choice', 4)).not.toBe(
+      seededAnswerIndex(222, 'choice-fixture-0:choice', 4),
+    );
+  });
+
+  test('selector handles a warmed 18k-candidate transition under the perf budget', () => {
+    const testDeck = flashcardDeck(
+      Array.from({ length: 18_000 }, (_, index) => ({
+        id: `bench-${String(index).padStart(5, '0')}`,
+      })),
+      'A1',
+      'bench-optimized',
+    );
+    const history: SelectionHistoryItem[] = [
+      { itemId: 'history-choice-1', lemmaId: 'history-choice-1', mode: 'choice' },
+      { itemId: 'history-choice-2', lemmaId: 'history-choice-2', mode: 'choice' },
+    ];
+
+    selectNextPracticeItem(testDeck, { now: NOW, modeFilter: 'flashcards', sessionSeed: 123456789 });
+    const start = performance.now();
+    const selection = selectNextPracticeItem(testDeck, {
+      now: NOW,
+      modeFilter: 'flashcards',
+      history,
+      sessionSeed: 123456789,
+    });
+    const elapsed = performance.now() - start;
+
+    console.info(
+      `BENCH optimized selectNextPracticeItem 18000 candidates: ${elapsed.toFixed(2)}ms selected=${
+        selection?.itemId ?? 'null'
+      }`,
+    );
+    expect(selection).not.toBeNull();
+    expect(elapsed).toBeLessThan(50);
+  });
+
   test('explicit cloze mode reaches authored cloze before recognition mastery', () => {
     const selection = selectNextPracticeItem(practiceDeck(), {
       now: NOW,
@@ -597,7 +795,7 @@ describe('lexicon SRS facade', () => {
     });
 
     expect(selection?.mode).toBe('cloze');
-    expect(selection?.cloze?.clozeId).toBe('alpha-cloze');
+    expect(['alpha-cloze', 'beta-cloze', 'gamma-cloze']).toContain(selection?.cloze?.clozeId);
   });
 
   test('cloze soft cap yields to lapsed cloze pressure', () => {

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -12,6 +12,7 @@
     "jsx": "react-jsx",
     "jsxImportSource": "react",
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@site/*": ["./*"]
     }

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -1,3 +1,5 @@
+/// <reference types="vitest/config" />
+
 /**
  * Vitest configuration — Astro's recommended approach.
  * `getViteConfig` applies the full Astro/Vite pipeline (React JSX transform,


### PR DESCRIPTION
## Summary

Fixes #4651.

- Caches practice deck maps and static selector candidates by deck identity + mode filter, then refreshes only dynamic card state for each selection.
- Precomputes urgency, penalty, level-bias, and seeded hash ranking keys before sorting, so the comparator no longer rebuilds history/candidate sets.
- Adds deterministic session-seeded tied-card ordering, seeded answer placement, and B1-level new-card bias while keeping due/lapsed reviews ahead of new cards.
- Updates stale TypeScript/Astro test plumbing required for `npx tsc --noEmit` and full `npm test` under current Astro/TS packages.

## Test notes

Existing old deterministic tied-new-card assertions were adapted where they pinned `newOrder` winners (`alpha-cloze`, first LexiconPractice fixture card). The replacement assertions preserve the behavior under test without relying on old tiebreak order.

## Raw evidence

### tests pass

Command: `cd site && npm test`

```text
Test Files 32 passed (32)
Tests 451 passed (451)
```

### lint clean

Command: `cd site && npx eslint astro.config.mjs src/components/HashTabSync.tsx src/components/LexiconPractice.tsx src/lib/lexicon/practice-api-shard.ts src/lib/lexicon/srs.ts src/env.d.ts tests/unit/LexiconPractice.test.tsx tests/unit/atlas-db-read.test.ts tests/unit/lexicon-srs.test.ts tsconfig.json vitest.config.ts --quiet`

```text
<no output; exit 0>
```

Command: `cd site && npx tsc --noEmit`

```text
<no output; exit 0>
```

### perf improved

Pre-fix command: one-off benchmark on old selector path, 18,000 synthetic candidates.

```text
BENCH old selectNextPracticeItem 18000 candidates: 8206.39ms selected=bench-00000:flashcards
```

Post-fix command: `cd site && npx vitest run tests/unit/lexicon-srs.test.ts --reporter=verbose -t "selector handles a warmed 18k-candidate transition under the perf budget"`

```text
BENCH optimized selectNextPracticeItem 18000 candidates: 13.03ms selected=bench-11970:flashcards
```

### independent review

Command: `.venv/bin/python scripts/ai_agent_bridge/__main__.py read 4`

```text
No blockers found. The fix correctly resolves the cache mutation issue while successfully preserving the performance budget.
```

### commit landed

Command: `git log -1 --oneline`

```text
4947d65225 fix(practice): #4651 selector perf + seeded ordering + level-biased intro
```