### PR TITLE
docs(adr): defer ADR-008 + ADR-010 per Krisztian (checker noise → 0)

### DIFF
--- a/docs/architecture/adr/README.md
+++ b/docs/architecture/adr/README.md
@@ -28,9 +28,9 @@ The threshold for writing an ADR: **would a new engineer need to know this to un
 | [ADR-005](adr-005-wiki-knowledge-base.md) | Wiki knowledge base — pre-compiled articles replace live RAG for seminar writes | Accepted |
 | [ADR-006](adr-006-compile-layer-retrieval.md) | Multi-tier compile-layer retrieval architecture | Accepted |
 | [ADR-007](adr-007-no-hard-grade-filter-for-cefr-retrieval.md) | No hard grade filter for CEFR-track retrieval | Accepted |
-| [ADR-008](adr-008-uk-native-track-destination.md) | Draft — UK-Native Track Destination & Naming | DRAFT — awaiting Krisztian decision 2026-04-21 |
+| [ADR-008](adr-008-uk-native-track-destination.md) | UK-Native Track Destination & Naming | Deferred — Krisztian decision 2026-07-07: revisit when the l2-uk-direct |
 | [ADR-009](adr-009-dispatch-timeout-unification-and-liveness.md) | Dispatch `hard_timeout` is a leak guard, not a productivity heuristic | Accepted |
-| [ADR-010](adr-010-mcp-verification-phase3.md) | MCP verification layer — Phase 3 architectural redesign | PROPOSED |
+| [ADR-010](adr-010-mcp-verification-phase3.md) | MCP verification layer — Phase 3 architectural redesign | Deferred — Krisztian decision 2026-07-07: Phase 2 tools (verify_quote, |
 <!-- ADR-INDEX-END -->
 
 ## Template

--- a/docs/architecture/adr/adr-008-uk-native-track-destination.md
+++ b/docs/architecture/adr/adr-008-uk-native-track-destination.md
@@ -1,6 +1,7 @@
-# ADR-008 — Draft — UK-Native Track Destination & Naming
+# ADR-008 — UK-Native Track Destination & Naming
 
-> **Status:** DRAFT — awaiting Krisztian decision 2026-04-21
+> **Status:** Deferred — Krisztian decision 2026-07-07: revisit when the l2-uk-direct
+> track has BUILT modules (no forcing function until that track produces content)
 > **Date:** 2026-04-21
 > **Deciders:** Krisztian, Claude, Codex
 > **Related:** EPIC #1365, `docs/session-state/2026-04-21-evening-strategic-audit.md`, `docs/plans/jiggly-soaring-forest.md`

--- a/docs/architecture/adr/adr-010-mcp-verification-phase3.md
+++ b/docs/architecture/adr/adr-010-mcp-verification-phase3.md
@@ -1,8 +1,10 @@
 # ADR-010: MCP verification layer — Phase 3 architectural redesign
 
-**Status**: PROPOSED
+**Status**: Deferred — Krisztian decision 2026-07-07: Phase 2 tools (verify_quote,
+verify_source_attribution) shipped and cover current reviewer needs; revisit when a
+reviewer/gate concretely needs the unified verdict envelope (build ahead of demand rejected)
 **Date**: 2026-05-11
-**Deciders**: Krisztian (pending), Claude (Opus 4.7 xhigh, this draft)
+**Deciders**: Krisztian (deferred 2026-07-07), Claude (Opus 4.7 xhigh, original draft)
 **Related**:
 - #1657 (parent EPIC — "MCP verification-layer improvements, 3-phase plan")
 - #1877, #1878 (Phase 2 remaining sub-issues — `verify_quote`, `verify_source_attribution`)


### PR DESCRIPTION
Final piece of the 2026-07-07 governance sweep — both stale drafts were awaiting Krisztian; he deferred both in-session with explicit revisit triggers:

- **ADR-008** (UK-native track destination): revisit when l2-uk-direct has BUILT modules.
- **ADR-010** (MCP Phase-3 envelope): Phase 2 covers current reviewer needs; revisit on concrete consumer demand.

`check_adrs` after this change: **0 warnings, 0 errors** (was 8 at session start). Combined with #4709: every cold-start governance nag resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)