### PR TITLE
docs(workflow): #4703 propagate auto-merge-at-gate-pass + out-of-lane >1h pickup threshold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,6 +305,20 @@ branch/worktree needs cleanup. If a PR remains open, the final response must say
 exactly why and what action is required. Leaving PRs in review hell wastes CI,
 agent, and human attention.
 
+**Arm auto-merge at review-gate-pass (#4703, user directive 2026-07-07).** The repo
+setting `allow_auto_merge` is enabled. The moment a PR's review gate passes
+(cross-family review evidence, no requested changes), the responsible
+orchestrator/reviewer runs `gh pr merge <N> --auto --squash --delete-branch` —
+GitHub merges when CI settles, nobody babysits. Dispatched agents do NOT
+self-enable auto-merge (the review gate comes first — unchanged). `--auto` waits
+for green and never bypasses blocking checks.
+
+**Out-of-lane pickup threshold (user directive 2026-07-07).** A PR belonging to
+another lane/track is hands-off for every other orchestrator — no shepherding,
+review-routing, or auto-merge arming — unless it has sat GREEN (CI passing +
+review gate passed) idle for MORE THAN 1 HOUR. Only then does the orchestrator
+sweep backstop pick it up. Fresh out-of-lane PRs belong to their lane.
+
 ---
 
 ## Economical Multi-Agent Delegation

--- a/agents_extensions/shared/rules/workflow.md
+++ b/agents_extensions/shared/rules/workflow.md
@@ -53,8 +53,10 @@ hours). Every lane: the moment a PR's review gate passes (cross-family review ev
 requested changes), run `gh pr merge <N> --auto --squash --delete-branch` — GitHub merges it
 when CI settles, nobody babysits. Dispatched agents still do NOT self-enable auto-merge
 (review gate first — unchanged). `--auto` waits for green and never bypasses blocking checks
-(#M-0.5 semantics unchanged). Orchestrator session sweeps remain the backstop for anything
-green+reviewed+idle.
+(#M-0.5 semantics unchanged). Orchestrator session sweeps remain the backstop — but ONLY for
+out-of-lane PRs that have sat green (CI passing + review gate passed) idle for MORE THAN
+1 HOUR (user directive 2026-07-07): a fresh PR belongs to its lane. Do not shepherd,
+review-route, or arm auto-merge on another lane's PR before that threshold.
 
 ## Two-tier handoffs (epic #1865 item #1, shipped 2026-05-11)
 

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -70,12 +70,16 @@ does not micromanage that track.
 | State | `docs/session-state/codex-orchestrator-handoff.md` and router | Track handoff (gitignored local), e.g. `.claude/bio-epic/CLAUDE-DRIVER-HANDOFF.md` — not in git/PRs |
 | Work selection | Repo-wide priorities, A1 spine, tooling, infra, tech debt, issues | Track backlog, batches, reviews, content quality |
 | Agent dispatch | Cross-track/tooling agents | Track-local writers/reviewers, including headless Codex |
-| Merge authority | Final reconcile and merge decision | Open PRs and route track feedback, never merge |
+| Merge authority | Final reconcile on cross-track/contested merges; sweep backstop for out-of-lane PRs sitting green >1h (#4703) | Open PRs, route track feedback; self-merge own-track PRs after cross-family review + green CI (#M-12 grant, user 2026-06-16); arm `gh pr merge --auto --squash --delete-branch` at review-gate-pass |
 
 **Boundary rule:** if a track orchestrator exists, the main orchestrator treats
 that track's PRs and delegates as awareness-only unless the track orchestrator
 asks for help. This keeps one owner per workstream and prevents duplicate
-triage.
+triage. The only exception is the merge-sweep backstop (user directive
+2026-07-07, #4703): an out-of-lane PR that has sat GREEN (CI passing + review
+gate passed) idle for more than 1 hour may be picked up by any orchestrator
+sweep. Fresh out-of-lane PRs are hands-off — do not shepherd, review-route, or
+arm auto-merge on them before that threshold.
 
 ### Track ↔ main communication protocol
 


### PR DESCRIPTION
Completes the propagation scope of #4703 and encodes today's user directive on out-of-lane PR handling.

- **AGENTS.md §14 (Do Not Leave PRs In Limbo):** arm `gh pr merge --auto --squash --delete-branch` the moment the review gate passes (cross-family review evidence, no requested changes). Dispatched agents still do NOT self-enable auto-merge. `--auto` waits for green, never bypasses blocking checks.
- **NEW — out-of-lane pickup threshold (user 2026-07-07):** a PR in another lane is hands-off unless it has sat GREEN (CI + review gate passed) idle for >1 hour; only then does the orchestrator sweep backstop pick it up.
- **served workflow.md § Merge policy:** backstop sentence scoped to the >1h threshold (core section already shipped by a prior lane).
- **agent-cooperation.md:** merge-authority row updated to the #M-12 self-merge grant (user 2026-06-16) — the stale 'never merge' cell contradicted it — plus the boundary-rule exception.

Docs-only. Deploy of served-rule targets happens post-merge as usual.

Refs #4703

🤖 Generated with [Claude Code](https://claude.com/claude-code)