### PR TITLE
feat(practice): #4658 session model UI (spec §6b)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: ddb90591c1b1928edb2544d49dbd5db0ee78d5a383ea7309ed94308816813c9f
+  components_sha256: f8a51a3ead23df43a7a342c82f81523cd3bae59d26f0bbd9f7570fa74e166ba3
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1565,6 +1565,118 @@ components:
       - 1
       category: Приклад
       instruction: Приклад
+    deprecated: false
+    deprecation_reason: null
+  PracticeErrorBoundary:
+    tab: lesson
+    level_scope: *id001
+    activity_type: null
+    placement: n/a
+    props:
+      required:
+      - name: children
+        type: ReactNode
+        description: children prop.
+        ukrainian_text: 'false'
+      optional: []
+    nested_types: {}
+    example:
+      children: <ReactNode>
+    deprecated: false
+    deprecation_reason: null
+  PracticeFlashcard:
+    tab: lesson
+    level_scope: *id001
+    activity_type: null
+    placement: n/a
+    props:
+      required:
+      - name: card
+        type: PracticeFlashcardData
+        description: card prop.
+        ukrainian_text: 'false'
+      - name: ratingLabels
+        type: Record<PracticeRating, string>
+        description: ratingLabels prop.
+        ukrainian_text: 'false'
+      - name: intervalPreviews
+        type: Record<PracticeRating, string>
+        description: intervalPreviews prop.
+        ukrainian_text: 'false'
+      optional: []
+    nested_types:
+      PracticeFlashcardData:
+      - name: front
+        type: string
+        description: front prop.
+        ukrainian_text: 'false'
+      - name: back
+        type: string
+        description: back prop.
+        ukrainian_text: 'false'
+      - name: subtitle
+        type: string
+        description: subtitle prop.
+        ukrainian_text: 'false'
+      - name: tag
+        type: string
+        description: tag prop.
+        ukrainian_text: 'false'
+      - name: tagColor
+        type: string
+        description: tagColor prop.
+        ukrainian_text: 'false'
+    example:
+      card: <PracticeFlashcardData>
+      ratingLabels: <Record<PracticeRating, string>>
+      intervalPreviews: <Record<PracticeRating, string>>
+    deprecated: false
+    deprecation_reason: null
+  PracticeSessionSummary:
+    tab: lesson
+    level_scope: *id001
+    activity_type: null
+    placement: n/a
+    props:
+      required:
+      - name: stats
+        type: SessionSummaryStats
+        description: stats prop.
+        ukrainian_text: 'false'
+      - name: showEnglishSubtitles
+        type: boolean
+        description: showEnglishSubtitles prop.
+        ukrainian_text: 'false'
+      optional: []
+    nested_types:
+      SessionSummaryStats:
+      - name: correct
+        type: number
+        description: correct prop.
+        ukrainian_text: 'false'
+      - name: lapsed
+        type: number
+        description: lapsed prop.
+        ukrainian_text: 'false'
+      - name: advancedToReview
+        type: string[]
+        description: advancedToReview prop.
+        ukrainian_text: 'false'
+      - name: streak
+        type: number
+        description: streak prop.
+        ukrainian_text: 'false'
+      - name: nextDueLabel
+        type: string | null
+        description: nextDueLabel prop.
+        ukrainian_text: 'false'
+      - name: deferredLemmas
+        type: PracticeLexeme[]
+        description: deferredLemmas prop.
+        ukrainian_text: 'false'
+    example:
+      stats: <SessionSummaryStats>
+      showEnglishSubtitles: false
     deprecated: false
     deprecation_reason: null
   PrimaryReading:

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: f8a51a3ead23df43a7a342c82f81523cd3bae59d26f0bbd9f7570fa74e166ba3
+  components_sha256: 028ecda324477dcb3ffab91c76b90b706065efea80fc1f7b7c8fdafd963aba7e
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -644,6 +644,16 @@ function shouldLoadCloze(mode: PracticeModeFilter): boolean {
   return ['mixed', 'cloze', 'stress', 'classify', 'paradigm', 'synonym'].includes(mode);
 }
 
