### PR TITLE
fix(hooks): harden Bash-guard segmentation against glued shell operators (#4876) + heredoc write-target FPs (#4538)

### DIFF
--- a/agents_extensions/shared/hooks/guard-admin-merge.py
+++ b/agents_extensions/shared/hooks/guard-admin-merge.py
@@ -70,6 +70,8 @@ def _strip_quotes(token: str) -> str:
 
 
 def _heredoc_delimiters(line: str) -> list[tuple[str, bool]]:
+    """Return (delimiter, strip_tabs) per heredoc opener; handles spaced
+    ``<< EOF`` / ``<< - EOF`` and attached ``<<-EOF`` / ``<<-'EOF'`` (#4877)."""
     try:
         lexer = shlex.shlex(line, posix=False, punctuation_chars=True)
         lexer.whitespace_split = True
@@ -86,33 +88,55 @@ def _heredoc_delimiters(line: str) -> list[tuple[str, bool]]:
             continue
         strip_tabs = False
         j = i + 1
-        if j < len(tokens) and tokens[j] == "-":
-            strip_tabs = True
-            j += 1
+        delim_tok = ""
         if j < len(tokens):
-            delimiter = _strip_quotes(tokens[j])
-            if delimiter:
-                delimiters.append((delimiter, strip_tabs))
+            nxt = tokens[j]
+            if nxt == "-":
+                strip_tabs = True
+                j += 1
+                if j < len(tokens):
+                    delim_tok = tokens[j]
+            elif nxt.startswith("-") and len(nxt) > 1:
+                strip_tabs = True
+                delim_tok = nxt[1:]
+            else:
+                delim_tok = nxt
+        delimiter = _strip_quotes(delim_tok)
+        if delimiter:
+            delimiters.append((delimiter, strip_tabs))
         i = j + 1
     return delimiters
 
 
 def _strip_heredoc_bodies(command: str) -> str:
-    """Drop heredoc BODY lines — document text is data, not commands."""
+    """Drop heredoc BODY lines — document text is data, not commands.
+
+    Fail-CLOSED on an unclosed heredoc (#4877): a never-closing / mis-parsed
+    opener must not make trailing real `gh pr merge --admin` vanish. Only a
+    heredoc that actually closes has its body + closer dropped.
+    """
     if "<<" not in command:
         return command
 
+    lines = command.splitlines()
     kept: list[str] = []
-    pending: list[tuple[str, bool]] = []
-    for line in command.splitlines():
-        if pending:
+    i = 0
+    n = len(lines)
+    while i < n:
+        kept.append(lines[i])
+        i += 1
+        pending = _heredoc_delimiters(lines[i - 1])
+        if not pending:
+            continue
+        body_start = i
+        while i < n and pending:
             delimiter, strip_tabs = pending[0]
-            candidate = line.lstrip("\t") if strip_tabs else line
+            candidate = lines[i].lstrip("\t") if strip_tabs else lines[i]
             if candidate == delimiter:
                 pending.pop(0)
-            continue
-        kept.append(line)
-        pending.extend(_heredoc_delimiters(line))
+            i += 1
+        if pending:
+            kept.extend(lines[body_start:i])
     return "\n".join(kept)
 
 
@@ -154,11 +178,28 @@ def _segments(command: str) -> list[list[str]]:
     return segs
 
 
+def _is_env_assignment(tok: str) -> bool:
+    return "=" in tok and not tok.startswith("-") and tok.split("=", 1)[0].isidentifier()
+
+
+def _skip_command_prefix(seg: list[str], i: int) -> int:
+    """Advance past wrappers / env-assignments / brace-group open so a
+    `env FOO=1 gh pr merge --admin` or `{ gh pr merge --admin; }` is not
+    missed (#4877)."""
+    while i < len(seg):
+        tok = seg[i]
+        if tok in {"sudo", "time", "env", "nohup", "command", "exec", "{"} or _is_env_assignment(
+            tok
+        ):
+            i += 1
+        else:
+            break
+    return i
+
+
 def _admin_merge_args(seg: list[str]) -> list[str] | None:
     """Return the args of a `gh pr merge ... --admin` segment, else None."""
-    i = 0
-    while i < len(seg) and seg[i] in {"sudo", "time", "env", "nohup"}:
-        i += 1
+    i = _skip_command_prefix(seg, 0)
     if seg[i : i + 3] != ["gh", "pr", "merge"]:
         return None
     args = seg[i + 3 :]

--- a/agents_extensions/shared/hooks/guard-admin-merge.py
+++ b/agents_extensions/shared/hooks/guard-admin-merge.py
@@ -116,6 +116,13 @@ def _strip_heredoc_bodies(command: str) -> str:
     return "\n".join(kept)
 
 
+def _join_line_continuations(text: str) -> str:
+    r"""Fold `\<newline>` into one logical line, as the shell does — so a
+    `\`-continued `gh pr merge --admin` is not split across physical lines
+    and missed. Over-folding a quoted literal `\` only merges argv text."""
+    return text.replace("\\\n", "")
+
+
 def _segments(command: str) -> list[list[str]]:
     """Quote-aware argv segments, robust to glued shell operators (#4876).
 
@@ -123,10 +130,11 @@ def _segments(command: str) -> list[list[str]]:
     stays one argv element — no false block. A `; gh pr merge --admin` glued
     to a preceding token (`…'; gh pr merge --admin`) is now split into its
     own segment and inspected — no evasion. Heredoc bodies are stripped
-    (document text is not commands); each line parses separately.
+    (document text is not commands); `\\`-continuations are folded; each
+    logical line parses separately.
     """
     segs: list[list[str]] = []
-    for line in _strip_heredoc_bodies(command).splitlines():
+    for line in _join_line_continuations(_strip_heredoc_bodies(command)).splitlines():
         try:
             lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
             lexer.whitespace_split = True

--- a/agents_extensions/shared/hooks/guard-admin-merge.py
+++ b/agents_extensions/shared/hooks/guard-admin-merge.py
@@ -56,27 +56,93 @@ def _command(payload: dict) -> str:
     return ((payload.get("tool_input") or {}).get("command") or "").strip()
 
 
-def _segments(command: str) -> list[list[str]]:
-    """Quote-aware tokenization split on shell separators (mirrors guard-branch-switch).
+# --- Command segmentation hardened against glued shell operators (#4876). ---
+# Pattern lifted from guard-secret-print.py. Hooks are standalone by design,
+# so the helpers are copied, not imported. Keep the three copies in
+# guard-branch-switch-in-main.py, guard-admin-merge.py, and
+# guard-push-pytest.py in sync.
 
-    Ensures a `--admin` inside a quoted commit body (`git commit -m "... --admin ..."`)
-    is one argv element, not a separate command — no false block.
-    """
+
+def _strip_quotes(token: str) -> str:
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {"'", '"'}:
+        return token[1:-1]
+    return token
+
+
+def _heredoc_delimiters(line: str) -> list[tuple[str, bool]]:
     try:
-        tokens = shlex.split(command, posix=True)
+        lexer = shlex.shlex(line, posix=False, punctuation_chars=True)
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
     except ValueError:
         return []
+
+    delimiters: list[tuple[str, bool]] = []
+    i = 0
+    while i < len(tokens):
+        if tokens[i] != "<<":
+            i += 1
+            continue
+        strip_tabs = False
+        j = i + 1
+        if j < len(tokens) and tokens[j] == "-":
+            strip_tabs = True
+            j += 1
+        if j < len(tokens):
+            delimiter = _strip_quotes(tokens[j])
+            if delimiter:
+                delimiters.append((delimiter, strip_tabs))
+        i = j + 1
+    return delimiters
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Drop heredoc BODY lines — document text is data, not commands."""
+    if "<<" not in command:
+        return command
+
+    kept: list[str] = []
+    pending: list[tuple[str, bool]] = []
+    for line in command.splitlines():
+        if pending:
+            delimiter, strip_tabs = pending[0]
+            candidate = line.lstrip("\t") if strip_tabs else line
+            if candidate == delimiter:
+                pending.pop(0)
+            continue
+        kept.append(line)
+        pending.extend(_heredoc_delimiters(line))
+    return "\n".join(kept)
+
+
+def _segments(command: str) -> list[list[str]]:
+    """Quote-aware argv segments, robust to glued shell operators (#4876).
+
+    A `--admin` inside a quoted commit body (`git commit -m "... --admin ..."`)
+    stays one argv element — no false block. A `; gh pr merge --admin` glued
+    to a preceding token (`…'; gh pr merge --admin`) is now split into its
+    own segment and inspected — no evasion. Heredoc bodies are stripped
+    (document text is not commands); each line parses separately.
+    """
     segs: list[list[str]] = []
-    cur: list[str] = []
-    for tok in tokens:
-        if tok in ("&&", "||", ";", "|"):
-            if cur:
-                segs.append(cur)
-                cur = []
-        else:
-            cur.append(tok)
-    if cur:
-        segs.append(cur)
+    for line in _strip_heredoc_bodies(command).splitlines():
+        try:
+            lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
+            lexer.whitespace_split = True
+            tokens = list(lexer)
+        except ValueError:
+            continue
+        cur: list[str] = []
+        for tok in tokens:
+            if tok and all(c in ";|&()<>" for c in tok):
+                if cur:
+                    segs.append(cur)
+                    cur = []
+            else:
+                cur.append(tok)
+        if cur:
+            segs.append(cur)
     return segs
 
 

--- a/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
+++ b/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
@@ -150,6 +150,19 @@ def _strip_heredoc_bodies(command: str) -> str:
     return "\n".join(kept)
 
 
+def _join_line_continuations(text: str) -> str:
+    r"""Fold `\<newline>` into a single logical line, as the shell does.
+
+    Without this, per-line parsing splits `git branch -D x \<newline>--extra`
+    into two physical lines; the first fails to tokenize (trailing escape)
+    and the dangerous verb rides through. The whole-command tokenizer this
+    replaced folded the continuation implicitly — preserve that. Over-folding
+    a literal `\` inside a quoted string can only merge argv text, never
+    create a false block (the guard matches specific verbs, not free text).
+    """
+    return text.replace("\\\n", "")
+
+
 def _segments(command: str) -> list[list[str]]:
     """Tokenize the command, split on shell command separators.
 
@@ -157,15 +170,16 @@ def _segments(command: str) -> list[list[str]]:
     the #4876 evasion class: `punctuation_chars` makes shlex emit operator
     runs (`;`, `|`, `&`, `(`, `)`, `<`, `>`) as their OWN tokens even when
     glued to a neighbour (`head -1; git …` no longer hides the `;` inside
-    the `-1;` token), each line is parsed separately (a newline separates
-    commands), and heredoc bodies are stripped first (document text must
-    not be parsed as commands). Quoting still collapses `git commit -m
-    "git checkout -b foo"` into a single argv element — no false block.
-    Default shlex comment handling drops `# …` trailers, matching shell
-    semantics: commented-out text can neither trigger nor hide a verb.
+    the `-1;` token), each logical line is parsed separately (a newline
+    separates commands; `\\`-continuations are folded first), and heredoc
+    bodies are stripped first (document text must not be parsed as
+    commands). Quoting still collapses `git commit -m "git checkout -b
+    foo"` into a single argv element — no false block. Default shlex
+    comment handling drops `# …` trailers, matching shell semantics:
+    commented-out text can neither trigger nor hide a verb.
     """
     segments: list[list[str]] = []
-    for line in _strip_heredoc_bodies(command).splitlines():
+    for line in _join_line_continuations(_strip_heredoc_bodies(command)).splitlines():
         try:
             lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
             lexer.whitespace_split = True

--- a/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
+++ b/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
@@ -90,34 +90,101 @@ def _in_main_worktree(project_root: Path) -> bool:
     return abs_gd == abs_cd
 
 
-def _segments(command: str) -> list[list[str]]:
-    """Tokenize the command line, split on shell command separators.
+# --- Command segmentation hardened against glued shell operators (#4876). ---
+# Pattern lifted from guard-secret-print.py (the reference parser among the
+# Bash guards). Hooks are standalone by design, so the helpers are copied,
+# not imported. Keep the three copies in guard-branch-switch-in-main.py,
+# guard-admin-merge.py, and guard-push-pytest.py in sync.
 
-    Returns a list of argv-style segments. Each segment is the token list
-    for one logical sub-command (everything between `&&`, `||`, `;`, `|`).
-    `shlex.split` respects single/double quotes, so a `git commit -m
-    "git checkout -b foo"` collapses to a single segment whose tokens
-    are `['git', 'commit', '-m', 'git checkout -b foo']` — the dangerous
-    substring is INSIDE a single argv element, not a separate command.
-    """
+
+def _strip_quotes(token: str) -> str:
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {"'", '"'}:
+        return token[1:-1]
+    return token
+
+
+def _heredoc_delimiters(line: str) -> list[tuple[str, bool]]:
     try:
-        tokens = shlex.split(command, posix=True)
+        lexer = shlex.shlex(line, posix=False, punctuation_chars=True)
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
     except ValueError:
-        # Unbalanced quotes — fall back to a degenerate split. We err on
-        # the safe side: if we can't parse, allow (the user will see the
-        # malformed command fail anyway).
         return []
+
+    delimiters: list[tuple[str, bool]] = []
+    i = 0
+    while i < len(tokens):
+        if tokens[i] != "<<":
+            i += 1
+            continue
+        strip_tabs = False
+        j = i + 1
+        if j < len(tokens) and tokens[j] == "-":
+            strip_tabs = True
+            j += 1
+        if j < len(tokens):
+            delimiter = _strip_quotes(tokens[j])
+            if delimiter:
+                delimiters.append((delimiter, strip_tabs))
+        i = j + 1
+    return delimiters
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Drop heredoc BODY lines — document text is data, not commands."""
+    if "<<" not in command:
+        return command
+
+    kept: list[str] = []
+    pending: list[tuple[str, bool]] = []
+    for line in command.splitlines():
+        if pending:
+            delimiter, strip_tabs = pending[0]
+            candidate = line.lstrip("\t") if strip_tabs else line
+            if candidate == delimiter:
+                pending.pop(0)
+            continue
+        kept.append(line)
+        pending.extend(_heredoc_delimiters(line))
+    return "\n".join(kept)
+
+
+def _segments(command: str) -> list[list[str]]:
+    """Tokenize the command, split on shell command separators.
+
+    Returns argv-style segments (one per logical sub-command). Robust to
+    the #4876 evasion class: `punctuation_chars` makes shlex emit operator
+    runs (`;`, `|`, `&`, `(`, `)`, `<`, `>`) as their OWN tokens even when
+    glued to a neighbour (`head -1; git …` no longer hides the `;` inside
+    the `-1;` token), each line is parsed separately (a newline separates
+    commands), and heredoc bodies are stripped first (document text must
+    not be parsed as commands). Quoting still collapses `git commit -m
+    "git checkout -b foo"` into a single argv element — no false block.
+    Default shlex comment handling drops `# …` trailers, matching shell
+    semantics: commented-out text can neither trigger nor hide a verb.
+    """
     segments: list[list[str]] = []
-    current: list[str] = []
-    for tok in tokens:
-        if tok in ("&&", "||", ";", "|"):
-            if current:
-                segments.append(current)
-                current = []
-        else:
-            current.append(tok)
-    if current:
-        segments.append(current)
+    for line in _strip_heredoc_bodies(command).splitlines():
+        try:
+            lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
+            lexer.whitespace_split = True
+            tokens = list(lexer)
+        except ValueError:
+            # Unparseable line (unbalanced quotes) — skip just this line;
+            # the shell will fail the malformed command anyway. Other
+            # lines in the same command are still inspected.
+            continue
+        current: list[str] = []
+        for tok in tokens:
+            if tok and all(c in ";|&()<>" for c in tok):
+                if current:
+                    segments.append(current)
+                    current = []
+            else:
+                current.append(tok)
+        if current:
+            segments.append(current)
     return segments
 
 

--- a/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
+++ b/agents_extensions/shared/hooks/guard-branch-switch-in-main.py
@@ -104,6 +104,15 @@ def _strip_quotes(token: str) -> str:
 
 
 def _heredoc_delimiters(line: str) -> list[tuple[str, bool]]:
+    """Return (delimiter, strip_tabs) for each heredoc opener on `line`.
+
+    Handles all four operator/marker forms (#4877): spaced ``<< EOF`` /
+    ``<< - EOF`` and attached ``<<-EOF`` / ``<<-'EOF'`` — the attached ``-``
+    means ``<<-`` (strip leading tabs on the closer), NOT part of the
+    delimiter word. Getting this wrong left a real heredoc effectively
+    unclosed, which (with the old strip) silently dropped everything after
+    the opener.
+    """
     try:
         lexer = shlex.shlex(line, posix=False, punctuation_chars=True)
         lexer.whitespace_split = True
@@ -120,33 +129,61 @@ def _heredoc_delimiters(line: str) -> list[tuple[str, bool]]:
             continue
         strip_tabs = False
         j = i + 1
-        if j < len(tokens) and tokens[j] == "-":
-            strip_tabs = True
-            j += 1
+        delim_tok = ""
         if j < len(tokens):
-            delimiter = _strip_quotes(tokens[j])
-            if delimiter:
-                delimiters.append((delimiter, strip_tabs))
+            nxt = tokens[j]
+            if nxt == "-":  # spaced: << - DELIM
+                strip_tabs = True
+                j += 1
+                if j < len(tokens):
+                    delim_tok = tokens[j]
+            elif nxt.startswith("-") and len(nxt) > 1:  # attached: <<-DELIM
+                strip_tabs = True
+                delim_tok = nxt[1:]
+            else:
+                delim_tok = nxt
+        delimiter = _strip_quotes(delim_tok)
+        if delimiter:
+            delimiters.append((delimiter, strip_tabs))
         i = j + 1
     return delimiters
 
 
 def _strip_heredoc_bodies(command: str) -> str:
-    """Drop heredoc BODY lines — document text is data, not commands."""
+    """Drop heredoc BODY lines — document text is data, not commands.
+
+    Fail-CLOSED on an unclosed heredoc (#4877): if a delimiter never appears
+    before EOF, the buffered lines were NOT a real heredoc body — a crafted
+    or malformed opener (never-closing marker, mis-parsed ``<<-``) must not
+    make trailing REAL commands/writes vanish from the parsed view. Those
+    lines are kept and inspected; only a heredoc that actually closes has
+    its body + closer dropped.
+    """
     if "<<" not in command:
         return command
 
+    lines = command.splitlines()
     kept: list[str] = []
-    pending: list[tuple[str, bool]] = []
-    for line in command.splitlines():
-        if pending:
+    i = 0
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        kept.append(line)
+        i += 1
+        pending = _heredoc_delimiters(line)
+        if not pending:
+            continue
+        body_start = i
+        while i < n and pending:
             delimiter, strip_tabs = pending[0]
-            candidate = line.lstrip("\t") if strip_tabs else line
+            candidate = lines[i].lstrip("\t") if strip_tabs else lines[i]
             if candidate == delimiter:
                 pending.pop(0)
-            continue
-        kept.append(line)
-        pending.extend(_heredoc_delimiters(line))
+            i += 1
+        if pending:
+            # Unclosed at EOF → not a real body; keep the lines (fail-closed).
+            kept.extend(lines[body_start:i])
+        # else: closed — body and closer consumed and dropped.
     return "\n".join(kept)
 
 
@@ -227,13 +264,33 @@ def _branch_force_reason(args: list[str]) -> str | None:
     return None
 
 
+def _is_env_assignment(tok: str) -> bool:
+    """`VAR=val` prefix (as before `env` or a bare command). Mirrors the
+    reference idiom in guard-primary-checkout-write._command_word."""
+    return "=" in tok and not tok.startswith("-") and tok.split("=", 1)[0].isidentifier()
+
+
+def _skip_command_prefix(seg: list[str], i: int) -> int:
+    """Advance past transparent leading tokens so we land on the real command
+    word: wrappers (`sudo`/`time`/`env`/`nohup`/`command`/`exec`), env
+    assignments (`FOO=1`), and a brace-group opener (`{`). Without this a
+    `env FOO=1 git branch -D x` or `{ git branch -D x; }` hid the verb (#4877)."""
+    while i < len(seg):
+        tok = seg[i]
+        if tok in {"sudo", "time", "env", "nohup", "command", "exec", "{"} or _is_env_assignment(
+            tok
+        ):
+            i += 1
+        else:
+            break
+    return i
+
+
 def _segment_is_dangerous(seg: list[str]) -> str | None:
     """Return a human-readable reason string if seg is a dangerous git op,
     else None."""
-    # Find `git` token; allow common leading wrappers (`sudo`, `time`, `env`).
-    i = 0
-    while i < len(seg) and seg[i] in {"sudo", "time", "env", "nohup"}:
-        i += 1
+    # Land on the command word past wrappers / env-assignments / brace open.
+    i = _skip_command_prefix(seg, 0)
     if i >= len(seg) or seg[i] != "git":
         return None
     # Skip over `git -C <dir>` / `git -c k=v` flag pairs and other top-level

--- a/agents_extensions/shared/hooks/guard-primary-checkout-write.py
+++ b/agents_extensions/shared/hooks/guard-primary-checkout-write.py
@@ -223,13 +223,22 @@ def _heredoc_delimiters(line: str) -> list[tuple[str, bool]]:
             continue
         strip_tabs = False
         j = i + 1
-        if j < len(tokens) and tokens[j] == "-":
-            strip_tabs = True
-            j += 1
+        delim_tok = ""
         if j < len(tokens):
-            delimiter = _strip_quotes_for_heredoc(tokens[j])
-            if delimiter:
-                delimiters.append((delimiter, strip_tabs))
+            nxt = tokens[j]
+            if nxt == "-":  # spaced: << - DELIM
+                strip_tabs = True
+                j += 1
+                if j < len(tokens):
+                    delim_tok = tokens[j]
+            elif nxt.startswith("-") and len(nxt) > 1:  # attached: <<-DELIM
+                strip_tabs = True
+                delim_tok = nxt[1:]
+            else:
+                delim_tok = nxt
+        delimiter = _strip_quotes_for_heredoc(delim_tok)
+        if delimiter:
+            delimiters.append((delimiter, strip_tabs))
         i = j + 1
     return delimiters
 
@@ -241,21 +250,35 @@ def _strip_heredoc_bodies(command: str) -> str:
     syntax. Without this, body text like ``>15%`` or markdown backtick spans
     is tokenized as redirects and misread as write targets — the recurring
     false-positive class. Pattern shared with guard-secret-print.py.
+
+    Fail-CLOSED on an unclosed heredoc (#4877): if a delimiter never appears
+    before EOF, the buffered lines were NOT a real body — a crafted or
+    malformed opener must not make trailing REAL writes vanish from the
+    tokenized view. Those lines are kept; only a heredoc that actually
+    closes has its body + closer dropped.
     """
     if "<<" not in command:
         return command
 
+    lines = command.splitlines()
     kept: list[str] = []
-    pending: list[tuple[str, bool]] = []
-    for line in command.splitlines():
-        if pending:
+    i = 0
+    n = len(lines)
+    while i < n:
+        kept.append(lines[i])
+        i += 1
+        pending = _heredoc_delimiters(lines[i - 1])
+        if not pending:
+            continue
+        body_start = i
+        while i < n and pending:
             delimiter, strip_tabs = pending[0]
-            candidate = line.lstrip("\t") if strip_tabs else line
+            candidate = lines[i].lstrip("\t") if strip_tabs else lines[i]
             if candidate == delimiter:
                 pending.pop(0)
-            continue
-        kept.append(line)
-        pending.extend(_heredoc_delimiters(line))
+            i += 1
+        if pending:
+            kept.extend(lines[body_start:i])
     return "\n".join(kept)
 
 

--- a/agents_extensions/shared/hooks/guard-primary-checkout-write.py
+++ b/agents_extensions/shared/hooks/guard-primary-checkout-write.py
@@ -200,16 +200,78 @@ _CONTROL_OPS = frozenset({"&&", "||", ";", "|", "&", "(", ")", "\n"})
 _FILE_REDIRECTS = frozenset({">", ">>", ">|", "&>", "&>>"})
 
 
+def _strip_quotes_for_heredoc(token: str) -> str:
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {"'", '"'}:
+        return token[1:-1]
+    return token
+
+
+def _heredoc_delimiters(line: str) -> list[tuple[str, bool]]:
+    try:
+        lexer = shlex.shlex(line, posix=False, punctuation_chars=True)
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
+    except ValueError:
+        return []
+
+    delimiters: list[tuple[str, bool]] = []
+    i = 0
+    while i < len(tokens):
+        if tokens[i] != "<<":
+            i += 1
+            continue
+        strip_tabs = False
+        j = i + 1
+        if j < len(tokens) and tokens[j] == "-":
+            strip_tabs = True
+            j += 1
+        if j < len(tokens):
+            delimiter = _strip_quotes_for_heredoc(tokens[j])
+            if delimiter:
+                delimiters.append((delimiter, strip_tabs))
+        i = j + 1
+    return delimiters
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Drop heredoc BODY lines before tokenizing (#4538 / #4855).
+
+    Content between ``<<'MARKER'`` and ``MARKER`` is document DATA, not shell
+    syntax. Without this, body text like ``>15%`` or markdown backtick spans
+    is tokenized as redirects and misread as write targets — the recurring
+    false-positive class. Pattern shared with guard-secret-print.py.
+    """
+    if "<<" not in command:
+        return command
+
+    kept: list[str] = []
+    pending: list[tuple[str, bool]] = []
+    for line in command.splitlines():
+        if pending:
+            delimiter, strip_tabs = pending[0]
+            candidate = line.lstrip("\t") if strip_tabs else line
+            if candidate == delimiter:
+                pending.pop(0)
+            continue
+        kept.append(line)
+        pending.extend(_heredoc_delimiters(line))
+    return "\n".join(kept)
+
+
 def _tokenize(command: str) -> list[str]:
     """Quote-aware tokens with redirection/control operators kept separate.
 
     ``punctuation_chars`` makes shlex split ``();<>|&`` runs into their own
     tokens while still respecting quotes, so ``echo a>b`` yields
     ``['echo','a','>','b']`` but ``echo "a>b"`` keeps ``a>b`` intact — the whole
-    reason this is Python and not a grep.
+    reason this is Python and not a grep. Heredoc bodies are stripped first:
+    document text carries no write targets (#4538).
     """
     try:
-        lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+        lexer = shlex.shlex(
+            _strip_heredoc_bodies(command), posix=True, punctuation_chars=True
+        )
         lexer.whitespace_split = True
         return list(lexer)
     except ValueError:

--- a/agents_extensions/shared/hooks/guard-push-pytest.py
+++ b/agents_extensions/shared/hooks/guard-push-pytest.py
@@ -70,33 +70,55 @@ def _heredoc_delimiters(line: str) -> list[tuple[str, bool]]:
             continue
         strip_tabs = False
         j = i + 1
-        if j < len(tokens) and tokens[j] == "-":
-            strip_tabs = True
-            j += 1
+        delim_tok = ""
         if j < len(tokens):
-            delimiter = _strip_quotes(tokens[j])
-            if delimiter:
-                delimiters.append((delimiter, strip_tabs))
+            nxt = tokens[j]
+            if nxt == "-":  # spaced: << - DELIM
+                strip_tabs = True
+                j += 1
+                if j < len(tokens):
+                    delim_tok = tokens[j]
+            elif nxt.startswith("-") and len(nxt) > 1:  # attached: <<-DELIM
+                strip_tabs = True
+                delim_tok = nxt[1:]
+            else:
+                delim_tok = nxt
+        delimiter = _strip_quotes(delim_tok)
+        if delimiter:
+            delimiters.append((delimiter, strip_tabs))
         i = j + 1
     return delimiters
 
 
 def _strip_heredoc_bodies(command: str) -> str:
-    """Drop heredoc BODY lines — document text is data, not commands."""
+    """Drop heredoc BODY lines — document text is data, not commands.
+
+    Fail-CLOSED on an unclosed heredoc (#4877): a never-closing / mis-parsed
+    opener must not make a trailing real `git push` vanish. Only a heredoc
+    that actually closes has its body + closer dropped.
+    """
     if "<<" not in command:
         return command
 
+    lines = command.splitlines()
     kept: list[str] = []
-    pending: list[tuple[str, bool]] = []
-    for line in command.splitlines():
-        if pending:
+    i = 0
+    n = len(lines)
+    while i < n:
+        kept.append(lines[i])
+        i += 1
+        pending = _heredoc_delimiters(lines[i - 1])
+        if not pending:
+            continue
+        body_start = i
+        while i < n and pending:
             delimiter, strip_tabs = pending[0]
-            candidate = line.lstrip("\t") if strip_tabs else line
+            candidate = lines[i].lstrip("\t") if strip_tabs else lines[i]
             if candidate == delimiter:
                 pending.pop(0)
-            continue
-        kept.append(line)
-        pending.extend(_heredoc_delimiters(line))
+            i += 1
+        if pending:
+            kept.extend(lines[body_start:i])
     return "\n".join(kept)
 
 
@@ -161,10 +183,18 @@ def _push_is_help(args: list[str]) -> bool:
     return any(arg in {"-h", "--help"} for arg in args)
 
 
+def _is_env_assignment(tok: str) -> bool:
+    return "=" in tok and not tok.startswith("-") and tok.split("=", 1)[0].isidentifier()
+
+
 def _git_push_args(seg: list[str]) -> list[str] | None:
     """Return args for a real ``git push`` segment, else None."""
+    # Skip wrappers / env-assignments / brace-group open so `env X=1 git push`
+    # and `{ git push; }` are not missed (#4877).
     i = 0
-    while i < len(seg) and seg[i] in WRAPPERS:
+    while i < len(seg) and (
+        seg[i] in WRAPPERS or seg[i] in {"command", "exec", "{"} or _is_env_assignment(seg[i])
+    ):
         i += 1
     if i >= len(seg) or seg[i] != "git":
         return None

--- a/agents_extensions/shared/hooks/guard-push-pytest.py
+++ b/agents_extensions/shared/hooks/guard-push-pytest.py
@@ -40,23 +40,91 @@ def _command(payload: dict) -> str:
     return ((payload.get("tool_input") or {}).get("command") or "").strip()
 
 
-def _segments(command: str) -> list[list[str]]:
-    """Quote-aware tokenization split on common shell separators."""
+# --- Command segmentation hardened against glued shell operators (#4876). ---
+# Pattern lifted from guard-secret-print.py. Hooks are standalone by design,
+# so the helpers are copied, not imported. Keep the three copies in
+# guard-branch-switch-in-main.py, guard-admin-merge.py, and
+# guard-push-pytest.py in sync.
+
+
+def _strip_quotes(token: str) -> str:
+    if len(token) >= 2 and token[0] == token[-1] and token[0] in {"'", '"'}:
+        return token[1:-1]
+    return token
+
+
+def _heredoc_delimiters(line: str) -> list[tuple[str, bool]]:
     try:
-        tokens = shlex.split(command, posix=True)
+        lexer = shlex.shlex(line, posix=False, punctuation_chars=True)
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        tokens = list(lexer)
     except ValueError:
         return []
+
+    delimiters: list[tuple[str, bool]] = []
+    i = 0
+    while i < len(tokens):
+        if tokens[i] != "<<":
+            i += 1
+            continue
+        strip_tabs = False
+        j = i + 1
+        if j < len(tokens) and tokens[j] == "-":
+            strip_tabs = True
+            j += 1
+        if j < len(tokens):
+            delimiter = _strip_quotes(tokens[j])
+            if delimiter:
+                delimiters.append((delimiter, strip_tabs))
+        i = j + 1
+    return delimiters
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Drop heredoc BODY lines — document text is data, not commands."""
+    if "<<" not in command:
+        return command
+
+    kept: list[str] = []
+    pending: list[tuple[str, bool]] = []
+    for line in command.splitlines():
+        if pending:
+            delimiter, strip_tabs = pending[0]
+            candidate = line.lstrip("\t") if strip_tabs else line
+            if candidate == delimiter:
+                pending.pop(0)
+            continue
+        kept.append(line)
+        pending.extend(_heredoc_delimiters(line))
+    return "\n".join(kept)
+
+
+def _segments(command: str) -> list[list[str]]:
+    """Quote-aware argv segments, robust to glued shell operators (#4876).
+
+    Operator runs (`;`, `|`, `&`, `(`, `)`, `<`, `>`) become their own
+    tokens even when glued to a neighbour, lines parse separately, and
+    heredoc bodies are stripped before parsing.
+    """
     segments: list[list[str]] = []
-    current: list[str] = []
-    for tok in tokens:
-        if tok in ("&&", "||", ";", "|"):
-            if current:
-                segments.append(current)
-                current = []
-        else:
-            current.append(tok)
-    if current:
-        segments.append(current)
+    for line in _strip_heredoc_bodies(command).splitlines():
+        try:
+            lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
+            lexer.whitespace_split = True
+            tokens = list(lexer)
+        except ValueError:
+            continue
+        current: list[str] = []
+        for tok in tokens:
+            if tok and all(c in ";|&()<>" for c in tok):
+                if current:
+                    segments.append(current)
+                    current = []
+            else:
+                current.append(tok)
+        if current:
+            segments.append(current)
     return segments
 
 

--- a/agents_extensions/shared/hooks/guard-push-pytest.py
+++ b/agents_extensions/shared/hooks/guard-push-pytest.py
@@ -100,15 +100,23 @@ def _strip_heredoc_bodies(command: str) -> str:
     return "\n".join(kept)
 
 
+def _join_line_continuations(text: str) -> str:
+    r"""Fold `\<newline>` into one logical line, as the shell does — so a
+    `\`-continued `git push` is not split across physical lines and missed.
+    Over-folding a quoted literal `\` only merges argv text."""
+    return text.replace("\\\n", "")
+
+
 def _segments(command: str) -> list[list[str]]:
     """Quote-aware argv segments, robust to glued shell operators (#4876).
 
     Operator runs (`;`, `|`, `&`, `(`, `)`, `<`, `>`) become their own
-    tokens even when glued to a neighbour, lines parse separately, and
-    heredoc bodies are stripped before parsing.
+    tokens even when glued to a neighbour, `\\`-continuations are folded,
+    logical lines parse separately, and heredoc bodies are stripped before
+    parsing.
     """
     segments: list[list[str]] = []
-    for line in _strip_heredoc_bodies(command).splitlines():
+    for line in _join_line_continuations(_strip_heredoc_bodies(command)).splitlines():
         try:
             lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
             lexer.whitespace_split = True

--- a/tests/test_guard_admin_merge.py
+++ b/tests/test_guard_admin_merge.py
@@ -182,3 +182,22 @@ def test_heredoc_admin_mention_not_detected():
 
 def test_backslash_continuation_admin_detected():
     assert _any_admin("gh pr merge 5 \\\n  --admin --squash")
+
+
+# --- #4877 adversarial round (grok-build msg 2334) ---
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "env FOO=1 gh pr merge 5 --admin",
+        "FOO=1 gh pr merge 5 --admin",
+        "{ gh pr merge 5 --admin; }",
+    ],
+)
+def test_wrapper_assignment_brace_admin_detected(cmd):
+    assert _any_admin(cmd)
+
+
+def test_unclosed_heredoc_does_not_hide_admin():
+    assert _any_admin("cat <<'NOEND'\nnote\ngh pr merge 5 --admin")

--- a/tests/test_guard_admin_merge.py
+++ b/tests/test_guard_admin_merge.py
@@ -151,3 +151,30 @@ def test_failing_checks_advisory_only_is_empty(monkeypatch):
 def test_failing_checks_garbage_output_is_failclosed(monkeypatch):
     _fake_gh(monkeypatch, returncode=0, stdout="not json")
     assert guard._failing_blocking_checks("5") is None
+
+
+# --- #4876: glued-operator evasion class ------------------------------------
+
+
+def _any_admin(command: str) -> bool:
+    return any(
+        guard._admin_merge_args(s) is not None for s in guard._segments(command)
+    )
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "true 2>&1 | head -1; gh pr merge 5 --admin",
+        "gh pr view 5 --jq '{state}'; gh pr merge 5 --admin --squash",
+        "echo hi\ngh pr merge 5 --admin",
+        "true;gh pr merge 5 --admin",
+    ],
+)
+def test_glued_operator_admin_merge_detected(cmd):
+    assert _any_admin(cmd)
+
+
+def test_heredoc_admin_mention_not_detected():
+    cmd = "cat > /tmp/n.md <<'EOF'\nrun gh pr merge 5 --admin manually\nEOF"
+    assert not _any_admin(cmd)

--- a/tests/test_guard_admin_merge.py
+++ b/tests/test_guard_admin_merge.py
@@ -178,3 +178,7 @@ def test_glued_operator_admin_merge_detected(cmd):
 def test_heredoc_admin_mention_not_detected():
     cmd = "cat > /tmp/n.md <<'EOF'\nrun gh pr merge 5 --admin manually\nEOF"
     assert not _any_admin(cmd)
+
+
+def test_backslash_continuation_admin_detected():
+    assert _any_admin("gh pr merge 5 \\\n  --admin --squash")

--- a/tests/test_guard_branch_switch_in_main.py
+++ b/tests/test_guard_branch_switch_in_main.py
@@ -205,3 +205,59 @@ def test_backslash_line_continuation_still_inspected():
     # tokenizer this replaced folded continuations implicitly (#4876).
     assert _dangerous("git branch -D victim \\\n  --force-ish") is not None
     assert _dangerous("git status \\\n  && git branch -D victim") is not None
+
+
+# --- #4877 adversarial round (grok-build msg 2334): env/brace/heredoc holes ---
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "env FOO=1 git branch -D victim",  # env + assignment before verb
+        "FOO=1 git branch -D victim",  # bare leading assignment
+        "{ git branch -D victim; }",  # compact brace group
+        "{ git branch -D victim",  # unterminated brace group
+        "command git branch -D victim",  # `command` wrapper
+    ],
+)
+def test_wrapper_and_assignment_prefixes_still_inspected(cmd):
+    assert _dangerous(cmd) is not None
+
+
+def test_unclosed_heredoc_does_not_hide_trailing_danger():
+    # A never-closing marker must NOT drop the real command after it (#4877
+    # fail-open): the buffered lines were not a real heredoc body.
+    assert _dangerous("cat <<'NOEND'\nbody > fake\ngit branch -D victim") is not None
+
+
+def test_attached_dash_heredoc_closes_and_body_dropped():
+    # `<<-EOF` with a tab-indented closer is a REAL heredoc: body dropped
+    # (no false positive on body content), trailing command still scanned.
+    cmd = "cat <<-EOF\n\tgit branch -D fake\n\tEOF\ngit branch -D victim"
+    assert _dangerous(cmd) is not None  # the trailing real one
+    # body-only (properly closed) must not trip:
+    assert _dangerous("cat <<-EOF\n\tgit branch -D fake\n\tEOF") is None
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        'bash -c "git branch -D x"',
+        'sh -c "git branch -D x"',
+        'eval "git branch -D x"',
+        "x=`git branch -D x`",  # backtick command substitution
+    ],
+)
+def test_known_boundary_verb_inside_string_or_backticks(cmd):
+    """DOCUMENTED LIMITATION (#4877, grok msg 2334): a verb hidden inside a
+    quoted string arg (`bash -c "…"`, `eval "…"`) or backticks is NOT
+    inspected — a segment guard cannot see it without becoming a recursive
+    shell parser (which would add false positives). The old whole-command
+    guard had the same blind spot. These guards are an honest-mistake safety
+    net, not an adversarial sandbox: an agent does not accidentally wrap a
+    destructive command in `bash -c`. This test PINS the boundary so any
+    future change to it is visible and deliberate. (Note: `$(…)` substitution
+    IS caught — see the dangerous-cases tests — because it leaks bare verb
+    tokens into a segment; only string-args and backticks are blind.)
+    """
+    assert _dangerous(cmd) is None

--- a/tests/test_guard_branch_switch_in_main.py
+++ b/tests/test_guard_branch_switch_in_main.py
@@ -197,3 +197,11 @@ def test_hardened_segments_no_false_positive(cmd):
 def test_heredoc_body_does_not_mask_following_command():
     cmd = "cat > /tmp/x.md <<'EOF'\nbody text\nEOF\ngit branch -D victim"
     assert _dangerous(cmd) is not None
+
+
+def test_backslash_line_continuation_still_inspected():
+    # `\`-continuation is ONE logical command; the folded line must still be
+    # scanned. Regression guard for the per-line refactor — the whole-command
+    # tokenizer this replaced folded continuations implicitly (#4876).
+    assert _dangerous("git branch -D victim \\\n  --force-ish") is not None
+    assert _dangerous("git status \\\n  && git branch -D victim") is not None

--- a/tests/test_guard_branch_switch_in_main.py
+++ b/tests/test_guard_branch_switch_in_main.py
@@ -150,3 +150,50 @@ def test_branch_force_reason_unit():
     assert guard._branch_force_reason(["-m", "old", "new"]) is None
     assert guard._branch_force_reason(["feature"]) is None
     assert guard._branch_force_reason([]) is None
+
+
+# --- #4876: glued-operator evasion class ------------------------------------
+# Live shapes from 2026-07-10: five `git branch -D` calls rode through the
+# guard because `;`/`|`/newlines glued to neighbouring tokens never became
+# separator tokens, collapsing the whole line into one segment.
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "true 2>&1 | head -1; git branch -D victim",
+        "gh pr view 9 --json s --jq '{state, mergedAt}'; git branch -D victim",
+        "cmd1\ngit branch -D victim",
+        (
+            "git worktree remove --force .worktrees/x 2>&1 | head -1; "
+            "git branch -D victim 2>/dev/null | head -1"
+        ),
+        "true;git checkout -b feature",
+        "true&&git switch -c feature",
+    ],
+)
+def test_glued_operator_evasion_blocked(cmd):
+    assert _dangerous(cmd) is not None
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        # Heredoc bodies are data — a dangerous-looking line inside one must
+        # not trigger…
+        "cat > /tmp/x.md <<'EOF'\ngit branch -D fake\nEOF",
+        # …quoting still protects commit messages…
+        'git commit -m "git branch -D notreal"',
+        # …and safe ops with glued separators stay allowed.
+        "git branch -d merged-ok; echo done",
+        # Commented-out danger is dead text.
+        "echo hi # git branch -D victim",
+    ],
+)
+def test_hardened_segments_no_false_positive(cmd):
+    assert _dangerous(cmd) is None
+
+
+def test_heredoc_body_does_not_mask_following_command():
+    cmd = "cat > /tmp/x.md <<'EOF'\nbody text\nEOF\ngit branch -D victim"
+    assert _dangerous(cmd) is not None

--- a/tests/test_guard_primary_checkout_write.py
+++ b/tests/test_guard_primary_checkout_write.py
@@ -306,3 +306,35 @@ def test_bash_write_from_worktree_targeting_main_blocked(repo: Path):
 )
 def test_heredoc_body_not_write_targets(command, expected):
     assert hook.bash_write_targets(command) == expected
+
+
+# --- #4877 adversarial round (grok-build msg 2334): heredoc fail-open ---------
+
+
+@pytest.mark.parametrize(
+    "command, expected",
+    [
+        # Never-closing marker: the whole buffer is inspected (fail-closed).
+        # The security-critical target `curriculum/tracked.md` must NOT vanish;
+        # the would-be body line `> fake` is conservatively over-reported too,
+        # which is the safe direction (a malformed heredoc gets full scrutiny).
+        (
+            "cat <<'NOEND'\nbody > fake\necho tampered > curriculum/tracked.md",
+            ["fake", "curriculum/tracked.md"],
+        ),
+        # Attached `<<-E` whose closer never appears → unclosed → keep the
+        # trailing real write.
+        (
+            "cat <<-E\n\tbody\nreal > target.txt",
+            ["target.txt"],
+        ),
+        # Attached `<<-EOF` PROPERLY closed (tab + EOF): body dropped, no FP,
+        # and the opener's own redirect target is still seen.
+        (
+            "cat > /tmp/a.md <<-EOF\n\tbody 2>&1 here\n\tEOF",
+            ["/tmp/a.md"],
+        ),
+    ],
+)
+def test_heredoc_failclosed_on_unclosed(command, expected):
+    assert hook.bash_write_targets(command) == expected

--- a/tests/test_guard_primary_checkout_write.py
+++ b/tests/test_guard_primary_checkout_write.py
@@ -270,3 +270,39 @@ def test_bash_write_from_worktree_targeting_main_blocked(repo: Path):
     }
     result = _run(repo, payload)
     assert result.returncode == 2, result.stderr
+
+
+# --- #4538 / #4855: heredoc bodies carry no write targets -------------------
+
+
+@pytest.mark.parametrize(
+    "command, expected",
+    [
+        # Body text with `>N` (previously misread as a redirect to '15%').
+        (
+            "cat > /tmp/brief.md <<'EOF'\n"
+            "... if >15% of the last 30 consecutive live passages ...\n"
+            "EOF",
+            ["/tmp/brief.md"],
+        ),
+        # Body text with markdown backtick code spans (#4855 live repro).
+        (
+            "cat > /tmp/brief.md <<'EOF'\n"
+            "run `.venv/bin/python scripts/x.py` then check\n"
+            "EOF",
+            ["/tmp/brief.md"],
+        ),
+        # Tab-indented body with <<- and a redirect-looking line.
+        (
+            "cat > /tmp/t.md <<-'DOC'\n\tdata 2>&1 goes here\n\tDOC",
+            ["/tmp/t.md"],
+        ),
+        # A real write AFTER the heredoc closes is still seen.
+        (
+            "cat > /tmp/a.md <<'EOF'\nbody\nEOF\necho x > out.txt",
+            ["/tmp/a.md", "out.txt"],
+        ),
+    ],
+)
+def test_heredoc_body_not_write_targets(command, expected):
+    assert hook.bash_write_targets(command) == expected

--- a/tests/test_guard_push_pytest.py
+++ b/tests/test_guard_push_pytest.py
@@ -140,3 +140,24 @@ def test_stamp_pytest_bash_smoke(tmp_path):
 
     assert detached_result.returncode == 0
     assert not list(tmp_path.glob("learn-uk-pytest*.stamp"))
+
+
+# --- #4876: glued-operator evasion class ------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "true 2>&1 | head -1; git push origin main",
+        "echo done\ngit push origin main",
+        "true;git push origin main",
+        "git add -A && git commit -m 'x'; git push",
+    ],
+)
+def test_glued_operator_push_detected(cmd):
+    assert guard._contains_git_push(cmd)
+
+
+def test_heredoc_push_mention_not_detected():
+    cmd = "cat > /tmp/n.md <<'EOF'\nthen git push origin main\nEOF"
+    assert not guard._contains_git_push(cmd)

--- a/tests/test_guard_push_pytest.py
+++ b/tests/test_guard_push_pytest.py
@@ -165,3 +165,22 @@ def test_heredoc_push_mention_not_detected():
 
 def test_backslash_continuation_push_detected():
     assert guard._contains_git_push("git push \\\n  origin main")
+
+
+# --- #4877 adversarial round (grok-build msg 2334) ---
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "env FOO=1 git push origin main",
+        "FOO=1 git push origin main",
+        "{ git push origin main; }",
+    ],
+)
+def test_wrapper_assignment_brace_push_detected(cmd):
+    assert guard._contains_git_push(cmd)
+
+
+def test_unclosed_heredoc_does_not_hide_push():
+    assert guard._contains_git_push("cat <<'NOEND'\nnote\ngit push origin main")

--- a/tests/test_guard_push_pytest.py
+++ b/tests/test_guard_push_pytest.py
@@ -161,3 +161,7 @@ def test_glued_operator_push_detected(cmd):
 def test_heredoc_push_mention_not_detected():
     cmd = "cat > /tmp/n.md <<'EOF'\nthen git push origin main\nEOF"
     assert not guard._contains_git_push(cmd)
+
+
+def test_backslash_continuation_push_detected():
+    assert guard._contains_git_push("git push \\\n  origin main")


### PR DESCRIPTION
## What

Three of five Bash guards segmented commands by matching `;` `&&` `||` `|` as **standalone tokens only** — but shlex glues operators to neighbours (`head -1; git` → token `-1;`), so any guarded command after a glued separator or newline was never inspected. **Proven live 2026-07-10:** five `git branch -D` calls in the main checkout rode through `guard-branch-switch-in-main` unblocked; the identical shape evades `guard-admin-merge` (the #M-0.5 guard) and `guard-push-pytest` (#M-7).

Fix adopts the in-repo reference parser (guard-secret-print): `punctuation_chars` tokenization + per-line parsing + heredoc-body stripping. Same strip applied to `guard-primary-checkout-write` → kills the recurring `>15%`/backtick-span false-positive class (#4538, dup #4855).

## Tool-backed evidence (#M-4)

- Repro before fix: `echo '{"tool_input":{"command":"true 2>&1 | head -1; git branch -D x"}}' | .claude/hooks/guard-branch-switch-in-main.py` → exit 0 (bare `git branch -D x` → exit 2).
- After fix: **128/128 pass** across the four guard suites (`pytest tests/test_guard_branch_switch_in_main.py tests/test_guard_admin_merge.py tests/test_guard_push_pytest.py tests/test_guard_primary_checkout_write.py` → `128 passed in 2.26s`) — includes new parametrized evasion cases using the exact live shapes and heredoc no-FP/no-mask probes; all pre-existing quoted-string/false-positive tests still green.
- E2E subprocess: glued `--admin` payload → exit 2 (guard-admin-merge). Branch-switch subprocess e2e from the worktree exits 0 BY DESIGN (`main()` derives root from `__file__` → added worktree is allowed; that logic is untouched by this diff). Post-merge deploy verification step below.
- Ruff lint clean on all 8 files; format divergence in hooks is pre-existing (untouched guard-secret-print flags too) and intentionally not churned.

## Post-merge (orchestrator)

1. `npm run agents:deploy` (hooks live in `agents_extensions/shared/` → `.claude/` is a deploy target).
2. Deployed-copy e2e: the glued repro payload against `.claude/hooks/guard-branch-switch-in-main.py` must exit 2.
3. #4674 (sanctioned squash-merged-branch deletion path) becomes immediately load-bearing — the accidental escape hatch is closed.

Closes #4876. Closes #4538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)