### PR TITLE
feat(routing-budget): complete #4640 CodexBar wiring (hard sub, ranked view, guards)

### DIFF
--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -100,7 +100,9 @@ _is_content_done = is_content_done
 router = APIRouter(tags=["state"])
 
 BUDGET_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "agent_budgets.yaml"
-AGENT_NAMES = ("claude", "codex", "gemini")
+SUBSCRIPTION_LANES = ("claude", "codex", "gemini", "grok", "cursor")
+API_LANES = ("deepseek",)  # representative; others via openrouter absent BY DESIGN
+AGENT_NAMES = SUBSCRIPTION_LANES  # only subscription lanes participate in CodexBar window checks
 STATE_SUMMARY_TTL_S = 60.0
 STATE_PIPELINE_TTL_S = 60.0
 STATE_RESEARCH_COVERAGE_TTL_S = 300.0
@@ -158,6 +160,18 @@ def _load_agent_budgets() -> tuple[dict[str, Any], list[str]]:
     return loaded, []
 
 
+def _load_budget_extras(budgets: dict[str, Any]) -> dict[str, Any]:
+    """Load optional extras like reset threshold (default 6h per sensible default for 'imminent')."""
+    if not isinstance(budgets, dict):
+        return {"reset_imminent_hours": 6}
+    val = budgets.get("reset_imminent_threshold_hours", 6)
+    try:
+        hours = int(val)
+    except (TypeError, ValueError):
+        hours = 6
+    return {"reset_imminent_hours": max(1, min(48, hours))}
+
+
 def _agent_key(raw_agent: str | None) -> str | None:
     agent = (raw_agent or "").lower().strip()
     for name in AGENT_NAMES:
@@ -194,7 +208,9 @@ def _sum_agent_spend(
     return spent, missing
 
 
-def _status_from_burn(burn_pct: float | None) -> str:
+def _status_from_burn(burn_pct: float | None, *, has_cap: bool = True) -> str:
+    if not has_cap:
+        return "unknown"
     if burn_pct is None:
         return "pre_launch"
     if burn_pct < 50:
@@ -230,6 +246,30 @@ def _days_until(today: date, target: date | None) -> int | None:
     return (target - today).days
 
 
+def _next_weekly_reset(current_time: datetime) -> str:
+    """Compute next ISO weekly reset boundary (treated as Monday 00:00Z for rolling weekly caps)."""
+    today = current_time.date()
+    # weekday: Mon=0 ... Sun=6; next Monday is (7 - wd) %7 , 0 means today if Mon
+    days_ahead = (7 - today.weekday()) % 7
+    if days_ahead == 0:
+        days_ahead = 7  # if exactly Monday, next is +7
+    reset_dt = datetime.combine(today + timedelta(days=days_ahead), datetime.min.time(), tzinfo=UTC)
+    return _isoformat_z(reset_dt)
+
+
+def _snapshot_is_stale(current_time: datetime, records: list[CostRecord], threshold_s: float = 900.0) -> tuple[bool, float | None]:
+    """Return (is_stale, age_s) based on most recent record mtime vs now.
+    15min=900s default per AC. If no records, not 'stale' but 'empty' handled separately.
+    """
+    if not records:
+        return False, None
+    latest = max((getattr(r, "mtime", datetime.min.replace(tzinfo=UTC)) or datetime.min.replace(tzinfo=UTC) for r in records), default=None)
+    if latest is None:
+        return False, None
+    age = (current_time - latest).total_seconds()
+    return age > threshold_s, round(age, 1)
+
+
 def _in_flight_by_agent() -> dict[str, int]:
     in_flight = {agent: 0 for agent in AGENT_NAMES}
     try:
@@ -245,76 +285,142 @@ def _in_flight_by_agent() -> dict[str, int]:
     return in_flight
 
 
-def _recommend_agent(agents: dict[str, Any], warnings: list[str]) -> dict[str, Any]:
-    status_by_agent = {
-        "claude": agents["claude"]["interactive"]["status"],
-        "codex": agents["codex"]["status"],
-        "gemini": agents["gemini"]["status"],
-    }
-    burn_by_agent = {
-        "claude": agents["claude"]["interactive"]["burn_pct_7d"],
-        "codex": agents["codex"]["burn_pct_7d"],
-        "gemini": agents["gemini"]["burn_pct_7d"],
-    }
+def _recommend_agent(
+    agents: dict[str, Any],
+    warnings: list[str],
+    *,
+    current_time: datetime | None = None,
+    reset_imminent_hours: int = 6,
+    is_stale: bool = False,
+    records_loaded: int = 0,
+) -> dict[str, Any]:
+    """Generalized recommendation over subscription lanes + reset-aware + empty/stale guards.
 
-    if all(status in {"hot", "near_cap"} for status in status_by_agent.values()):
-        warnings.append("all agents near cap — orchestrator inline-mode contingency may be needed soon")
+    Per design: when records_loaded==0 or empty snapshot, suppress primary rec (no confident pick from absent data).
+    Reset-aware: if top pick resets within N hours, note deferral warning (N configurable).
+    """
+    if is_stale:
+        warnings.append("snapshot stale (>15min old data) — advisory only, verify manually before trusting numbers")
+
+    if records_loaded == 0:
         return {
-            "primary_agent_for_code": "inline_orchestrator",
-            "rationale": "All agents are hot or near cap; preserve remaining provider quota for high-judgment work.",
+            "primary_agent_for_code": None,
+            "rationale": "Budget snapshot empty/absent (records_loaded=0); confident primary-lane recommendation suppressed per pinned design constraint. Use model-assignment.md + /api/orient runtime.headroom instead.",
+            "warnings": [*warnings, "empty snapshot — no recommendation emitted"],
+        }
+
+    # Build status/burn for core code lanes (claude special interactive, others flat); include grok/cursor if present
+    core = ["claude", "codex", "gemini"]
+    status_by_agent: dict[str, str] = {}
+    burn_by_agent: dict[str, float | None] = {}
+    resets_by: dict[str, str | None] = {}
+    for a in core:
+        if a not in agents:
+            continue
+        if a == "claude":
+            st = agents[a].get("interactive", {}).get("status") or agents[a].get("status", "unknown")
+            br = agents[a].get("interactive", {}).get("burn_pct_7d") or agents[a].get("burn_pct_7d")
+        else:
+            st = agents[a].get("status", "unknown")
+            br = agents[a].get("burn_pct_7d")
+        status_by_agent[a] = st
+        burn_by_agent[a] = br
+        resets_by[a] = agents[a].get("resets_at")
+
+    # include extra subs if they have data
+    for a in SUBSCRIPTION_LANES:
+        if a in core or a not in agents:
+            continue
+        status_by_agent[a] = agents[a].get("status", "unknown")
+        burn_by_agent[a] = agents[a].get("burn_pct_7d")
+        resets_by[a] = agents[a].get("resets_at")
+
+    # If no usable data at all for rec, suppress
+    usable = [a for a, s in status_by_agent.items() if s not in {"unknown", "pre_launch", None}]
+    if not usable or all(s in {"hot", "near_cap", "unknown"} for s in status_by_agent.values()):
+        if all(s in {"hot", "near_cap"} for s in status_by_agent.values() if s not in {"unknown"}):
+            warnings.append("all agents near cap — orchestrator inline-mode contingency may be needed soon")
+            return {
+                "primary_agent_for_code": "inline_orchestrator",
+                "rationale": "All agents are hot or near cap; preserve remaining provider quota for high-judgment work.",
+                "warnings": warnings,
+            }
+        return {
+            "primary_agent_for_code": None,
+            "rationale": "No usable subscription lane headroom data for confident recommendation (stale/empty/unknowns).",
             "warnings": warnings,
         }
 
+    # Reset-aware filter: identify imminent resets
+    imminent: list[str] = []
+    if current_time is not None:
+        for a, ra in resets_by.items():
+            if not ra:
+                continue
+            try:
+                rt = datetime.fromisoformat(ra.replace("Z", "+00:00"))
+                hours_left = (rt - current_time).total_seconds() / 3600.0
+                if 0 < hours_left <= reset_imminent_hours:
+                    imminent.append(a)
+            except Exception:
+                pass
+    if imminent:
+        warnings.append(f"lanes resetting soon (within {reset_imminent_hours}h): {', '.join(imminent)} — defer large batches on these if possible")
+
     if "near_cap" in status_by_agent.values():
-        candidates = [
-            agent for agent, status in status_by_agent.items()
-            if status in {"cool", "warm"}
-        ]
+        candidates = [agent for agent, st in status_by_agent.items() if st in {"cool", "warm"}]
         if candidates:
-            recommended = min(candidates, key=lambda agent: burn_by_agent[agent] or 0.0)
+            # prefer non-imminent if possible
+            non_imm = [c for c in candidates if c not in imminent] or candidates
+            recommended = min(non_imm, key=lambda agent: burn_by_agent.get(agent) or 0.0)
             return {
                 "primary_agent_for_code": recommended,
                 "rationale": (
                     f"At least one agent is near cap; {recommended} has the lowest "
-                    f"available 7d burn ({_format_pct(burn_by_agent[recommended])}%)."
+                    f"available 7d burn ({_format_pct(burn_by_agent.get(recommended))}%)."
                 ),
                 "warnings": warnings,
             }
 
-    agentic_pool = agents["claude"]["agentic_pool"]
-    if agentic_pool.get("active") and agentic_pool.get("status") == "cool":
+    # claude pool still special
+    if "claude" in agents:
+        agentic_pool = agents["claude"].get("agentic_pool", {})
+        if agentic_pool.get("active") and agentic_pool.get("status") == "cool":
+            return {
+                "primary_agent_for_code": "claude",
+                "rationale": "Claude agentic pool is active and cool; drain the separate monthly pool first.",
+                "warnings": warnings,
+            }
+
+    cool_warm = [a for a, s in status_by_agent.items() if s in {"cool", "warm"}]
+    if cool_warm:
+        # pick lowest burn, skip imminent if alternatives
+        pool = [c for c in cool_warm if c not in imminent] or cool_warm
+        recommended = min(pool, key=lambda agent: burn_by_agent.get(agent) or 0.0)
+        if recommended == "codex" or len(cool_warm) == len(status_by_agent):
+            rationale = (
+                "All agents cool or warm; default split applies. "
+                f"{recommended} 7d burn is {_format_pct(burn_by_agent.get(recommended))}%. "
+            )
+        else:
+            rationale = f"Mixed; {recommended} has lowest 7d burn ({_format_pct(burn_by_agent.get(recommended))}%)."
         return {
-            "primary_agent_for_code": "claude",
-            "rationale": "Claude agentic pool is active and cool; drain the separate monthly pool first.",
+            "primary_agent_for_code": recommended,
+            "rationale": rationale,
             "warnings": warnings,
         }
 
-    if all(status in {"cool", "warm"} for status in status_by_agent.values()):
-        codex_burn = burn_by_agent["codex"]
+    # fallback to lowest burn among known
+    known = list(status_by_agent.keys())
+    if known:
+        recommended = min(known, key=lambda agent: burn_by_agent.get(agent) or 0.0)
         return {
-            "primary_agent_for_code": "codex",
-            "rationale": (
-                "All agents cool or warm; default 3:3:3 split applies. "
-                f"Codex 7d burn is {_format_pct(codex_burn)}%. "
-                "Claude agentic pool "
-                + (
-                    "active."
-                    if agentic_pool.get("active")
-                    else "pre-launch — interactive pool used for claude headless."
-                )
-            ),
+            "primary_agent_for_code": recommended,
+            "rationale": f"Mixed routing state; {recommended} currently has the lowest 7d burn ({_format_pct(burn_by_agent.get(recommended))}%).",
             "warnings": warnings,
         }
 
-    recommended = min(status_by_agent, key=lambda agent: burn_by_agent[agent] or 0.0)
-    return {
-        "primary_agent_for_code": recommended,
-        "rationale": (
-            f"Mixed routing state; {recommended} currently has the lowest 7d burn "
-            f"({_format_pct(burn_by_agent[recommended])}%)."
-        ),
-        "warnings": warnings,
-    }
+    return {"primary_agent_for_code": None, "rationale": "insufficient data", "warnings": warnings}
 
 
 def compute_routing_budget(now: datetime | None = None) -> dict[str, Any]:
@@ -322,45 +428,49 @@ def compute_routing_budget(now: datetime | None = None) -> dict[str, Any]:
     today = current_time.date()
     window_start = current_time - timedelta(days=7)
     budgets, warnings = _load_agent_budgets()
+    extras = _load_budget_extras(budgets)
+    reset_hours = extras["reset_imminent_hours"]
+    resets_at = _next_weekly_reset(current_time)
+
+    # Empty config case: unknown statuses, suppressed rec (no confident pick from absent data)
     if not budgets:
-        agents = {
-            "claude": {
-                "interactive": {
-                    "spent_7d_usd": None,
-                    "weekly_cap_usd": None,
-                    "burn_pct_7d": None,
-                    "promo_active": False,
-                    "status": "pre_launch",
-                },
-                "agentic_pool": {
-                    "spent_cycle_usd": None,
-                    "monthly_cap_usd": None,
-                    "burn_pct_cycle": None,
-                    "active": False,
-                    "starts_on": None,
-                    "status": "pre_launch",
-                },
-            },
-            "codex": {"spent_7d_usd": None, "weekly_cap_usd": None, "burn_pct_7d": None, "status": "pre_launch"},
-            "gemini": {"spent_7d_usd": None, "weekly_cap_usd": None, "burn_pct_7d": None, "status": "pre_launch"},
+        agents = {}
+        for lane in SUBSCRIPTION_LANES:
+            if lane == "claude":
+                agents[lane] = {
+                    "interactive": {"spent_7d_usd": None, "weekly_cap_usd": None, "burn_pct_7d": None, "promo_active": False, "status": "unknown"},
+                    "agentic_pool": {"spent_cycle_usd": None, "monthly_cap_usd": None, "burn_pct_cycle": None, "active": False, "starts_on": None, "status": "unknown"},
+                    "spent_7d_usd": None, "weekly_cap_usd": None, "burn_pct_7d": None, "status": "unknown", "resets_at": resets_at,
+                }
+            else:
+                agents[lane] = {"spent_7d_usd": None, "weekly_cap_usd": None, "burn_pct_7d": None, "status": "unknown", "resets_at": resets_at}
+        rec = {
+            "primary_agent_for_code": None,
+            "rationale": "Budget config absent; recommendation suppressed (empty snapshot).",
+            "warnings": [*warnings, "empty snapshot — use model-assignment + /api/orient"],
         }
         return {
             "generated_at": _isoformat_z(current_time),
             "agents": agents,
             "in_flight": _in_flight_by_agent(),
-            "recommendation": {
-                "primary_agent_for_code": "inline_orchestrator",
-                "rationale": "Budget config could not be loaded; routing recommendation is unavailable.",
-                "warnings": warnings,
-            },
+            "recommendation": rec,
             "diagnostics": {
                 "records_loaded": 0,
                 "missing_cost_records": 0,
                 "window_start": _isoformat_z(window_start),
+                "stale": False,
+                "data_age_s": None,
+                "stale_threshold_s": 900,
             },
+            "ranked_by_headroom": [{"lane": lane, "type": "subscription", "status": "unknown", "burn_pct_7d": None, "remaining_pct": None, "resets_at": resets_at} for lane in SUBSCRIPTION_LANES] +
+                                 [{"lane": lane, "type": "api", "status": "unknown", "burn_pct_7d": None, "remaining_pct": None, "resets_at": None} for lane in API_LANES],
         }
 
     records = load_cost_records()
+    is_stale, data_age_s = _snapshot_is_stale(current_time, records)
+    if is_stale:
+        warnings.append("generatedAt/data age >15min — advisory downgraded to stale, verify manually (never hard block)")
+
     agents: dict[str, Any] = {}
     missing_cost_records = 0
 
@@ -375,6 +485,7 @@ def compute_routing_budget(now: datetime | None = None) -> dict[str, Any]:
     claude_spent, missing = _sum_agent_spend(records, agent="claude", since=window_start)
     missing_cost_records += missing
     claude_burn = _burn_pct(claude_spent, claude_cap)
+    claude_has_cap = claude_cap > 0
 
     starts_on = _parse_iso_date(agentic_config.get("starts_on"))
     agentic_active = bool(starts_on and today >= starts_on)
@@ -384,11 +495,18 @@ def compute_routing_budget(now: datetime | None = None) -> dict[str, Any]:
         agentic_spent, missing = _sum_agent_spend(records, agent="claude", since=cycle_start)
         missing_cost_records += missing
         agentic_burn = _burn_pct(agentic_spent, agentic_cap)
-        agentic_status = _status_from_burn(agentic_burn)
+        agentic_status = _status_from_burn(agentic_burn, has_cap=(agentic_cap > 0))
     else:
         agentic_spent = None
         agentic_burn = None
-        agentic_status = "pre_launch"
+        agentic_status = "pre_launch" if agentic_cap > 0 else "unknown"
+
+    claude_status = _status_from_burn(claude_burn, has_cap=claude_has_cap)
+    # empty snapshot special: force unknown (per AC, not cool when records_loaded==0)
+    force_unknown = (len(records) == 0)
+    if force_unknown:
+        claude_status = "unknown"
+        claude_burn = None
 
     agents["claude"] = {
         "interactive": {
@@ -396,7 +514,7 @@ def compute_routing_budget(now: datetime | None = None) -> dict[str, Any]:
             "weekly_cap_usd": _round_money(claude_cap),
             "burn_pct_7d": claude_burn,
             "promo_active": promo_active,
-            "status": _status_from_burn(claude_burn),
+            "status": claude_status,
         },
         "agentic_pool": {
             "spent_cycle_usd": _round_money(agentic_spent),
@@ -409,24 +527,34 @@ def compute_routing_budget(now: datetime | None = None) -> dict[str, Any]:
         "spent_7d_usd": _round_money(claude_spent),
         "weekly_cap_usd": _round_money(claude_cap),
         "burn_pct_7d": claude_burn,
-        "status": _status_from_burn(claude_burn),
+        "status": claude_status,
+        "resets_at": resets_at,
+        "remaining_pct": (100.0 - claude_burn) if claude_burn is not None else None,
     }
 
-    for agent in ("codex", "gemini"):
+    for agent in ("codex", "gemini", "grok", "cursor"):
         agent_config = budgets.get(agent) if isinstance(budgets.get(agent), dict) else {}
-        cap = float(agent_config.get("weekly_cap_usd") or 0.0)
+        cap = float(agent_config.get("weekly_cap_usd") or 0.0) if agent_config else 0.0
+        has_cap = cap > 0
         spent, missing = _sum_agent_spend(records, agent=agent, since=window_start)
         missing_cost_records += missing
-        burn = _burn_pct(spent, cap)
+        burn = _burn_pct(spent, cap) if has_cap else None
+        st = _status_from_burn(burn, has_cap=has_cap)
+        if force_unknown or not has_cap:
+            st = "unknown"
+            burn = None
         agents[agent] = {
             "spent_7d_usd": _round_money(spent),
-            "weekly_cap_usd": _round_money(cap),
+            "weekly_cap_usd": _round_money(cap) if has_cap else None,
             "burn_pct_7d": burn,
-            "status": _status_from_burn(burn),
+            "status": st,
+            "resets_at": resets_at,
+            "remaining_pct": (100.0 - burn) if burn is not None else None,
         }
 
+    # warnings for claude etc (only if not force_unknown)
     claude_burn_pct = agents["claude"]["interactive"]["burn_pct_7d"]
-    if agents["claude"]["interactive"]["status"] in {"hot", "near_cap"}:
+    if not force_unknown and agents["claude"]["interactive"]["status"] in {"hot", "near_cap"}:
         warnings.append(
             f"claude.interactive at {_format_pct(claude_burn_pct)}% — consider --agent codex for next mechanical fix"
         )
@@ -436,19 +564,61 @@ def compute_routing_budget(now: datetime | None = None) -> dict[str, Any]:
     promo_days = _days_until(today, promo_through)
     if promo_days is not None and 0 <= promo_days <= 14:
         warnings.append(
-            f"promo expires in {promo_days} days; +50% bonus capacity ends {promo_through.isoformat()}"
+            f"promo expires in {promo_days} days; +50% bonus capacity ends {promo_through.isoformat() if promo_through else ''}"
         )
+
+    rec = _recommend_agent(
+        agents, warnings,
+        current_time=current_time,
+        reset_imminent_hours=reset_hours,
+        is_stale=is_stale,
+        records_loaded=len(records),
+    )
+
+    # Build ranked view: subscription by remaining headroom (low burn = high remaining first), API always unknown
+    def _rank_key(lane: str) -> float:
+        a = agents.get(lane, {})
+        b = a.get("burn_pct_7d")
+        if b is None:
+            return 999.0
+        return b
+
+    ranked_subs = []
+    for lane in SUBSCRIPTION_LANES:
+        a = agents.get(lane, {})
+        ranked_subs.append({
+            "lane": lane,
+            "type": "subscription",
+            "status": a.get("status", "unknown"),
+            "burn_pct_7d": a.get("burn_pct_7d"),
+            "remaining_pct": a.get("remaining_pct"),
+            "resets_at": a.get("resets_at"),
+            "in_flight": _in_flight_by_agent().get(lane, 0),
+        })
+    ranked_subs.sort(key=lambda x: (x["status"] == "unknown", x.get("burn_pct_7d") or 999.0))
+
+    ranked_apis = [
+        {"lane": lane, "type": "api", "status": "unknown", "burn_pct_7d": None, "remaining_pct": None, "resets_at": None, "in_flight": 0}
+        for lane in API_LANES
+    ]
+    # per one design note treat absent as full, but AC requires status unknown NOT cool for ranked view
+    ranked = ranked_subs + ranked_apis
 
     return {
         "generated_at": _isoformat_z(current_time),
         "agents": agents,
         "in_flight": _in_flight_by_agent(),
-        "recommendation": _recommend_agent(agents, warnings),
+        "recommendation": rec,
         "diagnostics": {
             "records_loaded": len(records),
             "missing_cost_records": missing_cost_records,
             "window_start": _isoformat_z(window_start),
+            "stale": is_stale,
+            "data_age_s": data_age_s,
+            "stale_threshold_s": 900,
+            "reset_imminent_hours": reset_hours,
         },
+        "ranked_by_headroom": ranked,
     }
 
 

--- a/scripts/config/agent_budgets.yaml
+++ b/scripts/config/agent_budgets.yaml
@@ -23,3 +23,13 @@ codex:
   weekly_cap_usd: 1000
 gemini:
   weekly_cap_usd: 500
+
+# Subscription lanes (per CodexBar design constraint): claude/codex/gemini/cursor/grok only.
+# API-billed (deepseek etc.) absent from this snapshot BY DESIGN — absence ≠ unavailable.
+# For lanes without numeric cap here, status="unknown" (data lives in user's external CodexBar snapshot).
+grok:
+  # grok-build native CLI is the subscription lane for grok; appears in CodexBar (5h windows)
+  # cap value not duplicated here to avoid drift with user's live tracking.
+cursor:
+  # cursor composer subscription lane
+  # cap value not duplicated here to avoid drift with user's live tracking.

--- a/scripts/config/agent_fallback_substitutions.yaml
+++ b/scripts/config/agent_fallback_substitutions.yaml
@@ -1,6 +1,11 @@
 # Agent fallback substitution map — canonical source of truth.
-# Consumed by /api/state/routing-budget (when extended in follow-up PR) and
+# Consumed by /api/state/routing-budget and delegate.py --check-budget hard auto-sub.
 # referenced by orchestrator routing decisions (MEMORY.md, this file).
+
+# Machine-readable for hard auto-sub (when lane >90% burn on fresh snapshot):
+dispatch_fallbacks:
+  claude: codex
+  # codex/gemini/grok/cursor: unaffected (separate quotas) or per context in prose below
 #
 # Trigger condition: when a budget bucket is at status `near_cap` or higher
 # (burn_pct > 90), the orchestrator MUST use the substitution path below

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -102,11 +102,14 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 # Resolve repo root from this file's location so we work from any cwd.
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _TASKS_DIR = _REPO_ROOT / "batch_state" / "tasks"
 _BASH_SECRETS_PATH = Path.home() / ".bash_secrets"
 _GH_TOKEN_AGENTS = {"codex", "claude", "bridge"}
+_FALLBACK_SUBS_PATH = _REPO_ROOT / "scripts" / "config" / "agent_fallback_substitutions.yaml"
 _MONITOR_API_BASE_URL = "http://localhost:8765"
 _logger = logging.getLogger(__name__)
 
@@ -1676,7 +1679,9 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         return 2
 
     if getattr(args, "check_budget", False) and not getattr(args, "force_agent", False):
-        _check_routing_budget_for_dispatch(args.agent)
+        dispatch_agent = _resolve_agent_with_budget_guard(args.agent)
+    else:
+        dispatch_agent = args.agent
 
     if getattr(args, "dry_run", False):
         print(task_id)
@@ -1709,13 +1714,13 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         # resolves to ``.worktrees/dispatch/{agent}/{task}/``. Explicit
         # paths remain unchanged for back-compat with in-flight dispatches.
         resolved_raw = (
-            str(_auto_worktree_path(args.agent, task_id))
+            str(_auto_worktree_path(dispatch_agent, task_id))
             if worktree_arg == "auto"
             else worktree_arg
         )
         try:
             worktree_path, worktree_branch, worktree_telemetry = _ensure_worktree(
-                agent=args.agent,
+                agent=dispatch_agent,
                 task_id=task_id,
                 raw_path=resolved_raw,
                 base=getattr(args, "base", None) or "main",
@@ -1727,7 +1732,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     cwd = str(worktree_path or (Path(args.cwd) if args.cwd else _REPO_ROOT))
     prompt = _augment_prompt_with_worktree(prompt, worktree_path)
     start_telemetry = resolve_dispatch_start_telemetry(
-        agent_name=args.agent,
+        agent_name=dispatch_agent,
         requested_model=args.model,
         requested_effort=getattr(args, "effort", None),
     )
@@ -1738,7 +1743,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     worktree_layout = worktree_telemetry.get("layout") if worktree_path else None
     initial_state = {
         "task_id": task_id,
-        "agent": args.agent,
+        "agent": dispatch_agent,
         "model": start_telemetry.model,
         "effort": start_telemetry.effort,
         "cli_version": start_telemetry.cli_version,
@@ -1803,7 +1808,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         str(Path(__file__).resolve()),
         "_worker",
         "--task-id", task_id,
-        "--agent", args.agent,
+        "--agent", dispatch_agent,
         "--mode", args.mode,
         "--cwd", cwd,
         "--hard-timeout", str(args.hard_timeout),
@@ -1827,7 +1832,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     # explicit rather than implicit. Callers that want to scrub
     # secrets from the worker's env can override this here.
     worker_env = os.environ.copy()
-    _inject_gh_token_for_agent(worker_env, args.agent)
+    _inject_gh_token_for_agent(worker_env, dispatch_agent)
     worker_env["AGENT_NO_TELEMETRY_FOOTER"] = "1"
     if getattr(args, "allow_merge", False):
         worker_env.pop("AGENT_NO_MERGE", None)
@@ -2003,34 +2008,82 @@ def _fetch_routing_budget() -> dict[str, Any]:
     return payload if isinstance(payload, dict) else {}
 
 
-def _check_routing_budget_for_dispatch(agent: str) -> None:
+def _load_dispatch_fallbacks() -> dict[str, str]:
+    try:
+        data = yaml.safe_load(_FALLBACK_SUBS_PATH.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    subs = data.get("dispatch_fallbacks") if isinstance(data, dict) else {}
+    if isinstance(subs, dict):
+        return {str(k).lower(): str(v).lower() for k, v in subs.items() if v}
+    return {}
+
+
+def _resolve_agent_with_budget_guard(agent: str) -> str:
+    """Return possibly-substituted agent. Hard sub only on fresh snapshot when chosen lane near_cap (>90%).
+    Stale/empty: advisory only, no sub (never-trip guard). --force wins before call.
+    Substitution is NOTED (operator contract).
+    """
+    requested = (agent or "").strip().lower()
     try:
         payload = _fetch_routing_budget()
     except MonitorApiUnavailable:
         print("⚠ ROUTING CHECK SKIPPED: Monitor API unreachable", file=sys.stderr)
-        return
+        return requested
 
-    recommendation = payload.get("recommendation")
-    if not isinstance(recommendation, dict):
-        return
-    recommended = recommendation.get("primary_agent_for_code")
-    if not recommended or recommended == agent:
-        return
+    diags = payload.get("diagnostics") or {}
+    rec = payload.get("recommendation") or {}
+    agents = payload.get("agents") or {}
+    records_loaded = int(diags.get("records_loaded", 0) or 0)
+    is_stale = bool(diags.get("stale", False))
 
-    print(
-        f"⚠ ROUTING WARNING: budget recommends --agent {recommended}, "
-        f"you passed --agent {agent}.",
-        file=sys.stderr,
-    )
-    print(
-        f"Rationale: {recommendation.get('rationale') or 'No rationale provided.'}",
-        file=sys.stderr,
-    )
-    print(
-        "Proceed anyway? (use --force-agent to suppress this check, or Ctrl+C to abort.)",
-        file=sys.stderr,
-    )
-    time.sleep(3)
+    # empty or no data: suppress hard action + rec warning per constraint (a)
+    if records_loaded == 0 or not agents:
+        print("⚠ ROUTING CHECK: empty snapshot (records_loaded=0) — no primary rec, no hard sub (per design)", file=sys.stderr)
+        return requested
+
+    if is_stale:
+        print("⚠ ROUTING CHECK ADVISORY (stale snapshot, generatedAt/data age >15min) — verify manually; no hard sub", file=sys.stderr)
+        # still allow the rec warning if any, but no hard
+    else:
+        # advisory rec mismatch still emitted (for info)
+        recommended = rec.get("primary_agent_for_code")
+        if recommended and recommended != requested and recommended not in (None, "inline_orchestrator"):
+            print(
+                f"⚠ ROUTING WARNING: budget recommends --agent {recommended}, you passed --agent {requested}.",
+                file=sys.stderr,
+            )
+            if rec.get("rationale"):
+                print(f"Rationale: {rec['rationale']}", file=sys.stderr)
+
+    # HARD auto-sub only for subscription near_cap on FRESH non-empty
+    agent_info = agents.get(requested, {}) or {}
+    # claude may be nested
+    if requested == "claude":
+        status = (agent_info.get("interactive") or {}).get("status") or agent_info.get("status")
+    else:
+        status = agent_info.get("status")
+    burn = agent_info.get("burn_pct_7d") if requested != "claude" else (agent_info.get("interactive") or {}).get("burn_pct_7d") or agent_info.get("burn_pct_7d")
+
+    if status == "near_cap" and not is_stale and records_loaded > 0:
+        fallbacks = _load_dispatch_fallbacks()
+        sub = fallbacks.get(requested)
+        if not sub and requested == "claude":
+            # fallback inference for claude etc from prose in yaml
+            sub = "codex"
+        if sub and sub != requested:
+            note = (
+                f"🔄 HARD AUTO-SUBSTITUTE: --agent {requested} → {sub} "
+                f"(lane window >90% used / status=near_cap on FRESH snapshot; "
+                f"sub per agent_fallback_substitutions.yaml dispatch_fallbacks + documented cases). "
+                "Substitution noted for operator contract / review independence."
+            )
+            print(note, file=sys.stderr)
+            if burn is not None:
+                print(f"  (burn_pct_7d was ~{burn}%; resets_at={agent_info.get('resets_at')})", file=sys.stderr)
+            return sub
+
+    return requested
 
 
 def _status_or_fail_payload(task_id: str) -> dict[str, Any]:

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -110,6 +110,10 @@ _TASKS_DIR = _REPO_ROOT / "batch_state" / "tasks"
 _BASH_SECRETS_PATH = Path.home() / ".bash_secrets"
 _GH_TOKEN_AGENTS = {"codex", "claude", "bridge"}
 _FALLBACK_SUBS_PATH = _REPO_ROOT / "scripts" / "config" / "agent_fallback_substitutions.yaml"
+# Single source for dispatchable agents: argparse choices AND the hard-sub
+# validation in _resolve_agent_with_budget_guard (a yaml typo must never
+# dispatch a nonexistent adapter).
+_DISPATCH_AGENT_CHOICES = ("codex", "gemini", "claude", "grok", "grok-build", "deepseek", "agy", "cursor")
 _MONITOR_API_BASE_URL = "http://localhost:8765"
 _logger = logging.getLogger(__name__)
 
@@ -2044,7 +2048,8 @@ def _resolve_agent_with_budget_guard(agent: str) -> str:
 
     if is_stale:
         print("⚠ ROUTING CHECK ADVISORY (stale snapshot, generatedAt/data age >15min) — verify manually; no hard sub", file=sys.stderr)
-        # still allow the rec warning if any, but no hard
+        # Rec warning deliberately suppressed on stale: a recommendation from
+        # stale numbers is worse than none (same rationale as the empty case).
     else:
         # advisory rec mismatch still emitted (for info)
         recommended = rec.get("primary_agent_for_code")
@@ -2068,9 +2073,16 @@ def _resolve_agent_with_budget_guard(agent: str) -> str:
     if status == "near_cap" and not is_stale and records_loaded > 0:
         fallbacks = _load_dispatch_fallbacks()
         sub = fallbacks.get(requested)
-        if not sub and requested == "claude":
-            # fallback inference for claude etc from prose in yaml
-            sub = "codex"
+        # The yaml `dispatch_fallbacks` map is the ONLY source for hard subs —
+        # no inferred/hardcoded mappings (a deleted config entry must mean
+        # "no hard sub", not silently resurrect an old route).
+        if sub and sub not in _DISPATCH_AGENT_CHOICES:
+            print(
+                f"⚠ ROUTING: dispatch_fallbacks maps {requested} → {sub}, "
+                "not a known dispatch agent — ignoring hard sub.",
+                file=sys.stderr,
+            )
+            sub = None
         if sub and sub != requested:
             note = (
                 f"🔄 HARD AUTO-SUBSTITUTE: --agent {requested} → {sub} "
@@ -2371,7 +2383,7 @@ def build_parser() -> argparse.ArgumentParser:
         formatter_class=_dispatch_help_formatter,
     )
     d.add_argument("--agent", required=True,
-                   choices=["codex", "gemini", "claude", "grok", "grok-build", "deepseek", "agy", "cursor"],
+                   choices=list(_DISPATCH_AGENT_CHOICES),
                    # "qwen" removed from choices (banned agent): advertising it in --help
                    # while the routing guard rejects it at dispatch is a UX trap. The
                    # guard still catches programmatic Namespace bypass.

--- a/tests/api/test_routing_budget_endpoint.py
+++ b/tests/api/test_routing_budget_endpoint.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -163,3 +163,71 @@ def test_promo_through_uses_promo_cap_until_expiry(monkeypatch, tmp_path):
     assert before_data["agents"]["claude"]["interactive"]["burn_pct_7d"] == 50.0
     assert after_data["agents"]["claude"]["interactive"]["weekly_cap_usd"] == 460.0
     assert after_data["agents"]["claude"]["interactive"]["burn_pct_7d"] == 75.0
+
+
+def test_empty_snapshot_marks_unknown_and_suppresses_rec(monkeypatch, tmp_path):
+    """AC: empty/absent snapshot → status unknown (not cool), primary=None, no confident rec."""
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    _configure(monkeypatch, tmp_path, [])  # empty records
+
+    data = state_router.compute_routing_budget(now)
+
+    assert data["diagnostics"]["records_loaded"] == 0
+    assert data["recommendation"]["primary_agent_for_code"] is None
+    assert "empty" in (data["recommendation"].get("rationale") or "").lower() or any("empty" in w for w in data["recommendation"].get("warnings", []))
+    for lane in ("claude", "codex", "gemini"):
+        st = data["agents"][lane].get("status") or data["agents"][lane].get("interactive", {}).get("status")
+        assert st == "unknown", f"{lane} should be unknown on empty"
+    # ranked includes subs + api unknown
+    ranked = data.get("ranked_by_headroom", [])
+    assert any(r["lane"] == "deepseek" and r["status"] == "unknown" and r["type"] == "api" for r in ranked)
+    assert any(r["lane"] == "codex" and r["type"] == "subscription" for r in ranked)
+
+
+def test_stale_snapshot_downgrades_to_advisory_no_hard(monkeypatch, tmp_path):
+    """AC: generated/data >15min → stale=true, advisory in warnings; never hard block."""
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    old = now - timedelta(minutes=20)
+    recs = [_record("codex (gpt-5.5)", 100.0, old)]
+    _configure(monkeypatch, tmp_path, recs)
+
+    data = state_router.compute_routing_budget(now)
+
+    assert data["diagnostics"]["stale"] is True
+    assert data["diagnostics"]["data_age_s"] and data["diagnostics"]["data_age_s"] > 900
+    assert any("stale" in w.lower() for w in data.get("recommendation", {}).get("warnings", []))
+    # still computes status from old data, but marked
+    assert "codex" in data["agents"]
+
+
+def test_ranked_by_headroom_orders_by_remaining_and_includes_api_unknown(monkeypatch, tmp_path):
+    """AC: load-spread ranked view; subs by headroom (low burn first), api=unknown."""
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    _configure(
+        monkeypatch,
+        tmp_path,
+        [
+            _record("claude (sonnet)", 100.0, now),
+            _record("codex (gpt-5.5)", 50.0, now),
+            _record("gemini (pro)", 400.0, now),
+        ],
+    )
+    data = state_router.compute_routing_budget(now)
+    ranked = data.get("ranked_by_headroom", [])
+    # codex lowest burn should sort before higher
+    codex_idx = next(i for i, r in enumerate(ranked) if r["lane"] == "codex")
+    gemini_idx = next(i for i, r in enumerate(ranked) if r["lane"] == "gemini")
+    assert codex_idx < gemini_idx
+    api_entry = next((r for r in ranked if r["type"] == "api"), None)
+    assert api_entry and api_entry["status"] == "unknown"
+    assert "resets_at" in ranked[0]
+
+
+def test_resets_at_and_reset_aware_present(monkeypatch, tmp_path):
+    now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)
+    _configure(monkeypatch, tmp_path, [_record("codex (gpt-5.5)", 10.0, now)])
+    data = state_router.compute_routing_budget(now)
+    assert "resets_at" in data["agents"]["codex"]
+    assert data["diagnostics"].get("reset_imminent_hours") == 6
+    # ranked carries it
+    assert any("resets_at" in r for r in data.get("ranked_by_headroom", []))

--- a/tests/test_delegate_check_budget.py
+++ b/tests/test_delegate_check_budget.py
@@ -13,8 +13,24 @@ import delegate
 
 
 class _FakeBudgetResponse:
-    def __init__(self, recommended: str = "codex"):
+    """Configurable fake for /routing-budget responses (supports rec, agents status for hard sub, stale, empty)."""
+
+    def __init__(
+        self,
+        recommended: str = "codex",
+        *,
+        status_for_agent: str | None = None,
+        burn_for_agent: float | None = None,
+        records_loaded: int = 5,
+        stale: bool = False,
+        empty: bool = False,
+    ):
         self.recommended = recommended
+        self.status_for_agent = status_for_agent
+        self.burn_for_agent = burn_for_agent
+        self.records_loaded = 0 if empty else records_loaded
+        self.stale = stale
+        self.empty = empty
 
     def __enter__(self):
         return self
@@ -23,15 +39,43 @@ class _FakeBudgetResponse:
         return False
 
     def read(self):
-        return json.dumps(
-            {
-                "recommendation": {
-                    "primary_agent_for_code": self.recommended,
-                    "rationale": "fixture rationale",
-                    "warnings": [],
+        rec = {
+            "primary_agent_for_code": None if self.empty else self.recommended,
+            "rationale": "fixture rationale (empty)" if self.empty else "fixture rationale",
+            "warnings": ["empty snapshot"] if self.empty else [],
+        }
+        agents = {}
+        # default fixture agents for claude/codex etc
+        for a in ("claude", "codex", "gemini"):
+            if a == "claude":
+                agents[a] = {
+                    "interactive": {"status": "cool", "burn_pct_7d": 10.0},
+                    "status": "cool",
+                    "burn_pct_7d": 10.0,
+                    "resets_at": "2026-07-14T00:00:00Z",
                 }
-            }
-        ).encode("utf-8")
+            else:
+                agents[a] = {"status": "cool", "burn_pct_7d": 20.0, "resets_at": "2026-07-14T00:00:00Z"}
+        if self.status_for_agent:
+            tgt = self.status_for_agent
+            if tgt == "claude":
+                agents["claude"]["status"] = "near_cap"
+                agents["claude"]["interactive"]["status"] = "near_cap"
+                agents["claude"]["interactive"]["burn_pct_7d"] = self.burn_for_agent or 95.0
+            elif tgt in agents:
+                agents[tgt]["status"] = self.status_for_agent
+                agents[tgt]["burn_pct_7d"] = self.burn_for_agent or 95.0
+        payload = {
+            "recommendation": rec,
+            "agents": agents if not self.empty else {},
+            "diagnostics": {
+                "records_loaded": self.records_loaded,
+                "stale": self.stale,
+                "data_age_s": 1000 if self.stale else 10,
+            },
+            "generated_at": "2026-07-07T12:00:00Z",
+        }
+        return json.dumps(payload).encode("utf-8")
 
 
 class _FakeStdin:
@@ -157,3 +201,59 @@ def test_check_budget_dry_run_does_not_spawn(monkeypatch, tmp_path, capsys):
     captured = capsys.readouterr()
     assert captured.out.strip() == "budget-check-fixture"
     assert "ROUTING WARNING" in captured.err
+
+
+def test_check_budget_hard_sub_on_near_cap_fresh(monkeypatch, tmp_path, capsys):
+    """AC1: >90% (near_cap) on fresh → hard auto-sub, note substitution, uses fallback."""
+    _patch_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(delegate.time, "sleep", lambda _s: None)
+    # patch urlopen to return payload where passed claude is near_cap
+    monkeypatch.setattr(
+        delegate.urllib.request,
+        "urlopen",
+        lambda *_a, **_k: _FakeBudgetResponse("codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False),
+    )
+
+    rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
+
+    assert rc == 0
+    out = capsys.readouterr()
+    assert "HARD AUTO-SUBSTITUTE" in out.err
+    assert "claude" in out.err and "codex" in out.err
+    assert "per agent_fallback_substitutions.yaml" in out.err
+
+
+def test_check_budget_no_hard_sub_on_stale(monkeypatch, tmp_path, capsys):
+    """Stale → no hard sub, advisory only."""
+    _patch_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(delegate.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        delegate.urllib.request,
+        "urlopen",
+        lambda *_a, **_k: _FakeBudgetResponse("codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=3, stale=True),
+    )
+
+    rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "stale" in err.lower()
+    assert "HARD AUTO-SUBSTITUTE" not in err
+
+
+def test_check_budget_no_sub_on_empty_snapshot(monkeypatch, tmp_path, capsys):
+    """Empty → no sub, suppressed."""
+    _patch_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(delegate.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        delegate.urllib.request,
+        "urlopen",
+        lambda *_a, **_k: _FakeBudgetResponse("codex", empty=True),
+    )
+
+    rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "empty snapshot" in err.lower()
+    assert "HARD AUTO-SUBSTITUTE" not in err

--- a/tests/test_delegate_check_budget.py
+++ b/tests/test_delegate_check_budget.py
@@ -257,3 +257,39 @@ def test_check_budget_no_sub_on_empty_snapshot(monkeypatch, tmp_path, capsys):
     err = capsys.readouterr().err
     assert "empty snapshot" in err.lower()
     assert "HARD AUTO-SUBSTITUTE" not in err
+
+
+def test_check_budget_no_hard_sub_without_yaml_mapping(monkeypatch, tmp_path, capsys):
+    """Removed hardcode regression: yaml mapping absent → NO hard sub, even near_cap fresh."""
+    _patch_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(delegate.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(delegate, "_load_dispatch_fallbacks", lambda: {})
+    monkeypatch.setattr(
+        delegate.urllib.request,
+        "urlopen",
+        lambda *_a, **_k: _FakeBudgetResponse("codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False),
+    )
+
+    rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
+
+    assert rc == 0
+    assert "HARD AUTO-SUBSTITUTE" not in capsys.readouterr().err
+
+
+def test_check_budget_hard_sub_ignores_unknown_fallback_target(monkeypatch, tmp_path, capsys):
+    """A yaml typo must never dispatch a nonexistent adapter: unknown target → warn + no sub."""
+    _patch_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(delegate.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(delegate, "_load_dispatch_fallbacks", lambda: {"claude": "gemeni"})
+    monkeypatch.setattr(
+        delegate.urllib.request,
+        "urlopen",
+        lambda *_a, **_k: _FakeBudgetResponse("codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False),
+    )
+
+    rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "not a known dispatch agent" in err
+    assert "HARD AUTO-SUBSTITUTE" not in err


### PR DESCRIPTION
**Fixes #4640** (remaining scope per issue + pinned design constraints)

## Verifiable claims (raw evidence)

### 1. --check-budget dry-run transcript (hard sub on near_cap fresh snapshot)
```
⚠ ROUTING WARNING: budget recommends --agent codex, you passed --agent claude.
Rationale: fixture rationale
🔄 HARD AUTO-SUBSTITUTE: --agent claude → codex (lane window >90% used / status=near_cap on FRESH snapshot; sub per agent_fallback_substitutions.yaml dispatch_fallbacks + documented cases). Substitution noted for operator contract / review independence.
  (burn_pct_7d was ~95.5%; resets_at=2026-07-14T00:00:00Z)
t-4640
DRY RC: 0
```

### 2. API response samples

**Empty snapshot (records_loaded=0):**
```json
{
  "recommendation": {"primary_agent_for_code": null, "rationale": "...empty snapshot..."},
  "agents": {"claude": {"status": "unknown", ...}, ...},
  "diagnostics": {"records_loaded": 0, "stale": false, ...},
  "ranked_by_headroom": [ {"lane":"codex", "type":"subscription", "status":"unknown"}, ..., {"lane":"deepseek", "type":"api", "status":"unknown"} ]
}
```

**Fresh (with data):**
```json
"ranked_by_headroom": [
  {"lane":"codex","type":"subscription","status":"cool","burn_pct_7d":12.3,"resets_at":"..."},
  ...
],
"diagnostics": {"records_loaded": N, "stale": false, "reset_imminent_hours":6}
```

**Stale:**
diagnostics.stale=true + warnings contain "stale ... advisory ... verify manually"

### 3. pytest (affected)
```
tests/api/test_routing_budget_endpoint.py ........... [11]
tests/test_delegate_check_budget.py ........ [8]
19 passed
```

All MANDATORY PRE-SUBMIT items checked:
- .python-version / yamllint / markdownlint untouched
- No status/audit/review/telemetry artifacts in diff
- No sys.executable
- No @skip empty
- No weakened asserts
- 6 files changed (<20)
- ruff + pytest clean (pre-commit + manual)
- X-Agent trailer on commit
- Worktree layout used
- No auto-merge (orchestrator will arm at gate)

## Implementation notes
- CodexBar = subscription lanes only (claude/codex/gemini/grok/cursor); API absent=unknown by design.
- Never-trip only on fresh; stale=advisory.
- Fleet-review-before-build is policy (no synthetic code gate).
- Substitution noted (operator contract).
- Isolated test fixtures only.

X-Agent: grok-build/4640-codexbar-remaining