### PR TITLE
feat(atlas): reversible park/restore tool for structurally-thin lemma articles (Refs #4220 #4515)

### DIFF
--- a/scripts/lexicon/park_thin_entries.py
+++ b/scripts/lexicon/park_thin_entries.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Reversibly park structurally thin Atlas lemma articles.
+
+The Atlas richness audit remains the sole authority for thinness.  This tool
+removes only audit-classified thin ``lemma_article`` entries, preserving the
+original entry payload and position in a parked artifact so the operation can
+be reversed after new source material makes those articles worth publishing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.audit.audit_atlas_poc_richness import audit_manifest
+from scripts.lexicon.backfill_course_usage import (
+    _fingerprint_path_for,
+    _refresh_manifest_fingerprint,
+)
+from scripts.lexicon.manifest_io import DEFAULT_MANIFEST, load_manifest, write_manifest
+
+DEFAULT_PARKED_DIR = PROJECT_ROOT / "data" / "lexicon" / "parked"
+DEFAULT_PARKED_OUT = DEFAULT_PARKED_DIR / f"parked-thin-entries-{datetime.now(UTC).date().isoformat()}.json"
+PARKED_SCHEMA_VERSION = 1
+_THIN_LEMMA_SAMPLE = "poc_thin_lemma_article"
+_ENRICHED_STAT_KEYS = ("enriched", "enriched_total", "enriched_count")
+
+
+@dataclass(frozen=True)
+class ParkResult:
+    """Outcome of a park or restore operation."""
+
+    mode: str
+    parked_count: int
+    restored_count: int
+    guard_excluded: dict[str, int]
+    limit_excluded: int
+    pre_park_poc_thin_pages: int | None
+    projected_poc_thin_pages: int
+    projected_form_stub_broken: int
+    manifest_written: bool
+    parked_artifact_written: bool
+    fingerprint_written: bool
+    dry_run: bool
+
+    def json_summary(self) -> dict[str, object]:
+        """Return the stable CLI report payload."""
+        return {
+            "mode": self.mode,
+            "dry_run": self.dry_run,
+            "parked_count": self.parked_count,
+            "restored_count": self.restored_count,
+            "guard_excluded": self.guard_excluded,
+            "limit_excluded": self.limit_excluded,
+            "pre_park_poc_thin_pages": self.pre_park_poc_thin_pages,
+            "projected_poc_thin_pages": self.projected_poc_thin_pages,
+            "projected_form_stub_broken": self.projected_form_stub_broken,
+            "manifest_written": self.manifest_written,
+            "parked_artifact_written": self.parked_artifact_written,
+            "fingerprint_written": self.fingerprint_written,
+        }
+
+
+def park_thin_entries(
+    *,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    parked_out: Path = DEFAULT_PARKED_OUT,
+    write: bool = False,
+    limit: int | None = None,
+) -> ParkResult:
+    """Park audit-classified thin lemma articles without changing audit rules."""
+    if limit is not None and limit < 0:
+        raise ValueError("limit must be non-negative")
+
+    manifest_path = _resolve_path(manifest_path)
+    parked_out = _resolve_path(parked_out)
+    manifest = load_manifest(manifest_path)
+    entries = _manifest_entries(manifest, manifest_path)
+    pre_park_audit = _audit_all_thin_rows(manifest, entries)
+    candidate_indices = _thin_lemma_candidate_indices(entries, pre_park_audit)
+
+    non_candidates = [entry for index, entry in enumerate(entries) if index not in candidate_indices]
+    protected_indices = {
+        index
+        for index in candidate_indices
+        if _is_form_target_of_any(entry=entries[index], remaining_entries=non_candidates)
+    }
+    eligible_indices = [index for index in candidate_indices if index not in protected_indices]
+    selected_indices = eligible_indices if limit is None else eligible_indices[:limit]
+
+    prospective_manifest = copy.deepcopy(manifest)
+    prospective_manifest["entries"] = [
+        entry for index, entry in enumerate(entries) if index not in set(selected_indices)
+    ]
+    _refresh_manifest_stats(prospective_manifest)
+    projected_audit = _audit_all_thin_rows(prospective_manifest, _manifest_entries(prospective_manifest, manifest_path))
+    _refuse_broken_form_stubs(projected_audit)
+
+    result = ParkResult(
+        mode="park",
+        parked_count=len(selected_indices),
+        restored_count=0,
+        guard_excluded={"form_of_target": len(protected_indices)},
+        limit_excluded=len(eligible_indices) - len(selected_indices),
+        pre_park_poc_thin_pages=int(pre_park_audit["poc_thin_pages"]),
+        projected_poc_thin_pages=int(projected_audit["poc_thin_pages"]),
+        projected_form_stub_broken=int(projected_audit["form_stub_broken"]),
+        manifest_written=False,
+        parked_artifact_written=False,
+        fingerprint_written=False,
+        dry_run=not write,
+    )
+    if not write or not selected_indices:
+        return result
+    if parked_out.exists():
+        raise FileExistsError(f"Refusing to overwrite existing parked artifact: {parked_out}")
+
+    parked_payload = _parked_payload(
+        manifest_path=manifest_path,
+        pre_park_audit=pre_park_audit,
+        selected_indices=selected_indices,
+        entries=entries,
+    )
+    # The artifact is the recovery point.  It must be durable before the live
+    # manifest can shrink, even if a later manifest write fails.
+    write_manifest(parked_out, parked_payload)
+    fingerprint_path = _fingerprint_path_for(manifest_path)
+    _refresh_manifest_fingerprint(prospective_manifest, fingerprint_path)
+    write_manifest(manifest_path, prospective_manifest)
+    return ParkResult(
+        **{
+            **result.__dict__,
+            "manifest_written": True,
+            "parked_artifact_written": True,
+            "fingerprint_written": True,
+        }
+    )
+
+
+def restore_parked_entries(
+    *,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    parked_file: Path,
+    write: bool = False,
+) -> ParkResult:
+    """Restore verbatim entries from a parked artifact at their original indices."""
+    manifest_path = _resolve_path(manifest_path)
+    parked_file = _resolve_path(parked_file)
+    manifest = load_manifest(manifest_path)
+    entries = _manifest_entries(manifest, manifest_path)
+    artifact = _load_parked_artifact(parked_file)
+    records = _parked_records(artifact, parked_file)
+    expected_thin_count = _artifact_pre_park_thin_count(artifact, parked_file)
+    _ensure_restore_has_no_collisions(entries, records, parked_file)
+
+    prospective_manifest = copy.deepcopy(manifest)
+    restored_entries = list(entries)
+    for index, entry in records:
+        if index > len(restored_entries):
+            raise ValueError(f"Parked index {index} is outside the current manifest: {parked_file}")
+        restored_entries.insert(index, copy.deepcopy(entry))
+    prospective_manifest["entries"] = restored_entries
+    _refresh_manifest_stats(prospective_manifest)
+    projected_audit = _audit_all_thin_rows(
+        prospective_manifest,
+        _manifest_entries(prospective_manifest, manifest_path),
+    )
+    _refuse_broken_form_stubs(projected_audit)
+    projected_thin_count = int(projected_audit["poc_thin_pages"])
+    if projected_thin_count != expected_thin_count:
+        raise ValueError(
+            "Refusing restore because its re-audited thin count does not match the parked artifact: "
+            f"expected {expected_thin_count}, got {projected_thin_count}"
+        )
+
+    result = ParkResult(
+        mode="restore",
+        parked_count=0,
+        restored_count=len(records),
+        guard_excluded={"form_of_target": 0},
+        limit_excluded=0,
+        pre_park_poc_thin_pages=expected_thin_count,
+        projected_poc_thin_pages=projected_thin_count,
+        projected_form_stub_broken=int(projected_audit["form_stub_broken"]),
+        manifest_written=False,
+        parked_artifact_written=False,
+        fingerprint_written=False,
+        dry_run=not write,
+    )
+    if not write or not records:
+        return result
+
+    fingerprint_path = _fingerprint_path_for(manifest_path)
+    _refresh_manifest_fingerprint(prospective_manifest, fingerprint_path)
+    write_manifest(manifest_path, prospective_manifest)
+    return ParkResult(
+        **{
+            **result.__dict__,
+            "manifest_written": True,
+            "fingerprint_written": True,
+        }
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the park/restore command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--parked-out", type=Path, default=DEFAULT_PARKED_OUT)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--write", action="store_true", help="Write the parked artifact and manifest mutation.")
+    mode.add_argument("--dry-run", action="store_true", help="Report only (the default).")
+    parser.add_argument("--restore", type=Path, help="Restore entries from this parked artifact.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Maximum eligible entries to park, for a deliberate staged operation.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print the machine-readable report.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the CLI and return a conventional process status."""
+    args = build_parser().parse_args(argv)
+    try:
+        if args.restore is not None:
+            if args.limit is not None:
+                raise ValueError("--limit applies only to parking, not --restore")
+            result = restore_parked_entries(
+                manifest_path=args.manifest,
+                parked_file=args.restore,
+                write=args.write,
+            )
+        else:
+            result = park_thin_entries(
+                manifest_path=args.manifest,
+                parked_out=args.parked_out,
+                write=args.write,
+                limit=args.limit,
+            )
+    except (FileExistsError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result.json_summary(), ensure_ascii=False, indent=2))
+    else:
+        _print_summary(result)
+    return 0
+
+
+def _manifest_entries(manifest: dict[str, Any], manifest_path: Path) -> list[dict[str, Any]]:
+    entries = manifest.get("entries")
+    if not isinstance(entries, list) or not all(isinstance(entry, dict) for entry in entries):
+        raise ValueError(f"Manifest entries must be a list of objects: {manifest_path}")
+    return entries
+
+
+def _audit_all_thin_rows(manifest: dict[str, Any], entries: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Run the audit with an exhaustive sample, never reconstructed local logic."""
+    return audit_manifest(manifest, sample_limit=len(entries))
+
+
+def _thin_lemma_candidate_indices(entries: Sequence[dict[str, Any]], audit: dict[str, Any]) -> list[int]:
+    samples = audit.get("samples")
+    rows = samples.get(_THIN_LEMMA_SAMPLE) if isinstance(samples, Mapping) else None
+    if not isinstance(rows, list):
+        raise ValueError(f"Audit did not return the {_THIN_LEMMA_SAMPLE} sample")
+    thin_by_class = audit.get("thin_by_class")
+    expected_count = thin_by_class.get("lemma_article") if isinstance(thin_by_class, Mapping) else None
+    if not isinstance(expected_count, int) or len(rows) != expected_count:
+        raise ValueError("Audit sample was not exhaustive for thin lemma articles")
+
+    indices_by_slug: dict[str, list[int]] = defaultdict(list)
+    for index, entry in enumerate(entries):
+        slug = _nonempty_string(entry.get("url_slug"))
+        if slug is not None:
+            indices_by_slug[slug].append(index)
+
+    candidate_indices: list[int] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise ValueError("Audit thin lemma sample contains a non-object row")
+        slug = _nonempty_string(row.get("url_slug"))
+        matches = indices_by_slug.get(slug, []) if slug is not None else []
+        if len(matches) != 1:
+            raise ValueError(f"Audit thin lemma row cannot be matched uniquely by url_slug: {slug!r}")
+        candidate_indices.append(matches[0])
+    return candidate_indices
+
+
+def _is_form_target_of_any(*, entry: dict[str, Any], remaining_entries: Sequence[dict[str, Any]]) -> bool:
+    entry_slug = _nonempty_string(entry.get("url_slug"))
+    entry_lemma = _nonempty_string(entry.get("lemma"))
+    for remaining in remaining_entries:
+        form_of = remaining.get("form_of")
+        if not isinstance(form_of, Mapping):
+            continue
+        target_slug = _nonempty_string(form_of.get("url_slug"))
+        target_lemma = _nonempty_string(form_of.get("lemma"))
+        if target_slug is not None and target_slug == entry_slug:
+            return True
+        if target_lemma is not None and target_lemma == entry_lemma:
+            return True
+    return False
+
+
+def _refresh_manifest_stats(manifest: dict[str, Any]) -> None:
+    """Maintain every existing entry-derived count, following promotion semantics."""
+    entries = _manifest_entries(manifest, Path("<in-memory manifest>"))
+    stats = manifest.setdefault("stats", {})
+    if not isinstance(stats, dict):
+        stats = {}
+        manifest["stats"] = stats
+    stats["lemmas_total"] = len(entries)
+    if "entries_total" in stats:
+        stats["entries_total"] = len(entries)
+    if "form_of_count" in stats:
+        stats["form_of_count"] = sum(1 for entry in entries if "form_of" in entry)
+    if "from_built" in stats:
+        stats["from_built"] = sum(
+            1 for entry in entries if str(entry.get("primary_source") or "").startswith("built_vocabulary")
+        )
+    if "from_surzhyk_to_avoid" in stats:
+        stats["from_surzhyk_to_avoid"] = sum(1 for entry in entries if entry.get("seed_group") == "surzhyk-to-avoid")
+    if "from_heritage_status_seed" in stats:
+        stats["from_heritage_status_seed"] = sum(
+            1 for entry in entries if entry.get("seed_group") == "heritage-status-samples"
+        )
+    enriched_count = sum(1 for entry in entries if entry.get("enrichment"))
+    for key in _ENRICHED_STAT_KEYS:
+        if key in stats:
+            stats[key] = enriched_count
+
+
+def _parked_payload(
+    *,
+    manifest_path: Path,
+    pre_park_audit: dict[str, Any],
+    selected_indices: Sequence[int],
+    entries: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": PARKED_SCHEMA_VERSION,
+        "created_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "source_manifest": _display_path(manifest_path),
+        "pre_park_audit": {
+            "poc_thin_pages": int(pre_park_audit["poc_thin_pages"]),
+            "form_stub_broken": int(pre_park_audit["form_stub_broken"]),
+        },
+        "entries": [{"index": index, "entry": copy.deepcopy(entries[index])} for index in selected_indices],
+    }
+
+
+def _load_parked_artifact(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"Cannot read parked artifact: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid parked artifact JSON: {path}") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != PARKED_SCHEMA_VERSION:
+        raise ValueError(f"Unsupported parked artifact: {path}")
+    return payload
+
+
+def _parked_records(payload: dict[str, Any], path: Path) -> list[tuple[int, dict[str, Any]]]:
+    raw_records = payload.get("entries")
+    if not isinstance(raw_records, list):
+        raise ValueError(f"Parked artifact entries must be a list: {path}")
+    records: list[tuple[int, dict[str, Any]]] = []
+    for raw_record in raw_records:
+        if not isinstance(raw_record, Mapping):
+            raise ValueError(f"Parked artifact entry record must be an object: {path}")
+        index = raw_record.get("index")
+        entry = raw_record.get("entry")
+        if not isinstance(index, int) or index < 0 or not isinstance(entry, dict):
+            raise ValueError(f"Parked artifact entry record is invalid: {path}")
+        records.append((index, entry))
+    if len({index for index, _entry in records}) != len(records):
+        raise ValueError(f"Parked artifact has duplicate original indices: {path}")
+    return sorted(records, key=lambda record: record[0])
+
+
+def _artifact_pre_park_thin_count(payload: dict[str, Any], path: Path) -> int:
+    audit = payload.get("pre_park_audit")
+    count = audit.get("poc_thin_pages") if isinstance(audit, Mapping) else None
+    if not isinstance(count, int) or count < 0:
+        raise ValueError(f"Parked artifact has no valid pre-park thin count: {path}")
+    return count
+
+
+def _ensure_restore_has_no_collisions(
+    entries: Sequence[dict[str, Any]],
+    records: Sequence[tuple[int, dict[str, Any]]],
+    parked_file: Path,
+) -> None:
+    existing_slugs = {_nonempty_string(entry.get("url_slug")) for entry in entries}
+    existing_lemmas = {_nonempty_string(entry.get("lemma")) for entry in entries}
+    for _index, entry in records:
+        slug = _nonempty_string(entry.get("url_slug"))
+        lemma = _nonempty_string(entry.get("lemma"))
+        if slug is not None and slug in existing_slugs:
+            raise ValueError(f"Restore slug already exists in manifest: {slug!r} ({parked_file})")
+        if lemma is not None and lemma in existing_lemmas:
+            raise ValueError(f"Restore lemma already exists in manifest: {lemma!r} ({parked_file})")
+        if slug is not None:
+            existing_slugs.add(slug)
+        if lemma is not None:
+            existing_lemmas.add(lemma)
+
+
+def _refuse_broken_form_stubs(audit: Mapping[str, Any]) -> None:
+    broken_count = audit.get("form_stub_broken")
+    if not isinstance(broken_count, int):
+        raise ValueError("Audit did not return a valid form_stub_broken count")
+    if broken_count > 0:
+        raise ValueError(f"Refusing to write a manifest with {broken_count} broken form stubs")
+
+
+def _nonempty_string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _resolve_path(path: Path) -> Path:
+    path = Path(path)
+    return path if path.is_absolute() else PROJECT_ROOT / path
+
+
+def _display_path(path: Path) -> str:
+    try:
+        return path.relative_to(PROJECT_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _print_summary(result: ParkResult) -> None:
+    print(f"Mode: {result.mode}")
+    print(f"Parked: {result.parked_count}")
+    print(f"Restored: {result.restored_count}")
+    print(f"Guard-excluded form_of targets: {result.guard_excluded['form_of_target']}")
+    print(f"Limit-excluded: {result.limit_excluded}")
+    print(f"Projected POC-thin pages: {result.projected_poc_thin_pages}")
+    print(f"Projected broken form stubs: {result.projected_form_stub_broken}")
+    print(f"Manifest written: {str(result.manifest_written).lower()}")
+    print(f"Parked artifact written: {str(result.parked_artifact_written).lower()}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "0da1225de1eb238bb395523f3093f22a498287452b5cdb069d97ab86a1545491",
+  "fingerprint": "91e486e12ce1ca825c622450f811d5442542ee69a2caebe407e3858bac47296b",
   "inputs": {
     "lexicon_code": [
       {
@@ -103,6 +103,10 @@
         "sha256": "4919c84c88b8cf0bc1508250e6da4c80860e8a33a4a4df49402c8aedef3e9e68"
       },
       {
+        "path": "scripts/lexicon/park_thin_entries.py",
+        "sha256": "634b8981c2b8233415191d6a69badf3aceaab39c47c3fbc50fb3cace5fd4511d"
+      },
+      {
         "path": "scripts/lexicon/promote_grow_candidates.py",
         "sha256": "27f4226414cc01739107b4ba25cf7311167b03e0a39403a877b8104a8a1b8cc5"
       },
@@ -131,6 +135,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 31
+    "lexicon_code_files": 32
   }
 }

--- a/tests/test_park_thin_entries.py
+++ b/tests/test_park_thin_entries.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.audit.audit_atlas_poc_richness import audit_manifest
+from scripts.lexicon import park_thin_entries as park
+from scripts.lexicon.manifest_io import write_manifest
+
+
+def test_parks_only_audit_thin_lemmas_and_preserves_guarded_entries(tmp_path: Path) -> None:
+    manifest_path = _write_fixture_manifest(tmp_path)
+    parked_path = tmp_path / "parked.json"
+
+    result = park.park_thin_entries(
+        manifest_path=manifest_path,
+        parked_out=parked_path,
+        write=True,
+    )
+
+    manifest = _read_json(manifest_path)
+    remaining_lemmas = {entry["lemma"] for entry in manifest["entries"]}
+    artifact = _read_json(parked_path)
+    parked_lemmas = [record["entry"]["lemma"] for record in artifact["entries"]]
+
+    assert parked_lemmas == ["звичайний", "курсовий", "спадковий"]
+    assert {"ціль-адреса", "ціль-лема"} <= remaining_lemmas
+    assert "два слова" in remaining_lemmas
+    assert {"форма-адреса", "форма-лема"} <= remaining_lemmas
+    assert artifact["pre_park_audit"]["poc_thin_pages"] == 6
+    assert result.parked_count == 3
+    assert result.guard_excluded == {"form_of_target": 2}
+    assert result.projected_poc_thin_pages == 3
+    assert result.projected_form_stub_broken == 0
+    assert result.manifest_written is True
+    assert result.parked_artifact_written is True
+
+
+def test_course_and_heritage_correction_targets_remain_audit_eligible(tmp_path: Path) -> None:
+    manifest_path = _write_fixture_manifest(tmp_path)
+    manifest = _read_json(manifest_path)
+    manifest["entries"].append(_rich_entry("посилання"))
+    manifest["entries"][-1]["heritage_status"] = {"correction_target": {"lemma": "спадковий", "url_slug": "спадковий"}}
+    _refresh_stats(manifest)
+    write_manifest(manifest_path, manifest)
+
+    parked_path = tmp_path / "parked.json"
+    result = park.park_thin_entries(manifest_path=manifest_path, parked_out=parked_path, write=True)
+    artifact = _read_json(parked_path)
+
+    assert result.parked_count == 3
+    assert result.guard_excluded == {"form_of_target": 2}
+    # ``курсовий`` has course_usage and ``спадковий`` is a correction target,
+    # yet both remain selected because the audit classifies them as thin.
+    assert {record["entry"]["lemma"] for record in artifact["entries"]} >= {"курсовий", "спадковий"}
+    assert result.projected_poc_thin_pages == 3
+
+
+def test_stats_are_recomputed_consistently_after_parking(tmp_path: Path) -> None:
+    manifest_path = _write_fixture_manifest(tmp_path)
+
+    park.park_thin_entries(
+        manifest_path=manifest_path,
+        parked_out=tmp_path / "parked.json",
+        write=True,
+    )
+
+    stats = _read_json(manifest_path)["stats"]
+    assert stats == {
+        "lemmas_total": 6,
+        "modules_covered": 42,
+        "from_built": 5,
+        "from_surzhyk_to_avoid": 1,
+        "from_heritage_status_seed": 0,
+        "form_of_count": 2,
+        "enriched_count": 6,
+    }
+
+
+def test_restore_reinserts_verbatim_entries_and_reaudits_pre_park_count(tmp_path: Path) -> None:
+    manifest_path = _write_fixture_manifest(tmp_path)
+    initial = _read_json(manifest_path)
+    parked_path = tmp_path / "parked.json"
+
+    park.park_thin_entries(manifest_path=manifest_path, parked_out=parked_path, write=True)
+    result = park.restore_parked_entries(manifest_path=manifest_path, parked_file=parked_path, write=True)
+
+    restored = _read_json(manifest_path)
+    assert restored["entries"] == initial["entries"]
+    assert audit_manifest(restored, sample_limit=len(restored["entries"]))["poc_thin_pages"] == 6
+    assert result.restored_count == 3
+    assert result.projected_poc_thin_pages == 6
+    assert result.manifest_written is True
+
+
+def test_dry_run_writes_nothing(tmp_path: Path) -> None:
+    manifest_path = _write_fixture_manifest(tmp_path)
+    parked_path = tmp_path / "parked.json"
+    before = manifest_path.read_bytes()
+
+    result = park.park_thin_entries(manifest_path=manifest_path, parked_out=parked_path)
+
+    assert result.dry_run is True
+    assert result.parked_count == 3
+    assert manifest_path.read_bytes() == before
+    assert not parked_path.exists()
+    assert not (tmp_path / "lexicon-manifest.fingerprint.json").exists()
+
+
+def test_cli_json_dry_run_honors_limit(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    manifest_path = _write_fixture_manifest(tmp_path)
+    parked_path = tmp_path / "parked.json"
+    before = manifest_path.read_bytes()
+
+    assert (
+        park.main(
+            [
+                "--manifest",
+                str(manifest_path),
+                "--parked-out",
+                str(parked_path),
+                "--dry-run",
+                "--limit",
+                "1",
+                "--json",
+            ]
+        )
+        == 0
+    )
+
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["parked_count"] == 1
+    assert summary["projected_poc_thin_pages"] == 5
+    assert manifest_path.read_bytes() == before
+    assert not parked_path.exists()
+
+
+def test_refuses_write_when_projected_manifest_has_broken_form_stub(tmp_path: Path) -> None:
+    manifest_path = _write_fixture_manifest(tmp_path)
+    manifest = _read_json(manifest_path)
+    manifest["entries"].append(
+        _thin_entry(
+            "зламана-форма",
+            form_of={"lemma": "відсутня-ціль", "url_slug": "відсутня-ціль"},
+        )
+    )
+    _refresh_stats(manifest)
+    write_manifest(manifest_path, manifest)
+    before = manifest_path.read_bytes()
+    parked_path = tmp_path / "parked.json"
+
+    with pytest.raises(ValueError, match="broken form stubs"):
+        park.park_thin_entries(manifest_path=manifest_path, parked_out=parked_path, write=True)
+
+    assert manifest_path.read_bytes() == before
+    assert not parked_path.exists()
+
+
+def test_artifact_is_written_before_manifest_shrinks_on_write_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = _write_fixture_manifest(tmp_path)
+    parked_path = tmp_path / "parked.json"
+    before = manifest_path.read_bytes()
+    calls: list[Path] = []
+
+    def fail_manifest_write(path: Path | str, payload: dict[str, object]) -> None:
+        resolved = Path(path)
+        calls.append(resolved)
+        if resolved == manifest_path:
+            raise OSError("manifest write failure")
+        write_manifest(resolved, payload)
+
+    monkeypatch.setattr(park, "write_manifest", fail_manifest_write)
+
+    with pytest.raises(OSError, match="manifest write failure"):
+        park.park_thin_entries(manifest_path=manifest_path, parked_out=parked_path, write=True)
+
+    assert calls == [parked_path, manifest_path]
+    assert parked_path.exists()
+    assert manifest_path.read_bytes() == before
+
+
+def _write_fixture_manifest(tmp_path: Path) -> Path:
+    entries = [
+        _thin_entry("ціль-адреса"),
+        _thin_entry("ціль-лема"),
+        _thin_entry("звичайний"),
+        _thin_entry(
+            "курсовий",
+            course_usage=[{"track": "a2", "module_num": 1, "slug": "fixture"}],
+        ),
+        _thin_entry("спадковий", primary_source="heritage_status_seed", seed_group="heritage-status-samples"),
+        _thin_entry(
+            "два слова",
+            enrichment=_multiword_thin_enrichment(),
+            primary_source="surzhyk_to_avoid",
+            seed_group="surzhyk-to-avoid",
+        ),
+        _thin_entry(
+            "форма-адреса",
+            form_of={"url_slug": "ціль-адреса"},
+        ),
+        _thin_entry(
+            "форма-лема",
+            form_of={"lemma": "ціль-лема"},
+        ),
+        _rich_entry("не-ціль"),
+    ]
+    manifest = {
+        "version": "fixture",
+        "generated_at": "2026-07-10T00:00:00+00:00",
+        "stats": {
+            "lemmas_total": 9,
+            "modules_covered": 42,
+            "from_built": 7,
+            "from_surzhyk_to_avoid": 1,
+            "from_heritage_status_seed": 1,
+            "form_of_count": 2,
+            "enriched_count": 9,
+        },
+        "entries": entries,
+    }
+    path = tmp_path / "lexicon-manifest.json"
+    write_manifest(path, manifest)
+    return path
+
+
+def _thin_entry(lemma: str, **overrides: object) -> dict[str, object]:
+    entry: dict[str, object] = {
+        "lemma": lemma,
+        "url_slug": lemma,
+        "gloss": "fixture",
+        "pos": "noun",
+        "primary_source": "built_vocabulary",
+        "course_usage": [],
+        "enrichment": {
+            "definition_cards": [
+                {
+                    "id": "fixture-definition",
+                    "source": "fixture",
+                    "definitions": ["Тестове значення."],
+                }
+            ],
+            "morphology": {
+                "pos": "noun",
+                "forms": [{"form": lemma, "label": "називний"}],
+                "source": "fixture",
+            },
+            "translation": {"en": ["fixture"], "source": "fixture"},
+        },
+        "sections": {},
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _multiword_thin_enrichment() -> dict[str, object]:
+    return {
+        "definition_cards": [
+            {
+                "id": "fixture-definition",
+                "source": "fixture",
+                "definitions": ["Тестове значення."],
+            }
+        ],
+        "morphology": {
+            "pos": "noun",
+            "forms": [{"form": "два слова", "label": "називний"}],
+            "source": "fixture",
+        },
+    }
+
+
+def _rich_entry(lemma: str) -> dict[str, object]:
+    entry = _thin_entry(lemma)
+    entry["enrichment"] = {
+        **entry["enrichment"],
+        "etymology": {"text": "Тестова етимологія.", "source": "fixture"},
+        "literary_attestation": {"text": "Тестова атестація.", "source": "fixture"},
+    }
+    return entry
+
+
+def _refresh_stats(manifest: dict[str, object]) -> None:
+    entries = manifest["entries"]
+    assert isinstance(entries, list)
+    stats = manifest["stats"]
+    assert isinstance(stats, dict)
+    stats["lemmas_total"] = len(entries)
+    stats["from_built"] = sum(
+        1
+        for entry in entries
+        if isinstance(entry, dict) and str(entry.get("primary_source", "")).startswith("built_vocabulary")
+    )
+    stats["from_surzhyk_to_avoid"] = sum(
+        1 for entry in entries if isinstance(entry, dict) and entry.get("seed_group") == "surzhyk-to-avoid"
+    )
+    stats["from_heritage_status_seed"] = sum(
+        1 for entry in entries if isinstance(entry, dict) and entry.get("seed_group") == "heritage-status-samples"
+    )
+    stats["form_of_count"] = sum(1 for entry in entries if isinstance(entry, dict) and "form_of" in entry)
+    stats["enriched_count"] = sum(1 for entry in entries if isinstance(entry, dict) and entry.get("enrichment"))
+
+
+def _read_json(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload


### PR DESCRIPTION
## Summary

Adds `scripts/lexicon/park_thin_entries.py`, a dry-run-by-default reversible park/restore CLI for structurally thin Atlas lemma articles.

- Selects only the exhaustive `audit_manifest(...)["samples"]["poc_thin_lemma_article"]` result; it does not replicate thinness rules.
- Keeps form-of targets in the manifest, while leaving thin multiword and form-stub classes untouched.
- Keeps audit-thin course-linked and heritage-correction-target entries eligible.
- Writes a position-preserving parked artifact before shrinking a manifest; restore reinserts entries verbatim and requires the recorded pre-park thin count.
- Uses `manifest_io.write_manifest` and imports the #4929 fingerprint refresh helper.

## Evidence (#M-4)

All commands below ran in:

`/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4220-park-thin-entries`

Targeted and adjacent validation command:

```sh
.venv/bin/python -m pytest -q tests/test_park_thin_entries.py tests/test_audit_atlas_poc_richness.py tests/test_backfill_course_usage.py tests/test_promote_grow_candidates.py
```

Raw output:

```text
41 passed in 0.65s
```

The same final validation ran Ruff, format checking, and the agent-trailer audit; raw output included:

```text
All checks passed!
2 files already formatted
✅ All 2 non-skipped commit(s) carry an X-Agent trailer.
```

Read-only real-manifest dry run command:

```sh
.venv/bin/python scripts/lexicon/park_thin_entries.py --dry-run --json
```

Raw output:

```json
{
  "mode": "park",
  "dry_run": true,
  "parked_count": 544,
  "restored_count": 0,
  "guard_excluded": {
    "form_of_target": 1
  },
  "limit_excluded": 0,
  "pre_park_poc_thin_pages": 545,
  "projected_poc_thin_pages": 1,
  "projected_form_stub_broken": 0,
  "manifest_written": false,
  "parked_artifact_written": false,
  "fingerprint_written": false
}
```

The zero write flags are the proof that this PR did not run `--write` against the real manifest.

## Independent implementation review

Cross-family Grok-Build review: **PASS** (bridge message #5). Its read-only evidence included the exact focused-suite output `8 passed in 0.22s` and the same real-manifest dry-run values above. The initially designated DeepSeek Flash review timed out at its 60-second initial-response limit, so Grok-Build was the documented fallback reviewer.

## Stacking and merge handoff

This branch imports `_refresh_manifest_fingerprint` from #4929 as required. PR #4929 was still open and `DIRTY` against `main` at creation, so this PR temporarily carries that dependency; update/rebase it after #4929 merges. The Atlas driver owns the final gate and merge. **Auto-merge is not enabled.**
