### PR TITLE
feat(bio): add music readings batch 10

### DIFF
--- a/curriculum/l2-uk-en/plans/bio/filaret-kolessa.yaml
+++ b/curriculum/l2-uk-en/plans/bio/filaret-kolessa.yaml
@@ -119,11 +119,111 @@ references:
   path: docs/research/bio/filaret-kolessa.md
   title: Філарет Михайлович Колесса — Research Dossier
   type: research
+readings:
+- title: Колесса Філарет Михайлович
+  language: uk
+  genre: Енциклопедична стаття / біографічна довідка
+  source_type: reference
+  role: primary_bio
+  source: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-5631
+  license: copyrighted
+  rights_note: >-
+    ЕСУ є авторитетним референсом; користуватися як фактологічним ядром, без
+    розширення формулювань правового контексту без додаткових джерел.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Зіставити основні дати, університети, посади й ключові праці Колесси, а
+    потім перевірити, де довідка узагальнює складні інтерпретації.
+  caveats: >-
+    Довідка не замінює первинних текстових джерел з експедицій, партитур і
+    листування.
+- title: Kolessa, Filaret
+  language: en
+  genre: Encyclopaedia entry / biography
+  source_type: reference
+  role: supplementary-reading
+  source: Internet Encyclopedia of Ukraine
+  source_url: >-
+    https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CO%5CKolessaFilaret.htm
+  license: copyrighted
+  rights_note: >-
+    Важливо звіряти українсько-українську термінологію з ЕСУ та ЕІУ; стаття є
+    синтетичною і не дає повного опису джерельного корпусу.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Порівняти англомовний огляд із українськими довідками; скласти список
+    пунктів, що розходяться за датуванням або термінологією.
+  caveats: >-
+    IEU дає стислу рамку; для методологічних деталей потрібні інші академічні
+    матеріали.
+- title: Колесса Філарет Михайлович
+  language: uk
+  genre: Енциклопедична стаття / історична довідка
+  source_type: reference
+  role: supplementary-reading
+  source: Енциклопедія історії України
+  source_url: >-
+    https://resource.history.org.ua/cgi-bin/eiu/history.exe?&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN%3D&S21COLORTERMS=0&S21STR=Kolessa_F
+  license: copyrighted
+  rights_note: >-
+    ЕІУ містить стабільні ідентифікатори й базову хронологію; використовувати
+    для звіряння дат та інституційних фактів.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Визначити, які факти ЕІУ подає в односторінковій рамці, а які потребують
+    перевірки в дослідницьких та музично-джерельних матеріалах.
+  caveats: >-
+    Розкриття політичного контексту колекційного періоду потребує додаткової
+    контекстної літератури.
+- title: Колесса Філарет Михайлович
+  language: uk
+  genre: Історико-джерельний календар
+  source_type: reference
+  role: institutional-context
+  source: Український інститут національної пам'яті
+  source_url: >-
+    https://uinp.gov.ua/istorychnyy-kalendar/lypen/17/1871-narodyvsya-filaret-kolessa-ukrayinskyy-muzykoznavec-kompozytor-folkloryst
+  license: copyrighted
+  rights_note: >-
+    UINP надає базову біографічну рамку; вона корисна для дат, але не замінює
+    джерельний аналіз творів.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Використати як коротку перевірку дат і посад, а потім уточнити кожен факт
+    через ЕСУ, ЕІУ та наукові джерела.
+  caveats: >-
+    Не містить повної дискусії про авторські методи і суперечки навколо
+    етнографічних публікацій.
+- title: «Українські народні думи» (джерельний корпус)
+  language: uk
+  genre: Первинний нотний корпус / епічна традиція
+  source_type: primary
+  role: primary-work
+  source: Колесса Філарет Михайлович
+  source_url: reading-needed
+  license: reading-needed
+  rights_note: >-
+    Повні видання/фотофаксиміле нотних збірок і поліфонічних фрагментів
+    потребують окремого правового доступу до конкретних інституційних
+    екземплярів.
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: >-
+    Підготувати таблицю для верифікації: назва публікації, рік видання,
+    редактор/виконавець, архівне зберігання, наявні правові умови доступу.
+  caveats: >-
+    Без читання корпусу є ризик змішати сучасні перевидання з першими
+    редакціями; зафіксувати цей ризик у модульному коментарі.
 sequence: 359
 slug: filaret-kolessa
 subtitle: 'Filaret Kolessa: Ethnomusicology and the Rhythm of Folk Song'
 title: 'Філарет Колесса: етномузикологія й ритміка народної пісні'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: наука про народну музику; Колесса — один із її основоположників в українській традиції
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/klyment-kvitka.yaml
+++ b/curriculum/l2-uk-en/plans/bio/klyment-kvitka.yaml
@@ -119,11 +119,110 @@ references:
   path: docs/research/bio/klyment-kvitka.md
   title: Климент Васильович Квітка — Research Dossier
   type: research
