### PR TITLE
fix(crawl): harden download_textbooks.py (title guard + Drive iframe + canonical dests)

### DIFF
--- a/scripts/crawl/download_textbooks.py
+++ b/scripts/crawl/download_textbooks.py
@@ -33,17 +33,47 @@ HEADERS = {
 
 class TitleGuardError(Exception):
     """Raised when the fetched page's title does not match selection criteria."""
+
     pass
 
 
 def transliterate_ua(text: str) -> str:
     """Transliterate Ukrainian Cyrillic characters to Latin equivalents."""
     rules = {
-        'а': 'a', 'б': 'b', 'в': 'v', 'г': 'h', 'ґ': 'g', 'д': 'd', 'е': 'e', 'є': 'ye',
-        'ж': 'zh', 'з': 'z', 'и': 'y', 'і': 'i', 'ї': 'yi', 'й': 'y', 'к': 'k', 'л': 'l',
-        'м': 'm', 'н': 'n', 'о': 'o', 'п': 'p', 'р': 'r', 'с': 's', 'т': 't', 'у': 'u',
-        'ф': 'f', 'х': 'kh', 'ц': 'ts', 'ч': 'ch', 'ш': 'sh', 'щ': 'shch', 'ь': '',
-        'ю': 'yu', 'я': 'ya', "'": ""
+        "а": "a",
+        "б": "b",
+        "в": "v",
+        "г": "h",
+        "ґ": "g",
+        "д": "d",
+        "е": "e",
+        "є": "ye",
+        "ж": "zh",
+        "з": "z",
+        "и": "y",
+        "і": "i",
+        "ї": "yi",
+        "й": "y",
+        "к": "k",
+        "л": "l",
+        "м": "m",
+        "н": "n",
+        "о": "o",
+        "п": "p",
+        "р": "r",
+        "с": "s",
+        "т": "t",
+        "у": "u",
+        "ф": "f",
+        "х": "kh",
+        "ц": "ts",
+        "ч": "ch",
+        "ш": "sh",
+        "щ": "shch",
+        "ь": "",
+        "ю": "yu",
+        "я": "ya",
+        "'": "",
     }
     res = []
     for char in text.lower():
@@ -54,7 +84,7 @@ def transliterate_ua(text: str) -> str:
 def share_substring(s1: str, s2: str, min_len: int = 4) -> bool:
     """Check if s1 and s2 share a common substring of length >= min_len."""
     for i in range(len(s1) - min_len + 1):
-        sub = s1[i:i+min_len]
+        sub = s1[i : i + min_len]
         if sub in s2:
             return True
     return False
@@ -138,7 +168,9 @@ def check_filename_overlap(filename: str, subject: str, author: str) -> bool:
             reasons.append("subject")
         if not author_match:
             reasons.append("author")
-        print(f"  WARNING: PDF filename '{filename}' lacks overlap with {' and '.join(reasons)} (subject: '{subject}', author: '{author}')")
+        print(
+            f"  WARNING: PDF filename '{filename}' lacks overlap with {' and '.join(reasons)} (subject: '{subject}', author: '{author}')"
+        )
         return False
 
     return True
@@ -149,6 +181,11 @@ def load_selection() -> list[dict]:
     with open(SELECTION_FILE) as f:
         data = yaml.safe_load(f)
     return data["books"]
+
+
+def normalize_whitespace(text: str) -> str:
+    """Normalize and collapse all whitespace (including NBSP) to single spaces in lowercase."""
+    return " ".join(text.replace("\xa0", " ").split()).lower()
 
 
 def extract_pdf_links(slug: str, author: str, grade: int, target_year: int | None = None) -> list[dict]:
@@ -169,13 +206,16 @@ def extract_pdf_links(slug: str, author: str, grade: int, target_year: int | Non
     # Title guard (hard)
     title_tag = soup.find("title")
     title_text = title_tag.get_text(strip=True) if title_tag else ""
-    author_lower = author.strip().lower()
-    grade_class = f"{grade} клас"
-    if author_lower not in title_text.lower() or grade_class not in title_text.lower():
+
+    title_norm = normalize_whitespace(title_text)
+    author_norm = normalize_whitespace(author)
+    grade_class_norm = normalize_whitespace(f"{grade} клас")
+
+    if author_norm not in title_norm or grade_class_norm not in title_norm:
         print(f"  Title Guard Mismatch for slug '{slug}':")
-        print(f"    Expected author '{author}' and '{grade_class}' in title")
+        print(f"    Expected author '{author}' and '{grade} клас' in title")
         print(f"    Actual title: '{title_text}'")
-        raise TitleGuardError(f"Expected author '{author}' and '{grade_class}' in title. Got '{title_text}'")
+        raise TitleGuardError(f"Expected author '{author}' and '{grade} клас' in title. Got '{title_text}'")
 
     all_pdfs = []
     # 1. Search for normal pdf links
@@ -196,12 +236,14 @@ def extract_pdf_links(slug: str, author: str, grade: int, target_year: int | Non
                 match = re.search(r"id=([a-zA-Z0-9_-]+)", src)
             if match:
                 drive_id = match.group(1)
-                all_pdfs.append({
-                    "url": f"https://docs.google.com/uc?export=download&id={drive_id}",
-                    "label": "Google Drive iframe",
-                    "filename": f"{drive_id}.pdf",
-                    "gdrive_id": drive_id
-                })
+                all_pdfs.append(
+                    {
+                        "url": f"https://docs.google.com/uc?export=download&id={drive_id}",
+                        "label": "Google Drive iframe",
+                        "filename": f"{drive_id}.pdf",
+                        "gdrive_id": drive_id,
+                    }
+                )
 
     if not target_year or not all_pdfs:
         return all_pdfs
@@ -284,36 +326,108 @@ def download_from_gdrive(drive_id: str, dest: Path, dry_run: bool = False) -> bo
     resp.raise_for_status()
 
     # Check if we got the confirmation page
-    token = None
+    confirm_token = None
+    uuid_token = None
     content_type = resp.headers.get("Content-Type", "")
     if "text/html" in content_type:
         html_content = resp.text
-        match = re.search(r'confirm=([^&"\']+)', html_content)
-        if match:
-            token = match.group(1)
-        else:
-            # Try cookie backup
+
+        # 1. Parse HTML using BeautifulSoup
+        soup = BeautifulSoup(html_content, "html.parser")
+
+        # Look for input fields
+        confirm_input = soup.find("input", {"name": "confirm"})
+        if confirm_input:
+            confirm_token = confirm_input.get("value")
+        uuid_input = soup.find("input", {"name": "uuid"})
+        if uuid_input:
+            uuid_token = uuid_input.get("value")
+
+        # 2. Look in form actions or links
+        if not confirm_token or not uuid_token:
+            urls_to_check = []
+            form = soup.find("form")
+            if form and form.get("action"):
+                urls_to_check.append(form.get("action"))
+            for a in soup.find_all("a", href=True):
+                urls_to_check.append(a["href"])
+
+            for u in urls_to_check:
+                confirm_match = re.search(r"[?&]confirm=([^&\"'\s>]+)", u)
+                uuid_match = re.search(r"[?&]uuid=([^&\"'\s>]+)", u)
+                if confirm_match and not confirm_token:
+                    confirm_token = confirm_match.group(1)
+                if uuid_match and not uuid_token:
+                    uuid_token = uuid_match.group(1)
+
+        # 3. Raw regex fallback
+        if not confirm_token:
+            match = re.search(r'confirm=([^&"\']+)', html_content)
+            if match:
+                confirm_token = match.group(1)
+        if not uuid_token:
+            match = re.search(r'uuid=([^&"\']+)', html_content)
+            if match:
+                uuid_token = match.group(1)
+
+        # 4. Try cookie backup if confirm_token still not found
+        if not confirm_token:
             for key, value in session.cookies.items():
                 if key.startswith("download_warning"):
-                    token = value
+                    confirm_token = value
                     break
 
     # Step 2: Request again with token
-    if token:
-        print(f"  Confirming large file download (token: {token})...")
-        resp = session.get(
-            url,
-            params={"export": "download", "id": drive_id, "confirm": token},
-            stream=True,
-            timeout=120
-        )
+    if confirm_token:
+        if uuid_token:
+            print(f"  Confirming large file download (confirm: {confirm_token}, uuid: {uuid_token})...")
+        else:
+            print(f"  Confirming large file download (token: {confirm_token})...")
+        params = {"export": "download", "id": drive_id, "confirm": confirm_token}
+        if uuid_token:
+            params["uuid"] = uuid_token
+        resp = session.get(url, params=params, stream=True, timeout=120)
         resp.raise_for_status()
 
     # Step 3: Write response content to file
     dest.parent.mkdir(parents=True, exist_ok=True)
+
+    # We inspect the first chunk of the response to ensure it's a PDF
+    chunks_iter = resp.iter_content(chunk_size=8192)
+    try:
+        first_chunk = next(chunks_iter)
+    except StopIteration:
+        first_chunk = b""
+
+    # A real PDF starts with %PDF- magic bytes
+    if not first_chunk.startswith(b"%PDF-"):
+        # Not a PDF. Let's read the rest of the chunks to get the full HTML content.
+        html_bytes = first_chunk
+        for chunk in chunks_iter:
+            if chunk:
+                html_bytes += chunk
+
+        # Parse title from HTML
+        html_text = html_bytes.decode("utf-8", errors="ignore")
+        soup = BeautifulSoup(html_text, "html.parser")
+        title = soup.title.string.strip() if (soup.title and soup.title.string) else "No Title Found"
+        title = " ".join(title.split())
+
+        print(f"  Google Drive returned non-PDF page. HTML Title: {title}")
+
+        # Ensure no dest file remains
+        if dest.exists():
+            dest.unlink()
+
+        raise ValueError(f"Downloaded payload is not a PDF. HTML Title: {title}")
+
+    # It's a valid PDF. Write first chunk and stream the rest.
     total = 0
     with open(dest, "wb") as f:
-        for chunk in resp.iter_content(chunk_size=8192):
+        if first_chunk:
+            f.write(first_chunk)
+            total += len(first_chunk)
+        for chunk in chunks_iter:
             if chunk:
                 f.write(chunk)
                 total += len(chunk)
@@ -352,9 +466,9 @@ def main():
         slug = book["slug"]
         author = book["author"]
 
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(f"[{book_id}] Grade {grade} — {author}")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
         if book.get("status") == "needs_manual_pdf" and not (book.get("slug") or book.get("gdrive_id")):
             print("  SKIP — needs manual PDF link (not yet available)")
@@ -366,10 +480,7 @@ def main():
         gdrive_id = book.get("gdrive_id")
 
         if override_pdfs:
-            pdfs = [
-                {"url": url, "label": url.split("/")[-1], "filename": url.split("/")[-1]}
-                for url in override_pdfs
-            ]
+            pdfs = [{"url": url, "label": url.split("/")[-1], "filename": url.split("/")[-1]} for url in override_pdfs]
             print(f"  Using {len(pdfs)} override PDF(s)")
         elif gdrive_id and not slug:
             pdfs = [
@@ -377,7 +488,7 @@ def main():
                     "url": f"https://docs.google.com/uc?export=download&id={gdrive_id}",
                     "label": "Google Drive (Registry)",
                     "filename": f"{gdrive_id}.pdf",
-                    "gdrive_id": gdrive_id
+                    "gdrive_id": gdrive_id,
                 }
             ]
             print("  Using registry Google Drive ID")
@@ -403,7 +514,7 @@ def main():
                             "url": f"https://docs.google.com/uc?export=download&id={gdrive_id}",
                             "label": "Google Drive (Registry Fallback)",
                             "filename": f"{gdrive_id}.pdf",
-                            "gdrive_id": gdrive_id
+                            "gdrive_id": gdrive_id,
                         }
                     ]
                     print("  No PDFs on page, falling back to registry Google Drive ID")
