### PR TITLE
data(atlas): #4220 grow auto_merge triage ledger — first grow ledger (2893 approve / 115 deferred)

### DIFF
--- a/data/lexicon/source-inventory-review-decisions/2026-07-10-first-grow-automerge-ledger-batch.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-10-first-grow-automerge-ledger-batch.yaml
@@ -1,0 +1,18243 @@
+version: 1
+kind: atlas_grow_automerge_triage_ledger
+batch_id: grow-automerge-triage-first-grow-ledger-batch-2026-07-10
+batch_label: first-grow-automerge-ledger-batch
+reviewer: claude/4220-automerge-triage (judgment seat)
+reviewed_at: '2026-07-10'
+epic: '#4220 grow judgment+publish arc (atlas-intake); feeds practice-hub veins #4505/#4506 + atlas thin
+  pages'
+scope: auto_merge bucket ONLY (3008 candidates); needs_review (8639) is a separate arc and untouched.
+provenance:
+  input_file: /tmp/atlas-full-grow-candidates.json (64MB, machine-local)
+  generated_from: content_lexicon_reconciler.missing_lemmas
+  input_counts:
+    total_delta: 11647
+    processed: 11647
+    auto_merge: 3008
+    needs_review: 8639
+  input_limit: null
+schema_note: Grow candidates do not map onto the source_inventory publish-queue schema (no source_inventory
+  key/path/locator). This ledger uses the minimal task-specified row shape {lemma, pos, decision, bucket,
+  reason, sample_verified}. decision is one of approve|reject|deferred (deferred replaces the queue's
+  approve_for_publish/hold split; all flagged buckets are deferred to the driver's adjudication list,
+  never rejected).
+decision_counts:
+  approve: 2893
+  reject: 0
+  deferred: 115
+  total: 3008
+bucket_counts:
+  approve: 2893
+  reject:missing-meaning: 0
+  flag:heritage: 31
+  flag:form-anomaly: 5
+  flag:formof: 21
+  flag:gloss-unresolved: 58
+bucket_partition_note: 'Buckets are a PRECEDENCE PARTITION (each candidate in exactly one primary bucket;
+  sums to 3008): reject > heritage > form-anomaly > formof > gloss-unresolved > approve. Secondary flags
+  are appended to a row''s reason (''| also: ...''). Flag MEMBERSHIP incl. overlaps: heritage=31, form-anomaly=8
+  (3 also heritage), formof=21 (1 also heritage), gloss-unresolved=58.'
+predicates:
+  reject:missing-meaning: 'NOT (enrichment.meaning.definitions OR any definition_cards[].definitions OR
+    enrichment.translation.en has a non-empty string). Result: 0 — every candidate carries some gloss;
+    records whose ONLY gloss is a ''див.'' cross-reference are NOT rejected (they are real VESUM lemmas)
+    but DEFERRED under flag:gloss-unresolved.'
+  flag:heritage: 'is_russianism OR russian_shadow OR calque_warning present OR warning_severity in {russianism_red,
+    calque_yellow, soviet_def_blue} OR classification NOT in {standard}. DEVIATION FROM TASK PREDICATE
+    (documented): task said warning_severity != ''none'', but heritage_classifier.py:382 emits ''treasured''
+    as a POSITIVE marker (treasured classifications, or standard+positive-attestation) — the OPPOSITE
+    of a warning; 2991/3008 are ''treasured''. Literal ''!= none'' would flag ~2999 (nearly all), defeating
+    the auto_merge bucket. Corrected predicate uses only the warning-side severities. Data here: is_russianism=0,
+    russian_shadow=0, calque_warning=0, calque_yellow=8, classification!=standard=23.'
+  flag:form-anomaly: lemma has a digit OR Latin char OR internal space OR is a single letter OR is an
+    all-caps acronym (>=2 uppercase Cyrillic letters) OR top-level pos disagrees with VESUM morphology.pos
+    EXCLUDING benign substantivization (pos=noun with morphology in {прикметник,прислівник,дієприслівник,числівник})
+    and code-vs-label artefacts. Hyphenated compounds (будь-куди, врешті-решт) are NOT anomalies.
+  flag:formof: primary meaning/translation gloss starts with a form-of pointer (e.g. 'endearing form of',
+    'YYYY-YYYY spelling of', 'emphatic form of') OR pos=adj possessive form (-ів/-їв, gen.pl. homograph)
+    defined only by the base-noun card OR the one sampling-gate manual defer (франка). Parent resolution
+    is a separate driver step.
+  flag:gloss-unresolved: EVERY definition/gloss in the record reduces to a bare 'див. X' cross-reference
+    (no usable inline gloss). Real, VESUM-attested lemmas (mostly perfective verbs / у-~в- prothetic variants)
+    that need an inline gloss before publish — deferred, not rejected.
+sampling_evidence:
+  method: Two seeded random rounds over the approve bucket + a full-bucket VESUM sweep. VESUM re-check
+    via mcp__sources__verify_words; lemma/pos coherence via data/vesum.db.
+  round1_pre_correction:
+    seed: 4220
+    n: 300
+    pct_of_approve: 10.11%
+    vesum_found: 300/300
+    finding: 'surfaced 2 systematic defect patterns in the initial approve bucket (2967): 58 ''див.''-only
+      records + 15 possessive -ів adjectives = ~2.46% > 2% stop-threshold.'
+  root_cause_fix: Added flag:gloss-unresolved (див.-only) and folded possessive -ів adjectives into flag:formof;
+    re-bucketed 73 records to deferred.
+  round2_post_correction:
+    seed: 42210
+    n: 290
+    pct_of_approve: 10.02%
+    vesum_found: 290/290
+    residual_defects: 1
+    residual_pct: 0.34%
+    residual: франка (gloss/lemma mismatch) — manually deferred.
+  full_bucket_vesum_sweep:
+    n: 2893
+    form_as_lemma: 0
+    pos_incoherence_non_benign: 0
+    not_in_vesum: 0
+    guarantee: every approve lemma is a real VESUM headword at a pos consistent with its record (benign
+      substantivization allowed).
+  reject_sample: reject:missing-meaning bucket is EMPTY (0) — nothing to sample; the truly-empty predicate
+    matched 0 records (all carry some gloss).
+  heritage_working_paper: All 31 flag:heritage rows carry a one-line driver note in their reason (|| NOTE:).
+driver_next_steps:
+- '1. Adjudicate the 115 deferred rows: 31 heritage (clear the calque_yellow/mis-tag soft flags, decide
+  acronym + archaic/dialect policy), 5 form-anomaly (acronyms + віра/гай/слід/стоп pos), 21 formof (parent
+  resolution incl. франка normalisation), 58 gloss-unresolved (attach inline glosses).'
+- 2. Fold adjudicated approves + the 2893 clean approves into the registry/inventory.
+- '3. Run #4532 fill-first headroom gate BEFORE publishing (publishing is gated).'
+- '4. Publish to atlas thin pages / practice-hub veins #4505/#4506.'
+decisions:
+- lemma: ВООЗ
+  pos: noun
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=unknown | also: form-anomaly[acronym-allcaps] || NOTE: WHO acronym
+    (СУМ-20 + Wikipedia attested); classification=unknown only because acronym; not a russianism — driver:
+    atlas policy on institutional acronyms.'
+  sample_verified: true
+- lemma: НКВС
+  pos: noun
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=unknown | also: form-anomaly[acronym-allcaps] || NOTE: Soviet
+    secret-police acronym (marked іст.); Soviet-era term, heritage-sensitive — driver: decide inclusion
+    of Soviet institution acronyms.'
+  sample_verified: true
+- lemma: УНІАН
+  pos: noun
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=unknown | also: form-anomaly[acronym-allcaps] || NOTE: Ukrainian
+    news-agency acronym (est. 1993); modern proper-noun abbreviation, benign; unknown class is acronym
+    artefact — driver: confirm.'
+  sample_verified: true
+- lemma: активний
+  pos: adj
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — warning_severity=calque_yellow || NOTE: common standard adj ''active''; calque_yellow
+    is a soft reverse-calque flag (native alt енергійний/діяльний) — benign, driver clears.'
+  sample_verified: true
+- lemma: безкоштовний
+  pos: adj
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=unknown || NOTE: adj ''free of charge''; classification=unknown
+    (heuristic gap) but clearly standard — driver clears.'
+  sample_verified: true
+- lemma: безкоштовно
+  pos: adv
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=unknown || NOTE: adv ''for free''; classification=unknown but
+    clearly standard — driver clears.'
+  sample_verified: true
+- lemma: богів
+  pos: adj
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=authentic-archaism | also: formof || NOTE: possessive/archaic
+    adj "God''s"; classification authentic-archaism (treasured) — driver: modern-headword usefulness.'
+  sample_verified: true
+- lemma: біда
+  pos: noun
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=historism || NOTE: noun ''misfortune''; tagged historism but
+    a common modern word — mis-tag, driver clears.'
+  sample_verified: true
+- lemma: врешті-решт
+  pos: adv
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — warning_severity=calque_yellow || NOTE: standard idiom ''in the end''; calque_yellow
+    soft reverse-calque flag — benign, driver clears.'
+  sample_verified: true
+- lemma: відволікати
+  pos: verb
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=unknown || NOTE: verb ''to distract/drag away''; unknown class
+    = English-Wiktionary fallback gloss; normal modern verb — driver clears.'
+  sample_verified: true
+- lemma: відволікти
+  pos: verb
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=unknown || NOTE: verb (perfective of above); unknown class =
+    fallback gloss; normal modern verb — driver clears.'
+  sample_verified: true
+- lemma: горі
+  pos: adv
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=authentic-archaism || NOTE: archaic adv ''up/above''; treasured,
+    but the attached gloss looks corrupted (literary-text leak) — driver: verify gloss + archaic status.'
+  sample_verified: true
+- lemma: захід
+  pos: noun
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — warning_severity=calque_yellow || NOTE: core word ''west/measure/event''; calque_yellow
+    soft reverse-calque flag — benign, driver clears.'
+  sample_verified: true
+- lemma: зловити
+  pos: verb
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=historism || NOTE: verb ''to catch''; tagged historism but common
+    modern — mis-tag, driver clears.'
+  sample_verified: true
+- lemma: кожний
+  pos: noun
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — warning_severity=calque_yellow || NOTE: standard ''each/every''; calque_yellow
+    soft reverse-calque flag — benign, driver clears.'
+  sample_verified: true
+- lemma: лютувати
+  pos: verb
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=authentic-archaism || NOTE: verb ''to rage''; tagged authentic-archaism
+    but reads as a normal modern verb — likely mis-tag, driver confirms.'
+  sample_verified: true
+- lemma: молодий
+  pos: noun
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — warning_severity=calque_yellow || NOTE: standard ''young'' / substantivised
+    ''bridegroom''; calque_yellow soft flag — benign, driver clears.'
+  sample_verified: true
+- lemma: мід
+  pos: noun
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=authentic-archaism || NOTE: dialectal variant of мед ''honey''
+    (діал.); treasured — driver: dialect-form inclusion policy.'
+  sample_verified: true
+- lemma: най
+  pos: part
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=authentic-archaism || NOTE: particle ''let/may''; treasured,
+    colloquial/dialectal — driver confirms register.'
+  sample_verified: true
+- lemma: насправді
+  pos: adv
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — warning_severity=calque_yellow || NOTE: core adverb ''in fact''; calque_yellow
+    soft reverse-calque flag — benign, driver clears.'
+  sample_verified: true
+- lemma: обі
+  pos: numr
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=authentic-archaism || NOTE: numeral variant of обидві ''both'';
+    treasured, archaic/dialectal — driver confirms.'
+  sample_verified: true
+- lemma: основний
+  pos: adj
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — warning_severity=calque_yellow || NOTE: standard adj ''basic/fundamental'';
+    calque_yellow soft flag — benign, driver clears.'
+  sample_verified: true
+- lemma: поворот
+  pos: noun
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=authentic-archaism || NOTE: noun ''turn''; tagged authentic-archaism
+    but a normal modern word — likely mis-tag, driver clears.'
+  sample_verified: true
+- lemma: пільга
+  pos: noun
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=authentic-archaism || NOTE: noun ''benefit/privilege''; treasured
+    + spurious formof-LEAD hit on gloss containing ''in the form of'' — normal modern word, driver clears.'
+  sample_verified: true
+- lemma: різнокольоровий
+  pos: adj
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=unknown || NOTE: adj ''multicoloured'' (= синонім різнобарвний);
+    unknown class heuristic gap, standard — driver clears.'
+  sample_verified: true
+- lemma: ріст
+  pos: noun
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=historism || NOTE: noun ''growth''; tagged historism but common
+    modern — mis-tag, driver clears.'
+  sample_verified: true
+- lemma: справжній
+  pos: adj
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — warning_severity=calque_yellow || NOTE: standard adj ''real/genuine''; calque_yellow
+    soft flag — benign, driver clears.'
+  sample_verified: true
+- lemma: тим
+  pos: adv
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=authentic-archaism || NOTE: function word (adv/conj); tagged
+    authentic-archaism but common modern — likely mis-tag, driver clears.'
+  sample_verified: true
+- lemma: уряд
+  pos: noun
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=historism || NOTE: noun ''government''; tagged historism but
+    core modern word — mis-tag, driver clears.'
+  sample_verified: true
+- lemma: фактор
+  pos: noun
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=authentic-archaism || NOTE: noun ''factor'' (borrowing); treasured,
+    normal modern word — driver clears.'
+  sample_verified: true
+- lemma: яково
+  pos: adv
+  decision: deferred
+  bucket: flag:heritage
+  reason: 'flag:heritage — classification=authentic-archaism || NOTE: archaic adv ''how (much)''; treasured
+    archaism — driver: likely exclude from modern atlas.'
+  sample_verified: true
+- lemma: СРСР
+  pos: noun
+  decision: deferred
+  bucket: flag:form-anomaly
+  reason: flag:form-anomaly — acronym-allcaps
+  sample_verified: true
+- lemma: віра
+  pos: noun
+  decision: deferred
+  bucket: flag:form-anomaly
+  reason: flag:form-anomaly — pos-mismatch(top=noun,morph=вигук)
+  sample_verified: true
+- lemma: гай
+  pos: noun
+  decision: deferred
+  bucket: flag:form-anomaly
+  reason: flag:form-anomaly — pos-mismatch(top=noun,morph=вигук)
+  sample_verified: true
+- lemma: слід
+  pos: noun
+  decision: deferred
+  bucket: flag:form-anomaly
+  reason: flag:form-anomaly — pos-mismatch(top=noun,morph=noninfl)
+  sample_verified: true
+- lemma: стоп
+  pos: noun
+  decision: deferred
+  bucket: flag:form-anomaly
+  reason: flag:form-anomaly — pos-mismatch(top=noun,morph=вигук)
+  sample_verified: true
+- lemma: алігаторів
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: апостолів
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: господарів
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: катедра
+  pos: noun
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — 1928–1933 spelling of ка́федра (káfedra), which was deprecated in the orthography
+    reform o
+  sample_verified: true
+- lemma: клієнтів
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: комарів
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: лікарів
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: малесенький
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — endearing form of мале́нький (malénʹkyj, “little, small”)
+  sample_verified: true
+- lemma: москалів
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: місяців
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: офіцерів
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: предків
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: равликів
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: соловейко
+  pos: noun
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — endearing form of солове́й
+  sample_verified: true
+- lemma: увесь
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — Emphatic form of весь (vesʹ)
+  sample_verified: true
+- lemma: франка
+  pos: noninfl
+  decision: deferred
+  bucket: flag:formof
+  reason: 'flag:gloss-unresolved/formof — sampling-gate catch: lemma ''франка'' is VESUM noninfl:foreign
+    but the record is glossed with франк (currency, a declinable noun whose gen.sg is франка); needs lemma
+    normalisation/disambiguation before publish (parent resolution)'
+  sample_verified: true
+- lemma: хлопців
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: хлопчиків
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: художників
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: чоловіків
+  pos: adj
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — possessive-adjective form (-ів); only base-noun definition present -> parent resolution
+  sample_verified: true
+- lemma: якнайкраще
+  pos: adv
+  decision: deferred
+  bucket: flag:formof
+  reason: flag:formof — intensified form of (superlative) найкра́ще (najkrášče)
+  sample_verified: true
+- lemma: вблагати
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: вжалити
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: вигуляти
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: вистрибнути
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: вкритися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: вмитися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: вплутати
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: вподобати
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: вполювати
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: втупитися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: віддалитися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: відписатися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: відсидіти
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: відімкнути
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: завісити
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: загадати
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: загартуватися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: заговорити
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: загорнутися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: заковтнути
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: замучити
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: замісити
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: запинитися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: зарахувати
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: засмагнути
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: застебнути
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: застрахуватися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: застрибнути
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: заховати
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: згнити
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: злизати
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: зомліти
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: зігрітися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: зіштовхнути
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: налетіти
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: обморозити
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: отруїтися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: перебудуватися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: перегоріти
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: передатися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: пережувати
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: пересадити
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: переслухати
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: понизити
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: присягтися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: провчити
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: протиснутися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: пукнути
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: підбігти
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: підвернути
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: підлікувати
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: свят
+  pos: intj
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: скавчати
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: скоювати
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: струсити
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: схилитися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: урватися
+  pos: verb
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: усього
+  pos: adv
+  decision: deferred
+  bucket: flag:gloss-unresolved
+  reason: flag:gloss-unresolved — only definition is a 'див.' cross-reference; needs inline gloss before
+    publish
+  sample_verified: true
+- lemma: абонемент
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: авокадо
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: австрійка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: австрієць
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: авто
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: автор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: авторів
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: авітаміноз
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: агресивний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: агресивно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: адаптація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: адаптуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: адвокат
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: аеродром
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: акне
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: активно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: активність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: активізувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: акурат
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: алкоголь
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: алкоголізм
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: алкоголік
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: алфавіт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: алібі
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: амбасадор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: амінокислота
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: аналогічно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: анонс
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: анонсувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: антикварний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: антирадянський
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ані
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: апарат
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: аплодисменти
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: арахіс
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: арешт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: армія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: аромат
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: архаїка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: асиміляція
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: асистент
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: асоціюватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: аспірант
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: аспірантура
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: асфальт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: атлет
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ахнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: бавовна
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: бавовняний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: багатий
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: багаторазовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: багаторічний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бажане
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бажаний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: базування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: байдужість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бакалаврат
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бактерія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бал
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: балакати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: баланс
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: балуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: банановий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бандит
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бар'єр
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: барабанчик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бджолиний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бджолярство
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: бджілка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: без
+  pos: prep
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: безглуздо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: бездомний
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: безлад
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: безнадійно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: безоплатно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: безпека
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: безперешкодний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: безпечний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: безплатний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: безплатно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: безробіття
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: безсоння
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: безхатько
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: безхребетний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: беркут
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: битися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: блакить
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ближче
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: блискавка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: блокувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: блондинка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: блукати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: бляшанка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бобові
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бог
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: богомол
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: боже
+  pos: intj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: божевілля
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: божевільний
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: божий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: боком
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: болото
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: боляче
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бомбардувальник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: борг
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: боротися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: боротьба
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: борщик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: бос
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: босоніж
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бочка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: боєць
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: брак
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: бракувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: браслет
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: брехати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: брехня
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бригада
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: броколі
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: броня
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: брудно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бубонець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: будити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: будь-куди
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: буквально
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: бульйон
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: буркотати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: буркотливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бурмотіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бурхливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бурчати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бус
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: буф
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: буханець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бухгалтер
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: буцім
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: буцімто
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: біб
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бібліотекарка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бігун
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бідкатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бідний
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бідолашка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бідолашний
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бізнес
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бійка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бік
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: білка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: білочка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: білченя
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: більш-менш
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: більше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: більшість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: біографія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: біологічний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: біологія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: бісити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: біситися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: в'їхати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вага
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ваги
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вагітна
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вагітність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: важити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: важливе
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: важливо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: важливість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: важче
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вазон
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вакцина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вакцинація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вакцинуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: валер'янка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: валитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ванна
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вантажівка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: варене
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: варення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: варитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вата
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вбивати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вбити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вболівати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вгору
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вдавати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вдало
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вдвічі
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вдосконалення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вдосконалити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вдосконалювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вдягнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вдіяти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: веб
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ведення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ведмідь
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: величезний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: велоспорт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: веранда
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вередувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: верещати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: версія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: верхній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: веселитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: весело
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: весняний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: весільний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вечірній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вже
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вживання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: взагалі
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: взаємність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: взаємодіяти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вздовж
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: взувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: взути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: взуття
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вибачити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вибирати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вибіг
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виведення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виводити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вигадати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вигляд
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вигнання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вигода
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вигодовувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вигодувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: виготовити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: виготовляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вигулювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: видимий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: видно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виділення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виділятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виживання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виживати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вижити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: визнавати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: визнати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: визначати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виймати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вийняти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: викидати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: викинути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: виключати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виключити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виключно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: використання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: використати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: використовувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вилазити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вилив
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вилити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вилупитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вилізти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вимагати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вимикач
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вимити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вимкнення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вимовити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вимірювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виміряти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: винахід
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: виникати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виникнення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виникнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: винний
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: винятковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: випадково
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: випадковість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: випадок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: випивати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: випити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: випльовувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виплювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: випробувальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: випробувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: випускання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виражений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вираз
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вирити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: виробити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вироблення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виростати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вирости
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виростити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виріз
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вирій
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вирішення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: висипати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: висипатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: висиплятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вислизнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виснажити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виснажливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виснажливо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: високо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: високочастотний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: висохнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виспатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вистрілити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: висувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: висунути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: висівки
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: висіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: витвір
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: витрата
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: витратити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: витрачати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: витріщатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: витріщитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: витяжка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вихваляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вихвалятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: виховання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вишиваний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вишукано
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виявитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: виявлятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вказувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: включати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: включити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: включно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вкрасти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вкриватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вкусити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: влада
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: власноруч
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: власність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: влаштовувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: влаштувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вмерти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вмить
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вмотивований
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вміст
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: внесок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: внутрішньо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вовна
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: водій
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: волейбол
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: воло
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: волога
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вологий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: волого
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вологість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: волонтерити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: волосся
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: воля
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: воскреснути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: восьминіг
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: впакувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: впевнений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вперед
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вперше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: впливати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вплинути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вплутувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: впізнавати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вражати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вражений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: врешті
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: врятувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: всередині
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: всесвітній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: встановлений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: встановлення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: встановлювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: встати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: всього
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: всюди
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: всяк
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: всі
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: всіляко
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: втекти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: втеча
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: втома
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: втомитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: втомлений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: втомлюватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: втрата
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вуглевод
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вузол
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вуличка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вчений
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вчинок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вчителів
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вшанувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вівсянка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вівчарка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: відбиватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: відбуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відвідати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відвідування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відвідуваність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відвідувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відвідувач
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: віддавати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: віддалятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: віддати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відео
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відзначати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відкласти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відлуння
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: відмикати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: відмовитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відмовляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відмовлятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відмінність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відмінюватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відмітити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: відновлювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: відновлюватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відносно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відоме
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відомо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відпочити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відправитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відправляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відправлятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відпустити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відразу
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: відро
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відродження
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: відсвяткувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: відстань
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відстежити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відстоювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відстояти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відтак
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відточити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відхилити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: відчай
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: відчайдушно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відчувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: відчуження
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: відчути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: відчуття
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відштовхуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відьма
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: відіграти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: візовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: війка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: війна
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: військовий
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вільха
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: віртуальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вірувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вірус
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вісімсот
+  pos: numr
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вітамін
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вітамінний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вітамінізація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: вітрина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вітряний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вітряно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: вішати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гавкати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гаджет
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: газета
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: галузь
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гаманець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: гамбургер
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: гарбуз
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гаряче
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: гарячка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: гаяти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гейби
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: геймер
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гелікоптер
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: генрі
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: геть
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гидливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: глузд
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: глузливо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: глузувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гнати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: гнити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гнів
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гніватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гній
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: годувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: головоломка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: голодомор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: голос
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: голосно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: голосування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: голубий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гоління
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: горизонт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: гормон
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: горох
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: гороховий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: горошок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: горщик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: горіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: горіх
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: готування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гра
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: грабувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: град
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: граціозний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: граціозно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: грецький
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гречка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: грибний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: григоріанський
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гризти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гриль
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: громадянство
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: громіздкий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: груба
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: грубий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: грубо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: грудинка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: група
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: грім
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: губитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: гугл
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гусеня
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гуска
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гучність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гівно
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гімн
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гіповітаміноз
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: гітара
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: давати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: давно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: давній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дайвінг
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: далекий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дальший
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дані
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: даремно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дарма
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дах
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дбати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дверцята
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: двигун
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: двічі
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: де-небудь
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: дев'ятсот
+  pos: numr
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дедалі
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дезінформація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: декрет
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: декуди
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: демократ
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: денно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: депозит
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: депортувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: депресивність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: депресія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: деревце
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: держава
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: детальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: детектив
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дефіцит
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: джаз
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: джин
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дзвінка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: дзвінок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дзижчати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дивак
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дивний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дивно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: диво
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дивовижний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дивувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дизель-поїзд
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дикий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: дим
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: диміти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дискомфорт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дискредитувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дискримінація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: дистанціювання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дитяча
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дифірамб
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дихальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: дихати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дно
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: доба
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: добиратися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: добові
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: добратися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: добрий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: довгий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: довгостроковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: доводити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: доволі
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: довший
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: доглядати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: доглянути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: додатковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: додатково
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: дозволяти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: докладний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: докласти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: доконаний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: доктор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: докір
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: долар
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: домашні
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: домівка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: донатити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: допитливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: допустити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: дорожній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дорослий
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дорікати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: досить
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дослід
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: дослідити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дослідник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: доставити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: доставляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: достатній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: достаток
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: достоту
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: доступний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: досхочу
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: досягати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: досягнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: досі
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дотичний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: дотримання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дотриматися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: дофамін
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дочитувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дощити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дощовик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: драматично
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дратувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дрова
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дрон
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: дружній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дрімати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дуже
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дур
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дурень
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дурненький
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дурненько
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дурний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: дурня
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дух
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: душ
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: діабет
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: діалект
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: діарея
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дівчатко
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дівчина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дівчинка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: діжка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дізнаватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: дійсно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ділити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: діло
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: дільниця
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: діяльність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: діяти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ейфорія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: економити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: екскурсовод
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: експансія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: експеримент
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: електричка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: електричний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: електронний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: емоційно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: емпатія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: еміграція
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ендорфін
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: енергійно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: енергія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: епідемічний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: епідемія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: епілептичний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ера
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: есе
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: естафета
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: етап
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: етер
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: етика
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: етнічність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ефективний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ефір
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ехо
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: жаба
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жалити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: жало
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жалюгідний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жарт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жах
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жахливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жахливо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жебрак
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жебракувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жезл
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жертвувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жертовність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: живучи
+  pos: advp
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жир
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: жирний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: житній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жито
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: життєвий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жовток
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: жодний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жорстокість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жуйка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: журнал
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: журнальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жінка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: жіночий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: з'явитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: з'являтися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: з'їсти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: забезпечений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: забезпечувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: забирати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: забитий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заборонений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: заборонити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: забрати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: завгодно
+  pos: noninfl
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: завітати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: загадковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: загалом
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: загартовування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: загартовуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: загортатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: загострення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: загрожувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: загроза
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: загубитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: задзвонити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: задовго
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: задоволений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: задонатити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: задумати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зазвучати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заздрощі
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заздрість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зазнати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зазіхати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зайве
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зайвий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зайнятість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зайчик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: закипіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: закон
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: закордонний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: закохатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: закричати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: закрутка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: залежно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: залицятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: залишати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: залишити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: залоза
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: залом
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: залюбки
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: замикати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: замислитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: замкнений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: замкнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: замкнуто
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заморожений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: замотувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: замочити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заміж
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: замішування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: занепад
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: занепокоєний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: занепокоєння
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: занудний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зануритися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заохочення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заощадити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: запал
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: запалити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: запальничка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: запалювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: запам'ятати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: запах
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: запашний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: записатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: запитання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: запитувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: запліснявілий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: запліснявіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: запобігання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: заповнений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: заповнити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: запорошений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: заправка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: запропонувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: запускати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: запустити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заражатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зараження
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заразитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зарахований
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зарити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заробити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заробляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заручник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заряд
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заряджати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зарядити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: засвоювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: засвоюватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: засвоїти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: засвітити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: засинання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: засинати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: засмага
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: засмагати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: засмутити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: засмучений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заснути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: засніжений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заспокоюватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заспокоїтися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: заспокійливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: застати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: застосовувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: застосування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: застосувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: застрягати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: застрягнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заступник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: засяяти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: затамувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: затим
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: затримання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: затриматися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: затягнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: затягувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: затікати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: затінок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: захаращений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: захворювання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: захворюваність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: захворіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: захисний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: захист
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: захиститися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: заховатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: захопитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: захопливо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зачарувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зачекати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зачинити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зачиняти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зашкодити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: збагатити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: збагачений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: збагачувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: збивати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: збити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: збиток
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: збрехати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зброя
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: збільшення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: збільшити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: збільшувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: збірка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зв'язатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зважаючи
+  pos: advp
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зважити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: звалитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: званий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зварити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: звенигородський
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: звертати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: звертатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зверху
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: звикання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: звикати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: звикнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: звинувачена
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: звичний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зволікання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зволікати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: звідкіля
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: звідси
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: звільняти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: звісно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: згадати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: згадка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: згадувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: згодом
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: згоріти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: згідно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: здавати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: здавна
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: здати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: здатний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: здатність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: здебільшого
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: здивований
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: здивування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: здивувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: здивуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: здирати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: здогадатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: здоровий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: здуття
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: здібність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: здійсненний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: здійснити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зелень
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зелені
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: землетрус
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: земля
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зерно
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зернові
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зимний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зимовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зламатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: злий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зловживання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зловживати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: злодій
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: злочин
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: злочинець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: злочинність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: злякатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зліва
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: злісно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: злість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: змалку
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зменшення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зменшити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зменшувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зменшуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: змити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: змовчати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: змога
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зморшка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зморщити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зморщувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: змусити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: змушений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: змушувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зміна
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: змінити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: змінювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зміцнити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: змішати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: знадобитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: знайома
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: знаменник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: знаходити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зневага
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зневоднення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зненацька
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: знепритомніти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: знести
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зниження
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: знижувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: знизити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: знизу
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зникнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: знищення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: знищити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: знову
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: знущатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зняти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: знімати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зобов'язаний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зовсім
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зокрема
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зоопарк
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зосереджений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зосереджуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зосередитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зрадіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зразок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зрив
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зрозумілий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зростання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зрубати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зруйнований
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зручно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зрізаний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зрілий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зсередини
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зумовленість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зупинити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зупиняти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зупинятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зусилля
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зухвалість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зібратися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зіграти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зійти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зіпсований
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зіпсувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зіпсуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: зір
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: зірватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ймовірно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ймовірність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: йододефіцит
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: йтися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кабан
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кабачок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кавун
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кажучи
+  pos: advp
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: казка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: какао
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кактус
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: календар
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: калорія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: калькувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: каліграфія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: каміння
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: камінь
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: канапка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: капризувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кар'єр
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кар'єра
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: карати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: картати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: картина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: картинка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: картоплина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: карієс
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кататися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: квасоля
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: квочка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: квітка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: квітник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кидати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кидатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кий
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: килим
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кинути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кип'ятити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кипіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кисень
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кисломолочний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кисневий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кицюня
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: киця
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кишеньковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кишківник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: клавіатура
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: класика
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: класти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: клоун
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: клумба
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: клімат
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: клінічний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: клітка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: книжковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: книжно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: князь
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кокос
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кокосовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: коктейль
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: колесо
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: коли-небудь
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: коливання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: колосальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кольоровий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: коляска
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: коліно
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: командир
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: командний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: комар
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: комаха
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: комбінувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: комедійний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: комендантська
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: компартія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: компонент
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: компромісний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: комфортно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: конкурент
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: консенсус
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: консервований
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: контакт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: контейнер
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: контрабанда
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: контракт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: контроль
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: контролювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: контррозвідка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: конфлікт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: концентрація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: концентруватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: копнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: коригування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: корисне
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: корисно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кориця
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: коробка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: королева
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: король
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: королівство
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: короткий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: короткочасний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: коротший
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кортизол
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: коріння
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: космос
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: косуля
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: котик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: коцик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кошеня
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кошмар
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: краватка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: крадій
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: крайній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кран
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: краса
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: красти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: креветка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кредит
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кредо
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: криза
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: критичний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: крихкий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кричачи
+  pos: advp
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кровити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: крок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кропива
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кросівка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кругозір
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: круто
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: крізь
+  pos: prep
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кріль
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кріп
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кріпак
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: куди-небудь
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кудись
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: культ
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: культурний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кулінарний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: куліш
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кунжут
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: купа
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: купатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: курдський
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: куртка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: курятина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: куріння
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кусати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: куточок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кухар
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кухонний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кущ
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ківі
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кілометр
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кількадесят
+  pos: numr
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: кільканадцять
+  pos: numr
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кількасот
+  pos: numr
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: кістка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ладан
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: лазанья
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ламатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ланцюжок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ласка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ласкаво
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лате
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: латинка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: легально
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: легкий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: легко
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: легше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ледве-ледве
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ледь
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ледь-ледь
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лежачи
+  pos: advp
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лисиця
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: листок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: листя
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лихоманка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лице
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лиш
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лишати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лише
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лишитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: лоб
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ловити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: логічний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: логічно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лось
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лоток
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: лунати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: львівський
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: льодяник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: люд
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: людство
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: лягати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лякати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: лякатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лідер
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лідерка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лікарняний
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: лісоруб
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: літа
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: м'яз
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: м'ята
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: магія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мадяр
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: майбутній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: майданчик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: майно
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: мак
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: максимальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: малеча
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: малий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: маловідомо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: малорухливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: маля
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: малятко
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: малі
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мамографія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мандрівник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: марафон
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: марина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: маркетинг
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: маса
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: маскулінний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: масовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: математик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: матч
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: матюкатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: медитація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: медичний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: медовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: межувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мелатонін
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мелодія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: менеджер
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: менеджмент
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: менше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мертвий
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: метаболізм
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: метеорит
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: метеоритний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: метушитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: механізм
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мигдаль
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мила
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: минати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: минуле
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: минути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мито
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: миття
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: миттєво
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: млн
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: млявість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мобілка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мов
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мова
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: мовби
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мовбито
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мовчання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мовчки
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: могутній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: можливе
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мозковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: мозок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мозоля
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: мокрий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: молити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: молитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: молодше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: молоток
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: момент
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: монополія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: монстр
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: монітор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: морально
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: морквина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: морквяний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: морозиво
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: морщити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: моряк
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: мотив
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мотиватор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мотиваційний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мотивація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мотивувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мотоцикліст
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мох
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мочити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мошка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мураха
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мурашка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мучити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мігрень
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мікробіом
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: мікрофлора
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мікс
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: міксер
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: міль
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мільярд
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: мінімум
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: міністерство
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: міністр
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: місити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: містити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: міський
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: міт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: міф
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: міфологія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: міцно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: набити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: набридати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: набриднути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: набувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: наважитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наважуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: навичка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: навколішки
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: навряд
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: навчити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: навчитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: навіть
+  pos: part
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нагадати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нагляд
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нагодувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нагрів
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: надавати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: надвір
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: надлишок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: надмірний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: надовго
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: надолужити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: надто
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: надягати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: наді
+  pos: prep
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: назавжди
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: назад
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: назва
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: називати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: найактивніше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: найбільше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: найважливіше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: найважливіший
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: найголовніший
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: найдальший
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наймати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наймолодший
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: найняти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: найраніше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: найсильніший
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: найстарший
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наказовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: накричати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: налаштований
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: налаштовувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: налаштування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: налаштувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наливка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: налисник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: налити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наляканий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: налякати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: налякатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: намагатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: намалювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: намочити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: напад
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: напевно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наперед
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: напитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наповнений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: напризволяще
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наприкінці
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: напрочуд
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: напруга
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наркоманія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: народжений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: народження
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: народжування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: народжувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: народжуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: народити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: населений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: населення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: насильний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: насильство
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: насичений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наскільки
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наслідковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: насмішити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: настання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: настати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: настоянка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: настільки
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: натуральний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: натякати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: натякнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: науковець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: науковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: науково
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нахилитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: національний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: націоналізм
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: начальниця
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наче
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: начинка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: начхати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нашестя
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нашкодити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наші
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наявність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: наївно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: наїстися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: небезпека
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: небезпечний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: небезпечно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: небо
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: невдаха
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: невігластво
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: невідомий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: невідомі
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: негативний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: негативно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неглибокий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неграмотність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: недавно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: недозрілий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: недоконаний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: недолік
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: недоречний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: недосипання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: недослухати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: недостатньо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: недостатній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: незадоволення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: незалежність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: незамінний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: незаперечно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: незбагненний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: незважаючи
+  pos: prep
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: незвично
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: незграба
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: незграбний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: нездоровий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: незліченний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: незнайомець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: незнайомка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: незручно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: незручність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: незрівнянний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неймовірний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нейромедіатор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: некомпетентність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: некомфортно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нектар
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нема
+  pos: noninfl
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: неминуче
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: немов
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: немовби
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: немовбито
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неможливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неможливо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ненавидіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ненависть
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ненадійно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неначе
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: неначеб
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неначебто
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: необхідний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: необхідно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: необхідність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: неодноразово
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неохайний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: неочікувано
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: неперевершений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неперевершено
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: непередбачуваний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неповнолітній
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неповторний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неповторно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: непокоїти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: непомітно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: непорозуміння
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: непотріб
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: непотрібний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: непохитний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неправда
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неправильний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: непрофесійно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нервовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нервувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нерівність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нескінченний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: неслухняний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: несподіваність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: несправедливо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: несправедливість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нестерпно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нестримний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нестямно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: несумісність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нехарактерний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нещасний
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нещодавно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: неїстівний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нижче
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: низка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: низько
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нині
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нинішній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: нитка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: новорічний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нон-стоп
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нормалізація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: носок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: носій
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ноутбук
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ночувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нощно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нудота
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нянька
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: няня
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ніби
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нібито
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нідерландський
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ніжка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нізащо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: нікуди
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: німецька
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: німецький
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: об'єднувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обганяти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обгризання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обережний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: обзиватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: облаштувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: обливання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: облизувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: облизуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обман
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обманути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обманювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обмежити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: обмежуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обморожувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обмінювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обожнювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: оболонка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обприскування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ображений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: образа
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: образливо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обробити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оброблений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обробляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обручка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обстоювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обстояти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обстрілювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обстріляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обтирання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обурення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: обходити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обходитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обчислення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обігнати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: обігрів
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обіймати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: обійняти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: овес
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: одержати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: однаково
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: однокласник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: однокласниця
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: однолітка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: одразу
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: одружитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: одужання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: одужувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: одяг
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: одягати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: одягнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ожиріння
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: оздоровлення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: означати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: океан
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: окремий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: окрім
+  pos: prep
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оленя
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оливка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ом
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: омега
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оминути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: омлет
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: омолодження
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: омріяний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оновити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оновитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оновлення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оновлювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оновлюватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: опера
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: операція
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: опинитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: опинятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: опитування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оповідь
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оптимальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: опускати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: опустити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: опуститися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: опік
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: опірність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: організація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: організм
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: організований
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: освоїти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: освічений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ослаблений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ослаблення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ослаблювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: особистий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: особисто
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: особливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: особливо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: особовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: осоромити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: осоромлювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: останнє
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: останній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: оточення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: оточити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оточувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: отримувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: отрута
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: отруюватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: отруєння
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оформити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оформляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: охолодження
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: охолоджуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: охолодитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: охопити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: охоронець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: охороняти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: охоче
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оцінити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: оцінювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: очевидний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: очистити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: очищати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: очищення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: очікувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: п'яний
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: п'ятеро
+  pos: numr
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: п'ятнадцятий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: падло
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пакувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: палати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пальто
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пам'ятати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: пам'ятник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пам'ять
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: памперс
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: панування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: панікувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: папа
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: папуга
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: папірець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: паралельний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: паркування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пасивний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пасти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пастися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пастух
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пасіка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: пекельно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пекти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пердун
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: переборщити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перебрати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перебування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: перебувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перебіг
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перевага
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перевантажений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: перевантажувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: перевесло
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перевищення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перевищувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перевтома
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: переганяти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: перегляд
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перегнати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перегони
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: передбачити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: переддень
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: передзвонити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: передувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: передчуття
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: переді
+  pos: prep
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перезавантаження
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перезрілий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: переймати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: перейматися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перейменувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перейняти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: переклад
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перекладати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перекладач
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: перекласти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: переконання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: переконати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: переконатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: переконливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: переконливо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: переконуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перелом
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: перемагати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перемир'я
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перемовини
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перемога
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перемогти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: переносити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: переночувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: переплутати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: перерва
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: переробляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перерости
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: переселенець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пересів
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: перетворити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перетравити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перетравлювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перефразувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перешкоджати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перешкодити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: переїдання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: персик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перстень
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: перше
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: період
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пес
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: песик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: петрушка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: печений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: печера
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: печиво
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: печінка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пильність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пиріг
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пиріжок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пиття
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: пихатий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: плакати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: плата
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: плач
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: плитка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: плоский
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: плювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: плюватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: плюнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пляж
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пляма
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: плівка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пліснява
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пліснявіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: по-різному
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: по-своєму
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: по-справжньому
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: по-старому
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: по-третє
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: побити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: побитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: побороти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: побудувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: побутувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: побіжно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пов'язаний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пов'язати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пов'язувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поведінка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: повернути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: поверхня
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: повинний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: повинно
+  pos: noninfl
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: повиснути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: повноліття
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: повноцінний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: повністю
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поводити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: повстанець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: повстання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: повсюди
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: повсюдний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: повсякденний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: повів
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: повільно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: повішати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: погадати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поглянути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: погодитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поголитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пограбувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пограти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: погрожувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: погріб
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: погуляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: погіршення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: погіршитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: погіршуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: подати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: податок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: подбати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: подивитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: подих
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: подразнення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: подумати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: подібний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: подібно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поділити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: поема
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: пожартувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пожежник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: пожертвувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поживний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пожувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: позаяк
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: позбавитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: позбавлятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: позбуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: позика
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: позитивно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: показувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: покарання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: покататися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: покидати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: покинути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: покладатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: покласти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: покликати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: покоління
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: покращення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: покривало
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: покрити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: покуття
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: покійний
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: покінчити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поламати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поласувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: полегшення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: полегшувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: полежати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: полк
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: полон
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: полонений
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: полювання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: полювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: політ
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: політехніка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: політехнічний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: померзнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: померлий
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: помилково
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: помилування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: помирати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: помиритися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поміркувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: помістити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: понаднормово
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: понижувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пообідати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: попередній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: попити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: попкорн
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: попливти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поповнити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: попрати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: популярний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пора
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: порадитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поранення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: порекомендувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поринути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: порода
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: порозумітися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: порох
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: порушення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: порівнювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: порівняльний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: порівняно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: порізати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: посадити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: посвітити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: посилення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поскаржитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: послизнутися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: послуговуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: послухати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: посмажити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: посмішка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: посміятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: посольство
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поставити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: постити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: постувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поступовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: постійний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: постійно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: посуха
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: посів
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: потанцювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: потенціал
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: потенційний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: потому
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: потоп
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: потопити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: потрапити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: потрапляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: потрібний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: потягнутися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: потіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: похапцем
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: похибка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: похилити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: похитати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: похмурий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поховання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поховати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: початися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: почервоніння
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: почервоніти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: почувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: почути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: почуття
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поширення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поширитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поширюватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: пошкодження
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пошукати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: поєднувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: поїзд
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поїздка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: поїсти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: правда
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: праведний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: правий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: право
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: православний
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прагнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: практика
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: практикувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: практично
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: працевлаштований
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: працездатність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: працелюбний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: праця
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: предмет
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: предок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: представник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: прекрасний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прем'єр
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прем'єра
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: при
+  pos: prep
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приблизно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приборкати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прибути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: привабливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: привернути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: привертати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: привид
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: привітно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пригадати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пригадувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приглушений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приглушено
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пригода
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приголомшений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приготування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приготуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: придуманий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: придумати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: придумувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: придушити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приділити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приділяти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: призвести
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: призводити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приземлитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приземлятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: призначати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: призначений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прийняти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прийняття
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прикрасити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прикрашений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: примружено
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: примусити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: примушувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: примхливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приміщення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: принаймні
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приналежність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: принишкнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: принц
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: принцип
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: припинення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: припинити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приречена
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: присвятити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: присвячений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: присвячувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пристосовувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пристосувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пристрасть
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прихильник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прихистити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прихисток
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прихищати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приховати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прихід
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: причинно-наслідковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: причиновий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: причому
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приєднатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: приєднуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: приємність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: про
+  pos: prep
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пробний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пробувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пробурмотіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: провина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: провисання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: проводити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: провідний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: провітрювання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: провітрювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прогнозувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: проголошення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: програвати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: програма
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: програти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: продавати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: продати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: продовжити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: продовжувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: продовольство
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: продукція
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: проект
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: проживання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прожити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прокачувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прокрутити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: проломити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: промова
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: промокати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: промокнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: промінь
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: проникати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пронос
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пропаганда
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пропонувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пропорційний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пропуск
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пропускати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: пропустити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пропущений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: простий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: просто
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: простір
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: простіше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: протилежність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: протистояти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: професійний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: професійно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: проходження
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: процент
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: процесор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прочитання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: прочитувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: прошепотіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прощальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: проявити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: проігнорувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: проіснувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: проїздити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: пряжа
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: пряник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пріоритет
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: прірва
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: псевдонім
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: психологічний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: психологія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: психувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: психіка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: психічний
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: псувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: псуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: птах
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: птаха
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пташеня
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пташка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: публічно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пукати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пульс
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пуск
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пустий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: путін
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пухнастий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: пшениця
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: пшоно
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: піаніно
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: півлітровий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: під'їжджати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: під'їхати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підбирати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: підвищити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: підвищувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підвіконня
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підгодовувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підготування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: піддавати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підйом
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підкреслення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підлабузник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підлітка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підлітковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підліток
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: піднятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підписатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підписувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підпільний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підпільно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підряд
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підсилення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підслухати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підстрибнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: підібрати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: пізніше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: пікантність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: піт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: піца
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: раб
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: равлик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ради
+  pos: prep
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: радий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: радикально
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: радо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: радше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: радянський
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: раз
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рак
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рама
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рана
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ранковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ранком
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ранній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рано-вранці
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: раптовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: раптово
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: раціонально
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рвати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: реактивність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: реально
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ребро
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: регулювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: регулярний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: регулярність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: редактор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: редька
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: режим
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: резолюція
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рейка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: реклама
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: рекомендація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рекомендуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рекорд
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: респіраторний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ретельний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: решта
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: риб'ячий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рибний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ризик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ризикований
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ризиковано
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ризиковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ризикувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ринопластика
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: риса
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: риторика
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ритуал
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: робітник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розбитий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розбудити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розв'язувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розвинути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розгадування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: розділ
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: розказати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розказувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розкрити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розкішно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розлад
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розлив
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розлитий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: розлючений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розмова
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розмовляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: розмотувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розпад
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розпач
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розплата
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розповсюджуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розповсюдитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розповідати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розряджатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розряджений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розрядитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: розсада
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розслабити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розслаблення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розслаблятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розум
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розчавити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розчарований
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розчарування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розчарувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розчулений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розширити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розширювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розширяти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: розірвати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: роман
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рости
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: росія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рот
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рота
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рубати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: руда
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рудий
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: русалка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рухатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ряд
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рятувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рівень
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рівнодення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рівня
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: рівність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рідина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рідкісний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рідше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ріелтор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: різдвяний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: різкий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: різко
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: різний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: різниця
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ріпа
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: річниця
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: рішуче
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: рішучість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сад
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: садити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: садка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: садовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: садочок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: садівництво
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: самвидав
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: самий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: само
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: самовпевненість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: самозахист
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: самолікування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: самолікуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: самонавіювання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: саморобний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: самотужки
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: санчата
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сарай
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: сварливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: свинина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: свиня
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: свята
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: святий
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: святковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: святково
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: святкування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: священний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: священник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: свідомо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: свідомість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: свідчити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: свіжо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: світ
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: світанок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: світити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: світло
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: світловий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: світовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сезон
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: секрет
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сектор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: секунда
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: селера
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: селище
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сендвіч
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: сенс
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сер
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сервер
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сердито
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: середина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: середньовіччя
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: середньостатистичний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: середній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: середовище
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: серйозний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: серйозно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: серотонін
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сигаретний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сила
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сильний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сильно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сильніше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сильніший
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: символічно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: симптоматичний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: синдром
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: синтез
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: синтезувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: синтезуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сипати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сирий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сирник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: система
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сито
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ситуація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сич
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скакалка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скакати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скалькувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скандал
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: скарб
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скасовувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скасувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: складатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: складений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: складно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скласти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скло
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скоро
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скоріше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: скривджений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скрипка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скрипт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скрізь
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: скупий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скупчення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: скуштувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: слабкий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: слабкість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: слава
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: славетний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: слива
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: словесно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: слухняний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сльоза
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: сльозотеча
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: сліпо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: смак
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: смакувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: смалець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: смартфон
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: смачненьке
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: смердючий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: смердіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: смерть
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: смородина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сморід
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: смуга
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: смузі
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сміливість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сміти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сміх
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: снігопад
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: сніжити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сніжний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: солодощі
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: солома
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сонливість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сонний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сорока
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сором
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сором'язливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сорочка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: сосиска
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сотий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сохнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: соціальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сочевиця
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: союз
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спазм
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спакувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спалах
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спалахнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спектр
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спереду
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спершу
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спеціальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спеціально
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спеціалізація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спеціаліст
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: спитати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сповнений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сповільнення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сповільнюватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: споживаний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: споживання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: споживати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спожити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спокій
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спокійно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сполучний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спонтанний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спортивний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спостерегти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спостереження
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спостерігати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спостерігатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спохмурніти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: справа
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: справляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: спрага
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сприймати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спритно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спричинений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: спричинити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сприяти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спроба
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спровокований
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спрогнозувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: співпереживання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: співробітник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: співчуття
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спідниця
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: спіймати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спільник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спільнота
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: спітнілий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: стабільність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: став
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ставати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ставатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ставити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ставок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стагнація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стайня
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стала
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: стало
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стандарт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: становити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: старанно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: старослов'янський
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: старіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: статистика
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: статися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: статично
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: статус
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: статуя
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стаціонарний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: створений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: створювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: створюватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стежина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стиглий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стильно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стимулювання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: стимулювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стовбур
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стовпчик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стовідсотково
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: столик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стратегічний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: страх
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: страшний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: страшно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стрес
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стресовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стрибати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стрибнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стримати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стримувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: структурний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: струна
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: стрілець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стріляти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стрімко
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стюардеса
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стійкий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: стільки
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: сувенірний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: суворо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: судома
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сукня
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сума
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сумний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сумніватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сунути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: супроводжуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: супутник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: супчик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сусідній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сусідів
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: суттєво
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: сутінок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сухий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: сухість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сучасне
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: суші
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сфокусуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сфотографуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: схильний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: схилятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сховати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сходити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: схожий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: схрещування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: схуднути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сюди
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сяяти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сідало
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: сімейний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: січовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: так-так
+  pos: intj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: таки
+  pos: part
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: такий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: талановитий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: танго
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: танець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: танцювальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тахта
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: таємний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: таємничий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тварина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: твердження
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: творити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: творчий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: телебачення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: телевізор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: телешоу
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: телятина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: темно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: темрява
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тепер
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: теперішній
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: теплиця
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: теплоізоляція
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: територія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: термометр
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: терпець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: тесла
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тест
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тимчасом
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тип
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: типу
+  pos: part
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тирозин
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тис
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тихий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тихо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: тиша
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тобто
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: товктися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: товстий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тож
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: токсин
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: том
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: тон
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: тонзиліт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тонкий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: топити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: топінамбур
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: торба
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: торговий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тостер
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: точно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: точність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: травлення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: травмувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: травмуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: травний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: трагедія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: традиційно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тракт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: трактор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: траплятися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тремтіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тренажерний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тренувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тренуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тривало
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тривога
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: тривожний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тривожно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: трилер
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тримати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: триматися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: триптофан
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: тричі
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: тротуар
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: трошки
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: трубочка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: труднощі
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: трішки
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тупий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тупо
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тур
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: турбота
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: турбуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: турецький
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: турок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тікати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: тіло
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ув'язнення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: увага
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: уважно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: уві
+  pos: prep
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: увійти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: угода
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: угрупування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: удав
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: удар
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: удвічі
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: удома
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: уже
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: узагальнити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: узимку
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: український
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: укус
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ультиматум
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: улюбленець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: улюблений
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: умовний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: уникання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: уникнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: уночі
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: унітаз
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: уперто
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: уподобання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ураження
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: уранці
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: урочисто
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: усвідомити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: усвідомлювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: усе
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: усередині
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ускладнення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ускладнити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: усміхатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: усмішка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: успіх
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: успішний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: успішно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: усі
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: утворення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: утворити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: утік
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ухвалення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: участь
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: учень
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: уявлення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: фанат
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: фантастичний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: фейсбук
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: фен
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: феномен
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ферма
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: фермент
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: фермер
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: фермерський
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: фольга
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: формування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: формувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: формуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: форте
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: фотогенічний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: фотографуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: францій
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: фрукт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: фруктовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: функціонування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: функціонувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: футболка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: футбольний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: фігурка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: фізичний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: фіксувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: філологія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: фінальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: хандра
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: хаос
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: характерний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: характерно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: харчовий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: харчуватися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: хата
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: хвіст
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: хиба
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: хитрий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: хлопець
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: хлопчик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: хлібом-сіллю
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: хлів
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: хміль
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ховати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ходьба
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: хол
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: хороше
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: хороший
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: хрещеник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: хронічний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: хропіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: худий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: худнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: худоба
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: художник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: хімія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цвісти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цезар
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: цензура
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цивільний
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цигарка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цикл
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: циркулювати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цитрусові
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: цить
+  pos: intj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: цифра
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цифровий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цукерка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цукерок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цунамі
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цуценя
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цуцик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цькування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: цілий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цілком
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: цінність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: цінувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чайна
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чарка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: часом
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: частування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: частіше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чашка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чемний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: чемпіонат
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: черга
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: черевце
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чесно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чеський
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чин
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чисельник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: член
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чогось
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чоловічий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чорнослив
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чувак
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чутливий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чутливість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чхання
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чхати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чхнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чіпати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чітко
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: чіткіше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шабля
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: шанс
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: шанувальник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шахрай
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шашлична
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: швидкий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: шедевр
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шепотіти
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шершень
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шеф
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шипшина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ширина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ширитися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: шкаралупа
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шкарпетка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шкварка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шкодити
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шкрябати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шкідливість
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шкіра
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шлунок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шляхом
+  pos: prep
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: шматка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шматочок
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шоколад
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шоколадний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шорти
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: шоу
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шпигун
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шпигунство
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шпинат
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шрифт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: штовхатися
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шторм
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: штурхнути
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: штучно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: шум
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: шумний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: шумно
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: щиколотка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: щоби
+  pos: conj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: щовесни
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: щовечора
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: щоденник
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: щомісяця
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: щонайменше
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: щонеділі
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: щоночі
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: щотижня
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: щохвилини
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: щур
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: щільність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: юліанський
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: юний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ютуб
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: яблучний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: явище
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ядерний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ядро
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: язик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: як-от
+  pos: part
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: який-небудь
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: якраз
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ялинковий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: яловичина
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: янголятко
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: японський
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ясна
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ять
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: євробачення
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: європейський
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: єдиний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ігнорувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: іграшка
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ігровий
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: ігроманія
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ідеальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ідеально
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ідея
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: імбирний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: імпровізувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: імунний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: імунітет
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: інвалідність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: індивідуально
+  pos: adv
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: інспектор
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: інстаграм
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: інститут
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: інсульт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: інтеграція
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: інтелект
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: інтелектуальний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: інтенсивний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: інтенсивність
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: інфекція
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: інформація
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: інформування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: інформувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: інфраструктурний
+  pos: adj
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: інфікування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: інше
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: інші
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: іскра
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: існування
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: існувати
+  pos: verb
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true
+- lemma: історик
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: false
+- lemma: ґрунт
+  pos: noun
+  decision: approve
+  bucket: approve
+  reason: approve — standard classification, usable inline meaning, coherent form
+  sample_verified: true


