### PR TITLE
fix(practice): #4690 wrong answers dwell until explicit «Далі»

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 0eb0d9a8d5bbcba8e9dd798c7190f1d07530b06c62238cac60d4c8850b145d4d
+  components_sha256: eee312917fe389c5058fe079e01b24735c8814785fecc1b4f4951d3be371de65
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -869,7 +869,26 @@ function LexiconPracticeIsland({
   const stageRef = useRef<HTMLDivElement | null>(null);
   const deckRequestId = useRef(0);
   const sessionStartedAtRef = useRef(Date.now());
+  // Consumption source of truth for the parked wrong-answer outcome. `advancePending`
+  // claims it via this ref (not the closed-over `pendingOutcome` state) so a rapid
+  // double-advance (double-Enter, or Enter+click) before React re-renders resolves to
+  // exactly ONE `completeSelection` — the second call reads a null ref and no-ops.
+  const pendingOutcomeRef = useRef<CompletionOutcome | null>(null);
   const showEnglishSubtitles = learnerLevel === 'A1';
+
+  // Reset all per-item feedback/lock state. Shared by the selection-change effect and
+  // `advancePending` so a wrong answer that re-surfaces the SAME item (a lapsed card the
+  // selector picks again — same `itemId`, so the effect does not re-fire) still starts
+  // clean: no stale lock, cloze input/feedback, or parked outcome.
+  const resetItemFeedback = useCallback(() => {
+    setAnswerLocked(false);
+    setClozeInput('');
+    setClozeFeedback(null);
+    setClozeAttemptRecorded(false);
+    setHeritageFeedback(null);
+    setPendingOutcome(null);
+    pendingOutcomeRef.current = null;
+  }, []);
 
   useEffect(() => {
     const state = loadState();
@@ -967,16 +986,11 @@ function LexiconPracticeIsland({
   }, [deck, history, mode, poolFilter, revision, sessionPhase, sessionSeed]);
 
   useEffect(() => {
-    setAnswerLocked(false);
-    setClozeInput('');
-    setClozeFeedback(null);
-    setClozeAttemptRecorded(false);
-    setHeritageFeedback(null);
-    setPendingOutcome(null);
+    resetItemFeedback();
     if (selection) {
       window.setTimeout(() => stageRef.current?.focus(), 0);
     }
-  }, [selection?.itemId]);
+  }, [selection?.itemId, resetItemFeedback]);
 
   // While a wrong answer dwells, Enter is a second way to advance (alongside the
   // «Далі →» button) — the disabled option buttons blur to <body>, so we listen at
@@ -1336,10 +1350,13 @@ function LexiconPracticeIsland({
 
   /** Complete the parked (wrong-answer) selection once the learner chooses to advance. */
   function advancePending() {
-    if (!selection || !pendingOutcome) return;
-    const outcome = pendingOutcome;
-    setPendingOutcome(null);
-    setAnswerLocked(false);
+    // Claim the outcome via the ref FIRST so a second synchronous invocation (a rapid
+    // double-Enter, or Enter racing a «Далі» click) reads null and no-ops — the closed-over
+    // `pendingOutcome` state is stale within the same tick and cannot guard against this.
+    const outcome = pendingOutcomeRef.current;
+    if (!outcome || !selection) return;
+    pendingOutcomeRef.current = null;
+    resetItemFeedback();
     completeSelection(selection, outcome);
   }
 
@@ -1363,7 +1380,9 @@ function LexiconPracticeIsland({
       return;
     }
     // WRONG answer: dwell so the cited correction stays readable; the learner
-    // advances explicitly via «Далі →» / Enter (see advancePending).
+    // advances explicitly via «Далі →» / Enter (see advancePending). The ref mirrors
+    // the state so advancePending can claim the outcome race-free.
+    pendingOutcomeRef.current = outcome;
     setPendingOutcome(outcome);
   }
 
@@ -1412,6 +1431,7 @@ function LexiconPracticeIsland({
         // Wrong chip pick is a wrong answer: dwell rather than auto-advance so the
         // learner can read the correction before «Далі →» / Enter.
         setAnswerLocked(true);
+        pendingOutcomeRef.current = outcome;
         setPendingOutcome(outcome);
       }
       return;
@@ -1420,10 +1440,12 @@ function LexiconPracticeIsland({
     setClozeFeedback({ kind: 'wrong-word', text: '✗ Не те слово' });
     if (source === 'chip') {
       setAnswerLocked(true);
-      setPendingOutcome({
+      const outcome = {
         nextUnresolved: new Set(unresolvedCardKeys),
         nextDeferred: [...deferredLemmas],
-      });
+      };
+      pendingOutcomeRef.current = outcome;
+      setPendingOutcome(outcome);
     }
   }
 

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -88,6 +88,12 @@ interface ClozeFeedback {
   text: string;
 }
 
+/** Result of scoring an item, carried until the learner completes/advances it. */
+interface CompletionOutcome {
+  nextUnresolved: Set<string>;
+  nextDeferred: PracticeLexeme[];
+}
+
 const STREAK_KEY = 'lu-lexicon-practice-streak';
 const MASTERED_THRESHOLD = 21;
 type SessionPhase = 'idle' | 'active' | 'summary';
@@ -839,6 +845,10 @@ function LexiconPracticeIsland({
   const [revision, setRevision] = useState(0);
   const [history, setHistory] = useState<SelectionHistoryItem[]>([]);
   const [answerLocked, setAnswerLocked] = useState(false);
+  // A WRONG answer parks its scored outcome here instead of auto-advancing, so the
+  // feedback panel (e.g. the §9.5 cited calque correction) dwells until the learner
+  // explicitly moves on via «Далі →» or Enter. Correct answers never set this.
+  const [pendingOutcome, setPendingOutcome] = useState<CompletionOutcome | null>(null);
   const [streak, setStreak] = useState<StreakState>({
     version: 1,
     current: 0,
@@ -962,10 +972,25 @@ function LexiconPracticeIsland({
     setClozeFeedback(null);
     setClozeAttemptRecorded(false);
     setHeritageFeedback(null);
+    setPendingOutcome(null);
     if (selection) {
       window.setTimeout(() => stageRef.current?.focus(), 0);
     }
   }, [selection?.itemId]);
+
+  // While a wrong answer dwells, Enter is a second way to advance (alongside the
+  // «Далі →» button) — the disabled option buttons blur to <body>, so we listen at
+  // the window level rather than on the stage.
+  useEffect(() => {
+    if (!pendingOutcome) return undefined;
+    const handleEnter = (event: KeyboardEvent) => {
+      if (event.key !== 'Enter') return;
+      event.preventDefault();
+      advancePending();
+    };
+    window.addEventListener('keydown', handleEnter);
+    return () => window.removeEventListener('keydown', handleEnter);
+  }, [pendingOutcome, selection]);
 
   useEffect(() => {
     if (sessionPhase !== 'active') return;
@@ -1309,6 +1334,15 @@ function LexiconPracticeIsland({
     completeSelection(current, outcome);
   }
 
+  /** Complete the parked (wrong-answer) selection once the learner chooses to advance. */
+  function advancePending() {
+    if (!selection || !pendingOutcome) return;
+    const outcome = pendingOutcome;
+    setPendingOutcome(null);
+    setAnswerLocked(false);
+    completeSelection(selection, outcome);
+  }
+
   function handleChoice(option: ChoiceOption) {
     if (!selection || answerLocked) return;
     const rating = option.correct ? 'good' : 'again';
@@ -1321,10 +1355,16 @@ function LexiconPracticeIsland({
     setFeedback(
       option.correct ? `${selection.lemma.lemma}: Правильно` : `${selection.lemma.lemma}: Ще раз`,
     );
-    window.setTimeout(() => {
-      setAnswerLocked(false);
-      completeSelection(selection, outcome);
-    }, advanceDelayMs);
+    if (option.correct) {
+      window.setTimeout(() => {
+        setAnswerLocked(false);
+        completeSelection(selection, outcome);
+      }, advanceDelayMs);
+      return;
+    }
+    // WRONG answer: dwell so the cited correction stays readable; the learner
+    // advances explicitly via «Далі →» / Enter (see advancePending).
+    setPendingOutcome(outcome);
   }
 
   function submitCloze(value: string, source: 'typed' | 'chip') {
@@ -1369,11 +1409,10 @@ function LexiconPracticeIsland({
       setClozeAttemptRecorded(true);
       setClozeFeedback({ kind: 'wrong-word', text: '✗ Не те слово' });
       if (source === 'chip') {
+        // Wrong chip pick is a wrong answer: dwell rather than auto-advance so the
+        // learner can read the correction before «Далі →» / Enter.
         setAnswerLocked(true);
-        window.setTimeout(() => {
-          setAnswerLocked(false);
-          completeSelection(selection, outcome);
-        }, advanceDelayMs);
+        setPendingOutcome(outcome);
       }
       return;
     }
@@ -1381,13 +1420,10 @@ function LexiconPracticeIsland({
     setClozeFeedback({ kind: 'wrong-word', text: '✗ Не те слово' });
     if (source === 'chip') {
       setAnswerLocked(true);
-      window.setTimeout(() => {
-        setAnswerLocked(false);
-        completeSelection(selection, {
-          nextUnresolved: new Set(unresolvedCardKeys),
-          nextDeferred: [...deferredLemmas],
-        });
-      }, advanceDelayMs);
+      setPendingOutcome({
+        nextUnresolved: new Set(unresolvedCardKeys),
+        nextDeferred: [...deferredLemmas],
+      });
     }
   }
 
@@ -1656,20 +1692,34 @@ function LexiconPracticeIsland({
           {deck && deck.index.length > 0 && (
             <div className="lexicon-practice-stage" ref={stageRef} tabIndex={-1}>
               {selection ? (
-                <PracticeItem
-                  selection={selection}
-                  deck={deck}
-                  sessionSeed={sessionSeed}
-                  answerLocked={answerLocked}
-                  clozeInput={clozeInput}
-                  clozeFeedback={clozeFeedback}
-                  heritageFeedback={heritageFeedback}
-                  onClozeInput={setClozeInput}
-                  onFlashcardRating={(rating) => rateAndComplete(selection, rating)}
-                  onChoice={handleChoice}
-                  onMatchingComplete={() => rateAndComplete(selection, 'good')}
-                  onClozeSubmit={submitCloze}
-                />
+                <>
+                  <PracticeItem
+                    selection={selection}
+                    deck={deck}
+                    sessionSeed={sessionSeed}
+                    answerLocked={answerLocked}
+                    clozeInput={clozeInput}
+                    clozeFeedback={clozeFeedback}
+                    heritageFeedback={heritageFeedback}
+                    onClozeInput={setClozeInput}
+                    onFlashcardRating={(rating) => rateAndComplete(selection, rating)}
+                    onChoice={handleChoice}
+                    onMatchingComplete={() => rateAndComplete(selection, 'good')}
+                    onClozeSubmit={submitCloze}
+                  />
+                  {pendingOutcome ? (
+                    <div className="lexicon-practice-advance" data-testid="practice-advance">
+                      <button
+                        type="button"
+                        className="btn btn-accent lexicon-practice-advance-btn"
+                        data-testid="practice-advance-button"
+                        onClick={advancePending}
+                      >
+                        Далі →
+                      </button>
+                    </div>
+                  ) : null}
+                </>
               ) : mode === 'cloze' && deck.cloze.length === 0 ? (
                 <p className="lexicon-practice-muted" data-testid="practice-cloze-empty">
                   Вправи з пропусками для цього рівня ще готуються. Спробуйте флешкартки, добір пар або вибір.

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -764,4 +764,95 @@ describe('LexiconPractice', () => {
     const good = container.querySelector('[data-rate="good"] .ri');
     expect(good?.textContent).toMatch(/‹.+›/);
   });
+
+  test('wrong answer dwells: feedback stays and it never auto-advances past 650ms', async () => {
+    const user = userEvent.setup();
+    // Default 650ms auto-advance window; a wrong answer must ignore it entirely.
+    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" />);
+
+    await user.click(
+      within(screen.getByTestId('practice-heritage')).getByRole('button', { name: /дом/ }),
+    );
+
+    // A wrong (calque) pick parks in a dwell state with an explicit advance control.
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+    expect(screen.getByTestId('practice-heritage-feedback')).toHaveTextContent('калька');
+
+    // Wait well past the 650ms correct-answer window — the item must still be here.
+    await new Promise((resolve) => setTimeout(resolve, 750));
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+    expect(screen.getByTestId('practice-heritage-feedback')).toHaveTextContent('калька');
+  });
+
+  test('wrong answer advances on «Далі» click and on Enter', async () => {
+    const clickUser = userEvent.setup();
+    const clicked = render(
+      <LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" advanceDelayMs={20} />,
+    );
+    await clickUser.click(
+      within(screen.getByTestId('practice-heritage')).getByRole('button', { name: /дом/ }),
+    );
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+    await clickUser.click(screen.getByTestId('practice-advance-button'));
+    await waitFor(() =>
+      expect(screen.queryByTestId('practice-advance-button')).not.toBeInTheDocument(),
+    );
+    clicked.unmount();
+
+    const enterUser = userEvent.setup();
+    render(
+      <LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" advanceDelayMs={20} />,
+    );
+    await enterUser.click(
+      within(screen.getByTestId('practice-heritage')).getByRole('button', { name: /дом/ }),
+    );
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+    await enterUser.keyboard('{Enter}');
+    await waitFor(() =>
+      expect(screen.queryByTestId('practice-advance-button')).not.toBeInTheDocument(),
+    );
+  });
+
+  test('correct answer still auto-advances (never enters dwell)', async () => {
+    const user = userEvent.setup();
+    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" advanceDelayMs={20} />);
+
+    await user.click(
+      within(screen.getByTestId('practice-heritage')).getByRole('button', { name: 'дім' }),
+    );
+
+    // Correct answers keep the snappy auto-advance: no dwell control ever appears.
+    expect(screen.queryByTestId('practice-advance-button')).not.toBeInTheDocument();
+    expect(screen.getByTestId('practice-heritage-feedback')).toHaveTextContent('Правильно');
+
+    // The snappy timer fires and moves off the item on its own — no «Далі» needed.
+    await waitFor(() =>
+      expect(screen.queryByTestId('practice-heritage-feedback')).not.toBeInTheDocument(),
+    );
+  });
+
+  test('heritage calque citation stays visible until «Далі»', async () => {
+    const user = userEvent.setup();
+    // Tiny auto-advance window — the cited correction must still outlast it.
+    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" advanceDelayMs={20} />);
+
+    await user.click(
+      within(screen.getByTestId('practice-heritage')).getByRole('button', { name: /дом/ }),
+    );
+
+    expect(screen.getByTestId('practice-heritage-feedback')).toHaveTextContent(
+      'Джерело: Антоненко-Давидович: fixture',
+    );
+
+    // The cited §9.5 correction is the teaching moment — the 20ms timer must not erase it.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(screen.getByTestId('practice-heritage-feedback')).toHaveTextContent(
+      'Джерело: Антоненко-Давидович: fixture',
+    );
+
+    await user.click(screen.getByTestId('practice-advance-button'));
+    await waitFor(() =>
+      expect(screen.queryByTestId('practice-advance-button')).not.toBeInTheDocument(),
+    );
+  });
 });

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LexiconPractice from '@site/src/components/LexiconPractice';
 import {
@@ -854,5 +854,68 @@ describe('LexiconPractice', () => {
     await waitFor(() =>
       expect(screen.queryByTestId('practice-advance-button')).not.toBeInTheDocument(),
     );
+  });
+
+  test('cloze wrong chip dwells (no auto-advance past 650ms) and «Далі» resets to a clean item', async () => {
+    seedRecognitionMastery('knyha');
+    const user = userEvent.setup();
+    // Default 650ms auto-advance window; a wrong chip pick must ignore it entirely.
+    render(<LexiconPractice initialDeck={sampleDeck()} autoStart initialMode="cloze" />);
+
+    expect(screen.getByTestId('practice-cloze')).toBeInTheDocument();
+
+    // A wrong CHIP pick (a different lemma — not a case-miss, not correct) parks in a
+    // dwell state with an explicit advance control instead of auto-advancing.
+    await user.click(screen.getByRole('button', { name: 'робота' }));
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+    expect(screen.getByText('✗ Не те слово')).toBeInTheDocument();
+
+    // Wait well past the 650ms correct-answer window — the wrong chip must still dwell.
+    await new Promise((resolve) => setTimeout(resolve, 750));
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+    expect(screen.getByText('✗ Не те слово')).toBeInTheDocument();
+
+    // «Далі» advances. The lapsed card re-surfaces with the SAME itemId (so the
+    // selection-change effect does not re-fire) — it must still start clean: unlocked
+    // chips, empty input, no stale wrong-word feedback.
+    await user.click(screen.getByTestId('practice-advance-button'));
+    await waitFor(() =>
+      expect(screen.queryByTestId('practice-advance-button')).not.toBeInTheDocument(),
+    );
+    expect(screen.getByTestId('practice-cloze')).toBeInTheDocument();
+    expect(screen.getByLabelText('Відповідь у знахідний')).toHaveValue('');
+    expect(screen.getByRole('button', { name: 'книгу' })).not.toBeDisabled();
+    expect(screen.queryByText('✗ Не те слово')).not.toBeInTheDocument();
+  });
+
+  test('double-Enter during dwell advances exactly once (no double completion)', async () => {
+    const { fn } = mockShardFetch({});
+    vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+    const user = userEvent.setup();
+    render(<LexiconPractice initialDeck={heritageDeck()} autoStart initialMode="heritage" advanceDelayMs={20} />);
+
+    // Wrong (calque) pick parks in a dwell state with an explicit advance control.
+    await user.click(
+      within(screen.getByTestId('practice-heritage')).getByRole('button', { name: /дом/ }),
+    );
+    expect(screen.getByTestId('practice-advance-button')).toBeInTheDocument();
+
+    // Fire TWO Enter keydowns within a single tick, before React re-renders — the real
+    // double-advance race. Only the first may consume the parked outcome; the second must
+    // no-op. A single completion increments the today counter by exactly one.
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    });
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('practice-advance-button')).not.toBeInTheDocument(),
+    );
+
+    // Return home to read the today counter (only surfaced on the idle home ring).
+    await user.click(screen.getByRole('button', { name: /Додому/ }));
+    const ring = await screen.findByTestId('practice-today-ring');
+    // Exactly one completion — a double-advance would have recorded two.
+    expect(Number(ring.textContent?.split('/')[0])).toBe(1);
   });
 });


### PR DESCRIPTION
## What
Wrong answers (choice mode, heritage calque picks, cloze chip submissions) no longer auto-advance after `advanceDelayMs` 650ms. The scored outcome parks in `pendingOutcome`; the feedback panel — including the §9.5 cited calque correction, the pedagogy-critical teaching moment — dwells until the learner explicitly advances via «Далі →» button or Enter (window-level listener, since disabled option buttons blur focus to `<body>`). Correct answers keep the snappy 650ms auto-advance. Reuses the existing `answerLocked` stop-state mechanism (cloze case-miss precedent) rather than a parallel one.

`docs/lesson-schema.yaml`: generated `components_sha256` bump (schema-drift gate).

## Evidence (#M-4 — raw tool output)
vitest (worktree, direct run):
```
 Test Files  1 passed (1)
      Tests  24 passed (24)
   Duration  2.51s
EXIT=0
```
tsc --noEmit (with generated manifest symlinked): `EXIT=0`, 0 errors.
```
 docs/lesson-schema.yaml                  |   2 +-
 site/src/components/LexiconPractice.tsx  | 108 ++++++++++++++++++++++---------
 site/tests/unit/LexiconPractice.test.tsx |  91 ++++++++++++++++++++++++++
 3 files changed, 171 insertions(+), 30 deletions(-)
```

## Provenance
Implemented by the cursor lane (task `4690-feedback-dwell`); CLI silent-exited before finalize — track driver verified (tests + types + full diff review) and finalized.

Fixes #4690

🤖 Generated with [Claude Code](https://claude.com/claude-code)