### PR TITLE
fix(bio): add readings batch 2

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/hennadii-afanasiev.yaml
+++ b/curriculum/l2-uk-en/plans/bio/hennadii-afanasiev.yaml
@@ -107,11 +107,42 @@ references:
   path: https://www.president.gov.ua/documents/7412025-56717
   title: Указ Президента України №741/2025
   type: reference
+readings:
+- title: Афанасьєв Геннадій Сергійович
+  language: uk
+  genre: Енциклопедична стаття / біографічна довідка
+  source_type: reference
+  role: orientation
+  source: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-891170
+  license: copyrighted
+  rights_note: Використовувати як link-only довідку; не хостити повний текст.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Виписати етапи кримського спротиву, полону, правозахисної діяльності,
+    військової служби та вшанування.
+  caveats: Довідка має доповнюватися контекстом сфабрикованої справи Сенцова-Кольченка.
+- title: Указ Президента України №741/2025
+  language: uk
+  genre: Офіційний документ
+  source_type: primary
+  role: supplementary-reading
+  source: Президент України
+  source_url: https://www.president.gov.ua/documents/7412025-56717
+  license: public-domain
+  rights_note: Офіційний нормативний акт використовувати link-only як джерело державного визнання.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Визначити, як офіційний документ формулює підставу для посмертного звання
+    Героя України.
+  caveats: Документ не є повною біографією і потребує читання разом з довідкою.
 sequence: 295
 slug: hennadii-afanasiev
 subtitle: The Prisoner Who Broke the Russian Case and Fell for Ukraine
 title: 'Геннадій Афанасьєв: Від кримського в''язня до Героя України'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: особа, засуджена або ув'язнена через свої політичні погляди чи діяльність
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/hlib-babich.yaml
+++ b/curriculum/l2-uk-en/plans/bio/hlib-babich.yaml
@@ -120,11 +120,58 @@ references:
   path: Wikipedia (UA)
   title: Бабич Гліб Валерійович (Вікіпедія)
   type: reference
+readings:
+- title: Гліб Бабіч загинув на Харківщині
+  language: uk
+  genre: Меморіальний життєпис
+  source_type: reference
+  role: orientation
+  source: Платформа пам'яті Меморіал
+  source_url: https://memorial.ua/obituaries/militaries/babich-hlib-2711
+  license: copyrighted
+  rights_note: Використовувати як link-only меморіальний профіль; не хостити повний текст або фото.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Виписати факти про поетичну, ветеранську, волонтерську і військову діяльність
+    Бабича.
+  caveats: Меморіальний тон потребує балансу між пошаною і критичним аналізом джерел.
+- title: Бабіч Гліб Валерійович
+  language: uk
+  genre: Енциклопедична стаття / біографічна довідка
+  source_type: reference
+  role: supplementary-reading
+  source: Вікіпедія
+  source_url: https://uk.wikipedia.org/wiki/Бабіч_Гліб_Валерійович
+  license: CC BY-SA 4.0
+  rights_note: Link-only достатньо; при використанні тексту потрібна атрибуція CC BY-SA.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Зіставити біографічні факти, службу, громадську діяльність і посмертне
+    видання поезії.
+  caveats: Перевіряти факти про твори й службу за додатковими джерелами на етапі source packet.
+- title: Уривки з пісень і поезії Гліба Бабича
+  language: uk
+  genre: Поезія / пісенна лірика
+  source_type: primary
+  role: reading-needed
+  source: 'reading-needed: hlib-babich-poetry-song-excerpts'
+  source_url: 'reading-needed'
+  license: unknown
+  rights_note: >-
+    reading-needed: знайти легальний link-only або ліцензований спосіб працювати
+    з короткими уривками; не хостити повні тексти віршів чи пісень.
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: >-
+    Проаналізувати, як військовий досвід переходить у поетичний і пісенний образ.
+  caveats: Пісенна лірика має суворі авторські права; використовувати тільки короткі дозволені цитати.
 sequence: 297
 slug: hlib-babich
 subtitle: The Frontline Poet Who Wrote the Anthems of Resistance
 title: 'Гліб Бабич: Поезія війни та камуфляжна Мадонна'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: земляний насип на зовнішньому боці траншеї для захисту від куль і снарядів
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/stanislav-asieiev.yaml
+++ b/curriculum/l2-uk-en/plans/bio/stanislav-asieiev.yaml
@@ -114,11 +114,61 @@ references:
   title: В ізоляції
   type: primary
   work: В ізоляції
