### PR TITLE
fix(atlas): segregate style-marked VESUM forms from the modern paradigm (#4891)

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -562,6 +562,59 @@ _POS_LABELS: dict[str, str] = {
     "intj": "вигук",
 }
 
+# VESUM style/register markers → learner-facing Ukrainian label. Forms carrying any
+# of these are non-standard/stylistic and must NOT render inline with the modern
+# paradigm (#4891 — корисная «нестягнена» read as ordinary «жін., називний» beside
+# корисна). Marker semantics are quoted verbatim from the official dict_uk tagset
+# doc (``doc/tags.txt`` @ github.com/brown-uk/dict_uk), cross-checked against
+# ground-truth forms in ``data/vesum.db``:
+#   long  L40 "нестягнені форми прикметників" · L32 "наказові форми на -іте"
+#         · L61 "звортні дієприслівники на -ся"
+#   arch  L114 "застаріле/архаїчне/(інколи) діалектне"
+#   short L39 "короткі форми прикметників" · L31 "короткі форми дієслів 3-ї особи…"
+#   rare  L112 "другий зн. в. для істот (в президенти), плюс декілька рідкісних форм"
+#   slang L115 "сленг та (проф)жаргонізми"
+#   coll  L113 "розмовне слово/розмовна форма (наразі не генеруємо на виході)"
+#   obsc  L118 "обсценне"
+#   bad   L109 "покруч"
+#   alt   L116 "альтернативне написання (не за чинним правописом)"
+#   up19  L121 "за правописом 2019 (на виході вилучаємо)"
+#   up92  L120 "за правописом 1992 (на виході конвертуємо в alt)"
+# `ns` (L92 "множинний іменник") is DELIBERATELY EXCLUDED: it is a grammatical
+# sub-class (pluralia tantum — двері, окуляри, ножиці, гроші), whose plural forms
+# ARE the modern literary norm; segregating it would empty those paradigms.
+# `coll`/`bad` never appear in our VESUM build ("не генеруємо на виході") but are
+# mapped for completeness so any future dictionary refresh stays labelled.
+_STYLE_MARKER_LABELS: dict[str, str] = {
+    "long": "нестягнена форма",
+    "arch": "застаріла форма",
+    "short": "коротка форма",
+    "rare": "рідковживана форма",
+    "slang": "сленгова форма",
+    "coll": "розмовна форма",
+    "obsc": "обсценна форма",
+    "bad": "спотворена форма",
+    "alt": "альтернативне написання",
+    "up19": "форма за правописом 2019 року",
+    "up92": "форма за правописом 1992 року",
+}
+
+# Tokens that move a form out of the modern paradigm. Equal to the verified-label keys
+# today, kept as a distinct set so a future VESUM style flag can be segregated (falling
+# back to the generic label below) BEFORE its Ukrainian label is authored — without ever
+# silently reclassifying a grammatical token. Grammatical sub-tags (rev/adjp/pasv/actv/
+# comps/compc/impers/xp1/xp2/subst/nv/ns …) are deliberately absent.
+_STYLE_MARKERS: frozenset[str] = frozenset(_STYLE_MARKER_LABELS)
+
+# Never guess a description for a marker we have not verified (#M-4): an unlabelled but
+# segregated marker gets this honest generic label rather than a fabricated meaning.
+_GENERIC_STYLE_MARKER_LABEL = "інша маркована форма"
+
+# Cap on rows shipped per paradigm section. ``form_count`` is reported AFTER the cap
+# so it never disagrees with the rows actually rendered (pre-#4891 it reported the
+# uncapped total → «41 форм» beside 40 rows for корисний).
+_MORPHOLOGY_FORM_CAP = 40
+
 _NOUN_CASE_ORDER = (
     "називний",
     "родовий",
@@ -586,6 +639,15 @@ def _decode_tag(tag: str) -> str:
     seen: set[str] = set()
     out = [x for x in labels if not (x in seen or seen.add(x))]
     return ", ".join(out)
+
+
+def _style_markers_in_tag(tag: str) -> list[str]:
+    """Style/register markers present in a raw VESUM tag, in tag-token order.
+
+    Matches whole colon-delimited tokens (never substrings) so grammatical tokens
+    are never mistaken for a marker. Returns ``[]`` for a plain modern-paradigm tag.
+    """
+    return [token for token in tag.split(":") if token in _STYLE_MARKERS]
 
 
 def _split_label(label: str) -> list[str]:
@@ -2360,7 +2422,16 @@ def _is_slovnyk_warning_candidate(entry: dict[str, Any], status: dict[str, Any])
 
 
 def _morphology(lemma: str) -> dict | None:
-    """Full VESUM paradigm for a single-token lemma, decoded and de-duplicated."""
+    """Full VESUM paradigm for a single-token lemma, decoded and de-duplicated.
+
+    Style/register-marked forms (нестягнені, застарілі, розмовні … — any tag token
+    in ``_STYLE_MARKER_LABELS``) are partitioned into ``marked_forms`` so they never
+    render inline with the modern paradigm (#4891). The main ``forms``, ``form_count``
+    and ``paradigm`` describe the modern (unmarked) paradigm only; ``marked_forms``
+    carries ``{form, label, marker, marker_label, stress?}`` rows with the Ukrainian
+    style label, and ``marked_form_count`` its post-cap length. Both keys are omitted
+    when the lemma has no marked forms, so unmarked lemmas are unaffected.
+    """
     if " " in lemma.strip():
         return None  # phrases have no single-lemma paradigm
     try:
@@ -2371,12 +2442,35 @@ def _morphology(lemma: str) -> dict | None:
         return None
     pos_raw = forms[0].get("pos") or ""
     seen: set[tuple[str, str]] = set()
+    seen_marked: set[tuple[str, str, str]] = set()
     decoded: list[dict[str, str]] = []
+    marked: list[dict[str, str]] = []
     for row in forms:
         form = row.get("word_form") or ""
-        label = _decode_tag(row.get("tags") or "")
+        if not form:
+            continue
+        raw_tag = row.get("tags") or ""
+        label = _decode_tag(raw_tag)
+        markers = _style_markers_in_tag(raw_tag)
+        if markers:
+            marker = markers[0]
+            marked_key = (form, label, marker)
+            if marked_key in seen_marked:
+                continue
+            seen_marked.add(marked_key)
+            marked_row = {
+                "form": form,
+                "label": label,
+                "marker": marker,
+                "marker_label": _STYLE_MARKER_LABELS.get(marker, _GENERIC_STYLE_MARKER_LABEL),
+            }
+            stressed_form = _stress_display_form(form)
+            if stressed_form:
+                marked_row["stress"] = stressed_form
+            marked.append(marked_row)
+            continue
         key = (form, label)
-        if not form or key in seen:
+        if key in seen:
             continue
         seen.add(key)
         decoded_row = {"form": form, "label": label}
@@ -2384,12 +2478,13 @@ def _morphology(lemma: str) -> dict | None:
         if stressed_form:
             decoded_row["stress"] = stressed_form
         decoded.append(decoded_row)
-    if not decoded:
+    if not decoded and not marked:
         return None
+    forms_out = decoded[:_MORPHOLOGY_FORM_CAP]
     morphology = {
         "pos": _POS_LABELS.get(pos_raw, pos_raw),
-        "form_count": len(decoded),
-        "forms": decoded[:40],
+        "form_count": len(forms_out),
+        "forms": forms_out,
         "source": "VESUM",
     }
     paradigm = _build_paradigm(pos_raw, decoded)
@@ -2405,6 +2500,10 @@ def _morphology(lemma: str) -> dict | None:
                 stressed_forms[form] = stressed_form
     if stressed_forms:
         morphology["stress"] = {"source": _STRESS_SOURCE, "forms": stressed_forms}
+    if marked:
+        marked_out = marked[:_MORPHOLOGY_FORM_CAP]
+        morphology["marked_forms"] = marked_out
+        morphology["marked_form_count"] = len(marked_out)
     return morphology
 
 

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "c424dc955e0aed545a3c89665465766b014dff6cc13f71d9240fb9a4f87a4551",
+  "fingerprint": "84dae67f39a13c4e4a79816cb6a15b7017e2b434d5450be08944ab3ea07394b7",
   "inputs": {
     "lexicon_code": [
       {
@@ -48,7 +48,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "2d50d186b827e582e504b18745218182ee2c9256acaf63fddf297a13b6ec6d00"
+        "sha256": "3b71a4ed2741c02c6350c99dd14bbbc474519509d0fdff3bd94d69557baf34b1"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -56,6 +56,10 @@ interface Enrichment {
     paradigm?: MorphologyParadigm;
     stress?: { source: string; forms: Record<string, string> };
     source: string;
+    // Style/register-marked forms (нестягнені, застарілі, розмовні …) kept OUT of
+    // the modern paradigm above and rendered in a separate collapsed subsection (#4891).
+    marked_forms?: Array<{ form: string; label: string; marker: string; marker_label: string; stress?: string }>;
+    marked_form_count?: number;
   };
   meaning?: {
     definitions: string[];
@@ -175,6 +179,19 @@ const cefrLevel = enrichment?.cefr?.level ?? null;
 const paradigm = enrichment?.morphology?.paradigm ?? null;
 const nounParadigm = paradigm?.kind === "noun" ? paradigm : null;
 const verbParadigm = paradigm?.kind === "verb" ? paradigm : null;
+// Group style-marked forms (#4891) by their Ukrainian marker label so each stylistic
+// class (нестягнені, застарілі, розмовні …) gets its own labelled block. Preserves
+// first-seen order of both groups and rows.
+const markedForms = enrichment?.morphology?.marked_forms ?? [];
+const markedFormGroups: Array<{ marker_label: string; forms: typeof markedForms }> = [];
+for (const form of markedForms) {
+  let group = markedFormGroups.find((entry) => entry.marker_label === form.marker_label);
+  if (!group) {
+    group = { marker_label: form.marker_label, forms: [] };
+    markedFormGroups.push(group);
+  }
+  group.forms.push(form);
+}
 // entry_type-branched rendering (GH #4385): non-lemma article types are not
 // single inflecting heads, so they must NOT be forced through the lemma
 // paradigm/morphology template. A multiword_term / expression / phraseologism /
@@ -750,6 +767,30 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
                 </tr>
               ))}
             </table>
+          )}
+          {markedFormGroups.length > 0 && (
+            <details class="marked-forms">
+              <summary>Марковані форми (нестягнені, застарілі, розмовні)</summary>
+              <p class="atlas-muted marked-forms-note">
+                Це нестандартні або стилістично забарвлені форми, які трапляються в
+                поезії, фольклорі та давніших текстах. Вони не належать до сучасної
+                літературної норми.
+              </p>
+              {markedFormGroups.map((group) => (
+                <div class="marked-forms-group">
+                  <div class="marked-forms-label">{group.marker_label}</div>
+                  <table class="paradigm-table">
+                    <tr><th>Форма</th><th>Позначка</th></tr>
+                    {group.forms.map((form) => (
+                      <tr>
+                        <td class="form">{form.stress ?? stressDisplay(form.form)}</td>
+                        <td class="case-name">{form.label}</td>
+                      </tr>
+                    ))}
+                  </table>
+                </div>
+              ))}
+            </details>
           )}
         </section>
       )}

