### PR TITLE
feat(bio): add human-rights dissent readings batch 51

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/leonid-pliushch.yaml
+++ b/curriculum/l2-uk-en/plans/bio/leonid-pliushch.yaml
@@ -139,6 +139,28 @@ persona:
     як інструментом політичного примусу.
   voice: Human Rights Historian
 phase: BIO
+readings:
+- language: uk
+  hosting: link-only
+  notes: Енциклопедична стаття з хронологією життя та репресій.
+  rights_note: Link-only classroom source; do not host the full article in this repository.
+  source_name: Енциклопедія сучасної України (ЕСУ)
+  source_url: https://esu.com.ua/article-879739
+  title: Плющ Леонід Іванович
+- language: uk
+  hosting: link-only
+  notes: Профіль із деталями статті 62 та каральної психіатрії.
+  rights_note: Link-only classroom source; cite and summarize rather than republishing the full page.
+  source_name: Віртуальний музей дисидентського руху (ХПГ)
+  source_url: https://museum.khpg.org/1113936077
+  title: Плющ Леонід Іванович
+- language: uk
+  hosting: link-only
+  notes: Електронна сторінка мемуарів.
+  rights_note: Copyrighted memoir page; use as link-only reading and do not host full text in this repository.
+  source_name: Diasporiana
+  source_url: https://diasporiana.org.ua/memuari/5057-plyushh-l-u-karnavali-istoriyi/
+  title: У карнавалі історії (Свідчення)
 references:
 - note: Енциклопедична стаття з хронологією життя, наукової праці, репресій і видань.
   path: https://esu.com.ua/article-879739
@@ -165,7 +187,7 @@ sequence: 270
 slug: leonid-pliushch
 subtitle: Mathematician, Witness, and Victim of Punitive Psychiatry
 title: 'Леонід Плющ: карнавал історії і каральна психіатрія'
-version: '4.2'
+version: '4.4'
 vocabulary_hints:
 - definition: самостійне поширення текстів поза державною цензурою; у справі Плюща канал правозахисного свідчення
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/oleksa-tykhyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oleksa-tykhyi.yaml
@@ -111,6 +111,28 @@ persona:
     Донбасу.
   voice: Human Rights Historian
 phase: BIO
+readings:
+- language: uk
+  hosting: reading-needed
+  notes: Біографічна довідка правозахисника та засновника УГГ.
+  role: reading-needed
+  source: 'reading-needed: oleksa-tykhyi-khpg-profile'
+  source_name: Віртуальний музей дисидентського руху (ХПГ)
+  title: Тихий Олексій Іванович
+- language: uk
+  hosting: reading-needed
+  notes: Енциклопедична стаття про життя та діяльність.
+  role: reading-needed
+  source: 'reading-needed: oleksa-tykhyi-esu-profile'
+  source_name: Енциклопедія сучасної України (ЕСУ)
+  title: Тихий Олекса Іванович
+- language: uk
+  hosting: reading-needed
+  notes: Есе про мовні права Донбасу (1972). Потребує надійного українського онлайн-джерела.
+  role: reading-needed
+  source: 'reading-needed: dumky-pro-ridnyi-donetskyi-krai'
+  source_name: Самвидав
+  title: Думки про рідний донецький край
 references:
 - note: Профіль у музеї-архіві дисидентського руху (англ.).
   title: TYKHY Oleksa (Oleskiy Ivanovych) (Дисидентський рух в Україні)
@@ -134,7 +156,7 @@ sequence: 265
 slug: oleksa-tykhyi
 subtitle: Teacher, Language-Rights Activist, and UHG Co-Founder Who Died in Custody
 title: 'Олекса Тихий: мова, Донбас і ціна правозахисництва'
-version: '1.0'
+version: '1.2'
 vocabulary_hints:
 - definition: людина, яка захищає права людини в умовах переслідування
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/serhii-paradzhanov.yaml
+++ b/curriculum/l2-uk-en/plans/bio/serhii-paradzhanov.yaml
@@ -103,6 +103,21 @@ persona:
     культурний примус.
   voice: Film Historian
 phase: BIO
