### PR TITLE
feat(routing): deepseek first-party direct provider

### DIFF
--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -46,14 +46,16 @@ several models are reachable through more than one. Know both axes before routin
 | Harness | What it adds to ANY model it hosts | Models reachable through it | Entry points¹ |
 |---|---|---|---|
 | **hermes** (v0.18.x — full agent platform, NOT a thin wrapper) | SOUL.md project persona · `sources` MCP (30+ UK tools) auto-attached · 16 built-in toolsets (web, browser, terminal, code-exec, files, delegation, cron, session-search…) · session store w/ FTS5 search · agent loop up to 90 turns | deepseek (API key) · gpt-5.5 (codex OAuth) · grok (xai OAuth) · zai/GLM (API key — ⚠️ same China-egress LOCAL-ONLY rule as opencode glm) · OpenRouter catalog (qwen², gemma, …) — probe `hermes auth list` | `ab ask-hermes --model <m>` (one-shot Q&A/review) · `delegate.py dispatch --agent deepseek\|grok\|qwen² --mode danger --worktree` (execution — worktree MANDATORY per delegate-must-use-worktree) · V7 `--writer/--reviewer grok-tools\|deepseek-tools\|qwen-tools` (all hermes-backed) |
-| **opencode** (multi-provider router) | lightpanda MCP configured (`~/.config/opencode/opencode.jsonc`) → **live web browsing/fact-check is a HARNESS property here**, available to tool-capable hosted models (kubedojo-verified for pool·glm·deepseek routes; verify before relying on a new route) | pool (poolside laguna-m.1, free) · glm (⚠️ LOCAL-ONLY) · gemma · deepseek · any OpenRouter model | `ab ask-pool` / `ask-glm` / `ask-gemma` (named) · `ab ask-opencode <model>` (generic) |
+| **opencode** (multi-provider router) | lightpanda MCP configured (`~/.config/opencode/opencode.jsonc`) → **live web browsing/fact-check is a HARNESS property here**, available to tool-capable hosted models (kubedojo-verified for pool·glm·deepseek routes; verify before relying on a new route) | pool (poolside laguna-m.1, free) · glm (⚠️ LOCAL-ONLY) · gemma · deepseek-direct (first-party `api.deepseek.com`; #4358/#4626 QG bakeoff default) · OpenRouter deepseek/gemma baselines · any OpenRouter model | `ab ask-pool` / `ask-glm` / `ask-gemma` (named) · `ab ask-opencode <model>` (generic) |
 | **native CLIs** (codex, cursor, agy, grok-build, claude) | each CLI's own tool loop + repo context; capabilities differ per CLI. grok-build = the NATIVE grok CLI lane; plain `--agent grok` routes via hermes (row above) | one primary family each | `ab ask-codex` / `ask-cursor` / `ask-agy` / `ask-grok-build` / `ask-claude` · `delegate.py dispatch --agent <a> --mode danger --worktree` |
 
 ¹ `ab` = the user's shell alias for `.venv/bin/python scripts/ai_agent_bridge/__main__.py`.
 In scripts, docs meant for copy-paste, and anything automated, ALWAYS write the full path —
 bare `ab` resolves to ApacheBench (`/usr/sbin/ab`) outside the user's shell (AGENTS.md rule).
-There is NO `ask-deepseek`: one-shot deepseek = `ask-hermes --model <deepseek-model>` or
-`ask-opencode <deepseek-model>`; execution = `delegate.py dispatch --agent deepseek`.
+There is NO `ask-deepseek`: one-shot deepseek = `ask-hermes --model <deepseek-model>` (first-party
+as attributed on 2026-07-07) or `ask-opencode deepseek-direct/<deepseek-model>`; execution =
+`delegate.py dispatch --agent deepseek`. Use `ask-opencode openrouter/deepseek/...` only for the
+OpenRouter comparison baseline.
 ² qwen is reachable but EXCLUDED from routine routing (cost, user 2026-05-29) — reachable ≠ routable.
 
 Consequences:

--- a/scripts/ai_agent_bridge/routing_guard.py
+++ b/scripts/ai_agent_bridge/routing_guard.py
@@ -29,10 +29,14 @@ _QWEN_RE = re.compile(r"(?:^|[/:_-])qwen", re.IGNORECASE)
 _SUBSCRIPTION_VIA_OPENROUTER_RE = re.compile(
     r"openrouter/(?:anthropic/|openai/|google/gemini)", re.IGNORECASE
 )
-_SUBSCRIPTION_VIA_DEEPSEEK_DIRECT_RE = re.compile(
-    r"deepseek-direct/(?:anthropic/|openai/|google/gemini|claude|gpt-|gemini)",
-    re.IGNORECASE,
-)
+# deepseek-direct is a POSITIVE allowlist, not a family blocklist: the grok-build
+# adversarial review of #4730 produced working bypasses for every blocklist
+# formulation tried (anthropic-claude, openai-gpt, google-gemini, ../claude,
+# some-claude-model — hyphen/underscore/embedding variants). Fail closed
+# instead: a deepseek-direct pin is valid ONLY if its model segment is
+# DeepSeek-family. Underscore spelling normalizes to the same rule.
+_DEEPSEEK_DIRECT_PREFIX_RE = re.compile(r"^deepseek[-_]direct/", re.IGNORECASE)
+_DEEPSEEK_FAMILY_MODEL_RE = re.compile(r"^deepseek", re.IGNORECASE)
 _OVERRIDE_ENV = "LU_ROUTING_GUARD_OVERRIDE"
 
 
@@ -64,12 +68,13 @@ def assert_model_routing_allowed(model: str | None, *, context: str) -> None:
             f"Use the native subscription lane instead. Set {_OVERRIDE_ENV}=1 "
             f"only with explicit user authorization."
         )