+function sessionScopeIndexForMode(
+  index: PracticeIndexItem[],
+  modeFilter: PracticeModeFilter,
+): PracticeIndexItem[] {
+  if (modeFilter === 'mixed') return index;
+  return index
+    .filter((item) => item.modes.includes(modeFilter))
+    .map((item) => ({ ...item, modes: [modeFilter] }));
+}
+
 /** Learner level persisted in the shared `lu-learner-level` key (also used by Words of the Day). */
 function readLearnerLevel(fallback: CefrLevel): CefrLevel {
   if (typeof window === 'undefined') return fallback;
@@ -768,9 +778,11 @@ function LexiconPracticeIsland({
 
   useEffect(() => {
     if (!autoStart || !deck || plannedTotal > 0) return;
-    const plan = computeSessionScope(deck.index, sessionBudget, { dailyNewCount });
+    const plan = computeSessionScope(sessionScopeIndexForMode(deck.index, mode), sessionBudget, {
+      dailyNewCount,
+    });
     resetSessionTracking(plan, sessionBudget);
-  }, [autoStart, dailyNewCount, deck, plannedTotal, sessionBudget]);
+  }, [autoStart, dailyNewCount, deck, mode, plannedTotal, sessionBudget]);
 
   useEffect(() => {
     const page = document.querySelector('.lexicon-practice-page');
@@ -1025,7 +1037,7 @@ function LexiconPracticeIsland({
     setError(null);
     const loadedDeck = await ensureDeck(shouldLoadCloze(nextMode));
     if (!loadedDeck) return;
-    const index = loadedDeck.index;
+    const index = sessionScopeIndexForMode(loadedDeck.index, nextMode);
     const plan = computeSessionScope(index, budget, { dailyNewCount });
     const nextSeed = resume?.sessionSeed ?? makePracticeSessionSeed();
     if (resume) {

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1,18 +1,35 @@
-import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
-import FlashcardDeck from './FlashcardDeck';
+import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import MatchUp from './MatchUp';
+import PracticeErrorBoundary from './PracticeErrorBoundary';
+import PracticeFlashcard from './PracticeFlashcard';
+import PracticeSessionSummary, { type SessionSummaryStats } from './PracticeSessionSummary';
 import {
+  DEFAULT_NEW_PER_DAY,
+  PUBLISHED_PRACTICE_LEVELS,
+  buildSessionPoolConstraintState,
   combinePracticeShards,
+  computeSessionScope,
+  computeTodayRingDenominator,
+  countDueReviewCards,
   czNorm,
-  getDueQueue,
+  isPracticeNewCard,
+  isPracticeSessionResumable,
   isWrongCaseAnswer,
   loadState,
   masteredCount,
+  nextDuePreviewTime,
+  previewRatingIntervals,
   rateCard,
+  resolveSessionCompletion,
+  readNewCardsDailyState,
+  readPracticeSessionSnapshot,
   selectNextPracticeItem,
   seededAnswerIndex,
+  sessionPoolAllowsCandidate,
   uaPlural,
   validateClozeOptions,
+  writeNewCardsDailyState,
+  writePracticeSessionSnapshot,
   type ChoicePolarity,
   type PracticeClozeItem,
   type PracticeDeckData,
@@ -23,7 +40,10 @@ import {
   type PracticeModeFilter,
   type PracticeRating,
   type PracticeSelection,
+  type PracticeSessionSnapshot,
   type SelectionHistoryItem,
+  type SessionBudget,
+  type SessionScopeStats,
   type PracticeClassifySet,
 } from '../lib/lexicon/srs';
 import {
@@ -60,6 +80,18 @@ interface ClozeFeedback {
 
 const STREAK_KEY = 'lu-lexicon-practice-streak';
 const MASTERED_THRESHOLD = 21;
+type SessionPhase = 'idle' | 'active' | 'summary';
+
+const SESSION_LABELS_A1: Record<string, string> = {
+  startSession: 'Start session',
+  continueSession: 'Continue session',
+  focusPractice: 'Focus practice',
+  budget10: 'Quick (10)',
+  budget20: 'Standard (20)',
+  budgetZero: 'Until clear',
+  newToday: 'New today',
+  dueReviews: 'Due for review',
+};
 
 function makePracticeSessionSeed(): number {
   return (Date.now() ^ Math.floor(Math.random() * 4294967296)) >>> 0;
@@ -652,7 +684,15 @@ function mergeDecks(decks: PracticeDeckData[], level: CefrLevel): PracticeDeckDa
   };
 }
 
-export default function LexiconPractice({
+export default function LexiconPractice(props: LexiconPracticeProps) {
+  return (
+    <PracticeErrorBoundary>
+      <LexiconPracticeIsland {...props} />
+    </PracticeErrorBoundary>
+  );
+}
+
+function LexiconPracticeIsland({
   deckLevel = 'A1',
   shardBaseUrl = '/lexicon',
   initialDeck,
@@ -665,9 +705,23 @@ export default function LexiconPractice({
     const normalized = normalizeInitialDeck(initialDeck);
     return Boolean(normalized && normalized.cloze.length > 0);
   });
-  const [started, setStarted] = useState(autoStart);
+  const [sessionPhase, setSessionPhase] = useState<SessionPhase>(autoStart ? 'active' : 'idle');
   const [sessionSeed, setSessionSeed] = useState(() => makePracticeSessionSeed());
   const [mode, setMode] = useState<PracticeModeFilter>(initialMode);
+  const [sessionBudget, setSessionBudget] = useState<SessionBudget>(20);
+  const [sessionPlan, setSessionPlan] = useState<SessionScopeStats | null>(null);
+  const [plannedReviews, setPlannedReviews] = useState(0);
+  const [plannedTotal, setPlannedTotal] = useState(0);
+  const [sessionCompleted, setSessionCompleted] = useState(0);
+  const [reviewsCompleted, setReviewsCompleted] = useState(0);
+  const [sessionNewIntroduced, setSessionNewIntroduced] = useState(0);
+  const [extensionUsed, setExtensionUsed] = useState(0);
+  const [unresolvedCardKeys, setUnresolvedCardKeys] = useState<Set<string>>(() => new Set());
+  const [deferredLemmas, setDeferredLemmas] = useState<PracticeLexeme[]>([]);
+  const [sessionCorrect, setSessionCorrect] = useState(0);
+  const [sessionLapsed, setSessionLapsed] = useState(0);
+  const [advancedToReview, setAdvancedToReview] = useState<string[]>([]);
+  const [resumeSnapshot, setResumeSnapshot] = useState<PracticeSessionSnapshot | null>(null);
   const [learnerLevel, setLearnerLevel] = useState<CefrLevel>(() =>
     readLearnerLevel(normalizeCefrLevel(deckLevel)),
   );
@@ -682,29 +736,52 @@ export default function LexiconPractice({
     current: 0,
     lastPracticeDate: null,
   });
-  const [mastered, setMastered] = useState(0);
-  const [correctToday, setCorrectToday] = useState(0);
+  const [, setMastered] = useState(0);
+  const [completedToday, setCompletedToday] = useState(0);
+  const [dailyNewCount, setDailyNewCount] = useState(0);
   const [storageWarning, setStorageWarning] = useState<string | null>(null);
   const [clozeInput, setClozeInput] = useState('');
   const [clozeFeedback, setClozeFeedback] = useState<ClozeFeedback | null>(null);
   const [clozeAttemptRecorded, setClozeAttemptRecorded] = useState(false);
-  // Lightweight per-level index used to show the due-count on the home BEFORE a mode
-  // is started. Superseded by `deck.index` once a full deck loads.
   const [dueIndex, setDueIndex] = useState<PracticeIndexItem[] | null>(null);
+  const [publishedLevels] = useState<Set<CefrLevel>>(
+    () => new Set(PUBLISHED_PRACTICE_LEVELS as unknown as CefrLevel[]),
+  );
   const stageRef = useRef<HTMLDivElement | null>(null);
-  // Monotonic id so a slow earlier deck fetch can't overwrite a newer one (rapid level switches).
   const deckRequestId = useRef(0);
+  const sessionStartedAtRef = useRef(Date.now());
+  const showEnglishSubtitles = learnerLevel === 'A1';
 
   useEffect(() => {
     const state = loadState();
     setStreak(readStreak());
     setMastered(masteredCount(MASTERED_THRESHOLD));
+    setDailyNewCount(readNewCardsDailyState().count);
+    const snapshot = readPracticeSessionSnapshot();
+    setResumeSnapshot(isPracticeSessionResumable(snapshot) ? snapshot : null);
     if (state.flags.corrupt || state.flags.migrationFailed) {
       setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
     } else if (state.flags.clockJump) {
       setStorageWarning('Час повторення може бути неточним: змінився годинник пристрою.');
     }
   }, []);
+
+  useEffect(() => {
+    if (!autoStart || !deck || plannedTotal > 0) return;
+    const plan = computeSessionScope(deck.index, sessionBudget, { dailyNewCount });
+    resetSessionTracking(plan, sessionBudget);
+  }, [autoStart, dailyNewCount, deck, plannedTotal, sessionBudget]);
+
+  useEffect(() => {
+    const page = document.querySelector('.lexicon-practice-page');
+    if (!page) return undefined;
+    if (sessionPhase === 'active') {
+      page.setAttribute('data-in-session', 'true');
+    } else {
+      page.removeAttribute('data-in-session');
+    }
+    return () => page.removeAttribute('data-in-session');
+  }, [sessionPhase]);
 
   // Eager-load ONLY the lightweight per-level index shards on mount (and on a
   // pre-session level change) so the «До повторення» tile + today ring reflect the
@@ -739,15 +816,34 @@ export default function LexiconPractice({
     };
   }, [deck, learnerLevel, shardBaseUrl]);
 
+  const indexForStats = deck?.index ?? dueIndex ?? [];
+
+  const sessionPoolConstraints = useMemo(
+    () =>
+      buildSessionPoolConstraintState({
+        plannedReviews,
+        reviewsCompleted,
+        sessionNewIntroduced,
+        dailyNewCount,
+      }),
+    [dailyNewCount, plannedReviews, reviewsCompleted, sessionNewIntroduced],
+  );
+
+  const poolFilter = useCallback(
+    (candidate: PracticeSelection) => sessionPoolAllowsCandidate(candidate, sessionPoolConstraints),
+    [sessionPoolConstraints],
+  );
+
   const selection = useMemo(() => {
-    if (!deck) return null;
+    if (!deck || sessionPhase !== 'active') return null;
     return selectNextPracticeItem(deck, {
       history,
       modeFilter: mode,
       now: new Date(),
       sessionSeed,
+      poolFilter: sessionPhase === 'active' ? poolFilter : undefined,
     });
-  }, [deck, history, mode, revision, sessionSeed]);
+  }, [deck, history, mode, poolFilter, revision, sessionPhase, sessionSeed]);
 
   useEffect(() => {
     setAnswerLocked(false);
@@ -760,9 +856,9 @@ export default function LexiconPractice({
   }, [selection?.itemId]);
 
   useEffect(() => {
-    if (!started) return;
+    if (sessionPhase !== 'active') return;
     document.title = `${MODE_LABELS[visiblePracticeMode(mode)]} Practice - Words of the Day`;
-  }, [mode, started]);
+  }, [mode, sessionPhase]);
 
   async function ensureDeck(
     includeCloze = shouldLoadCloze(mode),
@@ -852,32 +948,155 @@ export default function LexiconPractice({
       setClozeLoaded(nextClozeLoaded);
       return nextDeck;
     } catch {
-      if (deckRequestId.current === requestId) setError('Не вдалося завантажити колоду для практики.');
+      if (deckRequestId.current === requestId) {
+        setError('Не вдалося завантажити колоду для практики.');
+      }
       return null;
     } finally {
       if (deckRequestId.current === requestId) setLoading(false);
     }
   }
 
-  async function start(nextMode: PracticeModeFilter = mode) {
+  function resetSessionTracking(plan: SessionScopeStats, budget: SessionBudget) {
+    const reviewSlots =
+      budget === 'until-zero' ? plan.dueReviews : Math.min(plan.dueReviews, budget);
+    setSessionPlan(plan);
+    setPlannedReviews(reviewSlots);
+    setPlannedTotal(plan.plannedTotal);
+    setSessionCompleted(0);
+    setReviewsCompleted(0);
+    setSessionNewIntroduced(0);
+    setExtensionUsed(0);
+    setUnresolvedCardKeys(new Set());
+    setDeferredLemmas([]);
+    setSessionCorrect(0);
+    setSessionLapsed(0);
+    setAdvancedToReview([]);
+  }
+
+  function buildSessionSnapshot(
+    overrides: Partial<PracticeSessionSnapshot> = {},
+  ): PracticeSessionSnapshot {
+    return {
+      sessionSeed,
+      history,
+      budget: sessionBudget,
+      completed: sessionCompleted,
+      modeFilter: mode,
+      level: learnerLevel,
+      startedAt: sessionStartedAtRef.current,
+      extensionUsed,
+      sessionNewIntroduced,
+      plannedReviews,
+      plannedNew: sessionPlan?.plannedNew ?? 0,
+      plannedTotal,
+      reviewsCompleted,
+      unresolvedCardKeys: [...unresolvedCardKeys],
+      ...overrides,
+    };
+  }
+
+  function persistSessionSnapshot(
+    overrides: Partial<PracticeSessionSnapshot> = {},
+    options: { force?: boolean } = {},
+  ) {
+    if (!options.force && sessionPhase !== 'active') return;
+    writePracticeSessionSnapshot(buildSessionSnapshot(overrides));
+  }
+
+  function effectiveSessionTarget(): number {
+    return plannedTotal + extensionUsed;
+  }
+
+  function openSummary(deferred: PracticeLexeme[] = deferredLemmas) {
+    if (deferred.length) setDeferredLemmas(deferred);
+    writePracticeSessionSnapshot(null);
+    setResumeSnapshot(null);
+    setSessionPhase('summary');
+  }
+
+  async function beginSession(
+    nextMode: PracticeModeFilter = 'mixed',
+    budget: SessionBudget = sessionBudget,
+    resume?: PracticeSessionSnapshot,
+  ) {
     setMode(nextMode);
-    setStarted(true);
-    setSessionSeed(makePracticeSessionSeed());
-    await ensureDeck(shouldLoadCloze(nextMode));
+    setSessionBudget(budget);
+    setError(null);
+    const loadedDeck = await ensureDeck(shouldLoadCloze(nextMode));
+    if (!loadedDeck) return;
+    const index = loadedDeck.index;
+    const plan = computeSessionScope(index, budget, { dailyNewCount });
+    const nextSeed = resume?.sessionSeed ?? makePracticeSessionSeed();
+    if (resume) {
+      sessionStartedAtRef.current = resume.startedAt;
+      setSessionSeed(nextSeed);
+      setHistory(resume.history);
+      setSessionCompleted(resume.completed);
+      setPlannedReviews(resume.plannedReviews ?? plan.dueReviews);
+      setPlannedTotal(resume.plannedTotal ?? plan.plannedTotal);
+      setReviewsCompleted(resume.reviewsCompleted ?? 0);
+      setSessionNewIntroduced(resume.sessionNewIntroduced ?? 0);
+      setExtensionUsed(resume.extensionUsed ?? 0);
+      setUnresolvedCardKeys(new Set(resume.unresolvedCardKeys ?? []));
+      setSessionPlan(plan);
+    } else {
+      sessionStartedAtRef.current = Date.now();
+      setSessionSeed(nextSeed);
+      setHistory([]);
+      resetSessionTracking(plan, budget);
+    }
+    setSessionPhase('active');
+    const reviewSlots = budget === 'until-zero' ? plan.dueReviews : Math.min(plan.dueReviews, budget);
+    writePracticeSessionSnapshot({
+      sessionSeed: nextSeed,
+      history: resume?.history ?? [],
+      budget,
+      completed: resume?.completed ?? 0,
+      modeFilter: nextMode,
+      level: learnerLevel,
+      startedAt: sessionStartedAtRef.current,
+      extensionUsed: resume?.extensionUsed ?? 0,
+      sessionNewIntroduced: resume?.sessionNewIntroduced ?? 0,
+      plannedReviews: resume?.plannedReviews ?? reviewSlots,
+      plannedNew: plan.plannedNew,
+      plannedTotal: resume?.plannedTotal ?? plan.plannedTotal,
+      reviewsCompleted: resume?.reviewsCompleted ?? 0,
+      unresolvedCardKeys: resume?.unresolvedCardKeys ?? [],
+    });
+  }
+
+  async function startSession(
+    budget: SessionBudget = 20,
+    nextMode: PracticeModeFilter = 'mixed',
+  ) {
+    writePracticeSessionSnapshot(null);
+    setResumeSnapshot(null);
+    await beginSession(nextMode, budget);
+  }
+
+  async function resumeSession() {
+    if (!resumeSnapshot) return;
+    await beginSession(resumeSnapshot.modeFilter, resumeSnapshot.budget, resumeSnapshot);
+  }
+
+  async function startFocusMode(nextMode: PracticeModeFilter) {
+    await startSession(sessionBudget, nextMode);
   }
 
   async function changeLevel(nextLevel: CefrLevel) {
-    if (nextLevel === learnerLevel) return;
+    if (nextLevel === learnerLevel || !publishedLevels.has(nextLevel)) return;
     setLearnerLevel(nextLevel);
     writeLearnerLevel(nextLevel);
-    // The pool changed: drop the loaded deck + per-session history and, if a session is
-    // already running, immediately reload the cumulative pool for the new level.
     setClozeLoaded(false);
     setHistory([]);
-    if (started) {
+    writePracticeSessionSnapshot(null);
+    setResumeSnapshot(null);
+    if (sessionPhase === 'active') {
       await ensureDeck(shouldLoadCloze(mode), { level: nextLevel, force: true });
     } else {
       setDeck(null);
+      setSessionPhase('idle');
     }
   }
 
@@ -890,63 +1109,100 @@ export default function LexiconPractice({
     setRevision((value) => value + 1);
   }
 
-  function completeSelection(current: PracticeSelection) {
-    setHistory((items) => [...items.slice(-49), historyFromSelection(current)]);
-    refreshProgress();
-  }
-
-  function recordReview(current: PracticeSelection, rating: PracticeRating) {
+  function recordReview(
+    current: PracticeSelection,
+    rating: PracticeRating,
+  ): { nextUnresolved: Set<string>; nextDeferred: PracticeLexeme[] } {
+    const wasNew = isPracticeNewCard(current.cardState);
+    const nextUnresolved = new Set(unresolvedCardKeys);
+    let nextDeferred = [...deferredLemmas];
     try {
       rateCard(current.lemma.lemmaId, current.mode, rating, new Date());
       setStreak(recordStreak());
       if (rating === 'good' || rating === 'easy') {
-        setCorrectToday((value) => value + 1);
+        setSessionCorrect((value) => value + 1);
       }
+      if (rating === 'again') {
+        setSessionLapsed((value) => value + 1);
+      }
+      if (wasNew && rating !== 'again') {
+        const daily = readNewCardsDailyState();
+        const nextDaily = { date: daily.date, count: daily.count + 1 };
+        writeNewCardsDailyState(nextDaily);
+        setDailyNewCount(nextDaily.count);
+        setSessionNewIntroduced((value) => value + 1);
+      }
+      if (!wasNew) {
+        setReviewsCompleted((value) => value + 1);
+      }
+      if (wasNew && (rating === 'good' || rating === 'easy')) {
+        setAdvancedToReview((items) =>
+          items.includes(current.lemma.lemma) ? items : [...items, current.lemma.lemma],
+        );
+      }
+      if (rating === 'again') {
+        nextUnresolved.add(current.cardKey);
+        if (!nextDeferred.some((entry) => entry.lemmaId === current.lemma.lemmaId)) {
+          nextDeferred = [...nextDeferred, current.lemma];
+        }
+      } else if (rating === 'good' || rating === 'easy') {
+        if (nextUnresolved.delete(current.cardKey)) {
+          nextDeferred = nextDeferred.filter((entry) => entry.lemmaId !== current.lemma.lemmaId);
+        }
+      }
+      setUnresolvedCardKeys(nextUnresolved);
+      setDeferredLemmas(nextDeferred);
       setFeedback(`${current.lemma.lemma}: ${RATING_LABELS[rating]}`);
     } catch {
       setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
     }
+    return { nextUnresolved, nextDeferred };
+  }
+
+  function completeSelection(
+    current: PracticeSelection,
+    outcome: { nextUnresolved: Set<string>; nextDeferred: PracticeLexeme[] },
+  ) {
+    setHistory((items) => [...items.slice(-49), historyFromSelection(current)]);
+    const nextCompleted = sessionCompleted + 1;
+    setSessionCompleted(nextCompleted);
+    setCompletedToday((value) => value + 1);
+    refreshProgress();
+    persistSessionSnapshot({ completed: nextCompleted });
+    const decision = resolveSessionCompletion({
+      completed: nextCompleted,
+      plannedTotal,
+      extensionUsed,
+      unresolvedCount: outcome.nextUnresolved.size,
+    });
+    if (decision === 'continue') return;
+    if (decision === 'extend') {
+      setExtensionUsed((value) => value + 1);
+      return;
+    }
+    if (decision === 'summary-with-deferred') {
+      openSummary(outcome.nextDeferred);
+      return;
+    }
+    openSummary();
   }
 
   function rateAndComplete(current: PracticeSelection, rating: PracticeRating) {
-    recordReview(current, rating);
-    completeSelection(current);
+    const outcome = recordReview(current, rating);
+    completeSelection(current, outcome);
   }
-
-  useEffect(() => {
-    if (!started || !selection || selection.mode !== 'flashcards') return undefined;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.altKey || event.ctrlKey || event.metaKey) return;
-      const key = event.key.toLowerCase();
-      const rating =
-        key === 'a' || key === '1'
-          ? 'again'
-          : key === 'h' || key === '2'
-            ? 'hard'
-            : key === 'g' || key === '3'
-              ? 'good'
-              : key === 'e' || key === '4'
-                ? 'easy'
-                : null;
-      if (!rating) return;
-      event.preventDefault();
-      rateAndComplete(selection, rating);
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [started, selection]);
 
   function handleChoice(option: ChoiceOption) {
     if (!selection || answerLocked) return;
     const rating = option.correct ? 'good' : 'again';
-    recordReview(selection, rating);
+    const outcome = recordReview(selection, rating);
     setAnswerLocked(true);
     setFeedback(
       option.correct ? `${selection.lemma.lemma}: Правильно` : `${selection.lemma.lemma}: Ще раз`,
     );
     window.setTimeout(() => {
       setAnswerLocked(false);
-      completeSelection(selection);
+      completeSelection(selection, outcome);
     }, advanceDelayMs);
   }
 
@@ -959,9 +1215,9 @@ export default function LexiconPractice({
     const caseMiss = isWrongCaseAnswer(answer, selection.lemma, cloze);
 
     if (correct) {
-      if (!clozeAttemptRecorded) {
-        recordReview(selection, 'good');
-      }
+      const outcome = clozeAttemptRecorded
+        ? { nextUnresolved: new Set(unresolvedCardKeys), nextDeferred: [...deferredLemmas] }
+        : recordReview(selection, 'good');
       setClozeFeedback({
         kind: 'correct',
         text: `✓ ${cloze.form} (${cloze.caseRule.caseLabel})`,
@@ -969,7 +1225,7 @@ export default function LexiconPractice({
       setAnswerLocked(true);
       window.setTimeout(() => {
         setAnswerLocked(false);
-        completeSelection(selection);
+        completeSelection(selection, outcome);
       }, advanceDelayMs);
       return;
     }
@@ -988,28 +1244,56 @@ export default function LexiconPractice({
     }
 
     if (!clozeAttemptRecorded) {
-      recordReview(selection, 'again');
+      const outcome = recordReview(selection, 'again');
       setClozeAttemptRecorded(true);
+      setClozeFeedback({ kind: 'wrong-word', text: '✗ Не те слово' });
+      if (source === 'chip') {
+        setAnswerLocked(true);
+        window.setTimeout(() => {
+          setAnswerLocked(false);
+          completeSelection(selection, outcome);
+        }, advanceDelayMs);
+      }
+      return;
     }
+
     setClozeFeedback({ kind: 'wrong-word', text: '✗ Не те слово' });
     if (source === 'chip') {
       setAnswerLocked(true);
       window.setTimeout(() => {
         setAnswerLocked(false);
-        completeSelection(selection);
+        completeSelection(selection, {
+          nextUnresolved: new Set(unresolvedCardKeys),
+          nextDeferred: [...deferredLemmas],
+        });
       }, advanceDelayMs);
     }
   }
 
-  // Prefer the full deck's index once loaded; otherwise fall back to the eager
-  // index so the due-count is live on the home before any mode starts.
-  const dueNow = useMemo(() => {
-    const entries = deck ? deck.index : dueIndex;
-    return entries ? getDueQueue(entries, new Date()).length : 0;
-  }, [correctToday, deck, dueIndex, revision]);
-  const todayWorkload = correctToday + dueNow;
+  const dueReviews = useMemo(
+    () => (indexForStats.length ? countDueReviewCards(indexForStats, new Date()) : 0),
+    [completedToday, dailyNewCount, indexForStats, revision],
+  );
+  const homeScope = useMemo(
+    () =>
+      indexForStats.length
+        ? computeSessionScope(indexForStats, sessionBudget, { dailyNewCount })
+        : null,
+    [dailyNewCount, indexForStats, sessionBudget],
+  );
+  const todayDenominator = useMemo(
+    () =>
+      indexForStats.length
+        ? computeTodayRingDenominator(indexForStats, { dailyNewCount })
+        : 0,
+    [completedToday, dailyNewCount, indexForStats, revision],
+  );
   const todayPct =
-    todayWorkload > 0 ? Math.min(100, (correctToday / todayWorkload) * 100) : correctToday > 0 ? 100 : 0;
+    todayDenominator > 0
+      ? Math.min(100, (completedToday / todayDenominator) * 100)
+      : completedToday > 0
+        ? 100
+        : 0;
   const todayRingStyle = { '--pct': String(todayPct) } as CSSProperties;
   const stageMode: PracticeModeFilter = selection?.mode ?? mode;
   const visibleStageMode = visiblePracticeMode(stageMode);
@@ -1017,17 +1301,38 @@ export default function LexiconPractice({
     mode === 'mixed' && selection && visibleStageMode !== 'mixed'
       ? `Мікс · ${MODE_META[visibleStageMode].title}`
       : MODE_META[visibleStageMode].title;
-  const correctLabel = `${correctToday} ${uaPlural(correctToday)}`;
+  const progressLabel = `${sessionCompleted}/${effectiveSessionTarget()}`;
+  const summaryStats: SessionSummaryStats = {
+    correct: sessionCorrect,
+    lapsed: sessionLapsed,
+    advancedToReview,
+    streak: streak.current,
+    nextDueLabel: formatNextDueLabel(nextDuePreviewTime()),
+    deferredLemmas,
+  };
+
+  function finishPractice() {
+    setSessionPhase('idle');
+    setHistory([]);
+    setDeck(null);
+    setClozeLoaded(false);
+    writePracticeSessionSnapshot(null);
+  }
 
   return (
     <section className="lexicon-practice" aria-label="Практика слів дня">
       <p className="lexicon-practice-status" aria-live="polite">
-        {feedback || (started ? 'Готово до вправи' : 'Оберіть режим практики')}
+        {feedback ||
+          (sessionPhase === 'active'
+            ? `Сесія ${progressLabel}`
+            : sessionPhase === 'summary'
+              ? 'Сесію завершено'
+              : 'Оберіть сесію практики')}
       </p>
 
       {storageWarning && <p className="lexicon-practice-warning">{storageWarning}</p>}
 
-      {!started && (
+      {sessionPhase === 'idle' && (
         <div className="lexicon-practice-home">
           <div className="lexicon-practice-progress" role="group" aria-label="Сьогоднішній прогрес">
             <div
@@ -1041,29 +1346,84 @@ export default function LexiconPractice({
               <span className="val">🔥 {streak.current}</span>
               <span className="lab">Днів поспіль</span>
             </div>
-            <div className="pstat" aria-label={`${dueNow} до повторення`}>
-              <span className="val">{deck || dueIndex ? dueNow : '—'}</span>
+            <div className="pstat" aria-label={`${dueReviews} до повторення`}>
+              <span className="val">{indexForStats.length ? dueReviews : '—'}</span>
               <span className="lab">До повторення</span>
+              {showEnglishSubtitles ? (
+                <span className="lab-sub">{SESSION_LABELS_A1.dueReviews}</span>
+              ) : null}
             </div>
-            <div className="pstat" aria-label={`${mastered} опановано`}>
-              <span className="val">{mastered}</span>
-              <span className="lab">Опановано</span>
+            <div className="pstat" aria-label={`Нові сьогодні ${dailyNewCount}/${DEFAULT_NEW_PER_DAY}`}>
+              <span className="val">
+                {dailyNewCount}/{DEFAULT_NEW_PER_DAY}
+              </span>
+              <span className="lab">Нові сьогодні</span>
+              {showEnglishSubtitles ? (
+                <span className="lab-sub">{SESSION_LABELS_A1.newToday}</span>
+              ) : null}
             </div>
             <div className="pstat today">
               <div
                 className="ring"
                 role="img"
-                aria-label={`Сьогодні виконано ${correctToday} із ${todayWorkload}`}
+                aria-label={`Сьогодні виконано ${completedToday} із ${todayDenominator}`}
                 style={todayRingStyle}
+                data-testid="practice-today-ring"
               >
                 <b>
-                  {correctToday}/{todayWorkload}
+                  {completedToday}/{todayDenominator}
                 </b>
               </div>
               <div>
                 <span className="lab">Сьогодні</span>
               </div>
             </div>
+          </div>
+
+          <div className="lexicon-practice-session-start">
+            {homeScope ? (
+              <p className="lexicon-session-scope" data-testid="practice-session-scope">
+                {homeScope.dueReviews} до повторення + {homeScope.plannedNew} нових ≈{' '}
+                {homeScope.estimatedMinutes} хв
+              </p>
+            ) : null}
+            <div className="lexicon-session-budgets" role="group" aria-label="Розмір сесії">
+              {([10, 20, 'until-zero'] as const).map((budget) => (
+                <button
+                  key={String(budget)}
+                  type="button"
+                  className={sessionBudget === budget ? 'active' : ''}
+                  aria-pressed={sessionBudget === budget}
+                  onClick={() => setSessionBudget(budget)}
+                >
+                  {budget === 10 ? '10' : budget === 20 ? '20' : 'до нуля'}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              className="btn btn-accent lexicon-session-primary"
+              data-testid="practice-start-session"
+              onClick={() => void startSession(sessionBudget, 'mixed')}
+            >
+              Почати сесію
+              {showEnglishSubtitles ? (
+                <span className="btn-sub">{SESSION_LABELS_A1.startSession}</span>
+              ) : null}
+            </button>
+            {resumeSnapshot ? (
+              <button
+                type="button"
+                className="btn lexicon-session-resume"
+                data-testid="practice-resume-session"
+                onClick={() => void resumeSession()}
+              >
+                Продовжити сесію ({resumeSnapshot.completed}/{resumeSnapshot.plannedTotal ?? resumeSnapshot.budget})
+                {showEnglishSubtitles ? (
+                  <span className="btn-sub">{SESSION_LABELS_A1.continueSession}</span>
+                ) : null}
+              </button>
+            ) : null}
           </div>
 
           <div className="lexicon-practice-levels">
@@ -1073,70 +1433,94 @@ export default function LexiconPractice({
               aria-label="Рівень учня — практика охоплює цей рівень і нижчі"
             >
               <span className="lexicon-practice-levels-label">Рівень</span>
-              {CEFR_LEVELS.map((level) => (
-                <button
-                  type="button"
-                  key={level}
-                  className={learnerLevel === level ? 'active' : ''}
-                  aria-pressed={learnerLevel === level}
-                  onClick={() => void changeLevel(level)}
-                >
-                  {level}
-                </button>
-              ))}
+              {CEFR_LEVELS.map((level) => {
+                const published = publishedLevels.has(level);
+                return (
+                  <button
+                    type="button"
+                    key={level}
+                    className={learnerLevel === level ? 'active' : ''}
+                    aria-pressed={learnerLevel === level}
+                    disabled={!published}
+                    title={published ? undefined : 'скоро'}
+                    onClick={() => void changeLevel(level)}
+                  >
+                    {level}
+                    {!published ? <span className="level-soon">скоро</span> : null}
+                  </button>
+                );
+              })}
             </div>
             <p className="lexicon-practice-muted lexicon-practice-levels-hint">
               Практика обмежена вашим рівнем і нижчими (накопичувально).
             </p>
           </div>
 
-          <div className="mode-grid">
-            {MODE_CARD_ORDER.map((practiceMode) => {
-              const meta = MODE_META[practiceMode];
-              return (
-                <button
-                  type="button"
-                  key={practiceMode}
-                  className="mode-card"
-                  data-mode={practiceMode}
-                  data-accent={meta.accent}
-                  aria-pressed={mode === practiceMode}
-                  onClick={() => void start(practiceMode)}
-                >
-                  <div className="mc-top">
-                    <span className="mc-ico">
-                      <ModeIcon mode={practiceMode} />
-                    </span>
-                    <span>
-                      <span className="mc-title">{meta.title}</span>
-                      <span className="mc-en">{meta.en}</span>
-                    </span>
-                  </div>
-                  <span className="mc-desc">{meta.description}</span>
-                  <span className="mc-meta">
-                    <span className="mc-step">{meta.step}</span>
-                    <span className="mc-arrow" aria-hidden="true">
-                      →
-                    </span>
-                  </span>
-                </button>
-              );
-            })}
+          <div className="lexicon-focus-practice">
+            <h3>
+              Фокус-практика
+              {showEnglishSubtitles ? (
+                <span className="heading-sub">{SESSION_LABELS_A1.focusPractice}</span>
+              ) : null}
+            </h3>
+            <div className="mode-grid mode-grid-focus">
+              {MODE_CARD_ORDER.filter((practiceMode) => practiceMode !== 'mixed').map((practiceMode) => {
+                const meta = MODE_META[practiceMode];
+                return (
+                  <button
+                    type="button"
+                    key={practiceMode}
+                    className="mode-card"
+                    data-mode={practiceMode}
+                    data-accent={meta.accent}
+                    onClick={() => void startFocusMode(practiceMode)}
+                  >
+                    <div className="mc-top">
+                      <span className="mc-ico">
+                        <ModeIcon mode={practiceMode} />
+                      </span>
+                      <span>
+                        <span className="mc-title">{meta.title}</span>
+                        {showEnglishSubtitles ? <span className="mc-en">{meta.en}</span> : null}
+                      </span>
+                    </div>
+                    <span className="mc-desc">{meta.description}</span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
         </div>
       )}
 
       {loading && <p className="lexicon-practice-muted">Завантажуємо…</p>}
-      {error && <p className="lexicon-practice-warning">{error}</p>}
-      {started && (
+      {error && (
+        <div className="lexicon-practice-fallback" data-testid="practice-fetch-error">
+          <p className="lexicon-practice-warning">{error}</p>
+          <button type="button" className="btn btn-accent" onClick={() => window.location.reload()}>
+            Спробувати ще раз
+          </button>
+        </div>
+      )}
+
+      {sessionPhase === 'summary' && (
+        <PracticeSessionSummary
+          stats={summaryStats}
+          showEnglishSubtitles={showEnglishSubtitles}
+          onAnotherSession={() => void startSession(sessionBudget, mode)}
+          onDone={finishPractice}
+        />
+      )}
+
+      {sessionPhase === 'active' && (
         <div className="lexicon-practice-stage-shell">
           <div className="lexicon-practice-stage-bar">
-            <button type="button" className="stage-back" onClick={() => setStarted(false)}>
-              ← Режими
+            <button type="button" className="stage-back" onClick={finishPractice}>
+              ← Додому
             </button>
             <h2>{stageTitle}</h2>
-            <span className="queue-pill" aria-label={correctLabel}>
-              {correctLabel}
+            <span className="queue-pill" aria-label={`Прогрес ${progressLabel}`} data-testid="practice-session-progress">
+              {progressLabel}
             </span>
           </div>
 
@@ -1145,35 +1529,43 @@ export default function LexiconPractice({
           )}
 
           {deck && deck.index.length > 0 && (
-        <div className="lexicon-practice-stage" ref={stageRef} tabIndex={-1}>
-          {selection ? (
-            <PracticeItem
-              selection={selection}
-              deck={deck}
-              sessionSeed={sessionSeed}
-              answerLocked={answerLocked}
-              clozeInput={clozeInput}
-              clozeFeedback={clozeFeedback}
-                onClozeInput={setClozeInput}
-                onFlashcardRating={(rating) => rateAndComplete(selection, rating)}
-                onChoice={handleChoice}
-                onMatchingComplete={() => rateAndComplete(selection, 'good')}
-                onClozeSubmit={submitCloze}
-              />
-          ) : mode === 'cloze' && deck.cloze.length === 0 ? (
-              // Cloze is fail-closed until reviewed sentences are authored (#3797).
-              <p className="lexicon-practice-muted" data-testid="practice-cloze-empty">
-                Вправи з пропусками для цього рівня ще готуються. Спробуйте флешкартки, добір пар або вибір.
-              </p>
-            ) : (
-              <p className="lexicon-practice-muted">Усі картки на зараз повторено.</p>
-            )}
-          </div>
+            <div className="lexicon-practice-stage" ref={stageRef} tabIndex={-1}>
+              {selection ? (
+                <PracticeItem
+                  selection={selection}
+                  deck={deck}
+                  sessionSeed={sessionSeed}
+                  answerLocked={answerLocked}
+                  clozeInput={clozeInput}
+                  clozeFeedback={clozeFeedback}
+                  onClozeInput={setClozeInput}
+                  onFlashcardRating={(rating) => rateAndComplete(selection, rating)}
+                  onChoice={handleChoice}
+                  onMatchingComplete={() => rateAndComplete(selection, 'good')}
+                  onClozeSubmit={submitCloze}
+                />
+              ) : mode === 'cloze' && deck.cloze.length === 0 ? (
+                <p className="lexicon-practice-muted" data-testid="practice-cloze-empty">
+                  Вправи з пропусками для цього рівня ще готуються. Спробуйте флешкартки, добір пар або вибір.
+                </p>
+              ) : (
+                <p className="lexicon-practice-muted">Усі картки на зараз повторено.</p>
+              )}
+            </div>
           )}
         </div>
       )}
     </section>
   );
+}
+
+function formatNextDueLabel(nextDue: Date | null): string | null {
+  if (!nextDue) return null;
+  const hours = nextDue.getHours().toString().padStart(2, '0');
+  const minutes = nextDue.getMinutes().toString().padStart(2, '0');
+  const remainingMs = nextDue.getTime() - Date.now();
+  const remaining = Math.max(1, Math.ceil(remainingMs / (60 * 60 * 1000)));
+  return `ще ${remaining} о ${hours}:${minutes}`;
 }
 
 function PracticeItem({
@@ -1202,25 +1594,18 @@ function PracticeItem({
   onClozeSubmit(value: string, source: 'typed' | 'chip'): void;
 }) {
   if (selection.mode === 'flashcards') {
+    const intervalPreviews = previewRatingIntervals(
+      selection.lemma.lemmaId,
+      selection.mode,
+      new Date(),
+    );
     return (
-      <>
-        <FlashcardDeck key={selection.itemId} cards={[cardData(selection.lemma)]} />
-        <div className="lexicon-rating-bar rating-bar" role="group" aria-label="Оцініть, наскільки легко згадалось">
-        {(['again', 'hard', 'good', 'easy'] as const).map((rating, index) => (
-          <button
-            type="button"
-            key={rating}
-            className="rate-btn"
-            data-rate={rating}
-            aria-keyshortcuts={String(index + 1)}
-            onClick={() => onFlashcardRating(rating)}
-          >
-            <span className="rk">{index + 1}</span>
-            <span className="rt">{RATING_LABELS[rating]}</span>
-          </button>
-        ))}
-        </div>
-      </>
+      <PracticeFlashcard
+        card={cardData(selection.lemma)}
+        ratingLabels={RATING_LABELS}
+        intervalPreviews={intervalPreviews}
+        onRate={onFlashcardRating}
+      />
     );
   }
 

--- a/site/src/components/PracticeErrorBoundary.tsx
+++ b/site/src/components/PracticeErrorBoundary.tsx
@@ -1,0 +1,40 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface PracticeErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface PracticeErrorBoundaryState {
+  error: Error | null;
+}
+
+export default class PracticeErrorBoundary extends Component<
+  PracticeErrorBoundaryProps,
+  PracticeErrorBoundaryState
+> {
+  state: PracticeErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): PracticeErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('Practice hub render failure', error, info);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="lexicon-practice-fallback" role="alert" data-testid="practice-error-fallback">
+          <p className="lexicon-practice-warning">
+            Не вдалося завантажити практику. Спробуйте оновити сторінку.
+          </p>
+          <button type="button" className="btn btn-accent" onClick={() => window.location.reload()}>
+            Спробувати ще раз
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/site/src/components/PracticeFlashcard.tsx
+++ b/site/src/components/PracticeFlashcard.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useRef, useState } from 'react';
+import type { PracticeRating } from '../lib/lexicon/srs';
+
+export interface PracticeFlashcardData {
+  front: string;
+  back: string;
+  subtitle?: string;
+  tag?: string;
+  tagColor?: string;
+}
+
+interface PracticeFlashcardProps {
+  card: PracticeFlashcardData;
+  ratingLabels: Record<PracticeRating, string>;
+  intervalPreviews: Record<PracticeRating, string>;
+  onRate(rating: PracticeRating): void;
+}
+
+const RATING_ORDER: PracticeRating[] = ['again', 'hard', 'good', 'easy'];
+
+export default function PracticeFlashcard({
+  card,
+  ratingLabels,
+  intervalPreviews,
+  onRate,
+}: PracticeFlashcardProps) {
+  const [flipped, setFlipped] = useState(false);
+  const ratingBarRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setFlipped(false);
+  }, [card.front, card.back]);
+
+  useEffect(() => {
+    if (!flipped) return undefined;
+    const timer = window.setTimeout(() => {
+      ratingBarRef.current?.querySelector<HTMLButtonElement>('[data-rate="good"]')?.focus();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [flipped]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.altKey || event.ctrlKey || event.metaKey) return;
+      const key = event.key.toLowerCase();
+      if (!flipped && (key === ' ' || key === 'enter')) {
+        event.preventDefault();
+        setFlipped(true);
+        return;
+      }
+      if (!flipped) return;
+      const rating =
+        key === 'a' || key === '1'
+          ? 'again'
+          : key === 'h' || key === '2'
+            ? 'hard'
+            : key === 'g' || key === '3'
+              ? 'good'
+              : key === 'e' || key === '4'
+                ? 'easy'
+                : null;
+      if (!rating) return;
+      event.preventDefault();
+      onRate(rating);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [flipped, onRate]);
+
+  return (
+    <>
+      <div
+        className={`flashcard${flipped ? ' flipped' : ''}`}
+        data-activity="flashcard"
+        data-flipped={flipped ? 'true' : 'false'}
+        onClick={() => setFlipped((value) => !value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            setFlipped((value) => !value);
+          }
+        }}
+        role="button"
+        tabIndex={0}
+        aria-label={flipped ? `${card.back} — натисніть, щоб перевернути` : `${card.front} — натисніть, щоб перевернути`}
+      >
+        <div className="flashcard-inner">
+          <div className="flashcard-front">
+            <span className="flashcard-word">{card.front}</span>
+            {card.subtitle && <span className="flashcard-subtitle">{card.subtitle}</span>}
+            {card.tag && (
+              <span
+                className="flashcard-tag"
+                style={card.tagColor ? { background: card.tagColor, color: 'white' } : undefined}
+              >
+                {card.tag}
+              </span>
+            )}
+          </div>
+          <div className="flashcard-back">
+            <span className="flashcard-word">{card.back}</span>
+            {card.subtitle && <span className="flashcard-subtitle">{card.subtitle}</span>}
+          </div>
+        </div>
+      </div>
+      <div
+        className="lexicon-rating-bar rating-bar"
+        ref={ratingBarRef}
+        role="group"
+        aria-label="Оцініть, наскільки легко згадалось"
+        data-revealed={flipped ? 'true' : 'false'}
+      >
+        {RATING_ORDER.map((rating, index) => (
+          <button
+            type="button"
+            key={rating}
+            className="rate-btn"
+            data-rate={rating}
+            aria-keyshortcuts={String(index + 1)}
+            disabled={!flipped}
+            aria-disabled={!flipped}
+            onClick={() => {
+              if (!flipped) return;
+              onRate(rating);
+            }}
+          >
+            <span className="rk">{index + 1}</span>
+            <span className="rt">{ratingLabels[rating]}</span>
+            {flipped ? <span className="ri">‹{intervalPreviews[rating]}›</span> : null}
+          </button>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/site/src/components/PracticeSessionSummary.tsx
+++ b/site/src/components/PracticeSessionSummary.tsx
@@ -1,0 +1,82 @@
+import type { PracticeLexeme } from '../lib/lexicon/srs';
+
+export interface SessionSummaryStats {
+  correct: number;
+  lapsed: number;
+  advancedToReview: string[];
+  streak: number;
+  nextDueLabel: string | null;
+  deferredLemmas: PracticeLexeme[];
+}
+
+interface PracticeSessionSummaryProps {
+  stats: SessionSummaryStats;
+  showEnglishSubtitles: boolean;
+  onAnotherSession(): void;
+  onDone(): void;
+}
+
+export default function PracticeSessionSummary({
+  stats,
+  showEnglishSubtitles,
+  onAnotherSession,
+  onDone,
+}: PracticeSessionSummaryProps) {
+  return (
+    <div className="lexicon-session-summary" data-testid="practice-session-summary">
+      <h2 className="lexicon-session-summary-title">Сесія завершена</h2>
+      {showEnglishSubtitles ? (
+        <p className="lexicon-session-summary-sub">Session complete</p>
+      ) : null}
+      <dl className="lexicon-session-summary-stats">
+        <div>
+          <dt>Правильно</dt>
+          <dd>{stats.correct}</dd>
+        </div>
+        <div>
+          <dt>З lapses</dt>
+          <dd>{stats.lapsed}</dd>
+        </div>
+        <div>
+          <dt>Серія</dt>
+          <dd>🔥 {stats.streak}</dd>
+        </div>
+      </dl>
+      {stats.advancedToReview.length > 0 ? (
+        <section className="lexicon-session-advanced">
+          <h3>Перейшли до Review</h3>
+          <ul>
+            {stats.advancedToReview.map((lemma) => (
+              <li key={lemma}>{lemma}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+      {stats.nextDueLabel ? (
+        <p className="lexicon-session-next-due" data-testid="practice-next-due">
+          {stats.nextDueLabel}
+        </p>
+      ) : null}
+      {stats.deferredLemmas.length > 0 ? (
+        <section className="lexicon-session-deferred" data-testid="practice-deferred-list">
+          <h3>повторимо наступного разу</h3>
+          <ul>
+            {stats.deferredLemmas.map((lemma) => (
+              <li key={lemma.lemmaId}>{lemma.lemma}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+      <div className="lexicon-session-summary-actions">
+        <button type="button" className="btn btn-accent" onClick={onAnotherSession}>
+          Ще одна сесія
+          {showEnglishSubtitles ? <span className="btn-sub">Another session</span> : null}
+        </button>
+        <button type="button" className="btn" onClick={onDone}>
+          Готово
+          {showEnglishSubtitles ? <span className="btn-sub">Done</span> : null}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -12,11 +12,20 @@ import {
 export const SRS_STORAGE_KEY = 'lu-lexicon-srs';
 export const SRS_SETTINGS_KEY = 'lu-lexicon-srs-settings';
 export const SRS_BACKUP_KEY = 'lu-lexicon-srs.backup';
+export const PRACTICE_NEW_CARDS_KEY = 'lu-practice-newcards';
+export const PRACTICE_SESSION_STORAGE_KEY = 'lu-practice-session';
+export const DEFAULT_NEW_PER_SESSION = 8;
+export const DEFAULT_NEW_PER_DAY = 20;
+export const SESSION_CLOSURE_EXTENSION_MAX = 5;
+export const SESSION_ITEM_ESTIMATE_SEC = 20;
+/** Levels with published practice shards (C2 ships «скоро» until deck exists). */
+export const PUBLISHED_PRACTICE_LEVELS = ['A1', 'A2', 'B1', 'B2', 'C1'] as const;
 
 const CURRENT_VERSION = 3;
 const SETTINGS_VERSION = 1;
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
+export const SESSION_RESUME_MAX_MS = 6 * HOUR_MS;
 const WIDENED_DUE_WINDOW_MS = 6 * HOUR_MS;
 const MIN_WORD_REPEAT_WINDOW = 8;
 const DEFAULT_RECOGNITION_STABILITY = 3;
@@ -334,6 +343,45 @@ export interface PracticeSelection {
   choicePolarity: ChoicePolarity;
 }
 
+export type SessionBudget = number | 'until-zero';
+
+export interface PracticeSessionSnapshot {
+  sessionSeed: number;
+  history: SelectionHistoryItem[];
+  budget: SessionBudget;
+  completed: number;
+  modeFilter: PracticeModeFilter;
+  level: string;
+  startedAt: number;
+  /** Resume helpers — not part of selector state; safe to persist for closure rule. */
+  extensionUsed?: number;
+  sessionNewIntroduced?: number;
+  plannedReviews?: number;
+  plannedNew?: number;
+  plannedTotal?: number;
+  reviewsCompleted?: number;
+  unresolvedCardKeys?: string[];
+}
+
+export interface NewCardsDailyState {
+  date: string;
+  count: number;
+}
+
+export interface SessionScopeStats {
+  dueReviews: number;
+  plannedNew: number;
+  plannedTotal: number;
+  estimatedMinutes: number;
+}
+
+export interface SessionPoolConstraintState {
+  allowNewInPool: boolean;
+  newRemainingSession: number;
+  newRemainingDaily: number;
+  sessionNewIntroduced: number;
+}
+
 export interface SelectPracticeOptions {
   now?: Date | number;
   history?: SelectionHistoryItem[];
@@ -343,6 +391,8 @@ export interface SelectPracticeOptions {
   dueWindowMs?: number;
   wordRepeatWindow?: number;
   sessionSeed?: number;
+  /** §6b session pool constraint — eligibility filter only; ordering unchanged. */
+  poolFilter?: (candidate: PracticeSelection) => boolean;
 }
 
 interface PersistedSrsSchemaV3 {
@@ -1115,6 +1165,14 @@ function levelMatchBias(candidate: PracticeSelection, deckLevel: string): number
   return candidate.indexItem.cefr === deckLevel ? 0 : 1;
 }
 
+function applyPoolFilter(
+  pool: PracticeSelection[],
+  poolFilter?: (candidate: PracticeSelection) => boolean,
+): PracticeSelection[] {
+  if (!poolFilter) return pool;
+  return pool.filter(poolFilter);
+}
+
 function rankCandidates(
   pool: PracticeSelection[],
   history: SelectionHistoryItem[],
@@ -1355,18 +1413,25 @@ export function selectNextPracticeItem(
     nowTime,
   );
 
-  const overduePool = candidates.filter((candidate) => candidate.due <= nowTime);
-  const windowPool = candidates.filter(
-    (candidate) => candidate.due <= nowTime + Math.max(dueWindowMs, WIDENED_DUE_WINDOW_MS),
+  const overduePool = applyPoolFilter(
+    candidates.filter((candidate) => candidate.due <= nowTime),
+    options.poolFilter,
+  );
+  const windowPool = applyPoolFilter(
+    candidates.filter((candidate) => candidate.due <= nowTime + Math.max(dueWindowMs, WIDENED_DUE_WINDOW_MS)),
+    options.poolFilter,
   );
   let scheduledPool = overduePool.length ? overduePool : windowPool;
   scheduledPool = applySpacingFilters(scheduledPool, history, wordRepeatWindow);
   if (!scheduledPool.length && windowPool.length) scheduledPool = windowPool;
   if (!scheduledPool.length) {
-    const borrowedPool = candidates
-      .filter((candidate) => candidate.due > nowTime)
-      .sort((left, right) => left.due - right.due)
-      .slice(0, Math.max(1, Math.min(4, candidates.length)));
+    const borrowedPool = applyPoolFilter(
+      candidates
+        .filter((candidate) => candidate.due > nowTime)
+        .sort((left, right) => left.due - right.due)
+        .slice(0, Math.max(1, Math.min(4, candidates.length))),
+      options.poolFilter,
+    );
     scheduledPool = applySpacingFilters(borrowedPool, history, wordRepeatWindow);
     if (!scheduledPool.length) scheduledPool = borrowedPool;
   }
@@ -1488,4 +1553,286 @@ export function combinePracticeShards(
     synonym: modeShards.synonym?.synonym ?? [],
     fixtureNote: indexShard.fixtureNote,
   };
+}
+
+export function isPracticeNewCard(card: CardState | null | undefined): boolean {
+  if (!card) return true;
+  return card.reps === 0 && card.state === State.New;
+}
+
+export function isDueReviewCard(card: CardState | null | undefined, nowTime: number): boolean {
+  if (!card || isPracticeNewCard(card)) return false;
+  return card.due <= nowTime;
+}
+
+export function countDueReviewCards(
+  index: PracticeIndexItem[],
+  now: Date | number = Date.now(),
+): number {
+  const state = currentState();
+  const nowTime = toTime(now) ?? Date.now();
+  let count = 0;
+  for (const item of index) {
+    for (const mode of item.modes) {
+      if (!isPracticeMode(mode)) continue;
+      const card = state.cards.get(cardKey(item.lemmaId, mode));
+      if (isDueReviewCard(card, nowTime)) count += 1;
+    }
+  }
+  return count;
+}
+
+export function countAvailableNewCards(
+  index: PracticeIndexItem[],
+  now: Date | number = Date.now(),
+): number {
+  const state = currentState();
+  const nowTime = toTime(now) ?? Date.now();
+  let count = 0;
+  for (const item of index) {
+    for (const mode of item.modes) {
+      if (!isPracticeMode(mode)) continue;
+      const card = state.cards.get(cardKey(item.lemmaId, mode));
+      if (isPracticeNewCard(card) && (!card || card.due <= nowTime)) count += 1;
+    }
+  }
+  return count;
+}
+
+export function readNewCardsDailyState(
+  storage: StorageLike = resolveStorage(),
+  dateKey = todayDateKey(),
+): NewCardsDailyState {
+  try {
+    const raw = storage.getItem(PRACTICE_NEW_CARDS_KEY);
+    if (!raw) return { date: dateKey, count: 0 };
+    const parsed = JSON.parse(raw) as Partial<NewCardsDailyState>;
+    if (parsed.date !== dateKey || typeof parsed.count !== 'number') {
+      return { date: dateKey, count: 0 };
+    }
+    return { date: dateKey, count: parsed.count };
+  } catch {
+    return { date: dateKey, count: 0 };
+  }
+}
+
+export function writeNewCardsDailyState(
+  state: NewCardsDailyState,
+  storage: StorageLike = resolveStorage(),
+): void {
+  try {
+    storage.setItem(PRACTICE_NEW_CARDS_KEY, JSON.stringify(state));
+  } catch {
+    // Best-effort persistence.
+  }
+}
+
+function todayDateKey(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function computeSessionScope(
+  index: PracticeIndexItem[],
+  budget: SessionBudget,
+  options: {
+    now?: Date | number;
+    newPerSession?: number;
+    newPerDay?: number;
+    dailyNewCount?: number;
+  } = {},
+): SessionScopeStats {
+  const now = options.now ?? Date.now();
+  const newPerSession = options.newPerSession ?? DEFAULT_NEW_PER_SESSION;
+  const newPerDay = options.newPerDay ?? DEFAULT_NEW_PER_DAY;
+  const dailyNewCount = options.dailyNewCount ?? readNewCardsDailyState(resolveStorage(), todayDateKey(new Date(now))).count;
+  const dueReviews = countDueReviewCards(index, now);
+  const availableNew = countAvailableNewCards(index, now);
+  const remainingDailyNew = Math.max(0, newPerDay - dailyNewCount);
+  const maxNew = Math.min(newPerSession, remainingDailyNew, availableNew);
+  if (budget === 'until-zero') {
+    const plannedTotal = dueReviews + maxNew;
+    return {
+      dueReviews,
+      plannedNew: maxNew,
+      plannedTotal,
+      estimatedMinutes: Math.max(1, Math.ceil((plannedTotal * SESSION_ITEM_ESTIMATE_SEC) / 60)),
+    };
+  }
+  const reviewSlots = Math.min(dueReviews, budget);
+  const newSlots = Math.min(maxNew, Math.max(0, budget - reviewSlots));
+  const plannedTotal = reviewSlots + newSlots;
+  return {
+    dueReviews,
+    plannedNew: newSlots,
+    plannedTotal,
+    estimatedMinutes: Math.max(1, Math.ceil((plannedTotal * SESSION_ITEM_ESTIMATE_SEC) / 60)),
+  };
+}
+
+export function computeTodayRingDenominator(
+  index: PracticeIndexItem[],
+  options: {
+    now?: Date | number;
+    newPerDay?: number;
+    dailyNewCount?: number;
+  } = {},
+): number {
+  const now = options.now ?? Date.now();
+  const newPerDay = options.newPerDay ?? DEFAULT_NEW_PER_DAY;
+  const dailyNewCount = options.dailyNewCount ?? readNewCardsDailyState(resolveStorage(), todayDateKey(new Date(now))).count;
+  const dueReviews = countDueReviewCards(index, now);
+  const availableNew = countAvailableNewCards(index, now);
+  const remainingDailyNew = Math.max(0, newPerDay - dailyNewCount);
+  return dueReviews + Math.min(remainingDailyNew, availableNew);
+}
+
+export function buildSessionPoolConstraintState(options: {
+  plannedReviews: number;
+  reviewsCompleted: number;
+  sessionNewIntroduced: number;
+  newPerSession?: number;
+  newPerDay?: number;
+  dailyNewCount?: number;
+}): SessionPoolConstraintState {
+  const newPerSession = options.newPerSession ?? DEFAULT_NEW_PER_SESSION;
+  const newPerDay = options.newPerDay ?? DEFAULT_NEW_PER_DAY;
+  const dailyNewCount = options.dailyNewCount ?? 0;
+  const newRemainingSession = Math.max(0, newPerSession - options.sessionNewIntroduced);
+  const newRemainingDaily = Math.max(0, newPerDay - dailyNewCount);
+  const reviewsSatisfied =
+    options.plannedReviews <= 0 || options.reviewsCompleted >= options.plannedReviews;
+  return {
+    allowNewInPool: reviewsSatisfied && newRemainingSession > 0 && newRemainingDaily > 0,
+    newRemainingSession,
+    newRemainingDaily,
+    sessionNewIntroduced: options.sessionNewIntroduced,
+  };
+}
+
+export function sessionPoolAllowsCandidate(
+  candidate: PracticeSelection,
+  constraints: SessionPoolConstraintState,
+): boolean {
+  if (!isPracticeNewCard(candidate.cardState)) return true;
+  if (!constraints.allowNewInPool) return false;
+  if (constraints.newRemainingDaily <= 0) return false;
+  if (constraints.newRemainingSession <= 0) return false;
+  return true;
+}
+
+export function formatFsrsIntervalUk(from: Date, to: Date): string {
+  const deltaMs = Math.max(0, to.getTime() - from.getTime());
+  const minutes = Math.max(1, Math.round(deltaMs / (60 * 1000)));
+  if (minutes < 60) return `${minutes} хв`;
+  const days = Math.max(1, Math.round(deltaMs / DAY_MS));
+  if (days < 30) return `${days} д`;
+  const months = Math.max(1, Math.round(days / 30));
+  return `${months} міс`;
+}
+
+const FSRS_RATING_ORDER: PracticeRating[] = ['again', 'hard', 'good', 'easy'];
+
+export function previewRatingIntervals(
+  lemmaId: string,
+  mode: PracticeMode,
+  now: Date | number = Date.now(),
+): Record<PracticeRating, string> {
+  const reviewDate = now instanceof Date ? now : new Date(now);
+  const state = currentState();
+  const scheduler = fsrs(state.settings.params);
+  const existing = state.cards.get(cardKey(lemmaId, mode));
+  const fsrsCard = existing ? fsrsCardFromState(existing) : createEmptyCard(reviewDate);
+  const records = scheduler.repeat(fsrsCard, reviewDate);
+  const previews = {} as Record<PracticeRating, string>;
+  for (const rating of FSRS_RATING_ORDER) {
+    const grade = RATING_TO_FSRS[rating];
+    const record = records[grade];
+    previews[rating] = formatFsrsIntervalUk(reviewDate, record.card.due);
+  }
+  return previews;
+}
+
+export function readPracticeSessionSnapshot(
+  storage: StorageLike = resolveStorage(),
+): PracticeSessionSnapshot | null {
+  try {
+    const raw = storage.getItem(PRACTICE_SESSION_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<PracticeSessionSnapshot>;
+    if (
+      typeof parsed.sessionSeed !== 'number' ||
+      !Array.isArray(parsed.history) ||
+      (typeof parsed.budget !== 'number' && parsed.budget !== 'until-zero') ||
+      typeof parsed.completed !== 'number' ||
+      typeof parsed.modeFilter !== 'string' ||
+      typeof parsed.level !== 'string' ||
+      typeof parsed.startedAt !== 'number'
+    ) {
+      return null;
+    }
+    return parsed as PracticeSessionSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+export function writePracticeSessionSnapshot(
+  snapshot: PracticeSessionSnapshot | null,
+  storage: StorageLike = resolveStorage(),
+): void {
+  try {
+    if (!snapshot) {
+      storage.removeItem(PRACTICE_SESSION_STORAGE_KEY);
+      return;
+    }
+    storage.setItem(PRACTICE_SESSION_STORAGE_KEY, JSON.stringify(snapshot));
+  } catch {
+    // Best-effort persistence.
+  }
+}
+
+export function isPracticeSessionResumable(
+  snapshot: PracticeSessionSnapshot | null,
+  now: Date | number = Date.now(),
+): boolean {
+  if (!snapshot) return false;
+  const nowTime = toTime(now) ?? Date.now();
+  if (nowTime - snapshot.startedAt >= SESSION_RESUME_MAX_MS) return false;
+  const plannedTotal = snapshot.plannedTotal ?? snapshot.budget;
+  if (typeof plannedTotal === 'number' && snapshot.completed >= plannedTotal) {
+    const unresolved = snapshot.unresolvedCardKeys?.length ?? 0;
+    if (unresolved === 0) return false;
+  }
+  return true;
+}
+
+export function nextDuePreviewTime(now: Date | number = Date.now()): Date | null {
+  const state = currentState();
+  const nowTime = toTime(now) ?? Date.now();
+  let nextDue: number | null = null;
+  for (const card of state.cards.values()) {
+    if (card.due <= nowTime) continue;
+    if (nextDue === null || card.due < nextDue) nextDue = card.due;
+  }
+  return nextDue === null ? null : new Date(nextDue);
+}
+
+export type SessionCompletionDecision = 'continue' | 'extend' | 'summary' | 'summary-with-deferred';
+
+export function resolveSessionCompletion(options: {
+  completed: number;
+  plannedTotal: number;
+  extensionUsed: number;
+  unresolvedCount: number;
+  maxExtension?: number;
+}): SessionCompletionDecision {
+  const maxExtension = options.maxExtension ?? SESSION_CLOSURE_EXTENSION_MAX;
+  const target = options.plannedTotal + options.extensionUsed;
+  if (options.completed < target) return 'continue';
+  if (options.unresolvedCount > 0 && options.extensionUsed < maxExtension) return 'extend';
+  if (options.unresolvedCount > 0) return 'summary-with-deferred';
+  return 'summary';
 }

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -963,4 +963,133 @@ const frontmatter = {
       width: 100%;
     }
   }
+
+  .lexicon-practice-page[data-in-session="true"] .lexicon-practice-intro {
+    max-height: 0;
+    margin: 0;
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .lexicon-practice-page[data-in-session="true"] {
+    padding-top: 1.25rem;
+  }
+
+  :global(.lexicon-practice-session-start) {
+    display: grid;
+    gap: 0.85rem;
+    padding: 1.2rem 1.25rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 14px;
+    background: var(--lu-surface-raised);
+    box-shadow: var(--lu-shadow);
+  }
+
+  :global(.lexicon-session-scope) {
+    margin: 0;
+    color: var(--lu-text);
+    font-size: 1.05rem;
+    font-weight: 800;
+  }
+
+  :global(.lexicon-session-budgets) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  :global(.lexicon-session-primary) {
+    min-height: 52px;
+    font-size: 1.05rem;
+  }
+
+  :global(.btn-sub),
+  :global(.lab-sub),
+  :global(.heading-sub) {
+    display: block;
+    margin-top: 0.15rem;
+    color: var(--lu-text-muted);
+    font-size: 0.78rem;
+    font-weight: 700;
+  }
+
+  :global(.lexicon-focus-practice h3) {
+    margin: 0 0 0.65rem;
+    font-size: 1rem;
+    font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  :global(.mode-grid-focus) {
+    margin-top: 0;
+  }
+
+  :global(.level-soon) {
+    display: block;
+    font-size: 0.62rem;
+    font-weight: 800;
+    text-transform: lowercase;
+  }
+
+  :global(.lexicon-practice-stage) {
+    min-height: 420px;
+  }
+
+  :global(.rate-btn .ri) {
+    color: var(--lu-text-muted);
+    font-size: 0.72rem;
+    font-weight: 800;
+  }
+
+  :global(.rate-btn:disabled) {
+    opacity: 0.45;
+    cursor: not-allowed;
+    transform: none;
+  }
+
+  :global(.lexicon-session-summary) {
+    display: grid;
+    gap: 1rem;
+    padding: 1.25rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 14px;
+    background: var(--lu-surface-raised);
+  }
+
+  :global(.lexicon-session-summary-stats) {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.75rem;
+    margin: 0;
+  }
+
+  :global(.lexicon-session-summary-stats dt) {
+    color: var(--lu-text-muted);
+    font-size: 0.75rem;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
+  :global(.lexicon-session-summary-stats dd) {
+    margin: 0.15rem 0 0;
+    font-size: 1.35rem;
+    font-weight: 900;
+  }
+
+  :global(.lexicon-session-summary-actions) {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+  }
+
+  :global(.lexicon-practice-fallback) {
+    display: grid;
+    gap: 0.75rem;
+    padding: 1rem;
+    border: 1px solid var(--lu-border);
+    border-radius: 12px;
+    background: var(--lu-surface-raised);
+  }
 </style>

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -307,16 +307,27 @@ describe('LexiconPractice', () => {
     expect(requested.some((u) => u.includes('practice-cloze'))).toBe(false);
   });
 
-  test('shows the real SRS due-count on the home before any mode starts', async () => {
+  test('shows due review count on the home before any session starts', async () => {
     const { fn } = mockShardFetch({ A1: 3 });
     vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+    const state = loadState(localStorage, NOW);
+    state.cards.set(cardKey('A1-0', 'flashcards'), {
+      due: NOW.getTime() - 60_000,
+      stability: 4,
+      difficulty: 4,
+      elapsed_days: 1,
+      scheduled_days: 1,
+      learning_steps: 0,
+      reps: 2,
+      lapses: 0,
+      state: 2,
+    });
+    saveState(state, localStorage, NOW.getTime());
 
     render(<LexiconPractice />);
 
-    // Three never-reviewed A1 cards are all due → the «До повторення» tile shows 3
-    // on mount (not the placeholder '—'), without entering a mode first.
     await waitFor(() =>
-      expect(screen.getByLabelText('3 до повторення')).toBeInTheDocument(),
+      expect(screen.getByLabelText('1 до повторення')).toBeInTheDocument(),
     );
   });
 
@@ -325,9 +336,8 @@ describe('LexiconPractice', () => {
     const { fn, requested } = mockShardFetch({ A1: 2, A2: 1, B1: 3, B2: 5, C1: 4 });
     vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
     const user = userEvent.setup();
-    const { container } = render(<LexiconPractice initialMode="flashcards" />);
+    const { container } = render(<LexiconPractice />);
 
-    // Start = clicking a mode card (the redesign has no separate "Start Practice" button).
     await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
 
     // A1+A2+B1 load (cumulative); B2/C1 are above the learner level and must never be fetched.
@@ -346,13 +356,11 @@ describe('LexiconPractice', () => {
     const { fn, requested } = mockShardFetch({ A1: 2, A2: 1, B1: 3 });
     vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
     const user = userEvent.setup();
-    const { container } = render(<LexiconPractice initialMode="flashcards" />);
+    const { container } = render(<LexiconPractice />);
 
-    // The level chips live on the practice home; raising the level persists the shared key.
     await user.click(screen.getByRole('button', { name: 'B1' }));
     expect(localStorage.getItem(LEARNER_LEVEL_STORAGE_KEY)).toBe('B1');
 
-    // Starting now loads the cumulative B1 pool (A1+A2+B1); B2 is above the level and never loads.
     await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
     await waitFor(() =>
       expect(requested.some((u) => u.includes('practice-index.B1'))).toBe(true),
@@ -370,11 +378,14 @@ describe('LexiconPractice', () => {
 
     const flashcard = container.querySelector<HTMLElement>('[data-activity="flashcard"]');
     expect(flashcard).toBeInTheDocument();
+    const goodButton = container.querySelector<HTMLButtonElement>('[data-rate="good"]')!;
+    expect(goodButton).toBeDisabled();
+
     await user.click(flashcard!);
     expect(flashcard).toHaveAttribute('data-flipped', 'true');
+    expect(goodButton).not.toBeDisabled();
 
-    // Rating buttons carry a "1-4" key span; target the stable data-rate hook.
-    await user.click(container.querySelector<HTMLButtonElement>('[data-rate="good"]')!);
+    await user.click(goodButton);
 
     await waitFor(() => {
       expect(storedState().cards[cardKey('knyha', 'flashcards')]).toBeTruthy();
@@ -511,5 +522,57 @@ describe('LexiconPractice', () => {
     );
     expect(screen.getByText(/uk-author/)).toHaveTextContent('en-author');
     expect(screen.getByText(/CC-BY 2.0 FR/)).toBeInTheDocument();
+  });
+
+  test('today ring uses review + capped-new denominator, not whole deck', async () => {
+    const { fn } = mockShardFetch({ A1: 1150 });
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+    render(<LexiconPractice />);
+    await waitFor(() => expect(screen.getByTestId('practice-today-ring')).toBeInTheDocument());
+    const ring = screen.getByTestId('practice-today-ring');
+    expect(ring.textContent).toMatch(/0\/\d+/);
+    const denominator = Number(ring.textContent?.split('/')[1]);
+    expect(denominator).toBeLessThan(1150);
+  });
+
+  test('A1 renders English subtitles on session labels; A2 does not', async () => {
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A1');
+    const { unmount } = render(<LexiconPractice />);
+    expect(screen.getByText('Start session')).toBeInTheDocument();
+    unmount();
+
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'A2');
+    render(<LexiconPractice />);
+    expect(screen.queryByText('Start session')).not.toBeInTheDocument();
+  });
+
+  test('unpublished C2 level button is disabled with «скоро»', () => {
+    render(<LexiconPractice />);
+    const c2 = screen.getByRole('button', { name: /C2/ });
+    expect(c2).toBeDisabled();
+    expect(c2).toHaveTextContent('скоро');
+  });
+
+  test('flashcard rating keys are inert before reveal', async () => {
+    const user = userEvent.setup();
+    render(
+      <LexiconPractice initialDeck={sampleDeckWithOnlyMode('knyha', 'flashcards')} autoStart initialMode="flashcards" />,
+    );
+    await user.keyboard('3');
+    expect(storedState().reviews ?? []).toHaveLength(0);
+    const flashcard = document.querySelector('[data-activity="flashcard"]')!;
+    await user.click(flashcard);
+    await user.keyboard('3');
+    await waitFor(() => expect(storedState().reviews?.length).toBe(1));
+  });
+
+  test('post-flip rating buttons show FSRS interval previews', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <LexiconPractice initialDeck={sampleDeckWithOnlyMode('knyha', 'flashcards')} autoStart initialMode="flashcards" />,
+    );
+    await user.click(container.querySelector('[data-activity="flashcard"]')!);
+    const good = container.querySelector('[data-rate="good"] .ri');
+    expect(good?.textContent).toMatch(/‹.+›/);
   });
 });

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -451,7 +451,7 @@ describe('LexiconPractice', () => {
         lemmaId: entry.lemmaId,
         lemma: entry.lemma,
         cefr: 'A1',
-        modes: ['flashcards', 'matching', 'choice'],
+        modes: entry.lemmaId === 'bachyty' ? ['choice'] : ['flashcards'],
         hasCloze: false,
         clozeIds: [],
         newOrder: index,
@@ -463,7 +463,7 @@ describe('LexiconPractice', () => {
     const labels = within(choice)
       .getAllByRole('button')
       .map((button) => button.querySelector('span:not(.mc-key)')?.textContent ?? '');
-    // First card is the small-POS verb (newOrder 0). Without cross-POS backfill it
+    // The only selectable choice card is the small-POS verb. Without cross-POS backfill it
     // would starve (<3 distractors) and not render; it must show a full 4-option set.
     expect(labels).toHaveLength(4);
     // The verb answer is present whichever polarity the selector picked.

--- a/site/tests/unit/practice-session.test.ts
+++ b/site/tests/unit/practice-session.test.ts
@@ -1,0 +1,327 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { Rating, fsrs, createEmptyCard } from 'ts-fsrs';
+import {
+  DEFAULT_NEW_PER_DAY,
+  DEFAULT_NEW_PER_SESSION,
+  PRACTICE_NEW_CARDS_KEY,
+  PRACTICE_SESSION_STORAGE_KEY,
+  SRS_STORAGE_KEY,
+  buildSessionPoolConstraintState,
+  cardKey,
+  computeSessionScope,
+  computeTodayRingDenominator,
+  countAvailableNewCards,
+  countDueReviewCards,
+  formatFsrsIntervalUk,
+  isPracticeNewCard,
+  isPracticeSessionResumable,
+  loadState,
+  previewRatingIntervals,
+  readNewCardsDailyState,
+  readPracticeSessionSnapshot,
+  resolveSessionCompletion,
+  saveState,
+  selectNextPracticeItem,
+  sessionPoolAllowsCandidate,
+  writeNewCardsDailyState,
+  writePracticeSessionSnapshot,
+  type PracticeDeckData,
+  type PracticeIndexItem,
+  type PracticeLexeme,
+  type SelectionHistoryItem,
+} from '@site/src/lib/lexicon/srs';
+
+const NOW = new Date('2026-06-23T12:00:00.000Z');
+
+function lexeme(lemmaId: string, lemma = lemmaId): PracticeLexeme {
+  return {
+    lemmaId,
+    lemma,
+    lemmaPlain: lemma,
+    gloss: `${lemma} gloss`,
+    ipa: null,
+    pos: 'noun',
+    cefr: 'A1',
+    heritage: null,
+    severity: null,
+    paradigm: { cases: { nominative: { singular: lemma } } },
+  };
+}
+
+function indexItem(lemmaId: string, order: number): PracticeIndexItem {
+  return {
+    lemmaId,
+    lemma: lemmaId,
+    cefr: 'A1',
+    modes: ['flashcards'],
+    hasCloze: false,
+    clozeIds: [],
+    newOrder: order,
+  };
+}
+
+function deckFromIds(ids: string[]): PracticeDeckData {
+  const lexemes = ids.map((id) => lexeme(id));
+  return {
+    deckVersion: 'session-test',
+    level: 'A1',
+    lexemes,
+    cloze: [],
+    index: ids.map((id, order) => indexItem(id, order)),
+  };
+}
+
+function dueCard(lemmaId: string) {
+  return {
+    due: NOW.getTime() - 60_000,
+    stability: 4,
+    difficulty: 4,
+    elapsed_days: 1,
+    scheduled_days: 1,
+    learning_steps: 0,
+    reps: 2,
+    lapses: 0,
+    state: 2,
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  loadState(localStorage, NOW);
+});
+
+describe('practice session helpers', () => {
+  test('today-ring denominator excludes uncapped deck size', () => {
+    const index = Array.from({ length: 50 }, (_, i) => indexItem(`w${i}`, i));
+    const denominator = computeTodayRingDenominator(index, {
+      now: NOW,
+      dailyNewCount: 0,
+      newPerDay: DEFAULT_NEW_PER_DAY,
+    });
+    expect(denominator).toBe(DEFAULT_NEW_PER_DAY);
+    expect(denominator).toBeLessThan(index.length);
+  });
+
+  test('session scope prioritizes reviews then caps new cards', () => {
+    const index = Array.from({ length: 30 }, (_, i) => indexItem(`w${i}`, i));
+    const state = loadState(localStorage, NOW);
+    state.cards.set(cardKey('w0', 'flashcards'), dueCard('w0'));
+    state.cards.set(cardKey('w1', 'flashcards'), dueCard('w1'));
+    saveState(state, localStorage, NOW.getTime());
+    const scope = computeSessionScope(index, 20, {
+      now: NOW,
+      newPerSession: DEFAULT_NEW_PER_SESSION,
+      newPerDay: DEFAULT_NEW_PER_DAY,
+      dailyNewCount: 0,
+    });
+    expect(scope.dueReviews).toBe(2);
+    expect(scope.plannedNew).toBe(8);
+    expect(scope.plannedTotal).toBe(10);
+  });
+
+  test('daily new allowance gates session scope', () => {
+    const index = Array.from({ length: 10 }, (_, i) => indexItem(`w${i}`, i));
+    const scope = computeSessionScope(index, 20, {
+      now: NOW,
+      dailyNewCount: 18,
+      newPerDay: DEFAULT_NEW_PER_DAY,
+    });
+    expect(scope.plannedNew).toBe(2);
+  });
+
+  test('session pool blocks new cards until review quota is satisfied', () => {
+    const candidate = {
+      itemId: 'new-1',
+      lemma: lexeme('new-1'),
+      indexItem: indexItem('new-1', 0),
+      mode: 'flashcards' as const,
+      cardKey: cardKey('new-1', 'flashcards'),
+      cardState: null,
+      due: 0,
+      lapsed: false,
+      recallDirection: 'uk-to-meaning' as const,
+      choicePolarity: 'word-to-meaning' as const,
+    };
+    const blocked = buildSessionPoolConstraintState({
+      plannedReviews: 5,
+      reviewsCompleted: 2,
+      sessionNewIntroduced: 0,
+      dailyNewCount: 0,
+    });
+    const allowed = buildSessionPoolConstraintState({
+      plannedReviews: 5,
+      reviewsCompleted: 5,
+      sessionNewIntroduced: 0,
+      dailyNewCount: 0,
+    });
+    expect(sessionPoolAllowsCandidate(candidate, blocked)).toBe(false);
+    expect(sessionPoolAllowsCandidate(candidate, allowed)).toBe(true);
+  });
+
+  test('session pool enforces new-per-session and daily caps', () => {
+    const candidate = {
+      itemId: 'new-2',
+      lemma: lexeme('new-2'),
+      indexItem: indexItem('new-2', 1),
+      mode: 'flashcards' as const,
+      cardKey: cardKey('new-2', 'flashcards'),
+      cardState: null,
+      due: 0,
+      lapsed: false,
+      recallDirection: 'uk-to-meaning' as const,
+      choicePolarity: 'word-to-meaning' as const,
+    };
+    const sessionCap = buildSessionPoolConstraintState({
+      plannedReviews: 0,
+      reviewsCompleted: 0,
+      sessionNewIntroduced: DEFAULT_NEW_PER_SESSION,
+      dailyNewCount: 0,
+    });
+    const dailyCap = buildSessionPoolConstraintState({
+      plannedReviews: 0,
+      reviewsCompleted: 0,
+      sessionNewIntroduced: 0,
+      dailyNewCount: DEFAULT_NEW_PER_DAY,
+    });
+    expect(sessionPoolAllowsCandidate(candidate, sessionCap)).toBe(false);
+    expect(sessionPoolAllowsCandidate(candidate, dailyCap)).toBe(false);
+  });
+
+  test('pool filter leaves §6 ordering precedence intact for due reviews', () => {
+    const state = loadState(localStorage, NOW);
+    state.cards.set(cardKey('due-a', 'flashcards'), dueCard('due-a'));
+    state.cards.set(cardKey('due-b', 'flashcards'), {
+      ...dueCard('due-b'),
+      due: NOW.getTime() - 120_000,
+    });
+    saveState(state, localStorage, NOW.getTime());
+    const testDeck = deckFromIds(['due-a', 'due-b', 'fresh-c']);
+    const constraints = buildSessionPoolConstraintState({
+      plannedReviews: 2,
+      reviewsCompleted: 0,
+      sessionNewIntroduced: 0,
+      dailyNewCount: 0,
+    });
+    const selection = selectNextPracticeItem(testDeck, {
+      now: NOW,
+      modeFilter: 'flashcards',
+      poolFilter: (candidate) => sessionPoolAllowsCandidate(candidate, constraints),
+    });
+    expect(selection?.lemma.lemmaId).toBe('due-b');
+  });
+
+  test('snapshot round-trip restores seed history budget and recomputes live selection', () => {
+    const testDeck = deckFromIds(['alpha', 'beta']);
+    const history: SelectionHistoryItem[] = [
+      { itemId: 'alpha:flashcards', lemmaId: 'alpha', mode: 'flashcards' },
+    ];
+    writePracticeSessionSnapshot({
+      sessionSeed: 424242,
+      history,
+      budget: 10,
+      completed: 1,
+      modeFilter: 'flashcards',
+      level: 'A1',
+      startedAt: NOW.getTime(),
+      plannedReviews: 2,
+      plannedNew: 2,
+      plannedTotal: 4,
+      reviewsCompleted: 1,
+      sessionNewIntroduced: 0,
+      extensionUsed: 0,
+      unresolvedCardKeys: [],
+    });
+    const snapshot = readPracticeSessionSnapshot();
+    expect(snapshot).toMatchObject({
+      sessionSeed: 424242,
+      history,
+      budget: 10,
+      completed: 1,
+    });
+    expect(isPracticeSessionResumable(snapshot, NOW)).toBe(true);
+    const live = selectNextPracticeItem(testDeck, {
+      now: NOW,
+      modeFilter: 'flashcards',
+      history: snapshot?.history ?? [],
+      sessionSeed: snapshot?.sessionSeed,
+    });
+    expect(live?.lemma.lemmaId).toBeTruthy();
+  });
+
+  test('interval labels match ts-fsrs repeat preview output', () => {
+    const previews = previewRatingIntervals('alpha', 'flashcards', NOW);
+    const scheduler = fsrs(loadState(localStorage, NOW).settings.params);
+    const records = scheduler.repeat(createEmptyCard(NOW), NOW);
+    expect(previews.good).toBe(formatFsrsIntervalUk(NOW, records[Rating.Good].card.due));
+    expect(previews.again).toBe(formatFsrsIntervalUk(NOW, records[Rating.Again].card.due));
+  });
+
+  test('formatFsrsIntervalUk uses minutes days and months buckets', () => {
+    expect(formatFsrsIntervalUk(NOW, new Date(NOW.getTime() + 10 * 60_000))).toBe('10 хв');
+    expect(formatFsrsIntervalUk(NOW, new Date(NOW.getTime() + 3 * 24 * 60 * 60_000))).toBe('3 д');
+    expect(formatFsrsIntervalUk(NOW, new Date(NOW.getTime() + 90 * 24 * 60 * 60_000))).toBe('3 міс');
+  });
+
+  test('new cards daily state resets on a new day', () => {
+    writeNewCardsDailyState({ date: '2026-06-22', count: 12 });
+    expect(readNewCardsDailyState(localStorage, '2026-06-23').count).toBe(0);
+    localStorage.setItem(
+      PRACTICE_NEW_CARDS_KEY,
+      JSON.stringify({ date: '2026-06-23', count: 4 }),
+    );
+    expect(readNewCardsDailyState(localStorage, '2026-06-23').count).toBe(4);
+  });
+
+  test('due and available counts distinguish reviews from new cards', () => {
+    const index = [indexItem('review-me', 0), indexItem('brand-new', 1)];
+    const state = loadState(localStorage, NOW);
+    state.cards.set(cardKey('review-me', 'flashcards'), dueCard('review-me'));
+    saveState(state, localStorage, NOW.getTime());
+    expect(countDueReviewCards(index, NOW)).toBe(1);
+    expect(countAvailableNewCards(index, NOW)).toBe(1);
+    expect(isPracticeNewCard(null)).toBe(true);
+  });
+
+  test('expired snapshot is not resumable', () => {
+    writePracticeSessionSnapshot({
+      sessionSeed: 1,
+      history: [],
+      budget: 10,
+      completed: 2,
+      modeFilter: 'mixed',
+      level: 'A1',
+      startedAt: NOW.getTime() - 7 * 60 * 60_000,
+      plannedTotal: 10,
+    });
+    expect(isPracticeSessionResumable(readPracticeSessionSnapshot(), NOW)).toBe(false);
+    localStorage.removeItem(PRACTICE_SESSION_STORAGE_KEY);
+    localStorage.removeItem(SRS_STORAGE_KEY);
+  });
+
+  test('failed-card closure extends up to five items then defers leftovers', () => {
+    expect(
+      resolveSessionCompletion({
+        completed: 10,
+        plannedTotal: 10,
+        extensionUsed: 0,
+        unresolvedCount: 2,
+      }),
+    ).toBe('extend');
+    expect(
+      resolveSessionCompletion({
+        completed: 15,
+        plannedTotal: 10,
+        extensionUsed: 5,
+        unresolvedCount: 1,
+      }),
+    ).toBe('summary-with-deferred');
+    expect(
+      resolveSessionCompletion({
+        completed: 10,
+        plannedTotal: 10,
+        extensionUsed: 0,
+        unresolvedCount: 0,
+      }),
+    ).toBe('summary');
+  });
+});


### PR DESCRIPTION
## Feature list from recovered WIP

Full §6b implementation: session machine, primary CTA + scope, new-card caps, summary + failed-card closure, resume, reveal gate + FSRS interval previews, error boundary, and disabled C2 level affordance.

## Root cause and fix

Focused cloze sessions were computing `plannedReviews` from the full multi-mode deck before applying the focus `modeFilter`. A due flashcard review therefore made `sessionPoolAllowsCandidate` reject the new cloze card, but the selector was running with `modeFilter="cloze"` and could never pick that flashcard to satisfy the review quota. The fix scopes `computeSessionScope` to the active focus mode while leaving mixed sessions on the full index, so the session layer constrains the same pool the selector can actually serve. The choice backfill test fixture was also made deterministic under seeded new-card ordering; that is a test stabilization, not a §6b contract change.

## Evidence

`cd site && npm run hydrate` was run before the full suite so ignored local Atlas/practice shards existed.

```text
$ cd site && npx vitest run
 Test Files  33 passed (33)
      Tests  469 passed (469)
```

```text
$ cd site && npx tsc --noEmit
```

```text
$ cd site && npx eslint src/components/LexiconPractice.tsx tests/unit/LexiconPractice.test.tsx --quiet
```

Both `tsc` and `eslint` exited 0 with no output.

Cross-family review gate: Cursor `auto` returned “No blocking findings” and confirmed the root cause. Route note: Gemini was unavailable in CodexBar, Hermes/DeepSeek and Grok Build invocations stalled, so Cursor was used as the working non-Codex reviewer.

Refs #4658 #4387
