### PR TITLE
feat(streams): eval-harness stream (#4913) — split harness product from fleet plumbing

### DIFF
--- a/docs/WORKSTREAMS.md
+++ b/docs/WORKSTREAMS.md
@@ -30,6 +30,7 @@ The registry `scripts/config/issue_streams.yaml` is the single source of truth (
 | atlas-intake | #4220, #4378 | Full-corpus intake into the Atlas |
 | corpus-channels | #4706 | Acquisition & ingestion (textbooks · ZNO · Ohoiko-media · press · academic) |
 | infra-harness | #4707 | Fleet, hooks, deps, routing, CI reliability |
+| eval-harness | #4913 | UA eval harness: QG grounding/entailment gates, grammar-lexical gate, annotation, bakeoffs, cutovers |
 | benchmark-2156 | #4639 | UA LLM factuality benchmark community release |
 | core-quality | #4274 | Deterministic track audits + remediation (A1–B2) |
 | seminars-folk | #2836 | FOLK re-research + rebuild |

--- a/scripts/config/issue_streams.yaml
+++ b/scripts/config/issue_streams.yaml
@@ -19,8 +19,11 @@ streams:
     title: "Corpus channels — acquisition & ingestion"
     epics: [4706]
   infra-harness:
-    title: "Infra & harness reliability"
+    title: "Infra & fleet reliability (hooks, deps, dispatch, routing)"
     epics: [4707]
+  eval-harness:
+    title: "UA eval harness — QG gates, grammar-lexical gate, annotation, bakeoffs"
+    epics: [4913]
   benchmark-2156:
     title: "Ukrainian LLM factuality benchmark — community release"
     epics: [4639]


### PR DESCRIPTION
Registers stream `eval-harness` → epic #4913 (user-initiated 2026-07-10: 'should we create dedicated harness epic like we have for atlas?' — yes). Members #4797/#4789 already moved from #4707 via the sub-issue API; the auditor's only orphan is #4913 itself, which this registration exempts (epics are exempt once registered). #4707's title tightened to its real contents (fleet/hooks/deps/routing). WORKSTREAMS §Streams mirror updated per the registry header contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)