-    if _SUBSCRIPTION_VIA_DEEPSEEK_DIRECT_RE.search(text):
+    direct_prefix = _DEEPSEEK_DIRECT_PREFIX_RE.match(text)
+    if direct_prefix and not _DEEPSEEK_FAMILY_MODEL_RE.match(text[direct_prefix.end() :]):
         raise RoutingGuardError(
-            f"{context}: {text!r} routes a SUBSCRIPTION family (anthropic/"
-            f"openai/gemini) through the DeepSeek first-party provider. "
-            "deepseek-direct may only run DeepSeek-family pins. Use the "
-            "native subscription lane instead. "
+            f"{context}: {text!r} routes a non-DeepSeek model through the "
+            "DeepSeek first-party provider. deepseek-direct accepts ONLY "
+            "DeepSeek-family model ids (fail-closed allowlist; subscription "
+            "families use their native lanes). "
             f"Set {_OVERRIDE_ENV}=1 only with explicit user authorization."
         )
 

--- a/scripts/ai_agent_bridge/routing_guard.py
+++ b/scripts/ai_agent_bridge/routing_guard.py
@@ -29,6 +29,10 @@ _QWEN_RE = re.compile(r"(?:^|[/:_-])qwen", re.IGNORECASE)
 _SUBSCRIPTION_VIA_OPENROUTER_RE = re.compile(
     r"openrouter/(?:anthropic/|openai/|google/gemini)", re.IGNORECASE
 )
+_SUBSCRIPTION_VIA_DEEPSEEK_DIRECT_RE = re.compile(
+    r"deepseek-direct/(?:anthropic/|openai/|google/gemini|claude|gpt-|gemini)",
+    re.IGNORECASE,
+)
 _OVERRIDE_ENV = "LU_ROUTING_GUARD_OVERRIDE"
 
 
@@ -59,6 +63,14 @@ def assert_model_routing_allowed(model: str | None, *, context: str) -> None:
             f"2026-07-05 (subscription already paid; metered spend is waste). "
             f"Use the native subscription lane instead. Set {_OVERRIDE_ENV}=1 "
             f"only with explicit user authorization."
+        )
+    if _SUBSCRIPTION_VIA_DEEPSEEK_DIRECT_RE.search(text):
+        raise RoutingGuardError(
+            f"{context}: {text!r} routes a SUBSCRIPTION family (anthropic/"
+            f"openai/gemini) through the DeepSeek first-party provider. "
+            "deepseek-direct may only run DeepSeek-family pins. Use the "
+            "native subscription lane instead. "
+            f"Set {_OVERRIDE_ENV}=1 only with explicit user authorization."
         )
 
 

