### PR TITLE
feat(harness): grammar-lexical gate Phase 0 — schemas, annotation guide, contract tests (dec-010)

### DIFF
--- a/docs/projects/ua-eval-harness/grammar-lexical-annotation-guide.md
+++ b/docs/projects/ua-eval-harness/grammar-lexical-annotation-guide.md
@@ -1,0 +1,147 @@
+# Ukrainian grammar and lexical annotation guide
+
+This guide operationalizes the Phase 0 data contracts in
+[the grammar and lexical gate design](grammar-lexical-gate-design.md). It
+defines labels and static validation only. It does not authorize runtime work,
+writer dispatch, audit-threshold changes, source behavior changes, scoring, or
+judge routing.
+
+## Scope and frozen inputs
+
+The labeling lead freezes the input artifact, source snapshots, detector and
+registry versions, and skeleton dataset before annotation. Record their stable
+identities and SHA-256 digests in the evidence artifact. Do not replace a
+captured source result with a search summary, a recollection, a newly generated
+answer, or a synonym.
+
+Phase 0 is deliberately not qualification-ready. Each partial skeleton dataset
+sets `qualification_eligible: false` and lists its missing coverage. It is not
+evidence that the gate is implemented, calibrated, or eligible to block
+learner-facing content.
+
+## Twelve-step labeling procedure
+
+1. **Freeze the case.** Record the artifact hash, source snapshots, input text,
+   parser version, and planned detector versions before assigning labels.
+2. **Partition every visible surface.** Create ordered, raw-mappable,
+   non-overlapping `SurfaceRegion` records that cover every user-visible code
+   point. A gap, overlap, invalid offset, or learner-visible `UNKNOWN_ROLE` is
+   coverage missing, never a pass.
+3. **Assign roles structurally.** Use only the registered role methods:
+   `STRUCTURED_FIELD`, `TABLE_COLUMN`, `EXPLICIT_LANGUAGE_TAG`,
+   `EXPLICIT_BILINGUAL_SEPARATOR`, `INLINE_UKRAINIAN_RUN`, and
+   `QUOTATION_CONTRACT`. Do not infer a bilingual relationship from proximity.
+4. **Tokenize after roles are known.** Keep raw spans and hashes. English gloss
+   tokens, citation-only text, code, and metadata do not enter the Ukrainian
+   denominator. Ukrainian target text still receives all applicable scans.
+5. **Materialize the finite scan manifest.** For each eligible token, lexical
+   use, phrase window, finite clause, local shape, bilingual pair, and
+   disposition, record every required detector. An omitted detector record is
+   not `NOT_APPLICABLE`.
+6. **Record outcomes before fusion.** Every detector run has an applicability
+   state and one registered outcome. `UNCOVERED`, `UNCURATED_SENSE`,
+   `BINDING_FAILED`, required `SPARSE_EVIDENCE`, and `FAILED` remain visible as
+   coverage missing.
+7. **Bind evidence immutably.** Each `EvidenceBinding` points to its immutable
+   Layer B candidate and records exact source role, authority class, target
+   spans, snapshot, and ancestors. A missing, truncated, mismatched, ambiguous,
+   or forbidden-provenance source audits.
+8. **Label local recognizers conservatively.** Assign a deterministic
+   compatibility or impossibility decision only when the registered local
+   recognizer has a complete positive match and all exclusion conditions are
+   false. Otherwise record residue, uncovered coverage, or audit; do not parse
+   the sentence by intuition.
+9. **Fuse lexical evidence in the fixed precedence order.** Structural
+   exclusion and required-source integrity come first; heritage and modern
+   contrary-attestation conflicts precede exact rule outcomes. GRAC and Балла
+   are observational in v2 and cannot reject by themselves.
+10. **Bind residue candidates.** A `GateCandidate` needs a candidate class,
+    locus spans, falsifiable hypothesis, target window, and closed allowed
+    relation set. An LLM output is valid only when it stays inside that supplied
+    candidate and relation contract.
+11. **Account for coverage and errors separately.** A word is scored only when
+    its token and every required containing higher-order unit are terminal.
+    Preserve `eligible_ukrainian_words`, `scored_ukrainian_words`, and
+    `coverage_missing_ukrainian_words` so the identity
+    `eligible = scored + coverage_missing` can be checked.
+12. **Mark qualification honestly.** Record adjudication status and all missing
+    fixture families. Do not call a partial set eligible or publish comparative
+    rates when coverage is incomplete.
+
+## Surface-role probes
+
+Use the design §12.2 probes as structural labels, not prose judgments.
+
+- In `hard | складний | Це складне завдання.`, the first field is
+  `ENGLISH_GLOSS`; the Ukrainian headword and example are targets.
+- For the bilingual dialogue `Олена: Я беру участь у гуртку. — I take part in
+  the club.`, separate the speaker label, Ukrainian utterance, and English
+  translation only when the field contract declares the separator.
+- In `Use «Я беру участь у гуртку» for “I take part in the club.”`, classify the
+  embedded Ukrainian run independently from the English explanation.
+- In `Кажемо «Я беру участь», а не *«Я приймаю участь».`, preserve the correction
+  side as Ukrainian target text and the intentionally bad side as
+  `TEACHING_CONTRAST_BAD`; the latter is not an authored-content error.
+- In `hard — складний`, English remains excluded from Ukrainian calque scoring,
+  while the Ukrainian side stays eligible for form and lexical-use coverage.
+
+Never guess an undeclared dash separator, flatten a mixed-language block into a
+single coarse role, or silently split a mixed-script learner token.
+
+## Local-recognizer probes
+
+The §12.4 fixtures label recognizer boundaries as carefully as positive cases.
+`нова книжка`, `Я читаю.`, and `без цукру` test compatible registered shapes;
+`новий книжка`, `Я читає.`, and `без цукор` test complete incompatible shapes.
+
+The adversarial probes are equally binding: `новий і цікавий підручник`,
+`Черговий відповів.`, `нова школа мистецтв`, `Мене бачить Олена.`, `Їй
+подобаються квіти.`, `за столом`, and `без цукру й молока` must not become
+invented deterministic grammar failures. Label the documented exclusion,
+residue, uncovered coverage, or audit outcome.
+
+## Lexical and source-contract probes
+
+Exact curated evidence can decide only its recorded construction and sense.
+The `приймати участь` / `брати участь` rows test rejection and positive allowance
+in their stated roles. A quoted bad-form role suppresses an otherwise exact
+rule. A matching heritage conflict or active `ModernAttestationCard` changes an
+otherwise exact rejection to audit; raw GRAC observations do not.
+
+Use the evidence-source restrictions exactly:
+
+- WordNet auto-translation is forbidden in every transitive curated-rule
+  ancestry. The WordNet provenance trap rejects the rule card before it enters a
+  registry.
+- СУМ-11 is `SECONDARY_SOVIET_PERIOD` support only. `SUM11_SUPPORT` alone is
+  `AUDIT / SUM11_SOLE_AUTHORITY`; contrary СУМ-11 use does not overrule an
+  independent modern exact rule.
+- Preserve both raw and normalized heritage lookup forms for `кобета -> кобіта`.
+  Lookup normalization does not rewrite learner text.
+- `коцюба` is a negative control against a false nonword or Russianism claim;
+  `кочерга` is not a quotation-equivalent or automatic substitution.
+- Балла result order has no frequency or correctness meaning. A complete
+  applicable observation remains `AUDIT / BALLA_UNQUALIFIED_V2` in v2.
+
+## Coverage and flattening controls
+
+Label a complete-or-audit outcome for every required scan unit. Missing
+detectors, failed bilingual bindings, sparse required GRAC, unresolved residue,
+unknown roles, mixed-script learner tokens, and source or registry failures are
+coverage missing. They must not be converted into zero errors.
+
+Record target-vocabulary realization and lexical-diversity fields even when no
+rate can be published. A target-vocabulary coverage below `1.0` or lexical
+diversity retention below `0.85` is flattening and makes the scorecard
+`INELIGIBLE_FLATTENING`; lower grammar or lexical error counts cannot override
+that status.
+
+## Validation boundary
+
+Validate evidence with
+`schemas/ua-grammar-lexical-evidence.v2.schema.json` and scorecards with
+`schemas/ua-grammar-lexical-score.v2.schema.json`. JSON Schema checks closed
+shape, required fields, registered enums, and SHA-256 syntax. The Phase 0
+contract tests additionally check representative coverage and output-total
+invariants and round-trip the data-only golden skeletons. Those tests are not
+gate runtime logic.

