### PR TITLE
feat(delegate): reuse branches and complete dispatch telemetry

### DIFF
--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -224,6 +224,13 @@ When a worktree is reused, it is validated:
    behind, attempt `git rebase origin/<base>` and raise
    `WorktreeStaleBase` if that fails.
 
+For follow-up work on an existing PR, pass `--branch EXISTING` to
+`delegate.py dispatch`. Delegate fetches `origin/EXISTING`, attaches the
+worktree to that branch rather than `origin/main`, and applies the same clean
+tree / branch-match validation. It refuses `main`/`master` and a branch already
+checked out in another worktree. A branch-reuse `--dry-run` validates an
+existing worktree without creating or rebasing one.
+
 Offline fallback: if `git fetch` fails (no network, no remote), delegate
 warns on stderr and branches from the local ref. Pin the `--base` flag
 to override the default `main`.
@@ -252,6 +259,12 @@ The state file at `batch_state/tasks/<task-id>.json` now carries:
 
 `delegate.py list` surfaces `worktree_layout`; `delegate.py status`
 prints a deprecation notice for flat-layout tasks.
+
+Telemetry uses `not-exposed` when a CLI genuinely has no effort setting (for
+example Agy and Cursor), instead of printing an `unknown` warning on every
+dispatch. `unknown` remains reserved for an unexpected resolution failure.
+Every terminal state records a concrete subprocess `returncode`, or a
+`returncode_reason` when no child process ever yielded one.
 
 ## Common mistakes
 

--- a/docs/agent-runtime-guide.md
+++ b/docs/agent-runtime-guide.md
@@ -227,9 +227,11 @@ When a worktree is reused, it is validated:
 For follow-up work on an existing PR, pass `--branch EXISTING` to
 `delegate.py dispatch`. Delegate fetches `origin/EXISTING`, attaches the
 worktree to that branch rather than `origin/main`, and applies the same clean
