### PR TITLE
[codex] fix agent runtime no-first-byte failover

### DIFF
--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -162,8 +162,9 @@ primary is not re-probed immediately.
 
 Eligible trigger classes are deliberately narrow: 401/403 auth failure,
 429/quota exhaustion, 5xx/overloaded, transport failures such as connection
-refused/reset/read timeout, and parsed-but-empty responses. Content-policy
-refusals and 4xx request-format errors do not fail over.
+refused/reset/read timeout, initial-response timeout with no observed output,
+and parsed-but-empty responses. Content-policy refusals, 4xx request-format
+errors, and mid-stream silence timeouts after partial output do not fail over.
 
 Every runner-level switch emits the same substitution-shaped payload used by
 Hermes fallback surfacing: `requested_provider`, `requested_model`,

--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -163,8 +163,9 @@ primary is not re-probed immediately.
 Eligible trigger classes are deliberately narrow: 401/403 auth failure,
 429/quota exhaustion, 5xx/overloaded, transport failures such as connection
 refused/reset/read timeout, initial-response timeout with no observed output,
-and parsed-but-empty responses. Content-policy refusals, 4xx request-format
-errors, and mid-stream silence timeouts after partial output do not fail over.
+stdout-silence timeout before first stdout, and parsed-but-empty responses.
+Content-policy refusals, 4xx request-format errors, and mid-stream silence
+timeouts after partial output do not fail over.
 
 Every runner-level switch emits the same substitution-shaped payload used by
 Hermes fallback surfacing: `requested_provider`, `requested_model`,

--- a/scripts/agent_runtime/errors.py
+++ b/scripts/agent_runtime/errors.py
@@ -8,6 +8,8 @@ Issue: #1184
 """
 from __future__ import annotations
 
+from typing import Any
+
 
 class AgentRuntimeError(Exception):
     """Base class for all errors raised by the agent runtime."""
@@ -49,9 +51,16 @@ class AgentTimeoutError(AgentRuntimeError):
     that legitimately need more than 30 minutes should request it per-call.
     """
 
-    def __init__(self, agent: str, hard_timeout: int):
+    def __init__(
+        self,
+        agent: str,
+        hard_timeout: int,
+        *,
+        substitution: dict[str, Any] | None = None,
+    ):
         self.agent = agent
         self.hard_timeout = hard_timeout
+        self.substitution = substitution
         super().__init__(
             f"{agent} exceeded hard_timeout={hard_timeout}s"
         )
@@ -78,11 +87,13 @@ class AgentStalledError(AgentRuntimeError):
         last_activity_age: float,
         *,
         kind: str = "stall",
+        substitution: dict[str, Any] | None = None,
     ):
         self.agent = agent
         self.stall_timeout = stall_timeout
         self.last_activity_age = last_activity_age
         self.kind = kind
