### PR TITLE
feat(atlas): #4385 PR-2 entry_type-branched rendering

### DIFF
--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -135,6 +135,7 @@ interface LexiconEntry {
   lemma: string;
   url_slug: string;
   gloss: string | null;
+  entry_type?: string | null;
   form_of?: { lemma: string; url_slug: string } | null;
   pos: string | null;
   ipa: string | null;
@@ -174,6 +175,20 @@ const cefrLevel = enrichment?.cefr?.level ?? null;
 const paradigm = enrichment?.morphology?.paradigm ?? null;
 const nounParadigm = paradigm?.kind === "noun" ? paradigm : null;
 const verbParadigm = paradigm?.kind === "verb" ? paradigm : null;
+// entry_type-branched rendering (GH #4385): non-lemma article types are not
+// single inflecting heads, so they must NOT be forced through the lemma
+// paradigm/morphology template. A multiword_term / expression / phraseologism /
+// proverb page renders headword, gloss, usage, citations and heritage banners,
+// but never a «Парадигма»/case table — even when the migrated payload happens to
+// carry stray morphology (e.g. aspect-pair rows). Lemma and proper_name keep the
+// full paradigm view unchanged (zero visual regression).
+const MORPHOLOGY_SUPPRESSED_TYPES = new Set([
+  "multiword_term",
+  "expression",
+  "phraseologism",
+  "proverb",
+]);
+const suppressMorphology = MORPHOLOGY_SUPPRESSED_TYPES.has(entry.entry_type ?? "");
 const posLabel = formatPos(entry.pos, enrichment?.morphology?.pos);
 const headwordIpa = formatIpa(entry.pronunciation?.ipa ?? entry.ipa);
 const heritageBoxes = resolveHeritageBoxes(entry);
@@ -364,7 +379,7 @@ function buildArticleOverview() {
   const idiomCount = sections?.idioms?.items.length ?? 0;
   const externalCount = externalGroups.reduce((total, group) => total + group.materials.length, 0);
   const definitionCount = definitionCards.length + (enrichment?.meaning ? 1 : 0) + (phraseHasGloss ? 1 : 0);
-  return [
+  const cards = [
     {
       label: "Значення",
       ready: definitionCount > 0,
@@ -421,6 +436,8 @@ function buildArticleOverview() {
       detail: externalCount > 0 ? `${externalCount} матеріалів` : "очікує добірку",
     },
   ];
+  // Non-lemma entries never surface a morphology card (no paradigm to await).
+  return suppressMorphology ? cards.filter((card) => card.label !== "Морфологія") : cards;
 }
 
 function sourceHost(url: string) {
@@ -688,7 +705,7 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
         </section>
       )}
 
-      {enrichment?.morphology && (
+      {enrichment?.morphology && !suppressMorphology && (
         <section class="atlas-section">
           <h2>Морфологія</h2>
           <p class="atlas-muted">

--- a/site/src/lib/lexicon/atlasDb.ts
+++ b/site/src/lib/lexicon/atlasDb.ts
@@ -13,6 +13,11 @@ export interface LexiconEntry {
   lemma: string;
   url_slug: string;
   gloss: string | null;
+  // entry_type is the article-record kind from `articles.entry_type`
+  // (lemma | expression | phraseologism | proverb | multiword_term | proper_name).
+  // Payloads themselves do not carry it, so it is joined on read from the
+  // `articles` table. `form_of` alias routes have no article row → null.
+  entry_type?: string | null;
   form_of?: { lemma: string; url_slug: string } | null;
   pos?: string | null;
   ipa?: string | null;
@@ -28,6 +33,7 @@ export interface LexiconEntry {
 interface PayloadRow {
   slug: string;
   payload_json: string;
+  entry_type: string | null;
 }
 
 interface MetadataRow {
@@ -62,6 +68,97 @@ export function resetAtlasPayloadCacheForTests(): void {
   _practiceLemmasCache = null;
 }
 
+type BetterSqliteDatabase = InstanceType<typeof Database>;
+
+export interface EntryModelGateCounts {
+  reviewedEntries: number;
+  publicRoutes: number;
+  formOfRoutes: number;
+  aliasRecords: number;
+}
+
+/**
+ * Site-build assertions for the two DB-enforced entry-model gates
+ * (`docs/runbooks/word-atlas-entry-model.md` § Acceptance Gates). These mirror
+ * the DB builder's checks (`scripts/atlas/atlas_db.py`) so a bad `atlas.db`
+ * fails the Astro build loudly instead of silently shipping inflated counts or
+ * dangling aliases. Wording is kept identical to the deterministic gates.
+ *
+ * - `article_vs_alias_count`: `form_of` and alias records do not increment
+ *   reviewed entry totals.
+ * - `alias_target_integrity`: every public alias `target_slug` resolves to an
+ *   approved public article.
+ */
+export function runEntryModelGates(db: BetterSqliteDatabase): EntryModelGateCounts {
+  const scalar = (sql: string): number => (db.prepare(sql).get() as { n: number }).n;
+
+  // article_vs_alias_count — reviewed entries are the approved+public `articles`
+  // rows only. `form_of` alias routes (no `articles` row) and `aliases` records
+  // must be excluded, so the reviewed total must equal the public routes minus
+  // the form_of routes, and must equal the routes that join an approved+public
+  // article. Any drift means an alias/form_of record has leaked into the totals.
+  const reviewedEntries = scalar(
+    `SELECT COUNT(*) AS n FROM articles WHERE review_state = 'approved' AND visibility = 'public'`,
+  );
+  const publicRoutes = scalar(`SELECT COUNT(*) AS n FROM article_payloads WHERE is_public_route = 1`);
+  const formOfRoutes = scalar(
+    `SELECT COUNT(*) AS n FROM article_payloads ap
+     LEFT JOIN articles a ON a.slug = ap.slug
+     WHERE ap.is_public_route = 1 AND a.slug IS NULL`,
+  );
+  const routedReviewed = scalar(
+    `SELECT COUNT(*) AS n FROM article_payloads ap
+     JOIN articles a ON a.slug = ap.slug
+     WHERE ap.is_public_route = 1 AND a.review_state = 'approved' AND a.visibility = 'public'`,
+  );
+  const aliasRecords = scalar(`SELECT COUNT(*) AS n FROM aliases`);
+
+  if (reviewedEntries !== publicRoutes - formOfRoutes || reviewedEntries !== routedReviewed) {
+    throw new Error(
+      `article_vs_alias_count failure: form_of and alias records must not increment reviewed entry totals — ` +
+        `reviewed entries=${reviewedEntries}, public routes=${publicRoutes}, form_of routes=${formOfRoutes} ` +
+        `(public - form_of = ${publicRoutes - formOfRoutes}), routed approved-public articles=${routedReviewed}`,
+    );
+  }
+
+  // alias_target_integrity — mirrors scripts/atlas/atlas_db.py::validate_alias_targets.
+  const failures = db
+    .prepare(
+      `SELECT al.alias AS alias, al.kind AS kind, al.target_slug AS target_slug,
+              a.review_state AS review_state, a.visibility AS visibility
+       FROM aliases al
+       LEFT JOIN articles a ON a.slug = al.target_slug
+       WHERE al.visibility = 'public'
+         AND (a.slug IS NULL OR a.review_state != 'approved' OR a.visibility != 'public')
+       ORDER BY al.target_slug, al.kind, al.alias`,
+    )
+    .all() as Array<{
+    alias: string;
+    kind: string;
+    target_slug: string;
+    review_state: string | null;
+    visibility: string | null;
+  }>;
+
+  if (failures.length > 0) {
+    for (const row of failures) {
+      const reason =
+        row.review_state === null
+          ? 'missing target article'
+          : row.review_state !== 'approved'
+            ? `target review_state=${JSON.stringify(row.review_state)}`
+            : `target visibility=${JSON.stringify(row.visibility)}`;
+      console.error(
+        `alias_target_integrity failure: alias=${JSON.stringify(row.alias)} ` +
+          `kind=${JSON.stringify(row.kind)} target_slug=${JSON.stringify(row.target_slug)} reason=${reason}`,
+      );
+    }
+    throw new Error(`${failures.length} alias target(s) are not approved public articles`);
+  }
+
+  return { reviewedEntries, publicRoutes, formOfRoutes, aliasRecords };
+}
+
 export function getAtlasPayloadCache(): AtlasPayloadCache {
   if (cachedAtlasPayloads) return cachedAtlasPayloads;
 
@@ -75,12 +172,16 @@ export function getAtlasPayloadCache(): AtlasPayloadCache {
 
   const db = new Database(dbPath, { readonly: true, fileMustExist: true });
   try {
+    // Fail the build loudly on entry-model gate violations before reading rows.
+    runEntryModelGates(db);
+
     const payloadRows = db
       .prepare(
-        `SELECT slug, payload_json
-         FROM article_payloads
-         WHERE is_public_route = 1
-         ORDER BY route_order`,
+        `SELECT ap.slug AS slug, ap.payload_json AS payload_json, a.entry_type AS entry_type
+         FROM article_payloads ap
+         LEFT JOIN articles a ON a.slug = ap.slug
+         WHERE ap.is_public_route = 1
+         ORDER BY ap.route_order`,
       )
       .all() as PayloadRow[];
     const metadataRows = db
@@ -90,7 +191,13 @@ export function getAtlasPayloadCache(): AtlasPayloadCache {
          WHERE key IN ('generated_at', 'version')`,
       )
       .all() as MetadataRow[];
-    const entries = payloadRows.map((row) => JSON.parse(row.payload_json) as LexiconEntry);
+    const entries = payloadRows.map((row) => {
+      const entry = JSON.parse(row.payload_json) as LexiconEntry;
+      // entry_type is authoritative from the `articles` table (SSOT), not the
+      // payload JSON. `form_of` alias routes have no article row → null.
+      entry.entry_type = row.entry_type ?? null;
+      return entry;
+    });
     const bySlug = new Map<string, LexiconEntry>();
     for (const entry of entries) {
       bySlug.set(entry.url_slug, entry);

--- a/site/src/pages/lexicon/[lemma].astro
+++ b/site/src/pages/lexicon/[lemma].astro
@@ -1,6 +1,14 @@
 ---
 /**
- * Атлас слів (Лексикон) — per-lemma detail route.
+ * Атлас слів (Лексикон) — article detail route.
+ *
+ * Route semantics (GH #4385): the `[lemma]` param is an ENTRY slug, not a lemma
+ * parameter. The value is always `entry.url_slug`, so multiword-term slugs
+ * (e.g. `брати-взяти`, `іі-відміна`) resolve exactly like single-lemma slugs.
+ * The Astro filename stays `[lemma].astro` (a later PR handles the rename); the
+ * `entry_type` carried on each entry drives per-type rendering in the article
+ * component. The DB-enforced entry-model gates run when `getAtlasPayloadCache()`
+ * loads, failing the build loudly on violations.
  */
 import CourseLayout from "../../layouts/CourseLayout.astro";
 import WordAtlasArticle from "../../lexicon/WordAtlasArticle.astro";

--- a/site/tests/unit/atlas-db-read.test.ts
+++ b/site/tests/unit/atlas-db-read.test.ts
@@ -139,11 +139,16 @@ describe('Atlas DB SSG read parity', () => {
       const dbEntry = cache.bySlug.get(slug);
       expect(manifestEntry, `manifest fixture missing: ${slug}`).toBeDefined();
       expect(dbEntry, `DB fixture missing: ${slug}`).toBeDefined();
-      expect(dbEntry).toEqual(manifestEntry);
+      // entry_type is a DB-only field (the manifest predates the entry model).
+      // Align the manifest fixture with the DB's entry_type so this parity check
+      // isolates payload-projection fidelity from entry_type branching, which is
+      // covered by atlas-entry-type-templates.test.ts.
+      const alignedManifestEntry = { ...manifestEntry!, entry_type: dbEntry!.entry_type };
+      expect(dbEntry).toEqual(alignedManifestEntry);
 
       const manifestHtml = await container.renderToString(WordAtlasArticle, {
         props: {
-          entry: manifestEntry,
+          entry: alignedManifestEntry,
           allEntries: manifestEntries,
           generatedAt: data.generated_at,
           manifestVersion: data.version,

--- a/site/tests/unit/atlas-entry-type-templates.test.ts
+++ b/site/tests/unit/atlas-entry-type-templates.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment node
+
+import Database from 'better-sqlite3';
+import reactRenderer from '@astrojs/react/server.js';
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, expect, test, beforeAll, vi } from 'vitest';
+import { resolve } from 'node:path';
+import {
+  getAtlasPayloadCache,
+  resetAtlasPayloadCacheForTests,
+  runEntryModelGates,
+  type AtlasPayloadCache,
+  type LexiconEntry,
+} from '@site/src/lib/lexicon/atlasDb';
+
+type AstroComponent = Parameters<AstroContainer['renderToString']>[0];
+interface AstroComponentModule {
+  default: AstroComponent;
+}
+
+const atlasDbPath = resolve(process.cwd(), '../data/atlas.db');
+
+// Fixtures live in the real atlas.db:
+//  - брати-взяти is a multiword_term whose migrated payload STILL carries a verb
+//    paradigm — proving the morphology suppression is load-bearing, not a no-op.
+//  - вода is a plain lemma with a noun paradigm — proving lemma pages are unchanged.
+const MULTIWORD_FIXTURE = 'брати-взяти';
+const LEMMA_FIXTURE = 'вода';
+
+/** Minimal in-memory atlas.db shaped like the entry-model schema for gate tests. */
+function makeFixtureDb(): InstanceType<typeof Database> {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE articles (
+      slug TEXT PRIMARY KEY, display_head TEXT, lemma TEXT, entry_type TEXT,
+      review_state TEXT, visibility TEXT
+    );
+    CREATE TABLE article_payloads (
+      slug TEXT PRIMARY KEY, route_order INTEGER, payload_json TEXT, is_public_route INTEGER
+    );
+    CREATE TABLE aliases (
+      alias TEXT, kind TEXT, source TEXT, target_slug TEXT, visibility TEXT DEFAULT 'public'
+    );
+  `);
+  return db;
+}
+
+describe('entry_type-branched article rendering (#4385)', () => {
+  let container: AstroContainer;
+  let WordAtlasArticle: AstroComponent;
+  let cache: AtlasPayloadCache;
+
+  beforeAll(async () => {
+    resetAtlasPayloadCacheForTests();
+    cache = getAtlasPayloadCache();
+    ({ default: WordAtlasArticle } = (await import(
+      '@site/src/lexicon/WordAtlasArticle.astro'
+    )) as AstroComponentModule);
+    container = await AstroContainer.create();
+    container.addServerRenderer({ renderer: reactRenderer });
+  });
+
+  async function render(entry: LexiconEntry | undefined, slug: string): Promise<string> {
+    expect(entry, `fixture missing: ${slug}`).toBeDefined();
+    return container.renderToString(WordAtlasArticle, {
+      props: {
+        entry,
+        allEntries: cache.entries,
+        generatedAt: 'test',
+        manifestVersion: 'test',
+      },
+    });
+  }
+
+  test('entry_type is joined onto payloads from the articles table', () => {
+    expect(cache.bySlug.get(MULTIWORD_FIXTURE)?.entry_type).toBe('multiword_term');
+    expect(cache.bySlug.get(LEMMA_FIXTURE)?.entry_type).toBe('lemma');
+    // form_of alias routes have no articles row → entry_type is null, not undefined.
+    const formOf = cache.entries.find((entry) => entry.form_of);
+    expect(formOf, 'expected at least one form_of alias route in the fixture DB').toBeDefined();
+    expect(formOf?.entry_type).toBeNull();
+
+    // The multiword payload genuinely carries a paradigm, so suppression matters.
+    const morphology = (
+      cache.bySlug.get(MULTIWORD_FIXTURE)?.enrichment as
+        | { morphology?: { paradigm?: { kind?: string } } }
+        | null
+        | undefined
+    )?.morphology;
+    expect(morphology?.paradigm?.kind).toBe('verb');
+  });
+
+  test('multiword_term renders via the non-lemma template — no paradigm/morphology', async () => {
+    const html = await render(cache.bySlug.get(MULTIWORD_FIXTURE), MULTIWORD_FIXTURE);
+    // No case/paradigm table and no morphology section or overview card at all.
+    expect(html).not.toContain('paradigm-table');
+    expect(html).not.toContain('Морфологія');
+    // The non-lemma template still renders the headword.
+    expect(html).toContain('word-title');
+  });
+
+  test('lemma renders unchanged — paradigm/morphology section present', async () => {
+    const html = await render(cache.bySlug.get(LEMMA_FIXTURE), LEMMA_FIXTURE);
+    expect(html).toContain('paradigm-table');
+    expect(html).toContain('Морфологія');
+  });
+});
+
+describe('runEntryModelGates — site-build assertions (#4385)', () => {
+  test('passes on a valid entry-model DB and returns the aggregate counts', () => {
+    const db = makeFixtureDb();
+    db.prepare(`INSERT INTO articles VALUES ('good', 'g', 'g', 'lemma', 'approved', 'public')`).run();
+    db.prepare(`INSERT INTO article_payloads VALUES ('good', 0, '{}', 1)`).run();
+    db.prepare(`INSERT INTO aliases VALUES ('доброго', 'inflected_form', 'vesum', 'good', 'public')`).run();
+    try {
+      expect(runEntryModelGates(db)).toEqual({
+        reviewedEntries: 1,
+        publicRoutes: 1,
+        formOfRoutes: 0,
+        aliasRecords: 1,
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  test('alias_target_integrity: fails loudly on an alias whose target is not an approved public article', () => {
+    const db = makeFixtureDb();
+    db.prepare(`INSERT INTO articles VALUES ('good', 'g', 'g', 'lemma', 'approved', 'public')`).run();
+    db.prepare(`INSERT INTO article_payloads VALUES ('good', 0, '{}', 1)`).run();
+    db.prepare(`INSERT INTO aliases VALUES ('привид', 'canonical', 'seed', 'missing-slug', 'public')`).run();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => runEntryModelGates(db)).toThrow(/alias target\(s\) are not approved public articles/);
+      expect(errSpy).toHaveBeenCalled();
+      const message = String(errSpy.mock.calls[0]?.[0] ?? '');
+      expect(message).toContain('alias_target_integrity failure');
+      expect(message).toContain('missing-slug');
+      expect(message).toContain('missing target article');
+    } finally {
+      errSpy.mockRestore();
+      db.close();
+    }
+  });
+
+  test('article_vs_alias_count: fails when a public route is not a reviewed entry', () => {
+    const db = makeFixtureDb();
+    db.prepare(`INSERT INTO articles VALUES ('good', 'g', 'g', 'lemma', 'approved', 'public')`).run();
+    // A needs_review article that has (wrongly) been given a public route.
+    db.prepare(`INSERT INTO articles VALUES ('draft', 'd', 'd', 'lemma', 'needs_review', 'public')`).run();
+    db.prepare(`INSERT INTO article_payloads VALUES ('good', 0, '{}', 1)`).run();
+    db.prepare(`INSERT INTO article_payloads VALUES ('draft', 1, '{}', 1)`).run();
+    try {
+      expect(() => runEntryModelGates(db)).toThrow(/article_vs_alias_count failure/);
+    } finally {
+      db.close();
+    }
+  });
+
+  test('the production atlas.db satisfies both entry-model gates', () => {
+    const db = new Database(atlasDbPath, { readonly: true, fileMustExist: true });
+    try {
+      const counts = runEntryModelGates(db);
+      expect(counts.reviewedEntries).toBeGreaterThan(0);
+      expect(counts.reviewedEntries).toBe(counts.publicRoutes - counts.formOfRoutes);
+    } finally {
+      db.close();
+    }
+  });
+});


### PR DESCRIPTION
## What & why

`Refs #4385` (roadmap step 5 / frontend plan PR-2, **narrowed first slice** per dispatch — no `[lemma].astro` rename, no POC design source; those stay for later PRs).

The migrated `atlas.db` carries an `entry_type` per article (`lemma`=4166, `multiword_term`=1285 live), but the site still rendered **every** entry through the lemma template — force-feeding non-lemma entries a paradigm/case table. Aspect-pair rows such as `брати-взяти` (a `multiword_term`) actually shipped a full verb paradigm. This PR branches rendering by `entry_type` and wires two DB-enforced gates onto the site-build path.

### Scope (this PR only)
1. **Route semantics** — `/lexicon/{slug}` is treated as an **entry slug** (works for multiword slugs); `entry_type` is joined from `articles` on read and flows through the entry prop. Astro filename stays `[lemma].astro` (rename deferred).
2. **entry_type-branched component** — `WordAtlasArticle` suppresses the «Морфологія» paradigm/case section **and** its overview card for `multiword_term / expression / phraseologism / proverb`. `lemma`/`proper_name` render exactly as before (zero visual regression). Headword, gloss, usage, citations and heritage/calque banners are retained for all types.
3. **Two DB gates as site-build assertions** in `getAtlasPayloadCache()` (fail the `astro build` loudly), wording mirrored from `scripts/atlas/atlas_db.py`:
   - `article_vs_alias_count` — `form_of`/alias records don't inflate reviewed entry totals.
   - `alias_target_integrity` — every public alias `target_slug` resolves to an approved public article.

## Evidence (raw tool output)

**Unit / build-render tests** — `npx vitest run` (bare exit 0):
```
$ npx vitest run tests/unit/atlas-entry-type-templates.test.ts tests/unit/atlas-db-read.test.ts
atlas render parity golden diff: fixtures=8 differing=0
 Test Files  2 passed (2)
      Tests  11 passed (11)
```
Full site suite (regression):
```
$ npx vitest run
 Test Files  35 passed (35)
      Tests  510 passed (510)
```

**`astro build`** — `npx astro build` (bare):
```
ASTRO_BUILD_EXIT: 0
[build] 6204 page(s) built in 50.82s
[build] Complete!
```

**Rendered-output excerpts** (`dist/lexicon/.../index.html`):

`брати-взяти` — **multiword_term whose payload still carries a verb paradigm** → no morphology at all:
```
paradigm-table count: 0
Морфологія count:     0            (neither section heading nor overview card)
<h1 class="word-title"> брати / взяти
overview labels: Значення Походження Стилістика Синонімія Фразеологія Засвідчення Курс Переклад Wikimedia Зовнішні
h2 sections: Дані Атласу · Значення · Фразеологізми та сталі вирази · У курсі …
```

`вода` — **lemma, unchanged** → paradigm intact:
```
<h2>Морфологія</h2>  count: 1
<h2>Морфологія</h2> <p class="atlas-muted"> іменник · 14 форм · VESUM </p> <table class="paradigm-table"> <tr><th class="col-case">Відмінок</th>… <td class="case-name">Називний</td> <td class="form">вода́</td>
```

## Tests added
`site/tests/unit/atlas-entry-type-templates.test.ts`:
- multiword_term renders via the non-lemma template (no paradigm section/card); `entry_type` correctly joined; `form_of` routes → `entry_type=null`.
- lemma renders the paradigm/morphology section unchanged.
- `runEntryModelGates` throws `alias_target_integrity` on a seeded bad alias (in-memory fixture DB) and `article_vs_alias_count` on a non-entry public route; the production `atlas.db` passes both gates.
- Existing render-parity test (`atlas-db-read.test.ts`) aligned to the DB-only `entry_type` field (byte-identical parity preserved: `differing=0`).

## Out of scope (later PRs)
`[lemma].astro`→`[slug].astro` rename, `expression-detail.html` POC source, search/alias split, status-counts API. Scope unchanged — **not** "Fixes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)