### PR TITLE
fix(folk): surface inline primary readings

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 7906551b36edb49559e7956c6a73b7de240b601aa9de6af9102d17a9207b39bd
+  components_sha256: ddb90591c1b1928edb2544d49dbd5db0ee78d5a383ea7309ed94308816813c9f
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1582,6 +1582,10 @@ components:
       - name: href
         type: string
         description: href prop.
+        ukrainian_text: 'false'
+      - name: id
+        type: string
+        description: id prop.
         ukrainian_text: 'false'
       - name: mode
         type: '''verse'' | ''prose'''

--- a/scripts/generate_mdx/converters.py
+++ b/scripts/generate_mdx/converters.py
@@ -308,8 +308,10 @@ def convert_folk_content_blocks(content: str) -> str:
             attrs = _directive_attrs(raw_attrs)
             work = attrs.get("reading") or _primary_reading_work_title(block_content)
             href = reading_href_for(work) if work else None
+            anchor = f'reading-{attrs["reading"]}' if attrs.get("reading") else ""
+            id_prop = f' id="{escape_jsx(anchor)}"' if anchor else ''
             href_prop = f' href="{escape_jsx(href)}"' if href else ''
-            return f"<PrimaryReading{href_prop}>\n\n{block_content}\n\n</PrimaryReading>\n"
+            return f"<PrimaryReading{id_prop}{href_prop}>\n\n{block_content}\n\n</PrimaryReading>\n"
 
         payload = _yaml_directive_payload(block_content)
         if block_type == 'myth-box':

--- a/scripts/generate_mdx/core.py
+++ b/scripts/generate_mdx/core.py
@@ -170,6 +170,13 @@ def _activity_plans_to_jsx(plans: list[dict]) -> str:
 _INJECT_ACTIVITY_RE = re.compile(r'<!--\s*INJECT_ACTIVITY:\s*([A-Za-z0-9_-]+)\s*-->')
 _INLINE_SECTION_HEADING_RE = re.compile(r'^#{2,3}\s+(.+?)\s*#*\s*$')
 _READING_SECTION_RE = re.compile(r'^(##\s+(?:Читання|Reading)[^\n]*\n)', re.MULTILINE)
+_PRIMARY_READING_DIRECTIVE_RE = re.compile(
+    r"^:::primary-reading(?P<attrs>[^\n]*)\n(?P<body>.*?)\n:::\s*$",
+    re.MULTILINE | re.DOTALL,
+)
+_DIRECTIVE_ATTR_RE = re.compile(r'([A-Za-z_][\w-]*)\s*=\s*"([^"]*)"')
+_PRIMARY_READING_ATTRIBUTION_RE = re.compile(r"^—[^\n]*[«\"“](?P<title>[^»\"”]+)[»\"”]", re.MULTILINE)
+_PRIMARY_READING_QUOTED_LINE_RE = re.compile(r"^>\s*(?P<line>\S.*?)\s*$", re.MULTILINE)
 
 
 def _activity_id(activity: Activity | dict) -> str:
@@ -273,32 +280,84 @@ def _inject_inline_activities(
     )
 
 
-def _format_plan_readings_for_mdx(readings: object) -> str:
+def _directive_attrs(raw: str) -> dict[str, str]:
+    raw = raw.strip()
+    if not raw.startswith("{") or not raw.endswith("}"):
+        return {}
+    return {match.group(1): match.group(2).strip() for match in _DIRECTIVE_ATTR_RE.finditer(raw[1:-1])}
+
+
+def _reading_title_from_primary_block(body: str, slug: str) -> str:
+    matches = list(_PRIMARY_READING_ATTRIBUTION_RE.finditer(body))
+    if matches:
+        return matches[-1].group("title").strip()
+    first_line = _PRIMARY_READING_QUOTED_LINE_RE.search(body)
+    if first_line:
+        return first_line.group("line").strip(" ,.;:")
+    return slug.replace("-", " ").strip()
+
+
+def _inline_primary_readings_for_mdx(body: str, existing_slugs: set[str]) -> list[dict[str, str]]:
+    readings: list[dict[str, str]] = []
+    seen = set(existing_slugs)
+    for match in _PRIMARY_READING_DIRECTIVE_RE.finditer(body):
+        attrs = _directive_attrs(match.group("attrs"))
+        slug = attrs.get("reading", "").strip()
+        if not slug or slug in seen:
+            continue
+        seen.add(slug)
+        href = reading_href_for(slug) or f"#reading-{slug}"
+        readings.append(
+            {
+                "title": _reading_title_from_primary_block(match.group("body"), slug),
+                "href": href,
+                "detail": "уривок у цьому модулі" if href.startswith("#") else "хрестоматія",
+            }
+        )
+    return readings
+
+
+def _format_plan_readings_for_mdx(readings: object, body: str = "", *, include_inline: bool = False) -> str:
     """Render the plan-level reading assignment as an integrity-gated MDX list."""