--- a/schemas/ua-grammar-lexical-evidence.v2.schema.json
+++ b/schemas/ua-grammar-lexical-evidence.v2.schema.json
@@ -276,7 +276,7 @@
       ]
     },
     "gateDecision": {
-      "enum": ["ACCEPT", "REJECT", "DEFER", "UNCOVERED", "AUDIT"]
+      "enum": ["ACCEPT", "ACCEPT_FORM_ONLY", "REJECT", "DEFER", "UNCOVERED", "AUDIT"]
     },
     "layerAReason": {
       "enum": [

--- a/schemas/ua-grammar-lexical-evidence.v2.schema.json
+++ b/schemas/ua-grammar-lexical-evidence.v2.schema.json
@@ -1,0 +1,581 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/ua-grammar-lexical-evidence.v2.schema.json",
+  "title": "Ukrainian grammar and lexical evidence v2",
+  "description": "Normative per-artifact evidence contract for the Ukrainian grammar and lexical gate. It implements the static shape in docs/projects/ua-eval-harness/grammar-lexical-gate-design.md §§3, 4, 7, and 9; it does not implement or enable gate runtime behavior.",
+  "$comment": "JSON Schema validates closed shapes, registered enums, and SHA-256 syntax. It cannot prove raw offset ordering or exhaustiveness, SHA-256 contents, detector-manifest equality, terminal candidate state, source lineage, candidate uniqueness, or coverage arithmetic. The Layer A reason, local-recognizer decision, and lexical-fusion registers are retained as explicit compatibility definitions because Dec-010 requires them but §9.1 does not add fields for them. tests/test_grammar_lexical_schemas.py keeps those Phase 0 checks test-only.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "run_id",
+    "gate_version",
+    "target",
+    "source_snapshots",
+    "surface_regions",
+    "tokens",
+    "scan_units",
+    "detector_runs",
+    "candidates",
+    "evidence_bindings",
+    "findings",
+    "audits",
+    "coverage",
+    "metrics",
+    "result"
+  ],
+  "properties": {
+    "schema_version": {"const": "ua_grammar_lexical_evidence.v2"},
+    "artifact_kind": {"const": "gate_result"},
+    "run_id": {"$ref": "#/$defs/stableString"},
+    "gate_version": {"$ref": "#/$defs/stableString"},
+    "target": {"$ref": "#/$defs/target"},
+    "source_snapshots": {"$ref": "#/$defs/sourceSnapshots"},
+    "surface_regions": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/surfaceRegion"}
+    },
+    "tokens": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/surfaceToken"}
+    },
+    "scan_units": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/scanUnit"}
+    },
+    "detector_runs": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/detectorRun"}
+    },
+    "candidates": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/gateCandidate"}
+    },
+    "evidence_bindings": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/evidenceBinding"}
+    },
+    "findings": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/canonicalFinding"}
+    },
+    "audits": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/auditRecord"}
+    },
+    "coverage": {"$ref": "#/$defs/coverage"},
+    "metrics": {"$ref": "#/$defs/metrics"},
+    "result": {"enum": ["PASS", "FAIL_CONTENT", "NEEDS_AUDIT"]}
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "stableString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "nonnegativeInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "nullableString": {
+      "type": ["string", "null"]
+    },
+    "stringTuple": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/stableString"}
+    },
+    "nonemptyStringTuple": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/stableString"}
+    },
+    "rawSpan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["start", "end"],
+      "properties": {
+        "start": {"$ref": "#/$defs/nonnegativeInteger"},
+        "end": {"$ref": "#/$defs/nonnegativeInteger"}
+      }
+    },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_id",
+        "artifact_type",
+        "content_sha256",
+        "level_policy",
+        "writer_model_id",
+        "writer_family"
+      ],
+      "properties": {
+        "artifact_id": {"$ref": "#/$defs/stableString"},
+        "artifact_type": {
+          "enum": ["module", "activity", "vocabulary", "atlas_entry", "eval_output"]
+        },
+        "content_sha256": {"$ref": "#/$defs/sha256"},
+        "level_policy": {"$ref": "#/$defs/nullableString"},
+        "writer_model_id": {"$ref": "#/$defs/nullableString"},
+        "writer_family": {"$ref": "#/$defs/nullableString"}
+      }
+    },
+    "sourceSnapshots": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["vesum", "pravopys_rules", "ua_gec", "antonenko", "grac", "balla", "heritage", "sum11"],
+      "properties": {
+        "vesum": {"$ref": "#/$defs/stableString"},
+        "pravopys_rules": {"$ref": "#/$defs/stableString"},
+        "ua_gec": {"$ref": "#/$defs/stableString"},
+        "antonenko": {"$ref": "#/$defs/stableString"},
+        "grac": {"$ref": "#/$defs/stableString"},
+        "balla": {"$ref": "#/$defs/stableString"},
+        "heritage": {"$ref": "#/$defs/stableString"},
+        "sum11": {"$ref": "#/$defs/stableString"}
+      }
+    },
+    "surfaceRegion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["region_id", "raw_start", "raw_end", "surface_kind", "role", "role_method", "raw_sha256"],
+      "properties": {
+        "region_id": {"$ref": "#/$defs/sha256"},
+        "raw_start": {"$ref": "#/$defs/nonnegativeInteger"},
+        "raw_end": {"$ref": "#/$defs/nonnegativeInteger"},
+        "surface_kind": {
+          "enum": [
+            "VOCABULARY_ROW",
+            "DIALOGUE_LINE",
+            "GRAMMAR_NOTE",
+            "LESSON_PROSE",
+            "ACTIVITY_FIELD",
+            "SOURCE_QUOTE",
+            "METADATA"
+          ]
+        },
+        "role": {
+          "enum": [
+            "UKRAINIAN_TARGET",
+            "ENGLISH_GLOSS",
+            "QUOTED_BAD_FORM",
+            "TEACHING_CONTRAST_BAD",
+            "TEACHING_CONTRAST_GOOD",
+            "SOURCE_QUOTE",
+            "PROPER_NAME_OR_CITATION",
+            "CODE_OR_METADATA",
+            "UNKNOWN_ROLE"
+          ]
+        },
+        "role_method": {
+          "enum": [
+            "STRUCTURED_FIELD",
+            "TABLE_COLUMN",
+            "EXPLICIT_LANGUAGE_TAG",
+            "EXPLICIT_BILINGUAL_SEPARATOR",
+            "INLINE_UKRAINIAN_RUN",
+            "QUOTATION_CONTRACT"
+          ]
+        },
+        "raw_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "surfaceToken": {
+      "description": "The design uses SurfaceToken identities and raw spans but does not prescribe a further token payload in §9.1.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["token_id", "region_id", "raw_start", "raw_end", "raw_sha256"],
+      "properties": {
+        "token_id": {"$ref": "#/$defs/sha256"},
+        "region_id": {"$ref": "#/$defs/sha256"},
+        "raw_start": {"$ref": "#/$defs/nonnegativeInteger"},
+        "raw_end": {"$ref": "#/$defs/nonnegativeInteger"},
+        "raw_sha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "scanUnit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scan_unit_id", "unit_kind", "region_ids", "token_ids", "raw_start", "raw_end", "required_detector_ids"],
+      "properties": {
+        "scan_unit_id": {"$ref": "#/$defs/sha256"},
+        "unit_kind": {
+          "enum": ["TOKEN", "LEXICAL_USE", "PHRASE_WINDOW", "FINITE_CLAUSE", "LOCAL_SHAPE", "BILINGUAL_PAIR", "DISPOSITION"]
+        },
+        "region_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/sha256"}
+        },
+        "token_ids": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/sha256"}
+        },
+        "raw_start": {"$ref": "#/$defs/nonnegativeInteger"},
+        "raw_end": {"$ref": "#/$defs/nonnegativeInteger"},
+        "required_detector_ids": {"$ref": "#/$defs/nonemptyStringTuple"}
+      }
+    },
+    "detectorRun": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "detector_run_id",
+        "scan_unit_id",
+        "detector_id",
+        "detector_version",
+        "applicability",
+        "outcome",
+        "candidate_ids",
+        "evidence_binding_ids",
+        "failure_reason"
+      ],
+      "properties": {
+        "detector_run_id": {"$ref": "#/$defs/sha256"},
+        "scan_unit_id": {"$ref": "#/$defs/sha256"},
+        "detector_id": {"$ref": "#/$defs/stableString"},
+        "detector_version": {"$ref": "#/$defs/stableString"},
+        "applicability": {"enum": ["APPLICABLE", "NOT_APPLICABLE"]},
+        "outcome": {
+          "enum": [
+            "CLEAN",
+            "CANDIDATE",
+            "EXCLUDED",
+            "UNCOVERED",
+            "UNCURATED_SENSE",
+            "BINDING_FAILED",
+            "SPARSE_EVIDENCE",
+            "FAILED"
+          ]
+        },
+        "candidate_ids": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/sha256"}
+        },
+        "evidence_binding_ids": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/sha256"}
+        },
+        "failure_reason": {"$ref": "#/$defs/nullableString"}
+      }
+    },
+    "relation": {
+      "enum": [
+        "ACCEPTABLE",
+        "AGREEMENT_ERROR",
+        "CASE_GOVERNMENT_ERROR",
+        "WORD_CHOICE_ERROR",
+        "COLLOCATION_ERROR",
+        "MIXED",
+        "INSUFFICIENT_CONTEXT",
+        "ABSTAIN"
+      ]
+    },
+    "gateDecision": {
+      "enum": ["ACCEPT", "REJECT", "DEFER", "UNCOVERED", "AUDIT"]
+    },
+    "layerAReason": {
+      "enum": [
+        "ANCHORED_CONTIGUOUS",
+        "ANCHORED_ORDERED_SEGMENTS",
+        "PRESENT_MULTI",
+        "ABSENT",
+        "FUZZY_AMBIGUOUS",
+        "OUTSIDE_SCAN",
+        "RAW_MAPPING_AMBIGUOUS",
+        "CROSS_EVENT_STITCH_FORBIDDEN",
+        "INCOMPLETE_CAPTURE",
+        "INCOMPLETE_CANDIDATE_SET",
+        "TOOL_ERROR",
+        "INSUFFICIENT_MASS",
+        "BELOW_TAU",
+        "DIGIT_NOT_ALIGNED",
+        "SALIENT_NOT_ALIGNED"
+      ]
+    },
+    "gateCandidate": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "candidate_id",
+        "candidate_class",
+        "hypothesis",
+        "target_window",
+        "evidence_candidate_ids",
+        "allowed_relations",
+        "canonical_rule_family"
+      ],
+      "properties": {
+        "candidate_id": {"$ref": "#/$defs/sha256"},
+        "candidate_class": {
+          "enum": ["AGREEMENT", "CASE_GOVERNMENT", "SENSE_RESTRICTED_CALQUE", "WORD_SENSE_SELECTION", "COLLOCATION"]
+        },
+        "hypothesis": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["hypothesis_id", "type", "target_locus_spans", "involved_token_ids", "asserted_risk"],
+          "properties": {
+            "hypothesis_id": {"$ref": "#/$defs/sha256"},
+            "type": {"$ref": "#/$defs/stableString"},
+            "target_locus_spans": {
+              "type": "array",
+              "minItems": 1,
+              "items": {"$ref": "#/$defs/rawSpan"}
+            },
+            "involved_token_ids": {
+              "type": "array",
+              "minItems": 1,
+              "items": {"$ref": "#/$defs/sha256"}
+            },
+            "asserted_risk": {"$ref": "#/$defs/stableString"}
+          }
+        },
+        "target_window": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["candidate_id", "window_start", "window_end", "window_sha256", "logical_unit_complete"],
+          "properties": {
+            "candidate_id": {"$ref": "#/$defs/stableString"},
+            "window_start": {"$ref": "#/$defs/nonnegativeInteger"},
+            "window_end": {"$ref": "#/$defs/nonnegativeInteger"},
+            "window_sha256": {"$ref": "#/$defs/sha256"},
+            "logical_unit_complete": {"type": "boolean"}
+          }
+        },
+        "evidence_candidate_ids": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/sha256"}
+        },
+        "allowed_relations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/relation"}
+        },
+        "canonical_rule_family": {"$ref": "#/$defs/stableString"}
+      }
+    },
+    "lexicalFusedClass": {
+      "enum": [
+        "EXACT_ANTONENKO_REJECT",
+        "EXACT_UA_GEC_REJECT",
+        "EXACT_RULE_PLUS_MODERN_CONTRARY",
+        "POSITIVE_EXACT_ALLOW",
+        "AUTHENTIC_HERITAGE_DEFENSE",
+        "HEURISTIC_OR_GRAC_ONLY",
+        "BALLA_OBSERVATION",
+        "NO_DECISIVE_EVIDENCE",
+        "LINEAGE_OR_SOURCE_FAILURE"
+      ]
+    },
+    "evidenceBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evidence_binding_id",
+        "candidate_id",
+        "source_role",
+        "authority_class",
+        "target_span_ids",
+        "rule_or_pair_id",
+        "corpus_snapshot_id",
+        "ancestor_source_ids"
+      ],
+      "properties": {
+        "evidence_binding_id": {"$ref": "#/$defs/sha256"},
+        "candidate_id": {"$ref": "#/$defs/sha256"},
+        "source_role": {
+          "enum": [
+            "VESUM_ANALYSIS",
+            "PRAVOPYS_RULE",
+            "UA_GEC_PAIR",
+            "ANTONENKO_STRUCTURED",
+            "ANTONENKO_PROSE",
+            "GRAC_OBSERVATION",
+            "MODERN_ATTESTATION_CARD",
+            "BALLA_OBSERVATION",
+            "PHRASEOLOGICAL_ATTESTATION",
+            "HERITAGE_DEFENSE",
+            "SUM11_SUPPORT",
+            "RUSSIAN_SHADOW_SIGNAL"
+          ]
+        },
+        "authority_class": {
+          "enum": ["NORMATIVE", "CURATED_RULE", "ADJUDICATED_PAIR", "POSITIVE_DEFENSE", "OBSERVATIONAL", "HEURISTIC"]
+        },
+        "target_span_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/stableString"}
+        },
+        "rule_or_pair_id": {"$ref": "#/$defs/nullableString"},
+        "corpus_snapshot_id": {"$ref": "#/$defs/stableString"},
+        "ancestor_source_ids": {"$ref": "#/$defs/stringTuple"}
+      }
+    },
+    "canonicalFinding": {
+      "description": "Closed projection of the existing ua_contact_quality_evidence.v1 finding contract required unchanged by §3.2.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "finding_id",
+        "issue_id",
+        "issue_class",
+        "dimension",
+        "severity",
+        "contact_source_lang",
+        "source_lang",
+        "track_l1",
+        "ua_gec_tag",
+        "confidence",
+        "disposition",
+        "file",
+        "line",
+        "span",
+        "excerpt",
+        "message",
+        "suggested_replacement",
+        "detector",
+        "attribution"
+      ],
+      "properties": {
+        "finding_id": {"$ref": "#/$defs/stableString"},
+        "issue_id": {"$ref": "#/$defs/stableString"},
+        "issue_class": {
+          "enum": [
+            "calque",
+            "grammar",
+            "collocation",
+            "false_friend",
+            "register",
+            "leakage",
+            "pedagogy",
+            "fluency",
+            "mechanics",
+            "other"
+          ]
+        },
+        "dimension": {
+          "enum": ["contact_grammar", "contact_calque", "ukrainian_style", "mechanics", "naturalness", "level_policy"]
+        },
+        "severity": {"enum": ["critical", "warning", "info"]},
+        "contact_source_lang": {"enum": ["ru", "pl", "en", "unknown", "other"]},
+        "source_lang": {"enum": ["ru", "pl", "en", "unknown", "other"]},
+        "track_l1": {"enum": ["uk", "en", "pl", "ru", "unknown", "other"]},
+        "ua_gec_tag": {"$ref": "#/$defs/nullableString"},
+        "confidence": {"enum": ["deterministic", "lookup_heuristic", "llm_judgment"]},
+        "disposition": {
+          "enum": ["defect", "teaching_contrast", "quoted_bad_form", "heritage_allowed", "suppressed_fp"]
+        },
+        "file": {"$ref": "#/$defs/stableString"},
+        "line": {"type": ["integer", "null"], "minimum": 1},
+        "span": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["start", "end"],
+          "properties": {
+            "start": {"type": ["integer", "null"], "minimum": 0},
+            "end": {"type": ["integer", "null"], "minimum": 0}
+          }
+        },
+        "excerpt": {"type": "string", "minLength": 1, "maxLength": 160},
+        "message": {"$ref": "#/$defs/stableString"},
+        "suggested_replacement": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/stableString"}
+        },
+        "detector": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["adapter", "rule_id", "pattern_id"],
+          "properties": {
+            "adapter": {"$ref": "#/$defs/stableString"},
+            "rule_id": {"$ref": "#/$defs/stableString"},
+            "pattern_id": {"$ref": "#/$defs/stableString"}
+          }
+        },
+        "attribution": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["corpus", "license", "doc_id", "pair_id", "evidence"],
+          "properties": {
+            "corpus": {"$ref": "#/$defs/nullableString"},
+            "license": {"$ref": "#/$defs/nullableString"},
+            "doc_id": {"$ref": "#/$defs/nullableString"},
+            "pair_id": {"$ref": "#/$defs/nullableString"},
+            "evidence": {"$ref": "#/$defs/nullableString"}
+          }
+        }
+      }
+    },
+    "auditRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["audit_id", "reason"],
+      "properties": {
+        "audit_id": {"$ref": "#/$defs/sha256"},
+        "reason": {"$ref": "#/$defs/stableString"}
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scan_units_total",
+        "scan_units_complete",
+        "coverage_missing",
+        "coverage_missing_by_reason",
+        "eligible_ukrainian_words",
+        "scored_ukrainian_words",
+        "coverage_missing_ukrainian_words"
+      ],
+      "properties": {
+        "scan_units_total": {"$ref": "#/$defs/nonnegativeInteger"},
+        "scan_units_complete": {"$ref": "#/$defs/nonnegativeInteger"},
+        "coverage_missing": {"$ref": "#/$defs/nonnegativeInteger"},
+        "coverage_missing_by_reason": {
+          "type": "object",
+          "additionalProperties": {"$ref": "#/$defs/nonnegativeInteger"}
+        },
+        "eligible_ukrainian_words": {"$ref": "#/$defs/nonnegativeInteger"},
+        "scored_ukrainian_words": {"$ref": "#/$defs/nonnegativeInteger"},
+        "coverage_missing_ukrainian_words": {"$ref": "#/$defs/nonnegativeInteger"}
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "confirmed_grammar_errors",
+        "confirmed_lexical_errors",
+        "unresolved_candidates",
+        "target_vocab_required",
+        "target_vocab_realized",
+        "target_vocab_coverage",
+        "content_lemma_tokens",
+        "mattr_window",
+        "mattr",
+        "reference_mattr",
+        "lexical_diversity_retention",
+        "flattening_flag"
+      ],
+      "properties": {
+        "confirmed_grammar_errors": {"$ref": "#/$defs/nonnegativeInteger"},
+        "confirmed_lexical_errors": {"$ref": "#/$defs/nonnegativeInteger"},
+        "unresolved_candidates": {"$ref": "#/$defs/nonnegativeInteger"},
+        "target_vocab_required": {"$ref": "#/$defs/nonnegativeInteger"},
+        "target_vocab_realized": {"$ref": "#/$defs/nonnegativeInteger"},
+        "target_vocab_coverage": {"type": ["number", "null"], "minimum": 0},
+        "content_lemma_tokens": {"$ref": "#/$defs/nonnegativeInteger"},
+        "mattr_window": {"type": ["integer", "null"], "minimum": 1},
+        "mattr": {"type": ["number", "null"], "minimum": 0},
+        "reference_mattr": {"type": ["number", "null"], "minimum": 0},
+        "lexical_diversity_retention": {"type": ["number", "null"], "minimum": 0},
+        "flattening_flag": {"type": "boolean"}
+      }
+    }
+  }
+}

