### PR TITLE
chore(governance): decision-journal sweep + retroactive ADR Deciders (cold-start noise 12→2)

### DIFF
--- a/docs/architecture/adr/adr-001-v6-pipeline.md
+++ b/docs/architecture/adr/adr-001-v6-pipeline.md
@@ -2,6 +2,7 @@
 
 **Status**: Accepted
 **Date**: 2026-03-24 (first implemented) / 2026-04-11 (recorded)
+**Deciders**: Krisztian (project owner) — recorded retroactively 2026-07-07; ADR predates the Deciders convention
 **Related**: #1185 (self-healing repair), #1161 (compile prompts), `dec-001` (decision journal entry "V6 uses reviewer-as-fixer")
 
 ## Context

--- a/docs/architecture/adr/adr-002-model-tiering.md
+++ b/docs/architecture/adr/adr-002-model-tiering.md
@@ -2,6 +2,7 @@
 
 **Status**: Accepted
 **Date**: 2026-04-01 (first implemented) / 2026-04-11 (recorded)
+**Deciders**: Krisztian (project owner) — recorded retroactively 2026-07-07; ADR predates the Deciders convention
 **Related**: `scripts/build/batch_gemini_config.py`, `scripts/build/dispatch.py`, `dec-005` (decision journal entry on Gemini model choice)
 
 ## Context

--- a/docs/architecture/adr/adr-003-activity-system-v2.md
+++ b/docs/architecture/adr/adr-003-activity-system-v2.md
@@ -2,6 +2,7 @@
 
 **Status**: Accepted
 **Date**: 2026-02 (implemented) / 2026-04-11 (recorded)
+**Deciders**: Krisztian (project owner) — recorded retroactively 2026-07-07; ADR predates the Deciders convention
 **Related**: `docs/architecture/activity-system-v2.md`, `scripts/build/activity_schema.py`, `scripts/build/activity_validator.py`, `scripts/build/activity_repair.py`, `starlight/src/components/activities/`, #1185
 
 ## Context

--- a/docs/architecture/adr/adr-004-agent-runtime.md
+++ b/docs/architecture/adr/adr-004-agent-runtime.md
@@ -2,6 +2,7 @@
 
 **Status**: Accepted
 **Date**: 2026-04-10 (landed) / 2026-04-11 (recorded)
+**Deciders**: Krisztian (project owner) — recorded retroactively 2026-07-07; ADR predates the Deciders convention
 **Related**: #1184 (implementation), `scripts/agent_runtime/`, `docs/agent-runtime-guide.md`
 
 ## Context

--- a/docs/architecture/adr/adr-005-wiki-knowledge-base.md
+++ b/docs/architecture/adr/adr-005-wiki-knowledge-base.md
@@ -8,6 +8,7 @@
 
 **Status**: Accepted
 **Date**: 2026-04-06 (landed) / 2026-04-11 (recorded)
+**Deciders**: Krisztian (project owner) — recorded retroactively 2026-07-07; ADR predates the Deciders convention
 **Related**: #1129 (epic), #1136, #1161, #1171, `scripts/wiki/`, `docs/best-practices/track-architecture.md`
 
 ## Context

--- a/docs/architecture/adr/adr-006-compile-layer-retrieval.md
+++ b/docs/architecture/adr/adr-006-compile-layer-retrieval.md
@@ -2,6 +2,7 @@
 
 **Status**: Accepted
 **Date**: 2026-04-20
+**Deciders**: Krisztian (project owner) — recorded retroactively 2026-07-07; ADR predates the Deciders convention
 **Related**: #1335 (epic), #1330 (diagnostic), #1101 (benchmark), ADR-005 (partially superseded), #1337, #1338, #1339, #1340, #1341, #1342, #1348
 
 ## Context

--- a/docs/decisions/decisions.yaml
+++ b/docs/decisions/decisions.yaml
@@ -12,11 +12,16 @@
 
 decisions:
   - id: dec-001
-    status: active
+    status: superseded
     date: "2026-03-24"
     expires: "2026-06-24"
     scope: pipeline
     title: "V6 uses reviewer-as-fixer, not full rewrite"
