### PR TITLE
fix(infra): align cursor danger mode for commit/push/PR finalize (#4750)

### DIFF
--- a/scripts/agent_runtime/adapters/cursor.py
+++ b/scripts/agent_runtime/adapters/cursor.py
@@ -10,8 +10,9 @@ Key design points:
   shell-limit issues with large prompts.
 - **JSONL event stream.** Parses stdout using ``parse_json_events`` to
   extract tool-call telemetry and the final assistant response.
-- **Security boundaries.** Explicitly avoids ``--yolo`` and ``--force``
-  flags. Uses ``--mode plan`` for workspace-write by default.
+- **Security boundaries.** read-only and workspace-write use sandboxed
+  profiles. Danger mode (inside verified dispatch worktree) uses ``--force``
+  + sandbox disabled for full finalize parity with other lanes (#4750).
 - **Per-invocation workspace.** Caller can specify ``cursor_workspace`` in
   ``tool_config`` to scope the agent to a specific directory.
 
@@ -156,17 +157,17 @@ class CursorAdapter:
         elif mode == "danger":
             # Danger mode: no --mode flag (cursor-agent default allows edits;
             # --mode plan blocks edits, --mode ask is read-only Q&A — neither
-            # matches "danger" intent). Sandbox + approve-mcps kept on for
-            # MCP discipline + shell-side guard; --yolo deliberately omitted
-            # so shell tools still need explicit approval (matches the
-            # "no --yolo in any path" Phase 2 spec §2 boundary).
+            # matches "danger" intent).
             #
-            # Use sparingly — most delegate calls should use workspace-write
-            # (which blocks edits via --mode plan).
+            # Emit --force (command approval grant) + --sandbox disabled so
+            # that git commit (pre-commit hooks: pytest/ruff), git push, and
+            # gh pr create can run unattended inside the dispatch worktree.
+            # This aligns cursor danger with the contract used by codex/agy/
+            # grok-build. The verified dispatch worktree (not the in-process
+            # sandbox) is the isolation boundary. Fixes #4750.
             if self._should_approve_mcps(config, default=True):
                 cmd.append("--approve-mcps")
-            sandbox = config.get("sandbox", "enabled")
-            cmd.extend(["--sandbox", sandbox])
+            cmd.extend(["--force", "--sandbox", "disabled"])
 
         return InvocationPlan(
             cmd=cmd,

--- a/tests/agent_runtime/adapters/test_cursor_adapter.py
+++ b/tests/agent_runtime/adapters/test_cursor_adapter.py
@@ -142,12 +142,13 @@ def test_cursor_adapter_build_invocation_danger(adapter, tmp_path, monkeypatch):
     # Danger mode: no --mode flag (cursor-agent default allows edits;
     # --mode plan blocks edits, --mode ask is read-only Q&A).
     assert "--mode" not in plan.cmd
-    # MCP discipline + sandbox kept on; --yolo deliberately omitted per Phase 2 spec.
+    # --force for shell/git/gh approval + --sandbox disabled for parity with
+    # other adapters' danger mode (worktree is the isolation boundary). #4750
     assert "--approve-mcps" in plan.cmd
+    assert "--force" in plan.cmd
     assert "--sandbox" in plan.cmd
-    assert "enabled" in plan.cmd
+    assert "disabled" in plan.cmd
     assert "--yolo" not in plan.cmd
-    assert "--force" not in plan.cmd
 
 
 def test_cursor_adapter_no_literal_dash_argument_anywhere(adapter, tmp_path, monkeypatch):


### PR DESCRIPTION
Cursor dispatches were completing work but failing to finalize (commit, push, gh pr create) because danger mode still forced `--sandbox enabled` and omitted `--force`.

Root cause confirmed in build_invocation and the enforcing test.

Now matches the danger contract used by codex/agy/grok-build adapters: the dispatch worktree is the isolation boundary.

- Updated adapter + test
- All cursor adapter tests pass

Refs #4750 (infra/harness #4707)

X-Agent: grok/4750-cursor-danger-finalize