--- a/schemas/ua-grammar-lexical-score.v2.schema.json
+++ b/schemas/ua-grammar-lexical-score.v2.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/ua-grammar-lexical-score.v2.schema.json",
+  "title": "Ukrainian grammar and lexical scorecard v2",
+  "description": "Normative per-model scorecard contract from docs/projects/ua-eval-harness/grammar-lexical-gate-design.md §9.2. This schema defines data shape only and does not implement bakeoff aggregation or ranking.",
+  "$comment": "Output invariants from §9.2: outputs_total equals the sum of outputs_pass, outputs_fail_content, and outputs_needs_audit; outputs_total equals the count of unique output_artifact_ids; aggregate eligible/scored/error counts equal exact sums of unique per-artifact records. Duplicate IDs, absent artifacts, or sum mismatches produce INELIGIBLE_COVERAGE. Rates publish only when eligible and scored word counts are equal. JSON Schema cannot compute these cross-field totals; tests/test_grammar_lexical_schemas.py validates representative Phase 0 contract data without runtime aggregation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "artifact_kind",
+    "evaluation_set_id",
+    "evaluation_set_sha256",
+    "prompt_set_sha256",
+    "generation_config_sha256",
+    "reference_set_sha256",
+    "model",
+    "gate_version",
+    "source_snapshot_ids",
+    "output_artifact_ids",
+    "counts",
+    "rates",
+    "reproducibility",
+    "rank_eligibility"
+  ],
+  "properties": {
+    "schema_version": {"const": "ua_grammar_lexical_score.v2"},
+    "artifact_kind": {"const": "model_scorecard"},
+    "evaluation_set_id": {"$ref": "#/$defs/stableString"},
+    "evaluation_set_sha256": {"$ref": "#/$defs/sha256"},
+    "prompt_set_sha256": {"$ref": "#/$defs/sha256"},
+    "generation_config_sha256": {"$ref": "#/$defs/sha256"},
+    "reference_set_sha256": {"$ref": "#/$defs/sha256"},
+    "model": {"$ref": "#/$defs/model"},
+    "gate_version": {"$ref": "#/$defs/stableString"},
+    "source_snapshot_ids": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/$defs/stableString"}
+    },
+    "output_artifact_ids": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/stableString"}
+    },
+    "counts": {"$ref": "#/$defs/counts"},
+    "rates": {"$ref": "#/$defs/rates"},
+    "reproducibility": {
+      "enum": ["DETERMINISTIC_NO_JUDGE", "DETERMINISTIC_CONDITIONAL_ON_FROZEN_GATE_OUTPUTS"]
+    },
+    "rank_eligibility": {
+      "enum": ["ELIGIBLE", "INELIGIBLE_AUDIT", "INELIGIBLE_COVERAGE", "INELIGIBLE_FLATTENING"]
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "stableString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "nonnegativeInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "nullableNumber": {
+      "type": ["number", "null"]
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "model_id", "family", "revision"],
+      "properties": {
+        "provider": {"$ref": "#/$defs/stableString"},
+        "model_id": {"$ref": "#/$defs/stableString"},
+        "family": {"$ref": "#/$defs/stableString"},
+        "revision": {"type": ["string", "null"]}
+      }
+    },
+    "counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "outputs_total",
+        "outputs_pass",
+        "outputs_fail_content",
+        "outputs_needs_audit",
+        "eligible_ukrainian_words",
+        "scored_ukrainian_words",
+        "coverage_missing_ukrainian_words",
+        "coverage_missing",
+        "grammar_error_units",
+        "lexical_error_units",
+        "unresolved_candidates",
+        "target_vocab_required",
+        "target_vocab_realized",
+        "outputs_below_target_vocab",
+        "outputs_flattened"
+      ],
+      "properties": {
+        "outputs_total": {"$ref": "#/$defs/nonnegativeInteger"},
+        "outputs_pass": {"$ref": "#/$defs/nonnegativeInteger"},
+        "outputs_fail_content": {"$ref": "#/$defs/nonnegativeInteger"},
+        "outputs_needs_audit": {"$ref": "#/$defs/nonnegativeInteger"},
+        "eligible_ukrainian_words": {"$ref": "#/$defs/nonnegativeInteger"},
+        "scored_ukrainian_words": {"$ref": "#/$defs/nonnegativeInteger"},
+        "coverage_missing_ukrainian_words": {"$ref": "#/$defs/nonnegativeInteger"},
+        "coverage_missing": {"$ref": "#/$defs/nonnegativeInteger"},
+        "grammar_error_units": {"$ref": "#/$defs/nonnegativeInteger"},
+        "lexical_error_units": {"$ref": "#/$defs/nonnegativeInteger"},
+        "unresolved_candidates": {"$ref": "#/$defs/nonnegativeInteger"},
+        "target_vocab_required": {"$ref": "#/$defs/nonnegativeInteger"},
+        "target_vocab_realized": {"$ref": "#/$defs/nonnegativeInteger"},
+        "outputs_below_target_vocab": {"$ref": "#/$defs/nonnegativeInteger"},
+        "outputs_flattened": {"$ref": "#/$defs/nonnegativeInteger"}
+      }
+    },
+    "rates": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "grammar_errors_per_1000",
+        "lexical_errors_per_1000",
+        "target_vocab_coverage",
+        "aggregate_mattr",
+        "lexical_diversity_retention",
+        "flattening_trend_delta"
+      ],
+      "properties": {
+        "grammar_errors_per_1000": {"$ref": "#/$defs/nullableNumber"},
+        "lexical_errors_per_1000": {"$ref": "#/$defs/nullableNumber"},
+        "target_vocab_coverage": {"$ref": "#/$defs/nullableNumber"},
+        "aggregate_mattr": {"$ref": "#/$defs/nullableNumber"},
+        "lexical_diversity_retention": {"$ref": "#/$defs/nullableNumber"},
+        "flattening_trend_delta": {"$ref": "#/$defs/nullableNumber"}
+      }
+    }
+  }
+}

