### PR TITLE
docs(autopsy): canonical Root cause + Prevention headings (postmortem hygiene)

### DIFF
--- a/docs/bug-autopsies/qg-grounding-gate-fuzzy-false-accept.md
+++ b/docs/bug-autopsies/qg-grounding-gate-fuzzy-false-accept.md
@@ -12,7 +12,10 @@ fact — at the DEFAULT threshold, e.g. real output «Сковорода нар�
 skeptical read. It took **5 cross-family review rounds** (codex reviewing agy's builds) + 2 fleet design
 panels to harden.
 
-## Why (root causes, one per round)
+## Root cause
+
+Four interacting bugs, one surfaced per review round:
+
 1. **Fuzzy char-similarity + `any()` content guard.** Acceptance was `SequenceMatcher(excerpt, window).ratio()
    ≥ τ` plus `any(content_token in matched_span)`. A near-copy is ~95% similar (only the year differs), and
    the shared proper noun satisfied `any(...)` while the swapped digit «1900» (absent — real span has «1722»)
@@ -42,7 +45,10 @@ anchors). Semantic correctness (verb/claim, entity attribution) is explicitly La
 MUST entail against the RAW tool output, never the excerpt. VESUM lemma tightening is an OPTIONAL follow-up,
 never part of the fail-closed guarantee.
 
-## Prevention (the transferable lessons)
+## Prevention
+
+The transferable lessons:
+
 1. **A fail-closed gate's adversarial tests must run at the DEFAULT threshold.** A stricter override in a
    test that hides the shipped behavior is worse than no test — it manufactures false confidence.
 2. **Fuzzy string similarity cannot ground factual tokens.** Require positional/structural alignment


### PR DESCRIPTION
## What

The QG grounding-gate autopsy (`docs/bug-autopsies/qg-grounding-gate-fuzzy-false-accept.md`, shipped in #4800) used descriptive section headings — `## Why (root causes, one per round)` and `## Prevention (the transferable lessons)` — that the postmortem checker's exact-match whitelist does **not** accept. Result:

- Every SessionStart flagged `missing required field: Root cause` + `Prevention`.
- The **Postmortem Hygiene** CI job was **red on #4800** (it still merged — see follow-up below).

## Fix

Rename the two headings to the canonical template forms `## Root cause` / `## Prevention`. Per `docs/best-practices/postmortem-management.md`, the whitelist's non-canonical variants exist only so **historical** files avoid mechanical backfill — *"new files should use the template."* This file is new (2026-07-08), so conform it rather than abuse the historical-compat escape hatch by adding another whitelist entry. Autopsy **content is unchanged**; the round-by-round framing and "transferable lessons" note move into lead text under each heading.

## Verify (deterministic)

```
check_postmortems.py --check  →  exit 0 · 23 postmortems validated · INDEX fresh
```

## Follow-up (separate, not in this PR)

Investigating this surfaced a systemic gate-integrity gap: `main` branch protection requires **only** `Test (pytest)`. `Postmortem Hygiene` (and ruff / gitleaks / radon / schema-drift / prompt-lint / frontend) are advisory in practice — which is why #4800 merged with Hygiene red. Proper fix (required aggregation "CI gate" job + branch-protection change) is being designed + fleet-reviewed separately; it's a governance change needing explicit sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)