+readings:
+- title: Квітка Климент Васильович
+  language: uk
+  genre: Енциклопедична стаття / біографічна довідка
+  source_type: reference
+  role: primary_bio
+  source: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-11614
+  license: copyrighted
+  rights_note: >-
+    ЕСУ подає базову біографічну рамку й ключові дати; для модульного матеріалу
+    її слід поєднувати з ЕІУ та архівними або дослідницькими джерелами.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Виписати основні біографічні вузли (народження, правнича освіта, шлюб,
+    ВУАН, репресивний контекст) та позначити, де потрібні зовнішні джерела.
+  caveats: >-
+    Біографічна стаття стисло подає суперечливі правові сюжети; деталі справи
+    не слід домислювати.
+- title: Klyment Kvitka
+  language: en
+  genre: Encyclopaedia entry / biography
+  source_type: reference
+  role: supplementary-reading
+  source: Internet Encyclopedia of Ukraine
+  source_url: >-
+    https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CK%5CV%5CKvitkaKlyment.htm
+  license: copyrighted
+  rights_note: >-
+    IEU дає англомовний огляд; при роботі з термінами (ВУАН, кабінет,
+    фонографічні праці) перевіряти український контекст.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Підготувати порівняльну таблицю українських та англомовних біографічних
+    формулювань: що збігається, а що редукується.
+  caveats: >-
+    Англомовний текст узагальнює наукові спори; не замінює методичних деталей
+    інституційної праці Квітки.
+- title: Квітка Климентій Васильович
+  language: uk
+  genre: Енциклопедична стаття / довідка
+  source_type: reference
+  role: supplementary-reading
+  source: Енциклопедія історії України
+  source_url: >-
+    https://resource.history.org.ua/cgi-bin/eiu/history.exe?&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN%3D&S21COLORTERMS=0&S21STR=Kvitka_K
+  license: copyrighted
+  rights_note: >-
+    ЕІУ корисна для перевірки дат, посад, назв праць і етапів інституційної
+    діяльності; статус мови та правових застережень дивитись окремо.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Зіставити ідентифікацію перехідних моментів (від права до музики, ВУАН,
+    репресивні роки) з іншими джерелами та вказати розбіжності.
+  caveats: >-
+    ЕІУ не деталізує метод роботи з фонограмами й репресивною траєкторією до
+    рівня джерельної реконструкції.
+- title: Квітка Климентій Васильович
+  language: uk
+  genre: Історико-архівна довідка / біографічний календар
+  source_type: reference
+  role: institutional-context
+  source: Український інститут національної пам'яті
+  source_url: >-
+    https://uinp.gov.ua/istorychnyy-kalendar/lyutyy/4/1880-narodyvsya-klyment-kvitka
+  license: copyrighted
+  rights_note: >-
+    Календар дає базові віхи, але потребує верифікації методологічних деталей у
+    наукових та архівних матеріалах.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Використати цю довідку для звірки дат і місць, а не для висновків про метод
+    і роль Квітки в транскрипції.
+  caveats: >-
+    Коротка форма календаря може замовчувати часову послідовність публікацій та
+    дискусійні деталі.
+- title: «Народні мелодії. З голосу Лесі Українки» (первинний корпус)
+  language: uk
+  genre: Первинний збірник / нотна методика
+  source_type: primary
+  role: primary-work
+  source: Квітка Климент Васильович
+  source_url: reading-needed
+  license: reading-needed
+  rights_note: >-
+    Для повної роботи з текстом збірки потрібен доступ до конкретного архівного
+    або бібліотечного примірника; без перевірки прав не хостити повну версію.
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: >-
+    Підготувати чекліст для верифікації збірки (технічні дані видання, редакція,
+    джерела запису, інформація про виконання), не підміняючи її вторинними резюме.
+  caveats: >-
+    Не всі томи й редакції доступні відкрито; ризик змішати публікації різних
+    років і редакцій.
 sequence: 360
 slug: klyment-kvitka
 subtitle: 'Klyment Kvitka: Musical Ethnography and Its Method'
 title: 'Климент Квітка: музична етнографія та її метод'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: наука про народну музику; Квітка будував її як метод і інституцію у ВУАН
   pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/levko-revutskyi.yaml
