### PR TITLE
fix(corpus): add barjakhtar author variant (ingest-gate catch)

### DIFF
--- a/scripts/wiki/textbook_subjects.py
+++ b/scripts/wiki/textbook_subjects.py
@@ -393,6 +393,7 @@ AUTHOR_UK_BY_TRANSLIT: dict[str, str] = {
     "kovbasenko": "Ковбасенко",
     "merzlyak": "Мерзляк",
     "merzljak": "Мерзляк",
+    "barjakhtar": "Бар'яхтар",
     "grygorovych": "Григорович",
     "zadorozhnyj": "Задорожний",
     "zadorozhnij": "Задорожний",

--- a/tests/test_textbook_subjects.py
+++ b/tests/test_textbook_subjects.py
@@ -326,6 +326,7 @@ def test_batch3_author_translits_resolve_to_cyrillic() -> None:
         "gudima": "Гудима",
         "homiak": "Криховець-Хом'як",
         "bojko": "Бойко",
+        "barjakhtar": "Бар'яхтар",
         "merzljak": "Мерзляк",
         "zadorozhnij": "Задорожний",
         "zasekina": "Засєкіна",


### PR DESCRIPTION
One-key fix: `barjakhtar` → Бар'яхтар. The #4593 batch-3 ingest `--dry-run` strictness gate hard-failed on `10-klas-fizyka-barjakhtar-2018` — the j-variant was mis-checked as covered during #4667 review. Deterministic scan of all 48 batch-3 stems (token-before-year vs live `AUTHOR_UK_BY_TRANSLIT`) confirms this was the only missing key; test row added.

Raw evidence: ruff `All checks passed!` · pytest `65 passed`. Gate working exactly as designed — blocks ingest, names the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)