### PR TITLE
fix(qg): shadow-harness metric conflated claim-truth with excerpt provenance

### DIFF
--- a/scripts/audit/grounding_shadow_compare.py
+++ b/scripts/audit/grounding_shadow_compare.py
@@ -15,7 +15,7 @@ import os
 import sys
 from collections import defaultdict
 from collections.abc import Mapping
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -186,8 +186,23 @@ def main() -> int:
     recovered_gold_false = sum(1 for r in records if not r["v1_admissible"] and r["v2_anchored"] and r["gold_is_true"] is False)
     recovered_unlabeled = sum(1 for r in records if not r["v1_admissible"] and r["v2_anchored"] and r["gold_is_true"] is None)
 
-    fp_total = sum(1 for r in records if r["gold_is_true"] is False)
-    fp_count = sum(1 for r in records if r["gold_is_true"] is False and r["v2_anchored"])
+    # Cutover headline metric (fleet-reviewed, task qg-metric-reframe / #4764).
+    # We deliberately do NOT report a "false-positive rate on fabricated/labeled-false
+    # claims". That conflated CLAIM truth (`gold_is_true`, a Layer B / entailment concern)
+    # with excerpt PROVENANCE (`v2_anchored`, Layer A). A gold-FALSE claim can carry a
+    # genuine verbatim excerpt that Layer A CORRECTLY anchors and hands to Layer B, so
+    # counting it as a false accept is wrong and inflates v2's apparent error.
+    #
+    # A true Layer A false-accept = v2 anchors an excerpt NOT present in the tool output.
+    # Claim-truth labels cannot measure that; it is covered by the fail-closed unit tests in
+    # tests/test_grounding_gate_v2.py and (future) an excerpt-provenance-labeled fixture set.
+    # => True Layer A FP rate is UNMEASURED by this harness. Do not infer it from the numbers.
+    v1_gold_true = sum(1 for r in records if r["v1_admissible"] and r["gold_is_true"] is True)
+    v2_gold_true = sum(1 for r in records if r["v2_anchored"] and r["gold_is_true"] is True)
+    net_gold_true_recall = v2_gold_true - v1_gold_true
+    # Pessimistic UPPER BOUND on new Layer A risk vs v1 (per fleet review): v2-incremental
+    # anchors on gold-false claims (== recovered_gold_false). Audit candidates, NOT an FP rate.
+    audit_candidates_gold_false = recovered_gold_false
 
     # Breakdown by seat_arm
     seat_stats = defaultdict(lambda: {"total": 0, "v1": 0, "v2": 0, "rec": 0, "reg": 0, "abs": 0})
