### PR TITLE
fix(practice): #4719 heritage availability floor wins over level-local placement

### DIFF
--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -1729,9 +1729,19 @@ def _build_heritage_items(
     if not frames:
         return []
     # Heritage SRS identity is the native lemma, and the static client reaches
-    # drill items through the same-level index/lexeme shards. Emit the item in
-    # the native lexeme's CEFR shard so every heritage card is reachable.
-    level = _normalize_cefr(lexeme.get("cefr")) or _heritage_availability_level(pair)
+    # drill items through the same-level index/lexeme shards — so the item must
+    # sit AT OR ABOVE the lexeme's shard (cumulative loading pulls lower-level
+    # lexeme shards in, keeping the join resolvable). But the curator
+    # availability floor (§9.5, agy-reviewed: B1+ default, A2 only by curator
+    # flag) is a hard pedagogy gate — level-local placement must never drop
+    # BELOW it (#4719: b1-flagged calque drills were served at A1).
+    lexeme_level = _normalize_cefr(lexeme.get("cefr"))
+    floor = _heritage_availability_level(pair)
+    level = max(
+        (lvl for lvl in (lexeme_level, floor) if lvl),
+        key=lambda lvl: CEFR_RANK[lvl],
+        default=floor,
+    )
     items: list[dict[str, Any]] = []
     for index, frame in enumerate(frames, start=1):
         answer_form = _clean_text(frame.get("answer_form"))
@@ -2240,7 +2250,13 @@ def build_practice_shards(
                 )
                 continue
             mode_by_level[level]["heritage"].append(public_item)
-            mode_lemma_ids[level]["heritage"].add(native_lexeme["lemmaId"])
+            # Tag the heritage mode on the NATIVE LEXEME's own index entry (its
+            # shard), not the item's floor level — index entries only exist at
+            # the lexeme's level. A learner below the floor loads the tag but
+            # not the item shard; the client skips missing items (same pattern
+            # as stress/classify). At/above the floor, cumulative loading has
+            # both → reachable AND pedagogy-gated (#4719).
+            mode_lemma_ids[native_lexeme["cefr"]]["heritage"].add(native_lexeme["lemmaId"])
     if heritage_frame_debt:
         print(
             f"heritage frame coverage: {heritage_frame_debt} records without frames — emitted 0 items for them",

--- a/tests/test_generate_practice_deck.py
+++ b/tests/test_generate_practice_deck.py
@@ -324,7 +324,7 @@ def test_heritage_items_wire_mode_counts_and_index_modes() -> None:
     assert "heritage" in index_item["modes"]
 
 
-def test_heritage_items_follow_native_cefr_when_availability_differs() -> None:
+def test_heritage_availability_floor_wins_over_native_cefr() -> None:
     entries = json.loads(json.dumps(read_manifest(MANIFEST)))
     for entry in entries:
         entry["enrichment"]["cefr"]["level"] = "A2"
@@ -349,9 +349,15 @@ def test_heritage_items_follow_native_cefr_when_availability_differs() -> None:
     b1_heritage = shards["B1"]["heritage"]["heritage"]
     index_item = next(item for item in a2["index"]["items"] if item["lemmaId"] == "knyha")
 
-    assert len(a2_heritage) == 1
-    assert a2_heritage[0]["lemmaId"] == "knyha"
-    assert not any(item["lemmaId"] == "knyha" for item in b1_heritage)
+    # #4719: the curator availability floor (b1) WINS over the native lexeme's
+    # level (A2) for ITEM placement — B1-flagged calque drills must never reach
+    # learners below the floor. Reachability is preserved via the index-mode
+    # tag on the lexeme's own (A2) entry: at/above the floor, cumulative
+    # loading has both the tag and the B1 item shard.
+    assert a2_heritage == []
+    assert len(b1_heritage) == 1
+    assert b1_heritage[0]["lemmaId"] == "knyha"
+    assert b1_heritage[0]["cefr"] == "B1"
     assert "heritage" in index_item["modes"]
 
 


### PR DESCRIPTION
Fixes #4719. `dcd510cb6d` (direct-to-main) fixed REAL heritage reachability but replaced the §9.5 curator availability floor — the live asset serves 50 b1-flagged calque drills at A1 (evidence on the issue).

**Fix keeps both properties:**
- Item placement: `max(native lexeme cefr, availability floor)` — pedagogy gate restored, level-locality kept where it's above the floor
- Index `heritage` mode tag → the lexeme's OWN index entry: below the floor the client loads the tag but not the item shard and skips (stress/classify pattern); at/above it, cumulative loading resolves the join

**Evidence:** `pytest tests/test_generate_practice_deck.py` → `41 passed` (incl. the rewritten `test_heritage_availability_floor_wins_over_native_cefr`); real regen: `A1=0 A2=34 B1=76 B2=16` (126 items preserved), scripted floor check → `floor violations: 0`.

Post-merge: deck republish + pointer PR (new version via the #4660 all-inputs fingerprint — no clobber). Refs #4700 wave 1, spec §9.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)