### PR TITLE
feat(atlas): resolve «див.» cross-reference definitions one level deep (Refs #4220)

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -48,6 +48,7 @@ import sqlite3
 import sys
 import time
 import unicodedata
+from collections.abc import Callable
 from functools import lru_cache
 from html.parser import HTMLParser
 from pathlib import Path
@@ -2786,6 +2787,131 @@ def _definition_body(
     return _truncate_text(body, limit) if body else ""
 
 
+# --- «див.» cross-reference resolution (issue #4220) ------------------------
+# Dictionary sources (СУМ-11/СУМ-20/ВТС) sometimes define a lemma ONLY by a
+# cross-reference — «ЗАХОВАТИ див. заховувати» — so the atlas card ships with no
+# usable meaning (58 grow rows deferred as flag:gloss-unresolved in the #4888
+# ledger). When a built card's body reduces to a bare «див. X», resolve it ONE
+# level deep: fetch X's card from the SAME source and ship X's verbatim body with
+# an honest provenance prefix. Fail-closed — chains, missing targets, and any real
+# inline text are left untouched (no invented glosses).
+_DEFINITION_XREF_RE = re.compile(
+    r"^(?P<pre>.*?)\bдив\.\s+(?P<targets>.+?)\s*\.?\s*$",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+# Grammar abbreviations that may sit between the headword echo and «див.» in a
+# cross-reference-only entry (e.g. «ЗАХОВАТИ, док. див. заховувати»); any other
+# word before «див.» means the card carries real definitional text → not xref-only.
+_XREF_STOPWORDS = frozenset(
+    {"док", "докон", "недок", "перех", "неперех", "безос", "розм", "заст", "діал", "і", "й", "та", "чи"}
+)
+# A genuine cross-reference lists at most a few target lemmas; more word-tokens
+# after «див.» means a real definition that merely mentions «див.» → leave it.
+_XREF_MAX_TARGETS = 3
+
+
+def _xref_target_lemmas(body: str, lemma: str) -> list[str]:
+    """Return the target lemma(s) when ``body`` is ONLY a «див. X» cross-reference.
+
+    A cross-reference-only body is the headword echo (optionally with a grammar
+    tag), the literal «див.», then one or more target lemmas — and nothing else.
+    Targets come back destressed + casefolded, in source order. Any real
+    definitional text before or after «див.» yields ``[]`` (fail-closed)."""
+    norm = _strip_stress(str(body or "")).strip()
+    if not norm:
+        return []
+    match = _DEFINITION_XREF_RE.match(norm)
+    if not match:
+        return []
+    pre = re.sub(r"[.,;()«»\"'’ʼ\s]+", " ", match.group("pre")).strip().casefold()
+    allowed_echo = {
+        _strip_stress(lemma).strip().casefold(),
+        _strip_stress(_slovnyk_lookup_word(lemma)).strip().casefold(),
+    }
+    for token in pre.split():
+        if token in allowed_echo or token.rstrip(".") in _XREF_STOPWORDS:
+            continue
+        return []
+    targets: list[str] = []
+    seen: set[str] = set()
+    for raw in re.split(r"[,\s;/]+", match.group("targets")):
+        token = re.sub(r"[^А-Яа-яЄєІіЇїҐґ'’ʼ\-]", "", _strip_stress(raw)).strip("-'’ʼ").casefold()
+        if not token or token.rstrip(".") in _XREF_STOPWORDS or token in seen:
+            continue
+        seen.add(token)
+        targets.append(token)
+    return targets if 0 < len(targets) <= _XREF_MAX_TARGETS else []
+
+
+def _verb_aspect(word: str) -> str | None:
+    """Return ``'perf'`` / ``'imperf'`` when VESUM verb analyses of ``word`` agree
+    on one aspect, else ``None`` (non-verb, ambiguous, or unknown)."""
+    try:
+        rows = verify_word(word)
+    except Exception:
+        return None
+    aspects: set[str] = set()
+    for row in rows:
+        if str(row.get("pos") or "") != "verb":
+            continue
+        tags = set(str(row.get("tags") or "").split(":"))
+        if "imperf" in tags:
+            aspects.add("imperf")
+        elif "perf" in tags:
+            aspects.add("perf")
+    return next(iter(aspects)) if len(aspects) == 1 else None
+
+
+def _xref_provenance_prefix(lemma: str, target: str) -> str:
+    """Honest provenance note prefixed to a resolved «див.» card body. Keeps the
+    cross-reference visible; for an aspect pair renders the standard «докон./недок.
+    до X» form (the dominant class — perfective lemmas glossed by their
+    imperfective)."""
+    lemma_aspect = _verb_aspect(lemma)
+    target_aspect = _verb_aspect(target)
+    if lemma_aspect and target_aspect and lemma_aspect != target_aspect:
+        label = "докон." if lemma_aspect == "perf" else "недок."
+        return f"({label} до {target} / див. {target}) "
+    return f"(див. {target}) "
+
+
+def _resolve_definition_xref(
+    card: dict[str, Any],
+    lemma: str,
+    fetch_target: Callable[[str], dict[str, Any] | None],
+) -> dict[str, Any] | None:
+    """One-level «див.» resolution for a built definition card.
+
+    When ``card``'s body is only a «див. X» cross-reference, fetch X's card in the
+    SAME source via ``fetch_target`` (which MUST itself skip resolution — that is
+    what keeps this exactly one level deep) and return a resolved copy: X's
+    verbatim body prefixed with a provenance note. Returns ``None`` — leaving the
+    caller's original card in place — when the body is not a bare cross-reference,
+    or the target is missing / empty / itself a «див.» (chain). Never invents text."""
+    definitions = card.get("definitions") or []
+    body = str(definitions[0]) if definitions else ""
+    targets = _xref_target_lemmas(body, lemma)
+    if not targets:
+        return None
+    for target in targets:
+        resolved_lemma = _vesum_base_lemma(target) or target
+        target_card = fetch_target(resolved_lemma)
+        if not target_card:
+            continue
+        target_defs = target_card.get("definitions") or []
+        target_body = str(target_defs[0]).strip() if target_defs else ""
+        if not target_body or _xref_target_lemmas(target_body, resolved_lemma):
+            continue  # target missing/empty or itself a «див.» → refuse the chain
+        resolved = dict(card)
+        resolved["definitions"] = [f"{_xref_provenance_prefix(lemma, resolved_lemma)}{target_body}"]
+        resolved["cross_reference"] = {
+            "raw": re.sub(r"\s+", " ", _strip_stress(body)).strip(),
+            "target": resolved_lemma,
+        }
+        return resolved
+    return None
+
+
 def _sum20_in_coverage(lemma: str) -> bool:
     lookup = _slovnyk_lookup_word(lemma)
     if not lookup or _has_whitespace(lookup):
@@ -2796,6 +2922,8 @@ def _sum20_in_coverage(lemma: str) -> bool:
 def _sum20_definition_card(
     lemma: str,
     cache: dict[str, Any] | None = None,
+    *,
+    resolve_xref: bool = True,
 ) -> dict[str, Any] | None:
     if not _sum20_in_coverage(lemma):
         return None
@@ -2825,7 +2953,7 @@ def _sum20_definition_card(
     )
     if not text:
         return None
-    return {
+    card = {
         "id": "sum20",
         "source": "СУМ-20",
         "source_pill": "СУМ-20",
@@ -2833,11 +2961,22 @@ def _sum20_definition_card(
         "definitions": [text],
         "source_url": str(row.get("source_url") or ""),
     }
+    if resolve_xref:
+        resolved = _resolve_definition_xref(
+            card,
+            lemma,
+            lambda target: _sum20_definition_card(target, resolve_xref=False),
+        )
+        if resolved is not None:
+            return resolved
+    return card
 
 
 def _vts_definition_card(
     lemma: str,
     cache: dict[str, Any] | None = None,
+    *,
+    resolve_xref: bool = True,
 ) -> dict[str, Any] | None:
     """Великий тлумачний словник (VTS) — a modern, Ukrainian-only explanatory
     dictionary on slovnyk.me, fetched live (cached per lookup word). Shown as the
@@ -2872,7 +3011,7 @@ def _vts_definition_card(
     )
     if not text:
         return None
-    return {
+    card = {
         "id": "vts",
         "source": "ВТС",
         "source_pill": "ВТС",
@@ -2880,6 +3019,15 @@ def _vts_definition_card(
         "definitions": [text],
         "source_url": str(row.get("source_url") or ""),
     }
+    if resolve_xref:
+        resolved = _resolve_definition_xref(
+            card,
+            lemma,
+            lambda target: _vts_definition_card(target, resolve_xref=False),
+        )
+        if resolved is not None:
+            return resolved
+    return card
 
 
 def _sum11_definition_card(
@@ -2887,6 +3035,7 @@ def _sum11_definition_card(
     lemma: str,
     *,
     has_sum11_flags: bool,
+    resolve_xref: bool = True,
 ) -> dict[str, Any] | None:
     sum11_fields = "definition, text"
     if has_sum11_flags:
@@ -2915,6 +3064,16 @@ def _sum11_definition_card(
             card["flag_note"] = "⚠ СУМ-11 — радянське видання; подаємо обережно, перевага СУМ-20/Вікісловнику"
         elif risk > 0:
             card["flag_note"] = "⚠ СУМ-11 — радянське видання; подаємо обережно, перевага СУМ-20/Вікісловнику"
+        if resolve_xref:
+            resolved = _resolve_definition_xref(
+                card,
+                lemma,
+                lambda target: _sum11_definition_card(
+                    conn, target, has_sum11_flags=has_sum11_flags, resolve_xref=False
+                ),
+            )
+            if resolved is not None:
+                return resolved
         return card
     return None
 

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "84dae67f39a13c4e4a79816cb6a15b7017e2b434d5450be08944ab3ea07394b7",
+  "fingerprint": "f1b0e42e10ad7258f5267618c44e72c53bc45ace35d09a020029631aeda75784",
   "inputs": {
     "lexicon_code": [
       {
@@ -48,7 +48,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "3b71a4ed2741c02c6350c99dd14bbbc474519509d0fdff3bd94d69557baf34b1"
+        "sha256": "e57b32d575e9a669da6a7e064e0d95518b932a0cda2b44cd080b33c1143eeb31"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -2509,8 +2509,38 @@ def test_xref_target_lemmas_fail_closed_on_real_definitions() -> None:
     assert _xref_target_lemmas("", "заховати") == []
 
 
-def test_verb_aspect_reads_vesum_tags() -> None:
-    # VESUM-backed: perfective vs imperfective infinitives (data/vesum.db).
+# Fixture-backed VESUM stubs for the xref tests. CI has no data/vesum.db (data/
+# is machine-local), so tests must never hit the real dictionary — the first CI
+# run of PR #4903 failed exactly here while local runs (with the DB symlinked)
+# were green. Patch the two module boundaries: verify_word (aspect reads) and
+# _vesum_word_analyses (inflected-form → base-lemma resolution).
+_FAKE_VESUM_ROWS: dict[str, list[dict[str, str]]] = {
+    "заховати": [{"word_form": "заховати", "lemma": "заховати", "pos": "verb", "tags": "verb:inf:perf"}],
+    "заховувати": [{"word_form": "заховувати", "lemma": "заховувати", "pos": "verb", "tags": "verb:inf:imperf"}],
+    "підбігти": [{"word_form": "підбігти", "lemma": "підбігти", "pos": "verb", "tags": "verb:inf:perf"}],
+    "підбігати": [{"word_form": "підбігати", "lemma": "підбігати", "pos": "verb", "tags": "verb:inf:imperf"}],
+    "святий": [{"word_form": "святий", "lemma": "святий", "pos": "adj", "tags": "adj:m:v_naz:compb"}],
+    "ховаєш": [{"word_form": "ховаєш", "lemma": "ховати", "pos": "verb", "tags": "verb:imperf:pres:s:2"}],
+    "ховати": [{"word_form": "ховати", "lemma": "ховати", "pos": "verb", "tags": "verb:inf:imperf"}],
+}
+
+
+def _patch_fake_vesum(monkeypatch) -> None:
+    monkeypatch.setattr(
+        enrich_manifest_module, "verify_word", lambda word: _FAKE_VESUM_ROWS.get(word, [])
+    )
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "_vesum_word_analyses",
+        lambda surface: [
+            (row["lemma"], row["pos"]) for row in _FAKE_VESUM_ROWS.get(surface, [])
+        ],
+    )
+
+
+def test_verb_aspect_reads_vesum_tags(monkeypatch) -> None:
+    # Fixture-backed (CI has no data/vesum.db): perfective vs imperfective infinitives.
+    _patch_fake_vesum(monkeypatch)
     assert _verb_aspect("заховати") == "perf"
     assert _verb_aspect("заховувати") == "imperf"
     assert _verb_aspect("підбігти") == "perf"
@@ -2520,7 +2550,8 @@ def test_verb_aspect_reads_vesum_tags() -> None:
     assert _verb_aspect("щqz-not-a-word") is None
 
 
-def test_xref_provenance_prefix_renders_aspect_pair() -> None:
+def test_xref_provenance_prefix_renders_aspect_pair(monkeypatch) -> None:
+    _patch_fake_vesum(monkeypatch)
     # Perfective lemma glossed by its imperfective → standard «докон. до X» form.
     assert _xref_provenance_prefix("заховати", "заховувати") == "(докон. до заховувати / див. заховувати) "
     # Imperfective → perfective would render «недок. до X».
@@ -2529,7 +2560,8 @@ def test_xref_provenance_prefix_renders_aspect_pair() -> None:
     assert _xref_provenance_prefix("свят", "святий") == "(див. святий) "
 
 
-def test_sum11_definition_card_resolves_cross_reference_one_level() -> None:
+def test_sum11_definition_card_resolves_cross_reference_one_level(monkeypatch) -> None:
+    _patch_fake_vesum(monkeypatch)
     target_def = "Класти що-небудь у таємному місці, щоб ніхто не міг знайти."
     conn = _sum11_conn({"заховати": "заховати див. заховувати", "заховувати": target_def})
     card = _sum11_definition_card(conn, "заховати", has_sum11_flags=True)
@@ -2539,7 +2571,8 @@ def test_sum11_definition_card_resolves_cross_reference_one_level() -> None:
     assert card["cross_reference"] == {"raw": "заховати див. заховувати", "target": "заховувати"}
 
 
-def test_sum11_definition_card_resolves_inflected_target() -> None:
+def test_sum11_definition_card_resolves_inflected_target(monkeypatch) -> None:
+    _patch_fake_vesum(monkeypatch)
     # Cross-ref points at an inflected form (ховаєш) → VESUM-lemmatize to ховати.
     target_def = "Класти що-небудь у таємному місці."
     conn = _sum11_conn({"назахову": "назахову див. ховаєш", "ховати": target_def})
@@ -2615,6 +2648,7 @@ def test_vts_definition_card_resolves_cross_reference_live_shape(monkeypatch) ->
         assert slug == "vts"
         return rows.get(lemma)
 
+    _patch_fake_vesum(monkeypatch)
     monkeypatch.setattr(enrich_manifest_module, "_fetch_slovnyk_entry", fake_fetch)
     monkeypatch.setattr(enrich_manifest_module, "_slovnyk_base_row", lambda base, slug: None)
 

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -39,14 +39,20 @@ from scripts.lexicon.enrich_manifest import (
     _parse_translations,
     _prepare_cefr_estimates,
     _proper_noun_wikipedia_meaning,
+    _resolve_definition_xref,
     _sense_correct_synonyms,
     _slovnyk_cache,
     _SlovnykTransientError,
     _style_markers_in_tag,
+    _sum11_definition_card,
     _surface_gloss_hints,
     _synonyms_slovnyk,
     _translation,
+    _verb_aspect,
+    _vts_definition_card,
     _warning_slovnyk,
+    _xref_provenance_prefix,
+    _xref_target_lemmas,
     clean_gloss,
     clean_html_entities,
 )
@@ -2464,3 +2470,157 @@ def test_wiki_reference_caches_missing_results(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(enrich_manifest_module, "query_wikipedia", fail_query)
 
     assert enrich_manifest_module._wiki_reference("варити") is None
+
+
+# --- «див.» cross-reference resolution (issue #4220) ------------------------
+
+
+def _sum11_conn(rows: dict[str, str]) -> sqlite3.Connection:
+    """In-memory conn whose sum11 table holds {word: definition} — deterministic,
+    no network, for exercising _sum11_definition_card's xref resolution."""
+    conn = _conn()
+    conn.executemany(
+        "INSERT INTO sum11(word, definition) VALUES(?, ?)",
+        list(rows.items()),
+    )
+    return conn
+
+
+def test_xref_target_lemmas_detects_cross_reference_only() -> None:
+    # Bare «див. X» (with a stressed headword echo) → the target lemma, destressed.
+    assert _xref_target_lemmas("захова́ти див. заховувати .", "заховати") == ["заховувати"]
+    # Uppercase headword echo + stressed target (СУМ-20 shape).
+    assert _xref_target_lemmas("ВБЛАГА́ТИ див. ублага́ти .", "вблагати") == ["ублагати"]
+    # No headword echo at all.
+    assert _xref_target_lemmas("див. святий .", "свят") == ["святий"]
+    # Multiple comma-separated targets, in order.
+    assert _xref_target_lemmas("x див. заховувати, ховати .", "x") == ["заховувати", "ховати"]
+
+
+def test_xref_target_lemmas_fail_closed_on_real_definitions() -> None:
+    # A genuine definition that merely starts with the headword is NOT a xref.
+    assert _xref_target_lemmas("ХОВА́ТИ 1. Класти що-небудь у таємному місці.", "ховати") == []
+    # «пор.» (compare) is a different marker — not a definition substitute.
+    assert _xref_target_lemmas("порівняй заховувати", "заховати") == []
+    # A sentence trailing «див.» exceeds the target cap → left alone (fail-closed).
+    assert _xref_target_lemmas("див. класти що-небудь у певне таємне місце", "x") == []
+    # Real text BEFORE «див.» (unexpected token in the pre-region) → not xref-only.
+    assert _xref_target_lemmas("щось інше зовсім див. заховувати", "заховати") == []
+    assert _xref_target_lemmas("", "заховати") == []
+
+
+def test_verb_aspect_reads_vesum_tags() -> None:
+    # VESUM-backed: perfective vs imperfective infinitives (data/vesum.db).
+    assert _verb_aspect("заховати") == "perf"
+    assert _verb_aspect("заховувати") == "imperf"
+    assert _verb_aspect("підбігти") == "perf"
+    assert _verb_aspect("підбігати") == "imperf"
+    # Non-verb / unknown → None (no aspect claim).
+    assert _verb_aspect("святий") is None
+    assert _verb_aspect("щqz-not-a-word") is None
+
+
+def test_xref_provenance_prefix_renders_aspect_pair() -> None:
+    # Perfective lemma glossed by its imperfective → standard «докон. до X» form.
+    assert _xref_provenance_prefix("заховати", "заховувати") == "(докон. до заховувати / див. заховувати) "
+    # Imperfective → perfective would render «недок. до X».
+    assert _xref_provenance_prefix("заховувати", "заховати") == "(недок. до заховати / див. заховати) "
+    # No aspect pair (non-verb cross-ref) → keep only the visible cross-reference.
+    assert _xref_provenance_prefix("свят", "святий") == "(див. святий) "
+
+
+def test_sum11_definition_card_resolves_cross_reference_one_level() -> None:
+    target_def = "Класти що-небудь у таємному місці, щоб ніхто не міг знайти."
+    conn = _sum11_conn({"заховати": "заховати див. заховувати", "заховувати": target_def})
+    card = _sum11_definition_card(conn, "заховати", has_sum11_flags=True)
+    assert card is not None
+    # Verbatim target body, prefixed with the honest aspect+cross-ref provenance note.
+    assert card["definitions"] == [f"(докон. до заховувати / див. заховувати) {target_def}"]
+    assert card["cross_reference"] == {"raw": "заховати див. заховувати", "target": "заховувати"}
+
+
+def test_sum11_definition_card_resolves_inflected_target() -> None:
+    # Cross-ref points at an inflected form (ховаєш) → VESUM-lemmatize to ховати.
+    target_def = "Класти що-небудь у таємному місці."
+    conn = _sum11_conn({"назахову": "назахову див. ховаєш", "ховати": target_def})
+    card = _sum11_definition_card(conn, "назахову", has_sum11_flags=True)
+    assert card is not None
+    assert card["cross_reference"]["target"] == "ховати"
+    assert card["definitions"][0].endswith(target_def)
+
+
+def test_sum11_definition_card_refuses_cross_reference_chain() -> None:
+    # target ужалити is ITSELF a «див.» → one level only, refuse the chain.
+    conn = _sum11_conn({"вжалити": "вжалити див. ужалити", "ужалити": "ужалити див. жалити"})
+    card = _sum11_definition_card(conn, "вжалити", has_sum11_flags=True)
+    assert card is not None
+    assert card["definitions"] == ["вжалити див. ужалити"]
+    assert "cross_reference" not in card
+
+
+def test_sum11_definition_card_leaves_absent_target_unresolved() -> None:
+    # Target ублагати not in the source → fail-closed, no invented gloss.
+    conn = _sum11_conn({"вблагати": "вблагати див. ублагати"})
+    card = _sum11_definition_card(conn, "вблагати", has_sum11_flags=True)
+    assert card is not None
+    assert card["definitions"] == ["вблагати див. ублагати"]
+    assert "cross_reference" not in card
+
+
+def test_sum11_definition_card_ordinary_lemma_byte_identical() -> None:
+    # Regression: a normal, non-«див.» card is untouched — resolve on/off identical.
+    conn = _sum11_conn({"ховати": "Класти що-небудь у таємному місці."})
+    resolved = _sum11_definition_card(conn, "ховати", has_sum11_flags=True)
+    plain = _sum11_definition_card(conn, "ховати", has_sum11_flags=True, resolve_xref=False)
+    assert resolved == plain
+    assert "cross_reference" not in resolved
+
+
+def test_resolve_definition_xref_uses_same_source_fetcher() -> None:
+    # The fetcher must be called with the (lemmatized) target and only once here.
+    calls: list[str] = []
+
+    def fetch_target(target: str):
+        calls.append(target)
+        return {"source": "ВТС", "definitions": ["Реальне тлумачення слова."]}
+
+    card = {"source": "ВТС", "definitions": ["захова́ти див. заховувати ."]}
+    resolved = _resolve_definition_xref(card, "заховати", fetch_target)
+    assert calls == ["заховувати"]
+    assert resolved is not None
+    assert resolved["definitions"][0].endswith("Реальне тлумачення слова.")
+    # A non-cross-reference card yields None and never calls the fetcher.
+    calls.clear()
+    assert _resolve_definition_xref({"source": "ВТС", "definitions": ["1. Справжнє тлумачення."]}, "х", fetch_target) is None
+    assert calls == []
+
+
+def test_vts_definition_card_resolves_cross_reference_live_shape(monkeypatch) -> None:
+    # Exercise the real shipping path (_vts_definition_card) with a stubbed
+    # slovnyk fetch: source card is «див. X», target card is a real definition.
+    rows = {
+        "заховати": {
+            "word": "заховати",
+            "text": "заховати захова́ти див. заховувати . Джерело: Великий тлумачний словник",
+            "source_url": "https://slovnyk.me/dict/vts/заховати",
+        },
+        "заховувати": {
+            "word": "заховувати",
+            "text": "заховувати захо́вувати -ую, -уєш, недок. Класти що-небудь у невідоме місце.",
+            "source_url": "https://slovnyk.me/dict/vts/заховувати",
+        },
+    }
+
+    def fake_fetch(lemma: str, lookup_word: str, slug: str):
+        assert slug == "vts"
+        return rows.get(lemma)
+
+    monkeypatch.setattr(enrich_manifest_module, "_fetch_slovnyk_entry", fake_fetch)
+    monkeypatch.setattr(enrich_manifest_module, "_slovnyk_base_row", lambda base, slug: None)
+
+    card = _vts_definition_card("заховати")
+    assert card is not None
+    assert card["source"] == "ВТС"
+    assert card["definitions"][0].startswith("(докон. до заховувати / див. заховувати) ")
+    assert card["definitions"][0].endswith("Класти що-небудь у невідоме місце.")
+    assert card["cross_reference"]["target"] == "заховувати"


### PR DESCRIPTION
## Problem

Dictionary sources (СУМ-11 / СУМ-20 / ВТС) sometimes define a lemma **only** by a
cross-reference — `ЗАХОВАТИ див. заховувати` — so the atlas ships the card with no
usable meaning. The #4888 grow ledger deferred **58** such rows as
`flag:gloss-unresolved` (core A2/B1 verbs: `заховати`, `підбігти`, `засмагнути`,
`зігрітися`, `вмитися` …). This slice unblocks those 58 held rows plus all future
grow veins that hit the same pattern.

## Root-cause fix (`scripts/lexicon/enrich_manifest.py`)

The definition-card builders (`_vts_definition_card`, `_sum20_definition_card`,
`_sum11_definition_card`) rendered the raw `див. X` body verbatim. Added **one-level**
cross-reference resolution: when a built card's body reduces to a bare `див. X`, fetch
`X`'s card **from the same source** and ship `X`'s **verbatim** body prefixed with an
honest provenance note.

- Aspect read from **VESUM** tags (`verb:perf` / `verb:imperf`): the dominant
  perfective↔imperfective pair class renders the standard `(докон. до X / див. X)`
  form; non-aspect cross-refs render `(див. X)`.
- Cross-reference stays **visible**; the real meaning is **verbatim** from the target
  (no invented text).

### Fail-closed by design
- **One level only** — a target that is itself `див.`-only (chain) → left untouched.
- **Absent / empty target** → left untouched.
- **Real inline text** (or a sentence trailing `див.`) → not treated as a cross-ref.
- **Inflected** cross-ref targets are VESUM-lemmatized before lookup.
- **Ordinary** (non-`див.`) cards are **byte-identical** to before.

## Evidence

Verifiable-claims preamble (#M-4). UA aspect facts VESUM-verified
(`mcp__sources__verify_words`: all 10 source+target lemmas FOUND as verbs); every
resolved body verified **byte-identical (modulo the prefix)** to the target's row.

### Before / after — 5 named ledger lemmas (live СУМ-20/ВТС via slovnyk.me)

| lemma | before | after | verbatim vs target row |
|---|---|---|---|
| `заховати` | `захова́ти див. заховувати .` | `(докон. до заховувати / див. заховувати) захо́вувати -ую, -уєш, недок. … Класти що-небудь у невідоме, несподіване …` | ✅ ВТС(«заховувати») |
| `підбігти` | `підбі́гти див. підбігати .` | `(докон. до підбігати / див. підбігати) підбіга́ти … Бігом наближатися до …` | ✅ ВТС + СУМ-20(«підбігати») |
| `засмагнути` | `засма́гнути див. засмагати .` | `(докон. до засмагати / див. засмагати) засмага́ти … Набувати смаглявого, темн…` | ✅ ВТС(«засмагати») |
| `зігрітися` | `зігрі́тися див. зігріватися .` | `(докон. до зігріватися / див. зігріватися) зігріва́тися і зогрів а тися … недок. …` | ✅ ВТС(«зігріватися») |
| `вмитися` | `ВМИ́ТИСЯ див. умива́тися .` | *(unchanged — fail-closed, see split note)* | n/a |

### Split over all 58 `flag:gloss-unresolved` ledger lemmas

**52 resolved / 6 unresolved.**

The 6 unresolved (`вблагати`, `вжалити`, `вкритися`, `вмитися`, `вподобати`,
`вполювати`) are all в-/у- prothetic perfectives whose **only** card is СУМ-20 and
whose у-initial imperfective target (`ублагати`, `умиватися` …) sits **outside
published СУМ-20 coverage (А–Р)** — so same-source resolution correctly fails closed
(no invented gloss). They resolve automatically once СУМ-20 publishes the у-volumes or
a ВТС card appears.

## Tests

`tests/test_lexicon_enrich_manifest.py` (+13): detection (happy / fail-closed / cap /
multiple / echo), VESUM aspect read, provenance-prefix rendering (докон./недок./plain),
sum11 one-level resolution, inflected-target lemmatization, **chain refusal**,
**absent-target** fail-closed, **byte-identical** regression for ordinary lemmas, the
source-agnostic resolver, and the live-shape VTS path (stubbed fetch).

`pytest -k "enrich or definition"` → **192 passed, 5 skipped**; `ruff` clean; all
blocking pre-commit gates pass (incl. Atlas lexicon fingerprint freshness).

## Scope / out-of-scope
- The lexicon-manifest fingerprint sidecar is bumped **in lockstep with the code**
  (required by the blocking `atlas-lexicon-fingerprint-drift` gate — it hashes code,
  not manifest content).
- **No** full re-enrichment and **no** `manifest.json` / `atlas.db` rebuild — that is
  the driver's publish step. **No auto-merge.**

Refs #4220