### PR TITLE
feat(practice): pointer bump — corrected heritage deck live

### DIFF
--- a/scripts/audit/generate_practice_deck.py
+++ b/scripts/audit/generate_practice_deck.py
@@ -30,7 +30,7 @@ if str(AUDIT_DIR) not in sys.path:
 
 from lexeme_filter import SURFACE_CLOZE, is_practice_eligible, is_surface_admitted
 
-from scripts.practice_deck.io import compute_deck_version
+from scripts.practice_deck.io import compute_deck_inputs_fingerprint, compute_deck_version
 
 DEFAULT_MANIFEST = Path("site/src/data/lexicon-manifest.json")
 DEFAULT_ATLAS_DB = Path("data/atlas.db")
@@ -1004,7 +1004,12 @@ def validate_option_sets(cloze_items: list[dict[str, Any]]) -> list[str]:
             if isinstance(option, dict) and _plain(str(option.get("label") or "")) == normalized_answer:
                 positions.append(index)
                 break
-    if len(positions) > 1 and len(set(positions)) == 1:
+    # Variance is only statistically meaningful with enough items: on tiny
+    # decks (fixtures, thin levels) 2-3 seeded placements can legitimately
+    # collide, and failing here wipes the LEVEL'S ENTIRE CLOZE with a WARN
+    # (#4722: a seed change flipped fixture tests this way). Require variance
+    # only from 4 items up, where a collision is a real anti-gaming signal.
+    if len(positions) >= 4 and len(set(positions)) == 1:
         return ["answer position must vary across the deck"]
     return []
 
@@ -2100,7 +2105,12 @@ def build_practice_shards(
         cloze_sources,
         SCHEMA_VERSION,
     )
-    rng_seed = int(hashlib.sha256(deck_version.encode("utf-8")).hexdigest()[:16], 16)
+    # Seed from the DATA-ONLY fingerprint, not deck_version: builder-version
+    # bumps mint new asset names but must not reshuffle seeded content.
+    inputs_fingerprint = compute_deck_inputs_fingerprint(
+        entries, heritage_pairs, synonym_verdicts, cloze_sources, SCHEMA_VERSION
+    )
+    rng_seed = int(hashlib.sha256(inputs_fingerprint.encode("utf-8")).hexdigest()[:16], 16)
     rng = random.Random(rng_seed)
     eligible = [entry for entry in entries if is_practice_eligible(entry)]
     course_entries = [entry for entry in eligible if _course_usage(entry)]

--- a/scripts/practice_deck/io.py
+++ b/scripts/practice_deck/io.py
@@ -33,7 +33,7 @@ REQUIRED_POINTER_KEYS = (
 )
 DOWNLOAD_ATTEMPTS = 3
 ALLOWED_RELEASE_PATH_PREFIX = "/learn-ukrainian/learn-ukrainian.github.io/releases/download/"
