### PR TITLE
feat(practice): pointer bump — UA-first heritage deck live (#4691)

### DIFF
--- a/site/src/data/lexicon-practice-deck.pointer.json
+++ b/site/src/data/lexicon-practice-deck.pointer.json
@@ -1,12 +1,12 @@
 {
-  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-9e5b4a65d92bf9c9.json.gz",
+  "asset_url": "https://github.com/learn-ukrainian/learn-ukrainian.github.io/releases/download/atlas-practice-deck/lexicon-practice-deck-atlas-practice-v1-0bbaf111d30c029b.json.gz",
   "release_tag": "atlas-practice-deck",
-  "deck_version": "atlas-practice-v1-9e5b4a65d92bf9c9",
+  "deck_version": "atlas-practice-v1-0bbaf111d30c029b",
   "package_schema_version": 1,
-  "gz_sha256": "8b9720e10662985f4d9947a67a71c53572694ab978895632b6d3d8078b522997",
-  "package_sha256": "8bfef448bceb1da660ba39656588437d757a434e760fcb19d3baa9b562b12d8b",
-  "gz_bytes": 612252,
-  "package_bytes": 14394983,
+  "gz_sha256": "550b6e2d0c1069873cd5522e742d317c479651cd9aa6ee2b62770fad0a180f87",
+  "package_sha256": "6d83c1891df7d5bee32c098322afacfbcbf38f6f58b527751d7ab71e22beb2ab",
+  "gz_bytes": 612892,
+  "package_bytes": 14398265,
   "file_count": 45,
   "files": [
     {
@@ -15,7 +15,7 @@
       "level": "A1",
       "schema": "atlas-practice-index",
       "bytes": 318863,
-      "sha256": "b2a8d8eae53d5dfe2ed3b45b3d68f8125bda3e4797d1808be1c2fe4f00634bee",
+      "sha256": "1f778bcd29f50105278fd70b977bea4b3cd083875bd971dcc852456e7513e76b",
       "counts": {
         "lexemes": 1150,
         "cloze": 22,
@@ -29,15 +29,15 @@
       "level": "A1",
       "schema": "atlas-practice-lexemes",
       "bytes": 562939,
-      "sha256": "aa1d8e8d3bdb58e1b68d9830d12b7ecca186ec4fb1816ea8d63c8560d1d2bfc8"
+      "sha256": "7ee8c9711166bd1e90700d87deba12954c49f4e0cd625e5a21687c2a688291ad"
     },
     {
       "path": "practice-cloze.A1.json",
       "kind": "cloze",
       "level": "A1",
       "schema": "atlas-practice-cloze",
-      "bytes": 44716,
-      "sha256": "28e3159220ee61abf8da5645256260fcf7a2193a5783673fbbd2dc8f887d3d63"
+      "bytes": 44782,
+      "sha256": "78911dcdbc9f2de3af04923e3006af45b94d18eb559ecbc55ecfdf9c75775e90"
     },
     {
       "path": "practice-stress.A1.json",
@@ -45,7 +45,7 @@
       "level": "A1",
       "schema": "atlas-practice-stress",
       "bytes": 382927,
-      "sha256": "061627ec5b443c929296435df3bdb0ebeb2f30919f4eaac061e5adef1fdf03df"
+      "sha256": "f0e7245e664b0cac5b3e07513495392dc1cb7df57473771b95cb1add0b88e487"
     },
     {
       "path": "practice-classify.A1.json",
@@ -53,7 +53,7 @@
       "level": "A1",
       "schema": "atlas-practice-classify",
       "bytes": 437057,
-      "sha256": "aeca3b3780ad1651489db1cb747fc6ae0ba237a14eeacc2c3370401f42dc5022"
+      "sha256": "6f02c8885f8ac3118aa108959c7e750c06d7421c73f4f2f1424e71c45ef63539"
     },
     {
       "path": "practice-paradigm.A1.json",
@@ -61,7 +61,7 @@
       "level": "A1",
       "schema": "atlas-practice-paradigm",
       "bytes": 533851,
-      "sha256": "888468b722cd111c103070c1df98ec6b99294443db7935c0f5880581286bbf19"
+      "sha256": "462b6686fbcd9e5362eb91c45b7eebe3ede65d138fe451b73689faea45833cb6"
     },
     {
       "path": "practice-synonym.A1.json",
@@ -69,7 +69,7 @@
       "level": "A1",
       "schema": "atlas-practice-synonym",
       "bytes": 317,
-      "sha256": "5ecbff25c12b85f1c3e3325e7a9d6c982aa4d25c5bbb2dfd71242a15a0dba919"
+      "sha256": "d5ba6b9a1c346b6a8fb2a417465b6b786df7a71c321ddff4723aca1df11343b3"
     },
     {
       "path": "practice-heritage.A1.json",
@@ -77,7 +77,7 @@
       "level": "A1",
       "schema": "atlas-practice-heritage",
       "bytes": 319,
-      "sha256": "3d55d57088eb8bb60a140e142f7af5d2edc5f1a6b3e03f8edb237e31fed981e3"
+      "sha256": "79d219878d41f0ce5586f1652df329da26d3c564ae1bd33f486895ac4efad0c9"
     },
     {
       "path": "practice-paronym.A1.json",
@@ -85,7 +85,7 @@
       "level": "A1",
       "schema": "atlas-practice-paronym",
       "bytes": 317,
-      "sha256": "8f75912414cb14313407596096072d8b0fbdccaa252c719d38985b36c58100d6"
+      "sha256": "bf44341c27072ba373682890d8f315457436b80d8f4c350f93601942b71c893b"
     },
     {
       "path": "practice-index.A2.json",
@@ -93,7 +93,7 @@
       "level": "A2",
       "schema": "atlas-practice-index",
       "bytes": 281800,
-      "sha256": "2787bf1e292f139f008daeefa246fb72d09b5aa28bdd7b0876b54ebc77431472",
+      "sha256": "ac36fa81217fa973713acf8a9d585f620d1d93d4650e3f156e134fc2c97baba8",
       "counts": {
         "lexemes": 967,
         "cloze": 0,
@@ -107,7 +107,7 @@
       "level": "A2",
       "schema": "atlas-practice-lexemes",
       "bytes": 474613,
-      "sha256": "c7e48273938aac23bd949dd135490104e2fe0b564e47aca0750b17e7f078f59e"
+      "sha256": "dfd484f32c793799178464ee62e53cfff0bc2cf8224bdd74d1e1a4d4ed668b9b"
     },
     {
       "path": "practice-cloze.A2.json",
@@ -115,7 +115,7 @@
       "level": "A2",
       "schema": "atlas-practice-cloze",
       "bytes": 313,
-      "sha256": "aefa1ddbed0d0e5a2fa3c94a4b507e166e4b9ed342df426dc1af131990e18c55"
+      "sha256": "6ab97b77f0d746930e33c88f7660dfd346c4ffcd1efdb7368e9c2cdaab1b231f"
     },
     {
       "path": "practice-stress.A2.json",
@@ -123,7 +123,7 @@
       "level": "A2",
       "schema": "atlas-practice-stress",
       "bytes": 395787,
-      "sha256": "25f0b01adc66a62129371774880f944484d6bff26572c912f2753071144a75fe"
+      "sha256": "e13a489affae29f58baca7504f5c42eaa6a9925d3d35c77bd244f4d37d4161e1"
     },
     {
       "path": "practice-classify.A2.json",
@@ -131,7 +131,7 @@
       "level": "A2",
       "schema": "atlas-practice-classify",
       "bytes": 1121136,
-      "sha256": "885d4ed2b3eb5080479726b490417318d8e2f2ab4f242469871ab70f6bd97518"
+      "sha256": "b362c306ae1363e2b3c0ea976258e234881079fd2a994e95ae54b26b8e65284a"
     },
     {
       "path": "practice-paradigm.A2.json",
@@ -139,7 +139,7 @@
       "level": "A2",
       "schema": "atlas-practice-paradigm",
       "bytes": 420424,
-      "sha256": "b090a6e03a111dbf7d212613a2c12dfce0a6d170dd24a77051c20a183caec3f3"
+      "sha256": "5ab90f7eb9d7cf04901286970a6febd282f3ae484086a99144c2184607da8e22"
     },
     {
       "path": "practice-synonym.A2.json",
@@ -147,15 +147,15 @@
       "level": "A2",
       "schema": "atlas-practice-synonym",
       "bytes": 317,
-      "sha256": "de4463e08c652fc7f425f82116e85ab06d50b0702ed91583f5cf42fb945ed223"
+      "sha256": "ce961b44778ed670fe8a45e2db12709ced425e58fed7703ef5f627f28e68922e"
     },
     {
       "path": "practice-heritage.A2.json",
       "kind": "heritage",
       "level": "A2",
       "schema": "atlas-practice-heritage",
-      "bytes": 39651,
-      "sha256": "1853505bc8c5f2c2384995a6456f63c3a2b15879c1b9a9dcf43cfed6c0cd6aff"
+      "bytes": 40619,
+      "sha256": "be5a25eca6a4c25819fe76e037ab9220928a07f0674287007dce03e2267ad913"
     },
     {
       "path": "practice-paronym.A2.json",
@@ -163,7 +163,7 @@
       "level": "A2",
       "schema": "atlas-practice-paronym",
       "bytes": 317,
-      "sha256": "87e0df00986d5f67ad64f5accc542c457af8fd27b36ea60872663f4ef32f5f8c"
+      "sha256": "c12c69ec574f0b851b3f761c22abc8bd252bcc4b2a0ae96eb2712dad99e3eefc"
     },
     {
       "path": "practice-index.B1.json",
@@ -171,7 +171,7 @@
       "level": "B1",
       "schema": "atlas-practice-index",
       "bytes": 433687,
-      "sha256": "f85912a64c424e1fc39ef3a0893519e688b9e0b9d9259ea8fc9f43c7478ade6b",
+      "sha256": "8547a7035d4c795797c1e568d00e525d1b1778dcff8cb3841ffb0b8a6e836561",
       "counts": {
         "lexemes": 1485,
         "cloze": 0,
@@ -185,7 +185,7 @@
       "level": "B1",
       "schema": "atlas-practice-lexemes",
       "bytes": 748382,
-      "sha256": "3985a9bccac3772300bd0335e232e5e2ec8529d03a1ffb63e51394a15e4d02bc"
+      "sha256": "539647054ad4bf915c7de254e32106f0cb8f376cc1c00c47e20c8fee822e8d88"
     },
     {
       "path": "practice-cloze.B1.json",
@@ -193,7 +193,7 @@
       "level": "B1",
       "schema": "atlas-practice-cloze",
       "bytes": 313,
-      "sha256": "f64a969f66505dd33de51b2ba94bcbe5c7cccafd75205db276cdc46fcde5a897"
+      "sha256": "13e5b431e6b0157f7c022adb8ac883ac9ea0cdabd0f0c9db2f4f86b40299f5a1"
     },
     {
       "path": "practice-stress.B1.json",
@@ -201,7 +201,7 @@
       "level": "B1",
       "schema": "atlas-practice-stress",
       "bytes": 447184,
-      "sha256": "528bdba2e3b9a576b96bc339200109811c35f7c2d05828a05df61543fce9a854"
+      "sha256": "8407ba26903316644e6a98b12297eb09ddbb7b9b77d861aa34b003c90cfad01e"
     },
     {
       "path": "practice-classify.B1.json",
@@ -209,7 +209,7 @@
       "level": "B1",
       "schema": "atlas-practice-classify",
       "bytes": 1449662,
-      "sha256": "693b864daad55558b1c1e6cabfd5808c933af37b1f510119318528dd4b88f9b8"
+      "sha256": "39eb375963b01b2fc906f61de82af555d29dceceb020e3b9558f99ebe1c05fdd"
     },
     {
       "path": "practice-paradigm.B1.json",
@@ -217,7 +217,7 @@
       "level": "B1",
       "schema": "atlas-practice-paradigm",
       "bytes": 583013,
-      "sha256": "9625ae24f2eeec517151a2aaf6531c4671e6031e2ed2c0aef1e909b94d1a4510"
+      "sha256": "6697c54b8b42025dff8fd3996ab5f06253bfd6b0f68a0095ed6d3a8ffd681453"
     },
     {
       "path": "practice-synonym.B1.json",
@@ -225,15 +225,15 @@
       "level": "B1",
       "schema": "atlas-practice-synonym",
       "bytes": 112522,
-      "sha256": "cb2ce8bef2460b1ee7c5cf5286a6de0e32251ddb89ae416ccd887fd2d5f878c8"
+      "sha256": "a93cf620d65b30b0d19a6887cefc5389c2e93250be5058fdd20b608f4353721e"
     },
     {
       "path": "practice-heritage.B1.json",
       "kind": "heritage",
       "level": "B1",
       "schema": "atlas-practice-heritage",
-      "bytes": 93565,
-      "sha256": "04fa74a59ddf128c4926f4feb4fbcdd7316824141a34fa01295ee74f015296d1"
+      "bytes": 95711,
+      "sha256": "cf1c1dc406b44e585f6f3956e058a32d5ae08635343debe49d626ee42b8a36b6"
     },
     {
       "path": "practice-paronym.B1.json",
@@ -241,7 +241,7 @@
       "level": "B1",
       "schema": "atlas-practice-paronym",
       "bytes": 317,
-      "sha256": "47b0a47c7f6cb16768c1c628abf190d63a713fbb132a8e9bda69f5b86df44edc"
+      "sha256": "d921080973111c886e77af1e89072d1cb7d9661e7ffea6b6f728bbc13db14dc6"
     },
     {
       "path": "practice-index.B2.json",
@@ -249,7 +249,7 @@
       "level": "B2",
       "schema": "atlas-practice-index",
       "bytes": 254076,
-      "sha256": "0fa92b1a2144179d32159c0c3e849b3c8847bbac0d466c6288c9f96aa6633019",
+      "sha256": "ef27b524adce1a6522e4613deb883b76464272efa951124c204027948ffe7f6a",
       "counts": {
         "lexemes": 853,
         "cloze": 0,
@@ -263,7 +263,7 @@
       "level": "B2",
       "schema": "atlas-practice-lexemes",
       "bytes": 443931,
-      "sha256": "773753f4182ac604e99b6a63c8d2b18e32615936206899591c44b9738943fc29"
+      "sha256": "3e359aed72b37e9403daf5e195a9c19f71a5dab53d60a8c962e33f68d7ad87b9"
     },
     {
       "path": "practice-cloze.B2.json",
@@ -271,7 +271,7 @@
       "level": "B2",
       "schema": "atlas-practice-cloze",
       "bytes": 313,
-      "sha256": "7443d3c71e338489cfc96ddeb8fe364df2347b6be18ab16cf9ff55ff9d7b5ebc"
+      "sha256": "6b91bbbe62bca3e44a3aadee6551117d489a43880cdf26f8c0b52c471bf244d7"
     },
     {
       "path": "practice-stress.B2.json",
@@ -279,7 +279,7 @@
       "level": "B2",
       "schema": "atlas-practice-stress",
       "bytes": 301091,
-      "sha256": "121ee2380c3ef94fbc68e63741beef89fc97f7ece29d654b04fd081b008e11c0"
+      "sha256": "91653a88a666796ded4ef19cda82a580f0f0e1be38533ca5b4f0884930af19b3"
     },
     {
       "path": "practice-classify.B2.json",
@@ -287,7 +287,7 @@
       "level": "B2",
       "schema": "atlas-practice-classify",
       "bytes": 901024,
-      "sha256": "76aa3c33e6c59c9bc54b4a1df1cdd90ff867e9dc1c758fa7694f7093a47127ee"
+      "sha256": "5fa2c49447aa037f4fc2b10466684e007ea43ecd70bae9f9b1a13306e28f74c4"
     },
     {
       "path": "practice-paradigm.B2.json",
@@ -295,7 +295,7 @@
       "level": "B2",
       "schema": "atlas-practice-paradigm",
       "bytes": 400063,
-      "sha256": "a8a535cfe50f8202405262bd660f96b706544b94ca243034d5011aee71190ea1"
+      "sha256": "399311184c1644fad6458d89e8089447969a328d9055f723668b9d9d0e18be49"
     },
     {
       "path": "practice-synonym.B2.json",
@@ -303,7 +303,7 @@
       "level": "B2",
       "schema": "atlas-practice-synonym",
       "bytes": 40785,
-      "sha256": "d0627aa2923db5dd6ca019ccf2559fe2a92711e5eb1359053becd60e8b4b46fb"
+      "sha256": "9dec5da7bf58b5ef6c07e48b037c4e82564572af722b3d6c23ed0650251d66dc"
     },
     {
       "path": "practice-heritage.B2.json",
@@ -311,7 +311,7 @@
       "level": "B2",
       "schema": "atlas-practice-heritage",
       "bytes": 20155,
-      "sha256": "b2f9dfde83695eeb8749ded759b24836f08bd684f46a2607f0f5bd0b7af83b83"
+      "sha256": "68c199f050ca4bb1fb58292fc3d362984f2f72b8635439b6880a54c161ad3048"
     },
     {
       "path": "practice-paronym.B2.json",
@@ -319,7 +319,7 @@
       "level": "B2",
       "schema": "atlas-practice-paronym",
       "bytes": 317,
-      "sha256": "f46950f321118ae8ef42067a9d5b217d976b1eb5c05de1c8557268c9fcc7eaa6"
+      "sha256": "78b5e3b333f3568e2bb031b352617c5b6422387e298c5d765b398261be4e7684"
     },
     {
       "path": "practice-index.C1.json",
@@ -327,7 +327,7 @@
       "level": "C1",
       "schema": "atlas-practice-index",
       "bytes": 121829,
-      "sha256": "7835bce2107d44f62480565fb09e21676e5f1e5b03ad73c6dcafc559240f32ee",
+      "sha256": "9611c9e918046ce0bed05c5395715b1018794d253096c43fbc03c1e6e9a7659a",
       "counts": {
         "lexemes": 403,
         "cloze": 0,
@@ -341,7 +341,7 @@
       "level": "C1",
       "schema": "atlas-practice-lexemes",
       "bytes": 229361,
-      "sha256": "7cdb1da5626f63a5aaabfc62a681eb375848ca4892d987b955101719da000e75"
+      "sha256": "dd1faf3f59d86fbb033d4fdf35b310870c1db8755b90d32d87d2fa5de0564951"
     },
     {
       "path": "practice-cloze.C1.json",
@@ -349,7 +349,7 @@
       "level": "C1",
       "schema": "atlas-practice-cloze",
       "bytes": 313,
-      "sha256": "2c5ae947af74a7c9a65d9324b6922d42bd34917460b17e7edbef7fa8b3771e50"
+      "sha256": "350b15619fbefcea0f6279d4747d2f1a5b80a483371f7b4a30ee9919c5b73280"
     },
     {
       "path": "practice-stress.C1.json",
@@ -357,7 +357,7 @@
       "level": "C1",
       "schema": "atlas-practice-stress",
       "bytes": 200434,
-      "sha256": "29dfad0e4bf904b504a0a53097090d29d44a978d27cea2c11c68780669c42572"
+      "sha256": "cc1217c5046b55ec05a60447501547db45c9b8e63c866e6dca442c26096e5f57"
     },
     {
       "path": "practice-classify.C1.json",
@@ -365,7 +365,7 @@
       "level": "C1",
       "schema": "atlas-practice-classify",
       "bytes": 585487,
-      "sha256": "fbd2078fa2fbec039b12ac13cb9fcb32e4d20b6ab2b3a3f7f245eb81950868ef"
+      "sha256": "9677878f649aa2a3fe42d12c581fb7fe69af3487fb2c7f0019a3dfef2ea5028f"
     },
     {
       "path": "practice-paradigm.C1.json",
@@ -373,7 +373,7 @@
       "level": "C1",
       "schema": "atlas-practice-paradigm",
       "bytes": 342080,
-      "sha256": "39b79d38bf954a5e072b83dd66b54effb1367f69601a1e17660eb95cbdf5de82"
+      "sha256": "9725822bef5d86789687b4c79e43823dca05756f42bbaa0fe460ffe47c101d56"
     },
     {
       "path": "practice-synonym.C1.json",
@@ -381,7 +381,7 @@
       "level": "C1",
       "schema": "atlas-practice-synonym",
       "bytes": 16896,
-      "sha256": "71530d545f837df28d51b419aceafffc3f990ee3ee17addec9925a86755a7036"
+      "sha256": "097ec24b34c2936e7b9ab5149da62d53fb68ae3c6d91043a1fcd0ec898d0a47d"
     },
     {
       "path": "practice-heritage.C1.json",
@@ -389,7 +389,7 @@
       "level": "C1",
       "schema": "atlas-practice-heritage",
       "bytes": 319,
-      "sha256": "54243009d28ea07635667b346fda529eb3bbd6a4f5b13e0ec7f56001785b2779"
+      "sha256": "d89536c8ba77561c74c04f7d4a26b96e05f5a115ee83edf45ac9000a929dfbfc"
     },
     {
       "path": "practice-paronym.C1.json",
@@ -397,7 +397,7 @@
       "level": "C1",
       "schema": "atlas-practice-paronym",
       "bytes": 317,
-      "sha256": "1d081e3c4aedde659900dece4a08a344464c8574c115609c3aaa5c76628964b3"
+      "sha256": "b06540876af1ff34139da288d60a30cbabedcd5571eecffb0aabdea70c8c9440"
     }
   ],
   "note": "Pins GitHub Release asset practice deck for #3796; hydrate it build/test time instead of committing shards. Deck versions fingerprint public atlas DB entries, heritage pairs, synonym verdicts, and cloze sources; the first publish after that input expansion mints a new versioned asset by design."


### PR DESCRIPTION
Pointer-only bump to `atlas-practice-v1-0bbaf111d30c029b` (45 shards) — the first publish after #4744 (UA-first calque notes) merged; builder v4 fingerprint.

## Verification (#M-4, all run by the track driver post-publish)
- **sha**: downloaded `asset_url`, `gz_sha256` matches pointer: `550b6e2d0c1069873cd5522e742d317c479651cd9aa6ee2b62770fad0a180f87` ✓
- **content**: heritage A1=0/A2=34/B1=76/B2=16 = **126 items**, #4720 availability floor intact (A1 empty by design)
- **new payload**: `rationaleUk` present in published heritage items (A2=2, B1=4); learner-facing detail now UA-only, EN-omit fallback verified in client (#4744)

Refs #4691, #4505.

🤖 Generated with [Claude Code](https://claude.com/claude-code)