### PR TITLE
fix(codex): harden UI cold-start orientation

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1543,6 +1543,12 @@ still populates. A single wedged collector never takes down the
 whole response — this fixed the incident logged in the first entry
 of `docs/monitor-api/cold-start-baseline.md`.
 
+If the `issues` collector returns `issues_error` or the GitHub
+subsection times out, run
+`.venv/bin/python scripts/orchestration/issue_stream_audit.py --json`
+to refresh the issue-stream hygiene cache instead of retrying the full
+orient bundle blindly.
+
 ---
 
 ## Cold-Start Consolidation — `/api/state/manifest`, `/api/rules`, `/api/session/current`, `/api/comms/inbox` (#1309)
@@ -1598,7 +1604,9 @@ filenames (newest first). The default agent is `orchestrator`; use
 `agent=codex`, `agent=claude`, or `agent=gemini` to read that agent's
 mapped handoff file. The Codex orchestrator handoff lives at
 `docs/session-state/codex-orchestrator-handoff.md`; other durable agent
-handoffs normally use `docs/session-state/current.<agent>.md`. Pass
+handoffs normally use `docs/session-state/current.<agent>.md`. Codex UI
+rollovers read `docs/session-state/current.orchestrator.md`, which is a
+thin pointer to the durable orchestrator handoff above. Pass
 `agent=router` only when you need the small compatibility router at
 `docs/session-state/current.md`.
 

--- a/docs/architecture/agent-coordination-ledger.md
+++ b/docs/architecture/agent-coordination-ledger.md
@@ -114,7 +114,7 @@ constraints are clear. Until then, workers write via the local CLI.
 - Workers report through the ledger, their Codex thread, and their owned
   GitHub issue or PR.
 - Workers must not write `docs/session-state/current.md`,
-  `docs/session-state/current.codex.md`, or any shared session-state file.
+  `docs/session-state/current.orchestrator.md`, or any shared session-state file.
 - The orchestrator remains responsible for review routing, merge decisions,
   issue hygiene, PR queue hygiene, and final summaries.
 - Independent review remains mandatory before merge.

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -131,7 +131,7 @@ Durable role handoffs and thread rollover packets are separate:
 | Agent | Durable role handoff |
 |---|---|
 | orchestrator | `docs/session-state/codex-orchestrator-handoff.md` |
-| codex | `docs/session-state/current.codex.md` |
+| codex | `docs/session-state/current.orchestrator.md` → `docs/session-state/codex-orchestrator-handoff.md` |
 | claude | `docs/session-state/current.claude.md` |
 | gemini | `docs/session-state/current.gemini.md` |
 
@@ -144,6 +144,9 @@ state file.
 For compatibility, `docs/session-state/current.orchestrator.md` remains a thin
 pointer to `docs/session-state/codex-orchestrator-handoff.md` while older
 routers and cold-start hooks still reference it.
+
+Codex UI cold-starts should read the orchestrator pointer above instead of a
+missing Codex-specific handoff file.
 
 Use `/api/session/current?agent=<name>` or read the matching
 durable role handoff directly. Only the orchestrator updates the router by

--- a/docs/best-practices/codex-thread-handoff.md
+++ b/docs/best-practices/codex-thread-handoff.md
@@ -43,6 +43,9 @@ prompt, scoped by agent name:
 - Thread rollover packet: `.agent/<agent>-thread-handoff.md` (gitignored)
 - Durable Codex orchestrator handoff:
   `docs/session-state/codex-orchestrator-handoff.md`
+- Codex role handoff pointer:
+  `docs/session-state/current.orchestrator.md` (thin pointer to the durable
+  orchestrator handoff above)
 - Other durable agent handoffs: `docs/session-state/current.<agent>.md`
 - Compatibility router: `docs/session-state/current.md` (git-tracked; not used
   for normal thread rollover)
@@ -106,6 +109,16 @@ The generated prompt is the exact replacement-thread bootstrap. If the Codex
 app `create_thread` tool is available to the current agent, use it with that
 prompt. If it is not available, create one new Codex UI thread manually and
 paste the generated prompt. That is the only unavoidable UI action.
