### PR TITLE
feat(qg_bakeoff): Claude/GPT subscription tooled routes (#4762 #4763)

### DIFF
--- a/docs/dispatch-briefs/qg-bakeoff-claude-1x17-sweep.md
+++ b/docs/dispatch-briefs/qg-bakeoff-claude-1x17-sweep.md
@@ -1,0 +1,46 @@
+# QG bakeoff — Claude 1×17 sweep (GLM-5.2, #4763)
+
+**Prerequisite:** PR #4762/#4763 harness merged on `main` (tooled_runtime_claude + lenient JSON + session JSONL tool recovery).
+
+You are the measurement driver. **Run ONE Python command.** Do not write bash scripts, do not use a shell tool, do not run `nohup`.
+
+## The only command
+
+From repo root `/Users/krisztiankoos/projects/learn-ukrainian`:
+
+```
+cd /Users/krisztiankoos/projects/learn-ukrainian
+QG_BAKEOFF=1 .venv/bin/python scripts/audit/run_subscription_1x17_sweep.py --model claude-opus-4-8
+```
+
+## What it does
+
+- **34 cells:** 17 fixtures × tooled + bare (greenfield — do not reuse old multirun bare cells).
+- **Output:** `audit/2026-07-08-claude-multirun-1x/` (`_sweep.log`, `RESULTS.tsv`, `SCORECARD.md`).
+- **Serial** with 90s/60s pauses between cells.
+
+## Parallel with GPT
+
+Claude and GPT use different subscription buckets. GPT sweep can run at the same time in a **separate** session:
+
+```
+cd /Users/krisztiankoos/projects/learn-ukrainian
+QG_BAKEOFF=1 .venv/bin/python scripts/audit/run_subscription_1x17_sweep.py --model gpt-5.5
+```
+
+Do not share the same `--out-dir`.
+
+## When finished
+
+Write `audit/2026-07-08-claude-multirun-1x/REPORT.md` with SCORECARD link, 17×lift table, and viability verdict under STRICT.
+
+## Hard stops
+
+- `QG_BAKEOFF=1` not set
+- More than 2 consecutive cell failures
+- Harness cells with `status=error` and `tool_call_count=0` on tooled arm (report — do not patch harness)
+
+## Never
+
+- Edit harness code or open PRs during measurement
+- Rerun gemini/gemma/deepseek arms

--- a/docs/dispatch-briefs/qg-bakeoff-gpt-1x17-sweep.md
+++ b/docs/dispatch-briefs/qg-bakeoff-gpt-1x17-sweep.md
@@ -1,0 +1,38 @@
+# QG bakeoff — GPT (Codex) 1×17 sweep (Codex / GLM, #4762)
+
+**Prerequisite:** PR #4762/#4763 harness merged on `main` (tooled_runtime_gpt via Codex exec).
+
+You are the measurement driver. **Run ONE Python command.** Do not write bash scripts, do not use a shell tool, do not run `nohup`.
+
+## The only command
+
+From repo root `/Users/krisztiankoos/projects/learn-ukrainian`:
+
+```
+cd /Users/krisztiankoos/projects/learn-ukrainian
+QG_BAKEOFF=1 .venv/bin/python scripts/audit/run_subscription_1x17_sweep.py --model gpt-5.5
+```
+
+## What it does
+
+- **34 cells:** 17 fixtures × tooled + bare (greenfield).
+- **Output:** `audit/2026-07-08-gpt-multirun-1x/`.
+- **Serial** with pauses between cells.
+
+## Parallel with Claude
+
+Safe to run alongside the Claude sweep (different model pin, different out dir). Gemini 1×17 may still be running — that is fine (Antigravity quota is separate).
+
+## When finished
+
+Write `audit/2026-07-08-gpt-multirun-1x/REPORT.md` with SCORECARD link, lift table, viability verdict.
+
+## Hard stops
+
+- `QG_BAKEOFF=1` not set
+- More than 2 consecutive cell failures
+
+## Never
+
+- Edit harness during measurement
+- Reuse old multirun bare artifacts for engine selection

--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -44,6 +44,7 @@ Issue: #1184
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -338,18 +339,32 @@ class ClaudeAdapter:
         Claude Code writes the response to stdout. On success, stdout is
         the clean output; on failure, stderr carries the diagnostic.
         """
-        # plan / call_start_time unused — Claude doesn't need session-file
-        # recovery because the Claude CLI flushes stdout before exit.
-        # Kept in the signature to match the uniform protocol (see
-        # adapters/base.py).
         _ = output_file  # Unused — Claude doesn't use -o file
-        _ = plan
         _ = call_start_time
 
         events = parse_json_events(stdout, source="claude", logger=_logger)
         tool_calls = normalize_tool_calls(events)
         stream_response = _extract_stream_json_response(events)
         effective_stdout = stream_response if events else stdout.strip()
+
+        session_id: str | None = None
+        sid_match = _SESSION_ID_RE.search(stdout or "")
+        if sid_match:
+            session_id = sid_match.group(1)
+        for event in events:
+            sid = event.get("session_id") or event.get("sessionId")
+            if isinstance(sid, str) and sid:
+                session_id = sid
+                break
+
+        # Session JSONL is authoritative when stream-json stdout drops tool rows
+        # (measured: subscription tooled bakeoff cells with MCP, 2026-07-08).
+        if plan is not None and plan.cwd is not None and session_id:
+            session_path = _claude_session_jsonl_path(plan.cwd, session_id)
+            if session_path is not None:
+                recovered = _tool_calls_from_claude_session_jsonl(session_path)
+                if len(recovered) > len(tool_calls):
+                    tool_calls = recovered
 
         # Claude Code 2.1.117 does not document a dedicated rate-limit exit
         # code in `claude --help`. The safest remaining signal is a
@@ -369,17 +384,6 @@ class ClaudeAdapter:
         if not ok:
             excerpt_source = stderr.strip() or effective_stdout or stdout.strip() or ""
             stderr_excerpt = excerpt_source[:500] or None
-
-        # Session ID extraction (rare — caller usually passes it IN)
-        session_id: str | None = None
-        sid_match = _SESSION_ID_RE.search(stdout or "")
-        if sid_match:
-            session_id = sid_match.group(1)
-        for event in events:
-            sid = event.get("session_id") or event.get("sessionId")
-            if isinstance(sid, str) and sid:
-                session_id = sid
-                break
 
         return ParseResult(
             ok=ok,
@@ -430,6 +434,32 @@ class ClaudeAdapter:
             except OSError:
                 pass
         return ()
+
+
+def _claude_project_slug(cwd: Path) -> str:
+    return str(cwd.resolve()).replace("/", "-")
+
+
+def _claude_session_jsonl_path(cwd: Path, session_id: str) -> Path | None:
+    candidate = (
+        Path.home() / ".claude" / "projects" / _claude_project_slug(cwd) / f"{session_id}.jsonl"
+    )
+    return candidate if candidate.is_file() else None
+
+
+def _tool_calls_from_claude_session_jsonl(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for raw_line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+    return normalize_tool_calls(events)
 
 
 def _extract_stream_json_response(events: list[dict[str, Any]]) -> str:

--- a/scripts/audit/qg_bakeoff.py
+++ b/scripts/audit/qg_bakeoff.py
@@ -337,6 +337,20 @@ def _subscription_tooled_tool_config(runtime_agent: str) -> dict[str, Any]:
 
     if runtime_agent == "agy":
         config, diagnostics = build_mcp_tool_config("agy", mcp_servers=["sources"])
+    elif runtime_agent == "claude":
+        config, diagnostics = build_mcp_tool_config(
+            "claude",
+            mcp_servers=["sources"],
+            allowed_tools="mcp__sources__*",
+        )
+        if config is not None:
+            config = {
+                **config,
+                "output_format": "stream-json",
+                "use_bare": False,
+            }
+    elif runtime_agent == "codex":
+        config, diagnostics = build_mcp_tool_config("codex", mcp_servers=["sources"])
     else:
         raise BakeoffConfigError(f"subscription tooled runtime not wired for agent {runtime_agent!r}")
     if config is None:
@@ -345,6 +359,34 @@ def _subscription_tooled_tool_config(runtime_agent: str) -> dict[str, Any]:
 
 
 SUBSCRIPTION_TOOLED_ROUTES: tuple[llm_reviewer_dispatch.ReviewerRoute, ...] = (
+    llm_reviewer_dispatch.ReviewerRoute(
+        route_name="tooled_runtime_claude",
+        bridge_command=_runtime_bridge_command(
+            "claude",
+            CLAUDE_SUBSCRIPTION_BARE_MODEL_ID,
+            entrypoint=TOOLED_RUNTIME_ENTRYPOINT,
+        ),
+        reviewer_model_id=CLAUDE_SUBSCRIPTION_BARE_MODEL_ID,
+        reviewer_family="anthropic",
+        purpose="Subscription-runtime tooled fact-check via Claude Code (#4763)",
+        input_usd_per_mtok=0.0,
+        output_usd_per_mtok=0.0,
+        requires_mcp=True,
+    ),
+    llm_reviewer_dispatch.ReviewerRoute(
+        route_name="tooled_runtime_gpt",
+        bridge_command=_runtime_bridge_command(
+            "codex",
+            GPT_SUBSCRIPTION_BARE_MODEL_ID,
+            entrypoint=TOOLED_RUNTIME_ENTRYPOINT,
+        ),
+        reviewer_model_id=GPT_SUBSCRIPTION_BARE_MODEL_ID,
+        reviewer_family="openai",
+        purpose="Subscription-runtime tooled fact-check via Codex exec (#4762)",
+        input_usd_per_mtok=0.0,
+        output_usd_per_mtok=0.0,
+        requires_mcp=True,
+    ),
     llm_reviewer_dispatch.ReviewerRoute(
         route_name="tooled_runtime_gemini",
         bridge_command=_runtime_bridge_command(
@@ -397,6 +439,26 @@ _SUBSCRIPTION_BARE_IDENTITIES: dict[str, RouteIdentity] = {
     ),
 }
 _SUBSCRIPTION_TOOLED_IDENTITIES: dict[str, RouteIdentity] = {
+    "tooled_runtime_claude": RouteIdentity(
+        transport="runtime-claude",
+        entrypoint=TOOLED_RUNTIME_ENTRYPOINT,
+        session_policy="fresh",
+        measurement_tier=SUBSCRIPTION_RUNTIME_TOOLED_TIER,
+        pricing_basis=_SUBSCRIPTION_PRICING_BASIS,
+        resolved_model=CLAUDE_SUBSCRIPTION_BARE_MODEL_ID,
+        runtime_agent="claude",
+        tool_config=None,
+    ),
+    "tooled_runtime_gpt": RouteIdentity(
+        transport="runtime-codex",
+        entrypoint=TOOLED_RUNTIME_ENTRYPOINT,
+        session_policy="fresh",
+        measurement_tier=SUBSCRIPTION_RUNTIME_TOOLED_TIER,
+        pricing_basis=_SUBSCRIPTION_PRICING_BASIS,
+        resolved_model=GPT_SUBSCRIPTION_BARE_MODEL_ID,
+        runtime_agent="codex",
+        tool_config=None,
+    ),
     "tooled_runtime_gemini": RouteIdentity(
         transport="runtime-agy",
         entrypoint=TOOLED_RUNTIME_ENTRYPOINT,
@@ -411,12 +473,15 @@ _SUBSCRIPTION_TOOLED_IDENTITIES: dict[str, RouteIdentity] = {
 
 
 def _lenient_first_json_object(response_text: str) -> Mapping[str, Any] | None:
-    """Parse the FIRST JSON object from a response with trailing garbage.
+    """Parse the FIRST JSON object from a response with leading/trailing garbage.
 
     Measured live (deepseek-v4-flash): a valid payload followed by extra text
     ("Extra data: char 7498"). JSON hygiene is a contract defect worth
-    counting, not a reason to void the fact-check measurement. Returns None
-    when no leading object parses.
+    counting, not a reason to void the fact-check measurement.
+
+    Measured live (claude-opus tooled, 2026-07-08): prose preamble before the
+    JSON object ("I've completed the required search protocol..."). Returns None
+    when no object parses.
     """
     text = response_text.strip()
     if "```json" in text:
@@ -424,11 +489,16 @@ def _lenient_first_json_object(response_text: str) -> Mapping[str, Any] | None:
     elif text.startswith("```"):
         text = text.split("```", 1)[1]
     text = text.lstrip()
-    try:
-        payload, _end = json.JSONDecoder().raw_decode(text)
-    except json.JSONDecodeError:
-        return None
-    return payload if isinstance(payload, Mapping) else None
+    for candidate in (text, text[text.find("{") :] if "{" in text else ""):
+        if not candidate or not candidate.lstrip().startswith("{"):
+            continue
+        try:
+            payload, _end = json.JSONDecoder().raw_decode(candidate.lstrip())
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, Mapping):
+            return payload
+    return None
 
 
 def require_offline_opt_in() -> None:
