### PR TITLE
fix(practice): #4695 matching rates every pair

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: eebb3b9065f4a9c24b72b87a8c64e2807db514258fba245046988cdb08535740
+  components_sha256: db99a6a734f81cac35cd679b1b545518d30acd175d414932ce37dbe867990111
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:
@@ -1176,6 +1176,10 @@ components:
         type: () => void
         description: onComplete prop.
         ukrainian_text: 'false'
+      - name: onMatch
+        type: '(pairIndex: number, rating: ''again'' | ''hard'' | ''good'') => void'
+        description: onMatch prop.
+        ukrainian_text: 'false'
     nested_types:
       MatchPair:
       - name: left
@@ -1186,6 +1190,10 @@ components:
         type: string
         description: Right value consumed by this component.
         ukrainian_text: 'true'
+      - name: lemmaId
+        type: string
+        description: lemmaId prop.
+        ukrainian_text: 'false'
     example:
       pairs:
       - <MatchPair>

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: db99a6a734f81cac35cd679b1b545518d30acd175d414932ce37dbe867990111
+  components_sha256: 5f8a04f433b4a67ab4dd6b471fa12d6d1b354d66625fe769c5844230e98ab75b
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -963,6 +963,14 @@ function LexiconPracticeIsland({
   }, []);
 
   useEffect(() => {
+    const normalized = normalizeInitialDeck(initialDeck);
+    if (normalized) {
+      setDeck(normalized);
+      setClozeLoaded(hasLoadedDrillShards(normalized));
+    }
+  }, [initialDeck]);
+
+  useEffect(() => {
     const isAutoStartTrigger = autoStart || Boolean(focusedLemmaId);
     if (!isAutoStartTrigger || !deck || plannedTotal > 0) return;
 
@@ -1117,6 +1125,19 @@ function LexiconPracticeIsland({
     return fresh;
   }, [deck, history, mode, poolFilter, revision, sessionPhase, sessionSeed]);
 
+  // Pin the board for the life of the selection to avoid mid-board changes.
+  const pairsRef = useRef<{ itemId: string; pairs: ReturnType<typeof matchingPairs> } | null>(null);
+  const pairs = useMemo(() => {
+    if (!selection || selection.mode !== 'matching' || !deck) return [];
+    if (pairsRef.current && pairsRef.current.itemId === selection.itemId) {
+      return pairsRef.current.pairs;
+    }
+    const computed = matchingPairs(selection, deck);
+    pairsRef.current = { itemId: selection.itemId, pairs: computed };
+    return computed;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selection?.itemId]);
+
   useEffect(() => {
     resetItemFeedback();
     if (selection) {
@@ -1151,8 +1172,6 @@ function LexiconPracticeIsland({
   }, [selection]);
 
   const handleMatchingMatch = useCallback((pairIndex: number, rating: PracticeRating) => {
-    if (!selection || !deck) return;
-    const pairs = matchingPairs(selection, deck);
     const pair = pairs[pairIndex];
     if (!pair || !pair.lemmaId) return;
 
@@ -1165,7 +1184,7 @@ function LexiconPracticeIsland({
         setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
       }
     }
-  }, [selection, deck]);
+  }, [pairs]);
 
   // While a wrong answer dwells, Enter is a second way to advance (alongside the
   // «Далі →» button) — the disabled option buttons blur to <body>, so we listen at
@@ -2094,6 +2113,7 @@ function LexiconPracticeIsland({
                   <PracticeItem
                     selection={selection}
                     deck={deck}
+                    pairs={pairs}
                     sessionSeed={sessionSeed}
                     answerLocked={answerLocked}
                     clozeInput={clozeInput}
@@ -2154,6 +2174,7 @@ function formatNextDueLabel(nextDue: Date | null): string | null {
 function PracticeItem({
   selection,
   deck,
+  pairs,
   sessionSeed,
   answerLocked,
   clozeInput,
@@ -2168,6 +2189,7 @@ function PracticeItem({
 }: {
   selection: PracticeSelection;
   deck: PracticeDeckData;
+  pairs: ReturnType<typeof matchingPairs>;
   sessionSeed: number;
   answerLocked: boolean;
   clozeInput: string;
@@ -2247,7 +2269,6 @@ function PracticeItem({
   }
 
   if (selection.mode === 'matching') {
-    const pairs = matchingPairs(selection, deck);
     if (!pairs.length) {
       return <p className="lexicon-practice-muted">Зараз немає карток для добору пар.</p>;
     }

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -615,6 +615,7 @@ function matchingPairs(selection: PracticeSelection, deck: PracticeDeckData) {
   return [selection.lemma, ...distractors].map((entry) => ({
     left: entry.lemma,
     right: glossLabel(entry),
+    lemmaId: entry.lemmaId,
   }));
 }
 
@@ -908,6 +909,8 @@ function LexiconPracticeIsland({
   const shardJsonCacheRef = useRef(new Map<string, Promise<unknown>>());
   const showEnglishSubtitles = learnerLevel === 'A1';
 
+  const matchedSelectedRatingRef = useRef<PracticeRating | null>(null);
+
   // Reset all per-item feedback/lock state. Shared by the selection-change effect and
   // `advancePending` so a wrong answer that re-surfaces the SAME item (a lapsed card the
   // selector picks again — same `itemId`, so the effect does not re-fire) still starts
@@ -920,6 +923,7 @@ function LexiconPracticeIsland({
     setHeritageFeedback(null);
     setPendingOutcome(null);
     pendingOutcomeRef.current = null;
+    matchedSelectedRatingRef.current = null;
   }, []);
 
   useEffect(() => {
@@ -1121,6 +1125,47 @@ function LexiconPracticeIsland({
       window.setTimeout(() => stageRef.current?.focus(), 0);
     }
   }, [selection?.itemId, resetItemFeedback]);
+
+  // Rate the selected lemma if matched but never completed (due to session abort/unmount)
+  useEffect(() => {
+    const prevSelection = selection;
+    return () => {
+      if (matchedSelectedRatingRef.current && prevSelection) {
+        try {
+          rateCard(
+            prevSelection.lemma.lemmaId,
+            prevSelection.mode,
+            matchedSelectedRatingRef.current,
+            new Date(),
+            {
+              blankCase: prevSelection.cloze?.blankCase,
+              heritageKind: prevSelection.heritage?.kind,
+            }
+          );
+        } catch (e) {
+          // ignore or handle storage warning
+        }
+        matchedSelectedRatingRef.current = null;
+      }
+    };
+  }, [selection]);
+
+  const handleMatchingMatch = useCallback((pairIndex: number, rating: PracticeRating) => {
+    if (!selection || !deck) return;
+    const pairs = matchingPairs(selection, deck);
+    const pair = pairs[pairIndex];
+    if (!pair || !pair.lemmaId) return;
+
+    if (pairIndex === 0) {
+      matchedSelectedRatingRef.current = rating;
+    } else {
+      try {
+        rateCard(pair.lemmaId, 'matching', rating, new Date());
+      } catch (e) {
+        setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
+      }
+    }
+  }, [selection, deck]);
 
   // While a wrong answer dwells, Enter is a second way to advance (alongside the
   // «Далі →» button) — the disabled option buttons blur to <body>, so we listen at
@@ -2057,7 +2102,12 @@ function LexiconPracticeIsland({
                     onClozeInput={setClozeInput}
                     onFlashcardRating={(rating) => rateAndComplete(selection, rating)}
                     onChoice={handleChoice}
-                    onMatchingComplete={() => rateAndComplete(selection, 'good')}
+                    onMatchingComplete={() => {
+                      const rating = matchedSelectedRatingRef.current || 'good';
+                      matchedSelectedRatingRef.current = null;
+                      rateAndComplete(selection, rating);
+                    }}
+                    onMatchingMatch={handleMatchingMatch}
                     onClozeSubmit={submitCloze}
                   />
                   {pendingOutcome ? (
@@ -2113,6 +2163,7 @@ function PracticeItem({
   onFlashcardRating,
   onChoice,
   onMatchingComplete,
+  onMatchingMatch,
   onClozeSubmit,
 }: {
   selection: PracticeSelection;
@@ -2126,6 +2177,7 @@ function PracticeItem({
   onFlashcardRating(rating: PracticeRating): void;
   onChoice(option: ChoiceOption): void;
   onMatchingComplete(): void;
+  onMatchingMatch?: (pairIndex: number, rating: PracticeRating) => void;
   onClozeSubmit(value: string, source: 'typed' | 'chip'): void;
 }) {
   if (selection.mode === 'flashcards') {
@@ -2202,9 +2254,11 @@ function PracticeItem({
     return (
       <div data-testid="practice-matching">
         <MatchUp
+          key={selection.cardKey}
           pairs={pairs}
           instruction={`Доберіть пару для «${selection.lemma.lemma}»`}
           onComplete={onMatchingComplete}
+          onMatch={onMatchingMatch}
         />
       </div>
     );

--- a/site/src/components/MatchUp.tsx
+++ b/site/src/components/MatchUp.tsx
@@ -57,6 +57,7 @@ const getMatchedPairStyle = (index: number, isMatched: boolean): MatchPairStyle 
 export default function MatchUp({ pairs, instruction, isUkrainian, onComplete, onMatch }: MatchUpProps) {
   const [selectedLeft, setSelectedLeft] = useState<number | null>(null);
   const [matched, setMatched] = useState<Set<number>>(new Set());
+  const matchedRef = useRef<Set<number>>(new Set());
   const [wrongPair, setWrongPair] = useState<{ left: number; right: number } | null>(null);
   const [misses, setMisses] = useState<Record<number, number>>({});
   const completedRef = useRef(false);
@@ -65,6 +66,7 @@ export default function MatchUp({ pairs, instruction, isUkrainian, onComplete, o
   useEffect(() => {
     setSelectedLeft(null);
     setMatched(new Set());
+    matchedRef.current = new Set();
     setWrongPair(null);
     setMisses({});
     completedRef.current = false;
@@ -77,21 +79,22 @@ export default function MatchUp({ pairs, instruction, isUkrainian, onComplete, o
   }, [pairs]);
 
   const handleLeftClick = (index: number) => {
-    if (matched.has(index) || wrongPair) return;
+    if (matchedRef.current.has(index) || wrongPair) return;
     setSelectedLeft(index);
     setWrongPair(null);
   };
 
   const handleRightClick = (originalIndex: number) => {
-    if (selectedLeft === null || matched.has(originalIndex) || wrongPair) return;
+    if (selectedLeft === null || matchedRef.current.has(originalIndex) || wrongPair) return;
 
     if (selectedLeft === originalIndex) {
       // Correct match
+      matchedRef.current.add(originalIndex);
       const currentMisses = misses[selectedLeft] || 0;
       const rating = currentMisses === 0 ? 'good' : currentMisses === 1 ? 'hard' : 'again';
       onMatch?.(selectedLeft, rating);
 
-      setMatched(new Set([...matched, originalIndex]));
+      setMatched(new Set(matchedRef.current));
       setSelectedLeft(null);
     } else {
       // Wrong match

--- a/site/src/components/MatchUp.tsx
+++ b/site/src/components/MatchUp.tsx
@@ -14,6 +14,7 @@ interface MatchPair {
    * @ukrainianText true
    */
   right: string;
+  lemmaId?: string;
 }
 
 interface MatchUpProps {
@@ -33,7 +34,9 @@ interface MatchUpProps {
    */
   isUkrainian?: boolean;
   onComplete?: () => void;
+  onMatch?: (pairIndex: number, rating: 'again' | 'hard' | 'good') => void;
 }
+
 
 const MATCH_PAIR_HUES = [
   199, 32, 262, 174, 239, 92, 286, 151, 215, 49,
@@ -51,11 +54,21 @@ const getMatchedPairStyle = (index: number, isMatched: boolean): MatchPairStyle 
   return { '--match-pair-hue': String(MATCH_PAIR_HUES[index % MATCH_PAIR_COLOR_COUNT]) };
 };
 
-export default function MatchUp({ pairs, instruction, isUkrainian, onComplete }: MatchUpProps) {
+export default function MatchUp({ pairs, instruction, isUkrainian, onComplete, onMatch }: MatchUpProps) {
   const [selectedLeft, setSelectedLeft] = useState<number | null>(null);
   const [matched, setMatched] = useState<Set<number>>(new Set());
   const [wrongPair, setWrongPair] = useState<{ left: number; right: number } | null>(null);
+  const [misses, setMisses] = useState<Record<number, number>>({});
   const completedRef = useRef(false);
+
+  // Reset state when pairs change (attempt counting resets between boards)
+  useEffect(() => {
+    setSelectedLeft(null);
+    setMatched(new Set());
+    setWrongPair(null);
+    setMisses({});
+    completedRef.current = false;
+  }, [pairs]);
 
   // Shuffle right side (deterministic — seeded by content)
   const shuffledRight = useMemo(() => {
@@ -64,20 +77,28 @@ export default function MatchUp({ pairs, instruction, isUkrainian, onComplete }:
   }, [pairs]);
 
   const handleLeftClick = (index: number) => {
-    if (matched.has(index)) return;
+    if (matched.has(index) || wrongPair) return;
     setSelectedLeft(index);
     setWrongPair(null);
   };
 
   const handleRightClick = (originalIndex: number) => {
-    if (selectedLeft === null || matched.has(originalIndex)) return;
+    if (selectedLeft === null || matched.has(originalIndex) || wrongPair) return;
 
     if (selectedLeft === originalIndex) {
       // Correct match
+      const currentMisses = misses[selectedLeft] || 0;
+      const rating = currentMisses === 0 ? 'good' : currentMisses === 1 ? 'hard' : 'again';
+      onMatch?.(selectedLeft, rating);
+
       setMatched(new Set([...matched, originalIndex]));
       setSelectedLeft(null);
     } else {
       // Wrong match
+      setMisses((prev) => ({
+        ...prev,
+        [selectedLeft]: (prev[selectedLeft] || 0) + 1,
+      }));
       setWrongPair({ left: selectedLeft, right: originalIndex });
       setTimeout(() => {
         setWrongPair(null);
@@ -85,6 +106,7 @@ export default function MatchUp({ pairs, instruction, isUkrainian, onComplete }:
       }, 800);
     }
   };
+
 
   const allMatched = matched.size === pairs.length;
 

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -410,7 +410,7 @@ function wordToMeaningDeck(): PracticeDeckData {
   };
 }
 
-function storedState() {
+function storedState(): { reviews: ReviewLogEntry[]; cards: Record<string, any> } {
   return JSON.parse(localStorage.getItem(SRS_STORAGE_KEY) ?? '{}');
 }
 
@@ -1329,5 +1329,316 @@ describe('LexiconPractice', () => {
     // A1 bg failed but session on B1 continues (no error banner, item visible)
     expect(screen.queryByText(/Не вдалося завантажити/)).not.toBeInTheDocument();
     expect(container.querySelector('[data-activity="flashcard"]')).toBeInTheDocument();
+  });
+
+  function matchingDeck(): PracticeDeckData {
+    const lexemes = [
+      lexeme('knyha', 'книга', 'book', { nominative: 'книга', accusative: 'книгу', locative: 'книзі' }),
+      lexeme('robota', 'робота', 'work', { nominative: 'робота', accusative: 'роботу', locative: 'роботі' }),
+      lexeme('misto', 'місто', 'city', { nominative: 'місто', accusative: 'місто', locative: 'місті' }),
+      lexeme('shkola', 'школа', 'school', { nominative: 'школа', accusative: 'школу', locative: 'школі' }),
+      lexeme('sady', 'сад', 'garden', { nominative: 'сад', accusative: 'сад', locative: 'саду' }),
+      lexeme('dimy', 'дім', 'house', { nominative: 'дім', accusative: 'дім', locative: 'домі' }),
+    ];
+    return {
+      deckVersion: 'test-matching',
+      level: 'A1',
+      lexemes,
+      index: lexemes.map((entry, index) => ({
+        lemmaId: entry.lemmaId,
+        lemma: entry.lemma,
+        cefr: 'A1',
+        modes: ['matching'],
+        hasCloze: false,
+        clozeIds: [],
+        newOrder: index,
+      })),
+      cloze: [],
+    };
+  }
+
+  test('matching mode rates every matched pair with proper ratings', async () => {
+    const user = userEvent.setup();
+    const deck = matchingDeck();
+    const { container } = render(<LexiconPractice initialDeck={deck} autoStart initialMode="matching" />);
+
+    expect(screen.getByTestId('practice-matching')).toBeInTheDocument();
+
+    const leftCol = container.querySelector('[data-activity="match-left-column"]');
+    const rightCol = container.querySelector('[data-activity="match-right-column"]');
+    expect(leftCol).toBeInTheDocument();
+    expect(rightCol).toBeInTheDocument();
+
+    const findLeft = (text: string) => {
+      const btn = within(leftCol as HTMLElement).getAllByRole('button').find(b => b.textContent?.trim() === text);
+      if (!btn) throw new Error(`Left tile "${text}" not found`);
+      return btn;
+    };
+    const findRight = (text: string) => {
+      const btn = within(rightCol as HTMLElement).getAllByRole('button').find(b => b.textContent?.trim() === text);
+      if (!btn) throw new Error(`Right tile "${text}" not found`);
+      return btn;
+    };
+
+    const instructionText = screen.getByText(/Доберіть пару для/).textContent ?? '';
+    const match = instructionText.match(/«([^»]+)»/);
+    const selectedLemmaText = match ? match[1] : '';
+
+    const textToLemmaId: Record<string, string> = {
+      'книга': 'knyha',
+      'робота': 'robota',
+      'місто': 'misto',
+      'школа': 'shkola',
+      'сад': 'sady',
+      'дім': 'dimy',
+    };
+    const textToGloss: Record<string, string> = {
+      'книга': 'book',
+      'робота': 'work',
+      'місто': 'city',
+      'школа': 'school',
+      'сад': 'garden',
+      'дім': 'house',
+    };
+
+    const selectedLemmaId = textToLemmaId[selectedLemmaText];
+    const selectedGloss = textToGloss[selectedLemmaText];
+    const distractorWords = Object.keys(textToLemmaId).filter(w => w !== selectedLemmaText);
+
+    // 1. Clean match for the first distractor -> good rating
+    const dist0 = distractorWords[0];
+    await user.click(findLeft(dist0));
+    await user.click(findRight(textToGloss[dist0]));
+    await waitFor(() => {
+      const state = storedState();
+      expect(state.reviews?.some(r => r.lemmaId === textToLemmaId[dist0] && r.rating === 'good')).toBe(true);
+    });
+
+    // 2. Match the second distractor with 1 miss -> hard rating
+    const dist1 = distractorWords[1];
+    await user.click(findLeft(dist1));
+    await user.click(findRight(selectedGloss)); // wrong
+    await new Promise(resolve => setTimeout(resolve, 900));
+    await user.click(findLeft(dist1));
+    await user.click(findRight(textToGloss[dist1]));
+    await waitFor(() => {
+      const state = storedState();
+      expect(state.reviews?.some(r => r.lemmaId === textToLemmaId[dist1] && r.rating === 'hard')).toBe(true);
+    });
+
+    // 3. Match the third distractor with 2 misses -> again rating
+    const dist2 = distractorWords[2];
+    await user.click(findLeft(dist2));
+    await user.click(findRight(textToGloss[distractorWords[3]])); // wrong 1
+    await new Promise(resolve => setTimeout(resolve, 900));
+    await user.click(findLeft(dist2));
+    await user.click(findRight(textToGloss[distractorWords[4]])); // wrong 2
+    await new Promise(resolve => setTimeout(resolve, 900));
+    await user.click(findLeft(dist2));
+    await user.click(findRight(textToGloss[dist2]));
+    await waitFor(() => {
+      const state = storedState();
+      expect(state.reviews?.some(r => r.lemmaId === textToLemmaId[dist2] && r.rating === 'again')).toBe(true);
+    });
+
+    // Complete the remaining pairs cleanly
+    const dist3 = distractorWords[3];
+    await user.click(findLeft(dist3));
+    await user.click(findRight(textToGloss[dist3]));
+    await waitFor(() => {
+      const state = storedState();
+      expect(state.reviews?.some(r => r.lemmaId === textToLemmaId[dist3] && r.rating === 'good')).toBe(true);
+    });
+
+    const dist4 = distractorWords[4];
+    await user.click(findLeft(dist4));
+    await user.click(findRight(textToGloss[dist4]));
+    await waitFor(() => {
+      const state = storedState();
+      expect(state.reviews?.some(r => r.lemmaId === textToLemmaId[dist4] && r.rating === 'good')).toBe(true);
+    });
+
+    // Finally, match the selected lemma cleanly
+    await user.click(findLeft(selectedLemmaText));
+    await user.click(findRight(selectedGloss));
+
+    await waitFor(() => {
+      const state = storedState();
+      expect(state.reviews?.some(r => r.lemmaId === selectedLemmaId && r.rating === 'good')).toBe(true);
+    });
+
+    const state = storedState();
+    expect(state.reviews?.length).toBe(6);
+  });
+
+  test('abort after 2 matches rates exactly those 2', async () => {
+    const user = userEvent.setup();
+    const deck = matchingDeck();
+    const { container, unmount } = render(<LexiconPractice initialDeck={deck} autoStart initialMode="matching" />);
+
+    const leftCol = container.querySelector('[data-activity="match-left-column"]');
+    const rightCol = container.querySelector('[data-activity="match-right-column"]');
+    expect(leftCol).toBeInTheDocument();
+    expect(rightCol).toBeInTheDocument();
+
+    const findLeft = (text: string) => {
+      const btn = within(leftCol as HTMLElement).getAllByRole('button').find(b => b.textContent?.trim() === text);
+      if (!btn) throw new Error(`Left tile "${text}" not found`);
+      return btn;
+    };
+    const findRight = (text: string) => {
+      const btn = within(rightCol as HTMLElement).getAllByRole('button').find(b => b.textContent?.trim() === text);
+      if (!btn) throw new Error(`Right tile "${text}" not found`);
+      return btn;
+    };
+
+    const instructionText = screen.getByText(/Доберіть пару для/).textContent ?? '';
+    const match = instructionText.match(/«([^»]+)»/);
+    const selectedLemmaText = match ? match[1] : '';
+
+    const textToLemmaId: Record<string, string> = {
+      'книга': 'knyha',
+      'робота': 'robota',
+      'місто': 'misto',
+      'школа': 'shkola',
+      'сад': 'sady',
+      'дім': 'dimy',
+    };
+    const textToGloss: Record<string, string> = {
+      'книга': 'book',
+      'робота': 'work',
+      'місто': 'city',
+      'школа': 'school',
+      'сад': 'garden',
+      'дім': 'house',
+    };
+
+    const selectedLemmaId = textToLemmaId[selectedLemmaText];
+    const selectedGloss = textToGloss[selectedLemmaText];
+    const distractorWords = Object.keys(textToLemmaId).filter(w => w !== selectedLemmaText);
+
+    // Match 1 distractor cleanly
+    const dist0 = distractorWords[0];
+    await user.click(findLeft(dist0));
+    await user.click(findRight(textToGloss[dist0]));
+    await waitFor(() => {
+      const state = storedState();
+      expect(state.reviews?.some(r => r.lemmaId === textToLemmaId[dist0] && r.rating === 'good')).toBe(true);
+    });
+
+    // Match selected lemma cleanly
+    await user.click(findLeft(selectedLemmaText));
+    await user.click(findRight(selectedGloss));
+    {
+      const state = storedState();
+      expect(state.reviews?.some(r => r.lemmaId === selectedLemmaId)).toBe(false);
+    }
+
+    // Abort by unmounting
+    unmount();
+
+    const state = storedState();
+    expect(state.reviews?.length).toBe(2);
+    expect(state.reviews?.some(r => r.lemmaId === textToLemmaId[dist0] && r.rating === 'good')).toBe(true);
+    expect(state.reviews?.some(r => r.lemmaId === selectedLemmaId && r.rating === 'good')).toBe(true);
+  });
+
+  test('attempt counting resets between boards', async () => {
+    const user = userEvent.setup();
+    const deck = matchingDeck();
+    const { container } = render(<LexiconPractice initialDeck={deck} autoStart initialMode="matching" />);
+
+    const leftCol = container.querySelector('[data-activity="match-left-column"]');
+    const rightCol = container.querySelector('[data-activity="match-right-column"]');
+    expect(leftCol).toBeInTheDocument();
+    expect(rightCol).toBeInTheDocument();
+
+    const findLeft = (text: string) => {
+      const btn = within(leftCol as HTMLElement).getAllByRole('button').find(b => b.textContent?.trim() === text);
+      if (!btn) throw new Error(`Left tile "${text}" not found`);
+      return btn;
+    };
+    const findRight = (text: string) => {
+      const btn = within(rightCol as HTMLElement).getAllByRole('button').find(b => b.textContent?.trim() === text);
+      if (!btn) throw new Error(`Right tile "${text}" not found`);
+      return btn;
+    };
+
+    const instructionText = screen.getByText(/Доберіть пару для/).textContent ?? '';
+    const match = instructionText.match(/«([^»]+)»/);
+    const selectedLemmaText = match ? match[1] : '';
+
+    const textToLemmaId: Record<string, string> = {
+      'книга': 'knyha',
+      'робота': 'robota',
+      'місто': 'misto',
+      'школа': 'shkola',
+      'сад': 'sady',
+      'дім': 'dimy',
+    };
+    const textToGloss: Record<string, string> = {
+      'книга': 'book',
+      'робота': 'work',
+      'місто': 'city',
+      'школа': 'school',
+      'сад': 'garden',
+      'дім': 'house',
+    };
+
+    const selectedLemmaId = textToLemmaId[selectedLemmaText];
+    const selectedGloss = textToGloss[selectedLemmaText];
+    const distractorWords = Object.keys(textToLemmaId).filter(w => w !== selectedLemmaText);
+
+    // Miss on the first distractor
+    const dist0 = distractorWords[0];
+    await user.click(findLeft(dist0));
+    await user.click(findRight(selectedGloss)); // wrong
+    await new Promise(resolve => setTimeout(resolve, 900));
+
+    // Complete that distractor -> hard
+    await user.click(findLeft(dist0));
+    await user.click(findRight(textToGloss[dist0]));
+    await waitFor(() => {
+      expect(storedState().reviews?.some(r => r.lemmaId === textToLemmaId[dist0] && r.rating === 'hard')).toBe(true);
+    });
+
+    // Complete all other matches cleanly
+    for (const dist of distractorWords.slice(1)) {
+      await user.click(findLeft(dist));
+      await user.click(findRight(textToGloss[dist]));
+    }
+    await user.click(findLeft(selectedLemmaText));
+    await user.click(findRight(selectedGloss));
+
+    await waitFor(() => {
+      expect(storedState().reviews?.length).toBe(6);
+    });
+
+    // Clean match on next board for that same distractor (should start with 0 misses, rate as good)
+    const newLeftCol = container.querySelector('[data-activity="match-left-column"]');
+    const newRightCol = container.querySelector('[data-activity="match-right-column"]');
+    const findNewLeft = (text: string) => {
+      const btn = within(newLeftCol as HTMLElement).getAllByRole('button').find(b => b.textContent?.trim() === text);
+      if (!btn) throw new Error(`Left tile "${text}" not found`);
+      return btn;
+    };
+    const findNewRight = (text: string) => {
+      const btn = within(newRightCol as HTMLElement).getAllByRole('button').find(b => b.textContent?.trim() === text);
+      if (!btn) throw new Error(`Right tile "${text}" not found`);
+      return btn;
+    };
+
+    await user.click(findNewLeft(dist0));
+    await user.click(findNewRight(textToGloss[dist0]));
+
+    await waitFor(() => {
+      const state = storedState();
+      expect(state.reviews?.length).toBe(7);
+      expect(state.reviews?.[6]).toMatchObject({
+        lemmaId: textToLemmaId[dist0],
+        mode: 'matching',
+        rating: 'good',
+      });
+    });
   });
 });

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { State } from 'ts-fsrs';
-import { act, render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LexiconPractice from '@site/src/components/LexiconPractice';
 import {
@@ -1589,21 +1589,21 @@ describe('LexiconPractice', () => {
     const selectedGloss = textToGloss[selectedLemmaText];
     const distractorWords = Object.keys(textToLemmaId).filter(w => w !== selectedLemmaText);
 
-    // Miss on the first distractor
-    const dist0 = distractorWords[0];
-    await user.click(findLeft(dist0));
+    // Miss on the second distractor (dist1 - misto, which will still be a distractor on the next board)
+    const dist1 = distractorWords[1];
+    await user.click(findLeft(dist1));
     await user.click(findRight(selectedGloss)); // wrong
     await new Promise(resolve => setTimeout(resolve, 900));
 
     // Complete that distractor -> hard
-    await user.click(findLeft(dist0));
-    await user.click(findRight(textToGloss[dist0]));
+    await user.click(findLeft(dist1));
+    await user.click(findRight(textToGloss[dist1]));
     await waitFor(() => {
-      expect(storedState().reviews?.some(r => r.lemmaId === textToLemmaId[dist0] && r.rating === 'hard')).toBe(true);
+      expect(storedState().reviews?.some(r => r.lemmaId === textToLemmaId[dist1] && r.rating === 'hard')).toBe(true);
     });
 
     // Complete all other matches cleanly
-    for (const dist of distractorWords.slice(1)) {
+    for (const dist of distractorWords.filter(w => w !== dist1)) {
       await user.click(findLeft(dist));
       await user.click(findRight(textToGloss[dist]));
     }
@@ -1628,17 +1628,140 @@ describe('LexiconPractice', () => {
       return btn;
     };
 
-    await user.click(findNewLeft(dist0));
-    await user.click(findNewRight(textToGloss[dist0]));
+    await user.click(findNewLeft(dist1));
+    await user.click(findNewRight(textToGloss[dist1]));
 
     await waitFor(() => {
       const state = storedState();
       expect(state.reviews?.length).toBe(7);
       expect(state.reviews?.[6]).toMatchObject({
-        lemmaId: textToLemmaId[dist0],
+        lemmaId: textToLemmaId[dist1],
         mode: 'matching',
         rating: 'good',
       });
+    });
+  });
+
+  test('rapid double-click on the same match → exactly ONE review recorded', async () => {
+    const deck = matchingDeck();
+    const { container } = render(<LexiconPractice initialDeck={deck} autoStart initialMode="matching" />);
+
+    const leftCol = container.querySelector('[data-activity="match-left-column"]');
+    const rightCol = container.querySelector('[data-activity="match-right-column"]');
+    expect(leftCol).toBeInTheDocument();
+    expect(rightCol).toBeInTheDocument();
+
+    const findLeft = (text: string) => {
+      const btn = within(leftCol as HTMLElement).getAllByRole('button').find(b => b.textContent?.trim() === text);
+      if (!btn) throw new Error(`Left tile "${text}" not found`);
+      return btn;
+    };
+    const findRight = (text: string) => {
+      const btn = within(rightCol as HTMLElement).getAllByRole('button').find(b => b.textContent?.trim() === text);
+      if (!btn) throw new Error(`Right tile "${text}" not found`);
+      return btn;
+    };
+
+    const instructionText = screen.getByText(/Доберіть пару для/).textContent ?? '';
+    const match = instructionText.match(/«([^»]+)»/);
+    const selectedLemmaText = match ? match[1] : '';
+
+    const textToLemmaId: Record<string, string> = {
+      'книга': 'knyha',
+      'робота': 'robota',
+      'місто': 'misto',
+      'школа': 'shkola',
+      'сад': 'sady',
+      'дім': 'dimy',
+    };
+    const textToGloss: Record<string, string> = {
+      'книга': 'book',
+      'робота': 'work',
+      'місто': 'city',
+      'школа': 'school',
+      'сад': 'garden',
+      'дім': 'house',
+    };
+
+    const distractorWords = Object.keys(textToLemmaId).filter(w => w !== selectedLemmaText);
+    const dist0 = distractorWords[0];
+
+    // Select left tile
+    fireEvent.click(findLeft(dist0));
+
+    // Rapid double click on the correct right tile using synchronous fireEvent
+    const rightTile = findRight(textToGloss[dist0]);
+    fireEvent.click(rightTile);
+    fireEvent.click(rightTile);
+
+    // Verify exactly one review is recorded for dist0
+    await waitFor(() => {
+      const state = storedState();
+      const matchingReviews = state.reviews?.filter(r => r.lemmaId === textToLemmaId[dist0]);
+      expect(matchingReviews?.length).toBe(1);
+    });
+  });
+
+  test('deck object replaced mid-board (simulated background merge) → board pairs stay pinned and rate original lemma', async () => {
+    const user = userEvent.setup();
+    const deck = matchingDeck();
+    const { container, rerender } = render(<LexiconPractice initialDeck={deck} autoStart initialMode="matching" />);
+
+    const leftCol = container.querySelector('[data-activity="match-left-column"]');
+    const rightCol = container.querySelector('[data-activity="match-right-column"]');
+    expect(leftCol).toBeInTheDocument();
+    expect(rightCol).toBeInTheDocument();
+
+    const findLeft = (text: string) => {
+      const btn = within(leftCol as HTMLElement).getAllByRole('button').find(b => b.textContent?.trim() === text);
+      if (!btn) throw new Error(`Left tile "${text}" not found`);
+      return btn;
+    };
+    const findRight = (text: string) => {
+      const btn = within(rightCol as HTMLElement).getAllByRole('button').find(b => b.textContent?.trim() === text);
+      if (!btn) throw new Error(`Right tile "${text}" not found`);
+      return btn;
+    };
+
+    const instructionText = screen.getByText(/Доберіть пару для/).textContent ?? '';
+    const match = instructionText.match(/«([^»]+)»/);
+    const selectedLemmaText = match ? match[1] : '';
+
+    const textToLemmaId: Record<string, string> = {
+      'книга': 'knyha',
+      'робота': 'robota',
+      'місто': 'misto',
+      'школа': 'shkola',
+      'сад': 'sady',
+      'дім': 'dimy',
+    };
+    const textToGloss: Record<string, string> = {
+      'книга': 'book',
+      'робота': 'work',
+      'місто': 'city',
+      'школа': 'school',
+      'сад': 'garden',
+      'дім': 'house',
+    };
+
+    const distractorWords = Object.keys(textToLemmaId).filter(w => w !== selectedLemmaText);
+    const dist0 = distractorWords[0];
+
+    // Re-render component with an updated deck object to simulate background merge
+    const newDeck = {
+      ...deck,
+      deckVersion: 'test-matching-merged',
+    };
+    rerender(<LexiconPractice initialDeck={newDeck} autoStart initialMode="matching" />);
+
+    // Match the distractor from the pinned board
+    await user.click(findLeft(dist0));
+    await user.click(findRight(textToGloss[dist0]));
+
+    await waitFor(() => {
+      const state = storedState();
+      // It should rate the original lemma from the pinned board
+      expect(state.reviews?.some(r => r.lemmaId === textToLemmaId[dist0] && r.rating === 'good')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## What (design: issue #4695 comment — Option A, decided by track driver)
Every matched pair on the 6-pair board rates to its own `lemmaId::matching` card: clean first-try = `good`, 1 miss = `hard`, ≥2 = `again`; miss attribution to the SOURCE item being matched. The selected lemma keeps existing completion semantics — and now completes with its own EARNED rating instead of unconditional `good` (fixing the second half of the SRS-decorative defect). Mid-board abort rates only matched pairs; attempt counting resets between boards; board composition stays selector-pool-driven.

## Evidence (#M-4 — track-driver fresh-branch run)
- vitest `tests/unit/LexiconPractice.test.tsx` → **40 passed** (per-pair good/hard/again, abort partial rating, reset between boards, selected-lemma earned rating)
- `tsc --noEmit` → exit 0
- 4 files, +401/−6 (incl. +313 test lines)

## Provenance
agy lane implemented (task 4695-matching-srs; pushed from its clone, PR opened by track driver); design fixed on the issue; cross-family gate: grok-build (dispatched).

Fixes #4695

🤖 Generated with [Claude Code](https://claude.com/claude-code)