### PR TITLE
feat(harness): label-the-union Step 1 tooling — keyed union, scaffold, merge (Refs #4913)

### DIFF
--- a/scripts/audit/grounding_shadow_compare.py
+++ b/scripts/audit/grounding_shadow_compare.py
@@ -19,20 +19,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from scripts.audit import grounding_gate_v2
-from scripts.audit.llm_reviewer_dispatch import (
-    _event_output_text,
-    _grounding_matches_events,
-    _normalize_for_match,
-    _v2_abstain_recovered,
-    tool_events_from_dispatch_meta,
-)
-from scripts.audit.qg_bakeoff import (
-    _artifact_arm_from_path,
-    _is_bakeoff_cell,
-    _match_rows_to_claims,
-    load_fixtures,
-)
+from scripts.audit.grounding_gate_v2 import DEFAULT_TAU
+from scripts.audit.layerb_derivation import derive_keyed_records
 
 
 def parse_args() -> argparse.Namespace:
@@ -158,112 +146,20 @@ def main() -> int:
             try:
                 tau = float(env_tau)
             except ValueError:
-                tau = grounding_gate_v2.DEFAULT_TAU
+                tau = DEFAULT_TAU
         else:
-            tau = grounding_gate_v2.DEFAULT_TAU
-
-    # Load fixtures
-    fixtures = {}
-    if args.fixtures_dir.is_dir():
-        fixtures = {f.slug: f for f in load_fixtures(args.fixtures_dir)}
-    else:
+            tau = DEFAULT_TAU
+    fixtures_dir = args.fixtures_dir if args.fixtures_dir.is_dir() else None
+    if fixtures_dir is None:
         print(
             f"Warning: Fixtures directory not found: {args.fixtures_dir}. False positive rates won't be calculated.",
             file=sys.stderr,
         )
-
-    records: list[dict[str, Any]] = []
-
-    # Find and process all bakeoff cell json files
-    for path in sorted(args.artifacts_dir.glob("*.json")):
-        try:
-            artifact = json.loads(path.read_text(encoding="utf-8"))
-        except Exception as exc:
-            print(f"Warning: Failed to parse {path.name}: {exc}", file=sys.stderr)
-            continue
-
-        if not _is_bakeoff_cell(artifact):
-            continue
-
-        payload = artifact.get("payload") or {}
-        dispatch_meta = artifact.get("dispatch") or {}
-        slug = (artifact.get("fixture") or {}).get("slug")
-        fixture = fixtures.get(slug) if isinstance(slug, str) else None
-        arm = _artifact_arm_from_path(path, artifact)
-        seat = artifact.get("seat") or artifact.get("model") or "unknown"
-
-        events = tool_events_from_dispatch_meta(dispatch_meta)
-
-        fact_checks = payload.get("fact_checks", [])
-        if not isinstance(fact_checks, list):
-            fact_checks = []
-
-        row_to_claim_idx = {}
-        if fixture is not None:
-            fc_list = [dict(fc) for fc in fact_checks]
-            matched, _ = _match_rows_to_claims(fc_list, fixture)
-            for claim_id, row in matched.items():
-                for idx, orig_row in enumerate(fc_list):
-                    if orig_row is row:
-                        row_to_claim_idx[idx] = claim_id
-                        break
-
-        for idx, fc in enumerate(fact_checks):
-            if not isinstance(fc, Mapping):
-                continue
-            grounding = fc.get("grounding")
-            if not isinstance(grounding, Mapping):
-                continue
-
-            claim_text = str(fc.get("claim") or "")
-            excerpt_text = str(grounding.get("evidence_excerpt") or "")
-
-            # Run v1
-            v1_admissible = _grounding_matches_events(grounding, events)
-
-            # Run v2
-            res_v2 = grounding_gate_v2.anchor_evidence_to_events(grounding, events, tau=tau)
-            v2_anchored = res_v2.anchored
-            v2_abstained = res_v2.abstained
-            similarity = res_v2.similarity
-
-            tool_query_matched = False
-            if res_v2.source_index is not None:
-                tool_query_matched = grounding_gate_v2._tool_query_match(grounding, events[res_v2.source_index])
-
-            best_span_preview = ""
-            if res_v2.span is not None and res_v2.source_index is not None:
-                out_text = _event_output_text(events[res_v2.source_index])
-                if out_text is not None:
-                    norm_out = _normalize_for_match(out_text)
-                    best_span_preview = norm_out[res_v2.span[0] : res_v2.span[1]][:160]
-
-            gold_is_true = None
-            if (claim_id := row_to_claim_idx.get(idx)) and fixture is not None:
-                claim_obj = next((c for c in fixture.claims if c.claim_id == claim_id), None)
-                if claim_obj is not None:
-                    gold_is_true = claim_obj.is_true
-
-            abstain_recovered = _v2_abstain_recovered(res_v2)
-            v2_effective = v2_anchored or abstain_recovered
-
-            records.append(
-                {
-                    "fixture": slug or "unknown",
-                    "seat_arm": f"{seat}/{arm}",
-                    "claim": claim_text,
-                    "excerpt": excerpt_text,
-                    "v1_admissible": v1_admissible,
-                    "v2_anchored": v2_anchored,
-                    "v2_abstained": v2_abstained,
-                    "similarity": similarity,
-                    "abstain_recovered": abstain_recovered,
-                    "v2_effective": v2_effective,
-                    "tool_query_matched": tool_query_matched,
-                    "best_span_preview": best_span_preview,
-                    "gold_is_true": gold_is_true,
-                }
-            )
+    source_records = derive_keyed_records(args.artifacts_dir, fixtures_dir=fixtures_dir, tau=tau)
+    records = [
+        {key: value for key, value in record.items() if key not in {"grounding_key", "fact_check_index"}}
+        for record in source_records
+    ]
 
     # Calculate statistics
     stats = compute_summary(records)

--- a/scripts/audit/layerb_candidates.py
+++ b/scripts/audit/layerb_candidates.py
@@ -36,10 +36,10 @@ from hashlib import sha256
 from typing import Any
 
 from scripts.audit import anchor_primitives
+from scripts.audit.layerb_keys import EVENT_OUTPUT_IDENTITY_VERSION
 
 CANDIDATE_SCHEMA_VERSION = "qg-anchor-candidate.v1"
 ANCHOR_SET_SCHEMA_VERSION = "qg-anchor-set.v1"
-EVENT_OUTPUT_IDENTITY_VERSION = "qg-event-output.v1"
 CANONICAL_SOURCE_IDENTITY_VERSION = "qg-canonical-source.v1"
 MAX_SCANNED_OUTPUT_CHARS = 50_000
 MAX_CANDIDATE_WINDOWS = 64

--- a/scripts/audit/layerb_derivation.py
+++ b/scripts/audit/layerb_derivation.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Pure source derivation for offline Layer B comparison records.
+
+The comparison record is reconstructed while each raw bakeoff artifact and
+``fact_checks`` entry is in hand.  That is the only point at which the stable
+grounding identity is unambiguous; downstream label tools must never recover it
+by matching a duplicate-prone rendered row.
+
+This module deliberately has no reviewer-dispatch or bakeoff-runtime imports.
+It shares only the stateless Layer A primitives and so is safe to import from
+the offline label-handoff tools.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.audit import anchor_primitives, grounding_gate_v2
+from scripts.audit.layerb_keys import _stable_grounding_key
+from scripts.audit.layerb_label_common import LabelJoinError
+
+DEFAULT_TAU = 0.75
+_CLAIM_PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
+_LEADING_CLAIM_FILLER_RE = re.compile(r"^(?:або|чи)\s+", re.IGNORECASE)
+_RECOVER_ABSTAIN_MIN_SIMILARITY = 1.0
+_ARMS = frozenset({"bare", "tooled", "both"})
+
+
+@dataclass(frozen=True)
+class FixtureClaim:
+    """The fixture fields required for deterministic truth lookup."""
+
+    claim_id: str
+    claim: str
+    is_true: bool
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LabelJoinError(f"cannot read source JSON {path}: {exc}") from exc
+
+
+def _normalize_claim_loose(text: str) -> str:
+    """Mirror the baked comparison's punctuation-insensitive claim matching."""
+    normalized = unicodedata.normalize("NFC", text).lower()
+    normalized = normalized.replace("’", "'").replace("`", "'")
+    normalized = re.sub(r"\s+", " ", normalized).strip(" \t\r\n.。")
+    normalized = _LEADING_CLAIM_FILLER_RE.sub("", normalized)
+    return " ".join(_CLAIM_PUNCT_RE.sub(" ", normalized).split())
+
+
+def _judgment_verdict(row: Mapping[str, Any]) -> str:
+    if row.get("admissibility_downgraded") is True and isinstance(row.get("original_verdict"), str):
+        return str(row["original_verdict"]).strip().upper()
+    return str(row.get("verdict") or "").strip().upper()
+
+
+def _load_fixture_claims(fixtures_dir: Path | None) -> dict[str, tuple[FixtureClaim, ...]]:
+    if fixtures_dir is None:
+        return {}
+    if not fixtures_dir.is_dir():
+        raise LabelJoinError(f"fixtures directory does not exist: {fixtures_dir}")
+    fixtures: dict[str, tuple[FixtureClaim, ...]] = {}
+    for path in sorted(fixtures_dir.glob("*.json")):
+        document = _read_json(path)
+        if not isinstance(document, Mapping):
+            raise LabelJoinError(f"fixture is not an object: {path}")
+        slug = document.get("slug")
+        raw_claims = document.get("claims")
+        if not isinstance(slug, str) or not slug or not isinstance(raw_claims, list):
+            raise LabelJoinError(f"fixture lacks slug or claims: {path}")
+        claims: list[FixtureClaim] = []
+        for item in raw_claims:
+            if not isinstance(item, Mapping):
+                raise LabelJoinError(f"fixture claim is not an object: {path}")
+            claim_id = item.get("claim_id")
+            claim = item.get("claim")
+            is_true = item.get("is_true")
+            if not isinstance(claim_id, str) or not isinstance(claim, str) or not isinstance(is_true, bool):
+                raise LabelJoinError(f"fixture claim lacks identity or truth value: {path}")
+            claims.append(FixtureClaim(claim_id, claim, is_true))
+        fixtures[slug] = tuple(claims)
+    if not fixtures:
+        raise LabelJoinError(f"no bakeoff fixtures found in {fixtures_dir}")
+    return fixtures
+
+
+def _match_rows_to_fixture_claims(
+    rows: list[dict[str, Any]], claims: Sequence[FixtureClaim]
+) -> dict[str, dict[str, Any]]:
+    """Reuse the frozen comparison's precedence and polarity guard exactly."""
+    matched: dict[str, dict[str, Any]] = {}
+    norm_rows = [(_normalize_claim_loose(str(row.get("claim") or "")), row) for row in rows]
+    for claim in claims:
+        wanted = _normalize_claim_loose(claim.claim)
+        if not wanted:
+            continue
+        hit = next((index for index, (row_claim, _row) in enumerate(norm_rows) if row_claim == wanted), None)
+        if hit is None:
+            candidates = [
+                index
+                for index, (row_claim, row) in enumerate(norm_rows)
+                if row_claim
+                and wanted in row_claim
+                and (not claim.is_true or _judgment_verdict(row) == "CONFIRMED")
+            ]
+            if candidates:
+                hit = min(candidates, key=lambda index: len(norm_rows[index][0]))
+        if hit is None:
+            candidates = [
+                index
+                for index, (row_claim, _row) in enumerate(norm_rows)
+                if row_claim and row_claim in wanted and len(row_claim) >= max(20, int(0.6 * len(wanted)))
+            ]
+            if candidates:
+                hit = max(candidates, key=lambda index: len(norm_rows[index][0]))
+        if hit is not None:
+            matched[claim.claim_id] = norm_rows[hit][1]
+    return matched
+
+
+def _artifact_is_bakeoff_cell(artifact: Mapping[str, Any]) -> bool:
+    schema = artifact.get("schema_version")
+    return isinstance(schema, str) and schema.startswith("qg_bakeoff_run.")
+
+
+def _artifact_arm(path: Path, artifact: Mapping[str, Any]) -> str:
+    arm = artifact.get("arm")
+    if isinstance(arm, str) and arm in _ARMS:
+        return arm
+    return "bare" if "__bare" in path.stem else "tooled"
+
+
+def _tool_events(dispatch: Any) -> tuple[dict[str, Any], ...]:
+    if not isinstance(dispatch, Mapping):
+        return ()
+    raw_events = dispatch.get("tool_events")
+    if not isinstance(raw_events, Sequence) or isinstance(raw_events, (str, bytes)):
+        return ()
+    return tuple(dict(event) for event in raw_events if isinstance(event, Mapping))
+
+
+def _grounding_matches_events(grounding: Mapping[str, Any], events: Sequence[Mapping[str, Any]]) -> bool:
+    query = str(grounding.get("query") or "").strip()
+    excerpt = str(grounding.get("evidence_excerpt") or "").strip()
+    if not query or not excerpt:
+        return False
+    tool = anchor_primitives.canonical_tool_name(grounding.get("tool"))
+    for event in events:
+        if tool and anchor_primitives.canonical_tool_name(event.get("tool")) != tool:
+            continue
+        if not anchor_primitives.event_input_matches_query(event, query):
+            continue
+        output = anchor_primitives.event_output_text(event)
+        if output is not None and anchor_primitives.output_contains_excerpt(output, excerpt):
+            return True
+    return False
+
+
+def _abstain_recovered(result: grounding_gate_v2.AnchorResult) -> bool:
+    return result.abstained and result.similarity >= _RECOVER_ABSTAIN_MIN_SIMILARITY
+
+
+def derive_keyed_records(
+    artifacts_dir: Path,
+    *,
+    fixtures_dir: Path | None,
+    tau: float = DEFAULT_TAU,
+) -> list[dict[str, Any]]:
+    """Regenerate records and keys while walking ``(artifact, fact_check)``.
+
+    The emitted non-key fields are intentionally identical to the historical
+    ``grounding_shadow_compare`` records at the same tau.  The two identity
+    fields are appended at source and are therefore not the result of a join.
+    A comparison-only caller may pass ``fixtures_dir=None`` to retain the
+    legacy no-gold fallback; source-keyed label derivation passes a real
+    fixture directory and proves every field against its frozen baseline.
+    """
+    if not artifacts_dir.is_dir():
+        raise LabelJoinError(f"artifacts directory does not exist: {artifacts_dir}")
+    fixtures = _load_fixture_claims(fixtures_dir)
+    records: list[dict[str, Any]] = []
+    for path in sorted(artifacts_dir.glob("*.json")):
+        artifact = _read_json(path)
+        if not isinstance(artifact, Mapping):
+            continue
+        if not _artifact_is_bakeoff_cell(artifact):
+            continue
+        payload = artifact.get("payload")
+        fact_checks = payload.get("fact_checks") if isinstance(payload, Mapping) else []
+        if not isinstance(fact_checks, list):
+            fact_checks = []
+        fixture_data = artifact.get("fixture")
+        slug = fixture_data.get("slug") if isinstance(fixture_data, Mapping) else None
+        fixture = fixtures.get(slug) if isinstance(slug, str) else None
+        if not all(isinstance(fact_check, Mapping) for fact_check in fact_checks):
+            raise LabelJoinError(f"bakeoff fact_checks contains a non-object: {path}")
+        fact_rows = [dict(fact_check) for fact_check in fact_checks]
+        matched = _match_rows_to_fixture_claims(fact_rows, fixture) if fixture is not None else {}
+        truth_by_fact_index: dict[int, bool] = {}
+        for claim_id, row in matched.items():
+            truth = next(claim.is_true for claim in fixture if claim.claim_id == claim_id)
+            index = next(index for index, source_row in enumerate(fact_rows) if source_row is row)
+            truth_by_fact_index[index] = truth
+        events = _tool_events(artifact.get("dispatch"))
+        seat = artifact.get("seat") or artifact.get("model") or "unknown"
+        seat_arm = f"{seat}/{_artifact_arm(path, artifact)}"
+        for fact_check_index, fact_check in enumerate(fact_checks):
+            if not isinstance(fact_check, Mapping):
+                continue
+            grounding = fact_check.get("grounding")
+            if not isinstance(grounding, Mapping):
+                continue
+            v1_admissible = _grounding_matches_events(grounding, events)
+            result = grounding_gate_v2.anchor_evidence_to_events(grounding, events, tau=tau)
+            tool_query_matched = False
+            if result.source_index is not None:
+                tool_query_matched = grounding_gate_v2._tool_query_match(grounding, events[result.source_index])
+            best_span_preview = ""
+            if result.span is not None and result.source_index is not None:
+                output = anchor_primitives.event_output_text(events[result.source_index])
+                if output is not None:
+                    normalized_output = anchor_primitives.normalize_for_match(output)
+                    best_span_preview = normalized_output[result.span[0] : result.span[1]][:160]
+            record = {
+                "fixture": slug or "unknown",
+                "seat_arm": seat_arm,
+                "claim": str(fact_check.get("claim") or ""),
+                "excerpt": str(grounding.get("evidence_excerpt") or ""),
+                "v1_admissible": v1_admissible,
+                "v2_anchored": result.anchored,
+                "v2_abstained": result.abstained,
+                "similarity": result.similarity,
+                "abstain_recovered": _abstain_recovered(result),
+                "v2_effective": result.anchored or _abstain_recovered(result),
+                "tool_query_matched": tool_query_matched,
+                "best_span_preview": best_span_preview,
+                "gold_is_true": truth_by_fact_index.get(fact_check_index),
+                "grounding_key": _stable_grounding_key(path, fact_check_index, fact_check),
+                "fact_check_index": fact_check_index,
+            }
+            records.append(record)
+    keys = [str(record["grounding_key"]) for record in records]
+    if len(keys) != len(set(keys)):
+        raise LabelJoinError("source derivation emitted duplicate grounding keys")
+    return records

--- a/scripts/audit/layerb_keys.py
+++ b/scripts/audit/layerb_keys.py
@@ -1,0 +1,120 @@
+"""Pure identity helpers shared by offline Layer B tooling.
+
+This module is deliberately stdlib-only.  Label handoff tools use these
+helpers without importing the shadow runner, which owns reviewer dispatch and
+other runtime-facing concerns.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+EVENT_OUTPUT_IDENTITY_VERSION = "qg-event-output.v1"
+_STABLE_SOURCE_FIELDS = ("document_id", "source_id", "url", "revision", "section_id", "item_id")
+
+
+def _canonical_json(value: Any) -> str:
+    """Serialize identity material in the established canonical form."""
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _sha256_text(value: str) -> str:
+    """Return the lowercase SHA-256 of UTF-8 text."""
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
+def _event_output_text(event: Mapping[str, Any]) -> str | None:
+    """Extract output text using Layer A's established deterministic form."""
+    output = event.get("output")
+    if output is None:
+        return None
+    if isinstance(output, str):
+        return output
+    if isinstance(output, (Mapping, list)):
+        return json.dumps(output, ensure_ascii=False, default=str)
+    return str(output)
+
+
+def _canonical_tool_name(name: Any) -> str:
+    """Canonicalize tool identity without widening malformed names."""
+    canonical = str(name or "").strip()
+    if not canonical:
+        return ""
+    for prefix in ("mcp__", "mcp_"):
+        if canonical.startswith(prefix):
+            canonical = canonical[len(prefix) :]
+            break
+    if "." in canonical:
+        server, _separator, tool = canonical.partition(".")
+        if server and tool:
+            canonical = tool
+    else:
+        for prefix in ("sources__", "sources_"):
+            if canonical.startswith(prefix):
+                canonical = canonical[len(prefix) :]
+                break
+    return canonical.casefold()
+
+
+def _capture_complete(event: Mapping[str, Any]) -> bool:
+    """Return explicit capture completeness; unknown is treated as complete."""
+    return (
+        not any(event.get(key) is True for key in ("output_truncated", "truncated", "capture_truncated"))
+        and event.get("output_capture_complete") is not False
+    )
+
+
+def _stable_source_material(event: Mapping[str, Any]) -> dict[str, Any]:
+    """Extract only declared stable source fields; never infer IDs from prose."""
+    material: dict[str, Any] = {}
+    for container in (event, event.get("input")):
+        if isinstance(container, Mapping):
+            for key in _STABLE_SOURCE_FIELDS:
+                value = container.get(key)
+                if value not in (None, ""):
+                    material[key] = value
+    return material
+
+
+def _stable_grounding_key(path: Path, fact_index: int, fact_check: Mapping[str, Any]) -> str:
+    """Return the persistent fact-check identity used by the shadow runner."""
+    explicit = fact_check.get("fact_check_id")
+    if isinstance(explicit, str) and explicit.strip():
+        suffix = explicit.strip()
+    else:
+        suffix = _sha256_text(_canonical_json(fact_check))[:16]
+    return f"{path.name}#fact_checks[{fact_index}]::{suffix}"
+
+
+def _build_event_index(events: Sequence[Mapping[str, Any]]) -> dict[str, str]:
+    """Map materializer-derived event IDs to captured raw output safely."""
+    index: dict[str, str] = {}
+    for event in events:
+        raw = _event_output_text(event)
+        if raw is None:
+            continue
+        material = {
+            "version": EVENT_OUTPUT_IDENTITY_VERSION,
+            "tool": _canonical_tool_name(event.get("tool")),
+            "query": _canonical_json(event.get("input") if "input" in event else {}),
+            "status_envelope": {
+                "status": event.get("status"),
+                "error": event.get("error"),
+                "errors": event.get("errors"),
+            },
+            "stable_source": _stable_source_material(event),
+            "raw_output_sha256": _sha256_text(raw),
+            "output_capture_complete": _capture_complete(event),
+        }
+        event_id = _sha256_text(_canonical_json(material))
+        previous = index.get(event_id)
+        if previous is not None and previous != raw:
+            # An identity collision with different bytes is unsafe to use.
+            index.pop(event_id, None)
+            continue
+        index[event_id] = raw
+    return index

--- a/scripts/audit/layerb_label_common.py
+++ b/scripts/audit/layerb_label_common.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Shared deterministic primitives for the offline Layer B label tools.
 
-This module intentionally contains only stdlib code plus the already-offline
-Layer B shadow helper.  It is not imported by the QG runtime.
+This module intentionally contains only stdlib code plus the pure Layer B
+identity helper.  It is not imported by the QG runtime.
 """
 
 from __future__ import annotations
@@ -16,7 +16,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
-from scripts.audit.layerb_shadow import _stable_grounding_key
+from scripts.audit.layerb_keys import _stable_grounding_key
 
 
 class LabelJoinError(ValueError):
@@ -238,6 +238,120 @@ def render_key(key: Sequence[str]) -> str:
     return canonical_json(list(key))
 
 
+def _shadow_candidate_profile(shadow: Mapping[str, Any]) -> str:
+    """Canonicalize every Layer-A field that can change emitted candidates."""
+    layer_a = shadow.get("layer_a")
+    if not isinstance(layer_a, Mapping):
+        raise LabelJoinError(f"shadow record has no Layer A object: {shadow.get('grounding_key')!r}")
+    candidates = layer_a.get("candidates")
+    if not isinstance(candidates, list) or not all(isinstance(candidate, Mapping) for candidate in candidates):
+        raise LabelJoinError(f"shadow Layer A candidates are malformed: {shadow.get('grounding_key')!r}")
+    return canonical_json(
+        {
+            "decision": layer_a.get("decision"),
+            "reason": layer_a.get("reason"),
+            "candidate_set_complete": layer_a.get("candidate_set_complete"),
+            # Candidate IDs, source indexes, similarities, hashes, and spans
+            # are retained in full; sorting makes member order immaterial.
+            "candidates": sorted(canonical_json(dict(candidate)) for candidate in candidates),
+        }
+    )
+
+
+def _shadow_matches_derivation(
+    derivation: Mapping[str, Any], shadow: Mapping[str, Any], corpus: Mapping[str, Mapping[str, Any]]
+) -> bool:
+    """Check every derivation signal represented by the shadow evidence.
+
+    The source-index check is performed by :func:`resolve_derivation_indices`
+    before this join.  This function then verifies the fact-check structural
+    correspondence plus every per-fact Layer-A signal preserved by both
+    reports.  Fields not retained by the shadow report are deliberately not
+    invented as a matching heuristic.
+    """
+    _artifact_path, fact_check = artifact_fact_check(shadow, corpus)
+    if (
+        str(derivation.get("fixture") or "") != str(shadow.get("fixture") or "")
+        or str(derivation.get("claim") or "") != str(fact_check.get("claim") or "")
+        or str(derivation.get("excerpt") or "") != excerpt_from_fact_check(fact_check)
+    ):
+        return False
+    layer_a = shadow.get("layer_a")
+    if not isinstance(layer_a, Mapping):
+        return False
+    candidates = layer_a.get("candidates")
+    if not isinstance(candidates, list) or not all(isinstance(candidate, Mapping) for candidate in candidates):
+        return False
+
+    anchored = layer_a.get("decision") == "ANCHOR"
+    if isinstance(derivation.get("v2_anchored"), bool) and derivation["v2_anchored"] is not anchored:
+        return False
+    # A non-recovered effective result has the same meaning as the materialized
+    # Layer-A anchor.  Abstain recovery is not retained in the shadow record,
+    # so it cannot be used as a fabricated identity signal.
+    if (
+        derivation.get("abstain_recovered") is not True
+        and isinstance(derivation.get("v2_effective"), bool)
+        and derivation["v2_effective"] is not anchored
+    ):
+        return False
+    if (
+        isinstance(derivation.get("similarity"), (int, float))
+        and not isinstance(derivation.get("similarity"), bool)
+        and not any(candidate.get("similarity") == derivation["similarity"] for candidate in candidates)
+    ):
+        return False
+    return not (
+        isinstance(derivation.get("tool_query_matched"), bool)
+        and not any(candidate.get("tool_query_matched") is derivation["tool_query_matched"] for candidate in candidates)
+    )
+
+
+def _unrepresented_derivation_profile(row: Mapping[str, Any]) -> str:
+    """Return fields that cannot safely identify a particular shadow record.
+
+    A duplicate group may use per-row matching only when every field not
+    preserved by the shadow is uniform across the group.  Otherwise a unique
+    match on a subset would still silently assign a fact-check key across a
+    derivation distinction that the shadow cannot verify.
+    """
+    represented = {
+        "fixture",
+        "seat_arm",
+        "claim",
+        "excerpt",
+        "source_index",
+        "union_categories",
+        "v2_anchored",
+        "v2_effective",
+        "similarity",
+        "tool_query_matched",
+    }
+    return canonical_json({key: value for key, value in row.items() if key not in represented})
+
+
+def _unique_perfect_matching(edges: Sequence[Sequence[int]]) -> list[int] | None:
+    """Return the sole perfect matching, or ``None`` when it is absent/ambiguous."""
+    solutions: list[list[int]] = []
+
+    def search(row: int, used: set[int], selected: list[int]) -> None:
+        if len(solutions) > 1:
+            return
+        if row == len(edges):
+            solutions.append(list(selected))
+            return
+        for candidate in edges[row]:
+            if candidate not in used:
+                used.add(candidate)
+                selected.append(candidate)
+                search(row + 1, used, selected)
+                selected.pop()
+                used.remove(candidate)
+
+    search(0, set(), [])
+    return solutions[0] if len(solutions) == 1 else None
+
+
 def _derivation_comparable(row: Mapping[str, Any]) -> dict[str, Any]:
     """Discard only union membership metadata for an exact source-index check."""
     return {key: value for key, value in row.items() if key not in {"union_categories", "source_index"}}
@@ -291,27 +405,50 @@ def resolve_derivation_to_shadow(
     derivations: Sequence[Mapping[str, Any]],
     shadows: Sequence[Mapping[str, Any]],
     corpus: Mapping[str, Mapping[str, Any]],
-) -> dict[int, dict[str, Any]]:
-    """Create a total deterministic multiset bijection to unordered shadow rows.
+    *,
+    derivation_indexes: Sequence[int] | None = None,
+) -> tuple[dict[int, dict[str, Any]], dict[tuple[str, str, str, str], dict[str, Any]]]:
+    """Create a total derivation-to-shadow bijection without positional pairing.
 
-    Group membership is an exact tuple of seat metadata, fixture, claim, and
-    raw evidence excerpt.  Only ties *within that exact group* are ordered by
-    stable derivation index and immutable grounding key.  This never relies on
-    the (known-different) global iteration order of the two frozen reports.
+    A singleton structural key is self-identifying.  A duplicate group must
+    instead either have one evidence-backed perfect matching, or first prove
+    that every member has the same complete candidate-relevant Layer-A
+    profile.  There is intentionally no sort-and-zip fallback for a group
+    whose members might carry different grounding identities.
     """
