### PR TITLE
fix(api): routing-budget CLI guard fail-honest on empty ledger (#4824)

### DIFF
--- a/scripts/api/codexbar_usage.py
+++ b/scripts/api/codexbar_usage.py
@@ -9,6 +9,8 @@ import json
 import subprocess
 import threading
 import time
+from collections.abc import Iterable
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from typing import Any, Optional
 
@@ -29,6 +31,38 @@ PROVIDER_TO_LANE = {
 _last_good_data: dict[str, tuple[float, dict[str, Any]]] = {}
 _refresh_lock = threading.Lock()
 _refresh_thread: threading.Thread | None = None
+
+
+def refresh_provider_usage_data(providers: Iterable[str], *, timeout_s: float = 2.0) -> dict[str, dict[str, Any]]:
+    """Synchronously refresh selected providers in parallel for an explicit caller.
+
+    The regular API path intentionally remains cache-only and non-blocking. This
+    helper is reserved for callers, such as the dispatch budget guard, which
+    explicitly need a bounded fresh verdict before acting.
+    """
+    from scripts.api.state_helpers import cache_set
+
+    unique_providers = tuple(dict.fromkeys(providers))
+    if not unique_providers:
+        return {}
+
+    refreshed: dict[str, dict[str, Any]] = {}
+    with ThreadPoolExecutor(max_workers=len(unique_providers)) as executor:
+        futures = {
+            provider: executor.submit(fetch_codexbar_usage, provider, timeout_s=timeout_s)
+            for provider in unique_providers
+        }
+        for provider, future in futures.items():
+            try:
+                data = future.result()
+            except Exception:
+                data = None
+            if data is None:
+                continue
+            cache_set(f"codexbar_usage:{provider}", data)
+            _last_good_data[provider] = (time.monotonic(), data)
+            refreshed[provider] = data
+    return refreshed
 
 
 def fetch_codexbar_usage(provider: str, *, timeout_s: float = 45.0) -> dict[str, Any] | None:

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -48,7 +48,7 @@ except ImportError:
     from ..path_safety import safe_join  # scripts.api package import (production)
 
 from . import delegate_router as delegate_api
-from .codexbar_usage import get_provider_usage_data
+from .codexbar_usage import get_provider_usage_data, refresh_provider_usage_data
 from .config import CURRICULUM_ROOT, LEVELS
 from .state_build import (
     compute_build_stats,
@@ -299,16 +299,19 @@ def _recommend_agent(
     reset_imminent_hours: int = 6,
     is_stale: bool = False,
     records_loaded: int = 0,
+    authoritative_data_available: bool = False,
 ) -> dict[str, Any]:
     """Generalized recommendation over subscription lanes + reset-aware + empty/stale guards.
 
-    Per design: when records_loaded==0 or empty snapshot, suppress primary rec (no confident pick from absent data).
+    When both the ledger and CodexBar are empty, suppress the primary rec. A
+    fresh CodexBar overlay is authoritative even when the local USD ledger is
+    empty.
     Reset-aware: if top pick resets within N hours, note deferral warning (N configurable).
     """
     if is_stale:
         warnings.append("snapshot stale (>15min old data) — advisory only, verify manually before trusting numbers")
 
-    if records_loaded == 0:
+    if records_loaded == 0 and not authoritative_data_available:
         return {
             "primary_agent_for_code": None,
             "rationale": "Budget snapshot empty/absent (records_loaded=0); confident primary-lane recommendation suppressed per pinned design constraint. Use model-assignment.md + /api/orient runtime.headroom instead.",
@@ -439,7 +442,7 @@ def _recommend_agent(
     return {"primary_agent_for_code": None, "rationale": "insufficient data", "warnings": warnings}
 
 
-def compute_routing_budget(now: datetime | None = None) -> dict[str, Any]:
+def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool = False) -> dict[str, Any]:
     current_time = (now or datetime.now(UTC)).astimezone(UTC)
     today = current_time.date()
     window_start = current_time - timedelta(days=7)
@@ -613,9 +616,10 @@ def compute_routing_budget(now: datetime | None = None) -> dict[str, Any]:
     cb_sourced_any = False
     cb_stale = False
     cb_max_age_s = None
+    refreshed_codexbar = refresh_provider_usage_data(SUBSCRIPTION_LANES) if fresh_codexbar else {}
 
     for lane in SUBSCRIPTION_LANES:
-        cb_data = get_provider_usage_data(lane)
+        cb_data = refreshed_codexbar.get(lane) or get_provider_usage_data(lane)
         if cb_data and cb_data.get("weekly_used_pct") is not None:
             cb_sourced_any = True
             weekly_used = cb_data["weekly_used_pct"]
@@ -744,6 +748,7 @@ def compute_routing_budget(now: datetime | None = None) -> dict[str, Any]:
         reset_imminent_hours=reset_hours,
         is_stale=is_stale,
         records_loaded=len(records),
+        authoritative_data_available=cb_sourced_any,
     )
 
     # Build ranked view: subscription by remaining headroom (low burn = high remaining first), API always unknown
@@ -798,6 +803,8 @@ def compute_routing_budget(now: datetime | None = None) -> dict[str, Any]:
             "data_age_s": data_age_s,
             "stale_threshold_s": 900,
             "reset_imminent_hours": reset_hours,
+            "codexbar_data_available": cb_sourced_any,
+            "fresh_codexbar_requested": fresh_codexbar,
         },
         "ranked_by_headroom": ranked,
     }
@@ -807,9 +814,9 @@ def compute_routing_budget(now: datetime | None = None) -> dict[str, Any]:
 
 
 @router.get("/routing-budget")
-async def routing_budget():
+async def routing_budget(fresh_codexbar: bool = Query(False)):
     """Per-agent soft-cap burn and routing recommendation for dispatch planning."""
-    return await asyncio.to_thread(compute_routing_budget)
+    return await asyncio.to_thread(compute_routing_budget, fresh_codexbar=fresh_codexbar)
 
 
 @router.get("/summary")

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -82,6 +82,7 @@ Design notes:
 
 Issue: #1184.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -147,11 +148,7 @@ def _read_github_token_from_bash_secrets(path: Path | None = None) -> str | None
 
 def _resolve_github_token() -> str | None:
     """Resolve the GitHub token used for GH_TOKEN pass-through."""
-    return (
-        os.environ.get("GITHUB_TOKEN")
-        or _read_github_token_from_bash_secrets()
-        or os.environ.get("GH_TOKEN")
-    )
+    return os.environ.get("GITHUB_TOKEN") or _read_github_token_from_bash_secrets() or os.environ.get("GH_TOKEN")
 
 
 def _inject_gh_token_for_agent(worker_env: dict[str, str], agent: str) -> None:
@@ -200,7 +197,7 @@ def _main_checkout_root(repo_root: Path = _REPO_ROOT) -> Path:
     if not first_line.startswith(prefix):
         return repo_root
 
-    git_dir = Path(first_line[len(prefix):].strip())
+    git_dir = Path(first_line[len(prefix) :].strip())
     if not git_dir.is_absolute():
         git_dir = repo_root / git_dir
     git_dir = git_dir.resolve()
@@ -215,6 +212,7 @@ def _main_checkout_root(repo_root: Path = _REPO_ROOT) -> Path:
 # ---------------------------------------------------------------------------
 # State file helpers
 # ---------------------------------------------------------------------------
+
 
 def _state_path(task_id: str) -> Path:
     _TASKS_DIR.mkdir(parents=True, exist_ok=True)
@@ -317,6 +315,7 @@ def _normalize_worktree_path(raw_path: str) -> Path:
 # remediation command in its message so operators can unblock without
 # digging.
 
+
 class WorktreeBranchMismatch(RuntimeError):
     """Existing worktree is on a branch other than the expected dispatch branch."""
 
@@ -339,7 +338,7 @@ def _normalize_task_id(agent: str, task_id: str) -> str:
     """
     for prefix in (f"{agent}-", f"{agent}/"):
         if task_id.startswith(prefix):
-            return task_id[len(prefix):]
+            return task_id[len(prefix) :]
     return task_id
 
 
@@ -414,6 +413,7 @@ def _load_worktree_containment():
     if str(_REPO_ROOT) not in sys.path:
         sys.path.insert(0, str(_REPO_ROOT))
     from scripts.guardrails import worktree_containment
+
     return worktree_containment
 
 
@@ -454,7 +454,10 @@ def _is_verified_added_worktree(path: Path) -> bool:
 
 
 def _resolve_write_cwd_error(
-    *, mode: str, worktree_arg: str | None, cwd_arg: str | None,
+    *,
+    mode: str,
+    worktree_arg: str | None,
+    cwd_arg: str | None,
 ) -> str | None:
     """Reject a write-capable dispatch that would run outside a verified worktree.
 
@@ -705,11 +708,7 @@ def _auto_finalize_changed_files(worktree: Path) -> tuple[str, ...]:
     )
     if tracked.returncode != 0 or untracked.returncode != 0:
         return ()
