### PR TITLE
fix(audit): heritage lemmaId resolves against cumulative lexeme shards (≤ level)

### DIFF
--- a/scripts/audit/check_static_practice_assets.py
+++ b/scripts/audit/check_static_practice_assets.py
@@ -310,6 +310,8 @@ def _check_level(
     min_lexemes: int,
     reviewed: set[tuple[str, str]],
     errors: list[str],
+    *,
+    lower_lexeme_ids: set[str] | None = None,
 ) -> dict[str, Any]:
     paths = {
         "index": practice_dir / f"practice-index.{level}.json",
@@ -428,7 +430,20 @@ def _check_level(
             if not _has_text(lemma_id):
                 errors.append(f"{prefix} missing lemmaId")
             elif str(lemma_id) not in lexeme_by_id:
-                errors.append(f"{prefix} lemmaId {lemma_id!r} missing from {level} lexeme shard")
+                # Heritage items sit at max(lexeme cefr, curator availability floor)
+                # (#4719/#4720), so their native lexeme may live in a LOWER-level
+                # shard. The static client loads lexeme shards cumulatively, keeping
+                # that join resolvable (generate_practice_deck.py, heritage placement
+                # note) — mirror that here for heritage ONLY; all other drill kinds
+                # remain strictly same-level.
+                if kind == "heritage" and str(lemma_id) in (lower_lexeme_ids or set()):
+                    pass
+                elif kind == "heritage":
+                    errors.append(
+                        f"{prefix} lemmaId {lemma_id!r} missing from lexeme shards at or below {level}"
+                    )
+                else:
+                    errors.append(f"{prefix} lemmaId {lemma_id!r} missing from {level} lexeme shard")
         if kind == "classify":
             classify_rows = [item for item in rows if isinstance(item, dict)]
             for index, item in enumerate(classify_rows):
@@ -502,6 +517,7 @@ def _check_level(
         "cloze": len(cloze_items),
         **{kind: len(rows) for kind, rows in mode_items.items() if isinstance(rows, list)},
         "deck_versions": sorted(versions),
+        "lexeme_ids": frozenset(lexeme_by_id),
     }
 
 
@@ -520,10 +536,21 @@ def check_assets(
     errors: list[str] = []
     daily = _check_daily_pool(daily_pool, min_daily_pool_size, errors)
     reviewed = _reviewed_source_keys(reviewed_sources, errors)
-    practice = {
-        level: _check_level(practice_dir, level, min_practice_lexemes_per_level, reviewed, errors)
-        for level in levels
-    }
+    practice: dict[str, dict[str, Any]] = {}
+    # Levels are ordered (A1..C1); heritage items may reference native lexemes from
+    # any LOWER level (availability floor, #4720) — accumulate ids as we ascend.
+    seen_lexeme_ids: set[str] = set()
+    for level in levels:
+        row = _check_level(
+            practice_dir,
+            level,
+            min_practice_lexemes_per_level,
+            reviewed,
+            errors,
+            lower_lexeme_ids=seen_lexeme_ids,
+        )
+        seen_lexeme_ids |= set(row.pop("lexeme_ids", None) or ())
+        practice[level] = row
 
     deck_versions = {
         version

--- a/tests/test_check_static_practice_assets.py
+++ b/tests/test_check_static_practice_assets.py
@@ -472,3 +472,103 @@ def test_check_assets_accepts_tatoeba_attributed_cloze(tmp_path: Path) -> None:
 
     assert summary["ok"] is True
     assert summary["total_cloze"] == 1
+
+
+def _retarget_level_lexeme(practice_dir: Path, *, level: str, lemma_id: str, lemma: str) -> None:
+    """Point a level's lexeme + index shards at a different lemma so the default
+    fixture lemma ('dim') is NOT present at that level."""
+    lexemes_path = practice_dir / f"practice-lexemes.{level}.json"
+    payload = json.loads(lexemes_path.read_text(encoding="utf-8"))
+    payload["lexemes"][0]["lemmaId"] = lemma_id
+    payload["lexemes"][0]["lemma"] = lemma
+    payload["lexemes"][0]["lemmaPlain"] = lemma
+    _write_json(lexemes_path, payload)
+
+    index_path = practice_dir / f"practice-index.{level}.json"
+    index_payload = json.loads(index_path.read_text(encoding="utf-8"))
+    index_payload["items"][0]["lemmaId"] = lemma_id
+    index_payload["items"][0]["lemma"] = lemma
+    _write_json(index_path, index_payload)
+
+
+_VALID_HERITAGE_OPTIONS: list[dict[str, object]] = [
+    {"label": "дім"},
+    {"label": "дом"},
+    {"label": "сад"},
+    {"label": "ліс"},
+]
+
+
+def test_heritage_lemma_from_lower_level_shard_is_allowed(tmp_path: Path) -> None:
+    """#4720 availability floor: a heritage item floored to A2 may reference a native
+    lexeme that lives in the A1 shard — the client loads lexeme shards cumulatively."""
+    daily_pool, practice_dir, reviewed_sources = _fixture_paths(tmp_path)  # A1: lemma 'dim'
+    _write_level(practice_dir, level="A2")
+    _retarget_level_lexeme(practice_dir, level="A2", lemma_id="slovo", lemma="слово")
+    # Heritage item at A2 referencing 'dim' (present only in the A1 lexeme shard).
+    _add_heritage_item(practice_dir, options=_VALID_HERITAGE_OPTIONS, level="A2")
+
+    summary = check_assets(
+        daily_pool=daily_pool,
+        practice_dir=practice_dir,
+        reviewed_sources=reviewed_sources,
+        levels=("A1", "A2"),
+        min_daily_pool_size=2,
+        min_practice_lexemes_per_level=1,
+    )
+
+    assert summary["ok"] is True, summary["errors"]
+
+
+def test_heritage_lemma_unknown_at_or_below_level_still_fails(tmp_path: Path) -> None:
+    daily_pool, practice_dir, reviewed_sources = _fixture_paths(tmp_path)
+    _write_level(practice_dir, level="A2")
+    _retarget_level_lexeme(practice_dir, level="A2", lemma_id="slovo", lemma="слово")
+    _add_heritage_item(practice_dir, options=_VALID_HERITAGE_OPTIONS, level="A2")
+
+    heritage_path = practice_dir / "practice-heritage.A2.json"
+    payload = json.loads(heritage_path.read_text(encoding="utf-8"))
+    payload["heritage"][0]["lemmaId"] = "ghost"
+    _write_json(heritage_path, payload)
+
+    summary = check_assets(
+        daily_pool=daily_pool,
+        practice_dir=practice_dir,
+        reviewed_sources=reviewed_sources,
+        levels=("A1", "A2"),
+        min_daily_pool_size=2,
+        min_practice_lexemes_per_level=1,
+    )
+
+    assert summary["ok"] is False
+    assert any("missing from lexeme shards at or below A2" in error for error in summary["errors"])
+
+
+def test_non_heritage_modes_stay_strictly_same_level(tmp_path: Path) -> None:
+    """The cumulative carve-out is heritage-only: a stress item referencing a
+    lower-level lexeme must still fail."""
+    daily_pool, practice_dir, reviewed_sources = _fixture_paths(tmp_path)
+    _write_level(practice_dir, level="A2")
+    _retarget_level_lexeme(practice_dir, level="A2", lemma_id="slovo", lemma="слово")
+
+    stress_path = practice_dir / "practice-stress.A2.json"
+    payload = json.loads(stress_path.read_text(encoding="utf-8"))
+    payload["stress"] = [{"lemmaId": "dim"}]
+    _write_json(stress_path, payload)
+    index_path = practice_dir / "practice-index.A2.json"
+    index_payload = json.loads(index_path.read_text(encoding="utf-8"))
+    index_payload["counts"]["modeCounts"]["stress"] = 1
+    index_payload["counts"]["modeCoverage"]["stress"] = 1.0
+    _write_json(index_path, index_payload)
+
+    summary = check_assets(
+        daily_pool=daily_pool,
+        practice_dir=practice_dir,
+        reviewed_sources=reviewed_sources,
+        levels=("A1", "A2"),
+        min_daily_pool_size=2,
+        min_practice_lexemes_per_level=1,
+    )
+
+    assert summary["ok"] is False
+    assert any("lemmaId 'dim' missing from A2 lexeme shard" in error for error in summary["errors"])


### PR DESCRIPTION
The static-asset gate rejected heritage items whose native lexeme lives in a lower-level shard — exactly what the #4720 availability floor produces (`level = max(lexeme cefr, curator floor)`), with the join resolvable at runtime via cumulative shard loading (per the generator's placement note). Exposed by #4746; pre-existing checker bug (pool diagnosis msg 2179, confirmed against the CI log: `heritage[8] lemmaId 'так' missing from A2 lexeme shard` etc.).

**Fix**: accumulate lexeme ids through the ordered level loop; heritage lemmaId resolves against shards ≤ item level. All other drill kinds remain strictly same-level.

## Evidence (#M-4, raw)
- `pytest tests/test_check_static_practice_assets.py` → **12 passed in 0.38s** (3 new regression tests: lower-level allowed · unknown lemma still fails with `missing from lexeme shards at or below A2` · stress item referencing a lower-level lexeme still fails same-level)
- Fixed checker vs the REAL published shards that failed CI on #4746 → **exit 0** (counts identical to the CI log: A2 heritage=34, B1=76, B2=16)
- ruff clean.

Unblocks #4746 (pointer bump, auto-merge already armed there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)