+
+The bootstrap starts with a checklist that is deliberately hard to skip:
+
+- repo root + `git status --short --branch`
+- local `.agent/<agent>-thread-handoff.md`
+- `/api/orient?fresh=true`
+- `.venv/bin/python scripts/orchestration/issue_stream_audit.py --json` when
+  the GitHub issue subsection errors or times out
+- open PR list
+- current worktree hygiene via `git worktree list`
 
 The generated bootstrap also tells the replacement thread to read the
 orchestrator worker inbox:

--- a/scripts/api/session_router.py
+++ b/scripts/api/session_router.py
@@ -144,7 +144,15 @@ def _resolve_session_path(agent: str) -> str:
         return SESSION_ROUTER_PATH
 
     router_path = PROJECT_ROOT / SESSION_ROUTER_PATH
-    agent_default = f"docs/session-state/current.{agent}.md"
+    agent_default = (
+        # If the small compatibility router is absent, the API should still
+        # serve Codex UI the durable orchestrator state directly. Thread
+        # bootstrap prompts separately name the current.orchestrator.md pointer
+        # because that is the stable local file agents should read first.
+        ORCHESTRATOR_HANDOFF_PATH
+        if agent == "codex"
+        else f"docs/session-state/current.{agent}.md"
+    )
     if not router_path.is_file():
         return agent_default
 
@@ -153,7 +161,7 @@ def _resolve_session_path(agent: str) -> str:
     if agent in handoffs:
         handoff_path = handoffs[agent]
         if (
-            agent == DEFAULT_SESSION_AGENT
+            agent in {DEFAULT_SESSION_AGENT, "codex"}
             and handoff_path == LEGACY_ORCHESTRATOR_HANDOFF_PATH
             and (PROJECT_ROOT / ORCHESTRATOR_HANDOFF_PATH).is_file()
         ):
@@ -162,7 +170,7 @@ def _resolve_session_path(agent: str) -> str:
 
     # Backward compatibility for older current.md files that still contained
     # the detailed orchestrator handoff rather than an Agent-Handoff router.
-    if agent == DEFAULT_SESSION_AGENT and not handoffs:
+    if agent in {DEFAULT_SESSION_AGENT, "codex"} and not handoffs:
         return SESSION_ROUTER_PATH
     return agent_default
 

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -84,6 +84,10 @@ def default_thread_handoff_path(agent: str) -> Path:
 def default_handoff_path(agent: str) -> Path:
     if agent == DEFAULT_AGENT:
         return ORCHESTRATOR_HANDOFF_PATH
+    if agent == "codex":
+        # Codex UI rollovers read the orchestrator compatibility pointer. There
+        # is no separate Codex-specific durable handoff file in this repo.
+        return Path("docs/session-state/current.orchestrator.md")
     return Path(f"docs/session-state/current.{agent}.md")
 
 
@@ -503,6 +507,24 @@ def context_line(context_percent: float | None, threshold: float) -> str:
     return f"Context estimate: {context_percent:.1f}% ({state}; threshold {threshold:.1f}%)."
 
 
