### PR TITLE
fix(corpus): stage ukrlib acquisitions atomically (#4861)

### DIFF
--- a/scripts/rag/scrape_ukrlib.py
+++ b/scripts/rag/scrape_ukrlib.py
@@ -34,12 +34,15 @@ Usage:
 """
 
 import argparse
+import contextlib
 import hashlib
 import html
 import json
+import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
 from html.parser import HTMLParser
 from pathlib import Path
@@ -55,6 +58,99 @@ else:
 BASE_URL = "https://www.ukrlib.com.ua"
 DELAY_BETWEEN_PAGES = 0.3  # seconds
 DELAY_BETWEEN_WORKS = 0.5
+
+JSONL_REQUIRED_FIELDS = frozenset({
+    "chunk_id",
+    "text",
+    "source_url",
+    "work",
+    "author",
+    "year",
+    "genre",
+    "language_period",
+})
+
+
+class JsonlValidationError(RuntimeError):
+    """Raised when a staged JSONL artifact is unsafe to publish."""
+
+
+def _validate_staged_jsonl(path: Path) -> int:
+    """Validate a complete staged JSONL artifact before its atomic swap.
+
+    A scraper result is publishable only when it has at least one row, every
+    line is valid JSON, and every chunk has the fields consumed by downstream
+    literary ingestion. This deliberately validates the staged file rather
+    than the live artifact, which is not touched until validation succeeds.
+    """
+    row_count = 0
+    with path.open(encoding="utf-8") as f:
+        for line_no, line in enumerate(f, 1):
+            try:
+                chunk = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise JsonlValidationError(
+                    f"{path.name}: line {line_no} is not valid JSON"
+                ) from exc
+
+            if not isinstance(chunk, dict):
+                raise JsonlValidationError(
+                    f"{path.name}: line {line_no} is not a JSON object"
+                )
+
+            missing = JSONL_REQUIRED_FIELDS - set(chunk)
+            if missing:
+                raise JsonlValidationError(
+                    f"{path.name}: line {line_no} is missing required fields: "
+                    f"{', '.join(sorted(missing))}"
+                )
+            row_count += 1
+
+    if row_count == 0:
+        raise JsonlValidationError(f"{path.name}: staged JSONL has no rows")
+    return row_count
+
+
+@contextlib.contextmanager
+def staged_jsonl(output_path: Path):
+    """Yield a sibling staging path and atomically publish it after validation.
+
+    The sibling temp file guarantees that ``Path.replace()`` is a same-filesystem
+    atomic rename. Any failure, including ``KeyboardInterrupt``, removes only
+    the temp file and leaves the previous live artifact intact.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_fd, temp_name = tempfile.mkstemp(
+        dir=output_path.parent,
+        prefix=f".{output_path.name}.",
+        suffix=".building",
+    )
+    temp_path = Path(temp_name)
+
+    try:
+        os.close(temp_fd)
+        yield temp_path
+        _validate_staged_jsonl(temp_path)
+        temp_path.replace(output_path)
+    except BaseException:
+        temp_path.unlink(missing_ok=True)
+        raise
+
+
+def _copy_existing_jsonl(source: Path, destination: Path) -> None:
+    """Copy an existing resume artifact into the staged replacement file."""
+    if not source.exists():
+        return
+
+    with source.open(encoding="utf-8") as src, destination.open(
+        "a", encoding="utf-8"
+    ) as dst:
+        last_line = ""
+        for line in src:
+            dst.write(line)
+            last_line = line
+        if last_line and not last_line.endswith("\n"):
+            dst.write("\n")
 
 # ── Author/Work Definitions ─────────────────────────────────────────
 # All IDs verified against live ukrlib author.php pages (2026-03-08)
@@ -931,7 +1027,6 @@ def audit_jsonl(path: Path, author_info: dict | None = None) -> tuple[bool, list
     Returns (passed, list_of_errors).
     """
     errors = []
-    required_fields = {"chunk_id", "text", "source_url", "work", "author", "year", "genre", "language_period"}
     chunk_ids = set()
     total_chars = 0
     works = set()
@@ -950,7 +1045,7 @@ def audit_jsonl(path: Path, author_info: dict | None = None) -> tuple[bool, list
             chunk_id = chunk.get("chunk_id", f"line_{line_no}")
 
             # Check required fields
-            missing = required_fields - set(chunk.keys())
+            missing = JSONL_REQUIRED_FIELDS - set(chunk.keys())
             if missing:
                 errors.append(f"Chunk {chunk_id}: missing fields: {missing}")
 
@@ -1116,51 +1211,53 @@ def scrape_author(slug: str, author_info: dict, dry_run: bool = False,
         return existing
 
     new_chunks = 0
-    output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Append mode for resume
-    with open(output_path, "a", encoding="utf-8") as f:
-        for i, work_info in enumerate(total_items, 1):
-            tid = work_info["tid"]
-            title = work_info["title"]
-            is_bio = work_info in pending_bios
-            genre = "biography" if is_bio else guess_genre(title, genre_default)
+    # Resume data and new chunks both go through a sibling staging file. The
+    # current output remains untouched until every newly acquired row validates.
+    with staged_jsonl(output_path) as staged_path:
+        _copy_existing_jsonl(output_path, staged_path)
+        with staged_path.open("a", encoding="utf-8") as f:
+            for i, work_info in enumerate(total_items, 1):
+                tid = work_info["tid"]
+                title = work_info["title"]
+                is_bio = work_info in pending_bios
+                genre = "biography" if is_bio else guess_genre(title, genre_default)
 
-            label = "[BIO] " if is_bio else ""
-            print(f"\n  [{i}/{len(total_items)}] {label}{title} (tid={tid}, genre={genre})")
-            try:
-                text, source_url = scrape_work_text(
-                    tid,
-                    is_bio=is_bio,
-                    expected_author=source_author,
-                    expected_title=title,
-                )
-            except Exception as e:
-                print(f"    ERROR: {e}")
-                continue
+                label = "[BIO] " if is_bio else ""
+                print(f"\n  [{i}/{len(total_items)}] {label}{title} (tid={tid}, genre={genre})")
+                try:
+                    text, source_url = scrape_work_text(
+                        tid,
+                        is_bio=is_bio,
+                        expected_author=source_author,
+                        expected_title=title,
+                    )
+                except Exception as e:
+                    print(f"    ERROR: {e}")
+                    continue
 
-            if not text or len(text) < 100:
-                print(f"    Skipped: too short ({len(text)} chars)")
-                continue
+                if not text or len(text) < 100:
+                    print(f"    Skipped: too short ({len(text)} chars)")
+                    continue
 
-            work_title = f"{author_info['full_name']}. {title}"
-            chunks = chunk_text(text, work_title, source_url)
+                work_title = f"{author_info['full_name']}. {title}"
+                chunks = chunk_text(text, work_title, source_url)
 
-            for chunk in chunks:
-                chunk.update({
-                    "work": work_title,
-                    "author": author_name,
-                    "year": int(author_info["years"].split("-")[0]),
-                    "genre": genre,
-                    "language_period": period,
-                })
-                f.write(json.dumps(chunk, ensure_ascii=False) + "\n")
+                for chunk in chunks:
+                    chunk.update({
+                        "work": work_title,
+                        "author": author_name,
+                        "year": int(author_info["years"].split("-")[0]),
+                        "genre": genre,
+                        "language_period": period,
+                    })
+                    f.write(json.dumps(chunk, ensure_ascii=False) + "\n")
 
-            print(f"    {len(text):,} chars → {len(chunks)} chunks")
-            new_chunks += len(chunks)
+                print(f"    {len(text):,} chars → {len(chunks)} chunks")
+                new_chunks += len(chunks)
 
-            if i < len(total_items):
-                time.sleep(DELAY_BETWEEN_WORKS)
+                if i < len(total_items):
+                    time.sleep(DELAY_BETWEEN_WORKS)
 
     # Count total chunks in file
     total_in_file = 0
@@ -1294,9 +1391,10 @@ def scrape_narod(dry_run: bool = False) -> int:
             print(f"    genre={w['genre_id']:>2} bookid={w['bookid']:>3}  [{w['genre']:<15}]  {w['title']}")
         return 0
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
     total_chunks = 0
-    with open(output_path, "w", encoding="utf-8") as f:
+    with staged_jsonl(output_path) as staged_path, staged_path.open(
+        "w", encoding="utf-8"
+    ) as f:
         for i, w in enumerate(worklist, 1):
             print(f"\n  [{i}/{n}] {w['title']} (genre={w['genre_id']}, bookid={w['bookid']})")
             try:
@@ -1419,8 +1517,9 @@ def main():
         slug = re.sub(r"[^\w\s-]", "", args.work.lower())
         slug = re.sub(r"[\s]+", "-", slug)[:60]
         output_path = LITERARY_DIR / f"ukrlib-single-{slug}.jsonl"
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(output_path, "w", encoding="utf-8") as f:
+        with staged_jsonl(output_path) as staged_path, staged_path.open(
+            "w", encoding="utf-8"
+        ) as f:
             for chunk in chunks:
                 f.write(json.dumps(chunk, ensure_ascii=False) + "\n")
         print(f"\n{len(text):,} chars → {len(chunks)} chunks → {output_path.name}")

--- a/tests/test_scrape_ukrlib_atomic.py
+++ b/tests/test_scrape_ukrlib_atomic.py
@@ -1,0 +1,206 @@
+"""Failure-atomic JSONL staging tests for the ukrlib scraper."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.rag import scrape_ukrlib as scrape
+
+AUTHOR_INFO = {
+    "id": 999,
+    "name": "Тест Т.",
+    "full_name": "Тестовий Автор",
+    "years": "1900-1950",
+    "genre_default": "prose",
+    "period": "modern",
+}
+WORKS = [{"tid": 1, "title": "Перший твір"}, {"tid": 2, "title": "Другий твір"}]
+
+
+def _chunk(tid: int | str) -> dict[str, object]:
+    return {
+        "chunk_id": f"chunk-{tid}",
+        "text": "Тестовий український текст. " * 20,
+        "source_url": f"https://example.test/printit.php?tid={tid}",
+        "token_count": 20,
+    }
+
+
+def _complete_chunk(tid: int | str) -> dict[str, object]:
+    return {
+        **_chunk(tid),
+        "work": "Тестовий Автор. Попередній твір",
+        "author": "Тест Т.",
+        "year": 1900,
+        "genre": "prose",
+        "language_period": "modern",
+    }
+
+
+def _chunk_for_source(*args, **_kwargs) -> list[dict[str, object]]:
+    return [{**_chunk("new"), "source_url": args[2]}]
+
+
+def _configure_author_scrape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setattr(scrape, "LITERARY_DIR", tmp_path)
+    monkeypatch.setattr(scrape, "PROGRESS_DIR", tmp_path / ".ukrlib_progress")
+    monkeypatch.setattr(scrape, "get_author_works", lambda _author_id: (WORKS, []))
+    monkeypatch.setattr(
+        scrape,
+        "scrape_work_text",
+        lambda tid, **_kwargs: ("Український текст. " * 20, f"https://example.test/?tid={tid}"),
+    )
+    monkeypatch.setattr(scrape.time, "sleep", lambda _seconds: None)
+    return tmp_path / "ukrlib-test-author.jsonl"
+
+
+def _assert_no_staging_file(tmp_path: Path, output_path: Path) -> None:
+    assert not list(tmp_path.glob(f".{output_path.name}.*.building"))
+
+
+def test_mid_scrape_interrupt_creates_no_output_and_cleans_stage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fatal second-work failure cannot publish the first work's rows."""
+    output_path = _configure_author_scrape(monkeypatch, tmp_path)
+    calls = 0
+
+    def fail_after_first_chunk(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise KeyboardInterrupt()
+        return [_chunk(1)]
+
+    monkeypatch.setattr(scrape, "chunk_text", fail_after_first_chunk)
+
+    with pytest.raises(KeyboardInterrupt):
+        scrape.scrape_author("test-author", AUTHOR_INFO)
+
+    assert not output_path.exists()
+    assert not (tmp_path / ".ukrlib_progress" / "test-author.done").exists()
+    _assert_no_staging_file(tmp_path, output_path)
+
+
+def test_mid_scrape_interrupt_preserves_previous_output_and_cleans_stage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fatal second-work failure leaves the previous artifact byte-identical."""
+    output_path = _configure_author_scrape(monkeypatch, tmp_path)
+    previous = (json.dumps(_complete_chunk(999), ensure_ascii=False) + "\n").encode()
+    output_path.write_bytes(previous)
+    calls = 0
+
+    def fail_after_first_chunk(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise KeyboardInterrupt()
+        return [_chunk(1)]
+
+    monkeypatch.setattr(scrape, "chunk_text", fail_after_first_chunk)
+
+    with pytest.raises(KeyboardInterrupt):
+        scrape.scrape_author("test-author", AUTHOR_INFO)
+
+    assert output_path.read_bytes() == previous
+    assert not (tmp_path / ".ukrlib_progress" / "test-author.done").exists()
+    _assert_no_staging_file(tmp_path, output_path)
+
+
+def test_successful_scrape_validates_stage_then_replaces_complete_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Writes occur in a sibling temp file, which is validated before rename."""
+    output_path = _configure_author_scrape(monkeypatch, tmp_path)
+    previous = (json.dumps(_complete_chunk(999), ensure_ascii=False) + "\n").encode()
+    output_path.write_bytes(previous)
+    monkeypatch.setattr(scrape, "chunk_text", _chunk_for_source)
+
+    validated_paths: list[Path] = []
+    real_validate = scrape._validate_staged_jsonl
+
+    def record_validation(path: Path) -> int:
+        validated_paths.append(path)
+        assert path.parent == output_path.parent
+        assert path != output_path
+        assert path.exists()
+        return real_validate(path)
+
+    replacements: list[tuple[Path, Path]] = []
+    real_replace = Path.replace
+
+    def record_replace(source: Path, target: Path) -> Path:
+        replacements.append((source, target))
+        return real_replace(source, target)
+
+    monkeypatch.setattr(scrape, "_validate_staged_jsonl", record_validation)
+    monkeypatch.setattr(Path, "replace", record_replace)
+
+    assert scrape.scrape_author("test-author", AUTHOR_INFO) == 3
+
+    assert output_path.read_bytes() != previous
+    rows = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 3
+    assert all(row.keys() >= scrape.JSONL_REQUIRED_FIELDS for row in rows)
+    assert replacements == [(validated_paths[0], output_path)]
+    assert not validated_paths[0].exists()
+    assert (tmp_path / ".ukrlib_progress" / "test-author.done").exists()
+
+
+def test_validation_failure_prevents_swap_and_cleans_stage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A staged row without a required field cannot replace the live JSONL."""
+    output_path = _configure_author_scrape(monkeypatch, tmp_path)
+    previous = (json.dumps(_complete_chunk(999), ensure_ascii=False) + "\n").encode()
+    output_path.write_bytes(previous)
+    monkeypatch.setattr(
+        scrape,
+        "chunk_text",
+        lambda *_args, **_kwargs: [{"text": "bad staged row", "source_url": "https://example.test"}],
+    )
+
+    with pytest.raises(scrape.JsonlValidationError, match="chunk_id"):
+        scrape.scrape_author("test-author", AUTHOR_INFO)
+
+    assert output_path.read_bytes() == previous
+    assert not (tmp_path / ".ukrlib_progress" / "test-author.done").exists()
+    _assert_no_staging_file(tmp_path, output_path)
+
+
+def test_recovery_after_marker_failure_does_not_duplicate_chunks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A post-swap marker failure resumes from source tids without appending again."""
+    output_path = _configure_author_scrape(monkeypatch, tmp_path)
+    monkeypatch.setattr(scrape, "chunk_text", _chunk_for_source)
+    real_mark_done = scrape.mark_done
+
+    def fail_marker(*_args, **_kwargs) -> None:
+        raise RuntimeError("progress marker failed")
+
+    monkeypatch.setattr(scrape, "mark_done", fail_marker)
+    with pytest.raises(RuntimeError, match="progress marker failed"):
+        scrape.scrape_author("test-author", AUTHOR_INFO)
+    published = output_path.read_bytes()
+
+    monkeypatch.setattr(scrape, "mark_done", real_mark_done)
+    monkeypatch.setattr(
+        scrape,
+        "chunk_text",
+        lambda *_args, **_kwargs: pytest.fail("already-published tid was scraped again"),
+    )
+
+    assert scrape.scrape_author("test-author", AUTHOR_INFO) == 2
+    assert output_path.read_bytes() == published
+
+
+def test_staged_validation_rejects_invalid_json(tmp_path: Path) -> None:
+    staged_path = tmp_path / "invalid.jsonl"
+    staged_path.write_text("not json\n", encoding="utf-8")
+
+    with pytest.raises(scrape.JsonlValidationError, match="not valid JSON"):
+        scrape._validate_staged_jsonl(staged_path)


### PR DESCRIPTION
Fixes #4861.

## Summary

All `scrape_ukrlib` JSONL writers now acquire into a sibling `.building` temp file on the target filesystem. The complete staged JSONL must validate before `Path.replace()` atomically publishes it. Any `BaseException`, including `KeyboardInterrupt`, removes the temp and leaves the current target untouched.

Author resume copies the current JSONL into staging before adding pending source tids; progress markers are still written only after a successful swap. The `--narod` and single-work writer paths use the same staging helper without changing output names or row schema.

## Validation before swap

`_validate_staged_jsonl()` requires:

- row count greater than zero;
- `json.loads()` succeeds for every line; and
- every JSON object contains `chunk_id`, `text`, `source_url`, `work`, `author`, `year`, `genre`, and `language_period`.

## #M-4 evidence

| Claim | Evidence |
| --- | --- |
| Late failure leaves no partial live output | `test_mid_scrape_interrupt_creates_no_output_and_cleans_stage` injects `KeyboardInterrupt` after the first staged work and asserts the target is absent, marker is absent, and no `.building` file remains. `test_mid_scrape_interrupt_preserves_previous_output_and_cleans_stage` asserts the prior target bytes remain identical. |
| Successful run swaps atomically | `test_successful_scrape_validates_stage_then_replaces_complete_output` proves validation reads a sibling temp path before a recorded `Path.replace()` into the final path, then asserts all three JSONL rows are complete. |
| Validation precedes the swap | `_validate_staged_jsonl()` implements the required nonzero-count, per-line JSON, and required-field checks. `test_validation_failure_prevents_swap_and_cleans_stage` supplies a row missing `chunk_id` and proves the target bytes remain unchanged; `test_staged_validation_rejects_invalid_json` covers malformed JSON. |
| Marker failure cannot duplicate data on recovery | `test_recovery_after_marker_failure_does_not_duplicate_chunks` fails after the atomic publication, then proves the existing tid scan recognizes the published rows and performs no second scrape. |
| Hermetic tests and lint pass | `.venv/bin/python -m pytest tests/test_scrape_ukrlib_atomic.py tests/test_scrape_ukrlib_recipes.py tests/test_rag_ingestion.py -q` → `64 passed in 0.36s`; `.venv/bin/ruff check scripts/rag/scrape_ukrlib.py tests/test_scrape_ukrlib_atomic.py` → `All checks passed!`. Tests stub the fetch layer and use only `tmp_path`. |

## Review

Independent cross-family review: Agy / Gemini 3.1 Pro returned `APPROVE` for the final diff (bridge message #6).

## Checks

- [x] Targeted scraper and ingestion tests
- [x] Ruff
- [x] `git diff --check`
- [x] `.venv/bin/python -m py_compile scripts/rag/scrape_ukrlib.py`
- [x] Commit trailer audit
- [x] Pre-commit ruff, affected-file pytest, and gitleaks hooks

No auto-merge has been enabled.