+        self.substitution = substitution
         super().__init__(
             f"{agent} stalled: {last_activity_age:.0f}s since last activity "
             f"(stall_timeout={stall_timeout}s)"

--- a/scripts/agent_runtime/failover.py
+++ b/scripts/agent_runtime/failover.py
@@ -357,7 +357,7 @@ def classify_failover_trigger(
         return "overloaded"
     if _TRANSPORT_RE.search(text):
         return "transport"
-    if kill_reason in {"stdout_silence_timeout", "initial_response_timeout"}:
+    if kill_reason == "initial_response_timeout":
         return "transport"
     if _EMPTY_RESPONSE_RE.search(text):
         return "empty_response"

--- a/scripts/agent_runtime/failover.py
+++ b/scripts/agent_runtime/failover.py
@@ -359,6 +359,8 @@ def classify_failover_trigger(
         return "transport"
     if kill_reason == "initial_response_timeout":
         return "transport"
+    if kill_reason == "stdout_silence_timeout" and not (stdout_text or "").strip():
+        return "transport"
     if _EMPTY_RESPONSE_RE.search(text):
         return "empty_response"
     if (

--- a/scripts/agent_runtime/probe_stall_failover.py
+++ b/scripts/agent_runtime/probe_stall_failover.py
@@ -7,14 +7,21 @@ throwaway config/cooldown DB, and spawns real subprocesses:
   response timeout should cool it and rotate to the fallback route.
 - ``streaming-silence``: primary route emits one line, then sleeps; this is a
   mid-stream silence timeout and must not rotate.
+- ``delegate-hermes-stdout-silence``: a real ``delegate.py`` worker routes
+  through the Hermes DeepSeek adapter, with ``hermes`` replaced by a temp shim.
+  The primary route emits no output and trips ``stdout_silence_timeout`` while
+  the fallback route succeeds.
 """
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
+import subprocess
 import sys
 import tempfile
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -40,6 +47,7 @@ FALLBACK_MODEL = "fallback-ok"
 PRIMARY_PROVIDER = "primary-provider"
 FALLBACK_PROVIDER = "fallback-provider"
 SUCCESS_TEXT = "stall failover ok"
+DELEGATE_HERMES_CASE = "delegate-hermes-stdout-silence"
 
 
 class ProbeError(RuntimeError):
@@ -122,7 +130,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--case",
-        choices=("no-first-byte", "streaming-silence"),
+        choices=("no-first-byte", "streaming-silence", DELEGATE_HERMES_CASE),
         default="no-first-byte",
         help="Probe case to run. Default: no-first-byte.",
     )
@@ -141,7 +149,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--stdout-silence-timeout",
         type=int,
         default=1,
-        help="Composite silence timeout seconds for streaming-silence. Default: 1.",
+        help="Composite silence timeout seconds for silence cases. Default: 1.",
     )
     parser.add_argument(
         "--hard-timeout",
@@ -179,6 +187,87 @@ def _write_probe_config(path: Path) -> Path:
     return config_path
 
 
+def _write_delegate_hermes_config(path: Path) -> Path:
+    config_path = path / "agent_runtime_failover.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "chains:",
+                "  deepseek:",
+                "    cooldown_ttl_s: 60",
+                "    routes:",
+                "      - provider: deepseek",
+                "        model: deepseek-v4-flash",
+                "      - provider: openrouter",
+                "        model: deepseek/deepseek-v4-flash",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _write_fake_hermes(bin_dir: Path, attempts_log: Path) -> Path:
+    hermes = bin_dir / "hermes"
+    hermes.write_text(
+        "\n".join(
+            [
+                "#!/bin/sh",
+                "model=''",
+                "provider=''",
+                "while [ \"$#\" -gt 0 ]; do",
+                "  case \"$1\" in",
+                "    --version|-V|version)",
+                "      printf '%s\\n' 'Hermes Agent vprobe'",
+                "      exit 0",
+                "      ;;",
+                "    -m|--model)",
+                "      shift",
+                "      model=\"$1\"",
+                "      ;;",
+                "    --provider)",
+                "      shift",
+                "      provider=\"$1\"",
+                "      ;;",
+                "  esac",
+                "  shift",
+                "done",
+                f"printf '%s/%s\\n' \"$provider\" \"$model\" >> {str(attempts_log)!r}",
+                "if [ \"$provider\" = 'openrouter' ]; then",
+                f"  printf '%s\\n' {SUCCESS_TEXT!r}",
+                "  exit 0",
+                "fi",
+                "sleep 60",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    hermes.chmod(0o700)
+    return hermes
+
+
+def _delegate_state_path(task_id: str) -> Path:
+    safe = task_id.replace("/", "_").replace("\\", "_")
+    return REPO_ROOT / "batch_state" / "tasks" / f"{safe}.json"
+
+
+def _cleanup_delegate_task(task_id: str, state: dict[str, Any] | None) -> None:
+    state_path = _delegate_state_path(task_id)
+    log_dir = state_path.parent / "logs"
+    paths = [
+        state_path,
+        log_dir / f"{task_id}.stdout.log",
+        log_dir / f"{task_id}.stderr.log",
+    ]
+    if isinstance(state, dict) and state.get("result_file"):
+        paths.append(Path(str(state["result_file"])))
+    for path in paths:
+        with contextlib.suppress(OSError):
+            path.unlink()
+
+
 def _patch_runtime(adapter: _ProbeAdapter, events: list[dict[str, Any]]) -> None:
     def fake_has_headroom(_agent: str, _model: str) -> tuple[bool, str]:
         return True, ""
@@ -199,7 +288,174 @@ def _patch_runtime(adapter: _ProbeAdapter, events: list[dict[str, Any]]) -> None
     runner_mod.resolve_invocation_telemetry = fake_resolve_invocation_telemetry
 
 
+def _run_delegate_hermes_probe(args: argparse.Namespace) -> dict[str, Any]:
+    temp_dir = tempfile.TemporaryDirectory(prefix="agent-runtime-delegate-hermes-")
+    root = Path(temp_dir.name)
+    task_id = f"stall-probe-delegate-hermes-{os.getpid()}-{int(time.time() * 1000)}"
+    state: dict[str, Any] | None = None
+    try:
+        fake_bin = root / "bin"
+        fake_bin.mkdir()
+        hermes_home = root / "hermes-home"
+        (hermes_home / "logs").mkdir(parents=True)
+        (hermes_home / "config.yaml").write_text(
+            "\n".join(
+                [
+                    "model:",
+                    "  provider: deepseek",
+                    "  default: deepseek-v4-flash",
+                    "mcp_servers:",
+                    "  sources:",
+                    "    enabled: true",
+                    "    url: http://127.0.0.1:9",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        attempts_log = root / "attempts.log"
+        _write_fake_hermes(fake_bin, attempts_log)
+        config_path = _write_delegate_hermes_config(root)
+        cooldown_db = root / "cooldowns.sqlite3"
+
+        env = os.environ.copy()
+        env[FAILOVER_CONFIG_ENV] = str(config_path)
+        env[FAILOVER_COOLDOWN_DB_ENV] = str(cooldown_db)
+        env["HERMES_HOME"] = str(hermes_home)
+        env["LU_BYPASS_RATE_LIMIT"] = "1"
+        env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+
+        python_bin = REPO_ROOT / ".venv" / "bin" / "python"
+        delegate_py = REPO_ROOT / "scripts" / "delegate.py"
+        dispatch = subprocess.run(
+            [
+                str(python_bin),
+                str(delegate_py),
+                "dispatch",
+                "--agent",
+                "deepseek",
+                "--task-id",
+                task_id,
+                "--prompt",
+                "probe",
+                "--mode",
+                "read-only",
+                "--cwd",
+                str(args.cwd.expanduser().resolve()),
+                "--model",
+                "deepseek-v4-flash",
+                "--hard-timeout",
+                str(args.hard_timeout),
+                "--silence-timeout",
+                str(args.stdout_silence_timeout),
+                "--initial-response-timeout",
+                "0",
+                "--force-agent",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=10,
+        )
+        if dispatch.returncode != 0:
+            raise ProbeError(
+                "delegate dispatch failed: "
+                f"rc={dispatch.returncode} stderr={dispatch.stderr.strip()!r}"
+            )
+
+        wait_timeout = max(10, int(args.stdout_silence_timeout) * 4 + 10)
+        waited = subprocess.run(
+            [
+                str(python_bin),
+                str(delegate_py),
+                "wait",
+                task_id,
+                "--timeout",
+                str(wait_timeout),
+                "--poll-interval",
+                "0.5",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=wait_timeout + 5,
+        )
+        try:
+            state = json.loads(waited.stdout)
+        except json.JSONDecodeError as exc:
+            raise ProbeError(
+                "delegate wait did not return task JSON: "
+                f"rc={waited.returncode} stdout={waited.stdout!r} "
+                f"stderr={waited.stderr.strip()!r}"
+            ) from exc
+        if waited.returncode != 0 or state.get("status") != "done":
+            raise ProbeError(
+                "delegate hermes probe did not finish cleanly: "
+                f"rc={waited.returncode} state={state!r} "
+                f"stderr={waited.stderr.strip()!r}"
+            )
+
+        substitution = state.get("substitution")
+        if not isinstance(substitution, dict) or not substitution.get("substituted"):
+            raise ProbeError(
+                f"delegate state did not surface substitution: {substitution!r}"
+            )
+        if substitution.get("source") != "agent-runtime-failover:transport":
+            raise ProbeError(f"unexpected substitution source: {substitution!r}")
+
+        attempts = (
+            attempts_log.read_text(encoding="utf-8").splitlines()
+            if attempts_log.exists()
+            else []
+        )
+        expected_attempts = [
+            "deepseek/deepseek-v4-flash",
+            "openrouter/deepseek/deepseek-v4-flash",
+        ]
+        if attempts != expected_attempts:
+            raise ProbeError(f"unexpected hermes attempts: {attempts!r}")
+
+        return {
+            "ok": True,
+            "case": args.case,
+            "attempts": attempts,
+            "cooldown_db": str(cooldown_db),
+            "rotated": True,
+            "state_status": state.get("status"),
+            "stdout_silence_timeout": args.stdout_silence_timeout,
+            "initial_response_timeout": 0,
+            "substitution": substitution,
+        }
+    finally:
+        state_path = _delegate_state_path(task_id)
+        if state is None and state_path.exists():
+            with contextlib.suppress(Exception):
+                state = json.loads(state_path.read_text(encoding="utf-8"))
+        if isinstance(state, dict) and state.get("status") in {"running", "spawning"}:
+            with contextlib.suppress(Exception):
+                subprocess.run(
+                    [
+                        str(REPO_ROOT / ".venv" / "bin" / "python"),
+                        str(REPO_ROOT / "scripts" / "delegate.py"),
+                        "cancel",
+                        task_id,
+                    ],
+                    cwd=REPO_ROOT,
+                    env=os.environ.copy(),
+                    text=True,
+                    capture_output=True,
+                    timeout=5,
+                )
+        _cleanup_delegate_task(task_id, state)
+        temp_dir.cleanup()
+
+
 def run_probe(args: argparse.Namespace) -> dict[str, Any]:
+    if args.case == DELEGATE_HERMES_CASE:
+        return _run_delegate_hermes_probe(args)
+
     temp_dir = tempfile.TemporaryDirectory(prefix="agent-runtime-stall-probe-")
     root = Path(temp_dir.name)
     if args.cooldown_db is None:

--- a/scripts/agent_runtime/probe_stall_failover.py
+++ b/scripts/agent_runtime/probe_stall_failover.py
@@ -1,0 +1,353 @@
+"""Deterministic probe for initial-response failover rotation.
+
+The probe installs an in-process fake adapter, points runner failover at a
+throwaway config/cooldown DB, and spawns real subprocesses:
+
+- ``no-first-byte``: primary route emits no output and sleeps; the initial
+  response timeout should cool it and rotate to the fallback route.
+- ``streaming-silence``: primary route emits one line, then sleeps; this is a
+  mid-stream silence timeout and must not rotate.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+SCRIPT_PATH = Path(__file__).resolve()
+SCRIPTS_DIR = SCRIPT_PATH.parents[1]
+REPO_ROOT = SCRIPT_PATH.parents[2]
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from agent_runtime import runner as runner_mod
+from agent_runtime.adapters.base import InvocationPlan
+from agent_runtime.errors import AgentStalledError
+from agent_runtime.failover import FAILOVER_CONFIG_ENV, FAILOVER_COOLDOWN_DB_ENV
+from agent_runtime.result import ParseResult
+from agent_runtime.routes import RUNTIME_ROUTE_TOOL_CONFIG_KEY
+from agent_runtime.telemetry import InvocationTelemetry
+
+PROBE_AGENT = "stall-probe"
+PRIMARY_MODEL = "primary-stall"
+FALLBACK_MODEL = "fallback-ok"
+PRIMARY_PROVIDER = "primary-provider"
+FALLBACK_PROVIDER = "fallback-provider"
+SUCCESS_TEXT = "stall failover ok"
+
+
+class ProbeError(RuntimeError):
+    """Expected probe/configuration failure."""
+
+
+@dataclass
+class _ProbeAdapter:
+    """Small fake adapter that turns failover routes into subprocess shapes."""
+
+    case: str
+    attempts: list[str] = field(default_factory=list)
+
+    name = PROBE_AGENT
+    default_model = PRIMARY_MODEL
+    supported_modes = frozenset({"read-only"})
+
+    def build_invocation(
+        self,
+        *,
+        prompt: str,
+        mode: str,
+        cwd: Path,
+        model: str | None,
+        task_id: str | None,
+        session_id: str | None,
+        tool_config: dict | None,
+        effort: str | None = None,
+    ) -> InvocationPlan:
+        _ = prompt
+        _ = mode
+        _ = task_id
+        _ = session_id
+        _ = effort
+        route = dict((tool_config or {}).get(RUNTIME_ROUTE_TOOL_CONFIG_KEY) or {})
+        route_model = str(route.get("model") or model or self.default_model)
+        self.attempts.append(route_model)
+        if route_model == FALLBACK_MODEL:
+            shell = f"printf '%s\\n' {SUCCESS_TEXT!r}"
+        elif self.case == "streaming-silence":
+            shell = "printf '%s\\n' 'partial output'; sleep 60"
+        else:
+            shell = "sleep 60"
+        return InvocationPlan(
+            cmd=["/bin/sh", "-c", shell],
+            cwd=cwd,
+            metadata={"route_model": route_model},
+        )
+
+    def parse_response(
+        self,
+        *,
+        stdout: str,
+        stderr: str,
+        returncode: int,
+        output_file: Path | None,
+        plan: InvocationPlan | None = None,
+        call_start_time: float | None = None,
+    ) -> ParseResult:
+        _ = stderr
+        _ = returncode
+        _ = output_file
+        _ = plan
+        _ = call_start_time
+        if SUCCESS_TEXT in stdout:
+            return ParseResult(ok=True, response=stdout.strip(), stderr_excerpt=None)
+        return ParseResult(ok=False, response="", stderr_excerpt=None)
+
+    def liveness_signal_paths(self, plan: InvocationPlan) -> tuple[Path, ...]:
+        _ = plan
+        return ()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Probe runner-level failover behavior for no-first-byte stalls "
+            "using an isolated failover config and cooldown DB."
+        )
+    )
+    parser.add_argument(
+        "--case",
+        choices=("no-first-byte", "streaming-silence"),
+        default="no-first-byte",
+        help="Probe case to run. Default: no-first-byte.",
+    )
+    parser.add_argument(
+        "--cooldown-db",
+        type=Path,
+        help="Throwaway SQLite cooldown DB path. Defaults to a temp directory.",
+    )
+    parser.add_argument(
+        "--initial-response-timeout",
+        type=int,
+        default=1,
+        help="Initial response timeout seconds. Default: 1.",
+    )
+    parser.add_argument(
+        "--stdout-silence-timeout",
+        type=int,
+        default=1,
+        help="Composite silence timeout seconds for streaming-silence. Default: 1.",
+    )
+    parser.add_argument(
+        "--hard-timeout",
+        type=int,
+        default=30,
+        help="Hard timeout seconds. Default: 30.",
+    )
+    parser.add_argument(
+        "--cwd",
+        type=Path,
+        default=REPO_ROOT,
+        help="Working directory for probe subprocesses. Default: repo root.",
+    )
+    return parser
+
+
+def _write_probe_config(path: Path) -> Path:
+    config_path = path / "agent_runtime_failover.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "chains:",
+                f"  {PROBE_AGENT}:",
+                "    cooldown_ttl_s: 60",
+                "    routes:",
+                f"      - provider: {PRIMARY_PROVIDER}",
+                f"        model: {PRIMARY_MODEL}",
+                f"      - provider: {FALLBACK_PROVIDER}",
+                f"        model: {FALLBACK_MODEL}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _patch_runtime(adapter: _ProbeAdapter, events: list[dict[str, Any]]) -> None:
+    def fake_has_headroom(_agent: str, _model: str) -> tuple[bool, str]:
+        return True, ""
+
+    def fake_write_record(record: dict[str, Any]) -> None:
+        events.append({"event_name": "usage_record", **record})
+
+    def fake_resolve_invocation_telemetry(**_kwargs: Any) -> InvocationTelemetry:
+        return InvocationTelemetry(
+            model=adapter.attempts[-1] if adapter.attempts else PRIMARY_MODEL,
+            effort="unknown",
+            cli_version="probe",
+        )
+
+    runner_mod._ADAPTER_CACHE[PROBE_AGENT] = adapter
+    runner_mod.has_headroom = fake_has_headroom
+    runner_mod.write_record = fake_write_record
+    runner_mod.resolve_invocation_telemetry = fake_resolve_invocation_telemetry
+
+
+def run_probe(args: argparse.Namespace) -> dict[str, Any]:
+    temp_dir = tempfile.TemporaryDirectory(prefix="agent-runtime-stall-probe-")
+    root = Path(temp_dir.name)
+    if args.cooldown_db is None:
+        cooldown_db = root / "cooldowns.sqlite3"
+    else:
+        cooldown_db = args.cooldown_db.expanduser().resolve()
+        cooldown_db.parent.mkdir(parents=True, exist_ok=True)
+        if cooldown_db.exists():
+            temp_dir.cleanup()
+            raise ProbeError(
+                f"cooldown DB already exists; pass an isolated path: {cooldown_db}"
+            )
+
+    old_config = os.environ.get(FAILOVER_CONFIG_ENV)
+    old_cooldown = os.environ.get(FAILOVER_COOLDOWN_DB_ENV)
+    old_cache_entry = runner_mod._ADAPTER_CACHE.get(PROBE_AGENT)
+    old_has_headroom = runner_mod.has_headroom
+    old_write_record = runner_mod.write_record
+    old_resolve_invocation_telemetry = runner_mod.resolve_invocation_telemetry
+    events: list[dict[str, Any]] = []
+    adapter = _ProbeAdapter(case=args.case)
+
+    try:
+        config_path = _write_probe_config(root)
+        os.environ[FAILOVER_CONFIG_ENV] = str(config_path)
+        os.environ[FAILOVER_COOLDOWN_DB_ENV] = str(cooldown_db)
+        _patch_runtime(adapter, events)
+
+        def event_sink(event_name: str, **fields: Any) -> None:
+            events.append({"event_name": event_name, **fields})
+
+        if args.case == "streaming-silence":
+            try:
+                runner_mod.invoke(
+                    PROBE_AGENT,
+                    "probe",
+                    mode="read-only",
+                    cwd=args.cwd.expanduser().resolve(),
+                    task_id="stall-failover-probe-streaming-silence",
+                    entrypoint="runtime",
+                    hard_timeout=args.hard_timeout,
+                    initial_response_timeout=args.initial_response_timeout,
+                    stdout_silence_timeout=args.stdout_silence_timeout,
+                    event_sink=event_sink,
+                )
+            except AgentStalledError as exc:
+                if exc.kind != "stdout_silence_timeout":
+                    raise ProbeError(
+                        f"expected stdout_silence_timeout, got {exc.kind!r}"
+                    ) from exc
+                usage_substitution = [
+                    event.get("substitution")
+                    for event in events
+                    if event.get("event_name") == "usage_record"
+                    and isinstance(event.get("substitution"), dict)
+                ]
+                if usage_substitution:
+                    raise ProbeError(
+                        "streaming-silence unexpectedly persisted substitution"
+                    ) from exc
+                if adapter.attempts != [PRIMARY_MODEL]:
+                    raise ProbeError(
+                        f"streaming-silence rotated unexpectedly: {adapter.attempts!r}"
+                    ) from exc
+                return {
+                    "ok": True,
+                    "case": args.case,
+                    "attempts": adapter.attempts,
+                    "cooldown_db": str(cooldown_db),
+                    "rotated": False,
+                    "stalled_kind": exc.kind,
+                }
+            raise ProbeError("streaming-silence did not raise AgentStalledError")
+
+        result = runner_mod.invoke(
+            PROBE_AGENT,
+            "probe",
+            mode="read-only",
+            cwd=args.cwd.expanduser().resolve(),
+            task_id="stall-failover-probe-no-first-byte",
+            entrypoint="runtime",
+            hard_timeout=args.hard_timeout,
+            initial_response_timeout=args.initial_response_timeout,
+            stdout_silence_timeout=None,
+            event_sink=event_sink,
+        )
+        substitution = result.substitution
+        if not isinstance(substitution, dict) or not substitution.get("substituted"):
+            raise ProbeError(f"missing failover substitution: {substitution!r}")
+        if substitution.get("source") != "agent-runtime-failover:transport":
+            raise ProbeError(f"unexpected substitution source: {substitution!r}")
+        usage_records = [
+            event for event in events if event.get("event_name") == "usage_record"
+        ]
+        if not usage_records or not isinstance(
+            usage_records[-1].get("substitution"), dict
+        ):
+            raise ProbeError("usage record did not persist substitution")
+        usage_substitution = usage_records[-1]["substitution"]
+        if adapter.attempts != [PRIMARY_MODEL, FALLBACK_MODEL]:
+            raise ProbeError(f"unexpected route attempts: {adapter.attempts!r}")
+        return {
+            "ok": True,
+            "case": args.case,
+            "attempts": adapter.attempts,
+            "cooldown_db": str(cooldown_db),
+            "response": result.response,
+            "rotated": True,
+            "substitution": substitution,
+            "usage_substitution": usage_substitution,
+            "usage_record_surfaced": True,
+        }
+    finally:
+        if old_config is None:
+            os.environ.pop(FAILOVER_CONFIG_ENV, None)
+        else:
+            os.environ[FAILOVER_CONFIG_ENV] = old_config
+        if old_cooldown is None:
+            os.environ.pop(FAILOVER_COOLDOWN_DB_ENV, None)
+        else:
+            os.environ[FAILOVER_COOLDOWN_DB_ENV] = old_cooldown
+        if old_cache_entry is None:
+            runner_mod._ADAPTER_CACHE.pop(PROBE_AGENT, None)
+        else:
+            runner_mod._ADAPTER_CACHE[PROBE_AGENT] = old_cache_entry
+        runner_mod.has_headroom = old_has_headroom
+        runner_mod.write_record = old_write_record
+        runner_mod.resolve_invocation_telemetry = old_resolve_invocation_telemetry
+        temp_dir.cleanup()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        summary = run_probe(args)
+    except ProbeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:
+        print(
+            f"ERROR: unexpected probe failure: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    print(json.dumps(summary, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -1286,11 +1286,15 @@ def _raise_for_kill_reason(
     stall_timeout: int,
     hard_timeout: int,
     event_sink: Callable[..., None] | None = None,
+    substitution: dict[str, Any] | None = None,
 ) -> None:
     """Map watchdog kill reasons to typed runtime errors + usage records."""
     if not kill_reason:
         return
     parse = execution.parse
+    record_substitution = (
+        substitution if substitution is not None else parse.substitution
+    )
     if kill_reason == "hard_timeout" and parse.ok:
         return
     if kill_reason == "stdout_silence_timeout":
@@ -1311,7 +1315,7 @@ def _raise_for_kill_reason(
             stalled=True,
             stderr_excerpt=parse.stderr_excerpt or execution.stderr_text[:500],
             tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
-            substitution=parse.substitution,
+            substitution=record_substitution,
         )
         _emit_substitution_event(
             agent_name=agent_name,
@@ -1319,7 +1323,7 @@ def _raise_for_kill_reason(
             task_id=task_id,
             cwd=cwd,
             model=model,
-            substitution=parse.substitution,
+            substitution=record_substitution,
             event_sink=event_sink,
         )
         write_record(record)
@@ -1328,6 +1332,7 @@ def _raise_for_kill_reason(
             stdout_silence_timeout or stall_timeout,
             execution.duration_s,
             kind="stdout_silence_timeout",
+            substitution=record_substitution,
         )
 
     if kill_reason == "initial_response_timeout":
@@ -1356,7 +1361,7 @@ def _raise_for_kill_reason(
                 )
             ),
             tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
-            substitution=parse.substitution,
+            substitution=record_substitution,
         )
         _emit_substitution_event(
             agent_name=agent_name,
@@ -1364,7 +1369,7 @@ def _raise_for_kill_reason(
             task_id=task_id,
             cwd=cwd,
             model=model,
-            substitution=parse.substitution,
+            substitution=record_substitution,
             event_sink=event_sink,
         )
         write_record(record)
@@ -1373,6 +1378,7 @@ def _raise_for_kill_reason(
             initial_response_timeout or stall_timeout,
             execution.duration_s,
             kind="initial_response_timeout",
+            substitution=record_substitution,
         )
 
     if kill_reason == "hard_timeout" and not parse.ok:
@@ -1397,7 +1403,7 @@ def _raise_for_kill_reason(
                 or tail_liveness_file_for_debug(execution.liveness_paths)[:500]
             ),
             tokens=None,  # TODO(#3153 PR2): extract tokens for this result path.
-            substitution=parse.substitution,
+            substitution=record_substitution,
         )
         _emit_substitution_event(
             agent_name=agent_name,
@@ -1405,11 +1411,15 @@ def _raise_for_kill_reason(
             task_id=task_id,
             cwd=cwd,
             model=model,
-            substitution=parse.substitution,
+            substitution=record_substitution,
             event_sink=event_sink,
         )
         write_record(record)
-        raise AgentTimeoutError(agent_name, hard_timeout)
+        raise AgentTimeoutError(
+            agent_name,
+            hard_timeout,
+            substitution=record_substitution,
+        )
 
 
 def _invoke_gemini_with_fallback(
@@ -1980,6 +1990,21 @@ def _invoke_with_runner_failover(
                 continue
 
         if execution.kill_reason:
+            source_trigger = trigger or last_trigger
+            if route != requested_route and source_trigger == "requested":
+                source_trigger = "cooldown"
+            timeout_substitution = None
+            if route != requested_route or parse.substitution:
+                timeout_substitution = _route_substitution_for_attempt(
+                    requested_route=requested_route,
+                    actual_route=route,
+                    source_trigger=source_trigger,
+                    adapter_substitution=parse.substitution,
+                )
+                emit_runner_substitution_marker(
+                    timeout_substitution,
+                    logger=_logger,
+                )
             _raise_for_kill_reason(
                 agent_name=agent_name,
                 kill_reason=execution.kill_reason,
@@ -1996,6 +2021,7 @@ def _invoke_with_runner_failover(
                 stall_timeout=stall_timeout,
                 hard_timeout=hard_timeout,
                 event_sink=event_sink,
+                substitution=timeout_substitution,
             )
 
         if parse.rate_limited:

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1389,6 +1389,7 @@ def _run_worker(
     rate_limited = False
     timed_out = False
     result = None
+    substitution: dict[str, Any] | None = None
 
     cancelled = False
     try:
@@ -1421,6 +1422,7 @@ def _run_worker(
         stderr_excerpt = result.stderr_excerpt
         returncode = result.returncode
         rate_limited = result.rate_limited
+        substitution = getattr(result, "substitution", None)
     except KeyboardInterrupt as exc:
         # Raised by our SIGTERM handler (or by Ctrl+C in manual runs).
         # The runtime's finally block has already killed the CLI
@@ -1433,6 +1435,7 @@ def _run_worker(
         stderr_excerpt = str(exc)[:500]
     except AgentStalledError as exc:
         timed_out = True
+        substitution = getattr(exc, "substitution", None)
         prefix = (
             "initial_response_timeout"
             if getattr(exc, "kind", "stall") == "initial_response_timeout"
@@ -1440,6 +1443,7 @@ def _run_worker(
         )
         stderr_excerpt = f"{prefix}: {exc}"[:500]
     except AgentTimeoutError as exc:
+        substitution = getattr(exc, "substitution", None)
         stderr_excerpt = f"hard_timeout: {exc}"[:500]
     except AgentRuntimeError as exc:
         stderr_excerpt = f"runtime error: {type(exc).__name__}: {exc}"[:500]
@@ -1521,7 +1525,9 @@ def _run_worker(
         worktree_reap = _reap_finished_worktree(Path(worktree_path))
 
     usage_record = getattr(result, "usage_record", None)
-    substitution = getattr(result, "substitution", None)
+    result_substitution = getattr(result, "substitution", None)
+    if result_substitution is not None:
+        substitution = result_substitution
     if substitution is None and isinstance(usage_record, dict):
         substitution = usage_record.get("substitution")
 

--- a/tests/agent_runtime/test_runner_failover.py
+++ b/tests/agent_runtime/test_runner_failover.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from agent_runtime import runner as runner_mod
 from agent_runtime.adapters.base import InvocationPlan
-from agent_runtime.errors import RateLimitedError
+from agent_runtime.errors import AgentStalledError, RateLimitedError
 from agent_runtime.failover import (
     FAILOVER_CONFIG_ENV,
     FAILOVER_COOLDOWN_DB_ENV,
@@ -214,6 +214,16 @@ _TRIGGER_CASES = [
         },
     ),
     (
+        "transport",
+        {
+            "parse": ParseResult(ok=False, response="", stderr_excerpt=None),
+            "returncode": -9,
+            "kill_reason": "initial_response_timeout",
+            "stdout_text": "",
+            "stderr_text": "",
+        },
+    ),
+    (
         "empty_response",
         {
             "parse": ParseResult(ok=False, response="", stderr_excerpt=None),
@@ -300,6 +310,37 @@ def test_runner_failover_does_not_switch_for_content_policy(
     assert records[0]["outcome"] == "error"
     assert "substitution" not in records[0]
     assert RUNNER_FAILOVER_MARKER not in capsys.readouterr().err
+
+
+def test_runner_failover_does_not_switch_for_streaming_silence_timeout(
+    tmp_path,
+    monkeypatch,
+):
+    adapter, records, _emitted_events = _install_fake_runtime(
+        monkeypatch,
+        tmp_path,
+        {
+            "primary-model": {
+                "parse": ParseResult(ok=False, response="", stderr_excerpt=None),
+                "returncode": -9,
+                "kill_reason": "stdout_silence_timeout",
+                "stdout_text": "partial output\n",
+                "stderr_text": "",
+            },
+            "fallback-model": {
+                "parse": ParseResult(ok=True, response="fallback ok"),
+                "returncode": 0,
+            },
+        },
+    )
+
+    with pytest.raises(AgentStalledError) as exc_info:
+        runner_mod.invoke("failover-test", "hello", mode="read-only", cwd=tmp_path)
+
+    assert exc_info.value.kind == "stdout_silence_timeout"
+    assert adapter.attempts == ["primary-model"]
+    assert records[0]["outcome"] == "stalled"
+    assert "substitution" not in records[0]
 
 
 def test_runner_failover_cooldown_routes_next_dispatch_directly_to_fallback(
@@ -487,6 +528,34 @@ def test_classifier_refuses_to_rotate_on_inband_400():
         returncode=0,
         kill_reason=None,
         stdout_text="",
+        stderr_text="",
+    )
+
+    assert trigger is None
+
+
+def test_classifier_routes_initial_response_timeout_to_transport():
+    from agent_runtime.failover import classify_failover_trigger
+
+    trigger = classify_failover_trigger(
+        parse=ParseResult(ok=False, response="", stderr_excerpt=None),
+        returncode=-9,
+        kill_reason="initial_response_timeout",
+        stdout_text="",
+        stderr_text="",
+    )
+
+    assert trigger == "transport"
+
+
+def test_classifier_refuses_to_rotate_on_streaming_silence_timeout():
+    from agent_runtime.failover import classify_failover_trigger
+
+    trigger = classify_failover_trigger(
+        parse=ParseResult(ok=False, response="", stderr_excerpt=None),
+        returncode=-9,
+        kill_reason="stdout_silence_timeout",
+        stdout_text="partial output\n",
         stderr_text="",
     )
 

--- a/tests/agent_runtime/test_runner_failover.py
+++ b/tests/agent_runtime/test_runner_failover.py
@@ -224,6 +224,16 @@ _TRIGGER_CASES = [
         },
     ),
     (
+        "transport",
+        {
+            "parse": ParseResult(ok=False, response="", stderr_excerpt=None),
+            "returncode": -9,
+            "kill_reason": "stdout_silence_timeout",
+            "stdout_text": "",
+            "stderr_text": "",
+        },
+    ),
+    (
         "empty_response",
         {
             "parse": ParseResult(ok=False, response="", stderr_excerpt=None),
@@ -341,6 +351,47 @@ def test_runner_failover_does_not_switch_for_streaming_silence_timeout(
     assert adapter.attempts == ["primary-model"]
     assert records[0]["outcome"] == "stalled"
     assert "substitution" not in records[0]
+
+
+def test_runner_failover_surfaces_substitution_when_final_route_times_out(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    adapter, records, emitted_events = _install_fake_runtime(
+        monkeypatch,
+        tmp_path,
+        {
+            "primary-model": {
+                "parse": ParseResult(ok=False, response="", stderr_excerpt=None),
+                "returncode": -9,
+                "kill_reason": "initial_response_timeout",
+                "stdout_text": "",
+                "stderr_text": "",
+            },
+            "fallback-model": {
+                "parse": ParseResult(ok=False, response="", stderr_excerpt=None),
+                "returncode": -9,
+                "kill_reason": "initial_response_timeout",
+                "stdout_text": "",
+                "stderr_text": "",
+            },
+        },
+    )
+
+    with pytest.raises(AgentStalledError) as exc_info:
+        runner_mod.invoke("failover-test", "hello", mode="read-only", cwd=tmp_path)
+
+    assert exc_info.value.kind == "initial_response_timeout"
+    assert adapter.attempts == ["primary-model", "fallback-model"]
+    assert exc_info.value.substitution is not None
+    assert exc_info.value.substitution["requested_provider"] == "primary-provider"
+    assert exc_info.value.substitution["actual_provider"] == "fallback-provider"
+    assert exc_info.value.substitution["source"] == "agent-runtime-failover:transport"
+    assert records[0]["outcome"] == "stalled"
+    assert records[0]["substitution"]["substituted"] is True
+    assert emitted_events[0][0] == "agent_runtime_substitution"
+    assert RUNNER_FAILOVER_MARKER in capsys.readouterr().err
 
 
 def test_runner_failover_cooldown_routes_next_dispatch_directly_to_fallback(


### PR DESCRIPTION
## Summary

- Preserved the existing narrowing: `stdout_silence_timeout` after partial stdout still does not rotate.
- Added the missing no-output boundary: `stdout_silence_timeout` before first stdout now classifies as `transport`, the same operational bucket as `initial_response_timeout`.
- Propagated runner-level substitution metadata through final timeout exceptions so delegate task state, usage records, telemetry, and the stderr marker do not lose route evidence when the last fallback route also times out.
- Extended `scripts/agent_runtime/probe_stall_failover.py` with `delegate-hermes-stdout-silence`, which spawns a real `delegate.py` worker through the Hermes DeepSeek adapter using a temp fake `hermes` binary, isolated `HERMES_HOME`, isolated failover config, and isolated cooldown DB.
- Updated `docs/agent-runtime-guide.md` to document the no-output silence timeout boundary.

## 544s Explanation

Tool-backed live state from the issue repro shows the constant ~544s death was not a single 544s watchdog. It was three configured DeepSeek-route attempts, each killed by the 180s initial-response watchdog at ~181s:

```console
$ jq '{task_id,agent,model,hard_timeout,silence_timeout,initial_response_timeout,status,duration_s,stderr_excerpt,substitution}' /Users/krisztiankoos/projects/learn-ukrainian/batch_state/tasks/review-4735-stall-failover.json
{
  "task_id": "review-4735-stall-failover",
  "agent": "deepseek",
  "model": "deepseek-v4-flash",
  "hard_timeout": 7200,
  "silence_timeout": 240,
  "initial_response_timeout": 180,
  "status": "timeout",
  "duration_s": 544.398,
  "stderr_excerpt": "initial_response_timeout: deepseek stalled: 181s since last activity (stall_timeout=180s)",
  "substitution": null
}

$ jq '{task_id,agent,model,hard_timeout,silence_timeout,initial_response_timeout,status,duration_s,stderr_excerpt,substitution}' /Users/krisztiankoos/projects/learn-ukrainian/batch_state/tasks/review-4736-downloader.json
{
  "task_id": "review-4736-downloader",
  "agent": "deepseek",
  "model": "deepseek-v4-flash",
  "hard_timeout": 7200,
  "silence_timeout": 240,
  "initial_response_timeout": 180,
  "status": "timeout",
  "duration_s": 543.988,
  "stderr_excerpt": "initial_response_timeout: deepseek stalled: 181s since last activity (stall_timeout=180s)",
  "substitution": null
}
```

The route count is the shipped chain:

```console
$ sed -n '35,50p' scripts/config/agent_runtime_failover.yaml
  deepseek:
    cooldown_ttl_s: 300
    routes:
      - provider: deepseek
      - provider: openrouter
        model: deepseek/deepseek-v4-pro
      - provider: openrouter
        model: deepseek/deepseek-v4-flash
```

So the observed runtime is approximately `3 × 181s = 543s`, plus wrapper overhead. `--silence-timeout 240` did not get the chance to fire in that repro because `--initial-response-timeout 180` is lower and fires first on each silent route. The real surfacing gap was that the final timeout raised instead of returning a `Result`, so delegate state ended with `substitution: null` even after routed attempts. This remediation carries the route substitution on timeout exceptions and adds the no-output `stdout_silence_timeout` rotation path.

## Evidence (#M-4)

Original no-first-byte probe still rotates and persists substitution:

```console
$ .venv/bin/python scripts/agent_runtime/probe_stall_failover.py --case no-first-byte --cooldown-db "$(mktemp -d /tmp/stall-failover-probe.XXXXXX)/cooldowns.sqlite3"
AGENT_RUNTIME_FAILOVER_SUBSTITUTION: primary-provider/primary-stall -> fallback-provider/fallback-ok source=agent-runtime-failover:transport
AGENT_RUNTIME_FAILOVER_SUBSTITUTION: primary-provider/primary-stall -> fallback-provider/fallback-ok source=agent-runtime-failover:transport
{"attempts": ["primary-stall", "fallback-ok"], "case": "no-first-byte", "ok": true, "rotated": true, "usage_record_surfaced": true}
```

Streaming/partial-output silence still does not rotate:

```console
$ .venv/bin/python scripts/agent_runtime/probe_stall_failover.py --case streaming-silence --cooldown-db "$(mktemp -d /tmp/stall-failover-streaming.XXXXXX)/cooldowns.sqlite3"
{"attempts": ["primary-stall"], "case": "streaming-silence", "ok": true, "rotated": false, "stalled_kind": "stdout_silence_timeout"}
```

New delegate→Hermes-shaped probe exercises the real delegate worker and Hermes adapter path with `initial_response_timeout=0`, so rotation depends on `stdout_silence_timeout`:

```console
$ .venv/bin/python scripts/agent_runtime/probe_stall_failover.py --case delegate-hermes-stdout-silence --stdout-silence-timeout 1 --hard-timeout 30
{"attempts": ["deepseek/deepseek-v4-flash", "openrouter/deepseek/deepseek-v4-flash"], "case": "delegate-hermes-stdout-silence", "initial_response_timeout": 0, "ok": true, "rotated": true, "state_status": "done", "stdout_silence_timeout": 1, "substitution": {"actual_model": "deepseek/deepseek-v4-flash", "actual_provider": "openrouter", "marker": "AGENT_RUNTIME_FAILOVER_SUBSTITUTION", "requested_model": "deepseek-v4-flash", "requested_provider": "deepseek", "source": "agent-runtime-failover:transport", "substituted": true}}
```

Test and lint:

```console
$ .venv/bin/pytest tests/agent_runtime/ -q
132 passed in 21.36s

$ .venv/bin/ruff check scripts/delegate.py scripts/agent_runtime/errors.py scripts/agent_runtime/failover.py scripts/agent_runtime/runner.py scripts/agent_runtime/probe_stall_failover.py tests/agent_runtime/test_runner_failover.py
All checks passed!

$ git diff --check
# no output

$ .venv/bin/python scripts/audit/lint_agent_trailer.py
✅ All 2 non-skipped commit(s) carry an X-Agent trailer.
```

Additional commit-hook evidence on commit `1613e29c52`:

```console
pre-commit: ruff check... All checks passed!
pre-commit: pytest on affected files... 123 passed in 6.12s
ruff (lint) Passed
gitleaks (secret scan) Passed
```

Fixes #4672
