### PR TITLE
chore(api): PLC0415 advisory lint for scripts/api (epic #4707)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ select = [
     "B",     # flake8-bugbear (common bugs)
     "SIM",   # flake8-simplify
     "RUF",   # Ruff-specific rules
+    "PLC0415",  # import-outside-top-level (scripts/api only; advisory API import hygiene)
 ]
 ignore = [
     # Legitimate project-specific ignores (Ukrainian codebase)
@@ -50,6 +51,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+"!scripts/api/**.py" = ["PLC0415"]  # advisory API import-hygiene scope
 "scripts/api/*.py" = ["B008"]  # function call in default arg (FastAPI Depends)
 "tests/*.py" = ["F841", "SIM117"]  # unused variables + nested with OK in tests
 "scripts/*.py" = ["F401", "F811", "E302", "F821"]  # stubs at root — redirect boilerplate

--- a/scripts/api/artifacts_router.py
+++ b/scripts/api/artifacts_router.py
@@ -21,6 +21,7 @@ checks. Codex flagged that mixing these would muddy the contract.
 from __future__ import annotations
 
 import asyncio
+import json
 import re
 from pathlib import Path
 from typing import Any
@@ -35,6 +36,7 @@ except ImportError:
 
 from .config import CURRICULUM_ROOT, LEVELS, PROJECT_ROOT
 from .docs_router import collect_html_artifacts
+from .review_parsing import count_review_issues, extract_review_score, extract_review_verdict
 from .state_compute import _compute_shippable, _get_review_score
 from .state_helpers import (
     find_content_file,
@@ -626,12 +628,6 @@ def _read_review_file(path: Path) -> dict[str, Any] | None:
     except OSError:
         return None
 
-    from .review_parsing import (
-        count_review_issues,
-        extract_review_score,
-        extract_review_verdict,
-    )
-
     score = extract_review_score(text)
     verdict = extract_review_verdict(text)
     findings = count_review_issues(text)
@@ -765,8 +761,6 @@ def _state_drift_check(track: str, slug: str) -> dict[str, Any]:
     state_phases: dict[str, Any] = {}
     if state_path and state_path.is_file():
         try:
-            import json
-
             state_phases = (json.loads(state_path.read_text("utf-8")) or {}).get("phases") or {}
         except Exception:
             drifts.append(

--- a/scripts/api/blue_router.py
+++ b/scripts/api/blue_router.py
@@ -22,8 +22,18 @@ except ImportError:
 from .config import BATCH_STATE_DIR, CURRICULUM_ROOT, LEVELS, PROJECT_ROOT
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from audit.checks.activity_validation import (
+    check_fill_in_answer_in_options,
+    check_mark_the_words_answers_in_text,
+    check_quiz_single_correct,
+    check_select_min_correct,
+    check_translate_single_correct,
+    check_unjumble_out_of_scope_dative,
+    check_unjumble_runon_answer,
+)
 from audit.status_cache import get_source_paths, read_status
 from slug_utils import to_bare_slug
+from yaml_activities import ActivityParser
 
 router = APIRouter(tags=["blue"])
 
@@ -246,16 +256,6 @@ async def get_activity_errors(track_id: str, slug: str):
         return {"track": track_id, "slug": slug, "error": "No activities file found", "violations": []}
 
     try:
-        from audit.checks.activity_validation import (
-            check_fill_in_answer_in_options,
-            check_mark_the_words_answers_in_text,
-            check_quiz_single_correct,
-            check_select_min_correct,
-            check_translate_single_correct,
-            check_unjumble_out_of_scope_dative,
-            check_unjumble_runon_answer,
-        )
-        from yaml_activities import ActivityParser
         parser = ActivityParser()
         activities = parser.parse(activities_path)
 
@@ -328,7 +328,6 @@ async def get_final_review_summary(track_id: str, slug: str):
             }
             if data.get("last_audit"):
                 try:
-                    from datetime import datetime
                     last = datetime.fromisoformat(data["last_audit"].replace("Z", "+00:00"))
                     audit_age_seconds = max(0, int((datetime.now(UTC) - last).total_seconds()))
                 except Exception:
@@ -352,16 +351,6 @@ async def get_final_review_summary(track_id: str, slug: str):
     activities_path = safe_join(track_dir, "activities", f"{bare}.yaml")
     if activities_path.exists():
         try:
-            from audit.checks.activity_validation import (
-                check_fill_in_answer_in_options,
-                check_mark_the_words_answers_in_text,
-                check_quiz_single_correct,
-                check_select_min_correct,
-                check_translate_single_correct,
-                check_unjumble_out_of_scope_dative,
-                check_unjumble_runon_answer,
-            )
-            from yaml_activities import ActivityParser
             activities = ActivityParser().parse(activities_path)
             violations = (
                 check_select_min_correct(activities)

--- a/scripts/api/codexbar_usage.py
+++ b/scripts/api/codexbar_usage.py
@@ -14,6 +14,8 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from typing import Any, Optional
 
+from scripts.api.state_helpers import cache_get_with_age, cache_set
+
 WEEKLY_WINDOW_MINUTES = 10080
 # Reject monthly/long windows when no exact weekly window exists (e.g. 43200 min).
 WEEKLY_WINDOW_TOLERANCE_MINUTES = 5040
@@ -40,8 +42,6 @@ def refresh_provider_usage_data(providers: Iterable[str], *, timeout_s: float = 
     helper is reserved for callers, such as the dispatch budget guard, which
     explicitly need a bounded fresh verdict before acting.
     """
-    from scripts.api.state_helpers import cache_set
-
     unique_providers = tuple(dict.fromkeys(providers))
     if not unique_providers:
         return {}
@@ -262,8 +262,6 @@ def trigger_background_refresh() -> None:
 
 
 def _run_all_refreshes() -> None:
-    from scripts.api.state_helpers import cache_set
-
     # List of unique providers to refresh
     providers = ["claude", "codex", "cursor", "gemini", "grok"]
     for provider in providers:
@@ -283,8 +281,6 @@ def get_provider_usage_data(provider: str) -> dict[str, Any]:
     Triggers a background refresh on cache miss/expiration.
     Returns a normalized record indicating stale/unknown state.
     """
-    from scripts.api.state_helpers import cache_get_with_age
-
     cache_key = f"codexbar_usage:{provider}"
     cached = cache_get_with_age(cache_key, ttl=300.0)
 

--- a/scripts/api/comms_router.py
+++ b/scripts/api/comms_router.py
@@ -17,6 +17,7 @@ Endpoints:
   POST /api/comms/acknowledge/{id}     Ack single message
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -27,6 +28,8 @@ import time
 import uuid
 from datetime import UTC, datetime
 from importlib import util as importlib_util
+
+import yaml
 
 logger = logging.getLogger(__name__)
 
@@ -194,8 +197,8 @@ def _maybe_run_delivery_expiry_sweep() -> None:
 
 def _run_delivery_expiry_sweep(message_db: "os.PathLike[str]") -> None:
     try:
-        from ai_agent_bridge import _channels as _ch
-        from ai_agent_bridge import _db as _ch_db
+        from ai_agent_bridge import _channels as _ch  # noqa: PLC0415 — optional broker bridge
+        from ai_agent_bridge import _db as _ch_db  # noqa: PLC0415 — optional broker bridge
     except Exception:
         logger.exception("bridge delivery-expiry sweep: ai_agent_bridge not importable")
         return
@@ -862,8 +865,6 @@ def _scan_track_progress(track: str) -> dict:
     # Count total expected from curriculum.yaml
     total_expected = 0
     try:
-        import yaml
-
         curriculum_yaml = CURRICULUM_ROOT / "curriculum.yaml"
         if curriculum_yaml.exists():
             data = yaml.safe_load(curriculum_yaml.read_text()) or {}
@@ -901,8 +902,6 @@ def _scan_track_progress(track: str) -> dict:
 
 def _check_build_processes() -> list[dict]:
     """Find running legacy build_module.py processes."""
-    import subprocess
-
     try:
         result = subprocess.run(
             ["ps", "aux"],
@@ -937,8 +936,6 @@ async def batch_progress():
 
     This is the main endpoint for monitoring overnight/background builds.
     """
-    import asyncio
-
     cache_key = f"comms_batch_progress_{LOG_DIR}_{PID_DIR}"
     cached = cache_get(cache_key, ttl=10.0)
     if cached is not None:
@@ -996,8 +993,6 @@ async def batch_progress():
 @router.get("/batch-progress/{track}")
 async def batch_progress_track(track: str):
     """Detailed progress for one track."""
-    import asyncio
-
     tp = await asyncio.to_thread(_scan_track_progress, track)
 
     # Get research file timeline (last 20 files)
@@ -1168,8 +1163,6 @@ async def live_activity(
     response.headers["Warning"] = (
         '299 - "This endpoint is deprecated; migrate to /api/state/build-status + /api/build/events (#1309)"'
     )
-
-    import asyncio
 
     acts, completions = await asyncio.gather(
         asyncio.to_thread(_scan_live_activity, minutes),
@@ -1455,7 +1448,7 @@ async def get_channel_endpoint(name: str):
     context_preview = ""
     context_sha = ""
     try:
-        from ai_agent_bridge import _channels as _ch
+        from ai_agent_bridge import _channels as _ch  # noqa: PLC0415 — optional broker bridge
 
         ctx_path = _ch.channel_context_path(name)
         if ctx_path.exists():
@@ -1660,7 +1653,7 @@ async def post_to_channel(name: str, req: ChannelPostRequest, request: Request):
     try:
         # Import inside handler so the bridge package isn't a hard
         # dependency for the rest of the API server startup.
-        from ai_agent_bridge import _channels as _ch
+        from ai_agent_bridge import _channels as _ch  # noqa: PLC0415 — optional broker bridge
     except ImportError:
         return JSONResponse(
             status_code=500,
@@ -1890,7 +1883,7 @@ def comms_inbox(
     ``ai_agent_bridge`` to actually drain messages.
     """
     try:
-        from scripts.ai_agent_bridge._channels import pending_deliveries_for
+        from scripts.ai_agent_bridge._channels import pending_deliveries_for  # noqa: PLC0415 — optional broker bridge
     except ImportError:
         return JSONResponse(
             status_code=500,

--- a/scripts/api/consultation_router.py
+++ b/scripts/api/consultation_router.py
@@ -16,6 +16,7 @@ Endpoints:
 from __future__ import annotations
 
 import asyncio
+import re
 import shutil
 import sys
 from collections import Counter
@@ -181,7 +182,6 @@ def _resolve_template_path(file_field: str) -> Path | None:
 
 def _normalize_ws(text: str) -> str:
     """Collapse all whitespace to single spaces for fuzzy matching."""
-    import re
     return re.sub(r"\s+", " ", text).strip()
 
 

--- a/scripts/api/dashboard_comms.py
+++ b/scripts/api/dashboard_comms.py
@@ -5,6 +5,7 @@ pipeline queue scanning, and dispatcher state.
 """
 
 import json
+import os
 import sqlite3
 
 from .config import BATCH_STATE_DIR, CURRICULUM_ROOT, MESSAGE_DB, PROJECT_ROOT
@@ -39,7 +40,6 @@ def get_broker_db():
 
 def is_watcher_running() -> dict:
     """Check watcher daemon health."""
-    import os
     pid = None
     running = False
     if WATCHER_PID_FILE.exists():

--- a/scripts/api/dashboard_helpers.py
+++ b/scripts/api/dashboard_helpers.py
@@ -200,8 +200,6 @@ def build_module_info(track_dir, plans_dir, track_id, slug, idx) -> dict:
     friction_path = _safe_join(orch_dir, "friction.yaml") if orch_exists else None
     if friction_path and friction_path.exists():
         try:
-            import yaml
-
             fdata = yaml.safe_load(friction_path.read_text("utf-8"))
             for f in fdata.get("frictions", []) if fdata else []:
                 if f.get("status") == "active":

--- a/scripts/api/dashboard_router.py
+++ b/scripts/api/dashboard_router.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, HTTPException
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from audit.config import ACTIVITY_COMPLEXITY, ACTIVITY_RESTRICTIONS, LEVEL_CONFIG, VALID_ACTIVITY_TYPES
 from common.thresholds import REVIEW_PASS_FLOOR
 
 from .config import CURRICULUM_ROOT, LEVELS, SEMINAR_TRACK_IDS
@@ -344,13 +345,6 @@ async def pipeline_status():
 @router.get("/activity-config")
 async def activity_config():
     """Activity type reference: types, min items per level, forbidden types."""
-    from audit.config import (
-        ACTIVITY_COMPLEXITY,
-        ACTIVITY_RESTRICTIONS,
-        LEVEL_CONFIG,
-        VALID_ACTIVITY_TYPES,
-    )
-
     types = []
     for act_type in VALID_ACTIVITY_TYPES:
         complexity = ACTIVITY_COMPLEXITY.get(act_type, {})

--- a/scripts/api/docs_router.py
+++ b/scripts/api/docs_router.py
@@ -13,6 +13,7 @@ import re
 from datetime import UTC, datetime
 from pathlib import Path
 
+import yaml
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import FileResponse
 
@@ -173,8 +174,6 @@ def _extract_md_frontmatter(path: Path) -> dict[str, str]:
 
     yaml_str = head[4:end_idx]  # Skip opening "---\n"
     try:
-        import yaml
-
         data = yaml.safe_load(yaml_str)
         if isinstance(data, dict):
             for key, value in data.items():

--- a/scripts/api/images_router.py
+++ b/scripts/api/images_router.py
@@ -171,7 +171,7 @@ class _PDFPool:
                 self._pool.move_to_end(pdf_path)
                 return self._pool[pdf_path]
 
-            import pymupdf
+            import pymupdf  # noqa: PLC0415 — optional PDF rendering dependency
             doc = pymupdf.open(pdf_path)
 
             if len(self._pool) >= self._max_size:
@@ -216,7 +216,7 @@ def _read_pdf_page_count(pdf_path: str) -> int:
         return cached[2]
 
     try:
-        import pymupdf
+        import pymupdf  # noqa: PLC0415 — optional PDF rendering dependency
 
         doc = pymupdf.open(pdf_path)
         try:
@@ -329,7 +329,11 @@ async def get_page_context(pdf_stem: str, page_num: int):
         raise HTTPException(400, f"Page {page_num} out of range (1-{len(doc)})")
 
     def _extract(doc, page_num):
-        from rag.poc_pair_page import SCALE, extract_images, extract_text_blocks
+        from rag.poc_pair_page import (  # noqa: PLC0415  — optional RAG dependency
+            SCALE,
+            extract_images,
+            extract_text_blocks,
+        )
         page = doc[page_num - 1]
         text_blocks = extract_text_blocks(page)
         images = extract_images(page)
@@ -398,7 +402,7 @@ async def render_page_png(pdf_stem: str, page_num: int):
         raise HTTPException(400, f"Page {page_num} out of range (1-{len(doc)})")
 
     def _render(doc, page_num):
-        from rag.poc_pair_page import RENDER_DPI
+        from rag.poc_pair_page import RENDER_DPI  # noqa: PLC0415  — optional RAG dependency
         page = doc[page_num - 1]
         pix = page.get_pixmap(dpi=RENDER_DPI)
         return pix.tobytes("png")

--- a/scripts/api/issues_router.py
+++ b/scripts/api/issues_router.py
@@ -27,6 +27,8 @@ from typing import Any
 
 from fastapi import APIRouter, Query
 
+from scripts.orchestration import issue_stream_audit as audit
+
 from .config import PROJECT_ROOT
 
 router = APIRouter(tags=["issues"])
@@ -195,8 +197,6 @@ async def issues_streams(
     """
 
     def _load() -> dict[str, Any]:
-        from scripts.orchestration import issue_stream_audit as audit
-
         try:
             if fresh:
                 return audit.run_audit()

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -26,6 +26,8 @@ from fastapi import FastAPI, HTTPException, Query, Request, WebSocket, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 
+from scripts.guardrails import worktree_containment
+
 try:
     from path_safety import safe_join  # scripts/ on sys.path (test sys.path-hack)
 except ImportError:
@@ -279,8 +281,6 @@ def _run_command(args: list[str], *, timeout: float = 2.0) -> subprocess.Complet
 
 
 def _collect_git_orient_data() -> dict:
-    from scripts.guardrails import worktree_containment
-
     branch_proc = _run_command(["git", "branch", "--show-current"])
     head_proc = _run_command(["git", "rev-parse", "--short=9", "HEAD"])
     ahead_proc = _run_command(["git", "rev-list", "--count", "origin/main..HEAD"])
@@ -419,7 +419,7 @@ def _collect_delegate_orient_data() -> dict:
 
 
 def _collect_bridge_pending_orient_data() -> dict:
-    from scripts.ai_agent_bridge import _channels
+    from scripts.ai_agent_bridge import _channels  # noqa: PLC0415 — optional broker bridge
 
     return _channels.bridge_pending_summary()
 
@@ -501,9 +501,9 @@ def _core_bare_canary() -> bool:
     the canary must not break health collection.
     """
     try:
-        from scripts.audit.check_core_bare import check_core_bare
+        from scripts.audit.check_core_bare import check_core_bare  # noqa: PLC0415 — script-path fallback
     except ImportError:  # path-flavoured import for test/script contexts
-        from audit.check_core_bare import check_core_bare
+        from audit.check_core_bare import check_core_bare  # noqa: PLC0415 — script-path fallback
     try:
         ok, message = check_core_bare(PROJECT_ROOT, fix=True)
     except Exception:
@@ -528,9 +528,9 @@ def _self_symlink_canary() -> bool:
     ``docs/bug-autopsies/node-modules-eloop-symlink.md``.
     """
     try:
-        from scripts.audit.check_self_symlinks import check_self_symlinks
+        from scripts.audit.check_self_symlinks import check_self_symlinks  # noqa: PLC0415 — script-path fallback
     except ImportError:  # path-flavoured import for test/script contexts
-        from audit.check_self_symlinks import check_self_symlinks
+        from audit.check_self_symlinks import check_self_symlinks  # noqa: PLC0415 — script-path fallback
     try:
         ok, message = check_self_symlinks(PROJECT_ROOT, fix=True)
     except Exception:
@@ -807,7 +807,7 @@ async def orient(
 async def get_config():
     # Import pipeline phase config — single source of truth
     try:
-        from scripts.build.phase_constants import PHASE_LABELS, PHASES
+        from scripts.build.phase_constants import PHASE_LABELS, PHASES  # noqa: PLC0415 — preserves endpoint fallback
 
         pipeline_info = {"phases": PHASES, "phase_labels": PHASE_LABELS}
     except ImportError:

--- a/scripts/api/module_dashboard.py
+++ b/scripts/api/module_dashboard.py
@@ -18,6 +18,8 @@ import re
 import sys
 from pathlib import Path
 
+import yaml
+
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
 
@@ -34,8 +36,6 @@ except ImportError:
 
 def _load_curriculum_order(level: str) -> list[str]:
     """Load module slugs in curriculum order from curriculum.yaml."""
-    import yaml
-
     manifest = CURRICULUM_ROOT / "curriculum.yaml"
     if not manifest.exists():
         return []
@@ -78,8 +78,6 @@ def _count_frictions(level: str, slug: str) -> tuple[int, int]:
     if not path.exists():
         return (0, 0)
     try:
-        import yaml
-
         data = yaml.safe_load(path.read_text())
         frictions = data.get("frictions", []) if data else []
         active = sum(1 for f in frictions if f.get("status") == "active")

--- a/scripts/api/preload.py
+++ b/scripts/api/preload.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import logging
 import time
+from importlib import util as importlib_util
 from pathlib import Path
 
 logger = logging.getLogger("api.preload")
@@ -104,7 +105,6 @@ def _load_migration_strategy() -> tuple[int, int, list[str]]:
     migration_path = api_dir.parent / "migrations" / "2026-05-06-broker-indexes.py"
     if migration_path.exists():
         try:
-            from importlib import util as importlib_util
             spec = importlib_util.spec_from_file_location("broker_indexes_20260506", migration_path)
             if spec is not None and spec.loader is not None:
                 module = importlib_util.module_from_spec(spec)

--- a/scripts/api/rag_router.py
+++ b/scripts/api/rag_router.py
@@ -28,7 +28,7 @@ async def search_text(
     trust_tier: int | None = Query(None, description="Trust tier"),
     limit: int = Query(5, ge=1, le=20),
 ):
-    from rag.query import search_text as _search_text
+    from rag.query import search_text as _search_text  # noqa: PLC0415 — optional RAG dependency
 
     return _search_text(q, grade=grade, subject=subject, trust_tier=trust_tier, limit=limit)
 
@@ -41,7 +41,7 @@ async def search_images(
     subject: str | None = Query(None, description="Filter by subject"),
     limit: int = Query(5, ge=1, le=20),
 ):
-    from rag.query import search_images as _search_images
+    from rag.query import search_images as _search_images  # noqa: PLC0415 — optional RAG dependency
 
     return _search_images(
         q,
@@ -60,14 +60,14 @@ async def search_literary(
     period: str | None = Query(None, description="Filter by language period"),
     limit: int = Query(5, ge=1, le=20),
 ):
-    from rag.query import search_literary as _search_literary
+    from rag.query import search_literary as _search_literary  # noqa: PLC0415 — optional RAG dependency
 
     return _search_literary(q, work=work, genre=genre, period=period, limit=limit)
 
 
 @router.get("/stats")
 async def collection_stats():
-    from rag.query import collection_stats as _collection_stats
+    from rag.query import collection_stats as _collection_stats  # noqa: PLC0415 — optional RAG dependency
 
     return _collection_stats()
 

--- a/scripts/api/resilience.py
+++ b/scripts/api/resilience.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 import os
@@ -175,8 +176,6 @@ async def resilience_middleware(request: Request, call_next):
 
     start = time.perf_counter()
     try:
-        import asyncio
-
         response = await asyncio.wait_for(call_next(request), timeout=request_timeout_s())
     except TimeoutError:
         elapsed_ms = (time.perf_counter() - start) * 1000

--- a/scripts/api/rules_router.py
+++ b/scripts/api/rules_router.py
@@ -26,6 +26,7 @@ import hashlib
 from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Query, Request, Response
+from fastapi.responses import JSONResponse, PlainTextResponse
 
 from .config import PROJECT_ROOT
 from .telemetry.response import (
@@ -154,8 +155,6 @@ def get_rules(
     # Raw Markdown path. FastAPI's default str response is
     # application/json, which would JSON-encode the whole blob — wrong
     # for an agent trying to drop it straight into a prompt.
-    from fastapi.responses import PlainTextResponse
-
     return PlainTextResponse(
         content=append_telemetry_footer(markdown, session_id),
         media_type="text/markdown; charset=utf-8",
@@ -170,8 +169,6 @@ def _rules_json_response(
     etag: str,
     session_id: str | None,
 ):
-    from fastapi.responses import JSONResponse
-
     return JSONResponse(
         content=add_json_telemetry(
             {

--- a/scripts/api/runtime_router.py
+++ b/scripts/api/runtime_router.py
@@ -19,6 +19,7 @@ from .config import BATCH_STATE_DIR
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from agent_runtime.adapters.gemini import has_gemini_oauth_credentials, resolve_gemini_auth_mode
 from agent_runtime.usage import has_headroom
 
 router = APIRouter(tags=["runtime"])
@@ -306,16 +307,8 @@ async def runtime_auth():
     All information is derived from env + filesystem — no subprocess,
     no network call. Cheap and safe to poll.
     """
-    from datetime import UTC, datetime
-    from pathlib import Path as _Path
-
-    from agent_runtime.adapters.gemini import (
-        has_gemini_oauth_credentials,
-        resolve_gemini_auth_mode,
-    )
-
     env = os.environ
-    home = _Path.home()
+    home = Path.home()
 
     # Sanitize GEMINI_AUTH_MODE rather than echo it raw. Reviewer
     # Codex BLOCKER on #1312 pre-merge: this endpoint's contract says

--- a/scripts/api/state_compute.py
+++ b/scripts/api/state_compute.py
@@ -16,6 +16,13 @@ import yaml
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from common.thresholds import REVIEW_PASS_FLOOR
+from research_quality import (
+    DIMENSION_SHORT_LABELS,
+    assess_research_compat,
+    find_research_path,
+    get_dimensions,
+    get_rubric,
+)
 
 from scripts.audit.llm_qg_store import (
     current_payload_for_module,
@@ -65,14 +72,6 @@ def severity_key(m: dict) -> int:
 
 def compute_research_detail(track_id: str, level_cfg: dict, min_score: int) -> dict:
     """Compute per-module research quality for a track."""
-    from research_quality import (
-        DIMENSION_SHORT_LABELS,
-        assess_research_compat,
-        find_research_path,
-        get_dimensions,
-        get_rubric,
-    )
-
     track_dir = CURRICULUM_ROOT / level_cfg["path"]
     plan_slugs = get_plan_slugs(track_id)
     rubric_name = get_rubric(track_id)
@@ -157,7 +156,6 @@ def _get_friction_data(orch_dir: Path) -> dict:
     if not friction_path.exists():
         return {"active": 0, "resolved": 0, "items": []}
     try:
-        import yaml
         data = yaml.safe_load(friction_path.read_text("utf-8"))
         frictions = data.get("frictions", []) if data else []
         active = [f for f in frictions if f.get("status") == "active"]
@@ -210,7 +208,6 @@ def _get_stress_issues(orch_dir: Path) -> dict:
     if not screen_path.exists():
         return {"mismatches": 0, "unknown": 0, "details": []}
     try:
-        import json
         data = json.loads(screen_path.read_text("utf-8"))
         issues = data.get("deterministic_issues", [])
         stress = [i for i in issues if i.get("type", "").startswith("STRESS_")]
@@ -231,7 +228,6 @@ def _get_quick_verify(orch_dir: Path) -> dict:
     if not qv_path.exists():
         return {}
     try:
-        import json
         return json.loads(qv_path.read_text("utf-8"))
     except Exception:
         return {}
@@ -431,7 +427,7 @@ def compute_module_detail(track_id: str, num: int, level_cfg: dict) -> dict:
 def get_phases_for_version(orch_dir, version, *, state_data: dict | None = None):
     """Get phase status dict appropriate for the pipeline version."""
     if version == "v6":
-        from .state_build import V6_PHASE_ORDER
+        from .state_build import V6_PHASE_ORDER  # noqa: PLC0415 — breaks state-build import cycle
         v6 = state_data if state_data is not None else read_v2_state(orch_dir)
         phases = v6.get("phases", {})
         return {

--- a/scripts/api/state_helpers.py
+++ b/scripts/api/state_helpers.py
@@ -14,6 +14,7 @@ Pipeline version note (#1186, 2026-04-11):
 """
 
 import contextlib
+import hashlib
 import json
 import re
 import sqlite3
@@ -552,7 +553,6 @@ def is_review_stale(review_path: Path, content_path: Path | None) -> bool:
     if not content_path or not content_path.exists():
         return False
 
-    import hashlib
     review_hash = extract_content_hash(review_path)
     if review_hash:
         try:

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -28,6 +28,7 @@ Performance notes:
 
 import asyncio
 import json
+import logging
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -51,8 +52,11 @@ from . import delegate_router as delegate_api
 from .codexbar_usage import get_provider_usage_data, refresh_provider_usage_data
 from .config import CURRICULUM_ROOT, LEVELS
 from .lane_health import compute_lane_health
+from .rules_router import rules_hash
+from .session_router import session_hash
 from .state_build import (
     compute_build_stats,
+    compute_build_stats_all,
     compute_build_status_all,
     compute_build_status_track,
     compute_enrichment_status,
@@ -93,6 +97,7 @@ from .state_issues import (
     compute_final_reviews,
     compute_issues,
 )
+from .telemetry.response import add_json_telemetry, session_id_from_request
 
 # Re-export symbols used by dashboard_router and tests (backward compat)
 _detect_pipeline_version = detect_pipeline_version
@@ -505,7 +510,6 @@ def compute_routing_budget(now: datetime | None = None, *, fresh_codexbar: bool 
             now=current_time
         )
     except Exception as exc:
-        import logging
         logging.getLogger("state_router").debug("Failed to compute lane health: %s", exc)
 
     # Empty config case: unknown statuses, suppressed rec (no confident pick from absent data)
@@ -1475,8 +1479,6 @@ async def llm_qg_track(
 @router.get("/build-stats")
 async def build_stats_all():
     """V6 build stats aggregated across all tracks."""
-    from .state_build import compute_build_stats_all
-
     return await asyncio.to_thread(compute_build_stats_all)
 
 
@@ -1825,17 +1827,10 @@ async def manifest(request: Request):
     session, every compaction. The manifest collapses the steady
     state to one tiny call.
     """
-    from datetime import UTC
-    from datetime import datetime as _dt
-
-    from .rules_router import rules_hash
-    from .session_router import session_hash
-    from .telemetry.response import add_json_telemetry, session_id_from_request
-
     session_id = session_id_from_request(request)
     return add_json_telemetry(
         {
-            "generated_at": _dt.now(UTC).isoformat().replace("+00:00", "Z"),
+            "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
             "rules": {
                 "hash": rules_hash(),
                 "url": "/api/rules?format=markdown",

--- a/tests/test_manifest_api.py
+++ b/tests/test_manifest_api.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 import scripts.api.main as api_main
 import scripts.api.rules_router as rules_router
 import scripts.api.session_router as session_router
+import scripts.api.state_router as state_router
 
 client = TestClient(api_main.app, raise_server_exceptions=False)
 
@@ -257,9 +258,12 @@ def test_session_current_404_without_current_md(tmp_path, monkeypatch):
 
 def test_manifest_shape_and_hashes(monkeypatch, tmp_path):
     """Manifest exposes a hash + URL for rules + session; orient + inbox don't need hashes."""
-    # Stub rules + session so we get deterministic hashes.
-    monkeypatch.setattr(rules_router, "rules_hash", lambda: "r" * 64)
-    monkeypatch.setattr(session_router, "session_hash", lambda: "s" * 64)
+    # Stub rules + session so we get deterministic hashes. Patch the names
+    # where they are USED (state_router binds them at import time via
+    # top-level `from .rules_router import rules_hash` — patching the origin
+    # module would not affect the already-bound reference).
+    monkeypatch.setattr(state_router, "rules_hash", lambda: "r" * 64)
+    monkeypatch.setattr(state_router, "session_hash", lambda: "s" * 64)
 
     resp = client.get("/api/state/manifest")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Enables Ruff PLC0415 as an advisory import-hygiene check for `scripts/api/**` only. Ruff 0.15.5 exposes this rule without preview mode.

- Hoisted or removed all 43 trivially safe current violations.
- Retained 20 behavior-sensitive imports with line-level `# noqa: PLC0415` reasons.
- Preserves the PR-A preload registry and import-pinning guard unchanged.

Relates to #4707.

## #M-4 evidence

### Ruff

```text
$ .venv/bin/ruff check scripts/api/
All checks passed!

$ .venv/bin/ruff check scripts/api/ --select PLC0415
All checks passed!
```

Scope probe: an identical function-level import passes for `scripts/probe_plc0415.py` and is flagged for `scripts/api/probe_plc0415.py`. Preview remains disabled.

### Hoisted / removed — 43 violations

- `artifacts_router`: `json`; review-parsing helpers.
- `blue_router`: activity validators (two call sites), `ActivityParser` (two), already-imported `datetime`.
- `codexbar_usage`: `cache_set` (two), `cache_get_with_age`.
- `comms_router`: `yaml`, `subprocess`, `asyncio` (three).
- `consultation_router`: `re`; `dashboard_comms`: `os`; `dashboard_helpers`: `yaml`; `dashboard_router`: audit configuration; `docs_router`: `yaml`.
- `issues_router`: issue-stream auditor; `main`: worktree-containment helper; `module_dashboard`: `yaml` (two); `preload`: `importlib.util`.
- `resilience`: `asyncio`; `rules_router`: `PlainTextResponse` and `JSONResponse`; `runtime_router`: `datetime`, `Path`, Gemini auth adapter.
- `state_compute`: research-quality helpers, `yaml`, `json` (two); `state_helpers`: `hashlib`; `state_router`: `logging`, build-stat helper, `datetime` (two), rules/session hashes, telemetry helpers.

### Retained local with `noqa` — 20 violations

- `comms_router` (5): optional `ai_agent_bridge` imports; endpoints retain graceful degradation when the broker bridge is absent.
- `images_router` (4): optional/heavy `pymupdf` and `rag.poc_pair_page` dependencies.
- `rag_router` (4): optional/heavy `rag.query` backend.
- `main` (6): optional bridge, both sides of two script-path fallback shims, and the `/api/config` optional pipeline fallback.
- `state_compute` (1): `V6_PHASE_ORDER` stays local to break the `state_build -> state_compute` import cycle.

### Tests

```text
$ .venv/bin/python -m pytest tests/api/ -q
collected 40 items
tests/api/test_import_pinning.py .....
(exit 0)

pre-commit affected-file pytest: 75 passed in 1.84s
```

The API suite includes the import-pinning guard (`tests/api/test_import_pinning.py`): all five guard tests passed.