### PR TITLE
fix(routing): guard-refuse openrouter/deepseek — deepseek is first-party only (user order)

### DIFF
--- a/agents_extensions/shared/rules/model-assignment.md
+++ b/agents_extensions/shared/rules/model-assignment.md
@@ -54,8 +54,10 @@ In scripts, docs meant for copy-paste, and anything automated, ALWAYS write the 
 bare `ab` resolves to ApacheBench (`/usr/sbin/ab`) outside the user's shell (AGENTS.md rule).
 There is NO `ask-deepseek`: one-shot deepseek = `ask-hermes --model <deepseek-model>` (first-party
 as attributed on 2026-07-07) or `ask-opencode deepseek-direct/<deepseek-model>`; execution =
-`delegate.py dispatch --agent deepseek`. Use `ask-opencode openrouter/deepseek/...` only for the
-OpenRouter comparison baseline.
+`delegate.py dispatch --agent deepseek`. `openrouter/deepseek/*` is **guard-REFUSED** (user order
+2026-07-07 — the OR account was drained by deepseek bakeoff cells; deepseek runs FIRST-PARTY only.
+The user's OR BYOK now bills deepseek underneath, so transport-comparison runs (#4321/#4358) are
+billing-safe behind `LU_ROUTING_GUARD_OVERRIDE=1` — deliberate, user-authorized only).
 ² qwen is reachable but EXCLUDED from routine routing (cost, user 2026-05-29) — reachable ≠ routable.
 
 Consequences:

--- a/data/telemetry/llm_qg_live_circuit.json
+++ b/data/telemetry/llm_qg_live_circuit.json
@@ -1,0 +1,34 @@
+{
+  "failure_rate_threshold": 0.15,
+  "live_outcomes": [
+    {
+      "created_at": "2026-07-07T10:54:02.277452Z",
+      "gate_version": "qg_workflow.v3",
+      "level": "b1",
+      "reason": null,
+      "reviewer_family": "google",
+      "reviewer_model": "openrouter/google/gemma-4-31b-it",
+      "route_name": "gemma_surface",
+      "slug": "first",
+      "status": "parse_failure",
+      "terminal_failure": true
+    },
+    {
+      "created_at": "2026-07-07T10:54:02.280298Z",
+      "gate_version": "qg_workflow.v3",
+      "level": "b1",
+      "reason": "observed_cost_gt_125pct_estimate",
+      "reviewer_family": "google",
+      "reviewer_model": "openrouter/google/gemma-4-31b-it",
+      "route_name": "gemma_surface",
+      "slug": "sample",
+      "status": "cost_overrun",
+      "terminal_failure": false
+    }
+  ],
+  "opened_at": null,
+  "operator_message": null,
+  "schema_version": "llm_qg_live_circuit.v1",
+  "updated_at": "2026-07-07T10:54:02.280298Z",
+  "window_size": 30
+}

--- a/scripts/ai_agent_bridge/routing_guard.py
+++ b/scripts/ai_agent_bridge/routing_guard.py
@@ -29,6 +29,14 @@ _QWEN_RE = re.compile(r"(?:^|[/:_-])qwen", re.IGNORECASE)
 _SUBSCRIPTION_VIA_OPENROUTER_RE = re.compile(
     r"openrouter/(?:anthropic/|openai/|google/gemini)", re.IGNORECASE
 )
+# DeepSeek defaults to FIRST-PARTY, never OpenRouter (user order 2026-07-07:
+# the 306-cell multirun matrix drained the OpenRouter account with ~200
+# deepseek cells the night before deepseek-direct landed). The user has since
+# enabled DeepSeek BYOK on OpenRouter, so the OR path now bills the DeepSeek
+# key underneath — but it still adds OpenRouter's BYOK fee and a needless hop.
+# deepseek-direct/<model> is canonical; transport-comparison experiments
+# (#4321/#4358) go through the override env.
+_DEEPSEEK_VIA_OPENROUTER_RE = re.compile(r"openrouter/deepseek", re.IGNORECASE)
 # deepseek-direct is a POSITIVE allowlist, not a family blocklist: the grok-build
 # adversarial review of #4730 produced working bypasses for every blocklist
 # formulation tried (anthropic-claude, openai-gpt, google-gemini, ../claude,
@@ -67,6 +75,15 @@ def assert_model_routing_allowed(model: str | None, *, context: str) -> None:
             f"2026-07-05 (subscription already paid; metered spend is waste). "
             f"Use the native subscription lane instead. Set {_OVERRIDE_ENV}=1 "
             f"only with explicit user authorization."
+        )
+    if _DEEPSEEK_VIA_OPENROUTER_RE.search(text):
+        raise RoutingGuardError(
+            f"{context}: {text!r} routes DeepSeek through OpenRouter. "
+            "Default is FIRST-PARTY (user order 2026-07-07 after the account "
+            "drain; OR now BYOKs to the DeepSeek key but still adds the BYOK "
+            "fee + a needless hop). Use deepseek-direct/<model>. "
+            f"Set {_OVERRIDE_ENV}=1 for a deliberate transport-comparison "
+            "run (#4321/#4358) — billing-safe under BYOK."
         )
     direct_prefix = _DEEPSEEK_DIRECT_PREFIX_RE.match(text)
     if direct_prefix and not _DEEPSEEK_FAMILY_MODEL_RE.match(text[direct_prefix.end() :]):

