### PR TITLE
feat(bridge): wave 2 — broadcast, delivery TTL/auto-expire, unified thread retrieval (#4837)

### DIFF
--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -108,6 +108,27 @@ DEFAULT_DELIVERY_LEASE_SECONDS = 600
 DEFAULT_MAX_DELIVERY_ATTEMPTS = 3
 DEFAULT_RATE_LIMIT_RETRY_SECONDS = 300
 
+# ── Delivery TTL policy (#4837 item 4) ─────────────────────────────────
+#
+# FYI/broadcast messages use the channel's configured ``max_age_hours``
+# (default 24h, see ``channels.max_age_hours`` / ``ab channel set-ttl``).
+# action_required messages (asks, review requests) get a fixed, longer
+# TTL regardless of the channel setting — a slow reviewer's thread should
+# not vanish before it's picked up. Expiring one is annotated as an
+# escalation rather than a routine drop (see ``expire_stale_deliveries``).
+PRIORITY_FYI = "fyi"
+PRIORITY_ACTION_REQUIRED = "action_required"
+VALID_MESSAGE_PRIORITIES = (PRIORITY_FYI, PRIORITY_ACTION_REQUIRED)
+DEFAULT_ACTION_REQUIRED_TTL_HOURS = 24 * 7
+
+# Lanes currently known to be retired/unstaffed — e.g. "gemini-cli retired
+# -> agy" (agents_extensions/shared/rules/model-assignment.md). A lane
+# absent from ``live_agents()`` is "dead" for broadcast recipient
+# selection and dead-lane bulk-expire (#4837 items 3-4). Override with
+# AB_DEAD_LANES (comma-separated) for local testing or when a lane's
+# status changes without a code deploy.
+DEFAULT_DEAD_LANE_AGENTS = frozenset({"gemini"})
+
 # Default channel that every other channel includes unless overridden.
 # Holds project-wide pinned context that agents need on every message
 # (coding conventions, current sprint summary, etc.).
@@ -195,6 +216,29 @@ def _validate_post_agent(agent: str) -> None:
 def _validate_recipient_agent(agent: str) -> None:
     if agent not in VALID_RECIPIENT_AGENTS:
         raise ValueError(f"Unknown delivery target '{agent}'. Expected one of {VALID_RECIPIENT_AGENTS}.")
+
+
+def _validate_priority(priority: str) -> None:
+    if priority not in VALID_MESSAGE_PRIORITIES:
+        raise ValueError(f"Unknown priority '{priority}'. Expected one of {VALID_MESSAGE_PRIORITIES}.")
+
+
+def dead_lane_agents() -> frozenset[str]:
+    """Return the set of agents currently treated as dead lanes.
+
+    Reads ``AB_DEAD_LANES`` (comma-separated) when set, so a lane's status
+    can change without a code deploy; falls back to ``DEFAULT_DEAD_LANE_AGENTS``.
+    """
+    raw = os.environ.get("AB_DEAD_LANES")
+    if raw is None:
+        return DEFAULT_DEAD_LANE_AGENTS
+    return frozenset(a.strip() for a in raw.split(",") if a.strip())
+
+
+def live_agents() -> list[str]:
+    """Return ``VALID_AGENTS`` minus current dead lanes, registry order preserved."""
+    dead = dead_lane_agents()
+    return [a for a in VALID_AGENTS if a not in dead]
 
 
 def _validate_kind(kind: str) -> None:
@@ -801,6 +845,7 @@ def post(
     parent_id: str | None = None,
     correlation_id: str | None = None,
     kind: str = "post",
+    priority: str = PRIORITY_FYI,
     from_model: str | None = None,
     to_model: str | None = None,
     attachments: list[dict[str, Any]] | None = None,
@@ -850,6 +895,7 @@ def post(
     """
     _validate_post_agent(from_agent)
     _validate_kind(kind)
+    _validate_priority(priority)
     for agent in to_agents or []:
         _validate_recipient_agent(agent)
     body = redact_text(body) or ""
@@ -966,10 +1012,10 @@ def post(
             """
             INSERT INTO channel_messages (
                 message_id, channel, thread_id, parent_id, correlation_id,
-                round_index, from_agent, from_model, kind, body,
+                round_index, from_agent, from_model, kind, priority, body,
                 attachments, context_rev_shared, context_rev_channel,
                 monitor_state_snapshot, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 message_id,
@@ -981,6 +1027,7 @@ def post(
                 from_agent,
                 from_model,
                 kind,
+                priority,
                 body,
                 attachments_json,
                 context_rev_shared,
@@ -1082,7 +1129,7 @@ def read(
             rows = conn.execute(
                 """
                 SELECT message_id, channel, thread_id, parent_id, correlation_id,
-                       round_index, from_agent, from_model, kind, body,
+                       round_index, from_agent, from_model, kind, priority, body,
                        attachments, context_rev_shared, context_rev_channel,
                        monitor_state_snapshot, created_at
                 FROM channel_messages
@@ -1095,7 +1142,7 @@ def read(
             rows = conn.execute(
                 """
                 SELECT message_id, channel, thread_id, parent_id, correlation_id,
-                       round_index, from_agent, from_model, kind, body,
+                       round_index, from_agent, from_model, kind, priority, body,
                        attachments, context_rev_shared, context_rev_channel,
                        monitor_state_snapshot, created_at
                 FROM (
@@ -1125,6 +1172,7 @@ def _row_to_message(row) -> dict[str, Any]:
         "from_agent": row["from_agent"],
         "from_model": row["from_model"],
         "kind": row["kind"],
+        "priority": row["priority"],
         "body": redact_text(row["body"]) or "",
         "attachments": (redact_value(json.loads(row["attachments"])) if row["attachments"] else None),
         "context_rev_shared": row["context_rev_shared"],
@@ -1405,19 +1453,47 @@ def release_expired_leases(now: str | None = None) -> int:
         conn.close()
 
 
+def _effective_ttl_hours_sql() -> str:
+    """SQL fragment computing effective TTL hours from a joined cm/c row.
+
+    action_required messages get the fixed escalation TTL regardless of the
+    channel's configured ``max_age_hours``; everything else (fyi/broadcast)
+    keeps using the per-channel setting (default 24h) — see the module-level
+    TTL policy comment above ``PRIORITY_FYI``.
+    """
+    return (
+        "CASE WHEN cm.priority = 'action_required' THEN :action_ttl "
+        "ELSE COALESCE(c.max_age_hours, 24) END"
+    )
+
+
 def expire_stale_deliveries(now: str | None = None) -> int:
-    """Mark pending deliveries older than their channel TTL as expired."""
+    """Mark pending deliveries older than their effective TTL as expired.
+
+    fyi/broadcast messages use the channel's configured TTL (unchanged
+    behavior). action_required messages (asks, review requests) use
+    ``DEFAULT_ACTION_REQUIRED_TTL_HOURS`` instead, and their expiry error
+    is tagged ``ESCALATION`` so a stalled review request stands out from
+    routine drops (#4837 item 4) instead of silently disappearing.
+    """
     now = now or _now_iso()
     conn = get_db()
     try:
         conn.execute("BEGIN IMMEDIATE")
         cursor = conn.execute(
-            """
+            f"""
             UPDATE deliveries
             SET status = 'expired',
                 error = (
-                    SELECT 'auto-expired (>' || COALESCE(c.max_age_hours, 24)
-                           || 'h pending, channel=' || cm.channel || ')'
+                    SELECT CASE
+                        WHEN cm.priority = 'action_required' THEN
+                            'auto-expired ESCALATION (action-required, >' || :action_ttl
+                            || 'h pending, channel=' || cm.channel
+                            || ', thread=' || cm.thread_id || ')'
+                        ELSE
+                            'auto-expired (>' || COALESCE(c.max_age_hours, 24)
+                            || 'h pending, channel=' || cm.channel || ')'
+                    END
                     FROM channel_messages cm
                     JOIN channels c ON c.name = cm.channel
                     WHERE cm.message_id = deliveries.message_id
@@ -1432,17 +1508,125 @@ def expire_stale_deliveries(now: str | None = None) -> int:
                     JOIN channels c ON c.name = cm.channel
                     WHERE cm.message_id = deliveries.message_id
                       AND (
-                            julianday(?) - julianday(cm.created_at)
-                          ) * 24.0 > COALESCE(c.max_age_hours, 24)
+                            julianday(:now) - julianday(cm.created_at)
+                          ) * 24.0 > {_effective_ttl_hours_sql()}
               )
             """,
-            (now,),
+            {"now": now, "action_ttl": DEFAULT_ACTION_REQUIRED_TTL_HOURS},
         )
         conn.commit()
         return cursor.rowcount
     except Exception:
         conn.rollback()
         raise
+    finally:
+        conn.close()
+
+
+def preview_stale_deliveries(now: str | None = None) -> list[dict[str, Any]]:
+    """Read-only preview of what ``expire_stale_deliveries()`` would change.
+
+    Used by ``ab cleanup --expire --dry-run`` — never mutates the DB.
+    """
+    now = now or _now_iso()
+    conn = get_db()
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT d.delivery_id, d.to_agent, cm.channel, cm.thread_id, cm.priority,
+                   cm.created_at,
+                   (julianday(:now) - julianday(cm.created_at)) * 24.0 AS age_hours
+            FROM deliveries d
+            JOIN channel_messages cm ON cm.message_id = d.message_id
+            JOIN channels c ON c.name = cm.channel
+            WHERE d.status = 'pending'
+              AND (
+                    julianday(:now) - julianday(cm.created_at)
+                  ) * 24.0 > {_effective_ttl_hours_sql()}
+            ORDER BY cm.created_at ASC
+            """,
+            {"now": now, "action_ttl": DEFAULT_ACTION_REQUIRED_TTL_HOURS},
+        ).fetchall()
+        return [
+            {
+                "delivery_id": r["delivery_id"],
+                "to_agent": r["to_agent"],
+                "channel": r["channel"],
+                "thread_id": r["thread_id"],
+                "priority": r["priority"],
+                "age_hours": r["age_hours"],
+            }
+            for r in rows
+        ]
+    finally:
+        conn.close()
+
+
+def bulk_expire_dead_lanes(dead_lanes: frozenset[str] | None = None) -> dict[str, int]:
+    """Force-expire ALL pending deliveries for lanes absent from the live registry.
+
+    A dead lane (e.g. a retired CLI) never runs ``ab inbox run <agent>``, so
+    the routine ``expire_stale_deliveries()`` sweep — which only fires from
+    that agent's own inbox drain — would otherwise never touch its queue,
+    letting it accumulate forever regardless of TTL (#4837 item 4). Returns
+    a per-agent count of rows expired (agents with 0 pending are omitted).
+    """
+    dead = dead_lanes if dead_lanes is not None else dead_lane_agents()
+    if not dead:
+        return {}
+    conn = get_db()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        counts: dict[str, int] = {}
+        for agent in sorted(dead):
+            cursor = conn.execute(
+                """
+                UPDATE deliveries
+                SET status = 'expired',
+                    error = 'auto-expired (dead lane: ' || ? || ')',
+                    lease_until = NULL,
+                    retry_after = NULL,
+                    last_error_kind = NULL
+                WHERE status = 'pending' AND to_agent = ?
+                """,
+                (agent, agent),
+            )
+            if cursor.rowcount:
+                counts[agent] = cursor.rowcount
+        conn.commit()
+        return counts
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def preview_dead_lane_deliveries(dead_lanes: frozenset[str] | None = None) -> list[dict[str, Any]]:
+    """Read-only, delivery-level preview of what ``bulk_expire_dead_lanes()`` would change.
+
+    Row-level (not pre-aggregated) so a caller combining this with
+    ``preview_stale_deliveries()`` can dedupe by ``delivery_id`` — a dead-lane
+    row already past its TTL would otherwise be double-counted by both
+    previews even though a real run only expires it once (the age-based
+    sweep runs first).
+    """
+    dead = dead_lanes if dead_lanes is not None else dead_lane_agents()
+    if not dead:
+        return []
+    conn = get_db()
+    try:
+        placeholders = ",".join("?" for _ in dead)
+        rows = conn.execute(
+            f"""
+            SELECT delivery_id, to_agent
+            FROM deliveries
+            WHERE status = 'pending' AND to_agent IN ({placeholders})
+            ORDER BY to_agent ASC
+            """,
+            tuple(sorted(dead)),
+        ).fetchall()
+        return [{"delivery_id": r["delivery_id"], "to_agent": r["to_agent"]} for r in rows]
     finally:
         conn.close()
 

--- a/scripts/ai_agent_bridge/_channels.py
+++ b/scripts/ai_agent_bridge/_channels.py
@@ -1579,17 +1579,30 @@ def bulk_expire_dead_lanes(dead_lanes: frozenset[str] | None = None) -> dict[str
         conn.execute("BEGIN IMMEDIATE")
         counts: dict[str, int] = {}
         for agent in sorted(dead):
+            # action_required rows keep the ESCALATION tag even on the
+            # dead-lane path (review-4897 F3): a stalled review request
+            # must stand out in the expiry log regardless of WHY it
+            # expired, so escalation greps catch both expiry paths.
             cursor = conn.execute(
                 """
                 UPDATE deliveries
                 SET status = 'expired',
-                    error = 'auto-expired (dead lane: ' || ? || ')',
+                    error = COALESCE((
+                        SELECT CASE
+                            WHEN cm.priority = 'action_required' THEN
+                                'auto-expired ESCALATION (action-required, dead lane: ' || ? || ')'
+                            ELSE
+                                'auto-expired (dead lane: ' || ? || ')'
+                        END
+                        FROM channel_messages cm
+                        WHERE cm.message_id = deliveries.message_id
+                    ), 'auto-expired (dead lane: ' || ? || ')'),
                     lease_until = NULL,
                     retry_after = NULL,
                     last_error_kind = NULL
                 WHERE status = 'pending' AND to_agent = ?
                 """,
-                (agent, agent),
+                (agent, agent, agent, agent),
             )
             if cursor.rowcount:
                 counts[agent] = cursor.rowcount

--- a/scripts/ai_agent_bridge/_channels_cli.py
+++ b/scripts/ai_agent_bridge/_channels_cli.py
@@ -17,14 +17,17 @@ ab channel context <name> [--edit] [--show]
 ab channel tail <name> [--n N] [--thread TID]
 ab channel watch <thread_id> [--follow] [--event-stream]
 
-ab post <channel> <body> [--to A,...] [--parent ID] [--corr ID] [--model MODEL]
-ab p <channel> <agent> <body>                    # shorthand
+ab post <channel> <body> [--to A,...] [--broadcast] [--priority fyi|action-required]
+                          [--parent ID] [--corr ID] [--model MODEL]
+ab p <channel> <agent[,agent2,...]> <body>       # shorthand, multi-recipient
+ab p <channel> --broadcast <body>                # shorthand, all live seats
 
 ab inbox run <agent> [--once] [--max-messages N] [--stop-after-seconds N] [--deadline SECONDS]
 ab inbox show <agent>
 ab inbox ack <delivery_id> [--error NOTE]
 ab reconcile [--dry-run]
 ab sync <agent> | ab sync --all
+ab cleanup --expire [--dry-run]                  # channel-delivery TTL + dead-lane sweep (#4837)
 
 ab discuss <channel> <body> --with A,B [--max-rounds N] [--models agy:gemini-3.1-pro-high]
 ```
@@ -386,6 +389,23 @@ def register_channel_commands(subparsers: Any) -> None:
         help="Comma-separated list of recipient agents (default: channel subscribers)",
     )
     post_parser.add_argument(
+        "--broadcast", action="store_true",
+        help=(
+            "Send to all live seats from the registry (channel subscribers, "
+            "or all VALID_AGENTS if the channel has none), excluding dead "
+            "lanes (AB_DEAD_LANES). Mutually exclusive with --to (#4837)."
+        ),
+    )
+    post_parser.add_argument(
+        "--priority", default=None, choices=["fyi", "action-required"],
+        help=(
+            "Delivery TTL policy (#4837): 'fyi' expires fast off the channel "
+            "TTL (default). 'action-required' lingers longer and escalates "
+            "instead of silently expiring. Defaults to 'action-required' "
+            "when --review is set, else 'fyi'."
+        ),
+    )
+    post_parser.add_argument(
         "--parent", default=None,
         help="parent message_id — marks this as a reply",
     )
@@ -426,15 +446,20 @@ def register_channel_commands(subparsers: Any) -> None:
     # ── top-level: p (shortcut) ───────────────────────────────────
     p_parser = subparsers.add_parser(
         "p",
-        help="Quick post: ab p <channel> <agent> <body>",
+        help="Quick post: ab p <channel> <agent[,agent2,...]|--broadcast> <body>",
     )
     p_parser.add_argument("channel", help="Channel name")
     p_parser.add_argument(
         "agent",
-        choices=list(_channels.VALID_AGENTS),
-        help="Single recipient agent",
+        nargs="?",
+        default=None,
+        help="Recipient agent, or comma-separated agents (omit when using --broadcast)",
     )
     p_parser.add_argument("body", help="Message body (use '-' for stdin)")
+    p_parser.add_argument(
+        "--broadcast", action="store_true",
+        help="Send to all live seats from the registry, excluding dead lanes (#4837)",
+    )
     p_parser.add_argument(
         "--review", action="store_true",
         help="Prepend docs/review-protocol.md for channel deliveries",
@@ -848,7 +873,17 @@ def _pending_backlog_rows() -> list[dict[str, Any]]:
 
 
 def _maybe_print_backlog_warnings() -> None:
-    """Emit one stderr warning per agent with stale pending deliveries."""
+    """Emit one stderr warning per agent with stale pending deliveries.
+
+    Intentionally read-only — see ``run_delivery_expiry_cleanup`` (``ab
+    cleanup --expire``) and the Monitor API server's periodic sweep
+    (``scripts/api/comms_router.py``) for where the TTL policy actually
+    mutates rows (#4837 item 4). This function only warns; a print-a-
+    warning helper mutating the DB on every single CLI invocation —
+    including e.g. ``ab cleanup --dry-run`` — would be a surprising,
+    hard-to-predict side effect and would break dry-run's no-mutation
+    contract.
+    """
     threshold = timedelta(hours=_parse_backlog_warn_hours())
     now = _now_utc()
     for row in _pending_backlog_rows():
@@ -1087,6 +1122,26 @@ def _handle_channel_watch(args) -> int:
         return 1
 
 
+def _normalize_priority(raw: str | None, *, review: bool) -> str:
+    """Resolve the CLI-facing priority flag to the internal DB value.
+
+    Explicit ``--priority`` always wins. Otherwise ``--review`` implies
+    action-required (a review request is exactly the "asks, review
+    requests" case item 4 calls out), else fyi (#4837).
+    """
+    if raw is not None:
+        return raw.replace("-", "_")
+    return _channels.PRIORITY_ACTION_REQUIRED if review else _channels.PRIORITY_FYI
+
+
+def _broadcast_recipients(channel: dict[str, Any]) -> list[str]:
+    """All live seats for a channel — its subscribers, or every valid agent
+    if the channel has none configured — minus current dead lanes (#4837)."""
+    live = set(_channels.live_agents())
+    base = channel["subscribers"] or list(_channels.VALID_AGENTS)
+    return [a for a in base if a in live]
+
+
 def _handle_post(args) -> int:
     body = _resolve_body(args.body)
     if not body.strip():
@@ -1098,8 +1153,16 @@ def _handle_post(args) -> int:
         print(f"❌ channel '{args.channel}' does not exist", file=sys.stderr)
         return 1
 
-    # Default recipients = channel subscribers
-    to_agents = _parse_csv(args.to) if args.to else ch["subscribers"]
+    broadcast = getattr(args, "broadcast", False)
+    if broadcast and args.to:
+        print("❌ --broadcast cannot be combined with --to", file=sys.stderr)
+        return 1
+
+    # Default recipients = channel subscribers; --broadcast overrides with
+    # all live seats (subscribers or every valid agent, minus dead lanes).
+    to_agents = _broadcast_recipients(ch) if broadcast else (_parse_csv(args.to) if args.to else ch["subscribers"])
+    priority = _normalize_priority(getattr(args, "priority", None), review=args.review)
+
     model = getattr(args, "model", None)
     deadline = getattr(args, "deadline", None)
 
@@ -1124,6 +1187,7 @@ def _handle_post(args) -> int:
             args.from_agent,
             body,
             to_agents=to_agents,
+            priority=priority,
             attachments=[{"kind": "review_protocol"}] if args.review else None,
             parent_id=args.parent,
             correlation_id=args.corr,
@@ -1137,21 +1201,34 @@ def _handle_post(args) -> int:
         print(f"❌ {e}", file=sys.stderr)
         return 1
 
-    print(f"✅ posted to #{args.channel}")
+    print(f"✅ posted to #{args.channel} (priority={priority})")
     print(f"   message_id: {result['message_id']}")
     print(f"   thread_id:  {result['thread_id']}")
     if to_agents:
-        print(f"   → {', '.join(to_agents)}  ({len(result['delivery_ids'])} deliveries)")
+        label = "📢 broadcast" if broadcast else "→"
+        print(f"   {label} {', '.join(to_agents)}  ({len(result['delivery_ids'])} deliveries)")
+    if broadcast:
+        excluded = sorted((set(ch["subscribers"] or _channels.VALID_AGENTS)) & _channels.dead_lane_agents())
+        if excluded:
+            print(f"   excluded dead lanes: {', '.join(excluded)}")
     return 0
 
 
 def _handle_p(args) -> int:
-    """Shortcut: ab p <channel> <agent> <body>."""
+    """Shortcut: ab p <channel> <agent[,agent2,...]|--broadcast> <body>."""
+    if args.broadcast and args.agent:
+        print("❌ pass either an agent (or comma-separated agents) or --broadcast, not both", file=sys.stderr)
+        return 2
+    if not args.broadcast and not args.agent:
+        print("❌ missing recipient: pass an agent (or agents) or --broadcast", file=sys.stderr)
+        return 2
+
     # Rewrite to _handle_post's args shape
     class _Args:
         channel = args.channel
         body = args.body
-        to = args.agent
+        to = "" if args.broadcast else args.agent
+        broadcast = args.broadcast
         parent = None
         corr = None
         from_agent = "user"
@@ -1159,6 +1236,7 @@ def _handle_p(args) -> int:
         model = None
         deadline = None
         review = args.review
+        priority = None
 
     return _handle_post(_Args())
 
@@ -1253,6 +1331,51 @@ def _handle_inbox_ack(args) -> int:
         f"(to={row['to_agent']}, message={row['message_id']})"
     )
     return 0
+
+
+def run_delivery_expiry_cleanup(*, dry_run: bool = False) -> None:
+    """Channel-delivery TTL auto-expire + dead-lane bulk-expire (#4837 item 4).
+
+    Called from ``ab cleanup --expire`` and the Monitor API server's
+    periodic background sweep (``scripts/api/comms_router.py``). Always
+    logs what it expired (or would expire, in dry-run) so the sweep is
+    auditable from cron/API logs as well as an interactive terminal.
+    """
+    dead = _channels.dead_lane_agents()
+
+    if dry_run:
+        stale = _channels.preview_stale_deliveries()
+        stale_ids = {row["delivery_id"] for row in stale}
+        # Dedupe against `stale`: a real run's age-based sweep runs first, so
+        # a dead-lane row already past its TTL is only expired once, not twice.
+        dead_rows = [r for r in _channels.preview_dead_lane_deliveries(dead) if r["delivery_id"] not in stale_ids]
+        dead_counts: dict[str, int] = {}
+        for row in dead_rows:
+            dead_counts[row["to_agent"]] = dead_counts.get(row["to_agent"], 0) + 1
+
+        for row in stale:
+            marker = "ESCALATION " if row["priority"] == "action_required" else ""
+            print(
+                f"  would expire {marker}delivery {row['delivery_id']} → {row['to_agent']} "
+                f"(#{row['channel']}, priority={row['priority']}, "
+                f"{row['age_hours']:.1f}h pending)"
+            )
+        for agent, count in sorted(dead_counts.items()):
+            print(f"  would expire {count} pending deliveries for dead lane '{agent}'")
+        total = len(stale) + len(dead_rows)
+        print(f"🧹 cleanup --expire (DRY RUN): {total} deliveries would expire")
+        return
+
+    released = _channels.release_expired_leases()
+    expired = _channels.expire_stale_deliveries()
+    dead_counts = _channels.bulk_expire_dead_lanes(dead)
+    for agent, count in sorted(dead_counts.items()):
+        print(f"🧹 dead-lane expire: {count} pending deliveries for '{agent}'")
+    total_dead = sum(dead_counts.values())
+    print(
+        f"🧹 cleanup --expire: {released} leases released, "
+        f"{expired} deliveries auto-expired, {total_dead} dead-lane deliveries expired"
+    )
 
 
 def _handle_reconcile(args) -> int:

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -42,6 +42,7 @@ from ._messaging import (
     check_inbox,
     get_conversation,
     read_message,
+    resolve_thread,
     send_message,
 )
 from ._model import check_model
@@ -468,6 +469,14 @@ def _build_parser() -> argparse.ArgumentParser:
     # conversation
     conv_parser = subparsers.add_parser("conversation", help="Get conversation history")
     conv_parser.add_argument("task_id", help="Task ID")
+
+    # thread — unified retrieval (#4837 item 5): accepts either identifier
+    # `conversation` wants (task-id) or `read` wants (numeric message id).
+    thread_parser = subparsers.add_parser(
+        "thread",
+        help="Show the full thread for a task ID or a numeric message ID",
+    )
+    thread_parser.add_argument("identifier", help="Task ID or numeric message ID")
 
     # process (for Gemini)
     proc_parser = subparsers.add_parser("process", help="Process message with Gemini and respond")
@@ -951,6 +960,13 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Delete acknowledged/terminal broker rows older than this age (default: 30d)",
     )
     cleanup_parser.add_argument("--dry-run", action="store_true", help="Report what would be cleaned")
+    cleanup_parser.add_argument(
+        "--expire", action="store_true",
+        help=(
+            "Also run the channel-delivery TTL auto-expire + dead-lane "
+            "bulk-expire sweep (#4837 item 4). Honors --dry-run."
+        ),
+    )
 
     # status
     subparsers.add_parser("status", help="Show running bridge processes")
@@ -1114,6 +1130,8 @@ def _dispatch_command(args):
         acknowledge_all(args.agent)
     elif args.command == "conversation":
         get_conversation(args.task_id)
+    elif args.command == "thread":
+        resolve_thread(args.identifier)
     elif args.command == "process":
         process_and_respond(args.message_id, args.model, no_timeout=args.no_timeout)
     elif args.command == "process-claude":
@@ -1168,6 +1186,10 @@ def _dispatch_command(args):
         sys.exit(0 if ok else 1)
     elif args.command == "cleanup":
         broker_cleanup(args.max_age, args.dry_run, args.older_than)
+        if args.expire:
+            from ._channels_cli import run_delivery_expiry_cleanup
+
+            run_delivery_expiry_cleanup(dry_run=args.dry_run)
     elif args.command == "status":
         bridge_status()
     elif args.command == "serve":

--- a/scripts/ai_agent_bridge/_db.py
+++ b/scripts/ai_agent_bridge/_db.py
@@ -99,6 +99,7 @@ CREATE TABLE IF NOT EXISTS channel_messages (
     from_agent TEXT NOT NULL,             -- claude/gemini/codex/user
     from_model TEXT,                      -- exact model ID
     kind TEXT DEFAULT 'post',             -- post/reply/system/fanout_start/fanout_end
+    priority TEXT DEFAULT 'fyi',          -- fyi/action_required — drives delivery TTL (#4837)
     body TEXT NOT NULL,
     attachments TEXT,                     -- JSON array
     context_rev_shared TEXT,              -- sha256 hex of shared/context.md at post-time
@@ -316,6 +317,17 @@ def get_db():
                 conn.execute(
                     "ALTER TABLE channels ADD COLUMN max_age_hours INTEGER DEFAULT 24"
                 )
+
+            cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='channel_messages'"
+            )
+            if cursor.fetchone():
+                cursor.execute("PRAGMA table_info(channel_messages)")
+                channel_message_columns = [row[1] for row in cursor.fetchall()]
+                if "priority" not in channel_message_columns:
+                    conn.execute(
+                        "ALTER TABLE channel_messages ADD COLUMN priority TEXT DEFAULT 'fyi'"
+                    )
 
             cursor.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='deliveries'"

--- a/scripts/ai_agent_bridge/_db.py
+++ b/scripts/ai_agent_bridge/_db.py
@@ -258,6 +258,24 @@ def _ensure_legacy_indexes(conn: sqlite3.Connection) -> None:
     """)
 
 
+def _add_column_racesafe(conn: sqlite3.Connection, ddl: str) -> None:
+    """Run an ``ALTER TABLE ... ADD COLUMN``, tolerating the concurrent-
+    migration race (review-4897 F1).
+
+    ``get_db()`` runs its migration block on every bridge operation, and
+    multiple agent CLIs regularly open the same messages.db within the
+    same second. Two processes can both observe a column as missing and
+    both issue the ALTER; SQLite raises ``duplicate column name`` in the
+    loser. That outcome means the column now exists — the migration's
+    goal — so it is swallowed. Every other OperationalError re-raises.
+    """
+    try:
+        conn.execute(ddl)
+    except sqlite3.OperationalError as exc:
+        if "duplicate column name" not in str(exc):
+            raise
+
+
 def get_db():
     """Get database connection with auto-migration (#604, #1190)."""
     if not DB_PATH.exists():
@@ -276,7 +294,7 @@ def get_db():
             conn.executescript(_LEGACY_SCHEMA)
         elif "status" not in columns:
             print("🔧 Migrating database: adding 'status' column to 'messages' table")
-            conn.execute("ALTER TABLE messages ADD COLUMN status TEXT DEFAULT 'pending'")
+            _add_column_racesafe(conn, "ALTER TABLE messages ADD COLUMN status TEXT DEFAULT 'pending'")
         _ensure_legacy_indexes(conn)
 
         # --- Sessions table migration (#604) ---
@@ -294,7 +312,7 @@ def get_db():
         session_columns = [row[1] for row in cursor.fetchall()]
         if "codex_session_id" not in session_columns:
             print("🔧 Migrating database: adding 'codex_session_id' column to 'sessions' table")
-            conn.execute("ALTER TABLE sessions ADD COLUMN codex_session_id TEXT")
+            _add_column_racesafe(conn, "ALTER TABLE sessions ADD COLUMN codex_session_id TEXT")
 
         # --- Channel bridge tables (#1190) ---
         # GATED by table-existence check. Running executescript() on
@@ -314,8 +332,8 @@ def get_db():
             cursor.execute("PRAGMA table_info(channels)")
             channel_columns = [row[1] for row in cursor.fetchall()]
             if "max_age_hours" not in channel_columns:
-                conn.execute(
-                    "ALTER TABLE channels ADD COLUMN max_age_hours INTEGER DEFAULT 24"
+                _add_column_racesafe(
+                    conn, "ALTER TABLE channels ADD COLUMN max_age_hours INTEGER DEFAULT 24"
                 )
 
             cursor.execute(
@@ -325,8 +343,8 @@ def get_db():
                 cursor.execute("PRAGMA table_info(channel_messages)")
                 channel_message_columns = [row[1] for row in cursor.fetchall()]
                 if "priority" not in channel_message_columns:
-                    conn.execute(
-                        "ALTER TABLE channel_messages ADD COLUMN priority TEXT DEFAULT 'fyi'"
+                    _add_column_racesafe(
+                        conn, "ALTER TABLE channel_messages ADD COLUMN priority TEXT DEFAULT 'fyi'"
                     )
 
             cursor.execute(
@@ -337,20 +355,20 @@ def get_db():
                 delivery_columns = [row[1] for row in cursor.fetchall()]
 
                 if "lease_until" not in delivery_columns:
-                    conn.execute("ALTER TABLE deliveries ADD COLUMN lease_until TEXT")
+                    _add_column_racesafe(conn, "ALTER TABLE deliveries ADD COLUMN lease_until TEXT")
                 if "attempt_count" not in delivery_columns:
-                    conn.execute(
-                        "ALTER TABLE deliveries ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0"
+                    _add_column_racesafe(
+                        conn, "ALTER TABLE deliveries ADD COLUMN attempt_count INTEGER NOT NULL DEFAULT 0"
                     )
                 if "retry_after" not in delivery_columns:
-                    conn.execute("ALTER TABLE deliveries ADD COLUMN retry_after TEXT")
+                    _add_column_racesafe(conn, "ALTER TABLE deliveries ADD COLUMN retry_after TEXT")
                 if "last_error_kind" not in delivery_columns:
-                    conn.execute(
-                        "ALTER TABLE deliveries ADD COLUMN last_error_kind TEXT"
+                    _add_column_racesafe(
+                        conn, "ALTER TABLE deliveries ADD COLUMN last_error_kind TEXT"
                     )
                 if "deadline_seconds" not in delivery_columns:
-                    conn.execute(
-                        "ALTER TABLE deliveries ADD COLUMN deadline_seconds INTEGER"
+                    _add_column_racesafe(
+                        conn, "ALTER TABLE deliveries ADD COLUMN deadline_seconds INTEGER"
                     )
 
                 cursor.execute(

--- a/scripts/ai_agent_bridge/_messaging.py
+++ b/scripts/ai_agent_bridge/_messaging.py
@@ -300,6 +300,28 @@ def get_conversation_context(task_id: str, max_chars: int = 30000) -> tuple[str,
     return "\n\n".join(kept), len(rows)
 
 
+def resolve_thread(identifier: str) -> None:
+    """Show the full thread for either a numeric message ID or a task ID.
+
+    Unifies ``conversation`` (wants a task ID) and ``read`` (wants a
+    numeric message ID) — with only a message ID in hand (e.g. from
+    ``ab asks``), a caller previously had to fetch the message just to
+    learn its task_id before running ``conversation`` (#4837 item 5).
+    """
+    if identifier.isdigit():
+        msg = read_message(int(identifier), quiet=True)
+        if msg is None:
+            print(f"❌ Message {identifier} not found")
+            return
+        if msg["task_id"]:
+            get_conversation(msg["task_id"])
+        else:
+            # No task grouping to expand — show the single message.
+            read_message(int(identifier))
+    else:
+        get_conversation(identifier)
+
+
 def _extract_issue_number(task_id: str) -> int | None:
     """Extract GH issue number from task_id. Returns None if no issue pattern."""
     if not task_id:

--- a/scripts/api/comms_router.py
+++ b/scripts/api/comms_router.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import sqlite3
+import threading
 import time
 import uuid
 from datetime import UTC, datetime
@@ -123,6 +124,106 @@ def _table_exists(conn: sqlite3.Connection, table: str) -> bool:
         (table,),
     ).fetchone()
     return row is not None
+
+
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    return any(row["name"] == column for row in conn.execute(f"PRAGMA table_info({table})"))
+
+
+# ── Delivery-expiry background sweep (#4837 item 4) ────────────────────
+#
+# Precedent: codexbar_usage.trigger_background_refresh() (this package) —
+# a lazy, cache-miss-triggered background thread rather than a true cron.
+# Dead lanes (e.g. a retired CLI) never call `ab inbox run`, so nothing
+# else in the process ever runs the expire sweep for them; hooking it to
+# a frequently-polled dashboard endpoint means it fires on a real cadence
+# without needing a separate scheduler process.
+
+_EXPIRE_SWEEP_INTERVAL_S = 900.0  # 15 minutes
+_expire_sweep_lock = threading.Lock()
+_expire_sweep_thread: threading.Thread | None = None
+
+
+def _maybe_run_delivery_expiry_sweep() -> None:
+    """Lazily trigger the channel-delivery TTL + dead-lane expire sweep.
+
+    Non-blocking: the sweep runs in a daemon thread so a slow SQLite
+    write never delays the caller's response. At most one sweep thread
+    runs at a time and at most once per ``_EXPIRE_SWEEP_INTERVAL_S``.
+    Skips entirely if this router's broker DB doesn't exist yet, the
+    channel-bridge tables aren't there yet, or the schema predates the TTL
+    columns (``channels.max_age_hours`` / ``channel_messages.priority``) —
+    the sweep must never be what triggers ``ai_agent_bridge``'s own schema
+    auto-migration (adding those columns) as a side effect of a dashboard
+    poll. That migration is safe when the bridge CLI runs it deliberately,
+    but silently altering + then expiring rows in some OTHER schema this
+    router's DB happens to resemble (e.g. an older/synthetic fixture) is
+    not — it must look exactly like a current, real broker DB first.
+    """
+    if not MESSAGE_DB.exists():
+        return
+    if cache_get("bridge_expire_sweep", ttl=_EXPIRE_SWEEP_INTERVAL_S) is not None:
+        return
+
+    conn = _get_db()
+    if conn is None:
+        return
+    try:
+        if not all(_table_exists(conn, table) for table in ("channels", "deliveries", "channel_messages")):
+            return
+        if not _column_exists(conn, "channels", "max_age_hours"):
+            return
+        if not _column_exists(conn, "channel_messages", "priority"):
+            return
+    finally:
+        conn.close()
+
+    cache_set("bridge_expire_sweep", True)
+
+    global _expire_sweep_thread
+    with _expire_sweep_lock:
+        if _expire_sweep_thread is not None and _expire_sweep_thread.is_alive():
+            return
+        # Snapshot MESSAGE_DB on the request thread (respects test patches of
+        # this module's MESSAGE_DB) and hand it to the sweep explicitly.
+        _expire_sweep_thread = threading.Thread(
+            target=_run_delivery_expiry_sweep, args=(MESSAGE_DB,), daemon=True
+        )
+        _expire_sweep_thread.start()
+
+
+def _run_delivery_expiry_sweep(message_db: "os.PathLike[str]") -> None:
+    try:
+        from ai_agent_bridge import _channels as _ch
+        from ai_agent_bridge import _db as _ch_db
+    except Exception:
+        logger.exception("bridge delivery-expiry sweep: ai_agent_bridge not importable")
+        return
+
+    # `_db.get_db()` reads its own module-level DB_PATH, bound once from
+    # AB_DB_PATH at first import — it does not track this router's
+    # MESSAGE_DB. Point it at the exact same broker DB this router already
+    # resolved so the sweep can never land on a different file (this is
+    # also what makes the sweep respect test patches of MESSAGE_DB).
+    previous_db_path = _ch_db.DB_PATH
+    _ch_db.DB_PATH = message_db
+    try:
+        released = _ch.release_expired_leases()
+        expired = _ch.expire_stale_deliveries()
+        dead_counts = _ch.bulk_expire_dead_lanes()
+        total_dead = sum(dead_counts.values())
+        if released or expired or total_dead:
+            logger.info(
+                "bridge delivery-expiry sweep: released=%d expired=%d dead_lane_expired=%d (%s)",
+                released,
+                expired,
+                total_dead,
+                dead_counts,
+            )
+    except Exception:
+        logger.exception("bridge delivery-expiry sweep failed")
+    finally:
+        _ch_db.DB_PATH = previous_db_path
 
 
 def _parse_agent_csv(raw: str | None) -> list[str]:
@@ -1657,7 +1758,12 @@ def agent_activity(
     This complements `/api/comms/inbox`: inbox answers "what is waiting
     for one agent?", while this endpoint answers "what should the
     orchestrator watch or drain next?" in one cheap API call.
+
+    Also lazily triggers the delivery-expiry background sweep (#4837
+    item 4) — this is the endpoint dashboards poll to see per-agent
+    pending counts, so it doubles as the sweep's periodic trigger.
     """
+    _maybe_run_delivery_expiry_sweep()
     selected_agents = _parse_agent_csv(agents)
     conn = _get_db()
     if not conn:

--- a/tests/test_bridge_channels.py
+++ b/tests/test_bridge_channels.py
@@ -556,6 +556,160 @@ def test_expire_stale_deliveries_skips_already_delivered():
     assert expired == 0
     assert _delivery_row(delivery_id)["status"] == "delivered"
 
+
+# 5b. Message priority + TTL policy (#4837 item 4)
+
+
+def test_post_default_priority_is_fyi():
+    _channels.create_channel("topic")
+    res = _channels.post("topic", "user", "hi", to_agents=["claude"], auto_snapshot=False)
+    msgs = _channels.read("topic", tail=1)
+    assert msgs[0]["message_id"] == res["message_id"]
+    assert msgs[0]["priority"] == "fyi"
+
+
+def test_post_explicit_action_required_priority_roundtrips():
+    _channels.create_channel("topic")
+    _channels.post(
+        "topic", "user", "please review", to_agents=["claude"],
+        priority=_channels.PRIORITY_ACTION_REQUIRED, auto_snapshot=False,
+    )
+    msgs = _channels.read("topic", tail=1)
+    assert msgs[0]["priority"] == "action_required"
+
+
+def test_post_invalid_priority_raises():
+    _channels.create_channel("topic")
+    with pytest.raises(ValueError, match="Unknown priority"):
+        _channels.post("topic", "user", "hi", to_agents=["claude"], priority="urgent", auto_snapshot=False)
+
+
+def test_expire_stale_deliveries_action_required_lingers_past_channel_ttl():
+    """action_required survives the channel's short fyi-oriented TTL."""
+    _channels.create_channel("topic")
+    _channels.set_channel_ttl("topic", 2)
+    res = _channels.post(
+        "topic", "user", "review this", to_agents=["claude"],
+        priority=_channels.PRIORITY_ACTION_REQUIRED, auto_snapshot=False,
+    )
+    _set_message_created_at(str(res["message_id"]), _iso_at(0))
+
+    # Well past the channel's 2h TTL, but nowhere near the 168h action-required TTL.
+    expired = _channels.expire_stale_deliveries(now=_iso_at(24 * 3600))
+
+    assert expired == 0
+    assert _delivery_row(str(res["delivery_ids"][0]))["status"] == "pending"
+
+
+def test_expire_stale_deliveries_action_required_expires_as_escalation():
+    _channels.create_channel("topic")
+    res = _channels.post(
+        "topic", "user", "review this", to_agents=["claude"],
+        priority=_channels.PRIORITY_ACTION_REQUIRED, auto_snapshot=False,
+    )
+    _set_message_created_at(str(res["message_id"]), _iso_at(0))
+
+    past_action_ttl = (_channels.DEFAULT_ACTION_REQUIRED_TTL_HOURS + 1) * 3600
+    expired = _channels.expire_stale_deliveries(now=_iso_at(past_action_ttl))
+
+    assert expired == 1
+    row = _delivery_row(str(res["delivery_ids"][0]))
+    assert row["status"] == "expired"
+    assert "ESCALATION" in row["error"]
+    assert "action-required" in row["error"]
+
+
+def test_preview_stale_deliveries_matches_expire_without_mutating():
+    _channels.create_channel("topic")
+    res = _channels.post("topic", "user", "stale", to_agents=["claude"], auto_snapshot=False)
+    _set_message_created_at(str(res["message_id"]), _iso_at(0))
+
+    now = _iso_at(25 * 3600)
+    preview = _channels.preview_stale_deliveries(now=now)
+
+    assert len(preview) == 1
+    assert preview[0]["delivery_id"] == res["delivery_ids"][0]
+    assert preview[0]["priority"] == "fyi"
+    # Preview must not mutate — the row is still pending afterward.
+    assert _delivery_row(str(res["delivery_ids"][0]))["status"] == "pending"
+
+    expired = _channels.expire_stale_deliveries(now=now)
+    assert expired == len(preview)
+
+
+# 5c. Dead-lane registry + bulk-expire (#4837 items 3-4)
+
+
+def test_dead_lane_agents_defaults_to_gemini(monkeypatch):
+    monkeypatch.delenv("AB_DEAD_LANES", raising=False)
+    assert _channels.dead_lane_agents() == frozenset({"gemini"})
+
+
+def test_dead_lane_agents_env_override(monkeypatch):
+    monkeypatch.setenv("AB_DEAD_LANES", "gemini, qwen")
+    assert _channels.dead_lane_agents() == frozenset({"gemini", "qwen"})
+
+
+def test_dead_lane_agents_env_override_can_be_empty(monkeypatch):
+    monkeypatch.setenv("AB_DEAD_LANES", "")
+    assert _channels.dead_lane_agents() == frozenset()
+
+
+def test_live_agents_excludes_dead_lanes(monkeypatch):
+    monkeypatch.setenv("AB_DEAD_LANES", "gemini")
+    live = _channels.live_agents()
+    assert "gemini" not in live
+    assert "claude" in live
+    assert "codex" in live
+
+
+def test_bulk_expire_dead_lanes_expires_fresh_pending_regardless_of_age():
+    """A dead lane never comes back to drain its inbox — bulk-expire must
+    not wait for the message to age past any TTL."""
+    _channels.create_channel("topic")
+    res = _channels.post("topic", "user", "hi", to_agents=["gemini"], auto_snapshot=False)
+    # Freshly created — well within any TTL.
+
+    counts = _channels.bulk_expire_dead_lanes(frozenset({"gemini"}))
+
+    assert counts == {"gemini": 1}
+    row = _delivery_row(str(res["delivery_ids"][0]))
+    assert row["status"] == "expired"
+    assert "dead lane" in row["error"]
+    assert "gemini" in row["error"]
+
+
+def test_bulk_expire_dead_lanes_skips_non_pending():
+    _channels.create_channel("topic")
+    res = _channels.post("topic", "user", "hi", to_agents=["gemini"], auto_snapshot=False)
+    _channels.mark_delivery(str(res["delivery_ids"][0]), "delivered")
+
+    counts = _channels.bulk_expire_dead_lanes(frozenset({"gemini"}))
+
+    assert counts == {}
+    assert _delivery_row(str(res["delivery_ids"][0]))["status"] == "delivered"
+
+
+def test_bulk_expire_dead_lanes_empty_dead_set_is_noop():
+    _channels.create_channel("topic")
+    res = _channels.post("topic", "user", "hi", to_agents=["gemini"], auto_snapshot=False)
+
+    counts = _channels.bulk_expire_dead_lanes(frozenset())
+
+    assert counts == {}
+    assert _delivery_row(str(res["delivery_ids"][0]))["status"] == "pending"
+
+
+def test_preview_dead_lane_deliveries_matches_bulk_without_mutating():
+    _channels.create_channel("topic")
+    res = _channels.post("topic", "user", "hi", to_agents=["gemini"], auto_snapshot=False)
+
+    preview = _channels.preview_dead_lane_deliveries(frozenset({"gemini"}))
+
+    assert preview == [{"delivery_id": res["delivery_ids"][0], "to_agent": "gemini"}]
+    assert _delivery_row(str(res["delivery_ids"][0]))["status"] == "pending"
+
+
 # 6. Concurrency
 
 def test_concurrent_post_no_data_loss(isolate_db):

--- a/tests/test_bridge_channels.py
+++ b/tests/test_bridge_channels.py
@@ -1462,3 +1462,47 @@ class TestDeliveryLeasing:
         second = _channels.claim_next_delivery("claude", now=_iso_at(1))
         assert second is not None
         assert _delivery_row(delivery_id)["attempt_count"] == 2
+
+
+def test_bulk_expire_dead_lanes_tags_action_required_as_escalation():
+    """Dead-lane expiry of an action_required delivery must carry the
+    ESCALATION tag just like age-based expiry — a stalled review request
+    stands out in the expiry log regardless of WHY it expired
+    (review-4897 F3)."""
+    _channels.create_channel("topic")
+    res = _channels.post(
+        "topic", "user", "review this", to_agents=["gemini"],
+        priority=_channels.PRIORITY_ACTION_REQUIRED, auto_snapshot=False,
+    )
+
+    counts = _channels.bulk_expire_dead_lanes(frozenset({"gemini"}))
+
+    assert counts == {"gemini": 1}
+    row = _delivery_row(str(res["delivery_ids"][0]))
+    assert row["status"] == "expired"
+    assert "ESCALATION" in row["error"]
+    assert "action-required" in row["error"]
+    assert "dead lane" in row["error"]
+
+
+def test_add_column_racesafe_swallows_duplicate_and_reraises_others(tmp_path):
+    """Two processes can both see a column as missing and both ALTER —
+    the loser gets 'duplicate column name', which must be swallowed
+    (the column exists = migration goal). Any other OperationalError
+    must re-raise. (review-4897 F1 — concurrent migration race.)"""
+    import sqlite3
+
+    from ai_agent_bridge._db import _add_column_racesafe
+
+    conn = sqlite3.connect(str(tmp_path / "race.db"))
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+
+    ddl = "ALTER TABLE t ADD COLUMN priority TEXT DEFAULT 'fyi'"
+    _add_column_racesafe(conn, ddl)          # first ALTER: applies
+    _add_column_racesafe(conn, ddl)          # loser's ALTER: swallowed
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(t)").fetchall()]
+    assert cols.count("priority") == 1
+
+    with pytest.raises(sqlite3.OperationalError):
+        _add_column_racesafe(conn, "ALTER TABLE nonexistent ADD COLUMN x TEXT")
+    conn.close()

--- a/tests/test_bridge_wave2_cli.py
+++ b/tests/test_bridge_wave2_cli.py
@@ -1,0 +1,259 @@
+"""CLI-level tests for #4837 wave 2: broadcast post, delivery TTL/auto-expire
++ cleanup automation, and unified thread retrieval.
+
+Follows the `_run_cli` + `isolate_db` pattern established in
+tests/test_ab_reconcile.py and tests/test_bridge_inbox_cli.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from ai_agent_bridge import _channels, _cli, _db, _messaging
+
+
+@pytest.fixture(autouse=True)
+def isolate_db(tmp_path):
+    db_file = tmp_path / "messages.db"
+    with patch("ai_agent_bridge._config.DB_PATH", db_file), patch("ai_agent_bridge._db.DB_PATH", db_file):
+        _db.init_db()
+        yield db_file
+
+
+def _run_cli(argv: list[str]) -> int:
+    with patch.object(sys, "argv", ["ab", *argv]):
+        try:
+            _cli.main()
+        except SystemExit as exc:
+            return exc.code if isinstance(exc.code, int) else 0
+    return 0
+
+
+def _hours_ago(hours: float) -> str:
+    return (datetime.now(UTC) - timedelta(hours=hours)).isoformat()
+
+
+def _set_message_created_at(message_id: str, created_at: str) -> None:
+    conn = _db.get_db()
+    try:
+        conn.execute("UPDATE channel_messages SET created_at = ? WHERE message_id = ?", (created_at, message_id))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _delivery_status(delivery_id: str) -> str:
+    conn = _db.get_db()
+    try:
+        row = conn.execute("SELECT status FROM deliveries WHERE delivery_id = ?", (delivery_id,)).fetchone()
+        return str(row["status"])
+    finally:
+        conn.close()
+
+
+def _pending_agents_for_message(message_id: str) -> set[str]:
+    conn = _db.get_db()
+    try:
+        rows = conn.execute(
+            "SELECT to_agent FROM deliveries WHERE message_id = ? AND status = 'pending'", (message_id,)
+        ).fetchall()
+        return {row["to_agent"] for row in rows}
+    finally:
+        conn.close()
+
+
+def _message_priority(message_id: str) -> str:
+    conn = _db.get_db()
+    try:
+        row = conn.execute(
+            "SELECT priority FROM channel_messages WHERE message_id = ?", (message_id,)
+        ).fetchone()
+        return str(row["priority"])
+    finally:
+        conn.close()
+
+
+# ── Item 3: broadcast post ──────────────────────────────────────────────
+
+
+def test_p_single_recipient_still_works(capsys):
+    _channels.create_channel("shared")
+    rc = _run_cli(["p", "shared", "claude", "hello"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "→ claude" in out
+    assert "1 deliveries" in out
+
+
+def test_p_multi_recipient_comma_list(capsys):
+    _channels.create_channel("shared")
+    rc = _run_cli(["p", "shared", "claude,codex", "hello team"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "claude" in out and "codex" in out
+    assert "2 deliveries" in out
+
+
+def test_p_broadcast_excludes_dead_lane(capsys, monkeypatch):
+    monkeypatch.setenv("AB_DEAD_LANES", "gemini")
+    _channels.create_channel("ops", subscribers=["claude", "codex", "gemini"])
+    rc = _run_cli(["p", "ops", "--broadcast", "fleet announcement"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "claude" in out
+    assert "codex" in out
+    assert "excluded dead lanes: gemini" in out
+    # Broadcast defaults to fyi priority (#4837 item 3).
+    msgs = _channels.read("ops", tail=1)
+    assert msgs[0]["priority"] == "fyi"
+    delivered_agents = {d["to_agent"] for d in _channels.deliveries_for_message(msgs[0]["message_id"])}
+    assert delivered_agents == {"claude", "codex"}
+
+
+def test_p_broadcast_and_agent_conflict_errors(capsys):
+    _channels.create_channel("shared")
+    rc = _run_cli(["p", "shared", "claude", "hello", "--broadcast"])
+    assert rc == 2
+    assert "not both" in capsys.readouterr().err
+
+
+def test_p_missing_recipient_errors(capsys):
+    _channels.create_channel("shared")
+    rc = _run_cli(["p", "shared", "hello with no recipient"])
+    assert rc == 2
+    assert "missing recipient" in capsys.readouterr().err
+
+
+def test_post_broadcast_and_to_conflict_errors(capsys):
+    _channels.create_channel("shared")
+    rc = _run_cli(["post", "shared", "hello", "--broadcast", "--to", "claude"])
+    assert rc == 1
+    assert "cannot be combined" in capsys.readouterr().err
+
+
+def test_post_review_flag_implies_action_required_priority():
+    _channels.create_channel("shared")
+    rc = _run_cli(["post", "shared", "please review this", "--to", "claude", "--review", "--no-snapshot"])
+    assert rc == 0
+    msgs = _channels.read("shared", tail=1)
+    assert msgs[0]["priority"] == "action_required"
+
+
+def test_post_explicit_priority_overrides_review_flag():
+    _channels.create_channel("shared")
+    rc = _run_cli(
+        ["post", "shared", "fyi + review text", "--to", "claude", "--review", "--priority", "fyi", "--no-snapshot"]
+    )
+    assert rc == 0
+    msgs = _channels.read("shared", tail=1)
+    assert msgs[0]["priority"] == "fyi"
+
+
+def test_post_explicit_action_required_priority_without_review():
+    _channels.create_channel("shared")
+    rc = _run_cli(
+        ["post", "shared", "urgent", "--to", "claude", "--priority", "action-required", "--no-snapshot"]
+    )
+    assert rc == 0
+    msgs = _channels.read("shared", tail=1)
+    assert msgs[0]["priority"] == "action_required"
+
+
+# ── Item 4: delivery TTL/auto-expire + cleanup automation ──────────────
+
+
+def test_cleanup_expire_dry_run_previews_without_mutating(capsys):
+    _channels.create_channel("shared")
+    res = _channels.post("shared", "user", "stale", to_agents=["claude"], auto_snapshot=False)
+    _set_message_created_at(res["message_id"], _hours_ago(30))
+
+    rc = _run_cli(["cleanup", "--expire", "--dry-run"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "would expire" in out
+    assert "1 deliveries would expire" in out
+    assert _delivery_status(res["delivery_ids"][0]) == "pending"
+
+
+def test_cleanup_expire_applies_and_logs(capsys):
+    _channels.create_channel("shared")
+    res = _channels.post("shared", "user", "stale", to_agents=["claude"], auto_snapshot=False)
+    _set_message_created_at(res["message_id"], _hours_ago(30))
+
+    rc = _run_cli(["cleanup", "--expire"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "1 deliveries auto-expired" in out
+    assert _delivery_status(res["delivery_ids"][0]) == "expired"
+
+
+def test_cleanup_expire_bulk_expires_dead_lane_regardless_of_age(capsys, monkeypatch):
+    monkeypatch.setenv("AB_DEAD_LANES", "gemini")
+    _channels.create_channel("shared")
+    res = _channels.post("shared", "user", "fresh", to_agents=["gemini"], auto_snapshot=False)
+    # No backdating — this delivery is brand new, well within any TTL.
+
+    rc = _run_cli(["cleanup", "--expire"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "dead-lane expire: 1 pending deliveries for 'gemini'" in out
+    assert _delivery_status(res["delivery_ids"][0]) == "expired"
+
+
+def test_cleanup_without_expire_flag_leaves_channel_deliveries_untouched():
+    _channels.create_channel("shared")
+    res = _channels.post("shared", "user", "stale", to_agents=["claude"], auto_snapshot=False)
+    _set_message_created_at(res["message_id"], _hours_ago(30))
+
+    rc = _run_cli(["cleanup"])
+
+    assert rc == 0
+    assert _delivery_status(res["delivery_ids"][0]) == "pending"
+
+
+def test_action_required_delivery_survives_plain_cleanup_expire_before_escalation_ttl():
+    """A review request 3 days old must not be swept by the fast fyi path."""
+    _channels.create_channel("shared")
+    res = _channels.post(
+        "shared", "user", "please review", to_agents=["claude"],
+        priority=_channels.PRIORITY_ACTION_REQUIRED, auto_snapshot=False,
+    )
+    _set_message_created_at(res["message_id"], _hours_ago(72))
+
+    rc = _run_cli(["cleanup", "--expire"])
+
+    assert rc == 0
+    assert _delivery_status(res["delivery_ids"][0]) == "pending"
+
+
+# ── Item 5: unified thread retrieval ────────────────────────────────────
+
+
+def test_thread_cli_by_task_id(capsys):
+    _messaging.send_message("hello", task_id="t-4837", quiet=True)
+    rc = _run_cli(["thread", "t-4837"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Conversation: t-4837" in out
+    assert "hello" in out
+
+
+def test_thread_cli_by_numeric_message_id_resolves_task(capsys):
+    msg_id = _messaging.send_message("ask", task_id="t-4837b", from_llm="claude", to_llm="codex", quiet=True)
+    _messaging.send_message("reply", task_id="t-4837b", from_llm="codex", to_llm="claude", quiet=True)
+    rc = _run_cli(["thread", str(msg_id)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Conversation: t-4837b (2 messages)" in out
+    assert "ask" in out
+    assert "reply" in out

--- a/tests/test_comms_router_expiry_sweep.py
+++ b/tests/test_comms_router_expiry_sweep.py
@@ -70,8 +70,15 @@ def _delivery_status(db_path: Path, delivery_id: str) -> str:
 def test_sweep_expires_stale_and_dead_lane_rows_in_the_routers_own_db(tmp_path):
     db_path = tmp_path / "messages.db"
     ids = _seed_channel_db(db_path)
-    assert not ab_config.DB_PATH.exists(), "real default DB must not exist before the sweep"
+    # Snapshot the default-path state instead of asserting global absence:
+    # other tests on the same pytest-xdist worker may legitimately have
+    # created the (conftest-patched) default DB before this one runs — this
+    # test only has to prove the sweep does not CREATE or MODIFY that file.
+    # (The absence precondition flaked in CI run 29085878896, 2026-07-10.)
     real_default_db_path = ab_config.DB_PATH
+    default_db_before = (
+        real_default_db_path.read_bytes() if real_default_db_path.exists() else None
+    )
 
     with patch.object(comms_router, "MESSAGE_DB", db_path):
         comms_router._maybe_run_delivery_expiry_sweep()
@@ -82,9 +89,13 @@ def test_sweep_expires_stale_and_dead_lane_rows_in_the_routers_own_db(tmp_path):
     assert _delivery_status(db_path, ids["stale_delivery_id"]) == "expired"
     assert _delivery_status(db_path, ids["dead_delivery_id"]) == "expired"
 
-    # The real ai_agent_bridge default DB path must remain untouched — no
-    # stray file created, and its module-level DB_PATH must be restored.
-    assert not real_default_db_path.exists()
+    # The real ai_agent_bridge default DB path must remain untouched by the
+    # sweep — not created, not modified — and the module-level DB_PATH must
+    # be restored.
+    if default_db_before is None:
+        assert not real_default_db_path.exists()
+    else:
+        assert real_default_db_path.read_bytes() == default_db_before
     assert real_default_db_path == ab_db.DB_PATH
     assert real_default_db_path == ab_config.DB_PATH
 

--- a/tests/test_comms_router_expiry_sweep.py
+++ b/tests/test_comms_router_expiry_sweep.py
@@ -1,0 +1,206 @@
+"""Tests for the Monitor API server's periodic delivery-expiry sweep (#4837 item 4).
+
+The sweep is a lazy, codexbar-style background trigger hooked to
+GET /api/comms/agent-activity (scripts/api/comms_router.py). The critical
+property under test: it must operate on THIS router's own `MESSAGE_DB`
+(so it respects test patches and never diverges from what the router
+reports), and must NEVER touch `ai_agent_bridge`'s own default DB path —
+a real production risk since `ai_agent_bridge._db.get_db()` resolves its
+own DB_PATH independently and would silently create + migrate a fresh
+broker DB if ever pointed at a path that doesn't exist yet.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from ai_agent_bridge import _channels
+from ai_agent_bridge import _config as ab_config
+from ai_agent_bridge import _db as ab_db
+
+from scripts.api import comms_router
+from scripts.api.state_helpers import cache_invalidate
+
+
+@pytest.fixture(autouse=True)
+def _reset_sweep_state():
+    cache_invalidate("bridge_expire_sweep")
+    comms_router._expire_sweep_thread = None
+    yield
+    cache_invalidate("bridge_expire_sweep")
+    comms_router._expire_sweep_thread = None
+
+
+def _seed_channel_db(db_path: Path) -> dict:
+    """Build a real channel-bridge DB at db_path via the actual bridge code,
+    temporarily redirecting ai_agent_bridge's own DB_PATH — then restore it,
+    so the seeded file is indistinguishable from a real broker DB but the
+    live default path is never touched."""
+    with patch.object(ab_config, "DB_PATH", db_path), patch.object(ab_db, "DB_PATH", db_path):
+        ab_db.init_db()
+        _channels.create_channel("ops")
+        stale = _channels.post("ops", "user", "stale fyi", to_agents=["claude"], auto_snapshot=False)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "UPDATE channel_messages SET created_at = '2020-01-01T00:00:00+00:00' WHERE message_id = ?",
+            (stale["message_id"],),
+        )
+        conn.commit()
+        conn.close()
+        dead = _channels.post("ops", "user", "for a dead lane", to_agents=["gemini"], auto_snapshot=False)
+    return {"stale_delivery_id": stale["delivery_ids"][0], "dead_delivery_id": dead["delivery_ids"][0]}
+
+
+def _delivery_status(db_path: Path, delivery_id: str) -> str:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute("SELECT status FROM deliveries WHERE delivery_id = ?", (delivery_id,)).fetchone()
+        return str(row[0])
+    finally:
+        conn.close()
+
+
+def test_sweep_expires_stale_and_dead_lane_rows_in_the_routers_own_db(tmp_path):
+    db_path = tmp_path / "messages.db"
+    ids = _seed_channel_db(db_path)
+    assert not ab_config.DB_PATH.exists(), "real default DB must not exist before the sweep"
+    real_default_db_path = ab_config.DB_PATH
+
+    with patch.object(comms_router, "MESSAGE_DB", db_path):
+        comms_router._maybe_run_delivery_expiry_sweep()
+        assert comms_router._expire_sweep_thread is not None
+        comms_router._expire_sweep_thread.join(timeout=5)
+        assert not comms_router._expire_sweep_thread.is_alive()
+
+    assert _delivery_status(db_path, ids["stale_delivery_id"]) == "expired"
+    assert _delivery_status(db_path, ids["dead_delivery_id"]) == "expired"
+
+    # The real ai_agent_bridge default DB path must remain untouched — no
+    # stray file created, and its module-level DB_PATH must be restored.
+    assert not real_default_db_path.exists()
+    assert real_default_db_path == ab_db.DB_PATH
+    assert real_default_db_path == ab_config.DB_PATH
+
+
+def test_sweep_is_noop_when_message_db_missing(tmp_path):
+    missing = tmp_path / "does-not-exist.db"
+    with patch.object(comms_router, "MESSAGE_DB", missing):
+        comms_router._maybe_run_delivery_expiry_sweep()
+    assert comms_router._expire_sweep_thread is None
+    assert not missing.exists()
+
+
+def test_sweep_is_noop_when_channel_tables_missing(tmp_path):
+    """A legacy-only broker DB (messages table, no channel bridge tables)
+    must not be auto-migrated as a side effect of the sweep trigger."""
+    db_path = tmp_path / "messages.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY, content TEXT)")
+    conn.commit()
+    conn.close()
+
+    with patch.object(comms_router, "MESSAGE_DB", db_path):
+        comms_router._maybe_run_delivery_expiry_sweep()
+
+    assert comms_router._expire_sweep_thread is None
+    conn = sqlite3.connect(str(db_path))
+    try:
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    finally:
+        conn.close()
+    assert tables == {"messages"}, "sweep must not auto-migrate a legacy-only DB"
+
+
+def test_sweep_is_noop_on_pre_priority_column_schema(tmp_path):
+    """Regression (found via tests/test_manifest_api.py collision): a broker
+    DB with the three channel tables but PRE-DATING the max_age_hours/
+    priority columns must not trigger the sweep. ``ai_agent_bridge._db.get_db()``
+    silently ALTER TABLE-migrates any DB missing those columns — if the sweep
+    ran anyway, that dormant migration would fire as a side effect of a
+    dashboard poll, then the newly-defaulted columns would make every row in
+    an old/synthetic fixture look 24h+ stale and get force-expired."""
+    db_path = tmp_path / "messages.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE channels (
+            name TEXT PRIMARY KEY, created_at TEXT, description TEXT, include TEXT, subscribers TEXT
+        );
+        CREATE TABLE channel_messages (
+            message_id TEXT PRIMARY KEY, channel TEXT, thread_id TEXT, parent_id TEXT,
+            correlation_id TEXT, round_index INTEGER, from_agent TEXT, from_model TEXT,
+            kind TEXT, body TEXT, attachments TEXT, context_rev_shared TEXT,
+            context_rev_channel TEXT, monitor_state_snapshot TEXT, created_at TEXT
+        );
+        CREATE TABLE deliveries (
+            delivery_id TEXT PRIMARY KEY, message_id TEXT, to_agent TEXT, to_model TEXT,
+            status TEXT, dispatched_at TEXT, delivered_at TEXT, error TEXT, lease_until TEXT,
+            attempt_count INTEGER DEFAULT 0, retry_after TEXT, last_error_kind TEXT
+        );
+        """
+    )
+    conn.execute("INSERT INTO channels VALUES ('reviews', '2026-05-31T10:00:00Z', '', '', '')")
+    conn.execute(
+        "INSERT INTO channel_messages (message_id, channel, thread_id, from_agent, kind, body, created_at, "
+        "round_index) VALUES ('m1', 'reviews', 't1', 'claude', 'post', 'hi', '2026-05-31T10:01:00Z', 0)"
+    )
+    conn.execute(
+        "INSERT INTO deliveries (delivery_id, message_id, to_agent, status) VALUES ('d1', 'm1', 'codex', 'pending')"
+    )
+    conn.commit()
+    conn.close()
+
+    with patch.object(comms_router, "MESSAGE_DB", db_path):
+        comms_router._maybe_run_delivery_expiry_sweep()
+
+    assert comms_router._expire_sweep_thread is None
+    assert _delivery_status(db_path, "d1") == "pending"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        columns = {r[1] for r in conn.execute("PRAGMA table_info(channels)")}
+    finally:
+        conn.close()
+    assert "max_age_hours" not in columns, "sweep must not auto-migrate the schema either"
+
+
+def test_sweep_triggers_at_most_once_per_interval(tmp_path):
+    db_path = tmp_path / "messages.db"
+    _seed_channel_db(db_path)
+
+    with patch.object(comms_router, "MESSAGE_DB", db_path):
+        comms_router._maybe_run_delivery_expiry_sweep()
+        first_thread = comms_router._expire_sweep_thread
+        first_thread.join(timeout=5)
+
+        comms_router._maybe_run_delivery_expiry_sweep()
+        # Cache still warm — no second thread spawned.
+        assert comms_router._expire_sweep_thread is first_thread
+
+
+def test_agent_activity_endpoint_triggers_sweep(tmp_path):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    db_path = tmp_path / "messages.db"
+    ids = _seed_channel_db(db_path)
+
+    app = FastAPI()
+    app.include_router(comms_router.router, prefix="/api/comms")
+    client = TestClient(app)
+
+    with patch.object(comms_router, "MESSAGE_DB", db_path):
+        resp = client.get("/api/comms/agent-activity")
+        assert resp.status_code == 200
+        thread = comms_router._expire_sweep_thread
+        assert thread is not None
+        thread.join(timeout=5)
+
+    assert _delivery_status(db_path, ids["stale_delivery_id"]) == "expired"
+    assert _delivery_status(db_path, ids["dead_delivery_id"]) == "expired"

--- a/tests/test_coverage_bridge_audit.py
+++ b/tests/test_coverage_bridge_audit.py
@@ -39,8 +39,14 @@ class TestConfig:
     def test_cli_paths_are_correct_types(self):
         from scripts.ai_agent_bridge._config import AGY_CLI, CLAUDE_CMD, GEMINI_CLI
         assert isinstance(CLAUDE_CMD, list)
-        assert CLAUDE_CMD[0] == "npx"
-        assert "@anthropic-ai/claude-code" in CLAUDE_CMD[1]
+        # #4875: prefers a native `claude` binary on PATH (single-element
+        # command) and only falls back to the npx shim when none is found —
+        # both are correct depending on the machine running the test.
+        if CLAUDE_CMD[0] == "npx":
+            assert "@anthropic-ai/claude-code" in CLAUDE_CMD[1]
+        else:
+            assert len(CLAUDE_CMD) == 1
+            assert CLAUDE_CMD[0].endswith("claude")
         assert isinstance(AGY_CLI, str)
         assert isinstance(GEMINI_CLI, str)
 
@@ -604,6 +610,47 @@ class TestMessaging:
     def test_get_conversation_not_found(self, msg_db, capsys):
         from scripts.ai_agent_bridge._messaging import get_conversation
         get_conversation("no-such-task")
+        assert "No messages found" in capsys.readouterr().out
+
+    # -- resolve_thread (#4837 item 5: unified `ab thread <task-id|msg-id>`) --
+
+    def test_resolve_thread_by_task_id(self, msg_db, capsys):
+        from scripts.ai_agent_bridge._messaging import resolve_thread
+        self._insert(msg_db, "t1", "claude", "gemini", "msg1")
+        resolve_thread("t1")
+        out = capsys.readouterr().out
+        assert "Conversation: t1" in out
+        assert "msg1" in out
+
+    def test_resolve_thread_by_numeric_id_resolves_full_task_thread(self, msg_db, capsys):
+        """A numeric message ID expands to the FULL conversation for its task,
+        not just that one row — this is the whole point of unifying `read`
+        (numeric-id-only) with `conversation` (task-id-only)."""
+        from scripts.ai_agent_bridge._messaging import resolve_thread
+        self._insert(msg_db, "t1", "claude", "gemini", "ask body")
+        self._insert(msg_db, "t1", "gemini", "claude", "reply body")
+        resolve_thread("1")
+        out = capsys.readouterr().out
+        assert "Conversation: t1 (2 messages)" in out
+        assert "ask body" in out
+        assert "reply body" in out
+
+    def test_resolve_thread_by_numeric_id_without_task_shows_single_message(self, msg_db, capsys):
+        from scripts.ai_agent_bridge._messaging import resolve_thread
+        self._insert(msg_db, None, "claude", "gemini", "solo message")
+        resolve_thread("1")
+        out = capsys.readouterr().out
+        assert "Message #1" in out
+        assert "solo message" in out
+
+    def test_resolve_thread_unknown_numeric_id_reports_not_found(self, msg_db, capsys):
+        from scripts.ai_agent_bridge._messaging import resolve_thread
+        resolve_thread("999")
+        assert "not found" in capsys.readouterr().out
+
+    def test_resolve_thread_unknown_task_id_reports_not_found(self, msg_db, capsys):
+        from scripts.ai_agent_bridge._messaging import resolve_thread
+        resolve_thread("no-such-task")
         assert "No messages found" in capsys.readouterr().out
 
 


### PR DESCRIPTION
## Summary

Implements items 3, 4, 5 of #4837 (comms/bridge cluster). Items 1-2 (#4841) and 6 (#4834) already landed; items 7-10 (dispatch cluster) untouched.

- **Item 3 — broadcast**: `ab p`/`ab post` gain `--broadcast` (all live seats, excluding dead lanes) alongside the existing `--to a,b,c` multi-recipient. Broadcasts default to `fyi` priority per the issue's request.
- **Item 4 — TTL/auto-expire + cleanup automation**: new `channel_messages.priority` column (`fyi` default / `action_required`). `fyi` keeps the existing per-channel TTL (default 24h); `action_required` (asks, review requests — auto-inferred from `--review`) gets a fixed 168h TTL and expires with an `ESCALATION` marker instead of a routine drop. Dead-lane pending deliveries (`AB_DEAD_LANES`, defaults to `{gemini}` — "gemini-cli retired → agy" per `model-assignment.md`) get bulk-expired regardless of age, since a dead lane never runs `ab inbox run` to trigger the routine sweep. Exposed as `ab cleanup --expire [--dry-run]`, and wired into the Monitor API's `GET /api/comms/agent-activity` as a lazy, codexbar-style background sweep (`scripts/api/comms_router.py`).
- **Item 5 — unified retrieval**: `ab thread <task-id|msg-id>` resolves either form to the full legacy conversation (a numeric id first resolves its task_id, then expands to the full thread).

## Wiring decision (item 4 automation)

Chose the dashboard-poll trigger over a dedicated cron process, matching the existing `codexbar_usage.trigger_background_refresh()` precedent in the same package (lazy, cache-gated, daemon-threaded). During development this surfaced two real bugs, both now covered by regression tests in `tests/test_comms_router_expiry_sweep.py`:
1. The sweep must operate on the router's own `MESSAGE_DB` (not `ai_agent_bridge`'s independently-resolved default), or it diverges from what the endpoint reports and risks writing to the wrong file in test/prod path-mismatch scenarios.
2. The sweep must require the `channels`/`channel_messages`/`deliveries` tables **and** the `max_age_hours`/`priority` columns already exist before running — otherwise `ai_agent_bridge._db.get_db()`'s dormant auto-migration would fire as a side effect of a dashboard poll, silently altering + then TTL-expiring rows in any older/synthetic broker-shaped schema. This was caught because it broke an unrelated pre-existing test (`tests/test_manifest_api.py::test_agent_activity_summarizes_deliveries_and_events`) in a combined run before the gate was tightened; that test is green again with the current gate.

## #M-4 evidence

**1. Broadcast — pytest output, temp-DB fixtures:**
```
tests/test_bridge_wave2_cli.py::test_p_single_recipient_still_works PASSED
tests/test_bridge_wave2_cli.py::test_p_multi_recipient_comma_list PASSED
tests/test_bridge_wave2_cli.py::test_p_broadcast_excludes_dead_lane PASSED
tests/test_bridge_wave2_cli.py::test_p_broadcast_and_agent_conflict_errors PASSED
tests/test_bridge_wave2_cli.py::test_p_missing_recipient_errors PASSED
tests/test_bridge_wave2_cli.py::test_post_broadcast_and_to_conflict_errors PASSED
6 passed, 10 deselected in 1.01s
```
Live CLI demo against a disposable temp DB (`AB_DB_PATH=/tmp/...`, never the live DB):
```
$ ab p ops --broadcast "fleet-wide announcement" --review
✅ posted to #ops (priority=action_required)
   📢 broadcast claude, codex  (2 deliveries)
   excluded dead lanes: gemini
```

**2. TTL/auto-expire — pytest output, seeded stale deliveries in temp DBs:**
```
tests/test_bridge_channels.py::test_post_explicit_action_required_priority_roundtrips PASSED
tests/test_bridge_channels.py::test_expire_stale_deliveries_action_required_lingers_past_channel_ttl PASSED
tests/test_bridge_channels.py::test_expire_stale_deliveries_action_required_expires_as_escalation PASSED
3 passed, 93 deselected in 0.13s

tests/test_bridge_channels.py::test_dead_lane_agents_defaults_to_gemini PASSED
tests/test_bridge_channels.py::test_bulk_expire_dead_lanes_expires_fresh_pending_regardless_of_age PASSED
tests/test_bridge_channels.py::test_bulk_expire_dead_lanes_skips_non_pending PASSED
... (12 passed, 84 deselected in 0.17s — full priority/dead-lane suite)
```
`fyi` still expires at `>24h pending, channel=X` (unchanged, verified by the pre-existing `test_expire_stale_deliveries_marks_aged_pending_as_expired`, still green); `action_required` does **not** expire at that TTL and instead lingers to 168h with an `auto-expired ESCALATION (...)` error marker.

**3. Cleanup automation — code path + dry-run invocation:**
- Code path: `ab cleanup --expire` → `_cli.py` dispatch → `_channels_cli.run_delivery_expiry_cleanup()` → `_channels.release_expired_leases()` / `expire_stale_deliveries()` / `bulk_expire_dead_lanes()`. Periodic path: `GET /api/comms/agent-activity` → `comms_router._maybe_run_delivery_expiry_sweep()` (15 min interval, daemon thread).
- Dry-run pytest evidence:
```
tests/test_bridge_wave2_cli.py::test_cleanup_expire_dry_run_previews_without_mutating PASSED
tests/test_bridge_wave2_cli.py::test_cleanup_expire_applies_and_logs PASSED
tests/test_bridge_wave2_cli.py::test_cleanup_expire_bulk_expires_dead_lane_regardless_of_age PASSED
tests/test_bridge_wave2_cli.py::test_cleanup_without_expire_flag_leaves_channel_deliveries_untouched PASSED
tests/test_bridge_wave2_cli.py::test_action_required_delivery_survives_plain_cleanup_expire_before_escalation_ttl PASSED
5 passed, 11 deselected in 0.49s
```
- Live dry-run invocation (disposable temp DB):
```
$ ab cleanup --expire --dry-run
✅ Broker is clean — nothing to do (DRY RUN)
🧹 cleanup --expire (DRY RUN): 0 deliveries would expire
```
- Sweep safety (never touches the live/default DB, never auto-migrates a foreign schema as a side effect):
```
tests/test_comms_router_expiry_sweep.py::test_sweep_expires_stale_and_dead_lane_rows_in_the_routers_own_db PASSED
tests/test_comms_router_expiry_sweep.py::test_sweep_is_noop_when_message_db_missing PASSED
tests/test_comms_router_expiry_sweep.py::test_sweep_is_noop_when_channel_tables_missing PASSED
tests/test_comms_router_expiry_sweep.py::test_sweep_is_noop_on_pre_priority_column_schema PASSED
tests/test_comms_router_expiry_sweep.py::test_sweep_triggers_at_most_once_per_interval PASSED
tests/test_comms_router_expiry_sweep.py::test_agent_activity_endpoint_triggers_sweep PASSED
6 passed in 0.75s
```

**5. Unified thread retrieval:**
```
tests/test_coverage_bridge_audit.py::TestMessaging::test_resolve_thread_by_task_id PASSED
tests/test_coverage_bridge_audit.py::TestMessaging::test_resolve_thread_by_numeric_id_resolves_full_task_thread PASSED
tests/test_coverage_bridge_audit.py::TestMessaging::test_resolve_thread_by_numeric_id_without_task_shows_single_message PASSED
tests/test_coverage_bridge_audit.py::TestMessaging::test_resolve_thread_unknown_numeric_id_reports_not_found PASSED
tests/test_coverage_bridge_audit.py::TestMessaging::test_resolve_thread_unknown_task_id_reports_not_found PASSED
tests/test_bridge_wave2_cli.py::test_thread_cli_by_task_id PASSED
tests/test_bridge_wave2_cli.py::test_thread_cli_by_numeric_message_id_resolves_task PASSED
7 passed, 209 deselected in 1.32s
```

**4. Full touched-file suite:**
```
$ .venv/bin/python -m pytest tests/test_bridge_channels.py tests/test_bridge_wave2_cli.py tests/test_comms_router_expiry_sweep.py tests/test_coverage_bridge_audit.py -q
318 passed in 2.22s
```
Broader regression sweep (bridge + comms API routers + dashboards, 802 tests) also green; ran multiple times to rule out the flakiness discovered during development.

**5. Ruff:**
```
$ .venv/bin/ruff check scripts/ai_agent_bridge/_channels.py scripts/ai_agent_bridge/_channels_cli.py scripts/ai_agent_bridge/_cli.py scripts/ai_agent_bridge/_db.py scripts/ai_agent_bridge/_messaging.py scripts/api/comms_router.py tests/test_bridge_channels.py tests/test_coverage_bridge_audit.py tests/test_bridge_wave2_cli.py tests/test_comms_router_expiry_sweep.py
All checks passed!
```

## Unrelated fix bundled in (blocked pre-commit on a touched file)

`tests/test_coverage_bridge_audit.py::TestConfig::test_cli_paths_are_correct_types` hardcoded `CLAUDE_CMD[0] == "npx"`, predating #4875's native-binary-preferred `CLAUDE_CMD` resolution — it fails on any machine with a native `claude` binary on PATH (this one included). Since the pre-commit hook runs affected-file pytest and I already touch this file for the `resolve_thread` tests, left unfixed it would block every future commit here too. Updated the assertion to accept both the native-binary and npx-fallback shapes.

## Verified vs not verified
- Verified: all new behavior via temp-DB pytest fixtures (never the live `messages.db`) + live CLI smoke tests against a disposable `AB_DB_PATH`.
- Not verified against the real `.mcp/servers/message-broker/messages.db` — per the dispatch brief's guardrail, live verification was read-only only (I confirmed it doesn't exist in this worktree) or `--dry-run`; no destructive/mutating command was ever run against it.
- Noted but NOT fixed (out of scope): running the full test suite from a clean checkout — even without any of my changes — creates a stray `.mcp/servers/message-broker/messages.db` file via some pre-existing test not properly isolating `ai_agent_bridge._config.DB_PATH`. Reproduced identically with this branch's diff fully stashed. Gitignored, so harmless, but worth a follow-up issue.

## Test plan
- [x] `ab p`/`ab post --broadcast` fan out to live seats, excluding dead lanes
- [x] `ab p`/`ab post --to a,b` multi-recipient (pre-existing `--to`, now also on `p`)
- [x] fyi vs action-required TTL, escalation marker, dead-lane bulk-expire
- [x] `ab cleanup --expire --dry-run` previews without mutating; without `--dry-run` applies and logs
- [x] Monitor API periodic sweep never touches the wrong DB or auto-migrates a foreign schema
- [x] `ab thread <task-id|msg-id>` unifies `conversation`/`read`
- [x] ruff clean on all touched files
- [x] full bridge + comms API test suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)