+++ b/curriculum/l2-uk-en/plans/bio/levko-revutskyi.yaml
@@ -207,11 +207,108 @@ references:
     path: https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CE%5CRevutskyLev.htm
     type: reference
     work: Internet Encyclopedia of Ukraine
+readings:
+  - title: Revutsky, Lev
+    language: en
+    genre: Encyclopaedia entry / biography
+    source_type: reference
+    role: primary_bio
+    source: Internet Encyclopedia of Ukraine
+    source_url: >-
+      https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CR%5CE%5CRevutskyLev.htm
+    license: copyrighted
+    rights_note: >-
+      IEU подає англомовний біографічний огляд; для навчального модуля потрібна
+      верифікація ключових тез через українські джерела.
+    hosting: link-only
+    cefr_min: C1
+    learner_task: >-
+      Зіставити англомовний опис із українськими джерелами щодо ролі Ревуцького
+      як «зберігача лисенківської лінії» та механізмів інституційного
+      співіснування.
+    caveats: >-
+      IEU подає узагальнення; деталізація радянських репресивних механізмів
+      потребує додаткових першоджерел.
+  - title: Ревуцький Лев Миколайович
+    language: uk
+    genre: Енциклопедична стаття / історична довідка
+    source_type: reference
+    role: supplementary-reading
+    source: Енциклопедія історії України
+    source_url: https://history.org.ua/index.php?termin=Revutskyj_L
+    license: copyrighted
+    rights_note: >-
+      ЕІУ використовується для звірки базової дати, посад і ключових подій;
+      пізніші оцінки радянського періоду треба звіряти додатково.
+    hosting: link-only
+    cefr_min: C1
+    learner_task: >-
+      Зробити виписку з акцентом на датах арешту, нагляду, педагогічної
+      діяльності та публікаційної історії й відмітити невизначені пункти.
+    caveats: >-
+      ЕІУ рідко розкриває повну джерельну структуру творів і програм редакцій.
+  - title: Levko Revutskyi
+    language: en
+    genre: Reference page
+    source_type: reference
+    role: supplementary-reading
+    source: Wikipedia
+    source_url: https://en.wikipedia.org/wiki/Levko_Revutsky
+    license: CC-BY-SA-4.0
+    rights_note: >-
+      Вікіпедія дає вхідний огляд за ліцензією CC-BY-SA-4.0, але потребує
+      перехресної перевірки за рахунок енциклопедій і інституційних довідок.
+    hosting: link-only
+    cefr_min: C1
+    learner_task: >-
+      Виписати тезу про творчі періоди Ревуцького з українськими джерелами та
+      перевірити відмінності між англомовною й українською подачею.
+    caveats: >-
+      Краудсорсинг не гарантує наукової виваженості; критично перевіряти
+      посилання на конкретні архівні джерела.
+  - title: Levko Revutskyi — Research Dossier
+    language: uk
+    genre: Internal research dossier / risk notes
+    source_type: secondary
+    role: critical-supplement
+    source: Документ дослідницького блоку
+    source_url: docs/research/bio/levko-revutskyi.md
+    license: unknown
+    rights_note: >-
+      Досьє надає структуровані ризики, але його зміст не підміняє первинних
+      документів чи виданих партитур.
+    hosting: link-only
+    cefr_min: C1
+    learner_task: >-
+      Перевірити, які твердження досьє потребують підкріплення з оригінальних
+      публікацій або архівних матеріалів.
+    caveats: >-
+      Локальне дослідницьке зведення не є єдиним доказовим джерелом для
+      цитування у фінальному навчальному модулі.
+  - title: «Друга симфонія» та фортепіанний концерт фа мажор (фрагменти)
+    language: uk
+    genre: Первинний музичний твір / нотний матеріал
+    source_type: primary
+    role: primary-work
+    source: Левко Ревуцький
+    source_url: reading-needed
+    license: reading-needed
+    rights_note: >-
+      Нотні джерела можуть мати різні редакції та інституційні умови доступу;
+      публікацію повних версій слід погоджувати після перевірки прав.
+    hosting: reading-needed
+    cefr_min: C1
+    learner_task: >-
+      Підготувати робочу схему порівняння симфонії та концерту з довідковими
+      описами (датування, структура, інституційне виконання).
+    caveats: >-
+      Без надійного доступу до нотних або архівних примірників ризик змішати
+      авторські редакції та реконструкції.
 sequence: 369
 slug: levko-revutskyi
 subtitle: Lysenko-Line Continuity Through Soviet Institutions
 title: 'Левко Ревуцький: Хранитель лисенківської лінії'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
   - definition: монументальний, зазвичай чотиричастинний, твір для симфонічного оркестру
     pos: ж.

