### PR TITLE
docs(decisions): dec-010 — grammar + word-choice priority; finetuning parked

### DIFF
--- a/docs/decisions/2026-07-10-grammar-wordchoice-priority-finetuning-parked.md
+++ b/docs/decisions/2026-07-10-grammar-wordchoice-priority-finetuning-parked.md
@@ -1,0 +1,57 @@
+# ACCEPTED — Grammar + word-choice gate is the priority harness track; model finetuning PARKED
+
+**Status:** ACCEPTED
+**Decided on:** 2026-07-10 (user decision, recorded same day)
+**Scope:** ua-eval-harness evaluation priorities + any model-training initiative
+**Review trigger:** a specific grammar/word-choice quality gap survives TWO model
+rotations despite gate-driven routing, OR training hardware becomes available,
+OR 2026-10-08 — whichever comes first.
+
+## Decision
+
+1. **Evaluation priority = grammar + lexical naturalness.** The harness's primary
+   track is a gate + leaderboard dimension for (a) morphology/orthography
+   (VESUM + Правопис — near-total deterministic authority) and (b) word
+   choice/collocations — the "Google-translate smell" where grammar is perfect
+   but the word is EN-sense-blind (приймати участь vs брати участь;
+   відноситися vs ставитися). Observed live by a native speaker on free-tier AI
+   output (2026-07-10): translation-quality word selection, not grammar failure.
+   These checks are **corpus-independent** — they apply to any sentence any
+   model generates, unlike fact-checking.
+
+2. **Fact-checking is scoped honestly to anti-fabrication.** Our corpus is
+   closed-world: we can verify "attested in what we have," never world-truth.
+   The Layer A/B machinery (#4853/#4860) stays as the trust substrate — it
+   stops fabricated evidence in seminar tracks and wraps ANY future LLM judge
+   (including grammar-track judges) in provenance/injection contracts. It is
+   not, and must not claim to be, a general fact oracle
+   (`UNATTESTED_AFTER_SEARCH → AUDIT` stays).
+
+3. **Fine-tuning / retraining (e.g. Gemma 4) is PARKED.** Reasons:
+   - No training hardware for fast iteration cycles.
+   - Frontier rotation outpaces any finetune we could run (GPT-5.6, Grok 4.5,
+     Fable — all within one week of this decision); a finetune depreciates the
+     day a better base ships.
+   - Our durable asset is **verification data, not weights**: golden sets,
+     UA-GEC-calibrated probes, GRAC attestation, labeled error corpora transfer
+     to every new model generation for free — and they ARE the training set if
+     we ever un-park this. The current path keeps the option open at zero cost.
+
+## Alternatives rejected
+
+| Option | Rejected because |
+| --- | --- |
+| Finetune Gemma 4 for Ukrainian now | No HW for iteration; depreciates against model rotation; measurement + routing achieves the learner-facing goal without training |
+| Fact-checking as the primary harness track | Corpus-bounded (closed-world) — cannot cover arbitrary generated content; grammar/word-choice checks can |
+| Treat nativeness/style as a hard gate | Judgment-shaped, not binary — scored/ranked dimension, advisory; only calque/collocation patterns with UA-GEC/Antonenko evidence gate |
+
+## Consequences
+
+- Next design cycle: `grammar-lexical-gate-design` (two deterministic cores:
+  VESUM/pravopys morphology; ГРАК + UA-GEC F/Calque+F/Collocation + Antonenko +
+  Балла sense-fan lexical naturalness), LLM only for the syntax-level residue
+  wrapped in Layer B judge contracts. Panel-reviewed before commit (hard gate).
+- New leaderboard dimension: grammar-error rate + collocation/calque error rate
+  per 1000 words, deterministically scored per model — the ungameable
+  "which model writes native-quality Ukrainian" measurement.
+- Layer B Phase 1 continues as queued (substrate, not competitor).

--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -6,6 +6,7 @@ Staleness check: `.venv/bin/python scripts/check_decisions.py`
 
 | ID | Date | Expires | Scope | Status | Title |
 |----|------|---------|-------|--------|-------|
+| dec-010 | 2026-07-10 | 2026-10-08 | harness | active | Grammar + word-choice gate priority; finetuning parked |
 | dec-009 | 2026-07-07 | 2026-10-05 | benchmark-2156 | active | Public benchmark release (epic #4639) parked; deploy-first |
 | dec-008 | 2026-06-14 | 2026-09-12 | content | active | A1/A2 live maintenance favors workbook enrichment over rebuilds |
 | dec-007 | 2026-04-24 | 2027-04-23 | pipeline | active | Enforce dec-001 at code level — no LLM regeneration during review (ADR-007) |

--- a/docs/decisions/decisions.yaml
+++ b/docs/decisions/decisions.yaml
@@ -236,5 +236,7 @@ decisions:
         rejected_because: "No training HW; depreciates against weekly frontier rotation; measurement+routing achieves the learner-facing goal without weights"
       - option: "Fact-checking as primary harness track"
         rejected_because: "Closed-world corpus cannot cover arbitrary generated content; grammar/word-choice checks can"
+      - option: "Treat nativeness/style as a hard gate"
+        rejected_because: "Judgment-shaped, not binary - scored/advisory dimension; only calque/collocation patterns with UA-GEC/Antonenko evidence gate"
     superseded_by: null
     depends_on: []

--- a/docs/decisions/decisions.yaml
+++ b/docs/decisions/decisions.yaml
@@ -212,3 +212,29 @@ decisions:
         rejected_because: "Revisit triggers are plausible (Hramatka shipping / community signal); the epic is the parking record"
     superseded_by: null
     depends_on: []
+  - id: dec-010
+    status: active
+    date: "2026-07-10"
+    expires: "2026-10-08"
+    scope: harness
+    title: "Grammar + word-choice gate is priority harness track; finetuning parked"
+    reasoning: >
+      User decision 2026-07-10: evaluation priority is grammar/morphology
+      (VESUM+pravopys, deterministic) plus lexical naturalness (GRAC
+      attestation, UA-GEC F/Calque+F/Collocation, Antonenko, Balla sense-fan)
+      - corpus-independent checks that apply to any generated sentence.
+      Fact-checking stays scoped to anti-fabrication over our closed-world
+      corpus (Layer A/B substrate, #4853/#4860). Fine-tuning/retraining
+      (e.g. Gemma 4) parked: no training HW for iteration, frontier rotation
+      outpaces finetune cycles, and the labeled data we build IS the
+      training set if ever un-parked - option stays open at zero cost.
+      Trigger case: native speaker observed free-tier AI producing
+      EN-sense-blind word choices (translation quality) with valid grammar.
+    evidence: "User discussion 2026-07-10; docs/decisions/2026-07-10-grammar-wordchoice-priority-finetuning-parked.md; UA-GEC F/Calque+F/Collocation ingested; query_grac MCP live; 23/23 multi-span audit"
+    alternatives:
+      - option: "Finetune Gemma 4 for Ukrainian now"
+        rejected_because: "No training HW; depreciates against weekly frontier rotation; measurement+routing achieves the learner-facing goal without weights"
+      - option: "Fact-checking as primary harness track"
+        rejected_because: "Closed-world corpus cannot cover arbitrary generated content; grammar/word-choice checks can"
+    superseded_by: null
+    depends_on: []


### PR DESCRIPTION
Records the user's 2026-07-10 direction:
1. **Priority harness track** = grammar/morphology (VESUM + Правопис, deterministic) + **lexical naturalness** (ГРАК collocation attestation, UA-GEC `F/Calque`+`F/Collocation`, Antonenko, Балла sense-fan) — corpus-independent checks that apply to any generated sentence. Trigger case: native speaker observed free-tier AI output with valid grammar but EN-sense-blind word choice ("Google-translate quality").
2. **Fact-checking scoped honestly**: anti-fabrication over our closed-world corpus (Layer A/B substrate #4853/#4860 unchanged; `UNATTESTED_AFTER_SEARCH → AUDIT` stays).
3. **Finetuning/retraining (e.g. Gemma 4) PARKED** with explicit un-park triggers — no training HW, frontier rotation outpaces finetune cycles, and our labeled data IS the future training set if ever needed.

Files: decision MD + `decisions.yaml` dec-010 + INDEX row. `check_decisions.py`: 5 active, no stale.

Design cycle for the gate itself is already dispatched (sol v1 → codex+agy panel → commit), separate PR when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)