+def first_turn_checklist_lines(
+    *,
+    repo_root: str,
+    thread_handoff_text: str,
+    role_handoff_text: str,
+) -> list[str]:
+    return [
+        "First-turn checklist:",
+        f"1. `cd {repo_root}`",
+        "2. `git status --short --branch`",
+        f"3. Read `{thread_handoff_text}` and `{role_handoff_text}`.",
+        "4. Check `/api/orient?fresh=true` from the local monitor.",
+        "5. If `/api/orient` returns an `issues_error` or the GitHub issue subsection times out, run `.venv/bin/python scripts/orchestration/issue_stream_audit.py --json`.",
+        "6. `gh pr list --state open --json number,title,headRefName,mergeStateStatus,statusCheckRollup,url,updatedAt,isDraft,reviewDecision --limit 20`",
+        "7. `git worktree list` and verify the active worktree is the one you intend to edit.",
+    ]
+
+
 def render_bootstrap_prompt(
     snapshot: dict[str, Any],
     state: dict[str, Any],
@@ -552,13 +574,16 @@ def render_bootstrap_prompt(
         "- Do not write docs/session-state/current.md for thread rollover.",
         "- Do not delete or migrate the old heartbeat automation until the confirm-started command below has succeeded.",
         "",
-        "Start by orienting from the local monitor and PR state:",
+        *first_turn_checklist_lines(
+            repo_root=str(git.get("repo_root")),
+            thread_handoff_text=thread_handoff_text,
+            role_handoff_text=handoff_text,
+        ),
+        "",
+        "Local monitor follow-up:",
         "```bash",
-        "cd " + str(git.get("repo_root")),
-        "curl -sS http://127.0.0.1:8765/api/orient",
         "curl -sS http://127.0.0.1:8765/api/delegate/active",
         "curl -sS http://127.0.0.1:8765/api/worktrees",
-        "gh pr list --state open --json number,title,headRefName,mergeStateStatus,statusCheckRollup,url,updatedAt,isDraft,reviewDecision --limit 20",
         ".venv/bin/python scripts/orchestration/orchestrator_control.py inbox --recent 20 --include-results",
         "```",
         "",
@@ -594,6 +619,7 @@ def render_current_markdown(
     cleanup = state.get("cleanup") or {}
     handoff = state.get("last_handoff") or {}
     prompt_path = replacement.get("bootstrap_prompt_path") or default_bootstrap_path(agent).as_posix()
+    thread_handoff_text = default_thread_handoff_path(agent).as_posix()
     role_handoff = (role_handoff_path or default_handoff_path(agent)).as_posix()
     title_agent = "Orchestrator" if agent == "orchestrator" else agent.title()
 
@@ -661,14 +687,19 @@ def render_current_markdown(
         "",
         f"- Count: `{(monitor.get('worktrees') or {}).get('count', 'unknown') if isinstance(monitor.get('worktrees'), dict) else 'unknown'}`",
         "",
-        "## Next Commands",
+        "## First-Turn Checklist",
+        "",
+        *first_turn_checklist_lines(
+            repo_root=str(git.get("repo_root")),
+            thread_handoff_text=thread_handoff_text,
+            role_handoff_text=role_handoff,
+        ),
+        "",
+        "## Local Monitor Follow-Up",
         "",
         "```bash",
-        "cd " + str(git.get("repo_root")),
-        "curl -sS http://127.0.0.1:8765/api/orient",
         "curl -sS http://127.0.0.1:8765/api/delegate/active",
         "curl -sS http://127.0.0.1:8765/api/worktrees",
-        "gh pr list --state open --json number,title,headRefName,mergeStateStatus,statusCheckRollup,url,updatedAt,isDraft,reviewDecision --limit 20",
         ".venv/bin/python scripts/orchestration/orchestrator_control.py inbox --recent 20 --include-results",
         "```",
         "",

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -112,6 +112,9 @@ def test_render_bootstrap_prompt_contains_guardrails(tmp_path: Path):
     assert "Thread handoff: .agent/orchestrator-thread-handoff.md" in prompt
     assert "Global router:" not in prompt
     assert "Do not write docs/session-state/current.md for thread rollover." in prompt
+    assert "git status --short --branch" in prompt
+    assert "issue_stream_audit.py --json" in prompt
+    assert "git worktree list" in prompt
     assert "confirm-started --agent orchestrator --new-thread-id <replacement-thread-id>" in prompt
     assert "Only after that command reports old_automation_ready_to_delete=true" in prompt
     assert "Context estimate: 90.0% (ROLL OVER NOW; threshold 82.0%)." in prompt
@@ -137,10 +140,61 @@ def test_render_current_markdown_includes_required_handoff_sections(tmp_path: Pa
     assert "### Modified Files" in rendered
     assert "## Open PRs" in rendered
     assert "## Delegated Tasks" in rendered
-    assert "## Next Commands" in rendered
+    assert "## First-Turn Checklist" in rendered
+    assert "issue_stream_audit.py --json" in rendered
     assert "confirm-started --agent orchestrator --new-thread-id <replacement-thread-id>" in rendered
     assert "orchestrator_control.py inbox --recent 20 --include-results" in rendered
     assert "Durable role handoff: `docs/session-state/codex-orchestrator-handoff.md`" in rendered
+
+
+def test_render_bootstrap_prompt_for_codex_uses_orchestrator_pointer(tmp_path: Path):
+    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
+    state = th.prepare_state(
+        {},
+        agent="codex",
+        now=now,
+        active_thread_id="old-thread",
+        active_automation_id="old-auto",
+        bootstrap_path=Path(".agent/bootstrap.md"),
+        context_percent=90.0,
+        force_new_replacement=False,
+    )
+    prompt = th.render_bootstrap_prompt(
+        sample_snapshot(tmp_path),
+        state,
+        agent="codex",
+        context_threshold=82.0,
+    )
+
+    assert "You are the replacement codex thread." in prompt
+    assert "Role handoff: docs/session-state/current.orchestrator.md" in prompt
+    assert "Thread handoff: .agent/codex-thread-handoff.md" in prompt
+    assert "issue_stream_audit.py --json" in prompt
+    assert "git worktree list" in prompt
+
+
+def test_render_current_markdown_for_codex_uses_orchestrator_pointer(tmp_path: Path):
+    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
+    state = th.prepare_state(
+        {},
+        agent="codex",
+        now=now,
+        active_thread_id="old-thread",
+        active_automation_id=None,
+        bootstrap_path=Path(".agent/bootstrap.md"),
+        context_percent=None,
+        force_new_replacement=False,
+    )
+    rendered = th.render_current_markdown(
+        sample_snapshot(tmp_path),
+        state,
+        agent="codex",
+        context_threshold=82.0,
+    )
+
+    assert "## First-Turn Checklist" in rendered
+    assert "Durable role handoff: `docs/session-state/current.orchestrator.md`" in rendered
+    assert "confirm-started --agent codex --new-thread-id <replacement-thread-id>" in rendered
 
 
 def test_render_router_markdown_contains_parseable_markers():
@@ -153,7 +207,7 @@ def test_render_router_markdown_contains_parseable_markers():
     assert "Latest-Brief: docs/session-state/codex-orchestrator-handoff.md" in rendered
     assert "Agent-Handoff:" in rendered
     assert "- orchestrator: docs/session-state/codex-orchestrator-handoff.md" in rendered
-    assert "- codex: docs/session-state/current.codex.md" in rendered
+    assert "- codex: docs/session-state/current.orchestrator.md" in rendered
     assert len(rendered.encode("utf-8")) < 1200
 
 
@@ -162,6 +216,7 @@ def test_default_agent_paths_are_agent_specific():
     assert th.default_bootstrap_path("claude") == Path(".agent/claude-thread-bootstrap.md")
     assert th.default_thread_handoff_path("claude") == Path(".agent/claude-thread-handoff.md")
     assert th.default_handoff_path("orchestrator") == Path("docs/session-state/codex-orchestrator-handoff.md")
+    assert th.default_handoff_path("codex") == Path("docs/session-state/current.orchestrator.md")
     assert th.default_handoff_path("claude") == Path("docs/session-state/current.claude.md")
 
 

--- a/tests/test_manifest_api.py
+++ b/tests/test_manifest_api.py
@@ -99,14 +99,14 @@ def session_fixture(tmp_path, monkeypatch):
         "Latest-Brief: docs/session-state/codex-orchestrator-handoff.md\n\n"
         "Agent-Handoff:\n"
         "- orchestrator: docs/session-state/codex-orchestrator-handoff.md\n"
-        "- codex: docs/session-state/current.codex.md\n",
+        "- codex: docs/session-state/current.orchestrator.md\n",
         encoding="utf-8",
     )
     (session_dir / "codex-orchestrator-handoff.md").write_text(
-        "# Current task\n\nWorking on #1309.\n", encoding="utf-8"
+        "# Current task\n\nWorking on #1309.\n\nCodex-specific handoff.\n", encoding="utf-8"
     )
-    (session_dir / "current.codex.md").write_text(
-        "# Codex task\n\nCodex-specific handoff.\n", encoding="utf-8"
+    (session_dir / "current.orchestrator.md").write_text(
+        "# Pointer\n\nSee durable state.\n", encoding="utf-8"
     )
     (session_dir / "2026-04-01-old.md").write_text("old handoff\n", encoding="utf-8")
     (session_dir / "2026-04-17-newest.md").write_text("new handoff\n", encoding="utf-8")
@@ -144,7 +144,8 @@ def test_session_current_agent_query(session_fixture):
     resp = client.get("/api/session/current?agent=codex")
     assert resp.status_code == 200
     assert "Codex-specific handoff." in resp.text
-    assert "Working on #1309." not in resp.text
+    assert "Working on #1309." in resp.text
+    assert "See durable state." not in resp.text
 
 
 def test_session_current_legacy_orchestrator_mapping_uses_durable_handoff(tmp_path, monkeypatch):
@@ -172,6 +173,73 @@ def test_session_current_legacy_orchestrator_mapping_uses_durable_handoff(tmp_pa
     body = resp.json()
     assert "Durable orchestrator state." in body["markdown"]
     assert body["sections"]["current"] == "docs/session-state/codex-orchestrator-handoff.md"
+
+
+def test_session_current_codex_without_router_uses_durable_handoff(tmp_path, monkeypatch):
+    project_root = tmp_path
+    session_dir = project_root / "docs" / "session-state"
+    session_dir.mkdir(parents=True)
+    (session_dir / "codex-orchestrator-handoff.md").write_text(
+        "# Durable task\n\nCodex UI state.\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(session_router, "PROJECT_ROOT", project_root)
+
+    resp = client.get("/api/session/current?agent=codex&format=json")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "Codex UI state." in body["markdown"]
+    assert body["sections"]["current"] == "docs/session-state/codex-orchestrator-handoff.md"
+
+
+def test_session_current_codex_empty_router_uses_router_body(tmp_path, monkeypatch):
+    project_root = tmp_path
+    session_dir = project_root / "docs" / "session-state"
+    session_dir.mkdir(parents=True)
+    (session_dir / "current.md").write_text(
+        "# Legacy current body\n\nNo agent router yet.\n", encoding="utf-8"
+    )
+    (session_dir / "codex-orchestrator-handoff.md").write_text(
+        "# Durable task\n\nCodex UI state.\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(session_router, "PROJECT_ROOT", project_root)
+
+    resp = client.get("/api/session/current?agent=codex&format=json")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "No agent router yet." in body["markdown"]
+    assert "Codex UI state." not in body["markdown"]
+    assert body["sections"]["current"] == "docs/session-state/current.md"
+
+
+def test_session_current_legacy_pointer_remap_is_codex_or_orchestrator_only(
+    tmp_path, monkeypatch
+):
+    project_root = tmp_path
+    session_dir = project_root / "docs" / "session-state"
+    session_dir.mkdir(parents=True)
+    (session_dir / "current.md").write_text(
+        "# Current Session Router\n\n"
+        "Agent-Handoff:\n"
+        "- claude: docs/session-state/current.orchestrator.md\n",
+        encoding="utf-8",
+    )
+    (session_dir / "current.orchestrator.md").write_text(
+        "# Pointer\n\nClaude was mapped here deliberately.\n", encoding="utf-8"
+    )
+    (session_dir / "codex-orchestrator-handoff.md").write_text(
+        "# Durable task\n\nDurable orchestrator state.\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(session_router, "PROJECT_ROOT", project_root)
+
+    resp = client.get("/api/session/current?agent=claude&format=json")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "Claude was mapped here deliberately." in body["markdown"]
+    assert "Durable orchestrator state." not in body["markdown"]
+    assert body["sections"]["current"] == "docs/session-state/current.orchestrator.md"
 
 
 def test_session_current_router_query(session_fixture):


### PR DESCRIPTION
## Summary
- Fixes #4813.
- Point Codex UI rollover/bootstrap at the existing orchestrator handoff pointer instead of the missing current.codex.md path.
- Add an explicit first-turn checklist covering repo status, local handoff, /api/orient, issue-stream audit fallback, open PRs, and worktree hygiene.
- Make /api/session/current?agent=codex resolve to the durable orchestrator handoff path.

## Validation
- .venv/bin/python -m pytest tests/orchestration/test_thread_handoff.py tests/test_manifest_api.py
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/orchestration/thread_handoff.py prepare --agent codex --context-percent 91 --dry-run
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/orchestration/issue_stream_audit.py --json -> ok: true, no orphans, no multi-homed issues
- git diff --check
- /Users/krisztiankoos/projects/learn-ukrainian/.venv/bin/python scripts/audit/lint_agent_trailer.py

## Issue hygiene
- #4813 is natively linked under #4707.
- #4816 orphan found during this pass was natively linked under #3120 because its body already declared that stream.

## Review gate
Draft until independent cross-family review is complete.