### PR TITLE
feat(atlas): entry-model PR-4 — expression-like detail view with component backlinks (#4385)

### DIFF
--- a/docs/poc/word-atlas/README.md
+++ b/docs/poc/word-atlas/README.md
@@ -18,16 +18,16 @@ is kept as a short compatibility stub for existing links.
 The route map predates the finalized entry model in
 [`docs/runbooks/word-atlas-entry-model.md`](../../runbooks/word-atlas-entry-model.md).
 Implementation must treat `/lexicon/{slug}` as an Atlas entry route, not as a
-lemma-only route. The current POC covers lemma-style articles only; the next
-design pass must add at least one expression-like detail view before shipping
-first-class `expression`, `phraseologism`, `proverb`, or `multiword_term`
-article support.
+lemma-only route. The current POC covers lemma-style articles and the
+implemented expression-like detail variant in `WordAtlasArticle.astro`. The
+route keeps the shared `/lexicon/{slug}` entry semantics for `expression`,
+`phraseologism`, `proverb`, and `multiword_term` records.
 
-Required future POC coverage:
+Implemented POC coverage:
 
-| Missing design source | Route | Entry model surface |
-| --- | --- | --- |
-| `expression-detail.html` or equivalent | `/lexicon/{slug}` | Fixed formula, idiom/proverb, or multiword term article with component lemma backlinks |
+| Design source | Route | Entry model surface | Status |
+| --- | --- | --- | --- |
+| `WordAtlasArticle.astro` expression-like branch | `/lexicon/{slug}` | Fixed formula, idiom/proverb, or multiword term article with labelled component lemma backlinks; unresolved components stay plain text | Implemented in entry-model PR-4 (#4385) |
 
 ## Drift Prevention
 

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -11,6 +11,7 @@ import {
   morphologyFormCountLabel,
   registerBadgeLabel,
 } from "../lib/lexicon/register-markers";
+import { normalize as normalizeAtlasSearchText } from "../lib/lexicon/search";
 
 interface CourseUsage {
   track: string;
@@ -166,11 +167,18 @@ interface LexiconEntry {
 interface Props {
   entry: LexiconEntry;
   allEntries: LexiconEntry[];
+  componentLinkTargets?: Map<string, string>;
   generatedAt: string;
   manifestVersion: string;
 }
 
-const { entry, allEntries, generatedAt, manifestVersion } = Astro.props as Props;
+const {
+  entry,
+  allEntries,
+  componentLinkTargets = new Map<string, string>(),
+  generatedAt,
+  manifestVersion,
+} = Astro.props as Props;
 const enrichment = entry.enrichment ?? null;
 const sections = entry.sections ?? null;
 const heritage = entry.heritage_status ?? null;
@@ -216,7 +224,9 @@ const MORPHOLOGY_SUPPRESSED_TYPES = new Set([
   "phraseologism",
   "proverb",
 ]);
-const suppressMorphology = MORPHOLOGY_SUPPRESSED_TYPES.has(entry.entry_type ?? "");
+const isExpressionLikeEntry = MORPHOLOGY_SUPPRESSED_TYPES.has(entry.entry_type ?? "");
+const suppressMorphology = isExpressionLikeEntry;
+const entryTypeLabel = expressionLikeEntryTypeLabel(entry.entry_type);
 const posLabel = formatPos(entry.pos, enrichment?.morphology?.pos);
 const headwordIpa = formatIpa(entry.pronunciation?.ipa ?? entry.ipa);
 const heritageBoxes = resolveHeritageBoxes(entry);
@@ -228,7 +238,7 @@ const courseUsage = entry.course_usage.slice().sort((a, b) => {
 });
 const textbookItems = enrichment?.textbooks ?? [];
 const externalGroups = groupExternalMaterials(enrichment?.external_materials ?? []);
-const componentLinks = buildComponentLinks(entry, allEntries);
+const componentLinks = buildComponentLinks(entry, allEntries, componentLinkTargets);
 const sourceList = buildSourceList();
 const phraseHasGloss = Boolean(entry.gloss && definitionCards.length === 0 && !enrichment?.meaning);
 const shouldShowEditorialWarning = Boolean(heritageBoxes.red);
@@ -299,6 +309,16 @@ function formatPos(pos: string | null | undefined, morphologyPos: string | undef
     interjection: "вигук",
   };
   return morphologyPos ?? (pos ? labels[pos] ?? pos : null);
+}
+
+function expressionLikeEntryTypeLabel(entryType: string | null | undefined) {
+  const labels: Record<string, string> = {
+    expression: "вираз",
+    phraseologism: "фразеологізм",
+    proverb: "прислів'я",
+    multiword_term: "термін",
+  };
+  return entryType ? labels[entryType] ?? null : null;
 }
 
 function isSum11DefinitionCard(card: DefinitionCard) {
@@ -484,18 +504,25 @@ function sourceHost(url: string) {
   }
 }
 
-function buildComponentLinks(current: LexiconEntry, entries: LexiconEntry[]) {
-  if (current.pos !== "phrase") return [];
-  const normalize = (value: string) =>
-    value
-      .toLocaleLowerCase("uk")
-      .normalize("NFD")
-      .replace(/[\u0300-\u036f]/g, "")
-      .replace(/[^\p{L}'’]+/gu, "");
-  const byLemma = new Map(entries.map((item) => [normalize(item.lemma), item]));
-  return Array.from(new Set(current.lemma.split(/\s+/).map(normalize)))
-    .map((word) => byLemma.get(word))
-    .filter((item): item is LexiconEntry => Boolean(item) && item.url_slug !== current.url_slug);
+function buildComponentLinks(
+  current: LexiconEntry,
+  entries: LexiconEntry[],
+  componentLinkTargets: Map<string, string>,
+) {
+  if (!MORPHOLOGY_SUPPRESSED_TYPES.has(current.entry_type ?? "")) return [];
+  const entriesBySlug = new Map(entries.map((item) => [item.url_slug, item]));
+  const tokens = current.lemma.match(/[\p{L}\p{M}]+(?:['’][\p{L}\p{M}]+)*/gu) ?? [];
+  return tokens.map((text) => {
+    const targetSlug = componentLinkTargets.get(normalizeAtlasSearchText(text));
+    const target = targetSlug ? entriesBySlug.get(targetSlug) : undefined;
+    return {
+      text,
+      target:
+        target && target.entry_type === "lemma" && target.url_slug !== current.url_slug
+          ? target
+          : null,
+    };
+  });
 }
 
 function buildSourceList() {
@@ -571,7 +598,7 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
       <>
         <div class="word-hero">
       <div class="word-hero-inner">
-        <span class="lexicon-badge">Лексикон · A-Я · {letter}</span>
+        <span class="lexicon-badge">{entryTypeLabel ? `Лексикон · ${entryTypeLabel}` : `Лексикон · A-Я · ${letter}`}</span>
         <h1 class="word-title">
           {entry.lemma}
           {headerStress && <span class="word-stress">[{headerStress}]</span>}
@@ -665,6 +692,23 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
         </div>
       </section>
 
+      {isExpressionLikeEntry && componentLinks.length > 0 && (
+        <section class="atlas-section expression-detail" data-expression-detail={entry.entry_type}>
+          <div class="component-links">
+            <div class="chip-label">Складники:</div>
+            <div class="chip-row">
+              {componentLinks.map((component) => (
+                component.target ? (
+                  <a class="chip" href={`/lexicon/${component.target.url_slug}/`}>{component.text}</a>
+                ) : (
+                  <span class="chip">{component.text}</span>
+                )
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
       {(definitionCards.length > 0 || enrichment?.meaning || phraseHasGloss) && (
         <section class="atlas-section">
           <h2>Значення</h2>
@@ -706,16 +750,6 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
               </div>
               <div class="def-text">
                 <p>{entry.gloss}</p>
-              </div>
-            </div>
-          )}
-          {componentLinks.length > 0 && (
-            <div class="component-links">
-              <div class="chip-label">Складники:</div>
-              <div class="chip-row">
-                {componentLinks.map((item) => (
-                  <a class="chip" href={`/lexicon/${item.url_slug}/`}>{item.lemma}</a>
-                ))}
               </div>
             </div>
           )}

--- a/site/src/lib/lexicon/atlasDb.ts
+++ b/site/src/lib/lexicon/atlasDb.ts
@@ -1,6 +1,7 @@
 import Database from 'better-sqlite3';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
+import { normalize as normalizeAtlasSearchText } from './search';
 
 export interface CourseUsage {
   track: string;
@@ -41,9 +42,20 @@ interface MetadataRow {
   value_json: string;
 }
 
+interface ComponentTargetRow {
+  lookup_text: string;
+  target_slug: string;
+}
+
 export interface AtlasPayloadCache {
   entries: LexiconEntry[];
   bySlug: Map<string, LexiconEntry>;
+  /**
+   * Public component text (canonical article head or alias) to a unique,
+   * approved-public lemma route. Ambiguous component text is intentionally
+   * absent so article templates cannot emit a misleading backlink.
+   */
+  componentLinkTargets: Map<string, string>;
   generatedAt: string;
   manifestVersion: string;
 }
@@ -61,6 +73,41 @@ function parseMetadata(rows: MetadataRow[]): { generatedAt: string; manifestVers
     generatedAt: String(metadata.get('generated_at') ?? ''),
     manifestVersion: String(metadata.get('version') ?? ''),
   };
+}
+
+function uniqueTargets(rows: ComponentTargetRow[]): Map<string, Set<string>> {
+  const targets = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const lookupText = normalizeAtlasSearchText(row.lookup_text);
+    if (!lookupText) continue;
+    const matchedTargets = targets.get(lookupText) ?? new Set<string>();
+    matchedTargets.add(row.target_slug);
+    targets.set(lookupText, matchedTargets);
+  }
+  return targets;
+}
+
+/**
+ * Resolve component text with the same precedence as Atlas search: a direct
+ * article-head hit wins; otherwise a public alias may resolve it. Only a
+ * single approved-public lemma target is safe for an inline backlink.
+ */
+export function buildComponentLinkTargets(
+  articleRows: ComponentTargetRow[],
+  aliasRows: ComponentTargetRow[],
+): Map<string, string> {
+  const articleTargets = uniqueTargets(articleRows);
+  const aliasTargets = uniqueTargets(aliasRows);
+  const targets = new Map<string, string>();
+
+  for (const [lookupText, matchedTargets] of articleTargets) {
+    if (matchedTargets.size === 1) targets.set(lookupText, [...matchedTargets][0]!);
+  }
+  for (const [lookupText, matchedTargets] of aliasTargets) {
+    if (articleTargets.has(lookupText) || matchedTargets.size !== 1) continue;
+    targets.set(lookupText, [...matchedTargets][0]!);
+  }
+  return targets;
 }
 
 export function resetAtlasPayloadCacheForTests(): void {
@@ -252,6 +299,29 @@ export function getAtlasPayloadCache(): AtlasPayloadCache {
          WHERE key IN ('generated_at', 'version')`,
       )
       .all() as MetadataRow[];
+    // Component backlinks deliberately resolve only to reviewed public lemma
+    // articles. The canonical article-head rows take precedence over aliases,
+    // matching the direct-article-first behavior in search.ts / PR-3.
+    const componentArticleRows = db
+      .prepare(
+        `SELECT display_head AS lookup_text, slug AS target_slug
+         FROM articles
+         WHERE review_state = 'approved' AND visibility = 'public' AND entry_type = 'lemma'
+         ORDER BY display_head COLLATE NOCASE, slug`,
+      )
+      .all() as ComponentTargetRow[];
+    const componentAliasRows = db
+      .prepare(
+        `SELECT al.alias AS lookup_text, al.target_slug AS target_slug
+         FROM aliases al
+         JOIN articles a ON a.slug = al.target_slug
+         WHERE al.visibility = 'public'
+           AND a.review_state = 'approved'
+           AND a.visibility = 'public'
+           AND a.entry_type = 'lemma'
+         ORDER BY al.alias COLLATE NOCASE, al.target_slug, al.kind`,
+      )
+      .all() as ComponentTargetRow[];
     const entries = payloadRows.map((row) => {
       const entry = JSON.parse(row.payload_json) as LexiconEntry;
       // entry_type is authoritative from the `articles` table (SSOT), not the
@@ -266,6 +336,7 @@ export function getAtlasPayloadCache(): AtlasPayloadCache {
     cachedAtlasPayloads = {
       entries,
       bySlug,
+      componentLinkTargets: buildComponentLinkTargets(componentArticleRows, componentAliasRows),
       ...parseMetadata(metadataRows),
     };
     return cachedAtlasPayloads;

--- a/site/src/pages/lexicon/[lemma].astro
+++ b/site/src/pages/lexicon/[lemma].astro
@@ -45,6 +45,7 @@ const frontmatter = {
   <WordAtlasArticle
     entry={entry}
     allEntries={lexemeEntries}
+    componentLinkTargets={atlasPayloads.componentLinkTargets}
     generatedAt={atlasPayloads.generatedAt}
     manifestVersion={atlasPayloads.manifestVersion}
   />

--- a/site/tests/unit/atlas-entry-type-templates.test.ts
+++ b/site/tests/unit/atlas-entry-type-templates.test.ts
@@ -9,6 +9,7 @@ import {
   getAtlasPayloadCache,
   resetAtlasPayloadCacheForTests,
   runEntryModelGates,
+  buildComponentLinkTargets,
   type AtlasPayloadCache,
   type LexiconEntry,
 } from '@site/src/lib/lexicon/atlasDb';
@@ -18,7 +19,9 @@ interface AstroComponentModule {
   default: AstroComponent;
 }
 
-const atlasDbPath = resolve(process.cwd(), '../data/atlas.db');
+const atlasDbPath = resolve(
+  process.env.ATLAS_DB_PATH ?? resolve(process.cwd(), '../data/atlas.db'),
+);
 
 // Fixtures live in the real atlas.db:
 //  - брати-взяти is a multiword_term whose migrated payload STILL carries a verb
@@ -26,6 +29,52 @@ const atlasDbPath = resolve(process.cwd(), '../data/atlas.db');
 //  - вода is a plain lemma with a noun paradigm — proving lemma pages are unchanged.
 const MULTIWORD_FIXTURE = 'брати-взяти';
 const LEMMA_FIXTURE = 'вода';
+
+const COMPONENT_LINK_TARGETS = new Map([
+  ['домі', 'dim'],
+  ['бити', 'byty'],
+  ['праці', 'pratsia'],
+  ['називний', 'nazyvnyi'],
+  ['відмінок', 'vidminok'],
+]);
+
+const COMPONENT_LEMMAS: LexiconEntry[] = [
+  ['дім', 'dim'],
+  ['бити', 'byty'],
+  ['праця', 'pratsia'],
+  ['називний', 'nazyvnyi'],
+  ['відмінок', 'vidminok'],
+].map(([lemma, url_slug]) => ({
+  lemma,
+  url_slug,
+  gloss: null,
+  entry_type: 'lemma',
+  pos: null,
+  ipa: null,
+  primary_source: 'fixture',
+  course_usage: [],
+}));
+
+function makeExpressionLikeFixture(entry_type: string, lemma: string): LexiconEntry {
+  return {
+    lemma,
+    url_slug: `fixture-${entry_type}`,
+    gloss: 'fixture gloss',
+    entry_type,
+    pos: 'phrase',
+    ipa: null,
+    primary_source: 'fixture',
+    course_usage: [
+      { track: 'a1', module_num: 1, slug: 'fixture-usage', context: 'built_vocabulary' },
+    ],
+    enrichment: {
+      meaning: { definitions: ['fixture meaning'], source: 'fixture-meaning' },
+      sources: ['fixture-citation'],
+      // Deliberately present: expression-like templates must suppress it.
+      morphology: { pos: 'noun', form_count: 1, forms: [], source: 'fixture-morphology' },
+    },
+  };
+}
 
 /** Minimal in-memory atlas.db shaped like the entry-model schema for gate tests. */
 function makeFixtureDb(): InstanceType<typeof Database> {
@@ -72,6 +121,21 @@ describe('entry_type-branched article rendering (#4385)', () => {
     });
   }
 
+  function renderFixture(
+    entry: LexiconEntry,
+    componentLinkTargets = COMPONENT_LINK_TARGETS,
+  ): Promise<string> {
+    return container.renderToString(WordAtlasArticle, {
+      props: {
+        entry,
+        allEntries: COMPONENT_LEMMAS,
+        componentLinkTargets,
+        generatedAt: 'test',
+        manifestVersion: 'test',
+      },
+    });
+  }
+
   test('entry_type is joined onto payloads from the articles table', () => {
     expect(cache.bySlug.get(MULTIWORD_FIXTURE)?.entry_type).toBe('multiword_term');
     expect(cache.bySlug.get(LEMMA_FIXTURE)?.entry_type).toBe('lemma');
@@ -103,6 +167,70 @@ describe('entry_type-branched article rendering (#4385)', () => {
     const html = await render(cache.bySlug.get(LEMMA_FIXTURE), LEMMA_FIXTURE);
     expect(html).toContain('paradigm-table');
     expect(html).toContain('Морфологія');
+  });
+
+  test.each([
+    ['expression', 'у до́мі', 'вираз', 'до́мі', 'dim', 'у'],
+    ['phraseologism', 'бити байдики', 'фразеологізм', 'бити', 'byty', 'байдики'],
+    ['proverb', 'без праці нема калача', "прислів'я", 'праці', 'pratsia', 'без'],
+    ['multiword_term', 'називний відмінок', 'термін', 'називний', 'nazyvnyi', null],
+  ])(
+    'renders %s as a detail page with safe component backlinks',
+    async (entryType, lemma, entryTypeLabel, linkedComponent, linkedSlug, unresolvedComponent) => {
+      const html = await renderFixture(makeExpressionLikeFixture(entryType, lemma));
+
+      expect(html.replace(/&#39;/g, "'")).toContain(`Лексикон · ${entryTypeLabel}`);
+      expect(html).toContain(`data-expression-detail="${entryType}"`);
+      expect(html).toContain('Складники:');
+      expect(html).toContain('fixture meaning');
+      expect(html).toContain('fixture-citation');
+      expect(html).toContain('fixture-usage');
+      expect(html).toContain(`href="/lexicon/${linkedSlug}/"`);
+      expect(html).toMatch(
+        new RegExp(`>${linkedComponent.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}</a>`),
+      );
+      if (unresolvedComponent) {
+        expect(html).toContain(`<span class="chip">${unresolvedComponent}</span>`);
+      }
+      expect(html).not.toContain('paradigm-table');
+      expect(html).not.toContain('Морфологія');
+    },
+  );
+
+  test('component_cross_links resolves a stress-marked alias and never emits a broken target', async () => {
+    const html = await renderFixture(makeExpressionLikeFixture('expression', 'у до́мі'));
+
+    expect(html).toContain('href="/lexicon/dim/"');
+    expect(html).not.toContain('href="/lexicon/у/"');
+    expect(html).not.toContain('href="/lexicon/до́мі/"');
+  });
+
+  test('lemma baseline remains byte-identical before and after entry-type branching', async () => {
+    const entry = makeExpressionLikeFixture('lemma', 'дім');
+    const { entry_type: _entryType, ...preEntryModelEntry } = entry;
+
+    const before = await renderFixture(preEntryModelEntry);
+    const after = await renderFixture(entry);
+
+    expect(after).toBe(before);
+  });
+});
+
+describe('component-link target resolution (#4385)', () => {
+  test('prefers direct approved article heads, uses unique aliases, and suppresses ambiguity', () => {
+    const targets = buildComponentLinkTargets(
+      [{ lookup_text: 'дім', target_slug: 'dim' }],
+      [
+        { lookup_text: 'дім', target_slug: 'other-dim' },
+        { lookup_text: 'домі', target_slug: 'dim' },
+        { lookup_text: 'спірний', target_slug: 'one' },
+        { lookup_text: 'спірний', target_slug: 'two' },
+      ],
+    );
+
+    expect(targets.get('дім')).toBe('dim');
+    expect(targets.get('домі')).toBe('dim');
+    expect(targets.has('спірний')).toBe(false);
   });
 });
 


### PR DESCRIPTION
Refs #4385 #4700

## Scope

- Added the `/lexicon/{slug}` expression-like branch for `expression`, `phraseologism`, `proverb`, and `multiword_term` articles.
- Component backlinks resolve canonical lemma heads first, then unique approved-public aliases; ambiguous or unresolved components stay non-link text.
- Added a labelled `Складники:` block, one AstroContainer fixture per expression-like type, and a byte-equality lemma baseline guard.
- Updated the POC route-map status. A build-wide `component_cross_links` gate is deferred to PR-5; this slice adds unit-level coverage only.

## Evidence — verified

All shell commands below used this cwd unless noted otherwise:

```text
/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4385-pr4-expression-detail/site
```

### Focused AstroContainer suite

```text
$ ATLAS_DB_PATH="$PWD/../../../../../data/atlas.db" npx vitest run tests/unit/atlas-entry-type-templates.test.ts --reporter=verbose

Test Files  1 passed (1)
     Tests  14 passed (14)
```

### TypeScript

```text
$ npx tsc --noEmit
npm notice run starlight@0.0.1 npx
npm notice run 'tsc' --noEmit
```

### Rendered component fragment

```text
$ node --input-type=module … # AstroContainer render of the expression fixture
<section class="atlas-section expression-detail" data-expression-detail="expression"> <div class="component-links"> <div class="chip-label">Складники:</div> <div class="chip-row"> <span class="chip">у</span><a class="chip" href="/lexicon/dim/">до́мі</a> </div> </div> </section>
```

### Current approved-entry counts (read-only DB query)

```text
cwd: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4385-pr4-expression-detail
sql: SELECT entry_type, COUNT(*) AS entries FROM articles WHERE review_state = 'approved' AND visibility = 'public' GROUP BY entry_type ORDER BY entry_type;
lemma	7085
multiword_term	1275
```

### Ukrainian labels and fixtures

```text
cwd: N/A (sources MCP)
Batch verification: 16 words
Found: 16/16
вираз; фразеологізм; прислів'я; термін; складники; у; домі; дім; бити; байдики; без; праці; нема; калача; називний; відмінок

Batch verification: 2 words
Found: 2/2
праця; спірний
```

## Not verified / known limitation

The complete `site/tests/unit` run was attempted but is not a passing verification in this checkout because the long-running Atlas data state is ahead of the checked-in static API artifacts. The isolated failure is outside this PR's five-file diff:

```text
$ ATLAS_DB_PATH="$PWD/../../../../../data/atlas.db" npx vitest run tests/unit/lexicon-api-routes.test.ts --reporter=default --silent

Test Files  1 failed (1)
     Tests  2 failed | 3 passed (5)

Expected: "ok"
Received: "warning"

expected 5777 to be greater than or equal to 8360
```

No site build, hydrate, or dev server was run; CI remains the build arbiter. No Python files changed, so Ruff was not applicable.
