### PR TITLE
feat(atlas): article-level register treatment for fully-marked lemmas (#4900)

### DIFF
--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -5,6 +5,12 @@ import {
   type WarningSeverity,
 } from "../lib/lexicon/heritage-severity";
 import { getPracticeLemmas } from "../lib/lexicon/atlasDb";
+import {
+  dominantMarkerLabel,
+  isFullyMarkedLemma,
+  morphologyFormCountLabel,
+  registerBadgeLabel,
+} from "../lib/lexicon/register-markers";
 
 interface CourseUsage {
   track: string;
@@ -192,6 +198,11 @@ for (const form of markedForms) {
   }
   group.forms.push(form);
 }
+const morphology = enrichment?.morphology ?? null;
+const isFullyMarked = isFullyMarkedLemma(morphology);
+const dominantRegisterLabel = isFullyMarked ? dominantMarkerLabel(markedForms) : null;
+const MARKED_LEARNER_NOTE =
+  "Це нестандартні або стилістично забарвлені форми, які трапляються в поезії, фольклорі та давніших текстах. Вони не належать до сучасної літературної норми.";
 // entry_type-branched rendering (GH #4385): non-lemma article types are not
 // single inflecting heads, so they must NOT be forced through the lemma
 // paradigm/morphology template. A multiword_term / expression / phraseologism /
@@ -354,6 +365,12 @@ function buildStatusBadges() {
   if (heritage?.classification === "dialect") {
     badges.push({ className: "dialect", label: "Регіонально-літературне" });
   }
+  if (isFullyMarked && dominantRegisterLabel) {
+    badges.push({
+      className: "register",
+      label: registerBadgeLabel(dominantRegisterLabel),
+    });
+  }
   return badges;
 }
 
@@ -410,7 +427,9 @@ function buildArticleOverview() {
     {
       label: "Морфологія",
       ready: Boolean(enrichment?.morphology),
-      detail: enrichment?.morphology ? `${enrichment.morphology.form_count} форм` : "очікує VESUM",
+      detail: enrichment?.morphology
+        ? morphologyFormCountLabel(enrichment.morphology, isFullyMarked)
+        : "очікує VESUM",
     },
     {
       label: "Стилістика",
@@ -726,7 +745,7 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
         <section class="atlas-section">
           <h2>Морфологія</h2>
           <p class="atlas-muted">
-            {enrichment.morphology.pos} · {enrichment.morphology.form_count} форм · {enrichment.morphology.source}
+            {enrichment.morphology.pos} · {morphologyFormCountLabel(enrichment.morphology, isFullyMarked)} · {enrichment.morphology.source}
           </p>
           {nounParadigm ? (
             <table class="paradigm-table">
@@ -758,39 +777,57 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
               ))}
             </>
           ) : (
-            <table class="paradigm-table">
-              <tr><th>Форма</th><th>Позначка</th></tr>
-              {enrichment.morphology.forms.slice(0, 24).map((form) => (
-                <tr>
-                  <td class="form">{form.stress ?? stressDisplay(form.form)}</td>
-                  <td class="case-name">{form.label}</td>
-                </tr>
-              ))}
-            </table>
+            !isFullyMarked && enrichment.morphology.forms.length > 0 && (
+              <table class="paradigm-table">
+                <tr><th>Форма</th><th>Позначка</th></tr>
+                {enrichment.morphology.forms.slice(0, 24).map((form) => (
+                  <tr>
+                    <td class="form">{form.stress ?? stressDisplay(form.form)}</td>
+                    <td class="case-name">{form.label}</td>
+                  </tr>
+                ))}
+              </table>
+            )
           )}
           {markedFormGroups.length > 0 && (
-            <details class="marked-forms">
-              <summary>Марковані форми (нестягнені, застарілі, розмовні)</summary>
-              <p class="atlas-muted marked-forms-note">
-                Це нестандартні або стилістично забарвлені форми, які трапляються в
-                поезії, фольклорі та давніших текстах. Вони не належать до сучасної
-                літературної норми.
-              </p>
-              {markedFormGroups.map((group) => (
-                <div class="marked-forms-group">
-                  <div class="marked-forms-label">{group.marker_label}</div>
-                  <table class="paradigm-table">
-                    <tr><th>Форма</th><th>Позначка</th></tr>
-                    {group.forms.map((form) => (
-                      <tr>
-                        <td class="form">{form.stress ?? stressDisplay(form.form)}</td>
-                        <td class="case-name">{form.label}</td>
-                      </tr>
-                    ))}
-                  </table>
-                </div>
-              ))}
-            </details>
+            isFullyMarked ? (
+              <div class="marked-forms marked-forms-primary">
+                <p class="atlas-muted marked-forms-note">{MARKED_LEARNER_NOTE}</p>
+                {markedFormGroups.map((group) => (
+                  <div class="marked-forms-group">
+                    <div class="marked-forms-label">{group.marker_label}</div>
+                    <table class="paradigm-table">
+                      <tr><th>Форма</th><th>Позначка</th></tr>
+                      {group.forms.map((form) => (
+                        <tr>
+                          <td class="form">{form.stress ?? stressDisplay(form.form)}</td>
+                          <td class="case-name">{form.label}</td>
+                        </tr>
+                      ))}
+                    </table>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <details class="marked-forms">
+                <summary>Марковані форми (нестягнені, застарілі, розмовні)</summary>
+                <p class="atlas-muted marked-forms-note">{MARKED_LEARNER_NOTE}</p>
+                {markedFormGroups.map((group) => (
+                  <div class="marked-forms-group">
+                    <div class="marked-forms-label">{group.marker_label}</div>
+                    <table class="paradigm-table">
+                      <tr><th>Форма</th><th>Позначка</th></tr>
+                      {group.forms.map((form) => (
+                        <tr>
+                          <td class="form">{form.stress ?? stressDisplay(form.form)}</td>
+                          <td class="case-name">{form.label}</td>
+                        </tr>
+                      ))}
+                    </table>
+                  </div>
+                ))}
+              </details>
+            )
           )}
         </section>
       )}

--- a/site/src/lib/lexicon/register-markers.ts
+++ b/site/src/lib/lexicon/register-markers.ts
@@ -1,0 +1,67 @@
+/** Morphology rows carrying VESUM style/register markers (#4891 / #4900). */
+export interface MarkedMorphologyForm {
+  marker_label: string;
+}
+
+export interface MorphologyRegisterCounts {
+  form_count?: number;
+  marked_form_count?: number;
+}
+
+/** Lemma whose entire VESUM paradigm is style-marked (e.g. дин — 32×:short). */
+export function isFullyMarkedLemma(morphology: MorphologyRegisterCounts | null | undefined): boolean {
+  if (!morphology) return false;
+  return (morphology.form_count ?? 0) === 0 && (morphology.marked_form_count ?? 0) > 0;
+}
+
+/** Dominant Ukrainian marker label by form count; ties break on first-seen order. */
+export function dominantMarkerLabel(forms: MarkedMorphologyForm[]): string | null {
+  if (!forms.length) return null;
+  const counts = new Map<string, number>();
+  const order: string[] = [];
+  for (const form of forms) {
+    if (!counts.has(form.marker_label)) order.push(form.marker_label);
+    counts.set(form.marker_label, (counts.get(form.marker_label) ?? 0) + 1);
+  }
+  let best = order[0];
+  let bestCount = 0;
+  for (const label of order) {
+    const count = counts.get(label) ?? 0;
+    if (count > bestCount) {
+      bestCount = count;
+      best = label;
+    }
+  }
+  return best;
+}
+
+// Lemma-level register badge text derived from enrich_manifest _STYLE_MARKER_LABELS (#4895).
+// Neuter short adjectives where the form-level label is feminine («застаріла форма» → «застаріле»).
+const REGISTER_BADGE_LABELS: Record<string, string> = {
+  "застаріла форма": "застаріле",
+  "розмовна форма": "розмовне",
+  "сленгова форма": "сленгове",
+  "рідковживана форма": "рідковживане",
+  "обсценна форма": "обсценне",
+  "спотворена форма": "спотворене",
+  "коротка форма": "коротка форма",
+  "нестягнена форма": "нестягнена форма",
+  "альтернативне написання": "альтернативне написання",
+  "форма за правописом 2019 року": "форма за правописом 2019 року",
+  "форма за правописом 1992 року": "форма за правописом 1992 року",
+  "інша маркована форма": "інша маркована форма",
+};
+
+export function registerBadgeLabel(markerLabel: string): string {
+  return REGISTER_BADGE_LABELS[markerLabel] ?? markerLabel;
+}
+
+export function morphologyFormCountLabel(
+  morphology: MorphologyRegisterCounts,
+  isFullyMarked: boolean,
+): string {
+  if (isFullyMarked) {
+    return `${morphology.marked_form_count} маркованих форм`;
+  }
+  return `${morphology.form_count ?? 0} форм`;
+}

--- a/site/src/styles/word-atlas.css
+++ b/site/src/styles/word-atlas.css
@@ -401,6 +401,12 @@
   border: 1px solid var(--brown);
 }
 
