### PR TITLE
feat(audit): add fail-closed BIO readiness ledger

### DIFF
--- a/curriculum/l2-uk-en/bio/promotion-evidence.yaml
+++ b/curriculum/l2-uk-en/bio/promotion-evidence.yaml
@@ -1,0 +1,33 @@
+---
+# Sparse, reviewed manual evidence for the live BIO promotion ledger.
+# Absence is deliberately reported as unknown; do not copy structural checks here.
+version: 1
+entries:
+  andrii-malyshko:
+    corpus_hammer:
+      status: pass
+      reviewer_family: mixed
+      date: 2026-07-09
+      evidence_url: https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4836#issuecomment-4929585737
+  oleksandr-bilash:
+    corpus_hammer:
+      status: pass
+      reviewer_family: claude
+      date: 2026-07-09
+      evidence_url: https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4836#issuecomment-4929529011
+    independent_content_review:
+      status: pass
+      reviewer_family: claude
+      date: 2026-07-09
+      evidence_url: https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4836#issuecomment-4929529011
+  platon-maiboroda:
+    corpus_hammer:
+      status: pass
+      reviewer_family: claude
+      date: 2026-07-09
+      evidence_url: https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4836#issuecomment-4929658808
+    independent_content_review:
+      status: pass
+      reviewer_family: claude
+      date: 2026-07-09
+      evidence_url: https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/4836#issuecomment-4929658808

--- a/docs/prompts/orchestrators/bio/suite-orchestrator.md
+++ b/docs/prompts/orchestrators/bio/suite-orchestrator.md
@@ -6,7 +6,7 @@ Last reviewed: 2026-07-04
 ## Source Assumptions
 
 - BIO is a seminar biography track, not C1 core. It uses source-tier dossiers, decolonization review, portrait/image-rights rules, politically charged biography framing, and human-centered narrative prose.
-- **SSOT module ordering / slugs:** `curriculum/l2-uk-en/curriculum.yaml` (`levels.bio.modules`, 387 slugs). The 2026-06-29 expansion appended **+77 new slugs** (`modules[310:387]`) in six groups; roster framing lives in `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md`, surface inventory in `docs/audits/bio-readiness-matrix-2026-06-29.md`.
+- **SSOT module ordering / slugs:** `curriculum/l2-uk-en/curriculum.yaml` (`levels.bio.modules`; derive the live count from the manifest). The 2026-06-29 expansion is historical context only; roster framing lives in `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md`, surface inventory in `docs/audits/bio-readiness-matrix-2026-06-29.md`.
 - The 130/180-figure appendix in `docs/audits/bio-track-gap-audit-2026-05-26.md` covers the original roster only; do not treat it as the SSOT for +77.
 - Current source surfaces include `curriculum/l2-uk-en/plans/bio/*.yaml`, `docs/research/bio/*.md`, `wiki/figures/*.md`, `wiki/figures/*.sources.yaml`, `curriculum/l2-uk-en/bio/<slug>/`, generated site BIO pages, BIO audits, and BIO best-practice docs.
 - Every production module needs primary-voice readings where available: autobiographical writing, letters, poems, speeches, memoir passages, court statements, diaries, interviews, archival documents, or reliable contemporaneous documents by/about the figure.
@@ -41,7 +41,9 @@ Use these states in issue comments, worker prompts, and monitor handoffs:
   leads and image-rights decisions recorded. This is the earliest state where a
   writer may build `curriculum/l2-uk-en/bio/<slug>/`.
 - `module-built`: module, activities, vocabulary, resources, generated MDX, and
-  permitted readings exist and pass deterministic gates.
+  permitted readings exist and pass deterministic gates. This is an observed
+  artifact state: a legacy pilot may be `module-built` while still blocked from
+  promotion by missing manual evidence.
 - `qg-current`: the built module has current persisted LLM-QG state in the local
   LLM-QG store or a current module-local `llm_qg.json`; generated QG artifacts
   and telemetry DBs stay out of PR diffs.
@@ -50,6 +52,19 @@ Use these states in issue comments, worker prompts, and monitor handoffs:
 If a slug is missing one or more prep surfaces, dispatch base-prep workers before
 module writers. If a slug is built but lacks current LLM-QG, route QG closure
 before claiming it shipped.
+
+Use `.venv/bin/python scripts/audit/bio_readiness_ledger.py --format summary`
+for the live roster. The ledger keeps fail-closed promotion milestones separate
+from observed `artifact_state` and `release_state`; an existing build with no
+current QG must remain visibly `qg-pending`. In a worktree, point
+`LEARN_UKRAINIAN_LLM_QG_DB` or `--llm-qg-db` at the operator's read-only store.
+If that store is unavailable, report QG as unknown rather than claiming zero
+current results.
+
+For `independent_content_review`, reviewer independence is evaluated against
+the module author/model family and recorded in the linked evidence. One
+cross-family review may supply both corpus-hammer and content-review evidence
+when it explicitly performs both checks; the ledger never infers either pass.
 
 ## Readiness Gate And Stage Sequencing
 

--- a/docs/templates/bio-research-dossier-template.md
+++ b/docs/templates/bio-research-dossier-template.md
@@ -4,10 +4,10 @@
 
 **Target length:** ~1500 words (range: 1200–2000 acceptable).
 **File location:** `docs/research/bio/{slug}.md`
