### PR TITLE
fix(agent-runtime): prefer local claude binary over broken npx shim — revives claude dispatch lane (#4875)

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1157,7 +1157,7 @@ Registered runtime adapters with default model and supported modes.
 ```json
 {
   "agents": [
-    {"name": "claude", "binary": "npx @anthropic-ai/claude-code@latest"},
+    {"name": "claude", "binary": "claude"},
     {"name": "gemini", "binary": "gemini"},
     {"name": "codex", "binary": "codex"}
   ]

--- a/scripts/agent_runtime/adapters/claude.py
+++ b/scripts/agent_runtime/adapters/claude.py
@@ -1,4 +1,4 @@
-"""ClaudeAdapter — wraps ``npx @anthropic-ai/claude-code@latest`` for the runtime.
+"""ClaudeAdapter — wraps the local ``claude`` CLI (npx fallback) for the runtime.
 
 Third production adapter. Phase 5 of #1184. Claude is the LAST adapter
 to land because it has the most special-case logic:
@@ -130,7 +130,7 @@ def _ensure_supported_claude_cli_version(cmd_prefix: tuple[str, ...]) -> tuple[i
 
 
 class ClaudeAdapter:
-    """Adapter for ``npx @anthropic-ai/claude-code@latest`` print mode."""
+    """Adapter for the ``claude`` CLI in print mode (local binary preferred)."""
 
     name: str = "claude"
     default_model: str = "claude-opus-4-8"
@@ -174,39 +174,42 @@ class ClaudeAdapter:
         if discussion_readonly and mode != "read-only":
             raise ValueError("AB_DISCUSS_READONLY requires mode='read-only'")
 
-        # Command prefix — match start-claude.sh:120's invariant: prefer
-        # ``npx @anthropic-ai/claude-code@latest`` so dispatched runs ride
-        # the same version as the interactive launcher and inherit npm's
-        # cache semantics (avoids stale-binary cache bugs and dropped
-        # prompt caching). The local ``claude`` binary on PATH is the
-        # last-resort fallback only — used when ``npx`` is unavailable
-        # (e.g. air-gapped CI without npm registry access).
+        # Command prefix — prefer the local native ``claude`` binary; ``npx``
+        # is the fallback for machines without a native install (#4875).
         #
-        # Pre-#1684 history: the order was inverted (local binary first,
-        # npx fallback). On 2026-05-05 that was empirically diagnosed —
-        # ``which claude`` resolved to ~/.local/bin/claude at 2.1.126
-        # while ``npx @latest`` resolved to 2.1.128, so every dispatched
-        # Claude run silently missed the 2.1.128 fixes (subagent
-        # prompt-cache reuse ~3× cache_creation reduction; 1M-context
-        # autocompact false-block fix; --bare >10MB stdin crash fix).
+        # History (both flips were empirically diagnosed — check before
+        # flipping again):
+        # - Pre-#1684: local binary first. On 2026-05-05 that let dispatched
+        #   runs silently drift behind the npx-managed version (local 2.1.126
+        #   vs npx 2.1.128), so #1684 flipped to npx-first.
+        # - #4875 (2026-07-10): the ``@anthropic-ai/claude-code`` npm package
+        #   became a thin shim around a NATIVE installer — ``npx @latest``
+        #   now exits rc=1 in ~8s with "Error: claude native binary not
+        #   installed" (stdout empty, no stderr diagnostic). Every dispatched
+        #   claude run died at spawn; last successful lane dispatch was
+        #   2026-05-31. The native binary on PATH self-updates, so the
+        #   #1684 version-drift concern no longer applies; the
+        #   ``_ensure_supported_claude_cli_version`` gate below still rejects
+        #   stale binaries (< 2.1.116) loudly.
         #
         # Callers can still override by passing
         # ``tool_config={"cmd_prefix": [...]}`` (preserved unchanged).
         cmd_prefix = tc.get("cmd_prefix")
         if cmd_prefix:
             cmd = [cmd_prefix] if isinstance(cmd_prefix, str) else list(cmd_prefix)
-        elif shutil.which("npx"):
-            cmd = ["npx", "@anthropic-ai/claude-code@latest"]
         else:
             claude_bin = shutil.which("claude")
-            if not claude_bin:
+            if claude_bin:
+                cmd = [claude_bin]
+            elif shutil.which("npx"):
+                cmd = ["npx", "@anthropic-ai/claude-code@latest"]
+            else:
                 raise RuntimeError(
-                    "Cannot dispatch Claude Code: neither `npx` nor a "
-                    "`claude` binary was found on PATH. Install Node.js "
-                    "(provides npx) or run "
-                    "`npm install -g @anthropic-ai/claude-code`."
+                    "Cannot dispatch Claude Code: neither a `claude` binary "
+                    "nor `npx` was found on PATH. Install the native Claude "
+                    "CLI (https://claude.com/claude-code) or Node.js "
+                    "(provides npx)."
                 )
-            cmd = [claude_bin]
 
         probe_prefix = tuple(cmd)
         cli_version = _ensure_supported_claude_cli_version(probe_prefix)

--- a/scripts/ai_agent_bridge/_config.py
+++ b/scripts/ai_agent_bridge/_config.py
@@ -26,9 +26,12 @@ PID_DIR = Path(
 )
 
 # Resolve CLI paths at import time (before detached children lose PATH)
-# Use npx to run Claude Code — avoids bugs in the globally installed version.
-# Returns a list: ["npx", "@anthropic-ai/claude-code"] to use as cmd prefix.
-CLAUDE_CMD = ["npx", "@anthropic-ai/claude-code@latest"]
+# Prefer the local native `claude` binary (#4875: the npm package became a
+# native-installer shim — `npx @latest` exits rc=1 with "Error: claude native
+# binary not installed" and empty stdout, killing every bridge Claude call at
+# spawn). npx stays as the fallback for machines without a native install.
+_CLAUDE_BIN = shutil.which("claude")
+CLAUDE_CMD = [_CLAUDE_BIN] if _CLAUDE_BIN else ["npx", "@anthropic-ai/claude-code@latest"]
 AGY_CLI = shutil.which("agy") or str(Path.home() / ".local/bin/agy")
 GEMINI_CLI = shutil.which("gemini") or "gemini"
 CODEX_CLI = shutil.which("codex") or "codex"

--- a/scripts/api/runtime_router.py
+++ b/scripts/api/runtime_router.py
@@ -142,7 +142,9 @@ def list_runtime_agents() -> list[dict[str, Any]]:
                 source = inspect.getsource(obj.build_invocation)
             except (OSError, TypeError):
                 source = ""
-            if "@anthropic-ai/claude-code@latest" in source:
+            if 'shutil.which("claude")' in source:
+                binary = "claude"
+            elif "@anthropic-ai/claude-code@latest" in source:
                 binary = "npx @anthropic-ai/claude-code@latest"
             elif 'shutil.which("gemini")' in source:
                 binary = "gemini"

--- a/tests/test_agent_runtime.py
+++ b/tests/test_agent_runtime.py
@@ -3408,20 +3408,21 @@ def test_claude_adapter_rejects_old_cli_version(tmp_path):
     claude_adapter_mod._probe_claude_cli_version.cache_clear()
 
 
-def test_claude_adapter_default_prefix_prefers_npx_over_local_binary(tmp_path, monkeypatch):
-    """Regression for #1684: default cmd_prefix MUST be npx@latest, not local
-    `claude` binary.
+def test_claude_adapter_default_prefix_prefers_local_binary_over_npx(tmp_path, monkeypatch):
+    """Regression for #4875: default cmd_prefix MUST be the local `claude`
+    binary, not ``npx @anthropic-ai/claude-code@latest``.
 
-    Pre-#1684, ``shutil.which("claude")`` was preferred. Empirically this
-    let dispatched runs silently drift behind the launcher's npx-managed
-    version (observed 2026-05-05: ~/.local/bin/claude at 2.1.126 vs
-    ``npx @latest`` at 2.1.128). The fix flips the order to match
-    start-claude.sh:120's invariant.
+    The npm package became a thin shim around a native installer: ``npx
+    @latest`` exits rc=1 in ~8s with "Error: claude native binary not
+    installed" and EMPTY stdout — every dispatched claude run died at spawn
+    (lane dead since 2026-05-31, diagnosed 2026-07-10). The native binary
+    self-updates, so the #1684 version-drift rationale for npx-first no
+    longer applies; the min-version gate still rejects stale binaries.
     """
     from agent_runtime.adapters import claude as claude_adapter_mod
 
     def _which(name: str) -> str | None:
-        # Both npx and a local claude exist. The bug was preferring claude.
+        # Both npx and a local claude exist. The #4875 bug was preferring npx.
         return {
             "npx": "/usr/local/bin/npx",
             "claude": "/Users/test/.local/bin/claude",
@@ -3440,21 +3441,21 @@ def test_claude_adapter_default_prefix_prefers_npx_over_local_binary(tmp_path, m
         tool_config=None,
     )
 
-    # First two argv tokens MUST be the npx invocation, not the local binary.
-    assert plan.cmd[0:2] == ["npx", "@anthropic-ai/claude-code@latest"], (
-        f"Default cmd_prefix should be npx@latest (matches start-claude.sh:120). Got: {plan.cmd[0:2]}"
+    # First argv token MUST be the local binary, not the npx invocation.
+    assert plan.cmd[0] == "/Users/test/.local/bin/claude", (
+        f"Default cmd_prefix should be the local claude binary (#4875). Got: {plan.cmd[0:2]}"
     )
-    # And specifically: must NOT be the local claude binary path.
-    assert "/Users/test/.local/bin/claude" not in plan.cmd
+    assert "npx" not in plan.cmd
 
 
-def test_claude_adapter_default_prefix_falls_back_to_local_when_npx_missing(tmp_path, monkeypatch):
-    """When npx is unavailable (e.g. air-gapped CI), the local `claude` binary
-    is the documented last-resort fallback. #1684."""
+def test_claude_adapter_default_prefix_falls_back_to_npx_when_local_missing(tmp_path, monkeypatch):
+    """When no local `claude` binary is installed, ``npx @latest`` remains the
+    documented fallback (it works on machines where the npm package still
+    resolves to a runnable CLI). #4875."""
     from agent_runtime.adapters import claude as claude_adapter_mod
 
     def _which(name: str) -> str | None:
-        return {"claude": "/Users/test/.local/bin/claude"}.get(name)
+        return {"npx": "/usr/local/bin/npx"}.get(name)
 
     monkeypatch.setattr(claude_adapter_mod.shutil, "which", _which)
 
@@ -3469,19 +3470,18 @@ def test_claude_adapter_default_prefix_falls_back_to_local_when_npx_missing(tmp_
         tool_config=None,
     )
 
-    assert plan.cmd[0] == "/Users/test/.local/bin/claude"
-    assert "npx" not in plan.cmd
+    assert plan.cmd[0:2] == ["npx", "@anthropic-ai/claude-code@latest"]
 
 
 def test_claude_adapter_default_prefix_raises_when_neither_present(tmp_path, monkeypatch):
-    """If neither npx nor claude is on PATH, fail loudly with a clear error
-    instead of silently producing an empty/broken cmd. #1684."""
+    """If neither claude nor npx is on PATH, fail loudly with a clear error
+    instead of silently producing an empty/broken cmd. #1684/#4875."""
     from agent_runtime.adapters import claude as claude_adapter_mod
 
     monkeypatch.setattr(claude_adapter_mod.shutil, "which", lambda _name: None)
 
     adapter = ClaudeAdapter()
-    with pytest.raises(RuntimeError, match=r"neither `npx` nor a `claude` binary"):
+    with pytest.raises(RuntimeError, match=r"neither a `claude` binary nor `npx`"):
         adapter.build_invocation(
             prompt="hello",
             mode="read-only",


### PR DESCRIPTION
## Root cause (reproduced, not guessed)

The `@anthropic-ai/claude-code` npm package became a thin shim around a **native installer**: `npx @anthropic-ai/claude-code@latest` exits **rc=1 in ~8s** with `Error: claude native binary not installed` and **empty stdout** — exactly the #4875 symptom. Every dispatched claude run died at spawn; last successful lane dispatch in `batch_state/tasks/` was **2026-05-31**.

## Fix

Invert the #1684 cmd-prefix order back to **local-binary-first** (npx stays as fallback) in both affected surfaces:

| Surface | File |
| --- | --- |
| delegate dispatch lane | `scripts/agent_runtime/adapters/claude.py` |
| bridge ask/discuss seat | `scripts/ai_agent_bridge/_config.py` (`CLAUDE_CMD`) |

The #1684 rationale for npx-first (local-binary version drift, 2026-05-05) no longer applies: the native binary self-updates, and the `_ensure_supported_claude_cli_version` gate still rejects stale binaries (<2.1.116) loudly. Both historical flips are documented in the code comment to prevent a third blind flip.

Also: `runtime_router` agent listing now reports `binary: "claude"` (source-sniff branch order fixed), MONITOR-API.md example updated, #1684 regression tests inverted with #4875 rationale.

## Evidence (#M-4 — all tool-backed)

- **Repro**: `npx @anthropic-ai/claude-code@latest --version` → `Error: claude native binary not installed`
- **Flag-level probe**: local binary + adapter's exact flags + `claude-opus-4-8` → rc=0, stream-json `result: "LANE-OK"`, $0.066
- **End-to-end**: `.venv/bin/python scripts/delegate.py dispatch --agent claude --task-id 4875-lane-probe --mode read-only` from this branch → `status: done, returncode: 0, response: "LANE-FIXED", duration_s: 9.163, model: claude-opus-4-8` — first successful claude-lane dispatch since 2026-05-31
- **Tests**: `tests/test_agent_runtime.py` + `tests/test_claude_version.py` → 182 passed; `tests/ai_agent_bridge` + `tests/api` → 88 passed; ruff clean

## Coordination

- The stalled `codex/claude-local-binary-startup` worktree (uncommitted since Jul 5) contains the same cmd-prefix flip plus a larger transcript-diagnostics arc — this PR takes only the minimal lane-revival slice; codex lane pinged to rebase their diagnostics on top (their uncommitted work untouched, #M-10).
- Remaining #4875 scope (lane-health-aware routing, per-lane dispatch self-test) split to a follow-up issue before this closes it.

Fixes #4875

🤖 Generated with [Claude Code](https://claude.com/claude-code)