### PR TITLE
data(audit): interim multi-run SCORECARD (306 cells, post-sweep)

### DIFF
--- a/audit/2026-07-06-qg-bakeoff-multirun/SCORECARD.md
+++ b/audit/2026-07-06-qg-bakeoff-multirun/SCORECARD.md
@@ -1,0 +1,446 @@
+# QG Bakeoff Scorecard
+
+Generated: 2026-07-07T07:13:52.392369Z
+
+Fractions are exact. `low-N` marks denominators below 10.
+
+
+## Runs
+
+| model | transport | entrypoint | passage | arm | run | status | failure_class | parse_lenient | model judgment | live admissible | missing | U honesty | M alignment | true unsupported | invalid | inadmissible | tools | wall_s |
+| --- | --- | --- | --- | --- | ---: | --- | --- | --- | ---: | ---: | ---: | --- | --- | --- | ---: | ---: | ---: | ---: |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | bare | 1 | ran | n/a | False | 120 | 120 | 0 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 46.711 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | bare | 2 | ran | n/a | False | 20 | 20 | 0 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 17.872 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | bare | 3 | ran | n/a | False | 20 | 20 | 0 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 24.862 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | tooled | 1 | ungrounded_findings | n/a | False | -90 | -90 | 9 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 2 | 0 | 12 | 208.138 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | tooled | 2 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 2 | 0 | 10 | 102.884 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | tooled | 3 | ungrounded_findings | n/a | True | 150 | 150 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 3 | 0 | 26 | 575.607 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | bare | 1 | ran | n/a | False | -100 | -100 | 4 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 37.232 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | bare | 2 | ran | n/a | False | -110 | -110 | 2 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 49.84 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | bare | 3 | ran | n/a | False | -200 | -200 | 4 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 47.439 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | tooled | 1 | ungrounded_findings | n/a | False | -30 | -30 | 7 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 3 | 0 | 35 | 185.184 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | tooled | 2 | ungrounded_findings | n/a | False | 110 | 110 | 2 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 6 | 0 | 30 | 211.019 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | tooled | 3 | ungrounded_findings | n/a | False | -70 | -70 | 8 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 10 | 0 | 26 | 266.702 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | bare | 1 | ran | n/a | False | -20 | -20 | 2 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 61.034 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | bare | 2 | ran | n/a | False | 80 | 80 | 3 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 9.717 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | bare | 3 | ran | n/a | False | 10 | 10 | 2 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 22.352 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | tooled | 1 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 1 | 0 | 11 | 125.61 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | tooled | 2 | error | model_failure | False | -90 | -90 | 9 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 342.837 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | tooled | 3 | ungrounded_findings | n/a | False | 60 | 60 | 4 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 2 | 0 | 16 | 448.458 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | bare | 1 | ran | n/a | False | -10 | -10 | 4 | 0/1 low-N | 0/2 low-N | 1/6 low-N | 0 | 0 | 0 | 36.153 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | bare | 2 | ran | n/a | False | 180 | 180 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 30.368 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | bare | 3 | ran | n/a | False | 120 | 120 | 2 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 25.679 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | tooled | 1 | ungrounded_findings | n/a | False | 140 | 140 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 4 | 0 | 25 | 300.162 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | tooled | 2 | ungrounded_findings | n/a | False | 160 | 160 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 10 | 0 | 25 | 353.401 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | tooled | 3 | ungrounded_findings | n/a | False | 130 | 130 | 2 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 7 | 0 | 19 | 115.567 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | bare | 1 | ran | n/a | False | 20 | 20 | 1 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 1 | 54.657 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | bare | 2 | ran | n/a | False | 60 | 60 | 1 | 0/1 low-N | 1/2 low-N | 2/6 low-N | 0 | 0 | 0 | 42.782 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | bare | 3 | ran | n/a | False | 50 | 50 | 0 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 39.007 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | tooled | 1 | ungrounded_findings | n/a | False | -50 | -50 | 5 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 2 | 0 | 16 | 143.214 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | tooled | 2 | ungrounded_findings | n/a | False | 100 | 100 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 9 | 0 | 20 | 208.298 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | tooled | 3 | factual_sweep_incomplete | n/a | False | -90 | -90 | 9 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 22 | 622.245 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | bare | 1 | ran | n/a | False | 180 | 180 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 57.526 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | bare | 2 | ran | n/a | False | 180 | 180 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 36.768 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | bare | 3 | ran | n/a | False | 150 | 150 | 0 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 67.275 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | tooled | 1 | ungrounded_findings | n/a | False | -60 | -60 | 8 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 9 | 0 | 22 | 206.635 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | tooled | 2 | ungrounded_findings | n/a | False | 160 | 160 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 8 | 0 | 19 | 482.054 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | tooled | 3 | ungrounded_findings | n/a | False | 140 | 140 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 6 | 0 | 33 | 448.725 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | bare | 1 | ran | n/a | False | 10 | 10 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 32.564 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | bare | 2 | ran | n/a | False | 50 | 50 | 2 | 0/1 low-N | 1/2 low-N | 2/6 low-N | 0 | 0 | 0 | 30.402 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | bare | 3 | ran | n/a | False | 80 | 80 | 2 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 26.103 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | tooled | 1 | error | model_failure | False | -90 | -90 | 9 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 253.137 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | tooled | 2 | ungrounded_findings | n/a | False | 30 | 0 | 5 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 5 | 1 | 23 | 143.553 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | tooled | 3 | error | model_failure | False | -90 | -90 | 9 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 195.171 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | bare | 1 | ran | n/a | False | 80 | 80 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 33.928 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | bare | 2 | ran | n/a | False | 110 | 110 | 2 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 24.747 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | bare | 3 | ran | n/a | False | 80 | 80 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 67.565 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | tooled | 1 | ungrounded_findings | n/a | False | 90 | 90 | 3 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 5 | 0 | 27 | 291.574 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | tooled | 2 | ungrounded_findings | n/a | False | 90 | 90 | 3 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 7 | 0 | 27 | 182.342 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | tooled | 3 | factual_sweep_incomplete | n/a | False | -90 | -90 | 9 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 33 | 372.709 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | bare | 1 | ran | n/a | False | 120 | 120 | 0 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 60.646 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | bare | 2 | ran | n/a | False | 120 | 120 | 0 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 35.977 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | bare | 3 | ran | n/a | False | 0 | 0 | 0 | 0/1 low-N | 0/2 low-N | 4/6 low-N | 0 | 0 | 0 | 48.372 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | tooled | 1 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 7 | 0 | 20 | 261.738 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | tooled | 2 | ungrounded_findings | n/a | False | 80 | 80 | 3 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 7 | 0 | 12 | 108.878 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | tooled | 3 | ungrounded_findings | n/a | False | 50 | 50 | 5 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 5 | 0 | 20 | 339.423 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | bare | 1 | ran | n/a | False | 80 | 80 | 3 | 0/1 low-N | 2/2 low-N | 1/6 low-N | 0 | 0 | 0 | 40.457 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | bare | 2 | ran | n/a | False | -20 | -20 | 6 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 1 | 76.988 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | bare | 3 | ran | n/a | False | 20 | 20 | 4 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 37.917 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | tooled | 1 | ungrounded_findings | n/a | False | 170 | 170 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 11 | 0 | 39 | 254.327 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | tooled | 2 | ungrounded_findings | n/a | False | 170 | 170 | 1 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 10 | 0 | 29 | 179.492 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | tooled | 3 | error | model_failure | False | -90 | -90 | 9 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 457.415 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | bare | 1 | ran | n/a | False | 10 | 10 | 2 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 32.705 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | bare | 2 | ran | n/a | False | 80 | 80 | 3 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 42.836 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | bare | 3 | ran | n/a | False | 50 | 50 | 3 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 47.841 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | tooled | 1 | ungrounded_findings | n/a | False | 80 | 80 | 4 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 11 | 0 | 15 | 106.664 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | tooled | 2 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 6 | 0 | 22 | 285.934 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | tooled | 3 | ungrounded_findings | n/a | False | 160 | 160 | 0 | 1/1 low-N | 2/2 low-N | 1/6 low-N | 8 | 0 | 20 | 287.492 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | bare | 1 | ran | n/a | False | 60 | 60 | 1 | 0/1 low-N | 2/2 low-N | 3/6 low-N | 0 | 0 | 0 | 46.516 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | bare | 2 | ran | n/a | False | 50 | 50 | 0 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 31.28 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | bare | 3 | ran | n/a | False | 180 | 180 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 43.711 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | tooled | 1 | ungrounded_findings | n/a | False | 170 | 170 | 1 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 3 | 0 | 25 | 160.502 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | tooled | 2 | error | model_failure | False | -90 | -90 | 9 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 265.936 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | tooled | 3 | ungrounded_findings | n/a | False | 30 | 30 | 5 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 8 | 0 | 17 | 239.914 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | bare | 1 | ran | n/a | False | 60 | 60 | 1 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 61.851 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | bare | 2 | ran | n/a | False | 120 | 120 | 1 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 36.941 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | bare | 3 | ran | n/a | False | 130 | 130 | 1 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 38.94 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | tooled | 1 | ungrounded_findings | n/a | False | 100 | 100 | 2 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 5 | 0 | 37 | 297.248 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | tooled | 2 | ungrounded_findings | n/a | False | -20 | -20 | 7 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 6 | 0 | 25 | 128.609 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | tooled | 3 | ungrounded_findings | n/a | False | 140 | 140 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 6 | 0 | 34 | 166.597 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | bare | 1 | ran | n/a | False | 20 | 20 | 4 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 19.484 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | bare | 2 | ran | n/a | False | -40 | -40 | 6 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 30.649 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | bare | 3 | ran | n/a | False | -10 | -10 | 0 | 0/1 low-N | 0/1 low-N | 1/6 low-N | 0 | 0 | 0 | 25.395 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | tooled | 1 | ungrounded_findings | n/a | False | 10 | 10 | 5 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 4 | 0 | 25 | 110.847 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | tooled | 2 | ungrounded_findings | n/a | False | 10 | 10 | 5 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 4 | 0 | 17 | 83.214 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | tooled | 3 | ungrounded_findings | n/a | True | 0 | 0 | 5 | 1/1 low-N | 0/1 low-N | 0/6 low-N | 8 | 0 | 19 | 164.256 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | bare | 1 | ran | n/a | False | -30 | -30 | 3 | 0/1 low-N | 1/2 low-N | 3/6 low-N | 0 | 0 | 0 | 29.132 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | bare | 2 | ran | n/a | False | 130 | 130 | 2 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 45.592 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | bare | 3 | ran | n/a | False | 150 | 150 | 1 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 50.193 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | tooled | 1 | ungrounded_findings | n/a | False | -50 | -50 | 8 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 7 | 0 | 20 | 175.522 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | tooled | 2 | ungrounded_findings | n/a | False | 130 | 130 | 1 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 7 | 0 | 21 | 392.67 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | tooled | 3 | ungrounded_findings | n/a | False | -90 | -90 | 9 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 6 | 0 | 12 | 332.403 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | bare | 1 | ran | n/a | False | 110 | 110 | 1 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 57.324 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | bare | 2 | ran | n/a | False | 170 | 170 | 1 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 37.261 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | bare | 3 | ran | n/a | False | 90 | 90 | 1 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 30.853 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | tooled | 1 | ungrounded_findings | n/a | False | 170 | 170 | 1 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 14 | 0 | 15 | 163.709 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | tooled | 2 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 1 | 0 | 23 | 228.84 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | tooled | 3 | ungrounded_findings | n/a | False | 170 | 170 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 11 | 0 | 13 | 299.125 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | bare | 1 | ran | n/a | False | -40 | -40 | 2 | 0/1 low-N | 0/2 low-N | 1/6 low-N | 0 | 0 | 0 | 60.164 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | bare | 2 | ran | n/a | False | 30 | 30 | 2 | 0/1 low-N | 0/2 low-N | 1/6 low-N | 0 | 0 | 0 | 50.734 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | bare | 3 | ran | n/a | False | -140 | -140 | 2 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 47.135 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | tooled | 1 | ungrounded_findings | n/a | False | 150 | 150 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 3 | 0 | 21 | 123.988 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | tooled | 2 | ungrounded_findings | n/a | False | 170 | 170 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 4 | 0 | 24 | 136.568 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | tooled | 3 | ungrounded_findings | n/a | False | 70 | 70 | 2 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 3 | 0 | 23 | 259.64 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | bare | 1 | ran | n/a | False | 90 | 90 | 0 | 0/1 low-N | 0/2 low-N | 1/6 low-N | 0 | 0 | 0 | 76.858 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | bare | 2 | ran | n/a | False | 120 | 120 | 0 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 67.668 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | bare | 3 | ran | n/a | False | 120 | 120 | 0 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 91.579 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | tooled | 1 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 8 | 0 | 12 | 234.285 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | tooled | 2 | ungrounded_findings | n/a | False | 170 | 170 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 1 | 0 | 10 | 207.363 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | tooled | 3 | factual_sweep_incomplete | n/a | True | -90 | -90 | 9 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 14 | 230.393 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | bare | 1 | ran | n/a | False | -70 | -70 | 4 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 120.405 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | bare | 2 | ran | n/a | False | 30 | 30 | 4 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 69.852 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | bare | 3 | ran | n/a | False | -70 | -70 | 3 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 57.159 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | tooled | 1 | ungrounded_findings | n/a | False | 40 | 40 | 4 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 8 | 0 | 17 | 220.903 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | tooled | 2 | ungrounded_findings | n/a | False | -20 | -20 | 6 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 2 | 0 | 13 | 205.396 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | tooled | 3 | ungrounded_findings | n/a | False | 50 | 50 | 4 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 1 | 0 | 22 | 223.325 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | bare | 1 | ran | n/a | False | 60 | 60 | 1 | 0/1 low-N | 0/2 low-N | 1/6 low-N | 0 | 0 | 0 | 50.207 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | bare | 2 | ran | n/a | False | 50 | 50 | 1 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 69.893 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | bare | 3 | ran | n/a | False | 150 | 150 | 0 | 1/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 50.266 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | tooled | 1 | ungrounded_findings | n/a | False | 140 | 140 | 2 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 2 | 0 | 17 | 299.273 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | tooled | 2 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 4 | 0 | 9 | 306.163 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | tooled | 3 | ungrounded_findings | n/a | False | 160 | 160 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 2 | 0 | 11 | 155.617 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | bare | 1 | ran | n/a | False | 60 | 60 | 2 | 0/1 low-N | 2/2 low-N | 2/6 low-N | 0 | 0 | 0 | 55.726 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | bare | 2 | ran | n/a | False | 180 | 180 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 67.163 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | bare | 3 | ran | n/a | False | 150 | 150 | 1 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 123.46 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | tooled | 1 | factual_sweep_incomplete | n/a | False | -90 | -90 | 9 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 10 | 190.328 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | tooled | 2 | ungrounded_findings | n/a | False | 50 | 50 | 3 | 1/1 low-N | 2/2 low-N | 1/6 low-N | 8 | 0 | 18 | 337.687 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | tooled | 3 | ungrounded_findings | n/a | False | 170 | 140 | 1 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 7 | 1 | 19 | 285.674 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | bare | 1 | ran | n/a | False | 180 | 180 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 24.123 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | bare | 2 | ran | n/a | False | 180 | 180 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 92.993 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | bare | 3 | ran | n/a | False | 120 | 120 | 0 | 0/1 low-N | 2/2 low-N | 2/6 low-N | 0 | 0 | 0 | 71.851 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | tooled | 1 | ungrounded_findings | n/a | False | 30 | 30 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 5 | 0 | 13 | 537.499 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | tooled | 2 | ungrounded_findings | n/a | False | 40 | 40 | 5 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 6 | 0 | 11 | 138.525 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | tooled | 3 | ungrounded_findings | n/a | False | 80 | 80 | 2 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 4 | 0 | 13 | 222.193 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | bare | 1 | ran | n/a | False | 180 | 180 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 133.172 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | bare | 2 | ran | n/a | False | 210 | 210 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 51.817 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | bare | 3 | ran | n/a | False | 50 | 50 | 0 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 54.879 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | tooled | 1 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 9 | 0 | 9 | 470.497 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | tooled | 2 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 4 | 0 | 21 | 376.172 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | tooled | 3 | ungrounded_findings | n/a | False | 160 | 160 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 10 | 0 | 18 | 303.393 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | bare | 1 | ran | n/a | False | 50 | 50 | 2 | 0/1 low-N | 0/2 low-N | 1/6 low-N | 0 | 0 | 0 | 136.912 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | bare | 2 | ran | n/a | False | -90 | -90 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 81.669 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | bare | 3 | ran | n/a | False | -80 | -80 | 2 | 0/1 low-N | 0/2 low-N | 2/6 low-N | 0 | 0 | 0 | 53.83 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | tooled | 1 | ungrounded_findings | n/a | False | 70 | 70 | 4 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 4 | 0 | 24 | 507.178 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | tooled | 2 | ungrounded_findings | n/a | False | 160 | 160 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 5 | 0 | 15 | 246.494 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | tooled | 3 | ungrounded_findings | n/a | False | 70 | 70 | 3 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 10 | 1 | 20 | 218.156 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | bare | 1 | ran | n/a | False | 50 | 50 | 2 | 0/1 low-N | 0/2 low-N | 1/6 low-N | 0 | 0 | 0 | 73.844 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | bare | 2 | ran | n/a | False | 80 | 80 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 64.043 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | bare | 3 | ran | n/a | False | 80 | 80 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 72.518 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | tooled | 1 | ungrounded_findings | n/a | False | 120 | 120 | 2 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 7 | 0 | 23 | 254.11 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | tooled | 2 | ungrounded_findings | n/a | False | 150 | 150 | 1 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 11 | 0 | 19 | 232.688 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | tooled | 3 | ungrounded_findings | n/a | False | 160 | 160 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 3 | 0 | 19 | 169.956 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | bare | 1 | ran | n/a | False | 60 | 60 | 1 | 0/1 low-N | 1/2 low-N | 2/6 low-N | 0 | 0 | 0 | 37.05 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | bare | 2 | ran | n/a | False | 50 | 50 | 0 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 56.266 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | bare | 3 | ran | n/a | False | 120 | 120 | 0 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 75.965 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | tooled | 1 | ungrounded_findings | n/a | False | 130 | 130 | 1 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 3 | 0 | 10 | 165.684 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | tooled | 2 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 5 | 0 | 13 | 243.199 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | tooled | 3 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 6 | 0 | 16 | 202.248 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | bare | 1 | ran | n/a | False | 140 | 140 | 1 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 50.604 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | bare | 2 | ran | n/a | False | 120 | 120 | 1 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 83.73 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | bare | 3 | ran | n/a | False | 110 | 110 | 2 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 63.236 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | tooled | 1 | ungrounded_findings | n/a | False | 140 | 140 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 5 | 0 | 14 | 206.33 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | tooled | 2 | ungrounded_findings | n/a | False | 170 | 170 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 7 | 0 | 12 | 183.875 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | tooled | 3 | ungrounded_findings | n/a | False | 170 | 170 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 4 | 0 | 18 | 199.266 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | bare | 1 | ran | n/a | False | -50 | -50 | 0 | 0/1 low-N | 2/2 low-N | 2/6 low-N | 0 | 0 | 0 | 63.796 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | bare | 2 | ran | n/a | False | 20 | 20 | 2 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 87.568 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | bare | 3 | ran | n/a | False | 100 | 100 | 3 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 65.171 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | tooled | 1 | ungrounded_findings | n/a | False | 60 | 60 | 1 | 1/1 low-N | 2/2 low-N | 1/6 low-N | 3 | 0 | 6 | 161.314 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | tooled | 2 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 12 | 0 | 9 | 318.098 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | tooled | 3 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 3 | 0 | 11 | 186.837 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | bare | 1 | ran | n/a | False | -10 | -10 | 0 | 0/1 low-N | 1/2 low-N | 2/6 low-N | 0 | 0 | 0 | 51.221 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | bare | 2 | ran | n/a | False | 180 | 180 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 45.621 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | bare | 3 | ran | n/a | False | 180 | 180 | 0 | 1/1 low-N | 2/2 low-N | 1/6 low-N | 0 | 0 | 0 | 97.011 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | tooled | 1 | error | model_failure | False | -90 | -90 | 9 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 156.573 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | tooled | 2 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 4 | 0 | 10 | 170.694 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | tooled | 3 | ungrounded_findings | n/a | False | 170 | 170 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 3 | 0 | 8 | 171.717 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | bare | 1 | ran | n/a | False | 90 | 90 | 1 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 99.841 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | bare | 2 | ran | n/a | False | 150 | 150 | 0 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 85.064 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | bare | 3 | ran | n/a | False | 120 | 120 | 1 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 83.868 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | tooled | 1 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 11 | 0 | 11 | 179.833 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | tooled | 2 | ungrounded_findings | n/a | False | 160 | 160 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 6 | 0 | 17 | 246.03 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | tooled | 3 | ungrounded_findings | n/a | True | 130 | 130 | 2 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 2 | 0 | 17 | 297.943 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | bare | 1 | ran | n/a | False | 20 | 20 | 3 | 0/1 low-N | 0/1 low-N | 1/6 low-N | 0 | 0 | 0 | 79.534 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | bare | 2 | ran | n/a | False | -10 | -10 | 5 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 76.111 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | bare | 3 | ran | n/a | False | -140 | -140 | 6 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 43.688 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | tooled | 1 | ungrounded_findings | n/a | False | -30 | -30 | 2 | 1/1 low-N | 0/1 low-N | 0/6 low-N | 4 | 0 | 13 | 142.401 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | tooled | 2 | error | model_failure | False | -80 | -80 | 8 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 194.677 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | tooled | 3 | ungrounded_findings | n/a | False | 0 | 0 | 5 | 1/1 low-N | 0/1 low-N | 0/6 low-N | 7 | 0 | 10 | 164.055 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | bare | 1 | ran | n/a | False | 150 | 150 | 1 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 112.049 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | bare | 2 | ran | n/a | False | 160 | 160 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 54.848 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | bare | 3 | ran | n/a | False | 150 | 150 | 1 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 72.644 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | tooled | 1 | ungrounded_findings | n/a | False | 70 | 70 | 4 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 4 | 0 | 16 | 404.872 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | tooled | 2 | ungrounded_findings | n/a | False | 160 | 160 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 10 | 0 | 18 | 181.453 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | tooled | 3 | ungrounded_findings | n/a | False | 60 | 60 | 4 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 5 | 0 | 12 | 212.862 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | bare | 1 | ran | n/a | False | 170 | 170 | 1 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 85.969 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | bare | 2 | ran | n/a | False | 140 | 140 | 1 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 79.26 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | bare | 3 | ran | n/a | False | 170 | 170 | 1 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 83.952 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | tooled | 1 | ungrounded_findings | n/a | False | 90 | 90 | 3 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 15 | 0 | 16 | 214.524 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | tooled | 2 | error | model_failure | False | -90 | -90 | 9 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 303.188 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | tooled | 3 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 1 | 0 | 12 | 188.446 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | bare | 1 | ran | n/a | False | 90 | 90 | 1 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 83.158 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | bare | 2 | ran | n/a | False | -40 | -40 | 1 | 0/1 low-N | 1/2 low-N | 2/6 low-N | 0 | 0 | 0 | 58.155 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | bare | 3 | ran | n/a | False | -40 | -40 | 2 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 72.776 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | tooled | 1 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 10 | 0 | 16 | 195.149 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | tooled | 2 | ungrounded_findings | n/a | False | 110 | 110 | 3 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 5 | 0 | 10 | 438.587 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | tooled | 3 | ungrounded_findings | n/a | False | 160 | 160 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 5 | 0 | 18 | 195.041 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | bare | 1 | ran | n/a | False | -80 | -80 | 0 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 58.908 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | bare | 2 | ran | n/a | False | -80 | -80 | 0 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 44.297 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | bare | 3 | ran | n/a | False | -80 | -80 | 0 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 19.459 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | tooled | 1 | ungrounded_findings | n/a | False | 170 | 170 | 1 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 1 | 0 | 3 | 151.618 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | tooled | 2 | ungrounded_findings | n/a | False | 0 | 0 | 2 | 1/1 low-N | 2/2 low-N | 2/6 low-N | 5 | 0 | 3 | 149.661 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | ahatanhel-krymskyi | tooled | 3 | ungrounded_findings | n/a | False | 0 | 0 | 2 | 1/1 low-N | 2/2 low-N | 2/6 low-N | 8 | 0 | 2 | 90.749 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | bare | 1 | ran | n/a | False | -240 | -240 | 2 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 39.716 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | bare | 2 | ran | n/a | False | -240 | -240 | 2 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 19.949 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | bare | 3 | ran | n/a | False | -150 | -150 | 3 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 25.217 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | tooled | 1 | ungrounded_findings | n/a | False | 90 | 90 | 0 | 1/1 low-N | 2/2 low-N | 2/6 low-N | 10 | 0 | 4 | 144.654 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | tooled | 2 | error | model_failure | False | -90 | -90 | 9 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 146.162 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | andriivski-vechornytsi | tooled | 3 | ungrounded_findings | n/a | False | 90 | 90 | 0 | 1/1 low-N | 2/2 low-N | 2/6 low-N | 5 | 0 | 3 | 93.04 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | bare | 1 | ran | n/a | False | 20 | 20 | 2 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 52.292 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | bare | 2 | ran | n/a | False | 20 | 20 | 2 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 14.935 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | bare | 3 | ran | n/a | False | 20 | 20 | 2 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 19.517 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | tooled | 1 | ran | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 4 | 75.727 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | tooled | 2 | ran | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 9 | 142.227 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | franko-ivan | tooled | 3 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 2 | 0 | 2 | 113.221 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | bare | 1 | ran | n/a | False | -40 | -40 | 2 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 64.622 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | bare | 2 | ran | n/a | False | -40 | -40 | 2 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 12.002 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | bare | 3 | ran | n/a | False | -10 | -10 | 1 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 24.207 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | tooled | 1 | ran | n/a | False | 40 | 40 | 0 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 4 | 164.897 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | tooled | 2 | ungrounded_findings | n/a | False | 150 | 150 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 1 | 0 | 4 | 98.139 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | holosinnia | tooled | 3 | ungrounded_findings | n/a | False | 10 | 10 | 1 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 1 | 0 | 4 | 81.382 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | bare | 1 | ran | n/a | False | 180 | 180 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 26.685 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | bare | 2 | ran | n/a | False | 180 | 180 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 12.683 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | bare | 3 | ran | n/a | False | 180 | 180 | 0 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 36.495 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | tooled | 1 | ungrounded_findings | n/a | False | 90 | 90 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 6 | 0 | 4 | 133.571 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | tooled | 2 | ungrounded_findings | n/a | False | -40 | -40 | 1 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 4 | 0 | 4 | 171.543 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khmelnytskyi-1648 | tooled | 3 | ungrounded_findings | n/a | False | 70 | 70 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 10 | 0 | 2 | 115.16 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | bare | 1 | ran | n/a | False | 10 | 10 | 2 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 17.301 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | bare | 2 | ran | n/a | False | -50 | -50 | 0 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 11.384 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | bare | 3 | ran | n/a | False | 10 | 10 | 2 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 24.353 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | tooled | 1 | ungrounded_findings | n/a | False | 170 | 170 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 10 | 0 | 3 | 62.9 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | tooled | 2 | ungrounded_findings | n/a | False | 150 | 150 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 6 | 0 | 3 | 160.118 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | khreshchennia-rusi | tooled | 3 | ungrounded_findings | n/a | False | 150 | 150 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 4 | 0 | 3 | 124.73 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | bare | 1 | ran | n/a | False | -50 | -50 | 2 | 0/1 low-N | 1/2 low-N | 2/6 low-N | 0 | 0 | 0 | 23.972 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | bare | 2 | ran | n/a | False | -20 | -20 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 12.512 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | bare | 3 | ran | n/a | False | -20 | -20 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 88.123 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | tooled | 1 | ungrounded_findings | n/a | False | 120 | 120 | 0 | 1/1 low-N | 2/2 low-N | 1/6 low-N | 4 | 0 | 5 | 205.862 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | tooled | 2 | ungrounded_findings | n/a | False | 140 | 140 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 3 | 0 | 7 | 156.668 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | koliadky | tooled | 3 | ungrounded_findings | n/a | False | 60 | 60 | 2 | 1/1 low-N | 2/2 low-N | 1/6 low-N | 10 | 0 | 4 | 107.197 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | bare | 1 | ran | n/a | False | -20 | -20 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 33.474 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | bare | 2 | ran | n/a | False | 80 | 80 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 12.039 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | bare | 3 | ran | n/a | False | -20 | -20 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 60.936 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | tooled | 1 | ungrounded_findings | n/a | False | 30 | 30 | 1 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 3 | 0 | 5 | 45.282 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | tooled | 2 | ungrounded_findings | n/a | False | 0 | 0 | 0 | 1/1 low-N | 0/2 low-N | 1/6 low-N | 7 | 0 | 6 | 31.066 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | kupalski | tooled | 3 | ungrounded_findings | n/a | False | 30 | 30 | 1 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 1 | 0 | 8 | 348.372 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | bare | 1 | ran | n/a | False | -80 | -80 | 0 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 10.571 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | bare | 2 | ran | n/a | False | -10 | -10 | 0 | 0/1 low-N | 0/2 low-N | 1/6 low-N | 0 | 0 | 0 | 24.225 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | bare | 3 | ran | n/a | False | 20 | 20 | 0 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 49.886 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | tooled | 1 | ungrounded_findings | n/a | False | 40 | 40 | 0 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 4 | 0 | 7 | 37.6 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | tooled | 2 | ungrounded_findings | n/a | False | 170 | 170 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 5 | 0 | 8 | 267.699 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | lesya-ukrainka | tooled | 3 | ungrounded_findings | n/a | False | 40 | 40 | 0 | 1/1 low-N | 1/2 low-N | 0/6 low-N | 1 | 0 | 3 | 165.464 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | bare | 1 | ran | n/a | False | 10 | 10 | 1 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 58.225 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | bare | 2 | ran | n/a | False | -20 | -20 | 2 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 27.149 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | bare | 3 | ran | n/a | False | 110 | 110 | 1 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 28.705 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | tooled | 1 | ungrounded_findings | n/a | False | 150 | 150 | 1 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 3 | 0 | 3 | 135.187 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | tooled | 2 | ungrounded_findings | n/a | False | 150 | 150 | 1 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 4 | 0 | 6 | 156.042 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalii | tooled | 3 | ungrounded_findings | n/a | False | 170 | 170 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 8 | 0 | 4 | 126.082 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | bare | 1 | ran | n/a | False | 140 | 140 | 2 | 0/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 0 | 75.803 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | bare | 2 | ran | n/a | False | 10 | 10 | 2 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 30.977 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | bare | 3 | ran | n/a | False | 100 | 100 | 3 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 35.65 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | tooled | 1 | ungrounded_findings | n/a | False | 60 | 60 | 0 | 1/1 low-N | 2/2 low-N | 3/6 low-N | 4 | 0 | 5 | 386.255 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | tooled | 2 | ungrounded_findings | n/a | False | 160 | 160 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 12 | 0 | 3 | 105.677 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | rusalka-dnistrova | tooled | 3 | ungrounded_findings | n/a | False | 160 | 160 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 7 | 0 | 6 | 271.208 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | bare | 1 | ran | n/a | False | 50 | 50 | 0 | 1/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 12.038 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | bare | 2 | ran | n/a | False | -30 | -30 | 0 | 0/1 low-N | 1/2 low-N | 6/6 low-N | 0 | 0 | 0 | 26.181 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | bare | 3 | ran | n/a | False | -30 | -30 | 0 | 0/1 low-N | 1/2 low-N | 6/6 low-N | 0 | 0 | 0 | 67.707 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | tooled | 1 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 9 | 0 | 5 | 412.8 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | tooled | 2 | ungrounded_findings | n/a | False | 120 | 120 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 1 | 0 | 2 | 96.279 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | skovoroda-hryhorii | tooled | 3 | ungrounded_findings | n/a | False | 130 | 130 | 0 | 1/1 low-N | 2/2 low-N | 2/6 low-N | 5 | 0 | 4 | 21.578 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | bare | 1 | ran | n/a | False | 110 | 110 | 1 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 28.493 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | bare | 2 | ran | n/a | False | 80 | 80 | 1 | 0/1 low-N | 1/2 low-N | 2/6 low-N | 0 | 0 | 0 | 29.903 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | bare | 3 | ran | n/a | False | 120 | 120 | 0 | 0/1 low-N | 1/2 low-N | 1/6 low-N | 0 | 0 | 0 | 27.591 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | tooled | 1 | ungrounded_findings | n/a | False | 90 | 90 | 1 | 1/1 low-N | 2/2 low-N | 1/6 low-N | 10 | 0 | 4 | 73.54 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | tooled | 2 | ungrounded_findings | n/a | False | 10 | 10 | 0 | 1/1 low-N | 1/2 low-N | 1/6 low-N | 7 | 0 | 8 | 123.622 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesilnyi-obriad | tooled | 3 | ungrounded_findings | n/a | False | 110 | 110 | 2 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 6 | 0 | 6 | 161.617 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | bare | 1 | ran | n/a | False | -50 | -50 | 3 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 18.964 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | bare | 2 | ran | n/a | False | -80 | -80 | 4 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 22.709 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | bare | 3 | ran | n/a | False | -50 | -50 | 3 | 0/1 low-N | 0/1 low-N | 0/6 low-N | 0 | 0 | 0 | 64.28 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | tooled | 1 | ungrounded_findings | n/a | False | 30 | 30 | 4 | 1/1 low-N | 0/1 low-N | 0/6 low-N | 1 | 0 | 4 | 93.959 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | tooled | 2 | ungrounded_findings | n/a | False | 30 | 30 | 4 | 1/1 low-N | 0/1 low-N | 0/6 low-N | 2 | 0 | 4 | 87.109 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | vesnianky | tooled | 3 | ungrounded_findings | n/a | False | 60 | 60 | 3 | 1/1 low-N | 0/1 low-N | 0/6 low-N | 1 | 0 | 4 | 160.017 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | bare | 1 | ran | n/a | False | 110 | 110 | 2 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 70.15 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | bare | 2 | ran | n/a | False | 110 | 110 | 2 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 6.552 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | bare | 3 | ran | n/a | False | 150 | 150 | 0 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 57.667 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | tooled | 1 | ungrounded_findings | n/a | False | 160 | 160 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 1 | 0 | 4 | 91.31 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | tooled | 2 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 12 | 0 | 3 | 160.7 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | yaroslav-sofiya | tooled | 3 | ungrounded_findings | n/a | False | 190 | 190 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 1 | 0 | 5 | 39.633 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | bare | 1 | ran | n/a | False | 10 | 10 | 1 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 25.336 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | bare | 2 | ran | n/a | False | 40 | 40 | 1 | 0/1 low-N | 1/2 low-N | 0/6 low-N | 0 | 0 | 0 | 37.37 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | bare | 3 | ran | n/a | False | -90 | -90 | 1 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 50.327 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | tooled | 1 | ungrounded_findings | n/a | True | 130 | 130 | 2 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 8 | 0 | 3 | 74.013 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | tooled | 2 | ran | n/a | False | 100 | 100 | 3 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 0 | 0 | 3 | 135.166 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zaporozka-sich | tooled | 3 | ungrounded_findings | n/a | False | 140 | 140 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 1 | 0 | 4 | 124.036 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | bare | 1 | ran | n/a | False | 80 | 80 | 2 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 40.905 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | bare | 2 | ran | n/a | False | 70 | 70 | 3 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 27.583 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | bare | 3 | ran | n/a | False | 20 | 20 | 0 | 0/1 low-N | 0/2 low-N | 0/6 low-N | 0 | 0 | 0 | 30.027 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | tooled | 1 | ungrounded_findings | n/a | False | 120 | 120 | 1 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 7 | 0 | 7 | 259.016 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | tooled | 2 | ungrounded_findings | n/a | False | 150 | 150 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 9 | 0 | 4 | 65.084 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | opencode | qg_bakeoff_opencode | zhnyvarski | tooled | 3 | ungrounded_findings | n/a | False | 150 | 150 | 0 | 1/1 low-N | 2/2 low-N | 0/6 low-N | 6 | 0 | 4 | 77.377 |
+
+## Totals With Anchor
+
+| model | arm | runs | passages/run | model judgment | live admissible | U honesty | M alignment headline | true unsupported | missing | invalid | inadmissible | tools | wall_s |
+| --- | --- | ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | bare | 3 | 17/17/17 | 886.667 ± 285.365 [670..1210] | 886.667 ± 285.365 [670..1210] | 0.059 ± 0 [0.059..0.059] | 0.444 ± 0.087 [0.394..0.545] | 0.088 ± 0.026 [0.069..0.118] | 29 ± 4.359 [24..32] | 0 ± 0 [0..0] | 0 ± 0 [0..0] | 0.667 ± 0.577 [0..1] | 696.492 ± 68.852 [630.754..768.084] |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | tooled | 3 | 17/17/17 | 1083.333 ± 500.033 [580..1580] | 1073.333 ± 485.215 [580..1550] | 0.549 ± 0.09 [0.471..0.647] | 0.646 ± 0.087 [0.545..0.697] | 0.003 ± 0.006 [0..0.01] | 62.667 ± 15.503 [47..78] | 88.667 ± 4.933 [83..92] | 0.333 ± 0.577 [0..1] | 341.667 ± 20.429 [327..365] | 4265.392 ± 1172.029 [3368.199..5591.449] |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | bare | 3 | 17/17/17 | 1360 ± 147.986 [1260..1530] | 1360 ± 147.986 [1260..1530] | 0.078 ± 0.068 [0..0.118] | 0.576 ± 0.08 [0.515..0.667] | 0.092 ± 0.05 [0.049..0.147] | 21.333 ± 2.309 [20..24] | 0 ± 0 [0..0] | 0 ± 0 [0..0] | 0 ± 0 [0..0] | 1253.348 ± 73.344 [1191.721..1334.469] |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | tooled | 3 | 17/17/17 | 1796.667 ± 312.143 [1440..2020] | 1786.667 ± 301.717 [1440..1990] | 0.784 ± 0.122 [0.647..0.882] | 0.788 ± 0.08 [0.697..0.848] | 0.007 ± 0.006 [0..0.01] | 38 ± 4 [34..42] | 87 ± 12.767 [73..98] | 0.667 ± 1.155 [0..2] | 230 ± 26.627 [205..258] | 4166.055 ± 478.445 [3627.122..4540.753] |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | bare | 3 | 17/17/17 | 153.333 ± 130.128 [20..280] | 153.333 ± 130.128 [20..280] | 0.078 ± 0.034 [0.059..0.118] | 0.354 ± 0.017 [0.333..0.364] | 0.092 ± 0.03 [0.059..0.118] | 23 ± 2.646 [20..25] | 0 ± 0 [0..0] | 0 ± 0 [0..0] | 0 ± 0 [0..0] | 580.017 ± 181.679 [372.45..710.147] |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | tooled | 3 | 17/17/17 | 1733.333 ± 145.717 [1580..1870] | 1733.333 ± 145.717 [1580..1870] | 0.922 ± 0.068 [0.882..1] | 0.848 ± 0.052 [0.788..0.879] | 0.059 ± 0.017 [0.039..0.069] | 16.333 ± 4.933 [13..22] | 78.667 ± 2.082 [77..81] | 0 ± 0 [0..0] | 73 ± 4.583 [68..77] | 2340.672 ± 180.432 [2220.863..2548.191] |
+
+## Harness Lift With Anchor
+
+Lift = tooled model judgment mean − bare model judgment mean (positive = the harness helps),
+over PAIRED passages only. For repeat runs each arm is averaged within a passage first;
+run indexes are not paired across arms. Ranges are across paired passage lifts.
+Observed run ceiling: 3.
+
+| model | paired passages | run coverage | tooled model judgment | bare model judgment | harness_lift | tooled M alignment | bare M alignment |
+| --- | ---: | --- | --- | --- | --- | --- | --- |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | 17 | 3..3/3 | 63.725 ± 63.758 [-50..176.667] | 52.157 ± 70.838 [-136.667..170] | 11.569 ± 81.532 [-96.667..180] | 0.627 ± 0.336 [0..1] low-N | 0.431 ± 0.283 [0..0.833] low-N |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | 17 | 3..3/3 | 105.686 ± 61.585 [-36.667..180] | 80 ± 72.159 [-43.333..160] | 25.686 ± 81.792 [-110..150] | 0.765 ± 0.257 [0..1] low-N | 0.559 ± 0.328 [0..1] low-N |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | 17 | 3..3/3 | 101.961 ± 55.114 [20..190] | 9.02 ± 88.559 [-210..180] | 92.941 ± 88.277 [-140..240] | 0.824 ± 0.285 [0..1] low-N | 0.343 ± 0.303 [0..1] low-N |
+
+## Totals Without Anchor
+
+| model | arm | runs | passages/run | model judgment | live admissible | U honesty | M alignment headline | true unsupported | missing | invalid | inadmissible | tools | wall_s |
+| --- | --- | ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | bare | 3 | 16/16/16 | 896.667 ± 313.9 [650..1250] | 896.667 ± 313.9 [650..1250] | 0.062 ± 0 [0.062..0.062] | 0.458 ± 0.09 [0.406..0.562] | 0.09 ± 0.03 [0.073..0.125] | 25.667 ± 2.082 [24..28] | 0 ± 0 [0..0] | 0 ± 0 [0..0] | 0.667 ± 0.577 [0..1] | 671.316 ± 74.434 [600.105..748.6] |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | tooled | 3 | 16/16/16 | 1076.667 ± 495.008 [580..1570] | 1066.667 ± 480.139 [580..1540] | 0.562 ± 0.108 [0.5..0.688] | 0.667 ± 0.09 [0.562..0.719] | 0.003 ± 0.006 [0..0.01] | 57.667 ± 15.503 [42..73] | 83.333 ± 7.234 [75..88] | 0.333 ± 0.577 [0..1] | 321.333 ± 16.289 [310..340] | 4145.953 ± 1136.959 [3257.352..5427.193] |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | bare | 3 | 16/16/16 | 1403.333 ± 151.767 [1240..1540] | 1403.333 ± 151.767 [1240..1540] | 0.083 ± 0.072 [0..0.125] | 0.594 ± 0.083 [0.531..0.688] | 0.094 ± 0.048 [0.052..0.146] | 16.667 ± 1.528 [15..18] | 0 ± 0 [0..0] | 0 ± 0 [0..0] | 0 ± 0 [0..0] | 1186.903 ± 69.72 [1115.61..1254.935] |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | tooled | 3 | 16/16/16 | 1833.333 ± 314.696 [1470..2020] | 1823.333 ± 306.159 [1470..2010] | 0.792 ± 0.144 [0.625..0.875] | 0.812 ± 0.083 [0.719..0.875] | 0.007 ± 0.006 [0..0.01] | 33 ± 6.083 [29..40] | 83.333 ± 15.144 [66..94] | 0.667 ± 1.155 [0..2] | 222.333 ± 22.679 [205..248] | 3999.01 ± 482.374 [3463.067..4398.352] |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | bare | 3 | 16/16/16 | 213.333 ± 115.036 [100..330] | 213.333 ± 115.036 [100..330] | 0.083 ± 0.036 [0.062..0.125] | 0.365 ± 0.018 [0.344..0.375] | 0.097 ± 0.032 [0.062..0.125] | 19.667 ± 2.309 [17..21] | 0 ± 0 [0..0] | 0 ± 0 [0..0] | 0 ± 0 [0..0] | 544.7 ± 168.879 [349.741..645.867] |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | tooled | 3 | 16/16/16 | 1693.333 ± 145.029 [1550..1840] | 1693.333 ± 145.029 [1550..1840] | 0.917 ± 0.072 [0.875..1] | 0.875 ± 0.054 [0.812..0.906] | 0.062 ± 0.018 [0.042..0.073] | 12.667 ± 4.726 [9..18] | 77.333 ± 2.309 [76..80] | 0 ± 0 [0..0] | 69 ± 4.583 [64..73] | 2226.977 ± 203.692 [2060.846..2454.232] |
+
+## Harness Lift Without Anchor
+
+Lift = tooled model judgment mean − bare model judgment mean (positive = the harness helps),
+over PAIRED passages only. For repeat runs each arm is averaged within a passage first;
+run indexes are not paired across arms. Ranges are across paired passage lifts.
+Observed run ceiling: 3.
+
+| model | paired passages | run coverage | tooled model judgment | bare model judgment | harness_lift | tooled M alignment | bare M alignment |
+| --- | ---: | --- | --- | --- | --- | --- | --- |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | 16 | 3..3/3 | 67.292 ± 64.074 [-50..176.667] | 56.042 ± 71.266 [-136.667..170] | 11.25 ± 84.194 [-96.667..180] | 0.667 ± 0.304 [0..1] low-N | 0.458 ± 0.269 [0..0.833] low-N |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | 16 | 3..3/3 | 114.583 ± 51.09 [23.333..180] | 87.708 ± 66.908 [-40..160] | 26.875 ± 84.323 [-110..150] | 0.812 ± 0.171 [0.5..1] low-N | 0.594 ± 0.304 [0.167..1] low-N |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | 16 | 3..3/3 | 105.833 ± 54.481 [20..190] | 13.333 ± 89.6 [-210..180] | 92.5 ± 91.153 [-140..240] | 0.875 ± 0.197 [0.333..1] low-N | 0.365 ± 0.299 [0..1] low-N |
+
+## Run Variance
+
+Run-level fractions are computed inside each run before mean/sd/range summaries; pooled numerators are not used.
+Cells whose `response_parse_lenient` flag differs across runs are flagged because parser leniency can inflate apparent class instability.
+Partial cells are excluded from arm-level stability. Error cells are flagged separately and never counted stable.
+
+### Per-Run Totals
+
+| model | arm | run | passages | errors | model judgment | live admissible | missing | U honesty | M alignment |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | bare | 1 | 17 | 0 | 670 | 670 | 32 | 1/17 | 13/33 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | bare | 2 | 17 | 0 | 1210 | 1210 | 31 | 1/17 | 18/33 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | bare | 3 | 17 | 0 | 780 | 780 | 24 | 1/17 | 13/33 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | tooled | 1 | 17 | 1 | 1090 | 1090 | 63 | 8/17 | 23/33 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | tooled | 2 | 17 | 2 | 1580 | 1550 | 47 | 11/17 | 23/33 |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | tooled | 3 | 17 | 2 | 580 | 580 | 78 | 9/17 | 18/33 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | bare | 1 | 17 | 0 | 1260 | 1260 | 20 | 0/17 | 18/33 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | bare | 2 | 17 | 0 | 1530 | 1530 | 20 | 2/17 | 22/33 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | bare | 3 | 17 | 0 | 1290 | 1290 | 24 | 2/17 | 17/33 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | tooled | 1 | 17 | 1 | 1440 | 1440 | 42 | 11/17 | 23/33 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | tooled | 2 | 17 | 2 | 1930 | 1930 | 38 | 14/17 | 28/33 |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | tooled | 3 | 17 | 0 | 2020 | 1990 | 34 | 15/17 | 27/33 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | bare | 1 | 17 | 0 | 160 | 160 | 24 | 2/17 | 12/33 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | bare | 2 | 17 | 0 | 20 | 20 | 25 | 1/17 | 12/33 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | bare | 3 | 17 | 0 | 280 | 280 | 20 | 1/17 | 11/33 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | tooled | 1 | 17 | 0 | 1870 | 1870 | 13 | 15/17 | 29/33 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | tooled | 2 | 17 | 1 | 1580 | 1580 | 22 | 15/17 | 26/33 |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | tooled | 3 | 17 | 0 | 1750 | 1750 | 14 | 17/17 | 29/33 |
+
+### Stability
+
+| model | arm | complete cells | partial cells | error cells | parse-lenient variance cells | stability |
+| --- | --- | ---: | ---: | ---: | ---: | --- |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | bare | 17 | 0 | 0 | 0 | 0.623 ± 0.216 [0.222..1] |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | tooled | 13 | 0 | 4 | 2 | 0.355 ± 0.281 [0..0.889] |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | bare | 17 | 0 | 0 | 0 | 0.671 ± 0.139 [0.333..0.889] |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | tooled | 14 | 0 | 3 | 2 | 0.54 ± 0.334 [0..0.889] |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | bare | 17 | 0 | 0 | 0 | 0.842 ± 0.162 [0.333..1] |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | tooled | 16 | 0 | 1 | 1 | 0.77 ± 0.183 [0.333..1] |
+
+### Flagged Cells
+
+| model | passage | arm | runs present | flags |
+| --- | --- | --- | --- | --- |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | ahatanhel-krymskyi | tooled | 1,2,3 | parse-lenient-variance |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | franko-ivan | tooled | 1,2,3 | error |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | koliadky | tooled | 1,2,3 | error |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | rusalii | tooled | 1,2,3 | error |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | skovoroda-hryhorii | tooled | 1,2,3 | error |
+| openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | vesnianky | tooled | 1,2,3 | parse-lenient-variance |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | ahatanhel-krymskyi | tooled | 1,2,3 | parse-lenient-variance |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | skovoroda-hryhorii | tooled | 1,2,3 | error |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | vesilnyi-obriad | tooled | 1,2,3 | parse-lenient-variance |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | vesnianky | tooled | 1,2,3 | error |
+| openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | zaporozka-sich | tooled | 1,2,3 | error |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | andriivski-vechornytsi | tooled | 1,2,3 | error |
+| openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | zaporozka-sich | tooled | 1,2,3 | parse-lenient-variance |
+
+## Domain Totals
+
+| domain | model | arm | runs | passages/run | model judgment | U honesty | M alignment headline | harness_lift |
+| --- | --- | --- | ---: | --- | --- | --- | --- | --- |
+| bio | openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | bare | 3 | 4/4/4 | 253.333 ± 37.859 [210..280] | 0 ± 0 [0..0] low-N | 0.375 ± 0 [0.375..0.375] low-N | 6.667 ± 44.472 [-60..30] |
+| bio | openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | tooled | 3 | 4/4/4 | 280 ± 185.203 [90..460] | 0.5 ± 0 [0.5..0.5] low-N | 0.625 ± 0.125 [0.5..0.75] low-N | 6.667 ± 44.472 [-60..30] |
+| bio | openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | bare | 3 | 4/4/4 | 390 ± 185.203 [200..570] | 0.167 ± 0.289 [0..0.5] low-N | 0.458 ± 0.191 [0.25..0.625] low-N | 30.833 ± 62.974 [-26.667..93.333] |
+| bio | openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | tooled | 3 | 4/4/4 | 513.333 ± 198.578 [370..740] | 0.75 ± 0.25 [0.5..1] low-N | 0.792 ± 0.191 [0.625..1] low-N | 30.833 ± 62.974 [-26.667..93.333] |
+| bio | openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | bare | 3 | 4/4/4 | -86.667 ± 15.275 [-100..-70] | 0.333 ± 0.144 [0.25..0.5] low-N | 0.25 ± 0 [0.25..0.25] low-N | 140.833 ± 26.58 [106.667..170] |
+| bio | openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | tooled | 3 | 4/4/4 | 476.667 ± 115.036 [360..590] | 0.917 ± 0.144 [0.75..1] low-N | 0.917 ± 0.072 [0.875..1] low-N | 140.833 ± 26.58 [106.667..170] |
+| folk | openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | bare | 3 | 8/8/8 | 166.667 ± 133.167 [80..320] | 0.083 ± 0.072 [0..0.125] low-N | 0.378 ± 0.077 [0.333..0.467] | 31.667 ± 95.236 [-96.667..180] |
+| folk | openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | tooled | 3 | 8/8/8 | 420 ± 374.7 [0..720] | 0.542 ± 0.072 [0.5..0.625] low-N | 0.6 ± 0.115 [0.467..0.667] | 31.667 ± 95.236 [-96.667..180] |
+| folk | openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | bare | 3 | 8/8/8 | 326.667 ± 170.392 [130..430] | 0 ± 0 [0..0] low-N | 0.422 ± 0.102 [0.333..0.533] | 52.5 ± 75.145 [-86.667..150] |
+| folk | openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | tooled | 3 | 8/8/8 | 746.667 ± 145.717 [630..910] | 0.75 ± 0.125 [0.625..0.875] low-N | 0.733 ± 0.176 [0.533..0.867] | 52.5 ± 75.145 [-86.667..150] |
+| folk | openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | bare | 3 | 8/8/8 | -123.333 ± 107.858 [-200..0] | 0 ± 0 [0..0] low-N | 0.267 ± 0 [0.267..0.267] | 94.167 ± 82.803 [-33.333..240] |
+| folk | openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | tooled | 3 | 8/8/8 | 630 ± 78.102 [540..680] | 0.875 ± 0.125 [0.75..1] low-N | 0.733 ± 0.115 [0.6..0.8] | 94.167 ± 82.803 [-33.333..240] |
+| history | openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | bare | 3 | 5/5/5 | 466.667 ± 166.233 [290..620] | 0.067 ± 0.115 [0..0.2] low-N | 0.6 ± 0.173 [0.5..0.8] | -16.667 ± 86.056 [-90..96.667] |
+| history | openrouter/deepseek/deepseek-v4-flash [opencode/qg_bakeoff_opencode] | tooled | 3 | 5/5/5 | 383.333 ± 349.476 [90..770] | 0.6 ± 0.4 [0.2..1] low-N | 0.733 ± 0.153 [0.6..0.9] | -16.667 ± 86.056 [-90..96.667] |
+| history | openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | bare | 3 | 5/5/5 | 643.333 ± 61.101 [590..710] | 0.133 ± 0.231 [0..0.4] low-N | 0.9 ± 0.1 [0.8..1] | -21.333 ± 98.364 [-110..123.333] |
+| history | openrouter/deepseek/deepseek-v4-pro [opencode/qg_bakeoff_opencode] | tooled | 3 | 5/5/5 | 536.667 ± 126.623 [440..680] | 0.867 ± 0.115 [0.8..1] low-N | 0.867 ± 0.115 [0.8..1] | -21.333 ± 98.364 [-110..123.333] |
+| history | openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | bare | 3 | 5/5/5 | 363.333 ± 80.829 [290..450] | 0 ± 0 [0..0] low-N | 0.567 ± 0.058 [0.5..0.6] | 52.667 ± 119.662 [-140..166.667] |
+| history | openrouter/google/gemma-4-31b-it [opencode/qg_bakeoff_opencode] | tooled | 3 | 5/5/5 | 626.667 ± 76.376 [560..710] | 1 ± 0 [1..1] low-N | 0.967 ± 0.058 [0.9..1] | 52.667 ± 119.662 [-140..166.667] |


### PR DESCRIPTION
Commits the first multi-run scorecard (Run Variance + Domain Totals live) so the primary checkout is clean and dispatch guards unblock. Interim: morning analysis may regenerate it (versioned evidence either way). Data-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)