### PR TITLE
feat(bridge): add agy to ab discuss VALID_AGENTS

### DIFF
--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -71,6 +71,7 @@ class StaleClaimError(Exception):
 # ── Constants ──────────────────────────────────────────────────────────
 
 VALID_AGENTS = (
+    "agy",
     "claude",
     "gemini",
     "codex",

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -70,6 +70,7 @@ def _cli_available_agent(agent: str) -> bool:
         from agent_runtime.registry import get_agent_entry
     except ImportError:
         return agent in {
+            "agy",
             "claude",
             "codex",
             "gemini",

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -26,7 +26,7 @@ ab inbox ack <delivery_id> [--error NOTE]
 ab reconcile [--dry-run]
 ab sync <agent> | ab sync --all
 
-ab discuss <channel> <body> --with A,B [--max-rounds N]   # B.4, stub for now
+ab discuss <channel> <body> --with A,B [--max-rounds N] [--models agy:gemini-3.1-pro-high]
 ```
 
 All commands use the storage primitives in ``_channels``. They do NOT
@@ -576,6 +576,14 @@ def register_channel_commands(subparsers: Any) -> None:
         "--review", action="store_true",
         help="Prepend docs/review-protocol.md before channel context",
     )
+    discuss_parser.add_argument(
+        "--models",
+        default=None,
+        help=(
+            "Optional per-participant model overrides as agent:model pairs "
+            "(comma-separated), e.g. agy:gemini-3.1-pro-high"
+        ),
+    )
 
 
 # ── dispatch ──────────────────────────────────────────────────────────
@@ -652,6 +660,25 @@ def _resolve_body(body_arg: str) -> str:
 
 def _parse_csv(s: str) -> list[str]:
     return [item.strip() for item in s.split(",") if item.strip()]
+
+
+def _parse_agent_models(s: str) -> dict[str, str]:
+    """Parse ``agent:model`` pairs from a comma-separated discuss ``--models`` value."""
+    models: dict[str, str] = {}
+    for item in _parse_csv(s):
+        if ":" not in item:
+            raise ValueError(
+                f"invalid --models entry {item!r}: expected agent:model (e.g. agy:gemini-3.1-pro-high)"
+            )
+        agent, model = item.split(":", 1)
+        agent = agent.strip()
+        model = model.strip()
+        if not agent or not model:
+            raise ValueError(
+                f"invalid --models entry {item!r}: agent and model must both be non-empty"
+            )
+        models[agent] = model
+    return models
 
 
 def _now_utc() -> datetime:
@@ -1350,6 +1377,22 @@ def _handle_discuss(args) -> int:
         )
         return 1
 
+    agent_models: dict[str, str] = {}
+    if getattr(args, "models", None):
+        try:
+            agent_models = _parse_agent_models(args.models)
+        except ValueError as exc:
+            print(f"❌ {exc}", file=sys.stderr)
+            return 1
+        unknown_models = [a for a in agent_models if a not in with_agents]
+        if unknown_models:
+            print(
+                "❌ --models names agent(s) not in --with: "
+                f"{', '.join(unknown_models)}",
+                file=sys.stderr,
+            )
+            return 1
+
     MAX_ROUNDS_CAP = 4
     max_rounds = min(max(1, args.max_rounds), MAX_ROUNDS_CAP)
     if args.max_rounds > MAX_ROUNDS_CAP:
@@ -1432,6 +1475,7 @@ def _handle_discuss(args) -> int:
                 prompt_text,
                 mode="read-only",
                 cwd=REPO_ROOT,
+                model=agent_models.get(agent_name),
                 task_id=f"discuss-{correlation_id[:8]}-r{round_idx}-{agent_name}",
                 # TODO(#1701): keep this flag in the sanitized child-env
                 # allowlist when the runner switches to build_agent_env().

--- a/tests/test_agy_integration.py
+++ b/tests/test_agy_integration.py
@@ -9,11 +9,42 @@ silently strip ``agy`` from ``ab discuss --with``.
 from __future__ import annotations
 
 import importlib
+import os
 import subprocess
 import sys
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
+_VENV_PYTHON = _REPO_ROOT / ".venv" / "bin" / "python"
+
+
+def _resolve_test_python() -> str:
+    if _VENV_PYTHON.exists():
+        return str(_VENV_PYTHON)
+    try:
+        common_dir = subprocess.check_output(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=_REPO_ROOT,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        if common_dir:
+            main_venv = (Path(common_dir) / ".." / ".venv" / "bin" / "python").resolve()
+            if main_venv.exists():
+                return str(main_venv)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        pass
+    active_venv = os.environ.get("VIRTUAL_ENV")
+    if active_venv:
+        candidate = Path(active_venv) / "bin" / "python"
+        if candidate.exists():
+            return str(candidate)
+    raise RuntimeError(
+        "No project virtualenv Python found. Run tests via `.venv/bin/python -m pytest`."
+    )
+
+
+_TEST_PYTHON = _resolve_test_python()
 
 
 def test_registry_exposes_agy():
@@ -33,7 +64,7 @@ def test_delegate_dispatch_accepts_agy_agent():
     """``delegate.py dispatch --agent agy ...`` must parse without error."""
     result = subprocess.run(
         [
-            sys.executable,
+            _TEST_PYTHON,
             str(_REPO_ROOT / "scripts" / "delegate.py"),
             "dispatch",
             "--agent",

--- a/tests/test_agy_integration.py
+++ b/tests/test_agy_integration.py
@@ -1,0 +1,125 @@
+"""Integration test surfaces for Agy in ab discuss / inbox / lint.
+
+The agent runtime registry already exposes ``agy`` via
+``scripts/agent_runtime/registry.py`` (AgyAdapter, ``cli_available:
+True``). These tests pin the bridge allowlists so future churn cannot
+silently strip ``agy`` from ``ab discuss --with``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_registry_exposes_agy():
+    """The agent_runtime registry is the canonical source of truth."""
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    from agent_runtime.registry import AGENTS, available_agents
+
+    assert "agy" in AGENTS, "agy must be in agent_runtime.registry.AGENTS"
+    assert AGENTS["agy"]["cli_available"] is True
+    assert AGENTS["agy"]["resume_policy"] == "bridge_only"
+    assert "agy" in available_agents()
+
+
+def test_delegate_dispatch_accepts_agy_agent():
+    """``delegate.py dispatch --agent agy ...`` must parse without error."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(_REPO_ROOT / "scripts" / "delegate.py"),
+            "dispatch",
+            "--agent",
+            "agy",
+            "--task-id",
+            "test-agy-argparse-probe",
+            "--prompt",
+            "noop",
+            "--dry-run",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=str(_REPO_ROOT),
+    )
+    assert result.returncode == 0, (
+        f"delegate dispatch --agent agy failed:\n"
+        f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert "test-agy-argparse-probe" in result.stdout
+
+
+def test_ab_channels_valid_agents_includes_agy():
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    from ai_agent_bridge import _channels
+
+    importlib.reload(_channels)
+    assert "agy" in _channels.VALID_AGENTS
+
+
+def test_ab_channels_cli_marks_agy_cli_available():
+    """``ab discuss`` requires the agent to be CLI-spawnable."""
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    from ai_agent_bridge import _channels_cli
+
+    assert _channels_cli._cli_available_agent("agy") is True
+
+
+def test_ab_discuss_accepts_agy_in_with_list(
+    tmp_path, monkeypatch,
+):
+    """``ab discuss --with agy`` passes agent validation and invokes runtime."""
+    from types import SimpleNamespace
+
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+    from ai_agent_bridge import _channels, _channels_cli, _db
+
+    monkeypatch.setattr(_db, "DB_PATH", tmp_path / "bridge.db")
+    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
+    monkeypatch.setattr(_channels, "context_sha256", lambda path: "")
+    monkeypatch.setattr(
+        _channels,
+        "load_channel_context",
+        lambda channel: {"body": "", "revs": {}, "missing": []},
+    )
+
+    _channels.create_channel("shared", exist_ok=True)
+    _channels.create_channel("agy-topic", exist_ok=True)
+
+    invoked: list[str] = []
+
+    def fake_invoke(agent_name: str, prompt: str, **kwargs):
+        invoked.append(agent_name)
+        return SimpleNamespace(
+            ok=True,
+            response="[AGREE] agy first take",
+            stderr_excerpt="",
+            session_id="agy-session-1",
+        )
+
+    monkeypatch.setattr("agent_runtime.runner.invoke", fake_invoke)
+
+    args = SimpleNamespace(
+        channel="agy-topic",
+        body="Does STRICT grounding measure model discipline fairly?",
+        with_agents="agy",
+        max_rounds=1,
+        review=False,
+    )
+
+    assert _channels_cli._handle_discuss(args) == 0
+    assert invoked == ["agy"]

--- a/tests/test_agy_integration.py
+++ b/tests/test_agy_integration.py
@@ -101,9 +101,11 @@ def test_ab_discuss_accepts_agy_in_with_list(
     _channels.create_channel("agy-topic", exist_ok=True)
 
     invoked: list[str] = []
+    invoke_kwargs: list[dict] = []
 
     def fake_invoke(agent_name: str, prompt: str, **kwargs):
         invoked.append(agent_name)
+        invoke_kwargs.append(kwargs)
         return SimpleNamespace(
             ok=True,
             response="[AGREE] agy first take",
@@ -119,7 +121,57 @@ def test_ab_discuss_accepts_agy_in_with_list(
         with_agents="agy",
         max_rounds=1,
         review=False,
+        models=None,
     )
 
     assert _channels_cli._handle_discuss(args) == 0
     assert invoked == ["agy"]
+    assert invoke_kwargs[0].get("model") is None
+
+
+def test_ab_discuss_passes_agy_pro_model_override(tmp_path, monkeypatch):
+    """``--models agy:gemini-3.1-pro-high`` reaches runtime_invoke as model=."""
+    from types import SimpleNamespace
+
+    scripts_dir = str(_REPO_ROOT / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+
+    from ai_agent_bridge import _channels, _channels_cli, _db
+
+    monkeypatch.setattr(_db, "DB_PATH", tmp_path / "bridge.db")
+    monkeypatch.setattr(_channels, "fetch_monitor_state", lambda: None)
+    monkeypatch.setattr(_channels, "context_sha256", lambda path: "")
+    monkeypatch.setattr(
+        _channels,
+        "load_channel_context",
+        lambda channel: {"body": "", "revs": {}, "missing": []},
+    )
+
+    _channels.create_channel("shared", exist_ok=True)
+    _channels.create_channel("agy-topic", exist_ok=True)
+
+    invoke_kwargs: list[dict] = []
+
+    def fake_invoke(agent_name: str, prompt: str, **kwargs):
+        invoke_kwargs.append(kwargs)
+        return SimpleNamespace(
+            ok=True,
+            response="[AGREE] pro take",
+            stderr_excerpt="",
+            session_id="agy-session-pro",
+        )
+
+    monkeypatch.setattr("agent_runtime.runner.invoke", fake_invoke)
+
+    args = SimpleNamespace(
+        channel="agy-topic",
+        body="STRICT bakeoff fairness?",
+        with_agents="agy",
+        max_rounds=1,
+        review=False,
+        models="agy:gemini-3.1-pro-high",
+    )
+
+    assert _channels_cli._handle_discuss(args) == 0
+    assert invoke_kwargs[0]["model"] == "gemini-3.1-pro-high"

--- a/tests/test_bridge_inbox_cli.py
+++ b/tests/test_bridge_inbox_cli.py
@@ -575,6 +575,7 @@ def test_sync_all_iterates_known_agents(monkeypatch, capsys):
     # via #2107, cursor via Phase 2 PR), this list tracks the registry —
     # the test guards the iteration order, not a frozen subset.
     cli_agents = [
+        "agy",
         "claude",
         "gemini",
         "codex",


### PR DESCRIPTION
## Summary
- Add `agy` to `VALID_AGENTS` so `ab discuss --with agy` passes validation
- Include `agy` in the `_cli_available_agent` fallback set (registry already has `cli_available=True`)
- Add integration tests pinning the discuss/inbox surfaces

## Test plan
- [x] `pytest tests/test_agy_integration.py tests/test_bridge_inbox_cli.py::test_sync_all_iterates_known_agents`
- [ ] After merge: `ab discuss qg-bakeoff-engine-selection "..." --with claude,agy,codex --max-rounds 2`


Made with [Cursor](https://cursor.com)