### PR TITLE
fix(launchers): fail-honest agent-extensions deploy (no more silent stale .claude)

### DIFF
--- a/scripts/audit/test_deploy_extensions.sh
+++ b/scripts/audit/test_deploy_extensions.sh
@@ -79,7 +79,9 @@ for launcher in start-claude.sh start-codex.sh; do
     || fail "$launcher no longer sources deploy_extensions.sh"
   grep -q 'deploy_agent_extensions' "$REPO_ROOT/$launcher" \
     || fail "$launcher no longer calls deploy_agent_extensions"
-  if grep -E 'npm run [a-z:]*deploy.*(\|\| true|2>/dev/null)' "$REPO_ROOT/$launcher" >/dev/null; then
+  # ^[^#]* keeps the guard from false-positiving on comments that merely
+  # describe the old pattern (deepseek review recommendation, PR #4843).
+  if grep -E '^[^#]*npm run [a-z:]*deploy.*(\|\| true|2>/dev/null)' "$REPO_ROOT/$launcher" >/dev/null; then
     fail "$launcher reintroduced a fail-silent npm deploy"
   fi
 done

--- a/scripts/audit/test_deploy_extensions.sh
+++ b/scripts/audit/test_deploy_extensions.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Fixtures for scripts/lib/deploy_extensions.sh — the fail-honest launcher
+# deploy helper. Wired into the required pytest gate via
+# tests/test_deploy_extensions.py so the deploy-failure banner (which replaced
+# the fail-silent `|| true` in start-claude.sh / start-codex.sh) stays
+# load-bearing: a regression back to silent success would fail these fixtures.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/lib/deploy_extensions.sh
+source "$REPO_ROOT/scripts/lib/deploy_extensions.sh"
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+contains() {
+  # contains <haystack> <needle> <label>
+  if [[ "$1" != *"$2"* ]]; then
+    fail "$3: expected output to contain [$2], got: $1"
+  fi
+}
+
+not_contains() {
+  if [[ "$1" == *"$2"* ]]; then
+    fail "$3: expected output NOT to contain [$2], got: $1"
+  fi
+}
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/deploy-ext-test.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Fake project with an agents:deploy script + a fake npm shim on PATH whose
+# behaviour is driven by FAKE_NPM_EXIT / FAKE_NPM_OUTPUT.
+mkdir -p "$WORK_DIR/project" "$WORK_DIR/bin"
+printf '{"scripts": {"agents:deploy": "scripts/deploy_prompts.sh"}}\n' > "$WORK_DIR/project/package.json"
+cat > "$WORK_DIR/bin/npm" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' "${FAKE_NPM_OUTPUT:-deploy output line}"
+exit "${FAKE_NPM_EXIT:-0}"
+FAKE
+chmod +x "$WORK_DIR/bin/npm"
+export PATH="$WORK_DIR/bin:$PATH"
+
+# --- success: one confirmation line, no failure banner, exit 0 ---
+out="$(FAKE_NPM_EXIT=0 deploy_agent_extensions "$WORK_DIR/project" agents:deploy)" \
+  || fail "success case: expected exit 0, got $?"
+contains "$out" "Agent extensions deployed" "success prints confirmation"
+not_contains "$out" "DEPLOY FAILED" "success has no failure banner"
+
+# --- failure: loud banner + real npm output surfaced + npm exit code returned ---
+rc=0
+out="$(FAKE_NPM_EXIT=3 FAKE_NPM_OUTPUT='rsync: permission denied somewhere' \
+  deploy_agent_extensions "$WORK_DIR/project" agents:deploy)" || rc=$?
+[[ "$rc" -eq 3 ]] || fail "failure case: expected exit 3, got $rc"
+contains "$out" "AGENT-EXTENSIONS DEPLOY FAILED" "failure prints banner"
+contains "$out" "exit 3" "failure banner includes exit code"
+contains "$out" "rsync: permission denied somewhere" "failure surfaces real deploy output"
+contains "$out" "may be STALE" "failure warns about stale targets"
+not_contains "$out" "Agent extensions deployed" "failure never claims success"
+
+# --- missing npm script: explicit skip warning, exit 0 ---
+mkdir -p "$WORK_DIR/bare"
+printf '{"scripts": {}}\n' > "$WORK_DIR/bare/package.json"
+out="$(deploy_agent_extensions "$WORK_DIR/bare" agents:deploy)" \
+  || fail "missing-script case: expected exit 0, got $?"
+contains "$out" "not found" "missing script warns instead of failing"
+
+# --- missing package.json: explicit skip warning, exit 0 ---
+mkdir -p "$WORK_DIR/empty"
+out="$(deploy_agent_extensions "$WORK_DIR/empty" agents:deploy)" \
+  || fail "no-package-json case: expected exit 0, got $?"
+contains "$out" "not found" "missing package.json warns instead of failing"
+
+# --- launchers actually use the helper (regression guard on the wiring) ---
+for launcher in start-claude.sh start-codex.sh; do
+  grep -q 'deploy_extensions.sh' "$REPO_ROOT/$launcher" \
+    || fail "$launcher no longer sources deploy_extensions.sh"
+  grep -q 'deploy_agent_extensions' "$REPO_ROOT/$launcher" \
+    || fail "$launcher no longer calls deploy_agent_extensions"
+  if grep -E 'npm run [a-z:]*deploy.*(\|\| true|2>/dev/null)' "$REPO_ROOT/$launcher" >/dev/null; then
+    fail "$launcher reintroduced a fail-silent npm deploy"
+  fi
+done
+
+echo "ok - deploy extensions fixtures passed"

