### PR TITLE
ci: add CI Gate aggregation job so deterministic gates become required (#4803)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -956,3 +956,53 @@ jobs:
       - uses: trufflesecurity/trufflehog@f446421baf832d6356c42c1743d99abff52ff334 # v3.95.7
         with:
           extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore
+
+  # Aggregation gate (#4803). The deterministic CI jobs above are CONDITIONAL
+  # (path-filtered via dorny/paths-filter), so none can be a branch-protection
+  # required check directly: on a PR that doesn't trigger it, the context never
+  # reports and the PR blocks forever ("Expected — waiting for status"). The
+  # team already hit this for the single required check and solved it narrowly
+  # (Test (pytest) uses `if: !cancelled()`, see #1644). This job generalizes
+  # that fix: it always runs, `needs:` every deterministic gate, and fails iff
+  # any non-skipped dependency failed. Make THIS job (`CI Gate`) the sole
+  # required status check so the whole set becomes load-bearing without the
+  # conditional-required-check footgun.
+  #
+  # Semantics: skipped -> pass (path-filtered out, nothing to check);
+  #            failure/cancelled -> block.
+  # `changes` is in `needs` so a broken paths-filter router fails the gate
+  # rather than silently letting every routed job report skipped.
+  # `frontend-e2e` (playwright) is intentionally EXCLUDED — flaky, stays
+  # advisory to protect fleet merge velocity. `frontend` (build + vitest) IS
+  # included: it is deterministic and a broken frontend build must not merge.
+  # Fleet-reviewed by codex/agy/cursor on #4803.
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - changes
+      - test                  # Test (pytest)
+      - lint                  # Lint (ruff)
+      - quality-gates         # Quality Gates (radon)
+      - lint-prompts          # Lint Prompts
+      - lesson-schema-drift   # Lesson Schema Drift
+      - mdx-source-parity     # MDX Source Parity
+      - mdx-generation-drift  # MDX Generation Drift
+      - postmortem-hygiene    # Postmortem Hygiene
+      - agent-config          # Agent Config
+      - scripts-root-guard    # No new root scripts
+      - secret-scan           # Secret Scanning (gitleaks)
+      - atlas-freshness       # Atlas Manifest Freshness
+      - frontend              # Frontend (build + vitest)
+    steps:
+      - name: Report required-job results
+        env:
+          RESULTS: ${{ join(needs.*.result, ',') }}
+        run: |
+          echo "required job results: $RESULTS"
+      - name: Fail if any required job failed or was cancelled
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "::error::A required CI job failed or was cancelled — see 'Report required-job results' for the per-job breakdown."
+          exit 1


### PR DESCRIPTION
Closes the mechanism half of #4803.

## Problem
`main` branch protection requires **only** `Test (pytest)`. Every other CI job (ruff, gitleaks, radon, prompt-lint, schema-drift, MDX-parity, postmortem-hygiene, agent-config, scripts-root-guard, atlas-freshness, **frontend**) is advisory in practice — `gh pr merge --auto` fires the moment pytest is green. Proof: #4800 merged with Postmortem Hygiene RED; #4805 is a live frontend vitest failure currently on main.

## Why they couldn't just be added to branch protection
Those jobs are conditional (path-filtered). A conditional job as a required check never reports on PRs that don't trigger it → PR stuck on "Expected". The team already solved this for the one required check (`Test` uses `if: !cancelled()`, #1644). This generalizes it.

## Change (this PR)
One always-running `CI Gate` job that `needs:` every deterministic gate and fails iff any **non-skipped** dep failed:
- `skipped → pass` (path-filtered out), `failure/cancelled → block`
- `changes` in `needs` → a broken paths-filter router fails the gate
- `frontend` (build+vitest) **included** (deterministic ship-blocker); `frontend-e2e` (playwright) **excluded** (flaky)

**This PR changes no merge policy** — it only adds a reporting job.

## Fleet review (#4803)
Independent families **codex / agy / cursor**, unanimous:
- **Add `frontend`** — my first draft omitted it; that's exactly the #4805 hole (MDX jobs are Python parity checks, not a substitute for `npm build`+vitest).
- Keep `changes` in `needs`.
- Adopt `contains(needs.*.result, 'failure')` enforcement + a diagnostic log line (env-var'd to keep zizmor clean).

Residual holes (pre-existing, out of scope, tracked in #4803): admin/direct-push bypass, workflow-file spoofing, `atlas-freshness`/`secret-scan` soft substeps.

## Rollout (owner-gated, NOT in this PR)
1. Merge this job (no policy change).
2. **Fix #4805** — frontend is RED on main, so the gate is red until fixed; protection can't flip while red.
3. Validate `CI Gate` reports green on a PR + main.
4. **Owner go** → branch protection required = `["CI Gate"]`, remove `Test (pytest)`. Do it promptly (closes the window where CI-Gate-red + Test-green still merges) and while 0 PRs are open.

## Verify (local, deterministic)
- Pinned actionlint (`scripts/audit/check_workflows.sh`) → all 9 workflows valid
- zizmor → no findings
- All 14 `needs` targets resolve to real jobs
- `tests/test_guard_admin_merge.py` + `tests/test_actionlint_workflow.py` → 28 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)