### PR TITLE
fix(telemetry): record dispatched model (registry default) for codex, not config.toml

### DIFF
--- a/scripts/agent_runtime/telemetry.py
+++ b/scripts/agent_runtime/telemetry.py
@@ -16,6 +16,7 @@ used by ``delegate.py dispatch`` so the task state file already contains the
 fields while the task is still spawning/running. The worker backfills the
 runtime-resolved values on completion.
 """
+
 from __future__ import annotations
 
 import contextlib
@@ -179,6 +180,16 @@ def _resolve_model_from_defaults(agent_name: str, requested_model: str | None) -
     if requested_model:
         return requested_model
     if agent_name == "codex":
+        # The codex adapter ALWAYS passes an explicit ``-m {registry default}``
+        # when no override is given (adapters/codex.py::build_invocation), so
+        # the registry — not ~/.codex/config.toml — is what actually runs.
+        # Recording the user's config.toml model here mislabeled dispatches
+        # (observed 2026-07-09: state file said gpt-5.6-sol while the CLI ran
+        # -m gpt-5.6-terra). config.toml remains correct for EFFORT, where the
+        # adapter genuinely falls through.
+        registry_default = _default_model_for(agent_name)
+        if registry_default:
+            return registry_default
         value = _codex_config().get("model")
         return str(value).strip() if isinstance(value, str) and str(value).strip() else None
     if agent_name == "gemini":

--- a/tests/test_dispatch_telemetry.py
+++ b/tests/test_dispatch_telemetry.py
@@ -19,12 +19,17 @@ from agent_runtime.telemetry import (
 from agent_runtime.usage import _reset_rate_limit_cache_for_tests
 
 
-def test_resolve_dispatch_start_telemetry_uses_codex_config(tmp_path, monkeypatch):
+def test_resolve_dispatch_start_telemetry_codex_model_from_registry_effort_from_config(tmp_path, monkeypatch):
+    """Model must record what the adapter actually sends (registry default),
+    NOT the user's config.toml — the adapter always passes an explicit ``-m``.
+    Effort genuinely falls through to config.toml, so it stays config-sourced.
+    Regression: 2026-07-09 state files recorded config.toml's gpt-5.6-sol while
+    the CLI ran -m gpt-5.6-terra."""
     home = tmp_path / "home"
     codex_dir = home / ".codex"
     codex_dir.mkdir(parents=True)
     (codex_dir / "config.toml").write_text(
-        'model = "gpt-5.5"\nmodel_reasoning_effort = "high"\n',
+        'model = "gpt-5.6-sol"\nmodel_reasoning_effort = "high"\n',
         encoding="utf-8",
     )
     monkeypatch.setattr("agent_runtime.telemetry.Path.home", lambda: home)
@@ -36,9 +41,29 @@ def test_resolve_dispatch_start_telemetry_uses_codex_config(tmp_path, monkeypatc
             requested_effort=None,
         )
 
-    assert telemetry.model == "gpt-5.5"
-    assert telemetry.effort == "high"
+    from agent_runtime.registry import AGENTS
+
+    assert telemetry.model == AGENTS["codex"]["default_model"]  # what -m actually sends
+    assert telemetry.model != "gpt-5.6-sol"  # never the config.toml value
+    assert telemetry.effort == "high"  # effort DOES fall through to config.toml
     assert telemetry.cli_version == "0.123.0"
+
+
+def test_resolve_dispatch_start_telemetry_codex_explicit_model_wins(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    (home / ".codex").mkdir(parents=True)
+    (home / ".codex" / "config.toml").write_text('model = "gpt-5.6-sol"\n', encoding="utf-8")
+    monkeypatch.setattr("agent_runtime.telemetry.Path.home", lambda: home)
+
+    with patch("agent_runtime.telemetry.codex_cli_version", return_value="0.123.0"):
+        telemetry = resolve_dispatch_start_telemetry(
+            agent_name="codex",
+            requested_model="gpt-5.6-luna",
+            requested_effort="medium",
+        )
+
+    assert telemetry.model == "gpt-5.6-luna"
+    assert telemetry.effort == "medium"
 
 
 def test_resolve_invocation_telemetry_reads_claude_plan_flags():
@@ -94,21 +119,29 @@ def test_runner_invoke_returns_resolved_telemetry(tmp_path):
     fake_proc.returncode = 0
     fake_proc.stdin = None
 
-    with patch("agent_runtime.runner._load_adapter", return_value=spy_adapter), patch(
-        "agent_runtime.runner.has_headroom",
-        return_value=(True, ""),
-    ), patch("agent_runtime.runner.write_record"), patch(
-        "agent_runtime.runner.subprocess.Popen",
-        return_value=fake_proc,
-    ), patch(
-        "agent_runtime.runner.start_watchdog",
-        return_value=(MagicMock(stdout_lines=[], stderr_lines=[]), []),
-    ), patch("agent_runtime.runner.stop_watchdog"), patch(
-        "agent_runtime.runner.resolve_invocation_telemetry",
-        return_value=runner_mod.InvocationTelemetry(
-            model="gpt-5.5",
-            effort="high",
-            cli_version="0.123.0",
+    with (
+        patch("agent_runtime.runner._load_adapter", return_value=spy_adapter),
+        patch(
+            "agent_runtime.runner.has_headroom",
+            return_value=(True, ""),
+        ),
+        patch("agent_runtime.runner.write_record"),
+        patch(
+            "agent_runtime.runner.subprocess.Popen",
+            return_value=fake_proc,
+        ),
+        patch(
+            "agent_runtime.runner.start_watchdog",
+            return_value=(MagicMock(stdout_lines=[], stderr_lines=[]), []),
+        ),
+        patch("agent_runtime.runner.stop_watchdog"),
+        patch(
+            "agent_runtime.runner.resolve_invocation_telemetry",
+            return_value=runner_mod.InvocationTelemetry(
+                model="gpt-5.5",
+                effort="high",
+                cli_version="0.123.0",
+            ),
         ),
     ):
         result = invoke(
@@ -164,21 +197,29 @@ def test_runner_usage_record_includes_correlation_ids_without_prompt_change(
         captured_env.update(kwargs.get("env") or {})
         return fake_proc
 
-    with patch("agent_runtime.runner._load_adapter", return_value=spy_adapter), patch(
-        "agent_runtime.runner.has_headroom",
-        return_value=(True, ""),
-    ), patch("agent_runtime.runner.write_record", side_effect=captured_records.append), patch(
-        "agent_runtime.runner.subprocess.Popen",
-        side_effect=fake_popen,
-    ), patch(
-        "agent_runtime.runner.start_watchdog",
-        return_value=(MagicMock(stdout_lines=[], stderr_lines=[]), []),
-    ), patch("agent_runtime.runner.stop_watchdog"), patch(
-        "agent_runtime.runner.resolve_invocation_telemetry",
-        return_value=runner_mod.InvocationTelemetry(
-            model="gpt-5.5",
-            effort="high",
-            cli_version="0.123.0",
+    with (
+        patch("agent_runtime.runner._load_adapter", return_value=spy_adapter),
+        patch(
+            "agent_runtime.runner.has_headroom",
+            return_value=(True, ""),
+        ),
+        patch("agent_runtime.runner.write_record", side_effect=captured_records.append),
+        patch(
+            "agent_runtime.runner.subprocess.Popen",
+            side_effect=fake_popen,
+        ),
+        patch(
+            "agent_runtime.runner.start_watchdog",
+            return_value=(MagicMock(stdout_lines=[], stderr_lines=[]), []),
+        ),
+        patch("agent_runtime.runner.stop_watchdog"),
+        patch(
+            "agent_runtime.runner.resolve_invocation_telemetry",
+            return_value=runner_mod.InvocationTelemetry(
+                model="gpt-5.5",
+                effort="high",
+                cli_version="0.123.0",
+            ),
         ),
     ):
         result = invoke(


### PR DESCRIPTION
start-telemetry probed ~/.codex/config.toml for the codex model, but the adapter ALWAYS passes an explicit `-m {registry default}` — so state files recorded whatever the user's interactive config said. Masked while both said gpt-5.5; exposed today when the user's config moved to `gpt-5.6-sol` while dispatches actually ran `-m gpt-5.6-terra` (observed: batch_state/tasks/bridge-ask-fixes.json said sol; invocation plan sends terra).

Fix: registry default wins for codex model telemetry (config.toml only as last resort); effort keeps config.toml sourcing — the adapter genuinely falls through for effort. Completion-time telemetry was already correct (reads the plan's -m); this fixes the start/running window.

Tests: rewrote the config-probe test to pin the new contract (registry model + config effort) + explicit-override test. 107 passed (tests/test_dispatch_telemetry.py + tests/test_delegate.py); ruff clean.

Refs #4837 (item 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)