--- a/scripts/lib/deploy_extensions.sh
+++ b/scripts/lib/deploy_extensions.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# deploy_extensions.sh — fail-honest agent-extensions deploy for launchers.
+#
+# Both launchers (start-claude.sh, start-codex.sh) deploy
+# agents_extensions/shared → .claude/.codex/.agents/... at startup. The old
+# inline blocks ran `npm run <script> --silent 2>/dev/null || true` and then
+# unconditionally printed a success line — so a failing deploy (orphan-path
+# guard trip, prompt-lint violation, rsync error) launched the session
+# against a silently STALE deploy target with zero signal. Same fail-silent
+# bug class as the codexbar budget-guard blindness (#4823).
+#
+# This helper runs the deploy with output captured, prints one line on
+# success, and on failure prints a loud banner plus the tail of the real
+# output. It returns the npm exit code so callers can decide whether to
+# abort; launchers deliberately continue (an interactive session with stale
+# skills beats no session) but the operator now SEES the failure.
+#
+# Usage: deploy_agent_extensions <project_dir> <npm_script>
+# Load-bearing tests: scripts/audit/test_deploy_extensions.sh (wrapped by
+# tests/test_deploy_extensions.py in the required pytest gate).
+
+deploy_agent_extensions() {
+    local project_dir="$1"
+    local npm_script="$2"
+
+    if ! command -v npm >/dev/null 2>&1; then
+        echo "⚠️  npm not found — skipping agent-extensions deploy (targets may be stale)"
+        return 0
+    fi
+    if [ ! -f "$project_dir/package.json" ] \
+        || ! grep -q "\"$npm_script\"" "$project_dir/package.json" 2>/dev/null; then
+        echo "⚠️  npm script '$npm_script' not found in $project_dir/package.json — skipping deploy"
+        return 0
+    fi
+
+    local log_file
+    log_file="$(mktemp "${TMPDIR:-/tmp}/agents-deploy.XXXXXX")" || {
+        echo "⚠️  mktemp failed — running deploy without output capture"
+        (cd "$project_dir" && npm run --silent "$npm_script")
+        return $?
+    }
+
+    local exit_code=0
+    (cd "$project_dir" && npm run --silent "$npm_script" >"$log_file" 2>&1) || exit_code=$?
+
+    if [ "$exit_code" -eq 0 ]; then
+        echo "Agent extensions deployed ($npm_script)"
+    else
+        echo ""
+        echo "⚠️⚠️  AGENT-EXTENSIONS DEPLOY FAILED (npm run $npm_script, exit $exit_code)  ⚠️⚠️"
+        echo "⚠️   Deploy targets (.claude/.codex/.agents/...) may be STALE."
+        echo "──── last 15 lines of deploy output ────"
+        tail -15 "$log_file"
+        echo "────────────────────────────────────────"
+        echo "Reproduce with: npm run $npm_script"
+    fi
+    rm -f "$log_file"
+    return "$exit_code"
+}

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -52,12 +52,13 @@ if git rev-parse --git-dir > /dev/null 2>&1; then
     fi
 fi
 
-# Deploy Claude skills (always run to ensure up-to-date)
-if [ -f "package.json" ] && grep -q "claude:deploy" package.json 2>/dev/null; then
-    echo "Checking Claude skills..."
-    npm run claude:deploy --silent 2>/dev/null || true
-    echo "Skills deployed"
-fi
+# Deploy agent extensions (always run to ensure up-to-date). Fail-honest: a
+# failing deploy prints a loud banner + the real output instead of the old
+# silent `|| true` that claimed "Skills deployed" over a stale .claude/.
+# shellcheck source=scripts/lib/deploy_extensions.sh
+source "$PROJECT_DIR/scripts/lib/deploy_extensions.sh"
+deploy_agent_extensions "$PROJECT_DIR" agents:deploy \
+    || echo "Continuing launch despite deploy failure (see banner above)."
 
 # Show project status
 echo ""