-tree / branch-match validation. It refuses `main`/`master` and a branch already
-checked out in another worktree. A branch-reuse `--dry-run` validates an
-existing worktree without creating or rebasing one.
+tree / branch-match validation. Staleness and fast-forward are validated
+against `origin/EXISTING` itself — never `origin/main`, since a follow-up
+worktree is almost always legitimately behind main. It refuses `main`/`master`
+and a branch already checked out in another worktree. A branch-reuse
+`--dry-run` validates an existing worktree without creating or rebasing one.
 
 Offline fallback: if `git fetch` fails (no network, no remote), delegate
 warns on stderr and branches from the local ref. Pin the `--base` flag

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -1100,6 +1100,7 @@ def _execute_invocation_plan(
 
         early_reap_check = getattr(adapter, "check_early_reap", None)
         kill_reason: str | None = None
+        returncode: int | None = None
         while True:
             if mcp_observer is not None:
                 observed_stdout_lines = mcp_observer.observe_lines(
@@ -1150,6 +1151,18 @@ def _execute_invocation_plan(
         duration_s = time.monotonic() - start_time
         assert watchdog_state is not None
 
+        # ``poll()`` is the authoritative completion observation.  Most
+        # CPython Popen objects also copy that value to ``.returncode``, but
+        # wrappers/adapters can expose the result first.  Do not discard a
+        # known terminal exit code while handing it to delegate state (#4837).
+        final_returncode = proc.returncode if proc.returncode is not None else returncode
+        if final_returncode is None:
+            try:
+                final_returncode = proc.wait(timeout=10.0)
+            except subprocess.TimeoutExpired:
+                _kill_process_tree(proc)
+                final_returncode = proc.returncode
+
         for thread in watchdog_threads:
             if "stdout" in thread.name or "stderr" in thread.name:
                 thread.join(timeout=5.0)
@@ -1185,14 +1198,14 @@ def _execute_invocation_plan(
         parse = adapter.parse_response(
             stdout=stdout_text,
             stderr=stderr_text,
-            returncode=proc.returncode if proc.returncode is not None else -1,
+            returncode=final_returncode if final_returncode is not None else -1,
             output_file=plan.output_file,
             plan=plan,
             call_start_time=start_time,
         )
         if (
             not parse.ok
-            and proc.returncode not in (None, 0)
+            and final_returncode not in (None, 0)
             and not parse.response
             and not (parse.stderr_excerpt or "").strip()
             and not stdout_text.strip()
@@ -1202,7 +1215,7 @@ def _execute_invocation_plan(
                 ok=False,
                 response="",
                 stderr_excerpt=(
-                    f"{agent_name} subprocess exited rc={proc.returncode} in "
+                    f"{agent_name} subprocess exited rc={final_returncode} in "
                     f"{duration_s:.2f}s with no captured stdout/stderr "
                     f"(stdin_bytes={len(plan.stdin_payload or '')})"
                 )[:500],
@@ -1215,7 +1228,7 @@ def _execute_invocation_plan(
         return _ExecutionOutcome(
             parse=parse,
             duration_s=duration_s,
-            returncode=proc.returncode,
+            returncode=final_returncode,
             kill_reason=kill_reason,
             stdout_text=stdout_text,
             stderr_text=stderr_text,

--- a/scripts/agent_runtime/telemetry.py
+++ b/scripts/agent_runtime/telemetry.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import os
 import re
 import subprocess
 import tomllib
@@ -36,6 +37,7 @@ from .registry import AGENTS
 _logger = logging.getLogger(__name__)
 _SEMVER_RE = re.compile(r"(?<![\d.])v?(\d+(?:\.\d+){1,3})(?![\d.])")
 _UNKNOWN = "unknown"
+_NOT_EXPOSED = "not-exposed"
 _ORIGINAL_SUBPROCESS_POPEN = subprocess.Popen
 
 
@@ -155,6 +157,19 @@ def _default_effort_for(agent_name: str) -> str | None:
     return str(raw).strip() if isinstance(raw, str) and str(raw).strip() else None
 
 
+def _hermes_configured_effort() -> str | None:
+    """Return Hermes's configured reasoning effort without reading secrets.
+
+    Hermes-routed adapters deliberately use the shared configuration rather
+    than a per-invocation effort flag.  Keep dispatch telemetry aligned with
+    that actual runtime behavior.
+    """
+    from .adapters.hermes_common import read_hermes_config, top_level_agent_effort
+
+    home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    return top_level_agent_effort(read_hermes_config(home / "config.yaml"))
+
+
 def _resolve_model_from_plan(agent_name: str, plan: InvocationPlan) -> str | None:
     del agent_name
     return _arg_after(plan.cmd, "-m", "--model")
@@ -205,6 +220,13 @@ def _resolve_model_from_defaults(agent_name: str, requested_model: str | None) -
 
 
 def _resolve_effort_from_defaults(agent_name: str, requested_effort: str | None) -> str | None:
+    # These CLIs do not expose a per-invocation effort value.  A deliberate
+    # marker is observability, not an error: warning on every dispatch made
+    # routine task state look broken (#4837).
+    if agent_name in {"agy", "cursor", "gemini"}:
+        return _NOT_EXPOSED
+    if agent_name in {"grok", "deepseek", "qwen"}:
+        return _hermes_configured_effort() or _NOT_EXPOSED
     if requested_effort:
         return requested_effort
     if agent_name == "codex":
@@ -242,6 +264,18 @@ def _gemini_version_prefix(cmd: list[str]) -> tuple[str, ...]:
     if cmd:
         return (cmd[0],)
     return ("gemini",)
+
+
+def _agy_version_prefix(cmd: list[str]) -> tuple[str, ...]:
+    if cmd:
+        return (cmd[0],)
+    return ("agy",)
+
+
+def _cursor_version_prefix(cmd: list[str]) -> tuple[str, ...]:
+    if cmd:
+        return (cmd[0],)
+    return ("cursor-agent",)
 
 
 def _hermes_version_prefix(cmd: list[str]) -> tuple[str, ...]:
@@ -288,6 +322,16 @@ def claude_cli_version(prefix: tuple[str, ...] = ("claude",)) -> str | None:
     return _probe_version(prefix)
 
 
+@lru_cache(maxsize=1)
+def agy_cli_version(prefix: tuple[str, ...] = ("agy",)) -> str | None:
+    return _probe_version(prefix)
+
+
+@lru_cache(maxsize=1)
+def cursor_cli_version(prefix: tuple[str, ...] = ("cursor-agent",)) -> str | None:
+    return _probe_version(prefix)
+
+
 def _resolve_cli_version(agent_name: str, plan: InvocationPlan | None = None) -> str | None:
     if agent_name == "codex":
         prefix = _codex_version_prefix(plan.cmd) if plan is not None else ("codex",)
@@ -298,6 +342,12 @@ def _resolve_cli_version(agent_name: str, plan: InvocationPlan | None = None) ->
     if agent_name == "claude":
         prefix = _claude_version_prefix(plan.cmd) if plan is not None else ("claude",)
         return claude_cli_version(prefix)
+    if agent_name == "agy":
+        prefix = _agy_version_prefix(plan.cmd) if plan is not None else ("agy",)
+        return agy_cli_version(prefix)
+    if agent_name == "cursor":
+        prefix = _cursor_version_prefix(plan.cmd) if plan is not None else ("cursor-agent",)
+        return cursor_cli_version(prefix)
     if agent_name == "grok-build":
         # Native `grok` CLI (Grok Build) — NOT hermes-backed; probe it directly.
         return _probe_version(("grok",))
@@ -370,3 +420,5 @@ def _reset_version_cache_for_tests() -> None:
     codex_cli_version.cache_clear()
     gemini_cli_version.cache_clear()
     claude_cli_version.cache_clear()
+    agy_cli_version.cache_clear()
+    cursor_cli_version.cache_clear()

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1273,7 +1273,13 @@ def _ensure_worktree(
         telemetry["rebased"] = _validate_existing_worktree(
             path=worktree_path,
             expected_branch=worktree_branch,
-            base=base,
+            # For --branch reuse the staleness/fast-forward reference is the
+            # requested branch ITSELF (origin/<branch>), never origin/main: a
+            # follow-up worktree for an existing PR is almost always behind
+            # main (main moved since the PR branched), and validating against
+            # main would spuriously fail the dry-run or rebase a PR branch
+            # onto main as a validation side effect. (review-4905-grok)
+            base=requested_branch or base,
             allow_rebase=not dry_run,
         )
         telemetry["base_sha"] = _resolve_sha(worktree_path)

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -48,7 +48,8 @@ State files live at ``batch_state/tasks/<task-id>.json``. Format:
         "response_chars": int | null,
         "result_file": str | null,   # path to the full response text
         "stderr_excerpt": str | null,
-        "returncode": int | null
+        "returncode": int | null,
+        "returncode_reason": str | null
     }
 
 Design notes:
@@ -588,6 +589,83 @@ def _fetch_base(base: str) -> bool:
     return verify.returncode == 0
 
 
+def _validate_branch_reuse_name(branch: str) -> str:
+    """Reject unsafe or ambiguous ``--branch`` values before touching git."""
+    normalized = branch.strip()
+    if not normalized:
+        raise ValueError("--branch must name an existing non-protected branch")
+    if normalized.startswith(("origin/", "refs/")):
+        raise ValueError(
+            "--branch must be a local branch name without origin/ or refs/ prefixes: "
+            f"got {branch!r}"
+        )
+
+    containment = _load_worktree_containment()
+    if normalized in containment.PROTECTED_BRANCHES:
+        raise ValueError(
+            f"refusing --branch {normalized!r}: protected branches may not be "
+            "attached to a dispatch worktree"
+        )
+    return normalized
+
+
+def _fetch_existing_branch(branch: str) -> None:
+    """Fetch and verify the remote branch used by ``--branch`` reuse mode."""
+    proc = subprocess.run(
+        ["git", "fetch", "origin", branch],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_sanitized_git_env(),
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"could not fetch existing branch {branch!r}: {_format_process_failure(proc)}"
+        )
+    verify = subprocess.run(
+        ["git", "rev-parse", "--verify", f"origin/{branch}"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_sanitized_git_env(),
+    )
+    if verify.returncode != 0:
+        raise RuntimeError(
+            f"origin/{branch} was not found after fetch; --branch requires an existing remote branch"
+        )
+
+
+def _branch_worktree_paths(branch: str) -> list[Path]:
+    """Return registered worktree roots currently attached to ``branch``."""
+    proc = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_sanitized_git_env(),
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"could not list git worktrees: {_format_process_failure(proc)}")
+
+    matches: list[Path] = []
+    current_path: Path | None = None
+    current_branch: str | None = None
+    for line in [*(proc.stdout or "").splitlines(), ""]:
+        if not line:
+            if current_path is not None and current_branch == branch:
+                matches.append(current_path.resolve())
+            current_path = None
+            current_branch = None
+        elif line.startswith("worktree "):
+            current_path = Path(line.removeprefix("worktree ").strip())
+        elif line.startswith("branch refs/heads/"):
+            current_branch = line.removeprefix("branch refs/heads/").strip()
+    return matches
+
+
 def _resolve_sha(path: Path, ref: str = "HEAD") -> str | None:
     """Return the commit SHA at ``ref`` in ``path``, or None if unresolvable."""
     proc = subprocess.run(
@@ -975,6 +1053,7 @@ def _validate_existing_worktree(
     path: Path,
     expected_branch: str,
     base: str,
+    allow_rebase: bool = True,
 ) -> bool:
     """Validate a reused worktree. Returns True if a rebase occurred.
 
@@ -1045,6 +1124,13 @@ def _validate_existing_worktree(
         behind = 0
     if behind == 0:
         return False
+
+    if not allow_rebase:
+        raise WorktreeStaleBase(
+            f"worktree at {path} is {behind} commit(s) behind {origin_ref}; "
+            "dry-run will not rebase it. Rerun without --dry-run after reviewing "
+            "the worktree."
+        )
 
     print(
         f"⚠️  worktree {path} is {behind} commit(s) behind {origin_ref}; attempting fast-forward rebase",
@@ -1144,6 +1230,8 @@ def _ensure_worktree(
     task_id: str,
     raw_path: str,
     base: str = "main",
+    branch: str | None = None,
+    dry_run: bool = False,
 ) -> tuple[Path, str, dict[str, Any]]:
     """Return a ready worktree path, creating or validating as needed.
 
@@ -1157,7 +1245,8 @@ def _ensure_worktree(
       than created.
     """
     worktree_path = _normalize_worktree_path(raw_path)
-    branch = _derive_worktree_branch(agent, task_id)
+    requested_branch = _validate_branch_reuse_name(branch) if branch else None
+    worktree_branch = requested_branch or _derive_worktree_branch(agent, task_id)
     layout = _classify_worktree_layout(worktree_path)
     telemetry: dict[str, Any] = {
         "base_sha": None,
@@ -1166,20 +1255,40 @@ def _ensure_worktree(
         "reused": False,
     }
 
+    if requested_branch:
+        _fetch_existing_branch(requested_branch)
+        occupied_paths = _branch_worktree_paths(requested_branch)
+        elsewhere = [path for path in occupied_paths if path != worktree_path]
+        if elsewhere:
+            locations = ", ".join(str(path) for path in elsewhere)
+            raise WorktreeBranchMismatch(
+                f"branch {requested_branch!r} is already checked out in {locations}; "
+                "refusing to attach it to another worktree"
+            )
+
     if worktree_path.exists():
         if not worktree_path.is_dir():
             raise ValueError(f"worktree path exists but is not a directory: {worktree_path}")
         telemetry["reused"] = True
         telemetry["rebased"] = _validate_existing_worktree(
             path=worktree_path,
-            expected_branch=branch,
+            expected_branch=worktree_branch,
             base=base,
+            allow_rebase=not dry_run,
         )
         telemetry["base_sha"] = _resolve_sha(worktree_path)
+        if dry_run:
+            return worktree_path, worktree_branch, telemetry
         # Reused worktrees may predate this provisioning hook; the helper is
         # idempotent and never clobbers existing files.
         _provision_data_symlinks(worktree_path, _main_checkout_root())
-        return worktree_path, branch, telemetry
+        return worktree_path, worktree_branch, telemetry
+
+    if dry_run:
+        raise ValueError(
+            f"branch reuse dry-run found no existing worktree at {worktree_path}; "
+            "rerun without --dry-run to create one"
+        )
 
     # Fix 1 (#1476): fetch origin/{base} and branch from the remote ref,
     # not the local one. Local `main` drifts the moment a PR merges while
@@ -1188,23 +1297,37 @@ def _ensure_worktree(
     # origin-prefixed ``base`` (``--base origin/main``, the mandated form)
     # fetches ``main`` and branches from ``origin/main`` — not the
     # unresolvable ``origin/origin/main``.
-    origin_ref = _origin_base_ref(base)
-    if _fetch_base(base):
-        worktree_base_ref = origin_ref
+    if requested_branch:
+        # Attach directly to the fetched PR/follow-up branch.  Never branch
+        # from origin/main here: that was the follow-up-dispatch footgun.
+        worktree_base_ref = requested_branch
     else:
-        print(
-            f"⚠️  `git fetch origin {_base_branch_name(base)}` failed or "
-            f"{origin_ref} is unresolvable; falling back to local {base}. "
-            f"This worktree may be branched from a stale tip.",
-            file=sys.stderr,
-        )
-        worktree_base_ref = base
+        origin_ref = _origin_base_ref(base)
+        if _fetch_base(base):
+            worktree_base_ref = origin_ref
+        else:
+            print(
+                f"⚠️  `git fetch origin {_base_branch_name(base)}` failed or "
+                f"{origin_ref} is unresolvable; falling back to local {base}. "
+                f"This worktree may be branched from a stale tip.",
+                file=sys.stderr,
+            )
+            worktree_base_ref = base
 
     # Ensure parent dirs exist for the dispatch/ subtree layout.
     worktree_path.parent.mkdir(parents=True, exist_ok=True)
 
+    add_command = ["git", "worktree", "add"]
+    if requested_branch and _resolve_sha(_REPO_ROOT, f"refs/heads/{requested_branch}"):
+        add_command.extend([str(worktree_path), requested_branch])
+    elif requested_branch:
+        add_command.extend(
+            ["--track", "-b", requested_branch, str(worktree_path), f"origin/{requested_branch}"]
+        )
+    else:
+        add_command.extend(["-b", worktree_branch, str(worktree_path), worktree_base_ref])
     proc = subprocess.run(
-        ["git", "worktree", "add", "-b", branch, str(worktree_path), worktree_base_ref],
+        add_command,
         cwd=_REPO_ROOT,
         capture_output=True,
         text=True,
@@ -1215,7 +1338,7 @@ def _ensure_worktree(
         raise RuntimeError(stderr)
     _provision_data_symlinks(worktree_path, _main_checkout_root())
     telemetry["base_sha"] = _resolve_sha(worktree_path)
-    return worktree_path, branch, telemetry
+    return worktree_path, worktree_branch, telemetry
 
 
 def _augment_prompt_with_worktree(prompt: str, worktree_path: Path | None) -> str:
@@ -1398,6 +1521,7 @@ def _run_worker(
     stderr_excerpt = None
     response = ""
     returncode: int | None = None
+    returncode_reason: str | None = None
     rate_limited = False
     timed_out = False
     result = None
@@ -1441,9 +1565,11 @@ def _run_worker(
         # this, so no extra cleanup is needed here. Mark as cancelled.
         cancelled = True
         stderr_excerpt = f"cancelled via SIGTERM or Ctrl+C: {exc}"[:500]
+        returncode_reason = "worker interrupted before a terminal subprocess returncode was available"
     except RateLimitedError as exc:
         rate_limited = True
         stderr_excerpt = str(exc)[:500]
+        returncode_reason = "runtime rejected the dispatch before a terminal subprocess returncode was available"
     except AgentStalledError as exc:
         timed_out = True
         substitution = getattr(exc, "substitution", None)
@@ -1453,16 +1579,20 @@ def _run_worker(
             else "stdout_silence_timeout"
         )
         stderr_excerpt = f"{prefix}: {exc}"[:500]
+        returncode_reason = "runtime timeout raised before a terminal subprocess returncode was available"
     except AgentTimeoutError as exc:
         substitution = getattr(exc, "substitution", None)
         stderr_excerpt = f"hard_timeout: {exc}"[:500]
+        returncode_reason = "runtime timeout raised before a terminal subprocess returncode was available"
     except AgentRuntimeError as exc:
         stderr_excerpt = f"runtime error: {type(exc).__name__}: {exc}"[:500]
+        returncode_reason = "runtime exception did not expose a terminal subprocess returncode"
     except Exception as exc:
         # Last-ditch: don't crash the worker on an unexpected bug — we
         # need to update the state file or the parent will see us as
         # "crashed" forever.
         stderr_excerpt = f"worker unexpected: {type(exc).__name__}: {exc}"[:500]
+        returncode_reason = "unexpected worker exception before a terminal subprocess returncode was available"
 
     duration_s = time.monotonic() - start
 
@@ -1482,6 +1612,18 @@ def _run_worker(
         ok_outcome=ok_outcome,
         timed_out=timed_out,
     )
+
+    # A successful runtime result must carry the completed child process's
+    # return code.  Refuse to persist a misleading ``done``/null combination
+    # if a future runner regression drops it; failures without a child code
+    # retain a precise reason instead of inventing a number (#4837).
+    if final_status == "done" and returncode is None:
+        final_status = "failed"
+        ok_outcome = False
+        returncode_reason = "runtime reported success without a terminal subprocess returncode"
+        stderr_excerpt = "runtime reported success without a terminal subprocess returncode"
+    elif returncode is None and returncode_reason is None:
+        returncode_reason = "no terminal subprocess returncode was available"
 
     final_state = _read_state(state_path) or {}
 
@@ -1555,6 +1697,7 @@ def _run_worker(
             "result_file": result_file,
             "stderr_excerpt": stderr_excerpt,
             "returncode": returncode,
+            "returncode_reason": returncode_reason,
             "worktree_dirty_on_exit": dirty_on_exit,
             "commits_ahead": commits_ahead,
             "needs_finalize": needs_finalize,
@@ -1615,6 +1758,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     task_id = args.task_id
     state_path = _state_path(task_id)
     worktree_arg = getattr(args, "worktree", None)
+    requested_branch = getattr(args, "branch", None)
     silence_timeout = getattr(args, "silence_timeout", DEFAULT_SILENCE_TIMEOUT_S)
     initial_response_timeout = getattr(
         args,
@@ -1624,9 +1768,15 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     max_budget_usd = getattr(args, "max_budget_usd", None)
     keep_worktree = bool(getattr(args, "keep_worktree", False))
 
+    # Branch reuse always needs an isolated worktree.  A bare --branch uses
+    # the normal dispatch subtree automatically; --cwd would otherwise make
+    # it unclear which checkout must be validated.
+    if requested_branch and not worktree_arg:
+        worktree_arg = "auto"
+
     if args.cwd and worktree_arg:
         print(
-            "❌ --cwd and --worktree are mutually exclusive. Use --worktree for delegated write isolation.",
+            "❌ --cwd cannot be combined with --worktree or --branch. Use --worktree for delegated write isolation.",
             file=sys.stderr,
         )
         return 2
@@ -1699,7 +1849,34 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     else:
         dispatch_agent = args.agent
 
-    if getattr(args, "dry_run", False):
+    if getattr(args, "dry_run", False) and not requested_branch:
+        print(task_id)
+        return 0
+
+    if getattr(args, "dry_run", False) and requested_branch:
+        resolved_raw = (
+            str(_auto_worktree_path(dispatch_agent, task_id))
+            if worktree_arg == "auto"
+            else worktree_arg
+        )
+        assert resolved_raw is not None  # --branch above supplies the auto sentinel.
+        try:
+            worktree_path, worktree_branch, worktree_telemetry = _ensure_worktree(
+                agent=dispatch_agent,
+                task_id=task_id,
+                raw_path=resolved_raw,
+                base=getattr(args, "base", None) or "main",
+                branch=requested_branch,
+                dry_run=True,
+            )
+        except (ValueError, RuntimeError) as exc:
+            print(f"❌ failed to validate branch reuse for {task_id!r}: {exc}", file=sys.stderr)
+            return 1
+        print(
+            f"🌲 branch reuse validated: branch={worktree_branch} "
+            f"path={worktree_path} base_sha={worktree_telemetry.get('base_sha') or '?'} [reused]",
+            file=sys.stderr,
+        )
         print(task_id)
         return 0
 
@@ -1736,6 +1913,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                 task_id=task_id,
                 raw_path=resolved_raw,
                 base=getattr(args, "base", None) or "main",
+                branch=requested_branch,
             )
         except (ValueError, RuntimeError) as exc:
             print(f"❌ failed to prepare worktree for {task_id!r}: {exc}", file=sys.stderr)
@@ -1784,6 +1962,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "result_file": None,
         "stderr_excerpt": None,
         "returncode": None,
+        "returncode_reason": None,
         "substitution": None,
     }
     _write_state_atomic(state_path, initial_state)
@@ -1887,6 +2066,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                     "finished_at": datetime.now(UTC).isoformat(),
                     "stderr_excerpt": (f"Popen failed: {type(exc).__name__}: {exc}")[:500],
                     "returncode": None,
+                    "returncode_reason": "worker process was not started",
                 }
             )
             _write_state_atomic(state_path, failed_state)
@@ -2477,6 +2657,18 @@ def build_parser() -> argparse.ArgumentParser:
             "alone (recommended) to auto-derive `.worktrees/dispatch/{agent}/"
             "{task}/`, or `--worktree PATH` to reuse a specific added worktree "
             "(validated against the expected dispatch branch before reuse)."
+        ),
+    )
+    d.add_argument(
+        "--branch",
+        default=None,
+        metavar="EXISTING",
+        help=(
+            "Attach the dispatch to this existing remote branch instead of creating "
+            "{agent}/{task}. Fetches and validates the branch, then creates/reuses "
+            "an isolated worktree on it (--branch implies --worktree). Refuses "
+            "protected branches (main/master) and branches checked out in another "
+            "worktree. --branch must omit origin/ and refs/ prefixes."
         ),
     )
     d.add_argument(

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -543,6 +543,8 @@ def test_dispatch_popen_failure_marks_task_failed(tmp_tasks_dir, capsys):
     assert state["status"] == "failed"
     assert "Popen failed" in (state.get("stderr_excerpt") or "")
     assert "FileNotFoundError" in (state.get("stderr_excerpt") or "")
+    assert state["returncode"] is None
+    assert state["returncode_reason"] == "worker process was not started"
     captured = capsys.readouterr()
     assert "failed to spawn" in captured.err
 
@@ -934,6 +936,8 @@ def test_run_worker_persists_runtime_telemetry(tmp_tasks_dir, tmp_path):
     assert state["model"] == "claude-opus-4-6"
     assert state["effort"] == "xhigh"
     assert state["cli_version"] == "2.1.89"
+    assert state["returncode"] == 0
+    assert state["returncode_reason"] is None
 
 
 def test_run_worker_emits_one_terminal_dispatch_event_with_cost_fields(
@@ -1999,6 +2003,138 @@ def test_dispatch_uses_existing_worktree_without_git_add(tmp_tasks_dir, tmp_path
     assert state["worktree_reused"] is True
 
 
+def test_branch_reuse_creates_worktree_from_existing_remote_branch(tmp_tasks_dir, tmp_path, monkeypatch):
+    """--branch must attach to its fetched branch, never origin/main (#4837)."""
+    target = tmp_path / "branch-reuse"
+    branch = "cursor/follow-up"
+    calls, base_stub = _make_run_stub(rev_parse_head_sha="branch-head")
+
+    def fake_run(cmd, **kwargs):
+        # No local branch yet: creating the worktree must create a tracking
+        # branch from the fetched remote ref.
+        if cmd[:2] == ["git", "rev-parse"] and cmd[-1] == f"refs/heads/{branch}":
+            return subprocess.CompletedProcess(cmd, 1, "", "")
+        return base_stub(cmd, **kwargs)
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    _, actual_branch, telemetry = delegate._ensure_worktree(
+        agent="cursor",
+        task_id="follow-up",
+        raw_path=str(target),
+        branch=branch,
+    )
+
+    assert actual_branch == branch
+    assert telemetry["reused"] is False
+    assert ["git", "fetch", "origin", branch] in calls
+    add_cmd = next(command for command in calls if command[:3] == ["git", "worktree", "add"])
+    assert add_cmd == [
+        "git",
+        "worktree",
+        "add",
+        "--track",
+        "-b",
+        branch,
+        str(target.resolve()),
+        f"origin/{branch}",
+    ]
+
+
+def test_branch_reuse_dry_run_validates_existing_worktree_without_adding(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    """A branch-reuse dry run performs the safe reuse checks without mutation."""
+    import argparse
+
+    worktree = tmp_path / "existing-branch-worktree"
+    worktree.mkdir()
+    branch = "cursor/follow-up"
+    calls, base_stub = _make_run_stub(
+        abbrev_ref=branch,
+        status_porcelain="",
+        rev_list_count="0",
+        rev_parse_head_sha="branch-head",
+    )
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["git", "worktree", "add"]:
+            pytest.fail("branch-reuse dry-run must not add a worktree")
+        return base_stub(cmd, **kwargs)
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+    args = argparse.Namespace(
+        agent="cursor",
+        task_id="branch-reuse-dry-run",
+        prompt="validate only",
+        prompt_file=None,
+        mode="read-only",
+        model=None,
+        cwd=None,
+        worktree=str(worktree),
+        branch=branch,
+        base="main",
+        hard_timeout=3600,
+        dry_run=True,
+    )
+
+    assert delegate.cmd_dispatch(args) == 0
+    assert ["git", "fetch", "origin", branch] in calls
+    output = capsys.readouterr()
+    assert "branch reuse validated" in output.err
+    assert "[reused]" in output.err
+    assert output.out.strip() == "branch-reuse-dry-run"
+
+
+def test_branch_reuse_refuses_protected_branch_before_git_calls(tmp_path, monkeypatch):
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    with pytest.raises(ValueError, match="protected"):
+        delegate._ensure_worktree(
+            agent="cursor",
+            task_id="unsafe",
+            raw_path=str(tmp_path / "unsafe"),
+            branch="main",
+        )
+    assert calls == []
+
+
+def test_branch_reuse_refuses_branch_checked_out_in_another_worktree(tmp_path, monkeypatch):
+    target = tmp_path / "target"
+    occupied = tmp_path / "occupied"
+    branch = "cursor/follow-up"
+    _, base_stub = _make_run_stub()
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["git", "worktree", "list"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                f"worktree {occupied}\nbranch refs/heads/{branch}\n\n",
+                "",
+            )
+        return base_stub(cmd, **kwargs)
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+
+    with pytest.raises(delegate.WorktreeBranchMismatch, match="already checked out"):
+        delegate._ensure_worktree(
+            agent="cursor",
+            task_id="follow-up",
+            raw_path=str(target),
+            branch=branch,
+        )
+
+
 # ---------------------------------------------------------------------------
 # cmd_list
 # ---------------------------------------------------------------------------
@@ -2730,13 +2866,25 @@ def test_dispatch_accepts_explicit_added_worktree(tmp_tasks_dir, tmp_path, monke
 def test_dispatch_help_omits_deprecated_cwd_dot_example():
     """Issue #4445: help/examples must not advertise `--cwd .` or a flat
     worktree layout for write-capable work."""
-    help_text = delegate.build_parser().format_help()
-    assert "--cwd ." not in help_text
-    assert "--mode workspace-write --cwd" not in help_text
+    parser = delegate.build_parser()
+    root_help = parser.format_help()
+    dispatch_parser = next(
+        action.choices["dispatch"]
+        for action in parser._actions
+        if action.dest == "command"
+    )
+    help_text = dispatch_parser.format_help()
+    assert "--cwd ." not in root_help
+    assert "--mode workspace-write --cwd" not in root_help
     # The flat `.worktrees/<agent>-<task>` example is gone; bare --worktree
     # is the advertised write-capable path.
-    assert ".worktrees/codex-pr-123" not in help_text
-    assert "--mode workspace-write --worktree" in help_text
+    assert ".worktrees/codex-pr-123" not in root_help
+    assert "--mode workspace-write --worktree" in root_help
+    assert "--branch EXISTING" in help_text
+    assert "protected branches" in help_text
+    assert "main/master" in help_text
+    assert "checked out" in help_text
+    assert "another" in help_text
 
 
 def test_list_and_status_walk_both_layouts(tmp_tasks_dir, tmp_path, capsys, monkeypatch):

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -2942,3 +2942,68 @@ def test_status_warns_on_flat_layout(tmp_tasks_dir, capsys):
     state = json.loads(captured.out)
     assert state["worktree_layout"] == "flat"
     assert "flat" in captured.err.lower() or "deprecated" in captured.err.lower()
+
+
+def test_branch_reuse_validates_staleness_against_the_branch_not_main(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    """--branch reuse validates the worktree against origin/<branch>, NOT
+    origin/main: a follow-up worktree for an existing PR is almost always
+    behind main (main moved since the PR branched), and that must neither
+    fail validation nor trigger a rebase-onto-main side effect.
+    (review-4905-grok blocking finding.)"""
+    import argparse
+
+    worktree = tmp_path / "existing-branch-worktree"
+    worktree.mkdir()
+    branch = "cursor/follow-up"
+    calls, base_stub = _make_run_stub(
+        abbrev_ref=branch,
+        status_porcelain="",
+        rev_list_count="0",
+        rev_parse_head_sha="branch-head",
+    )
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:2] == ["git", "rev-list"]:
+            calls.append(list(cmd))
+            ref = cmd[-1]
+            if "origin/main" in ref:
+                # Way behind main — must be IRRELEVANT for branch reuse.
+                return subprocess.CompletedProcess(cmd, 0, "5", "")
+            return subprocess.CompletedProcess(cmd, 0, "0", "")
+        if cmd[:3] == ["git", "worktree", "add"]:
+            pytest.fail("branch-reuse dry-run must not add a worktree")
+        return base_stub(cmd, **kwargs)
+
+    monkeypatch.setattr(delegate.subprocess, "run", fake_run)
+    args = argparse.Namespace(
+        agent="cursor",
+        task_id="branch-reuse-stale-main",
+        prompt="validate only",
+        prompt_file=None,
+        mode="read-only",
+        model=None,
+        cwd=None,
+        worktree=str(worktree),
+        branch=branch,
+        base="main",
+        hard_timeout=3600,
+        dry_run=True,
+    )
+
+    assert delegate.cmd_dispatch(args) == 0
+
+    rev_list_calls = [c for c in calls if c[:2] == ["git", "rev-list"]]
+    assert rev_list_calls, "reuse validation must check staleness via rev-list"
+    for cmd in rev_list_calls:
+        assert cmd[-1] == f"HEAD..origin/{branch}", (
+            "staleness must be checked against the requested branch, "
+            f"got {cmd[-1]!r}"
+        )
+    assert not any(c[:2] == ["git", "rebase"] for c in calls), (
+        "branch-reuse dry-run must never rebase"
+    )

--- a/tests/test_dispatch_telemetry.py
+++ b/tests/test_dispatch_telemetry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -93,6 +94,66 @@ def test_resolve_invocation_telemetry_reads_claude_plan_flags():
     assert telemetry.cli_version == "2.1.89"
 
 
+def test_expected_effort_markers_and_version_probes_do_not_warn(tmp_path, monkeypatch, caplog):
+    """Known CLI limits are explicit metadata, not dispatch warnings (#4837)."""
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: xhigh\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    def probe(prefix: tuple[str, ...]) -> str | None:
+        return {
+            "agy": "1.1.1",
+            "cursor-agent": "2026.07.09",
+            "hermes": "0.18.0",
+        }.get(Path(prefix[0]).name)
+
+    caplog.set_level(logging.WARNING, logger="agent_runtime.telemetry")
+    with patch("agent_runtime.telemetry._probe_version", side_effect=probe):
+        agy = resolve_dispatch_start_telemetry(
+            agent_name="agy",
+            requested_model=None,
+            requested_effort=None,
+        )
+        cursor = resolve_invocation_telemetry(
+            agent_name="cursor",
+            plan=InvocationPlan(cmd=["cursor-agent", "-p"], cwd=tmp_path),
+            requested_model=None,
+            requested_effort=None,
+        )
+        deepseek = resolve_dispatch_start_telemetry(
+            agent_name="deepseek",
+            requested_model=None,
+            requested_effort=None,
+        )
+
+    assert (agy.effort, agy.cli_version) == ("not-exposed", "1.1.1")
+    assert (cursor.effort, cursor.cli_version) == ("not-exposed", "2026.07.09")
+    assert (deepseek.effort, deepseek.cli_version) == ("xhigh", "0.18.0")
+    assert "dispatch telemetry for" not in caplog.text
+
+
+def test_unexpected_version_probe_failure_still_warns(caplog):
+    """Only a genuine resolution failure may produce an unknown warning."""
+    caplog.set_level(logging.WARNING, logger="agent_runtime.telemetry")
+    with patch("agent_runtime.telemetry._probe_version", return_value=None):
+        telemetry = resolve_dispatch_start_telemetry(
+            agent_name="agy",
+            requested_model=None,
+            requested_effort=None,
+        )
+
+    assert telemetry.effort == "not-exposed"
+    assert telemetry.cli_version == "unknown"
+    assert (
+        "dispatch telemetry for agy could not resolve cli_version: version probe failed; "
+        "recording 'unknown'"
+    ) in caplog.text
+
+
 def test_runner_invoke_returns_resolved_telemetry(tmp_path):
     from agent_runtime import runner as runner_mod
 
@@ -116,7 +177,9 @@ def test_runner_invoke_returns_resolved_telemetry(tmp_path):
 
     fake_proc = MagicMock()
     fake_proc.poll.return_value = 0
-    fake_proc.returncode = 0
+    # The completed poll result is authoritative even when a Popen wrapper
+    # has not reflected it through ``.returncode`` yet (#4837).
+    fake_proc.returncode = None
     fake_proc.stdin = None
 
     with (
@@ -156,6 +219,8 @@ def test_runner_invoke_returns_resolved_telemetry(tmp_path):
     assert result.model == "gpt-5.5"
     assert result.effort == "high"
     assert result.cli_version == "0.123.0"
+    assert result.returncode == 0
+    assert result.usage_record["returncode"] == 0
 
 
 def test_runner_usage_record_includes_correlation_ids_without_prompt_change(

--- a/tests/test_dispatch_telemetry.py
+++ b/tests/test_dispatch_telemetry.py
@@ -154,7 +154,7 @@ def test_unexpected_version_probe_failure_still_warns(caplog):
     ) in caplog.text
 
 
-def test_runner_invoke_returns_resolved_telemetry(tmp_path):
+def test_runner_invoke_preserves_observed_terminal_returncode_and_telemetry(tmp_path):
     from agent_runtime import runner as runner_mod
 
     spy_adapter = MagicMock()


### PR DESCRIPTION
Closes #4837

## Scope

Implements only issue items 7, 8, and 10:

- adds safe <code>--branch EXISTING</code> dispatch reuse;
- resolves routine Agy/Cursor/Hermes telemetry unknowns; and
- preserves completed subprocess return codes through terminal task state.

Item 9 is intentionally untouched: it already shipped in #4844.

## M-4 evidence

| Claim | Deterministic command | Raw result |
| --- | --- | --- |
| Branch reuse works | <code>.venv/bin/python scripts/delegate.py dispatch ... --branch codex/4837-dispatch-cluster --worktree &lt;this-worktree&gt; --dry-run</code> | <code>🌲 branch reuse validated: branch=codex/4837-dispatch-cluster ... [reused]</code> / <code>branch-reuse-live-proof</code> |
| Telemetry warnings resolved | resolver probe before and after | Before: five exact warning lines; after: three resolved records with no stderr warning (quoted below). |
| Completed dispatch keeps a return code | <code>.venv/bin/python -m pytest tests/test_dispatch_telemetry.py -k observed_terminal_returncode -vv</code> | <code>test_runner_invoke_preserves_observed_terminal_returncode_and_telemetry PASSED</code> |
| Tests and Ruff | targeted suites plus runtime suite and Ruff | <code>113 passed in 5.97s</code>; <code>158 passed in 25.42s</code>; <code>All checks passed!</code> |

### Raw branch-reuse proof

Command:

~~~console
.venv/bin/python scripts/delegate.py dispatch --agent codex --task-id branch-reuse-live-proof --prompt 'dry-run validation only; do not invoke an agent' --branch codex/4837-dispatch-cluster --worktree /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4837-dispatch-cluster --dry-run
~~~

Output:

~~~text
🌲 branch reuse validated: branch=codex/4837-dispatch-cluster path=/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4837-dispatch-cluster base_sha=582d076d004e50ef5831b8087b19079aae787900 [reused]
branch-reuse-live-proof
~~~

The new delegate tests also cover remote-branch creation, validated dry-run reuse, protected-branch rejection, and checked-out-elsewhere rejection.

### Raw telemetry before/after

Before:

~~~text
WARNING:agent_runtime.telemetry:dispatch telemetry for agy could not resolve effort: no explicit override or readable default; recording 'unknown'
WARNING:agent_runtime.telemetry:dispatch telemetry for agy could not resolve cli_version: version probe failed; recording 'unknown'
WARNING:agent_runtime.telemetry:dispatch telemetry for cursor could not resolve effort: no explicit override or readable default; recording 'unknown'
WARNING:agent_runtime.telemetry:dispatch telemetry for cursor could not resolve cli_version: version probe failed; recording 'unknown'
WARNING:agent_runtime.telemetry:dispatch telemetry for deepseek could not resolve effort: no explicit override or readable default; recording 'unknown'
agy: effort=unknown cli_version=unknown
cursor: effort=unknown cli_version=unknown
deepseek: effort=unknown cli_version=0.18.0
~~~

After:

~~~text
agy: effort=not-exposed cli_version=1.1.1
cursor: effort=not-exposed cli_version=2026.07.09
deepseek: effort=xhigh cli_version=0.18.0
~~~

DeepSeek's CLI version was already resolved in the pre-fix probe; its erroneous effort warning is now resolved from Hermes configuration. <code>not-exposed</code> is deliberate for Agy/Cursor effort because those CLIs do not expose an effort setting.

### Raw returncode proof

~~~text
tests/test_dispatch_telemetry.py::test_runner_invoke_preserves_observed_terminal_returncode_and_telemetry PASSED [100%]

======================= 1 passed, 6 deselected in 0.08s ========================
~~~

This regression supplies a completed process where <code>poll()</code> returns <code>0</code> while <code>.returncode</code> is absent, then asserts both the runtime result and usage record retain <code>0</code>. Delegate also refuses to persist <code>status: done</code> with a null return code and records <code>returncode_reason</code> when no child return code exists.

### Test and lint output

~~~text
.venv/bin/python -m pytest tests/test_delegate.py tests/test_dispatch_telemetry.py -q
============================= 113 passed in 5.97s ==============================

.venv/bin/python -m pytest tests/test_agent_runtime.py -q
============================= 158 passed in 25.42s =============================

.venv/bin/ruff check scripts/delegate.py scripts/agent_runtime/telemetry.py scripts/agent_runtime/runner.py tests/test_delegate.py tests/test_dispatch_telemetry.py
All checks passed!
~~~

The delegate fixture test command strips this session's runtime git shim from PATH; otherwise its intentional temporary <code>git push origin main</code> is correctly blocked by the shim. Pre-commit independently reran the affected 113 tests successfully.

<code>npx --no-install markdownlint-cli2 docs/agent-runtime-guide.md</code> reports 30 existing MD060 compact-table violations at unchanged lines 55, 73, 180, 195, and 245. No lint configuration was changed, and no new markdownlint failure was introduced.

## Changed files

- <code>scripts/delegate.py</code>
- <code>scripts/agent_runtime/runner.py</code>
- <code>scripts/agent_runtime/telemetry.py</code>
- <code>tests/test_delegate.py</code>
- <code>tests/test_dispatch_telemetry.py</code>
- <code>docs/agent-runtime-guide.md</code>

No auto-merge has been enabled; the orchestrator owns review and merge.
