### PR TITLE
data(practice): #4698 A2 synonym exceptions — curator pass (5/38 accepted)

### DIFF
--- a/data/lexicon/synonym_pair_verdicts.yaml
+++ b/data/lexicon/synonym_pair_verdicts.yaml
@@ -629,6 +629,9 @@ approved:
   polarity: antonym
   sources:
   - wiktionary
+  a2Exception: true
+  curator: "claude-opus/4698-a2-curation"
+  a2Rationale: "Canonical spatial antonym (exit / entrance); both A2 in PULS; dominant senses map 1:1, unmistakable at A2."
 - a: виїжджати
   b: подаватися
   polarity: synonym
@@ -1533,6 +1536,9 @@ approved:
   polarity: antonym
   sources:
   - wiktionary
+  a2Exception: true
+  curator: "claude-opus/4698-a2-curation"
+  a2Rationale: "Cardinal-direction antonym (west / east); both A2 adjectives in PULS; core geography vocabulary, trivially fair at A2."
 - a: збереження
   b: охорона
   polarity: synonym
@@ -2031,6 +2037,9 @@ approved:
   polarity: synonym
   sources:
   - synonyms
+  a2Exception: true
+  curator: "claude-opus/4698-a2-curation"
+  a2Rationale: "Both neutral A2 epistemic-possibility adverbs in PULS (probably / maybe); same POS and register, no polysemy trap; confidence nuance is degree-only."
 - a: майбутній час
   b: минулий час
   polarity: antonym
@@ -2200,6 +2209,9 @@ approved:
   polarity: antonym
   sources:
   - wiktionary
+  a2Exception: true
+  curator: "claude-opus/4698-a2-curation"
+  a2Rationale: "Place-preposition antonym (over / under); both A2 in PULS; staple of A1-A2 prepositions-of-place lessons."
 - a: надсилати
   b: подавати
   polarity: synonym
@@ -2817,6 +2829,9 @@ approved:
   polarity: antonym
   sources:
   - wiktionary
+  a2Exception: true
+  curator: "claude-opus/4698-a2-curation"
+  a2Rationale: "Cardinal-direction antonym (south / north); both A2 adjectives in PULS; core geography vocabulary, trivially fair at A2."
 - a: підробка
   b: фальсифікат
   polarity: synonym


### PR DESCRIPTION
## Curator pass — A2 synonym exceptions (#4698, wave 3 / #4700)

