### PR TITLE
feat(orchestration): #4708 issue-stream registry + auditor + fleet onboarding (incl. Codex UI)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,20 @@ bind as part of this contract.
 
 ---
 
+## Work Intake — Stream Epics (binding for ALL orchestrators; #4708)
+
+Every open GH issue belongs to **exactly one stream epic** — registry:
+`scripts/config/issue_streams.yaml` (streams → epic numbers). Your work queue is YOUR
+stream's epic, not the global issue list. Codex UI track drivers: your curriculum-track
+work hangs off its stream epic (seminars-folk #2836, seminars-bio #4431, core-quality
+#4274, …) — pick up from there, and link every issue you create to its stream epic at
+creation (native sub-issue preferred; `#N` checklist line in the epic body accepted).
+Unlinked issues are flagged as ORPHANS at every agent's cold start (session-setup 11b)
+and at `GET /api/issues/streams`. When a PR fixes an issue, close it with evidence —
+and if scope remains, split it into a new linked issue BEFORE the auto-close keyword
+eats it. Full protocol: `agents_extensions/shared/rules/workflow.md` § Work intake
+(served at `/api/rules`).
+
 ## Global Codex Operating Rules
 
 - Start every task at the repository root and run `git status --short --branch` before editing. **This is a read-only preflight/orientation step only.** Do not use this as permission to implement from the primary checkout.

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -219,6 +219,32 @@ $ISSUE_LIST")
   fi
 fi
 
+# 11b. Issue-stream hygiene (#4708) — cached, never blocks session start.
+# Fresh cache (<1h): surface orphans as ISSUES so every cold-starting agent
+# (Claude, Codex, agy, cursor) sees stream drift. Stale/no cache: kick a
+# background refresh so the NEXT start is covered.
+STREAM_AUDIT_CACHE="$PROJECT_DIR/batch_state/issue_stream_audit.json"
+if [ -f "$PROJECT_DIR/scripts/orchestration/issue_stream_audit.py" ]; then
+  STREAM_FRESH=0
+  if [ -f "$STREAM_AUDIT_CACHE" ]; then
+    STREAM_AGE=$(( $(date +%s) - $(jq -r '.generated_at // 0' "$STREAM_AUDIT_CACHE" 2>/dev/null || echo 0) ))
+    [ "$STREAM_AGE" -lt 3600 ] && STREAM_FRESH=1
+  fi
+  if [ "$STREAM_FRESH" -eq 1 ]; then
+    ORPHAN_COUNT=$(jq -r '.orphans | length' "$STREAM_AUDIT_CACHE" 2>/dev/null || echo 0)
+    if [ "$ORPHAN_COUNT" -gt 0 ]; then
+      ORPHAN_LIST=$(jq -r '.orphans[:5][] | "  #\(.number): \(.title)"' "$STREAM_AUDIT_CACHE" 2>/dev/null)
+      ISSUES+=("$ORPHAN_COUNT issue(s) in NO stream epic (link them — registry: scripts/config/issue_streams.yaml):
+$ORPHAN_LIST")
+    fi
+    MISSING_EPICS=$(jq -r '.closed_or_missing_epics | join(", ")' "$STREAM_AUDIT_CACHE" 2>/dev/null)
+    [ -n "$MISSING_EPICS" ] && ISSUES+=("Stream epic(s) closed/missing: #$MISSING_EPICS — fix scripts/config/issue_streams.yaml or reopen")
+  elif command -v gh >/dev/null 2>&1; then
+    (cd "$PROJECT_DIR" && nohup "$PROJECT_DIR/.venv/bin/python" -m scripts.orchestration.issue_stream_audit --json >/dev/null 2>&1 &)
+    INFO+=("issue-stream audit cache stale — background refresh started (#4708)")
+  fi
+fi
+
 # 12. Git hygiene — warn if too many dirty files accumulated.
 # See docs/best-practices/git-hygiene.md for policy.
 # Exempt paths (wiki/**, data/corpus_audit/draft_tickets/) can be legitimately

--- a/agents_extensions/shared/rules/workflow.md
+++ b/agents_extensions/shared/rules/workflow.md
@@ -185,11 +185,30 @@ use `/api/worktrees`. `claude agents` does not replace any of these.
 
 ---
 
+## Work intake — stream epics (#4708, binding for ALL orchestrators incl. Codex UI)
+
+Every OPEN issue belongs to **exactly one stream epic**. The registry is
+`scripts/config/issue_streams.yaml` (streams → epic numbers; mirrored in
+`docs/WORKSTREAMS.md` § Streams). This is how orchestrators stay on track and schedule:
+
+- **Cold start**: your queue = YOUR stream's epic checklist/sub-issues, not the global
+  issue list. Check `/api/issues/streams` (or the session-setup 11b warning) for drift.
+- **Creating an issue**: link it to its stream epic AT CREATION — native sub-issue
+  (preferred) or a `#N` checklist line in the epic body. An unlinked issue is an ORPHAN
+  and gets flagged at every agent's cold start until adopted.
+- **Closing**: when a PR fixes an issue, CLOSE it with evidence (auto-close keywords are
+  fine, but verify — `Fixes #N` closes the whole issue even when scope remains; split
+  remainders into a new linked issue FIRST).
+- **New stream?** Only with a new epic + a registry entry in the same PR — streams are
+  deliberate, not emergent.
+- Auditor: `.venv/bin/python -m scripts.orchestration.issue_stream_audit` (`--check` for
+  gates, `--migrate` to convert body references into native sub-issues).
+
 ## Mandatory task workflow
 
 Every task follows this workflow. No exceptions for non-trivial changes.
 
-1. **Create GH issue** — describe the problem, draft a plan
+1. **Create GH issue** — describe the problem, draft a plan, **link it to its stream epic** (see Work intake above)
 2. **Adversarial review of plan** — send to Gemini, incorporate feedback
 3. **Finalize ACs** — update issue with concrete acceptance criteria
 4. **Implement** — work through ACs one by one

--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -18,6 +18,30 @@
 
 ---
 
+## Streams = GitHub Epics (#4708 — supersedes hand-maintained tier rows for scheduling)
+
+Scheduling now lives in GitHub stream epics; this doc keeps the framework and pillars.
+The registry `scripts/config/issue_streams.yaml` is the single source of truth (auditor:
+`scripts/orchestration/issue_stream_audit.py`; live view: `GET /api/issues/streams`).
+
+| Stream | Epic(s) | Scope |
+|---|---|---|
+| atlas-practice | #4387 → #4700 | Word Atlas + Practice Hub product & UX |
+| atlas-intake | #4220, #4378 | Full-corpus intake into the Atlas |
+| corpus-channels | #4706 | Acquisition & ingestion (textbooks · ZNO · Ohoiko-media · press · academic) |
+| infra-harness | #4707 | Fleet, hooks, deps, routing, CI reliability |
+| benchmark-2156 | #4639 | UA LLM factuality benchmark community release |
+| core-quality | #4274 | Deterministic track audits + remediation (A1–B2) |
+| seminars-folk | #2836 | FOLK re-research + rebuild |
+| seminars-bio | #4431, #4215 | BIO readiness + builds |
+| seminars-cross | #3120, #3079 | Cross-seminar gates |
+| hramatka | #4542 | Teacher lesson service (user-gated) |
+
+Rules for every orchestrator (Claude, Codex UI, agy, cursor): work from your stream epic;
+link new issues to a stream at creation; orphans get flagged at every cold start.
+
+---
+
 ## Three Quality Pillars
 
 Every shipped module must pass all three:

--- a/scripts/api/issues_router.py
+++ b/scripts/api/issues_router.py
@@ -180,3 +180,43 @@ async def issues_map(
     Reviewer Codex-6 / #1313: makes queue management less manual.
     """
     return await asyncio.to_thread(_fetch_issues, limit)
+
+
+@router.get("/streams")
+async def issues_streams(
+    fresh: bool = Query(False, description="Re-run the auditor instead of serving the cache."),
+):
+    """Issue-stream hygiene report (#4708) — orphans, multi-homed, pending links.
+
+    Serves ``batch_state/issue_stream_audit.json`` written by
+    ``scripts/orchestration/issue_stream_audit.py``; ``?fresh=true`` re-runs the
+    auditor (network: several ``gh`` calls). Registry:
+    ``scripts/config/issue_streams.yaml``. Degrades to ``{"error": ...}``.
+    """
+
+    def _load() -> dict[str, Any]:
+        from scripts.orchestration import issue_stream_audit as audit
+
+        try:
+            if fresh:
+                return audit.run_audit()
+            # Default path is CACHE-ONLY (codex F3): a live audit is many gh
+            # calls and must never block a cold-start consumer. Serve a stale
+            # cache with a flag, or report no-cache + kick a background refresh.
+            report = audit.read_cache(max_age_s=3600)
+            if report is not None:
+                return report
+            stale = audit.read_cache(max_age_s=7 * 24 * 3600)
+            subprocess.Popen(
+                [str(PROJECT_ROOT / ".venv" / "bin" / "python"),
+                 "-m", "scripts.orchestration.issue_stream_audit", "--json"],
+                cwd=PROJECT_ROOT,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            if stale is not None:
+                return {**stale, "stale": True, "refreshing": True}
+            return {"status": "no-cache", "refreshing": True, "ok": None}
+        except Exception as exc:  # degrade, never 500 a state endpoint
+            return {"error": str(exc)[:300], "ok": False}
+
+    return await asyncio.to_thread(_load)

--- a/scripts/api/route_contracts.py
+++ b/scripts/api/route_contracts.py
@@ -428,6 +428,16 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
         "keep best-effort",
     ),
     RouteContract(
+        "/api/issues/streams", "exact", "http",
+        "Issue-stream hygiene report (#4708): orphans without a stream epic, multi-homed, pending native links.",
+        "batch_state/issue_stream_audit.json auditor cache; ?fresh=true reruns the auditor.",
+        "Cache TTL 3600s; session-setup hook 11b refreshes in background when stale.",
+        ("agents", "issue hygiene", "orchestrators"),
+        "Complements /api/issues/map (label categories) with stream-epic membership.",
+        "low — degrades to {error:...} without gh",
+        "keep best-effort",
+    ),
+    RouteContract(
         "/api/rules", "exact", "http",
         "Condensed agent rule set for cold start.",
         "Deployed rule/source markdown files.",

--- a/scripts/config/issue_streams.yaml
+++ b/scripts/config/issue_streams.yaml
@@ -1,0 +1,41 @@
+# Issue-stream registry — single source of truth for "which epic defines which stream".
+# Consumed by scripts/orchestration/issue_stream_audit.py, the session-setup hook, and
+# /api/state/issues-health. docs/WORKSTREAMS.md § Streams mirrors this table.
+#
+# Rules (binding, served via /api/rules → workflow.md § Work intake):
+# - Every OPEN issue must be a member of EXACTLY ONE stream (native sub-issue of a stream
+#   epic, or a #N reference in the epic body while migration is pending).
+# - New issues link their stream epic at creation time.
+# - Epics themselves (and their child drive boards) are exempt from membership.
+schema_version: 1
+streams:
+  atlas-practice:
+    title: "Word Atlas + Practice Hub product"
+    epics: [4387, 4700]        # umbrella + UX-quality-wave child board
+  atlas-intake:
+    title: "Word Atlas full-corpus intake"
+    epics: [4220, 4378]        # intake epic + entry-model DB epic
+  corpus-channels:
+    title: "Corpus channels — acquisition & ingestion"
+    epics: [4706]
+  infra-harness:
+    title: "Infra & harness reliability"
+    epics: [4707]
+  benchmark-2156:
+    title: "Ukrainian LLM factuality benchmark — community release"
+    epics: [4639]
+  core-quality:
+    title: "Core-track deterministic quality"
+    epics: [4274]
+  seminars-folk:
+    title: "FOLK track re-research + rebuild"
+    epics: [2836]
+  seminars-bio:
+    title: "BIO track readiness + builds"
+    epics: [4431, 4215]
+  seminars-cross:
+    title: "Cross-seminar gates (reading links, self-convergence)"
+    epics: [3120, 3079]
+  hramatka:
+    title: "Hramatka teacher lesson service (user-gated)"
+    epics: [4542]

--- a/scripts/orchestration/issue_stream_audit.py
+++ b/scripts/orchestration/issue_stream_audit.py
@@ -1,0 +1,289 @@
+"""Issue-stream auditor — every open GH issue must belong to exactly one stream epic.
+
+Registry: scripts/config/issue_streams.yaml (streams → epic issue numbers).
+Membership: native GitHub sub-issue of a stream epic, OR (fallback while the
+native migration is pending) a ``#N`` reference in a stream epic's body.
+
+Usage:
+  .venv/bin/python -m scripts.orchestration.issue_stream_audit           # human summary
+  .venv/bin/python -m scripts.orchestration.issue_stream_audit --json    # machine output
+  .venv/bin/python -m scripts.orchestration.issue_stream_audit --check   # exit 1 on orphans
+  .venv/bin/python -m scripts.orchestration.issue_stream_audit --from-cache --max-age 3600
+  .venv/bin/python -m scripts.orchestration.issue_stream_audit --migrate # body refs → native sub-issues
+
+Cache: batch_state/issue_stream_audit.json (gitignored runtime state) — written on
+every live run; the session-setup hook and /api/state/issues-health read it.
+
+GH incident #4708: manual epic checklists rot (fixed-but-open issues, auto-closed
+issues orphaning scope). This gate makes drift visible at every cold start.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_PATH = ROOT / "scripts" / "config" / "issue_streams.yaml"
+CACHE_PATH = ROOT / "batch_state" / "issue_stream_audit.json"
+ISSUE_REF_RE = re.compile(r"#(\d{2,6})\b")
+
+
+def load_registry(path: Path = REGISTRY_PATH) -> dict[str, list[int]]:
+    """Return {stream_key: [epic_numbers]}."""
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    streams = doc.get("streams") or {}
+    registry: dict[str, list[int]] = {}
+    for key, spec in streams.items():
+        epics = [int(n) for n in (spec.get("epics") or [])]
+        if not epics:
+            raise ValueError(f"stream {key!r} has no epics")
+        registry[key] = epics
+    if not registry:
+        raise ValueError("issue_streams.yaml defines no streams")
+    return registry
+
+
+def _gh_json(args: list[str], timeout_s: float = 30.0):
+    proc = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, timeout=timeout_s, cwd=ROOT
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args[:3])}… failed: {proc.stderr.strip()[:200]}")
+    return json.loads(proc.stdout)
+
+
+def fetch_open_issues() -> list[dict]:
+    return _gh_json(
+        ["issue", "list", "--state", "open", "--limit", "500",
+         "--json", "number,title"]
+    )
+
+
+_REPO_CACHE: dict[str, str] = {}
+
+
+def _repo_owner_name() -> tuple[str, str]:
+    """Resolve the actual owner/name once — GraphQL -f fields do NOT expand
+    the gh {owner}/{repo} placeholders (REST paths do). Caught by live probe."""
+    if not _REPO_CACHE:
+        data = _gh_json(["repo", "view", "--json", "owner,name"])
+        _REPO_CACHE["owner"] = data["owner"]["login"]
+        _REPO_CACHE["name"] = data["name"]
+    return _REPO_CACHE["owner"], _REPO_CACHE["name"]
+
+
+def fetch_epic_membership(epic: int) -> tuple[set[int], set[int]]:
+    """Return (native_sub_issue_numbers, body_reference_numbers) for one epic."""
+    owner, name = _repo_owner_name()
+    data = _gh_json([
+        "api", "graphql",
+        "-F", "number=" + str(epic),
+        "-f", f"owner={owner}", "-f", f"name={name}",
+        "-f",
+        "query=query($owner:String!,$name:String!,$number:Int!){"
+        "repository(owner:$owner,name:$name){issue(number:$number){body "
+        "subIssues(first:100){nodes{number}}}}}",
+    ])
+    issue = (data.get("data") or {}).get("repository", {}).get("issue") or {}
+    native = {n["number"] for n in (issue.get("subIssues") or {}).get("nodes") or []}
+    body = issue.get("body") or ""
+    refs = {int(m) for m in ISSUE_REF_RE.findall(body)}
+    return native, refs
+
+
+def classify(
+    open_issues: list[dict],
+    registry: dict[str, list[int]],
+    membership: dict[int, tuple[set[int], set[int]]],
+) -> dict:
+    """Pure classification — unit-testable without network."""
+    epic_numbers = {e for epics in registry.values() for e in epics}
+    stream_of_epic = {e: key for key, epics in registry.items() for e in epics}
+
+    native_streams: dict[int, set[str]] = {}
+    body_streams: dict[int, set[str]] = {}
+    native_linked: set[int] = set()
+    for epic, (native, refs) in membership.items():
+        stream = stream_of_epic[epic]
+        for n in native:
+            native_streams.setdefault(n, set()).add(stream)
+        for n in refs:
+            body_streams.setdefault(n, set()).add(stream)
+        native_linked |= native
+    # Native sub-issue links are DELIBERATE membership; body refs are the
+    # migration fallback. Once an issue has any native link, prose mentions in
+    # other epics' bodies must not multi-home it.
+    issue_streams: dict[int, set[str]] = {
+        n: (native_streams.get(n) or body_streams.get(n) or set())
+        for n in set(native_streams) | set(body_streams)
+    }
+
+    open_numbers = {i["number"] for i in open_issues}
+    titles = {i["number"]: i["title"] for i in open_issues}
+
+    orphans = sorted(
+        n for n in open_numbers if n not in epic_numbers and not issue_streams.get(n)
+    )
+    multi_homed = sorted(
+        n for n in open_numbers
+        if n not in epic_numbers and len(issue_streams.get(n, ())) > 1
+    )
+    body_only = sorted(
+        n for n in open_numbers
+        if n not in epic_numbers and issue_streams.get(n) and n not in native_linked
+    )
+    missing_epics = sorted(e for e in epic_numbers if e not in open_numbers)
+
+    return {
+        "generated_at": int(time.time()),
+        "open_total": len(open_numbers),
+        "streams": {k: sorted(v) for k, v in registry.items()},
+        "orphans": [{"number": n, "title": titles[n]} for n in orphans],
+        "multi_homed": [
+            {"number": n, "title": titles[n], "streams": sorted(issue_streams[n])}
+            for n in multi_homed
+        ],
+        "pending_native_link": body_only,
+        "closed_or_missing_epics": missing_epics,
+        # The invariant is EXACTLY ONE stream — multi-homed violates it (codex F1).
+        "ok": not orphans and not missing_epics and not multi_homed,
+    }
+
+
+def run_audit() -> dict:
+    registry = load_registry()
+    open_issues = fetch_open_issues()
+    membership = {
+        epic: fetch_epic_membership(epic)
+        for epics in registry.values()
+        for epic in epics
+    }
+    report = classify(open_issues, registry, membership)
+    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CACHE_PATH.write_text(json.dumps(report, ensure_ascii=False, indent=1), encoding="utf-8")
+    return report
+
+
+def read_cache(max_age_s: int) -> dict | None:
+    try:
+        report = json.loads(CACHE_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if time.time() - report.get("generated_at", 0) > max_age_s:
+        return None
+    return report
+
+
+def _node_id(number: int) -> str:
+    data = _gh_json([
+        "api", f"repos/{{owner}}/{{repo}}/issues/{number}", "--jq", "{node_id}"
+    ])
+    return data["node_id"]
+
+
+def migrate(report: dict) -> int:
+    """Create native sub-issue links for pending body-only references.
+
+    Ambiguous cases — body-referenced from MORE THAN ONE stream — are skipped
+    (codex F2): GitHub's single-parent constraint would otherwise make the
+    winner order-dependent instead of deliberate. Resolve them manually.
+    """
+    registry = load_registry()
+    ambiguous = {m["number"] for m in report.get("multi_homed", [])}
+    if ambiguous:
+        print(
+            "skipping ambiguous multi-homed (resolve manually): "
+            + ", ".join(f"#{n}" for n in sorted(ambiguous)),
+            file=sys.stderr,
+        )
+    created = 0
+    for stream_key, epics in registry.items():
+        for epic in epics:
+            native, refs = fetch_epic_membership(epic)
+            pending = sorted(
+                refs - native - ambiguous
+                - {e for es in registry.values() for e in es}
+            )
+            if not pending:
+                continue
+            epic_node = _node_id(epic)
+            for n in pending:
+                if n not in {x if isinstance(x, int) else x["number"]
+                             for x in report.get("pending_native_link", [])}:
+                    continue
+                try:
+                    child_node = _node_id(n)
+                    _gh_json([
+                        "api", "graphql",
+                        "-f",
+                        "query=mutation($p:ID!,$c:ID!){addSubIssue(input:{issueId:$p,"
+                        "subIssueId:$c}){issue{number}}}",
+                        "-f", f"p={epic_node}", "-f", f"c={child_node}",
+                    ])
+                    created += 1
+                    print(f"linked #{n} → epic #{epic} ({stream_key})")
+                except RuntimeError as exc:
+                    print(f"WARN: link #{n} → #{epic} failed: {exc}", file=sys.stderr)
+    return created
+
+
+def human_summary(report: dict) -> str:
+    lines = [
+        f"open issues: {report['open_total']} · streams: {len(report['streams'])}"
+        f" · ok: {report['ok']}"
+    ]
+    if report["orphans"]:
+        lines.append(f"ORPHANS ({len(report['orphans'])} — no stream epic):")
+        lines += [f"  #{o['number']} {o['title'][:80]}" for o in report["orphans"]]
+    if report["multi_homed"]:
+        lines.append(f"multi-homed ({len(report['multi_homed'])}):")
+        lines += [
+            f"  #{m['number']} in {', '.join(m['streams'])}" for m in report["multi_homed"]
+        ]
+    if report["pending_native_link"]:
+        lines.append(
+            f"pending native sub-issue link: {len(report['pending_native_link'])}"
+            " (run --migrate)"
+        )
+    if report["closed_or_missing_epics"]:
+        lines.append(f"⚠️ stream epics not open: {report['closed_or_missing_epics']}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--check", action="store_true", help="exit 1 unless ok")
+    parser.add_argument("--from-cache", action="store_true")
+    parser.add_argument("--max-age", type=int, default=3600)
+    parser.add_argument("--migrate", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = read_cache(args.max_age) if args.from_cache else None
+    if report is None:
+        if args.from_cache and args.check:
+            # Hook path: never block a session start on the network.
+            print("issue-stream audit: no fresh cache (run the auditor to refresh)")
+            return 0
+        report = run_audit()
+
+    if args.migrate:
+        created = migrate(report)
+        print(f"created {created} native sub-issue link(s)")
+        report = run_audit()
+
+    print(json.dumps(report, ensure_ascii=False, indent=1) if args.json
+          else human_summary(report))
+    return 0 if (report["ok"] or not args.check) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_issue_stream_audit.py
+++ b/tests/test_issue_stream_audit.py
@@ -1,0 +1,114 @@
+"""Hermetic tests for the issue-stream auditor (#4708) — no network, no gh."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from scripts.orchestration.issue_stream_audit import classify, load_registry
+
+
+@pytest.fixture()
+def registry(tmp_path):
+    path = tmp_path / "issue_streams.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """
+            schema_version: 1
+            streams:
+              product:
+                title: "Product"
+                epics: [100, 150]
+              infra:
+                title: "Infra"
+                epics: [200]
+            """
+        ),
+        encoding="utf-8",
+    )
+    return load_registry(path)
+
+
+def _issues(*numbers):
+    return [{"number": n, "title": f"issue {n}"} for n in numbers]
+
+
+def test_orphan_detected(registry):
+    report = classify(
+        _issues(100, 150, 200, 5, 6),
+        registry,
+        {100: ({5}, set()), 150: (set(), set()), 200: (set(), set())},
+    )
+    assert [o["number"] for o in report["orphans"]] == [6]
+    assert report["ok"] is False
+
+
+def test_epics_are_exempt_from_membership(registry):
+    report = classify(
+        _issues(100, 150, 200),
+        registry,
+        {100: (set(), set()), 150: (set(), set()), 200: (set(), set())},
+    )
+    assert report["orphans"] == []
+    assert report["ok"] is True
+
+
+def test_body_reference_counts_but_flags_pending_migration(registry):
+    report = classify(
+        _issues(100, 150, 200, 7),
+        registry,
+        {100: (set(), {7}), 150: (set(), set()), 200: (set(), set())},
+    )
+    assert report["orphans"] == []
+    assert report["pending_native_link"] == [7]
+
+
+def test_multi_homed_across_streams_flagged(registry):
+    report = classify(
+        _issues(100, 150, 200, 8),
+        registry,
+        {100: ({8}, set()), 150: (set(), set()), 200: ({8}, set())},
+    )
+    assert [m["number"] for m in report["multi_homed"]] == [8]
+    assert report["multi_homed"][0]["streams"] == ["infra", "product"]
+    # codex F1: multi-homed violates the exactly-one-stream invariant.
+    assert report["ok"] is False
+
+
+def test_same_stream_double_reference_is_not_multi_homed(registry):
+    report = classify(
+        _issues(100, 150, 200, 9),
+        registry,
+        {100: ({9}, set()), 150: ({9}, set()), 200: (set(), set())},
+    )
+    assert report["multi_homed"] == []
+
+
+def test_closed_epic_surfaces(registry):
+    report = classify(
+        _issues(100, 200),  # 150 is not open
+        registry,
+        {100: (set(), set()), 150: (set(), set()), 200: (set(), set())},
+    )
+    assert report["closed_or_missing_epics"] == [150]
+    assert report["ok"] is False
+
+
+def test_registry_rejects_empty_stream(tmp_path):
+    path = tmp_path / "issue_streams.yaml"
+    path.write_text("streams:\n  broken:\n    title: x\n    epics: []\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="broken"):
+        load_registry(path)
+
+
+def test_native_link_wins_over_prose_mention(registry):
+    """Once an issue is a native sub-issue somewhere, body refs elsewhere must
+    not multi-home it (prose mentions are not membership)."""
+    report = classify(
+        _issues(100, 150, 200, 11),
+        registry,
+        {100: ({11}, set()), 150: (set(), set()), 200: (set(), {11})},
+    )
+    assert report["multi_homed"] == []
+    assert report["orphans"] == []


### PR DESCRIPTION
Implements #4708 (user go 2026-07-07): streams = GH epics, enforced by a gate instead of grooming habits.

- **Registry** `scripts/config/issue_streams.yaml` — 10 streams → epic numbers (mirrors WORKSTREAMS § Streams)
- **Auditor** `issue_stream_audit.py` — orphans / multi-homed (native-sub-issue-wins over prose mentions) / pending-native-link / closed-epic; `--check` gate; `--migrate` converts epic-body `#N` refs to native sub-issues (GraphQL)
- **Wiring**: session-setup hook 11b (cached <1h, never blocks, background refresh) + `GET /api/issues/streams` + route contract
- **Onboarding, all providers**: `workflow.md` § Work intake (→ `/api/rules`), **AGENTS.md digest (the Codex UI surface — track drivers work from their stream epic)**, WORKSTREAMS.md streams table

Evidence:
- `pytest tests/test_issue_stream_audit.py` → `8 passed` (hermetic, no network)
- `pytest -k 'route_contract or issues_router or session_setup'` → `6 passed`
- ruff clean; `bash -n` hook OK
- LIVE run: `open issues: 110 · streams: 10` → 14 true orphans surfaced (incl. #4708 itself + the #4274 members that lived in a comment instead of the body — precisely the drift class this gate exists for), 82 pending native links
- Live probe caught a real gh bug: `{owner}/{repo}` placeholders don't expand in GraphQL `-f` fields — fixed via `gh repo view` resolution

Post-merge sequence (I run it): adopt the 14 orphans into their epics → `--migrate` (82+ links) → re-run → cache green for the fleet → bridge onboarding note to the Codex lane.

Deploy note: `agents_extensions/shared/` changes ride the auto-deploy hook; pre-existing 2-file drift is untouched.

Refs #4708, #4707. NO auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)