### PR TITLE
fix(deploy): declare canary orphans + single-source session-setup drift excludes

### DIFF
--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -140,10 +140,15 @@ if [ -d "$PROJECT_DIR/agents_extensions/shared" ] && [ -d "$PROJECT_DIR/.claude"
   if [ -f "$ORPHAN_PATHS_SH" ]; then
     # shellcheck disable=SC1090
     source "$ORPHAN_PATHS_SH"
+    # set -f: ORPHAN_PATHS_CLAUDE carries glob patterns (*-epic) that must reach
+    # diff --exclude LITERALLY; without noglob the unquoted expansion would match
+    # against the hook's cwd if a *-epic entry ever appears there.
+    set -f
     # shellcheck disable=SC2086
     for item in $ORPHAN_PATHS_CLAUDE; do
       DIFF_EXCLUDES+=("$item")
     done
+    set +f
     for path in "${CLAUDE_RULE_AUTOLOAD_EXCLUDES[@]}"; do
       DIFF_EXCLUDES+=("$(basename "$path")")
     done

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -131,27 +131,35 @@ if [ -f "$MEMORY_FILE" ]; then
 fi
 
 # 7. Check agents_extensions/shared/ → .claude/ sync drift
-# Excludes must match scripts/deploy_prompts.sh:
-#   - 6 rule files served by Monitor API (CLAUDE_RULE_AUTOLOAD_EXCLUDES) — intentionally
-#     removed from .claude/rules/ by remove_claude_autoload_rules() after sync.
-#   - ORPHAN_PATHS_CLAUDE: scheduled_tasks.lock (Claude scheduler state) + worktrees/ +
-#     folk-epic/ bio-epic/ (gitignored-local driver handoffs, user policy 2026-06-23).
-# Without these, every cold start flags a false-positive drift. Hook bug fix 2026-05-13.
+# Excludes must match scripts/deploy_prompts.sh, derived dynamically from
+# scripts/deploy_orphan_paths.sh to avoid hand-maintained drift (issue #4610).
+# Without these, every cold start flags a false-positive drift.
 if [ -d "$PROJECT_DIR/agents_extensions/shared" ] && [ -d "$PROJECT_DIR/.claude" ]; then
-  DRIFT=$(diff -rq "$PROJECT_DIR/agents_extensions/shared/" "$PROJECT_DIR/.claude/" \
-    --exclude='.DS_Store' \
-    --exclude='settings.local.json' \
-    --exclude='scheduled_tasks.lock' \
-    --exclude='worktrees' \
-    --exclude='folk-epic' \
-    --exclude='bio-epic' \
-    --exclude='critical-rules.md' \
-    --exclude='non-negotiable-rules.md' \
-    --exclude='workflow.md' \
-    --exclude='delegate-must-use-worktree.md' \
-    --exclude='cli-help-standard.md' \
-    --exclude='model-assignment.md' \
-    2>/dev/null | head -5)
+  DIFF_EXCLUDES=(".DS_Store")
+  ORPHAN_PATHS_SH="$PROJECT_DIR/scripts/deploy_orphan_paths.sh"
+  if [ -f "$ORPHAN_PATHS_SH" ]; then
+    # shellcheck disable=SC1090
+    source "$ORPHAN_PATHS_SH"
+    # shellcheck disable=SC2086
+    for item in $ORPHAN_PATHS_CLAUDE; do
+      DIFF_EXCLUDES+=("$item")
+    done
+    for path in "${CLAUDE_RULE_AUTOLOAD_EXCLUDES[@]}"; do
+      DIFF_EXCLUDES+=("$(basename "$path")")
+    done
+  else
+    # Fallback to the old static list if deploy_orphan_paths.sh is missing (graceful degradation)
+    for item in settings.local.json scheduled_tasks.lock worktrees folk-epic bio-epic critical-rules.md non-negotiable-rules.md workflow.md delegate-must-use-worktree.md cli-help-standard.md model-assignment.md; do
+      DIFF_EXCLUDES+=("$item")
+    done
+  fi
+
+  diff_args=(-rq)
+  for ex in "${DIFF_EXCLUDES[@]}"; do
+    diff_args+=("--exclude=$ex")
+  done
+
+  DRIFT=$(diff "${diff_args[@]}" "$PROJECT_DIR/agents_extensions/shared/" "$PROJECT_DIR/.claude/" 2>/dev/null | head -5)
   if [ -n "$DRIFT" ]; then
     DRIFT_COUNT=$(echo "$DRIFT" | wc -l | tr -d ' ')
     ISSUES+=("DEPLOY DRIFT: $DRIFT_COUNT file(s) differ between agents_extensions/shared/ and .claude/. Run: npm run agents:deploy")

--- a/tests/test_operator_contract_wiring.py
+++ b/tests/test_operator_contract_wiring.py
@@ -96,9 +96,11 @@ def test_deploy_lock_step_lists_include_contract() -> None:
     shared = (REPO / "scripts/deploy_orphan_paths.sh").read_text(encoding="utf-8")
     deploy = (REPO / "scripts/deploy_prompts.sh").read_text(encoding="utf-8")
     checker = (REPO / "scripts/check_rules_deployment.sh").read_text(encoding="utf-8")
+    session_setup = (REPO / "agents_extensions/shared/hooks/session-setup.sh").read_text(encoding="utf-8")
     assert 'rules/operator-expectations.md' in shared, "shared autoload-exclude missing"
     assert "deploy_orphan_paths.sh" in deploy, "deploy does not source the shared lists"
     assert "deploy_orphan_paths.sh" in checker, "drift-checker does not source the shared lists"
+    assert "deploy_orphan_paths.sh" in session_setup, "session-setup hook does not source the shared lists"
 
 
 def test_offline_fallback_lists_contract() -> None:

--- a/tests/test_session_setup_hook.py
+++ b/tests/test_session_setup_hook.py
@@ -33,5 +33,87 @@ def test_session_setup_hook_handoff_fixtures() -> None:
     assert result.returncode == 0, (
         f"hook fixtures failed (rc={result.returncode})\n"
         f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
-    )
+        )
     assert "ok - session setup hook handoff fixtures passed" in result.stdout
