### PR TITLE
fix(bio): add readings batch 3

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/andrii-melnyk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/andrii-melnyk.yaml
@@ -119,7 +119,8 @@ references:
   title: Melnyk, Andrii (IEU)
   type: reference
 - note: Стаття про ОУН.
-  path: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CO%5CR%5COrganizationofUkrainianNationalists.htm
+  path: >-
+    https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CO%5CR%5COrganizationofUkrainianNationalists.htm
   title: Organization of Ukrainian Nationalists (IEU)
   type: reference
 - note: Дослідження інтегрального націоналізму та авторитарних тенденцій ОУН.
@@ -130,11 +131,45 @@ references:
   path: Stepan Bandera
   title: Grzegorz Rossolinski-Liebe. "Stepan Bandera"
   type: reference
+readings:
+- title: Мельник Андрій Атанасович
+  language: uk
+  genre: Енциклопедична стаття / біографічна довідка
+  source_type: reference
+  role: orientation
+  source: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-66256
+  license: copyrighted
+  rights_note: Використовувати як link-only довідку; не хостити повний текст.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Простежити шлях від УСС і Армії УНР до УВО, ОУН(м), Заксенгаузена та
+    еміграції.
+  caveats: Довідка має бути доповнена джерелом про ідеологію ОУН(м) і розкол ОУН.
+- title: Українське читання про ОУН(м), розкол ОУН і авторитарну ідеологію
+  language: uk
+  genre: Наукова стаття / історіографічний огляд
+  source_type: reference
+  role: reading-needed
+  source: 'reading-needed: andrii-melnyk-ounm-critical-ukrainian-source'
+  source_url: 'reading-needed'
+  license: unknown
+  rights_note: >-
+    reading-needed: знайти стабільний український науковий або перекладний
+    матеріал про ОУН(м), розкол ОУН та авторитарний словник інтегрального
+    націоналізму.
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: >-
+    Пояснити різницю між мельниківським і бандерівським крилами без перенесення
+    відповідальності однієї фракції на іншу.
+  caveats: Без такого читання модуль ризикує спростити структуру ОУН до одного табору.
 sequence: 301
 slug: andrii-melnyk
 subtitle: The OUN-M Leader, UNR Army Veteran, and Factional Division
 title: 'Андрій Мельник: ОУН(м) та авторитарний націоналізм'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: ідеологічний напрям, що ставить інтереси нації вище за класові чи особисті інтереси
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/dmytro-kliachkivskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/dmytro-kliachkivskyi.yaml
@@ -103,7 +103,9 @@ objectives:
 - Аналізувати роль Дмитра Клячківського як командира УПА-Північ у подіях 1943-1945 років.
 - Досліджувати відповідальність командування УПА за масове насильство проти польського цивільного населення на Волині.
 - Розуміти історичні обставини загибелі Клячківського внаслідок радянської контрповстанської операції.
-- Оцінювати складні аспекти історичної пам'яті, уникаючи як заперечення фактів, так і російської пропагандистської риторики.
+- >-
+  Оцінювати складні аспекти історичної пам'яті, уникаючи як заперечення фактів,
+  так і російської пропагандистської риторики.
 pedagogy: CBI
 persona:
   role: >-
@@ -128,11 +130,60 @@ references:
   path: The Causes of Ukrainian-Polish Ethnic Cleansing 1943
   title: Timothy Snyder. "The Causes of Ukrainian-Polish Ethnic Cleansing 1943"
   type: reference