+    if derivation_indexes is None:
+        selected_indexes = list(range(len(derivations)))
+        require_full_bijection = True
+    else:
+        selected_indexes = list(derivation_indexes)
+        require_full_bijection = False
+        if len(set(selected_indexes)) != len(selected_indexes) or any(
+            index < 0 or index >= len(derivations) for index in selected_indexes
+        ):
+            raise LabelJoinError("selected derivation indexes must be unique in-range integers")
+
     derivation_groups: dict[tuple[str, str, str, str], list[int]] = defaultdict(list)
     shadow_groups: dict[tuple[str, str, str, str], list[dict[str, Any]]] = defaultdict(list)
-    for index, row in enumerate(derivations):
+    for index in selected_indexes:
+        row = derivations[index]
         derivation_groups[structural_key_from_union(row)].append(index)
     for shadow in shadows:
         shadow_groups[structural_key_from_shadow(shadow, corpus)].append(dict(shadow))
 
     missing = sorted(render_key(key) for key in derivation_groups.keys() - shadow_groups.keys())
-    extra = sorted(render_key(key) for key in shadow_groups.keys() - derivation_groups.keys())
+    extra = (
+        sorted(render_key(key) for key in shadow_groups.keys() - derivation_groups.keys())
+        if require_full_bijection
+        else []
+    )
     count_mismatches = sorted(
         render_key(key)
         for key in derivation_groups.keys() & shadow_groups.keys()
-        if len(derivation_groups[key]) != len(shadow_groups[key])
+        if (
+            len(derivation_groups[key]) != len(shadow_groups[key])
+            if require_full_bijection
+            else len(derivation_groups[key]) > len(shadow_groups[key])
+        )
     )
     if missing or extra or count_mismatches:
         details: list[str] = []