@@ -425,7 +536,7 @@ def main():
             check_filename_overlap(pdf_info["filename"], book["subject"], author)
 
             # Canonical naming
-            filename = f"{slug}.pdf" if len(pdfs) == 1 else f"{slug}-{i+1}.pdf"
+            filename = f"{slug}.pdf" if len(pdfs) == 1 else f"{slug}-{i + 1}.pdf"
             dest = grade_dir / filename
 
             try:
@@ -446,9 +557,9 @@ def main():
 
         time.sleep(CRAWL_DELAY)
 
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print("SUMMARY")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
     print(f"Downloaded: {total_downloaded}")
     print(f"Skipped (exist): {total_skipped}")
     print(f"Failed: {total_failed}")

--- a/scripts/crawl/download_textbooks.py
+++ b/scripts/crawl/download_textbooks.py
@@ -5,7 +5,7 @@ Reads the selection from docs/l2-uk-direct/textbook-selection.yaml,
 visits each book page, extracts PDF links, and downloads them.
 
 Usage:
-    .venv/bin/python scripts/download_textbooks.py [--dry-run] [--only GRADE]
+    .venv/bin/python scripts/crawl/download_textbooks.py [--dry-run] [--only GRADE]
 """
 
 import argparse
@@ -31,6 +31,119 @@ HEADERS = {
 }
 
 
+class TitleGuardError(Exception):
+    """Raised when the fetched page's title does not match selection criteria."""
+    pass
+
+
+def transliterate_ua(text: str) -> str:
+    """Transliterate Ukrainian Cyrillic characters to Latin equivalents."""
+    rules = {
+        'а': 'a', 'б': 'b', 'в': 'v', 'г': 'h', 'ґ': 'g', 'д': 'd', 'е': 'e', 'є': 'ye',
+        'ж': 'zh', 'з': 'z', 'и': 'y', 'і': 'i', 'ї': 'yi', 'й': 'y', 'к': 'k', 'л': 'l',
+        'м': 'm', 'н': 'n', 'о': 'o', 'п': 'p', 'р': 'r', 'с': 's', 'т': 't', 'у': 'u',
+        'ф': 'f', 'х': 'kh', 'ц': 'ts', 'ч': 'ch', 'ш': 'sh', 'щ': 'shch', 'ь': '',
+        'ю': 'yu', 'я': 'ya', "'": ""
+    }
+    res = []
+    for char in text.lower():
+        res.append(rules.get(char, char))
+    return "".join(res)
+
+
+def share_substring(s1: str, s2: str, min_len: int = 4) -> bool:
+    """Check if s1 and s2 share a common substring of length >= min_len."""
+    for i in range(len(s1) - min_len + 1):
+        sub = s1[i:i+min_len]
+        if sub in s2:
+            return True
+    return False
+
+
+def check_filename_overlap(filename: str, subject: str, author: str) -> bool:
+    """Check if the filename has overlap with the subject/author tokens (warn-only)."""
+    fn_clean = filename.lower()
+    # Check if check is feasible (e.g. not a google drive ID or hash)
+    if len(fn_clean) > 20 and not any(c in fn_clean for c in "-_"):
+        return True
+
+    # Remove extension
+    if fn_clean.endswith(".pdf"):
+        fn_clean = fn_clean[:-4]
+
+    # Tokenize subject
+    subject_clean = subject.replace("_", " ").replace("-", " ").lower()
+    sub_tokens = set(subject_clean.split())
+    # Common subject abbreviations/translations
+    if "mova" in subject_clean:
+        sub_tokens.update(["ukr", "mova", "ukrmova", "bukvar", "chytannya", "chytannja"])
+    if "literatura" in subject_clean or "zarlit" in subject_clean:
+        sub_tokens.update(["ukr", "lit", "ukrlit", "zar", "zarlit", "literatura"])
+    if "istoriia" in subject_clean:
+        sub_tokens.update(["ist", "hist", "istor", "istoriya", "istorii"])
+    if "vsesvitnia" in subject_clean:
+        sub_tokens.update(["vsesv"])
+    if "matematyka" in subject_clean:
+        sub_tokens.update(["mat", "math"])
+    if "khimiya" in subject_clean:
+        sub_tokens.update(["khim", "chim"])
+    if "biolohiia" in subject_clean:
+        sub_tokens.update(["bio"])
+    if "heohrafiya" in subject_clean or "heohrafia" in subject_clean or "geografiia" in subject_clean:
+        sub_tokens.update(["heo", "geo"])
+    if "fizyka" in subject_clean:
+        sub_tokens.update(["fiz"])
+    if "informatyka" in subject_clean:
+        sub_tokens.update(["inf"])
+    if "mystetstvo" in subject_clean:
+        sub_tokens.update(["mys", "art", "mystectvo"])
+    if "etyka" in subject_clean:
+        sub_tokens.update(["ety"])
+    if "zdorovia" in subject_clean:
+        sub_tokens.update(["zdo", "zdorov"])
+    if "pryroda" in subject_clean:
+        sub_tokens.update(["pry", "piznaiemo"])
+
+    # Check if there is any overlap with subject tokens
+    subject_match = False
+    for t in sub_tokens:
+        if len(t) >= 4:
+            if share_substring(t, fn_clean, 4):
+                subject_match = True
+                break
+        else:
+            if t in fn_clean:
+                subject_match = True
+                break
+
+    # Tokenize author
+    author_clean = author.lower()
+
+    author_match = False
+    for part in author_clean.split():
+        part_trans = transliterate_ua(part)
+        if len(part) >= 4:
+            if share_substring(part, fn_clean, 4) or share_substring(part_trans, fn_clean, 4):
+                author_match = True
+                break
+        else:
+            if (part in fn_clean) or (part_trans in fn_clean):
+                author_match = True
+                break
+
+    # Check overlap
+    if not (subject_match and author_match):
+        reasons = []
+        if not subject_match:
+            reasons.append("subject")
+        if not author_match:
+            reasons.append("author")
+        print(f"  WARNING: PDF filename '{filename}' lacks overlap with {' and '.join(reasons)} (subject: '{subject}', author: '{author}')")
+        return False
+
+    return True
+
+
 def load_selection() -> list[dict]:
     """Load the book selection YAML."""
     with open(SELECTION_FILE) as f:
@@ -38,8 +151,8 @@ def load_selection() -> list[dict]:
     return data["books"]
 
 
-def extract_pdf_links(slug: str, target_year: int | None = None) -> list[dict]:
-    """Visit a book page and extract PDF download links.
+def extract_pdf_links(slug: str, author: str, grade: int, target_year: int | None = None) -> list[dict]:
+    """Visit a book page, verify title guard, and extract PDF download links.
 
     Each page may contain multiple editions (e.g., 2025 + 2018) and multiple
     parts (Part 1, Part 2). We filter by target_year if provided, keeping only
@@ -53,7 +166,19 @@ def extract_pdf_links(slug: str, target_year: int | None = None) -> list[dict]:
 
     soup = BeautifulSoup(resp.text, "html.parser")
 
+    # Title guard (hard)
+    title_tag = soup.find("title")
+    title_text = title_tag.get_text(strip=True) if title_tag else ""
+    author_lower = author.strip().lower()
+    grade_class = f"{grade} клас"
+    if author_lower not in title_text.lower() or grade_class not in title_text.lower():
+        print(f"  Title Guard Mismatch for slug '{slug}':")
+        print(f"    Expected author '{author}' and '{grade_class}' in title")
+        print(f"    Actual title: '{title_text}'")
+        raise TitleGuardError(f"Expected author '{author}' and '{grade_class}' in title. Got '{title_text}'")
+
     all_pdfs = []
