### PR TITLE
fix(practice): record review on board-transition clean match (#4805)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 5f8a04f433b4a67ab4dd6b471fa12d6d1b354d66625fe769c5844230e98ab75b
+  components_sha256: 4981b3812406e17eee040b1f2166800e12cb7ebffa740982a0cab152ecd95607
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -910,6 +910,7 @@ function LexiconPracticeIsland({
   const showEnglishSubtitles = learnerLevel === 'A1';
 
   const matchedSelectedRatingRef = useRef<PracticeRating | null>(null);
+  const matchingTargetOutcomeRef = useRef<CompletionOutcome | null>(null);
 
   // Reset all per-item feedback/lock state. Shared by the selection-change effect and
   // `advancePending` so a wrong answer that re-surfaces the SAME item (a lapsed card the
@@ -924,6 +925,7 @@ function LexiconPracticeIsland({
     setPendingOutcome(null);
     pendingOutcomeRef.current = null;
     matchedSelectedRatingRef.current = null;
+    matchingTargetOutcomeRef.current = null;
   }, []);
 
   useEffect(() => {
@@ -1176,7 +1178,14 @@ function LexiconPracticeIsland({
     if (!pair || !pair.lemmaId) return;
 
     if (pairIndex === 0) {
-      matchedSelectedRatingRef.current = rating;
+      if (sessionCompleted === 0) {
+        matchedSelectedRatingRef.current = rating;
+      } else {
+        if (selection) {
+          const outcome = recordReview(selection, rating);
+          matchingTargetOutcomeRef.current = outcome;
+        }
+      }
     } else {
       try {
         rateCard(pair.lemmaId, 'matching', rating, new Date());
@@ -1184,7 +1193,7 @@ function LexiconPracticeIsland({
         setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
       }
     }
-  }, [pairs]);
+  }, [pairs, selection, sessionCompleted]);
 
   // While a wrong answer dwells, Enter is a second way to advance (alongside the
   // «Далі →» button) — the disabled option buttons blur to <body>, so we listen at
@@ -2123,9 +2132,15 @@ function LexiconPracticeIsland({
                     onFlashcardRating={(rating) => rateAndComplete(selection, rating)}
                     onChoice={handleChoice}
                     onMatchingComplete={() => {
-                      const rating = matchedSelectedRatingRef.current || 'good';
-                      matchedSelectedRatingRef.current = null;
-                      rateAndComplete(selection, rating);
+                      if (sessionCompleted === 0) {
+                        const rating = matchedSelectedRatingRef.current || 'good';
+                        matchedSelectedRatingRef.current = null;
+                        rateAndComplete(selection, rating);
+                      } else {
+                        const outcome = matchingTargetOutcomeRef.current || recordReview(selection, 'good');
+                        matchingTargetOutcomeRef.current = null;
+                        completeSelection(selection, outcome);
+                      }
                     }}
                     onMatchingMatch={handleMatchingMatch}
                     onClozeSubmit={submitCloze}


### PR DESCRIPTION
Fixes #4805 — Frontend build+vitest was RED on `main`.

## Symptom
`LexiconPractice > attempt counting resets between boards` expected a **7th** review (a lemma rated `hard` on board 1, cleanly matched again on board 2 → fresh `good` review) but only 6 were recorded. Undetected because the frontend gate is advisory (#4803).

## Root cause
The matching-review path from #4758 stored the target lemma's rating in `matchedSelectedRatingRef` for the board-1 completion flow only. On subsequent boards (`sessionCompleted > 0`) the ref was never consumed → the target match dropped its review.

## Fix
On subsequent boards, record the target review immediately in `handleMatchingMatch` (`recordReview`) and carry the outcome to `completeSelection` via a new `matchingTargetOutcomeRef` — recorded **exactly once** (no double-record; the rapid-double-click "exactly ONE review" test still passes). `handleMatchingMatch` deps updated (`selection`, `sessionCompleted`). `docs/lesson-schema.yaml` regenerated (`components_sha256`) — byte-identical to `generate_lesson_schema.py`, so Lesson Schema Drift passes.

## Verify (deterministic, local)
- Targeted: `npx vitest run tests/unit/LexiconPractice.test.tsx` → **42/42**
- Full suite: `npx vitest run` → **35 files / 515 tests pass** (was 1 failed)
- `npm run build` → **Complete, 6208 pages, rc=0**
- Schema regen sha matches generator output (drift gate green)
- Test file **not** weakened (no `tests/` changes)

## Provenance
Authored by **agy** (Gemini 3.1 Pro) under dispatch `fix-4805-frontend`; the dispatch exited `needs_finalize` before committing, so **claude-infra** verified end-to-end (cross-family review) and finalized.

Unblocks #4806 (CI Gate) — frontend must be green on main before it becomes a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)