+readings:
+- language: uk
+  hosting: reading-needed
+  notes: Базова енциклопедична стаття про життя і творчість кінорежисера.
+  role: reading-needed
+  source: 'reading-needed: serhii-paradzhanov-esu-profile'
+  source_name: Енциклопедія сучасної України (ЕСУ)
+  title: Параджанов Сергій Йосипович
+- language: uk
+  hosting: reading-needed
+  notes: Матеріали про фільм як вершину українського поетичного кіно. Потребує надійного текстового джерела.
+  role: reading-needed
+  source: 'reading-needed: tini-zabutykh-predkiv-dovzhenko-center'
+  source_name: Довженко-Центр
+  title: Тіні забутих предків (фільм)
 references:
 - note: Базова енциклопедична стаття — ім'я, дати, твори.
   title: Параджанов Сергій Йосипович (ЕСУ)
@@ -126,7 +141,7 @@ sequence: 267
 slug: serhii-paradzhanov
 subtitle: Transnational Filmmaker of Ukrainian Poetic Cinema and Soviet Cultural Repression
 title: 'Сергій Параджанов: «Тіні забутих предків» і ціна неформатності'
-version: '1.0'
+version: '1.2'
 vocabulary_hints:
 - definition: кінематограф з поетичною образністю, символікою та нелінійним монтажем
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/valerii-marchenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/valerii-marchenko.yaml
@@ -110,6 +110,28 @@ persona:
     політв'язництва.
   voice: Human Rights Historian
 phase: BIO
+readings:
+- language: uk
+  hosting: reading-needed
+  notes: Енциклопедична стаття про життя та діяльність філолога й перекладача.
+  role: reading-needed
+  source: 'reading-needed: valerii-marchenko-esu-profile'
+  source_name: Енциклопедія сучасної України (ЕСУ)
+  title: Марченко Валерій Веніамінович
+- language: uk
+  hosting: reading-needed
+  notes: Біографічний профіль у музеї дисидентського руху.
+  role: reading-needed
+  source: 'reading-needed: valerii-marchenko-khpg-profile'
+  source_name: Віртуальний музей дисидентського руху (ХПГ)
+  title: Марченко Валерій Веніамінович
+- language: uk
+  hosting: reading-needed
+  notes: Самвидавне есе (1973). Потребує надійного джерела для читання уривків.
+  role: reading-needed
+  source: 'reading-needed: kyivskyi-dialoh-primary'
+  source_name: Самвидав
+  title: Київський діалог
 references:
 - note: Енциклопедична стаття про життя та діяльність.
   title: Марченко Валерій Веніамінович (ЕСУ)
@@ -133,7 +155,7 @@ sequence: 268
 slug: valerii-marchenko
 subtitle: Philologist, Translator, and Dissident Who Died After Medical Release Was Denied
 title: 'Валерій Марченко: самвидав, ст. 62 і смерть у лікарні'
-version: '1.0'
+version: '1.2'
 vocabulary_hints:
 - definition: людина, яка захищає права людини в умовах переслідування
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/vasyl-holoborodko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/vasyl-holoborodko.yaml
@@ -105,6 +105,28 @@ persona:
     опору без ув'язнення.
   voice: Literary Historian
 phase: BIO
+readings:
+- language: uk
+  hosting: reading-needed
+  notes: Енциклопедична стаття про поета Київської школи.
+  role: reading-needed
+  source: 'reading-needed: vasyl-holoborodko-esu-profile'
+  source_name: Енциклопедія сучасної України (ЕСУ)
+  title: Голобородько Василь Іванович
+- language: uk
+  hosting: reading-needed
+  notes: Перша збірка (1970). Потребує надійного онлайн-джерела для читання (лише посилання на фрагменти, уникати порушення авторських прав).
+  role: reading-needed
+  source: 'reading-needed: letiuchie-vikontse-primary'
+  source_name: Видавництво "Смолоскип"
+  title: Летюче віконце
+- language: uk
+  hosting: reading-needed
+  notes: Інтерв'ю про публікаційну траєкторію та цензуру (2015).
+  role: reading-needed
+  source: 'reading-needed: mene-pidstrelyly-na-zleti-interview'
+  source_name: Українська літературна газета
+  title: «Мене підстрелили на злеті»
 references:
 - note: Енциклопедична стаття про життя та поетику.
   title: Голобородько Василь Іванович (ЕСУ)