+    superseded_note: >
+      2026-07-07 governance sweep: V6 pipeline retired (V7 only). The principle
+      SURVIVED — V7's reviewer emits exact <fixes> blocks applied deterministically
+      (linear_pipeline.py reviewer_fixes_* machinery); no full-rewrite path exists.
+      Empirical evidence (9.6→8.4 degradation) remains the canonical argument.
     reasoning: >
       Gemini proved FROM SCRATCH rewrites degrade content (9.6->9.2->8.4).
       Reviewer outputs exact find/replace pairs in <fixes> block. Pipeline
@@ -52,11 +57,16 @@ decisions:
     depends_on: []
 
   - id: dec-003
-    status: active
+    status: superseded
     date: "2026-04-03"
     expires: "2026-07-03"
     scope: pipeline
     title: "Cap review fix rounds at 4 with degradation detection"
+    superseded_note: >
+      2026-07-07 governance sweep: V7 replaced the flat 4-round cap with per-level
+      budgets — LLM_QG_CORE_MAX_ROUNDS=2, LLM_QG_SEMINAR_MAX_ROUNDS=3
+      (scripts/build/linear_pipeline.py:486-487). Degradation-detection principle
+      carried into the V7 gate design.
     reasoning: >
       5 rounds caused unnecessary API churn on modules where Gemini's
       severity gate was overly conservative (checkpoint-places: 8.9/10 for
@@ -78,9 +88,14 @@ decisions:
   - id: dec-004
     status: active
     date: "2026-03-28"
-    expires: "2026-06-28"
+    expires: "2027-07-07"
     scope: architecture
     title: "Bare slug filenames, no number prefixes"
+    renewal_note: >
+      2026-07-07 governance sweep: settled architecture — curriculum.yaml is the
+      ordering SSOT across the whole tree; zero rename cascades in 3+ months.
+      Renewed 12 months; candidate to fold into track-architecture.md and archive
+      at the next doc pass.
     reasoning: >
       Module ordering is defined in curriculum.yaml, not filenames.
       Bare slugs (my-family.md) are stable across reordering. Numbered
@@ -94,11 +109,16 @@ decisions:
     depends_on: []
 
   - id: dec-005
-    status: active
+    status: superseded
     date: "2026-04-03"
     expires: "2026-07-03"
     scope: tooling
     title: "Keep gemini-cli, fix dispatch retry logic"
+    superseded_note: >
+      2026-07-07 governance sweep: gemini-cli RETIRED — Gemini-family work routes
+      through the AGY lane (model-assignment.md; session-setup reports gemini-cli
+      not found). The retry-logic half of the decision survived and evolved into
+      the agent-runtime failover chains (#4501/#4580, live in production 2026-07-06).
     reasoning: >
       Evaluated vibeproxy, Factory Droid, OpenCode as gemini-cli replacements.
       Droid requires Factory API key (platform lock-in). VibeProxy/OpenCode


### PR DESCRIPTION
User-ordered governance sweep (2026-07-07 memory interview, 'sweep now'). Every judgment tool-backed:

| item | action | evidence |
|---|---|---|
| dec-001 V6 reviewer-as-fixer | superseded | V7-only policy; `<fixes>` machinery lives in linear_pipeline.py |
| dec-003 4-round cap | superseded | V7 per-level caps: CORE=2 / SEMINAR=3 (linear_pipeline.py:486-7) |
| dec-004 bare slugs | renewed → 2027-07-07 | settled architecture, curriculum.yaml SSOT |
| dec-005 keep gemini-cli | superseded | gemini-cli retired → agy; retry logic → failover chains #4501/#4580 |
| adr-001..006 missing Deciders | recorded retroactively (Krisztian) | matches adr-007/009 format |

Post-sweep: `check_decisions` → **0 stale** · `check_adrs` → **2 warnings** (adr-008 77d + adr-010 57d, both literally 'Deciders: Krisztian (pending)' — asked directly in-session, not sweepable by an agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)