-**SSOT for module ordering / slugs:** `curriculum/l2-uk-en/curriculum.yaml` (`levels.bio.modules`, 387 slugs total).
+**SSOT for module ordering / slugs:** `curriculum/l2-uk-en/curriculum.yaml` (`levels.bio.modules`; derive the live slug count from the manifest rather than hard-coding it).
 **Slug source (by roster):**
 - Original roster: the 130-figure appendix in `docs/audits/bio-track-gap-audit-2026-05-26.md` (per #2313).
-- +77 expansion roster (`modules[310:387]`): `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md` and the readiness inventory `docs/audits/bio-readiness-matrix-2026-06-29.md`. Do NOT look for an expansion slug in the 130-figure appendix — it is not there.
+- The dated expansion roster: `docs/audits/bio-ukrainian-expansion-research-2026-06-29.md` and the readiness inventory `docs/audits/bio-readiness-matrix-2026-06-29.md`. Do NOT use their historical totals as the live SSOT.
 
 > **No-module-writing gate (#2535 / #4006 prompt gate before #4005).** A dossier is the FIRST base-prep artifact. Writing a dossier is permitted only after the slug is promoted out of the readiness gate; do NOT write the plan YAML, site doc, or wiki packet from the same pass. Promotion order is fixed: dossier → `plans/bio/{slug}.yaml` → site/wiki. For the +77, honor the canonicity-over-currency and HIST-alignment constraints recorded in the expansion memo (see §6 and §7 below).
 

--- a/scripts/audit/bio_readiness_ledger.py
+++ b/scripts/audit/bio_readiness_ledger.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python3
+"""Report fail-closed BIO promotion readiness without generating artifacts.
+
+The source-controlled registry records only reviewed manual evidence. Everything
+else is calculated from the current manifest and source tree at report time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from collections.abc import Mapping
+from datetime import date
+from pathlib import Path
+from urllib.parse import urlparse
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+# Direct execution otherwise places scripts/audit ahead of the repository root,
+# causing ``scripts.audit`` to mistake its local config.py for scripts/config.py.
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) in sys.path:
+    sys.path.remove(str(SCRIPT_DIR))
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.audit import lint_bio_dossier_xref
+from scripts.audit.llm_qg_store import content_sha_for_module
+from scripts.audit.llm_qg_store import db_path as configured_qg_db_path
+from scripts.audit.module_quality_audit import PlannedModule, audit_one_module
+from scripts.audit.wiki_completeness_gate import check_wiki_completeness
+from scripts.build import linear_pipeline
+from scripts.validate import check_discovery_integrity, check_wiki_subject, lint_seminar_quality
+from scripts.wiki.domains import resolve_write_domain
+
+MANUAL_GATES = frozenset(
+    {
+        "dossier_grounding",
+        "reading_rights",
+        "wiki_grounding",
+        "wiki_quote_verification",
+        "image_rights",
+        "corpus_hammer",
+        "independent_content_review",
+        "cohort_promotion",
+        "hold",
+        "merged_publication",
+    }
+)
+MANUAL_STATUSES = frozenset({"pass", "fail"})
+REVIEWER_FAMILIES = frozenset({"agy", "claude", "codex", "deepseek", "gemini", "grok", "human", "mixed"})
+RIGHTS_DISPOSITIONS = frozenset({"approved", "exception-approved", "link-only-approved", "not-approved"})
+APPROVED_RIGHTS_DISPOSITIONS = RIGHTS_DISPOSITIONS - {"not-approved"}
+MILESTONES = (
+    "inventory",
+    "source-ready",
+    "plan-ready",
+    "wiki-ready",
+    "module-ready",
+    "module-built",
+    "qg-current",
+    "shipped",
+)
+
+
+class RegistryValidationError(ValueError):
+    """Raised when the manual promotion registry is malformed."""
+
+
+class _UniqueKeyLoader(yaml.SafeLoader):
+    pass
+
+
+def _construct_unique_mapping(loader: yaml.SafeLoader, node: yaml.nodes.MappingNode, deep: bool = False):
+    mapping: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise RegistryValidationError(f"duplicate YAML key: {key!r}")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+def _status(status: bool | None) -> str:
+    return "pass" if status is True else "fail" if status is False else "unknown"
+
+
+def _gate(status: bool | None, *, paths: list[str] | None = None, detail: str | None = None) -> dict:
+    result = {"status": _status(status), "evidence_paths": paths or []}
+    if detail:
+        result["detail"] = detail
+    return result
+
+
+def _manual_gate(record: Mapping[str, object] | None, registry_path: Path, slug: str, name: str) -> dict:
+    if record is None:
+        return _gate(None, paths=[f"{registry_path}#entries.{slug}.{name}"])
+    result = _gate(
+        record.get("status") == "pass",
+        paths=[f"{registry_path}#entries.{slug}.{name}"],
+    )
+    result["reviewer_family"] = record["reviewer_family"]
+    result["date"] = record["date"].isoformat() if isinstance(record["date"], date) else record["date"]
+    result["evidence_url"] = record["evidence_url"]
+    if "disposition" in record:
+        result["disposition"] = record["disposition"]
+    if "active" in record:
+        result["active"] = record["active"]
+    if "reason" in record:
+        result["reason"] = record["reason"]
+    return result
+
+
+def _http_url(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def load_manual_evidence(path: Path, manifest_slugs: set[str]) -> dict[str, dict[str, dict]]:
+    """Load and strictly validate sparse source-controlled manual evidence."""
+    if not path.exists():
+        return {}
+    try:
+        raw = yaml.load(path.read_text(encoding="utf-8"), Loader=_UniqueKeyLoader)
+    except (OSError, yaml.YAMLError, RegistryValidationError) as exc:
+        raise RegistryValidationError(f"invalid promotion evidence registry {path}: {exc}") from exc
+    if not isinstance(raw, Mapping) or raw.get("version") != 1:
+        raise RegistryValidationError("registry must be a mapping with version: 1")
+    entries = raw.get("entries", {})
+    if not isinstance(entries, Mapping):
+        raise RegistryValidationError("registry entries must be a mapping")
+
+    validated: dict[str, dict[str, dict]] = {}
+    for slug, gates in entries.items():
+        if not isinstance(slug, str) or slug not in manifest_slugs:
+            raise RegistryValidationError(f"off-manifest registry slug: {slug!r}")
+        if not isinstance(gates, Mapping) or not gates:
+            raise RegistryValidationError(f"registry entry for {slug!r} must be a non-empty mapping")
+        validated[slug] = {}
+        for name, record in gates.items():
+            if name not in MANUAL_GATES:
+                raise RegistryValidationError(f"unsupported manual evidence gate {name!r} for {slug!r}")
+            if not isinstance(record, Mapping):
+                raise RegistryValidationError(f"manual evidence {slug}.{name} must be a mapping")
+            status = record.get("status")
+            if status not in MANUAL_STATUSES:
+                raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid status {status!r}")
+            family = record.get("reviewer_family")
+            if family not in REVIEWER_FAMILIES:
+                raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid reviewer_family {family!r}")
+            raw_date = record.get("date")
+            if isinstance(raw_date, str):
+                try:
+                    parsed_date = date.fromisoformat(raw_date)
+                except ValueError as exc:
+                    raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid date") from exc
+            elif isinstance(raw_date, date):
+                parsed_date = raw_date
+            else:
+                raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid date")
+            if not _http_url(record.get("evidence_url")):
+                raise RegistryValidationError(f"manual evidence {slug}.{name} needs an HTTP(S) evidence_url")
+            clean = dict(record)
+            clean["date"] = parsed_date
+            if name in {"reading_rights", "image_rights"}:
+                disposition = clean.get("disposition")
+                if disposition not in RIGHTS_DISPOSITIONS:
+                    raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid disposition")
+                approved = disposition in APPROVED_RIGHTS_DISPOSITIONS
+                if (status == "pass") != approved:
+                    raise RegistryValidationError(
+                        f"manual evidence {slug}.{name} status conflicts with disposition {disposition!r}"
+                    )
+            if name == "hold":
+                if status != "pass":
+                    raise RegistryValidationError(f"manual evidence {slug}.hold must record a reviewed pass")
+                if (
+                    not isinstance(clean.get("active"), bool)
+                    or not isinstance(clean.get("reason"), str)
+                    or not clean["reason"].strip()
+                ):
+                    raise RegistryValidationError(f"manual evidence {slug}.hold needs active boolean and reason")
+            validated[slug][str(name)] = clean
+    return validated
+
+
+def manifest_inventory(root: Path, track: str) -> tuple[list[str], Counter[str]]:
+    manifest_path = root / "curriculum" / "l2-uk-en" / "curriculum.yaml"
+    raw = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+    modules = raw.get("levels", {}).get(track, {}).get("modules", [])
+    if not isinstance(modules, list) or not all(isinstance(slug, str) and slug for slug in modules):
+        raise ValueError(f"manifest levels.{track}.modules must be a list of non-empty slugs")
+    counts = Counter(modules)
+    duplicates = sorted(slug for slug, count in counts.items() if count != 1)
+    if duplicates:
+        raise ValueError(f"manifest levels.{track}.modules contains duplicate slugs: {', '.join(duplicates)}")
+    return modules, counts
+
+
+def resolved_wiki_paths(root: Path, track: str, slug: str) -> tuple[Path, Path]:
+    """Return the shared resolver's wiki/source pair, not a track-local fork."""
+    directory = root / "wiki" / resolve_write_domain(track, slug)
+    return directory / f"{slug}.md", directory / f"{slug}.sources.yaml"
+
+
+def _plan_has_reading_packet(plan: Mapping[str, object]) -> bool:
+    readings = plan.get("readings")
+    return isinstance(readings, list) and bool(readings)
+
+
+def _read_current_qg(db_path: Path, track: str, slug: str, module_dir: Path) -> dict:
+    """Read persisted QG state without initialising or changing the telemetry DB."""
+    if not db_path.exists():
+        return {
+            "current": None,
+            "passed": None,
+            "source": str(db_path),
+            "store_available": False,
+            "query_ok": False,
+            "detail": "QG store is unavailable",
+        }
+    try:
+        connection = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+        try:
+            row = connection.execute(
+                """
+                SELECT payload_json, run_id, created_at, reviewer_family, reviewer_model, gate_version
+                FROM llm_qg_runs
+                WHERE level = ? AND slug = ? AND content_sha = ?
+                ORDER BY created_at DESC, run_id DESC LIMIT 1
+                """,
+                (track, slug, content_sha_for_module(module_dir)),
+            ).fetchone()
+        finally:
+            connection.close()
+    except sqlite3.Error as exc:
+        return {
+            "current": None,
+            "passed": None,
+            "source": str(db_path),
+            "store_available": True,
+            "query_ok": False,
+            "detail": f"read-only QG query failed: {exc}",
+        }
+    if row is None:
+        return {
+            "current": False,
+            "passed": False,
+            "source": str(db_path),
+            "store_available": True,
+            "query_ok": True,
+        }
+    try:
+        payload = json.loads(row[0])
+    except (TypeError, json.JSONDecodeError):
+        payload = {}
+    aggregate = payload.get("aggregate", {}) if isinstance(payload, Mapping) else {}
+    terminal = (
+        aggregate.get("terminal_verdict", payload.get("terminal_verdict")) if isinstance(aggregate, Mapping) else None
+    )
+    return {
+        "current": True,
+        "passed": str(terminal).upper() == "PASS",
+        "source": str(db_path),
+        "store_available": True,
+        "query_ok": True,
+        "run_id": row[1],
+        "created_at": row[2],
+        "reviewer_family": row[3],
+        "reviewer_model": row[4],
+        "gate_version": row[5],
+        "terminal_verdict": terminal,
+    }
+
+
+def _build_gate(track: str, slug: str, module_dir: Path, plan_path: Path) -> dict:
+    """Use the current read-only deterministic module-quality surface gate.
+
+    ``verify_shippable`` performs external resource liveness checks, which are
+    deliberately not a deterministic readiness predicate. The ledger reports
+    the required checked-in MDX separately and leaves full ship verification to
+    its dedicated release workflow.
+    """
+    del plan_path  # The active writer plan check already runs independently.
+    audit = audit_one_module(
+        PlannedModule(num=0, level=track, slug=slug, profile="seminar"),
+        curriculum_root=module_dir.parents[1],
+        include_findings=False,
+    )
+    passed = audit.built and audit.surface_verdict == "PASS"
+    return _gate(passed, paths=[str(module_dir)], detail=f"surface verdict: {audit.surface_verdict}")
+
+
+def calculate_milestones(gates: Mapping[str, Mapping[str, object]]) -> dict[str, bool]:
+    """Apply the promotion contract in its declared order.
+
+    ``bundle`` and ``qg_result`` remain visible independently, but promotion
+    milestones are cumulative: a legacy built module cannot skip manual source
+    and cohort approval merely because its files happen to exist.
+    """
+
+    def passed(name: str) -> bool:
+        return gates[name]["status"] == "pass"
+
+    inventory = passed("inventory")
+    source = inventory and all(passed(name) for name in ("dossier", "dossier_xref", "dossier_grounding"))
+    plan = source and all(passed(name) for name in ("plan", "plan_check", "plan_language", "reading_or_rights"))
+    wiki = plan and all(
+        passed(name)
+        for name in (
+            "wiki_pair",
+            "wiki_completeness",
+            "wiki_subject",
+            "wiki_language",
+            "wiki_grounding",
+            "wiki_quote_verification",
+            "image_rights",
+        )
+    )
+    module_ready = wiki and all(
+        passed(name) for name in ("discovery", "discovery_integrity", "no_active_hold", "cohort_promotion")
+    )
+    module_built = module_ready and all(passed(name) for name in ("module_bundle", "mdx", "deterministic_build"))
+    qg_current = module_built and passed("qg_result")
+    shipped = qg_current and all(
+        passed(name) for name in ("qg_pass", "corpus_hammer", "independent_content_review", "merged_publication")
+    )
+    return {
+        "inventory": inventory,
+        "source-ready": source,
+        "plan-ready": plan,
+        "wiki-ready": wiki,
+        "module-ready": module_ready,
+        "module-built": module_built,
+        "qg-current": qg_current,
+        "shipped": shipped,
+    }
+
+
+def release_state(milestones: Mapping[str, bool], gates: Mapping[str, Mapping[str, object]]) -> str:
+    """Name release state from observed build/QG gates plus promotion policy.
+
+    A legacy pilot can be physically built before the promotion registry exists.
+    That does not promote it, but missing QG must still be visible as
+    ``qg-pending`` instead of being hidden behind ``promotion-blocked``.
+    """
+    if milestones["shipped"]:
+        return "shipped"
+    built = all(gates[name]["status"] == "pass" for name in ("module_bundle", "mdx", "deterministic_build"))
+    if built and gates["qg_result"]["status"] != "pass":
+        return "qg-pending"
+    if built and gates["qg_result"]["status"] == "pass" and gates["qg_pass"]["status"] != "pass":
+        return "qg-failed"
+    if milestones["qg-current"]:
+        return "release-review-pending"
+    return "promotion-blocked"
+
+
+def artifact_state(gates: Mapping[str, Mapping[str, object]]) -> str:
+    """Report observed build progress separately from fail-closed promotion."""
+    built = all(gates[name]["status"] == "pass" for name in ("module_bundle", "mdx", "deterministic_build"))
+    if not built:
+        return "not-built"
+    if gates["qg_result"]["status"] == "pass":
+        return "qg-current"
+    return "module-built"
+
+
+def _blockers(gates: Mapping[str, Mapping[str, object]]) -> list[str]:
+    codes = {
+        "dossier": "DOSSIER_MISSING",
+        "dossier_xref": "DOSSIER_XREF_FAIL",
+        "dossier_grounding": "DOSSIER_GROUNDING_UNKNOWN",
+        "plan": "PLAN_MISSING",
+        "plan_check": "PLAN_CHECK_FAIL",
+        "plan_language": "PLAN_LANGUAGE_HIGH",
+        "reading_or_rights": "READING_OR_RIGHTS_UNKNOWN",
+        "wiki_pair": "WIKI_PAIR_MISSING",
+        "wiki_completeness": "WIKI_COMPLETENESS_FAIL",
+        "wiki_subject": "WIKI_SUBJECT_FAIL",
+        "wiki_language": "WIKI_LANGUAGE_HIGH",
+        "wiki_grounding": "WIKI_GROUNDING_UNKNOWN",
+        "wiki_quote_verification": "WIKI_QUOTE_UNKNOWN",
+        "image_rights": "IMAGE_RIGHTS_UNKNOWN",
+        "discovery": "DISCOVERY_MISSING",
+        "discovery_integrity": "DISCOVERY_INTEGRITY_FAIL",
+        "no_active_hold": "ACTIVE_HOLD",
+        "cohort_promotion": "COHORT_PROMOTION_UNKNOWN",
+        "module_bundle": "MODULE_BUNDLE_MISSING",
+        "mdx": "MDX_MISSING",
+        "deterministic_build": "BUILD_GATE_FAIL",
+        "qg_result": "QG_CURRENT_MISSING",
+        "qg_pass": "QG_NOT_PASS",
+        "corpus_hammer": "CORPUS_HAMMER_UNKNOWN",
+        "independent_content_review": "INDEPENDENT_REVIEW_UNKNOWN",
+        "merged_publication": "MERGED_PUBLICATION_UNKNOWN",
+    }
+    blockers: list[str] = []
+    for name, code in codes.items():
+        status = gates[name]["status"]
+        if status == "pass":
+            continue
+        if name == "qg_result" and status == "unknown":
+            code = "QG_STORE_UNAVAILABLE"
+        elif name == "qg_pass" and status == "unknown":
+            code = "QG_PASS_UNKNOWN"
+        blockers.append(code)
+    return blockers
+
+
+def _off_manifest_artifacts(root: Path, track: str, manifest: set[str]) -> dict[str, list[str]]:
+    curriculum = root / "curriculum" / "l2-uk-en"
+    wiki_dir = root / "wiki" / resolve_write_domain(track, "")
+    categories = {
+        "dossiers": root / "docs" / "research" / track,
+        "plans": curriculum / "plans" / track,
+        "discovery": curriculum / track / "discovery",
+        "wiki": wiki_dir,
+        "wiki_sources": wiki_dir,
+        "modules": curriculum / track,
+    }
+    result: dict[str, list[str]] = {}
+    for category, directory in categories.items():
+        if not directory.exists():
+            result[category] = []
+            continue
+        if category == "modules":
+            paths = [item for item in directory.iterdir() if item.is_dir() and item.name != "discovery"]
+        elif category in {"wiki", "dossiers"}:
+            paths = list(directory.glob("*.md"))
+        elif category == "wiki_sources":
+            paths = list(directory.glob("*.sources.yaml"))
+        else:
+            paths = list(directory.glob("*.yaml"))
+        names = [path.name.removesuffix(".sources.yaml") if category == "wiki_sources" else path.stem for path in paths]
+        result[category] = sorted(name for name in names if name not in manifest)
+    return result
+
+
+def build_ledger(
+    *,
+    root: Path = PROJECT_ROOT,
+    track: str = "bio",
+    registry_path: Path | None = None,
+    qg_db_path: Path | None = None,
+) -> dict:
+    """Return a live, JSON-serializable promotion ledger without writing files."""
+    track = track.lower()
+    qg_db_path = configured_qg_db_path(qg_db_path)
+    slugs, _ = manifest_inventory(root, track)
+    manifest_set = set(slugs)
+    registry_path = registry_path or root / "curriculum" / "l2-uk-en" / track / "promotion-evidence.yaml"
+    evidence = load_manual_evidence(registry_path, manifest_set)
+    curriculum = root / "curriculum" / "l2-uk-en"
+    rows: list[dict] = []
+
+    for slug in slugs:
+        manual = evidence.get(slug, {})
+        dossier = root / "docs" / "research" / track / f"{slug}.md"
+        plan_path = curriculum / "plans" / track / f"{slug}.yaml"
+        discovery = curriculum / track / "discovery" / f"{slug}.yaml"
+        wiki_path, source_path = resolved_wiki_paths(root, track, slug)
+        module_dir = curriculum / track / slug
+        mdx_path = root / "site" / "src" / "content" / "docs" / track / f"{slug}.mdx"
+        gates: dict[str, dict] = {
+            # manifest_inventory rejects duplicates before row construction.
+            "inventory": _gate(True, paths=["curriculum/l2-uk-en/curriculum.yaml"]),
+            "dossier": _gate(dossier.exists(), paths=[str(dossier)]),
+            "dossier_grounding": _manual_gate(
+                manual.get("dossier_grounding"), registry_path, slug, "dossier_grounding"
+            ),
+            "plan": _gate(plan_path.exists(), paths=[str(plan_path)]),
+            "reading_rights": _manual_gate(manual.get("reading_rights"), registry_path, slug, "reading_rights"),
+            "wiki_grounding": _manual_gate(manual.get("wiki_grounding"), registry_path, slug, "wiki_grounding"),
+            "wiki_quote_verification": _manual_gate(
+                manual.get("wiki_quote_verification"), registry_path, slug, "wiki_quote_verification"
+            ),
+            "image_rights": _manual_gate(manual.get("image_rights"), registry_path, slug, "image_rights"),
+            "cohort_promotion": _manual_gate(manual.get("cohort_promotion"), registry_path, slug, "cohort_promotion"),
+            "hold": _manual_gate(manual.get("hold"), registry_path, slug, "hold"),
+            "corpus_hammer": _manual_gate(manual.get("corpus_hammer"), registry_path, slug, "corpus_hammer"),
+            "independent_content_review": _manual_gate(
+                manual.get("independent_content_review"), registry_path, slug, "independent_content_review"
+            ),
+            "merged_publication": _manual_gate(
+                manual.get("merged_publication"), registry_path, slug, "merged_publication"
+            ),
+        }
+        hold = manual.get("hold")
+        gates["no_active_hold"] = _gate(
+            not (hold and hold.get("active") is True),
+            paths=[f"{registry_path}#entries.{slug}.hold"],
+        )
+
+        if dossier.exists():
+            gates["dossier_xref"] = _gate(not lint_bio_dossier_xref.lint_dossier(dossier), paths=[str(dossier)])
+        else:
+            gates["dossier_xref"] = _gate(False, paths=[str(dossier)])
+
+        plan: Mapping[str, object] | None = None
+        raw_plan: Mapping[str, object] | None = None
+        if plan_path.exists():
+            try:
+                candidate = yaml.safe_load(plan_path.read_text(encoding="utf-8"))
+                raw_plan = candidate if isinstance(candidate, Mapping) else None
+            except yaml.YAMLError:
+                raw_plan = None
+            try:
+                plan = linear_pipeline.plan_check(plan_path)
+                gates["plan_check"] = _gate(True, paths=[str(plan_path)])
+            except Exception as exc:  # plan_check is the authoritative writer validator
+                gates["plan_check"] = _gate(False, paths=[str(plan_path)], detail=f"{type(exc).__name__}: {exc}")
+            high = [finding for finding in lint_seminar_quality.lint_plan(plan_path) if finding.severity == "high"]
+            gates["plan_language"] = _gate(not high, paths=[str(plan_path)], detail=f"{len(high)} high finding(s)")
+            gates["reading_packet"] = _gate(
+                raw_plan is not None and _plan_has_reading_packet(raw_plan),
+                paths=[str(plan_path)],
+                detail="plan contains a reading packet"
+                if raw_plan is not None and _plan_has_reading_packet(raw_plan)
+                else "plan has no reading packet",
+            )
+        else:
+            gates["plan_check"] = _gate(False, paths=[str(plan_path)])
+            gates["plan_language"] = _gate(False, paths=[str(plan_path)])
+            gates["reading_packet"] = _gate(False, paths=[str(plan_path)])
+        gates["reading_or_rights"] = _gate(
+            gates["reading_packet"]["status"] == "pass" or gates["reading_rights"]["status"] == "pass",
+            paths=[*gates["reading_packet"]["evidence_paths"], *gates["reading_rights"]["evidence_paths"]],
+            detail="valid-plan reading packet or approved manual exception with rights/hosting disposition",
+        )
+
+        gates["wiki_pair"] = _gate(
+            wiki_path.exists() and source_path.exists(), paths=[str(wiki_path), str(source_path)]
+        )
+        if wiki_path.exists() and source_path.exists():
+            report = check_wiki_completeness(wiki_path, level=track, slug=slug)
+            gates["wiki_completeness"] = _gate(
+                report["verdict"] == "PASS", paths=[str(wiki_path), str(source_path)], detail=report["diagnostic"]
+            )
+            title = str(plan.get("title", "")) if plan else None
+            subject_finding = check_wiki_subject.check_wiki_file(wiki_path, plan_title=title)
+            gates["wiki_subject"] = _gate(subject_finding is None, paths=[str(wiki_path)])
+            high = [finding for finding in lint_seminar_quality.lint_text(wiki_path) if finding.severity == "high"]
+            gates["wiki_language"] = _gate(not high, paths=[str(wiki_path)], detail=f"{len(high)} high finding(s)")
+        else:
+            for name in ("wiki_completeness", "wiki_subject", "wiki_language"):
+                gates[name] = _gate(False, paths=[str(wiki_path), str(source_path)])
+
+        gates["discovery"] = _gate(discovery.exists(), paths=[str(discovery)])
+        if discovery.exists() and plan is not None:
+            finding = check_discovery_integrity.check_discovery_file(discovery, plan_title=str(plan.get("title", "")))
+            gates["discovery_integrity"] = _gate(finding is None, paths=[str(discovery)])
+        else:
+            gates["discovery_integrity"] = _gate(False, paths=[str(discovery)])
+
+        bundle_files = [
+            module_dir / name for name in ("module.md", "activities.yaml", "vocabulary.yaml", "resources.yaml")
+        ]
+        gates["module_bundle"] = _gate(
+            all(path.exists() for path in bundle_files), paths=[str(path) for path in bundle_files]
+        )
+        gates["mdx"] = _gate(mdx_path.exists(), paths=[str(mdx_path)])
+        if gates["module_bundle"]["status"] == "pass" and gates["mdx"]["status"] == "pass" and plan_path.exists():
+            gates["deterministic_build"] = _build_gate(track, slug, module_dir, plan_path)
+            qg = _read_current_qg(qg_db_path, track, slug, module_dir)
+        else:
+            gates["deterministic_build"] = _gate(False, paths=[str(module_dir)])
+            qg = {
+                "current": False,
+                "passed": False,
+                "source": str(qg_db_path),
+                "store_available": qg_db_path.exists(),
+                "query_ok": None,
+                "detail": "QG is not applicable until the module bundle and MDX pass",
+            }
+        qg_detail = qg.get("terminal_verdict") or qg.get("detail")
+        gates["qg_result"] = _gate(qg["current"], paths=[qg["source"]], detail=qg_detail)
+        gates["qg_pass"] = _gate(qg["passed"], paths=[qg["source"]], detail=qg_detail)
+
+        milestones = calculate_milestones(gates)
+        highest = max((name for name, reached in milestones.items() if reached), key=MILESTONES.index, default="none")
+        state = release_state(milestones, gates)
+        rows.append(
+            {
+                "slug": slug,
+                "gates": gates,
+                "milestones": milestones,
+                "highest_milestone": highest,
+                "artifact_state": artifact_state(gates),
+                "release_state": state,
+                "blocker_codes": _blockers(gates),
+                "qg": qg,
+            }
+        )
+
+    summary = {
+        "track": track,
+        "manifest_rows": len(slugs),
+        "highest_milestones": dict(Counter(row["highest_milestone"] for row in rows)),
+        "release_states": dict(Counter(row["release_state"] for row in rows)),
+        "artifact_states": dict(Counter(row["artifact_state"] for row in rows)),
+        "qg_store": {"path": str(qg_db_path), "available": qg_db_path.exists()},
+        "qg_current_rows": sum(row["gates"]["qg_result"]["status"] == "pass" for row in rows),
+    }
+    return {
+        "summary": summary,
+        "rows": rows,
+        "off_manifest_artifacts": _off_manifest_artifacts(root, track, manifest_set),
+    }
+
+
+def _print_summary(report: Mapping[str, object]) -> None:
+    summary = report["summary"]
+    print(f"{summary['track']} readiness ledger: {summary['manifest_rows']} manifest rows")
+    print("highest milestones: " + json.dumps(summary["highest_milestones"], sort_keys=True))
+    print("release states: " + json.dumps(summary["release_states"], sort_keys=True))
+    print("artifact states: " + json.dumps(summary["artifact_states"], sort_keys=True))
+    print("QG store: " + json.dumps(summary["qg_store"], sort_keys=True))
+    off_manifest = report["off_manifest_artifacts"]
+    print("off-manifest artifacts: " + json.dumps(off_manifest, ensure_ascii=False, sort_keys=True))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--track", default="bio", help="Seminar track (default: bio)")
+    parser.add_argument("--format", choices=("summary", "json"), default="summary")
+    parser.add_argument("--output", type=Path, help="Optional explicit report path; default is stdout")
+    parser.add_argument("--registry", type=Path, help="Manual evidence registry path")
+    parser.add_argument(
+        "--llm-qg-db",
+        type=Path,
+        help="Read-only LLM-QG SQLite path (default: LEARN_UKRAINIAN_LLM_QG_DB or this checkout's store)",
+    )
+    args = parser.parse_args(argv)
+    try:
+        report = build_ledger(
+            root=PROJECT_ROOT, track=args.track, registry_path=args.registry, qg_db_path=args.llm_qg_db
+        )
+    except (RegistryValidationError, ValueError, OSError) as exc:
+        parser.error(str(exc))
+    rendered = json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True)
+    if args.output:
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    if args.format == "json":
+        print(rendered)
+    elif not args.output:
+        _print_summary(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/audit/test_bio_readiness_ledger.py
+++ b/tests/audit/test_bio_readiness_ledger.py
@@ -1,0 +1,384 @@
+"""Focused contract tests for the fail-closed BIO promotion ledger."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.audit import bio_readiness_ledger as ledger
+
+
+def _gates() -> dict[str, dict[str, str]]:
+    return {
+        name: {"status": "pass"}
+        for name in (
+            "inventory",
+            "dossier",
+            "dossier_xref",
+            "dossier_grounding",
+            "plan",
+            "plan_check",
+            "plan_language",
+            "reading_packet",
+            "reading_rights",
+            "reading_or_rights",
+            "wiki_pair",
+            "wiki_completeness",
+            "wiki_subject",
+            "wiki_language",
+            "wiki_grounding",
+            "wiki_quote_verification",
+            "image_rights",
+            "discovery",
+            "discovery_integrity",
+            "hold",
+            "no_active_hold",
+            "cohort_promotion",
+            "module_bundle",
+            "mdx",
+            "deterministic_build",
+            "qg_result",
+            "qg_pass",
+            "corpus_hammer",
+            "independent_content_review",
+            "merged_publication",
+        )
+    }
+
+
+@pytest.mark.parametrize(
+    ("gate", "expected"),
+    [
+        ("dossier", "inventory"),
+        ("dossier_grounding", "inventory"),
+        ("plan", "source-ready"),
+        ("plan_check", "source-ready"),
+        ("wiki_pair", "plan-ready"),
+        ("wiki_grounding", "plan-ready"),
+        ("discovery", "wiki-ready"),
+        ("cohort_promotion", "wiki-ready"),
+        ("module_bundle", "module-ready"),
+        ("deterministic_build", "module-ready"),
+        ("qg_result", "module-built"),
+        ("corpus_hammer", "qg-current"),
+        ("independent_content_review", "qg-current"),
+        ("merged_publication", "qg-current"),
+    ],
+)
+def test_each_milestone_transition_stops_at_its_previous_reached_stage(gate: str, expected: str) -> None:
+    gates = _gates()
+    gates[gate]["status"] = "unknown"
+    milestones = ledger.calculate_milestones(gates)
+
+    assert max((name for name, reached in milestones.items() if reached), key=ledger.MILESTONES.index) == expected
+
+
+def test_manual_unknown_and_structural_wiki_pass_do_not_grant_grounding() -> None:
+    gates = _gates()
+    gates["wiki_grounding"]["status"] = "unknown"
+
+    milestones = ledger.calculate_milestones(gates)
+
+    assert milestones["plan-ready"] is True
+    assert milestones["wiki-ready"] is False
+    assert ledger._manual_gate(None, Path("registry.yaml"), "slug", "wiki_grounding")["status"] == "unknown"
+
+
+def test_reading_packet_presence_is_independent_of_plan_validity() -> None:
+    assert ledger._plan_has_reading_packet({"readings": [{"title": "Source"}]}) is True
+    assert ledger._plan_has_reading_packet({"readings": []}) is False
+
+
+def test_active_hold_blocks_module_ready_even_when_other_inputs_pass() -> None:
+    gates = _gates()
+    gates["no_active_hold"]["status"] = "fail"
+
+    milestones = ledger.calculate_milestones(gates)
+
+    assert milestones["wiki-ready"] is True
+    assert milestones["module-ready"] is False
+
+
+def test_qg_pending_and_parallel_release_gates_are_not_inferred() -> None:
+    gates = _gates()
+    gates["qg_result"]["status"] = "unknown"
+    gates["qg_pass"]["status"] = "unknown"
+    milestones = ledger.calculate_milestones(gates)
+    assert milestones["module-built"] is True
+    assert ledger.release_state(milestones, gates) == "qg-pending"
+
+    gates = _gates()
+    gates["corpus_hammer"]["status"] = "unknown"
+    gates["independent_content_review"]["status"] = "unknown"
+    milestones = ledger.calculate_milestones(gates)
+    assert milestones["qg-current"] is True
+    assert milestones["shipped"] is False
+    assert ledger.release_state(milestones, gates) == "release-review-pending"
+
+
+def test_legacy_build_is_visible_without_skipping_promotion_gates() -> None:
+    gates = _gates()
+    gates["dossier_grounding"]["status"] = "unknown"
+    gates["qg_result"]["status"] = "unknown"
+    gates["qg_pass"]["status"] = "unknown"
+
+    milestones = ledger.calculate_milestones(gates)
+
+    assert milestones["source-ready"] is False
+    assert milestones["module-built"] is False
+    assert ledger.artifact_state(gates) == "module-built"
+    assert ledger.release_state(milestones, gates) == "qg-pending"
+
+
+def test_qg_store_unavailable_is_unknown_not_a_false_zero(tmp_path: Path) -> None:
+    result = ledger._read_current_qg(tmp_path / "missing.db", "bio", "known", tmp_path / "module")
+
+    assert result["store_available"] is False
+    assert result["current"] is None
+    gates = _gates()
+    gates["qg_result"] = ledger._gate(result["current"])
+    gates["qg_pass"] = ledger._gate(result["passed"])
+    assert "QG_STORE_UNAVAILABLE" in ledger._blockers(gates)
+
+
+@pytest.mark.parametrize(
+    ("terminal_verdict", "expected_pass", "expected_release"),
+    [("PASS", True, "release-review-pending"), ("REVISE", False, "qg-failed")],
+)
+def test_persisted_qg_row_controls_pass_and_release_state(
+    tmp_path: Path, terminal_verdict: str, expected_pass: bool, expected_release: str
+) -> None:
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text("# Модуль\n", encoding="utf-8")
+    db = tmp_path / "qg.db"
+    with sqlite3.connect(db) as connection:
+        connection.execute(
+            """
+            CREATE TABLE llm_qg_runs (
+                payload_json TEXT NOT NULL,
+                run_id TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                reviewer_family TEXT,
+                reviewer_model TEXT,
+                gate_version TEXT,
+                level TEXT NOT NULL,
+                slug TEXT NOT NULL,
+                content_sha TEXT NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO llm_qg_runs (
+                payload_json, run_id, created_at, reviewer_family,
+                reviewer_model, gate_version, level, slug, content_sha
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                json.dumps({"aggregate": {"terminal_verdict": terminal_verdict}}),
+                "run-1",
+                "2026-07-09T00:00:00Z",
+                "claude",
+                "claude-opus-4-8",
+                "v7.llm_qg.1",
+                "bio",
+                "known",
+                ledger.content_sha_for_module(module_dir),
+            ),
+        )
+
+    result = ledger._read_current_qg(db, "bio", "known", module_dir)
+
+    assert result["store_available"] is True
+    assert result["query_ok"] is True
+    assert result["current"] is True
+    assert result["passed"] is expected_pass
+    gates = _gates()
+    gates["qg_result"] = ledger._gate(result["current"])
+    gates["qg_pass"] = ledger._gate(result["passed"])
+    gates["corpus_hammer"]["status"] = "unknown"
+    assert ledger.release_state(ledger.calculate_milestones(gates), gates) == expected_release
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        {
+            "status": "approved",
+            "reviewer_family": "claude",
+            "date": "2026-07-09",
+            "evidence_url": "https://example.test/evidence",
+        },
+        {
+            "status": "pass",
+            "reviewer_family": "robot",
+            "date": "2026-07-09",
+            "evidence_url": "https://example.test/evidence",
+        },
+        {
+            "status": "pass",
+            "reviewer_family": "claude",
+            "date": "09-07-2026",
+            "evidence_url": "https://example.test/evidence",
+        },
+        {"status": "pass", "reviewer_family": "claude", "date": "2026-07-09", "evidence_url": "file:///proof"},
+    ],
+)
+def test_registry_rejects_malformed_manual_evidence(tmp_path: Path, entry: dict) -> None:
+    path = tmp_path / "registry.yaml"
+    path.write_text(
+        yaml.safe_dump({"version": 1, "entries": {"known": {"dossier_grounding": entry}}}), encoding="utf-8"
+    )
+
+    with pytest.raises(ledger.RegistryValidationError):
+        ledger.load_manual_evidence(path, {"known"})
+
+
+def test_registry_rejects_duplicate_and_off_manifest_slugs(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.yaml"
+    duplicate.write_text(
+        """version: 1
+entries:
+  known:
+    dossier_grounding: &e {status: pass, reviewer_family: claude, date: 2026-07-09, evidence_url: https://example.test/a}
+  known: *e
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ledger.RegistryValidationError, match="duplicate"):
+        ledger.load_manual_evidence(duplicate, {"known"})
+
+    off_manifest = tmp_path / "off-manifest.yaml"
+    off_manifest.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "entries": {
+                    "missing": {
+                        "dossier_grounding": {
+                            "status": "pass",
+                            "reviewer_family": "claude",
+                            "date": "2026-07-09",
+                            "evidence_url": "https://example.test/a",
+                        }
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ledger.RegistryValidationError, match="off-manifest"):
+        ledger.load_manual_evidence(off_manifest, {"known"})
+
+
+@pytest.mark.parametrize(
+    ("gate", "status", "disposition"),
+    [
+        ("reading_rights", "pass", "not-approved"),
+        ("reading_rights", "fail", "link-only-approved"),
+        ("image_rights", "pass", "not-approved"),
+        ("image_rights", "fail", "approved"),
+    ],
+)
+def test_registry_rejects_rights_status_disposition_conflicts(
+    tmp_path: Path, gate: str, status: str, disposition: str
+) -> None:
+    path = tmp_path / "registry.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "entries": {
+                    "known": {
+                        gate: {
+                            "status": status,
+                            "disposition": disposition,
+                            "reviewer_family": "claude",
+                            "date": "2026-07-09",
+                            "evidence_url": "https://example.test/evidence",
+                        }
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ledger.RegistryValidationError, match="conflicts"):
+        ledger.load_manual_evidence(path, {"known"})
+
+
+def test_registry_rejects_unreviewed_hold_status(tmp_path: Path) -> None:
+    path = tmp_path / "registry.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "entries": {
+                    "known": {
+                        "hold": {
+                            "status": "fail",
+                            "active": True,
+                            "reason": "A real blocker",
+                            "reviewer_family": "human",
+                            "date": "2026-07-09",
+                            "evidence_url": "https://example.test/evidence",
+                        }
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ledger.RegistryValidationError, match="reviewed pass"):
+        ledger.load_manual_evidence(path, {"known"})
+
+
+def test_duplicate_manifest_is_rejected(tmp_path: Path) -> None:
+    curriculum = tmp_path / "curriculum" / "l2-uk-en"
+    curriculum.mkdir(parents=True)
+    (curriculum / "curriculum.yaml").write_text(
+        yaml.safe_dump({"levels": {"bio": {"modules": ["known", "known"]}}}), encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="duplicate slugs"):
+        ledger.manifest_inventory(tmp_path, "bio")
+
+
+def test_off_manifest_artifacts_include_wiki_source_registries(tmp_path: Path) -> None:
+    curriculum = tmp_path / "curriculum" / "l2-uk-en"
+    (curriculum / "plans" / "bio").mkdir(parents=True)
+    (curriculum / "bio" / "discovery").mkdir(parents=True)
+    (curriculum / "bio" / "discovery" / "stray.yaml").write_text("topic: stray\n", encoding="utf-8")
+    wiki = tmp_path / "wiki" / "figures"
+    wiki.mkdir(parents=True)
+    (wiki / "stray.sources.yaml").write_text("sources: []\n", encoding="utf-8")
+
+    off_manifest = ledger._off_manifest_artifacts(tmp_path, "bio", {"known"})
+
+    assert off_manifest["discovery"] == ["stray"]
+    assert off_manifest["wiki_sources"] == ["stray"]
+
+
+def test_cli_json_reports_one_bio_row_and_shared_resolver_handles_another_track(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    curriculum = tmp_path / "curriculum" / "l2-uk-en"
+    (curriculum / "bio").mkdir(parents=True)
+    (curriculum / "curriculum.yaml").write_text(
+        yaml.safe_dump({"levels": {"bio": {"modules": ["known"]}}}), encoding="utf-8"
+    )
+    (curriculum / "bio" / "promotion-evidence.yaml").write_text("version: 1\nentries: {}\n", encoding="utf-8")
+    monkeypatch.setattr(ledger, "PROJECT_ROOT", tmp_path)
+
+    assert ledger.main(["--format", "json", "--llm-qg-db", str(tmp_path / "missing.db")]) == 0
+    output = json.loads(capsys.readouterr().out)
+    assert [row["slug"] for row in output["rows"]] == ["known"]
+    assert ledger.resolved_wiki_paths(tmp_path, "bio", "known")[0] == tmp_path / "wiki" / "figures" / "known.md"
+    assert ledger.resolved_wiki_paths(tmp_path, "hist", "period")[0] == tmp_path / "wiki" / "periods" / "period.md"


### PR DESCRIPTION
## Summary

- add a live, fail-closed BIO promotion ledger derived from the 409-slug manifest
- validate sparse manual review evidence and keep unrecorded gates unknown
- separate cumulative promotion milestones from observed artifact and release states
- report unavailable QG storage as unknown; built modules without current QG remain qg-pending
- update BIO orchestration docs to use the manifest as the live roster SSOT

## Live evidence

- 409 manifest rows
- observed artifacts: 404 not built, 4 module-built, 1 qg-current
- release states: 405 promotion-blocked, 4 qg-pending
- all 409 highest promotion milestones remain inventory until manual dossier grounding is recorded
- off-manifest discovery packet: petro-veskliaov

## Verification

- 57 focused tests passed across the BIO ledger, deterministic track audit, and wiki completeness gate
- Ruff lint and format checks passed
- pre-commit hooks and Markdown lint passed
- live ledger completed against the read-only production QG store
- git diff --check and X-Agent trailer audit passed

## Independent review

- Claude Opus 4.8 cross-family review: APPROVE
- reviewer independently reproduced 409 rows, five observed legacy builds, fail-closed promotion, and qg-pending behavior with an unavailable worktree QG store
- two minor notes were resolved before publication: unreachable duplicate-reporting code was removed and persisted PASS/REVISE SQLite paths gained tests

Stream epic: #4431
Closes #4835