-    if not isinstance(readings, list):
+    entries: list[dict[str, str]] = []
+    existing_slugs: set[str] = set()
+
+    if isinstance(readings, list):
+        for item in readings:
+            if not isinstance(item, dict):
+                continue
+            title = str(item.get("title") or "").strip()
+            slug = str(item.get("reading_slug") or "").strip()
+            if not title or not slug:
+                continue
+            href = reading_href_for(slug)
+            if not href:
+                continue
+            existing_slugs.add(slug)
+            entries.append(
+                {
+                    "title": title,
+                    "href": href,
+                    "detail": str(item.get("genre") or "").strip(),
+                }
+            )
+
+    if include_inline:
+        entries.extend(_inline_primary_readings_for_mdx(body, existing_slugs))
+
+    if not entries:
         return ""
 
     lines = ["**Тексти для читання**", ""]
-    for item in readings:
-        if not isinstance(item, dict):
-            continue
-        title = str(item.get("title") or "").strip()
-        slug = str(item.get("reading_slug") or "").strip()
-        if not title or not slug:
-            continue
-        href = reading_href_for(slug)
-        if not href:
-            continue
-        genre = str(item.get("genre") or "").strip()
-        detail = genre
-        suffix = f" — {detail}" if detail else ""
-        lines.append(f"- [{title}]({href}){suffix}")
+    for item in entries:
+        suffix = f" — {item['detail']}" if item["detail"] else ""
+        lines.append(f"- [{item['title']}]({item['href']}){suffix}")
 
     return "\n".join(lines) if len(lines) > 2 else ""
 
 
-def _insert_plan_readings_block(body: str, readings: object) -> str:
-    block = _format_plan_readings_for_mdx(readings)
+def _insert_plan_readings_block(body: str, readings: object, *, include_inline: bool = False) -> str:
+    block = _format_plan_readings_for_mdx(readings, body, include_inline=include_inline)
     if not block:
         return body
 
@@ -436,7 +495,11 @@ sidebar:
 
     # --- TAB 1: Lesson (prose only) ---
     lesson_content = body
