### PR TITLE
feat(practice): #4505 heritage mode client — selector + render + cited feedback

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 028ecda324477dcb3ffab91c76b90b706065efea80fc1f7b7c8fdafd963aba7e
+  components_sha256: 0eb0d9a8d5bbcba8e9dd798c7190f1d07530b06c62238cac60d4c8850b145d4d
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -18,6 +18,7 @@ import {
   loadState,
   masteredCount,
   nextDuePreviewTime,
+  parseCardKey,
   previewRatingIntervals,
   rateCard,
   resolveSessionCompletion,
@@ -33,6 +34,8 @@ import {
   type ChoicePolarity,
   type PracticeClozeItem,
   type PracticeDeckData,
+  type PracticeHeritageItem,
+  type PracticeHeritageShard,
   type PracticeIndexItem,
   type PracticeIndexShard,
   type PracticeLexeme,
@@ -71,6 +74,13 @@ interface StreakState {
 interface ChoiceOption {
   label: string;
   correct: boolean;
+  kind?: 'answer' | 'calque' | 'distractor';
+}
+
+interface HeritageFeedback {
+  kind: 'correct' | 'calque' | 'wrong';
+  text: string;
+  citations?: string[];
 }
 
 interface ClozeFeedback {
@@ -115,6 +125,7 @@ type VisiblePracticeModeFilter = Extract<
   | 'classify'
   | 'paradigm'
   | 'synonym'
+  | 'heritage'
 >;
 
 const MODE_LABELS: Record<VisiblePracticeModeFilter, string> = {
@@ -127,6 +138,7 @@ const MODE_LABELS: Record<VisiblePracticeModeFilter, string> = {
   classify: 'Classify',
   paradigm: 'Paradigm',
   synonym: 'Synonym',
+  heritage: 'Спадщина',
 };
 
 const MODE_CARD_ORDER: VisiblePracticeModeFilter[] = [
@@ -139,6 +151,7 @@ const MODE_CARD_ORDER: VisiblePracticeModeFilter[] = [
   'classify',
   'paradigm',
   'synonym',
+  'heritage',
 ];
 
 const MODE_META: Record<
@@ -213,6 +226,13 @@ const MODE_META: Record<
     description: 'Доберіть синонім або антонім до українського слова.',
     step: 'Лексика',
     accent: 'orange',
+  },
+  heritage: {
+    title: 'Спадщина',
+    en: 'Heritage',
+    description: 'Оберіть питоме українське слово.',
+    step: 'Питома лексика',
+    accent: 'teal',
   },
 };
 
@@ -405,6 +425,15 @@ function ModeIcon({ mode }: { mode: VisiblePracticeModeFilter }) {
     );
   }
 
+  if (mode === 'heritage') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M12 4 5 7.5v5.2c0 3.9 2.6 6.2 7 7.3 4.4-1.1 7-3.4 7-7.3V7.5L12 4Z" />
+        <path d="M9 12.2 11.1 14l4-4.6" />
+      </svg>
+    );
+  }
+
   if (mode === 'mixed') {
     return (
       <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
@@ -422,6 +451,18 @@ function ModeIcon({ mode }: { mode: VisiblePracticeModeFilter }) {
       <path d="M9 9h6" />
       <path d="M9 13h4" />
     </svg>
+  );
+}
+
+function hasLoadedDrillShards(deck: PracticeDeckData | null): boolean {
+  return Boolean(
+    deck &&
+      (deck.cloze.length > 0 ||
+        (deck.stress?.length ?? 0) > 0 ||
+        (deck.classify?.length ?? 0) > 0 ||
+        (deck.paradigm?.length ?? 0) > 0 ||
+        (deck.synonym?.length ?? 0) > 0 ||
+        (deck.heritage?.length ?? 0) > 0),
   );
 }
 
@@ -473,10 +514,17 @@ function historyFromSelection(selection: PracticeSelection): SelectionHistoryIte
     sentenceFrameId: selection.cloze?.sentenceFrameId,
     blankCase: selection.cloze?.blankCase,
     classifySetId: selection.classifySetId,
+    heritageId: selection.heritage?.heritageId,
     recallDirection: selection.recallDirection,
     choicePolarity: selection.choicePolarity,
     lapsed: selection.lapsed,
   };
+}
+
+function reviewLemmaId(selection: PracticeSelection): string {
+  const parsed = parseCardKey(selection.cardKey);
+  if (!parsed.quarantined && parsed.mode === selection.mode) return parsed.lemmaId;
+  return selection.lemma.lemmaId;
 }
 
 function orderedChoiceOptions(
@@ -597,6 +645,40 @@ function drillChoiceOptions(selection: PracticeSelection): ChoiceOption[] | null
   return null;
 }
 
