### PR TITLE
fix(practice): #4657 deck version fingerprints all deck inputs

### DIFF
--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -30,6 +30,8 @@ if str(AUDIT_DIR) not in sys.path:
 
 from lexeme_filter import SURFACE_CLOZE, is_practice_eligible, is_surface_admitted
 
+from scripts.practice_deck.io import compute_deck_version
+
 DEFAULT_MANIFEST = Path("site/src/data/lexicon-manifest.json")
 DEFAULT_ATLAS_DB = Path("data/atlas.db")
 # Deck shards are served as literal static files from public/ (not via dynamic .json.ts
@@ -492,11 +494,6 @@ def _stable_lemma_id(entry: dict[str, Any]) -> str:
         )
     )
     return hashlib.sha1(key.encode("utf-8")).hexdigest()[:16]
-
-
-def _manifest_fingerprint(entries: list[dict[str, Any]]) -> str:
-    payload = json.dumps(entries, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 
 def _normalize_cefr(value: Any) -> str | None:
@@ -2083,7 +2080,13 @@ def build_practice_shards(
         for level in CEFR_ORDER
     }
 
-    deck_version = f"atlas-practice-v{SCHEMA_VERSION}-{_manifest_fingerprint(entries)}"
+    deck_version = compute_deck_version(
+        entries,
+        heritage_pairs,
+        synonym_verdicts,
+        cloze_sources,
+        SCHEMA_VERSION,
+    )
     rng_seed = int(hashlib.sha256(deck_version.encode("utf-8")).hexdigest()[:16], 16)
     rng = random.Random(rng_seed)
     eligible = [entry for entry in entries if is_practice_eligible(entry)]

--- a/scripts/practice_deck/io.py
+++ b/scripts/practice_deck/io.py
@@ -48,6 +48,25 @@ def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def compute_deck_version(
+    entries: list[dict[str, Any]] | None,
+    heritage_pairs: list[dict[str, Any]] | None,
+    synonym_verdicts: dict[str, Any] | None,
+    cloze_sources: list[dict[str, Any]] | None,
+    schema_version: int,
+) -> str:
+    payload = {
+        "schema_version": schema_version,
+        "entries": entries or [],
+        "heritage_pairs": heritage_pairs or [],
+        "synonym_verdicts": synonym_verdicts or {},
+        "cloze_sources": cloze_sources or [],
+    }
+    canonical = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    fingerprint = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+    return f"atlas-practice-v{schema_version}-{fingerprint}"
+
+
 def _read_json(path: Path) -> dict[str, Any]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):

--- a/scripts/practice_deck/publish.py
+++ b/scripts/practice_deck/publish.py
@@ -18,7 +18,10 @@ ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_PRACTICE_DIR = ROOT / "site" / "public" / "lexicon"
 DEFAULT_POINTER = ROOT / "site" / "src" / "data" / "lexicon-practice-deck.pointer.json"
 DEFAULT_GZIP = ROOT / "site" / "src" / "data" / "lexicon-practice-deck.json.gz"
-DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
+DEFAULT_ATLAS_DB = ROOT / "data" / "atlas.db"
+DEFAULT_CLOZE_SOURCES = ROOT / "site" / "src" / "data" / "lexicon-practice-cloze-sources.json"
+DEFAULT_HERITAGE_PAIRS = ROOT / "data" / "lexicon" / "heritage_pairs.yaml"
+DEFAULT_SYNONYM_VERDICTS = ROOT / "data" / "lexicon" / "synonym_pair_verdicts.yaml"
 DEFAULT_RELEASE_TAG = "atlas-practice-deck"
 DEFAULT_REPO = "learn-ukrainian/learn-ukrainian.github.io"
 ASSET_NAME = "lexicon-practice-deck.json.gz"
@@ -52,23 +55,43 @@ def versioned_asset_name(deck_version: str) -> str:
     return f"lexicon-practice-deck-{deck_version}.json.gz"
 
 