--- a/curriculum/l2-uk-en/plans/bio/myroslav-skoryk.yaml
+++ b/curriculum/l2-uk-en/plans/bio/myroslav-skoryk.yaml
@@ -176,11 +176,108 @@ references:
   note: Структуроване дослідницьке досьє з верифікованими фактами та деколонізаційною рамкою.
   path: docs/research/bio/myroslav-skoryk.md
   type: dossier
+readings:
+- title: Skoryk, Myroslav
+  language: en
+  genre: Encyclopaedia entry / biography
+  source_type: reference
+  role: primary_bio
+  source: Internet Encyclopedia of Ukraine
+  source_url: >-
+    https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CS%5CK%5CSkorykMyroslav.htm
+  license: copyrighted
+  rights_note: >-
+    IEU подає загальний англомовний огляд; для точних українських деталей треба
+    зіставляти з локальними джерелами та інституційними матеріалами.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Зіставити англомовний виклад із українськими джерелами щодо ролі Скорика у
+    школі Людкевича й механізмів передачі музично-педагогічної лінії.
+  caveats: >-
+    Стаття може спрощувати позицію щодо радянської та пострадянської рецепції
+    його творів.
+- title: Скорик Мирослав Михайлович
+  language: uk
+  genre: Енциклопедична стаття / біографічна довідка
+  source_type: reference
+  role: supplementary-reading
+  source: Енциклопедія історії України
+  source_url: https://www.history.org.ua/?termin=Skoryk
+  license: copyrighted
+  rights_note: >-
+    ЕІУ використовується як основний інституційний довідковий текст; для
+    дебатних блоків брати також відомості про роботи, жанри й педагогіку з
+    додаткових джерел.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Виписати періоди навчання, основні жанри, ключові твори та формулювання про
+    роль Скорика в професійній музиці України.
+  caveats: >-
+    Історична доба та політичний фон подаються стисло; ризик вторинних редукцій
+    без джерельних уточнень.
+- title: Myroslav Skoryk
+  language: en
+  genre: Wikipedia / базова біографія
+  source_type: reference
+  role: supplementary-reading
+  source: Wikipedia
+  source_url: https://en.wikipedia.org/wiki/Myroslav_Skoryk
+  license: CC-BY-SA-4.0
+  rights_note: >-
+    Це вхідний орієнтир за ліцензією CC-BY-SA-4.0; для навчального модуля
+    посилання мають бути перевірені за каталогами й академічними джерелами.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Перевірити, чи збігаються відомі дати, твори та освітній маршрут із даними з
+    енциклопедій.
+  caveats: >-
+    Стаття є вторинною і може містити прогалини або невідображені уточнення.
+- title: Мирослав Скорик. Дослідницьке досьє
+  language: uk
+  genre: Internal research dossier / source risk summary
+  source_type: secondary
+  role: critical-supplement
+  source: Документ дослідницького блоку
+  source_url: docs/research/bio/myroslav-skoryk.md
+  license: unknown
+  rights_note: >-
+    Досьє допомагає з ризиковими полями для модуля, але не замінює авторитетних
+    джерел для цитат і фактчеків.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Проаналізувати розділ «ризики» з досьє та виписати, які твердження
+    потребують першоджерельного підтвердження.
+  caveats: >-
+    Локальний документ слід оновлювати окремо; не використовувати як єдине
+    підтверджувальне джерело.
+- title: «Мелодія», «Тіні забутих предків» (аудіо/ноти)
+  language: uk
+  genre: Первинний твір / кіномузичний матеріал
+  source_type: primary
+  role: primary-work
+  source: Мирослав Скорик
+  source_url: reading-needed
+  license: reading-needed
+  rights_note: >-
+    Аудіоверсії й повні партитури потребують точного правового статусу; на цьому
+    етапі потрібен лише опис доступності й правових умов.
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: >-
+    Підготувати перелік доступних відкритих фрагментів творів та окремо
+    позначити, де потрібне отримання дозволу або посилання на ліцензований архів.
+  caveats: >-
+    Без перевірки ліцензії неможливо включати повні аудіо/нотові завантаження до
+    навчального пакету.
 sequence: 376
 slug: myroslav-skoryk
 subtitle: The Voice of the Carpathians in Modern Ukrainian Concert Music
 title: 'Мирослав Скорик: Голос Карпат'