+function heritageOptions(item: PracticeHeritageItem): ChoiceOption[] {
+  const answer = czNorm(item.answer);
+  const calque = czNorm(item.calque);
+  return item.options.map((option) => {
+    const label = czNorm(option.label);
+    const correct = label === answer;
+    return {
+      label: option.label,
+      correct,
+      kind: correct ? 'answer' : label === calque ? 'calque' : 'distractor',
+    };
+  });
+}
+
+function heritageFeedbackFor(item: PracticeHeritageItem, option: ChoiceOption): HeritageFeedback {
+  if (option.correct) {
+    return {
+      kind: 'correct',
+      text: 'Правильно',
+    };
+  }
+  if (option.kind === 'calque') {
+    return {
+      kind: 'calque',
+      text: `⚠️ калька; ${item.rationale}`,
+      citations: item.citations,
+    };
+  }
+  return {
+    kind: 'wrong',
+    text: 'Ще раз',
+  };
+}
+
 function drillChoicePrompt(selection: PracticeSelection): { prompt: string; subtitle: string } | null {
   if (selection.stress) {
     return {
@@ -640,8 +722,13 @@ function clozeParts(item: PracticeClozeItem): [string, string] {
   return [before, after.join('___')];
 }
 
+function slotPromptParts(prompt: string): [string, string] {
+  const [before, ...after] = prompt.split('___');
+  return [before, after.join('___')];
+}
+
 function shouldLoadCloze(mode: PracticeModeFilter): boolean {
-  return ['mixed', 'cloze', 'stress', 'classify', 'paradigm', 'synonym'].includes(mode);
+  return ['mixed', 'cloze', 'stress', 'classify', 'paradigm', 'synonym', 'heritage'].includes(mode);
 }
 
 function sessionScopeIndexForMode(
@@ -652,6 +739,16 @@ function sessionScopeIndexForMode(
   return index
     .filter((item) => item.modes.includes(modeFilter))
     .map((item) => ({ ...item, modes: [modeFilter] }));
+}
+
+function shouldShowFocusModeCard(
+  practiceMode: VisiblePracticeModeFilter,
+  deck: PracticeDeckData | null,
+  indexForStats: PracticeIndexItem[],
+): boolean {
+  if (practiceMode !== 'heritage') return true;
+  if (deck) return (deck.heritage?.length ?? 0) > 0;
+  return indexForStats.some((item) => item.modes.includes('heritage'));
 }
 
 /** Learner level persisted in the shared `lu-learner-level` key (also used by Words of the Day). */
@@ -691,6 +788,7 @@ function mergeDecks(decks: PracticeDeckData[], level: CefrLevel): PracticeDeckDa
     classify: decks.flatMap((deck) => deck.classify ?? []),
     paradigm: decks.flatMap((deck) => deck.paradigm ?? []),
     synonym: decks.flatMap((deck) => deck.synonym ?? []),
+    heritage: decks.flatMap((deck) => deck.heritage ?? []),
   };
 }
 
@@ -713,7 +811,7 @@ function LexiconPracticeIsland({
   const [deck, setDeck] = useState<PracticeDeckData | null>(() => normalizeInitialDeck(initialDeck));
   const [clozeLoaded, setClozeLoaded] = useState(() => {
     const normalized = normalizeInitialDeck(initialDeck);
-    return Boolean(normalized && normalized.cloze.length > 0);
+    return hasLoadedDrillShards(normalized);
   });
   const [sessionPhase, setSessionPhase] = useState<SessionPhase>(autoStart ? 'active' : 'idle');
   const [sessionSeed, setSessionSeed] = useState(() => makePracticeSessionSeed());
@@ -753,6 +851,7 @@ function LexiconPracticeIsland({
   const [clozeInput, setClozeInput] = useState('');
   const [clozeFeedback, setClozeFeedback] = useState<ClozeFeedback | null>(null);
   const [clozeAttemptRecorded, setClozeAttemptRecorded] = useState(false);
+  const [heritageFeedback, setHeritageFeedback] = useState<HeritageFeedback | null>(null);
   const [dueIndex, setDueIndex] = useState<PracticeIndexItem[] | null>(null);
   const [publishedLevels] = useState<Set<CefrLevel>>(
     () => new Set(PUBLISHED_PRACTICE_LEVELS as unknown as CefrLevel[]),
@@ -862,6 +961,7 @@ function LexiconPracticeIsland({
     setClozeInput('');
     setClozeFeedback(null);
     setClozeAttemptRecorded(false);
+    setHeritageFeedback(null);
     if (selection) {
       window.setTimeout(() => stageRef.current?.focus(), 0);
     }
@@ -920,20 +1020,23 @@ function LexiconPracticeIsland({
               classifyResponse,
               paradigmResponse,
               synonymResponse,
+              heritageResponse,
             ] = await Promise.all([
               fetch(`${shardBaseUrl}/practice-cloze.${shardLevel}.json`),
               fetch(`${shardBaseUrl}/practice-stress.${shardLevel}.json`),
               fetch(`${shardBaseUrl}/practice-classify.${shardLevel}.json`),
               fetch(`${shardBaseUrl}/practice-paradigm.${shardLevel}.json`),
               fetch(`${shardBaseUrl}/practice-synonym.${shardLevel}.json`),
+              fetch(`${shardBaseUrl}/practice-heritage.${shardLevel}.json`),
             ]);
-            const [clozeShard, stressShard, classifyShard, paradigmShard, synonymShard] =
+            const [clozeShard, stressShard, classifyShard, paradigmShard, synonymShard, heritageShard] =
               await Promise.all([
                 clozeResponse.ok ? clozeResponse.json() : Promise.resolve({ cloze: [] }),
                 stressResponse.ok ? stressResponse.json() : Promise.resolve({ stress: [] }),
                 classifyResponse.ok ? classifyResponse.json() : Promise.resolve({ classify: [] }),
                 paradigmResponse.ok ? paradigmResponse.json() : Promise.resolve({ paradigm: [] }),
                 synonymResponse.ok ? synonymResponse.json() : Promise.resolve({ synonym: [] }),
+                heritageResponse.ok ? heritageResponse.json() : Promise.resolve({ heritage: [] }),
               ]);
             return {
               cloze: (clozeShard as { cloze?: PracticeClozeItem[] }).cloze ?? [],
@@ -941,6 +1044,7 @@ function LexiconPracticeIsland({
               classify: (classifyShard as PracticeDeckData).classify ?? [],
               paradigm: (paradigmShard as PracticeDeckData).paradigm ?? [],
               synonym: (synonymShard as PracticeDeckData).synonym ?? [],
+              heritage: (heritageShard as PracticeHeritageShard).heritage ?? [],
             };
           }),
         );
@@ -951,6 +1055,7 @@ function LexiconPracticeIsland({
           classify: shardBatches.flatMap((batch) => batch.classify),
           paradigm: shardBatches.flatMap((batch) => batch.paradigm),
           synonym: shardBatches.flatMap((batch) => batch.synonym),
+          heritage: shardBatches.flatMap((batch) => batch.heritage),
         };
         nextClozeLoaded = true;
       }
@@ -1129,7 +1234,7 @@ function LexiconPracticeIsland({
     const nextUnresolved = new Set(unresolvedCardKeys);
     let nextDeferred = [...deferredLemmas];
     try {
-      rateCard(current.lemma.lemmaId, current.mode, rating, new Date());
+      rateCard(reviewLemmaId(current), current.mode, rating, new Date());
       setStreak(recordStreak());
       if (rating === 'good' || rating === 'easy') {
         setSessionCorrect((value) => value + 1);
@@ -1208,7 +1313,11 @@ function LexiconPracticeIsland({
     if (!selection || answerLocked) return;
     const rating = option.correct ? 'good' : 'again';
     const outcome = recordReview(selection, rating);
+    const nextHeritageFeedback = selection.heritage
+      ? heritageFeedbackFor(selection.heritage, option)
+      : null;
     setAnswerLocked(true);
+    setHeritageFeedback(nextHeritageFeedback);
     setFeedback(
       option.correct ? `${selection.lemma.lemma}: Правильно` : `${selection.lemma.lemma}: Ще раз`,
     );
@@ -1476,7 +1585,11 @@ function LexiconPracticeIsland({
               ) : null}
             </h3>
             <div className="mode-grid mode-grid-focus">
-              {MODE_CARD_ORDER.filter((practiceMode) => practiceMode !== 'mixed').map((practiceMode) => {
+              {MODE_CARD_ORDER.filter(
+                (practiceMode) =>
+                  practiceMode !== 'mixed' &&
+                  shouldShowFocusModeCard(practiceMode, deck, indexForStats),
+              ).map((practiceMode) => {
                 const meta = MODE_META[practiceMode];
                 return (
                   <button
@@ -1550,6 +1663,7 @@ function LexiconPracticeIsland({
                   answerLocked={answerLocked}
                   clozeInput={clozeInput}
                   clozeFeedback={clozeFeedback}
+                  heritageFeedback={heritageFeedback}
                   onClozeInput={setClozeInput}
                   onFlashcardRating={(rating) => rateAndComplete(selection, rating)}
                   onChoice={handleChoice}
@@ -1559,6 +1673,10 @@ function LexiconPracticeIsland({
               ) : mode === 'cloze' && deck.cloze.length === 0 ? (
                 <p className="lexicon-practice-muted" data-testid="practice-cloze-empty">
                   Вправи з пропусками для цього рівня ще готуються. Спробуйте флешкартки, добір пар або вибір.
+                </p>
+              ) : mode === 'heritage' && (deck.heritage?.length ?? 0) === 0 ? (
+                <p className="lexicon-practice-muted" data-testid="practice-heritage-empty">
+                  Вправи зі спадщини для цього рівня ще готуються.
                 </p>
               ) : (
                 <p className="lexicon-practice-muted">Усі картки на зараз повторено.</p>
@@ -1587,6 +1705,7 @@ function PracticeItem({
   answerLocked,
   clozeInput,
   clozeFeedback,
+  heritageFeedback,
   onClozeInput,
   onFlashcardRating,
   onChoice,
@@ -1599,6 +1718,7 @@ function PracticeItem({
   answerLocked: boolean;
   clozeInput: string;
   clozeFeedback: ClozeFeedback | null;
+  heritageFeedback: HeritageFeedback | null;
   onClozeInput(value: string): void;
   onFlashcardRating(rating: PracticeRating): void;
   onChoice(option: ChoiceOption): void;
@@ -1630,6 +1750,17 @@ function PracticeItem({
         answerLocked={answerLocked}
         onInput={onClozeInput}
         onSubmit={onClozeSubmit}
+      />
+    );
+  }
+
+  if (selection.mode === 'heritage' && selection.heritage) {
+    return (
+      <PracticeHeritage
+        item={selection.heritage}
+        feedback={heritageFeedback}
+        answerLocked={answerLocked}
+        onChoice={onChoice}
       />
     );
   }
@@ -1700,6 +1831,61 @@ function PracticeItem({
           </li>
         ))}
       </ul>
+    </div>
+  );
+}
+
+function PracticeHeritage({
+  item,
+  feedback,
+  answerLocked,
+  onChoice,
+}: {
+  item: PracticeHeritageItem;
+  feedback: HeritageFeedback | null;
+  answerLocked: boolean;
+  onChoice(option: ChoiceOption): void;
+}) {
+  const [before, after] = slotPromptParts(item.prompt);
+  const options = heritageOptions(item);
+  const slotText = feedback?.kind === 'correct' ? item.answer : '___';
+  return (
+    <div className="lexicon-heritage" data-testid="practice-heritage">
+      <p className="heritage-task">Оберіть питоме українське слово.</p>
+      <p className="heritage-sentence">
+        <span>{before}</span>
+        <span className={feedback?.kind === 'correct' ? 'heritage-slot filled' : 'heritage-slot'}>
+          {slotText}
+        </span>
+        <span>{after}</span>
+      </p>
+      <ul className="lexicon-option-list mc-options">
+        {options.map((option, index) => (
+          <li key={`${option.label}-${index}`}>
+            <button
+              className={`mc-opt${answerLocked && option.correct ? ' correct' : ''}`}
+              type="button"
+              disabled={answerLocked}
+              onClick={() => onChoice(option)}
+            >
+              <span>{option.label}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+      {feedback ? (
+        <div
+          className={`heritage-feedback ${feedback.kind}`}
+          role={feedback.kind === 'wrong' ? 'alert' : 'status'}
+          aria-live="polite"
+          data-testid="practice-heritage-feedback"
+        >
+          <p>{feedback.text}</p>
+          {feedback.kind === 'calque' && feedback.citations?.length ? (
+            <p className="heritage-citation">Джерело: {feedback.citations.join('; ')}</p>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -198,6 +198,33 @@ export interface PracticeSynonymItem {
   source: string;
 }
 
+export interface PracticeHeritageOption {
+  label: string;
+}
+
+export interface PracticeHeritageItem {
+  heritageId: string;
+  lemmaId: string;
+  srsKey: string;
+  lemma?: string;
+  nativeLemma?: string;
+  calqueLabel?: string;
+  kind: 'lexical' | 'sense_restricted' | string;
+  prompt: string;
+  answer: string;
+  calque: string;
+  origin?: string;
+  frameIndex?: number;
+  cefr: string;
+  options: PracticeHeritageOption[];
+  rationale: string;
+  citations: string[];
+  corrections: string[];
+  sourceFamily?: string;
+  calqueSense?: string;
+  authenticSense?: string;
+}
+
 export interface PracticeShardMeta {
   schema: string;
   schemaVersion: number;
@@ -241,6 +268,10 @@ export interface PracticeSynonymShard extends PracticeShardMeta {
   synonym: PracticeSynonymItem[];
 }
 
+export interface PracticeHeritageShard extends PracticeShardMeta {
+  heritage: PracticeHeritageItem[];
+}
+
 export interface PracticeDeckData {
   deckVersion: string;
   level: string;
@@ -251,6 +282,7 @@ export interface PracticeDeckData {
   classify?: PracticeClassifyItem[];
   paradigm?: PracticeParadigmItem[];
   synonym?: PracticeSynonymItem[];
+  heritage?: PracticeHeritageItem[];
   fixtureNote?: string;
 }
 
@@ -319,6 +351,7 @@ export interface SelectionHistoryItem {
   sentenceFrameId?: string;
   blankCase?: string;
   classifySetId?: string;
+  heritageId?: string;
   recallDirection?: RecallDirection;
   choicePolarity?: ChoicePolarity;
   lapsed?: boolean;
@@ -339,6 +372,7 @@ export interface PracticeSelection {
   classifySetId?: string;
   paradigm?: PracticeParadigmItem;
   synonym?: PracticeSynonymItem;
+  heritage?: PracticeHeritageItem;
   recallDirection: RecallDirection;
   choicePolarity: ChoicePolarity;
 }
@@ -981,6 +1015,7 @@ interface DeckMaps {
   classify: Map<string, PracticeClassifyItem>;
   paradigm: Map<string, PracticeParadigmItem[]>;
   synonym: Map<string, PracticeSynonymItem[]>;
+  heritage: Map<string, PracticeHeritageItem[]>;
 }
 
 const deckMapsCache = new WeakMap<PracticeDeckData, DeckMaps>();
@@ -1005,6 +1040,7 @@ function deckMaps(deck: PracticeDeckData): DeckMaps {
     classify: new Map((deck.classify ?? []).map((item) => [item.lemmaId, item])),
     paradigm: groupByLemma(deck.paradigm),
     synonym: groupByLemma(deck.synonym),
+    heritage: groupByLemma(deck.heritage),
   };
   deckMapsCache.set(deck, maps);
   return maps;
@@ -1322,7 +1358,23 @@ function buildStaticCandidates(deck: PracticeDeckData, modeFilter: PracticeModeF
         }
         continue;
       }
-      if (mode === 'heritage' || mode === 'paronym') {
+      if (mode === 'heritage') {
+        const items = maps.heritage.get(indexItem.lemmaId) ?? [];
+        for (const heritage of items) {
+          candidates.push(
+            cachedSelection({
+              itemId: makeItemId(indexItem.lemmaId, mode, heritage.heritageId),
+              lemma,
+              indexItem,
+              mode,
+              cardKey: heritage.srsKey,
+              heritage,
+            }),
+          );
+        }
+        continue;
+      }
+      if (mode === 'paronym') {
         continue;
       }
       const key = cardKey(indexItem.lemmaId, mode);
@@ -1539,6 +1591,7 @@ export function combinePracticeShards(
     classify?: PracticeClassifyShard;
     paradigm?: PracticeParadigmShard;
     synonym?: PracticeSynonymShard;
+    heritage?: PracticeHeritageShard;
   } = {},
 ): PracticeDeckData {
   return {
@@ -1551,6 +1604,7 @@ export function combinePracticeShards(
     classify: modeShards.classify?.classify ?? [],
     paradigm: modeShards.paradigm?.paradigm ?? [],
     synonym: modeShards.synonym?.synonym ?? [],
+    heritage: modeShards.heritage?.heritage ?? [],
     fixtureNote: indexShard.fixtureNote,
   };
 }

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -714,9 +714,86 @@ const frontmatter = {
   }
 
   :global(.lexicon-choice),
-  :global(.lexicon-cloze) {
+  :global(.lexicon-cloze),
+  :global(.lexicon-heritage) {
     display: grid;
     gap: 1rem;
+  }
+
+  :global(.heritage-task) {
+    margin: 0 0 -0.1rem;
+    color: var(--lu-teal);
+    font-size: 0.92rem;
+    font-weight: 900;
+  }
+
+  :global(.heritage-sentence) {
+    margin: 0;
+    padding: 1.4rem 1.5rem;
+    border: 1px solid var(--lu-border);
+    border-left: 4px solid var(--lu-teal);
+    border-radius: 14px;
+    background: var(--lu-surface-raised);
+    box-shadow: var(--lu-shadow);
+    color: var(--lu-text);
+    font-size: 1.45rem;
+    font-weight: 700;
+    line-height: 1.6;
+  }
+
+  :global(.heritage-slot) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 96px;
+    padding: 0 10px;
+    margin: 0 4px;
+    border-bottom: 3px solid var(--lu-teal);
+    color: var(--lu-teal);
+    font-weight: 900;
+  }
+
+  :global(.heritage-slot.filled) {
+    border-bottom-color: var(--lu-green);
+    color: var(--lu-state-correct-fg);
+  }
+
+  :global(.heritage-feedback) {
+    margin: 0;
+    padding: 0.85rem 0.95rem;
+    border-radius: 8px;
+    font-weight: 800;
+    line-height: 1.45;
+  }
+
+  :global(.heritage-feedback p) {
+    margin: 0;
+  }
+
+  :global(.heritage-feedback p + p) {
+    margin-top: 0.35rem;
+  }
+
+  :global(.heritage-feedback.correct) {
+    background: var(--lu-state-correct-bg);
+    color: var(--lu-state-correct-fg);
+  }
+
+  :global(.heritage-feedback.calque) {
+    border: 1px solid color-mix(in srgb, var(--lu-orange) 40%, transparent);
+    background: var(--lu-orange-light);
+    color: var(--lu-orange);
+  }
+
+  :global(.heritage-feedback.wrong) {
+    background: var(--lu-state-wrong-bg);
+    color: var(--lu-state-wrong-fg);
+  }
+
+  :global(.heritage-citation) {
+    color: var(--lu-text-muted);
+    font-size: 0.86rem;
+    font-weight: 700;
   }
 
   :global(.mc-q) {

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -8,6 +8,7 @@ import {
   loadState,
   saveState,
   type PracticeDeckData,
+  type PracticeHeritageItem,
   type PracticeLexeme,
   type PracticeMode,
 } from '@site/src/lib/lexicon/srs';
@@ -29,13 +30,23 @@ function mockShardFetch(counts: Partial<Record<CefrLevel, number>>) {
   const fn = vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input);
     requested.push(url);
-    const match = url.match(/practice-(index|lexemes|cloze)\.([ABC][12])\.json/);
+    const match = url.match(
+      /practice-(index|lexemes|cloze|stress|classify|paradigm|synonym|heritage)\.([ABC][12])\.json/,
+    );
     if (!match) return notFoundResponse();
-    const kind = match[1] as 'index' | 'lexemes' | 'cloze';
+    const kind = match[1] as
+      | 'index'
+      | 'lexemes'
+      | 'cloze'
+      | 'stress'
+      | 'classify'
+      | 'paradigm'
+      | 'synonym'
+      | 'heritage';
     const level = match[2] as CefrLevel;
     const n = counts[level];
     if (n === undefined) return notFoundResponse(); // shard not published (e.g. C2)
-    if (kind === 'cloze') return okJson({ cloze: [] });
+    if (kind !== 'index' && kind !== 'lexemes') return okJson({ [kind]: [] });
     const lexemes = Array.from({ length: n }, (_unused, i) =>
       lexeme(
         `${level}-${i}`,
@@ -182,6 +193,70 @@ function sampleDeck(): PracticeDeckData {
         ],
       },
     ],
+  };
+}
+
+function heritagePracticeItem(): PracticeHeritageItem {
+  return {
+    heritageId: 'her-dim-fixture',
+    lemmaId: 'dim',
+    srsKey: cardKey('dim', 'heritage'),
+    lemma: 'дім',
+    nativeLemma: 'дім',
+    calqueLabel: 'дом',
+    kind: 'lexical',
+    prompt: 'Я бачу ___ щодня.',
+    answer: 'дім',
+    calque: 'дом',
+    origin: 'fixture',
+    frameIndex: 1,
+    cefr: 'A2',
+    options: [
+      { label: 'дім' },
+      { label: 'дом' },
+      { label: 'хата' },
+      { label: 'місто' },
+    ],
+    rationale: 'у цьому значенні потрібне питоме слово',
+    citations: ['Антоненко-Давидович: fixture'],
+    corrections: ['дім'],
+    sourceFamily: 'fixture',
+  };
+}
+
+function heritageDeck({ includeItems = true } = {}): PracticeDeckData {
+  const entry = lexeme(
+    'dim',
+    'дім',
+    'home',
+    {
+      nominative: 'дім',
+      accusative: 'дім',
+      locative: 'домі',
+    },
+    { cefr: 'A2', heritage: 'native' },
+  );
+  return {
+    deckVersion: 'test-heritage',
+    level: 'A2',
+    lexemes: [entry],
+    index: [
+      {
+        lemmaId: entry.lemmaId,
+        lemma: entry.lemma,
+        cefr: 'A2',
+        modes: ['heritage'],
+        hasCloze: false,
+        clozeIds: [],
+        newOrder: 0,
+      },
+    ],
+    cloze: [],
+    stress: [],
+    classify: [],
+    paradigm: [],
+    synonym: [],
+    heritage: includeItems ? [heritagePracticeItem()] : [],
   };
 }
 
@@ -468,6 +543,120 @@ describe('LexiconPractice', () => {
     expect(labels).toHaveLength(4);
     // The verb answer is present whichever polarity the selector picked.
     expect(labels.some((label) => label === 'бачити' || label === 'to see')).toBe(true);
+  });
+
+  test('heritage renders in mixed sessions and heritage focus mode', async () => {
+    const user = userEvent.setup();
+    const mixedRender = render(
+      <LexiconPractice
+        initialDeck={heritageDeck()}
+        autoStart
+        initialMode="mixed"
+        advanceDelayMs={10_000}
+      />,
+    );
+
+    expect(screen.getByTestId('practice-heritage')).toBeInTheDocument();
+    expect(screen.getByText('Оберіть питоме українське слово.')).toBeInTheDocument();
+    expect(screen.getByText(/Я бачу/)).toBeInTheDocument();
+
+    mixedRender.unmount();
+    const { container } = render(<LexiconPractice initialDeck={heritageDeck()} advanceDelayMs={10_000} />);
+    expect(screen.getByText('Спадщина')).toBeInTheDocument();
+
+    await user.click(container.querySelector<HTMLButtonElement>('[data-mode="heritage"]')!);
+
+    expect(await screen.findByTestId('practice-heritage')).toBeInTheDocument();
+  });
+
+  test('heritage calque miss scores again and shows cited correction', async () => {
+    const user = userEvent.setup();
+    render(
+      <LexiconPractice
+        initialDeck={heritageDeck()}
+        autoStart
+        initialMode="heritage"
+        advanceDelayMs={10_000}
+      />,
+    );
+
+    await user.click(
+      within(screen.getByTestId('practice-heritage')).getByRole('button', { name: /дом/ }),
+    );
+
+    const feedback = screen.getByTestId('practice-heritage-feedback');
+    expect(feedback).toHaveTextContent('⚠️ калька; у цьому значенні потрібне питоме слово');
+    expect(feedback).toHaveTextContent('Джерело: Антоненко-Давидович: fixture');
+    await waitFor(() => {
+      expect(storedState().reviews[0]).toMatchObject({
+        lemmaId: 'dim',
+        mode: 'heritage',
+        rating: 'again',
+        cardKey: cardKey('dim', 'heritage'),
+      });
+    });
+  });
+
+  test('heritage plain distractor miss does not leak calque correction feedback', async () => {
+    const user = userEvent.setup();
+    render(
+      <LexiconPractice
+        initialDeck={heritageDeck()}
+        autoStart
+        initialMode="heritage"
+        advanceDelayMs={10_000}
+      />,
+    );
+
+    await user.click(
+      within(screen.getByTestId('practice-heritage')).getByRole('button', { name: /місто/ }),
+    );
+
+    const feedback = screen.getByTestId('practice-heritage-feedback');
+    expect(feedback).toHaveTextContent('Ще раз');
+    expect(feedback).not.toHaveTextContent('калька');
+    expect(feedback).not.toHaveTextContent('у цьому значенні потрібне питоме слово');
+    expect(feedback).not.toHaveTextContent('Антоненко-Давидович');
+    await waitFor(() => {
+      expect(storedState().reviews[0]).toMatchObject({
+        lemmaId: 'dim',
+        mode: 'heritage',
+        rating: 'again',
+      });
+    });
+  });
+
+  test('heritage correct answer scores good', async () => {
+    const user = userEvent.setup();
+    render(
+      <LexiconPractice
+        initialDeck={heritageDeck()}
+        autoStart
+        initialMode="heritage"
+        advanceDelayMs={10_000}
+      />,
+    );
+
+    await user.click(
+      within(screen.getByTestId('practice-heritage')).getByRole('button', { name: /дім/ }),
+    );
+
+    expect(screen.getByTestId('practice-heritage-feedback')).toHaveTextContent('Правильно');
+    await waitFor(() => {
+      expect(storedState().reviews[0]).toMatchObject({
+        lemmaId: 'dim',
+        mode: 'heritage',
+        rating: 'good',
+        cardKey: cardKey('dim', 'heritage'),
+      });
+    });
+  });
+
+  test('hides heritage mode card when the loaded deck has no heritage items', () => {
+    render(<LexiconPractice initialDeck={heritageDeck({ includeItems: false })} />);
+
+    expect(screen.queryByText('Спадщина')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Спадщина/ })).not.toBeInTheDocument();
   });
 
   test('cloze wrong-case answer records one case miss and leaves blank open', async () => {

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -19,6 +19,7 @@ import {
   validateClozeOptions,
   type PracticeClozeItem,
   type PracticeDeckData,
+  type PracticeHeritageItem,
   type PracticeLexeme,
   type PracticeMode,
   type PracticeSelection,
@@ -115,6 +116,34 @@ function cloze(
         case: blankCase,
       },
     ],
+  };
+}
+
+function heritageItem(lemmaId: string, heritageId = `${lemmaId}:heritage:1`): PracticeHeritageItem {
+  return {
+    heritageId,
+    lemmaId,
+    srsKey: cardKey(lemmaId, 'heritage'),
+    lemma: lemmaId,
+    nativeLemma: lemmaId,
+    calqueLabel: `${lemmaId}-calque`,
+    kind: 'lexical',
+    prompt: 'Я бачу ___ щодня.',
+    answer: lemmaId,
+    calque: `${lemmaId}-calque`,
+    origin: 'fixture',
+    frameIndex: 1,
+    cefr: 'A1',
+    options: [
+      { label: lemmaId },
+      { label: `${lemmaId}-calque` },
+      { label: `${lemmaId}-d1` },
+      { label: `${lemmaId}-d2` },
+    ],
+    rationale: 'fixture rationale',
+    citations: ['fixture citation'],
+    corrections: [lemmaId],
+    sourceFamily: 'fixture',
   };
 }
 
@@ -225,6 +254,9 @@ function modeDeck(rows: { id: string; modes: PracticeMode[] }[]): PracticeDeckDa
           { label: `${row.id}-d3`, lemmaId: `${row.id}-d3`, kind: 'distractor' },
         ],
       })),
+    heritage: rows
+      .filter((row) => row.modes.includes('heritage'))
+      .map((row) => heritageItem(row.id)),
     index: rows.map((row, index) => ({
       lemmaId: row.id,
       lemma: row.id,
@@ -252,6 +284,7 @@ function flashcardDeck(
     classify: [],
     paradigm: [],
     synonym: [],
+    heritage: [],
     index: lexemes.map((entry, index) => ({
       lemmaId: entry.lemmaId,
       lemma: entry.lemma,
@@ -320,13 +353,27 @@ describe('lexicon SRS facade', () => {
       });
     }
 
-    for (const mode of ['paradigm', 'stress', 'classify', 'synonym'] as const) {
+    for (const mode of ['paradigm', 'stress', 'classify', 'synonym', 'heritage'] as const) {
       const selection = selectNextPracticeItem(modeDeck([{ id: `${mode}-alpha`, modes: [mode] }]), {
         now: NOW,
       });
       expect(selection?.mode).toBe(mode);
     }
-    expect(selectNextPracticeItem(modeDeck([{ id: 'heritage-alpha', modes: ['heritage'] }]), { now: NOW })).toBeNull();
+    expect(selectNextPracticeItem(modeDeck([{ id: 'paronym-alpha', modes: ['paronym'] }]), { now: NOW })).toBeNull();
+  });
+
+  test('emits heritage candidates from published items in mixed and focus modes', () => {
+    const testDeck = modeDeck([{ id: 'heritage-alpha', modes: ['heritage'] }]);
+
+    const mixed = selectNextPracticeItem(testDeck, { now: NOW, modeFilter: 'mixed' });
+    const focused = selectNextPracticeItem(testDeck, { now: NOW, modeFilter: 'heritage' });
+
+    expect(mixed?.mode).toBe('heritage');
+    expect(mixed?.heritage?.heritageId).toBe('heritage-alpha:heritage:1');
+    expect(mixed?.cardKey).toBe(cardKey('heritage-alpha', 'heritage'));
+    expect(focused?.mode).toBe('heritage');
+    expect(focused?.heritage?.heritageId).toBe('heritage-alpha:heritage:1');
+    expect(focused?.cardKey).toBe(cardKey('heritage-alpha', 'heritage'));
   });
 
   test('classify rotates outcome sets while keeping one SRS card key', () => {


### PR DESCRIPTION
## Summary

- Surfaces the live `heritage` practice deck through SRS candidate plumbing, cumulative shard loading, and focus/mixed practice selection.
- Adds the «Спадщина» mode card, sentence-slot renderer, and cited calque feedback contract.
- Keeps paronym fail-closed and preserves selector ordering/penalty semantics.
- Updates tests for heritage candidate emission, mixed/focus availability, native-lemma SRS routing, calque/distractor/correct feedback, and empty-deck mode hiding.
- Includes the hook-required `docs/lesson-schema.yaml` component hash update.

Refs #4505
Refs #4387

## Evidence

```text
$ cd site && npx vitest run
Test Files  33 passed (33)
Tests  475 passed (475)
```

```text
$ cd site && npx tsc --noEmit
<no output; exit 0>
```

```text
$ cd site && npx eslint src/lib/lexicon/srs.ts src/components/LexiconPractice.tsx src/pages/words-of-the-day/practice.astro tests/unit/lexicon-srs.test.ts tests/unit/LexiconPractice.test.tsx --quiet
<no output; exit 0>
```

```text
$ git diff --check
<no output; exit 0>
```

```text
$ .venv/bin/python scripts/audit/lint_agent_trailer.py
Checking 1 commit(s) in origin/main..HEAD:

  2ab6552921  PASS  X-Agent: codex/4505-heritage-render

✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

```text
$ git log -1 --oneline
2ab6552921 feat(practice): #4505 heritage mode client — selector + render + cited feedback
```

## Independent review

- CodexBar Gemini quota/config probe failed before routing: `Could not extract OAuth credentials from Gemini CLI`.
- Routed the required cross-family review through the project AGY bridge with `--to-model gemini-3.1-pro-high --review`.
- AGY finding: heritage options still displayed numeric key labels. Fixed by removing the visible key span from heritage options only; reran focused checks and the full suite after the fix.

## Notes

- `site/src/data/lexicon-manifest.json`, `data/atlas.db`, and `site/public/lexicon/practice-*.json` were hydrated locally for tests and remain ignored/uncommitted.
- No auto-merge requested.
