### PR TITLE
fix(infra): harden hermes log_tool_call.sh cwd validation for -z one-shots and root pollution (#4390)

### DIFF
--- a/scripts/agent_runtime/hermes_hooks/log_tool_call.sh
+++ b/scripts/agent_runtime/hermes_hooks/log_tool_call.sh
@@ -24,6 +24,10 @@
 # (pollution from -z one-shots / bridge runs where payload.cwd == toplevel)
 # and non-module paths. Skips gracefully; lanes should ensure module cwd.
 #
+# Note: heuristic (root detection + curriculum/ allowlist). Addresses
+# accumulation symptom. Root-cause positive signal (env/sentinel) suggested
+# in review for follow-up.
+#
 # Schema written
 # --------------
 # Each line is a single JSON object with the fields the gate expects:
@@ -84,8 +88,12 @@ if [ -f "$cwd/AGENTS.md" ] && [ -d "$cwd/scripts/agent_runtime/hermes_hooks" ]; 
   # This cwd is the project root.
   exit 0
 fi
-if [[ "$cwd" != */curriculum/* && "$cwd" != */plans/* && "$cwd" != */wiki/* ]]; then
-  # Not a typical module or content dir; skip to avoid pollution.
+# Heuristic allowlist scoped to V7 writer module dirs (under curriculum/).
+# Note (per cross-family review): this is a symptom-level guard, not root-cause
+# (positive env/sentinel from v7_build.py would be more robust). Plans/wiki
+# not documented V7-writer cwds; kept minimal to curriculum for now.
+if [[ "$cwd" != */curriculum/* ]]; then
+  # Not a V7 module writer dir; skip to avoid pollution.
   # Lanes should ensure proper cwd or use .agent/tmp/ for scratch.
   exit 0
 fi

--- a/scripts/agent_runtime/hermes_hooks/log_tool_call.sh
+++ b/scripts/agent_runtime/hermes_hooks/log_tool_call.sh
@@ -79,12 +79,14 @@ cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)"
 # to project root instead of a module dir).
 # V7 builds set cwd to the module dir; non-V7 may not.
 # Skip writes that would pollute the root or non-module paths.
-project_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "")"
-if [[ -z "$project_root" ]] || [[ "$cwd" == "$project_root" ]] || \
-   [[ "$cwd" != */curriculum/* && "$cwd" != */plans/* && "$cwd" != */wiki/* ]]; then
-  # Likely root pollution or unexpected cwd for writer telemetry.
-  # Lanes should ensure proper cwd (e.g. via module dir) or route scratch
-  # under .agent/tmp/. Do not write here.
+# Improved detection: use file presence (works even if cwd has no .git).
+if [ -f "$cwd/AGENTS.md" ] && [ -d "$cwd/scripts/agent_runtime/hermes_hooks" ]; then
+  # This cwd is the project root.
+  exit 0
+fi
+if [[ "$cwd" != */curriculum/* && "$cwd" != */plans/* && "$cwd" != */wiki/* ]]; then
+  # Not a typical module or content dir; skip to avoid pollution.
+  # Lanes should ensure proper cwd or use .agent/tmp/ for scratch.
   exit 0
 fi
 

--- a/scripts/agent_runtime/hermes_hooks/log_tool_call.sh
+++ b/scripts/agent_runtime/hermes_hooks/log_tool_call.sh
@@ -20,6 +20,10 @@
 # pipeline already globs ``*.write.jsonl`` (linear_pipeline.py:6882-6883)
 # so no pipeline-side changes are needed.
 #
+# #4390 infra fix: added cwd validation to avoid writing to project root
+# (pollution from -z one-shots / bridge runs where payload.cwd == toplevel)
+# and non-module paths. Skips gracefully; lanes should ensure module cwd.
+#
 # Schema written
 # --------------
 # Each line is a single JSON object with the fields the gate expects:
@@ -69,6 +73,20 @@ esac
 
 cwd="$(printf '%s' "$payload" | jq -r '.cwd // empty' 2>/dev/null || true)"
 [[ -z "$cwd" || ! -d "$cwd" ]] && exit 0
+
+# Infra fix for #4390: prevent accumulation in main checkout root (common
+# for hermes -z one-shots and bridge/ad-hoc runs where payload.cwd resolves
+# to project root instead of a module dir).
+# V7 builds set cwd to the module dir; non-V7 may not.
+# Skip writes that would pollute the root or non-module paths.
+project_root="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || echo "")"
+if [[ -z "$project_root" ]] || [[ "$cwd" == "$project_root" ]] || \
+   [[ "$cwd" != */curriculum/* && "$cwd" != */plans/* && "$cwd" != */wiki/* ]]; then
+  # Likely root pollution or unexpected cwd for writer telemetry.
+  # Lanes should ensure proper cwd (e.g. via module dir) or route scratch
+  # under .agent/tmp/. Do not write here.
+  exit 0
+fi
 
 log_path="$cwd/hermes.write.jsonl"
 


### PR DESCRIPTION
## Summary
Harden the Hermes `post_tool_call` hook (`log_tool_call.sh`) used for V7 writer tool telemetry.

- Added cwd validation to skip writes when payload `cwd` resolves to project root or non-module paths.
- This was causing `hermes.write.jsonl` accumulation in the main checkout root during `hermes -z` one-shots, bridge runs, and ad-hoc invocations (see #4390).
- V7 builds (which set proper `module_dir` cwd) are unaffected.
- Defensive: no change to successful writer runs; gracefully degrades.

Infra & harness stream (#4707).

## Changes
- `scripts/agent_runtime/hermes_hooks/log_tool_call.sh`: cwd guard + updated docs.

## Verification
- `bash -n` syntax clean.
- Pre-commit hooks passed on commit.
- Matches issue diagnosis and suggested direction (validate cwd against expected module context).

## Next
This is a small targeted infra fix. Full `-z` hook firing may need additional adapter/hermes config work; this prevents the symptom.

Refs #4390, #4707.

X-Agent: grok/4390-fix-hermes-telemetry