### PR TITLE
fix(audit): share seminar wiki write-domain resolution

### DIFF
--- a/scripts/audit/track_deterministic_audit.py
+++ b/scripts/audit/track_deterministic_audit.py
@@ -35,12 +35,11 @@ from audit.check_no_internal_ids import (
 from audit.checks.yaml_schema_validation import validate_activity_yaml_file
 from audit.content_surface_gates import scan_module_surface
 from manifest_utils import get_modules_for_level
-from wiki.config import TRACK_WRITE_DOMAIN
+from wiki.domains import resolve_write_domain
 
 CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
 SITE_DOCS_ROOT = PROJECT_ROOT / "site" / "src" / "content" / "docs"
 SITE_READINGS_ROOT = PROJECT_ROOT / "site" / "src" / "content" / "readings"
-WIKI_GRAMMAR_ROOT = PROJECT_ROOT / "wiki" / "grammar"
 DEFAULT_CONFIG = PROJECT_ROOT / "scripts" / "audit" / "track_deterministic_audit_config.yaml"
 VENV_PYTHON = PROJECT_ROOT / ".venv" / "bin" / "python"
 
@@ -193,13 +192,7 @@ def parse_slug_filter(values: list[str] | None) -> set[str] | None:
 def module_paths(track: str, module: Any) -> ModulePaths:
     slug = module.slug
     module_dir = CURRICULUM_ROOT / track / slug
-    if track in TRACK_WRITE_DOMAIN:
-        wiki_root = PROJECT_ROOT / "wiki" / TRACK_WRITE_DOMAIN[track]
-    else:
-        # Fallback for tracks NOT in TRACK_WRITE_DOMAIN (seminars use per-slug _get_domain() logic in scripts/wiki/compile.py):
-        # keep current grammar/{track} behavior UNCHANGED but leave a short comment noting seminar tracks need per-slug domain
-        # resolution at their deterministic-audit rollout.
-        wiki_root = WIKI_GRAMMAR_ROOT / track
+    wiki_root = PROJECT_ROOT / "wiki" / resolve_write_domain(track, slug)
     return ModulePaths(
         track=track,
         module_num=int(module.local_num),

--- a/scripts/wiki/compile.py
+++ b/scripts/wiki/compile.py
@@ -78,6 +78,7 @@ def _ts() -> str:
 from validate.check_wiki_verify_markers import find_verify_markers_text
 from wiki.compiler import WRITER_CHOICES, compile_article, update_index
 from wiki.config import ALL_TRACKS, CURRICULUM_DIR, TRACK_DOMAINS, WIKI_DIR
+from wiki.domains import resolve_write_domain
 from wiki.enrichment import enrich_sources
 from wiki.sources import (
     gather_discovery_sources,
@@ -93,55 +94,6 @@ from wiki.sources_schema import (
     validate_sources_registry,
 )
 from wiki.state import log_event, read_log
-
-# ── Domain mapping: how to group discovery slugs into wiki articles ──
-
-# For FOLK, each discovery slug maps directly to a wiki article
-# For other tracks, we may want to group multiple slugs into one article
-FOLK_DOMAIN_MAP: dict[str, str] = {
-    "narodna-kultura-yak-systema": "folk/overview",
-    # narodni-viruvannia-mifolohiia-demonolohiia + zamovliannia-zaklynannia-prymovky CUT 2026-06-25
-    # (folk reset — demonology/occult/spell-craft framing, no school-canon basis; FOLK-FRAMING-STANDARD.md)
-    "kalendarna-obriadovist-zvychai": "folk/ritual",
-    "koliadky-shchedrivky": "folk/ritual",
-    "vesnianky-hayivky": "folk/ritual",
-    "kupalski-rusalni-pisni": "folk/ritual",
-    "zhnyvarski-obzhynkovi-pisni": "folk/ritual",
-    "rodynna-obriadovist-zvychai": "folk/ritual",
-    "vesilni-pisni": "folk/ritual",
-    "holosinnya": "folk/ritual",
-    "dumy-nevilnytski-lytsarski": "folk/genres",
-    "bylyny-kyivskoho-tsyklu": "folk/genres",
-    "dumy-sotsialno-pobutovi": "folk/genres",
-    "kobzarstvo-lirnytstvo": "folk/genres",
-    "istorychni-pisni": "folk/historical",
-    "striletski-povstanski-pisni": "folk/historical",
-    "rodynno-pobutovi-pisni": "folk/lyric",
-    "kolomyiky": "folk/lyric",
-    "suspilno-pobutovi-pisni": "folk/lyric",
-    "narodni-balady": "folk/lyric",
-    "pisni-literaturnoho-pokhodzhennia": "folk/lyric",
-    "charivni-kazky": "folk/prose",
-    "kazky-pro-tvaryn": "folk/prose",
-    "sotsialno-pobutovi-kazky": "folk/prose",
-    "narodni-lehendy": "folk/prose",
-    "istorychni-perekazy": "folk/prose",
-    "narodni-opovidannia-buvalshchyny-memoraty": "folk/prose",
-    "prykazky-ta-pryslivia": "folk/short-forms",
-    "zahadky": "folk/short-forms",
-    "narodni-anekdoty": "folk/short-forms",
-    "dytiachyi-folklor-kolyskovi": "folk/short-forms",
-    "vertep-narodna-drama": "folk/performance",
-    "narodni-muzychni-instrumenty": "folk/performance",
-    "narodni-tantsi": "folk/performance",
-    "pysankarstvo": "folk/material",
-    "narodna-vyshyvka-rushnyk-strii": "folk/material",
-    "narodni-remesla-ta-khudozhni-promysly": "folk/material",
-    "narodne-zhytlo-sadyba-hospodarstvo": "folk/material",
-    "narodna-kukhnia-obriadova-yizha": "folk/material",
-    "rehionalni-etnokulturni-tradytsii": "folk/synthesis",
-    "narodna-kultura-ta-vysoka-kultura-mistky": "folk/synthesis",
-}
 
 
 def cmd_log(*, track: str | None = None) -> None:
@@ -808,35 +760,7 @@ def cmd_compile_all(track: str, *, limit: int | None = None,
 
 def _get_domain(track: str, slug: str) -> str:
     """Get the wiki domain path for a module slug."""
-    from wiki.config import TRACK_WRITE_DOMAIN
-
-    # Core levels have a direct mapping
-    if track in TRACK_WRITE_DOMAIN:
-        return TRACK_WRITE_DOMAIN[track]
-
-    # FOLK has per-slug subdomain mapping
-    if track == "folk":
-        return FOLK_DOMAIN_MAP.get(slug, "folk")
-
-    # Seminar tracks
-    domain_map = {
-        "hist": "periods",
-        "bio": "figures",
-        "istorio": "historiography",
-        "lit": "literature/works",
-        "lit-essay": "literature/works",
-        "lit-war": "literature/works",
-        "lit-hist-fic": "literature/works",
-        "lit-youth": "literature/works",
-        "lit-fantastika": "literature/works",
-        "lit-humor": "literature/works",
-        "lit-drama": "literature/works",
-        # lit-doc and lit-crimea were merged into other lit-* tracks; no longer
-        # exist in curriculum.yaml. Removed from compile config 2026-04-27.
-        "oes": "linguistics/oes",
-        "ruth": "linguistics/ruthenian",
-    }
-    return domain_map.get(track, track)
+    return resolve_write_domain(track, slug)
 
 
 def _existing_article_paths(track: str, *, slug: str | None = None) -> list[Path]:

--- a/scripts/wiki/domains.py
+++ b/scripts/wiki/domains.py
@@ -1,0 +1,82 @@
+"""Pure write-domain resolution for compiled wiki articles."""
+
+from __future__ import annotations
+
+from wiki.config import TRACK_WRITE_DOMAIN
+
+# FOLK uses per-slug subdomains instead of a single track-wide write domain.
+FOLK_DOMAIN_MAP: dict[str, str] = {
+    "narodna-kultura-yak-systema": "folk/overview",
+    # narodni-viruvannia-mifolohiia-demonolohiia + zamovliannia-zaklynannia-prymovky CUT 2026-06-25
+    # (folk reset - demonology/occult/spell-craft framing, no school-canon basis; FOLK-FRAMING-STANDARD.md)
+    "kalendarna-obriadovist-zvychai": "folk/ritual",
+    "koliadky-shchedrivky": "folk/ritual",
+    "vesnianky-hayivky": "folk/ritual",
+    "kupalski-rusalni-pisni": "folk/ritual",
+    "zhnyvarski-obzhynkovi-pisni": "folk/ritual",
+    "rodynna-obriadovist-zvychai": "folk/ritual",
+    "vesilni-pisni": "folk/ritual",
+    "holosinnya": "folk/ritual",
+    "dumy-nevilnytski-lytsarski": "folk/genres",
+    "bylyny-kyivskoho-tsyklu": "folk/genres",
+    "dumy-sotsialno-pobutovi": "folk/genres",
+    "kobzarstvo-lirnytstvo": "folk/genres",
+    "istorychni-pisni": "folk/historical",
+    "striletski-povstanski-pisni": "folk/historical",
+    "rodynno-pobutovi-pisni": "folk/lyric",
+    "kolomyiky": "folk/lyric",
+    "suspilno-pobutovi-pisni": "folk/lyric",
+    "narodni-balady": "folk/lyric",
+    "pisni-literaturnoho-pokhodzhennia": "folk/lyric",
+    "charivni-kazky": "folk/prose",
+    "kazky-pro-tvaryn": "folk/prose",
+    "sotsialno-pobutovi-kazky": "folk/prose",
+    "narodni-lehendy": "folk/prose",
+    "istorychni-perekazy": "folk/prose",
+    "narodni-opovidannia-buvalshchyny-memoraty": "folk/prose",
+    "prykazky-ta-pryslivia": "folk/short-forms",
+    "zahadky": "folk/short-forms",
+    "narodni-anekdoty": "folk/short-forms",
+    "dytiachyi-folklor-kolyskovi": "folk/short-forms",
+    "vertep-narodna-drama": "folk/performance",
+    "narodni-muzychni-instrumenty": "folk/performance",
+    "narodni-tantsi": "folk/performance",
+    "pysankarstvo": "folk/material",
+    "narodna-vyshyvka-rushnyk-strii": "folk/material",
+    "narodni-remesla-ta-khudozhni-promysly": "folk/material",
+    "narodne-zhytlo-sadyba-hospodarstvo": "folk/material",
+    "narodna-kukhnia-obriadova-yizha": "folk/material",
+    "rehionalni-etnokulturni-tradytsii": "folk/synthesis",
+    "narodna-kultura-ta-vysoka-kultura-mistky": "folk/synthesis",
+}
+
+SEMINAR_TRACK_DOMAIN_MAP: dict[str, str] = {
+    "hist": "periods",
+    "bio": "figures",
+    "istorio": "historiography",
+    "lit": "literature/works",
+    "lit-essay": "literature/works",
+    "lit-war": "literature/works",
+    "lit-hist-fic": "literature/works",
+    "lit-youth": "literature/works",
+    "lit-fantastika": "literature/works",
+    "lit-humor": "literature/works",
+    "lit-drama": "literature/works",
+    # lit-doc and lit-crimea were merged into other lit-* tracks; no longer
+    # exist in curriculum.yaml. Removed from compile config 2026-04-27.
+    "oes": "linguistics/oes",
+    "ruth": "linguistics/ruthenian",
+}
+
+
+def resolve_write_domain(track: str, slug: str) -> str:
+    """Return the wiki write domain for a track/slug pair."""
+    track_key = track.strip().lower()
+
+    if track_key in TRACK_WRITE_DOMAIN:
+        return TRACK_WRITE_DOMAIN[track_key]
+
+    if track_key == "folk":
+        return FOLK_DOMAIN_MAP.get(slug, "folk")
+
+    return SEMINAR_TRACK_DOMAIN_MAP.get(track_key, track)

--- a/tests/audit/test_track_deterministic_audit.py
+++ b/tests/audit/test_track_deterministic_audit.py
@@ -56,7 +56,6 @@ def patch_roots(monkeypatch, root: Path) -> None:
     monkeypatch.setattr(audit, "CURRICULUM_ROOT", root / "curriculum" / "l2-uk-en")
     monkeypatch.setattr(audit, "SITE_DOCS_ROOT", root / "site" / "src" / "content" / "docs")
     monkeypatch.setattr(audit, "SITE_READINGS_ROOT", root / "site" / "src" / "content" / "readings")
-    monkeypatch.setattr(audit, "WIKI_GRAMMAR_ROOT", root / "wiki" / "grammar")
     monkeypatch.setattr(
         audit,
         "get_modules_for_level",
@@ -181,11 +180,29 @@ def test_module_paths_wiki_resolution() -> None:
     assert "wiki/grammar/b1/aspect.md" in b1_paths.wiki.as_posix()
     assert "wiki/grammar/b1/aspect.sources.yaml" in b1_paths.wiki_sources.as_posix()
 
-    # 3. Unmapped track should fall back to grammar/track
+    # 3. Seminar tracks should use the compiler's track-aware write domains
+    bio_module = DummyModule("oleksandr-bilash", "Oleksandr Bilash", "bio", 1)
+    bio_paths = audit.module_paths("bio", bio_module)
+    assert "wiki/figures/oleksandr-bilash.md" in bio_paths.wiki.as_posix()
+    assert "wiki/figures/oleksandr-bilash.sources.yaml" in bio_paths.wiki_sources.as_posix()
+    assert "wiki/grammar/bio" not in bio_paths.wiki.as_posix()
+    assert "wiki/grammar/bio" not in bio_paths.wiki_sources.as_posix()
+
+    hist_module = DummyModule("kyivan-rus", "Kyivan Rus", "hist", 1)
+    hist_paths = audit.module_paths("hist", hist_module)
+    assert "wiki/periods/kyivan-rus.md" in hist_paths.wiki.as_posix()
+    assert "wiki/periods/kyivan-rus.sources.yaml" in hist_paths.wiki_sources.as_posix()
+
+    folk_module = DummyModule("koliadky-shchedrivky", "Koliadky", "folk", 1)
+    folk_paths = audit.module_paths("folk", folk_module)
+    assert "wiki/folk/ritual/koliadky-shchedrivky.md" in folk_paths.wiki.as_posix()
+    assert "wiki/folk/ritual/koliadky-shchedrivky.sources.yaml" in folk_paths.wiki_sources.as_posix()
+
+    # 4. Unknown tracks preserve the compiler fallback domain.
     unmapped_module = DummyModule("topic", "Topic", "unknown-track", 1)
     unmapped_paths = audit.module_paths("unknown-track", unmapped_module)
-    assert "wiki/grammar/unknown-track/topic.md" in unmapped_paths.wiki.as_posix()
-    assert "wiki/grammar/unknown-track/topic.sources.yaml" in unmapped_paths.wiki_sources.as_posix()
+    assert "wiki/unknown-track/topic.md" in unmapped_paths.wiki.as_posix()
+    assert "wiki/unknown-track/topic.sources.yaml" in unmapped_paths.wiki_sources.as_posix()
 
 
 def test_a1_config_requires_wiki_like_b2() -> None:

--- a/tests/test_wiki_domains.py
+++ b/tests/test_wiki_domains.py
@@ -1,0 +1,36 @@
+"""Tests for shared wiki write-domain resolution."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from wiki.compile import _get_domain
+from wiki.domains import resolve_write_domain
+
+
+def test_resolve_write_domain_preserves_core_domains() -> None:
+    assert resolve_write_domain("a1", "greeting") == "pedagogy/a1"
+    assert resolve_write_domain("b1", "aspect") == "grammar/b1"
+
+
+def test_resolve_write_domain_uses_seminar_track_domains() -> None:
+    assert resolve_write_domain("BIO", "oleksandr-bilash") == "figures"
+    assert resolve_write_domain("hist", "kyivan-rus") == "periods"
+    assert resolve_write_domain("istorio", "debate") == "historiography"
+    assert resolve_write_domain("lit-war", "poetry") == "literature/works"
+
+
+def test_resolve_write_domain_uses_folk_slug_subdomains() -> None:
+    assert resolve_write_domain("folk", "koliadky-shchedrivky") == "folk/ritual"
+    assert resolve_write_domain("folk", "prykazky-ta-pryslivia") == "folk/short-forms"
+    assert resolve_write_domain("folk", "unmapped-folk-topic") == "folk"
+
+
+def test_get_domain_is_compatibility_wrapper() -> None:
+    assert _get_domain("bio", "oleksandr-bilash") == resolve_write_domain("bio", "oleksandr-bilash")
+    assert _get_domain("folk", "koliadky-shchedrivky") == resolve_write_domain("folk", "koliadky-shchedrivky")


### PR DESCRIPTION
## What

- extract the wiki write-domain resolver into a pure shared helper
- make the deterministic audit use the same per-track/per-slug destination as the compiler
- preserve compiler compatibility through `_get_domain()`
- add direct coverage for BIO, HIST, FOLK, core, and unknown-track paths

## Why

BIO wiki artifacts live under `wiki/figures/<slug>`, but the deterministic audit previously looked under `wiki/grammar/bio/<slug>`. That false path made the readiness gate unreliable. The fix removes the duplicated resolver logic while keeping `wiki.config.TRACK_WRITE_DOMAIN` as the canonical core mapping.

## Verification

- `.venv/bin/python -m pytest -q tests/test_wiki_domains.py tests/audit/test_track_deterministic_audit.py` — 11 passed
- `.venv/bin/ruff check ...` — passed
- BIO smoke: `track_deterministic_audit.py --track bio --slugs oleksandr-bilash --format json --fail-on never` — 0 findings
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- `git diff --check origin/main...HEAD` — passed
- mandatory protected-file/artifact checks — passed

Fixes #4435