### PR TITLE
fix(corpus): enrich author_uk during --force rebuild via _LATIN_TO_UK (#4625)

### DIFF
--- a/scripts/wiki/build_sources_db.py
+++ b/scripts/wiki/build_sources_db.py
@@ -59,13 +59,13 @@ if __package__ in {None, ""}:
     from wiki.config import GDRIVE_DATA
     from wiki.extract_sections import DEFAULT_REPORT_PATH, extract_sections
     from wiki.sources import build_literary_row
-    from wiki.textbook_subjects import subject_for_source_file
+    from wiki.textbook_subjects import AUTHOR_UK_BY_TRANSLIT, subject_for_source_file
     from wiki.ukrainian_wiki_corpus import ensure_ukrainian_wiki_manifest, ensure_ukrainian_wiki_schema
 else:
     from .config import GDRIVE_DATA
     from .extract_sections import DEFAULT_REPORT_PATH, extract_sections
     from .sources import build_literary_row
-    from .textbook_subjects import subject_for_source_file
+    from .textbook_subjects import AUTHOR_UK_BY_TRANSLIT, subject_for_source_file
     from .ukrainian_wiki_corpus import ensure_ukrainian_wiki_manifest, ensure_ukrainian_wiki_schema
 
 SCHEMA = """
@@ -277,6 +277,21 @@ CREATE TABLE IF NOT EXISTS wikipedia_negative_cache (
 
 def _normalize_url(url: str) -> str:
     return url.replace("://www.", "://")
+
+
+def _enrich_author_uk(entry: dict, *, slug: str) -> dict:
+    """Fill author_uk from the canonical mapping when extraction left it null."""
+    author = str(entry.get("author") or "").strip()
+    if author and not str(entry.get("author_uk") or "").strip():
+        uk = AUTHOR_UK_BY_TRANSLIT.get(author.lower())
+        if uk is None:
+            from ingest.incremental_textbook_ingest import IngestError
+            raise IngestError(
+                f"{slug}: author {author!r} has no canonical Cyrillic form in "
+                "AUTHOR_UK — add it (title-probed, never guessed) before ingest."
+            )
+        entry = {**entry, "author_uk": uk}
+    return entry
 
 
 def _build_textbook_row(
@@ -655,6 +670,7 @@ def build(db_path: Path | None = None,
                         if not line:
                             continue
                         entry = json.loads(line)
+                        entry = _enrich_author_uk(entry, slug=source_file)
                         batch.append(_build_textbook_row(
                             entry,
                             source_file=source_file,

--- a/tests/test_sources_db.py
+++ b/tests/test_sources_db.py
@@ -398,3 +398,151 @@ def test_search_external_track_reranks_hist_sources(external_search_db):
     assert hist[0]["channel_id"] in {"realna_istoria", "imtgsh"}
     hist_positions = {row["channel_id"]: index for index, row in enumerate(hist)}
     assert hist_positions["realna_istoria"] < hist_positions["ulp_youtube"]
+
+
+def test_rebuild_author_uk_enrichment_regression(tmp_path, monkeypatch):
+    import wiki.build_sources_db as bdb
+    from wiki.build_sources_db import build
+
+    # Create temporary report path so we don't overwrite actual docs
+    monkeypatch.setattr(bdb, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(bdb, "DEFAULT_REPORT_PATH", tmp_path / "textbook_sections_audit.md")
+
+    # Set up a minimal textbooks structure
+    tb_dir = tmp_path / "textbooks" / "grade-05"
+    tb_dir.mkdir(parents=True)
+
+    # Row with author set and author_uk null
+    chunk = {
+        "chunk_id": "5-klas-test_s001",
+        "section_title": "Іменник",
+        "text": "Приклад тексту.",
+        "grade": "5",
+        "author": "avramenko",
+        "author_uk": None,
+        "token_count": 5
+    }
+
+    jsonl_path = tb_dir / "5-klas-ukrmova-avramenko-2022.jsonl"
+    with open(jsonl_path, "w", encoding="utf-8") as f:
+        f.write(json.dumps(chunk, ensure_ascii=False) + "\n")
+
+    # Fake empty directories for external, gdrive
+    ext_dir = tmp_path / "external"
+    ext_dir.mkdir()
+    gdrive = tmp_path / "gdrive"
+    gdrive.mkdir()
+
+    db_path = tmp_path / "rebuild_test.db"
+    build(
+        db_path=db_path,
+        external_dir=ext_dir,
+        textbook_dir=tmp_path / "textbooks",
+        gdrive_dir=gdrive,
+        force=True,
+    )
+
+    # Verify that the textbook chunk was ingested and author_uk was populated from mapping
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute("SELECT author, author_uk FROM textbooks").fetchone()
+    conn.close()
+    assert row is not None
+    assert row[0] == "avramenko"
+    assert row[1] == "Авраменко"
+
+
+def test_rebuild_author_absent_edge(tmp_path, monkeypatch):
+    import wiki.build_sources_db as bdb
+    from wiki.build_sources_db import build
+
+    # Create temporary report path so we don't overwrite actual docs
+    monkeypatch.setattr(bdb, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(bdb, "DEFAULT_REPORT_PATH", tmp_path / "textbook_sections_audit.md")
+
+    # Set up a minimal textbooks structure
+    tb_dir = tmp_path / "textbooks" / "grade-05"
+    tb_dir.mkdir(parents=True)
+
+    # Row with no author info (or empty author)
+    chunk = {
+        "chunk_id": "5-klas-test_s001",
+        "section_title": "Іменник",
+        "text": "Приклад тексту.",
+        "grade": "5",
+        "token_count": 5
+    }
+
+    jsonl_path = tb_dir / "5-klas-ukrmova-avramenko-2022.jsonl"
+    with open(jsonl_path, "w", encoding="utf-8") as f:
+        f.write(json.dumps(chunk, ensure_ascii=False) + "\n")
+
+    # Fake empty directories for external, gdrive
+    ext_dir = tmp_path / "external"
+    ext_dir.mkdir()
+    gdrive = tmp_path / "gdrive"
+    gdrive.mkdir()
+
+    db_path = tmp_path / "rebuild_test.db"
+    build(
+        db_path=db_path,
+        external_dir=ext_dir,
+        textbook_dir=tmp_path / "textbooks",
+        gdrive_dir=gdrive,
+        force=True,
+    )
+
+    # Verify that the textbook chunk was ingested and author/author_uk are empty/default
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute("SELECT author, author_uk FROM textbooks").fetchone()
+    conn.close()
+    assert row is not None
+    assert row[0] == ""
+    assert row[1] == ""
+
+
+def test_rebuild_author_unmapped_edge(tmp_path, monkeypatch):
+    import wiki.build_sources_db as bdb
+    from ingest.incremental_textbook_ingest import IngestError
+    from wiki.build_sources_db import build
+
+    # Create temporary report path so we don't overwrite actual docs
+    monkeypatch.setattr(bdb, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(bdb, "DEFAULT_REPORT_PATH", tmp_path / "textbook_sections_audit.md")
+
+    # Set up a minimal textbooks structure
+    tb_dir = tmp_path / "textbooks" / "grade-05"
+    tb_dir.mkdir(parents=True)
+
+    # Row with author set to an unmapped transliteration and author_uk null
+    chunk = {
+        "chunk_id": "5-klas-test_s001",
+        "section_title": "Іменник",
+        "text": "Приклад тексту.",
+        "grade": "5",
+        "author": "unknown_author_name",
+        "author_uk": None,
+        "token_count": 5
+    }
+
+    jsonl_path = tb_dir / "5-klas-ukrmova-avramenko-2022.jsonl"
+    with open(jsonl_path, "w", encoding="utf-8") as f:
+        f.write(json.dumps(chunk, ensure_ascii=False) + "\n")
+
+    # Fake empty directories for external, gdrive
+    ext_dir = tmp_path / "external"
+    ext_dir.mkdir()
+    gdrive = tmp_path / "gdrive"
+    gdrive.mkdir()
+
+    db_path = tmp_path / "rebuild_test.db"
+
+    # Expect IngestError parity with incremental-ingest
+    with pytest.raises(IngestError) as exc_info:
+        build(
+            db_path=db_path,
+            external_dir=ext_dir,
+            textbook_dir=tmp_path / "textbooks",
+            gdrive_dir=gdrive,
+            force=True,
+        )
+    assert "has no canonical Cyrillic form in AUTHOR_UK" in str(exc_info.value)


### PR DESCRIPTION
## Root Cause
`_build_textbook_row` in `scripts/wiki/build_sources_db.py` raises a `ValueError` when `author` is set but `author_uk` is empty (introduced by the Cyrillic-matcher ADR). During a full `--force` rebuild, the GDrive `textbook_chunks/*.jsonl` inputs are processed. Since the JSONL chunks carry `author_uk: null`, the rebuild path crashes on the first textbook row with an author. 

In contrast, the incremental-ingest path in [scripts/ingest/incremental_textbook_ingest.py:101](file:///Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/agy/4625-force-rebuild-authoruk/scripts/ingest/incremental_textbook_ingest.py#L101) avoids this by calling `enrich_author_uk` before passing the row to `_build_textbook_row`. `enrich_author_uk` (defined at [scripts/ingest/incremental_textbook_ingest.py:78](file:///Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/agy/4625-force-rebuild-authoruk/scripts/ingest/incremental_textbook_ingest.py#L78)) queries the shared author transliteration map `AUTHOR_UK_BY_TRANSLIT` from `wiki.textbook_subjects`.

## Fix Summary
We mirrored the incremental-ingest enrichment behavior inside the `--force` rebuild path of `scripts/wiki/build_sources_db.py` before `_build_textbook_row` is called:
1. Imported `AUTHOR_UK_BY_TRANSLIT` from `wiki.textbook_subjects` at [scripts/wiki/build_sources_db.py:62](file:///Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/agy/4625-force-rebuild-authoruk/scripts/wiki/build_sources_db.py#L62) and [scripts/wiki/build_sources_db.py:68](file:///Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/agy/4625-force-rebuild-authoruk/scripts/wiki/build_sources_db.py#L68).
2. Defined `_enrich_author_uk` at [scripts/wiki/build_sources_db.py:282](file:///Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/agy/4625-force-rebuild-authoruk/scripts/wiki/build_sources_db.py#L282) matching the logic in `incremental_textbook_ingest.py`, raising an `IngestError` from `ingest.incremental_textbook_ingest` if an author has no entry in the map.
3. Called `_enrich_author_uk` inside the rebuild loop in `scripts/wiki/build_sources_db.py:673`.

## Evidence

### Regression Reproduced
Failing pytest output from BEFORE the fix (where `author_uk` is `null`/`None`):
```
tests/test_sources_db.py::test_rebuild_author_uk_enrichment_regression FAILED [ 33%]
tests/test_sources_db.py::test_rebuild_author_absent_edge PASSED         [ 66%]
tests/test_sources_db.py::test_rebuild_author_unmapped_edge FAILED       [100%]

=================================== FAILURES ===================================
_________________ test_rebuild_author_uk_enrichment_regression _________________
tests/test_sources_db.py:437: in test_rebuild_author_uk_enrichment_regression
    build(
scripts/wiki/build_sources_db.py:658: in build
    batch.append(_build_textbook_row(
scripts/wiki/build_sources_db.py:307: in _build_textbook_row
    raise ValueError(
E   ValueError: Textbook entry in 5-klas-ukrmova-avramenko-2022 (chunk 0) has author='avramenko' but no author_uk. Ingestion paths must supply the canonical Cyrillic author form. See ADR docs/decisions/2026-05-15-cyrillic-native-matcher.md.
```

### Fixed
Passing pytest output AFTER the fix:
```
tests/test_sources_db.py::test_rebuild_author_uk_enrichment_regression PASSED [ 33%]
tests/test_sources_db.py::test_rebuild_author_absent_edge PASSED         [ 66%]
tests/test_sources_db.py::test_rebuild_author_unmapped_edge PASSED       [100%]

======================= 3 passed, 17 deselected in 0.27s =======================
```

### No Lint Debt
Output of `.venv/bin/ruff check <changed files>`:
```
$ .venv/bin/ruff check scripts/wiki/build_sources_db.py tests/test_sources_db.py
All checks passed!
```

Closes #4625
