### PR TITLE
fix(harness): merge tool — object key order is serialization, not annotation data (Refs #4913)

### DIFF
--- a/scripts/audit/layerb_label_merge.py
+++ b/scripts/audit/layerb_label_merge.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Compare two Layer B annotation sidecars without silently resolving labels.
 
-Material comparison is strict: values, mapping key order, and list order all
+Material comparison is strict: values and list order
 matter unless the labeling contract expressly defines a canonical order.  A
 materially disagreeing draft intentionally omits ``adjudication`` for that
 case, so the full label schema refuses it until a named adjudicator resolves
@@ -72,8 +72,14 @@ SPAN_FIELDS = {"ordered_segment_spans", "expected_support_spans"}
 
 
 def _ordered_json(value: Any) -> str:
-    """Preserve mapping insertion order; only values are compacted for comparison."""
-    return json.dumps(value, ensure_ascii=False, sort_keys=False, separators=(",", ":"))
+    """Canonicalize mapping key order for comparison; list order stays material.
+
+    JSON object key order is a serialization artifact, not annotation data — the
+    guide's material-field list never includes it, and independent annotators
+    legitimately serialize in different orders (observed 2026-07-10: one sorted
+    keys alphabetically, drowning 535/535 cases in key-order noise).
+    """
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
 
 
 def _same(left: Any, right: Any) -> bool:
@@ -102,10 +108,6 @@ def _candidate_differences(left: Any, right: Any) -> list[dict[str, Any]]:
         if not _same(left, right):
             differences.append({"field": "candidates_by_event_output_id", "left": left, "right": right})
         return differences
-    if list(left) != list(right):
-        differences.append(
-            {"field": "candidates_by_event_output_id.object_key_order", "left": list(left), "right": list(right)}
-        )
     for event_output_id in list(dict.fromkeys([*left.keys(), *right.keys()])):
         left_candidates = left.get(event_output_id)
         right_candidates = right.get(event_output_id)
@@ -124,14 +126,6 @@ def _candidate_differences(left: Any, right: Any) -> list[dict[str, Any]]:
                 if not _same(left_candidate, right_candidate):
                     differences.append({"field": candidate_prefix, "left": left_candidate, "right": right_candidate})
                 continue
-            if list(left_candidate) != list(right_candidate):
-                differences.append(
-                    {
-                        "field": candidate_prefix + ".object_key_order",
-                        "left": list(left_candidate),
-                        "right": list(right_candidate),
-                    }
-                )
             for field in CANDIDATE_MATERIAL_FIELDS:
                 if not _same(left_candidate.get(field), right_candidate.get(field)):
                     differences.append(
@@ -146,8 +140,6 @@ def _candidate_differences(left: Any, right: Any) -> list[dict[str, Any]]:
 
 def _material_differences(left: Mapping[str, Any], right: Mapping[str, Any]) -> list[dict[str, Any]]:
     differences: list[dict[str, Any]] = []
-    if list(left) != list(right):
-        differences.append({"field": "case.object_key_order", "left": list(left), "right": list(right)})
     for field in CASE_MATERIAL_FIELDS:
         if field == "candidates_by_event_output_id":
             differences.extend(_candidate_differences(left.get(field), right.get(field)))
@@ -240,7 +232,7 @@ def merge_annotator_sidecars(
         "cases": report_cases,
         "comparison_contract": {
             "exact_deep_equality": True,
-            "object_key_order_material": True,
+            "object_key_order_material": False,
             "list_order_material": True,
             "unadjudicated_cases_omit_adjudication": True,
         },

--- a/tests/test_layerb_label_tools.py
+++ b/tests/test_layerb_label_tools.py
@@ -665,3 +665,26 @@ def test_merge_treats_object_key_order_as_non_material(tmp_path: Path) -> None:
     report, _merged = merge_annotator_sidecars(left, right)
     assert report["counts"]["agreed"] == 1
     assert report["counts"]["material_disagreements"] == 0
+
+
+def test_merge_treats_list_order_as_material(tmp_path: Path) -> None:
+    """List order IS data (span order, segment order): reordered lists must DISAGREE."""
+    keyed, shadow, corpus_dir = _keyed_inputs(tmp_path)
+    scaffold, _report = build_scaffold(keyed, shadow, corpus_dir=corpus_dir, output_dir=tmp_path / "scaffold")
+    left = {"cases": [_completed_case(scaffold["cases"][0])]}
+    left_candidate = next(iter(left["cases"][0]["candidates_by_event_output_id"].values()))[0]
+    left_candidate["expected_support_spans"] = [
+        {"start": 0, "end": 10, "role": "SUPPORTS"},
+        {"start": 10, "end": 20, "role": "SUPPORTS"},
+    ]
+    right = copy.deepcopy(left)
+    right_candidate = next(iter(right["cases"][0]["candidates_by_event_output_id"].values()))[0]
+    right_candidate["expected_support_spans"] = list(reversed(right_candidate["expected_support_spans"]))
+    from scripts.audit.layerb_label_merge import merge_annotator_sidecars
+    report, _merged = merge_annotator_sidecars(left, right)
+    assert report["counts"]["agreed"] == 0
+    assert report["counts"]["material_disagreements"] == 1
+    assert any(
+        diff["field"].endswith("expected_support_spans")
+        for diff in report["cases"][0]["material_differences"]
+    )

--- a/tests/test_layerb_label_tools.py
+++ b/tests/test_layerb_label_tools.py
@@ -646,3 +646,22 @@ def test_merge_agreement_and_exact_span_disagreement(tmp_path: Path) -> None:
     assert report["cases"][0]["material_differences"][0]["field"].endswith("ordered_segment_spans")
     assert "adjudication" not in merged["cases"][0]
     assert list(VALIDATOR.iter_errors(merged))
+
+
+def test_merge_treats_object_key_order_as_non_material(tmp_path: Path) -> None:
+    """Serialization key order is not data: reordered-keys records must AGREE."""
+    keyed, shadow, corpus_dir = _keyed_inputs(tmp_path)
+    scaffold, _report = build_scaffold(keyed, shadow, corpus_dir=corpus_dir, output_dir=tmp_path / "scaffold")
+    left = {"cases": [_completed_case(scaffold["cases"][0])]}
+    # right: same data, every mapping's keys re-serialized in sorted order
+    def resort(value):
+        if isinstance(value, dict):
+            return {k: resort(value[k]) for k in sorted(value)}
+        if isinstance(value, list):
+            return [resort(v) for v in value]
+        return value
+    right = resort(copy.deepcopy(left))
+    from scripts.audit.layerb_label_merge import merge_annotator_sidecars
+    report, _merged = merge_annotator_sidecars(left, right)
+    assert report["counts"]["agreed"] == 1
+    assert report["counts"]["material_disagreements"] == 0


### PR DESCRIPTION
## Problem
Running the real A-vs-B merge over the 535-case dual annotation returned **535/535 material disagreements, 0 agreed** — one annotator serialized JSON keys alphabetically, and the tool treated mapping key order as material. Key order is NOT in the annotation guide's material-field list (identities/hashes, completeness, offsets, Layer A result, eligibility/error, relations, spans, decisions); it drowned the ~190 REAL field disagreements in noise.

## Fix
- `_ordered_json` canonicalizes mapping keys (`sort_keys=True`); JSON arrays keep order — list order stays material (spans/segments are ordered data)
- The three `object_key_order` difference emitters removed; report metadata now `object_key_order_material: false`
- Regression test: records identical up to key order → AGREED

## Evidence
- 21/21 tests (`tests/test_layerb_label_tools.py`), ruff clean
- Real-artifact rerun posted in a follow-up comment (adjudication unblocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)