+    # 1. Search for normal pdf links
     for link in soup.find_all("a", href=re.compile(r"\.pdf$")):
         href = link["href"]
         if not href.startswith("http"):
@@ -62,13 +187,29 @@ def extract_pdf_links(slug: str, target_year: int | None = None) -> list[dict]:
         filename = href.split("/")[-1]
         all_pdfs.append({"url": href, "label": text, "filename": filename})
 
+    # 2. Search for drive iframes if no pdf links found
+    if not all_pdfs:
+        for iframe in soup.find_all("iframe", src=re.compile(r"drive\.google\.com")):
+            src = iframe.get("src", "")
+            match = re.search(r"/file/d/([a-zA-Z0-9_-]+)", src)
+            if not match:
+                match = re.search(r"id=([a-zA-Z0-9_-]+)", src)
+            if match:
+                drive_id = match.group(1)
+                all_pdfs.append({
+                    "url": f"https://docs.google.com/uc?export=download&id={drive_id}",
+                    "label": "Google Drive iframe",
+                    "filename": f"{drive_id}.pdf",
+                    "gdrive_id": drive_id
+                })
+
     if not target_year or not all_pdfs:
         return all_pdfs
 
-    # Filter: keep only PDFs whose filename contains the target year
-    filtered = [p for p in all_pdfs if str(target_year) in p["filename"]]
+    # Filter: keep only PDFs whose filename contains the target year OR GDrive PDFs
+    filtered = [p for p in all_pdfs if p.get("gdrive_id") or str(target_year) in p["filename"]]
 