@@ -908,6 +978,7 @@ def invoke_subscription_tooled_route(
             entrypoint=TOOLED_RUNTIME_ENTRYPOINT,
             hard_timeout=1800,
             stall_timeout=600,
+            effort="xhigh" if runtime_agent == "claude" else None,
         )
     except RateLimitedError as exc:
         raise BakeoffOpsQuotaError(str(exc)) from exc

--- a/scripts/audit/run_subscription_1x17_sweep.py
+++ b/scripts/audit/run_subscription_1x17_sweep.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Serial subscription-runtime 1×17 QG bakeoff sweep (#4761 / #4762 / #4763).
+
+Python-only — no bash. Examples:
+  QG_BAKEOFF=1 .venv/bin/python scripts/audit/run_subscription_1x17_sweep.py --model claude-opus-4-8
+  QG_BAKEOFF=1 .venv/bin/python scripts/audit/run_subscription_1x17_sweep.py --model gpt-5.5
+
+Claude and GPT can run in parallel (separate out dirs, separate subscription buckets).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import unicodedata
+from datetime import UTC, datetime
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+PY = REPO / ".venv" / "bin" / "python"
+
+ALL_FIXTURES = [
+    "vesnianky",
+    "koliadky",
+    "khreshchennia-rusi",
+    "skovoroda-hryhorii",
+    "ahatanhel-krymskyi",
+    "andriivski-vechornytsi",
+    "franko-ivan",
+    "holosinnia",
+    "khmelnytskyi-1648",
+    "kupalski",
+    "lesya-ukrainka",
+    "rusalii",
+    "rusalka-dnistrova",
+    "vesilnyi-obriad",
+    "yaroslav-sofiya",
+    "zaporozka-sich",
+    "zhnyvarski",
+]
+
+MODEL_OUT_DIRS = {
+    "claude-opus-4-8": REPO / "audit" / "2026-07-08-claude-multirun-1x",
+    "gpt-5.5": REPO / "audit" / "2026-07-08-gpt-multirun-1x",
+}
+
+
+def _pin_slug(pin: str) -> str:
+    normalized = unicodedata.normalize("NFKD", pin).encode("ascii", "ignore").decode("ascii")
+    slug = re.sub(r"[^a-z0-9]+", "-", normalized.lower()).strip("-")
+    return slug or "model"
+
+
+def _log(out: Path, msg: str) -> None:
+    ts = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    line = f"[{ts}] {msg}"
+    print(line, flush=True)
+    log_path = out / "_sweep.log"
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+
+
+def _artifact_path(out: Path, model: str, slug: str, arm: str) -> Path | None:
+    pin = _pin_slug(model)
+    for path in out.glob(f"{pin}__{slug}*.json"):
+        if "SCORECARD" in path.name:
+            continue
+        is_bare = "__bare__" in path.name
+        if arm == "bare" and is_bare:
+            return path
+        if arm == "tooled" and not is_bare:
+            return path
+    return None
+
+
+def _record(out: Path, model: str, slug: str, arm: str) -> None:
+    path = _artifact_path(out, model, slug, arm)
+    if path is None:
+        _log(out, f"WARN no artifact for {slug}/{arm}")
+        return
+    j = json.loads(path.read_text(encoding="utf-8"))
+    sc = j.get("score") or {}
+    blob = json.dumps(j)
+    toolcap = "hard cap is 40" in blob or "used 46 tools" in blob
+    row = (
+        f"{slug}\t{arm}\t{j.get('status')}\t{sc.get('model_judgment_score')}\t"
+        f"{sc.get('live_admissible_score')}\t{sc.get('invalid_fact_checks')}\t"
+        f"{j.get('tool_call_count')}\t{j.get('wall_seconds')}\t"
+        f"{j.get('raw_response') is not None}\t{toolcap}\n"
+    )
+    results = out / "RESULTS.tsv"
+    if not results.exists():
+        results.write_text(
+            "fixture\tarm\tstatus\tmodel_judgment\tlive_admissible\t"
+            "invalid_fact_checks\ttool_call_count\twall_seconds\t"
+            "raw_response_nonnull\ttoolcap_error\n",
+            encoding="utf-8",
+        )
+    with results.open("a", encoding="utf-8") as fh:
+        fh.write(row)
+    _log(out, f"recorded {slug}/{arm} status={j.get('status')}")
+
+
+def _run_cell(out: Path, model: str, slug: str, arm: str) -> int:
+    if _artifact_path(out, model, slug, arm) is not None:
+        _log(out, f"skip {slug}/{arm} (artifact exists)")
+        return 0
+    _log(out, f"run {slug}/{arm}")
+    proc = subprocess.run(
+        [
+            str(PY),
+            "-m",
+            "scripts.audit.qg_bakeoff",
+            "--models",
+            model,
+            "--arm",
+            arm,
+            "--fixture",
+            slug,
+            "--out-dir",
+            str(out),
+        ],
+        cwd=str(REPO),
+        env={**os.environ, "QG_BAKEOFF": "1"},
+        check=False,
+    )
+    _record(out, model, slug, arm)
+    pause = 90 if arm == "tooled" else 60
+    _log(out, f"pause {pause}s after {slug}/{arm}")
+    time.sleep(pause)
+    return proc.returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--model",
+        required=True,
+        choices=sorted(MODEL_OUT_DIRS),
+        help="Subscription-runtime model pin",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="Override output directory (default: model-specific audit dir)",
+    )
+    args = parser.parse_args(argv)
+
+    if os.environ.get("QG_BAKEOFF") != "1":
+        print("ERROR: export QG_BAKEOFF=1 before running", file=sys.stderr)
+        return 2
+    if not PY.is_file():
+        print(f"ERROR: venv python not found at {PY}", file=sys.stderr)
+        return 2
+
+    out = args.out_dir or MODEL_OUT_DIRS[args.model]
+    out.mkdir(parents=True, exist_ok=True)
+    _log(out, f"start model={args.model} out={out}")
+
+    errors = 0
+    consecutive_errors = 0
+    for arm in ("tooled", "bare"):
+        for slug in ALL_FIXTURES:
+            rc = _run_cell(out, args.model, slug, arm)
+            if rc != 0:
+                errors += 1
+                consecutive_errors += 1
+            else:
+                consecutive_errors = 0
+            if consecutive_errors > 2:
+                _log(out, "HARD STOP: more than 2 consecutive cell failures")
+                return 1
+    _log(out, f"DONE errors={errors}")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/audit/test_qg_bakeoff.py
+++ b/tests/audit/test_qg_bakeoff.py
@@ -1307,17 +1307,41 @@ def test_subscription_runtime_bare_artifact_identity_and_filename(tmp_path: Path
     assert all(not str(part).startswith("ask-") for part in model["bridge_command"])
 
 
-def test_subscription_native_pins_are_refused_for_tooled_or_both() -> None:
-    with pytest.raises(qg_bakeoff.BakeoffConfigError, match="bare-only"):
-        qg_bakeoff.route_for_matrix_pin(
-            qg_bakeoff.GPT_SUBSCRIPTION_BARE_MODEL_ID,
-            arm=qg_bakeoff.TOOLED_ARM,
-        )
+def test_subscription_native_pins_are_refused_for_both_arm() -> None:
     with pytest.raises(qg_bakeoff.BakeoffConfigError, match="do not support --arm both"):
         qg_bakeoff.route_for_matrix_pin(
             qg_bakeoff.GEMINI_SUBSCRIPTION_BARE_MODEL_ID,
             arm=qg_bakeoff.BOTH_ARM,
         )
+    with pytest.raises(qg_bakeoff.BakeoffConfigError, match="do not support --arm both"):
+        qg_bakeoff.route_for_matrix_pin(
+            qg_bakeoff.CLAUDE_SUBSCRIPTION_BARE_MODEL_ID,
+            arm=qg_bakeoff.BOTH_ARM,
+        )
+
+
+def test_subscription_runtime_tooled_claude_route_resolves() -> None:
+    route = qg_bakeoff.route_for_matrix_pin(
+        qg_bakeoff.CLAUDE_SUBSCRIPTION_BARE_MODEL_ID,
+        arm=qg_bakeoff.TOOLED_ARM,
+    )
+    assert route.route_name == "tooled_runtime_claude"
+    identity = qg_bakeoff._route_identity(route)
+    assert identity.transport == "runtime-claude"
+    assert identity.entrypoint == qg_bakeoff.TOOLED_RUNTIME_ENTRYPOINT
+    assert identity.measurement_tier == qg_bakeoff.SUBSCRIPTION_RUNTIME_TOOLED_TIER
+
+
+def test_subscription_runtime_tooled_gpt_route_resolves() -> None:
+    route = qg_bakeoff.route_for_matrix_pin(
+        qg_bakeoff.GPT_SUBSCRIPTION_BARE_MODEL_ID,
+        arm=qg_bakeoff.TOOLED_ARM,
+    )
+    assert route.route_name == "tooled_runtime_gpt"
+    identity = qg_bakeoff._route_identity(route)
+    assert identity.transport == "runtime-codex"
+    assert identity.entrypoint == qg_bakeoff.TOOLED_RUNTIME_ENTRYPOINT
+    assert identity.measurement_tier == qg_bakeoff.SUBSCRIPTION_RUNTIME_TOOLED_TIER
 
 
 def test_subscription_runtime_tooled_gemini_route_resolves() -> None:
@@ -2535,3 +2559,18 @@ def test_offline_bakeoff_tooled_run_firewalls_stray_reviewer_write(
     assert not list(repo.rglob("*-review.json"))
     assert not (repo / "curriculum" / "l2-uk-en" / "folk" / "status").exists()
     assert run.artifact_path.parent == out_dir
+
+
+def test_lenient_first_json_object_skips_leading_prose() -> None:
+    payload = {"fact_checks": [{"claim": "x", "verdict": "CONFIRMED"}]}
+    text = (
+        "I've completed the required search protocol and here is the JSON.\n\n"
+        + json.dumps(payload)
+        + "\n\nLet me know if you need anything else."
+    )
+    parsed = qg_bakeoff._lenient_first_json_object(text)
+    assert parsed == payload
+
+
+def test_lenient_first_json_object_returns_none_without_object() -> None:
+    assert qg_bakeoff._lenient_first_json_object("no json here") is None

--- a/tests/test_runner_tool_calls.py
+++ b/tests/test_runner_tool_calls.py
@@ -5,6 +5,8 @@ import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from agent_runtime.adapters.base import InvocationPlan
@@ -69,6 +71,55 @@ def test_claude_stream_json_without_text_fails_loudly() -> None:
     assert result.ok is False
     assert result.response == ""
     assert result.tool_calls[0]["name"] == "mcp__sources__verify_words"
+
+
+def test_claude_adapter_recovers_tool_calls_from_session_jsonl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cwd = tmp_path / "work"
+    cwd.mkdir()
+    session_id = "abc-123"
+    slug = str(cwd.resolve()).replace("/", "-")
+    session_dir = tmp_path / ".claude" / "projects" / slug
+    session_dir.mkdir(parents=True)
+    session_file = session_dir / f"{session_id}.jsonl"
+    session_file.write_text(
+        "\n".join([
+            (
+                '{"type":"assistant","message":{"content":['
+                '{"type":"tool_use","id":"u1","name":"mcp__sources__verify_word",'
+                '"input":{"word":"тест"}}]}}'
+            ),
+            (
+                '{"type":"user","message":{"content":['
+                '{"type":"tool_result","tool_use_id":"u1","content":"ok"}]}}'
+            ),
+        ])
+        + "\n",
+        encoding="utf-8",
+    )
+    stdout = (
+        '{"type":"result","subtype":"success","result":"Done.","session_id":"abc-123"}'
+    )
+    plan = InvocationPlan(
+        cmd=["claude"],
+        cwd=cwd,
+        stdin_payload="",
+        output_file=None,
+        env_overrides={},
+    )
+    result = ClaudeAdapter().parse_response(
+        stdout=stdout,
+        stderr="",
+        returncode=0,
+        output_file=None,
+        plan=plan,
+    )
+    assert result.ok is True
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0]["name"] == "mcp__sources__verify_word"
+    assert result.tool_calls[0]["output_summary"] == "ok"
 
 
 def test_claude_stream_json_invocation_adds_verbose(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Wire `tooled_runtime_claude` and `tooled_runtime_gpt` subscription bakeoff routes (#4762/#4763)
- Lenient first-JSON extraction for prose-prefixed reviewer payloads (measured on claude-opus tooled)
- Recover MCP tool calls from Claude session JSONL when stream-json stdout drops tool rows
- Add `run_subscription_1x17_sweep.py` + GLM/Codex dispatch briefs for parallel Claude/GPT 1×17 sweeps

## Evidence

Re-smoke `claude-opus-4-8` tooled × `vesnianky`: `ungrounded_findings` (harness OK), 7 tools, `parse_lenient: true`, `raw_response` persisted — was `error`/0 tools before.

## Test plan

- [x] `pytest tests/audit/test_qg_bakeoff.py tests/test_runner_tool_calls.py` (93 passed)
- [x] Live re-smoke: `claude-opus-4-8` tooled on `vesnianky`
- [ ] Cross-family review (Gemini/AGY)

## Post-merge measurement

| Lane | Command |
| --- | --- |
| Claude 1×17 | `QG_BAKEOFF=1 .venv/bin/python scripts/audit/run_subscription_1x17_sweep.py --model claude-opus-4-8` |
| GPT 1×17 | `QG_BAKEOFF=1 .venv/bin/python scripts/audit/run_subscription_1x17_sweep.py --model gpt-5.5` |

Safe to run Claude + GPT in parallel (separate out dirs). Gemini 1×17 sweep unaffected.

swarm_used: false
swarm_note: solo inline implementation + live re-smoke


Made with [Cursor](https://cursor.com)