### PR TITLE
feat(harness): apply label adjudication final qg-layer-b-labels.v2 sidecar tooling

### DIFF
--- a/scripts/audit/layerb_apply_adjudication.py
+++ b/scripts/audit/layerb_apply_adjudication.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Apply frozen Layer B adjudication rulings to a complete labels sidecar.
+
+The adjudication decisions, annotator records, and digest are immutable
+offline inputs.  This tool does not interpret evidence: it only enforces the
+already-recorded A/B/UNION/CUSTOM/UNRESOLVED instructions and writes one
+atomic final sidecar.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    project_root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(project_root))
+    sys.path.insert(0, str(project_root / "scripts"))
+
+from scripts.audit.layerb_keys import _build_event_index
+from scripts.audit.layerb_label_common import LabelJoinError, atomic_write_json, read_json, sha256_file
+from scripts.audit.layerb_label_scaffold import _artifact_events, validate_annotator_record
+
+ADJUDICATOR = "claude-infra (Fable, session d2d784aa)"
+ANNOTATORS = ["annotator-a-claude-opus", "annotator-b-codex-terra"]
+CASE_JUDGMENT_FIELDS = {"expected_aggregate_relation", "expected_fact_check_decision"}
+CANDIDATE_JUDGMENT_FIELDS = {"expected_source_relation", "expected_support_spans"}
+CUSTOM_FIELD_NAMES = {
+    "aggregate_relation": "expected_aggregate_relation",
+    "fact_check_decision": "expected_fact_check_decision",
+}
+UNRESOLVED_BLOCKER_PREFIX = "UNRESOLVED case pending re-adjudication: "
+STANDING_BLOCKER = "2 UNRESOLVED cases pending re-adjudication"
+
+
+def _case_map(document: Mapping[str, Any], label: str) -> dict[str, dict[str, Any]]:
+    """Return cases keyed by stable ID, rejecting incomplete input shape."""
+    cases = document.get("cases")
+    if not isinstance(cases, list):
+        raise LabelJoinError(f"{label} has no cases list")
+    result: dict[str, dict[str, Any]] = {}
+    for case in cases:
+        if not isinstance(case, Mapping) or not isinstance(case.get("case_id"), str) or not case["case_id"]:
+            raise LabelJoinError(f"{label} has a case without a non-empty case_id")
+        case_id = str(case["case_id"])
+        if case_id in result:
+            raise LabelJoinError(f"{label} repeats case_id={case_id}")
+        result[case_id] = dict(case)
+    return result
+
+
+def _decision_map(decisions: Any) -> dict[str, dict[str, Any]]:
+    """Index frozen rulings and reject malformed or duplicate decisions."""
+    if not isinstance(decisions, list):
+        raise LabelJoinError("adjudication decisions must be a list")
+    result: dict[str, dict[str, Any]] = {}
+    for decision in decisions:
+        if not isinstance(decision, Mapping):
+            raise LabelJoinError("adjudication decisions must contain objects")
+        case_id = decision.get("case_id")
+        rationale = decision.get("rationale")
+        if not isinstance(case_id, str) or not case_id:
+            raise LabelJoinError("adjudication decision has no non-empty case_id")
+        if not isinstance(rationale, str) or not rationale:
+            raise LabelJoinError(f"adjudication decision {case_id} has no rationale")
+        if decision.get("adjudicator") != ADJUDICATOR:
+            raise LabelJoinError(f"adjudication decision {case_id} has an unexpected adjudicator")
+        if case_id in result:
+            raise LabelJoinError(f"adjudication decisions repeat case_id={case_id}")
+        result[case_id] = dict(decision)
+    return result
+
+
+def _digest_map(digest: Any) -> dict[str, dict[str, Any]]:
+    """Index the frozen field-level disagreement digest."""
+    if not isinstance(digest, list):
+        raise LabelJoinError("adjudication digest must be a list")
+    result: dict[str, dict[str, Any]] = {}
+    for entry in digest:
+        if not isinstance(entry, Mapping):
+            raise LabelJoinError("adjudication digest must contain objects")
+        case_id = entry.get("case_id")
+        fields = entry.get("fields")
+        if not isinstance(case_id, str) or not case_id or not isinstance(fields, Mapping):
+            raise LabelJoinError("adjudication digest entry is malformed")
+        unexpected = sorted(set(fields) - CASE_JUDGMENT_FIELDS - CANDIDATE_JUDGMENT_FIELDS)
+        if unexpected:
+            raise LabelJoinError(f"adjudication digest {case_id} has unsupported fields: {', '.join(unexpected)}")
+        if case_id in result:
+            raise LabelJoinError(f"adjudication digest repeats case_id={case_id}")
+        result[case_id] = dict(entry)
+    return result
+
+
+def _candidate_groups(case: Mapping[str, Any], label: str) -> Mapping[str, Any]:
+    groups = case.get("candidates_by_event_output_id")
+    if not isinstance(groups, Mapping):
+        raise LabelJoinError(f"{label} case {case.get('case_id')!r} has no candidate groups")
+    return groups
+
+
+def _aligned_candidate_groups(
+    target: Mapping[str, Any], source: Mapping[str, Any], label: str
+) -> list[tuple[list[Any], list[Any]]]:
+    """Pair candidates by immutable event-output ID and list position."""
+    target_groups = _candidate_groups(target, "target")
+    source_groups = _candidate_groups(source, label)
+    if list(target_groups) != list(source_groups):
+        raise LabelJoinError(f"candidate event-output IDs differ between target and {label}")
+    aligned: list[tuple[list[Any], list[Any]]] = []
+    for event_output_id in target_groups:
+        target_candidates = target_groups[event_output_id]
+        source_candidates = source_groups[event_output_id]
+        if not isinstance(target_candidates, list) or not isinstance(source_candidates, list):
+            raise LabelJoinError(f"candidate group {event_output_id} is not a list")
+        if len(target_candidates) != len(source_candidates):
+            raise LabelJoinError(f"candidate count differs for event output {event_output_id}")
+        for target_candidate, source_candidate in zip(target_candidates, source_candidates, strict=True):
+            if not isinstance(target_candidate, dict) or not isinstance(source_candidate, Mapping):
+                raise LabelJoinError(f"candidate group {event_output_id} contains a non-object")
+            if target_candidate.get("candidate_id") != source_candidate.get("candidate_id"):
+                raise LabelJoinError(f"candidate ID differs for event output {event_output_id}")
+        aligned.append((target_candidates, source_candidates))
+    return aligned
+
+
+def _copy_differing_fields(target: dict[str, Any], source: Mapping[str, Any], fields: set[str], label: str) -> None:
+    """Copy only digest-listed judgment fields from an adjudicated source side."""
+    for field in sorted(fields & CASE_JUDGMENT_FIELDS):
+        target[field] = copy.deepcopy(source.get(field))
+    candidate_fields = fields & CANDIDATE_JUDGMENT_FIELDS
+    if not candidate_fields:
+        return
+    for target_candidates, source_candidates in _aligned_candidate_groups(target, source, label):
+        for target_candidate, source_candidate in zip(target_candidates, source_candidates, strict=True):
+            for field in sorted(candidate_fields):
+                target_candidate[field] = copy.deepcopy(source_candidate.get(field))
+
+
+def _union_support_spans(target: dict[str, Any], left: Mapping[str, Any], right: Mapping[str, Any]) -> None:
+    """Use A then B spans, retaining each exact span object once per candidate."""
+    left_pairs = _aligned_candidate_groups(target, left, "annotator-a")
+    right_pairs = _aligned_candidate_groups(target, right, "annotator-b")
+    for (target_candidates, left_candidates), (_same_target, right_candidates) in zip(
+        left_pairs, right_pairs, strict=True
+    ):
+        for target_candidate, left_candidate, right_candidate in zip(
+            target_candidates, left_candidates, right_candidates, strict=True
+        ):
+            left_spans = left_candidate.get("expected_support_spans")
+            right_spans = right_candidate.get("expected_support_spans")
+            if not isinstance(left_spans, list) or not isinstance(right_spans, list):
+                raise LabelJoinError("UNION requires expected_support_spans lists")
+            union: list[Any] = []
+            for span in [*left_spans, *right_spans]:
+                if span not in union:
+                    union.append(copy.deepcopy(span))
+            target_candidate["expected_support_spans"] = union
+
+
+def _parse_custom_ruling(ruling: str) -> dict[str, str]:
+    """Translate frozen CUSTOM keys to the corresponding sidecar field names."""
+    if not ruling.startswith("CUSTOM:"):
+        raise LabelJoinError(f"not a CUSTOM ruling: {ruling!r}")
+    assignments = ruling.removeprefix("CUSTOM:").split(",")
+    result: dict[str, str] = {}
+    for assignment in assignments:
+        key, separator, value = assignment.partition("=")
+        field = CUSTOM_FIELD_NAMES.get(key)
+        if not separator or field is None or not value or field in result:
+            raise LabelJoinError(f"malformed CUSTOM ruling: {ruling!r}")
+        result[field] = value
+    return result
+
+
+def _custom_residual_source(decision: Mapping[str, Any]) -> str:
+    """Apply the frozen rationale's explicit source-relation instruction.
+
+    The two contradiction customs name a contradiction in the rationale (one
+    explicitly says B's source relation is right); their candidate relation
+    and spans therefore come from B.  The insufficient-context customs do not
+    instruct a B source relation, so their residual candidate fields stay A.
+    """
+    rationale = str(decision["rationale"]).casefold()
+    if "b's srel right" in rationale or ("source says" in rationale and "contradicts" in rationale):
+        return "B"
+    return "A"
+
+
+def _adjudication(status: str, note: str) -> dict[str, Any]:
+    return {"status": status, "adjudicator": ADJUDICATOR, "note": note}
+
+
+def apply_ruling(
+    draft_case: Mapping[str, Any],
+    annotator_a_case: Mapping[str, Any],
+    annotator_b_case: Mapping[str, Any],
+    decision: Mapping[str, Any],
+    digest_entry: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Apply one already-recorded ruling without making an evidence judgment."""
+    result = copy.deepcopy(dict(draft_case))
+    ruling = decision.get("ruling")
+    rationale = decision.get("rationale")
+    if not isinstance(ruling, str) or not isinstance(rationale, str):
+        raise LabelJoinError(f"malformed adjudication decision for {draft_case.get('case_id')!r}")
+    fields = set((digest_entry.get("fields") or {}).keys())
+    if ruling == "A":
+        _copy_differing_fields(result, annotator_a_case, fields, "annotator-a")
+        result["adjudication"] = _adjudication("ADJUDICATED", rationale)
+    elif ruling == "B":
+        _copy_differing_fields(result, annotator_b_case, fields, "annotator-b")
+        result["adjudication"] = _adjudication("ADJUDICATED", rationale)
+    elif ruling == "UNION":
+        _copy_differing_fields(result, annotator_a_case, fields - {"expected_support_spans"}, "annotator-a")
+        _union_support_spans(result, annotator_a_case, annotator_b_case)
+        result["adjudication"] = _adjudication(
+            "ADJUDICATED", rationale + " [UNION: A then B support spans, exact duplicates removed.]"
+        )
+    elif ruling == "UNRESOLVED":
+        _copy_differing_fields(result, annotator_a_case, fields, "annotator-a")
+        result["adjudication"] = _adjudication("UNRESOLVED", rationale)
+    elif ruling.startswith("CUSTOM:"):
+        source = annotator_b_case if _custom_residual_source(decision) == "B" else annotator_a_case
+        _copy_differing_fields(result, source, fields, "annotator-b" if source is annotator_b_case else "annotator-a")
+        for field, value in _parse_custom_ruling(ruling).items():
+            result[field] = value
+        result["adjudication"] = _adjudication("ADJUDICATED", rationale)
+    else:
+        raise LabelJoinError(f"unsupported ruling {ruling!r} for {draft_case.get('case_id')!r}")
+    return result
+
+
+def build_event_outputs(corpus_dir: Path) -> dict[str, str]:
+    """Derive the event-output index required by working-record validation."""
+    if not corpus_dir.is_dir():
+        raise LabelJoinError(f"event corpus directory does not exist: {corpus_dir}")
+    events: list[Mapping[str, Any]] = []
+    paths = sorted(corpus_dir.glob("*.json"))
+    if not paths:
+        raise LabelJoinError(f"event corpus contains no JSON artifacts: {corpus_dir}")
+    for path in paths:
+        artifact = read_json(path)
+        if not isinstance(artifact, Mapping):
+            raise LabelJoinError(f"event corpus artifact is not an object: {path}")
+        events.extend(_artifact_events(artifact))
+    return _build_event_index(events)
+
+
+def _validate_completed_case(case: Mapping[str, Any], event_outputs: Mapping[str, str]) -> None:
+    """Validate completed labels with the existing working-record hard checks."""
+    working = copy.deepcopy(dict(case))
+    working.pop("annotators", None)
+    working.pop("adjudication", None)
+    validate_annotator_record(working, event_outputs)
+    if case.get("annotators") != ANNOTATORS:
+        raise LabelJoinError(f"case {case.get('case_id')!r} has incorrect annotators")
+    adjudication = case.get("adjudication")
+    if not isinstance(adjudication, Mapping) or adjudication.get("status") not in {
+        "AGREED",
+        "ADJUDICATED",
+        "UNRESOLVED",
+    }:
+        raise LabelJoinError(f"case {case.get('case_id')!r} has incomplete adjudication")
+    if any(value is None for value in working.values()):
+        raise LabelJoinError(f"case {case.get('case_id')!r} has a null case judgment")
+    for candidates in _candidate_groups(case, "completed").values():
+        for candidate in candidates:
+            if (
+                not isinstance(candidate, Mapping)
+                or candidate.get("expected_source_relation") is None
+                or candidate.get("expected_support_spans") is None
+            ):
+                raise LabelJoinError(f"case {case.get('case_id')!r} has a null candidate judgment")
+
+
+def apply_adjudications(
+    draft: Mapping[str, Any],
+    annotator_a: Mapping[str, Any],
+    annotator_b: Mapping[str, Any],
+    decisions: Any,
+    digest: Any,
+    *,
+    event_outputs: Mapping[str, str],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return a schema-ready final sidecar and deterministic accounting summary."""
+    draft_cases = _case_map(draft, "merge draft")
+    a_cases = _case_map(annotator_a, "annotator-a record")
+    b_cases = _case_map(annotator_b, "annotator-b record")
+    decision_cases = _decision_map(decisions)
+    digest_cases = _digest_map(digest)
+    if set(decision_cases) != set(digest_cases):
+        raise LabelJoinError("decision and digest case IDs differ")
+    if set(draft_cases) != set(a_cases) or set(draft_cases) != set(b_cases):
+        raise LabelJoinError("draft and annotator case IDs differ")
+
+    for case in a_cases.values():
+        validate_annotator_record(case, event_outputs)
+    for case in b_cases.values():
+        validate_annotator_record(case, event_outputs)
+
+    final_cases: list[dict[str, Any]] = []
+    unresolved_case_ids: list[str] = []
+    agreed = 0
+    for case in draft.get("cases", []):
+        case_id = str(case["case_id"])
+        if case_id in decision_cases:
+            final_case = apply_ruling(
+                case, a_cases[case_id], b_cases[case_id], decision_cases[case_id], digest_cases[case_id]
+            )
+            if final_case["adjudication"]["status"] == "UNRESOLVED":
+                unresolved_case_ids.append(case_id)
+        else:
+            final_case = copy.deepcopy(dict(case))
+            adjudication = final_case.get("adjudication")
+            if not isinstance(adjudication, Mapping) or adjudication.get("status") != "AGREED":
+                raise LabelJoinError(f"non-adjudicated case {case_id} is not already AGREED")
+            agreed += 1
+        final_case.pop("notes", None)
+        final_case["annotators"] = list(ANNOTATORS)
+        _validate_completed_case(final_case, event_outputs)
+        final_cases.append(final_case)
+
+    statuses = Counter(str(case["adjudication"]["status"]) for case in final_cases)
+    if agreed != 417 or statuses != Counter({"AGREED": 417, "ADJUDICATED": 116, "UNRESOLVED": 2}):
+        raise LabelJoinError(f"unexpected adjudication status counts: {dict(sorted(statuses.items()))}")
+    if len(unresolved_case_ids) != 2:
+        raise LabelJoinError(f"expected 2 UNRESOLVED cases, found {len(unresolved_case_ids)}")
+
+    final = copy.deepcopy(dict(draft))
+    final["qualification_eligible"] = False
+    final["qualification_blockers"] = [
+        STANDING_BLOCKER,
+        *[UNRESOLVED_BLOCKER_PREFIX + case_id for case_id in sorted(unresolved_case_ids)],
+    ]
+    final["cases"] = final_cases
+    summary = {
+        "cases": len(final_cases),
+        "rulings": dict(sorted(Counter(str(decision["ruling"]) for decision in decision_cases.values()).items())),
+        "adjudication_statuses": dict(sorted(statuses.items())),
+        "unresolved_case_ids": sorted(unresolved_case_ids),
+    }
+    return final, summary
+
+
+def write_final_sidecar(
+    *,
+    decisions_path: Path,
+    merge_draft_path: Path,
+    annotator_a_path: Path,
+    annotator_b_path: Path,
+    digest_path: Path,
+    event_corpus_dir: Path,
+    output_path: Path,
+) -> dict[str, Any]:
+    """Apply frozen records and atomically write the idempotent final sidecar."""
+    event_outputs = build_event_outputs(event_corpus_dir)
+    final, summary = apply_adjudications(
+        read_json(merge_draft_path),
+        read_json(annotator_a_path),
+        read_json(annotator_b_path),
+        read_json(decisions_path),
+        read_json(digest_path),
+        event_outputs=event_outputs,
+    )
+    atomic_write_json(output_path, final)
+    return {**summary, "output": str(output_path), "sha256": sha256_file(output_path)}
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--decisions", type=Path, required=True)
+    parser.add_argument("--merge-draft", type=Path, required=True)
+    parser.add_argument("--annotator-a", type=Path, required=True)
+    parser.add_argument("--annotator-b", type=Path, required=True)
+    parser.add_argument("--digest", type=Path, required=True)
+    parser.add_argument("--event-corpus-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    summary = write_final_sidecar(
+        decisions_path=args.decisions,
+        merge_draft_path=args.merge_draft,
+        annotator_a_path=args.annotator_a,
+        annotator_b_path=args.annotator_b,
+        digest_path=args.digest,
+        event_corpus_dir=args.event_corpus_dir,
+        output_path=args.output,
+    )
+    print(json.dumps(summary, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through the CLI
+    raise SystemExit(main())

--- a/tests/test_layerb_apply_adjudication.py
+++ b/tests/test_layerb_apply_adjudication.py
@@ -1,0 +1,182 @@
+"""Unit tests for mechanical Layer B adjudication application."""
+
+from __future__ import annotations
+
+from scripts.audit.layerb_apply_adjudication import ADJUDICATOR, apply_ruling
+
+EVENT_OUTPUT_ID = "a" * 64
+
+
+def _span(start: int, role: str = "SUPPORTS") -> dict[str, int | str]:
+    return {"start": start, "end": start + 2, "role": role}
+
+
+def _case(
+    *,
+    aggregate: str = "NO_RELATION",
+    fact_check: str = "REJECT",
+    source_relation: str = "NO_RELATION",
+    spans: list[dict[str, int | str]] | None = None,
+) -> dict[str, object]:
+    return {
+        "case_id": "case-1",
+        "expected_aggregate_relation": aggregate,
+        "expected_fact_check_decision": fact_check,
+        "candidates_by_event_output_id": {
+            EVENT_OUTPUT_ID: [
+                {
+                    "candidate_id": "candidate-1",
+                    "expected_source_relation": source_relation,
+                    "expected_support_spans": spans or [],
+                }
+            ]
+        },
+    }
+
+
+def _decision(ruling: str, rationale: str = "Frozen rationale.") -> dict[str, str]:
+    return {
+        "case_id": "case-1",
+        "ruling": ruling,
+        "rationale": rationale,
+        "adjudicator": ADJUDICATOR,
+    }
+
+
+def _digest(*fields: str) -> dict[str, object]:
+    return {"case_id": "case-1", "fields": {field: {} for field in fields}}
+
+
+def _candidate(case: dict[str, object]) -> dict[str, object]:
+    groups = case["candidates_by_event_output_id"]
+    assert isinstance(groups, dict)
+    candidates = groups[EVENT_OUTPUT_ID]
+    assert isinstance(candidates, list)
+    candidate = candidates[0]
+    assert isinstance(candidate, dict)
+    return candidate
+
+
+def test_apply_ruling_copies_selected_a_or_b_judgment_fields() -> None:
+    draft = _case()
+    left = _case(aggregate="ENTAILS", fact_check="ACCEPT", source_relation="ENTAILS", spans=[_span(1)])
+    right = _case(
+        aggregate="CONTRADICTS",
+        fact_check="AUDIT",
+        source_relation="CONTRADICTS",
+        spans=[_span(7, "CONTRADICTS")],
+    )
+    digest = _digest(
+        "expected_aggregate_relation",
+        "expected_fact_check_decision",
+        "expected_source_relation",
+        "expected_support_spans",
+    )
+
+    selected_a = apply_ruling(draft, left, right, _decision("A"), digest)
+    selected_b = apply_ruling(draft, left, right, _decision("B"), digest)
+
+    assert selected_a["expected_aggregate_relation"] == "ENTAILS"
+    assert selected_a["expected_fact_check_decision"] == "ACCEPT"
+    assert _candidate(selected_a)["expected_source_relation"] == "ENTAILS"
+    assert selected_b["expected_aggregate_relation"] == "CONTRADICTS"
+    assert selected_b["expected_fact_check_decision"] == "AUDIT"
+    assert _candidate(selected_b)["expected_source_relation"] == "CONTRADICTS"
+    assert selected_b["adjudication"] == {
+        "status": "ADJUDICATED",
+        "adjudicator": ADJUDICATOR,
+        "note": "Frozen rationale.",
+    }
+
+
+def test_apply_ruling_unions_spans_in_a_then_b_order_without_duplicates() -> None:
+    draft = _case(spans=[_span(1)])
+    left = _case(spans=[_span(1), _span(3, "CONTRADICTS")])
+    right = _case(spans=[_span(3, "CONTRADICTS"), _span(5, "UNCERTAINTY")])
+
+    result = apply_ruling(draft, left, right, _decision("UNION"), _digest("expected_support_spans"))
+
+    assert _candidate(result)["expected_support_spans"] == [
+        _span(1),
+        _span(3, "CONTRADICTS"),
+        _span(5, "UNCERTAINTY"),
+    ]
+    assert result["adjudication"]["status"] == "ADJUDICATED"
+    assert "UNION" in result["adjudication"]["note"]
+
+
+def test_apply_ruling_custom_uses_rationale_selected_b_candidate_values() -> None:
+    draft = _case()
+    left = _case(aggregate="MIXED", fact_check="AUDIT", source_relation="MIXED", spans=[_span(1)])
+    right = _case(
+        aggregate="INSUFFICIENT_CONTEXT",
+        fact_check="AUDIT",
+        source_relation="CONTRADICTS",
+        spans=[_span(7, "CONTRADICTS")],
+    )
+    ruling = "CUSTOM:aggregate_relation=CONTRADICTS,fact_check_decision=ACCEPT"
+
+    result = apply_ruling(
+        draft,
+        left,
+        right,
+        _decision(ruling, "B's srel right; frozen custom aggregate."),
+        _digest(
+            "expected_aggregate_relation",
+            "expected_fact_check_decision",
+            "expected_source_relation",
+            "expected_support_spans",
+        ),
+    )
+
+    assert result["expected_aggregate_relation"] == "CONTRADICTS"
+    assert result["expected_fact_check_decision"] == "ACCEPT"
+    assert _candidate(result)["expected_source_relation"] == "CONTRADICTS"
+    assert _candidate(result)["expected_support_spans"] == [_span(7, "CONTRADICTS")]
+
+
+def test_apply_ruling_custom_without_b_source_instruction_keeps_a_candidate_values() -> None:
+    draft = _case()
+    left = _case(source_relation="NO_RELATION")
+    right = _case(source_relation="ENTAILS", spans=[_span(3)])
+    ruling = "CUSTOM:aggregate_relation=INSUFFICIENT_CONTEXT,fact_check_decision=AUDIT"
+
+    result = apply_ruling(
+        draft,
+        left,
+        right,
+        _decision(ruling, "The source relates thinly but is not decisive."),
+        _digest(
+            "expected_aggregate_relation",
+            "expected_fact_check_decision",
+            "expected_source_relation",
+            "expected_support_spans",
+        ),
+    )
+
+    assert result["expected_aggregate_relation"] == "INSUFFICIENT_CONTEXT"
+    assert result["expected_fact_check_decision"] == "AUDIT"
+    assert _candidate(result)["expected_source_relation"] == "NO_RELATION"
+    assert _candidate(result)["expected_support_spans"] == []
+
+
+def test_apply_ruling_marks_unresolved_without_changing_a_values() -> None:
+    draft = _case()
+    left = _case(aggregate="ENTAILS", source_relation="ENTAILS", spans=[_span(1)])
+    right = _case(aggregate="INSUFFICIENT_CONTEXT", source_relation="NO_RELATION")
+
+    result = apply_ruling(
+        draft,
+        left,
+        right,
+        _decision("UNRESOLVED"),
+        _digest("expected_aggregate_relation", "expected_source_relation", "expected_support_spans"),
+    )
+
+    assert result["expected_aggregate_relation"] == "ENTAILS"
+    assert _candidate(result)["expected_source_relation"] == "ENTAILS"
+    assert result["adjudication"] == {
+        "status": "UNRESOLVED",
+        "adjudicator": ADJUDICATOR,
+        "note": "Frozen rationale.",
+    }


### PR DESCRIPTION
## Summary

- Adds deterministic, idempotent tooling to apply the 118 frozen Layer B adjudication rulings.
- Validates both annotator records against event outputs reconstructed from the frozen multirun corpus.
- Adds focused coverage for A, B, UNION, CUSTOM, and UNRESOLVED application paths.

## Final sidecar evidence

Generated, ignored artifact: `audit/2026-07-10-layerb-phase1-shadow/merge/labels-final.v2.json`

- SHA-256: `5082f4305c0b10e05be5434a841ad72e7e6fd8fca5b815e1cafb7de90f1a558a`
- Cases: 535
- Adjudication statuses: AGREED 417, ADJUDICATED 116, UNRESOLVED 2
- Judgment nulls: 0
- Full-document JSON Schema errors: 0
- Rulings: A 77, B 16, UNION 16, CUSTOM 7, UNRESOLVED 2
- Qualification remains ineligible with the standing `2 UNRESOLVED cases pending re-adjudication` blocker plus both case IDs.

## Validation

Executed from `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4913-apply-adjudication`:

- `.venv/bin/python scripts/audit/layerb_apply_adjudication.py …` ran twice. Raw second-run summary:

```json
{"adjudication_statuses":{"ADJUDICATED":116,"AGREED":417,"UNRESOLVED":2},"cases":535,"sha256":"5082f4305c0b10e05be5434a841ad72e7e6fd8fca5b815e1cafb7de90f1a558a"}
```

- Full `Draft202012Validator` validation and judgment-null check. Raw output:

```json
{"adjudication_statuses":{"ADJUDICATED":116,"AGREED":417,"UNRESOLVED":2},"cases":535,"jsonschema_errors":0,"judgment_nulls":0}
```

- `.venv/bin/pytest tests/test_layerb_apply_adjudication.py tests/test_layerb_label_tools.py tests/test_qg_layer_b_labels_schema.py` — 40 passed.
- `.venv/bin/ruff check scripts/audit/layerb_apply_adjudication.py tests/test_layerb_apply_adjudication.py` — passed.
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed.

## Handoff

Draft PR by design. No auto-merge was enabled. The orchestrator owns cross-family review and merge after the review gate passes.

Refs #4913