-version: '4.1'
+version: '4.2'
 vocabulary_hints:
 - definition: напрям у музиці, що використовує фольклорні мелодії та ритми, трансформуючи їх модерними засобами
   pos: ч.

--- a/curriculum/l2-uk-en/plans/bio/stanislav-liudkevych.yaml
+++ b/curriculum/l2-uk-en/plans/bio/stanislav-liudkevych.yaml
@@ -109,11 +109,109 @@ references:
   path: docs/research/bio/stanislav-liudkevych.md
   title: Stanislav Liudkevych — Research Dossier
   type: research
+readings:
+- title: Людкевич Станіслав Пилипович
+  language: uk
+  genre: Енциклопедична стаття / біографічна довідка
+  source_type: reference
+  role: primary_bio
+  source: Енциклопедія Сучасної України
+  source_url: https://esu.com.ua/article-59909
+  license: copyrighted
+  rights_note: >-
+    ЕСУ забезпечує базову довідкову рамку; для навчального модуля її треба
+    доповнювати роботою з творами та інституційними матеріалами.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Виписати ключові віхи життя, освіти, інституційної праці й основні твори, а
+    потім перевірити, що з цих тез має джерельні підтвердження.
+  caveats: >-
+    Біографія стисло подає рамку і не розкриває повного контексту радянських
+    репресивних практик.
+- title: Liudkevych, Stanyslav
+  language: en
+  genre: Encyclopaedia entry / biography
+  source_type: reference
+  role: supplementary-reading
+  source: Internet Encyclopedia of Ukraine
+  source_url: >-
+    https://www.encyclopediaofukraine.com/display.asp?linkpath=pages%5CL%5CI%5CLiudkevychStanyslav.htm
+  license: copyrighted
+  rights_note: >-
+    Англомовний огляд слугує орієнтиром для дат і жанрів; для складних тем
+    (інституційна спадщина, репресивний контекст) потрібні локальні джерела.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Порівняти біографічні акценти з ЕСУ й ЕІУ та окреслити, де англомовний текст
+    обмежує деталізацію.
+  caveats: >-
+    Не підміняти аналіз музикології цією статтею; її завдання — базова
+    орієнтація.
+- title: Людкевич Станіслав Пилипович
+  language: uk
+  genre: Енциклопедична стаття / історична довідка
+  source_type: reference
+  role: supplementary-reading
+  source: Енциклопедія історії України
+  source_url: >-
+    https://resource.history.org.ua/cgi-bin/eiu/history.exe?&I21DBN=EIU&P21DBN=EIU&S21STN=1&S21REF=10&S21FMT=eiu_all&C21COM=S&S21CNR=20&S21P01=0&S21P02=0&S21P03=TRN=&S21COLORTERMS=0&S21STR=Lyudkevych_S_P
+  license: copyrighted
+  rights_note: >-
+    ЕІУ дає стабільну кадрово-посадову основу; для спорів про гестапо-арешт і
+    захист Барвінського потрібні додаткові підтвердження.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Виписати з ЕІУ дані про основні ролі й періоди служби, а потім зіставити їх
+    із фрагментами творів у курсі.
+  caveats: >-
+    Працюючи з юридичною лексикою («полон», «арешт», «захист Барвінського»),
+    уникати тверджень без верифікації першоджерел.
+- title: Українське джерело для перевірки тексту «Кавказ»
+  language: uk
+  genre: Первинний текстовий матеріал / джерельний фрагмент
+  source_type: primary
+  role: supplementary-reading
+  source: Оригінальний текст «Борітеся — поборете!» на Українському текстовому корпусі
+  source_url: reading-needed
+  license: reading-needed
+  rights_note: >-
+    Потрібна первинна перевірка повного тексту/партитурного супроводу; на цьому
+    етапі безпечніше працювати з оглядами та посиланнями.
+  hosting: reading-needed
+  cefr_min: C1
+  learner_task: >-
+    Підготувати порівняння: які строфи тексту входять у кантату і як змінюються
+    акценти між поезією та музичною обробкою.
+  caveats: >-
+    Без оригінального текстового та нотного пакета будь-яка інтерпретація цитат
+    про деталі є частковою.
+- title: Liudkevych, Stanislav — Research Dossier
+  language: uk
+  genre: Internal research dossier / risk synthesis
+  source_type: secondary
+  role: critical-supplement
+  source: Документ дослідницького блоку
+  source_url: docs/research/bio/stanislav-liudkevych.md
+  license: unknown
+  rights_note: >-
+    Досьє агрегує відомі ризикові зони (дати смерті, політичний контекст), але
+    не замінює пряму роботу з епохальними джерелами.
+  hosting: link-only
+  cefr_min: C1
+  learner_task: >-
+    Перевірити ризикові пункти з досьє та визначити, які з них слід підкріпити
+    додатковими епізодичними довідками або фрагментами творів.
+  caveats: >-
+    Локальний пакет не є публічною енциклопедичною довідкою; його роль —
+    підготовка контролю ризиків.
 sequence: 367
 slug: stanislav-liudkevych
 subtitle: 'Stanislav Liudkevych: Galician National Music, Continuity, and Survival Across Regimes'
 title: 'Станіслав Людкевич: Галицька професійна музика крізь імперії'
