### PR TITLE
fix(deploy): declare .agent canary probes (canary-*.json) as preserved orphans

### DIFF
--- a/scripts/deploy_orphan_paths.sh
+++ b/scripts/deploy_orphan_paths.sh
@@ -57,7 +57,13 @@ ORPHAN_PATHS_CLAUDE="scheduled_tasks.lock worktrees *-epic settings.local.json"
 #          (e.g. 4497-runner-failover.md). The dispatch-*.md FILE glob does not match a
 #          directory, so without this entry the first collected brief aborts every
 #          deploy — the #3456 failure class again, one level down.
-ORPHAN_PATHS_AGENT="wake cache prompts tmp *-thread-bootstrap.md *-handoff.md *-thread-lease.json *-brief.md dispatch-*.md dispatch-briefs settings.local.json"
+# canary-*.json — context-rot canary probes minted at cold-start
+#          (scripts/context_canary.py mint --out .agent/canary-<stamp>.json; mandated
+#          cold-start step 7 since 2026-07-07, #4701). Per-session runtime state,
+#          machine-local, NOT source-tracked. Without this glob the FIRST session that
+#          mints a canary aborts every subsequent deploy — the #3456/#4721 failure
+#          class with a new runtime file type.
+ORPHAN_PATHS_AGENT="wake cache prompts tmp *-thread-bootstrap.md *-handoff.md *-thread-lease.json *-brief.md dispatch-*.md dispatch-briefs canary-*.json settings.local.json"
 
 # --- shared/skills → .agents/skills ---
 ORPHAN_PATHS_AGENTS=""


### PR DESCRIPTION
Deploy on any machine that has minted a context canary (cold-start step 7, mandated 2026-07-07 via #4701) aborts with `undeclared orphan 'canary-*.json'` — hit live this session with another lane's `.agent/canary-20260707-infra.json`. Same failure class as #3456/#4721: a new runtime file type lands in a deploy target and the orphan guard (correctly) refuses to proceed.

**Fix:** declare `canary-*.json` in `ORPHAN_PATHS_AGENT` (single source consumed by deploy + drift checker per #4644), with rationale comment.

**Verified end-to-end (#M-4a):** planted a canary in a fresh checkout's `.agent/` → deploy aborted before the fix, passes after, canary preserved by `rsync --delete`. `tests/test_deploy_script_idempotency.py` 11/11 green (no full-string pin on ORPHAN_PATHS_AGENT — sibling-checked after this morning's #4723 class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)