+
+
+def test_session_setup_drift_fp_regression(tmp_path: Path) -> None:
+    import json
+    import os
+
+    # 1. Setup the project structure
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    # Create the minimal mock sources
+    shared_dir = project_dir / "agents_extensions" / "shared"
+    shared_dir.mkdir(parents=True)
+    shared_rules = shared_dir / "rules"
+    shared_rules.mkdir()
+
+    # Create a rule file that is present in both
+    (shared_rules / "pipeline.md").write_text("pipeline rule content", encoding="utf-8")
+    # Create operator-expectations.md which is excluded from autoload
+    (shared_rules / "operator-expectations.md").write_text("operator expectations content", encoding="utf-8")
+
+    # Create the target directory .claude/
+    claude_dir = project_dir / ".claude"
+    claude_dir.mkdir()
+    claude_rules = claude_dir / "rules"
+    claude_rules.mkdir()
+
+    # pipeline.md is deployed
+    (claude_rules / "pipeline.md").write_text("pipeline rule content", encoding="utf-8")
+    # operator-expectations.md is MISSING from .claude/rules/ by design (autoload exclude)
+
+    # Create atlas-epic/ in .claude/
+    atlas_epic = claude_dir / "atlas-epic"
+    atlas_epic.mkdir()
+    (atlas_epic / "CLAUDE-DRIVER-HANDOFF.md").write_text("driver handoff", encoding="utf-8")
+
+    # Create .agent/canary-x.json
+    agent_dir = project_dir / ".agent"
+    agent_dir.mkdir()
+    (agent_dir / "canary-x.json").write_text("{}", encoding="utf-8")
+
+    # Mock other things to avoid unrelated warnings/issues
+    venv_bin = project_dir / ".venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    (venv_bin / "python").write_text("#!/bin/sh\necho 'Python 3.12.8'", encoding="utf-8")
+    (venv_bin / "python").chmod(0o755)
+
+    db_dir = project_dir / ".mcp" / "servers" / "message-broker"
+    db_dir.mkdir(parents=True)
+    (db_dir / "messages.db").write_text("dummy", encoding="utf-8")
+
+    # Copy scripts/deploy_orphan_paths.sh to the project_dir
+    scripts_dir = project_dir / "scripts"
+    scripts_dir.mkdir()
+    shutil.copy2(_REPO_ROOT / "scripts" / "deploy_orphan_paths.sh", scripts_dir / "deploy_orphan_paths.sh")
+
+    # Run the hook script
+    hook_path = _REPO_ROOT / "agents_extensions" / "shared" / "hooks" / "session-setup.sh"
+
+    # Environment variables
+    env = {
+        "CLAUDE_PROJECT_DIR": str(project_dir),
+        "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS": "32000",
+        "PATH": f"{venv_bin}:{os.environ.get('PATH', '')}",
+    }
+
+    result = subprocess.run(
+        ["bash", str(hook_path)],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, f"session-setup.sh failed: {result.stderr}\n{result.stdout}"
+
+    try:
+        output_data = json.loads(result.stdout)
+        context = output_data.get("hookSpecificOutput", {}).get("additionalContext", "")
+    except Exception as e:
+        pytest.fail(f"Failed to parse JSON output: {e}\nStdout: {result.stdout}\nStderr: {result.stderr}")
+
+    assert "DEPLOY DRIFT" not in context, f"False positive drift detected! Context:\n{context}"


### PR DESCRIPTION
Fixes two session-setup/deploy defects (driver-verified this morning):

1. **Every deploy aborted after a cold start**: `.agent/canary-<stamp>.json` (cold-start canary mint mandated by #4701, merged 2026-07-07) was an undeclared orphan → `ORPHAN_PATHS_AGENT` now declares `canary-*.json` (the #3456 failure class).
2. **"DEPLOY DRIFT: 2 file(s)" false positive every session**: the SessionStart hook hand-maintained its own copy of the exclude lists — it never received the `*-epic` glob (flagged `.claude/atlas-epic`) nor the 7th autoload rule `operator-expectations.md`. The hook now sources `scripts/deploy_orphan_paths.sh` and derives excludes from `ORPHAN_PATHS_CLAUDE` + `CLAUDE_RULE_AUTOLOAD_EXCLUDES` — the #4610 single-source fix, applied to the last unconverted consumer (graceful static fallback if the allowlist file is absent).

Tests: new `test_session_setup_drift_fp_regression` drives the REAL hook against a synthetic tree containing all three FP triggers (atlas-epic/, missing operator-expectations.md, canary-x.json) and asserts zero DEPLOY DRIFT; consumer-wiring test extended to assert session-setup.sh sources the shared allowlist. 10 passed.

Driver hardening commit: `set -f` around the orphan-pattern expansion so `*-epic` reaches `diff --exclude` literally regardless of hook cwd contents.

Authored by agy (dispatch deploy-single-source); driver-reviewed (cross-family) + finalized by claude-infra. Post-merge the driver runs the real `npm run agents:deploy` end-to-end (#M-4a).

Refs #4610, #4701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)