### PR TITLE
feat(bio): add sixtiers public-culture readings batch 50

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/borys-antonenko-davydovych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/borys-antonenko-davydovych.yaml
@@ -86,7 +86,22 @@ sequence: 263
 slug: borys-antonenko-davydovych
 subtitle: The Prose Writer and Language Guardian Across Two Waves of Repression
 title: 'Борис Антоненко-Давидович: мова і табір'
-version: '1.0'
+readings:
+- title: "Антоненко-Давидович Борис Дмитрович"
+  source_name: "Енциклопедія Сучасної України"
+  source_url: "https://esu.com.ua/article-42948"
+  language: "uk"
+  role: "reference"
+  hosting: "link-only"
+  rights_note: "Open-access reference entry from ESU."
+- title: "Прямі тексти та свідчення з літературного доробку"
+  source_name: "reading-needed"
+  source_url: "reading-needed"
+  language: "uk"
+  role: "reading-needed"
+  hosting: "reading-needed"
+  rights_note: "reading-needed: primary literature text links in Ukrainian with stable learner-safe access."
+version: '1.1'
 vocabulary_hints:
 - word: проза
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/ivan-drach.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-drach.yaml
@@ -131,7 +131,29 @@ sequence: 259
 slug: ivan-drach
 subtitle: Poetry, Suppressed Cinema, and Coerced Repentance Without Imprisonment
 title: 'Іван Драч: поетичне кіно під цензурою'
-version: '1.0'
+readings:
+- title: "Драч Іван Федорович"
+  source_name: "Енциклопедія Сучасної України"
+  source_url: "https://esu.com.ua/article-21707"
+  language: "uk"
+  role: "reference"
+  hosting: "link-only"
+  rights_note: "Open-access reference entry from a Ukrainian encyclopedia platform."
+- title: "Стенограма художньої ради кіностудії ім. Довженка (29 січня 1966)"
+  source_name: "eKMAIR"
+  source_url: "https://ekmair.ukma.edu.ua/items/3fd967b0-ff6f-4ee6-a4bf-cf9848a3f8e7"
+  language: "uk"
+  role: "primary"
+  hosting: "link-only"
+  rights_note: "Institutional repository entry with archival document."
+- title: "Поезія Івана Драча (вибірка)"
+  source_name: "reading-needed"
+  source_url: "reading-needed"
+  language: "uk"
+  role: "reading-needed"
+  hosting: "reading-needed"
+  rights_note: "reading-needed: verify links to rights-cleared Ukrainian learner-facing primary-text excerpts."
+version: '1.1'
 vocabulary_hints:
 - definition: образ, що переносить властивості людини на неживу силу
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/mykola-vinhranovskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykola-vinhranovskyi.yaml
@@ -91,7 +91,22 @@ sequence: 260
 slug: mykola-vinhranovskyi
 subtitle: Poet, Filmmaker, and the Spectrum of Soviet Cultural Pressure
 title: 'Микола Вінграновський: свобода у формі'
-version: '1.0'
+readings:
+- title: "Вінграновський Микола Степанович"
+  source_name: "Енциклопедія Сучасної України"
+  source_url: "https://esu.com.ua/pdf/file/34622.pdf"
+  language: "uk"
+  role: "reference"
+  hosting: "link-only"
+  rights_note: "Open-access reference entry in Ukrainian from ESU."
+- title: "Поетика й публічні виступи Вінграновського"
+  source_name: "reading-needed"
+  source_url: "reading-needed"
+  language: "uk"
+  role: "reading-needed"
+  hosting: "reading-needed"
+  rights_note: "reading-needed: verify rights-safe Ukrainian source for verified primary excerpts."
+version: '1.1'
 vocabulary_hints:
 - word: шістдесятник
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/opanas-zalyvakha.yaml
+++ b/curriculum/l2-uk-en/plans/bio/opanas-zalyvakha.yaml
@@ -81,7 +81,22 @@ sequence: 261
 slug: opanas-zalyvakha
 subtitle: The Painter from Exhibition Closure to Political Imprisonment
 title: 'Опанас Заливаха: вітраж і табір'
-version: '1.0'
+readings:
+- title: "Заливаха Опанас Іванович"
+  source_name: "Енциклопедія Сучасної України"
+  source_url: "https://esu.com.ua/article-14749"
+  language: "uk"
+  role: "reference"
+  hosting: "link-only"
+  rights_note: "Open-access Ukrainian biography entry."
+- title: "ЗАЛИВАХА ОПАНАС ІВАНОВИЧ"
+  source_name: "КХПГ Музей"
+  source_url: "https://museum.khpg.org/1113910802"
+  language: "uk"
+  role: "historical-archive"
+  hosting: "link-only"
+  rights_note: "Museum-hosted Ukrainian-language oral-history and documentation page."
+version: '1.1'
 vocabulary_hints:
 - word: вітраж
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/stefaniia-shabatura.yaml
+++ b/curriculum/l2-uk-en/plans/bio/stefaniia-shabatura.yaml
@@ -83,7 +83,22 @@ sequence: 262
 slug: stefaniia-shabatura
 subtitle: The Tapestry Artist, Political Prisoner, and Helsinki Monitor
 title: 'Стефанія Шабатура: гобелен і протест'
-version: '1.0'
+readings:
+- title: "Шабатура Стефанія Михайлівна"
+  source_name: "КХПГ Музей / Музей шістдесятництва"
+  source_url: "https://museum.khpg.org/1314388686"
+  language: "uk"
+  role: "primary"
+  hosting: "link-only"
+  rights_note: "Museum source with documented interview and archival context in Ukrainian."
+- title: "Шабатура Стефанія Михайлівна (документи)"
+  source_name: "reading-needed"
+  source_url: "reading-needed"
+  language: "uk"
+  role: "reading-needed"
+  hosting: "reading-needed"
+  rights_note: "reading-needed: verify open, stable rights-cleared source for workshop-ready primary excerpts."
+version: '1.1'
 vocabulary_hints:
 - word: гобелен
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/yurii-badzo.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yurii-badzo.yaml
@@ -83,7 +83,22 @@ sequence: 264
 slug: yurii-badzo
 subtitle: The Literary Scholar and the Manuscript the State Feared
 title: 'Юрій Бадзьо: право жити'
-version: '1.0'
+readings:
+- title: "Бадзьо Юрій Васильович"
+  source_name: "Енциклопедія Сучасної України"
+  source_url: "https://esu.com.ua/article-38777"
+  language: "uk"
+  role: "reference"
+  hosting: "link-only"
+  rights_note: "Open-access encyclopedic biography entry."
+- title: "Бадзьо Юрій Васильович"
+  source_name: "КХПГ Музей"
+  source_url: "https://museum.khpg.org/1113843475"
+  language: "uk"
+  role: "historical-archive"
+  hosting: "link-only"
+  rights_note: "Museum-hosted biographical and historical archive page."
+version: '1.1'
 vocabulary_hints:
 - word: манускрипт
   pos: ч.


### PR DESCRIPTION
Recovery pass for BIO public-culture batch 50 readings in plan YAML only.

- This is a Codex Spark recovery after AGY/Gemini lane produced zero output.
- LLM-QG and Gemma were not used.
- Changes are limited to top-level readings blocks in six BIO plan files and plan version bumps to 1.1.
- No citation/source packet files were modified.