-    lesson_content = _insert_plan_readings_block(lesson_content, fm.get("readings"))
+    lesson_content = _insert_plan_readings_block(
+        lesson_content,
+        fm.get("readings"),
+        include_inline=level.lower() == "folk",
+    )
     lesson_content = embed_youtube_video_links(lesson_content)
     (
         lesson_content,
@@ -850,11 +913,17 @@ def main():
 
         # Detect pipeline version and build status
         pv, bs = detect_pipeline_info(level_dir, mod.slug)
+        output_file = output_dir / f'{mod.slug}.mdx'
+        if output_file.exists() and (pv is None or bs is None):
+            existing_fm, _ = parse_frontmatter(output_file.read_text(encoding='utf-8'))
+            if pv is None and isinstance(existing_fm.get("pipeline"), str):
+                pv = existing_fm["pipeline"]
+            if bs is None and isinstance(existing_fm.get("build_status"), str):
+                bs = existing_fm["build_status"]
 
         mdx_content = generate_mdx(md_content, mod.local_num, yaml_activities, meta_data, vocab_items, module_resources, mod.level, pipeline_version=pv, build_status=bs, activity_plans=loaded_activity_plans)
 
         # Write output
-        output_file = output_dir / f'{mod.slug}.mdx'
         output_file.write_text(mdx_content, encoding='utf-8')  # codeql[py/clear-text-storage-sensitive-data] - .mdx curriculum content, never sensitive data
 
     print('\n\u2705 MDX generation complete!')

--- a/site/src/components/PrimaryReading.tsx
+++ b/site/src/components/PrimaryReading.tsx
@@ -4,13 +4,14 @@ import ReadingText from './ReadingText';
 interface PrimaryReadingProps {
   children?: React.ReactNode;
   href?: string;
+  id?: string;
   mode?: 'verse' | 'prose';
   text?: string;
 }
 
-export default function PrimaryReading({ children, href, mode = 'verse', text }: PrimaryReadingProps) {
+export default function PrimaryReading({ children, href, id, mode = 'verse', text }: PrimaryReadingProps) {
   return (
-    <div className="primary-reading-box">
+    <div className="primary-reading-box" id={id}>
       <div className="primary-reading-header">
         <span aria-hidden="true">&#x1F4DC; </span>
         Читаємо першоджерело / Read the text

--- a/site/src/content/docs/folk/narodna-vyshyvka-rushnyk-strii.mdx
+++ b/site/src/content/docs/folk/narodna-vyshyvka-rushnyk-strii.mdx
@@ -65,6 +65,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Урок">
 
+**Тексти для читання**
+
+- [Дівчина Леся](#reading-hrinchenko-vyshyvaie-rushnyk-fragment) — уривок у цьому модулі
+
 ## Постановка проблеми
 
 Українську народну вишивку легко побачити занадто швидко: біла сорочка,
@@ -177,7 +181,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 У Бориса Грінченка рушник показаний через сам акт вишивання і через те, як
 річ переходить від руки до соціальної дії:
 
-<PrimaryReading>
+<PrimaryReading id="reading-hrinchenko-vyshyvaie-rushnyk-fragment">
 
 > От тепер вже два ока у Лесі,
 > Вишиває рушник вона пишно:

--- a/site/src/content/docs/folk/narodni-remesla-ta-khudozhni-promysly.mdx
+++ b/site/src/content/docs/folk/narodni-remesla-ta-khudozhni-promysly.mdx
@@ -65,6 +65,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Урок">
 
+**Тексти для читання**
+
+- [Домашній промисл](#reading-franko-domashnii-promysl-rodynna-peredacha-fragment) — уривок у цьому модулі
+
 ## Постановка проблеми
 
 Народні ремесла та художні промисли легко побачити як гарну вітрину:
@@ -199,7 +203,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 ярмарком, замовленням і родиною. У Франковій літературній сцені ложкар пояснює
 передавання ремесла в розмові з урядовим поглядом на "свідоцтво здатності":
 
-<PrimaryReading>
+<PrimaryReading id="reading-franko-domashnii-promysl-rodynna-peredacha-fragment">
 
 > Було то якось у пущінє, зимою,
 > а от так коло середопістя забираюся я з сином до ложок.

--- a/site/src/content/docs/folk/narodni-tantsi.mdx
+++ b/site/src/content/docs/folk/narodni-tantsi.mdx
@@ -66,6 +66,11 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Урок">
 
+**Тексти для читання**
+
+- [Історія української літератури](#reading-kryvyi-tanets-kintsia-ne-znaidemo-fragment) — уривок у цьому модулі
+- [Історія української літератури](#reading-shum-zelenoho-shuma-fragment) — уривок у цьому модулі
+
 ## Постановка проблеми
 
 Народний танець легко сплутати з видовищем. Досить згадати концертний гопак:
@@ -139,7 +144,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Один із базових записів цієї формули працює саме так:
 
-<PrimaryReading>
+<PrimaryReading id="reading-kryvyi-tanets-kintsia-ne-znaidemo-fragment">
 
 > Кривого танця йдемо,
 > Кінця му не знайдемо:
@@ -188,7 +193,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 Окремо стоїть `Шум`. У ньому весняна зелень, діброва, хода і жартівливе
 нарощення поєднуються в образ оживлення:
 
-<PrimaryReading>
+<PrimaryReading id="reading-shum-zelenoho-shuma-fragment">
 
 > Ой нумо, нумо,
 > В зеленого шума -

--- a/site/src/content/docs/folk/pysankarstvo.mdx
+++ b/site/src/content/docs/folk/pysankarstvo.mdx
@@ -65,6 +65,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs syncKey="module-tab">
 <TabItem label="Урок">
 
+**Тексти для читання**
+
+- [Христос воскрес, о тім](#reading-pysanky-velykodnii-dar-fragment) — уривок у цьому модулі
+
 ## Постановка проблеми
 
 Писанкарство легко звести до красивого великоднього предмета. Яйце лежить у
@@ -136,7 +140,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 не одним рядком, а як малий ранньомодерний сценарій обходу, прохання і
 віншування:
 
-<PrimaryReading>
+<PrimaryReading id="reading-pysanky-velykodnii-dar-fragment">
 
 > Христос воскрес, о тім
 > знайте

--- a/tests/test_reading_links.py
+++ b/tests/test_reading_links.py
@@ -143,7 +143,10 @@ def test_primary_reading_prefers_explicit_reading_attr(monkeypatch):
     )
 
     assert calls == ["shchedrivka-oi-syvaia-ta-i-zozulechka"]
-    assert '<PrimaryReading href="/readings/shchedrivka-oi-syvaia-ta-i-zozulechka/">' in out
+    assert (
+        '<PrimaryReading id="reading-shchedrivka-oi-syvaia-ta-i-zozulechka" '
+        'href="/readings/shchedrivka-oi-syvaia-ta-i-zozulechka/">'
+    ) in out
 
 
 def test_primary_reading_omits_missing_link(monkeypatch):
@@ -187,3 +190,65 @@ def test_plan_readings_block_is_integrity_gated(monkeypatch):
     assert "Колядка" in out
     assert "When world had no beginning" not in out
     assert "Broken" not in out
+
+
+def test_plan_readings_block_falls_back_to_structured_inline_readings(monkeypatch):
+    monkeypatch.setattr(core, "reading_href_for", lambda slug: None)
+
+    out = core._format_plan_readings_for_mdx(
+        [],
+        ':::primary-reading{reading="kryvyi-tanets-kintsia-ne-znaidemo-fragment"}\n'
+        "> Кривого танця йдемо,\n\n"
+        "— Михайло Грушевський, «Кривого танця йдемо»; права: суспільне надбання.\n"
+        ":::\n",
+        include_inline=True,
+    )
+
+    assert "**Тексти для читання**" in out
+    assert (
+        "- [Кривого танця йдемо](#reading-kryvyi-tanets-kintsia-ne-znaidemo-fragment) "
+        "— уривок у цьому модулі"
+    ) in out
+
+
+def test_plan_readings_block_uses_first_quoted_line_when_attribution_has_no_title(monkeypatch):
+    monkeypatch.setattr(core, "reading_href_for", lambda slug: None)
+
+    out = core._format_plan_readings_for_mdx(
+        [],
+        ':::primary-reading{reading="pysanky-velykodnii-dar-fragment"}\n'
+        "> Христос воскрес, о тім\n"
+        "> знайте\n\n"
+        "— Антологія давньої української літератури; права: суспільне надбання.\n"
+        ":::\n",
+        include_inline=True,
+    )
+
+    assert "[Христос воскрес, о тім](#reading-pysanky-velykodnii-dar-fragment)" in out
+    assert "pysanky velykodnii dar fragment" not in out
+
+
+def test_plan_readings_block_deduplicates_plan_and_inline_readings(monkeypatch):
+    monkeypatch.setattr(
+        core,
+        "reading_href_for",
+        lambda slug: f"/readings/{slug}/" if slug == "shared-reading" else None,
+    )
+
+    out = core._format_plan_readings_for_mdx(
+        [
+            {
+                "title": "«Плановий текст»",
+                "genre": "Пісня",
+                "reading_slug": "shared-reading",
+            }
+        ],
+        ':::primary-reading{reading="shared-reading"}\n'
+        "> Рядок.\n\n"
+        "— Народна творчість, «Інша назва»; права: суспільне надбання.\n"
+        ":::\n",
+        include_inline=True,
+    )
+
+    assert out.count("shared-reading") == 1
+    assert "Інша назва" not in out


### PR DESCRIPTION
## Summary
- Populate FOLK `Тексти для читання` from structured inline `:::primary-reading{reading=\"...\"}` blocks when plan-level readings do not already provide the section.
- Add stable `id=\"reading-...\"` anchors to generated `PrimaryReading` blocks while keeping hosted `/readings/.../` hrefs when available.
- Refresh M33-M36 generated FOLK MDX so the reading-content section is visible on those pages immediately.
- Preserve existing generated `pipeline`/`build_status` metadata during targeted regeneration and update `docs/lesson-schema.yaml` for the new optional `PrimaryReading.id` prop.

## Review
- Claude Opus 4.8 route was attempted first and failed at the Claude CLI layer before producing review findings.
- AGY/Gemini fallback (`gemini-3.1-pro-high`) reviewed the final staged diff and returned `PASS`.
- DeepSeek was not used.

## Verification
- `.venv/bin/python -m pytest tests/test_reading_links.py tests/test_reading_coverage_gate.py -q` — 36 passed
- `.venv/bin/python -m ruff check scripts/generate_mdx/core.py scripts/generate_mdx/converters.py tests/test_reading_links.py`
- `npm run validate:mdx`
- `.venv/bin/python scripts/audit/check_mdx_source_parity.py --changed-vs-base origin/main`
- `.venv/bin/python scripts/audit/check_mdx_forward_parity.py --changed-vs-base origin/main`
- `.venv/bin/python scripts/audit/check_mdx_generation_drift.py --changed-vs-base origin/main`
- `git diff --check origin/main...HEAD`
- Protected/generated-file scope scan: `changed_files=9`, no protected matches
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`
- `npm run build:starlight` — passed on rebased head; emitted stale Atlas pointer advisory but hydrated from existing assets and built 6200 pages

## Follow-up
This PR fixes the generator behavior and refreshes the four Batch F pages. The remaining FOLK generated pages with inline structured readings should be refreshed in small batches after this lands so their reading sections are populated by the fixed generator.