### PR TITLE
chore(gitignore): generalize dated audit evidence dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,10 +57,12 @@ curriculum/l2-uk-direct/_orchestration/
 # The trailing * also covers the -multirun out-dirs the #4539 harness derives
 # (audit/<date>-qg-bakeoff-multirun/) — see default_output_dir(multi_run=True).
 audit/*-qg-bakeoff*/*.json
-# QG bakeoff #4761 measurement trees written on main checkout (GLM sweeps).
-# Full JSON + sweep logs stay local; copy conclusions to docs/projects/ua-eval-harness/.
-audit/2026-07-07-*/
-audit/2026-07-08-*/
+# Dated audit evidence trees are LOCAL run artifacts (QG bakeoffs, shadow
+# baselines, per-item audits). Full JSON + logs stay local; conclusions get
+# copied to docs/projects/. Generalized 2026-07-10 from per-date entries
+# (audit/2026-07-07-*/, audit/2026-07-08-*/): every NEW dated dir was an
+# untracked-write guard landmine until someone extended this file by hand.
+audit/20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*/
 
 
 # Python


### PR DESCRIPTION
One-line generalization: `audit/2026-07-07-*/` + `audit/2026-07-08-*/` → `audit/20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-*/`.

The per-date entries made every NEW dated evidence dir a primary-checkout write-guard landmine (hit live today writing the QG real-loss audit — the guard classified the new dir `untracked_primary_checkout` and blocked). Verified: pattern matches new dated dirs (`git check-ignore`), 379 historical tracked files under dated dirs unaffected, future dated-dir evidence is local-by-default per existing policy (conclusions → `docs/projects/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)