-version: '4.0'
+version: '4.1'
 vocabulary_hints:
 - definition: великий жанр для хору й оркестру; форма «Кавказу» Людкевича
   pos: ж.


### PR DESCRIPTION
## Summary
- Adds normalized `readings:` blocks for five BIO music/ethnomusicology plans:
  - Filaret Kolessa
  - Klyment Kvitka
  - Levko Revutskyi
  - Myroslav Skoryk
  - Stanislav Liudkevych
- Bumps each touched plan version.
- Keeps scope to source/readings prep only; no module production or generated artifacts.

## Verification
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` PASS for `X-Agent: codex/bio-readings-music-ethno-batch-10-codex`.
- `git diff --check origin/main...HEAD` PASS.
- PyYAML parse/schema check PASS: each plan has 5 readings and the normalized key set/order.
- Parsed-object semantic comparison vs `origin/main`, excluding only `readings` and `version`, PASS for all five files.
- URL/local target check PASS: all link-only URLs resolve with HTTP 200; local dossier paths exist; primary materials remain `reading-needed`.
- `.venv/bin/yamllint` on the five files still reports pre-existing document-start/line-length debt in surrounding plan content; the new readings text was rewrapped, with only intact URL scalar lines above 120 chars.

## Review Gate
- Independent non-Codex review pending.
