### PR TITLE
fix(routing): remove ALL OpenRouter failover routes (deepseek first-party only; grok = grok-build seat)

### DIFF
--- a/scripts/config/agent_runtime_failover.yaml
+++ b/scripts/config/agent_runtime_failover.yaml
@@ -33,29 +33,20 @@
 # - agy: model override; provider is informational unless encoded by the CLI
 #   model label.
 # - Other adapters: chain only if their existing model flag can express it.
-chains:
-  deepseek:
-    cooldown_ttl_s: 300
-    routes:
-      # Primary: native DeepSeek API. Model inherits the dispatch request
-      # (deepseek-v4-pro content/review, deepseek-v4-flash code review).
-      - provider: deepseek
-      # Same-family fallbacks via OpenRouter (slugs verified against the
-      # live OpenRouter catalog 2026-07-06). Pro before flash: quality over
-      # cost on the degraded path.
-      - provider: openrouter
-        model: deepseek/deepseek-v4-pro
-      - provider: openrouter
-        model: deepseek/deepseek-v4-flash
-  grok:
-    cooldown_ttl_s: 300
-    routes:
-      # Primary: xai subscription seat (hermes oauth). Model inherits the
-      # dispatch request (grok-4.3 default).
-      - provider: xai
-      # Same-family fallback via OpenRouter, pay-per-token (1.25/2.50 USD
-      # per 1M, verified 2026-07-06). Only fires while the subscription
-      # seat faults; grok-lane volume is low-frequency review work, so a
-      # fault-window rotation costs cents (#4583 cost check on the issue).
-      - provider: openrouter
-        model: x-ai/grok-4.3
+# NO provider-level failover chains are currently shipped (user order
+# 2026-07-07, burned twice the same day):
+# - deepseek runs FIRST-PARTY ONLY. `openrouter/deepseek/*` is guard-REFUSED
+#   in routing_guard.py for direct routing, but the old fallback routes here
+#   BYPASSED that guard and leeched a fresh OpenRouter top-up (2026-07-07).
+#   The chain config must honor the same order as the guard.
+# - grok work belongs on the grok-build seat (native grok app CLI,
+#   subscription). grok-4.* via OpenRouter has no measured niche and
+#   402-drains the OR balance. The hermes xai seat remains reachable as a
+#   plain single route (no chain needed for that).
+# A single-route lane is NOT a failover chain (loader requires >= 2 routes),
+# so no chains are declared. On a lane fault the ORCHESTRATOR reroutes BY
+# SEAT per model-assignment.md (review stall -> grok-build; deepseek fault ->
+# grok-build/codex), never by silently burning API credit.
+# The chain machinery itself stays (tests + probe cover it) for any future
+# chain the user explicitly approves.
+chains: {}

--- a/tests/agent_runtime/test_runner_failover.py
+++ b/tests/agent_runtime/test_runner_failover.py
@@ -491,13 +491,14 @@ def test_runner_failover_rejects_forbidden_glm_target(tmp_path, monkeypatch):
         runner_mod.invoke("failover-test", "hello", mode="read-only", cwd=tmp_path)
 
 