+readings:
+- title: Асєєв Станіслав
+  language: uk
+  genre: Біографічний профіль / довідка
+  source_type: reference
+  role: orientation
+  source: PEN Ukraine
+  source_url: https://pen.org.ua/members/asyeyev-stanislav
+  license: copyrighted
+  rights_note: Використовувати як link-only профіль; не хостити повний текст або фото.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Виписати ключові етапи журналістської, письменницької та правозахисної
+    біографії Асєєва.
+  caveats: Профіль дає рамку, але не замінює читання про катівню "Ізоляція".
+- title: >-
+    Станіслав Асєєв: Всі окуповані території Донбасу — один великий концтабір
+    "Ізоляція"
+  language: uk
+  genre: Інтерв'ю / свідчення
+  source_type: primary
+  role: close-reading
+  source: Українська правда
+  source_url: https://www.pravda.com.ua/articles/2020/12/29/7278243/
+  license: copyrighted
+  rights_note: Використовувати як link-only інтерв'ю; не переносити повний текст.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Визначити, як Асєєв описує "Ізоляцію" як систему окупаційного терору, а не
+    лише окрему тюрму.
+  caveats: Працювати з короткими цитатами і травма-інформованим контекстом.
+- title: Уривки з книжок "В ізоляції" та "Світлий шлях"
+  language: uk
+  genre: Документальна проза / свідчення
+  source_type: primary
+  role: reading-needed
+  source: 'reading-needed: stanislav-asieiev-primary-excerpts'
+  source_url: 'reading-needed'
+  license: unknown
+  rights_note: >-
+    reading-needed: знайти легальний link-only або ліцензований спосіб працювати
+    з короткими уривками; не хостити повні тексти книжок.
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: >-
+    Порівняти репортажний голос у "В ізоляції" зі свідченням про катівню у
+    "Світлому шляху".
+  caveats: Авторські права і травматичний матеріал потребують обережного добору уривків.
 sequence: 293
 slug: stanislav-asieiev
 subtitle: The Journalist Who Documented the Occupation from Inside
 title: 'Станіслав Асєєв: Світлий шлях та голос з ізоляції'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: незаконне захоплення та контроль над частиною території іншої держави
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/viktor-hurniak.yaml
+++ b/curriculum/l2-uk-en/plans/bio/viktor-hurniak.yaml
@@ -117,11 +117,41 @@ references:
   path: https://esu.com.ua/article/hurnyak_viktor_petrovych
   title: Гурняк Віктор Петрович (ЕСУ)
   type: reference
+readings:
+- title: Указ Президента України №450/2021
+  language: uk
+  genre: Офіційний документ
+  source_type: primary
+  role: orientation
+  source: Президент України
+  source_url: https://www.president.gov.ua/documents/4502021-39965
+  license: public-domain
+  rights_note: Офіційний нормативний акт використовувати link-only як джерело державного визнання.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Визначити, як документ описує підставу для посмертного звання Героя України.
+  caveats: Указ не замінює біографічного матеріалу про журналістську й військову діяльність.
+- title: Гурняк Віктор Петрович
+  language: uk
+  genre: Енциклопедична стаття / біографічна довідка
+  source_type: reference
+  role: supplementary-reading
+  source: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article/hurnyak_viktor_petrovych
+  license: copyrighted
+  rights_note: Використовувати як link-only довідку; не хостити повний текст.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Скласти часову лінію від "Пласту" і фотожурналістики до служби, евакуації
+    поранених і загибелі.
+  caveats: Фотоархів і зображення мають окремі права; не переносити їх без ліцензійної перевірки.
 sequence: 296
 slug: viktor-hurniak
 subtitle: The Photojournalist Who Traded His Camera for the Frontline
 title: 'Віктор Гурняк: Фокус на війні та свободі'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: людина, яка добровільно й безоплатно займається суспільно корисною діяльністю, зокрема допомогою армії
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/vladyslav-yesypenko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/vladyslav-yesypenko.yaml
@@ -104,11 +104,44 @@ references:
   path: https://rsf.org/en/release-rferl-journalists-vladyslav-yesypenko-and-ihar-karnei-imprisoned-russia-and-belarus
   title: Release of RFE/RL journalists Vladyslav Yesypenko (RSF)
   type: reference
+readings:
+- title: Владислав Єсипенко
+  language: uk
+  genre: Авторський профіль / біографічна довідка
+  source_type: reference
+  role: orientation
+  source: Крим.Реалії
+  source_url: >-
+    https://ua.krymr.com/author/%D0%B2%D0%BB%D0%B0%D0%B4%D0%B8%D1%81%D0%BB%D0%B0%D0%B2-%D1%94%D1%81%D0%B8%D0%BF%D0%B5%D0%BD%D0%BA%D0%BE/k-kuq_
+  license: copyrighted
+  rights_note: Використовувати як link-only профіль; не хостити повний текст або медіа.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Виписати факти про журналістську роботу, арешт, тортури, вирок і звільнення
+    Єсипенка.
+  caveats: Профіль має читатися як рамка для теми свободи преси в окупації.
+- title: '"Ризикував, але робив свою роботу". Історія Владислава Єсипенка'
+  language: uk
+  genre: Біографічний матеріал / журналістський нарис
+  source_type: reference
+  role: supplementary-reading
+  source: Крим.Реалії
+  source_url: >-
+    https://ua.krymr.com/a/ryzykuvav-ale-robyv-svoyu-robotu-istoriya-vladyslava-yesypenka/33451946.html
+  license: copyrighted
+  rights_note: Використовувати як link-only український матеріал; не переносити повний текст.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Простежити, як звичайна журналістська робота в окупованому Криму була
+    криміналізована російською системою.
+  caveats: Уникати деталей тортур як сенсаційного матеріалу; працювати з правовим контекстом.
 sequence: 294
 slug: vladyslav-yesypenko
 subtitle: The Crimean Journalist Who Survived FSB Captivity for the Truth
 title: 'Владислав Єсипенко: Журналістика та опір системі ФСБ'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: неправдиве створення доказів чи обставин справи для незаконного звинувачення
   pos: ж.


### PR DESCRIPTION
## Summary
- Adds top-level BIO readings blocks for the next five manifest-order readings gaps: stanislav-asieiev, vladyslav-yesypenko, hennadii-afanasiev, viktor-hurniak, hlib-babich.
- Uses Ukrainian link-only sources where stable sources exist.
- Marks copyright-heavy primary text needs as explicit reading-needed exceptions for Asieiev and Babich.

Refs #4431
Refs #4400

## Validation
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python targeted readings/YAML shape check
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/yamllint targeted five plan files
- git diff --check
- compact BIO readiness recount: missing readings 116 -> 111; next missing starts at ihor-kozlovskyi
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py

## Review status
Draft until independent cross-family review verifies source scope, Ukrainian-only learner readings, and copyright-safe link-only/reading-needed handling.