### PR TITLE
feat(bio): add dissent network readings batch 52

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/ihor-kalynets.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ihor-kalynets.yaml
@@ -138,6 +138,13 @@ persona:
     культурної пам'яті.
   voice: Literary-Historical Analyst
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  notes: Оновлена енциклопедична стаття з датою смерті, біографією, творами і премією.
+  role: primary
+  source: Енциклопедія Сучасної України (ЕСУ)
+  url: https://esu.com.ua/article-10472
 references:
 - note: Оновлена енциклопедична стаття з датою смерті, біографією, творами і премією.
   path: https://esu.com.ua/article-10472
@@ -164,7 +171,7 @@ sequence: 272
 slug: ihor-kalynets
 subtitle: Neo-Baroque Poet, Political Prisoner, and Witness of Cultural Resistance
 title: 'Ігор Калинець: невольнича муза і поезія як вчинок'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: стильова манера складної, багатошарової образності, що переосмислює барокову спадщину в модерній поезії
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/iryna-kalynets.yaml
+++ b/curriculum/l2-uk-en/plans/bio/iryna-kalynets.yaml
@@ -138,6 +138,13 @@ persona:
     української культурної пам'яті.
   voice: Literary-Historical Analyst
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  notes: Енциклопедична стаття про біографію, твори, репресії і пізню освітню працю.
+  role: primary
+  source: Енциклопедія Сучасної України (ЕСУ)
+  url: https://esu.com.ua/article-10473
 references:
 - note: Енциклопедична стаття про біографію, твори, репресії і пізню освітню працю.
   path: https://esu.com.ua/article-10473
@@ -165,7 +172,7 @@ sequence: 273
 slug: iryna-kalynets
 subtitle: Poet, Teacher, Political Prisoner, and Keeper of Cultural Memory
 title: 'Ірина Калинець: школа пам''яті і дорога вигнання'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: українська християнська традиція, переслідувана радянською владою; важлива для родинної й культурної пам'яті Калинець
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/mykhailo-horyn.yaml
+++ b/curriculum/l2-uk-en/plans/bio/mykhailo-horyn.yaml
@@ -139,6 +139,13 @@ persona:
     репресій.
   voice: Human Rights Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  notes: Біографічна стаття.
+  role: primary
+  source: Енциклопедія Сучасної України (ЕСУ)
+  url: https://esu.com.ua/article-31261
 references:
 - note: Біографічна стаття.
   path: https://esu.com.ua/article-31261
@@ -160,7 +167,7 @@ sequence: 276
 slug: mykhailo-horyn
 subtitle: From Psychologist to Organizer of Resistance
 title: 'Михайло Горинь: Психолог, що став організатором спротиву'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: людина, яка відкрито не погоджується з панівною ідеологією й політикою держави
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/nadiia-svitlychna.yaml
+++ b/curriculum/l2-uk-en/plans/bio/nadiia-svitlychna.yaml
@@ -141,6 +141,13 @@ persona:
     досвід політичного ув'язнення.
   voice: Human Rights Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  notes: Стаття про життя і громадську діяльність.
+  role: primary
+  source: Енциклопедія Сучасної України (ЕСУ)
+  url: https://esu.com.ua/article-887407
 references:
 - note: Стаття про життя і громадську діяльність.
   path: https://esu.com.ua/article-887407
@@ -162,7 +169,7 @@ sequence: 274
 slug: nadiia-svitlychna
 subtitle: The Information Labor of Dissidence
 title: 'Надія Світлична: Інформаційна праця як спротив'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: представниця покоління українських митців та інтелектуалів 1960-х років, що обстоювали національну культуру й громадянські права
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/nina-strokata.yaml
+++ b/curriculum/l2-uk-en/plans/bio/nina-strokata.yaml
@@ -137,6 +137,13 @@ persona:
     Україні.
   voice: Human Rights Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  notes: Енциклопедична стаття про наукову кар'єру, арешт, табір, УГГ і публікації.
+  role: primary
+  source: Енциклопедія Сучасної України (ЕСУ)
+  url: https://esu.com.ua/article-886523
 references:
 - note: Енциклопедична стаття про наукову кар'єру, арешт, табір, УГГ і публікації.
   path: https://esu.com.ua/article-886523
@@ -164,7 +171,7 @@ sequence: 271
 slug: nina-strokata
 subtitle: Scientist, Human-Rights Defender, and Founding Helsinki Voice
 title: 'Ніна Строката: наука, право і голос українських жінок'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: наука про мікроорганізми; фахова сфера Строкатої до політичного переслідування
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/sviatoslav-karavanskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/sviatoslav-karavanskyi.yaml
@@ -141,6 +141,13 @@ persona:
     радянських репресій проти української мови.
   voice: Linguistic Historian
 phase: BIO
+readings:
+- hosting: link-only
+  language: uk
+  notes: Біографічна стаття.
+  role: primary
+  source: Енциклопедія Сучасної України (ЕСУ)
+  url: https://esu.com.ua/article-9625
 references:
 - note: Біографічна стаття.
   path: https://esu.com.ua/article-9625
@@ -166,7 +173,7 @@ sequence: 275
 slug: sviatoslav-karavanskyi
 subtitle: The Lexicographer Who Made Dictionaries a Weapon
 title: 'Святослав Караванський: Словник як національне «я»'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: фахівець, який укладає словники
   pos: ч.


### PR DESCRIPTION
Adds top-level BIO plan YAML readings blocks for the dissent network batch: nina-strokata, ihor-kalynets, iryna-kalynets, nadiia-svitlychna, sviatoslav-karavanskyi, and mykhailo-horyn.\n\nAGY/Gemini-authored. LLM-QG and Gemma were not used.\n\nValidation reported by worker: git diff --check, YAML/readings spot-check, owned-file diff scope, and forbidden-file scan.\n\nX-Agent: gemini/bio-readings-dissent-network-batch-52-agy