-def test_shipped_deepseek_chain_is_deepseek_family_only():
-    """Pin the shipped config: deepseek lane fails over inside its own family.
-
-    Guards the two banned drift directions for fallback targets: qwen
-    (cost-excluded) and zai/GLM (LOCAL-ONLY; the loader raises on it anyway).
-    Route 0 must inherit the dispatch-requested model so both pro and flash
-    dispatches keep their primary identity.
+def test_shipped_config_declares_no_deepseek_chain():
+    """Pin the shipped config: deepseek runs FIRST-PARTY ONLY (user order
+    2026-07-07) — NO failover chain exists for it. `openrouter/deepseek/*`
+    is guard-REFUSED for direct routing, and the old OR fallback routes in
+    this chain BYPASSED the guard and leeched a fresh OpenRouter top-up
+    (2026-07-07 burn). A deepseek fault is rerouted BY SEAT by the
+    orchestrator (grok-build/codex), never by burning API credit. Any future
+    chain must be explicitly user-approved and must not contain openrouter.
     """
     from agent_runtime.failover import (
         default_failover_config_path,
@@ -510,19 +511,12 @@ def test_shipped_deepseek_chain_is_deepseek_family_only():
         path=default_failover_config_path(),
     )
 
-    assert chain is not None, "shipped config must define the deepseek chain"
-    assert [route.provider for route in chain.routes] == [
-        "deepseek",
-        "openrouter",
-        "openrouter",
-    ]
-    assert chain.routes[0].model == "deepseek-v4-flash"
-    for route in chain.routes[1:]:
-        assert route.model.startswith("deepseek/"), (
-            f"fallback route {route.index} left the deepseek family: "
-            f"{route.provider}/{route.model}"
-        )
-    assert chain.cooldown_ttl_s == 300
+    assert chain is None, (
+        "deepseek must have NO failover chain (first-party only, user order "
+        f"2026-07-07); got routes: {[r.provider for r in chain.routes]}"
+        if chain is not None
+        else ""
+    )
 
 
 def test_classifier_routes_hermes_credential_startup_failure_to_auth():
@@ -639,9 +633,12 @@ def test_chain_route_missing_model_after_index_zero_warns_and_drops(
     assert any("deepseek[1] dropped" in rec.getMessage() for rec in caplog.records)
 
 
-def test_shipped_grok_chain_is_grok_family_only():
-    """#4583: grok lane fails over inside the x-ai family via openrouter.
-    Route 0 inherits the dispatch-requested model (xai subscription seat)."""
+def test_shipped_config_declares_no_grok_chain():
+    """Pin the shipped config: grok has NO failover chain (user order
+    2026-07-07 — grok work belongs on the grok-build native-app seat;
+    grok-4.* via OpenRouter has no measured niche and 402-drained the OR
+    balance). Supersedes the #4583 in-family-via-openrouter pin. The hermes
+    xai seat stays reachable as a plain single route without a chain."""
     from agent_runtime.failover import (
         default_failover_config_path,
         load_failover_chain,
@@ -653,10 +650,9 @@ def test_shipped_grok_chain_is_grok_family_only():
         path=default_failover_config_path(),
     )
 
-    assert chain is not None, "shipped config must define the grok chain"
-    assert [route.provider for route in chain.routes] == ["xai", "openrouter"]
-    assert chain.routes[0].model == "grok-4.3"
-    assert chain.routes[1].model.startswith("x-ai/"), (
-        f"fallback left the grok family: {chain.routes[1].model}"
+    assert chain is None, (
+        "grok must have NO failover chain (grok-build is the seat, user "
+        f"order 2026-07-07); got routes: {[r.provider for r in chain.routes]}"
+        if chain is not None
+        else ""
     )
-    assert chain.cooldown_ttl_s == 300


### PR DESCRIPTION
**User order 2026-07-07, burned twice the same day.**

1. The deepseek chain's `openrouter/deepseek-v4-{pro,flash}` fallback routes **bypassed the routing_guard first-party-only order** and leeched a fresh OpenRouter top-up when the native lane stalled this afternoon (3-route attempts logged on #4672).
2. The grok chain's `openrouter/x-ai/grok-4.3` fallback 402-drained the balance during the #4735/#4736 re-reviews. grok work belongs on the **grok-build** native-app subscription seat; grok-4.* via OR has no measured niche (model-assignment).

**Change:** `chains: {}` — no provider-level failover chains shipped (a single-route lane is not a chain; loader requires ≥2 routes). Lane faults reroute **by seat** per model-assignment (review stall → grok-build), never by silently burning API credit. Both pin-tests now enforce the ABSENCE of the chains with the order+burn documented in their docstrings; the chain machinery/probe (just landed in #4735) stays intact for any future explicitly-approved chain.

**Verified:** 287 agent_runtime tests green · yaml parses (`chains: {}`) · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)