### PR DESCRIPTION
## What this is

The **judgment-seat ledger** over all **3,008 `auto_merge` grow candidates** from
`content_lexicon_reconciler.missing_lemmas` — the reviewed working paper that makes the
driver's publish step safe. `Refs #4220` (atlas-intake stream; feeds practice-hub veins
#4505/#4506 + atlas thin pages).

**Scope guardrail:** `auto_merge` bucket ONLY. `needs_review` (8,639) is a separate arc,
untouched. The ledger is the **only** committed artifact — no manifest / registry / inventory /
`atlas.db` mutated. Publishing is the driver's gated (#4532 fill-first) step.

Artifact: `data/lexicon/source-inventory-review-decisions/2026-07-10-first-grow-automerge-ledger-batch.yaml`
(3,008 rows, one per candidate: `{lemma, pos, decision, bucket, reason, sample_verified}`).

## Bucket table (precedence partition — sums to 3,008)

| bucket | decision | count | grep-verified |
|---|---|---:|---|
| approve | approve | **2893** | `grep -c "  bucket: approve$"` → 2893 |
| reject:missing-meaning | reject | **0** | — |
| flag:heritage | deferred | **31** | `grep -c "  bucket: flag:heritage$"` → 31 |
| flag:form-anomaly | deferred | **5** | → 5 |
| flag:formof | deferred | **21** | → 21 |
| flag:gloss-unresolved | deferred | **58** | → 58 |
| **total** | | **3008** | `grep -c "^- lemma:"` → 3008 |