@@ -127,7 +149,7 @@ sequence: 266
 slug: vasyl-holoborodko
 subtitle: Kyiv School Poet Silenced by Cultural Gatekeeping, Not Imprisonment
 title: 'Василь Голобородько: міфопоетика під забороною друку'
-version: '1.0'
+version: '1.2'
 vocabulary_hints:
 - definition: напрям української поезії 1960–1980-х із асоціативною образністю та фольклорними резонансами
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/yurii-lytvyn.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yurii-lytvyn.yaml
@@ -109,6 +109,28 @@ persona:
     неопублікованих текстів.
   voice: Human Rights Historian
 phase: BIO
+readings:
+- language: uk
+  hosting: reading-needed
+  notes: Енциклопедична стаття про правозахисника та поета.
+  role: reading-needed
+  source: 'reading-needed: yurii-lytvyn-esu-profile'
+  source_name: Енциклопедія сучасної України (ЕСУ)
+  title: Литвин Юрій Тимонович
+- language: uk
+  hosting: reading-needed
+  notes: Профіль у музеї-архіві дисидентського руху.
+  role: reading-needed
+  source: 'reading-needed: yurii-lytvyn-khpg-profile'
+  source_name: Віртуальний музей дисидентського руху (ХПГ)
+  title: Литвин Юрій Тимонович
+- language: uk
+  hosting: reading-needed
+  notes: Есе про правозахисний рух (1979). Потребує надійного українського онлайн-джерела.
+  role: reading-needed
+  source: 'reading-needed: pravozakhysnyi-rukh-v-ukraini-primary'
+  source_name: Самвидав
+  title: Правозахисний рух в Україні, його засади і перспективи
 references:
 - note: Енциклопедична стаття; розбіжність метаданих по батькові зафіксована в досьє.
   title: Литвин Юрій Тимонович (ЕСУ)
@@ -132,7 +154,7 @@ sequence: 269
 slug: yurii-lytvyn
 subtitle: Poet, Publicist, and UHG Member Who Died in Special-Regime Custody
 title: 'Юрій Литвин: правозахисник, самвидав і табір 1984'
-version: '1.0'
+version: '1.2'
 vocabulary_hints:
 - definition: людина, яка захищає права людини в умовах переслідування
   pos: ч.


### PR DESCRIPTION
## Summary
- Add Ukrainian-only top-level readings blocks for six BIO human-rights dissent plans.
- Use explicit reading-needed placeholders where stable Ukrainian-hosted sources still need verification.
- Add link-only hostability/copyright notes for the concrete Pliushch readings.

## Owned scope
- curriculum/l2-uk-en/plans/bio/oleksa-tykhyi.yaml
- curriculum/l2-uk-en/plans/bio/vasyl-holoborodko.yaml
- curriculum/l2-uk-en/plans/bio/serhii-paradzhanov.yaml
- curriculum/l2-uk-en/plans/bio/valerii-marchenko.yaml
- curriculum/l2-uk-en/plans/bio/yurii-lytvyn.yaml
- curriculum/l2-uk-en/plans/bio/leonid-pliushch.yaml

## Verification
- git diff --name-only 10d6a91393c399de50b4c11960857f03ec8ec499..HEAD: only owned files
- git diff --check: pass
- .venv/bin/python PyYAML parse + readings schema check: pass
- pre-commit hooks during amend/push: pass

LLM-QG and Gemma were not used. No wiki writers or module builders were dispatched.