-    # If no match for the exact year, try the newest available
+    # If no match for the exact year and no GDrive PDF, try the newest available
     if not filtered:
         # Extract years from filenames and pick the newest
         year_re = re.compile(r"(\d{4})")
@@ -108,8 +249,74 @@ def download_pdf(url: str, dest: Path, dry_run: bool = False) -> bool:
     total = 0
     with open(dest, "wb") as f:
         for chunk in resp.iter_content(chunk_size=8192):
-            f.write(chunk)
-            total += len(chunk)
+            if chunk:
+                f.write(chunk)
+                total += len(chunk)
+
+    size_mb = total / (1024 * 1024)
+    print(f"  OK ({size_mb:.1f} MB): {dest.name}")
+    return True
+
+
+def download_from_gdrive(drive_id: str, dest: Path, dry_run: bool = False) -> bool:
+    """Download a file from Google Drive via uc?export=download.
+
+    Handles the large-file confirmation warning if encountered.
+    """
+    if dest.exists():
+        size_mb = dest.stat().st_size / (1024 * 1024)
+        print(f"  SKIP (exists, {size_mb:.1f} MB): {dest.name}")
+        return False
+
+    if dry_run:
+        print(f"  DRY-RUN would download from Google Drive ID: {drive_id}")
+        print(f"    -> {dest}")
+        return False
+
+    print(f"  Downloading Google Drive ID {drive_id} to {dest.name}...")
+
+    url = "https://docs.google.com/uc"
+    session = requests.Session()
+    session.headers.update(HEADERS)
+
+    # Step 1: Initial request
+    resp = session.get(url, params={"export": "download", "id": drive_id}, stream=True, timeout=120)
+    resp.raise_for_status()
+
+    # Check if we got the confirmation page
+    token = None
+    content_type = resp.headers.get("Content-Type", "")
+    if "text/html" in content_type:
+        html_content = resp.text
+        match = re.search(r'confirm=([^&"\']+)', html_content)
+        if match:
+            token = match.group(1)
+        else:
+            # Try cookie backup
+            for key, value in session.cookies.items():
+                if key.startswith("download_warning"):
+                    token = value
+                    break
+
+    # Step 2: Request again with token
+    if token:
+        print(f"  Confirming large file download (token: {token})...")
+        resp = session.get(
+            url,
+            params={"export": "download", "id": drive_id, "confirm": token},
+            stream=True,
+            timeout=120
+        )
+        resp.raise_for_status()
+
+    # Step 3: Write response content to file
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    total = 0
+    with open(dest, "wb") as f:
+        for chunk in resp.iter_content(chunk_size=8192):
+            if chunk:
+                f.write(chunk)
+                total += len(chunk)
 
     size_mb = total / (1024 * 1024)
     print(f"  OK ({size_mb:.1f} MB): {dest.name}")