@@ -233,7 +248,7 @@ def main() -> int:
     # Save JSON report
     report_data = {
         "metadata": {
-            "generated_at": datetime.utcnow().isoformat() + "Z",
+            "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
             "tau": tau,
             "artifacts_dir": str(args.artifacts_dir),
             "total_groundings_checked": total,
@@ -247,11 +262,17 @@ def main() -> int:
             "recovered_unlabeled": recovered_unlabeled,
             "regressions": regressions,
             "abstains": abstains,
-            "false_positives_on_fabricated": {
-                "total_fabricated_checked": fp_total,
-                "v2_false_accepts": fp_count,
-                "rate": fp_count / fp_total if fp_total > 0 else 0.0
-            }
+            "cutover_headline": {
+                "_what": "Net gold-TRUE recall gain drives the v1->v2 cutover. NO Layer A "
+                         "false-positive rate is reported: claim-truth labels do not measure "
+                         "excerpt provenance (Layer A). True Layer A false-accepts are covered "
+                         "by fail-closed unit tests + a future excerpt-provenance fixture set.",
+                "v1_gold_true_anchored": v1_gold_true,
+                "v2_gold_true_anchored": v2_gold_true,
+                "net_gold_true_recall": net_gold_true_recall,
+                "regressions_need_audit": regressions,
+                "audit_candidates_gold_false_incremental": audit_candidates_gold_false,
+            },
         },
         "breakdown": {
             "by_seat_arm": dict(seat_stats),
@@ -272,7 +293,6 @@ def main() -> int:
     rec_un_pct = (recovered_unlabeled / total * 100) if total > 0 else 0.0
     reg_pct = (regressions / total * 100) if total > 0 else 0.0
     abs_pct = (abstains / total * 100) if total > 0 else 0.0
-    fp_pct = (fp_count / fp_total * 100) if fp_total > 0 else 0.0
 
     regression_records = [r for r in records if r["v1_admissible"] and not r["v2_anchored"]]
     regressions_list_content = ""
@@ -295,7 +315,7 @@ def main() -> int:
 
     md_content = f"""# Grounding Gate Shadow Compare Report (v1 vs v2)
 
-- **Date:** {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')}
+- **Date:** {datetime.now(UTC).strftime('%Y-%m-%d %H:%M:%S UTC')}
 - **Tau (τ):** {tau}
 - **Artifacts Directory:** `{args.artifacts_dir}`
 
@@ -308,11 +328,28 @@ def main() -> int:
 | v2 Anchored | {v2_count} | {v2_pct:.2f}% |
 | Recovered Legit (v1 Reject ∧ v2 Anchor) | {recovered} | {rec_pct:.2f}% |
 |   - Gold-True Recovered (Good) | {recovered_gold_true} | {rec_gt_pct:.2f}% |
-|   - Gold-False Newly-Accepted (FP, Bad) | {recovered_gold_false} | {rec_gf_pct:.2f}% |
+|   - Gold-False v2-incremental anchors (AUDIT candidates, NOT an FP — see note) | {recovered_gold_false} | {rec_gf_pct:.2f}% |
 |   - Unlabeled Recovered (needs human review) | {recovered_unlabeled} | {rec_un_pct:.2f}% |
-| Regressions (v1 Accept ∧ v2 Reject) | {regressions} | {reg_pct:.2f}% |
+| Regressions (v1 Accept ∧ v2 Reject) — audit per-item | {regressions} | {reg_pct:.2f}% |
 | Abstains | {abstains} | {abs_pct:.2f}% |
-| New FP Rate (on Labeled False Claims) | {fp_count}/{fp_total} | {fp_pct:.2f}% |
+
+## Cutover Headline (v1 → v2)
+
+| Metric | Value |
+| :--- | :--- |
+| Gold-true claims v1 anchored | {v1_gold_true} |
+| Gold-true claims v2 anchored | {v2_gold_true} |
+| **Net gold-true recall gain (v2 − v1)** | **{net_gold_true_recall:+d}** |
+| Regressions to audit (v1 accept ∧ v2 reject) | {regressions} |
+| Audit candidates: v2-incremental anchors on gold-false claims (upper bound on new Layer A risk) | {audit_candidates_gold_false} |
+
+> **No Layer A false-positive rate is reported.** A gold-FALSE claim can carry a genuine verbatim
+> excerpt that Layer A *correctly* anchors and hands to Layer B — counting it as a false accept
+> conflates CLAIM truth (Layer B / entailment) with excerpt PROVENANCE (Layer A). A true Layer A
+> false-accept (v2 anchors an excerpt **not present** in the tool output) is **UNMEASURED** by
+> claim-truth labels; it is covered by the fail-closed unit tests in `tests/test_grounding_gate_v2.py`
+> and a future excerpt-provenance-labeled fixture set. Drive the cutover on **net gold-true recall
+> gain** with every regression audited (real-loss vs correct-tightening), not on a claim-truth "FP".
 
 ## Seat/Arm Breakdown
 

--- a/tests/test_grounding_gate_v2.py
+++ b/tests/test_grounding_gate_v2.py
@@ -362,8 +362,13 @@ def test_ellipsis_mass_12_to_14_still_anchors():
     assert res.similarity == 1.0
 
 
-def test_shadow_compare_harness_fp_counter(tmp_path):
-    # Feeds a gold-FALSE claim which v2 anchors and asserts the FP counter reports it (NOT 0/0)
+def test_shadow_compare_gold_false_verbatim_excerpt_is_not_an_fp(tmp_path):
+    # Regression guard for the qg-metric-reframe conflation fix.
+    # A gold-FALSE claim whose evidence_excerpt is VERBATIM present in the tool output:
+    # Layer A (v2) MUST anchor it (provenance is satisfied) and hand it to Layer B; v1
+    # (exact substring) anchors it too. Claim falsity is a Layer B / entailment concern,
+    # NOT a Layer A false-accept. The harness must NOT report this as a "false positive" —
+    # the old `false_positives_on_fabricated` metric conflated claim-truth with provenance.
     cell_payload = {
         "schema_version": "qg_bakeoff_run.v1",
         "seat": "test-seat",
@@ -433,9 +438,25 @@ def test_shadow_compare_harness_fp_counter(tmp_path):
     assert json_out.exists()
     report = json.loads(json_out.read_text(encoding="utf-8"))
 
-    # Assert FP counter reports it (NOT 0/0)
-    assert report["summary"]["false_positives_on_fabricated"]["total_fabricated_checked"] == 1
-    assert report["summary"]["false_positives_on_fabricated"]["v2_false_accepts"] == 1
+    summary = report["summary"]
+    # The misleading claim-truth "FP" metric is GONE (deleted, per fleet review — a reframed
+    # name would still invite re-conflation).
+    assert "false_positives_on_fabricated" not in summary
+    # Cutover is driven by net gold-true recall, not a claim-truth FP.
+    assert "cutover_headline" in summary
+    ch = summary["cutover_headline"]
+
+    # The verbatim excerpt is present → BOTH gates anchor. That is CORRECT Layer A behavior.
+    rec = report["records"][0]
+    assert rec["v1_admissible"] is True
+    assert rec["v2_anchored"] is True
+    assert rec["gold_is_true"] is False
+
+    # Gold-false, so it is NOT a gold-true recovery; and since v1 also anchored it, it is not
+    # a v2-incremental audit candidate. It is counted as neither a recovery nor an FP.
+    assert ch["net_gold_true_recall"] == 0
+    assert ch["audit_candidates_gold_false_incremental"] == 0
+    assert summary["recovered_gold_false"] == 0
 
 
 def test_find_best_window_performance():


### PR DESCRIPTION
Part 1 of Task #2 (τ-tune QG grounding gate v2). Fixes a measurement-correctness bug that would have driven a wrong v1→v2 cutover.

## Bug
`grounding_shadow_compare.py` reported a headline **"New FP Rate (on Labeled False Claims)"** = `(gold_is_true is False) ∧ v2_anchored` = **102/303 = 33.7%** on the strict corpus. That **conflates CLAIM truth** (`gold_is_true`, a Layer B / entailment concern) **with excerpt PROVENANCE** (`v2_anchored`, Layer A). A gold-FALSE claim can carry a genuine verbatim excerpt that Layer A *correctly* anchors and hands to Layer B — so counting it as a false accept is wrong and inflates v2's apparent error. A true Layer A false-accept (v2 anchors an excerpt **not present** in the tool output) is **UNMEASURED** by claim-truth labels.

## Fleet review (task `qg-metric-reframe`, codex + agy — independent families, unanimous)
- Layer A/B separation is correct; `gold_false ∧ v2_anchored` is not per se a Layer A FP.
- No sound absolute FP proxy exists from claim-truth labels → **stop reporting an FP rate**.
- **DELETE** the metric (don't just rename — a reframed "gold-false admitted to Layer B" still invites re-conflation/minimization).
- Keep the pessimistic upper bound (`v2_anchored ∧ ¬v1 ∧ gold_false` = 38) as explicit **audit candidates**.
- Cutover headline = **net gold-true recall gain**, every regression audited.

## Changes
- Remove `false_positives_on_fabricated`; add `cutover_headline` (v1/v2 gold-true anchored, net recall, regressions-to-audit, gold-false audit candidates) + a plain "Layer A unmeasured" caveat in JSON + MD.
- Rewrite the test that **pinned the bug**: `test_shadow_compare_harness_fp_counter` (asserted a verbatim gold-false excerpt as `v2_false_accepts==1`) → `test_shadow_compare_gold_false_verbatim_excerpt_is_not_an_fp`, which asserts the metric is gone and the verbatim case is anchored-not-FP. *(Autopsy lesson: a test that encodes the bug is worse than none.)*
- Cosmetics: `datetime.utcnow()` → `datetime.now(UTC)`.

## Reframed real-corpus finding (τ=0.75)
Net gold-true recall = **+0** (v1 & v2 both anchor 337), **232 regressions to audit**, 38 gold-false audit candidates — the honest picture the old 33.7% "FP" obscured. The next Task #2 step is auditing those 232 (correct-tightening vs real-loss) to drive the τ + cutover decision.

## Verify
- ruff clean · **21/21** `tests/test_grounding_gate_v2.py` · reframed harness run on the 315-cell strict corpus renders `cutover_headline` with no FP key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)