### PR TITLE
fix(qg): recover exact-match multi-output abstains in v2 grounding enforcement

### DIFF
--- a/scripts/audit/llm_reviewer_dispatch.py
+++ b/scripts/audit/llm_reviewer_dispatch.py
@@ -1399,6 +1399,12 @@ def mark_deep_read_attempted(payload: Mapping[str, Any]) -> dict[str, Any]:
     return out
 
 
+# Guard 3 abstain-recovery threshold (task guard3-abstain). Only exact-match (verbatim)
+# multi-output abstains are recovered as provenance-passed; fuzzy near-tie abstains stay
+# fail-closed until audited. SequenceMatcher.ratio() of a normalized verbatim window is 1.0.
+_V2_ABSTAIN_RECOVERY_MIN_SIM = 1.0
+
+
 def enforce_grounding_against_tool_events(
     payload: Mapping[str, Any],
     dispatch_meta: Mapping[str, Any],
@@ -1449,9 +1455,22 @@ def enforce_grounding_against_tool_events(
             if resolved_version == "v2":
                 from scripts.audit import grounding_gate_v2
                 res = grounding_gate_v2.anchor_evidence_to_events(grounding, events)
-                is_matched = res.anchored
+                # Guard 3 abstain-recovery (fleet-reviewed, task guard3-abstain; unanimous
+                # codex/agy/cursor). res.abstained means the excerpt is verbatim-present in >=2
+                # DIFFERENT captured tool outputs — Layer A provenance SATISFIED, source ambiguous.
+                # The gate returns anchored=False for that ambiguity; enforcement previously mapped it
+                # to a hard REJECT, over-rejecting ~117 gold-true groundings. Provenance is Layer A's
+                # job; "which of the real sources" is attribution (Layer B, not yet built). Recover
+                # only EXACT-match (sim==1.0) multi-output abstains; leave fuzzy near-tie abstains
+                # fail-closed until audited (codex caution). source_index stays None + anchor_abstained
+                # is recorded so a future Layer B must still entail the excerpt against the RAW output
+                # (the excerpt must not self-prove attribution). Boilerplate with no salient tokens
+                # never reaches this path — the gate rejects it as no_salient_anchor before Guard 3.
+                recovered_abstain = res.abstained and res.similarity >= _V2_ABSTAIN_RECOVERY_MIN_SIM
+                is_matched = res.anchored or recovered_abstain
                 item["anchor_similarity"] = res.similarity
                 item["anchor_abstained"] = res.abstained
+                item["anchor_recovered_ambiguous"] = bool(recovered_abstain)
                 item["grounding_gate_version"] = "v2"
                 if res.anchor_low_signal_reason is not None:
                     item["anchor_low_signal_reason"] = res.anchor_low_signal_reason

--- a/scripts/audit/llm_reviewer_dispatch.py
+++ b/scripts/audit/llm_reviewer_dispatch.py
@@ -1405,6 +1405,28 @@ def mark_deep_read_attempted(payload: Mapping[str, Any]) -> dict[str, Any]:
 _V2_ABSTAIN_RECOVERY_MIN_SIM = 1.0
 
 
+def _v2_abstain_recovered(res) -> bool:
+    """Guard 3 abstain-recovery (task guard3-abstain; fleet-reviewed codex/agy/cursor).
+
+    ``res.abstained`` means the excerpt is verbatim-present in >=2 DIFFERENT captured tool
+    outputs — Layer A provenance SATISFIED, source ambiguous. "Which of the real sources" is
+    attribution (Layer B, not yet built), NOT a Layer A fabrication. The gate returns
+    ``anchored=False`` for that ambiguity; enforcement previously mapped abstain to a hard
+    REJECT, over-rejecting ~117 gold-true groundings (all sim=1.0). Recover ONLY exact-match
+    (``similarity == 1.0``) multi-output abstains; fuzzy near-tie abstains (``similarity < 1.0``)
+    stay fail-closed until audited (codex caution). The 5-round-hardened gate is untouched;
+    it keeps ``source_index=None`` on abstain and callers record ``anchor_abstained`` so a future
+    Layer B must still entail the excerpt against the RAW output (no self-proving).
+
+    Excerpts with no salient tokens are rejected (``no_salient_anchor``) before Guard 3, but
+    boilerplate WITH salient tokens (e.g. an error string) can reach abstain and recover here —
+    that is a Layer B substance concern, not a Layer A fabrication (panel-accepted; matches v1's
+    exact-substring behavior). Near-copy fabrication (digit/name swap, truncation) never reaches
+    ``abstained=True`` — it fails the per-window salient-token opcode alignment first.
+    """
+    return res.abstained and res.similarity >= _V2_ABSTAIN_RECOVERY_MIN_SIM
+
+
 def enforce_grounding_against_tool_events(
     payload: Mapping[str, Any],
     dispatch_meta: Mapping[str, Any],
@@ -1431,7 +1453,9 @@ def enforce_grounding_against_tool_events(
             if resolved_version == "v2":
                 from scripts.audit import grounding_gate_v2
                 res = grounding_gate_v2.anchor_evidence_to_events(grounding, events)
-                is_matched = res.anchored
+                recovered_abstain = _v2_abstain_recovered(res)
+                is_matched = res.anchored or recovered_abstain
+                item["anchor_recovered_ambiguous"] = bool(recovered_abstain)
             else:
                 is_matched = _grounding_matches_events(grounding, events)
 
@@ -1455,18 +1479,7 @@ def enforce_grounding_against_tool_events(
             if resolved_version == "v2":
                 from scripts.audit import grounding_gate_v2
                 res = grounding_gate_v2.anchor_evidence_to_events(grounding, events)
-                # Guard 3 abstain-recovery (fleet-reviewed, task guard3-abstain; unanimous
-                # codex/agy/cursor). res.abstained means the excerpt is verbatim-present in >=2
-                # DIFFERENT captured tool outputs — Layer A provenance SATISFIED, source ambiguous.
-                # The gate returns anchored=False for that ambiguity; enforcement previously mapped it
-                # to a hard REJECT, over-rejecting ~117 gold-true groundings. Provenance is Layer A's
-                # job; "which of the real sources" is attribution (Layer B, not yet built). Recover
-                # only EXACT-match (sim==1.0) multi-output abstains; leave fuzzy near-tie abstains
-                # fail-closed until audited (codex caution). source_index stays None + anchor_abstained
-                # is recorded so a future Layer B must still entail the excerpt against the RAW output
-                # (the excerpt must not self-prove attribution). Boilerplate with no salient tokens
-                # never reaches this path — the gate rejects it as no_salient_anchor before Guard 3.
-                recovered_abstain = res.abstained and res.similarity >= _V2_ABSTAIN_RECOVERY_MIN_SIM
+                recovered_abstain = _v2_abstain_recovered(res)
                 is_matched = res.anchored or recovered_abstain
                 item["anchor_similarity"] = res.similarity
                 item["anchor_abstained"] = res.abstained

--- a/tests/test_llm_reviewer_dispatch.py
+++ b/tests/test_llm_reviewer_dispatch.py
@@ -1708,3 +1708,96 @@ def test_grounding_matches_events_across_dot_and_underscore_tool_forms() -> None
     for malformed in ("mcp__sources.", "sources.", ".query_wikipedia"):
         g = dict(grounding, tool=malformed)
         assert llm_reviewer_dispatch._grounding_matches_events(g, (event,)) is False, malformed
+
+
+# --- Guard 3 abstain-recovery (task guard3-abstain; fleet-reviewed codex/agy/cursor) ---
+# The v2 gate ABSTAINS (anchored=False) when an excerpt is verbatim-present in >=2 DIFFERENT
+# tool outputs — provenance is satisfied, source is ambiguous. Enforcement previously mapped that
+# to a hard reject, over-rejecting ~117 gold-true groundings. Enforcement now recovers only the
+# EXACT-match (sim==1.0) multi-output abstains; fuzzy near-tie abstains stay fail-closed, and the
+# hardened gate is untouched (its fail-closed probes still assert on grounding_gate_v2 directly).
+
+
+def _stub_anchor(monkeypatch, *, anchored: bool, abstained: bool, similarity: float) -> None:
+    from scripts.audit import grounding_gate_v2
+
+    def fake(grounding, events, *, tau=None):
+        return grounding_gate_v2.AnchorResult(
+            anchored=anchored,
+            abstained=abstained,
+            similarity=similarity,
+            source_index=None,
+            span=None,
+            reason="stub",
+        )
+
+    monkeypatch.setattr(grounding_gate_v2, "anchor_evidence_to_events", fake)
+
+
+def _enforce_v2(payload):
+    return llm_reviewer_dispatch.enforce_grounding_against_tool_events(
+        payload,
+        {"tool_events": [_sources_event()]},
+        policy_family="seminar",
+        gate_version="v2",
+    )
+
+
+def test_v2_enforcement_recovers_exact_multi_output_abstain(monkeypatch) -> None:
+    _stub_anchor(monkeypatch, anchored=False, abstained=True, similarity=1.0)
+    result = _enforce_v2(json.loads(_fact_response()))
+    assert result.invalid_fact_checks == 0  # recovered as provenance-passed, not dropped
+    fc = result.payload["fact_checks"][0]
+    assert fc["anchor_recovered_ambiguous"] is True
+    assert fc["anchor_abstained"] is True
+
+
+def test_v2_enforcement_fuzzy_abstain_stays_fail_closed(monkeypatch) -> None:
+    _stub_anchor(monkeypatch, anchored=False, abstained=True, similarity=0.9)
+    result = _enforce_v2(json.loads(_fact_response()))
+    assert result.invalid_fact_checks == 1  # below the exact-match recovery threshold → rejected
+    assert result.payload["fact_checks"][0]["anchor_recovered_ambiguous"] is False
+
+
+def test_v2_enforcement_non_anchor_non_abstain_rejected(monkeypatch) -> None:
+    _stub_anchor(monkeypatch, anchored=False, abstained=False, similarity=0.5)
+    result = _enforce_v2(json.loads(_fact_response()))
+    assert result.invalid_fact_checks == 1  # ordinary below-tau miss → rejected (fabrication path intact)
+
+
+def test_v2_enforcement_real_multi_output_verbatim_recovered() -> None:
+    # Real gate: excerpt with a salient token, verbatim in TWO different outputs → abstain → recovered.
+    excerpt = "Сковорода народився у 1722 році"
+    payload = json.loads(_fact_response(evidence_excerpt=excerpt, grounding_query="Сковорода"))
+    events = [
+        _sources_event(
+            query="Сковорода",
+            output="Григорій Сковорода народився у 1722 році. Він був філософом.",
+            call_id="call_1",
+        ),
+        _sources_event(
+            query="Сковорода",
+            output="Сковорода народився у 1722 році згідно з джерелами.",
+            call_id="call_2",
+        ),
+    ]
+    result = llm_reviewer_dispatch.enforce_grounding_against_tool_events(
+        payload, {"tool_events": events}, policy_family="seminar", gate_version="v2"
+    )
+    fc = result.payload["fact_checks"][0]
+    assert result.invalid_fact_checks == 0
+    assert fc["anchor_abstained"] is True
+    assert fc["anchor_recovered_ambiguous"] is True
+
+
+def test_v2_enforcement_real_number_swap_still_rejected() -> None:
+    # Fabrication defense must be intact: a swapped year is not verbatim-present → digit_not_aligned reject.
+    payload = json.loads(
+        _fact_response(evidence_excerpt="Сковорода народився у 1900 році", grounding_query="Сковорода")
+    )
+    events = [_sources_event(query="Сковорода", output="Сковорода народився у 1722 році.", call_id="call_1")]
+    result = llm_reviewer_dispatch.enforce_grounding_against_tool_events(
+        payload, {"tool_events": events}, policy_family="seminar", gate_version="v2"
+    )
+    assert result.invalid_fact_checks == 1
+    assert result.payload["fact_checks"][0]["anchor_recovered_ambiguous"] is False

--- a/tests/test_llm_reviewer_dispatch.py
+++ b/tests/test_llm_reviewer_dispatch.py
@@ -1801,3 +1801,32 @@ def test_v2_enforcement_real_number_swap_still_rejected() -> None:
     )
     assert result.invalid_fact_checks == 1
     assert result.payload["fact_checks"][0]["anchor_recovered_ambiguous"] is False
+
+
+def test_v2_enforcement_findings_path_recovers_exact_abstain(monkeypatch) -> None:
+    # The findings loop must recover abstains the same way the fact_checks loop does (sibling path).
+    _stub_anchor(monkeypatch, anchored=False, abstained=True, similarity=1.0)
+    payload = {
+        "findings": [
+            {
+                "issue_id": "SEMINAR_FACTUAL_DETAIL",
+                "issue_class": "other",
+                "dimension": "seminar_sensitivity",
+                "severity": "warning",
+                "excerpt": "весняні обрядові пісні",
+                "message": "grounded finding",
+                "grounding": {
+                    "tool": "sources_query_wikipedia",
+                    "query": "Веснянки",
+                    "evidence_excerpt": "весняні обрядові пісні",
+                    "tool_call_id": "call_1",
+                },
+            }
+        ]
+    }
+    result = llm_reviewer_dispatch.enforce_grounding_against_tool_events(
+        payload, {"tool_events": [_sources_event()]}, policy_family="seminar", gate_version="v2"
+    )
+    kept = result.payload.get("findings", [])
+    assert len(kept) == 1  # recovered as provenance-passed, not dropped as ungrounded
+    assert kept[0]["anchor_recovered_ambiguous"] is True


### PR DESCRIPTION
Unblocks the v1→v2 grounding-gate cutover (Task #2). The v2 gate over-rejected **117 gold-true groundings** at τ=0.75 — the dominant reason v2 showed +0 net gold-true recall.

## Root cause
The v2 gate ABSTAINS (`anchored=False`, `reason=abstain_ambiguous`) when a reviewer's `evidence_excerpt` is verbatim-present in **≥2 different** captured tool outputs — provenance IS satisfied, only the source is ambiguous. But enforcement (`enforce_grounding_against_tool_events`) mapped `is_matched = res.anchored`, so **abstain → hard REJECT**. That over-rejected the 117 (all sim=1.0). The bug is in the **enforcement wiring, not the hardened gate.**

## Fleet review (task `guard3-abstain`, unanimous — agy / codex / cursor)
- Multi-match is **not** a fabrication signal: near-copy fakes are killed per-window by salient-token opcode alignment *before* Guard 3; boilerplate with no salient tokens is rejected as `no_salient_anchor` *before* Guard 3.
- "Which of the real sources" is **attribution (Layer B)**, not a Layer A provenance failure.
- Fix the **enforcement**, don't touch the 5-round-hardened gate.

## Change (enforcement-only)
```python
is_matched = res.anchored or (res.abstained and res.similarity >= 1.0)
```
Recover **only** exact-match (sim==1.0) multi-output abstains; fuzzy near-tie abstains stay **fail-closed** until audited (codex caution). `source_index` stays `None` + `anchor_abstained` recorded so a future Layer B must still entail vs the RAW output (excerpt can't self-prove attribution). New `anchor_recovered_ambiguous` flag for observability. **The hardened gate is untouched.**

## Verify
- New tests: stubbed recover-exact / fuzzy-fail-closed / non-anchor-rejected; **real** multi-output-verbatim recovered; **real** number-swap still rejected (verified the real gate abstains on the first, `digit_not_aligned`-rejects the second).
- **90 tests pass** — the 6 fail-closed fabrication probes + every enforcement test still green. ruff clean.

## Follow-up (next arc, NOT here)
`grounding_shadow_compare` should score the EFFECTIVE decision (`anchored OR sim=1.0 abstain`) so the recovered 117 show at corpus level → re-baseline → **cutover decision** (flip `QG_GROUNDING_GATE_VERSION`, user-gated). Capacity note: built entirely deterministically / on non-deficit review lanes — no codex/claude spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)