### PR TITLE
fix(hygiene): gitignore the .pids/ runtime dir, not just *.pid files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ tmp/
 temp/
 *.tmp
 *.pid
+.pids/
 *.yaml.bak
 *.yml.bak
 *.yaml.orig


### PR DESCRIPTION
## Root cause
`.gitignore:100` has `*.pid`, which covers `services.sh`'s four pid files — but the restart path also creates `.pids/.restart.lock.d/pid` (extensionless). That file leaks as untracked dirt in the primary checkout and **fail-closes every write-capable delegate dispatch** (pre-flight refuses on dirty checkout; observed live 2026-07-10 00:19).

## Fix
One line: ignore the whole `.pids/` runtime dir (placed next to the existing `*.pid` rule).

## Evidence
- `git check-ignore -v .pids/api.pid` → `.gitignore:100:*.pid` (files covered)
- probe `.pids/.probe.lock.d/pid` → `git check-ignore` exit 1, shows as `??` in status (leak reproduced)
- after fix: probe file ignored (verified in worktree)

Refs #4706 (stream hygiene; this unblocked the stream's dispatches tonight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)