### PR TITLE
feat(cursor): 200k-context cold-start protocol

### DIFF
--- a/.cursor/rules/cold-start.mdc
+++ b/.cursor/rules/cold-start.mdc
@@ -1,0 +1,31 @@
+---
+description: 200k-context cold start — Monitor API live state only; skip duplicate rules
+alwaysApply: true
+---
+
+# Cold start (Cursor · 200k)
+
+**At session start, before other work:**
+
+```bash
+.venv/bin/python scripts/cursor_cold_start.py
+```
+
+## Do not fetch at boot
+
+- `/api/rules` — `AGENTS.md` + `CLAUDE.md` already in workspace rules (~50k tokens)
+- `/api/session/current?agent=orchestrator` — wrong agent lane
+- `context_canary.py mint` — 1M orchestrator only
+- `Read` on `CLAUDE.md`, `AGENTS.md`, `memory/MEMORY.md`
+
+## Fetch on demand
+
+| Need | Call |
+| --- | --- |
+| Fleet inbox | `/api/comms/inbox?agent=cursor` |
+| Dispatches | `/api/delegate/active` |
+| Track state | `/api/state/summary` |
+| One module | `/api/state/module/{track}/slug/{slug}` |
+| After commit | `/api/orient?fresh=true` |
+
+Protocol: `agents_extensions/cursor/rules/cold-start.md`

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ service-account*.json
 # Cursor IDE local state — keep project-level mcp.json committed (parallel to .mcp.json)
 .cursor/*
 !.cursor/mcp.json
+!.cursor/rules/
+!.cursor/rules/**
 
 # Stale build-orchestration scratchpad — load-bearing artifacts auto-commit to build/<level>/<slug>-<stamp> branches per #M-10 (PR #1952). Anything lingering in main worktree is pre-#1952 leftover state.
 curriculum/l2-uk-en/_orchestration/

--- a/agents_extensions/README.md
+++ b/agents_extensions/README.md
@@ -14,6 +14,7 @@ agents_extensions/
 ├── README.md
 ├── shared/          # Agent-agnostic previous extension source/
 └── codex/           # Codex-owned durable rules, memory, and overlays
+└── cursor/          # Cursor IDE rules (deploy to .cursor/rules/)
 ```
 
 Deploy extensions with:

--- a/agents_extensions/cursor/rules/cold-start.md
+++ b/agents_extensions/cursor/rules/cold-start.md
@@ -1,0 +1,53 @@
+# Cursor cold start (200k context)
+
+Cursor already loads `AGENTS.md` + `CLAUDE.md` as workspace rules (~40–60k tokens).
+Do **not** refetch `/api/rules` unless those files are missing from context.
+
+## Budget
+
+| Reserve | Tokens | Purpose |
+| --- | --- | --- |
+| Workspace rules | ~50k | AGENTS + CLAUDE (Cursor-injected) |
+| Cold-start API | ~3–5k | manifest + condensed orient |
+| Task work | ~120–140k | reads, edits, reasoning |
+| Headroom | ~10k | tool output spikes |
+
+## Sequence (every session)
+
+```bash
+.venv/bin/python scripts/cursor_cold_start.py
+```
+
+Equivalent manual calls:
+
+```bash
+curl -s http://localhost:8765/api/state/manifest
+curl -s http://localhost:8765/api/orient   # parse git, health, delegate, governance only
+```
+
+## Skip (orchestrator / 1M lanes)
+
+- `/api/rules` — duplicates workspace rules
+- `/api/session/current?agent=orchestrator` — wrong agent
+- `context_canary.py mint` — 1M orchestrator sessions only
+- `Read` on `CLAUDE.md`, `AGENTS.md`, or `memory/MEMORY.md` at boot
+
+## Fetch on demand (task-scoped)
+
+| Task | Endpoint |
+| --- | --- |
+| Fleet inbox | `/api/comms/inbox?agent=cursor` |
+| Active dispatches | `/api/delegate/active` |
+| Track / curriculum | `/api/state/summary`, `/api/state/track-health/{track}` |
+| One module | `/api/state/module/{track}/slug/{slug}` |
+| Open PRs | `gh pr list` (not full orient replay) |
+| Usage limits | CodaxBar.app + `/api/runtime/agents` |
+
+## After local writes
+
+`curl -s 'http://localhost:8765/api/orient?fresh=true'`
+
+## Offline fallback
+
+If Monitor API is down: `git status --short --branch` + read
+`agents_extensions/shared/rules/operator-expectations.md` (digest only).

--- a/scripts/cursor_cold_start.py
+++ b/scripts/cursor_cold_start.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Condensed Monitor API cold start for Cursor (200k context).
+
+Skips /api/rules (AGENTS.md + CLAUDE.md already in Cursor workspace rules).
+Prints a compact markdown briefing (~3–5k tokens) for session orientation.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_BASE = "http://localhost:8765"
+TIMEOUT_S = 5.0
+
+
+def _get(path: str) -> dict | list | None:
+    url = DEFAULT_BASE + path
+    try:
+        with urllib.request.urlopen(url, timeout=TIMEOUT_S) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        print(f"<!-- monitor api unreachable: {exc} -->", file=sys.stderr)
+        return None
+
+
+def _lines_orient(orient: dict) -> list[str]:
+    lines: list[str] = []
+    git_info = orient.get("git") or {}
+    lines.append(
+        f"- **git:** `{git_info.get('branch', '?')}` @ `{str(git_info.get('head', ''))[:10]}`"
+        f" (ahead {git_info.get('ahead_of_origin', 0)})"
+    )
+    for commit in (git_info.get("recent_commits") or [])[:3]:
+        sha = str(commit.get("sha", ""))[:8]
+        subject = str(commit.get("subject", ""))[:100]
+        lines.append(f"  - `{sha}` {subject}")
+
+    health = orient.get("health") or {}
+    bad = [k for k, v in health.items() if v is False]
+    if bad:
+        lines.append(f"- **health:** FAIL {', '.join(bad)}")
+    else:
+        lines.append("- **health:** all green")
+
+    delegate = orient.get("delegate") or {}
+    active = delegate.get("active_count", 0)
+    lines.append(f"- **delegate:** {active} active")
+    for row in (delegate.get("recent") or [])[:3]:
+        if row.get("status") == "done":
+            continue
+        lines.append(
+            f"  - {row.get('agent')}/{row.get('task_id')}: {row.get('status')}"
+        )
+
+    gov = orient.get("governance") or {}
+    stale = gov.get("decisions_stale", 0)
+    exp = gov.get("decisions_approaching_expiry", 0)
+    if stale or exp:
+        lines.append(f"- **governance:** stale={stale} expiring={exp}")
+
+    issues = orient.get("issues") or []
+    if issues:
+        lines.append("- **open issues (top):**")
+        for issue in issues[:5]:
+            num = issue.get("number", "?")
+            title = str(issue.get("title", ""))[:80]
+            lines.append(f"  - #{num} {title}")
+    elif orient.get("issues_error"):
+        lines.append(f"- **issues:** unavailable ({orient['issues_error']})")
+
+    hints = orient.get("session_hints") or []
+    for hint in hints[:3]:
+        if isinstance(hint, dict):
+            text = f"{hint.get('file', '')}: {hint.get('first_line', '')}"[:120]
+        else:
+            text = str(hint)[:120]
+        lines.append(f"- **hint:** {text}")
+
+    return lines
+
+
+def main() -> int:
+    manifest = _get("/api/state/manifest")
+    orient = _get("/api/orient")
+
+    print("# Cursor cold start\n")
+    if manifest:
+        rules_hash = (manifest.get("rules") or {}).get("hash", "")[:12]
+        print(f"_manifest rules={rules_hash}… (rules skipped — already in workspace)_\n")
+
+    if orient:
+        print("## Live state\n")
+        for line in _lines_orient(orient):
+            print(line)
+        print()
+    else:
+        print("## Live state\n")
+        print("- Monitor API down — run `git status --short --branch`\n")
+
+    print("## Context budget (200k)\n")
+    print("- Workspace rules: ~50k (AGENTS + CLAUDE, do not re-read)")
+    print("- This briefing: ~3–5k")
+    print("- Task budget: ~140k; fetch scoped endpoints only when needed")
+    print("- Full protocol: `agents_extensions/cursor/rules/cold-start.md`")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a Cursor-specific cold-start protocol tuned for ~200k context: skip `/api/rules` (already covered by workspace `AGENTS.md` + `CLAUDE.md`) and fetch only condensed live state from the Monitor API.
- Add `scripts/cursor_cold_start.py` — one-command bootstrap (~1.2KB output vs ~80KB full orchestrator boot).
- Add always-on Cursor rule `.cursor/rules/cold-start.mdc` and tracked source `agents_extensions/cursor/rules/cold-start.md`.
- Allow `.cursor/rules/` in git (like `mcp.json`) so the rule persists across clones.

## Test plan

- [x] `.venv/bin/python scripts/cursor_cold_start.py` runs and prints git/health/delegate summary
- [x] `ruff check scripts/cursor_cold_start.py` passes
- [x] pre-commit hooks pass on commit


Made with [Cursor](https://cursor.com)