--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -59,6 +59,12 @@ _ARM_CHOICES = (TOOLED_ARM, BARE_ARM, BOTH_ARM)
 OPENCODE_TRANSPORT = "opencode"
 OPENCODE_ENTRYPOINT = "qg_bakeoff_opencode"
 OPENCODE_MEASUREMENT_TIER = "opencode_bare_or_tooled"
+DEEPSEEK_DIRECT_FLASH_PIN = "deepseek-direct/deepseek-v4-flash"
+DEEPSEEK_DIRECT_PRO_PIN = "deepseek-direct/deepseek-v4-pro"
+DEEPSEEK_DIRECT_PINS = (DEEPSEEK_DIRECT_FLASH_PIN, DEEPSEEK_DIRECT_PRO_PIN)
+DEEPSEEK_OPENROUTER_FLASH_PIN = "openrouter/deepseek/deepseek-v4-flash"
+DEEPSEEK_OPENROUTER_PRO_PIN = "openrouter/deepseek/deepseek-v4-pro"
+DEEPSEEK_OPENROUTER_PINS = (DEEPSEEK_OPENROUTER_FLASH_PIN, DEEPSEEK_OPENROUTER_PRO_PIN)
 BARE_RUNTIME_ENTRYPOINT = "qg_bakeoff_runtime"
 SUBSCRIPTION_RUNTIME_BARE_TIER = "subscription_runtime_bare"
 SUBSCRIPTION_BARE_BANNER = (
@@ -115,11 +121,14 @@ class CandidateModel:
     unresolved: bool = False
 
 
-# TODO(#2156): resolve exact OpenRouter pins at run time via ``--models`` after
-# checking the currently served opencode/OpenRouter model list. Do not guess.
+# TODO(#2156): resolve exact subscription-family pins at run time via
+# ``--models`` after checking the currently served native CLI/model list. Do not
+# guess. DeepSeek defaults are first-party direct pins; OpenRouter DeepSeek pins
+# remain available through ``DEEPSEEK_OPENROUTER_PINS`` as comparison baselines.
 DEFAULT_CANDIDATE_MODELS: tuple[CandidateModel, ...] = (
     CandidateModel("gemma-4-31b", "openrouter/google/gemma-4-31b-it"),
-    CandidateModel("deepseek-v4", "TODO_OPENROUTER_DEEPSEEK_V4_PIN", unresolved=True),
+    CandidateModel("deepseek-v4-flash-direct", DEEPSEEK_DIRECT_FLASH_PIN),
+    CandidateModel("deepseek-v4-pro-direct", DEEPSEEK_DIRECT_PRO_PIN),
     CandidateModel("claude-frontier-openrouter-unreachable", "TODO_OPENROUTER_ANTHROPIC_FRONTIER_PIN", unresolved=True),
     CandidateModel("gpt-frontier-openrouter-unreachable", "TODO_OPENROUTER_OPENAI_FRONTIER_PIN", unresolved=True),
     CandidateModel("gemini-frontier-openrouter-unreachable", "TODO_OPENROUTER_GOOGLE_GEMINI_FRONTIER_PIN", unresolved=True),
@@ -2076,7 +2085,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         "--models",
         action="append",
         help=(
-            "Comma-separated or repeated model pins. OpenRouter/opencode pins work for tooled/bare; "
+            "Comma-separated or repeated model pins. opencode provider/model pins "
+            "(including deepseek-direct/... and OpenRouter baselines) work for tooled/bare; "
             "subscription native pins (claude-opus-4-8,gpt-5.5,gemini-3.1-pro-high) are --arm bare only. "
             "LU_ROUTING_GUARD_OVERRIDE=1 is invalid for published scorecards."
         ),

--- a/tests/audit/test_qg_bakeoff.py
+++ b/tests/audit/test_qg_bakeoff.py
@@ -274,6 +274,33 @@ def test_bakeoff_deepseek_route_stays_unregistered_while_live_policy_rejects_dee
         llm_reviewer_dispatch.assert_route_allowed(hermes_route)
 
 
+def test_deepseek_direct_bakeoff_pins_use_opencode_identity_and_guard_allowed() -> None:
+    from scripts.ai_agent_bridge.routing_guard import assert_model_routing_allowed
+
+    for pin in qg_bakeoff.DEEPSEEK_DIRECT_PINS:
+        route = qg_bakeoff.bakeoff_route_for_model(pin)
+        identity = qg_bakeoff._route_identity(route)
+
+        assert route.bridge_command == ("ask-opencode", "--model", pin)
+        assert route.reviewer_family == "deepseek"
+        assert identity.transport == qg_bakeoff.OPENCODE_TRANSPORT
+        assert identity.entrypoint == qg_bakeoff.OPENCODE_ENTRYPOINT
+        assert identity.resolved_model == pin
+        assert_model_routing_allowed(pin, context="test")
+
+    for pin in qg_bakeoff.DEEPSEEK_OPENROUTER_PINS:
+        assert_model_routing_allowed(pin, context="test")
+
+
+def test_default_deepseek_candidates_use_first_party_direct_pins() -> None:
+    deepseek_candidates = [
+        candidate for candidate in qg_bakeoff.DEFAULT_CANDIDATE_MODELS if "deepseek" in candidate.label
+    ]
+
+    assert [candidate.pin for candidate in deepseek_candidates] == list(qg_bakeoff.DEEPSEEK_DIRECT_PINS)
+    assert all(not candidate.unresolved for candidate in deepseek_candidates)
+
+
 def test_scoring_counts_missing_claim_and_preserves_model_judgment_on_downgrade() -> None:
     payload = {
         "fact_checks": [

--- a/tests/test_qg_bakeoff_multirun.py
+++ b/tests/test_qg_bakeoff_multirun.py
@@ -215,6 +215,7 @@ def test_multirun_matrix_resume_retry_and_narrower_runs_leave_r3(
 def test_cell_artifact_path_round_trips_all_arms_and_mismatch_fails(tmp_path: Path) -> None:
     fixture = _fixture()
     route = qg_bakeoff.bakeoff_route_for_model(PIN)
+    direct = qg_bakeoff.bakeoff_route_for_model(qg_bakeoff.DEEPSEEK_DIRECT_FLASH_PIN)
     subscription = qg_bakeoff.route_for_matrix_pin(qg_bakeoff.GPT_SUBSCRIPTION_BARE_MODEL_ID, arm=qg_bakeoff.BARE_ARM)
 
     assert qg_bakeoff.default_output_dir(date(2026, 7, 6), multi_run=True).name == "2026-07-06-qg-bakeoff-multirun"
@@ -226,6 +227,12 @@ def test_cell_artifact_path_round_trips_all_arms_and_mismatch_fails(tmp_path: Pa
     )
     assert qg_bakeoff._cell_artifact_path(tmp_path, route, fixture, qg_bakeoff.BARE_ARM, 3).name == (
         "openrouter-google-gemma-4-31b-it__vesnianky__bare__opencode__r3.json"
+    )
+    assert qg_bakeoff._cell_artifact_path(tmp_path, direct, fixture, qg_bakeoff.TOOLED_ARM).name == (
+        "deepseek-direct-deepseek-v4-flash__vesnianky.json"
+    )
+    assert qg_bakeoff._cell_artifact_path(tmp_path, direct, fixture, qg_bakeoff.BARE_ARM, 3).name == (
+        "deepseek-direct-deepseek-v4-flash__vesnianky__bare__opencode__r3.json"
     )
     assert qg_bakeoff._cell_artifact_path(tmp_path, subscription, fixture, qg_bakeoff.BARE_ARM, 2).name == (
         "gpt-5-5__vesnianky__bare__runtime-codex__r2.json"

--- a/tests/test_routing_guard.py
+++ b/tests/test_routing_guard.py
@@ -26,6 +26,14 @@ def _no_override(monkeypatch: pytest.MonkeyPatch):
         "openrouter/openai/gpt-5.5",
         "openrouter/google/gemini-3.1-pro-preview",
         "OPENROUTER/ANTHROPIC/CLAUDE-OPUS-4.8",
+        "deepseek-direct/qwen/qwen3.6-plus",
+        "deepseek-direct/qwen3.6-plus",
+        "deepseek-direct/openai/gpt-5.5",
+        "deepseek-direct/gpt-5.5",
+        "deepseek-direct/anthropic/claude-sonnet-5",
+        "deepseek-direct/claude-sonnet-5",
+        "deepseek-direct/google/gemini-3.1-pro-preview",
+        "deepseek-direct/gemini-3.1-pro-preview",
     ],
 )
 def test_forbidden_models_refused(model: str) -> None:
@@ -39,6 +47,8 @@ def test_forbidden_models_refused(model: str) -> None:
         "openrouter/google/gemma-4-31b-it",  # google/ but NOT gemini — no subscription lane
         "openrouter/deepseek/deepseek-v4-flash",
         "openrouter/deepseek/deepseek-v4-pro",
+        "deepseek-direct/deepseek-v4-flash",
+        "deepseek-direct/deepseek-v4-pro",
         "gemini-3.1-pro-high",  # agy NATIVE lane (no openrouter/ prefix) is the subscription path
         "claude-opus-4.8",  # native Anthropic lane
         "gpt-5.5",  # native codex lane
@@ -108,12 +118,11 @@ def test_delegate_help_does_not_advertise_qwen() -> None:
     so both argparse choices AND help prose are covered (codex re-review of
     #4500: the first source-check missed a prose mention)."""
     import subprocess
-    import sys
     from pathlib import Path
 
     repo_root = Path(__file__).resolve().parent.parent
     result = subprocess.run(
-        [sys.executable, str(repo_root / "scripts" / "delegate.py"), "dispatch", "--help"],
+        [str(repo_root / ".venv" / "bin" / "python"), str(repo_root / "scripts" / "delegate.py"), "dispatch", "--help"],
         capture_output=True,
         text=True,
         cwd=repo_root,
@@ -128,13 +137,12 @@ def test_delegate_dispatch_dry_run_rejects_guarded_model(tmp_path) -> None:
     exit 2 with the guard message BEFORE the dry-run task_id prints — proving
     cmd_dispatch actually reaches the guard (late import included)."""
     import subprocess
-    import sys
     from pathlib import Path
 
     repo_root = Path(__file__).resolve().parent.parent
     result = subprocess.run(
         [
-            sys.executable,
+            str(repo_root / ".venv" / "bin" / "python"),
             str(repo_root / "scripts" / "delegate.py"),
             "dispatch",
             "--agent",

--- a/tests/test_routing_guard.py
+++ b/tests/test_routing_guard.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+
 import pytest
 
 from scripts.ai_agent_bridge.routing_guard import (
@@ -34,6 +36,19 @@ def _no_override(monkeypatch: pytest.MonkeyPatch):
         "deepseek-direct/claude-sonnet-5",
         "deepseek-direct/google/gemini-3.1-pro-preview",
         "deepseek-direct/gemini-3.1-pro-preview",
+        # grok-build adversarial corpus (review-4730-guard): blocklist bypass
+        # variants that motivated the positive fail-closed allowlist.
+        "deepseek-direct/anthropic-claude-sonnet-5",
+        "deepseek-direct/anthropic_claude-sonnet-5",
+        "deepseek-direct/openai-gpt-5.5",
+        "deepseek-direct/google-gemini-3.1-pro",
+        "deepseek-direct/../claude-opus-4-8",
+        "deepseek-direct/some-claude-model",
+        "deepseek-direct/someqwenmodel",
+        "deepseek_direct/claude-sonnet-5",
+        # non-subscription but non-DeepSeek: refused by the allowlist too
+        "deepseek-direct/mistral-large",
+        "deepseek-direct/",
     ],
 )
 def test_forbidden_models_refused(model: str) -> None:
@@ -122,7 +137,7 @@ def test_delegate_help_does_not_advertise_qwen() -> None:
 
     repo_root = Path(__file__).resolve().parent.parent
     result = subprocess.run(
-        [str(repo_root / ".venv" / "bin" / "python"), str(repo_root / "scripts" / "delegate.py"), "dispatch", "--help"],
+        [sys.executable, str(repo_root / "scripts" / "delegate.py"), "dispatch", "--help"],
         capture_output=True,
         text=True,
         cwd=repo_root,
@@ -142,7 +157,7 @@ def test_delegate_dispatch_dry_run_rejects_guarded_model(tmp_path) -> None:
     repo_root = Path(__file__).resolve().parent.parent
     result = subprocess.run(
         [
-            str(repo_root / ".venv" / "bin" / "python"),
+            sys.executable,
             str(repo_root / "scripts" / "delegate.py"),
             "dispatch",
             "--agent",


### PR DESCRIPTION
## Summary
- Attributed the current Hermes `deepseek-v4-pro` path with request-level CONNECT trace evidence: it already reaches first-party `api.deepseek.com`, so no Hermes model-provider flip was needed.
- Added qg bakeoff first-party opencode pins `deepseek-direct/deepseek-v4-flash` and `deepseek-direct/deepseek-v4-pro`, while keeping OpenRouter DeepSeek pins available as named comparison baselines.
- Tightened `routing_guard` so `deepseek-direct/*` accepts DeepSeek-family pins but still refuses qwen and subscription-family aliases.
- Updated `agents_extensions/shared/rules/model-assignment.md` to flag first-party `deepseek-direct` as the #4358/#4626 QG bakeoff default.

Refs #4358
Refs #4321

## Evidence

### Hermes route attribution
Captured with a local CONNECT proxy around `hermes -z ... -m deepseek-v4-pro`; key material was not logged.

```text
trace_id=TRACE-4358-PROXY-20260707T095525Z
TRACE_PROXY CONNECT api.deepseek.com:443
TRACE_PROXY CONNECT api.deepseek.com:443
TRACE_PROXY CONNECT api.deepseek.com:443
returncode=0
stdout=TRACE-4358-PROXY-20260707T095525Z
```

Hermes config backup made before trace/config toggles:

```text
/Users/krisztiankoos/.hermes/config.yaml.bak.20260707_095415
```

### opencode first-party provider
Local opencode config backup made before editing:

```text
/Users/krisztiankoos/.config/opencode/opencode.jsonc.bak.20260707_095745
```

Redacted custom provider stanza now present in `~/.config/opencode/opencode.jsonc`:

```json
"deepseek-direct": {
  "npm": "@ai-sdk/openai-compatible",
  "name": "DeepSeek Direct",
  "options": {
    "baseURL": "https://api.deepseek.com",
    "apiKey": "[REDACTED]"
  },
  "models": {
    "deepseek-v4-flash": {
      "name": "DeepSeek V4 Flash"
    },
    "deepseek-v4-pro": {
      "name": "DeepSeek V4 Pro"
    }
  }
}
```

Provider model list:

```text
$ opencode models deepseek-direct
deepseek-direct/deepseek-v4-flash
deepseek-direct/deepseek-v4-pro
```

Live one-line direct probe:

```text
$ opencode run --model deepseek-direct/deepseek-v4-flash --format json -- "Reply with exactly DS_DIRECT_OK_4358 and no other text."
{"type":"text",...,"text":"DS_DIRECT_OK_4358",...}
{"type":"step_finish",...,"tokens":{"total":28157,"input":28127,"output":8,"reasoning":22,...},"cost":0}
```

### Routing guard
DeepSeek direct pins are accepted by unit coverage; qwen and subscription-family pins under `deepseek-direct/` are refused. OpenRouter DeepSeek pins remain allowed for the comparison baseline.

```text
$ .venv/bin/pytest tests/test_routing_guard.py tests/audit/test_qg_bakeoff.py tests/test_qg_bakeoff_multirun.py tests/test_qg_bakeoff_emitter.py -q
============================== 99 passed in 0.85s ==============================
```

### Additional verification

```text
$ .venv/bin/ruff check scripts/ai_agent_bridge/routing_guard.py scripts/audit/qg_bakeoff.py tests/test_routing_guard.py tests/audit/test_qg_bakeoff.py tests/test_qg_bakeoff_multirun.py
All checks passed!

$ git diff --check
# no output

$ .venv/bin/python scripts/audit/lint_agent_trailer.py
✅ All 1 non-skipped commit(s) carry an X-Agent trailer.
```

Pre-commit on commit also passed ruff, affected pytest, gitleaks, and repository hooks.

### Independent review
Poolside (`poolside/poolside/laguna-m.1`, high) reviewed the inline diff for blockers and returned: **No blockers found.**

### GLM/zai note-only assessment
Hermes credential inventory already includes `zai`; opencode `ask-glm` remains the existing LOCAL-ONLY route. This PR intentionally makes no GLM routing changes and leaves the LOCAL-ONLY CI guard unchanged.

## Driver-review note
Draft status is intentional. Per dispatch brief, stop before merge for driver review and secrets pass.
