### PR TITLE
fix(audit): count marked-forms paradigms as the morphology section (Refs #4891 #4900 #4220)

### DIFF
--- a/scripts/audit/audit_atlas_poc_richness.py
+++ b/scripts/audit/audit_atlas_poc_richness.py
@@ -105,7 +105,11 @@ def rendered_sections(entry: dict[str, Any]) -> set[str]:
         sections.add("etymology")
 
     morphology = enrichment.get("morphology") if isinstance(enrichment.get("morphology"), dict) else {}
-    if _nonempty_items(morphology.get("forms")) or isinstance(morphology.get("paradigm"), dict):
+    if (
+        _nonempty_items(morphology.get("forms"))
+        or _nonempty_items(morphology.get("marked_forms"))
+        or isinstance(morphology.get("paradigm"), dict)
+    ):
         sections.add("morphology")
 
     synonyms = extra_sections.get("synonyms") if isinstance(extra_sections.get("synonyms"), dict) else {}

--- a/tests/test_audit_atlas_poc_richness.py
+++ b/tests/test_audit_atlas_poc_richness.py
@@ -87,6 +87,52 @@ def test_rendered_sections_ignores_empty_placeholder_blocks() -> None:
     assert rendered_sections(entry) == set()
 
 
+def test_rendered_sections_counts_marked_forms_only_morphology() -> None:
+    entry = _entry(
+        enrichment={
+            "definition_cards": [
+                {"id": "vts-main", "source": "ВТС", "definitions": ["Тест."]}
+            ],
+            "morphology": {
+                "pos": "noun",
+                "form_count": 0,
+                "marked_form_count": 2,
+                "forms": [],
+                "marked_forms": [
+                    {"form": "слово́", "label": "називний", "style": "arch"},
+                    {"form": "слова́", "label": "родовий", "style": "arch"},
+                ],
+                "source": "VESUM",
+            },
+            "translation": {"en": ["word"], "source": "test"},
+        },
+    )
+
+    assert "morphology" in rendered_sections(entry)
+
+
+def test_rendered_sections_ignores_empty_morphology_without_paradigm() -> None:
+    entry = _entry(
+        gloss=None,
+        enrichment={
+            "morphology": {
+                "forms": [],
+                "marked_forms": [],
+                "source": "VESUM",
+            },
+            "translation": {"en": [], "source": "test"},
+        },
+    )
+
+    assert "morphology" not in rendered_sections(entry)
+
+
+def test_rendered_sections_plain_forms_morphology_unchanged() -> None:
+    entry = _entry()
+
+    assert "morphology" in rendered_sections(entry)
+
+
 def test_audit_cli_runs_as_direct_script(tmp_path) -> None:
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(


### PR DESCRIPTION
## Summary

- `rendered_sections` in `audit_atlas_poc_richness.py` now counts morphology when `morphology.marked_forms` is non-empty, matching `WordAtlasArticle` rendering for fully-marked lemmas (#4895 / #4916).
- Added unit tests: marked-forms-only → counted; empty morphology → not counted; plain `forms` behavior unchanged.

## Evidence (#M-4)

**cwd:** `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/cursor/4220-audit-marked-morphology`

### Manifest richness audit (read-only, main-tree manifest)

```bash
.venv/bin/python scripts/audit/audit_atlas_poc_richness.py \
  --local \
  --manifest /Users/krisztiankoos/projects/learn-ukrainian/site/src/data/lexicon-manifest.json \
  --format json
```

| | `poc_thin_pages` | `total_entries` |
|---|---|---|
| **Before** (origin/main) | 1510 | 8706 |
| **After** (this PR) | 1502 | 8706 |

Delta: **−8** false-thin signals (fully-marked lemmas that render morphology via `marked_forms` only).

### Tests

```bash
.venv/bin/ruff check scripts/audit/audit_atlas_poc_richness.py tests/test_audit_atlas_poc_richness.py
# All checks passed!

.venv/bin/pytest tests/test_audit_atlas_poc_richness.py -v
# 8 passed in 0.49s
```

## Test plan

- [x] `pytest tests/test_audit_atlas_poc_richness.py` — 8/8 pass
- [x] `ruff check` on changed files — clean
- [x] Real manifest audit before/after — thin count drops 1510 → 1502

Refs #4220


Made with [Cursor](https://cursor.com)