-PRACTICE_DECK_BUILDER_VERSION = 2
+PRACTICE_DECK_BUILDER_VERSION = 3
 STALE_POINTER_HINT = (
     "If your branch predates the latest practice deck publish, its committed pointer is stale — "
     "update the branch from origin/main (gh pr update-branch <N> / git merge origin/main). "

--- a/scripts/practice_deck/io.py
+++ b/scripts/practice_deck/io.py
@@ -49,6 +49,31 @@ def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def compute_deck_inputs_fingerprint(
+    entries: list[dict[str, Any]] | None,
+    heritage_pairs: list[dict[str, Any]] | None,
+    synonym_verdicts: dict[str, Any] | None,
+    cloze_sources: list[dict[str, Any]] | None,
+    schema_version: int,
+) -> str:
+    """Canonical hash of the deck DATA inputs only (no builder version).
+
+    Seeds deterministic generation randomness: identical inputs must produce
+    identical rolls regardless of code revision, so builder-version bumps
+    never reshuffle seeded content (and seed-sensitive fixture tests stay
+    stable across semantics releases).
+    """
+    payload = {
+        "schema_version": schema_version,
+        "entries": entries or [],
+        "heritage_pairs": heritage_pairs or [],
+        "synonym_verdicts": synonym_verdicts or {},
+        "cloze_sources": cloze_sources or [],
+    }
+    canonical = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
 def compute_deck_version(
     entries: list[dict[str, Any]] | None,
     heritage_pairs: list[dict[str, Any]] | None,

--- a/site/src/data/lexicon-practice-deck.pointer.json
+++ b/site/src/data/lexicon-practice-deck.pointer.json
@@ -1,12 +1,12 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-7a2596958af7ce32.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-9e5b4a65d92bf9c9.json.gz",
   "release_tag": "atlas-practice-deck",
-  "deck_version": "atlas-practice-v1-7a2596958af7ce32",
+  "deck_version": "atlas-practice-v1-9e5b4a65d92bf9c9",
   "package_schema_version": 1,
-  "gz_sha256": "71c0272769f8ad0eb01a94cf96c470d9f48084274e2eec1182742970e696481f",
-  "package_sha256": "091e3869ec8798c00dd1319c298a3813234d398bd46d9d5f7068c393327b3c26",
-  "gz_bytes": 614019,
-  "package_bytes": 14395084,
+  "gz_sha256": "8b9720e10662985f4d9947a67a71c53572694ab978895632b6d3d8078b522997",
+  "package_sha256": "8bfef448bceb1da660ba39656588437d757a434e760fcb19d3baa9b562b12d8b",
+  "gz_bytes": 612252,
+  "package_bytes": 14394983,
   "file_count": 45,
   "files": [
     {
@@ -14,8 +14,8 @@
       "kind": "index",
       "level": "A1",
       "schema": "atlas-practice-index",
-      "bytes": 318867,
-      "sha256": "a756432cb11f67ef8177ba21588ebc2a28670b329adc233f0c9249b87cb42cef",
+      "bytes": 318863,
+      "sha256": "b2a8d8eae53d5dfe2ed3b45b3d68f8125bda3e4797d1808be1c2fe4f00634bee",
       "counts": {
         "lexemes": 1150,
         "cloze": 22,
@@ -29,15 +29,15 @@
       "level": "A1",
       "schema": "atlas-practice-lexemes",
       "bytes": 562939,
-      "sha256": "74783f6cfa6e30fdaa4efacbeaddd00a6f958b7b1d366a835e4dca67443f6570"
+      "sha256": "aa1d8e8d3bdb58e1b68d9830d12b7ecca186ec4fb1816ea8d63c8560d1d2bfc8"
     },
     {
       "path": "practice-cloze.A1.json",
       "kind": "cloze",
       "level": "A1",
       "schema": "atlas-practice-cloze",
-      "bytes": 44802,
-      "sha256": "d0fe985f713704b713a0031d1cc204ccde0a034e4f8d7790e2c5da6ac12361f2"
+      "bytes": 44716,
+      "sha256": "28e3159220ee61abf8da5645256260fcf7a2193a5783673fbbd2dc8f887d3d63"
     },
     {
       "path": "practice-stress.A1.json",
@@ -45,7 +45,7 @@
       "level": "A1",
       "schema": "atlas-practice-stress",
       "bytes": 382927,
-      "sha256": "99a2bb8d18b852f73d37d86e61078d6c05ef4feeb145cc9b85d9e255c023353e"
+      "sha256": "061627ec5b443c929296435df3bdb0ebeb2f30919f4eaac061e5adef1fdf03df"
     },
     {
       "path": "practice-classify.A1.json",
@@ -53,7 +53,7 @@
       "level": "A1",
       "schema": "atlas-practice-classify",
       "bytes": 437057,
-      "sha256": "6088760cf1bffaef91d39804a934ee31eec43632a2a9cbad313001683bc319b2"
+      "sha256": "aeca3b3780ad1651489db1cb747fc6ae0ba237a14eeacc2c3370401f42dc5022"
     },
     {
       "path": "practice-paradigm.A1.json",
@@ -61,7 +61,7 @@
       "level": "A1",
       "schema": "atlas-practice-paradigm",
       "bytes": 533851,
-      "sha256": "e60665a4c3253dc46b8f9c094a20d20af8b95a005f8c9f45d222cad58dc01ff5"
+      "sha256": "888468b722cd111c103070c1df98ec6b99294443db7935c0f5880581286bbf19"
     },
     {
       "path": "practice-synonym.A1.json",
@@ -69,15 +69,15 @@
       "level": "A1",
       "schema": "atlas-practice-synonym",
       "bytes": 317,
-      "sha256": "fd2c2833c517c19b6f9f729223f9eb8854a55880598fb10e26499278f0e577b0"
+      "sha256": "5ecbff25c12b85f1c3e3325e7a9d6c982aa4d25c5bbb2dfd71242a15a0dba919"
     },
     {
       "path": "practice-heritage.A1.json",
       "kind": "heritage",
       "level": "A1",
       "schema": "atlas-practice-heritage",
-      "bytes": 59009,
-      "sha256": "ac2cd61eeebd1981e00c1a7cce6eb605362e40053d7bd296970e6acdd6613f1f"
+      "bytes": 319,
+      "sha256": "3d55d57088eb8bb60a140e142f7af5d2edc5f1a6b3e03f8edb237e31fed981e3"
     },
     {
       "path": "practice-paronym.A1.json",
@@ -85,7 +85,7 @@
       "level": "A1",
       "schema": "atlas-practice-paronym",
       "bytes": 317,
-      "sha256": "7ed838f20117874a56a192f746268c2eb110e9bd2bd5f175480a2e2515d218b9"
+      "sha256": "8f75912414cb14313407596096072d8b0fbdccaa252c719d38985b36c58100d6"
     },
     {
       "path": "practice-index.A2.json",
@@ -93,7 +93,7 @@
       "level": "A2",
       "schema": "atlas-practice-index",
       "bytes": 281800,
-      "sha256": "7265edb3736f5cb5fe256d45bc057753cbe37c14796f1def4829fd35d9db56fa",
+      "sha256": "2787bf1e292f139f008daeefa246fb72d09b5aa28bdd7b0876b54ebc77431472",
       "counts": {
         "lexemes": 967,
         "cloze": 0,
@@ -107,7 +107,7 @@
       "level": "A2",
       "schema": "atlas-practice-lexemes",
       "bytes": 474613,
-      "sha256": "b538ea0bdcf27d43e671cda38134e8ea966537a57b45652fd41416dfd620e933"
+      "sha256": "c7e48273938aac23bd949dd135490104e2fe0b564e47aca0750b17e7f078f59e"
     },
     {
       "path": "practice-cloze.A2.json",
@@ -115,7 +115,7 @@
       "level": "A2",
       "schema": "atlas-practice-cloze",
       "bytes": 313,
-      "sha256": "5ec1b71678f154366cc14629bb8fa3d234b042479777ebc69a7499e0047849fd"
+      "sha256": "aefa1ddbed0d0e5a2fa3c94a4b507e166e4b9ed342df426dc1af131990e18c55"
     },
     {
       "path": "practice-stress.A2.json",
@@ -123,7 +123,7 @@
       "level": "A2",
       "schema": "atlas-practice-stress",
       "bytes": 395787,
-      "sha256": "a2f9ffc27b76f27366fd9bfbb16203564a519510bd358f9e65cb6664b7e1ebf5"
+      "sha256": "25f0b01adc66a62129371774880f944484d6bff26572c912f2753071144a75fe"
     },
     {
       "path": "practice-classify.A2.json",
@@ -131,7 +131,7 @@
       "level": "A2",
       "schema": "atlas-practice-classify",
       "bytes": 1121136,
-      "sha256": "48701c3c690406d6ec2a534ec5adfa05a709e4dd9f9cfac990fd310a512dc987"
+      "sha256": "885d4ed2b3eb5080479726b490417318d8e2f2ab4f242469871ab70f6bd97518"
     },
     {
       "path": "practice-paradigm.A2.json",
@@ -139,7 +139,7 @@
       "level": "A2",
       "schema": "atlas-practice-paradigm",
       "bytes": 420424,
-      "sha256": "f696a7e22290ba86d4683aa5e1b624b190e52e973d7ec216f5489ce27fc55c47"
+      "sha256": "b090a6e03a111dbf7d212613a2c12dfce0a6d170dd24a77051c20a183caec3f3"
     },
     {
       "path": "practice-synonym.A2.json",
@@ -147,15 +147,15 @@
       "level": "A2",
       "schema": "atlas-practice-synonym",
       "bytes": 317,
-      "sha256": "2d23829670a98bc9a9357db58bc380fca1199678da6bd7f48dfb6521e43b7cf5"
+      "sha256": "de4463e08c652fc7f425f82116e85ab06d50b0702ed91583f5cf42fb945ed223"
     },
     {
       "path": "practice-heritage.A2.json",
       "kind": "heritage",
       "level": "A2",
       "schema": "atlas-practice-heritage",
-      "bytes": 37585,
-      "sha256": "726dbaa588eb962d16437264ad1f6814b6ddb7fce728d06dfa9b4095ed3948da"
+      "bytes": 39651,
+      "sha256": "1853505bc8c5f2c2384995a6456f63c3a2b15879c1b9a9dcf43cfed6c0cd6aff"
     },
     {
       "path": "practice-paronym.A2.json",
@@ -163,7 +163,7 @@
       "level": "A2",
       "schema": "atlas-practice-paronym",
       "bytes": 317,
-      "sha256": "368ae0cb339c09910a624cf889fa5c65b6d75fd8b4581d586b57af730215c3ea"
+      "sha256": "87e0df00986d5f67ad64f5accc542c457af8fd27b36ea60872663f4ef32f5f8c"
     },
     {
       "path": "practice-index.B1.json",
@@ -171,7 +171,7 @@
       "level": "B1",
       "schema": "atlas-practice-index",
       "bytes": 433687,
-      "sha256": "e97336bbd41921f4280fd7728aff9f500ee7ecb26d66d22f53077a2508f83ca9",
+      "sha256": "f85912a64c424e1fc39ef3a0893519e688b9e0b9d9259ea8fc9f43c7478ade6b",
       "counts": {
         "lexemes": 1485,
         "cloze": 0,
@@ -185,7 +185,7 @@
       "level": "B1",
       "schema": "atlas-practice-lexemes",
       "bytes": 748382,
-      "sha256": "0cae44e64adb81eac333f0d11555b58d3b56bd8a8b9c2334e5c5acba7eb55ec2"
+      "sha256": "3985a9bccac3772300bd0335e232e5e2ec8529d03a1ffb63e51394a15e4d02bc"
     },
     {
       "path": "practice-cloze.B1.json",
@@ -193,7 +193,7 @@
       "level": "B1",
       "schema": "atlas-practice-cloze",
       "bytes": 313,
-      "sha256": "0c1a0078775049f2214c5b57874328afc38e18eca904b419893152e6713e18b0"
+      "sha256": "f64a969f66505dd33de51b2ba94bcbe5c7cccafd75205db276cdc46fcde5a897"
     },
     {
       "path": "practice-stress.B1.json",
@@ -201,7 +201,7 @@
       "level": "B1",
       "schema": "atlas-practice-stress",
       "bytes": 447184,
-      "sha256": "ca42a0be144b7a039106f8d350b9394cdc41a7adffdf93b4c77aadf39264d444"
+      "sha256": "528bdba2e3b9a576b96bc339200109811c35f7c2d05828a05df61543fce9a854"
     },
     {
       "path": "practice-classify.B1.json",
@@ -209,7 +209,7 @@
       "level": "B1",
       "schema": "atlas-practice-classify",
       "bytes": 1449662,
-      "sha256": "53da2d12d317de66b3c0192bd07350bc3397f9701011330633d3bc60dd16c2cd"
+      "sha256": "693b864daad55558b1c1e6cabfd5808c933af37b1f510119318528dd4b88f9b8"
     },
     {
       "path": "practice-paradigm.B1.json",
@@ -217,7 +217,7 @@
       "level": "B1",
       "schema": "atlas-practice-paradigm",
       "bytes": 583013,
-      "sha256": "2fa7173597867fc07470ebce559e0193421a11e274c104ea703deb35dccae194"
+      "sha256": "9625ae24f2eeec517151a2aaf6531c4671e6031e2ed2c0aef1e909b94d1a4510"
     },
     {
       "path": "practice-synonym.B1.json",
@@ -225,15 +225,15 @@
       "level": "B1",
       "schema": "atlas-practice-synonym",
       "bytes": 112522,
-      "sha256": "13dcb8afc855a15251a3ca170835b7e0b07def061e0778d7cf0822b0712a45c5"
+      "sha256": "cb2ce8bef2460b1ee7c5cf5286a6de0e32251ddb89ae416ccd887fd2d5f878c8"
     },
     {
       "path": "practice-heritage.B1.json",
       "kind": "heritage",
       "level": "B1",
       "schema": "atlas-practice-heritage",
-      "bytes": 36951,
-      "sha256": "53ad213f5c1800ac3624021583af6533551fd97bc47d228bfdf11fa028cba92d"
+      "bytes": 93565,
+      "sha256": "04fa74a59ddf128c4926f4feb4fbcdd7316824141a34fa01295ee74f015296d1"
     },
     {
       "path": "practice-paronym.B1.json",
@@ -241,7 +241,7 @@
       "level": "B1",
       "schema": "atlas-practice-paronym",
       "bytes": 317,
-      "sha256": "e9317d27fbc1f25e05d13ff65334be5280df1b0c2a1b8d4f6ad606beec36e714"
+      "sha256": "47b0a47c7f6cb16768c1c628abf190d63a713fbb132a8e9bda69f5b86df44edc"
     },
     {
       "path": "practice-index.B2.json",
@@ -249,7 +249,7 @@
       "level": "B2",
       "schema": "atlas-practice-index",
       "bytes": 254076,
-      "sha256": "7a797a1fc7d9a34b2a3381b859841d208505f9fcce53b9d6e7ee8da15399fce7",
+      "sha256": "0fa92b1a2144179d32159c0c3e849b3c8847bbac0d466c6288c9f96aa6633019",
       "counts": {
         "lexemes": 853,
         "cloze": 0,
@@ -263,7 +263,7 @@
       "level": "B2",
       "schema": "atlas-practice-lexemes",
       "bytes": 443931,
-      "sha256": "39effd96d44ca788a5898aa8121bbf126b88561c45baf767d5240a563d878906"
+      "sha256": "773753f4182ac604e99b6a63c8d2b18e32615936206899591c44b9738943fc29"
     },
     {
       "path": "practice-cloze.B2.json",
@@ -271,7 +271,7 @@
       "level": "B2",
       "schema": "atlas-practice-cloze",
       "bytes": 313,
-      "sha256": "b6e6bf3641ebf90bb1b973d393a2456721ccffa29ef055beee318d776ea98f0b"
+      "sha256": "7443d3c71e338489cfc96ddeb8fe364df2347b6be18ab16cf9ff55ff9d7b5ebc"
     },
     {
       "path": "practice-stress.B2.json",
@@ -279,7 +279,7 @@
       "level": "B2",
       "schema": "atlas-practice-stress",
       "bytes": 301091,
-      "sha256": "c42a147fcb992fa0cc23d6be02af1e67cf06b42fec3a228d99992df8a15971ba"
+      "sha256": "121ee2380c3ef94fbc68e63741beef89fc97f7ece29d654b04fd081b008e11c0"
     },
     {
       "path": "practice-classify.B2.json",
@@ -287,7 +287,7 @@
       "level": "B2",
       "schema": "atlas-practice-classify",
       "bytes": 901024,
-      "sha256": "256be946fa7de393180d2e13d8842a294608fb861954f507a502fbd4f0149a8b"
+      "sha256": "76aa3c33e6c59c9bc54b4a1df1cdd90ff867e9dc1c758fa7694f7093a47127ee"
     },
     {
       "path": "practice-paradigm.B2.json",
@@ -295,7 +295,7 @@
       "level": "B2",
       "schema": "atlas-practice-paradigm",
       "bytes": 400063,
-      "sha256": "f826f88798566fc0970facec2903406eb03937724c8eaac9f352d6bd3b58eadb"
+      "sha256": "a8a535cfe50f8202405262bd660f96b706544b94ca243034d5011aee71190ea1"
     },
     {
       "path": "practice-synonym.B2.json",
@@ -303,7 +303,7 @@
       "level": "B2",
       "schema": "atlas-practice-synonym",
       "bytes": 40785,
-      "sha256": "48b9bcb90044b5acc16677af3b85f1628eaeb2de00fd6552226964a9e9e13aa5"
+      "sha256": "d0627aa2923db5dd6ca019ccf2559fe2a92711e5eb1359053becd60e8b4b46fb"
     },
     {
       "path": "practice-heritage.B2.json",
@@ -311,7 +311,7 @@
       "level": "B2",
       "schema": "atlas-practice-heritage",
       "bytes": 20155,
-      "sha256": "e3417065b9589a168863155308969981a10ab4a7d5467465ce1d15efe1c0a881"
+      "sha256": "b2f9dfde83695eeb8749ded759b24836f08bd684f46a2607f0f5bd0b7af83b83"
     },
     {
       "path": "practice-paronym.B2.json",
@@ -319,7 +319,7 @@
       "level": "B2",
       "schema": "atlas-practice-paronym",
       "bytes": 317,
-      "sha256": "6f72be88e5f9ed38f715c4bdb239aff4f7b1896ac85e9d750d52eb82a66bf991"
+      "sha256": "f46950f321118ae8ef42067a9d5b217d976b1eb5c05de1c8557268c9fcc7eaa6"
     },
     {
       "path": "practice-index.C1.json",
@@ -327,7 +327,7 @@
       "level": "C1",
       "schema": "atlas-practice-index",
       "bytes": 121829,
-      "sha256": "6a6503e24947267402cfa68664d9638f7fc112b794c79c22475877a1e9c32fff",
+      "sha256": "7835bce2107d44f62480565fb09e21676e5f1e5b03ad73c6dcafc559240f32ee",
       "counts": {
         "lexemes": 403,
         "cloze": 0,
@@ -341,7 +341,7 @@
       "level": "C1",
       "schema": "atlas-practice-lexemes",
       "bytes": 229361,
-      "sha256": "b221be354513723bf063ff4bc3144426bbedbc57d8ceedb297e1abeac5405b96"
+      "sha256": "7cdb1da5626f63a5aaabfc62a681eb375848ca4892d987b955101719da000e75"
     },
     {
       "path": "practice-cloze.C1.json",
@@ -349,7 +349,7 @@
       "level": "C1",
       "schema": "atlas-practice-cloze",
       "bytes": 313,
-      "sha256": "d3309994190668128ea9a023931606ae03888f0b3f6b62d28c15714091880ba4"
+      "sha256": "2c5ae947af74a7c9a65d9324b6922d42bd34917460b17e7edbef7fa8b3771e50"
     },
     {
       "path": "practice-stress.C1.json",
@@ -357,7 +357,7 @@
       "level": "C1",
       "schema": "atlas-practice-stress",
       "bytes": 200434,
-      "sha256": "2d5479b14b2ae4c8dc41045a48fc795357b783863606bb6209016e1710bcc7ba"
+      "sha256": "29dfad0e4bf904b504a0a53097090d29d44a978d27cea2c11c68780669c42572"
     },
     {
       "path": "practice-classify.C1.json",
@@ -365,7 +365,7 @@
       "level": "C1",
       "schema": "atlas-practice-classify",
       "bytes": 585487,
-      "sha256": "e72a763c86b2c6c4c3af712a76d5960d4b05ee50ada96c15e4c1e8d587067391"
+      "sha256": "fbd2078fa2fbec039b12ac13cb9fcb32e4d20b6ab2b3a3f7f245eb81950868ef"
     },
     {
       "path": "practice-paradigm.C1.json",
@@ -373,7 +373,7 @@
       "level": "C1",
       "schema": "atlas-practice-paradigm",
       "bytes": 342080,
-      "sha256": "a5776550004f51eac179f98c3c3ae96a328121bdfa17ad729d678385ee991b01"
+      "sha256": "39b79d38bf954a5e072b83dd66b54effb1367f69601a1e17660eb95cbdf5de82"
     },
     {
       "path": "practice-synonym.C1.json",
@@ -381,7 +381,7 @@
       "level": "C1",
       "schema": "atlas-practice-synonym",
       "bytes": 16896,
-      "sha256": "3e7b634366f64e98b2b8f13452b761d17c523f11521274ac79e51acd2ce844e8"
+      "sha256": "71530d545f837df28d51b419aceafffc3f990ee3ee17addec9925a86755a7036"
     },
     {
       "path": "practice-heritage.C1.json",
@@ -389,7 +389,7 @@
       "level": "C1",
       "schema": "atlas-practice-heritage",
       "bytes": 319,
-      "sha256": "fdc59310ac36392ddf90eb729961ce60d75a819209ae0a30f3f33d5fabd5348a"
+      "sha256": "54243009d28ea07635667b346fda529eb3bbd6a4f5b13e0ec7f56001785b2779"
     },
     {
       "path": "practice-paronym.C1.json",
@@ -397,7 +397,7 @@
       "level": "C1",
       "schema": "atlas-practice-paronym",
       "bytes": 317,
-      "sha256": "9bc2b2479177747b64feb4a61041f56d7309ea152120319b59c332964385c7cf"
+      "sha256": "1d081e3c4aedde659900dece4a08a344464c8574c115609c3aaa5c76628964b3"
     }
   ],
   "note": "Pins GitHub Release asset practice deck for #3796; hydrate it build/test time instead of committing shards. Deck versions fingerprint public atlas DB entries, heritage pairs, synonym verdicts, and cloze sources; the first publish after that input expansion mints a new versioned asset by design."

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -234,7 +234,7 @@ def test_codex_hooks_json_is_managed_source_not_orphan() -> None:
     assert (REPO_ROOT / "agents_extensions" / "codex" / "hooks.json").exists()
     assert (
         'ORPHAN_PATHS_CODEX="agents/curriculum-orchestrator.toml '
-        'agents/curriculum-writer.toml config.toml"'
+        'agents/curriculum-writer.toml config.toml settings.local.json"'
     ) in shared
     assert 'CODEX_OVERLAY_PATHS="hooks.json memory"' in shared
     assert "$CODEX_OVERLAY_PATHS" in check


### PR DESCRIPTION
Final step of the #4719 regression response. Published `atlas-practice-v1-9e5b4a65d92bf9c9` (45 shards, new immutable asset). Post-publish verification (raw): `sha match: True`; heritage in the LIVE asset: `A1=0 A2=34 B1=76 B2=16, total 126` — availability floor restored, zero floor violations. Chain: #4719 → #4720 (floor) → #4722 (builder bump + data-only seed + variance guard) → this pointer. Refs #4719, #4505, #4700.

🤖 Generated with [Claude Code](https://claude.com/claude-code)