### PR TITLE
feat(bio): add Helsinki memory readings batch 53

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/bohdan-horyn.yaml
+++ b/curriculum/l2-uk-en/plans/bio/bohdan-horyn.yaml
@@ -165,11 +165,17 @@ references:
   path: https://uk.wikipedia.org/wiki/Горинь_Богдан_Миколайович
   title: Горинь Богдан Миколайович (Вікіпедія)
   type: reference
+readings:
+- hosting: link-only
+  language: uk
+  role: Основна біографічна довідка про Богдана Гориня.
+  source: Харківська правозахисна група (ХПГ)
+  url: https://museum.khpg.org/1113894082
 sequence: 277
 slug: bohdan-horyn
 subtitle: The Witness Who Outlived the System
 title: 'Богдан Горинь: Свідок, що пережив систему'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: фахівець з історії та теорії мистецтва
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/danylo-shumuk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/danylo-shumuk.yaml
@@ -165,11 +165,17 @@ references:
   title: Пережите й передумане
   type: primary
   work: Пережите й передумане
+readings:
+- hosting: link-only
+  language: uk
+  role: Основна біографічна стаття про Данила Шумука.
+  source: Енциклопедія Сучасної України
+  url: https://esu.com.ua/article-887860
 sequence: 280
 slug: danylo-shumuk
 subtitle: The Political Prisoner of Three Regimes and His Memoir
 title: 'Данило Шумук: В''язень трьох режимів і мемуар «Пережите й передумане»'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: автор спогадів про пережите; той, хто пише мемуари
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/ivan-kandyba.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ivan-kandyba.yaml
@@ -162,11 +162,17 @@ references:
   note: 'Незгодні: українська інтелігенція в русі опору 1960—1980-х років. К.: Либідь, 1995 — контекст дисидентського руху.'
   title: Незгодні
   type: reference
+readings:
+- hosting: link-only
+  language: uk
+  role: Основна біографічна стаття про Івана Кандибу.
+  source: Вікіпедія
+  url: https://uk.wikipedia.org/wiki/Кандиба_Іван_Олексійович
 sequence: 281
 slug: ivan-kandyba
 subtitle: The Jurist Who Co-Founded the Ukrainian Helsinki Group
 title: 'Іван Кандиба: Юрист Української Гельсінської групи'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: особа, що професійно або на громадських засадах захищає права людини
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/oksana-meshko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/oksana-meshko.yaml
@@ -122,11 +122,17 @@ references:
   title: Між смертю і життям
   type: primary
   work: Між смертю і життям
+readings:
+- hosting: link-only
+  language: uk
+  role: Основна біографічна стаття про Оксану Мешко.
+  source: Вікіпедія
+  url: https://uk.wikipedia.org/wiki/Мешко_Оксана_Яківна
 sequence: 278
 slug: oksana-meshko
 subtitle: The Cossack Mother of the Ukrainian Helsinki Group
 title: 'Оксана Мешко: Козацька матір Української Гельсінської групи'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: особа, що професійно або на громадських засадах захищає права людини.
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/vasyl-ovsiienko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/vasyl-ovsiienko.yaml
@@ -108,11 +108,17 @@ references:
   title: Світло людей
   type: primary
   work: Світло людей
+readings:
+- hosting: link-only
+  language: uk
+  role: Основна біографічна довідка про Василя Овсієнка.
+  source: Харківська правозахисна група (ХПГ)
+  url: https://museum.khpg.org/1321393033
 sequence: 282
 slug: vasyl-ovsiienko
 subtitle: The Samvydav Distributor and Chronicler of the Dissident Movement
 title: "Василь Овсієнко: Світло людей та право на пам'ять"
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: неофіційне копіювання та розповсюдження літератури, забороненої в СРСР
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/yurii-shukhevych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yurii-shukhevych.yaml
@@ -131,11 +131,17 @@ references:
   path: https://uk.wikipedia.org/wiki/Шухевич_Юрій-Богдан_Романович
   title: Шухевич Юрій-Богдан Романович
   type: reference
+readings:
+- hosting: link-only
+  language: uk
+  role: Основна біографічна довідка про Юрія Шухевича.
+  source: Харківська правозахисна група (ХПГ)
+  url: https://museum.khpg.org/1114002064
 sequence: 279
 slug: yurii-shukhevych
 subtitle: Punished as a Son, a Dissident by His Own Choice
 title: 'Юрій Шухевич: Покараний як син, інакодумець за власним вибором'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: людина, що відкрито дотримується поглядів, відмінних від панівної ідеології, і зазнає за
     це переслідувань.


### PR DESCRIPTION
Adds top-level BIO plan YAML readings blocks for the Helsinki memory batch: bohdan-horyn, oksana-meshko, yurii-shukhevych, danylo-shumuk, ivan-kandyba, and vasyl-ovsiienko.\n\nAGY/Gemini-authored. LLM-QG and Gemma were not used.\n\nValidation reported by worker: git diff --check, YAML/readings spot-check, owned-file diff scope, and forbidden-file scan.\n\nX-Agent: gemini/bio-readings-helsinki-memory-batch-53-agy