--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -123,8 +123,10 @@ class CandidateModel:
 
 # TODO(#2156): resolve exact subscription-family pins at run time via
 # ``--models`` after checking the currently served native CLI/model list. Do not
-# guess. DeepSeek defaults are first-party direct pins; OpenRouter DeepSeek pins
-# remain available through ``DEEPSEEK_OPENROUTER_PINS`` as comparison baselines.
+# guess. DeepSeek runs FIRST-PARTY ONLY (user order 2026-07-07; openrouter/deepseek
+# is guard-refused after the account drain). ``DEEPSEEK_OPENROUTER_PINS`` name the
+# historical baseline pins for artifact/scorecard readers; running them requires
+# LU_ROUTING_GUARD_OVERRIDE=1 with explicit user authorization.
 DEFAULT_CANDIDATE_MODELS: tuple[CandidateModel, ...] = (
     CandidateModel("gemma-4-31b", "openrouter/google/gemma-4-31b-it"),
     CandidateModel("deepseek-v4-flash-direct", DEEPSEEK_DIRECT_FLASH_PIN),

--- a/tests/audit/test_qg_bakeoff.py
+++ b/tests/audit/test_qg_bakeoff.py
@@ -288,8 +288,14 @@ def test_deepseek_direct_bakeoff_pins_use_opencode_identity_and_guard_allowed() 
         assert identity.resolved_model == pin
         assert_model_routing_allowed(pin, context="test")
 
+    # user order 2026-07-07: OpenRouter deepseek pins are guard-REFUSED by
+    # default (historical baselines; transport-comparison runs use the
+    # override env — billing-safe under the user's OR BYOK).
+    from scripts.ai_agent_bridge.routing_guard import RoutingGuardError
+
     for pin in qg_bakeoff.DEEPSEEK_OPENROUTER_PINS:
-        assert_model_routing_allowed(pin, context="test")
+        with pytest.raises(RoutingGuardError):
+            assert_model_routing_allowed(pin, context="test")
 
 
 def test_default_deepseek_candidates_use_first_party_direct_pins() -> None:

--- a/tests/test_routing_guard.py
+++ b/tests/test_routing_guard.py
@@ -49,6 +49,11 @@ def _no_override(monkeypatch: pytest.MonkeyPatch):
         # non-subscription but non-DeepSeek: refused by the allowlist too
         "deepseek-direct/mistral-large",
         "deepseek-direct/",
+        # user order 2026-07-07: deepseek NEVER via OpenRouter (account drained
+        # by bakeoff cells; first-party credit is paid + markup-free)
+        "openrouter/deepseek/deepseek-v4-flash",
+        "openrouter/deepseek/deepseek-v4-pro",
+        "OPENROUTER/DEEPSEEK/DEEPSEEK-V4-PRO",
     ],
 )
 def test_forbidden_models_refused(model: str) -> None:
@@ -60,8 +65,6 @@ def test_forbidden_models_refused(model: str) -> None:
     "model",
     [
         "openrouter/google/gemma-4-31b-it",  # google/ but NOT gemini — no subscription lane
-        "openrouter/deepseek/deepseek-v4-flash",
-        "openrouter/deepseek/deepseek-v4-pro",
         "deepseek-direct/deepseek-v4-flash",
         "deepseek-direct/deepseek-v4-pro",
         "gemini-3.1-pro-high",  # agy NATIVE lane (no openrouter/ prefix) is the subscription path


### PR DESCRIPTION
**User order 2026-07-07** after the OpenRouter account drain: ~200 deepseek cells of the 306-cell multirun matrix ran through `openrouter/deepseek/*` the night BEFORE #4730's deepseek-direct landed — that's where the OR balance went ($1.15 left).

- `routing_guard` now REFUSES `openrouter/deepseek/*` at every choke point (same load-bearing enforcement as the qwen ban + subscription-family rules — prose doesn't enforce, the guard does).
- deepseek runs FIRST-PARTY everywhere: hermes (already attributed first-party), opencode `deepseek-direct/*` (#4730), delegate.
- The user has since enabled DeepSeek **BYOK on OpenRouter**, so the OR path bills the DeepSeek key underneath — transport-comparison runs (#4321/#4358) stay possible and billing-safe behind `LU_ROUTING_GUARD_OVERRIDE=1` (deliberate, user-authorized only). Guard message says exactly this.
- Bakeoff `DEEPSEEK_OPENROUTER_PINS` remain as named historical constants (artifact/scorecard readers); tests flipped: OR pins now assert REFUSED.
- `model-assignment.md` updated (served rule).

99 guard+bakeoff tests green, ruff clean. Refs #4358 #4321 #4730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)