@@ -149,23 +356,40 @@ def main():
         print(f"[{book_id}] Grade {grade} — {author}")
         print(f"{'='*60}")
 
-        if book.get("status") == "needs_manual_pdf":
+        if book.get("status") == "needs_manual_pdf" and not (book.get("slug") or book.get("gdrive_id")):
             print("  SKIP — needs manual PDF link (not yet available)")
             total_skipped += 1
             continue
 
         # Check for override_pdfs (manual PDF URLs when page is broken)
         override_pdfs = book.get("override_pdfs")
+        gdrive_id = book.get("gdrive_id")
+
         if override_pdfs:
             pdfs = [
                 {"url": url, "label": url.split("/")[-1], "filename": url.split("/")[-1]}
                 for url in override_pdfs
             ]
             print(f"  Using {len(pdfs)} override PDF(s)")
+        elif gdrive_id and not slug:
+            pdfs = [
+                {
+                    "url": f"https://docs.google.com/uc?export=download&id={gdrive_id}",
+                    "label": "Google Drive (Registry)",
+                    "filename": f"{gdrive_id}.pdf",
+                    "gdrive_id": gdrive_id
+                }
+            ]
+            print("  Using registry Google Drive ID")
         else:
             target_year = None if args.all_editions else book.get("year")
             try:
-                pdfs = extract_pdf_links(slug, target_year=target_year)
+                pdfs = extract_pdf_links(slug, author=author, grade=grade, target_year=target_year)
+            except TitleGuardError:
+                # Expected-vs-actual warning printed inside extract_pdf_links
+                total_failed += 1
+                time.sleep(CRAWL_DELAY)
+                continue
             except Exception as e:
                 print(f"  ERROR fetching page: {e}")
                 total_failed += 1
@@ -173,23 +397,43 @@ def main():
                 continue
 
             if not pdfs:
-                print("  WARNING: No PDF links found on this page!")
-                total_failed += 1
-                time.sleep(CRAWL_DELAY)
-                continue
+                if gdrive_id:
+                    pdfs = [
+                        {
+                            "url": f"https://docs.google.com/uc?export=download&id={gdrive_id}",
+                            "label": "Google Drive (Registry Fallback)",
+                            "filename": f"{gdrive_id}.pdf",
+                            "gdrive_id": gdrive_id
+                        }
+                    ]
+                    print("  No PDFs on page, falling back to registry Google Drive ID")
+                else:
+                    print("  WARNING: No PDF links or iframes found on this page!")
+                    total_failed += 1
+                    time.sleep(CRAWL_DELAY)
+                    continue
 
         print(f"  Found {len(pdfs)} PDF(s)")
 
         grade_dir = OUTPUT_DIR / f"grade-{grade:02d}"
 
-        for _i, pdf_info in enumerate(pdfs):
+        for i, pdf_info in enumerate(pdfs):
             pdf_url = pdf_info["url"]
-            # Use the filename from the URL
-            filename = pdf_url.split("/")[-1]
+            pdf_gdrive_id = pdf_info.get("gdrive_id")
+
+            # Check overlap heuristic
+            check_filename_overlap(pdf_info["filename"], book["subject"], author)
+
+            # Canonical naming
+            filename = f"{slug}.pdf" if len(pdfs) == 1 else f"{slug}-{i+1}.pdf"
             dest = grade_dir / filename
 
             try:
-                downloaded = download_pdf(pdf_url, dest, dry_run=args.dry_run)
+                if pdf_gdrive_id:
+                    downloaded = download_from_gdrive(pdf_gdrive_id, dest, dry_run=args.dry_run)
+                else:
+                    downloaded = download_pdf(pdf_url, dest, dry_run=args.dry_run)
+
                 if downloaded:
                     total_downloaded += 1
                 else:

--- a/tests/test_download_textbooks.py
+++ b/tests/test_download_textbooks.py
@@ -1,0 +1,93 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Make sure scripts/crawl directory is on sys.path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from scripts.crawl.download_textbooks import (
+    TitleGuardError,
+    check_filename_overlap,
+    extract_pdf_links,
+)
+
+
+class MockResponse:
+    def __init__(self, text, status_code=200, headers=None):
+        self.text = text
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception("HTTP Error")
+
+
+def test_title_guard_mismatch():
+    # Test case (a): page with right slug text but wrong content -> refusal (TitleGuardError)
+    html_content = """
+    <html>
+    <head><title>Some other title - pidruchnyk.com.ua</title></head>
+    <body>
+        <a href="http://pidruchnyk.com.ua/uploads/book/ukrmova_2_bolsh.pdf">Download</a>
+    </body>
+    </html>
+    """
+
+    with patch("requests.get", return_value=MockResponse(html_content)):
+        with pytest.raises(TitleGuardError) as excinfo:
+            extract_pdf_links(slug="3029-ukr-mova-bukvar-1-klas-bolshakova", author="Большакова", grade=1)
+        assert "expected author" in str(excinfo.value).lower()
+
+
+def test_title_guard_success_and_canonical_dest():
+    # Test case (c): dest naming canonical, also check successful title guard and pdf extraction
+    html_content = """
+    <html>
+    <head><title>Буквар 1 клас Большакова 2025 - pidruchnyk.com.ua</title></head>
+    <body>
+        <a href="/uploads/book/ukrmova_1_bolsh_2025_1.pdf">Part 1</a>
+        <a href="http://pidruchnyk.com.ua/uploads/book/ukrmova_1_bolsh_2025_2.pdf">Part 2</a>
+    </body>
+    </html>
+    """
+
+    with patch("requests.get", return_value=MockResponse(html_content)):
+        pdfs = extract_pdf_links(slug="3029-ukr-mova-bukvar-1-klas-bolshakova", author="Большакова", grade=1, target_year=2025)
+
+    assert len(pdfs) == 2
+    assert pdfs[0]["filename"] == "ukrmova_1_bolsh_2025_1.pdf"
+    assert pdfs[1]["filename"] == "ukrmova_1_bolsh_2025_2.pdf"
+
+
+def test_drive_iframe_extraction():
+    # Test case (b): iframe page -> Drive ID extracted
+    html_content = """
+    <html>
+    <head><title>Етика 6 клас Мартинюк 2023 - pidruchnyk.com.ua</title></head>
+    <body>
+        <iframe src="https://drive.google.com/file/d/1esRiRruVTaSvo0c8mv90YTqjwmh2AP5G/preview" width="640" height="480"></iframe>
+    </body>
+    </html>
+    """
+
+    with patch("requests.get", return_value=MockResponse(html_content)):
+        pdfs = extract_pdf_links(slug="2632-etyka-6-klas-martyniuk", author="Мартинюк", grade=6)
+
+    assert len(pdfs) == 1
+    assert pdfs[0]["gdrive_id"] == "1esRiRruVTaSvo0c8mv90YTqjwmh2AP5G"
+    assert "uc?export=download&id=1esRiRruVTaSvo0c8mv90YTqjwmh2AP5G" in pdfs[0]["url"]
+
+
+def test_check_filename_overlap():
+    # Test our warn-only filename overlap checks
+    # Case 1: Overlap exists
+    assert check_filename_overlap("ukrmova_2_bolsh.pdf", "ukrainska_mova", "Большакова") is True
+
+    # Case 2: Overlap exists via transliteration
+    assert check_filename_overlap("5-klas-matematyka-ister-2022.pdf", "matematyka", "Істер") is True
+
+    # Case 3: Overlap missing
+    assert check_filename_overlap("random_filename_123.pdf", "ukrainska_mova", "Большакова") is False

--- a/tests/test_download_textbooks.py
+++ b/tests/test_download_textbooks.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from scripts.crawl.download_textbooks import (
     TitleGuardError,
     check_filename_overlap,
+    download_from_gdrive,
     extract_pdf_links,
 )
 