+readings:
+- title: Клячківський Дмитро-Роман Семенович
+  language: uk
+  genre: Енциклопедична стаття / біографічна довідка
+  source_type: reference
+  role: orientation
+  source: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-8656
+  license: copyrighted
+  rights_note: Використовувати як link-only довідку; не хостити повний текст.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Виписати біографічні факти, псевдоніми, командні ролі в УПА-Північ і
+    обставини загибелі.
+  caveats: Довідка має бути доповнена критичним джерелом про Волинь 1943 року.
+- title: Дмитро Клячківський — "Клим Савур"
+  language: uk
+  genre: Регіональний біографічний матеріал
+  source_type: reference
+  role: supplementary-reading
+  source: Рівненська обласна універсальна наукова бібліотека
+  source_url: https://libr.rv.ua/ua/virt/221
+  license: copyrighted
+  rights_note: Використовувати як link-only регіональний матеріал; не хостити повний текст або зображення.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Зіставити регіональний меморіальний наратив із нейтральною енциклопедичною
+    довідкою.
+  caveats: Меморіальний матеріал не закриває питання відповідальності за антипольське насильство.
+- title: Критичне українське читання про Волинь 1943 року і командування УПА-Північ
+  language: uk
+  genre: Наукова стаття / історіографічний огляд
+  source_type: reference
+  role: reading-needed
+  source: 'reading-needed: dmytro-kliachkivskyi-volyn-critical-ukrainian-source'
+  source_url: 'reading-needed'
+  license: unknown
+  rights_note: >-
+    reading-needed: знайти український або перекладний науковий матеріал про
+    Волинь 1943 року, командну роль УПА-Північ і відповідальність за цивільне
+    насильство.
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: >-
+    Проаналізувати, як історики формулюють відповідальність командування і як
+    відрізняють це від радянської чи російської пропагандистської мови.
+  caveats: Без такого читання модуль не готовий до build через високий ризик спрощення Волині.
 sequence: 302
 slug: dmytro-kliachkivskyi
 subtitle: The UPA-North Commander, Anti-Polish Violence, and the Soviet Counterinsurgency
 title: 'Дмитро Клячківський: Командування УПА-Північ та трагедія Волині'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: збройний підрозділ, військова одиниця в армії чи повстанських силах
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/ihor-kozlovskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/ihor-kozlovskyi.yaml
@@ -83,8 +83,9 @@ content_outline:
     [!epistemic-humility] Раптова смерть у Києві (6 вересня 2023 року). Трансформація
     пережитого досвіду у концептуальну філософську спадщину.
   - >-
-    Посмертна книга-діалог "Вільний у полоні" (2025), укладена з його інтерв'ю, лекцій і публічних виступів (не завершена ним особисто): систематизація етичного словника
-    та свідчення про збереження свободи всупереч фізичним ґратам.
+    Посмертна книга-діалог "Вільний у полоні" (2025), укладена з його інтерв'ю,
+    лекцій і публічних виступів (не завершена ним особисто): систематизація
+    етичного словника та свідчення про збереження свободи всупереч фізичним ґратам.
   section: 'Підсумок: Вільний повітрям і духом'
   words: 1200
 focus: >-
@@ -118,11 +119,60 @@ references:
   path: Suspilne
   title: Я читав лекції щурам, щоб чути голос... (Суспільне)
   type: reference
+readings:
+- title: Козловський Ігор Анатолійович
+  language: uk
+  genre: Енциклопедична стаття / біографічна довідка
+  source_type: reference
+  role: orientation
+  source: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-882085
+  license: copyrighted
+  rights_note: Використовувати як link-only довідку; не хостити повний текст.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Виписати наукові, громадські та правозахисні ролі Козловського до і після
+    полону.
+  caveats: Довідка не замінює свідчення про катівні та досвід внутрішньої свободи.
+- title: >-
+    "Я читав лекції щурам, щоб чути голос": спогади Ігоря Козловського про
+    полон та катівні у Донецьку
+  language: uk
+  genre: Спогади / інтерв'ю
+  source_type: primary
+  role: close-reading
+  source: Суспільне Донбас
+  source_url: >-
+    https://suspilne.media/donbas/568407-a-citav-lekcii-suram-sob-cuti-golos-spogadi-igora-kozlovskogo-pro-polon-ta-kativni-u-donecku/
+  license: copyrighted
+  rights_note: Використовувати як link-only свідчення; не переносити повний текст.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Проаналізувати, як Козловський описує внутрішню свободу, гідність і
+    психологічний спротив у полоні.
+  caveats: Травматичний матеріал потребує коротких цитат і обережного обговорення.
+- title: Гідність, а не жертва. Розмова з Ігорем Козловським
+  language: uk
+  genre: Розмова / філософське інтерв'ю
+  source_type: primary
+  role: supplementary-reading
+  source: PEN Ukraine
+  source_url: https://pen.org.ua/hidnist-a-ne-zhertva-rozmova-anny-hruver-z-ihorem-kozlovskym
+  license: copyrighted
+  rights_note: Використовувати як link-only розмову; не хостити повний текст або фото.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Визначити, як у розмові працюють поняття гідності, символу, відповідальності
+    та свободи.
+  caveats: Матеріал слід поєднувати з біографічною довідкою, а не читати як повну біографію.
 sequence: 298
 slug: ihor-kozlovskyi
 subtitle: The Religious Scholar Who Taught Freedom in Captivity
 title: 'Ігор Козловський: Вільний у полоні'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: наука, що комплексно вивчає релігію, її історію, сутність та вплив на суспільство
   pos: с.