Per spec §9.3 («⟦v5.1 — #4698 curation lane⟧»): `synonym` mode defaults to **B1+**; a pair
ships at **A2 only with a curator flag**. The mechanical `--nominate-a2` filter only *nominates* —
this PR adjudicates **every** nomination and flags the accepted minority. Fail-closed: rejected
pairs lose nothing (they still ship at B1+).

### Verdict: 5 accepted / 33 rejected of 38 nominations (13% — a deliberate minority)

> ⚠️ **Nomination count is 38, not the ~180 the brief estimated.** The live
> `--nominate-a2` run produced 38 rows (raw evidence below). Non-empty and exit 0, so I proceeded
> and adjudicated all 38. Flagging the count delta for the driver.

> 🔧 **Field-name correction (root-cause).** The brief's Step 4 says add `a2Curator`, but that key
> exists **nowhere** in the codebase — the loader (`generate_practice_deck.py:1507`) and the tests
> (`test_synonym_verdicts_pipeline.py`) both consume **`curator`**, and spec §9.3 specifies
> `curator`. Using `a2Curator` would fail flag-validation (`a2Exception requires curator`) and drop
> every pair back to B1+ — nullifying the task. I used **`curator`** with the intended value
> `claude-opus/4698-a2-curation`; the deck build confirms the flags are consumed (below).

## Accepted (5) — `a2Exception: true` + `curator` + `a2Rationale`

| Pair | Polarity | One-line rationale |
| --- | --- | --- |
| вихід ↔ вхід | antonym | Canonical spatial antonym (exit/entrance); both A2 in PULS; senses map 1:1, unmistakable at A2. |
| західний ↔ східний | antonym | Cardinal-direction antonym (west/east); both A2 adjectives in PULS; core geography, trivially fair. |
| південний ↔ північний | antonym | Cardinal-direction antonym (south/north); both A2 adjectives in PULS; core geography, trivially fair. |
| над ↔ під | antonym | Place-preposition antonym (over/under); both A2 in PULS; staple of A1–A2 prepositions-of-place. |
| мабуть ↔ можливо | synonym | Both neutral A2 epistemic-possibility adverbs in PULS (probably/maybe); same register, no polysemy trap; confidence nuance is degree-only. |

The four directional/spatial antonyms are the archetypal "gentle, high-frequency, unambiguous" A2
pairs. `мабуть/можливо` is the only synonym that clears every gate (both PULS-A2, same neutral
register, same POS, dominant senses in one field). WordNet's synset split for these is **not**
cited as disqualifying — its own tool caveat marks it auto-translated / "do not cite as authoritative."

## Rejected (33) — grouped by primary reject reason (all stay B1+)

**Polysemy trap — a leg's dominant sense jumps to an unrelated domain (10):**
`мрія/сон` (aspiration vs sleep — the textbook trap) · `певен/твердий` (sure vs physically-hard) ·
`голосний/гучний` (loud vs "vowel") · `закінчення/фінал` (grammatical ending vs sports final) ·
`лінійка/лінія` (ruler vs line) · `список/індекс` (list vs index/postal-code) ·
`темп/хода` (tempo vs gait) · `готуватися/збиратися` (prepare vs intend/be-about-to) ·
`витяг/уривок` (text excerpt vs official-extract/hoist) · `перетин/перехрестя` (road crossing vs math/abstract intersection).

**Register / markedness mismatch — bookish, official, colloquial, or dialectal (8):**
`вирішувати/ухвалювати` (ухвалювати = official/bureaucratic) · `погодити/узгодити` (bureaucratic) ·
`прибувати/приходити` (прибувати = formal/transport register) · `дебати/дискусія` (formal-political) ·
`думка/міркування` (міркування = abstract/bookish) · `либонь/мабуть` (либонь = archaic/dialectal-literary) ·
`деколи/інколи` (деколи = **розм.** per СУМ-11 vs neutral інколи) · `вартий/гідний` (гідний = abstract "dignity" register).

**Not core-A2 frequency — long-tail / formal, ≥1 leg absent from PULS (4):**
`відшкодувати/компенсувати` (financial-legal, B1+) · `знаряддя/інструмент` (formal + інструмент=musical polysemy) ·
`помалу/потроху` (neither PULS-listed, colloquial) · `уривок/фрагмент` (neither PULS-listed at A2).

**Sense divergence — not true synonyms; senses don't map (7):**
`конверт/пакет` (envelope vs bag/package) · `майстер/митець` (craftsman/repairman vs artist) ·
`оголошення/повідомлення` (public ad vs message) · `дискусія/суперечка` (neutral discussion vs conflictual quarrel) ·
`близько/поруч` (близько also = "approximately") · `десь/мабуть` (somewhere vs probably — different domains) ·
`колись/раніше` (someday-incl-future vs earlier-past — temporal direction).

**Aspect / motion-verb pair disguised as synonyms (1):**
`нести/носити` (determinate/indeterminate motion pair — spec forbids).

**Near-antonym ambiguity / 3-way paradigm, not a clean binary (3):**
`майбутній час/минулий час` and `минулий час/теперішній час` (tense paradigm is 3-way: future/past/present — "the" antonym is ambiguous) ·
`ніщо/щось` (loose; ніщо nominative is marked, everyday form is нічого).

---

## Raw tool evidence (#M-4 preamble)

**1. Nomination count — `generate_practice_deck.py --nominate-a2`:**
```
a	b	polarity	sources	prompt_cefr	target_cefr	distractors_ab	distractors_ba
total	38
```
(exit 0, empty stderr; full 38-row report adjudicated.)

**2. VESUM (`verify_words`) — all 10 accepted legs FOUND (16/16 incl. borderlines):**
```
вихід — FOUND (noun) · вхід — FOUND (noun)
західний — FOUND (adj) · східний — FOUND (adj)
південний — FOUND (adj) · північний — FOUND (adj)
над — FOUND (prep) · під — FOUND (prep)
мабуть — FOUND (adv) · можливо — FOUND (adv)
```

**3. PULS CEFR (`query_cefr_level`) — all 10 accepted legs A2:**
```
вихід (A2, іменник) · вхід (A2, іменник)
західний (A2, прикметник) · східний (A2, прикметник)
південний (A2, прикметник) · північний (A2, прикметник)
над (A2, прийменник) · під (A2, прийменник)
мабуть (A2, прислівник) · можливо (A2, прислівник) · інколи (A2, прислівник)
```
Rejected-side frequency evidence — **not** in PULS: `деколи`, `помалу`, `потроху`, `уривок`, `фрагмент`.

**4. СУМ-11 (`search_definitions`) — register evidence for the деколи/інколи reject:**
```
ДЕ́КОЛИ, присл., розм. Те саме, що іноді; коли-не-коли.
```
(`розм.` = colloquial, vs neutral інколи → register mismatch → reject.)

**5. Flags load into `a2_exception_set` — exactly the 5 accepted pairs, 0 WARN drops:**
```
a2_exception_set size: 5
WARN lines about a2Exception/drop: 0
a2_exception_set == exactly our 5: True
```

**6. Deck build (`--out-dir /tmp/deck-4698`) — exit 0; A2 synonym shard:**
```
practice-synonym.A1.json : 0 items          (no leak; synonym default stays B1+)
practice-synonym.A2.json : 6 items
  західний  --antonym--> східний    (distractors=3)
  південний --antonym--> північний  (distractors=3)
  північний --antonym--> південний  (distractors=3)
  під       --antonym--> над         (distractors=3)
  вихід     --antonym--> вхід        (distractors=3)
  мабуть    --synonym--> можливо     (distractors=3)
  LEAKED (unflagged in A2): NONE
  All 5 accepted pairs represented at A2: True
```

**7. Tests — `pytest -k "synonym or nominate or practice_deck"`:**
```
92 passed, 10489 deselected in 8.63s   (exit 0)
```
No fixture mirrors the real 550-record verdicts YAML (the pipeline tests use inline dict fixtures /
temp files), so no fixture update was required.

**8. Final flagged count — grep over the YAML:**
```
grep -c 'a2Exception: true'                        → 5
grep -c 'curator: "claude-opus/4698-a2-curation"'  → 5
```
Diff: **1 file changed, 15 insertions(+)** — 3 keys × 5 records, no reformatting/reordering.

---

**No auto-merge.** The spec-amendment AC stays open until the track driver confirms via
cross-family review and merges.

Refs #4698 #4700