Decision totals: **approve 2893 · reject 0 · deferred 115**. Header counts reconcile exactly
to row counts (validated). Flag *membership* incl. overlaps: heritage 31, form-anomaly 8 (3 also
heritage), formof 21 (1 also heritage), gloss-unresolved 58.

## Key judgment call — corrected heritage predicate (documented in file header)

The task's literal predicate was `warning_severity != "none"`. Grounding in the actual data +
`scripts/lexicon/heritage_classifier.py:382` showed **`treasured` is a POSITIVE marker** (treasured
classifications, or standard + positive attestation) — the *opposite* of a warning. Distribution:

```
warning_severity: treasured 2991 · none 9 · calque_yellow 8
classification:   standard 2985 · authentic-archaism 11 · unknown 8 · historism 4
is_russianism 0 · russian_shadow 0 · calque_warning 0
```

A literal `!= "none"` would flag ~2,999 rows (nearly the whole bucket), defeating the auto_merge
bucket entirely. **Corrected** to warning-side severities only `{russianism_red, calque_yellow,
soviet_def_blue}` + `classification not in {standard}` → **31 heritage flags**.

## Sampling evidence (raw tool output)

**Round 1** (seed 4220, n=300 = 10.11% of approve) — VESUM `mcp__sources__verify_words`:
```
Batch verification: 300 words
Found: 300/300
```
Sanity-read + pos-coherence surfaced **2 systematic defects** in the *initial* approve bucket (2967):
- **58 `"див."`-only records** — the entire "definition" is a bare `див. X` cross-reference
  (свят→"див. святий", згнити→"див. згнивати", вжалити→"див. ужалити"): no usable inline gloss.
