### PR TITLE
fix(tests): update ORPHAN_PATHS_CODEX pin for settings.local.json preserved orphan

### DIFF
--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -234,7 +234,7 @@ def test_codex_hooks_json_is_managed_source_not_orphan() -> None:
     assert (REPO_ROOT / "agents_extensions" / "codex" / "hooks.json").exists()
     assert (
         'ORPHAN_PATHS_CODEX="agents/curriculum-orchestrator.toml '
-        'agents/curriculum-writer.toml config.toml"'
+        'agents/curriculum-writer.toml config.toml settings.local.json"'
     ) in shared
     assert 'CODEX_OVERLAY_PATHS="hooks.json memory"' in shared
     assert "$CODEX_OVERLAY_PATHS" in check


### PR DESCRIPTION
Main is red on `test_codex_hooks_json_is_managed_source_not_orphan` since 6678f42743 (#4721): the PR added `settings.local.json` to `ORPHAN_PATHS_CODEX` in `scripts/deploy_orphan_paths.sh` but missed this pinned assertion. Pre-commit didn't catch it (shell-file change → no .py trigger) and CI's path filter skipped pytest for that diff — the exact `pytest | tail` burn documented in the 2026-07-07 handoff.

**Fix:** pin now matches the user-ordered post-#4717/#4721 state (script is correct; test was stale). `tests/test_deploy_script_idempotency.py` 11/11 green locally, ruff clean.

Refs #4721, #4717

🤖 Generated with [Claude Code](https://claude.com/claude-code)