-def expected_deck_version(manifest_path: Path) -> str:
-    if not manifest_path.exists():
+def expected_deck_version(
+    atlas_db_path: Path = DEFAULT_ATLAS_DB,
+    *,
+    heritage_pairs_path: Path | None = DEFAULT_HERITAGE_PAIRS,
+    synonym_verdicts_path: Path | None = DEFAULT_SYNONYM_VERDICTS,
+    cloze_sources_path: Path | None = DEFAULT_CLOZE_SOURCES,
+) -> str:
+    if not atlas_db_path.exists():
         raise PracticeDeckPublishError(
-            f"Manifest file {manifest_path} is missing. "
-            "Please build the manifest (e.g., run `make atlas`) first."
+            f"Atlas DB file {atlas_db_path} is missing. "
+            "Please build the atlas DB (e.g., run `npm --prefix site run atlas:build-db`) first."
         )
     try:
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-        entries = manifest.get("entries") if isinstance(manifest, dict) else manifest
-        if not isinstance(entries, list):
-            raise PracticeDeckPublishError("manifest entries must be a list")
-        entries = [entry for entry in entries if isinstance(entry, dict)]
-        payload = json.dumps(entries, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-        fingerprint = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
-        return f"atlas-practice-v1-{fingerprint}"
+        from scripts.audit.generate_practice_deck import (
+            SCHEMA_VERSION,
+            read_atlas_db,
+            read_cloze_sources,
+            read_heritage_pairs,
+            read_synonym_verdicts,
+        )
+        from scripts.practice_deck.io import compute_deck_version
+
+        entries = read_atlas_db(atlas_db_path)
+        heritage_pairs = read_heritage_pairs(heritage_pairs_path)
+        synonym_verdicts = read_synonym_verdicts(synonym_verdicts_path)
+        cloze_sources = read_cloze_sources(cloze_sources_path)
+        return compute_deck_version(
+            entries,
+            heritage_pairs,
+            synonym_verdicts,
+            cloze_sources,
+            SCHEMA_VERSION,
+        )
     except Exception as exc:
-        raise PracticeDeckPublishError(f"Failed to calculate expected deck version: {exc}") from exc
+        raise PracticeDeckPublishError(
+            f"Failed to calculate expected deck version from atlas DB projection: {exc}"
+        ) from exc
 
 
 def _read_json_bytes(path: Path) -> tuple[bytes, dict[str, Any]]:
@@ -163,7 +186,12 @@ def build_pointer(
         "package_bytes": len(package_bytes),
         "file_count": len(pointer_files),
         "files": pointer_files,
-        "note": "Pins GitHub Release asset practice deck for #3796; hydrate it build/test time instead of committing shards.",
+        "note": (
+            "Pins GitHub Release asset practice deck for #3796; hydrate it build/test time instead of "
+            "committing shards. Deck versions fingerprint public atlas DB entries, heritage pairs, "
+            "synonym verdicts, and cloze sources; the first publish after that input expansion mints "
+            "a new versioned asset by design."
+        ),
     }
 
 
@@ -304,17 +332,25 @@ def publish_practice_deck(
     practice_dir: Path = DEFAULT_PRACTICE_DIR,
     gzip_path: Path = DEFAULT_GZIP,
     pointer_path: Path = DEFAULT_POINTER,
-    manifest_path: Path = DEFAULT_MANIFEST,
+    atlas_db_path: Path = DEFAULT_ATLAS_DB,
+    heritage_pairs_path: Path | None = DEFAULT_HERITAGE_PAIRS,
+    synonym_verdicts_path: Path | None = DEFAULT_SYNONYM_VERDICTS,
+    cloze_sources_path: Path | None = DEFAULT_CLOZE_SOURCES,
     release_tag: str = DEFAULT_RELEASE_TAG,
     repo: str = DEFAULT_REPO,
     dry_run: bool = False,
 ) -> dict[str, Any]:
     deck_version, pointer_files, package_files = collect_shards(practice_dir)
-    expected_version = expected_deck_version(manifest_path)
+    expected_version = expected_deck_version(
+        atlas_db_path,
+        heritage_pairs_path=heritage_pairs_path,
+        synonym_verdicts_path=synonym_verdicts_path,
+        cloze_sources_path=cloze_sources_path,
+    )
     if deck_version != expected_version:
         raise PracticeDeckPublishError(
             f"Practice deck version on disk {deck_version!r} does not match expected "
-            f"version {expected_version!r} from manifest. "
+            f"version {expected_version!r} from the public atlas DB and curated deck inputs. "
             "Please rebuild the practice deck (e.g., run `make practice-deck`) before publishing."
         )
     package_bytes = build_package(deck_version, package_files)
@@ -341,7 +377,10 @@ def main() -> int:
     parser.add_argument("--practice-dir", type=Path, default=DEFAULT_PRACTICE_DIR)
     parser.add_argument("--gzip", type=Path, default=DEFAULT_GZIP)
     parser.add_argument("--pointer", type=Path, default=DEFAULT_POINTER)
-    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--atlas-db", type=Path, default=DEFAULT_ATLAS_DB)
+    parser.add_argument("--cloze-sources", type=Path, default=DEFAULT_CLOZE_SOURCES)
+    parser.add_argument("--heritage-pairs", type=Path, default=DEFAULT_HERITAGE_PAIRS)
+    parser.add_argument("--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS)
     parser.add_argument("--release-tag", default=DEFAULT_RELEASE_TAG)
     parser.add_argument("--repo", default=DEFAULT_REPO)
     parser.add_argument("--dry-run", action="store_true", help="Build metadata without uploading/writing pointer")
@@ -350,7 +389,10 @@ def main() -> int:
         practice_dir=args.practice_dir,
         gzip_path=args.gzip,
         pointer_path=args.pointer,
-        manifest_path=args.manifest,
+        atlas_db_path=args.atlas_db,
+        heritage_pairs_path=args.heritage_pairs,
+        synonym_verdicts_path=args.synonym_verdicts,
+        cloze_sources_path=args.cloze_sources,
         release_tag=args.release_tag,
         repo=args.repo,
         dry_run=args.dry_run,

--- a/scripts/practice_deck/publish.py
+++ b/scripts/practice_deck/publish.py
@@ -8,6 +8,7 @@ import gzip
 import hashlib
 import json
 import subprocess
+import sys
 import tempfile
 from contextlib import nullcontext
 from pathlib import Path
@@ -15,6 +16,12 @@ from typing import Any
 from urllib.parse import quote
 
 ROOT = Path(__file__).resolve().parents[2]
+# Keep the documented script-style invocation working (`make practice-deck-publish` runs
+# `$(PYTHON) scripts/practice_deck/publish.py`): the lazy `scripts.practice_deck.io` import
+# inside expected_deck_version() needs the repo root on sys.path — same bootstrap as
+# scripts/audit/generate_practice_deck.py (and the #4529 lazy-absolute-self-import lesson).
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 DEFAULT_PRACTICE_DIR = ROOT / "site" / "public" / "lexicon"
 DEFAULT_POINTER = ROOT / "site" / "src" / "data" / "lexicon-practice-deck.pointer.json"
 DEFAULT_GZIP = ROOT / "site" / "src" / "data" / "lexicon-practice-deck.json.gz"

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -66,6 +66,16 @@ def _fixture_heritage_pair() -> dict[str, object]:
     return read_heritage_pairs(HERITAGE_PAIRS)[0]
 
 
+def _single_deck_version(shards: dict[str, dict[str, dict[str, object]]]) -> str:
+    versions = {
+        payload["deckVersion"]
+        for level_shards in shards.values()
+        for payload in level_shards.values()
+    }
+    assert len(versions) == 1
+    return versions.pop()
+
+
 def test_fixture_build_emits_sharded_schema() -> None:
     shards = _build(BuildConfig(fixture_note="fixture sample", source_label="fixture"))
     apply_size_budgets(shards, raw_limit=50_000, gzip_limit=15_000)
@@ -113,6 +123,81 @@ def test_manifest_cloze_fields_are_ignored_without_curated_sources() -> None:
     assert shards["A1"]["index"]["counts"]["lexemes"] == 7
     assert shards["A1"]["index"]["counts"]["cloze"] == 0
     assert shards["A1"]["cloze"]["cloze"] == []
+
+
+def test_deck_version_changes_when_any_deck_input_changes() -> None:
+    entries = read_manifest(MANIFEST)
+    cloze_sources = read_cloze_sources(CLOZE_SOURCES)
+    heritage_pairs = read_heritage_pairs(HERITAGE_PAIRS)
+    synonym_verdicts = {"approved": [], "rejected": []}
+    allowlist = ReviewedSourceAllowlist.from_path(ALLOWLIST)
+    verifier = JsonVesumVerifier.from_path(VESUM)
+
+    def version_for(
+        *,
+        entries_override: list[dict[str, object]] | None = None,
+        cloze_sources_override: list[dict[str, object]] | None = None,
+        heritage_pairs_override: list[dict[str, object]] | None = None,
+        synonym_verdicts_override: dict[str, object] | None = None,
+    ) -> str:
+        shards = build_practice_shards(
+            entries_override or entries,
+            allowlist,
+            verifier,
+            cloze_sources_override or cloze_sources,
+            BuildConfig(),
+            heritage_pairs=heritage_pairs_override or heritage_pairs,
+            synonym_verdicts=synonym_verdicts_override or synonym_verdicts,
+        )
+        return _single_deck_version(shards)
+
+    base_version = version_for()
+    changed_entries = json.loads(json.dumps(entries))
+    changed_entries[0]["gloss"] = "changed gloss"
+    changed_cloze_sources = json.loads(json.dumps(cloze_sources))
+    changed_cloze_sources[0]["sentence"] = "Змінене речення з ___."
+    changed_heritage_pairs = json.loads(json.dumps(heritage_pairs))
+    changed_heritage_pairs[0]["rationale"] = "changed rationale"
+    changed_synonym_verdicts = {
+        "approved": [{"a": "кіт", "b": "пес", "polarity": "synonym"}],
+        "rejected": [],
+    }
+
+    assert version_for(entries_override=changed_entries) != base_version
+    assert version_for(cloze_sources_override=changed_cloze_sources) != base_version
+    assert version_for(heritage_pairs_override=changed_heritage_pairs) != base_version
+    assert version_for(synonym_verdicts_override=changed_synonym_verdicts) != base_version
+
+
+def test_deck_version_stable_across_double_regen_with_identical_inputs() -> None:
+    entries = read_manifest(MANIFEST)
+    cloze_sources = read_cloze_sources(CLOZE_SOURCES)
+    heritage_pairs = read_heritage_pairs(HERITAGE_PAIRS)
+    synonym_verdicts = {"approved": [], "rejected": []}
+    allowlist = ReviewedSourceAllowlist.from_path(ALLOWLIST)
+    verifier = JsonVesumVerifier.from_path(VESUM)
+
+    first = build_practice_shards(
+        json.loads(json.dumps(entries)),
+        allowlist,
+        verifier,
+        json.loads(json.dumps(cloze_sources)),
+        BuildConfig(),
+        heritage_pairs=json.loads(json.dumps(heritage_pairs)),
+        synonym_verdicts=json.loads(json.dumps(synonym_verdicts)),
+    )
+    second = build_practice_shards(
+        json.loads(json.dumps(entries)),
+        allowlist,
+        verifier,
+        json.loads(json.dumps(cloze_sources)),
+        BuildConfig(),
+        heritage_pairs=json.loads(json.dumps(heritage_pairs)),
+        synonym_verdicts=json.loads(json.dumps(synonym_verdicts)),
+    )
+
+    assert _single_deck_version(first) == _single_deck_version(second)
+    assert first == second
 
 
 def test_read_heritage_pairs_missing_file_warns(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -646,7 +731,24 @@ def test_source_inventory_cloze_requires_explicit_cloze_admission() -> None:
 
     allowlist = ReviewedSourceAllowlist.from_path(ALLOWLIST)
     verifier = JsonVesumVerifier.from_path(VESUM)
-    cloze_sources = read_cloze_sources(CLOZE_SOURCES)
+    cloze_sources = [
+        *read_cloze_sources(CLOZE_SOURCES),
+        {
+            "lemma": "школа",
+            "lemmaId": "shkola",
+            "sentence": "Вона у ___.",
+            "blankCase": "locative",
+            "form": "школі",
+            "number": "singular",
+            "caseRule": "locative_static_u",
+            "clozeEn": "She is at school.",
+            "provenance": {
+                "status": "reviewed",
+                "path": "curriculum/l2-uk-en/a1/vocabulary/school.yaml",
+                "cardId": "school-shkola-1",
+            },
+        },
+    ]
     shards = build_practice_shards(entries, allowlist, verifier, cloze_sources, BuildConfig())
     cloze_ids = {
         item["lemmaId"]

--- a/tests/test_practice_deck_io.py
+++ b/tests/test_practice_deck_io.py
@@ -62,6 +62,60 @@ def _pin_defaults(monkeypatch: pytest.MonkeyPatch, practice_dir: Path, pointer_p
     monkeypatch.setattr(practice_deck_io, "DEFAULT_POINTER", pointer_path)
 
 
+def test_compute_deck_version_fingerprints_all_inputs() -> None:
+    entries = [{"lemmaId": "knyha", "lemma": "knyha", "gloss": "book"}]
+    heritage_pairs = [{"nativeSlug": "knyha", "rationale": "fixture"}]
+    synonym_verdicts = {
+        "approved": [{"a": "knyha", "b": "tom", "polarity": "synonym"}],
+        "rejected": [],
+    }
+    cloze_sources = [{"lemmaId": "knyha", "sentence": "I read ___."}]
+
+    version = practice_deck_io.compute_deck_version(
+        entries,
+        heritage_pairs,
+        synonym_verdicts,
+        cloze_sources,
+        1,
+    )
+
+    assert version.startswith("atlas-practice-v1-")
+    fingerprint = version.removeprefix("atlas-practice-v1-")
+    assert len(fingerprint) == 16
+    assert all(char in "0123456789abcdef" for char in fingerprint)
+
+    variants = [
+        ([{**entries[0], "gloss": "book volume"}], heritage_pairs, synonym_verdicts, cloze_sources),
+        (entries, [{**heritage_pairs[0], "rationale": "changed"}], synonym_verdicts, cloze_sources),
+        (
+            entries,
+            heritage_pairs,
+            {"approved": synonym_verdicts["approved"], "rejected": [{"a": "x", "b": "y", "polarity": "antonym"}]},
+            cloze_sources,
+        ),
+        (entries, heritage_pairs, synonym_verdicts, [{**cloze_sources[0], "sentence": "Changed ___."}]),
+    ]
+    changed_versions = {
+        practice_deck_io.compute_deck_version(
+            variant_entries,
+            variant_heritage_pairs,
+            variant_synonym_verdicts,
+            variant_cloze_sources,
+            1,
+        )
+        for variant_entries, variant_heritage_pairs, variant_synonym_verdicts, variant_cloze_sources in variants
+    }
+
+    assert version not in changed_versions
+    assert len(changed_versions) == len(variants)
+
+
+def test_compute_deck_version_hashes_missing_inputs_as_empty_sentinels() -> None:
+    assert practice_deck_io.compute_deck_version(None, None, None, None, 1) == (
+        practice_deck_io.compute_deck_version([], [], {}, [], 1)
+    )
+
+
 def _request_url(request: object) -> str:
     return getattr(request, "full_url", str(request))
 

--- a/tests/test_publish_practice_deck.py
+++ b/tests/test_publish_practice_deck.py
@@ -2,11 +2,23 @@ from __future__ import annotations
 
 import gzip
 import json
+import sqlite3
 import subprocess
 from pathlib import Path
 
 import pytest
 
+from scripts.audit.generate_practice_deck import (
+    BuildConfig,
+    JsonVesumVerifier,
+    ReviewedSourceAllowlist,
+    build_practice_shards,
+    read_cloze_sources,
+    read_heritage_pairs,
+    read_manifest,
+    write_shards,
+)
+from scripts.practice_deck import publish as publish_module
 from scripts.practice_deck.publish import (
     ASSET_NAME,
     KINDS,
@@ -15,10 +27,78 @@ from scripts.practice_deck.publish import (
     publish_practice_deck,
 )
 
+FIXTURES = Path("tests/fixtures")
+MANIFEST = FIXTURES / "lexicon-practice-manifest.json"
+ALLOWLIST = FIXTURES / "lexicon-practice-reviewed-allowlist.json"
+VESUM = FIXTURES / "lexicon-practice-vesum.json"
+CLOZE_SOURCES = FIXTURES / "lexicon-practice-cloze-sources.json"
+HERITAGE_PAIRS = FIXTURES / "lexicon-practice-heritage-pairs.yaml"
+
 
 def _write_json(path: Path, payload: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def _write_atlas_db(
+    path: Path,
+    entries: list[dict[str, object]],
+    *,
+    public_flags: list[bool] | None = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        path.unlink()
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE article_payloads (
+                slug TEXT PRIMARY KEY,
+                route_order INTEGER NOT NULL,
+                payload_json TEXT NOT NULL,
+                is_public_route INTEGER NOT NULL
+            )
+            """
+        )
+        for index, entry in enumerate(entries):
+            slug = str(entry.get("url_slug") or entry.get("slug") or f"entry-{index}")
+            is_public = public_flags[index] if public_flags is not None else True
+            conn.execute(
+                """
+                INSERT INTO article_payloads (slug, route_order, payload_json, is_public_route)
+                VALUES (?, ?, ?, ?)
+                """,
+                (slug, index, json.dumps(entry, ensure_ascii=False), 1 if is_public else 0),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _write_publish_inputs(
+    base_dir: Path,
+    *,
+    entries: list[dict[str, object]] | None = None,
+    heritage_pairs: list[dict[str, object]] | None = None,
+    synonym_verdicts: dict[str, object] | None = None,
+    cloze_sources: list[dict[str, object]] | None = None,
+    public_flags: list[bool] | None = None,
+) -> dict[str, Path]:
+    paths = {
+        "atlas_db_path": base_dir / "atlas.db",
+        "heritage_pairs_path": base_dir / "heritage_pairs.yaml",
+        "synonym_verdicts_path": base_dir / "synonym_pair_verdicts.yaml",
+        "cloze_sources_path": base_dir / "lexicon-practice-cloze-sources.json",
+    }
+    _write_atlas_db(paths["atlas_db_path"], entries or [], public_flags=public_flags)
+    if heritage_pairs is not None:
+        _write_json(paths["heritage_pairs_path"], {"pairs": heritage_pairs})
+    if synonym_verdicts is not None:
+        _write_json(paths["synonym_verdicts_path"], synonym_verdicts)
+    if cloze_sources is not None:
+        _write_json(paths["cloze_sources_path"], cloze_sources)
+    return paths
 
 
 def _write_practice_deck(practice_dir: Path, *, deck_version: str = "atlas-practice-v1-test") -> None:
@@ -77,18 +157,17 @@ def _write_practice_deck(practice_dir: Path, *, deck_version: str = "atlas-pract
 def test_publish_practice_deck_dry_run_builds_hash_pinned_package(tmp_path: Path) -> None:
     practice_dir = tmp_path / "lexicon"
     gzip_path = tmp_path / "lexicon-practice-deck.json.gz"
-    manifest_path = tmp_path / "lexicon-manifest.json"
-    _write_json(manifest_path, {"entries": []})
+    input_paths = _write_publish_inputs(tmp_path / "inputs")
 
     from scripts.practice_deck.publish import expected_deck_version, versioned_asset_name
-    expected_version = expected_deck_version(manifest_path)
+    expected_version = expected_deck_version(**input_paths)
     _write_practice_deck(practice_dir, deck_version=expected_version)
 
     pointer = publish_practice_deck(
         practice_dir=practice_dir,
         gzip_path=gzip_path,
-        manifest_path=manifest_path,
         dry_run=True,
+        **input_paths,
     )
 
     assert pointer["deck_version"] == expected_version
@@ -105,16 +184,15 @@ def test_publish_practice_deck_dry_run_builds_hash_pinned_package(tmp_path: Path
 
 def test_publish_practice_deck_rejects_version_mismatch(tmp_path: Path) -> None:
     practice_dir = tmp_path / "lexicon"
-    manifest_path = tmp_path / "lexicon-manifest.json"
-    _write_json(manifest_path, {"entries": []})
+    input_paths = _write_publish_inputs(tmp_path / "inputs")
     _write_practice_deck(practice_dir, deck_version="atlas-practice-v1-other")
 
     with pytest.raises(PracticeDeckPublishError, match="does not match expected version"):
         publish_practice_deck(
             practice_dir=practice_dir,
             gzip_path=tmp_path / "deck.json.gz",
-            manifest_path=manifest_path,
             dry_run=True,
+            **input_paths,
         )
 
 
@@ -123,14 +201,12 @@ def test_publish_practice_deck_uploads_versioned_and_canonical_assets(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     practice_dir = tmp_path / "lexicon"
-    manifest_path = tmp_path / "lexicon-manifest.json"
     gzip_path = tmp_path / "lexicon-practice-deck.json.gz"
     pointer_path = tmp_path / "lexicon-practice-deck.pointer.json"
-
-    _write_json(manifest_path, {"entries": []})
+    input_paths = _write_publish_inputs(tmp_path / "inputs")
 
     from scripts.practice_deck.publish import expected_deck_version, versioned_asset_name
-    expected_version = expected_deck_version(manifest_path)
+    expected_version = expected_deck_version(**input_paths)
     _write_practice_deck(practice_dir, deck_version=expected_version)
     expected_versioned_name = versioned_asset_name(expected_version)
 
@@ -151,8 +227,8 @@ def test_publish_practice_deck_uploads_versioned_and_canonical_assets(
         practice_dir=practice_dir,
         gzip_path=gzip_path,
         pointer_path=pointer_path,
-        manifest_path=manifest_path,
         repo="learn-ukrainian/example",
+        **input_paths,
     )
 
     assert pointer["asset_url"].endswith(f"/{expected_versioned_name}")
@@ -167,14 +243,12 @@ def test_publish_practice_deck_skips_existing_verified_versioned_asset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     practice_dir = tmp_path / "lexicon"
-    manifest_path = tmp_path / "lexicon-manifest.json"
     gzip_path = tmp_path / "lexicon-practice-deck.json.gz"
     pointer_path = tmp_path / "lexicon-practice-deck.pointer.json"
-
-    _write_json(manifest_path, {"entries": []})
+    input_paths = _write_publish_inputs(tmp_path / "inputs")
 
     from scripts.practice_deck.publish import expected_deck_version, versioned_asset_name
-    expected_version = expected_deck_version(manifest_path)
+    expected_version = expected_deck_version(**input_paths)
     _write_practice_deck(practice_dir, deck_version=expected_version)
     expected_versioned_name = versioned_asset_name(expected_version)
 
@@ -200,19 +274,107 @@ def test_publish_practice_deck_skips_existing_verified_versioned_asset(
         practice_dir=practice_dir,
         gzip_path=gzip_path,
         pointer_path=pointer_path,
-        manifest_path=manifest_path,
         repo="learn-ukrainian/example",
         dry_run=True,
+        **input_paths,
     )
 
     publish_practice_deck(
         practice_dir=practice_dir,
         gzip_path=gzip_path,
         pointer_path=pointer_path,
-        manifest_path=manifest_path,
         repo="learn-ukrainian/example",
+        **input_paths,
     )
 
     assert download_calls == [expected_versioned_name]
     assert [Path(call[4]).name for call in upload_calls] == [ASSET_NAME]
     assert "--clobber" in upload_calls[0]
+
+
+def test_expected_deck_version_uses_public_atlas_db_projection(tmp_path: Path) -> None:
+    entries = read_manifest(MANIFEST)
+    public_only_paths = _write_publish_inputs(
+        tmp_path / "public-only",
+        entries=[entries[0]],
+    )
+    with_private_paths = _write_publish_inputs(
+        tmp_path / "with-private",
+        entries=[entries[0], entries[1]],
+        public_flags=[True, False],
+    )
+
+    from scripts.practice_deck.publish import expected_deck_version
+
+    assert expected_deck_version(**with_private_paths) == expected_deck_version(**public_only_paths)
+
+
+@pytest.mark.parametrize("stale_input", ["entries", "heritage_pairs", "synonym_verdicts", "cloze_sources"])
+def test_publish_guard_passes_fresh_regen_and_fails_stale_shards(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stale_input: str,
+) -> None:
+    monkeypatch.setattr(publish_module, "LEVELS", ("A1",))
+    practice_dir = tmp_path / "lexicon"
+    gzip_path = tmp_path / "lexicon-practice-deck.json.gz"
+    entries = read_manifest(MANIFEST)
+    cloze_sources = read_cloze_sources(CLOZE_SOURCES)
+    heritage_pairs = read_heritage_pairs(HERITAGE_PAIRS)
+    synonym_verdicts = {"approved": [], "rejected": []}
+    input_paths = _write_publish_inputs(
+        tmp_path / "inputs",
+        entries=entries,
+        heritage_pairs=heritage_pairs,
+        synonym_verdicts=synonym_verdicts,
+        cloze_sources=cloze_sources,
+    )
+    shards = build_practice_shards(
+        entries,
+        ReviewedSourceAllowlist.from_path(ALLOWLIST),
+        JsonVesumVerifier.from_path(VESUM),
+        cloze_sources,
+        BuildConfig(),
+        heritage_pairs=heritage_pairs,
+        synonym_verdicts=synonym_verdicts,
+    )
+    write_shards(shards, practice_dir)
+
+    pointer = publish_practice_deck(
+        practice_dir=practice_dir,
+        gzip_path=gzip_path,
+        dry_run=True,
+        **input_paths,
+    )
+    assert pointer["deck_version"] == next(
+        payload["deckVersion"]
+        for level_shards in shards.values()
+        for payload in level_shards.values()
+    )
+
+    if stale_input == "entries":
+        stale_entries = json.loads(json.dumps(entries))
+        stale_entries[0]["gloss"] = "changed stale gloss"
+        _write_atlas_db(input_paths["atlas_db_path"], stale_entries)
+    elif stale_input == "heritage_pairs":
+        stale_heritage_pairs = json.loads(json.dumps(heritage_pairs))
+        stale_heritage_pairs[0]["rationale"] = "changed stale rationale"
+        _write_json(input_paths["heritage_pairs_path"], {"pairs": stale_heritage_pairs})
+    elif stale_input == "synonym_verdicts":
+        stale_synonym_verdicts = {
+            "approved": [{"a": "кіт", "b": "пес", "polarity": "synonym"}],
+            "rejected": [],
+        }
+        _write_json(input_paths["synonym_verdicts_path"], stale_synonym_verdicts)
+    else:
+        stale_cloze_sources = json.loads(json.dumps(cloze_sources))
+        stale_cloze_sources[0]["sentence"] = "Свіжа версія має інше речення з ___."
+        _write_json(input_paths["cloze_sources_path"], stale_cloze_sources)
+
+    with pytest.raises(PracticeDeckPublishError, match="does not match expected version"):
+        publish_practice_deck(
+            practice_dir=practice_dir,
+            gzip_path=gzip_path,
+            dry_run=True,
+            **input_paths,
+        )

--- a/tests/test_publish_practice_deck.py
+++ b/tests/test_publish_practice_deck.py
@@ -378,3 +378,32 @@ def test_publish_guard_passes_fresh_regen_and_fails_stale_shards(
             dry_run=True,
             **input_paths,
         )
+
+
+def test_publish_script_style_invocation_reaches_projection_read(tmp_path: Path) -> None:
+    """The documented invocation (`make practice-deck-publish` → `$(PYTHON)
+    scripts/practice_deck/publish.py`) runs SCRIPT-style, without a package context.
+    The lazy `scripts.*` imports inside expected_deck_version() must still resolve
+    (#4660 review fix — sys.path bootstrap; the #4529 lazy-absolute-import class).
+    An empty sqlite file gets PAST the exists() guard and INTO the lazy-import path."""
+    import sys
+
+    repo_root = Path(publish_module.__file__).resolve().parents[2]
+    empty_db = tmp_path / "atlas.db"
+    empty_db.write_bytes(b"")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(repo_root / "scripts" / "practice_deck" / "publish.py"),
+            "--dry-run",
+            "--atlas-db",
+            str(empty_db),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    combined = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "No module named 'scripts'" not in combined
+    assert "Failed to calculate expected deck version" in combined

--- a/tests/test_publish_practice_deck.py
+++ b/tests/test_publish_practice_deck.py
@@ -385,10 +385,13 @@ def test_publish_script_style_invocation_reaches_projection_read(tmp_path: Path)
     scripts/practice_deck/publish.py`) runs SCRIPT-style, without a package context.
     The lazy `scripts.*` imports inside expected_deck_version() must still resolve
     (#4660 review fix — sys.path bootstrap; the #4529 lazy-absolute-import class).
-    An empty sqlite file gets PAST the exists() guard and INTO the lazy-import path."""
+    Hermetic: fixture shards in a tmp practice dir get PAST collect_shards, and an
+    empty sqlite file gets PAST the exists() guard and INTO the lazy-import path."""
     import sys
 
     repo_root = Path(publish_module.__file__).resolve().parents[2]
+    practice_dir = tmp_path / "lexicon"
+    _write_practice_deck(practice_dir)
     empty_db = tmp_path / "atlas.db"
     empty_db.write_bytes(b"")
     result = subprocess.run(
@@ -396,6 +399,12 @@ def test_publish_script_style_invocation_reaches_projection_read(tmp_path: Path)
             sys.executable,
             str(repo_root / "scripts" / "practice_deck" / "publish.py"),
             "--dry-run",
+            "--practice-dir",
+            str(practice_dir),
+            "--gzip",
+            str(tmp_path / "deck.json.gz"),
+            "--pointer",
+            str(tmp_path / "pointer.json"),
             "--atlas-db",
             str(empty_db),
         ],


### PR DESCRIPTION
## Summary
- Add shared `compute_deck_version()` over public deck entries, heritage pairs, synonym verdicts, cloze sources, and schema version.
- Stamp generator shards with that shared helper and make publish recompute from the same public atlas DB/curated-input projection.
- Extend regression coverage for version moves/stability and stale publish guards across all hashed inputs.

## Evidence

### Tests
Command: `.venv/bin/python -m pytest tests/test_generate_practice_deck.py tests/test_publish_practice_deck.py tests/test_practice_deck_io.py -q`
Cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4657-deck-version-inputs`
Raw final line:
```text
============================== 55 passed in 1.70s ==============================
```

### Lint
Command: `.venv/bin/ruff check scripts/practice_deck/io.py scripts/audit/generate_practice_deck.py scripts/practice_deck/publish.py tests/test_practice_deck_io.py tests/test_generate_practice_deck.py tests/test_publish_practice_deck.py`
Cwd: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4657-deck-version-inputs`
Raw output:
```text
All checks passed!
```

### Version moves/stays
New tests cover version changes for entries, heritage pairs, synonym verdicts, and cloze sources, plus stable double regen with identical fixture inputs.

Live double-regeneration demo against the default atlas/curated inputs, with `data/atlas.db` temporarily symlinked from the main checkout and removed after the run:
```text
demo_tmp=/var/folders/pd/wvj52r1j3bd4z9y3dfc2k4180000gn/T/tmp.7j5nLNIinx
regen1_deckVersion=atlas-practice-v1-90ac8bb756e5a88e
regen2_deckVersion=atlas-practice-v1-90ac8bb756e5a88e
versions_equal=yes
shards_diff=identical
regen1_stdout_lines=51
regen2_stdout_lines=51
regen1_stderr_last=WARN: C1 paronym coverage 0.0000 below 0.01; deck ships small without padding
regen2_stderr_last=WARN: C1 paronym coverage 0.0000 below 0.01; deck ships small without padding
```

### Commit
Command: `git log -1 --oneline`
Raw output:
```text
f956ec301a fix(practice): #4657 deck version fingerprints all deck inputs
```

### Cross-family review
AGY/Gemini review was requested with task id `review-4657-deck-version-inputs`. One accepted finding expanded publish stale-guard coverage to entries, heritage pairs, synonym verdicts, and cloze sources. Other findings requested hashing allowlist/verifier or hard-failing missing curated files; those conflict with #4657's explicit five-input hash projection and missing-input empty-sentinel requirement.

Refs #4657 #4505.