@@ -324,19 +461,73 @@ def resolve_derivation_to_shadow(
         raise LabelJoinError("derivation-to-shadow bijection failed: " + "; ".join(details))
 
     mapped: dict[int, dict[str, Any]] = {}
+    resolutions: dict[tuple[str, str, str, str], dict[str, Any]] = {}
     seen_keys: set[str] = set()
     for key in sorted(derivation_groups):
         indexes = sorted(derivation_groups[key])
-        candidates = sorted(shadow_groups[key], key=lambda row: str(row.get("grounding_key") or ""))
-        for index, shadow in zip(indexes, candidates, strict=True):
+        candidates = list(shadow_groups[key])
+        if len(indexes) == 1 and len(candidates) == 1:
+            pairs = [(indexes[0], candidates[0])]
+            resolution_basis = "unique_structural_key"
+        else:
+            profiles = {_shadow_candidate_profile(candidate) for candidate in candidates}
+            if len(profiles) == 1:
+                # This order is used only after the complete candidate profile
+                # has proven that all pairings are harmless.
+                pairs = list(
+                    zip(indexes, sorted(candidates, key=lambda row: str(row.get("grounding_key") or "")), strict=True)
+                )
+                resolution_basis = "equivalence_class"
+            else:
+                unrepresented_profiles = {_unrepresented_derivation_profile(derivations[index]) for index in indexes}
+                if len(unrepresented_profiles) != 1:
+                    raise LabelJoinError(
+                        "duplicate structural-key group has differing derivation fields that are not preserved "
+                        f"by the shadow record: key={render_key(key)} derivation_indexes={indexes}"
+                    )
+                ordered_candidates = sorted(candidates, key=lambda row: str(row.get("grounding_key") or ""))
+                edges = [
+                    [
+                        candidate_index
+                        for candidate_index, shadow in enumerate(ordered_candidates)
+                        if _shadow_matches_derivation(derivations[index], shadow, corpus)
+                    ]
+                    for index in indexes
+                ]
+                matching = _unique_perfect_matching(edges)
+                if matching is None:
+                    edge_counts = [len(edge) for edge in edges]
+                    raise LabelJoinError(
+                        "duplicate structural-key group cannot be resolved by per-row identity or equivalence "
+                        f"class: key={render_key(key)} derivation_indexes={indexes} candidate_edge_counts={edge_counts}"
+                    )
+                pairs = [
+                    (index, ordered_candidates[candidate_index])
+                    for index, candidate_index in zip(indexes, matching, strict=True)
+                ]
+                resolution_basis = "per_row_identity"
+        for index, shadow in pairs:
             grounding_key = shadow.get("grounding_key")
             if not isinstance(grounding_key, str) or grounding_key in seen_keys:
                 raise LabelJoinError(f"shadow grounding keys are not unique: {grounding_key!r}")
             seen_keys.add(grounding_key)
             mapped[index] = shadow
-    if len(mapped) != len(derivations) or len(seen_keys) != len(shadows):
+        resolutions[key] = {
+            "resolution_basis": resolution_basis,
+            "derivation_indexes": indexes,
+            "identity_fields": [
+                "union source_index -> exact derivation row",
+                "fact-check fixture/claim/evidence excerpt",
+                "layer_a.decision <-> v2_anchored",
+                "candidate.similarity",
+                "candidate.tool_query_matched",
+                "all shadow-unrepresented derivation fields equal within group",
+                "complete candidate profile (equivalence only)",
+            ],
+        }
+    if len(mapped) != len(selected_indexes) or (require_full_bijection and len(seen_keys) != len(shadows)):
         raise LabelJoinError(
-            f"derivation-to-shadow mapping is not total/bijective: derivation={len(derivations)} "
-            f"mapped={len(mapped)} shadow={len(shadows)}"
+            f"derivation-to-shadow mapping is not total/bijective: derivation={len(selected_indexes)} "
+            f"mapped={len(mapped)} shadow={len(shadows)} full_bijection={require_full_bijection}"
         )
-    return mapped
+    return mapped, resolutions

--- a/scripts/audit/layerb_label_common.py
+++ b/scripts/audit/layerb_label_common.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Shared deterministic primitives for the offline Layer B label tools.
+
+This module intentionally contains only stdlib code plus the already-offline
+Layer B shadow helper.  It is not imported by the QG runtime.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+import re
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from scripts.audit.layerb_shadow import _stable_grounding_key
+
+
+class LabelJoinError(ValueError):
+    """A frozen-input identity or accounting invariant failed."""
+
+
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+FACT_CHECK_INDEX_RE = re.compile(r"#fact_checks\[(\d+)\]::")
+
+
+def canonical_json(value: Any) -> str:
+    """Return a stable JSON representation used only for deterministic keys."""
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    """Hash immutable source bytes without interpreting their encoding."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise LabelJoinError(f"cannot read JSON input {path}: {exc}") from exc
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    """Atomically replace one output; a partial file is never publishable."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(text, encoding="utf-8")
+    temporary.replace(path)
+
+
+def atomic_write_json(path: Path, payload: Any) -> None:
+    atomic_write_text(path, json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+
+
+def atomic_write_jsonl(path: Path, rows: Iterable[Mapping[str, Any]]) -> None:
+    atomic_write_text(
+        path,
+        "".join(json.dumps(row, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n" for row in rows),
+    )
+
+
+def _dict_prefix(value: str) -> tuple[str, str]:
+    """Split a legacy ``{...}/tooled`` seat arm without evaluating its suffix."""
+    start = value.find("{")
+    if start == -1:
+        raise LabelJoinError(f"seat_arm has no dictionary prefix: {value!r}")
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for index, character in enumerate(value[start:], start=start):
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == quote:
+                quote = None
+            continue
+        if character in {"'", '"'}:
+            quote = character
+        elif character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                return value[start : index + 1], value[index + 1 :]
+    raise LabelJoinError(f"seat_arm has an unclosed dictionary prefix: {value!r}")
+
+
+def parse_seat_arm(value: Any) -> tuple[dict[str, Any], str]:
+    """Parse the documented stringified seat metadata and its trailing arm."""
+    if not isinstance(value, str):
+        raise LabelJoinError(f"seat_arm must be a string, got {type(value).__name__}")
+    prefix, suffix = _dict_prefix(value)
+    try:
+        parsed = ast.literal_eval(prefix)
+    except (SyntaxError, ValueError) as exc:
+        raise LabelJoinError(f"seat_arm dictionary cannot be parsed: {value!r}") from exc
+    if not isinstance(parsed, dict):
+        raise LabelJoinError("seat_arm dictionary prefix did not parse to an object")
+    return parsed, suffix
+
+
+def artifact_filename_from_union(row: Mapping[str, Any]) -> str:
+    """Return the documented base artifact filename from a frozen union row.
+
+    Historical replays may add a run suffix (for example ``__r2``).  The
+    keyed shadow record remains authoritative in that case; this helper keeps
+    the documented base identity available for fresh future derivations.
+    """
+    seat, _arm = parse_seat_arm(row.get("seat_arm"))
+    pin_slug = seat.get("pin_slug")
+    fixture = row.get("fixture")
+    if not isinstance(pin_slug, str) or not pin_slug or not isinstance(fixture, str) or not fixture:
+        raise LabelJoinError("seat_arm.pin_slug and fixture are required for an artifact filename")
+    return f"{pin_slug}__{fixture}.json"
+
+
+def fact_check_index_from_key(grounding_key: str) -> int:
+    match = FACT_CHECK_INDEX_RE.search(grounding_key)
+    if match is None:
+        raise LabelJoinError(f"grounding_key has no fact-check index: {grounding_key!r}")
+    return int(match.group(1))
+
+
+def _rows(document: Any, name: str) -> list[dict[str, Any]]:
+    if isinstance(document, list):
+        rows = document
+    elif isinstance(document, Mapping):
+        rows = document.get("rows")
+        if not isinstance(rows, list):
+            rows = document.get("records")
+    else:
+        rows = None
+    if not isinstance(rows, list) or not all(isinstance(row, Mapping) for row in rows):
+        raise LabelJoinError(f"{name} must contain a rows/records list of objects")
+    return [dict(row) for row in rows]
+
+
+def union_rows(document: Any) -> list[dict[str, Any]]:
+    return _rows(document, "union input")
+
+
+def derivation_rows(document: Any) -> list[dict[str, Any]]:
+    return _rows(document, "union derivation")
+
+
+def shadow_rows(document: Any) -> list[dict[str, Any]]:
+    return _rows(document, "phase1 shadow")
+
+
+def load_corpus(corpus_dir: Path) -> dict[str, dict[str, Any]]:
+    """Load the immutable raw corpus by filename, rejecting malformed inputs."""
+    if not corpus_dir.is_dir():
+        raise LabelJoinError(f"corpus directory does not exist: {corpus_dir}")
+    corpus: dict[str, dict[str, Any]] = {}
+    for path in sorted(corpus_dir.glob("*.json")):
+        document = read_json(path)
+        if isinstance(document, Mapping):
+            corpus[path.name] = dict(document)
+    if not corpus:
+        raise LabelJoinError(f"corpus contains no JSON artifacts: {corpus_dir}")
+    return corpus
+
+
+def artifact_fact_check(
+    shadow: Mapping[str, Any], corpus: Mapping[str, Mapping[str, Any]]
+) -> tuple[Path, dict[str, Any]]:
+    """Resolve one shadow row to its immutable artifact and fact-check object."""
+    artifact_name = shadow.get("artifact")
+    grounding_key = shadow.get("grounding_key")
+    if not isinstance(artifact_name, str) or not isinstance(grounding_key, str):
+        raise LabelJoinError("shadow record requires artifact and grounding_key strings")
+    artifact = corpus.get(artifact_name)
+    if artifact is None:
+        raise LabelJoinError(f"shadow artifact is absent from corpus: {artifact_name}")
+    payload = artifact.get("payload")
+    fact_checks = payload.get("fact_checks") if isinstance(payload, Mapping) else None
+    index = fact_check_index_from_key(grounding_key)
+    if (
+        not isinstance(fact_checks, list)
+        or not (0 <= index < len(fact_checks))
+        or not isinstance(fact_checks[index], Mapping)
+    ):
+        raise LabelJoinError(f"missing fact check {index} in corpus artifact {artifact_name}")
+    recomputed = _stable_grounding_key(Path(artifact_name), index, fact_checks[index])
+    if recomputed != grounding_key:
+        raise LabelJoinError(
+            f"stable grounding key mismatch for {artifact_name} fact_checks[{index}]: "
+            f"shadow={grounding_key!r} recomputed={recomputed!r}"
+        )
+    return Path(artifact_name), dict(fact_checks[index])
+
+
+def excerpt_from_fact_check(fact_check: Mapping[str, Any]) -> str:
+    grounding = fact_check.get("grounding")
+    return str(grounding.get("evidence_excerpt") or "") if isinstance(grounding, Mapping) else ""
+
+
+def structural_key_from_union(row: Mapping[str, Any]) -> tuple[str, str, str, str]:
+    seat, _arm = parse_seat_arm(row.get("seat_arm"))
+    return (
+        canonical_json(seat),
+        str(row.get("fixture") or ""),
+        str(row.get("claim") or ""),
+        str(row.get("excerpt") or ""),
+    )
+
+
+def structural_key_from_shadow(
+    shadow: Mapping[str, Any], corpus: Mapping[str, Mapping[str, Any]]
+) -> tuple[str, str, str, str]:
+    _path, fact_check = artifact_fact_check(shadow, corpus)
+    metadata = shadow.get("seat_metadata")
+    if not isinstance(metadata, Mapping):
+        raise LabelJoinError(f"shadow record has no seat_metadata for {shadow.get('grounding_key')!r}")
+    return (
+        canonical_json(dict(metadata)),
+        str(shadow.get("fixture") or ""),
+        str(shadow.get("claim") or ""),
+        excerpt_from_fact_check(fact_check),
+    )
+
+
+def render_key(key: Sequence[str]) -> str:
+    return canonical_json(list(key))
+
+
+def _derivation_comparable(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Discard only union membership metadata for an exact source-index check."""
+    return {key: value for key, value in row.items() if key not in {"union_categories", "source_index"}}
+
+
+def resolve_derivation_indices(
+    selected_rows: Sequence[Mapping[str, Any]], derivations: Sequence[Mapping[str, Any]]
+) -> list[int]:
+    """Resolve union rows to derivation rows without a shadow positional join.
+
+    The frozen union deliberately retains ``source_index`` as a reference to
+    the derivation list.  It is checked against every shared field rather than
+    trusted blindly.  Synthetic/future rows without that field use an exact
+    multiset key and fail loudly if a duplicate cannot be distinguished.
+    """
+    by_key: dict[tuple[str, str, str, str], list[int]] = defaultdict(list)
+    for index, row in enumerate(derivations):
+        by_key[structural_key_from_union(row)].append(index)
+    used: set[int] = set()
+    resolved: list[int] = []
+    missing: list[str] = []
+    ambiguous: list[str] = []
+    for row in selected_rows:
+        source_index = row.get("source_index")
+        if isinstance(source_index, int) and 0 <= source_index < len(derivations):
+            candidate = derivations[source_index]
+            if _derivation_comparable(row) == _derivation_comparable(candidate) and source_index not in used:
+                used.add(source_index)
+                resolved.append(source_index)
+                continue
+        key = structural_key_from_union(row)
+        candidates = [index for index in by_key.get(key, []) if index not in used]
+        if not candidates:
+            missing.append(render_key(key))
+        elif len(candidates) != 1:
+            ambiguous.append(render_key(key))
+        else:
+            used.add(candidates[0])
+            resolved.append(candidates[0])
+    if missing or ambiguous:
+        details: list[str] = []
+        if missing:
+            details.append("missing keys=" + ", ".join(sorted(set(missing))))
+        if ambiguous:
+            details.append("ambiguous keys=" + ", ".join(sorted(set(ambiguous))))
+        raise LabelJoinError("union-to-derivation exact join failed: " + "; ".join(details))
+    return resolved
+
+
+def resolve_derivation_to_shadow(
+    derivations: Sequence[Mapping[str, Any]],
+    shadows: Sequence[Mapping[str, Any]],
+    corpus: Mapping[str, Mapping[str, Any]],
+) -> dict[int, dict[str, Any]]:
+    """Create a total deterministic multiset bijection to unordered shadow rows.
+
+    Group membership is an exact tuple of seat metadata, fixture, claim, and
+    raw evidence excerpt.  Only ties *within that exact group* are ordered by
+    stable derivation index and immutable grounding key.  This never relies on
+    the (known-different) global iteration order of the two frozen reports.
+    """
+    derivation_groups: dict[tuple[str, str, str, str], list[int]] = defaultdict(list)
+    shadow_groups: dict[tuple[str, str, str, str], list[dict[str, Any]]] = defaultdict(list)
+    for index, row in enumerate(derivations):
+        derivation_groups[structural_key_from_union(row)].append(index)
+    for shadow in shadows:
+        shadow_groups[structural_key_from_shadow(shadow, corpus)].append(dict(shadow))
+
+    missing = sorted(render_key(key) for key in derivation_groups.keys() - shadow_groups.keys())
+    extra = sorted(render_key(key) for key in shadow_groups.keys() - derivation_groups.keys())
+    count_mismatches = sorted(
+        render_key(key)
+        for key in derivation_groups.keys() & shadow_groups.keys()
+        if len(derivation_groups[key]) != len(shadow_groups[key])
+    )
+    if missing or extra or count_mismatches:
+        details: list[str] = []
+        if missing:
+            details.append("missing shadow keys=" + ", ".join(missing))
+        if extra:
+            details.append("extra shadow keys=" + ", ".join(extra))
+        if count_mismatches:
+            details.append("ambiguous cardinality keys=" + ", ".join(count_mismatches))
+        raise LabelJoinError("derivation-to-shadow bijection failed: " + "; ".join(details))
+
+    mapped: dict[int, dict[str, Any]] = {}
+    seen_keys: set[str] = set()
+    for key in sorted(derivation_groups):
+        indexes = sorted(derivation_groups[key])
+        candidates = sorted(shadow_groups[key], key=lambda row: str(row.get("grounding_key") or ""))
+        for index, shadow in zip(indexes, candidates, strict=True):
+            grounding_key = shadow.get("grounding_key")
+            if not isinstance(grounding_key, str) or grounding_key in seen_keys:
+                raise LabelJoinError(f"shadow grounding keys are not unique: {grounding_key!r}")
+            seen_keys.add(grounding_key)
+            mapped[index] = shadow
+    if len(mapped) != len(derivations) or len(seen_keys) != len(shadows):
+        raise LabelJoinError(
+            f"derivation-to-shadow mapping is not total/bijective: derivation={len(derivations)} "
+            f"mapped={len(mapped)} shadow={len(shadows)}"
+        )
+    return mapped

--- a/scripts/audit/layerb_label_merge.py
+++ b/scripts/audit/layerb_label_merge.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Compare two Layer B annotation sidecars without silently resolving labels.
+
+Material comparison is strict: values, mapping key order, and list order all
+matter unless the labeling contract expressly defines a canonical order.  A
+materially disagreeing draft intentionally omits ``adjudication`` for that
+case, so the full label schema refuses it until a named adjudicator resolves
+the evidence-backed difference.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(project_root))
+    sys.path.insert(0, str(project_root / "scripts"))
+
+from scripts.audit.layerb_label_common import LabelJoinError, atomic_write_json, read_json
+
+CASE_MATERIAL_FIELDS = (
+    "case_id",
+    "artifact_sha256",
+    "fixture_id",
+    "fact_check_id",
+    "fact_check_index",
+    "expected_layer_a_decision",
+    "expected_layer_a_reason",
+    "anchor_scan_complete",
+    "candidate_set_complete",
+    "candidates_by_event_output_id",
+    "expected_aggregate_relation",
+    "expected_fact_check_decision",
+)
+CANDIDATE_MATERIAL_FIELDS = (
+    "candidate_id",
+    "canonical_source_id",
+    "source_index",
+    "tool_identity",
+    "query_identity",
+    "raw_output_sha256",
+    "normalized_output_sha256",
+    "output_capture_complete",
+    "anchor_scan_complete",
+    "match_type",
+    "similarity",
+    "eligibility",
+    "error_status",
+    "ordered_segment_spans",
+    "expected_source_relation",
+    "expected_support_spans",
+)
+COSMETIC_FIELDS = (
+    "claim",
+    "evidence_excerpt",
+    "claim_is_true",
+    "expected_reviewer_verdict",
+    "context_sufficient",
+    "failure_class",
+    "corpus_verification_status",
+    "annotators",
+    "adjudication",
+)
+SPAN_FIELDS = {"ordered_segment_spans", "expected_support_spans"}
+
+
+def _ordered_json(value: Any) -> str:
+    """Preserve mapping insertion order; only values are compacted for comparison."""
+    return json.dumps(value, ensure_ascii=False, sort_keys=False, separators=(",", ":"))
+
+
+def _same(left: Any, right: Any) -> bool:
+    return _ordered_json(left) == _ordered_json(right)
+
+
+def _cases(document: Mapping[str, Any], label: str) -> dict[str, dict[str, Any]]:
+    cases = document.get("cases")
+    if not isinstance(cases, list):
+        raise LabelJoinError(f"{label} sidecar has no cases list")
+    result: dict[str, dict[str, Any]] = {}
+    for case in cases:
+        if not isinstance(case, Mapping) or not isinstance(case.get("case_id"), str):
+            raise LabelJoinError(f"{label} sidecar contains a case without case_id")
+        case_id = str(case["case_id"])
+        if case_id in result:
+            raise LabelJoinError(f"{label} sidecar repeats case_id={case_id}")
+        result[case_id] = dict(case)
+    return result
+
+
+def _candidate_differences(left: Any, right: Any) -> list[dict[str, Any]]:
+    """Return exact candidate-map differences at the material contract fields."""
+    differences: list[dict[str, Any]] = []
+    if not isinstance(left, Mapping) or not isinstance(right, Mapping):
+        if not _same(left, right):
+            differences.append({"field": "candidates_by_event_output_id", "left": left, "right": right})
+        return differences
+    if list(left) != list(right):
+        differences.append(
+            {"field": "candidates_by_event_output_id.object_key_order", "left": list(left), "right": list(right)}
+        )
+    for event_output_id in list(dict.fromkeys([*left.keys(), *right.keys()])):
+        left_candidates = left.get(event_output_id)
+        right_candidates = right.get(event_output_id)
+        prefix = f"candidates_by_event_output_id.{event_output_id}"
+        if not isinstance(left_candidates, list) or not isinstance(right_candidates, list):
+            if not _same(left_candidates, right_candidates):
+                differences.append({"field": prefix, "left": left_candidates, "right": right_candidates})
+            continue
+        if len(left_candidates) != len(right_candidates):
+            differences.append(
+                {"field": prefix + ".list_length", "left": len(left_candidates), "right": len(right_candidates)}
+            )
+        for index, (left_candidate, right_candidate) in enumerate(zip(left_candidates, right_candidates, strict=False)):
+            candidate_prefix = f"{prefix}[{index}]"
+            if not isinstance(left_candidate, Mapping) or not isinstance(right_candidate, Mapping):
+                if not _same(left_candidate, right_candidate):
+                    differences.append({"field": candidate_prefix, "left": left_candidate, "right": right_candidate})
+                continue
+            if list(left_candidate) != list(right_candidate):
+                differences.append(
+                    {
+                        "field": candidate_prefix + ".object_key_order",
+                        "left": list(left_candidate),
+                        "right": list(right_candidate),
+                    }
+                )
+            for field in CANDIDATE_MATERIAL_FIELDS:
+                if not _same(left_candidate.get(field), right_candidate.get(field)):
+                    differences.append(
+                        {
+                            "field": candidate_prefix + "." + field,
+                            "left": left_candidate.get(field),
+                            "right": right_candidate.get(field),
+                        }
+                    )
+    return differences
+
+
+def _material_differences(left: Mapping[str, Any], right: Mapping[str, Any]) -> list[dict[str, Any]]:
+    differences: list[dict[str, Any]] = []
+    if list(left) != list(right):
+        differences.append({"field": "case.object_key_order", "left": list(left), "right": list(right)})
+    for field in CASE_MATERIAL_FIELDS:
+        if field == "candidates_by_event_output_id":
+            differences.extend(_candidate_differences(left.get(field), right.get(field)))
+        elif not _same(left.get(field), right.get(field)):
+            differences.append({"field": field, "left": left.get(field), "right": right.get(field)})
+    return differences
+
+
+def _cosmetic_differences(left: Mapping[str, Any], right: Mapping[str, Any]) -> list[dict[str, Any]]:
+    return [
+        {"field": field, "left": left.get(field), "right": right.get(field)}
+        for field in COSMETIC_FIELDS
+        if not _same(left.get(field), right.get(field))
+    ]
+
+
+def _span_only(differences: Sequence[Mapping[str, Any]]) -> bool:
+    if not differences:
+        return False
+    return all(any(field in str(difference["field"]) for field in SPAN_FIELDS) for difference in differences)
+
+
+def merge_annotator_sidecars(
+    left_document: Mapping[str, Any], right_document: Mapping[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return a disagreement report and an intentionally incomplete merge draft."""
+    left_cases = _cases(left_document, "left")
+    right_cases = _cases(right_document, "right")
+    all_case_ids = sorted(set(left_cases) | set(right_cases))
+    report_cases: list[dict[str, Any]] = []
+    span_only_cases: list[str] = []
+    cosmetic_only_cases: list[str] = []
+    merged_cases: list[dict[str, Any]] = []
+    agreed = 0
+    disagreeing = 0
+    for case_id in all_case_ids:
+        left = left_cases.get(case_id)
+        right = right_cases.get(case_id)
+        if left is None or right is None:
+            material = [{"field": "case_presence", "left": left is not None, "right": right is not None}]
+            report_cases.append({"case_id": case_id, "material_differences": material, "cosmetic_differences": []})
+            if left is not None:
+                draft_case = copy.deepcopy(left)
+                draft_case.pop("adjudication", None)
+                merged_cases.append(draft_case)
+            elif right is not None:
+                draft_case = copy.deepcopy(right)
+                draft_case.pop("adjudication", None)
+                merged_cases.append(draft_case)
+            disagreeing += 1
+            continue
+        material = _material_differences(left, right)
+        cosmetic = _cosmetic_differences(left, right)
+        if material:
+            report_cases.append(
+                {"case_id": case_id, "material_differences": material, "cosmetic_differences": cosmetic}
+            )
+            if _span_only(material):
+                span_only_cases.append(case_id)
+            draft_case = copy.deepcopy(left)
+            draft_case.pop("adjudication", None)
+            merged_cases.append(draft_case)
+            disagreeing += 1
+        else:
+            draft_case = copy.deepcopy(left)
+            draft_case["adjudication"] = {
+                "status": "AGREED",
+                "adjudicator": None,
+                "note": "Independent annotations matched all material fields.",
+            }
+            merged_cases.append(draft_case)
+            agreed += 1
+            if cosmetic:
+                cosmetic_only_cases.append(case_id)
+                report_cases.append({"case_id": case_id, "material_differences": [], "cosmetic_differences": cosmetic})
+    merged = copy.deepcopy(dict(left_document))
+    merged["cases"] = merged_cases
+    report = {
+        "report_version": "qg-layer-b-annotation-merge.v2",
+        "counts": {
+            "left_cases": len(left_cases),
+            "right_cases": len(right_cases),
+            "agreed": agreed,
+            "material_disagreements": disagreeing,
+            "span_only_disagreements": len(span_only_cases),
+            "cosmetic_only_differences": len(cosmetic_only_cases),
+        },
+        "span_only_case_ids": span_only_cases,
+        "cosmetic_only_case_ids": cosmetic_only_cases,
+        "cases": report_cases,
+        "comparison_contract": {
+            "exact_deep_equality": True,
+            "object_key_order_material": True,
+            "list_order_material": True,
+            "unadjudicated_cases_omit_adjudication": True,
+        },
+    }
+    return report, merged
+
+
+def write_merge(left_path: Path, right_path: Path, *, output_dir: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    report, merged = merge_annotator_sidecars(read_json(left_path), read_json(right_path))
+    output_dir.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(output_dir / "disagreement-report.json", report)
+    atomic_write_json(output_dir / "merged-sidecar-draft.json", merged)
+    return report, merged
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--left", type=Path, required=True)
+    parser.add_argument("--right", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    write_merge(args.left, args.right, output_dir=args.output_dir)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through the CLI
+    raise SystemExit(main())

--- a/scripts/audit/layerb_label_scaffold.py
+++ b/scripts/audit/layerb_label_scaffold.py
@@ -1,0 +1,651 @@
+#!/usr/bin/env python3
+"""Emit resumable Layer B annotation scaffolds from frozen keyed evidence.
+
+This is offline handoff tooling.  It fills source-derived identity material and
+leaves every human judgment field as ``null``.  Packets include navigation
+windows, but their explicit contract requires annotators to read the complete
+raw captured output before deciding any relation or support span.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(project_root))
+    sys.path.insert(0, str(project_root / "scripts"))
+
+from scripts.audit import anchor_primitives
+from scripts.audit.layerb_label_common import (
+    LabelJoinError,
+    atomic_write_json,
+    atomic_write_jsonl,
+    fact_check_index_from_key,
+    load_corpus,
+    read_json,
+    sha256_file,
+    sha256_text,
+    shadow_rows,
+    union_rows,
+)
+from scripts.audit.layerb_shadow import _build_event_index
+
+JUDGMENT_CASE_FIELDS = (
+    "claim_is_true",
+    "expected_reviewer_verdict",
+    "expected_layer_a_decision",
+    "expected_layer_a_reason",
+    "expected_aggregate_relation",
+    "expected_fact_check_decision",
+    "context_sufficient",
+    "failure_class",
+    "corpus_verification_status",
+    "annotators",
+    "adjudication",
+)
+JUDGMENT_CANDIDATE_FIELDS = ("expected_source_relation", "expected_support_spans")
+WORKING_CASE_REQUIRED = (
+    "case_id",
+    "artifact_sha256",
+    "fixture_id",
+    "fact_check_id",
+    "fact_check_index",
+    "claim",
+    "evidence_excerpt",
+    "claim_is_true",
+    "expected_reviewer_verdict",
+    "expected_layer_a_decision",
+    "expected_layer_a_reason",
+    "anchor_scan_complete",
+    "candidate_set_complete",
+    "candidates_by_event_output_id",
+    "expected_aggregate_relation",
+    "expected_fact_check_decision",
+    "context_sufficient",
+    "failure_class",
+    "corpus_verification_status",
+)
+WORKING_CANDIDATE_REQUIRED = (
+    "candidate_id",
+    "canonical_source_id",
+    "source_index",
+    "tool_identity",
+    "query_identity",
+    "raw_output_sha256",
+    "normalized_output_sha256",
+    "output_capture_complete",
+    "anchor_scan_complete",
+    "match_type",
+    "similarity",
+    "eligibility",
+    "error_status",
+    "ordered_segment_spans",
+    "expected_source_relation",
+    "expected_support_spans",
+)
+SHA_FIELDS = (
+    "candidate_id",
+    "canonical_source_id",
+    "raw_output_sha256",
+    "normalized_output_sha256",
+)
+SHA_RE = re.compile(r"^[a-f0-9]{64}$")
+WINDOW_COMMENT = "NAVIGATION AID ONLY — decisions require the full raw artifact read."
+HINT_COMMENT = "NON-authoritative fixture hint; establish claim truth independently per the annotation guide."
+REVIEWER_VERDICTS = {
+    "CONFIRMED",
+    "REFUTED_BY_CONTRADICTION",
+    "UNATTESTED_AFTER_SEARCH",
+    "CONTESTED",
+    "UNVERIFIED_INSUFFICIENT_SEARCH",
+}
+LAYER_A_DECISIONS = {"ANCHOR", "REJECT", "AUDIT"}
+LAYER_A_REASONS = {
+    "ANCHORED_CONTIGUOUS",
+    "ANCHORED_ORDERED_SEGMENTS",
+    "PRESENT_MULTI",
+    "ABSENT",
+    "FUZZY_AMBIGUOUS",
+    "OUTSIDE_SCAN",
+    "RAW_MAPPING_AMBIGUOUS",
+    "CROSS_EVENT_STITCH_FORBIDDEN",
+    "INCOMPLETE_CAPTURE",
+    "INCOMPLETE_CANDIDATE_SET",
+    "TOOL_ERROR",
+    "INSUFFICIENT_MASS",
+    "BELOW_TAU",
+    "DIGIT_NOT_ALIGNED",
+    "SALIENT_NOT_ALIGNED",
+}
+SOURCE_RELATIONS = {
+    "ENTAILS",
+    "CONTRADICTS",
+    "EXPLICITLY_UNCERTAIN",
+    "NO_RELATION",
+    "MIXED",
+    "TOOL_ERROR",
+    "INSUFFICIENT_CONTEXT",
+}
+AGGREGATE_RELATIONS = SOURCE_RELATIONS | {"ABSTAIN"}
+FACT_CHECK_DECISIONS = {"ACCEPT", "REJECT", "AUDIT"}
+FAILURE_CLASSES = {
+    "FABRICATED_EXCERPT_VALUE",
+    "ALTERED_CLAIM_VALUE",
+    "MEANING_INVERSION",
+    "ATTRIBUTION_OR_ROLE_SWAP",
+    "OVER_GENERALIZATION",
+    "ELLIPSIZED_GENUINE_EXCERPT",
+    "CROSS_EVENT_JOIN",
+    "LEXICAL_VARIANT",
+    "TOOL_ERROR_AS_EVIDENCE",
+    "MISSING_CONTRADICTORY_CANDIDATE",
+    "WRONG_NORMALIZED_RAW_MAPPING",
+    "CANONICAL_IDENTITY_FAILURE",
+    "PROMPT_INJECTION",
+    "IRRELEVANT_SUPPORT_OFFSET",
+    "JUDGE_TIMEOUT_OR_MALFORMED_RESULT",
+    "SEARCH_ONLY_WITHOUT_COVERAGE_PROOF",
+}
+CORPUS_STATUSES = {"VERIFIED", "FIXTURE_ATTESTED", "UNVERIFIED", "NOT_APPLICABLE"}
+SUPPORT_ROLES = {"SUPPORTS", "CONTRADICTS", "UNCERTAINTY"}
+
+
+def _artifact_events(artifact: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    dispatch = artifact.get("dispatch")
+    events = dispatch.get("tool_events") if isinstance(dispatch, Mapping) else None
+    if not isinstance(events, list):
+        return []
+    return [event for event in events if isinstance(event, Mapping)]
+
+
+def _schema_candidate(candidate: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+    event_output_id = candidate.get("event_output_id")
+    if not isinstance(event_output_id, str) or not SHA_RE.fullmatch(event_output_id):
+        raise LabelJoinError(f"candidate has invalid event_output_id: {event_output_id!r}")
+    result = {
+        key: candidate[key]
+        for key in WORKING_CANDIDATE_REQUIRED
+        if key not in JUDGMENT_CANDIDATE_FIELDS and key in candidate
+    }
+    missing = sorted(set(WORKING_CANDIDATE_REQUIRED) - set(result) - set(JUDGMENT_CANDIDATE_FIELDS))
+    if missing:
+        raise LabelJoinError(f"candidate {event_output_id} is missing mechanical fields: {', '.join(missing)}")
+    result["expected_source_relation"] = None
+    result["expected_support_spans"] = None
+    return event_output_id, result
+
+
+def _source_artifact_path(corpus_dir: Path, artifact_name: str) -> str:
+    """Produce the required repository-relative path where the caller supplied one."""
+    path = corpus_dir / artifact_name
+    for ancestor in (path, *path.parents):
+        if ancestor.name == "audit":
+            return str(path.relative_to(ancestor.parent))
+    return artifact_name
+
+
+def _fixture_sha256(fixture_id: str) -> str:
+    fixture_path = Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "qg_bakeoff" / f"{fixture_id}.json"
+    if not fixture_path.is_file():
+        raise LabelJoinError(f"fixture file required for scaffold source hashes is absent: {fixture_path}")
+    return sha256_file(fixture_path)
+
+
+def _case_from_row(
+    row: Mapping[str, Any],
+    shadow: Mapping[str, Any],
+    *,
+    corpus_dir: Path,
+    corpus: Mapping[str, Mapping[str, Any]],
+) -> tuple[dict[str, Any], dict[str, Any], str]:
+    grounding_key = row.get("grounding_key")
+    if not isinstance(grounding_key, str) or grounding_key != shadow.get("grounding_key"):
+        raise LabelJoinError(f"keyed row does not exactly resolve to a shadow grounding key: {grounding_key!r}")
+    artifact_name = shadow.get("artifact")
+    if not isinstance(artifact_name, str) or artifact_name not in corpus:
+        raise LabelJoinError(f"shadow artifact is unavailable: {artifact_name!r}")
+    artifact_path = corpus_dir / artifact_name
+    artifact = corpus[artifact_name]
+    layer_a = shadow.get("layer_a")
+    if not isinstance(layer_a, Mapping):
+        raise LabelJoinError(f"shadow {grounding_key} has no Layer A record")
+    candidates = layer_a.get("candidates")
+    if not isinstance(candidates, list):
+        raise LabelJoinError(f"shadow {grounding_key} has malformed Layer A candidates")
+    grouped_candidates: dict[str, list[dict[str, Any]]] = {}
+    for candidate in candidates:
+        if not isinstance(candidate, Mapping):
+            raise LabelJoinError(f"shadow {grounding_key} includes a non-object candidate")
+        event_output_id, shaped = _schema_candidate(candidate)
+        grouped_candidates.setdefault(event_output_id, []).append(shaped)
+    all_scans_complete = all(candidate.get("anchor_scan_complete") is True for candidate in candidates)
+    case: dict[str, Any] = {
+        "case_id": grounding_key,
+        "artifact_sha256": sha256_file(artifact_path),
+        "fixture_id": str(shadow.get("fixture") or row.get("fixture") or ""),
+        "fact_check_id": str(shadow.get("fact_check_id") or grounding_key),
+        "fact_check_index": fact_check_index_from_key(grounding_key),
+        "claim": str(row.get("claim") or shadow.get("claim") or ""),
+        "evidence_excerpt": str(row.get("excerpt") or ""),
+        "claim_is_true": None,
+        "expected_reviewer_verdict": None,
+        "expected_layer_a_decision": None,
+        "expected_layer_a_reason": None,
+        "anchor_scan_complete": all_scans_complete,
+        "candidate_set_complete": layer_a.get("candidate_set_complete") is True,
+        "candidates_by_event_output_id": grouped_candidates,
+        "expected_aggregate_relation": None,
+        "expected_fact_check_decision": None,
+        "context_sufficient": None,
+        "failure_class": None,
+        "corpus_verification_status": None,
+        "annotators": None,
+        "adjudication": None,
+    }
+    if not case["fixture_id"] or not case["claim"] or not case["evidence_excerpt"]:
+        raise LabelJoinError(f"shadow {grounding_key} cannot produce a complete mechanical case identity")
+    packet = _packet_case(case, row, artifact, corpus_dir=corpus_dir)
+    return case, packet, artifact_name
+
+
+def _candidate_navigation(
+    candidate: Mapping[str, Any], event_output_id: str, outputs: Mapping[str, str]
+) -> dict[str, Any]:
+    raw_output = outputs.get(event_output_id)
+    if raw_output is None:
+        raise LabelJoinError(f"candidate event output is unavailable: {event_output_id}")
+    if sha256_text(raw_output) != candidate.get("raw_output_sha256"):
+        raise LabelJoinError(f"candidate raw-output hash mismatch: {event_output_id}")
+    normalized_output = anchor_primitives.normalize_for_match(raw_output)
+    if sha256_text(normalized_output) != candidate.get("normalized_output_sha256"):
+        raise LabelJoinError(f"candidate normalized-output hash mismatch: {event_output_id}")
+    segments = candidate.get("ordered_segment_spans")
+    if not isinstance(segments, list) or not segments:
+        raise LabelJoinError(f"candidate has no ordered segment spans: {event_output_id}")
+    normalized_start = min(int(segment["output_normalized_start"]) for segment in segments)
+    normalized_end = max(int(segment["output_normalized_end"]) for segment in segments)
+    raw_start = min(int(segment["output_raw_start"]) for segment in segments)
+    raw_end = max(int(segment["output_raw_end"]) for segment in segments)
+    if not (
+        0 <= normalized_start < normalized_end <= len(normalized_output) and 0 <= raw_start < raw_end <= len(raw_output)
+    ):
+        raise LabelJoinError(f"candidate span is outside captured output: {event_output_id}")
+    return {
+        "event_output_id": event_output_id,
+        "full_output_sha256": sha256_text(raw_output),
+        "full_output_bytes": len(raw_output.encode("utf-8")),
+        "normalized_window_start": max(0, normalized_start - 800),
+        "normalized_window_end": min(len(normalized_output), normalized_end + 800),
+        "normalized_window_text": normalized_output[
+            max(0, normalized_start - 800) : min(len(normalized_output), normalized_end + 800)
+        ],
+        "raw_window_start": max(0, raw_start - 800),
+        "raw_window_end": min(len(raw_output), raw_end + 800),
+        "raw_window_text": raw_output[max(0, raw_start - 800) : min(len(raw_output), raw_end + 800)],
+        "comment": WINDOW_COMMENT,
+    }
+
+
+def _packet_case(
+    case: Mapping[str, Any], row: Mapping[str, Any], artifact: Mapping[str, Any], *, corpus_dir: Path
+) -> dict[str, Any]:
+    outputs = _build_event_index(_artifact_events(artifact))
+    navigation: list[dict[str, Any]] = []
+    candidates_by_output = case["candidates_by_event_output_id"]
+    for event_output_id in sorted(candidates_by_output):
+        for candidate in candidates_by_output[event_output_id]:
+            navigation.append(_candidate_navigation(candidate, event_output_id, outputs))
+    artifact_name = str(case["case_id"]).split("#fact_checks[", maxsplit=1)[0]
+    return {
+        "packet_version": "qg-layer-b-work-packet.v2",
+        "comment": WINDOW_COMMENT,
+        "case": dict(case),
+        "gold_is_true_hint": row.get("gold_is_true"),
+        "gold_is_true_hint_comment": HINT_COMMENT,
+        "union_categories": list(row.get("union_categories") or []),
+        "corpus_artifact_path": _source_artifact_path(corpus_dir, artifact_name),
+        "source_index": row.get("source_index"),
+        "candidate_navigation": navigation,
+    }
+
+
+def _done_marker_path(packets_dir: Path, shard: int) -> Path:
+    return packets_dir / f"shard-{shard:02d}.done.json"
+
+
+def _packet_checksum(path: Path) -> str:
+    return sha256_file(path)
+
+
+def _write_shard(path: Path, rows: list[dict[str, Any]], shard: int, *, resume: bool) -> None:
+    marker = _done_marker_path(path.parent, shard)
+    if resume and path.is_file() and marker.is_file():
+        state = read_json(marker)
+        if (
+            isinstance(state, Mapping)
+            and state.get("sha256") == _packet_checksum(path)
+            and state.get("count") == len(rows)
+        ):
+            expected_ids = [str(row["case"]["case_id"]) for row in rows]
+            if state.get("case_ids") == expected_ids:
+                return
+    atomic_write_jsonl(path, rows)
+    atomic_write_json(
+        marker,
+        {
+            "shard": shard,
+            "sha256": _packet_checksum(path),
+            "count": len(rows),
+            "case_ids": [str(row["case"]["case_id"]) for row in rows],
+        },
+    )
+
+
+def build_scaffold(
+    keyed_document: Mapping[str, Any],
+    shadow_document: Mapping[str, Any],
+    *,
+    corpus_dir: Path,
+    output_dir: Path,
+    shard_count: int = 4,
+    resume: bool = True,
+    crash_after_shards: int | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build the null-judgment scaffold and atomically materialize its packets."""
+    if shard_count < 1:
+        raise LabelJoinError("shard_count must be positive")
+    keyed_rows = union_rows(keyed_document)
+    shadows = shadow_rows(shadow_document)
+    shadow_by_key = {str(row.get("grounding_key")): row for row in shadows}
+    if len(shadow_by_key) != len(shadows):
+        raise LabelJoinError("phase1 shadow contains duplicate grounding_key values")
+    corpus = load_corpus(corpus_dir)
+    cases: list[dict[str, Any]] = []
+    packets: list[dict[str, Any]] = []
+    used_artifacts: set[str] = set()
+    seen_cases: set[str] = set()
+    for row in keyed_rows:
+        key = row.get("grounding_key")
+        shadow = shadow_by_key.get(str(key))
+        if shadow is None:
+            raise LabelJoinError(f"keyed union contains missing shadow grounding key: {key!r}")
+        case, packet, artifact_name = _case_from_row(row, shadow, corpus_dir=corpus_dir, corpus=corpus)
+        if case["case_id"] in seen_cases:
+            raise LabelJoinError(f"keyed union has duplicate case_id: {case['case_id']}")
+        seen_cases.add(case["case_id"])
+        cases.append(case)
+        packets.append(packet)
+        used_artifacts.add(artifact_name)
+    ordered_pairs = sorted(zip(cases, packets, strict=True), key=lambda pair: str(pair[0]["case_id"]))
+    cases = [case for case, _packet in ordered_pairs]
+    packets = [packet for _case, packet in ordered_pairs]
+    source_artifacts = [
+        {
+            "artifact_sha256": sha256_file(corpus_dir / artifact_name),
+            "fixture_set_sha256": _fixture_sha256(
+                str(next(case for case in cases if case["case_id"].startswith(artifact_name + "#"))["fixture_id"])
+            ),
+        }
+        for artifact_name in sorted(used_artifacts)
+    ]
+    scaffold = {
+        "schema_version": "qg-layer-b-labels.v2",
+        "dataset_id": "qg-layer-b-phase0-scaffold",
+        "source_artifacts": source_artifacts,
+        "qualification_eligible": False,
+        "qualification_blockers": ["Scaffold only: all annotation and adjudication fields remain null."],
+        "cases": cases,
+    }
+    output_dir.mkdir(parents=True, exist_ok=True)
+    atomic_write_json(output_dir / "labels-scaffold.v2.json", scaffold)
+    packets_dir = output_dir / "packets"
+    per_shard = (len(packets) + shard_count - 1) // shard_count
+    written = 0
+    for shard in range(shard_count):
+        start = shard * per_shard
+        packet_rows = packets[start : start + per_shard]
+        if not packet_rows:
+            continue
+        shard_path = packets_dir / f"shard-{shard:02d}.jsonl"
+        _write_shard(shard_path, packet_rows, shard, resume=resume)
+        written += 1
+        if crash_after_shards is not None and written >= crash_after_shards:
+            raise RuntimeError("simulated crash after atomic shard write")
+    report = {
+        "keyed_rows": len(keyed_rows),
+        "cases": len(cases),
+        "shards": sum(1 for shard in range(shard_count) if packets[shard * per_shard : (shard + 1) * per_shard]),
+        "candidates": sum(len(group) for case in cases for group in case["candidates_by_event_output_id"].values()),
+        "judgment_fields_prefilled": 0,
+        "join_report": dict((keyed_document.get("keying") or {}).get("join_report") or {}),
+    }
+    return scaffold, report
+
+
+def write_scaffold(
+    keyed_path: Path,
+    shadow_path: Path,
+    *,
+    corpus_dir: Path,
+    output_dir: Path,
+    shard_count: int = 4,
+    resume: bool = True,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build scaffold outputs and atomically write the input-pinned manifest."""
+    keyed_document = read_json(keyed_path)
+    shadow_document = read_json(shadow_path)
+    scaffold, report = build_scaffold(
+        keyed_document,
+        shadow_document,
+        corpus_dir=corpus_dir,
+        output_dir=output_dir,
+        shard_count=shard_count,
+        resume=resume,
+    )
+    used_artifacts = sorted({str(case["case_id"]).split("#fact_checks[", maxsplit=1)[0] for case in scaffold["cases"]})
+    manifest = {
+        "manifest_version": "qg-layer-b-scaffold-manifest.v2",
+        "inputs": {
+            "keyed_union": {"path": str(keyed_path), "sha256": sha256_file(keyed_path)},
+            "phase1_shadow": {"path": str(shadow_path), "sha256": sha256_file(shadow_path)},
+            "corpus_artifacts": {
+                artifact_name: sha256_file(corpus_dir / artifact_name) for artifact_name in used_artifacts
+            },
+            "fixture_sets": {
+                fixture_id: {
+                    "path": str(
+                        Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "qg_bakeoff" / f"{fixture_id}.json"
+                    ),
+                    "sha256": _fixture_sha256(fixture_id),
+                }
+                for fixture_id in sorted({str(case["fixture_id"]) for case in scaffold["cases"]})
+            },
+        },
+        "join_report": report["join_report"],
+        "counts": {key: value for key, value in report.items() if key != "join_report"},
+        "scaffold_sha256": sha256_file(output_dir / "labels-scaffold.v2.json"),
+    }
+    atomic_write_json(output_dir / "scaffold-manifest.json", manifest)
+    return scaffold, manifest
+
+
+def _require_hash(value: Any, field: str) -> None:
+    if not isinstance(value, str) or SHA_RE.fullmatch(value) is None:
+        raise LabelJoinError(f"{field} must be a lowercase SHA-256")
+
+
+def validate_annotator_record(record: Mapping[str, Any], event_outputs: Mapping[str, str]) -> None:
+    """Validate one completed working case before two-way sidecar merge.
+
+    The working format deliberately omits ``annotators`` and ``adjudication``;
+    those are added only by the merged sidecar.  This validator checks the
+    schema-shaped required fields and deterministic source-byte invariants.
+    """
+    missing = [field for field in WORKING_CASE_REQUIRED if field not in record]
+    forbidden = [field for field in ("annotators", "adjudication") if field in record]
+    if missing or forbidden:
+        raise LabelJoinError(
+            "invalid working record shape: "
+            + ("missing=" + ", ".join(missing) if missing else "")
+            + (" forbidden=" + ", ".join(forbidden) if forbidden else "")
+        )
+    if (
+        not isinstance(record.get("case_id"), str)
+        or not record["case_id"]
+        or not isinstance(record.get("fixture_id"), str)
+        or not record["fixture_id"]
+        or not isinstance(record.get("fact_check_id"), str)
+        or not record["fact_check_id"]
+        or not isinstance(record.get("fact_check_index"), int)
+        or record["fact_check_index"] < 0
+        or not isinstance(record.get("claim"), str)
+        or not record["claim"]
+        or not isinstance(record.get("evidence_excerpt"), str)
+        or not record["evidence_excerpt"]
+    ):
+        raise LabelJoinError("working record has an invalid case identity")
+    if not isinstance(record.get("claim_is_true"), bool):
+        raise LabelJoinError("claim_is_true must be a completed boolean in an annotator record")
+    enum_checks = {
+        "expected_reviewer_verdict": REVIEWER_VERDICTS,
+        "expected_layer_a_decision": LAYER_A_DECISIONS,
+        "expected_layer_a_reason": LAYER_A_REASONS,
+        "expected_aggregate_relation": AGGREGATE_RELATIONS,
+        "expected_fact_check_decision": FACT_CHECK_DECISIONS,
+        "failure_class": FAILURE_CLASSES,
+        "corpus_verification_status": CORPUS_STATUSES,
+    }
+    for field, allowed in enum_checks.items():
+        if record.get(field) not in allowed:
+            raise LabelJoinError(f"{field} must be a completed registered enum")
+    if not isinstance(record.get("anchor_scan_complete"), bool) or not isinstance(
+        record.get("candidate_set_complete"), bool
+    ):
+        raise LabelJoinError("scan and candidate-set completeness must be booleans")
+    if not isinstance(record.get("context_sufficient"), bool):
+        raise LabelJoinError("context_sufficient must be a completed boolean")
+    _require_hash(record.get("artifact_sha256"), "artifact_sha256")
+    candidates_by_output = record.get("candidates_by_event_output_id")
+    if not isinstance(candidates_by_output, Mapping):
+        raise LabelJoinError("candidates_by_event_output_id must be an object")
+    if record.get("expected_layer_a_decision") == "ANCHOR" and (
+        record.get("candidate_set_complete") is not True or not candidates_by_output
+    ):
+        raise LabelJoinError("ANCHOR working records require a complete non-empty candidate set")
+    for event_output_id, candidates in candidates_by_output.items():
+        _require_hash(event_output_id, "event_output_id")
+        raw_output = event_outputs.get(str(event_output_id))
+        if raw_output is None:
+            raise LabelJoinError(f"missing raw output for event_output_id={event_output_id}")
+        normalized_output = anchor_primitives.normalize_for_match(raw_output)
+        if not isinstance(candidates, list) or not candidates:
+            raise LabelJoinError(f"event output {event_output_id} needs a non-empty candidate list")
+        for candidate in candidates:
+            if not isinstance(candidate, Mapping):
+                raise LabelJoinError(f"event output {event_output_id} has a non-object candidate")
+            missing_candidate = [field for field in WORKING_CANDIDATE_REQUIRED if field not in candidate]
+            if missing_candidate:
+                raise LabelJoinError("candidate missing=" + ", ".join(missing_candidate))
+            for field in SHA_FIELDS:
+                _require_hash(candidate.get(field), field)
+            if sha256_text(raw_output) != candidate["raw_output_sha256"]:
+                raise LabelJoinError(f"raw output hash mismatch for {event_output_id}")
+            if sha256_text(normalized_output) != candidate["normalized_output_sha256"]:
+                raise LabelJoinError(f"normalized output hash mismatch for {event_output_id}")
+            if candidate.get("expected_source_relation") not in SOURCE_RELATIONS:
+                raise LabelJoinError("candidate expected_source_relation must be a completed registered enum")
+            previous_normalized_end = 0
+            previous_raw_end = 0
+            segments = candidate["ordered_segment_spans"]
+            if not isinstance(segments, list) or not segments:
+                raise LabelJoinError("candidate ordered_segment_spans must be a non-empty list")
+            for expected_index, segment in enumerate(segments):
+                if not isinstance(segment, Mapping) or segment.get("segment_index") != expected_index:
+                    raise LabelJoinError("segment indices must be consecutive and ordered")
+                try:
+                    normalized_start = int(segment["output_normalized_start"])
+                    normalized_end = int(segment["output_normalized_end"])
+                    raw_start = int(segment["output_raw_start"])
+                    raw_end = int(segment["output_raw_end"])
+                except (KeyError, TypeError, ValueError) as exc:
+                    raise LabelJoinError("segment offsets must be integer values") from exc
+                if not (
+                    0 <= normalized_start < normalized_end <= len(normalized_output)
+                    and 0 <= raw_start < raw_end <= len(raw_output)
+                    and previous_normalized_end <= normalized_start
+                    and previous_raw_end <= raw_start
+                ):
+                    raise LabelJoinError("segment spans are out of bounds or overlap")
+                normalized_segment = normalized_output[normalized_start:normalized_end]
+                raw_segment = raw_output[raw_start:raw_end]
+                if anchor_primitives.normalize_for_match(raw_segment) != normalized_segment:
+                    raise LabelJoinError("normalized-to-raw segment mapping does not round trip")
+                _require_hash(segment.get("normalized_segment_sha256"), "normalized_segment_sha256")
+                _require_hash(segment.get("raw_segment_sha256"), "raw_segment_sha256")
+                if (
+                    sha256_text(normalized_segment) != segment["normalized_segment_sha256"]
+                    or sha256_text(raw_segment) != segment["raw_segment_sha256"]
+                ):
+                    raise LabelJoinError("segment SHA-256 does not match captured output")
+                previous_normalized_end = normalized_end
+                previous_raw_end = raw_end
+            support_spans = candidate["expected_support_spans"]
+            if not isinstance(support_spans, list):
+                raise LabelJoinError("expected_support_spans must be a list")
+            for support in support_spans:
+                if (
+                    not isinstance(support, Mapping)
+                    or not isinstance(support.get("start"), int)
+                    or not isinstance(support.get("end"), int)
+                ):
+                    raise LabelJoinError("support spans must carry integer offsets")
+                if not 0 <= support["start"] < support["end"] <= len(raw_output):
+                    raise LabelJoinError("support span is out of bounds")
+                if support.get("role") not in SUPPORT_ROLES:
+                    raise LabelJoinError("support span role is not registered")
+            relation = candidate["expected_source_relation"]
+            roles = {str(support.get("role")) for support in support_spans if isinstance(support, Mapping)}
+            if relation == "ENTAILS" and "SUPPORTS" not in roles:
+                raise LabelJoinError("ENTAILS requires a SUPPORTS span")
+            if relation == "CONTRADICTS" and "CONTRADICTS" not in roles:
+                raise LabelJoinError("CONTRADICTS requires a CONTRADICTS span")
+            if relation == "EXPLICITLY_UNCERTAIN" and "UNCERTAINTY" not in roles:
+                raise LabelJoinError("EXPLICITLY_UNCERTAIN requires an UNCERTAINTY span")
+            if relation == "MIXED" and not ({"SUPPORTS"} <= roles and ({"CONTRADICTS", "UNCERTAINTY"} & roles)):
+                raise LabelJoinError("MIXED requires support and contradiction/uncertainty spans")
+            if relation in {"NO_RELATION", "INSUFFICIENT_CONTEXT", "TOOL_ERROR"} and support_spans:
+                raise LabelJoinError(f"{relation} requires no support spans")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--keyed-union", type=Path, required=True)
+    parser.add_argument("--shadow", type=Path, required=True)
+    parser.add_argument("--corpus-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--shards", type=int, default=4)
+    parser.add_argument("--no-resume", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    write_scaffold(
+        args.keyed_union,
+        args.shadow,
+        corpus_dir=args.corpus_dir,
+        output_dir=args.output_dir,
+        shard_count=args.shards,
+        resume=not args.no_resume,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through the CLI
+    raise SystemExit(main())

--- a/scripts/audit/layerb_label_scaffold.py
+++ b/scripts/audit/layerb_label_scaffold.py
@@ -262,6 +262,8 @@ def _case_from_row(
     grounding_key = row.get("grounding_key")
     if not isinstance(grounding_key, str) or grounding_key != shadow.get("grounding_key"):
         raise LabelJoinError(f"keyed row does not exactly resolve to a shadow grounding key: {grounding_key!r}")
+    if row.get("fact_check_index") != fact_check_index_from_key(grounding_key):
+        raise LabelJoinError(f"keyed row fact_check_index does not match grounding key: {grounding_key!r}")
     artifact_name = shadow.get("artifact")
     if not isinstance(artifact_name, str) or artifact_name not in corpus:
         raise LabelJoinError(f"shadow artifact is unavailable: {artifact_name!r}")

--- a/scripts/audit/layerb_label_scaffold.py
+++ b/scripts/audit/layerb_label_scaffold.py
@@ -22,6 +22,7 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(project_root / "scripts"))
 
 from scripts.audit import anchor_primitives
+from scripts.audit.layerb_keys import _build_event_index
 from scripts.audit.layerb_label_common import (
     LabelJoinError,
     atomic_write_json,
@@ -34,7 +35,6 @@ from scripts.audit.layerb_label_common import (
     shadow_rows,
     union_rows,
 )
-from scripts.audit.layerb_shadow import _build_event_index
 
 JUDGMENT_CASE_FIELDS = (
     "claim_is_true",
@@ -164,6 +164,61 @@ def _artifact_events(artifact: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     return [event for event in events if isinstance(event, Mapping)]
 
 
+def verify_candidate_segments(
+    candidate: Mapping[str, Any], event_output_id: str, outputs: Mapping[str, str]
+) -> tuple[str, str]:
+    """Re-hash every recorded segment against the captured raw source bytes.
+
+    The shadow record is immutable input, not an authority for its own offsets
+    or hashes.  Every candidate copied into a scaffold therefore has to prove
+    its raw and normalized spans again at emission time.
+    """
+    raw_output = outputs.get(event_output_id)
+    if raw_output is None:
+        raise LabelJoinError(f"candidate event output is unavailable: {event_output_id}")
+    if sha256_text(raw_output) != candidate.get("raw_output_sha256"):
+        raise LabelJoinError(f"candidate raw-output hash mismatch: {event_output_id}")
+    normalized_output = anchor_primitives.normalize_for_match(raw_output)
+    if sha256_text(normalized_output) != candidate.get("normalized_output_sha256"):
+        raise LabelJoinError(f"candidate normalized-output hash mismatch: {event_output_id}")
+    segments = candidate.get("ordered_segment_spans")
+    if not isinstance(segments, list) or not segments:
+        raise LabelJoinError(f"candidate has no ordered segment spans: {event_output_id}")
+    previous_normalized_end = 0
+    previous_raw_end = 0
+    for expected_index, segment in enumerate(segments):
+        if not isinstance(segment, Mapping) or segment.get("segment_index") != expected_index:
+            raise LabelJoinError(f"candidate segment indices are not consecutive: {event_output_id}")
+        offsets = (
+            "output_normalized_start",
+            "output_normalized_end",
+            "output_raw_start",
+            "output_raw_end",
+        )
+        values = [segment.get(name) for name in offsets]
+        if not all(isinstance(value, int) and not isinstance(value, bool) for value in values):
+            raise LabelJoinError(f"candidate segment offsets are not integer values: {event_output_id}")
+        normalized_start, normalized_end, raw_start, raw_end = values
+        if not (
+            0 <= normalized_start < normalized_end <= len(normalized_output)
+            and 0 <= raw_start < raw_end <= len(raw_output)
+            and previous_normalized_end <= normalized_start
+            and previous_raw_end <= raw_start
+        ):
+            raise LabelJoinError(f"candidate segment spans are out of bounds or overlap: {event_output_id}")
+        normalized_segment = normalized_output[normalized_start:normalized_end]
+        raw_segment = raw_output[raw_start:raw_end]
+        if anchor_primitives.normalize_for_match(raw_segment) != normalized_segment:
+            raise LabelJoinError(f"candidate normalized-to-raw segment mapping does not round trip: {event_output_id}")
+        if sha256_text(normalized_segment) != segment.get("normalized_segment_sha256") or sha256_text(
+            raw_segment
+        ) != segment.get("raw_segment_sha256"):
+            raise LabelJoinError(f"candidate segment SHA-256 does not match captured output: {event_output_id}")
+        previous_normalized_end = normalized_end
+        previous_raw_end = raw_end
+    return raw_output, normalized_output
+
+
 def _schema_candidate(candidate: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
     event_output_id = candidate.get("event_output_id")
     if not isinstance(event_output_id, str) or not SHA_RE.fullmatch(event_output_id):
@@ -203,7 +258,7 @@ def _case_from_row(
     *,
     corpus_dir: Path,
     corpus: Mapping[str, Mapping[str, Any]],
-) -> tuple[dict[str, Any], dict[str, Any], str]:
+) -> tuple[dict[str, Any], dict[str, Any], str, int]:
     grounding_key = row.get("grounding_key")
     if not isinstance(grounding_key, str) or grounding_key != shadow.get("grounding_key"):
         raise LabelJoinError(f"keyed row does not exactly resolve to a shadow grounding key: {grounding_key!r}")
@@ -218,11 +273,15 @@ def _case_from_row(
     candidates = layer_a.get("candidates")
     if not isinstance(candidates, list):
         raise LabelJoinError(f"shadow {grounding_key} has malformed Layer A candidates")
+    event_outputs = _build_event_index(_artifact_events(artifact))
     grouped_candidates: dict[str, list[dict[str, Any]]] = {}
+    segment_verified_candidates = 0
     for candidate in candidates:
         if not isinstance(candidate, Mapping):
             raise LabelJoinError(f"shadow {grounding_key} includes a non-object candidate")
         event_output_id, shaped = _schema_candidate(candidate)
+        verify_candidate_segments(shaped, event_output_id, event_outputs)
+        segment_verified_candidates += 1
         grouped_candidates.setdefault(event_output_id, []).append(shaped)
     all_scans_complete = all(candidate.get("anchor_scan_complete") is True for candidate in candidates)
     case: dict[str, Any] = {
@@ -251,23 +310,15 @@ def _case_from_row(
     if not case["fixture_id"] or not case["claim"] or not case["evidence_excerpt"]:
         raise LabelJoinError(f"shadow {grounding_key} cannot produce a complete mechanical case identity")
     packet = _packet_case(case, row, artifact, corpus_dir=corpus_dir)
-    return case, packet, artifact_name
+    return case, packet, artifact_name, segment_verified_candidates
 
 
 def _candidate_navigation(
     candidate: Mapping[str, Any], event_output_id: str, outputs: Mapping[str, str]
 ) -> dict[str, Any]:
-    raw_output = outputs.get(event_output_id)
-    if raw_output is None:
-        raise LabelJoinError(f"candidate event output is unavailable: {event_output_id}")
-    if sha256_text(raw_output) != candidate.get("raw_output_sha256"):
-        raise LabelJoinError(f"candidate raw-output hash mismatch: {event_output_id}")
-    normalized_output = anchor_primitives.normalize_for_match(raw_output)
-    if sha256_text(normalized_output) != candidate.get("normalized_output_sha256"):
-        raise LabelJoinError(f"candidate normalized-output hash mismatch: {event_output_id}")
+    raw_output, normalized_output = verify_candidate_segments(candidate, event_output_id, outputs)
     segments = candidate.get("ordered_segment_spans")
-    if not isinstance(segments, list) or not segments:
-        raise LabelJoinError(f"candidate has no ordered segment spans: {event_output_id}")
+    assert isinstance(segments, list) and segments
     normalized_start = min(int(segment["output_normalized_start"]) for segment in segments)
     normalized_end = max(int(segment["output_normalized_end"]) for segment in segments)
     raw_start = min(int(segment["output_raw_start"]) for segment in segments)
@@ -370,18 +421,20 @@ def build_scaffold(
     packets: list[dict[str, Any]] = []
     used_artifacts: set[str] = set()
     seen_cases: set[str] = set()
+    segment_verified_candidates = 0
     for row in keyed_rows:
         key = row.get("grounding_key")
         shadow = shadow_by_key.get(str(key))
         if shadow is None:
             raise LabelJoinError(f"keyed union contains missing shadow grounding key: {key!r}")
-        case, packet, artifact_name = _case_from_row(row, shadow, corpus_dir=corpus_dir, corpus=corpus)
+        case, packet, artifact_name, verified_count = _case_from_row(row, shadow, corpus_dir=corpus_dir, corpus=corpus)
         if case["case_id"] in seen_cases:
             raise LabelJoinError(f"keyed union has duplicate case_id: {case['case_id']}")
         seen_cases.add(case["case_id"])
         cases.append(case)
         packets.append(packet)
         used_artifacts.add(artifact_name)
+        segment_verified_candidates += verified_count
     ordered_pairs = sorted(zip(cases, packets, strict=True), key=lambda pair: str(pair[0]["case_id"]))
     cases = [case for case, _packet in ordered_pairs]
     packets = [packet for _case, packet in ordered_pairs]
@@ -422,6 +475,7 @@ def build_scaffold(
         "cases": len(cases),
         "shards": sum(1 for shard in range(shard_count) if packets[shard * per_shard : (shard + 1) * per_shard]),
         "candidates": sum(len(group) for case in cases for group in case["candidates_by_event_output_id"].values()),
+        "segment_verified_candidates": segment_verified_candidates,
         "judgment_fields_prefilled": 0,
         "join_report": dict((keyed_document.get("keying") or {}).get("join_report") or {}),
     }

--- a/scripts/audit/layerb_label_union.py
+++ b/scripts/audit/layerb_label_union.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python3
 """Build deterministic, key-addressable Layer B label-union inputs.
 
-``attach`` is authoritative for the 2026-07-10 frozen union.  It preserves
-each existing row and appends only ``grounding_key`` and ``fact_check_index``.
-``derive`` is for later tau replays; it sorts every control pool before seeded
-sampling.  It intentionally does not promise to reproduce the original ad-hoc
-control sample used by the frozen union.
+``rederive`` is the authoritative path: it emits keys while walking the raw
+corpus, proves that the 1,310 non-key records have not drifted, and hands those
+keyed records to ``derive``.  ``derive`` selects the flag-derived union and
+fresh deterministic controls without any shadow-row join.
+
+``attach`` remains available solely for inputs whose duplicate groups resolve
+under its strict D2 invariant.  It is unsafe for ambiguous groups and is never
+the authority for this frozen cycle.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import random
 import sys
 from collections import Counter, defaultdict
@@ -23,6 +27,7 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(project_root))
     sys.path.insert(0, str(project_root / "scripts"))
 
+from scripts.audit.layerb_derivation import DEFAULT_TAU, derive_keyed_records
 from scripts.audit.layerb_label_common import (
     LabelJoinError,
     artifact_filename_from_union,
@@ -42,6 +47,10 @@ from scripts.audit.layerb_label_common import (
 
 DEFAULT_CONTROL_SEED = 4913
 DEFAULT_CONTROL_PER_STRATUM = 25
+DEFAULT_REDERIVE_EXPECTED_ROWS = 1310
+KEY_FIELDS = frozenset({"grounding_key", "fact_check_index"})
+CATEGORY_NAMES = frozenset({"recovered", "regression", "abstain"})
+CATEGORY_ORDER = ("recovered", "regression", "abstain", "control_both_accept", "control_both_reject")
 
 
 def _rows_document(
@@ -92,11 +101,13 @@ def attach_keys(
     *,
     corpus_dir: Path,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Attach shadow-runner grounding identities to every frozen union row.
+    """Attach keys only when every duplicate group resolves under D2.
 
     The union's source index is checked against all shared derivation fields;
     shadow rows are then joined by an exact multiset identity rather than their
-    unrelated global list position.
+    unrelated global list position.  This compatibility path is deliberately
+    unsafe for ambiguous groups and must not be used as a frozen-cycle source
+    of authority; use :func:`rederive_keyed_derivation` instead.
     """
     selected = union_rows(union_document)
     derivations = derivation_rows(derivation_document)
@@ -127,7 +138,7 @@ def attach_keys(
         raise LabelJoinError("keyed union is not bijective; duplicate grounding keys=" + ", ".join(duplicates))
     duplicate_groups = _duplicate_group_report(selected, group_resolutions)
     report: dict[str, Any] = {
-        "mode": "attach",
+        "mode": "attach-unsafe-for-ambiguous-groups",
         "union_rows": len(selected),
         "derivation_rows": len(derivations),
         "shadow_rows": len(shadows),
@@ -141,7 +152,10 @@ def attach_keys(
         "stable_key_recomputations": len(shadows),
         "documented_base_artifact_filenames": len({artifact_filename_from_union(row) for row in selected}),
     }
-    return _rows_document(union_document, keyed_rows, mode="attach", report=report), report
+    return (
+        _rows_document(union_document, keyed_rows, mode="attach-unsafe-for-ambiguous-groups", report=report),
+        report,
+    )
 
 
 def _category_names(row: Mapping[str, Any]) -> set[str]:
@@ -157,24 +171,160 @@ def _category_names(row: Mapping[str, Any]) -> set[str]:
     return categories
 
 
+def _ordered_categories(categories: set[str]) -> list[str]:
+    """Render flag categories in the frozen derivation's semantic order."""
+    return [category for category in CATEGORY_ORDER if category in categories]
+
+
 def _stable_pool_order(row: Mapping[str, Any], index: int) -> tuple[str, str, str, str, int]:
     key = structural_key_from_union(row)
     return (*key, index)
 
 
+def _without_key_fields(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Project the legacy record shape for full-field multiset comparison."""
+    return {key: value for key, value in row.items() if key not in KEY_FIELDS}
+
+
+def _canonical_row_multiset(rows: Sequence[Mapping[str, Any]]) -> Counter[str]:
+    return Counter(canonical_json(_without_key_fields(row)) for row in rows)
+
+
+def _counter_rows(counter: Counter[str]) -> list[dict[str, Any]]:
+    """Render a compact, deterministic Counter difference for failure output."""
+    return [
+        {"count": count, "row": json.loads(row)}
+        for row, count in sorted(counter.items())
+        if count
+    ]
+
+
+def assert_no_drift(
+    regenerated_rows: Sequence[Mapping[str, Any]], frozen_derivation_document: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Hard-fail unless keyed source regeneration matches every frozen field.
+
+    Only the two source-emitted identity fields are excluded.  Every other
+    field—including booleans, float values, and nullable gold truth—is compared
+    as canonical JSON, with multiplicity retained.
+    """
+    frozen_rows = derivation_rows(frozen_derivation_document)
+    regenerated_counter = _canonical_row_multiset(regenerated_rows)
+    frozen_counter = _canonical_row_multiset(frozen_rows)
+    regenerated_only = regenerated_counter - frozen_counter
+    frozen_only = frozen_counter - regenerated_counter
+    report = {
+        "mode": "rederive-at-source",
+        "excluded_key_fields": sorted(KEY_FIELDS),
+        "regenerated_rows": len(regenerated_rows),
+        "frozen_rows": len(frozen_rows),
+        "regenerated_distinct_tuples": len(regenerated_counter),
+        "frozen_distinct_tuples": len(frozen_counter),
+        "symmetric_difference": {
+            "regenerated_only": _counter_rows(regenerated_only),
+            "frozen_only": _counter_rows(frozen_only),
+        },
+        "no_drift": not regenerated_only and not frozen_only,
+    }
+    if not report["no_drift"]:
+        raise LabelJoinError("rederive no-drift proof failed: " + canonical_json(report))
+    return report
+
+
+def rederive_keyed_derivation(
+    *,
+    artifacts_dir: Path,
+    fixtures_dir: Path,
+    frozen_derivation_document: Mapping[str, Any],
+    tau: float = DEFAULT_TAU,
+    expected_rows: int = DEFAULT_REDERIVE_EXPECTED_ROWS,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Emit a keyed derivation directly from raw source and prove no drift."""
+    records = derive_keyed_records(artifacts_dir, fixtures_dir=fixtures_dir, tau=tau)
+    if len(records) != expected_rows:
+        raise LabelJoinError(f"rederive emitted {len(records)} rows; expected {expected_rows}")
+    keys = [record.get("grounding_key") for record in records]
+    if not all(isinstance(key, str) and key for key in keys) or len(set(keys)) != len(keys):
+        raise LabelJoinError("rederive must emit one non-empty grounding_key per source record")
+    for record in records:
+        key = str(record["grounding_key"])
+        if record.get("fact_check_index") != fact_check_index_from_key(key):
+            raise LabelJoinError(f"rederive fact_check_index does not match grounding_key: {key!r}")
+    proof = assert_no_drift(records, frozen_derivation_document)
+    report = {
+        **proof,
+        "tau": tau,
+        "expected_rows": expected_rows,
+        "grounding_keys_unique": len(set(keys)),
+        "keyed_at_source": True,
+    }
+    document = {
+        "kind": "qg-layer-b-keyed-union-derivation",
+        "version": 1,
+        "total_rows": len(records),
+        "records": records,
+        "metadata": {
+            "tau": tau,
+            "artifacts_dir": str(artifacts_dir),
+            "fixtures_dir": str(fixtures_dir),
+            "keying": "source-artifact-path-plus-fact-check-index",
+            "no_drift": True,
+        },
+        "keying": {"mode": "rederive-at-source", "join_report": report},
+    }
+    return document, report
+
+
+def _category_rows(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        dict(row)
+        for row in rows
+        if CATEGORY_NAMES.intersection(row.get("union_categories") or [])
+    ]
+
+
+def _assert_category_membership(
+    category_rows: Sequence[Mapping[str, Any]], frozen_union_document: Mapping[str, Any]
+) -> dict[str, Any]:
+    frozen_category_rows = _category_rows(union_rows(frozen_union_document))
+    selected_counter = _canonical_row_multiset(category_rows)
+    frozen_counter = _canonical_row_multiset(frozen_category_rows)
+    selected_only = selected_counter - frozen_counter
+    frozen_only = frozen_counter - selected_counter
+    report = {
+        "category_rows": len(category_rows),
+        "frozen_category_rows": len(frozen_category_rows),
+        "category_multiset_equal": not selected_only and not frozen_only,
+        "category_symmetric_difference": {
+            "selected_only": _counter_rows(selected_only),
+            "frozen_only": _counter_rows(frozen_only),
+        },
+    }
+    if not report["category_multiset_equal"]:
+        raise LabelJoinError("flag-derived category membership drifted: " + canonical_json(report))
+    return report
+
+
 def derive_union(
     derivation_document: Mapping[str, Any],
-    shadow_document: Mapping[str, Any],
     *,
-    corpus_dir: Path,
+    frozen_union_document: Mapping[str, Any],
     seed: int = DEFAULT_CONTROL_SEED,
     control_per_stratum: int = DEFAULT_CONTROL_PER_STRATUM,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Re-derive future label membership with deterministic stratified controls."""
+    """Select the union directly from keyed source records and fresh controls."""
     derivations = derivation_rows(derivation_document)
-    shadows = shadow_rows(shadow_document)
-    corpus = load_corpus(corpus_dir)
-    derivation_to_shadow, _group_resolutions = resolve_derivation_to_shadow(derivations, shadows, corpus)
+    if control_per_stratum < 1:
+        raise LabelJoinError("control_per_stratum must be positive")
+    for row in derivations:
+        grounding_key = row.get("grounding_key")
+        if not isinstance(grounding_key, str) or not grounding_key:
+            raise LabelJoinError("derive requires source-keyed derivation records")
+        if row.get("fact_check_index") != fact_check_index_from_key(grounding_key):
+            raise LabelJoinError(f"keyed derivation fact_check_index is invalid: {grounding_key!r}")
+    grounding_keys = [str(row["grounding_key"]) for row in derivations]
+    if len(grounding_keys) != len(set(grounding_keys)):
+        raise LabelJoinError("keyed derivation contains duplicate grounding keys")
     selected_categories: dict[int, set[str]] = {
         index: _category_names(row) for index, row in enumerate(derivations) if _category_names(row)
     }
@@ -209,39 +359,35 @@ def derive_union(
     keyed_rows: list[dict[str, Any]] = []
     for index in sorted(selected_categories, key=lambda value: _stable_pool_order(derivations[value], value)):
         row = dict(derivations[index])
-        shadow = derivation_to_shadow[index]
-        grounding_key = str(shadow["grounding_key"])
         row["source_index"] = index
-        row["union_categories"] = sorted(selected_categories[index])
-        row["grounding_key"] = grounding_key
-        row["fact_check_index"] = fact_check_index_from_key(grounding_key)
+        row["union_categories"] = _ordered_categories(selected_categories[index])
         keyed_rows.append(row)
-    keys = [str(row["grounding_key"]) for row in keyed_rows]
-    if len(keys) != len(set(keys)):
-        raise LabelJoinError("fresh derivation selected duplicate grounding keys")
+    category_membership = _assert_category_membership(_category_rows(keyed_rows), frozen_union_document)
     category_counts = Counter(category for categories in selected_categories.values() for category in categories)
     report: dict[str, Any] = {
-        "mode": "derive",
+        "mode": "derive-from-keyed-rederive",
         "seed": seed,
         "control_per_stratum": control_per_stratum,
-        "derivation_rows": len(derivations),
-        "shadow_rows": len(shadows),
+        "keyed_derivation_rows": len(derivations),
         "matched_rows": len(keyed_rows),
         "category_counts": dict(sorted(category_counts.items())),
         "control_pool_counts": {"control_both_accept": len(both_accept), "control_both_reject": len(both_reject)},
         "sampled_control_indexes": selected_controls,
-        "mode_a_authoritative_for_frozen_cycle": True,
+        "control_resampled": True,
+        "category_membership": category_membership,
+        "source_keyed_derivation_required": True,
         "frozen_control_sample_reproduction_guaranteed": False,
     }
     document = {
         "kind": "qg-layer-b-label-union-input",
-        "version": 2,
+        "version": 3,
         "total_rows": len(keyed_rows),
         "control_seed": seed,
         "rows": keyed_rows,
         "keying": {
-            "mode": "derive",
-            "note": "Mode B is deterministic, but does not reproduce this cycle's ad-hoc frozen controls; Mode A is authoritative.",
+            "mode": "derive-from-keyed-rederive",
+            "note": "Category membership is source-keyed and frozen-verified; controls were freshly resampled.",
+            "control_resampled": True,
             "join_report": report,
         },
     }
@@ -258,37 +404,51 @@ def _write_outputs(
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="mode", required=True)
-    for mode in ("attach", "derive"):
+    for mode in ("attach", "derive", "rederive"):
         command = subparsers.add_parser(mode)
         command.add_argument("--derivation", type=Path, required=True)
-        command.add_argument("--shadow", type=Path, required=True)
-        command.add_argument("--corpus-dir", type=Path, required=True)
         command.add_argument("--output", type=Path, required=True)
         command.add_argument("--report", type=Path)
     attach = subparsers.choices["attach"]
     attach.add_argument("--union", type=Path, required=True)
+    attach.add_argument("--shadow", type=Path, required=True)
+    attach.add_argument("--corpus-dir", type=Path, required=True)
     derive = subparsers.choices["derive"]
+    derive.add_argument("--frozen-union", type=Path, required=True)
     derive.add_argument("--seed", type=int, default=DEFAULT_CONTROL_SEED)
     derive.add_argument("--control-per-stratum", type=int, default=DEFAULT_CONTROL_PER_STRATUM)
+    rederive = subparsers.choices["rederive"]
+    rederive.add_argument("--artifacts-dir", type=Path, required=True)
+    rederive.add_argument("--fixtures-dir", type=Path, default=Path("tests/fixtures/qg_bakeoff"))
+    rederive.add_argument("--tau", type=float, default=DEFAULT_TAU)
+    rederive.add_argument("--expected-rows", type=int, default=DEFAULT_REDERIVE_EXPECTED_ROWS)
     return parser.parse_args(argv)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     derivation_document = read_json(args.derivation)
-    shadow_document = read_json(args.shadow)
     if args.mode == "attach":
         document, report = attach_keys(
-            read_json(args.union), derivation_document, shadow_document, corpus_dir=args.corpus_dir
+            read_json(args.union), derivation_document, read_json(args.shadow), corpus_dir=args.corpus_dir
         )
-    else:
+    elif args.mode == "derive":
         document, report = derive_union(
             derivation_document,
-            shadow_document,
-            corpus_dir=args.corpus_dir,
+            frozen_union_document=read_json(args.frozen_union),
             seed=args.seed,
             control_per_stratum=args.control_per_stratum,
         )
+    else:
+        document, report = rederive_keyed_derivation(
+            artifacts_dir=args.artifacts_dir,
+            fixtures_dir=args.fixtures_dir,
+            frozen_derivation_document=derivation_document,
+            tau=args.tau,
+            expected_rows=args.expected_rows,
+        )
+        report["frozen_derivation"] = {"path": str(args.derivation), "sha256": sha256_file(args.derivation)}
+        document["metadata"]["frozen_derivation"] = dict(report["frozen_derivation"])
     _write_outputs(document, report, args.output, args.report)
     return 0
 

--- a/scripts/audit/layerb_label_union.py
+++ b/scripts/audit/layerb_label_union.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Build deterministic, key-addressable Layer B label-union inputs.
+
+``attach`` is authoritative for the 2026-07-10 frozen union.  It preserves
+each existing row and appends only ``grounding_key`` and ``fact_check_index``.
+``derive`` is for later tau replays; it sorts every control pool before seeded
+sampling.  It intentionally does not promise to reproduce the original ad-hoc
+control sample used by the frozen union.
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import sys
+from collections import Counter, defaultdict
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(project_root))
+    sys.path.insert(0, str(project_root / "scripts"))
+
+from scripts.audit.layerb_label_common import (
+    LabelJoinError,
+    artifact_filename_from_union,
+    atomic_write_json,
+    canonical_json,
+    derivation_rows,
+    fact_check_index_from_key,
+    load_corpus,
+    read_json,
+    resolve_derivation_indices,
+    resolve_derivation_to_shadow,
+    sha256_file,
+    shadow_rows,
+    structural_key_from_union,
+    union_rows,
+)
+
+DEFAULT_CONTROL_SEED = 4913
+DEFAULT_CONTROL_PER_STRATUM = 25
+
+
+def _rows_document(
+    document: Mapping[str, Any], rows: list[dict[str, Any]], *, mode: str, report: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Retain the original envelope while making output mode/provenance explicit."""
+    result = dict(document)
+    result["rows"] = rows
+    result["total_rows"] = len(rows)
+    result["keying"] = {
+        "mode": mode,
+        "grounding_key_source": "scripts.audit.layerb_shadow._stable_grounding_key",
+        "join_report": dict(report),
+    }
+    return result
+
+
+def _duplicate_group_report(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, str, str, str], list[int]] = defaultdict(list)
+    for index, row in enumerate(rows):
+        groups[structural_key_from_union(row)].append(index)
+    return [
+        {
+            "key": list(key),
+            "count": len(indexes),
+            "row_indexes": indexes,
+            "resolution": "frozen source_index -> exact derivation row -> grouped shadow bijection",
+        }
+        for key, indexes in sorted(groups.items())
+        if len(indexes) > 1
+    ]
+
+
+def attach_keys(
+    union_document: Mapping[str, Any],
+    derivation_document: Mapping[str, Any],
+    shadow_document: Mapping[str, Any],
+    *,
+    corpus_dir: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Attach shadow-runner grounding identities to every frozen union row.
+
+    The union's source index is checked against all shared derivation fields;
+    shadow rows are then joined by an exact multiset identity rather than their
+    unrelated global list position.
+    """
+    selected = union_rows(union_document)
+    derivations = derivation_rows(derivation_document)
+    shadows = shadow_rows(shadow_document)
+    corpus = load_corpus(corpus_dir)
+    selected_derivation_indexes = resolve_derivation_indices(selected, derivations)
+    derivation_to_shadow = resolve_derivation_to_shadow(derivations, shadows, corpus)
+
+    keyed_rows: list[dict[str, Any]] = []
+    for row, derivation_index in zip(selected, selected_derivation_indexes, strict=True):
+        shadow = derivation_to_shadow[derivation_index]
+        grounding_key = shadow.get("grounding_key")
+        if not isinstance(grounding_key, str):
+            raise LabelJoinError(f"shadow row has no grounding_key at derivation index {derivation_index}")
+        keyed = dict(row)
+        keyed["grounding_key"] = grounding_key
+        keyed["fact_check_index"] = fact_check_index_from_key(grounding_key)
+        keyed_rows.append(keyed)
+
+    grounding_keys = [str(row["grounding_key"]) for row in keyed_rows]
+    if len(set(grounding_keys)) != len(grounding_keys):
+        duplicates = sorted(key for key, count in Counter(grounding_keys).items() if count > 1)
+        raise LabelJoinError("keyed union is not bijective; duplicate grounding keys=" + ", ".join(duplicates))
+    duplicate_groups = _duplicate_group_report(selected)
+    report: dict[str, Any] = {
+        "mode": "attach",
+        "union_rows": len(selected),
+        "derivation_rows": len(derivations),
+        "shadow_rows": len(shadows),
+        "matched_rows": len(keyed_rows),
+        "grounding_keys_unique": len(set(grounding_keys)),
+        "total": len(keyed_rows) == len(selected),
+        "bijective": len(set(grounding_keys)) == len(keyed_rows),
+        "duplicate_group_count": len(duplicate_groups),
+        "duplicate_group_rows": sum(group["count"] for group in duplicate_groups),
+        "duplicate_group_resolutions": duplicate_groups,
+        "stable_key_recomputations": len(shadows),
+        "documented_base_artifact_filenames": len({artifact_filename_from_union(row) for row in selected}),
+    }
+    return _rows_document(union_document, keyed_rows, mode="attach", report=report), report
+
+
+def _category_names(row: Mapping[str, Any]) -> set[str]:
+    categories: set[str] = set()
+    v1 = row.get("v1_admissible") is True
+    effective = row.get("v2_effective") is True
+    if not v1 and effective:
+        categories.add("recovered")
+    if v1 and not effective:
+        categories.add("regression")
+    if row.get("v2_abstained") is True:
+        categories.add("abstain")
+    return categories
+
+
+def _stable_pool_order(row: Mapping[str, Any], index: int) -> tuple[str, str, str, str, int]:
+    key = structural_key_from_union(row)
+    return (*key, index)
+
+
+def derive_union(
+    derivation_document: Mapping[str, Any],
+    shadow_document: Mapping[str, Any],
+    *,
+    corpus_dir: Path,
+    seed: int = DEFAULT_CONTROL_SEED,
+    control_per_stratum: int = DEFAULT_CONTROL_PER_STRATUM,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Re-derive future label membership with deterministic stratified controls."""
+    derivations = derivation_rows(derivation_document)
+    shadows = shadow_rows(shadow_document)
+    corpus = load_corpus(corpus_dir)
+    derivation_to_shadow = resolve_derivation_to_shadow(derivations, shadows, corpus)
+    selected_categories: dict[int, set[str]] = {
+        index: _category_names(row) for index, row in enumerate(derivations) if _category_names(row)
+    }
+    selected_indexes = set(selected_categories)
+
+    both_accept = [
+        index
+        for index, row in enumerate(derivations)
+        if index not in selected_indexes and row.get("v1_admissible") is True and row.get("v2_effective") is True
+    ]
+    both_reject = [
+        index
+        for index, row in enumerate(derivations)
+        if index not in selected_indexes
+        and row.get("v1_admissible") is not True
+        and row.get("v2_effective") is not True
+    ]
+    rng = random.Random(seed)
+    selected_controls: dict[str, list[int]] = {}
+    for name, pool in (("control_both_accept", both_accept), ("control_both_reject", both_reject)):
+        ordered_pool = sorted(pool, key=lambda index: _stable_pool_order(derivations[index], index))
+        if len(ordered_pool) < control_per_stratum:
+            raise LabelJoinError(f"control pool {name} has {len(ordered_pool)} rows; requires {control_per_stratum}")
+        sampled = sorted(
+            rng.sample(ordered_pool, control_per_stratum),
+            key=lambda index: _stable_pool_order(derivations[index], index),
+        )
+        selected_controls[name] = sampled
+        for index in sampled:
+            selected_categories.setdefault(index, set()).add(name)
+
+    keyed_rows: list[dict[str, Any]] = []
+    for index in sorted(selected_categories, key=lambda value: _stable_pool_order(derivations[value], value)):
+        row = dict(derivations[index])
+        shadow = derivation_to_shadow[index]
+        grounding_key = str(shadow["grounding_key"])
+        row["source_index"] = index
+        row["union_categories"] = sorted(selected_categories[index])
+        row["grounding_key"] = grounding_key
+        row["fact_check_index"] = fact_check_index_from_key(grounding_key)
+        keyed_rows.append(row)
+    keys = [str(row["grounding_key"]) for row in keyed_rows]
+    if len(keys) != len(set(keys)):
+        raise LabelJoinError("fresh derivation selected duplicate grounding keys")
+    category_counts = Counter(category for categories in selected_categories.values() for category in categories)
+    report: dict[str, Any] = {
+        "mode": "derive",
+        "seed": seed,
+        "control_per_stratum": control_per_stratum,
+        "derivation_rows": len(derivations),
+        "shadow_rows": len(shadows),
+        "matched_rows": len(keyed_rows),
+        "category_counts": dict(sorted(category_counts.items())),
+        "control_pool_counts": {"control_both_accept": len(both_accept), "control_both_reject": len(both_reject)},
+        "sampled_control_indexes": selected_controls,
+        "mode_a_authoritative_for_frozen_cycle": True,
+        "frozen_control_sample_reproduction_guaranteed": False,
+    }
+    document = {
+        "kind": "qg-layer-b-label-union-input",
+        "version": 2,
+        "total_rows": len(keyed_rows),
+        "control_seed": seed,
+        "rows": keyed_rows,
+        "keying": {
+            "mode": "derive",
+            "note": "Mode B is deterministic, but does not reproduce this cycle's ad-hoc frozen controls; Mode A is authoritative.",
+            "join_report": report,
+        },
+    }
+    return document, report
+
+
+def _write_outputs(
+    document: Mapping[str, Any], report: Mapping[str, Any], output: Path, report_path: Path | None
+) -> None:
+    atomic_write_json(output, document)
+    atomic_write_json(report_path or output.with_name(output.stem + ".join-report.json"), report)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    for mode in ("attach", "derive"):
+        command = subparsers.add_parser(mode)
+        command.add_argument("--derivation", type=Path, required=True)
+        command.add_argument("--shadow", type=Path, required=True)
+        command.add_argument("--corpus-dir", type=Path, required=True)
+        command.add_argument("--output", type=Path, required=True)
+        command.add_argument("--report", type=Path)
+    attach = subparsers.choices["attach"]
+    attach.add_argument("--union", type=Path, required=True)
+    derive = subparsers.choices["derive"]
+    derive.add_argument("--seed", type=int, default=DEFAULT_CONTROL_SEED)
+    derive.add_argument("--control-per-stratum", type=int, default=DEFAULT_CONTROL_PER_STRATUM)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    derivation_document = read_json(args.derivation)
+    shadow_document = read_json(args.shadow)
+    if args.mode == "attach":
+        document, report = attach_keys(
+            read_json(args.union), derivation_document, shadow_document, corpus_dir=args.corpus_dir
+        )
+    else:
+        document, report = derive_union(
+            derivation_document,
+            shadow_document,
+            corpus_dir=args.corpus_dir,
+            seed=args.seed,
+            control_per_stratum=args.control_per_stratum,
+        )
+    _write_outputs(document, report, args.output, args.report)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through the CLI
+    raise SystemExit(main())

--- a/scripts/audit/layerb_label_union.py
+++ b/scripts/audit/layerb_label_union.py
@@ -59,20 +59,30 @@ def _rows_document(
     return result
 
 
-def _duplicate_group_report(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+def _duplicate_group_report(
+    rows: Sequence[Mapping[str, Any]],
+    resolutions: Mapping[tuple[str, str, str, str], Mapping[str, Any]],
+) -> list[dict[str, Any]]:
     groups: dict[tuple[str, str, str, str], list[int]] = defaultdict(list)
     for index, row in enumerate(rows):
         groups[structural_key_from_union(row)].append(index)
-    return [
-        {
-            "key": list(key),
-            "count": len(indexes),
-            "row_indexes": indexes,
-            "resolution": "frozen source_index -> exact derivation row -> grouped shadow bijection",
-        }
-        for key, indexes in sorted(groups.items())
-        if len(indexes) > 1
-    ]
+    reports: list[dict[str, Any]] = []
+    for key, indexes in sorted(groups.items()):
+        if len(indexes) < 2:
+            continue
+        resolution = resolutions.get(key)
+        if resolution is None:
+            raise LabelJoinError(f"duplicate union group has no shadow resolution: {canonical_json(list(key))}")
+        reports.append(
+            {
+                "key": list(key),
+                "count": len(indexes),
+                "row_indexes": indexes,
+                "resolution_basis": resolution.get("resolution_basis"),
+                "identity_fields": list(resolution.get("identity_fields") or []),
+            }
+        )
+    return reports
 
 
 def attach_keys(
@@ -93,7 +103,12 @@ def attach_keys(
     shadows = shadow_rows(shadow_document)
     corpus = load_corpus(corpus_dir)
     selected_derivation_indexes = resolve_derivation_indices(selected, derivations)
-    derivation_to_shadow = resolve_derivation_to_shadow(derivations, shadows, corpus)
+    derivation_to_shadow, group_resolutions = resolve_derivation_to_shadow(
+        derivations,
+        shadows,
+        corpus,
+        derivation_indexes=selected_derivation_indexes,
+    )
 
     keyed_rows: list[dict[str, Any]] = []
     for row, derivation_index in zip(selected, selected_derivation_indexes, strict=True):
@@ -110,7 +125,7 @@ def attach_keys(
     if len(set(grounding_keys)) != len(grounding_keys):
         duplicates = sorted(key for key, count in Counter(grounding_keys).items() if count > 1)
         raise LabelJoinError("keyed union is not bijective; duplicate grounding keys=" + ", ".join(duplicates))
-    duplicate_groups = _duplicate_group_report(selected)
+    duplicate_groups = _duplicate_group_report(selected, group_resolutions)
     report: dict[str, Any] = {
         "mode": "attach",
         "union_rows": len(selected),
@@ -159,7 +174,7 @@ def derive_union(
     derivations = derivation_rows(derivation_document)
     shadows = shadow_rows(shadow_document)
     corpus = load_corpus(corpus_dir)
-    derivation_to_shadow = resolve_derivation_to_shadow(derivations, shadows, corpus)
+    derivation_to_shadow, _group_resolutions = resolve_derivation_to_shadow(derivations, shadows, corpus)
     selected_categories: dict[int, set[str]] = {
         index: _category_names(row) for index, row in enumerate(derivations) if _category_names(row)
     }

--- a/scripts/audit/layerb_shadow.py
+++ b/scripts/audit/layerb_shadow.py
@@ -48,6 +48,7 @@ if __package__ in {None, ""}:
     sys.path.insert(0, str(project_root / "scripts"))
 
 from scripts.audit import anchor_primitives, layerb_candidates
+from scripts.audit.layerb_keys import _build_event_index, _stable_grounding_key
 from scripts.audit.llm_reviewer_dispatch import tool_events_from_dispatch_meta
 
 REPORT_VERSION = "qg-layer-b-shadow-report.v1-draft"
@@ -285,15 +286,6 @@ def _extract_lineages(
     return writer_family, qg_reviewer_family
 
 
-def _stable_grounding_key(path: Path, fact_index: int, fact_check: Mapping[str, Any]) -> str:
-    explicit = fact_check.get("fact_check_id")
-    if isinstance(explicit, str) and explicit.strip():
-        suffix = explicit.strip()
-    else:
-        suffix = _sha256_text(_canonical_json(fact_check))[:16]
-    return f"{path.name}#fact_checks[{fact_index}]::{suffix}"
-
-
 def _read_artifacts(artifacts_dir: Path) -> list[tuple[Path, Mapping[str, Any]]]:
     artifacts: list[tuple[Path, Mapping[str, Any]]] = []
     for path in sorted(artifacts_dir.glob("*.json")):
@@ -317,51 +309,6 @@ def _artifact_fact_checks(artifact: Mapping[str, Any]) -> Sequence[Any]:
 def _artifact_input_identity(artifacts: Iterable[tuple[Path, Mapping[str, Any]]]) -> str:
     material = [{"path": path.name, "sha256": _sha256_text(_canonical_json(artifact))} for path, artifact in artifacts]
     return _sha256_text(_canonical_json(material))
-
-
-def _build_event_index(events: Sequence[Mapping[str, Any]]) -> dict[str, str]:
-    """Map only materializer-derived event IDs to raw captured output safely."""
-    index: dict[str, str] = {}
-    for event in events:
-        raw = anchor_primitives.event_output_text(event)
-        if raw is None:
-            continue
-        capture_complete = not any(
-            event.get(key) is True for key in ("output_truncated", "truncated", "capture_truncated")
-        )
-        capture_complete = capture_complete and event.get("output_capture_complete") is not False
-        # Candidate materialization owns the identity contract.  Reproduce the
-        # public contract here rather than using diagnostic source indexes.
-        raw_name = str(event.get("tool") or "")
-        canonical_name = anchor_primitives.canonical_tool_name(raw_name)
-        query = _canonical_json(event.get("input") if "input" in event else {})
-        stable_source: dict[str, Any] = {}
-        for container in (event, event.get("input")):
-            if isinstance(container, Mapping):
-                for key in ("document_id", "source_id", "url", "revision", "section_id", "item_id"):
-                    if container.get(key) not in (None, ""):
-                        stable_source[key] = container[key]
-        material = {
-            "version": layerb_candidates.EVENT_OUTPUT_IDENTITY_VERSION,
-            "tool": canonical_name,
-            "query": query,
-            "status_envelope": {
-                "status": event.get("status"),
-                "error": event.get("error"),
-                "errors": event.get("errors"),
-            },
-            "stable_source": stable_source,
-            "raw_output_sha256": _sha256_text(raw),
-            "output_capture_complete": capture_complete,
-        }
-        event_id = _sha256_text(_canonical_json(material))
-        previous = index.get(event_id)
-        if previous is not None and previous != raw:
-            # Integrity collision: no raw source can safely be selected.
-            index.pop(event_id, None)
-            continue
-        index[event_id] = raw
-    return index
 
 
 def _injection_screen(raw_window: str) -> bool:

--- a/tests/test_layerb_label_tools.py
+++ b/tests/test_layerb_label_tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
+import subprocess
 from collections.abc import Mapping
 from hashlib import sha256
 from pathlib import Path
@@ -12,17 +13,17 @@ from typing import Any
 import pytest
 from jsonschema import Draft202012Validator
 
+from scripts.audit.layerb_keys import _build_event_index, _stable_grounding_key
 from scripts.audit.layerb_label_common import LabelJoinError, sha256_text
 from scripts.audit.layerb_label_merge import merge_annotator_sidecars
 from scripts.audit.layerb_label_scaffold import (
     JUDGMENT_CASE_FIELDS,
     _artifact_events,
-    _build_event_index,
     build_scaffold,
     validate_annotator_record,
+    write_scaffold,
 )
 from scripts.audit.layerb_label_union import attach_keys, derive_union
-from scripts.audit.layerb_shadow import _stable_grounding_key
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = json.loads((REPO_ROOT / "schemas" / "qg-layer-b-labels.v2.schema.json").read_text(encoding="utf-8"))
@@ -188,6 +189,28 @@ def _keyed_inputs(tmp_path: Path, count: int = 8) -> tuple[dict[str, Any], dict[
     return keyed, shadow, corpus_dir
 
 
+def _make_duplicate_structural_group(
+    tmp_path: Path,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], Path]:
+    """Create two fact checks with one structural key and distinct stable keys."""
+    union, derivation, shadow, corpus_dir = _inputs(tmp_path, count=2)
+    artifact_path = next(corpus_dir.glob("*.json"))
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    shared_claim = artifact["payload"]["fact_checks"][0]["claim"]
+    artifact["payload"]["fact_checks"][1]["claim"] = shared_claim
+    artifact_path.write_text(json.dumps(artifact, ensure_ascii=False), encoding="utf-8")
+    for document in (union, derivation):
+        document["rows" if document is union else "records"][1]["claim"] = shared_claim
+    for record in shadow["records"]:
+        record["claim"] = shared_claim
+    return union, derivation, shadow, corpus_dir
+
+
+def _shadow_for_fact_index(shadow: Mapping[str, Any], index: int) -> dict[str, Any]:
+    marker = f"#fact_checks[{index}]"
+    return next(record for record in shadow["records"] if marker in record["grounding_key"])
+
+
 def test_attach_totality_bijection_and_original_row_preservation_for_535_rows(tmp_path: Path) -> None:
     union, derivation, shadow, corpus_dir = _inputs(tmp_path, count=535)
 
@@ -211,6 +234,54 @@ def test_attach_hard_fails_with_exact_ambiguous_key(tmp_path: Path) -> None:
     union["rows"] = [ambiguous]
 
     with pytest.raises(LabelJoinError, match=r"ambiguous keys=.*Synthetic claim 0"):
+        attach_keys(union, derivation, shadow, corpus_dir=corpus_dir)
+
+
+def test_attach_duplicate_group_uses_per_row_candidate_identity(tmp_path: Path) -> None:
+    union, derivation, shadow, corpus_dir = _make_duplicate_structural_group(tmp_path)
+    derivation["records"][0]["similarity"] = 0.91
+    derivation["records"][1]["similarity"] = 0.82
+    union["rows"][0]["similarity"] = 0.91
+    union["rows"][1]["similarity"] = 0.82
+    for document in (union, derivation):
+        records = document["rows" if document is union else "records"]
+        records[1]["v1_admissible"] = False
+        records[1]["v2_anchored"] = True
+        records[1]["v2_effective"] = True
+    for index, similarity in enumerate((0.91, 0.82)):
+        record = _shadow_for_fact_index(shadow, index)
+        record["layer_a"]["candidates"][0]["similarity"] = similarity
+        record["layer_a"]["candidates"][0]["source_index"] = index
+        record["candidate_details"][0]["candidate"]["similarity"] = similarity
+        record["candidate_details"][0]["candidate"]["source_index"] = index
+
+    keyed, report = attach_keys(union, derivation, shadow, corpus_dir=corpus_dir)
+
+    expected = {index: _shadow_for_fact_index(shadow, index)["grounding_key"] for index in range(2)}
+    assert [row["grounding_key"] for row in keyed["rows"]] == [expected[0], expected[1]]
+    assert report["duplicate_group_resolutions"][0]["resolution_basis"] == "per_row_identity"
+
+
+def test_attach_duplicate_group_records_equivalence_class_resolution(tmp_path: Path) -> None:
+    union, derivation, shadow, corpus_dir = _make_duplicate_structural_group(tmp_path)
+    first = _shadow_for_fact_index(shadow, 0)
+    second = _shadow_for_fact_index(shadow, 1)
+    second["layer_a"] = copy.deepcopy(first["layer_a"])
+
+    _keyed, report = attach_keys(union, derivation, shadow, corpus_dir=corpus_dir)
+
+    assert report["duplicate_group_resolutions"][0]["resolution_basis"] == "equivalence_class"
+
+
+def test_attach_duplicate_group_hard_fails_when_members_differ_without_identity(tmp_path: Path) -> None:
+    union, derivation, shadow, corpus_dir = _make_duplicate_structural_group(tmp_path)
+    for document in (union, derivation):
+        document["rows" if document is union else "records"][1]["v1_admissible"] = False
+    second = _shadow_for_fact_index(shadow, 1)
+    second["layer_a"]["candidates"][0]["similarity"] = 0.82
+    second["candidate_details"][0]["candidate"]["similarity"] = 0.82
+
+    with pytest.raises(LabelJoinError, match="duplicate structural-key group"):
         attach_keys(union, derivation, shadow, corpus_dir=corpus_dir)
 
 
@@ -248,6 +319,7 @@ def test_scaffold_null_judgments_hashes_windows_and_resume(tmp_path: Path) -> No
     scaffold, report = build_scaffold(keyed, shadow, corpus_dir=corpus_dir, output_dir=output_dir, shard_count=4)
 
     assert report["cases"] == 8
+    assert report["segment_verified_candidates"] == 8
     assert all(case[field] is None for case in scaffold["cases"] for field in JUDGMENT_CASE_FIELDS)
     packet_case_ids: list[str] = []
     for packet_path in sorted((output_dir / "packets").glob("shard-*.jsonl")):
@@ -275,6 +347,52 @@ def test_scaffold_null_judgments_hashes_windows_and_resume(tmp_path: Path) -> No
                 for segment in candidate["ordered_segment_spans"]:
                     raw = RAW_OUTPUT[segment["output_raw_start"] : segment["output_raw_end"]]
                     assert sha256_text(raw) == segment["raw_segment_sha256"]
+    keyed_path = tmp_path / "keyed-union.json"
+    shadow_path = tmp_path / "phase1-shadow.json"
+    keyed_path.write_text(json.dumps(keyed, ensure_ascii=False), encoding="utf-8")
+    shadow_path.write_text(json.dumps(shadow, ensure_ascii=False), encoding="utf-8")
+    _manifest_scaffold, manifest = write_scaffold(
+        keyed_path,
+        shadow_path,
+        corpus_dir=corpus_dir,
+        output_dir=tmp_path / "manifest-scaffold",
+    )
+    assert manifest["counts"]["segment_verified_candidates"] == 8
+
+
+def test_scaffold_hard_fails_when_a_shadow_segment_hash_does_not_match(tmp_path: Path) -> None:
+    keyed, shadow, corpus_dir = _keyed_inputs(tmp_path)
+    corrupt = copy.deepcopy(shadow)
+    corrupt["records"][0]["layer_a"]["candidates"][0]["ordered_segment_spans"][0]["raw_segment_sha256"] = "0" * 64
+
+    with pytest.raises(LabelJoinError, match="segment SHA-256 does not match captured output"):
+        build_scaffold(keyed, corrupt, corpus_dir=corpus_dir, output_dir=tmp_path / "scaffold")
+
+
+@pytest.mark.parametrize(
+    "module",
+    (
+        "scripts.audit.layerb_label_common",
+        "scripts.audit.layerb_label_union",
+        "scripts.audit.layerb_label_scaffold",
+        "scripts.audit.layerb_label_merge",
+    ),
+)
+def test_label_tool_imports_do_not_load_runtime_reviewer_dispatch(module: str) -> None:
+    command = (
+        "import importlib, sys; "
+        f"importlib.import_module({module!r}); "
+        "raise SystemExit('scripts.audit.llm_reviewer_dispatch' in sys.modules)"
+    )
+    completed = subprocess.run(
+        [str(REPO_ROOT / ".venv" / "bin" / "python"), "-c", command],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def test_validate_annotator_record_rejects_out_of_bounds_spans(tmp_path: Path) -> None:

--- a/tests/test_layerb_label_tools.py
+++ b/tests/test_layerb_label_tools.py
@@ -1,0 +1,316 @@
+"""Focused offline tests for Layer B label-union, scaffold, and merge tooling."""
+
+from __future__ import annotations
+
+import copy
+import json
+from collections.abc import Mapping
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from scripts.audit.layerb_label_common import LabelJoinError, sha256_text
+from scripts.audit.layerb_label_merge import merge_annotator_sidecars
+from scripts.audit.layerb_label_scaffold import (
+    JUDGMENT_CASE_FIELDS,
+    _artifact_events,
+    _build_event_index,
+    build_scaffold,
+    validate_annotator_record,
+)
+from scripts.audit.layerb_label_union import attach_keys, derive_union
+from scripts.audit.layerb_shadow import _stable_grounding_key
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = json.loads((REPO_ROOT / "schemas" / "qg-layer-b-labels.v2.schema.json").read_text(encoding="utf-8"))
+VALIDATOR = Draft202012Validator(SCHEMA)
+RAW_OUTPUT = "source evidence used for deterministic label checks"
+EXCERPT = "source evidence"
+
+
+def _sha(value: str) -> str:
+    return sha256(value.encode("utf-8")).hexdigest()
+
+
+def _candidate(index: int, event_output_id: str) -> dict[str, Any]:
+    normalized = RAW_OUTPUT
+    return {
+        "schema_version": "qg-anchor-candidate.v1",
+        "candidate_id": _sha(f"candidate-{index}"),
+        "event_output_id": event_output_id,
+        "canonical_source_id": _sha("synthetic-source"),
+        "source_index": 0,
+        "tool_identity": {"raw_name": "sources_query_wikipedia", "canonical_name": "query_wikipedia"},
+        "query_identity": {"canonical_json": '{"query":"synthetic"}', "sha256": _sha('{"query":"synthetic"}')},
+        "raw_output_sha256": _sha(RAW_OUTPUT),
+        "normalized_output_sha256": _sha(normalized),
+        "output_capture_complete": True,
+        "anchor_scan_complete": True,
+        "match_type": "EXACT_CONTIGUOUS",
+        "similarity": 1.0,
+        "tool_query_matched": True,
+        "eligibility": "ELIGIBLE",
+        "error_status": "NONE",
+        "ordered_segment_spans": [
+            {
+                "segment_index": 0,
+                "excerpt_normalized_start": 0,
+                "excerpt_normalized_end": len(EXCERPT),
+                "output_normalized_start": 0,
+                "output_normalized_end": len(EXCERPT),
+                "output_raw_start": 0,
+                "output_raw_end": len(EXCERPT),
+                "normalized_segment_sha256": _sha(EXCERPT),
+                "raw_segment_sha256": _sha(EXCERPT),
+            }
+        ],
+    }
+
+
+def _inputs(tmp_path: Path, count: int = 8) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], Path]:
+    corpus_dir = tmp_path / "audit-corpus"
+    corpus_dir.mkdir()
+    metadata = {"pin_slug": "synthetic-pin", "family": "synthetic"}
+    artifact_name = "synthetic-pin__ahatanhel-krymskyi.json"
+    event = {
+        "tool": "sources_query_wikipedia",
+        "input": {"query": "synthetic"},
+        "status": "completed",
+        "output": RAW_OUTPUT,
+    }
+    event_output_id = next(iter(_build_event_index([event])))
+    fact_checks: list[dict[str, Any]] = []
+    for index in range(count):
+        fact_checks.append(
+            {
+                "fact_check_id": f"fact-{index}",
+                "claim": f"Synthetic claim {index}",
+                "verdict": "CONFIRMED",
+                "grounding": {
+                    "evidence_excerpt": EXCERPT,
+                    "tool": "sources_query_wikipedia",
+                    "query": "synthetic",
+                },
+            }
+        )
+    artifact = {
+        "schema_version": "qg_bakeoff_run.v1",
+        "seat_arm": metadata,
+        "fixture": {"slug": "ahatanhel-krymskyi"},
+        "payload": {"fact_checks": fact_checks},
+        "dispatch": {"tool_events": [event]},
+    }
+    (corpus_dir / artifact_name).write_text(json.dumps(artifact, ensure_ascii=False), encoding="utf-8")
+    derivations: list[dict[str, Any]] = []
+    shadows: list[dict[str, Any]] = []
+    union_rows: list[dict[str, Any]] = []
+    for index, fact_check in enumerate(fact_checks):
+        v1_admissible = index in {1, 3, 4}
+        v2_effective = index in {0, 2, 3, 4}
+        v2_abstained = index == 2
+        base = {
+            "fixture": "ahatanhel-krymskyi",
+            "seat_arm": repr(metadata) + "/tooled",
+            "claim": fact_check["claim"],
+            "excerpt": EXCERPT,
+            "v1_admissible": v1_admissible,
+            "v2_anchored": v2_effective and not v2_abstained,
+            "v2_abstained": v2_abstained,
+            "similarity": 1.0,
+            "abstain_recovered": v2_abstained,
+            "v2_effective": v2_effective,
+            "tool_query_matched": True,
+            "best_span_preview": EXCERPT,
+            "gold_is_true": True,
+        }
+        derivations.append(base)
+        key = _stable_grounding_key(Path(artifact_name), index, fact_check)
+        shadows.append(
+            {
+                "grounding_key": key,
+                "artifact": artifact_name,
+                "seat_metadata": metadata,
+                "fixture": "ahatanhel-krymskyi",
+                "fact_check_id": key,
+                "claim": fact_check["claim"],
+                "reviewer_verdict": "CONFIRMED",
+                "layer_a": {
+                    "decision": "ANCHOR",
+                    "reason": "ANCHORED_CONTIGUOUS",
+                    "candidate_set_complete": True,
+                    "candidates": [_candidate(index, event_output_id)],
+                },
+                "candidate_details": [{"candidate": _candidate(index, event_output_id)}],
+            }
+        )
+        union = dict(base)
+        union["source_index"] = index
+        union["union_categories"] = ["recovered"]
+        union_rows.append(union)
+    return (
+        {"kind": "qg-layer-b-label-union-input", "rows": union_rows, "total_rows": len(union_rows)},
+        {"records": derivations},
+        {"records": list(reversed(shadows))},
+        corpus_dir,
+    )
+
+
+def _completed_case(case: Mapping[str, Any]) -> dict[str, Any]:
+    result = copy.deepcopy(dict(case))
+    result.update(
+        {
+            "claim_is_true": True,
+            "expected_reviewer_verdict": "CONFIRMED",
+            "expected_layer_a_decision": "ANCHOR",
+            "expected_layer_a_reason": "ANCHORED_CONTIGUOUS",
+            "expected_aggregate_relation": "ENTAILS",
+            "expected_fact_check_decision": "ACCEPT",
+            "context_sufficient": True,
+            "failure_class": "ELLIPSIZED_GENUINE_EXCERPT",
+            "corpus_verification_status": "VERIFIED",
+            "annotators": ["annotator-a", "annotator-b"],
+            "adjudication": {"status": "AGREED", "adjudicator": None, "note": "Original completed case."},
+        }
+    )
+    for candidates in result["candidates_by_event_output_id"].values():
+        for candidate in candidates:
+            candidate["expected_source_relation"] = "ENTAILS"
+            candidate["expected_support_spans"] = [{"start": 0, "end": len(EXCERPT), "role": "SUPPORTS"}]
+    return result
+
+
+def _keyed_inputs(tmp_path: Path, count: int = 8) -> tuple[dict[str, Any], dict[str, Any], Path]:
+    union, derivation, shadow, corpus_dir = _inputs(tmp_path, count)
+    keyed, _report = attach_keys(union, derivation, shadow, corpus_dir=corpus_dir)
+    return keyed, shadow, corpus_dir
+
+
+def test_attach_totality_bijection_and_original_row_preservation_for_535_rows(tmp_path: Path) -> None:
+    union, derivation, shadow, corpus_dir = _inputs(tmp_path, count=535)
+
+    keyed, report = attach_keys(union, derivation, shadow, corpus_dir=corpus_dir)
+
+    assert report["matched_rows"] == report["union_rows"] == 535
+    assert report["total"] is True
+    assert report["bijective"] is True
+    assert len({row["grounding_key"] for row in keyed["rows"]}) == 535
+    for original, emitted in zip(union["rows"], keyed["rows"], strict=True):
+        preserved = {key: value for key, value in emitted.items() if key not in {"grounding_key", "fact_check_index"}}
+        assert preserved == original
+
+
+def test_attach_hard_fails_with_exact_ambiguous_key(tmp_path: Path) -> None:
+    union, derivation, shadow, corpus_dir = _inputs(tmp_path, count=2)
+    duplicate = copy.deepcopy(derivation["records"][0])
+    derivation["records"].append(duplicate)
+    ambiguous = copy.deepcopy(union["rows"][0])
+    ambiguous.pop("source_index")
+    union["rows"] = [ambiguous]
+
+    with pytest.raises(LabelJoinError, match=r"ambiguous keys=.*Synthetic claim 0"):
+        attach_keys(union, derivation, shadow, corpus_dir=corpus_dir)
+
+
+def test_attached_keys_equal_shadow_helper_for_sampled_rows(tmp_path: Path) -> None:
+    keyed, _shadow, corpus_dir = _keyed_inputs(tmp_path, count=12)
+    artifact_path = next(corpus_dir.glob("*.json"))
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    for row in keyed["rows"][::5]:
+        index = row["fact_check_index"]
+        assert row["grounding_key"] == _stable_grounding_key(
+            artifact_path, index, artifact["payload"]["fact_checks"][index]
+        )
+
+
+def test_mode_b_is_byte_identical_for_the_same_seed(tmp_path: Path) -> None:
+    union, derivation, shadow, corpus_dir = _inputs(tmp_path, count=8)
+    del union
+
+    first, first_report = derive_union(derivation, shadow, corpus_dir=corpus_dir, seed=4913, control_per_stratum=1)
+    second, second_report = derive_union(derivation, shadow, corpus_dir=corpus_dir, seed=4913, control_per_stratum=1)
+
+    assert json.dumps(first, ensure_ascii=False, separators=(",", ":")) == json.dumps(
+        second, ensure_ascii=False, separators=(",", ":")
+    )
+    assert first_report == second_report
+    assert first_report["frozen_control_sample_reproduction_guaranteed"] is False
+
+
+def test_scaffold_null_judgments_hashes_windows_and_resume(tmp_path: Path) -> None:
+    keyed, shadow, corpus_dir = _keyed_inputs(tmp_path, count=8)
+    output_dir = tmp_path / "scaffold"
+
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        build_scaffold(keyed, shadow, corpus_dir=corpus_dir, output_dir=output_dir, shard_count=4, crash_after_shards=1)
+    scaffold, report = build_scaffold(keyed, shadow, corpus_dir=corpus_dir, output_dir=output_dir, shard_count=4)
+
+    assert report["cases"] == 8
+    assert all(case[field] is None for case in scaffold["cases"] for field in JUDGMENT_CASE_FIELDS)
+    packet_case_ids: list[str] = []
+    for packet_path in sorted((output_dir / "packets").glob("shard-*.jsonl")):
+        marker = packet_path.with_suffix(".done.json")
+        assert marker.is_file()
+        for line in packet_path.read_text(encoding="utf-8").splitlines():
+            packet = json.loads(line)
+            packet_case_ids.append(packet["case"]["case_id"])
+            for navigation in packet["candidate_navigation"]:
+                assert navigation["full_output_sha256"] == _sha(RAW_OUTPUT)
+                assert navigation["full_output_bytes"] == len(RAW_OUTPUT.encode("utf-8"))
+                assert (
+                    navigation["raw_window_text"]
+                    == RAW_OUTPUT[navigation["raw_window_start"] : navigation["raw_window_end"]]
+                )
+                assert navigation["comment"].startswith("NAVIGATION AID ONLY")
+    assert sorted(packet_case_ids) == sorted(case["case_id"] for case in scaffold["cases"])
+    assert len(packet_case_ids) == len(set(packet_case_ids)) == 8
+    for case in scaffold["cases"]:
+        for event_output_id, candidates in case["candidates_by_event_output_id"].items():
+            for candidate in candidates:
+                assert candidate["raw_output_sha256"] == sha256_text(RAW_OUTPUT)
+                assert candidate["normalized_output_sha256"] == sha256_text(RAW_OUTPUT)
+                assert event_output_id
+                for segment in candidate["ordered_segment_spans"]:
+                    raw = RAW_OUTPUT[segment["output_raw_start"] : segment["output_raw_end"]]
+                    assert sha256_text(raw) == segment["raw_segment_sha256"]
+
+
+def test_validate_annotator_record_rejects_out_of_bounds_spans(tmp_path: Path) -> None:
+    keyed, shadow, corpus_dir = _keyed_inputs(tmp_path)
+    scaffold, _report = build_scaffold(keyed, shadow, corpus_dir=corpus_dir, output_dir=tmp_path / "scaffold")
+    working = _completed_case(scaffold["cases"][0])
+    working.pop("annotators")
+    working.pop("adjudication")
+    artifact = json.loads(next(corpus_dir.glob("*.json")).read_text(encoding="utf-8"))
+    outputs = _build_event_index(_artifact_events(artifact))
+
+    validate_annotator_record(working, outputs)
+    invalid = copy.deepcopy(working)
+    candidate = next(iter(invalid["candidates_by_event_output_id"].values()))[0]
+    candidate["ordered_segment_spans"][0]["output_raw_end"] = len(RAW_OUTPUT) + 1
+    with pytest.raises(LabelJoinError, match="out of bounds"):
+        validate_annotator_record(invalid, outputs)
+
+
+def test_merge_agreement_and_exact_span_disagreement(tmp_path: Path) -> None:
+    keyed, shadow, corpus_dir = _keyed_inputs(tmp_path)
+    scaffold, _report = build_scaffold(keyed, shadow, corpus_dir=corpus_dir, output_dir=tmp_path / "scaffold")
+    completed = copy.deepcopy(scaffold)
+    completed["cases"] = [_completed_case(case) for case in scaffold["cases"]]
+
+    report, merged = merge_annotator_sidecars(completed, copy.deepcopy(completed))
+    assert report["counts"]["agreed"] == len(completed["cases"])
+    assert all(case["adjudication"]["status"] == "AGREED" for case in merged["cases"])
+    assert not list(VALIDATOR.iter_errors(merged))
+
+    right = copy.deepcopy(completed)
+    target = next(iter(right["cases"][0]["candidates_by_event_output_id"].values()))[0]
+    target["ordered_segment_spans"][0]["output_raw_end"] -= 1
+    report, merged = merge_annotator_sidecars(completed, right)
+    assert report["counts"]["material_disagreements"] == 1
+    assert report["counts"]["span_only_disagreements"] == 1
+    assert report["cases"][0]["material_differences"][0]["field"].endswith("ordered_segment_spans")
+    assert "adjudication" not in merged["cases"][0]
+    assert list(VALIDATOR.iter_errors(merged))

--- a/tests/test_layerb_label_tools.py
+++ b/tests/test_layerb_label_tools.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 from jsonschema import Draft202012Validator
 
+from scripts.audit.layerb_derivation import derive_keyed_records
 from scripts.audit.layerb_keys import _build_event_index, _stable_grounding_key
 from scripts.audit.layerb_label_common import LabelJoinError, sha256_text
 from scripts.audit.layerb_label_merge import merge_annotator_sidecars
@@ -23,7 +24,12 @@ from scripts.audit.layerb_label_scaffold import (
     validate_annotator_record,
     write_scaffold,
 )
-from scripts.audit.layerb_label_union import attach_keys, derive_union
+from scripts.audit.layerb_label_union import (
+    assert_no_drift,
+    attach_keys,
+    derive_union,
+    rederive_keyed_derivation,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCHEMA = json.loads((REPO_ROOT / "schemas" / "qg-layer-b-labels.v2.schema.json").read_text(encoding="utf-8"))
@@ -189,6 +195,106 @@ def _keyed_inputs(tmp_path: Path, count: int = 8) -> tuple[dict[str, Any], dict[
     return keyed, shadow, corpus_dir
 
 
+def _keyed_derivation(derivation: Mapping[str, Any], shadow: Mapping[str, Any]) -> dict[str, Any]:
+    """Build source-keyed synthetic derivations without using ``attach``."""
+    records: list[dict[str, Any]] = []
+    for index, row in enumerate(derivation["records"]):
+        keyed = dict(row)
+        grounding_key = _shadow_for_fact_index(shadow, index)["grounding_key"]
+        keyed["grounding_key"] = grounding_key
+        keyed["fact_check_index"] = index
+        records.append(keyed)
+    return {"kind": "qg-layer-b-keyed-union-derivation", "records": records, "total_rows": len(records)}
+
+
+def _frozen_category_union(keyed_derivation: Mapping[str, Any]) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    for index, row in enumerate(keyed_derivation["records"]):
+        categories: list[str] = []
+        if row["v1_admissible"] is False and row["v2_effective"] is True:
+            categories.append("recovered")
+        if row["v1_admissible"] is True and row["v2_effective"] is False:
+            categories.append("regression")
+        if row["v2_abstained"] is True:
+            categories.append("abstain")
+        if not categories:
+            continue
+        frozen_row = {
+            key: value for key, value in row.items() if key not in {"grounding_key", "fact_check_index"}
+        }
+        frozen_row["source_index"] = index
+        frozen_row["union_categories"] = [
+            category for category in ("recovered", "regression", "abstain") if category in categories
+        ]
+        rows.append(frozen_row)
+    return {"kind": "qg-layer-b-label-union-input", "rows": rows, "total_rows": len(rows)}
+
+
+def _raw_rederive_inputs(tmp_path: Path) -> tuple[Path, Path, dict[str, Any]]:
+    corpus_dir = tmp_path / "raw-corpus"
+    fixtures_dir = tmp_path / "fixtures"
+    corpus_dir.mkdir()
+    fixtures_dir.mkdir()
+    claims = ["Synthetic source claim zero", "Synthetic source claim one"]
+    (fixtures_dir / "synthetic.json").write_text(
+        json.dumps(
+            {
+                "slug": "synthetic",
+                "title": "Synthetic",
+                "passage_md": " ".join(claims),
+                "claims": [
+                    {"claim_id": f"synthetic-{index}", "claim": claim, "is_true": True}
+                    for index, claim in enumerate(claims)
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    artifact = {
+        "schema_version": "qg_bakeoff_run.v1",
+        "arm": "tooled",
+        "seat": "synthetic-seat",
+        "fixture": {"slug": "synthetic"},
+        "payload": {
+            "fact_checks": [
+                {
+                    "fact_check_id": f"synthetic-{index}",
+                    "claim": claim,
+                    "verdict": "CONFIRMED",
+                    "grounding": {
+                        "evidence_excerpt": claim,
+                        "tool": "sources_query_wikipedia",
+                        "query": "synthetic",
+                    },
+                }
+                for index, claim in enumerate(claims)
+            ]
+        },
+        "dispatch": {
+            "tool_events": [
+                {
+                    "tool": "sources_query_wikipedia",
+                    "input": {"query": "synthetic"},
+                    "status": "completed",
+                    "output": " ".join(claims),
+                }
+            ]
+        },
+    }
+    (corpus_dir / "synthetic__synthetic.json").write_text(
+        json.dumps(artifact, ensure_ascii=False), encoding="utf-8"
+    )
+    records = derive_keyed_records(corpus_dir, fixtures_dir=fixtures_dir)
+    frozen = {
+        "records": [
+            {key: value for key, value in record.items() if key not in {"grounding_key", "fact_check_index"}}
+            for record in records
+        ]
+    }
+    return corpus_dir, fixtures_dir, frozen
+
+
 def _make_duplicate_structural_group(
     tmp_path: Path,
 ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], Path]:
@@ -296,18 +402,124 @@ def test_attached_keys_equal_shadow_helper_for_sampled_rows(tmp_path: Path) -> N
         )
 
 
-def test_mode_b_is_byte_identical_for_the_same_seed(tmp_path: Path) -> None:
-    union, derivation, shadow, corpus_dir = _inputs(tmp_path, count=8)
+def test_keyed_union_is_byte_identical_and_matches_frozen_category_fixture(tmp_path: Path) -> None:
+    union, derivation, shadow, _corpus_dir = _inputs(tmp_path, count=8)
     del union
+    keyed_derivation = _keyed_derivation(derivation, shadow)
+    frozen_union = _frozen_category_union(keyed_derivation)
 
-    first, first_report = derive_union(derivation, shadow, corpus_dir=corpus_dir, seed=4913, control_per_stratum=1)
-    second, second_report = derive_union(derivation, shadow, corpus_dir=corpus_dir, seed=4913, control_per_stratum=1)
+    first, first_report = derive_union(
+        keyed_derivation,
+        frozen_union_document=frozen_union,
+        seed=4913,
+        control_per_stratum=1,
+    )
+    second, second_report = derive_union(
+        keyed_derivation,
+        frozen_union_document=frozen_union,
+        seed=4913,
+        control_per_stratum=1,
+    )
 
     assert json.dumps(first, ensure_ascii=False, separators=(",", ":")) == json.dumps(
         second, ensure_ascii=False, separators=(",", ":")
     )
     assert first_report == second_report
+    assert first_report["category_membership"]["category_multiset_equal"] is True
+    assert first_report["control_resampled"] is True
     assert first_report["frozen_control_sample_reproduction_guaranteed"] is False
+
+
+def test_rederive_no_drift_positive_and_synthetic_drift_hard_fail(tmp_path: Path) -> None:
+    corpus_dir, fixtures_dir, frozen = _raw_rederive_inputs(tmp_path)
+    regenerated = derive_keyed_records(corpus_dir, fixtures_dir=fixtures_dir)
+
+    proof = assert_no_drift(regenerated, frozen)
+    document, rederive_report = rederive_keyed_derivation(
+        artifacts_dir=corpus_dir,
+        fixtures_dir=fixtures_dir,
+        frozen_derivation_document=frozen,
+        expected_rows=2,
+    )
+
+    assert proof["no_drift"] is True
+    assert document["total_rows"] == rederive_report["grounding_keys_unique"] == 2
+    drifted = copy.deepcopy(regenerated)
+    drifted[0]["claim"] = "Changed source claim"
+    with pytest.raises(LabelJoinError, match="symmetric_difference"):
+        assert_no_drift(drifted, frozen)
+
+
+def test_source_derivation_retains_comparison_only_no_fixture_fallback(tmp_path: Path) -> None:
+    corpus_dir, _fixtures_dir, _frozen = _raw_rederive_inputs(tmp_path)
+
+    records = derive_keyed_records(corpus_dir, fixtures_dir=None)
+
+    assert len(records) == 2
+    assert {record["gold_is_true"] for record in records} == {None}
+
+
+def test_rederive_cli_is_byte_identical_for_two_source_walks(tmp_path: Path) -> None:
+    corpus_dir, fixtures_dir, frozen = _raw_rederive_inputs(tmp_path)
+    frozen_path = tmp_path / "frozen-derivation.json"
+    frozen_path.write_text(json.dumps(frozen, ensure_ascii=False), encoding="utf-8")
+    first_path = tmp_path / "keyed-first.json"
+    second_path = tmp_path / "keyed-second.json"
+    command = [
+        str(REPO_ROOT / ".venv" / "bin" / "python"),
+        "scripts/audit/layerb_label_union.py",
+        "rederive",
+        "--derivation",
+        str(frozen_path),
+        "--artifacts-dir",
+        str(corpus_dir),
+        "--fixtures-dir",
+        str(fixtures_dir),
+        "--expected-rows",
+        "2",
+    ]
+    for output in (first_path, second_path):
+        completed = subprocess.run(
+            [*command, "--output", str(output)],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert completed.returncode == 0, completed.stderr
+
+    assert first_path.read_bytes() == second_path.read_bytes()
+    keyed_document = json.loads(first_path.read_text(encoding="utf-8"))
+    assert keyed_document["keying"]["join_report"]["no_drift"] is True
+    assert [row["fact_check_index"] for row in keyed_document["records"]] == [0, 1]
+
+
+def test_scaffold_consumes_union_derived_from_keyed_source_records(tmp_path: Path) -> None:
+    union, derivation, shadow, corpus_dir = _inputs(tmp_path, count=8)
+    del union
+    keyed_derivation = _keyed_derivation(derivation, shadow)
+    keyed_union, union_report = derive_union(
+        keyed_derivation,
+        frozen_union_document=_frozen_category_union(keyed_derivation),
+        seed=4913,
+        control_per_stratum=1,
+    )
+    keyed_path = tmp_path / "keyed-union.json"
+    shadow_path = tmp_path / "phase1-shadow.json"
+    keyed_path.write_text(json.dumps(keyed_union, ensure_ascii=False), encoding="utf-8")
+    shadow_path.write_text(json.dumps(shadow, ensure_ascii=False), encoding="utf-8")
+
+    scaffold, manifest = write_scaffold(
+        keyed_path,
+        shadow_path,
+        corpus_dir=corpus_dir,
+        output_dir=tmp_path / "keyed-scaffold",
+        shard_count=2,
+    )
+
+    assert len(scaffold["cases"]) == keyed_union["total_rows"] == 5
+    assert manifest["counts"]["segment_verified_candidates"] == 5
+    assert union_report["category_membership"]["category_rows"] == 3
 
 
 def test_scaffold_null_judgments_hashes_windows_and_resume(tmp_path: Path) -> None:
@@ -372,6 +584,7 @@ def test_scaffold_hard_fails_when_a_shadow_segment_hash_does_not_match(tmp_path:
 @pytest.mark.parametrize(
     "module",
     (
+        "scripts.audit.layerb_derivation",
         "scripts.audit.layerb_label_common",
         "scripts.audit.layerb_label_union",
         "scripts.audit.layerb_label_scaffold",

--- a/tests/test_layerb_label_tools.py
+++ b/tests/test_layerb_label_tools.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import json
 import subprocess
+import sys
 from collections.abc import Mapping
 from hashlib import sha256
 from pathlib import Path
@@ -466,7 +467,7 @@ def test_rederive_cli_is_byte_identical_for_two_source_walks(tmp_path: Path) -> 
     first_path = tmp_path / "keyed-first.json"
     second_path = tmp_path / "keyed-second.json"
     command = [
-        str(REPO_ROOT / ".venv" / "bin" / "python"),
+        sys.executable,
         "scripts/audit/layerb_label_union.py",
         "rederive",
         "--derivation",
@@ -598,7 +599,7 @@ def test_label_tool_imports_do_not_load_runtime_reviewer_dispatch(module: str) -
         "raise SystemExit('scripts.audit.llm_reviewer_dispatch' in sys.modules)"
     )
     completed = subprocess.run(
-        [str(REPO_ROOT / ".venv" / "bin" / "python"), "-c", command],
+        [sys.executable, "-c", command],
         cwd=REPO_ROOT,
         check=False,
         capture_output=True,


### PR DESCRIPTION
## Summary

Implements offline-only Layer B label-the-union Step 1 tooling:

- deterministic frozen-union key attachment and future seed-pinned re-derivation;
- null-judgment scaffold, checksummed/resumable annotation packets, manifest, and working-record validation;
- exact two-annotator merge with separate span-only and cosmetic reports.

## #M-4 evidence

| Claim | Deterministic proof | Result |
| --- | --- | --- |
| Union re-key totality/bijection | Real frozen `attach` run + join report | 535/535; 535 unique; 24 duplicate groups |
| Keys match shadow runner | Imported `_stable_grounding_key` recomputed against raw artifacts | 1,310 recomputations |
| Scaffold is judgment-free | Real scaffold scan | 0 pre-filled judgment fields |
| Corpus/segment hashes | Real raw-output and segment SHA-256 recomputation | 959 segment hashes |
| Mode B determinism | Two real `derive --seed 4913` outputs compared with `cmp -s` | byte-identical |
| Tests and lint | Requested pytest command and repository-wide Ruff command | 35 passed; clean |

### Raw tool output

~~~text
join: {'union_rows': 535, 'matched_rows': 535, 'grounding_keys_unique': 535, 'total': True, 'bijective': True, 'duplicate_group_count': 24, 'stable_key_recomputations': 1310}
row-preservation: 535/535 original row objects unchanged except grounding_key/fact_check_index
scaffold: {'cases': 535, 'candidate_segments_rehashed': 959, 'judgment_fields_prefilled': 0, 'packet_counts': [134, 134, 134, 133], 'unique_packet_cases': 535}
manifest: {'scaffold_sha256': '78efe13497813c77a3ca1b74cae8a14d6be204a4987e918a9c06350c982fe54f', 'corpus_artifact_hashes': 133, 'fixture_hashes': 17}
mode-b-byte-identical: true
~~~

~~~text
.venv/bin/python -m pytest tests/test_layerb_label_*.py tests/test_layerb_shadow.py tests/test_qg_layer_b_labels_schema.py
35 passed in 0.58s

.venv/bin/ruff check scripts/audit/ tests/
All checks passed!
~~~

### Generated-run evidence

The real frozen run emitted the join report and scaffold manifest from the pinned inputs. Generated audit outputs were deliberately not committed.

### Runtime untouched

~~~text
git diff --stat origin/main
 scripts/audit/layerb_label_common.py   | 342 +++++++++++++++++
 scripts/audit/layerb_label_merge.py    | 274 ++++++++++++++
 scripts/audit/layerb_label_scaffold.py | 651 +++++++++++++++++++++++++++++++++
 scripts/audit/layerb_label_union.py    | 282 ++++++++++++++
 tests/test_layerb_label_tools.py       | 316 +++++++++++++++
 5 files changed, 1865 insertions(+)
~~~

`grounding_gate_v2.py`, `llm_reviewer_dispatch.py`, and `linear_pipeline.py` are untouched.

No auto-merge or review routing was requested here; the orchestrator owns the review gate and any merge action.