### PR TITLE
fix(lexicon): preserve rare synonym qualifiers

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -1425,6 +1425,10 @@ def _extract_qualifier(text: str) -> str | None:
         return "розм."
     if re.search(r"\bзаст\b\.?|\bз\.", lower_text):
         return "заст."
+    if re.search(r"\bрідше\b\.?", lower_text):
+        return "рідше"
+    if re.search(r"\bрідко\b\.?", lower_text):
+        return "рідко"
     return None
 
 

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "ad1406c5f2a4c4182c734b5876cc15a6668e6be48782190184301cdb20d2b4f6",
+  "fingerprint": "fcdf4686b5db0486acff1853492287498d807821a9b2d168f12d55883a84a3aa",
   "inputs": {
     "lexicon_code": [
       {
@@ -48,7 +48,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "f0fea55451ffb19a04add49ca5a8d8f1380297fc9a97e63da8ff731574996409"
+        "sha256": "e867f8cb34ac73388ddbc6ef3f65e36071870df2c79c0e7da9ec80d9cdb9b786"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -502,6 +502,38 @@ def test_synonym_qualifiers_and_sense_guard_for_shliakh(monkeypatch) -> None:
     assert "кам'янка (діал.)" in items
 
 
+def test_synonym_frequency_qualifiers_are_preserved(monkeypatch) -> None:
+    _patch_vesum_analyses(
+        monkeypatch,
+        {
+            "джерело": "noun",
+            "ключ": "noun",
+            "криниця": "noun",
+            "криничка": "noun",
+            "керниця": "noun",
+        },
+    )
+    cache = {
+        "lookups": {
+            "synonyms": {
+                "dictionary_slug": "synonyms",
+                "dictionary_label": "Словник синонімів української мови",
+                "word": "джерело",
+                "source_url": "https://slovnyk.me/dict/synonyms/джерело",
+                "text": "джерело ДЖЕРЕЛО́, КЛЮЧ рідше, КРИНИ́ЧКА, КРИНИ́ЦЯ рідко, КЕРНИ́ЦЯ діал. Джерело: тест",
+            },
+        }
+    }
+
+    section = _synonyms_slovnyk("джерело", cache, entry_pos="noun")
+    assert section is not None
+    items = section["items"]
+
+    assert "ключ (рідше)" in items
+    assert "криниця (рідко)" in items
+    assert "керниця (діал.)" in items
+
+
 def test_synonym_sense_guard_for_richka(monkeypatch) -> None:
     _patch_vesum_analyses(
         monkeypatch,


### PR DESCRIPTION
## Summary

- Preserve `рідше` and `рідко` labels when extracting synonym chips from slovnyk.me rows.
- Add a regression test for `джерело` so rare synonyms such as `ключ` render as `ключ (рідше)` instead of appearing unqualified.
- Refresh the deterministic Atlas lexicon code fingerprint sidecar required by the freshness gate.

## Root Cause

The synonym extractor already preserved dialectal, colloquial, and obsolete labels, but it stripped frequency labels. That made a valid rare synonym look like an ordinary learner-facing synonym.

## Validation

- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_lexicon_enrich_manifest.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/ruff check scripts/lexicon/enrich_manifest.py tests/test_lexicon_enrich_manifest.py`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/lexicon/check_manifest_freshness.py`
- `git diff --check`
- `/Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py`