### PR TITLE
fix(mcp): #4681 add derived subject enum to search_images (+pin-test)

### DIFF
--- a/.mcp/servers/sources/server.py
+++ b/.mcp/servers/sources/server.py
@@ -183,7 +183,11 @@ async def list_tools() -> list[Tool]:
                     },
                     "subject": {
                         "type": "string",
-                        "description": "Filter by subject (e.g., 'bukvar', 'ukrainska-mova'). Optional."
+                        "description": (
+                            "Optional canonical textbook subject slug. "
+                            "Examples: 'ukrmova', 'ukrlit', 'istoriya', 'bukvar'."
+                        ),
+                        "enum": list(CANONICAL_TEXTBOOK_SUBJECTS),
                     },
                     "limit": {
                         "type": "integer",

--- a/tests/test_mcp_sources_server.py
+++ b/tests/test_mcp_sources_server.py
@@ -85,6 +85,13 @@ class TestListTools:
         assert subject["enum"] == list(server_module.CANONICAL_TEXTBOOK_SUBJECTS)
         assert "ukrmova" in subject["description"]
 
+    def test_search_images_subject_schema(self, server_module):
+        tools = _run(server_module.list_tools())
+        search_images = next(t for t in tools if t.name == "search_images")
+        subject = search_images.inputSchema["properties"]["subject"]
+        assert subject["enum"] == list(server_module.CANONICAL_TEXTBOOK_SUBJECTS)
+        assert "ukrmova" in subject["description"]
+
     def test_verify_words_schema(self, server_module):
         tools = _run(server_module.list_tools())
         vw = next(t for t in tools if t.name == "verify_words")


### PR DESCRIPTION
**Scope correction vs the issue:** live-probed the running server today (`tools/list` on :8766): `search_text` ALREADY serves the full derived 25-subject enum incl. batch-3 (`finansova` present) — fixed by #4605's `list(CANONICAL_TEXTBOOK_SUBJECTS)` derivation + #4667's canonical expansion + this morning's sources restart. The issue's 'stale after restart' observation was most likely a client-side cached schema. The REAL remaining gap was the sibling: **`search_images` had no enum at all** (live-verified: `enum: NONE`).

This PR (authored by agy, dispatch `4681-subject-enum`):
- adds `enum: list(CANONICAL_TEXTBOOK_SUBJECTS)` to `search_images`' subject param (same single-source derivation — no copied list)
- pin-test `test_search_images_subject_schema` mirroring the existing `search_text` pin (both fail if schema and canonical drift)

Sibling sweep (agy): `search_sources`/`search_literary`/`search_external` take no textbook-subject param — no further gaps.

**Post-merge:** sources service restart required to serve the new `search_images` schema (orchestrator will do it and live-verify both enums).

Fixes #4681

🤖 Generated with [Claude Code](https://claude.com/claude-code)