--- a/curriculum/l2-uk-en/plans/bio/stepan-bandera.yaml
+++ b/curriculum/l2-uk-en/plans/bio/stepan-bandera.yaml
@@ -140,11 +140,60 @@ references:
   path: https://ratinggroup.ua/
   title: Rating Group. "The Tenth National Survey" (2022)
   type: reference
+readings:
+- title: Бандера Степан Андрійович
+  language: uk
+  genre: Енциклопедична стаття / біографічна довідка
+  source_type: reference
+  role: orientation
+  source: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-40247
+  license: copyrighted
+  rights_note: Використовувати як link-only довідку; не хостити повний текст.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Скласти хронологію політичної діяльності, польського ув'язнення,
+    Заксенгаузена, еміграції та вбивства КДБ.
+  caveats: Енциклопедична довідка має доповнюватися критичною історіографією про ОУН(б).
+- title: 1909 — народився лідер ОУН Степан Бандера
+  language: uk
+  genre: Історичний календар / меморіальний нарис
+  source_type: reference
+  role: supplementary-reading
+  source: Український інститут національної пам'яті
+  source_url: https://uinp.gov.ua/istorychnyy-kalendar/sichen/1/1909-narodyvsya-lider-oun-stepan-bandera
+  license: copyrighted
+  rights_note: Використовувати як link-only матеріал; не хостити повний текст або зображення.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Відокремити факти про арешти, Акт 30 червня та Заксенгаузен від мови
+    сучасної політики пам'яті.
+  caveats: Матеріал УІНП має меморіальний кут зору; модуль повинен зберігати критичну дистанцію.
+- title: Критичне українське читання про ОУН(б), Волинь і Голокост
+  language: uk
+  genre: Наукова стаття / історіографічний огляд
+  source_type: reference
+  role: reading-needed
+  source: 'reading-needed: stepan-bandera-critical-ukrainian-historiography'
+  source_url: 'reading-needed'
+  license: unknown
+  rights_note: >-
+    reading-needed: знайти стабільний український науковий або перекладний
+    матеріал про політичне насильство ОУН(б), Волинь і Голокост; не замінювати
+    його англомовними джерелами для learner reading.
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: >-
+    Порівняти міфологізований образ Бандери з критичним аналізом відповідальності
+    руху та меж особистого контролю.
+  caveats: Без такого читання модуль не готовий до build через високоризикову тему пам'яті.
 sequence: 299
 slug: stepan-bandera
 subtitle: The OUN-B Leader, Political Violence, and the KGB Assassination
 title: 'Степан Бандера: Ідеолог ОУН(б) та міфи навколо нього'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: ідеологічний напрям, що ставить інтереси нації вище за класові чи особисті інтереси
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/yaroslav-stetsko.yaml
+++ b/curriculum/l2-uk-en/plans/bio/yaroslav-stetsko.yaml
@@ -104,7 +104,9 @@ module: bio-300
 objectives:
 - Аналізувати політичний та ідеологічний доробок Ярослава Стецька.
 - Розуміти історичні обставини проголошення Акта 30 червня 1941 року та його наслідки.
-- Досліджувати складні аспекти ідеології ОУН(б), включаючи елементи авторитаризму та антисемітизму в текстах 1939-1941 років.
+- >-
+  Досліджувати складні аспекти ідеології ОУН(б), включаючи елементи авторитаризму
+  та антисемітизму в текстах 1939-1941 років.
 - Оцінювати роль Стецька як лідера Антибільшовицького блоку народів у повоєнний час.
 pedagogy: CBI
 persona:
@@ -124,17 +126,68 @@ references:
   type: reference
 - note: Дослідження ставлення ОУН до євреїв через аналіз життєпису Стецька.
   path: Harvard Ukrainian Studies 23
-  title: Karel Berkhoff and Marco Carynnyk. "The Organization of Ukrainian Nationalists and Its Attitude toward Germans and Jews"
+  title: >-
+    Karel Berkhoff and Marco Carynnyk. "The Organization of Ukrainian
+    Nationalists and Its Attitude toward Germans and Jews"
   type: reference
 - note: Комплексне дослідження складних питань Голокосту та українського націоналізму.
   path: Ukrainian Nationalists and the Holocaust
   title: John-Paul Himka. "Ukrainian Nationalists and the Holocaust"
   type: reference
+readings:
+- title: Стецько Ярослав Семенович
+  language: uk
+  genre: Енциклопедична стаття / біографічна довідка
+  source_type: reference
+  role: orientation
+  source: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-884618
+  license: copyrighted
+  rights_note: Використовувати як link-only довідку; не хостити повний текст.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Виписати етапи підпільної діяльності, Акта 30 червня, ув'язнення та
+    повоєнної роботи в еміграції.
+  caveats: Довідка не закриває контроверсійні тексти 1941 року й потребує критичного читання.
+- title: 1941 — проголошення відновлення Української держави
+  language: uk
+  genre: Історичний календар / документальний контекст
+  source_type: reference
+  role: supplementary-reading
+  source: Український інститут національної пам'яті
+  source_url: https://uinp.gov.ua/istorychnyy-kalendar/cherven/30/1941-progoloshennya-vidnovlennya-ukrayinskoyi-derzhavy
+  license: copyrighted
+  rights_note: Використовувати як link-only матеріал; не хостити повний текст або зображення.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    З'ясувати політичний контекст Акта 30 червня і наслідки його невизнання
+    нацистською владою.
+  caveats: Меморіальний матеріал потребує зіставлення з критичною історіографією.
+- title: Критичне українське читання про тексти Стецька 1941 року
+  language: uk
+  genre: Наукова стаття / історіографічний огляд
+  source_type: reference
+  role: reading-needed
+  source: 'reading-needed: yaroslav-stetsko-1941-critical-ukrainian-source'
+  source_url: 'reading-needed'
+  license: unknown
+  rights_note: >-
+    reading-needed: знайти український або перекладний науковий матеріал про
+    антисемітські твердження й авторитарні елементи у текстах Стецька; не
+    використовувати англомовну статтю як learner reading без винятку.
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: >-
+    Розрізнити державницький жест Акта, тактичну співпрацю, антисемітські
+    твердження та пізнішу антикомуністичну риторику.
+  caveats: Без критичного україномовного джерела модуль не готовий до build.
 sequence: 300
 slug: yaroslav-stetsko
 subtitle: The 1941 Proclamation, Ideology, and Exile Leadership
 title: 'Ярослав Стецько: Акт 30 червня та ідеологія ОУН(б)'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: ідеологічний напрям, що ставить інтереси нації вище за класові чи особисті інтереси
   pos: ч.


### PR DESCRIPTION
## Summary
- Adds top-level BIO readings blocks for the next five manifest-order readings gaps: ihor-kozlovskyi, stepan-bandera, yaroslav-stetsko, andrii-melnyk, dmytro-kliachkivskyi.
- Uses Ukrainian link-only learner readings where stable sources exist.
- Adds explicit reading-needed exceptions for high-risk OUN/Volyn critical historiography where current plan references rely on English scholarship or still need a learner-safe Ukrainian source.

Refs #4431
Refs #4400

## Validation
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python targeted readings/YAML shape check
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/yamllint targeted five plan files
- git diff --check
- compact BIO readiness recount: missing readings 111 -> 106; next missing starts at yurii-tiutiunnyk
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python -m pytest tests/test_plan_targets_schema.py tests/test_guard_push_pytest.py -q

## Review status
Draft until independent cross-family review verifies source scope, Ukrainian-only learner readings, sensitive-topic caveats, and copyright-safe link-only/reading-needed handling.