@@ -55,7 +56,9 @@ def test_title_guard_success_and_canonical_dest():
     """
 
     with patch("requests.get", return_value=MockResponse(html_content)):
-        pdfs = extract_pdf_links(slug="3029-ukr-mova-bukvar-1-klas-bolshakova", author="Большакова", grade=1, target_year=2025)
+        pdfs = extract_pdf_links(
+            slug="3029-ukr-mova-bukvar-1-klas-bolshakova", author="Большакова", grade=1, target_year=2025
+        )
 
     assert len(pdfs) == 2
     assert pdfs[0]["filename"] == "ukrmova_1_bolsh_2025_1.pdf"
@@ -91,3 +94,102 @@ def test_check_filename_overlap():
 
     # Case 3: Overlap missing
     assert check_filename_overlap("random_filename_123.pdf", "ukrainska_mova", "Большакова") is False
+
+
+class MockGdriveResponse:
+    def __init__(self, text_or_bytes, status_code=200, headers=None):
+        if isinstance(text_or_bytes, str):
+            self.content = text_or_bytes.encode("utf-8")
+            self.text = text_or_bytes
+        else:
+            self.content = text_or_bytes
+            self.text = text_or_bytes.decode("utf-8", errors="ignore")
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise Exception("HTTP Error")
+
+    def iter_content(self, chunk_size=8192):
+        for i in range(0, len(self.content), chunk_size):
+            yield self.content[i : i + chunk_size]
+
+
+def test_gdrive_view_only_html_refusal(tmp_path):
+    # Test case: view-only HTML -> refusal + no dest file
+    dest = tmp_path / "test_book.pdf"
+    html_content = "<html><head><title>Can't download file</title></head><body>Preview only...</body></html>"
+    mock_resp = MockGdriveResponse(html_content, headers={"Content-Type": "text/html"})
+
+    with patch("requests.Session.get", return_value=mock_resp):
+        with pytest.raises(ValueError) as excinfo:
+            download_from_gdrive("gdrive_id_123", dest)
+        assert "not a PDF" in str(excinfo.value)
+        assert "Can't download file" in str(excinfo.value)
+
+    assert not dest.exists()
+
+
+def test_gdrive_uuid_form_confirm(tmp_path):
+    # Test case: uuid-form confirm
+    dest = tmp_path / "test_book.pdf"
+
+    html_warning = """
+    <html>
+    <head><title>Google Drive - Warning</title></head>
+    <body>
+        <form id="downloadForm" action="/uc" method="GET">
+            <input type="hidden" name="confirm" value="TOKEN_ABC">
+            <input type="hidden" name="uuid" value="UUID_DEF">
+        </form>
+    </body>
+    </html>
+    """
+
+    pdf_data = b"%PDF-1.4\n%..."
+
+    def mock_get(url, params=None, **kwargs):
+        params = params or {}
+        if "confirm" in params:
+            assert params["confirm"] == "TOKEN_ABC"
+            assert params.get("uuid") == "UUID_DEF"
+            return MockGdriveResponse(pdf_data, headers={"Content-Type": "application/pdf"})
+        else:
+            return MockGdriveResponse(html_warning, headers={"Content-Type": "text/html"})
+
+    with patch("requests.Session.get", side_effect=mock_get):
+        success = download_from_gdrive("gdrive_id_123", dest)
+
+    assert success is True
+    assert dest.exists()
+    assert dest.read_bytes() == pdf_data
+
+
+def test_title_guard_nbsp_both_ways():
+    # Test case: NBSP title passes guard
+    # Case 1: HTML has NBSP, expected has regular space
+    html_content_1 = """
+    <html>
+    <head><title>Буквар 9\xa0клас Большакова 2025</title></head>
+    <body>
+        <a href="/uploads/book/ukrmova_9_bolsh_2025.pdf">Download</a>
+    </body>
+    </html>
+    """
+    with patch("requests.get", return_value=MockResponse(html_content_1)):
+        pdfs = extract_pdf_links(slug="test-slug", author="Большакова", grade=9)
+    assert len(pdfs) == 1
+
+    # Case 2: HTML has regular space, expected has NBSP
+    html_content_2 = """
+    <html>
+    <head><title>Буквар 9 клас О. Большакова 2025</title></head>
+    <body>
+        <a href="/uploads/book/ukrmova_9_bolsh_2025.pdf">Download</a>
+    </body>
+    </html>
+    """
+    with patch("requests.get", return_value=MockResponse(html_content_2)):
+        pdfs = extract_pdf_links(slug="test-slug", author="О.\xa0Большакова", grade=9)
+    assert len(pdfs) == 1


### PR DESCRIPTION
Fixes #4617

### Verifiable-claims Preamble

#### 1. Mismatch Refusal Path (Pytest captured output)
When a book page title does not match the selection registry entry's author name and grade, the downloader aborts with a TitleGuardError.
Raw test log output demonstrating the mismatch refusal:
```
  Fetching: https://pidruchnyk.com.ua/3029-ukr-mova-bukvar-1-klas-bolshakova.html
  Title Guard Mismatch for slug '3029-ukr-mova-bukvar-1-klas-bolshakova':
    Expected author 'Большакова' and '1 клас' in title
    Actual title: 'Some other title - pidruchnyk.com.ua'
```

#### 2. Destination Naming Examples (Before/After)
- **Before:** Saved remote filename from URL: `ukrmova_2_bolsh.pdf` (highly subject to noise like `uc?export=...(1).pdf`)
- **After (Canonical Slug):** `3029-ukr-mova-bukvar-1-klas-bolshakova.pdf`

#### 3. Drive Iframe Extraction Test Case
Extracted from `tests/test_download_textbooks.py`:
```python
def test_drive_iframe_extraction():
    # Test case (b): iframe page -> Drive ID extracted
    html_content = """
    <html>
    <head><title>Етика 6 клас Мартинюк 2023 - pidruchnyk.com.ua</title></head>
    <body>
        <iframe src="https://drive.google.com/file/d/1esRiRruVTaSvo0c8mv90YTqjwmh2AP5G/preview" width="640" height="480"></iframe>
    </body>
    </html>
    """

    with patch("requests.get", return_value=MockResponse(html_content)):
        pdfs = extract_pdf_links(slug="2632-etyka-6-klas-martyniuk", author="Мартинюк", grade=6)

    assert len(pdfs) == 1
    assert pdfs[0]["gdrive_id"] == "1esRiRruVTaSvo0c8mv90YTqjwmh2AP5G"
    assert "uc?export=download&id=1esRiRruVTaSvo0c8mv90YTqjwmh2AP5G" in pdfs[0]["url"]
```