--- a/site/src/styles/word-atlas.css
+++ b/site/src/styles/word-atlas.css
@@ -836,6 +836,41 @@
   font-weight: 600;
 }
 
+/* #4891 — style/register-marked forms (нестягнені, застарілі, розмовні …) live in a
+   collapsed subsection, visually set apart from the modern paradigm with a warm
+   caution tone so learners never mistake them for the literary norm. */
+.marked-forms {
+  margin-top: 16px;
+  padding: 10px 14px;
+  border: 1px dashed var(--orange);
+  border-radius: var(--radius);
+  background: var(--orange-light);
+}
+
+.marked-forms > summary {
+  color: var(--orange);
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.marked-forms-note {
+  margin: 10px 0 4px;
+}
+
+.marked-forms-group {
+  margin-top: 12px;
+}
+
+.marked-forms-label {
+  margin-bottom: 4px;
+  color: var(--gray-800);
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
 .source-box {
   margin: 14px 0;
   padding: 16px 22px;

--- a/site/tests/unit/atlas-marked-forms.test.ts
+++ b/site/tests/unit/atlas-marked-forms.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment node
+//
+// #4891 — style/register-marked VESUM forms (нестягнені, застарілі, розмовні …) must
+// render in a SEPARATE collapsed subsection, never inline with the modern paradigm.
+// Renders WordAtlasArticle directly with hand-crafted enrichment (no atlas.db needed).
+
+import reactRenderer from '@astrojs/react/server.js';
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, expect, test, beforeAll } from 'vitest';
+
+type AstroComponent = Parameters<AstroContainer['renderToString']>[0];
+interface AstroComponentModule {
+  default: AstroComponent;
+}
+
+const MARKED_SUMMARY = 'Марковані форми (нестягнені, застарілі, розмовні)';
+const MARKED_LABEL = 'нестягнена форма';
+const MARKED_FORM = 'корисная';
+const LEARNER_NOTE = 'не належать до сучасної літературної норми';
+
+/** A корисний-shaped lemma whose нестягнені (:long) forms are segregated by the enricher. */
+function makeMorphology(withMarked: boolean) {
+  const morphology: Record<string, unknown> = {
+    pos: 'прикметник',
+    form_count: 4,
+    source: 'VESUM',
+    forms: [
+      { form: 'корисний', label: 'чол., називний' },
+      { form: 'корисна', label: 'жін., називний' },
+      { form: 'корисне', label: 'сер., називний' },
+      { form: 'корисні', label: 'множина, називний' },
+    ],
+  };
+  if (withMarked) {
+    morphology.marked_forms = [
+      { form: 'корисная', label: 'жін., називний', marker: 'long', marker_label: MARKED_LABEL },
+      { form: 'кориснеє', label: 'сер., називний', marker: 'long', marker_label: MARKED_LABEL },
+      { form: 'кориснії', label: 'множина, називний', marker: 'long', marker_label: MARKED_LABEL },
+    ];
+    morphology.marked_form_count = 3;
+  }
+  return morphology;
+}
+
+function makeEntry(withMarked: boolean) {
+  return {
+    lemma: 'корисний',
+    url_slug: 'korysnyi',
+    gloss: 'useful',
+    entry_type: 'lemma',
+    pos: 'adj',
+    ipa: null,
+    primary_source: 'test',
+    course_usage: [],
+    enrichment: { morphology: makeMorphology(withMarked) },
+  };
+}
+
+describe('marked-forms subsection (#4891)', () => {
+  let container: AstroContainer;
+  let WordAtlasArticle: AstroComponent;
+
+  beforeAll(async () => {
+    ({ default: WordAtlasArticle } = (await import(
+      '@site/src/lexicon/WordAtlasArticle.astro'
+    )) as AstroComponentModule);
+    container = await AstroContainer.create();
+    container.addServerRenderer({ renderer: reactRenderer });
+  });
+
+  function render(withMarked: boolean): Promise<string> {
+    return container.renderToString(WordAtlasArticle, {
+      props: {
+        entry: makeEntry(withMarked),
+        allEntries: [],
+        generatedAt: 'test',
+        manifestVersion: 'test',
+      },
+    });
+  }
+
+  test('marked forms render in a collapsed subsection with a Ukrainian learner note', async () => {
+    const html = await render(true);
+    // Collapse whitespace: the multi-line JSX learner note renders with newlines the
+    // browser folds away, so text assertions compare against a normalised copy.
+    const text = html.replace(/\s+/g, ' ');
+    // Morphology section and modern paradigm still render.
+    expect(html).toContain('Морфологія');
+    expect(html).toContain('paradigm-table');
+    // Collapsed <details> subsection with the marker-group label + learner note.
+    expect(html).toContain('<details');
+    expect(html).toContain('class="marked-forms"');
+    expect(html).toContain(MARKED_SUMMARY);
+    expect(html).toContain(MARKED_LABEL);
+    expect(text).toContain(LEARNER_NOTE);
+    // The нестягнена form itself is present — inside the marked subsection.
+    expect(html).toContain(MARKED_FORM);
+    expect(html.indexOf(MARKED_SUMMARY)).toBeLessThan(html.indexOf(MARKED_FORM));
+    // No English on this B-level+ surface.
+    expect(html).not.toMatch(/marked forms|archaic|colloquial/i);
+  });
+
+  test('marked forms never leak into the modern paradigm rows', async () => {
+    const html = await render(true);
+    // Everything before the marked subsection is the modern paradigm; корисная must
+    // appear ONLY after the subsection heading.
+    const modernParadigm = html.slice(0, html.indexOf(MARKED_SUMMARY));
+    expect(modernParadigm).not.toContain(MARKED_FORM);
+    expect(modernParadigm).not.toContain('кориснеє');
+    expect(modernParadigm).not.toContain('кориснії');
+  });
+
+  test('subsection is absent (no empty shell) when there are no marked forms', async () => {
+    const html = await render(false);
+    // Modern paradigm still renders …
+    expect(html).toContain('Морфологія');
+    expect(html).toContain('paradigm-table');
+    // … but no marked-forms subsection and none of the marked forms. (Match the class
+    // attribute, not the bare slug — the worktree path itself contains "marked-forms".)
+    expect(html).not.toContain(MARKED_SUMMARY);
+    expect(html).not.toContain('class="marked-forms"');
+    expect(html).not.toContain('<details');
+    expect(html).not.toContain(MARKED_FORM);
+  });
+});

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -10,6 +10,7 @@ from scripts.lexicon.enrich_manifest import (
     _BALLA_REVERSE_SOURCE,
     _DROP_ANTONYM_LEMMAS,
     _SLOVNYK_UKRENG_SOURCE,
+    _STYLE_MARKER_LABELS,
     _WRONG_ANTONYMS,
     _WRONG_SENSE_SYNONYMS,
     KAIKKI_SOURCE,
@@ -41,6 +42,7 @@ from scripts.lexicon.enrich_manifest import (
     _sense_correct_synonyms,
     _slovnyk_cache,
     _SlovnykTransientError,
+    _style_markers_in_tag,
     _surface_gloss_hints,
     _synonyms_slovnyk,
     _translation,
@@ -296,6 +298,165 @@ def test_morphology_can_use_base_form_from_pair_lemma(monkeypatch) -> None:
     assert morphology is not None
     assert morphology["pos"] == "дієслово"
     assert morphology["forms"][0] == {"form": "варити", "label": "інфінітив"}
+
+
+# --- #4891: style-marked forms segregated out of the modern paradigm ---
+
+
+def _korysnyi_vesum_rows() -> list[dict[str, str]]:
+    """Minimal VESUM fixture for корисний: the modern paradigm plus the :long
+    (нестягнені) forms that must be segregated. Mirrors data/vesum.db shape."""
+    return [
+        {"word_form": "корисний", "tags": "adj:m:v_naz:compb", "pos": "adj"},
+        {"word_form": "корисна", "tags": "adj:f:v_naz:compb", "pos": "adj"},
+        {"word_form": "корисне", "tags": "adj:n:v_naz:compb", "pos": "adj"},
+        {"word_form": "корисні", "tags": "adj:p:v_naz:compb", "pos": "adj"},
+        {"word_form": "корисная", "tags": "adj:f:v_naz:compb:long", "pos": "adj"},
+        {"word_form": "кориснеє", "tags": "adj:n:v_naz:compb:long", "pos": "adj"},
+        {"word_form": "кориснії", "tags": "adj:p:v_naz:compb:long", "pos": "adj"},
+    ]
+
+
+def test_style_markers_match_whole_tokens_only() -> None:
+    # A raw :long adjective tag surfaces the long marker …
+    assert _style_markers_in_tag("adj:f:v_naz:compb:long") == ["long"]
+    # … a plain modern-paradigm tag surfaces nothing …
+    assert _style_markers_in_tag("adj:f:v_naz:compb") == []
+    # … `ns` (pluralia tantum) is grammatical, NOT a style marker, so двері is clean.
+    assert _style_markers_in_tag("noun:inanim:p:v_naz:ns") == []
+    assert "ns" not in _STYLE_MARKER_LABELS
+
+
+def test_morphology_segregates_marked_forms_into_marked_group(monkeypatch) -> None:
+    monkeypatch.setattr(enrich_manifest_module, "verify_lemma", lambda lemma: _korysnyi_vesum_rows())
+    monkeypatch.setattr(enrich_manifest_module, "_stress_display_form", lambda form: "")
+
+    morphology = _morphology("корисний")
+
+    assert morphology is not None
+    # The modern paradigm carries only the 4 unmarked rows; the count matches.
+    modern_forms = {row["form"] for row in morphology["forms"]}
+    assert modern_forms == {"корисний", "корисна", "корисне", "корисні"}
+    assert morphology["form_count"] == 4
+    assert {"корисная", "кориснеє", "кориснії"}.isdisjoint(modern_forms)
+    # The :long forms are segregated with the doc-verified нестягнена label.
+    assert morphology["marked_form_count"] == 3
+    marked = morphology["marked_forms"]
+    assert [row["form"] for row in marked] == ["корисная", "кориснеє", "кориснії"]
+    assert all(row["marker"] == "long" for row in marked)
+    assert all(row["marker_label"] == "нестягнена форма" for row in marked)
+    # The grammatical label is preserved alongside the style label.
+    assert marked[0]["label"] == "жін., називний"
+
+
+def test_morphology_marked_form_stress_applies_like_modern_rows(monkeypatch) -> None:
+    monkeypatch.setattr(enrich_manifest_module, "verify_lemma", lambda lemma: _korysnyi_vesum_rows())
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "_stress_display_form",
+        lambda form: f"{form}́" if form == "корисная" else "",
+    )
+
+    morphology = _morphology("корисний")
+
+    assert morphology is not None
+    marked_by_form = {row["form"]: row for row in morphology["marked_forms"]}
+    assert marked_by_form["корисная"]["stress"] == "корисная́"
+    assert "stress" not in marked_by_form["кориснеє"]
+
+
+def test_unknown_grammatical_token_stays_in_modern_paradigm(monkeypatch) -> None:
+    # A token that is NOT a style marker (grammatical/unknown) must never be
+    # segregated — it stays inline, unchanged. `arch` IS a style marker, so it goes.
+    rows = [
+        {"word_form": "сад", "tags": "noun:inanim:m:v_naz", "pos": "noun"},
+        {"word_form": "садку", "tags": "noun:inanim:m:v_dav:xp1", "pos": "noun"},
+        {"word_form": "садовий", "tags": "noun:inanim:m:v_naz:arch", "pos": "noun"},
+    ]
+    monkeypatch.setattr(enrich_manifest_module, "verify_lemma", lambda lemma: rows)
+    monkeypatch.setattr(enrich_manifest_module, "_stress_display_form", lambda form: "")
+
+    morphology = _morphology("сад")
+
+    assert morphology is not None
+    modern_forms = {row["form"] for row in morphology["forms"]}
+    assert "садку" in modern_forms  # grammatical xp1 token → unchanged, stays modern
+    assert "садовий" not in modern_forms  # arch → segregated
+    assert [row["marker_label"] for row in morphology["marked_forms"]] == ["застаріла форма"]
+
+
+def test_segregated_but_unlabelled_marker_gets_generic_label(monkeypatch) -> None:
+    # If a future VESUM style flag is added to the segregation set before its Ukrainian
+    # label is authored, the form is still segregated but carries the honest generic
+    # label «інша маркована форма» — never a guessed description (#M-4).
+    monkeypatch.setattr(enrich_manifest_module, "_STYLE_MARKERS", frozenset({"long", "newmk"}))
+    rows = [
+        {"word_form": "новий", "tags": "adj:m:v_naz", "pos": "adj"},
+        {"word_form": "новомк", "tags": "adj:m:v_naz:newmk", "pos": "adj"},
+    ]
+    monkeypatch.setattr(enrich_manifest_module, "verify_lemma", lambda lemma: rows)
+    monkeypatch.setattr(enrich_manifest_module, "_stress_display_form", lambda form: "")
+
+    morphology = _morphology("новий")
+
+    assert morphology is not None
+    assert {row["form"] for row in morphology["forms"]} == {"новий"}
+    marked = morphology["marked_forms"]
+    assert marked[0]["marker"] == "newmk"
+    assert marked[0]["marker_label"] == enrich_manifest_module._GENERIC_STYLE_MARKER_LABEL
+    assert marked[0]["marker_label"] == "інша маркована форма"
+
+
+def test_morphology_pluralia_tantum_ns_stays_in_modern_paradigm(monkeypatch) -> None:
+    # двері carries :ns on every form; that is a grammatical class (pluralia tantum),
+    # not a style marker — the whole paradigm must remain modern, else A1 words empty out.
+    rows = [
+        {"word_form": "двері", "tags": "noun:inanim:p:v_naz:ns", "pos": "noun"},
+        {"word_form": "дверей", "tags": "noun:inanim:p:v_rod:ns", "pos": "noun"},
+        {"word_form": "дверям", "tags": "noun:inanim:p:v_dav:ns", "pos": "noun"},
+    ]
+    monkeypatch.setattr(enrich_manifest_module, "verify_lemma", lambda lemma: rows)
+    monkeypatch.setattr(enrich_manifest_module, "_stress_display_form", lambda form: "")
+
+    morphology = _morphology("двері")
+
+    assert morphology is not None
+    assert morphology["form_count"] == 3
+    assert "marked_forms" not in morphology
+    assert "marked_form_count" not in morphology
+
+
+def test_morphology_unmarked_lemma_omits_marked_keys(monkeypatch) -> None:
+    # A fully unmarked lemma produces the pre-#4891 shape: no marked_forms /
+    # marked_form_count keys, and form_count == len(forms).
+    rows = [
+        {"word_form": "робота", "tags": "noun:inanim:f:v_naz", "pos": "noun"},
+        {"word_form": "роботи", "tags": "noun:inanim:f:v_rod", "pos": "noun"},
+    ]
+    monkeypatch.setattr(enrich_manifest_module, "verify_lemma", lambda lemma: rows)
+    monkeypatch.setattr(enrich_manifest_module, "_stress_display_form", lambda form: "")
+
+    morphology = _morphology("робота")
+
+    assert morphology is not None
+    assert set(morphology) == {"pos", "form_count", "forms", "source"}
+    assert morphology["form_count"] == len(morphology["forms"]) == 2
+
+
+def test_morphology_form_count_matches_rendered_rows_after_cap(monkeypatch) -> None:
+    # form_count is reported AFTER the cap so it never disagrees with the rows shown
+    # (pre-#4891: «41 форм» beside 40 rows). 45 distinct unmarked rows → capped to 40.
+    rows = [
+        {"word_form": f"форма{i}", "tags": "noun:inanim:f:v_naz", "pos": "noun"} for i in range(45)
+    ]
+    monkeypatch.setattr(enrich_manifest_module, "verify_lemma", lambda lemma: rows)
+    monkeypatch.setattr(enrich_manifest_module, "_stress_display_form", lambda form: "")
+
+    morphology = _morphology("форма")
+
+    assert morphology is not None
+    assert len(morphology["forms"]) == enrich_manifest_module._MORPHOLOGY_FORM_CAP
+    assert morphology["form_count"] == len(morphology["forms"])
 
 
 def test_legacy_synonym_sources_drop_wordnet_and_ukrajinet_noise() -> None:


### PR DESCRIPTION
Fixes #4891

## Problem
VESUM ships style/register-marked forms alongside the modern paradigm. `enrich_manifest._decode_tag` **silently dropped every marker token**, so нестягнені/застарілі/розмовні forms got labels identical to the modern paradigm and rendered inline. On https://learn-ukrainian.github.io/lexicon/корисний/ , `корисная = adj:f:v_naz:compb:long` rendered as «жін., називний» — the same label as modern `корисна`. «корисная» reads as Russian to an English-speaking learner, so presenting it unlabelled actively undermined the decolonisation mission.

## Fix
`_morphology()` now **partitions** decoded rows: any form whose raw VESUM tag carries a style marker goes to a new `marked_forms[]` group (`{form, label, marker, marker_label, stress?}`); `forms[]`/`form_count`/`paradigm` are built from **unmarked rows only**. `WordAtlasArticle.astro` renders `marked_forms` in a separate **collapsed `<details>` subsection** below the paradigm, grouped by marker label, with a Ukrainian learner note — never inline; absent when empty.

### Marker semantics — doc-verified, not guessed (#M-4)
Every label is quoted verbatim from the official dict_uk tagset doc (`doc/tags.txt` @ github.com/brown-uk/dict_uk) **and** cross-checked against ground-truth forms in `data/vesum.db`:

| marker | tagset doc line | learner label |
|---|---|---|
| `long` | L40 «нестягнені форми прикметників» | нестягнена форма |
| `arch` | L114 «застаріле/архаїчне/(інколи) діалектне» | застаріла форма |
| `short` | L39 «короткі форми прикметників» | коротка форма |
| `rare` | L112 «…плюс декілька рідкісних форм» | рідковживана форма |
| `slang` | L115 «сленг та (проф)жаргонізми» | сленгова форма |
| `coll` | L113 «розмовне слово/розмовна форма» | розмовна форма |
| `obsc` | L118 «обсценне» | обсценна форма |
| `bad` | L109 «покруч» | спотворена форма |
| `alt` | L116 «альтернативне написання (не за чинним правописом)» | альтернативне написання |
| `up19` | L121 «за правописом 2019» | форма за правописом 2019 року |
| `up92` | L120 «за правописом 1992» | форма за правописом 1992 року |

All UI strings VESUM-verified via `verify_words` (31/31 found). `coll`/`bad` never appear in our VESUM build ("не генеруємо на виході") but are mapped for completeness. An unlabelled-but-segregated marker degrades to the generic «інша маркована форма» — never a guessed description.

### ⚠️ Root-cause correction: `ns` EXCLUDED
The issue's marker list included `ns`, but `tags.txt` L92 defines `ns` = «множинний іменник» (**pluralia tantum**), a *grammatical* class. `двері`, `окуляри`, `ножиці`, `гроші` all carry `:ns` on every form, and those forms **are** the modern literary norm. Segregating `ns` would move an entire everyday A1 paradigm into "marked forms" — a worse pedagogy bug than the original. `ns` is therefore treated as grammatical (kept inline), consistent with the "keep grammatical tokens OUT" rule. Regression-tested (двері stays fully modern, no `marked_forms`).

### Cap fix
`form_count` is now reported **after** the 40-row cap, so it never disagrees with the rows shown (корисний previously showed «41 форм» beside 40 rows).

## Before / after evidence — корисний
**BEFORE (HEAD):** `form_count = 41` but **40** rows rendered (cap bug); нестягнені shown inline with modern labels:
```json
[{"form":"корисная","label":"жін., називний"},{"form":"кориснеє","label":"сер., називний"},{"form":"кориснії","label":"множина, називний"}, …]
```
**AFTER (this PR):** modern paradigm = exactly the **32 unmarked** forms (`form_count = 32`, consistent); `marked_forms` = exactly the **9 `:long`** rows:
```json
{"form_count": 32, "marked_form_count": 9,
 "marked_forms": [
   {"form":"корисная","label":"жін., кличний","marker":"long","marker_label":"нестягнена форма"},
   {"form":"корисная","label":"жін., називний","marker":"long","marker_label":"нестягнена форма"},
   {"form":"корисную","label":"жін., знахідний","marker":"long","marker_label":"нестягнена форма"},
   {"form":"кориснеє","label":"сер., кличний","marker":"long","marker_label":"нестягнена форма"},
   … (9 total)
 ]}
```

## No regression for unmarked lemmas
Verified byte-identical `_morphology` output vs HEAD across 15 lemmas (робота, стіл, двері, окуляри, гроші, рука, місто, дім, книга, швидко …) — the only diffs are marked lemmas and the documented cap fix.

## Tests
- **Python** (`tests/test_lexicon_enrich_manifest.py`): partition (32 modern / 9 marked with нестягнена label), pluralia-tantum `ns` stays modern, whole-token marker matching, marked-form stress, unknown-grammatical-token stays inline, segregated-but-unlabelled → generic label, unmarked lemma omits marked keys, `form_count == len(forms)` after cap. `pytest -k "enrich or morpholog"` → **262 passed**.
- **Frontend** (`site/tests/unit/atlas-marked-forms.test.ts`): subsection renders (collapsed, grouped, learner note), no leak into the modern paradigm, absent when empty. `vitest` → **10 passed** (with existing entry-type test, no regression).
- ruff clean on touched files; `astro check` introduces **zero** new errors (27 pre-existing, unchanged).

## Scope note
Per the driver plan, this does **not** re-run enrichment or touch `lexicon-manifest.json` / `atlas.db`. The re-enrich + atlas publish is the driver's post-merge step. The only generated file committed is `lexicon-manifest.fingerprint.json`, which the pre-commit drift gate requires to stay in sync with `scripts/lexicon/*.py`. **No auto-merge.**

X-Agent: claude/4891-marked-forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)