+.status-badge.register {
+  background: var(--orange-light);
+  color: var(--brown);
+  border: 1px solid var(--orange);
+}
+
 .content-area {
   max-width: var(--content-width);
   margin: 0 auto;
@@ -869,6 +875,15 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.02em;
+}
+
+/* #4900 — fully-marked lemmas surface register-marked forms as the primary paradigm. */
+.marked-forms-primary {
+  margin-top: 0;
+}
+
+.marked-forms-primary > .marked-forms-note {
+  margin-top: 0;
 }
 
 .source-box {

--- a/site/tests/unit/atlas-marked-forms.test.ts
+++ b/site/tests/unit/atlas-marked-forms.test.ts
@@ -15,8 +15,13 @@ interface AstroComponentModule {
 
 const MARKED_SUMMARY = 'Марковані форми (нестягнені, застарілі, розмовні)';
 const MARKED_LABEL = 'нестягнена форма';
+const ARCHAIC_LABEL = 'застаріла форма';
+const SHORT_LABEL = 'коротка форма';
 const MARKED_FORM = 'корисная';
+const ARCHAIC_FORM = 'дину';
 const LEARNER_NOTE = 'не належать до сучасної літературної норми';
+const REGISTER_BADGE_SHORT = 'коротка форма';
+const REGISTER_BADGE_ARCHAIC = 'застаріле';
 
 /** A корисний-shaped lemma whose нестягнені (:long) forms are segregated by the enricher. */
 function makeMorphology(withMarked: boolean) {
@@ -42,6 +47,33 @@ function makeMorphology(withMarked: boolean) {
   return morphology;
 }
 
+function makeFullyMarkedMorphology() {
+  return {
+    pos: 'займенник',
+    form_count: 0,
+    forms: [],
+    source: 'VESUM',
+    marked_forms: [
+      { form: 'дин', label: 'чол., називний', marker: 'short', marker_label: SHORT_LABEL },
+      { form: ARCHAIC_FORM, label: 'чол., родовий', marker: 'short', marker_label: SHORT_LABEL },
+    ],
+    marked_form_count: 2,
+  };
+}
+
+function makeFullyMarkedArchaicMorphology() {
+  return {
+    pos: 'іменник',
+    form_count: 0,
+    forms: [],
+    source: 'VESUM',
+    marked_forms: [
+      { form: 'горі', label: 'множина, називний', marker: 'arch', marker_label: ARCHAIC_LABEL },
+    ],
+    marked_form_count: 1,
+  };
+}
+
 function makeEntry(withMarked: boolean) {
   return {
     lemma: 'корисний',
@@ -53,6 +85,22 @@ function makeEntry(withMarked: boolean) {
     primary_source: 'test',
     course_usage: [],
     enrichment: { morphology: makeMorphology(withMarked) },
+  };
+}
+
+function makeFullyMarkedEntry(kind: 'short' | 'archaic' = 'short') {
+  return {
+    lemma: kind === 'short' ? 'дин' : 'горі',
+    url_slug: kind === 'short' ? 'dyn' : 'hori',
+    gloss: null,
+    entry_type: 'lemma',
+    pos: kind === 'short' ? 'pron' : 'noun',
+    ipa: null,
+    primary_source: 'test',
+    course_usage: [],
+    enrichment: {
+      morphology: kind === 'short' ? makeFullyMarkedMorphology() : makeFullyMarkedArchaicMorphology(),
+    },
   };
 }
 
@@ -121,5 +169,99 @@ describe('marked-forms subsection (#4891)', () => {
     expect(html).not.toContain('class="marked-forms"');
     expect(html).not.toContain('<details');
     expect(html).not.toContain(MARKED_FORM);
+  });
+});
+
+describe('fully-marked lemma register treatment (#4900)', () => {
+  let container: AstroContainer;
+  let WordAtlasArticle: AstroComponent;
+  let unmarkedBaseline: string;
+
+  beforeAll(async () => {
+    ({ default: WordAtlasArticle } = (await import(
+      '@site/src/lexicon/WordAtlasArticle.astro'
+    )) as AstroComponentModule);
+    container = await AstroContainer.create();
+    container.addServerRenderer({ renderer: reactRenderer });
+    unmarkedBaseline = await container.renderToString(WordAtlasArticle, {
+      props: {
+        entry: makeEntry(false),
+        allEntries: [],
+        generatedAt: 'test',
+        manifestVersion: 'test',
+      },
+    });
+  });
+
+  function renderFullyMarked(kind: 'short' | 'archaic' = 'short'): Promise<string> {
+    return container.renderToString(WordAtlasArticle, {
+      props: {
+        entry: makeFullyMarkedEntry(kind),
+        allEntries: [],
+        generatedAt: 'test',
+        manifestVersion: 'test',
+      },
+    });
+  }
+
+  test('unmarked lemma rendering is unchanged', async () => {
+    const html = await container.renderToString(WordAtlasArticle, {
+      props: {
+        entry: makeEntry(false),
+        allEntries: [],
+        generatedAt: 'test',
+        manifestVersion: 'test',
+      },
+    });
+    expect(html).toBe(unmarkedBaseline);
+    expect(html).not.toContain('status-badge register');
+  });
+
+  test('fully-marked lemma renders a header register badge from the dominant marker', async () => {
+    const html = await renderFullyMarked('short');
+    expect(html).toContain(`status-badge register`);
+    expect(html).toContain(REGISTER_BADGE_SHORT);
+    expect(html).not.toContain(REGISTER_BADGE_ARCHAIC);
+  });
+
+  test('archaic fully-marked lemma renders the застаріле register badge', async () => {
+    const html = await renderFullyMarked('archaic');
+    expect(html).toContain(`status-badge register`);
+    expect(html).toContain(REGISTER_BADGE_ARCHAIC);
+  });
+
+  test('fully-marked lemma suppresses the empty modern paradigm table', async () => {
+    const html = await renderFullyMarked('short');
+    expect(html).not.toMatch(/0 форм/);
+    expect(html).toContain('2 маркованих форм');
+    // No orphan «Форма | Позначка» shell before the marked block.
+    const morphology = html.slice(html.indexOf('Морфологія'), html.indexOf('marked-forms-primary'));
+    expect(morphology).not.toContain('<table class="paradigm-table">');
+  });
+
+  test('fully-marked lemma renders marked forms expanded, not inside collapsed details', async () => {
+    const html = await renderFullyMarked('short');
+    expect(html).toContain('class="marked-forms marked-forms-primary"');
+    expect(html).not.toContain(MARKED_SUMMARY);
+    expect(html).not.toContain('<details');
+    const text = html.replace(/\s+/g, ' ');
+    expect(text).toContain(LEARNER_NOTE);
+    expect(html.indexOf(LEARNER_NOTE)).toBeLessThan(html.indexOf(ARCHAIC_FORM));
+  });
+
+  test('partial-marked lemma keeps collapsed details behavior', async () => {
+    const html = await container.renderToString(WordAtlasArticle, {
+      props: {
+        entry: makeEntry(true),
+        allEntries: [],
+        generatedAt: 'test',
+        manifestVersion: 'test',
+      },
+    });
+    expect(html).toContain('class="marked-forms"');
+    expect(html).not.toContain('marked-forms-primary');
+    expect(html).toContain('<details');
+    expect(html).toContain(MARKED_SUMMARY);
+    expect(html).not.toContain('status-badge register');
   });
 });


### PR DESCRIPTION
## Summary
- Fully-marked lemmas (`form_count == 0 && marked_form_count > 0`) no longer render an empty «Форма | Позначка» table; marked forms appear expanded with the register learner note first.
- Article header shows a `status-badge register` pill derived from the dominant `marker_label` (e.g. «коротка форма», «застаріле»).
- Unmarked and partially-marked lemmas are unchanged; atlas DB parity fixtures remain byte-identical.

## Test plan
- [x] `npx vitest run tests/unit/atlas-marked-forms.test.ts` — 9/9 pass (badge, empty-table suppression, unmarked baseline, partial-marked collapsed details)
- [x] `npx vitest run tests/unit/atlas-db-read.test.ts` — 4/4 pass (8 parity fixtures, 0 diffs)
- [x] `npm run build` — 6208 pages, no errors
- [x] Ukrainian UI strings VESUM-verified via `mcp_sources_verify_words`

Fixes #4900

Made with [Cursor](https://cursor.com)