### PR TITLE
fix(practice): SRS storage — bounded review log, quota recovery, no silent progress loss (Fixes #4923)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: bd41ad7aa3b2d8978e4ea83e0550d4426b35aeb4cf07c066509c352484b2ff9f
+  components_sha256: 1891e707363e1235febffb2679ddc25279457eb4615a7c2072f2b1026fd15145
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -6,6 +6,7 @@ import PracticeSessionSummary, { type SessionSummaryStats } from './PracticeSess
 import {
   DEFAULT_NEW_PER_DAY,
   PUBLISHED_PRACTICE_LEVELS,
+  SRS_STORAGE_FULL_WARNING,
   buildSessionPoolConstraintState,
   combinePracticeShards,
   extendWithLowerDecks,
@@ -938,7 +939,9 @@ function LexiconPracticeIsland({
     setDailyNewCount(readNewCardsDailyState().count);
     setReviewLog([...state.reviews]);
 
-    if (state.flags.corrupt || state.flags.migrationFailed) {
+    if (state.flags.storageFull) {
+      setStorageWarning(SRS_STORAGE_FULL_WARNING);
+    } else if (state.flags.storageWriteFailed || state.flags.corrupt || state.flags.migrationFailed) {
       setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
     } else if (state.flags.clockJump) {
       setStorageWarning('Час повторення може бути неточним: змінився годинник пристрою.');
@@ -1591,8 +1594,12 @@ function LexiconPracticeIsland({
     const state = loadState();
     setMastered(masteredCount(MASTERED_THRESHOLD));
     setReviewLog([...state.reviews]);
-    if (state.flags.corrupt || state.flags.migrationFailed) {
+    if (state.flags.storageFull) {
+      setStorageWarning(SRS_STORAGE_FULL_WARNING);
+    } else if (state.flags.storageWriteFailed || state.flags.corrupt || state.flags.migrationFailed) {
       setStorageWarning('Прогрес призупинено, доки сховище браузера не стане доступним.');
+    } else if (storageWarning === SRS_STORAGE_FULL_WARNING) {
+      setStorageWarning(null);
     }
     setRevision((value) => value + 1);
   }

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -21,8 +21,12 @@ export const SESSION_ITEM_ESTIMATE_SEC = 20;
 /** Levels with published practice shards (C2 ships «скоро» until deck exists). */
 export const PUBLISHED_PRACTICE_LEVELS = ['A1', 'A2', 'B1', 'B2', 'C1'] as const;
 
-const CURRENT_VERSION = 3;
+const CURRENT_VERSION = 4;
 const SETTINGS_VERSION = 1;
+/** Bound synchronous localStorage writes while retaining recent fitting history. */
+export const MAX_RAW_REVIEW_LOG_ENTRIES = 2_000;
+const RECOVERY_RAW_REVIEW_LOG_ENTRIES = 0;
+export const SRS_STORAGE_FULL_WARNING = 'Прогрес не зберігається — сховище переповнене';
 const HOUR_MS = 60 * 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 export const SESSION_RESUME_MAX_MS = 6 * HOUR_MS;
@@ -324,6 +328,17 @@ export interface ReviewLogEntry {
   heritageKind?: string;
 }
 
+/**
+ * Summary retained when raw review entries age out of the bounded fitting window.
+ * The key in `reviewAggregates` is the card key; the aggregate deliberately keeps
+ * the rating distribution and temporal span needed for future parameter fitting.
+ */
+export interface ReviewLogAggregate {
+  ratings: Record<PracticeRating, number>;
+  firstReview: number;
+  lastReview: number;
+}
+
 /** Optional per-review dimension metadata threaded from the active selection. */
 export interface ReviewMeta {
   blankCase?: string;
@@ -340,6 +355,8 @@ export interface SrsFlags {
   migrationFailed: boolean;
   migrated: boolean;
   backupWritten: boolean;
+  storageWriteFailed: boolean;
+  storageFull: boolean;
   settingsCorrupt: boolean;
   clockJump: ClockJump | null;
 }
@@ -353,6 +370,7 @@ export interface LoadedSrsState {
   version: typeof CURRENT_VERSION;
   cards: Map<string, CardState>;
   reviews: ReviewLogEntry[];
+  reviewAggregates: Record<string, ReviewLogAggregate>;
   settings: SrsSettings;
   flags: SrsFlags;
   raw: string | null;
@@ -444,10 +462,11 @@ export interface SelectPracticeOptions {
   poolFilter?: (candidate: PracticeSelection) => boolean;
 }
 
-interface PersistedSrsSchemaV3 {
+interface PersistedSrsSchemaV4 {
   version: typeof CURRENT_VERSION;
   cards: Record<string, CardState>;
   reviews?: ReviewLogEntry[];
+  reviewAggregates?: Record<string, ReviewLogAggregate>;
   lastSavedAt?: number;
 }
 
@@ -527,6 +546,7 @@ const memoryStorage: StorageLike = {
 };
 
 let activeState: LoadedSrsState | null = null;
+let activeStorage: StorageLike | null = null;
 
 function resolveStorage(): StorageLike {
   if (typeof window === 'undefined') return memoryStorage;
@@ -537,12 +557,18 @@ function resolveStorage(): StorageLike {
   }
 }
 
+function currentStorage(): StorageLike {
+  return activeStorage ?? resolveStorage();
+}
+
 function emptyFlags(clockJump: ClockJump | null = null): SrsFlags {
   return {
     corrupt: false,
     migrationFailed: false,
     migrated: false,
     backupWritten: false,
+    storageWriteFailed: false,
+    storageFull: false,
     settingsCorrupt: false,
     clockJump,
   };
@@ -710,44 +736,117 @@ function normalizeReviews(rawReviews: unknown): ReviewLogEntry[] | null {
   return reviews;
 }
 
+function emptyRatingCounts(): Record<PracticeRating, number> {
+  return { again: 0, hard: 0, good: 0, easy: 0 };
+}
+
+function normalizeReviewAggregate(raw: unknown): ReviewLogAggregate | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const source = raw as Record<string, unknown>;
+  const ratings = source.ratings;
+  const firstReview = toTime(source.firstReview as Date | number | string | undefined);
+  const lastReview = toTime(source.lastReview as Date | number | string | undefined);
+  if (!ratings || typeof ratings !== 'object' || firstReview === null || lastReview === null) return null;
+  const sourceRatings = ratings as Record<string, unknown>;
+  const normalizedRatings = emptyRatingCounts();
+  for (const rating of Object.keys(normalizedRatings) as PracticeRating[]) {
+    const value = sourceRatings[rating];
+    if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) return null;
+    normalizedRatings[rating] = value;
+  }
+  return { ratings: normalizedRatings, firstReview, lastReview };
+}
+
+function normalizeReviewAggregates(raw: unknown): Record<string, ReviewLogAggregate> | null {
+  if (raw === undefined) return {};
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const aggregates: Record<string, ReviewLogAggregate> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!key) return null;
+    const aggregate = normalizeReviewAggregate(value);
+    if (!aggregate) return null;
+    aggregates[key] = aggregate;
+  }
+  return aggregates;
+}
+
+function addReviewToAggregates(
+  review: ReviewLogEntry,
+  reviewAggregates: Record<string, ReviewLogAggregate>,
+): void {
+  const aggregate = reviewAggregates[review.cardKey];
+  if (aggregate) {
+    aggregate.ratings[review.rating] += 1;
+    aggregate.firstReview = Math.min(aggregate.firstReview, review.review);
+    aggregate.lastReview = Math.max(aggregate.lastReview, review.review);
+    return;
+  }
+  const ratings = emptyRatingCounts();
+  ratings[review.rating] = 1;
+  reviewAggregates[review.cardKey] = {
+    ratings,
+    firstReview: review.review,
+    lastReview: review.review,
+  };
+}
+
+function compactReviewHistory(
+  reviews: ReviewLogEntry[],
+  reviewAggregates: Record<string, ReviewLogAggregate>,
+  maximumRawEntries: number,
+): boolean {
+  const entriesToCompact = Math.max(0, reviews.length - maximumRawEntries);
+  if (entriesToCompact === 0) return false;
+  for (const review of reviews.splice(0, entriesToCompact)) {
+    addReviewToAggregates(review, reviewAggregates);
+  }
+  return true;
+}
+
 function hydrateStore(
-  store: PersistedSrsSchemaV3,
+  store: PersistedSrsSchemaV4,
   settings: SrsSettings,
   raw: string | null,
   flags: SrsFlags,
 ): LoadedSrsState | null {
   const cards = normalizeCards(store.cards);
   const reviews = normalizeReviews(store.reviews);
-  if (!cards || !reviews) return null;
+  const reviewAggregates = normalizeReviewAggregates(store.reviewAggregates);
+  if (!cards || !reviews || !reviewAggregates) return null;
   return {
     version: CURRENT_VERSION,
     cards,
     reviews,
+    reviewAggregates,
     settings,
     flags,
     raw,
   };
 }
 
-function migrateToCurrent(parsed: Record<string, unknown>): PersistedSrsSchemaV3 | null {
-  if (parsed.version === CURRENT_VERSION) return parsed as unknown as PersistedSrsSchemaV3;
-  if (parsed.version !== 1 && parsed.version !== 2) return null;
+function migrateToCurrent(parsed: Record<string, unknown>): PersistedSrsSchemaV4 | null {
+  if (parsed.version === CURRENT_VERSION) return parsed as unknown as PersistedSrsSchemaV4;
+  if (parsed.version !== 1 && parsed.version !== 2 && parsed.version !== 3) return null;
   const cards = normalizeCards(parsed.cards, true);
   const reviews = normalizeReviews(parsed.reviews);
-  if (!cards || !reviews) return null;
+  const reviewAggregates = normalizeReviewAggregates(parsed.reviewAggregates);
+  if (!cards || !reviews || !reviewAggregates) return null;
+  compactReviewHistory(reviews, reviewAggregates, MAX_RAW_REVIEW_LOG_ENTRIES);
   return {
     version: CURRENT_VERSION,
     cards: Object.fromEntries(cards),
     reviews,
+    reviewAggregates,
     lastSavedAt: Date.now(),
   };
 }
 
 function serializeState(state: LoadedSrsState, savedAt: number): string {
-  const store: PersistedSrsSchemaV3 = {
+  const store: PersistedSrsSchemaV4 = {
     version: CURRENT_VERSION,
     cards: Object.fromEntries(state.cards),
     reviews: state.reviews,
+    reviewAggregates: state.reviewAggregates,
     lastSavedAt: savedAt,
   };
   return JSON.stringify(store);
@@ -779,13 +878,23 @@ export function loadState(
   storage: StorageLike = resolveStorage(),
   now: Date | number = Date.now(),
 ): LoadedSrsState {
-  const { settings, corrupt: settingsCorrupt } = loadSettings(storage);
   const raw = storage.getItem(SRS_STORAGE_KEY);
+  if (
+    activeState?.flags.storageWriteFailed &&
+    activeStorage === storage &&
+    activeState.raw === raw
+  ) {
+    return activeState;
+  }
+
+  activeStorage = storage;
+  const { settings, corrupt: settingsCorrupt } = loadSettings(storage);
   if (!raw) {
     activeState = {
       version: CURRENT_VERSION,
       cards: new Map(),
       reviews: [],
+      reviewAggregates: {},
       settings,
       flags: { ...emptyFlags(), settingsCorrupt },
       raw: null,
@@ -801,6 +910,7 @@ export function loadState(
       version: CURRENT_VERSION,
       cards: new Map(),
       reviews: [],
+      reviewAggregates: {},
       settings,
       flags: { ...emptyFlags(), corrupt: true, settingsCorrupt },
       raw,
@@ -809,12 +919,15 @@ export function loadState(
   }
 
   if (parsed.version === CURRENT_VERSION) {
-    const state = hydrateStore(parsed as unknown as PersistedSrsSchemaV3, settings, raw, {
+    const state = hydrateStore(parsed as unknown as PersistedSrsSchemaV4, settings, raw, {
       ...emptyFlags(),
       settingsCorrupt,
-      clockJump: detectClockJump((parsed as unknown as PersistedSrsSchemaV3).lastSavedAt, now),
+      clockJump: detectClockJump((parsed as unknown as PersistedSrsSchemaV4).lastSavedAt, now),
     });
     if (state) {
+      if (compactReviewHistory(state.reviews, state.reviewAggregates, MAX_RAW_REVIEW_LOG_ENTRIES)) {
+        persistWithQuotaRecovery(state, storage, toTime(now) ?? Date.now());
+      }
       activeState = state;
       return state;
     }
@@ -822,6 +935,7 @@ export function loadState(
       version: CURRENT_VERSION,
       cards: new Map(),
       reviews: [],
+      reviewAggregates: {},
       settings,
       flags: { ...emptyFlags(), corrupt: true, settingsCorrupt },
       raw,
@@ -830,26 +944,24 @@ export function loadState(
   }
 
   try {
-    storage.setItem(SRS_BACKUP_KEY, raw);
     const migrated = migrateToCurrent(parsed);
     if (!migrated) throw new Error('unsupported SRS schema');
-    const nextRaw = JSON.stringify(migrated);
-    storage.setItem(SRS_STORAGE_KEY, nextRaw);
-    const state = hydrateStore(migrated, settings, nextRaw, {
+    const state = hydrateStore(migrated, settings, raw, {
       ...emptyFlags(),
       migrated: true,
-      backupWritten: true,
       settingsCorrupt,
       clockJump: detectClockJump(migrated.lastSavedAt, now),
     });
     if (!state) throw new Error('migrated SRS schema is invalid');
     activeState = state;
+    persistWithQuotaRecovery(state, storage, toTime(now) ?? Date.now());
     return state;
   } catch {
     activeState = {
       version: CURRENT_VERSION,
       cards: new Map(),
       reviews: [],
+      reviewAggregates: {},
       settings,
       flags: { ...emptyFlags(), migrationFailed: true, settingsCorrupt },
       raw,
@@ -878,18 +990,92 @@ export function saveState(
     return { ok: false, error };
   }
   try {
-    if (previousRaw && previousRaw !== nextRaw) {
-      storage.setItem(SRS_BACKUP_KEY, previousRaw);
-      state.flags.backupWritten = true;
-    }
     storage.setItem(SRS_STORAGE_KEY, nextRaw);
-    storage.setItem(SRS_SETTINGS_KEY, serializeSettings(state.settings));
-    state.raw = nextRaw;
-    activeState = state;
-    return { ok: true };
   } catch (error) {
     return { ok: false, error };
   }
+
+  state.raw = nextRaw;
+  activeState = state;
+  activeStorage = storage;
+  state.flags.backupWritten = false;
+
+  try {
+    storage.setItem(SRS_SETTINGS_KEY, serializeSettings(state.settings));
+  } catch {
+    // Scheduling state is already durable. Settings are unchanged during ratings and can retry later.
+  }
+
+  if (previousRaw && previousRaw !== nextRaw) {
+    try {
+      storage.setItem(SRS_BACKUP_KEY, previousRaw);
+      state.flags.backupWritten = true;
+    } catch {
+      // A backup must never turn a successful primary write into lost progress.
+    }
+  }
+  return { ok: true };
+}
+
+function isQuotaExceededError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const candidate = error as { name?: unknown; code?: unknown };
+  return (
+    candidate.name === 'QuotaExceededError' ||
+    candidate.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+    candidate.code === 22 ||
+    candidate.code === 1014
+  );
+}
+
+function persistWithQuotaRecovery(
+  state: LoadedSrsState,
+  storage: StorageLike,
+  savedAt: number,
+): { ok: boolean; error?: unknown } {
+  let result = saveState(state, storage, savedAt);
+  if (result.ok) {
+    state.flags.storageWriteFailed = false;
+    state.flags.storageFull = false;
+    return result;
+  }
+  if (!isQuotaExceededError(result.error)) {
+    state.flags.storageWriteFailed = true;
+    activeState = state;
+    return result;
+  }
+
+  try {
+    storage.removeItem(SRS_BACKUP_KEY);
+  } catch {
+    // Continue to the retry; a storage implementation may allow writes despite a failed removal.
+  }
+  result = saveState(state, storage, savedAt);
+  if (result.ok) {
+    state.flags.storageWriteFailed = false;
+    state.flags.storageFull = false;
+    return result;
+  }
+  if (!isQuotaExceededError(result.error)) {
+    state.flags.storageWriteFailed = true;
+    activeState = state;
+    return result;
+  }
+
+  compactReviewHistory(state.reviews, state.reviewAggregates, RECOVERY_RAW_REVIEW_LOG_ENTRIES);
+  result = saveState(state, storage, savedAt);
+  if (result.ok) {
+    state.flags.storageWriteFailed = false;
+    state.flags.storageFull = false;
+    return result;
+  }
+
+  state.flags.storageWriteFailed = true;
+  if (isQuotaExceededError(result.error)) {
+    state.flags.storageFull = true;
+    activeState = state;
+  }
+  return result;
 }
 
 function fsrsCardFromState(card: CardState): FsrsCard {
@@ -988,7 +1174,8 @@ export function rateCard(
   const next = stateFromFsrsCard(record.card);
   state.cards.set(key, next);
   state.reviews.push(serializeReview(key, lemmaId, mode, rating, record, meta));
-  saveState(state, resolveStorage(), reviewDate.getTime());
+  compactReviewHistory(state.reviews, state.reviewAggregates, MAX_RAW_REVIEW_LOG_ENTRIES);
+  persistWithQuotaRecovery(state, currentStorage(), reviewDate.getTime());
   return next;
 }
 

--- a/site/tests/unit/lexicon-srs.test.ts
+++ b/site/tests/unit/lexicon-srs.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, test } from 'vitest';
+import { State } from 'ts-fsrs';
 import {
   PRACTICE_MODE_DECK_VERSION,
   PRACTICE_MODES,
+  MAX_RAW_REVIEW_LOG_ENTRIES,
   SRS_BACKUP_KEY,
+  SRS_SETTINGS_KEY,
   SRS_STORAGE_KEY,
   cardKey,
   detectClockJump,
@@ -23,6 +26,7 @@ import {
   type PracticeLexeme,
   type PracticeMode,
   type PracticeSelection,
+  type ReviewLogEntry,
   type SelectionHistoryItem,
 } from '@site/src/lib/lexicon/srs';
 
@@ -43,6 +47,67 @@ function stateCard(overrides: Partial<ReturnType<typeof rateCard>> = {}) {
     state: 2,
     ...overrides,
   };
+}
+
+function reviewEntry(index: number, card = 'alpha'): ReviewLogEntry {
+  const reviewedAt = NOW.getTime() + index * 60_000;
+  return {
+    cardKey: cardKey(card, 'flashcards'),
+    lemmaId: card,
+    mode: 'flashcards',
+    rating: index % 2 === 0 ? 'good' : 'again',
+    state: State.Review,
+    due: reviewedAt + DAY_MS,
+    stability: 5,
+    difficulty: 4,
+    elapsed_days: 1,
+    last_elapsed_days: 1,
+    scheduled_days: 1,
+    learning_steps: 0,
+    review: reviewedAt,
+  };
+}
+
+class SizeLimitedStorage {
+  readonly values = new Map<string, string>();
+  readonly writes: string[] = [];
+  readonly removals: string[] = [];
+
+  constructor(private readonly maximumBytes: number, seed: Record<string, string> = {}) {
+    for (const [key, value] of Object.entries(seed)) this.values.set(key, value);
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.writes.push(key);
+    const previous = this.values.get(key)?.length ?? 0;
+    const nextTotal = [...this.values.values()].reduce((total, stored) => total + stored.length, 0) - previous + value.length;
+    if (nextTotal > this.maximumBytes) {
+      const error = new Error('storage quota exceeded');
+      error.name = 'QuotaExceededError';
+      throw error;
+    }
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.removals.push(key);
+    this.values.delete(key);
+  }
+}
+
+class BackupFailingStorage extends SizeLimitedStorage {
+  setItem(key: string, value: string): void {
+    if (key === SRS_BACKUP_KEY) {
+      const error = new Error('backup unavailable');
+      error.name = 'QuotaExceededError';
+      throw error;
+    }
+    super.setItem(key, value);
+  }
 }
 
 function lexeme(
@@ -538,6 +603,130 @@ describe('lexicon SRS facade', () => {
     rateCard('alpha', 'hard', new Date('2026-06-23T12:10:00.000Z'));
 
     expect(localStorage.getItem(SRS_BACKUP_KEY)).toBe(before);
+  });
+
+  test('writes the primary state before the best-effort backup', () => {
+    const storage = new SizeLimitedStorage(Number.MAX_SAFE_INTEGER);
+    loadState(storage, NOW);
+    rateCard('alpha', 'good', NOW);
+    storage.writes.length = 0;
+
+    rateCard('alpha', 'hard', new Date('2026-06-23T12:10:00.000Z'));
+
+    expect(storage.writes.indexOf(SRS_STORAGE_KEY)).toBeLessThan(
+      storage.writes.indexOf(SRS_BACKUP_KEY),
+    );
+  });
+
+  test('keeps a successful primary state when the backup write fails', () => {
+    const storage = new BackupFailingStorage(Number.MAX_SAFE_INTEGER);
+    const state = loadState(storage, NOW);
+    rateCard('alpha', 'good', NOW);
+
+    rateCard('alpha', 'hard', new Date('2026-06-23T12:10:00.000Z'));
+
+    const persisted = JSON.parse(storage.getItem(SRS_STORAGE_KEY) ?? '{}');
+    expect(persisted.cards[cardKey('alpha', 'flashcards')].reps).toBe(2);
+    expect(state.flags.backupWritten).toBe(false);
+    expect(state.flags.storageWriteFailed).toBe(false);
+  });
+
+  test('recovers a rating by dropping the backup when it is the quota blocker', () => {
+    const seedStorage = new SizeLimitedStorage(Number.MAX_SAFE_INTEGER);
+    loadState(seedStorage, NOW);
+    rateCard('alpha', 'good', NOW);
+    const previousRaw = seedStorage.getItem(SRS_STORAGE_KEY);
+    const settingsRaw = seedStorage.getItem(SRS_SETTINGS_KEY);
+    if (!previousRaw) throw new Error('expected seeded SRS state');
+
+    const probeStorage = new SizeLimitedStorage(Number.MAX_SAFE_INTEGER, {
+      [SRS_STORAGE_KEY]: previousRaw,
+      ...(settingsRaw ? { [SRS_SETTINGS_KEY]: settingsRaw } : {}),
+    });
+    loadState(probeStorage, NOW);
+    rateCard('alpha', 'hard', new Date('2026-06-23T12:10:00.000Z'));
+    const nextRaw = probeStorage.getItem(SRS_STORAGE_KEY);
+    const nextSettingsRaw = probeStorage.getItem(SRS_SETTINGS_KEY);
+    if (!nextRaw || !nextSettingsRaw) throw new Error('expected next persisted SRS state');
+
+    const storage = new SizeLimitedStorage(nextRaw.length + nextSettingsRaw.length + 1, {
+      [SRS_STORAGE_KEY]: previousRaw,
+      [SRS_BACKUP_KEY]: previousRaw,
+      [SRS_SETTINGS_KEY]: nextSettingsRaw,
+    });
+    loadState(storage, NOW);
+
+    rateCard('alpha', 'hard', new Date('2026-06-23T12:10:00.000Z'));
+
+    const persisted = JSON.parse(storage.getItem(SRS_STORAGE_KEY) ?? '{}');
+    expect(persisted.cards[cardKey('alpha', 'flashcards')].reps).toBe(2);
+    expect(storage.removals).toContain(SRS_BACKUP_KEY);
+    expect(loadState(storage, NOW).flags.storageFull).toBe(false);
+  });
+
+  test('keeps the rating in memory and exposes a storage-full state after exhausted recovery', () => {
+    const storage = new SizeLimitedStorage(1);
+    loadState(storage, NOW);
+
+    const card = rateCard('alpha', 'good', NOW);
+    const state = loadState(storage, NOW);
+
+    expect(state.cards.get(cardKey('alpha', 'flashcards'))).toEqual(card);
+    expect(state.flags.storageFull).toBe(true);
+  });
+
+  test('migrates and compacts oversized review history without changing card schedules', () => {
+    const cards = {
+      [cardKey('alpha', 'flashcards')]: stateCard({ due: NOW.getTime() + DAY_MS, stability: 12 }),
+      [cardKey('beta', 'choice')]: stateCard({ due: NOW.getTime() + 2 * DAY_MS, stability: 24 }),
+    };
+    const reviews = Array.from({ length: MAX_RAW_REVIEW_LOG_ENTRIES + 3 }, (_unused, index) =>
+      reviewEntry(index, index % 2 === 0 ? 'alpha' : 'beta'),
+    );
+    const oldRaw = JSON.stringify({
+      version: 3,
+      cards,
+      reviews,
+      lastSavedAt: NOW.getTime(),
+    });
+    const storage = new SizeLimitedStorage(Number.MAX_SAFE_INTEGER, { [SRS_STORAGE_KEY]: oldRaw });
+
+    const state = loadState(storage, NOW);
+    const saved = JSON.parse(storage.getItem(SRS_STORAGE_KEY) ?? '{}');
+
+    expect(state.flags.migrated).toBe(true);
+    expect(JSON.stringify(saved.cards)).toBe(JSON.stringify(cards));
+    expect(saved.reviews).toEqual(reviews.slice(-MAX_RAW_REVIEW_LOG_ENTRIES));
+    expect(saved.reviewAggregates[cardKey('alpha', 'flashcards')]).toEqual({
+      ratings: { again: 0, hard: 0, good: 2, easy: 0 },
+      firstReview: reviews[0].review,
+      lastReview: reviews[2].review,
+    });
+    expect(saved.reviewAggregates[cardKey('beta', 'flashcards')]).toEqual({
+      ratings: { again: 1, hard: 0, good: 0, easy: 0 },
+      firstReview: reviews[1].review,
+      lastReview: reviews[1].review,
+    });
+  });
+
+  test('bounds persisted review-state size across simulated long-term sessions', () => {
+    const sessions = MAX_RAW_REVIEW_LOG_ENTRIES * 3;
+    const reviews = Array.from({ length: sessions }, (_unused, index) =>
+      reviewEntry(index, `card-${index % 4}`),
+    );
+    const oldRaw = JSON.stringify({ version: 3, cards: {}, reviews, lastSavedAt: NOW.getTime() });
+    const storage = new SizeLimitedStorage(Number.MAX_SAFE_INTEGER, { [SRS_STORAGE_KEY]: oldRaw });
+
+    const state = loadState(storage, NOW);
+    const savedRaw = storage.getItem(SRS_STORAGE_KEY) ?? '';
+    const aggregatedCount = Object.values(state.reviewAggregates).reduce(
+      (total, aggregate) => total + Object.values(aggregate.ratings).reduce((sum, count) => sum + count, 0),
+      0,
+    );
+
+    expect(state.reviews).toHaveLength(MAX_RAW_REVIEW_LOG_ENTRIES);
+    expect(aggregatedCount).toBe(sessions - MAX_RAW_REVIEW_LOG_ENTRIES);
+    expect(savedRaw.length).toBeLessThan(oldRaw.length / 2);
   });
 
   test('keeps corrupt storage and surfaces fallback flag', () => {


### PR DESCRIPTION
Fixes #4923

## Summary

- Bumps persisted SRS state to v4, retaining at most 2,000 raw reviews and rolling older entries into per-card rating counts plus first/last review timestamps.
- Migrates v1–v3 state transparently while preserving card scheduling state; oversized v4 logs compact on load.
- Writes primary state before the backup; backup and settings failures cannot turn a durable rating into a failed save.
- Adds quota recovery: remove the backup and retry, then compact all raw reviews and retry. If storage is still full, retain the rating in memory and show «Прогрес не зберігається — сховище переповнене».

## Root cause

Every rating appended to an unbounded review log and synchronously rewrote both the previous backup and complete state. At quota, the backup-first write failed before the primary write, and `rateCard` ignored the result.

## Validation

- `npm_config_prefix=/tmp/learn-ukrainian-srs-4923/site npx tsc --noEmit -p tsconfig.srs.json` — passed for the changed SRS, practice UI, and unit test files.
- `node_modules/.bin/vitest run --config vitest.srs.config.ts tests/unit/lexicon-srs.test.ts` — 37 passed.
- Commit hooks and `scripts/audit/lint_agent_trailer.py` — passed.

## Independent review

Grok Build completed a read-only cross-family review of the actual branch diff and returned **APPROVE**. Its independent run reported 37 SRS tests passing and no blockers.

Auto-merge is intentionally not enabled; this PR awaits the driver's final gate.
