### PR TITLE
fix(ci): python changes-filter gains data/lexicon/source-inventory/** (#4894)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,10 @@ jobs:
               # data-only PR here skipped pytest and turned main red for every
               # subsequent code PR (2026-07-10, #4888 — same class as #3873).
               - 'data/lexicon/source-inventory-review-decisions/**'
+              # Same class (#4894, review-4893 sibling sweep):
+              # test_source_inventory_intake::test_committed_source_inventory_files_are_valid
+              # globs every file here — data-only edits must run pytest too.
+              - 'data/lexicon/source-inventory/**'
             frontend:
               - '.github/workflows/ci.yml'
               - 'site/**'


### PR DESCRIPTION
Fixes #4894. One line: the second pytest-validated committed-data directory joins the python changes-filter, closing the #4888 red-main class completely (review-4893's sibling sweep checked all four glob-all data-validation tests; this was the only uncovered one).

**Review provenance:** the exact line was prescribed by the cross-family reviewer in `batch_state/tasks/review-4893.result` §4 ("Recommend … add `- 'data/lexicon/source-inventory/**'` to the python changes filter"); this PR implements it verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)