-    changed = {
-        path.strip()
-        for path in (*tracked.stdout.splitlines(), *untracked.stdout.splitlines())
-        if path.strip()
-    }
+    changed = {path.strip() for path in (*tracked.stdout.splitlines(), *untracked.stdout.splitlines()) if path.strip()}
     return tuple(sorted(changed))
 
 
@@ -913,10 +912,7 @@ def _auto_finalize_dirty_worktree(
                 error = f"{error}; git reset failed: {reset_exc}"
             else:
                 if reset_proc.returncode != 0:
-                    error = (
-                        f"{error}; git reset failed: "
-                        f"{_format_process_failure(reset_proc)}"
-                    )
+                    error = f"{error}; git reset failed: {_format_process_failure(reset_proc)}"
                 else:
                     commit_sha = None
         return AutoFinalizeResult(
@@ -975,7 +971,10 @@ def _reap_finished_worktree(worktree: Path) -> dict[str, Any]:
 
 
 def _validate_existing_worktree(
-    *, path: Path, expected_branch: str, base: str,
+    *,
+    path: Path,
+    expected_branch: str,
+    base: str,
 ) -> bool:
     """Validate a reused worktree. Returns True if a rebase occurred.
 
@@ -1048,8 +1047,7 @@ def _validate_existing_worktree(
         return False
 
     print(
-        f"⚠️  worktree {path} is {behind} commit(s) behind {origin_ref}; "
-        f"attempting fast-forward rebase",
+        f"⚠️  worktree {path} is {behind} commit(s) behind {origin_ref}; attempting fast-forward rebase",
         file=sys.stderr,
     )
     rebase_proc = subprocess.run(
@@ -1063,7 +1061,10 @@ def _validate_existing_worktree(
         # Clean up so the worktree isn't left mid-rebase.
         subprocess.run(
             ["git", "rebase", "--abort"],
-            cwd=path, capture_output=True, text=True, check=False,
+            cwd=path,
+            capture_output=True,
+            text=True,
+            check=False,
         )
         raise WorktreeStaleBase(
             f"worktree at {path} is {behind} commit(s) behind {origin_ref} "
@@ -1128,8 +1129,7 @@ def _provision_data_symlinks(worktree_path: Path, main_repo_root: Path) -> None:
 
         if target.parent.exists() and not target.parent.is_dir():
             print(
-                f"⚠️  skipping worktree link because {target.parent} "
-                "is not a directory",
+                f"⚠️  skipping worktree link because {target.parent} is not a directory",
                 file=sys.stderr,
             )
             continue
@@ -1171,7 +1171,9 @@ def _ensure_worktree(
             raise ValueError(f"worktree path exists but is not a directory: {worktree_path}")
         telemetry["reused"] = True
         telemetry["rebased"] = _validate_existing_worktree(
-            path=worktree_path, expected_branch=branch, base=base,
+            path=worktree_path,
+            expected_branch=branch,
+            base=base,
         )
         telemetry["base_sha"] = _resolve_sha(worktree_path)
         # Reused worktrees may predate this provisioning hook; the helper is
@@ -1231,6 +1233,7 @@ def _augment_prompt_with_worktree(prompt: str, worktree_path: Path | None) -> st
 # ---------------------------------------------------------------------------
 # Worker entrypoint — runs inside the detached subprocess
 # ---------------------------------------------------------------------------
+
 
 def _worker_sigterm_handler(_signum, _frame):
     """SIGTERM handler for the worker process.
@@ -1403,9 +1406,7 @@ def _run_worker(
     cancelled = False
     try:
         stdout_silence_timeout = silence_timeout if silence_timeout > 0 else None
-        initial_probe = (
-            initial_response_timeout if initial_response_timeout > 0 else None
-        )
+        initial_probe = initial_response_timeout if initial_response_timeout > 0 else None
         tool_config: dict[str, Any] = {}
         if max_budget_usd is not None:
             tool_config["max_budget_usd"] = max_budget_usd
@@ -1541,35 +1542,37 @@ def _run_worker(
     if substitution is None and isinstance(usage_record, dict):
         substitution = usage_record.get("substitution")
 
-    final_state.update({
-        "model": getattr(result, "model", final_state.get("model")),
-        "effort": getattr(result, "effort", final_state.get("effort")),
-        "cli_version": getattr(result, "cli_version", final_state.get("cli_version")),
-        "substitution": substitution,
-        "status": final_status,
-        "finished_at": datetime.now(UTC).isoformat(),
-        "duration_s": round(duration_s, 3),
-        "response_chars": len(response),
-        "result_file": result_file,
-        "stderr_excerpt": stderr_excerpt,
-        "returncode": returncode,
-        "worktree_dirty_on_exit": dirty_on_exit,
-        "commits_ahead": commits_ahead,
-        "needs_finalize": needs_finalize,
-        "keep_worktree": keep_worktree,
-        "worktree_reap": worktree_reap,
-        "auto_finalize": (
-            {
-                "ok": auto_finalize.ok,
-                "commit_sha": auto_finalize.commit_sha,
-                "pr_url": auto_finalize.pr_url,
-                "error": auto_finalize.error,
-                "changed_files": list(auto_finalize.changed_files),
-            }
-            if auto_finalize is not None
-            else None
-        ),
-    })
+    final_state.update(
+        {
+            "model": getattr(result, "model", final_state.get("model")),
+            "effort": getattr(result, "effort", final_state.get("effort")),
+            "cli_version": getattr(result, "cli_version", final_state.get("cli_version")),
+            "substitution": substitution,
+            "status": final_status,
+            "finished_at": datetime.now(UTC).isoformat(),
+            "duration_s": round(duration_s, 3),
+            "response_chars": len(response),
+            "result_file": result_file,
+            "stderr_excerpt": stderr_excerpt,
+            "returncode": returncode,
+            "worktree_dirty_on_exit": dirty_on_exit,
+            "commits_ahead": commits_ahead,
+            "needs_finalize": needs_finalize,
+            "keep_worktree": keep_worktree,
+            "worktree_reap": worktree_reap,
+            "auto_finalize": (
+                {
+                    "ok": auto_finalize.ok,
+                    "commit_sha": auto_finalize.commit_sha,
+                    "pr_url": auto_finalize.pr_url,
+                    "error": auto_finalize.error,
+                    "changed_files": list(auto_finalize.changed_files),
+                }
+                if auto_finalize is not None
+                else None
+            ),
+        }
+    )
     _write_state_atomic(state_path, final_state)
     _emit_terminal_dispatch_event(
         task_id=task_id,
@@ -1603,6 +1606,7 @@ def _run_worker(
 # Dispatch command — spawn detached worker
 # ---------------------------------------------------------------------------
 
+
 def cmd_dispatch(args: argparse.Namespace) -> int:
     """Spawn a detached worker and return immediately with the task-id."""
     sys.path.insert(0, str(_REPO_ROOT / "scripts"))
@@ -1622,8 +1626,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
 
     if args.cwd and worktree_arg:
         print(
-            "❌ --cwd and --worktree are mutually exclusive. Use --worktree for "
-            "delegated write isolation.",
+            "❌ --cwd and --worktree are mutually exclusive. Use --worktree for delegated write isolation.",
             file=sys.stderr,
         )
         return 2
@@ -1726,11 +1729,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         # Fix 4 (#1476): the sentinel ``auto`` (from bare ``--worktree``)
         # resolves to ``.worktrees/dispatch/{agent}/{task}/``. Explicit
         # paths remain unchanged for back-compat with in-flight dispatches.
-        resolved_raw = (
-            str(_auto_worktree_path(dispatch_agent, task_id))
-            if worktree_arg == "auto"
-            else worktree_arg
-        )
+        resolved_raw = str(_auto_worktree_path(dispatch_agent, task_id)) if worktree_arg == "auto" else worktree_arg
         try:
             worktree_path, worktree_branch, worktree_telemetry = _ensure_worktree(
                 agent=dispatch_agent,
@@ -1820,13 +1819,20 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         python_bin,
         str(Path(__file__).resolve()),
         "_worker",
-        "--task-id", task_id,
-        "--agent", dispatch_agent,
-        "--mode", args.mode,
-        "--cwd", cwd,
-        "--hard-timeout", str(args.hard_timeout),
-        "--silence-timeout", str(silence_timeout),
-        "--initial-response-timeout", str(initial_response_timeout),
+        "--task-id",
+        task_id,
+        "--agent",
+        dispatch_agent,
+        "--mode",
+        args.mode,
+        "--cwd",
+        cwd,
+        "--hard-timeout",
+        str(args.hard_timeout),
+        "--silence-timeout",
+        str(silence_timeout),
+        "--initial-response-timeout",
+        str(initial_response_timeout),
     ]
     if keep_worktree:
         cmd.append("--keep-worktree")
@@ -1875,18 +1881,17 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             # (because zombie detection is gated on `pid and not alive`).
             # Codex 2026-04-10 audit finding.
             failed_state = _read_state(state_path) or initial_state
-            failed_state.update({
-                "status": "failed",
-                "finished_at": datetime.now(UTC).isoformat(),
-                "stderr_excerpt": (
-                    f"Popen failed: {type(exc).__name__}: {exc}"
-                )[:500],
-                "returncode": None,
-            })
+            failed_state.update(
+                {
+                    "status": "failed",
+                    "finished_at": datetime.now(UTC).isoformat(),
+                    "stderr_excerpt": (f"Popen failed: {type(exc).__name__}: {exc}")[:500],
+                    "returncode": None,
+                }
+            )
             _write_state_atomic(state_path, failed_state)
             print(
-                f"❌ failed to spawn worker for {task_id!r}: "
-                f"{type(exc).__name__}: {exc}",
+                f"❌ failed to spawn worker for {task_id!r}: {type(exc).__name__}: {exc}",
                 file=sys.stderr,
             )
             return 1
@@ -1925,6 +1930,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
 # Status command — read state + detect zombies
 # ---------------------------------------------------------------------------
 
+
 def cmd_status(args: argparse.Namespace) -> int:
     state_path = _state_path(args.task_id)
     state = _read_state(state_path)
@@ -1945,19 +1951,17 @@ def cmd_status(args: argparse.Namespace) -> int:
             state["status"] = "crashed"
             state["finished_at"] = datetime.now(UTC).isoformat()
             state["stderr_excerpt"] = (
-                f"worker pid {pid} is not alive but state said "
-                f"{prior_status!r}; marked crashed by status probe"
+                f"worker pid {pid} is not alive but state said {prior_status!r}; marked crashed by status probe"
             )
             _write_state_atomic(state_path, state)
 
     # Elapsed time for still-running tasks
     if state.get("status") == "running" and state.get("started_at"):
         try:
-            started = datetime.fromisoformat(
-                str(state["started_at"]).replace("Z", "+00:00")
-            )
+            started = datetime.fromisoformat(str(state["started_at"]).replace("Z", "+00:00"))
             state["elapsed_s"] = round(
-                (datetime.now(UTC) - started).total_seconds(), 1,
+                (datetime.now(UTC) - started).total_seconds(),
+                1,
             )
         except (ValueError, TypeError):
             pass
@@ -2014,9 +2018,9 @@ def _fetch_monitor_task(task_id: str) -> dict[str, Any] | None:
 
 
 def _fetch_routing_budget() -> dict[str, Any]:
-    url = f"{_monitor_api_base_url()}/api/state/routing-budget"
+    url = f"{_monitor_api_base_url()}/api/state/routing-budget?fresh_codexbar=true"
     try:
-        with urllib.request.urlopen(url, timeout=3) as response:
+        with urllib.request.urlopen(url, timeout=8) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except (OSError, TimeoutError, urllib.error.URLError, json.JSONDecodeError) as exc:
         raise MonitorApiUnavailable(str(exc)) from exc
@@ -2051,14 +2055,28 @@ def _resolve_agent_with_budget_guard(agent: str) -> str:
     agents = payload.get("agents") or {}
     records_loaded = int(diags.get("records_loaded", 0) or 0)
     is_stale = bool(diags.get("stale", False))
+    codexbar_data_available = bool(diags.get("codexbar_data_available", False))
 
-    # empty or no data: suppress hard action + rec warning per constraint (a)
-    if records_loaded == 0 or not agents:
-        print("⚠ ROUTING CHECK: empty snapshot (records_loaded=0) — no primary rec, no hard sub (per design)", file=sys.stderr)
+    # An empty ledger is only unknown when the explicit CodexBar refresh also
+    # yielded no authoritative weekly data. Never quietly fail open here.
+    if not agents or (records_loaded == 0 and not codexbar_data_available):
+        print(
+            "⚠ ROUTING CHECK UNKNOWN: budget UNKNOWN — could not verify CodexBar data; "
+            "lanes may be in deficit; no hard sub.",
+            file=sys.stderr,
+        )
         return requested
 
+    if records_loaded == 0:
+        for warning in rec.get("warnings") or []:
+            if "is in deficit" in str(warning):
+                print(f"⚠ ROUTING CHECK: {warning}; no hard sub (ledger empty).", file=sys.stderr)
+
     if is_stale:
-        print("⚠ ROUTING CHECK ADVISORY (stale snapshot, generatedAt/data age >15min) — verify manually; no hard sub", file=sys.stderr)
+        print(
+            "⚠ ROUTING CHECK ADVISORY (stale snapshot, generatedAt/data age >15min) — verify manually; no hard sub",
+            file=sys.stderr,
+        )
         # Rec warning deliberately suppressed on stale: a recommendation from
         # stale numbers is worse than none (same rationale as the empty case).
     else:
@@ -2079,7 +2097,11 @@ def _resolve_agent_with_budget_guard(agent: str) -> str:
         status = (agent_info.get("interactive") or {}).get("status") or agent_info.get("status")
     else:
         status = agent_info.get("status")
-    burn = agent_info.get("burn_pct_7d") if requested != "claude" else (agent_info.get("interactive") or {}).get("burn_pct_7d") or agent_info.get("burn_pct_7d")
+    burn = (
+        agent_info.get("burn_pct_7d")
+        if requested != "claude"
+        else (agent_info.get("interactive") or {}).get("burn_pct_7d") or agent_info.get("burn_pct_7d")
+    )
 
     if status == "near_cap" and not is_stale and records_loaded > 0:
         fallbacks = _load_dispatch_fallbacks()
@@ -2141,8 +2163,7 @@ def cmd_status_or_fail(args: argparse.Namespace) -> int:
         return 0
 
     print(
-        f"task {args.task_id} is not running "
-        f"(status={status['status']}, age={status['age_s']}s)",
+        f"task {args.task_id} is not running (status={status['status']}, age={status['age_s']}s)",
         file=sys.stderr,
     )
     return 1
@@ -2152,9 +2173,7 @@ def cmd_status_or_fail(args: argparse.Namespace) -> int:
 # Wait command — poll until terminal state or timeout
 # ---------------------------------------------------------------------------
 
-_TERMINAL_STATUSES = frozenset(
-    {"done", "failed", "timeout", "rate_limited", "crashed", "cancelled"}
-)
+_TERMINAL_STATUSES = frozenset({"done", "failed", "timeout", "rate_limited", "crashed", "cancelled"})
 
 
 def cmd_wait(args: argparse.Namespace) -> int:
@@ -2178,8 +2197,7 @@ def cmd_wait(args: argparse.Namespace) -> int:
                 state["status"] = "crashed"
                 state["finished_at"] = datetime.now(UTC).isoformat()
                 state["stderr_excerpt"] = (
-                    f"worker pid {pid} is not alive but state said "
-                    f"{prior_status!r}; marked crashed by wait probe"
+                    f"worker pid {pid} is not alive but state said {prior_status!r}; marked crashed by wait probe"
                 )
                 _write_state_atomic(state_path, state)
 
@@ -2212,6 +2230,7 @@ def cmd_wait(args: argparse.Namespace) -> int:
 # Cancel command — signal the worker
 # ---------------------------------------------------------------------------
 
+
 def cmd_cancel(args: argparse.Namespace) -> int:
     """Send SIGTERM to the worker's PID. Lets the runtime unwind cleanly.
 
@@ -2238,8 +2257,7 @@ def cmd_cancel(args: argparse.Namespace) -> int:
 
     if status not in ("running", "spawning"):
         print(
-            f"❌ task {args.task_id!r} has unexpected status {status!r}; "
-            f"refusing to cancel.",
+            f"❌ task {args.task_id!r} has unexpected status {status!r}; refusing to cancel.",
             file=sys.stderr,
         )
         return 1
@@ -2269,6 +2287,7 @@ def cmd_cancel(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 # List command — show all tasks (for operators)
 # ---------------------------------------------------------------------------
+
 
 def cmd_list(args: argparse.Namespace) -> int:
     _TASKS_DIR.mkdir(parents=True, exist_ok=True)
@@ -2310,9 +2329,7 @@ def cmd_list(args: argparse.Namespace) -> int:
     if flat_tasks:
         print(
             f"⚠️  {len(flat_tasks)} task(s) use the DEPRECATED flat worktree "
-            f"layout: {flat_tasks[:5]}"
-            + (" …" if len(flat_tasks) > 5 else "")
-            + ". New dispatches should use "
+            f"layout: {flat_tasks[:5]}" + (" …" if len(flat_tasks) > 5 else "") + ". New dispatches should use "
             "`.worktrees/dispatch/{agent}/{task}/`.",
             file=sys.stderr,
         )
@@ -2322,6 +2339,7 @@ def cmd_list(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 # _worker command — internal, called by cmd_dispatch's spawned process
 # ---------------------------------------------------------------------------
+
 
 def cmd_worker(args: argparse.Namespace) -> int:
     """Internal entrypoint for the detached worker subprocess."""
@@ -2350,6 +2368,7 @@ def cmd_worker(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 # CLI glue
 # ---------------------------------------------------------------------------
+
 
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
@@ -2394,29 +2413,36 @@ def build_parser() -> argparse.ArgumentParser:
         help="Fire a task, return immediately",
         formatter_class=_dispatch_help_formatter,
     )
-    d.add_argument("--agent", required=True,
-                   choices=list(_DISPATCH_AGENT_CHOICES),
-                   # "qwen" removed from choices (banned agent): advertising it in --help
-                   # while the routing guard rejects it at dispatch is a UX trap. The
-                   # guard still catches programmatic Namespace bypass.
-                   help="Agent to run for the task: codex, gemini, claude, grok (Hermes), "
-                        "grok-build (native grok CLI), deepseek, agy, or cursor.")
-    d.add_argument("--task-id", required=True,
-                   help="Stable task identifier used for state/log files, e.g. review-123.")
+    d.add_argument(
+        "--agent",
+        required=True,
+        choices=list(_DISPATCH_AGENT_CHOICES),
+        # "qwen" removed from choices (banned agent): advertising it in --help
+        # while the routing guard rejects it at dispatch is a UX trap. The
+        # guard still catches programmatic Namespace bypass.
+        help="Agent to run for the task: codex, gemini, claude, grok (Hermes), "
+        "grok-build (native grok CLI), deepseek, agy, or cursor.",
+    )
+    d.add_argument("--task-id", required=True, help="Stable task identifier used for state/log files, e.g. review-123.")
     d.add_argument("--prompt", help="Prompt text, or '-' to read the prompt from stdin.")
     d.add_argument("--prompt-file", help="Read the prompt body from this file path.")
-    d.add_argument("--mode", default="read-only",
-                   choices=["read-only", "workspace-write", "danger"],
-                   help="Runtime mode (default: read-only). workspace-write and danger "
-                        "require a verified dispatch worktree (bare --worktree, or --cwd "
-                        "pointing at an existing added worktree); read-only may run from repo root.")
-    d.add_argument("--model", default=None,
-                   help="Optional model override, e.g. gpt-5.5 or gemini-3.1-pro-preview.")
-    d.add_argument("--provider", default=None,
-                   choices=["openrouter"],
-                   help="Opt-in provider for Hermes-routed agents (e.g. deepseek). "
-                        "Default for DeepSeek is first-party (local-only). "
-                        "Use --provider openrouter for US-residency pinned path.")
+    d.add_argument(
+        "--mode",
+        default="read-only",
+        choices=["read-only", "workspace-write", "danger"],
+        help="Runtime mode (default: read-only). workspace-write and danger "
+        "require a verified dispatch worktree (bare --worktree, or --cwd "
+        "pointing at an existing added worktree); read-only may run from repo root.",
+    )
+    d.add_argument("--model", default=None, help="Optional model override, e.g. gpt-5.5 or gemini-3.1-pro-preview.")
+    d.add_argument(
+        "--provider",
+        default=None,
+        choices=["openrouter"],
+        help="Opt-in provider for Hermes-routed agents (e.g. deepseek). "
+        "Default for DeepSeek is first-party (local-only). "
+        "Use --provider openrouter for US-residency pinned path.",
+    )
     d.add_argument(
         "--effort",
         default=None,
@@ -2431,10 +2457,13 @@ def build_parser() -> argparse.ArgumentParser:
             "See #1396."
         ),
     )
-    d.add_argument("--cwd", default=None,
-                   help="Working directory for the worker (default: repo root). "
-                        "For workspace-write/danger it must be a verified added "
-                        "worktree, never the primary checkout — prefer --worktree.")
+    d.add_argument(
+        "--cwd",
+        default=None,
+        help="Working directory for the worker (default: repo root). "
+        "For workspace-write/danger it must be a verified added "
+        "worktree, never the primary checkout — prefer --worktree.",
+    )
     d.add_argument(
         "--worktree",
         nargs="?",
@@ -2583,10 +2612,8 @@ def build_parser() -> argparse.ArgumentParser:
     # wait
     w = sub.add_parser("wait", help="Block until task reaches terminal state")
     w.add_argument("task_id", help="Task ID to wait for, e.g. review-123.")
-    w.add_argument("--timeout", type=float, default=0,
-                   help="Max wait seconds (0 = forever)")
-    w.add_argument("--poll-interval", type=float, default=2.0,
-                   help="Poll interval seconds (default: 2.0)")
+    w.add_argument("--timeout", type=float, default=0, help="Max wait seconds (0 = forever)")
+    w.add_argument("--poll-interval", type=float, default=2.0, help="Poll interval seconds (default: 2.0)")
     w.set_defaults(func=cmd_wait)
 
     # cancel
@@ -2596,11 +2623,22 @@ def build_parser() -> argparse.ArgumentParser:
 
     # list
     l = sub.add_parser("list", help="List tasks (with optional status filter)")
-    l.add_argument("--status", default=None,
-                   choices=["spawning", "running", "done", "failed",
-                            "timeout", "rate_limited", "crashed", "cancelled",
-                            "needs_finalize"],
-                   help="Optional status filter, e.g. running or failed.")
+    l.add_argument(
+        "--status",
+        default=None,
+        choices=[
+            "spawning",
+            "running",
+            "done",
+            "failed",
+            "timeout",
+            "rate_limited",
+            "crashed",
+            "cancelled",
+            "needs_finalize",
+        ],
+        help="Optional status filter, e.g. running or failed.",
+    )
     l.set_defaults(func=cmd_list)
 
     # _worker (hidden — internal)

--- a/tests/api/test_routing_budget_endpoint.py
+++ b/tests/api/test_routing_budget_endpoint.py
@@ -206,6 +206,62 @@ def test_empty_snapshot_marks_unknown_and_suppresses_rec(monkeypatch, tmp_path):
     assert any(r["lane"] == "codex" and r["type"] == "subscription" for r in ranked)
 
 
+def test_empty_ledger_uses_fresh_codexbar_for_deficit_verdict(monkeypatch, tmp_path):
+    """A guard refresh must retain authoritative deficit data without ledger records."""
+    now = datetime(2026, 7, 9, 16, 13, tzinfo=UTC)
+    _configure(monkeypatch, tmp_path, [])
+    refreshed = {
+        "claude": {
+            "lane": "claude",
+            "primary_used_pct": 10.0,
+            "weekly_used_pct": 74.0,
+            "monthly_cap_usd": None,
+            "monthly_used_usd": None,
+            "weekly_resets_at": "2026-07-13T06:59:59Z",
+            "weekly_pace_delta_pct": 27.0,
+            "will_last_to_reset": False,
+            "pace_summary": "27% in deficit",
+            "source": "codexbar",
+            "fetched_at": "2026-07-09T16:13:00Z",
+            "stale": False,
+            "age_s": 0.0,
+        },
+        "codex": {
+            "lane": "codex",
+            "primary_used_pct": 5.0,
+            "weekly_used_pct": 20.0,
+            "monthly_cap_usd": None,
+            "monthly_used_usd": None,
+            "weekly_resets_at": "2026-07-12T19:26:49Z",
+            "weekly_pace_delta_pct": -30.0,
+            "will_last_to_reset": True,
+            "pace_summary": "30% in reserve",
+            "source": "codexbar",
+            "fetched_at": "2026-07-09T16:13:00Z",
+            "stale": False,
+            "age_s": 0.0,
+        },
+    }
+    monkeypatch.setattr(
+        state_router,
+        "refresh_provider_usage_data",
+        lambda providers: refreshed,
+    )
+    monkeypatch.setattr(
+        state_router,
+        "get_provider_usage_data",
+        lambda provider: {"lane": provider, "weekly_used_pct": None},
+    )
+
+    data = state_router.compute_routing_budget(now, fresh_codexbar=True)
+
+    assert data["diagnostics"]["records_loaded"] == 0
+    assert data["diagnostics"]["codexbar_data_available"] is True
+    assert data["agents"]["claude"]["status"] == "hot"
+    assert data["recommendation"]["primary_agent_for_code"] is not None
+    assert any("lane claude is in deficit" in warning for warning in data["recommendation"]["warnings"])
+
+
 def test_stale_snapshot_downgrades_to_advisory_no_hard(monkeypatch, tmp_path):
     """AC: generated/data >15min → stale=true, advisory in warnings; never hard block."""
     now = datetime(2026, 5, 13, 20, 30, tzinfo=UTC)

--- a/tests/test_delegate_check_budget.py
+++ b/tests/test_delegate_check_budget.py
@@ -211,7 +211,9 @@ def test_check_budget_hard_sub_on_near_cap_fresh(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(
         delegate.urllib.request,
         "urlopen",
-        lambda *_a, **_k: _FakeBudgetResponse("codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False),
+        lambda *_a, **_k: _FakeBudgetResponse(
+            "codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False
+        ),
     )
 
     rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
@@ -230,7 +232,9 @@ def test_check_budget_no_hard_sub_on_stale(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(
         delegate.urllib.request,
         "urlopen",
-        lambda *_a, **_k: _FakeBudgetResponse("codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=3, stale=True),
+        lambda *_a, **_k: _FakeBudgetResponse(
+            "codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=3, stale=True
+        ),
     )
 
     rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
@@ -241,21 +245,61 @@ def test_check_budget_no_hard_sub_on_stale(monkeypatch, tmp_path, capsys):
     assert "HARD AUTO-SUBSTITUTE" not in err
 
 
-def test_check_budget_no_sub_on_empty_snapshot(monkeypatch, tmp_path, capsys):
-    """Empty → no sub, suppressed."""
+def test_check_budget_reports_deficit_from_empty_ledger_codexbar(monkeypatch, tmp_path, capsys):
+    """Empty ledger plus authoritative CodexBar must show the live deficit."""
     _patch_spawn(monkeypatch, tmp_path)
     monkeypatch.setattr(delegate.time, "sleep", lambda _s: None)
     monkeypatch.setattr(
-        delegate.urllib.request,
-        "urlopen",
-        lambda *_a, **_k: _FakeBudgetResponse("codex", empty=True),
+        delegate,
+        "_fetch_routing_budget",
+        lambda: {
+            "recommendation": {
+                "primary_agent_for_code": "codex",
+                "rationale": "Codex has live headroom.",
+                "warnings": ["lane claude is in deficit (27% in deficit)"],
+            },
+            "agents": {"claude": {"status": "hot", "burn_pct_7d": 74.0}},
+            "diagnostics": {
+                "records_loaded": 0,
+                "stale": False,
+                "codexbar_data_available": True,
+            },
+        },
     )
 
     rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
 
     assert rc == 0
     err = capsys.readouterr().err
-    assert "empty snapshot" in err.lower()
+    assert "lane claude is in deficit (27% in deficit)" in err
+    assert "budget UNKNOWN" not in err
+    assert "HARD AUTO-SUBSTITUTE" not in err
+
+
+def test_check_budget_reports_unknown_when_empty_ledger_codexbar_unavailable(monkeypatch, tmp_path, capsys):
+    """A failed guard refresh must be explicit rather than using the old silent empty design."""
+    _patch_spawn(monkeypatch, tmp_path)
+    monkeypatch.setattr(delegate.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(
+        delegate,
+        "_fetch_routing_budget",
+        lambda: {
+            "recommendation": {"primary_agent_for_code": None, "warnings": []},
+            "agents": {"claude": {"status": "unknown", "burn_pct_7d": None}},
+            "diagnostics": {
+                "records_loaded": 0,
+                "stale": False,
+                "codexbar_data_available": False,
+            },
+        },
+    )
+
+    rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "budget UNKNOWN — could not verify CodexBar data; lanes may be in deficit" in err
+    assert "per design" not in err
     assert "HARD AUTO-SUBSTITUTE" not in err
 
 
@@ -267,7 +311,9 @@ def test_check_budget_no_hard_sub_without_yaml_mapping(monkeypatch, tmp_path, ca
     monkeypatch.setattr(
         delegate.urllib.request,
         "urlopen",
-        lambda *_a, **_k: _FakeBudgetResponse("codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False),
+        lambda *_a, **_k: _FakeBudgetResponse(
+            "codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False
+        ),
     )
 
     rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))
@@ -284,7 +330,9 @@ def test_check_budget_hard_sub_ignores_unknown_fallback_target(monkeypatch, tmp_
     monkeypatch.setattr(
         delegate.urllib.request,
         "urlopen",
-        lambda *_a, **_k: _FakeBudgetResponse("codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False),
+        lambda *_a, **_k: _FakeBudgetResponse(
+            "codex", status_for_agent="claude", burn_for_agent=95.0, records_loaded=10, stale=False
+        ),
     )
 
     rc = delegate.cmd_dispatch(_dispatch_args("--check-budget"))


### PR DESCRIPTION
Refs #4824

## Root cause

`cmd_dispatch()` executes the budget guard before its dry-run return (`scripts/delegate.py:1697-1703`). The guard queried the ordinary routing endpoint (`scripts/delegate.py:2020-2027`) and then returned immediately whenever `records_loaded == 0` (`scripts/delegate.py:2053-2068`), so it never surfaced any CodexBar overlay verdict.

That was compounded by two upstream behaviors:

- `get_provider_usage_data()` starts only a background refresh on cache miss and returns an all-unknown record immediately (`scripts/api/codexbar_usage.py:280-327`); its cached state is process-local (`:30-33`).
- `_recommend_agent()` previously suppressed a recommendation solely because the USD ledger was empty (`scripts/api/state_router.py:294-319`), even if the authoritative overlay had already populated lanes.

## Fix

- Added a guard-only parallel synchronous refresh with a 2-second timeout per provider. It stores normalized results in the existing cache; the normal cache-only endpoint path remains unchanged (`scripts/api/codexbar_usage.py:36-65`, `scripts/api/state_router.py:615-623`).
- `delegate --check-budget` requests `?fresh_codexbar=true` with an 8-second bounded HTTP timeout; ordinary `/routing-budget` remains nonblocking unless that explicit query is set (`scripts/delegate.py:2020-2027`, `scripts/api/state_router.py:816-819`).
- Empty-ledger recommendation suppression now applies only when no CodexBar weekly data was available (`scripts/api/state_router.py:744-752`). The guard prints real deficit warnings when live overlay data exists and `budget UNKNOWN — could not verify CodexBar data; lanes may be in deficit` otherwise; neither branch hard-substitutes (`scripts/delegate.py:2060-2073`).
- The provider-specific normalizer was not changed.

## Fresh-process verification

Fresh local server endpoint confirmed the branch took the synchronous route with no ledger records:

```text
{"codex": {"fetched_at": "2026-07-09T19:13:38.113045Z", "monthly_cap_usd": null, "monthly_used_usd": null, "pace_summary": "6% in deficit | Expected 57% used | Runs out in 2d 8h", "primary_used_pct": 3.0, "stale": false, "weekly_pace_delta_pct": 6.0, "weekly_resets_at": "2026-07-12T19:26:00Z", "weekly_used_pct": 63.0, "will_last_to_reset": false}, "diagnostics": {"codexbar_data_available": true, "data_age_s": null, "fresh_codexbar_requested": true, "missing_cost_records": 0, "records_loaded": 0, "reset_imminent_hours": 6, "stale": false, "stale_threshold_s": 900, "window_start": "2026-07-02T19:13:37.065648Z"}}
```

Then a fresh `delegate.py` process exercised the actual dry-run guard path:

```text
$ DELEGATE_MONITOR_API=http://127.0.0.1:8768 .venv/bin/python scripts/delegate.py dispatch --agent agy --task-id probe-verify --prompt x --dry-run --check-budget
⚠ ROUTING CHECK: lane codex is in deficit (6% in deficit | Expected 57% used | Runs out in 2d 8h); no hard sub (ledger empty).
⚠ ROUTING CHECK: lane cursor is in deficit (5.2% pace delta | Expected 27.0% used); no hard sub (ledger empty).
probe-verify
⚠ ROUTING WARNING: budget recommends --agent claude, you passed --agent agy.
Rationale: Claude agentic pool is active and cool; drain the separate monthly pool first.
```

## Verification

```text
$ .venv/bin/python -m pytest tests/api/ tests/test_codexbar_usage.py -q
============================== 23 passed in 1.09s ==============================

$ .venv/bin/python -m pytest tests/test_delegate_check_budget.py -q
============================== 11 passed in 0.15s ==============================

$ .venv/bin/ruff check scripts/api/codexbar_usage.py scripts/api/state_router.py scripts/delegate.py tests/api/test_routing_budget_endpoint.py tests/test_delegate_check_budget.py
All checks passed!

$ .venv/bin/ruff format --check scripts/api/codexbar_usage.py scripts/api/state_router.py scripts/delegate.py tests/api/test_routing_budget_endpoint.py tests/test_delegate_check_budget.py
5 files already formatted

$ git diff --check
```

The commit hook additionally ran 131 affected tests successfully and passed ruff plus gitleaks.

## Review handoff

No auto-merge is armed. AGY, Hermes, and Cursor cross-family review invocations returned no substantive finding/result in this session; the orchestrator should obtain the required independent cross-family review before merging.
