### PR TITLE
fix(api): quote both windows (weekly pace + 5h reserve) in deficit warnings

### DIFF
--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -722,7 +722,18 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
                 pace_sum = f"burn pct {burn_pct}%" if burn_pct is not None else "unknown"
 
             if is_in_deficit:
-                warnings.append(f"lane {lane} is in deficit ({pace_sum})")
+                # Deficit is a WEEKLY-pace signal. Quote the 5h window too:
+                # a lane can be week-deficit yet have full 5h reserve for
+                # normal work now — weekly-only wording misled toward
+                # over-restriction (user correction 2026-07-09).
+                five_h_pct = cb.get("primary_used_pct") if cb else None
+                if five_h_pct is not None:
+                    warnings.append(
+                        f"lane {lane} is in deficit ({pace_sum}; weekly-pace signal — "
+                        f"5h window {five_h_pct:.0f}% used, {100 - five_h_pct:.0f}% reserve)"
+                    )
+                else:
+                    warnings.append(f"lane {lane} is in deficit ({pace_sum})")
 
     # Legacy Claude Interactive warning
     if "claude" in agents:

--- a/tests/test_codexbar_usage.py
+++ b/tests/test_codexbar_usage.py
@@ -292,8 +292,14 @@ def test_routing_budget_surfaces_deficit_warnings(monkeypatch):
     assert res["agents"]["claude"]["status"] == "hot"
     assert res["agents"]["codex"]["status"] == "cool"
 
-    # Check that deficit warning was generated for claude
-    assert any("lane claude is in deficit" in w for w in res["recommendation"]["warnings"])
+    # Check that deficit warning was generated for claude, and that it quotes
+    # BOTH windows: the weekly-pace deficit AND the 5h reserve (weekly-only
+    # wording misled toward over-restriction — user correction 2026-07-09).
+    deficit_warnings = [w for w in res["recommendation"]["warnings"] if "lane claude is in deficit" in w]
+    assert deficit_warnings
+    assert "5h window 10% used" in deficit_warnings[0]
+    assert "90% reserve" in deficit_warnings[0]
+    assert "weekly-pace signal" in deficit_warnings[0]
 
 
 def test_monthly_window_only_does_not_mislabel_weekly_used_pct():


### PR DESCRIPTION
## Summary
Handoff-queued follow-up in the #4824 area (user budget-read correction 2026-07-09): routing-budget deficit warnings quoted **weekly pace only**, which misled toward over-restriction — a lane can be in weekly deficit while holding full 5h reserve for normal work right now.

## Change
`compute_routing_budget` deficit warnings now append the 5h window when the codexbar overlay carries it:
`lane claude is in deficit (27% in deficit; weekly-pace signal — 5h window 10% used, 90% reserve)`
Fallback path (no codexbar data) unchanged. `delegate.py --check-budget` matches on the `is in deficit` substring — unaffected, and its stderr line now carries the fuller context for free.

## Verification
- `pytest tests/test_codexbar_usage.py tests/test_delegate_check_budget.py tests/api/test_routing_budget_endpoint.py` → 29 passed
- Test extended to pin both windows in the warning text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)