- **15 possessive `-ів` adjectives** (алігаторів, лікарів, чоловіків…) — pos=adj, defined only by
  the base *noun*'s dictionary card (gen.pl. homographs).

That's **73/2967 ≈ 2.46% > the 2% stop-threshold** → I did **not** ship the broken bucket. Root-caused,
added `flag:gloss-unresolved`, folded possessive forms into `flag:formof`, re-bucketed 73 rows to deferred.

**Round 2** (seed 42210, n=290 = 10.02% of *corrected* approve):
```
Batch verification: 290 words
Found: 290/290
```
1 residual (**франка** — VESUM `noninfl:foreign` lemma glossed with the currency франк; gloss/lemma
mismatch) → **manually deferred**. Residual = **0.34% < 2%** ✓.

**Full-bucket VESUM sweep** (all 2893 approve lemmas vs `data/vesum.db`):
`form-as-lemma 0 · pos-incoherence(non-benign) 0 · not-in-VESUM 0` — every approve lemma is a real
VESUM headword at a pos consistent with its record (benign substantivization allowed).

`reject:missing-meaning` bucket is empty → nothing to sample there; the truly-glossless predicate
matched 0 records.

## Heritage-flag summary (all 31 carry a one-line driver note in the ledger)

- **8 `calque_yellow`** (активний, врешті-решт, захід, кожний, молодий, насправді, основний, справжній)
  — soft reverse-calque flags on common standard words; benign, driver clears.