--- a/tests/fixtures/grammar_lexical/golden_skeletons.yaml
+++ b/tests/fixtures/grammar_lexical/golden_skeletons.yaml
@@ -1,0 +1,346 @@
+---
+schema_version: ua-grammar-lexical-golden-skeletons.v1
+dataset_id: ua-grammar-lexical-phase-0-golden-skeletons
+qualification_eligible: false
+qualification_blockers:
+  - No frozen source outputs, VESUM analyses, or evidence bindings are labeled.
+  - No complete detector manifests, raw offset records, or adjudications are labeled.
+  - Fixtures 23, 54-59, and 62 have no concrete input text in design §12 and are intentionally absent.
+  - >-
+    Fixture 24 reuses the design's UAБ control from fixture 25; fixtures 19,
+    50, and 61 reuse design input text from related probes.
+  - No Phase 1 qualification run or calibration metrics are included.
+cases:
+  - case_id: fixture-16-vocabulary-row
+    fixture_numbers: [16]
+    input_text: "hard | складний | Це складне завдання."
+    expected_surface_roles: [ENGLISH_GLOSS, UKRAINIAN_TARGET, UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CLEAN]
+    expected_decision: null
+    expected_reason: null
+    annotation_status: SKELETON
+
+  - case_id: fixture-17-vocabulary-negative
+    fixture_numbers: [17]
+    input_text: "hard | складний | Це складний завдання."
+    expected_surface_roles: [ENGLISH_GLOSS, UKRAINIAN_TARGET, UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: REJECT
+    expected_reason: LOCAL_RELATION_IMPOSSIBLE
+    annotation_status: SKELETON
+
+  - case_id: fixture-18-bilingual-dialogue
+    fixture_numbers: [18]
+    input_text: "Олена: Я беру участь у гуртку. — I take part in the club."
+    expected_surface_roles: [PROPER_NAME_OR_CITATION, UKRAINIAN_TARGET, ENGLISH_GLOSS]
+    expected_detector_outcomes: [CLEAN]
+    expected_decision: null
+    expected_reason: null
+    annotation_status: SKELETON
+
+  - case_id: fixture-19-undeclared-dash-separator
+    fixture_numbers: [19]
+    input_text: "Олена: Я беру участь у гуртку. — I take part in the club."
+    expected_surface_roles: [UNKNOWN_ROLE]
+    expected_detector_outcomes: [BINDING_FAILED]
+    expected_decision: AUDIT
+    expected_reason: UNKNOWN_ROLE
+    annotation_status: SKELETON
+
+  - case_id: fixture-20-mixed-grammar-note
+    fixture_numbers: [20]
+    input_text: "Use «Я беру участь у гуртку» for “I take part in the club.”"
+    expected_surface_roles: [ENGLISH_GLOSS, UKRAINIAN_TARGET, ENGLISH_GLOSS]
+    expected_detector_outcomes: [CLEAN]
+    expected_decision: null
+    expected_reason: null
+    annotation_status: SKELETON
+
+  - case_id: fixture-21-teaching-contrast
+    fixture_numbers: [21, 50]
+    input_text: "Кажемо «Я беру участь», а не *«Я приймаю участь»."
+    expected_surface_roles: [UKRAINIAN_TARGET, TEACHING_CONTRAST_BAD]
+    expected_detector_outcomes: [EXCLUDED]
+    expected_decision: ACCEPT
+    expected_reason: SUPPRESSED_FP
+    annotation_status: SKELETON
+
+  - case_id: fixture-22-a1-gloss
+    fixture_numbers: [22]
+    input_text: "hard — складний"
+    expected_surface_roles: [ENGLISH_GLOSS, UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CLEAN]
+    expected_decision: null
+    expected_reason: null
+    annotation_status: SKELETON
+
+  - case_id: fixture-24-mixed-script
+    fixture_numbers: [24]
+    input_text: "UAБ"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [UNCOVERED]
+    expected_decision: AUDIT
+    expected_reason: INELIGIBLE_COVERAGE
+    annotation_status: SKELETON
+
+  - case_id: fixture-25-tokenizer
+    fixture_numbers: [25]
+    input_text: "Київ — 20-річний проєкт; будь-хто й п’ять, 2026, UAБ."
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [UNCOVERED]
+    expected_decision: AUDIT
+    expected_reason: INELIGIBLE_COVERAGE
+    expected_eligible_ukrainian_words: 6
+    annotation_status: SKELETON
+
+  - case_id: fixture-34-modifier-compatible
+    fixture_numbers: [34]
+    input_text: "нова книжка"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CLEAN]
+    expected_decision: ACCEPT
+    expected_reason: LOCAL_RELATION_COMPATIBLE
+    annotation_status: SKELETON
+
+  - case_id: fixture-35-modifier-impossible
+    fixture_numbers: [35]
+    input_text: "новий книжка"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: REJECT
+    expected_reason: LOCAL_RELATION_IMPOSSIBLE
+    annotation_status: SKELETON
+
+  - case_id: fixture-36-modifier-coordination
+    fixture_numbers: [36]
+    input_text: "новий і цікавий підручник"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [UNCOVERED]
+    expected_decision: null
+    allowed_decisions: [DEFER, UNCOVERED]
+    expected_reason: SYNTAX_RESIDUE
+    annotation_status: SKELETON
+
+  - case_id: fixture-37-nominalized-adjective
+    fixture_numbers: [37]
+    input_text: "Черговий відповів."
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [UNCOVERED]
+    expected_decision: null
+    allowed_decisions: [DEFER, UNCOVERED]
+    expected_reason: SYNTAX_RESIDUE
+    annotation_status: SKELETON
+
+  - case_id: fixture-38-dependent-tail
+    fixture_numbers: [38]
+    input_text: "нова школа мистецтв"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [UNCOVERED]
+    expected_decision: null
+    allowed_decisions: [DEFER, UNCOVERED]
+    expected_reason: SYNTAX_RESIDUE
+    annotation_status: SKELETON
+
+  - case_id: fixture-39-subject-verb-compatible
+    fixture_numbers: [39]
+    input_text: "Я читаю."
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CLEAN]
+    expected_decision: ACCEPT
+    expected_reason: LOCAL_RELATION_COMPATIBLE
+    annotation_status: SKELETON
+
+  - case_id: fixture-40-subject-verb-impossible
+    fixture_numbers: [40]
+    input_text: "Я читає."
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: REJECT
+    expected_reason: LOCAL_RELATION_IMPOSSIBLE
+    annotation_status: SKELETON
+
+  - case_id: fixture-41-object-not-subject
+    fixture_numbers: [41]
+    input_text: "Мене бачить Олена."
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [UNCOVERED]
+    expected_decision: null
+    allowed_decisions: [DEFER, UNCOVERED]
+    expected_reason: SYNTAX_RESIDUE
+    annotation_status: SKELETON
+
+  - case_id: fixture-42-dative-experiencer
+    fixture_numbers: [42]
+    input_text: "Їй подобаються квіти."
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [UNCOVERED]
+    expected_decision: null
+    allowed_decisions: [DEFER, UNCOVERED]
+    expected_reason: SYNTAX_RESIDUE
+    annotation_status: SKELETON
+
+  - case_id: fixture-43-government-compatible
+    fixture_numbers: [43]
+    input_text: "без цукру"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CLEAN]
+    expected_decision: ACCEPT
+    expected_reason: LOCAL_RELATION_COMPATIBLE
+    annotation_status: SKELETON
+
+  - case_id: fixture-44-government-impossible
+    fixture_numbers: [44]
+    input_text: "без цукор"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: REJECT
+    expected_reason: LOCAL_RELATION_IMPOSSIBLE
+    annotation_status: SKELETON
+
+  - case_id: fixture-45-no-closed-sense-card
+    fixture_numbers: [45]
+    input_text: "за столом"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [UNCOVERED]
+    expected_decision: null
+    allowed_decisions: [DEFER, UNCOVERED]
+    expected_reason: SYNTAX_RESIDUE
+    annotation_status: SKELETON
+
+  - case_id: fixture-46-government-coordination
+    fixture_numbers: [46]
+    input_text: "без цукру й молока"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [UNCOVERED]
+    expected_decision: null
+    allowed_decisions: [DEFER, UNCOVERED]
+    expected_reason: SYNTAX_RESIDUE
+    annotation_status: SKELETON
+
+  - case_id: fixture-47-missing-np-analysis
+    fixture_numbers: [47]
+    input_text: "без цукру"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [FAILED]
+    expected_decision: AUDIT
+    expected_reason: ANALYSIS_INCOMPLETE
+    annotation_status: SKELETON
+
+  - case_id: fixture-48-exact-curated-reject
+    fixture_numbers: [48]
+    input_text: "приймати участь"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: REJECT
+    expected_reason: EXACT_ANTONENKO_REJECT
+    annotation_status: SKELETON
+
+  - case_id: fixture-49-positive-card
+    fixture_numbers: [49]
+    input_text: "брати участь"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CLEAN]
+    expected_decision: ACCEPT
+    expected_reason: POSITIVE_EXACT_ALLOW
+    annotation_status: SKELETON
+
+  - case_id: fixture-51-heritage-rule-conflict
+    fixture_numbers: [51]
+    input_text: "приймати участь"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: AUDIT
+    expected_reason: HERITAGE_RULE_CONFLICT
+    annotation_status: SKELETON
+
+  - case_id: fixture-52-modern-attestation-conflict
+    fixture_numbers: [52]
+    input_text: "приймати участь"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: AUDIT
+    expected_reason: SOURCE_CONFLICT
+    annotation_status: SKELETON
+
+  - case_id: fixture-53-raw-grac-does-not-override
+    fixture_numbers: [53]
+    input_text: "приймати участь"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: REJECT
+    expected_reason: EXACT_ANTONENKO_REJECT
+    annotation_status: SKELETON
+
+  - case_id: fixture-60-balla-ordering
+    fixture_numbers: [60]
+    input_text: "hard — твердий / складний / важкий"
+    expected_surface_roles: [ENGLISH_GLOSS, UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: AUDIT
+    expected_reason: BALLA_UNQUALIFIED_V2
+    annotation_status: SKELETON
+
+  - case_id: fixture-61-balla-binding-failed
+    fixture_numbers: [61]
+    input_text: "hard — твердий / складний / важкий"
+    expected_surface_roles: [UNKNOWN_ROLE]
+    expected_detector_outcomes: [BINDING_FAILED]
+    expected_decision: AUDIT
+    expected_reason: BINDING_FAILED
+    annotation_status: SKELETON
+
+  - case_id: fixture-63-wordnet-provenance
+    fixture_numbers: [63]
+    input_text: "CuratedRuleCard.source -> intermediate-generated-list -> auto-translated-wordnet"
+    expected_surface_roles: [CODE_OR_METADATA]
+    expected_detector_outcomes: [FAILED]
+    expected_decision: REJECT
+    expected_reason: WORDNET_AUTO_TRANSLATED
+    annotation_status: SKELETON
+
+  - case_id: fixture-64-sum11-sole-authority
+    fixture_numbers: [64]
+    input_text: "target form: VESUM miss; evidence: SUM11_SUPPORT only"
+    expected_surface_roles: [CODE_OR_METADATA]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: AUDIT
+    expected_reason: SUM11_SOLE_AUTHORITY
+    annotation_status: SKELETON
+
+  - case_id: fixture-65-sum11-counter-evidence
+    fixture_numbers: [65]
+    input_text: "приймати участь"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: REJECT
+    expected_reason: EXACT_ANTONENKO_REJECT
+    annotation_status: SKELETON
+
+  - case_id: fixture-66-heritage-lookup-normalization
+    fixture_numbers: [66]
+    input_text: "кобета"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: ACCEPT
+    expected_reason: HERITAGE_ALLOWED
+    expected_lookup_alias: "кобіта"
+    annotation_status: SKELETON
+
+  - case_id: fixture-67-heritage-negative-control
+    fixture_numbers: [67]
+    input_text: "Коцюба стояла біля печі."
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: ACCEPT
+    expected_reason: HERITAGE_ALLOWED
+    annotation_status: SKELETON
+
+  - case_id: fixture-68-no-synonym-substitution
+    fixture_numbers: [68]
+    input_text: "коцюба"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: REJECT
+    expected_reason: NON_AUTHORITATIVE_SUBSTITUTION
+    proposed_substitution: "кочерга"
+    annotation_status: SKELETON

--- a/tests/fixtures/grammar_lexical/golden_skeletons.yaml
+++ b/tests/fixtures/grammar_lexical/golden_skeletons.yaml
@@ -344,3 +344,19 @@ cases:
     expected_reason: NON_AUTHORITATIVE_SUBSTITUTION
     proposed_substitution: "кочерга"
     annotation_status: SKELETON
+
+  # Design §6.7 rows AUTHENTIC_HERITAGE_DEFENSE × {A, N} → ACCEPT_FORM_ONLY:
+  # heritage evidence resolves ONLY the form-validity candidate; the containing
+  # LEXICAL_USE still requires contextual coverage (§6.7 line "resolves only a
+  # form-validity candidate"; §8.1). Added by committing reviewer — the enum
+  # value was missing from gateDecision, making these fusion cells
+  # unrepresentable.
+  - case_id: fusion-heritage-form-only
+    fixture_numbers: []
+    input_text: "кобіта"
+    expected_surface_roles: [UKRAINIAN_TARGET]
+    expected_detector_outcomes: [CANDIDATE]
+    expected_decision: ACCEPT_FORM_ONLY
+    expected_reason: HERITAGE_FORM_VALIDITY_ONLY
+    expected_lexical_use_coverage: OPEN
+    annotation_status: SKELETON

--- a/tests/test_grammar_lexical_schemas.py
+++ b/tests/test_grammar_lexical_schemas.py
@@ -1,0 +1,480 @@
+"""Phase 0 contracts for Ukrainian grammar and lexical gate artifacts.
+
+These tests validate schemas and data-only golden skeletons. They deliberately
+do not import or implement grammar, lexical, VESUM, scoring, or judge runtime
+behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from jsonschema import Draft202012Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EVIDENCE_SCHEMA = json.loads(
+    (REPO_ROOT / "schemas/ua-grammar-lexical-evidence.v2.schema.json").read_text(encoding="utf-8")
+)
+SCORE_SCHEMA = json.loads(
+    (REPO_ROOT / "schemas/ua-grammar-lexical-score.v2.schema.json").read_text(encoding="utf-8")
+)
+GOLDEN_SKELETONS = REPO_ROOT / "tests/fixtures/grammar_lexical/golden_skeletons.yaml"
+EVIDENCE_VALIDATOR = Draft202012Validator(EVIDENCE_SCHEMA)
+SCORE_VALIDATOR = Draft202012Validator(SCORE_SCHEMA)
+
+
+def _sha256(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
+def _schema_errors(validator: Draft202012Validator, document: dict[str, Any]) -> list[str]:
+    return sorted(error.message for error in validator.iter_errors(document))
+
+
+def _assert_evidence_invariants(document: dict[str, Any]) -> None:
+    """Validate §8.1 and §8.4 arithmetic outside JSON Schema."""
+
+    coverage = document["coverage"]
+    assert coverage["eligible_ukrainian_words"] == (
+        coverage["scored_ukrainian_words"] + coverage["coverage_missing_ukrainian_words"]
+    )
+    if document["result"] == "PASS":
+        assert coverage["coverage_missing"] == 0
+        assert coverage["coverage_missing_ukrainian_words"] == 0
+
+
+def _assert_score_invariants(document: dict[str, Any]) -> None:
+    """Validate the §9.2 totals that JSON Schema cannot calculate."""
+
+    counts = document["counts"]
+    assert counts["outputs_total"] == (
+        counts["outputs_pass"] + counts["outputs_fail_content"] + counts["outputs_needs_audit"]
+    )
+    assert counts["outputs_total"] == len(set(document["output_artifact_ids"]))
+    assert counts["eligible_ukrainian_words"] == (
+        counts["scored_ukrainian_words"] + counts["coverage_missing_ukrainian_words"]
+    )
+    if document["rank_eligibility"] == "ELIGIBLE":
+        assert counts["eligible_ukrainian_words"] == counts["scored_ukrainian_words"]
+        assert counts["coverage_missing_ukrainian_words"] == 0
+        assert counts["coverage_missing"] == 0
+        assert document["rates"]["grammar_errors_per_1000"] is not None
+        assert document["rates"]["lexical_errors_per_1000"] is not None
+
+
+def _valid_evidence_document() -> dict[str, Any]:
+    region_id = _sha256("surface-region")
+    token_id = _sha256("surface-token")
+    scan_unit_id = _sha256("scan-unit")
+    candidate_id = _sha256("gate-candidate")
+    binding_id = _sha256("evidence-binding")
+    return {
+        "schema_version": "ua_grammar_lexical_evidence.v2",
+        "artifact_kind": "gate_result",
+        "run_id": "phase-0-contract-test",
+        "gate_version": "v2",
+        "target": {
+            "artifact_id": "fixture-34",
+            "artifact_type": "eval_output",
+            "content_sha256": _sha256("fixture-34-content"),
+            "level_policy": "a1",
+            "writer_model_id": "fixture-writer",
+            "writer_family": "fixture-family",
+        },
+        "source_snapshots": {
+            "vesum": "vesum-fixture",
+            "pravopys_rules": "pravopys-fixture",
+            "ua_gec": "ua-gec-fixture",
+            "antonenko": "antonenko-fixture",
+            "grac": "grac-fixture",
+            "balla": "balla-fixture",
+            "heritage": "heritage-fixture",
+            "sum11": "sum11-fixture",
+        },
+        "surface_regions": [
+            {
+                "region_id": region_id,
+                "raw_start": 0,
+                "raw_end": 12,
+                "surface_kind": "ACTIVITY_FIELD",
+                "role": "UKRAINIAN_TARGET",
+                "role_method": "STRUCTURED_FIELD",
+                "raw_sha256": _sha256("fixture-surface"),
+            }
+        ],
+        "tokens": [
+            {
+                "token_id": token_id,
+                "region_id": region_id,
+                "raw_start": 0,
+                "raw_end": 4,
+                "raw_sha256": _sha256("fixture-token"),
+            }
+        ],
+        "scan_units": [
+            {
+                "scan_unit_id": scan_unit_id,
+                "unit_kind": "TOKEN",
+                "region_ids": [region_id],
+                "token_ids": [token_id],
+                "raw_start": 0,
+                "raw_end": 4,
+                "required_detector_ids": ["vesum-form-v2"],
+            }
+        ],
+        "detector_runs": [
+            {
+                "detector_run_id": _sha256("detector-run"),
+                "scan_unit_id": scan_unit_id,
+                "detector_id": "vesum-form-v2",
+                "detector_version": "v2",
+                "applicability": "APPLICABLE",
+                "outcome": "CANDIDATE",
+                "candidate_ids": [candidate_id],
+                "evidence_binding_ids": [binding_id],
+                "failure_reason": None,
+            }
+        ],
+        "candidates": [
+            {
+                "candidate_id": candidate_id,
+                "candidate_class": "AGREEMENT",
+                "hypothesis": {
+                    "hypothesis_id": _sha256("hypothesis"),
+                    "type": "LOCAL_RELATION",
+                    "target_locus_spans": [{"start": 0, "end": 4}],
+                    "involved_token_ids": [token_id],
+                    "asserted_risk": "registered fixture risk",
+                },
+                "target_window": {
+                    "candidate_id": "anchor-candidate",
+                    "window_start": 0,
+                    "window_end": 12,
+                    "window_sha256": _sha256("window"),
+                    "logical_unit_complete": True,
+                },
+                "evidence_candidate_ids": [_sha256("anchor-candidate")],
+                "allowed_relations": ["ACCEPTABLE", "AGREEMENT_ERROR"],
+                "canonical_rule_family": "fixture-local-agreement",
+            }
+        ],
+        "evidence_bindings": [
+            {
+                "evidence_binding_id": binding_id,
+                "candidate_id": _sha256("anchor-candidate"),
+                "source_role": "VESUM_ANALYSIS",
+                "authority_class": "NORMATIVE",
+                "target_span_ids": [token_id],
+                "rule_or_pair_id": None,
+                "corpus_snapshot_id": "vesum-fixture",
+                "ancestor_source_ids": [],
+            }
+        ],
+        "findings": [
+            {
+                "finding_id": "fixture-finding",
+                "issue_id": "FIXTURE_FINDING",
+                "issue_class": "grammar",
+                "dimension": "contact_grammar",
+                "severity": "info",
+                "contact_source_lang": "unknown",
+                "source_lang": "unknown",
+                "track_l1": "en",
+                "ua_gec_tag": None,
+                "confidence": "deterministic",
+                "disposition": "suppressed_fp",
+                "file": "tests/fixtures/grammar_lexical/golden_skeletons.yaml",
+                "line": 1,
+                "span": {"start": 0, "end": 4},
+                "excerpt": "fixture",
+                "message": "Static Phase 0 fixture finding.",
+                "suggested_replacement": [],
+                "detector": {
+                    "adapter": "phase-0-contract-test",
+                    "rule_id": "fixture-rule",
+                    "pattern_id": "fixture-pattern",
+                },
+                "attribution": {
+                    "corpus": "fixture",
+                    "license": None,
+                    "doc_id": None,
+                    "pair_id": None,
+                    "evidence": "Phase 0 contract test",
+                },
+            }
+        ],
+        "audits": [],
+        "coverage": {
+            "scan_units_total": 1,
+            "scan_units_complete": 1,
+            "coverage_missing": 0,
+            "coverage_missing_by_reason": {},
+            "eligible_ukrainian_words": 1,
+            "scored_ukrainian_words": 1,
+            "coverage_missing_ukrainian_words": 0,
+        },
+        "metrics": {
+            "confirmed_grammar_errors": 0,
+            "confirmed_lexical_errors": 0,
+            "unresolved_candidates": 0,
+            "target_vocab_required": 1,
+            "target_vocab_realized": 1,
+            "target_vocab_coverage": 1.0,
+            "content_lemma_tokens": 1,
+            "mattr_window": None,
+            "mattr": None,
+            "reference_mattr": None,
+            "lexical_diversity_retention": None,
+            "flattening_flag": False,
+        },
+        "result": "PASS",
+    }
+
+
+def _valid_score_document() -> dict[str, Any]:
+    return {
+        "schema_version": "ua_grammar_lexical_score.v2",
+        "artifact_kind": "model_scorecard",
+        "evaluation_set_id": "phase-0-contract-test",
+        "evaluation_set_sha256": _sha256("evaluation-set"),
+        "prompt_set_sha256": _sha256("prompt-set"),
+        "generation_config_sha256": _sha256("generation-config"),
+        "reference_set_sha256": _sha256("reference-set"),
+        "model": {
+            "provider": "fixture-provider",
+            "model_id": "fixture-model",
+            "family": "fixture-family",
+            "revision": None,
+        },
+        "gate_version": "v2",
+        "source_snapshot_ids": {"vesum": "vesum-fixture"},
+        "output_artifact_ids": ["fixture-34"],
+        "counts": {
+            "outputs_total": 1,
+            "outputs_pass": 1,
+            "outputs_fail_content": 0,
+            "outputs_needs_audit": 0,
+            "eligible_ukrainian_words": 1,
+            "scored_ukrainian_words": 1,
+            "coverage_missing_ukrainian_words": 0,
+            "coverage_missing": 0,
+            "grammar_error_units": 0,
+            "lexical_error_units": 0,
+            "unresolved_candidates": 0,
+            "target_vocab_required": 1,
+            "target_vocab_realized": 1,
+            "outputs_below_target_vocab": 0,
+            "outputs_flattened": 0,
+        },
+        "rates": {
+            "grammar_errors_per_1000": 0.0,
+            "lexical_errors_per_1000": 0.0,
+            "target_vocab_coverage": 1.0,
+            "aggregate_mattr": None,
+            "lexical_diversity_retention": None,
+            "flattening_trend_delta": None,
+        },
+        "reproducibility": "DETERMINISTIC_NO_JUDGE",
+        "rank_eligibility": "ELIGIBLE",
+    }
+
+
+def test_accepts_complete_valid_evidence_and_score_artifacts() -> None:
+    evidence = _valid_evidence_document()
+    score = _valid_score_document()
+
+    assert _schema_errors(EVIDENCE_VALIDATOR, evidence) == []
+    assert _schema_errors(SCORE_VALIDATOR, score) == []
+    _assert_evidence_invariants(evidence)
+    _assert_score_invariants(score)
+
+
+def test_rejects_unknown_registered_enum_values() -> None:
+    mutations = [
+        (EVIDENCE_VALIDATOR, _valid_evidence_document(), ("surface_regions", 0, "role")),
+        (EVIDENCE_VALIDATOR, _valid_evidence_document(), ("detector_runs", 0, "outcome")),
+        (EVIDENCE_VALIDATOR, _valid_evidence_document(), ("candidates", 0, "allowed_relations", 0)),
+        (EVIDENCE_VALIDATOR, _valid_evidence_document(), ("evidence_bindings", 0, "source_role")),
+        (SCORE_VALIDATOR, _valid_score_document(), ("rank_eligibility",)),
+    ]
+
+    for validator, document, path in mutations:
+        target: Any = document
+        for key in path[:-1]:
+            target = target[key]
+        target[path[-1]] = "UNKNOWN_ENUM"
+        assert _schema_errors(validator, document), f"unknown enum at {path} must be rejected"
+
+
+def test_rejects_missing_required_fields_and_bad_sha256_values() -> None:
+    evidence = _valid_evidence_document()
+    evidence["coverage"].pop("scored_ukrainian_words")
+    assert _schema_errors(EVIDENCE_VALIDATOR, evidence)
+
+    bad_evidence = _valid_evidence_document()
+    bad_evidence["target"]["content_sha256"] = "not-a-sha256"
+    assert _schema_errors(EVIDENCE_VALIDATOR, bad_evidence)
+
+    score = _valid_score_document()
+    score["counts"].pop("outputs_total")
+    assert _schema_errors(SCORE_VALIDATOR, score)
+
+    bad_score = _valid_score_document()
+    bad_score["reference_set_sha256"] = "g" * 64
+    assert _schema_errors(SCORE_VALIDATOR, bad_score)
+
+
+def test_rejects_additional_properties_at_every_contract_boundary() -> None:
+    evidence = _valid_evidence_document()
+    evidence["unexpected"] = True
+    assert _schema_errors(EVIDENCE_VALIDATOR, evidence)
+
+    evidence = _valid_evidence_document()
+    evidence["surface_regions"][0]["unexpected"] = True
+    assert _schema_errors(EVIDENCE_VALIDATOR, evidence)
+
+    score = _valid_score_document()
+    score["model"]["unexpected"] = True
+    assert _schema_errors(SCORE_VALIDATOR, score)
+
+
+def test_exposes_the_required_phase_zero_compatibility_registers() -> None:
+    assert EVIDENCE_SCHEMA["$defs"]["layerAReason"]["enum"] == [
+        "ANCHORED_CONTIGUOUS",
+        "ANCHORED_ORDERED_SEGMENTS",
+        "PRESENT_MULTI",
+        "ABSENT",
+        "FUZZY_AMBIGUOUS",
+        "OUTSIDE_SCAN",
+        "RAW_MAPPING_AMBIGUOUS",
+        "CROSS_EVENT_STITCH_FORBIDDEN",
+        "INCOMPLETE_CAPTURE",
+        "INCOMPLETE_CANDIDATE_SET",
+        "TOOL_ERROR",
+        "INSUFFICIENT_MASS",
+        "BELOW_TAU",
+        "DIGIT_NOT_ALIGNED",
+        "SALIENT_NOT_ALIGNED",
+    ]
+    assert EVIDENCE_SCHEMA["$defs"]["gateDecision"]["enum"] == [
+        "ACCEPT",
+        "REJECT",
+        "DEFER",
+        "UNCOVERED",
+        "AUDIT",
+    ]
+    assert EVIDENCE_SCHEMA["$defs"]["lexicalFusedClass"]["enum"] == [
+        "EXACT_ANTONENKO_REJECT",
+        "EXACT_UA_GEC_REJECT",
+        "EXACT_RULE_PLUS_MODERN_CONTRARY",
+        "POSITIVE_EXACT_ALLOW",
+        "AUTHENTIC_HERITAGE_DEFENSE",
+        "HEURISTIC_OR_GRAC_ONLY",
+        "BALLA_OBSERVATION",
+        "NO_DECISIVE_EVIDENCE",
+        "LINEAGE_OR_SOURCE_FAILURE",
+    ]
+
+
+def test_coverage_fields_represent_eligible_scored_and_missing_words() -> None:
+    evidence = _valid_evidence_document()
+    evidence["coverage"].update(
+        {
+            "eligible_ukrainian_words": 3,
+            "scored_ukrainian_words": 2,
+            "coverage_missing_ukrainian_words": 1,
+            "coverage_missing": 1,
+        }
+    )
+    evidence["result"] = "NEEDS_AUDIT"
+
+    assert _schema_errors(EVIDENCE_VALIDATOR, evidence) == []
+    _assert_evidence_invariants(evidence)
+
+    invalid = deepcopy(evidence)
+    invalid["coverage"]["eligible_ukrainian_words"] = 4
+    with pytest.raises(AssertionError):
+        _assert_evidence_invariants(invalid)
+
+
+def test_score_output_invariants_and_flattening_ineligibility_are_representable() -> None:
+    score = _valid_score_document()
+    score["counts"].update(
+        {
+            "outputs_total": 2,
+            "outputs_pass": 1,
+            "outputs_needs_audit": 1,
+            "eligible_ukrainian_words": 3,
+            "scored_ukrainian_words": 2,
+            "coverage_missing_ukrainian_words": 1,
+            "coverage_missing": 1,
+            "outputs_flattened": 1,
+        }
+    )
+    score["output_artifact_ids"] = ["fixture-34", "fixture-35"]
+    score["rank_eligibility"] = "INELIGIBLE_FLATTENING"
+    score["rates"]["grammar_errors_per_1000"] = None
+    score["rates"]["lexical_errors_per_1000"] = None
+
+    assert _schema_errors(SCORE_VALIDATOR, score) == []
+    _assert_score_invariants(score)
+
+    invalid = deepcopy(score)
+    invalid["counts"]["outputs_total"] = 3
+    with pytest.raises(AssertionError):
+        _assert_score_invariants(invalid)
+
+
+def test_round_trips_data_only_golden_skeletons() -> None:
+    skeletons = yaml.safe_load(GOLDEN_SKELETONS.read_text(encoding="utf-8"))
+    round_tripped = yaml.safe_load(yaml.safe_dump(skeletons, allow_unicode=True, sort_keys=False))
+
+    assert round_tripped == skeletons
+    assert skeletons["qualification_eligible"] is False
+    assert skeletons["qualification_blockers"]
+
+    role_enum = EVIDENCE_SCHEMA["$defs"]["surfaceRegion"]["properties"]["role"]["enum"]
+    outcome_enum = EVIDENCE_SCHEMA["$defs"]["detectorRun"]["properties"]["outcome"]["enum"]
+    decision_enum = EVIDENCE_SCHEMA["$defs"]["gateDecision"]["enum"]
+    fixture_numbers = set()
+    for case in skeletons["cases"]:
+        fixture_numbers.update(case["fixture_numbers"])
+        assert case["input_text"]
+        assert case["annotation_status"] == "SKELETON"
+        assert set(case["expected_surface_roles"]).issubset(role_enum)
+        assert set(case["expected_detector_outcomes"]).issubset(outcome_enum)
+        assert case["expected_decision"] in {None, *decision_enum}
+        assert set(case.get("allowed_decisions", [])).issubset(decision_enum)
+
+    assert fixture_numbers == {
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        24,
+        25,
+        *range(34, 48),
+        48,
+        49,
+        50,
+        51,
+        52,
+        53,
+        60,
+        61,
+        63,
+        64,
+        65,
+        66,
+        67,
+        68,
+    }

--- a/tests/test_grammar_lexical_schemas.py
+++ b/tests/test_grammar_lexical_schemas.py
@@ -364,6 +364,12 @@ def test_exposes_the_required_phase_zero_compatibility_registers() -> None:
     ]
     assert EVIDENCE_SCHEMA["$defs"]["gateDecision"]["enum"] == [
         "ACCEPT",
+        # Design §6.7: AUTHENTIC_HERITAGE_DEFENSE × {A, N} resolves ONLY the
+        # form-validity candidate; the containing LEXICAL_USE still requires
+        # contextual coverage (§8.1). Without this value those fusion cells
+        # are unrepresentable and implementations would round to ACCEPT
+        # (silently completing coverage) or AUDIT.
+        "ACCEPT_FORM_ONLY",
         "REJECT",
         "DEFER",
         "UNCOVERED",


### PR DESCRIPTION
## Summary

Implements the Dec-010 grammar-lexical gate Phase 0 contract only, following the merged design (#4869):

- adds closed v2 evidence and scorecard JSON Schemas;
- adds the Phase 0 annotation procedure;
- adds data-only, qualification-ineligible golden skeletons for the concrete §12 probes; and
- adds schema/fixture contract tests.

No V7 runtime, writer dispatch, audit threshold, VESUM, Atlas, bakeoff, reviewer-route, or generated-artifact behavior changed.

## #M-4 evidence

- `git diff --check origin/main...HEAD` passed; the committed diff contains five scoped files.
- `.venv/bin/python -m pytest tests/test_grammar_lexical_schemas.py -q` collected 8 and passed 8.
- `.venv/bin/ruff check tests/test_grammar_lexical_schemas.py`, `.venv/bin/yamllint tests/fixtures/grammar_lexical/golden_skeletons.yaml`, and `npx --no-install markdownlint-cli2 docs/projects/ua-eval-harness/grammar-lexical-annotation-guide.md` passed.
- Commit hooks reran the affected pytest suite (8 passed), Ruff, gitleaks, YAML syntax, and artifact guards successfully.
- Full `.venv/bin/python -m pytest -q` collected 10,518 tests and retained seven unrelated pre-existing failures in channel/citation/ESUM/Diasporiana/wiki/prompt-size/MLX tests; no failure is in this Phase 0 file set.
- Independent cross-family static review: AGY / Gemini 3.1 Pro High approved the corrected diff after five findings were fixed.

Design: #4869
Decision: dec-010

## Handoff

This PR is ready for normal repository CI and review. Auto-merge is intentionally **not** armed, per task instruction.