--- a/start-codex.sh
+++ b/start-codex.sh
@@ -151,14 +151,13 @@ fi
 
 # Deploy shared agent extensions into ignored runtime dirs for the checkout
 # Codex will actually use. This keeps .codex/.agents generated while
-# agents_extensions/ remains the tracked source of truth.
-if command -v npm >/dev/null 2>&1 \
-    && [ -f "$TARGET_DIR/package.json" ] \
-    && grep -q '"agents:deploy"' "$TARGET_DIR/package.json" 2>/dev/null; then
-    echo "Checking agent extensions..."
-    (cd "$TARGET_DIR" && npm run agents:deploy --silent >/dev/null 2>&1) || true
-    echo "Agent extensions deployed"
-fi
+# agents_extensions/ remains the tracked source of truth. Fail-honest: a
+# failing deploy prints a loud banner + the real output instead of the old
+# silent `|| true` that claimed success over stale deploy targets.
+# shellcheck source=scripts/lib/deploy_extensions.sh
+source "$PROJECT_DIR/scripts/lib/deploy_extensions.sh"
+deploy_agent_extensions "$TARGET_DIR" agents:deploy \
+    || echo "Continuing launch despite deploy failure (see banner above)."
 
 echo ""
 echo "LEARN UKRAINIAN - Ukrainian Language Learning"

--- a/tests/test_deploy_extensions.py
+++ b/tests/test_deploy_extensions.py
@@ -1,0 +1,40 @@
+"""Run the launcher deploy fail-honest fixtures under the required pytest gate.
+
+``scripts/audit/test_deploy_extensions.sh`` exercises
+``scripts/lib/deploy_extensions.sh`` — the helper both launchers
+(``start-claude.sh``, ``start-codex.sh``) use to deploy
+``agents_extensions/shared`` into the gitignored runtime dirs at startup.
+The old inline blocks ran the deploy behind ``2>/dev/null || true`` and then
+unconditionally printed a success line, so a failing deploy (orphan-path
+guard trip, prompt-lint violation, rsync error) silently launched against a
+STALE ``.claude``/``.codex``. This wrapper makes the failure banner and the
+launcher wiring load-bearing in the required ``Test (pytest)`` job.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_FIXTURES = _REPO_ROOT / "scripts" / "audit" / "test_deploy_extensions.sh"
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_deploy_extensions_fixtures() -> None:
+    assert _FIXTURES.is_file(), f"missing deploy fixtures: {_FIXTURES}"
+    result = subprocess.run(
+        ["bash", str(_FIXTURES)],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"deploy fixtures failed (rc={result.returncode})\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+    assert "ok - deploy extensions fixtures passed" in result.stdout


### PR DESCRIPTION
## Summary
User-reported check of the `start-claude.sh` deploy step found the deploy itself healthy but the launcher wrapper **fail-silent**: `npm run claude:deploy --silent 2>/dev/null || true` followed by an unconditional "Skills deployed". If the orphan-path guard or prompt lint ever trips, the session launches against a stale `.claude/` with zero signal. `start-codex.sh` had the identical pattern (sibling sweep).

## Changes
- **`scripts/lib/deploy_extensions.sh`** (new, shared): captured-output deploy; loud failure banner + last 15 lines of real output + repro command; returns npm's exit code. Skip-with-warning when npm/package.json/script are absent.
- **`start-claude.sh` / `start-codex.sh`**: source the lib; continue launch on failure but visibly. start-claude switches to canonical `agents:deploy`.
- **Load-bearing** (house pattern per `test_handoff_identity`): bash fixtures with a fake-npm shim covering success / failure / skip cases **plus a launcher-wiring regression guard** (fails if either launcher reintroduces a fail-silent `npm run …deploy… || true`), wrapped into the required pytest gate.

## Verification
- `bash scripts/audit/test_deploy_extensions.sh` → `ok - deploy extensions fixtures passed`
- `pytest tests/test_deploy_extensions.py tests/test_handoff_identity.py tests/test_session_setup_hook.py` → 4 passed
- `bash -n` clean on all four shell files; ruff clean on the pytest wrapper

Refs the deploy-check request (user, 2026-07-09).

🤖 Generated with [Claude Code](https://claude.com/claude-code)