- **3 acronyms** unknown-class (ВООЗ WHO, НКВС Soviet, УНІАН) — also form-anomaly; policy call on acronyms.
- **11 authentic-archaism** (treasured; богів, лютувати, мід, най, обі, поворот, пільга, тим, фактор, яково, горі)
  — archaic/dialectal or mis-tags; driver: modern-atlas usefulness.
- **4 historism** (біда, зловити, ріст, уряд) — read as common modern words mis-tagged; driver clears.
- **5 unknown-class** non-acronym (безкоштовний, безкоштовно, відволікати, відволікти, різнокольоровий)
  — classifier gaps on clearly-standard words; driver clears.

## What the DRIVER must do next

1. **Adjudicate the 115 deferred rows**: 31 heritage (clear soft flags / mis-tags, decide acronym +
   archaic/dialect policy), 5 form-anomaly (acronyms + віра/гай/слід/стоп pos), 21 formof (parent
   resolution incl. франка normalisation), 58 gloss-unresolved (attach inline glosses).
2. Fold adjudicated approves + the 2893 clean approves into the **registry/inventory**.
3. Run **#4532 fill-first headroom gate** BEFORE publishing (publishing is gated).
4. Publish to **atlas thin pages / practice-hub veins #4505/#4506**.

## Tests
`.venv/bin/python -m pytest tests/ -k "ledger or intake" -q` → **102 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)