### PR TITLE
fix(lexicon): load_manifest refuses to clobber a richer local manifest (intake-window guard)

### DIFF
--- a/docs/bug-autopsies/destructive-restores.md
+++ b/docs/bug-autopsies/destructive-restores.md
@@ -19,8 +19,9 @@ silently, on its happy path.
 **Prevention:** (the category rule) any restore/hydrate/sync tool that can overwrite
 local state must compare BEFORE writing and refuse when the local artifact is richer
 (more entries / newer generation), requiring an explicit force flag for intentional
-restores. Fixed for hydrate-manifest in the same PR (`ATLAS_MANIFEST_FORCE_HYDRATE=1`
-to force). Audit candidate for the same class: `hydrate-practice-deck.mjs` (confirmed by review —
-downloads a release asset and unconditionally overwrites local deck state, no local-work
-guard). `hydrate-lexicon-api-shards.ts` is NOT this class: it is a local generator over
+restores. Fixed for hydrate-manifest and both hydrate-practice-deck loaders in #4937
+(`ATLAS_MANIFEST_FORCE_HYDRATE=1` to force). `hydrate-lexicon-api-shards.ts` is NOT this
+class: it is a local generator over
 already-hydrated data — no download, no pointer, no overwrite-from-remote.
+
+Python twin fixed (#4937): `scripts/lexicon/manifest_io.py` now refuses a richer local default manifest unless `ATLAS_MANIFEST_FORCE_HYDRATE=1` is set.

--- a/scripts/lexicon/manifest_io.py
+++ b/scripts/lexicon/manifest_io.py
@@ -11,6 +11,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from contextlib import suppress
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +36,7 @@ REQUIRED_POINTER_KEYS = (
     "json_bytes",
 )
 DOWNLOAD_ATTEMPTS = 3
+FORCE_HYDRATE_ENV = "ATLAS_MANIFEST_FORCE_HYDRATE"
 
 
 def _sha256(data: bytes) -> str:
@@ -71,6 +73,54 @@ def _decode_manifest(data: bytes, source: Path | str) -> dict[str, Any]:
 
 def _read_local(path: Path) -> dict[str, Any]:
     return _decode_manifest(path.read_bytes(), path)
+
+
+def _entry_count(manifest: dict[str, Any]) -> int:
+    entries = manifest.get("entries")
+    return len(entries) if isinstance(entries, list) else 0
+
+
+def _generated_at(manifest: dict[str, Any]) -> tuple[str | None, datetime | None]:
+    value = manifest.get("generated_at")
+    if not isinstance(value, str):
+        return None, None
+    try:
+        return value, datetime.fromisoformat(value)
+    except ValueError:
+        return value, None
+
+
+def _refuse_richer_local(path: Path, release_manifest: dict[str, Any]) -> None:
+    """Refuse a release hydrate that would replace provably richer local work."""
+    if os.environ.get(FORCE_HYDRATE_ENV) == "1" or not path.exists():
+        return
+
+    try:
+        local_manifest = _read_local(path)
+    except (OSError, ValueError):
+        return
+
+    local_entries = _entry_count(local_manifest)
+    release_entries = _entry_count(release_manifest)
+    local_generated_at, local_timestamp = _generated_at(local_manifest)
+    release_generated_at, release_timestamp = _generated_at(release_manifest)
+    try:
+        local_is_newer = (
+            local_timestamp is not None
+            and release_timestamp is not None
+            and local_timestamp > release_timestamp
+        )
+    except TypeError:
+        local_is_newer = False
+
+    if local_entries > release_entries or local_is_newer:
+        raise ValueError(
+            f"refusing to hydrate {path}: local manifest has {local_entries} entries "
+            f"(generated_at={local_generated_at or '<missing>'}); release target has "
+            f"{release_entries} entries (generated_at={release_generated_at or '<missing>'}). "
+            "The local file looks like in-flight intake work. Publish it with make "
+            f"atlas-publish, or force the restore with {FORCE_HYDRATE_ENV}=1."
+        )
 
 
 def _write_atomic(path: Path, data: bytes) -> None:
@@ -167,6 +217,7 @@ def _hydrate(path: Path, pointer: dict[str, Any]) -> dict[str, Any]:
         )
 
     manifest = _decode_manifest(json_bytes, pointer["asset_url"])
+    _refuse_richer_local(path, manifest)
     _write_atomic(path, json_bytes)
     return manifest
 

--- a/scripts/practice_deck/io.py
+++ b/scripts/practice_deck/io.py
@@ -32,6 +32,7 @@ REQUIRED_POINTER_KEYS = (
     "files",
 )
 DOWNLOAD_ATTEMPTS = 3
+FORCE_HYDRATE_ENV = "ATLAS_MANIFEST_FORCE_HYDRATE"
 ALLOWED_RELEASE_PATH_PREFIX = "/learn-ukrainian/learn-ukrainian.github.io/releases/download/"
 PRACTICE_DECK_BUILDER_VERSION = 4  # 3→4: #4691 rationaleUk passthrough into heritage deck items
 STALE_POINTER_HINT = (
@@ -241,6 +242,38 @@ def _already_hydrated(practice_dir: Path, pointer: dict[str, Any]) -> bool:
     return True
 
 
+def _refuse_richer_local(practice_dir: Path, pointer: dict[str, Any]) -> None:
+    if os.environ.get(FORCE_HYDRATE_ENV) == "1":
+        return
+
+    local_lexemes = 0
+    release_lexemes = 0
+    try:
+        for name, metadata in _pointer_file_map(pointer).items():
+            if metadata["kind"] != "index":
+                continue
+            release_count = metadata.get("counts", {}).get("lexemes")
+            local_count = _read_json(practice_dir / name).get("counts", {}).get("lexemes")
+            if (
+                not isinstance(release_count, int)
+                or isinstance(release_count, bool)
+                or not isinstance(local_count, int)
+                or isinstance(local_count, bool)
+            ):
+                return
+            release_lexemes += release_count
+            local_lexemes += local_count
+    except (OSError, ValueError):
+        return
+
+    if local_lexemes > release_lexemes:
+        raise PracticeDeckHydrationError(
+            f"refusing to overwrite local practice deck with {local_lexemes} lexemes using the "
+            f"published release with only {release_lexemes}. Publish it with make "
+            f"practice-deck-publish, or force the restore with {FORCE_HYDRATE_ENV}=1."
+        )
+
+
 def _package_files(package: dict[str, Any], pointer: dict[str, Any]) -> list[tuple[str, bytes]]:
     if package.get("schema") != "atlas-practice-deck-package":
         raise PracticeDeckHydrationError("practice deck package schema mismatch")
@@ -326,6 +359,7 @@ def ensure_practice_deck_hydrated(
         raise PracticeDeckHydrationError(f"gz size mismatch: expected {pointer['gz_bytes']}, got {len(gz_bytes)}")
     package_bytes = gzip.decompress(gz_bytes)
     files = _decode_package(package_bytes, pointer)
+    _refuse_richer_local(practice_dir, pointer)
     _write_files(practice_dir, files)
     return pointer
 

--- a/site/scripts/hydrate-practice-deck.mjs
+++ b/site/scripts/hydrate-practice-deck.mjs
@@ -165,6 +165,37 @@ async function alreadyHydrated(pointer) {
   return true;
 }
 
+async function assertNotClobberingRicherLocal(pointer, localDir = practiceDir) {
+  if (process.env.ATLAS_MANIFEST_FORCE_HYDRATE === "1") return;
+
+  let localLexemeCount = 0;
+  let releaseLexemeCount = 0;
+  try {
+    for (const [name, metadata] of pointerFiles(pointer)) {
+      if (metadata.kind !== "index") continue;
+      const releaseCount = metadata.counts?.lexemes;
+      const local = JSON.parse(await readFile(resolve(localDir, name), "utf8"));
+      const localCount = local?.counts?.lexemes;
+      if (
+        !Number.isInteger(releaseCount) || releaseCount < 0 ||
+        !Number.isInteger(localCount) || localCount < 0
+      ) return;
+      releaseLexemeCount += releaseCount;
+      localLexemeCount += localCount;
+    }
+  } catch {
+    return; // missing or unreadable local shards may be replaced
+  }
+
+  if (localLexemeCount > releaseLexemeCount) {
+    throw new Error(
+      `refusing to overwrite local practice deck with ${localLexemeCount} lexemes using ` +
+        `the published release with only ${releaseLexemeCount}. Publish it with make ` +
+        `practice-deck-publish, or force the restore with ATLAS_MANIFEST_FORCE_HYDRATE=1.`,
+    );
+  }
+}
+
 function parsePackage(packageBytes, pointer) {
   if (packageBytes.length !== pointer.package_bytes) {
     throw new Error(`package size mismatch: expected ${pointer.package_bytes}, got ${packageBytes.length}`);
@@ -247,6 +278,7 @@ async function hydrate() {
   }
   const packageBytes = gunzipSync(gzBytes);
   const files = parsePackage(packageBytes, pointer);
+  await assertNotClobberingRicherLocal(pointer);
   await writeFiles(files);
   console.log(`✓ hydrated practice deck ${pointer.deck_version} from ${mb(gzBytes.length)} release asset`);
 }
@@ -258,4 +290,4 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   });
 }
 
-export { assertAllowedDownloadUrl, downloadGzip, downloadUrl, parsePackage };
+export { assertAllowedDownloadUrl, assertNotClobberingRicherLocal, downloadGzip, downloadUrl, parsePackage };

--- a/site/tests/unit/hydrate-practice-deck.test.ts
+++ b/site/tests/unit/hydrate-practice-deck.test.ts
@@ -1,8 +1,12 @@
 import { createHash } from 'node:crypto';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { gzipSync } from 'node:zlib';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import {
   assertAllowedDownloadUrl,
+  assertNotClobberingRicherLocal,
   downloadGzip,
   downloadUrl,
   parsePackage,
@@ -131,5 +135,37 @@ describe('hydrate practice deck release download', () => {
     ['https://github.com/attacker/repo/releases/download/t/evil.gz', 'github.com different repo'],
   ])('rejects non-allowlisted asset URL: %s (%s)', (url) => {
     expect(() => assertAllowedDownloadUrl(url)).toThrow(/allowlisted|https/);
+  });
+});
+
+describe('practice deck local-work guard', () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function richerLocalIndex(lexemes: number): string {
+    dir = mkdtempSync(join(tmpdir(), 'practice-deck-guard-'));
+    writeFileSync(join(dir, 'practice-index.A1.json'), JSON.stringify({ counts: { lexemes } }));
+    return dir;
+  }
+
+  function pointerWithIndexCount(lexemes: number) {
+    const { pointer } = packageFixture();
+    pointer.files[0].counts = { lexemes };
+    return pointer;
+  }
+
+  test('refuses to overwrite a richer local practice deck', async () => {
+    await expect(assertNotClobberingRicherLocal(pointerWithIndexCount(3), richerLocalIndex(5))).rejects.toThrow(
+      /local practice deck with 5 lexemes.*published release with only 3/,
+    );
+  });
+
+  test('force escape hatch permits an intentional practice deck restore', async () => {
+    vi.stubEnv('ATLAS_MANIFEST_FORCE_HYDRATE', '1');
+    await expect(assertNotClobberingRicherLocal(pointerWithIndexCount(3), richerLocalIndex(5))).resolves.toBeUndefined();
   });
 });

--- a/tests/test_manifest_io.py
+++ b/tests/test_manifest_io.py
@@ -94,6 +94,118 @@ def test_load_manifest_fetches_decompresses_and_writes_when_absent(
     assert manifest_path.read_bytes() == json_bytes
 
 
+def test_load_manifest_refuses_to_clobber_richer_local_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release_payload = {
+        "entries": [{"lemma": "слово"}],
+        "generated_at": "2026-07-05T17:13:27+00:00",
+    }
+    local_payload = {
+        "entries": [{"lemma": "слово"}, {"lemma": "вікно"}],
+        "generated_at": "2026-07-06T17:13:27+00:00",
+    }
+    json_bytes = _json_bytes(release_payload)
+    gz_bytes = gzip.compress(json_bytes)
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    pointer_path = tmp_path / "lexicon-manifest.pointer.json"
+    local_bytes = _json_bytes(local_payload)
+    manifest_path.write_bytes(local_bytes)
+    _write_pointer(pointer_path, json_bytes=json_bytes, gz_bytes=gz_bytes)
+    _pin_defaults(monkeypatch, manifest_path, pointer_path)
+    monkeypatch.setattr(manifest_io.urllib.request, "urlopen", lambda *_args, **_kwargs: io.BytesIO(gz_bytes))
+
+    with pytest.raises(ValueError, match="refusing to hydrate") as excinfo:
+        manifest_io.load_manifest(path=manifest_path)
+
+    assert "2 entries" in str(excinfo.value)
+    assert "1 entries" in str(excinfo.value)
+    assert "2026-07-06T17:13:27+00:00" in str(excinfo.value)
+    assert "2026-07-05T17:13:27+00:00" in str(excinfo.value)
+    assert "ATLAS_MANIFEST_FORCE_HYDRATE=1" in str(excinfo.value)
+    assert manifest_path.read_bytes() == local_bytes
+
+
+def test_load_manifest_hydrates_stale_poorer_local_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release_payload = {
+        "entries": [{"lemma": "слово"}, {"lemma": "вікно"}],
+        "generated_at": "2026-07-06T17:13:27+00:00",
+    }
+    local_payload = {
+        "entries": [{"lemma": "слово"}],
+        "generated_at": "2026-07-05T17:13:27+00:00",
+    }
+    json_bytes = _json_bytes(release_payload)
+    gz_bytes = gzip.compress(json_bytes)
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    pointer_path = tmp_path / "lexicon-manifest.pointer.json"
+    manifest_path.write_bytes(_json_bytes(local_payload))
+    _write_pointer(pointer_path, json_bytes=json_bytes, gz_bytes=gz_bytes)
+    _pin_defaults(monkeypatch, manifest_path, pointer_path)
+    monkeypatch.setattr(manifest_io.urllib.request, "urlopen", lambda *_args, **_kwargs: io.BytesIO(gz_bytes))
+
+    assert manifest_io.load_manifest(path=manifest_path) == release_payload
+    assert manifest_path.read_bytes() == json_bytes
+
+
+def test_load_manifest_force_hydrates_richer_local_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release_payload = {
+        "entries": [{"lemma": "слово"}],
+        "generated_at": "2026-07-05T17:13:27+00:00",
+    }
+    local_payload = {
+        "entries": [{"lemma": "слово"}, {"lemma": "вікно"}],
+        "generated_at": "2026-07-06T17:13:27+00:00",
+    }
+    json_bytes = _json_bytes(release_payload)
+    gz_bytes = gzip.compress(json_bytes)
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    pointer_path = tmp_path / "lexicon-manifest.pointer.json"
+    manifest_path.write_bytes(_json_bytes(local_payload))
+    _write_pointer(pointer_path, json_bytes=json_bytes, gz_bytes=gz_bytes)
+    _pin_defaults(monkeypatch, manifest_path, pointer_path)
+    monkeypatch.setenv("ATLAS_MANIFEST_FORCE_HYDRATE", "1")
+    monkeypatch.setattr(manifest_io.urllib.request, "urlopen", lambda *_args, **_kwargs: io.BytesIO(gz_bytes))
+
+    assert manifest_io.load_manifest(path=manifest_path) == release_payload
+    assert manifest_path.read_bytes() == json_bytes
+
+
+def test_load_manifest_refuses_newer_local_manifest_with_equal_entry_count(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release_payload = {
+        "entries": [{"lemma": "слово"}],
+        "generated_at": "2026-07-05T17:13:27+00:00",
+    }
+    local_payload = {
+        "entries": [{"lemma": "слово"}],
+        "generated_at": "2026-07-06T17:13:27+00:00",
+    }
+    json_bytes = _json_bytes(release_payload)
+    gz_bytes = gzip.compress(json_bytes)
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    pointer_path = tmp_path / "lexicon-manifest.pointer.json"
+    local_bytes = _json_bytes(local_payload)
+    manifest_path.write_bytes(local_bytes)
+    _write_pointer(pointer_path, json_bytes=json_bytes, gz_bytes=gz_bytes)
+    _pin_defaults(monkeypatch, manifest_path, pointer_path)
+    monkeypatch.setattr(manifest_io.urllib.request, "urlopen", lambda *_args, **_kwargs: io.BytesIO(gz_bytes))
+
+    with pytest.raises(ValueError, match="refusing to hydrate"):
+        manifest_io.load_manifest(path=manifest_path)
+
+    assert manifest_path.read_bytes() == local_bytes
+
+
 def test_load_manifest_raises_on_gz_sha256_mismatch(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_practice_deck_io.py
+++ b/tests/test_practice_deck_io.py
@@ -27,7 +27,19 @@ def _write_pointer(
     gz_sha256: str | None = None,
     package_sha256: str | None = None,
     deck_version: str = "deck-v1",
+    shard_bytes: bytes = b"content-data",
+    lexeme_count: int | None = None,
 ) -> None:
+    shard = {
+        "path": "practice-index.A1.json",
+        "kind": "index",
+        "level": "A1",
+        "schema": "atlas-practice-index",
+        "bytes": len(shard_bytes),
+        "sha256": _sha256(shard_bytes),
+    }
+    if lexeme_count is not None:
+        shard["counts"] = {"lexemes": lexeme_count}
     pointer_path.write_text(
         json.dumps(
             {
@@ -40,16 +52,7 @@ def _write_pointer(
                 "gz_bytes": len(gz_bytes),
                 "package_bytes": len(package_bytes),
                 "file_count": 1,
-                "files": [
-                    {
-                        "path": "practice-index.A1.json",
-                        "kind": "index",
-                        "level": "A1",
-                        "schema": "atlas-practice-index",
-                        "bytes": len(b"content-data"),
-                        "sha256": _sha256(b"content-data"),
-                    }
-                ],
+                "files": [shard],
                 "note": "test pointer",
             }
         ),
@@ -191,6 +194,74 @@ def test_ensure_practice_deck_hydrated_fetches_decompresses_and_writes_when_abse
     shard_path = practice_dir / "practice-index.A1.json"
     assert shard_path.exists()
     assert shard_path.read_bytes() == b"content-data"
+
+
+def test_ensure_practice_deck_hydrated_refuses_to_clobber_richer_local_deck(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    practice_dir = tmp_path / "lexicon"
+    pointer_path = tmp_path / "lexicon-practice-deck.pointer.json"
+    release_content = _json_bytes({"counts": {"lexemes": 3}})
+    local_content = _json_bytes({"counts": {"lexemes": 5}})
+    package = {
+        "schema": "atlas-practice-deck-package",
+        "schemaVersion": 1,
+        "deckVersion": "deck-v1",
+        "files": [{"path": "practice-index.A1.json", "content": release_content.decode("utf-8")}],
+    }
+    package_bytes = _json_bytes(package)
+    gz_bytes = gzip.compress(package_bytes)
+    shard_path = practice_dir / "practice-index.A1.json"
+    shard_path.parent.mkdir(parents=True, exist_ok=True)
+    shard_path.write_bytes(local_content)
+    _write_pointer(
+        pointer_path,
+        package_bytes=package_bytes,
+        gz_bytes=gz_bytes,
+        shard_bytes=release_content,
+        lexeme_count=3,
+    )
+    _pin_defaults(monkeypatch, practice_dir, pointer_path)
+    monkeypatch.setattr(practice_deck_io.urllib.request, "urlopen", lambda *_args, **_kwargs: io.BytesIO(gz_bytes))
+
+    with pytest.raises(practice_deck_io.PracticeDeckHydrationError, match="refusing to overwrite"):
+        practice_deck_io.ensure_practice_deck_hydrated(practice_dir=practice_dir, pointer_path=pointer_path)
+
+    assert shard_path.read_bytes() == local_content
+
+
+def test_ensure_practice_deck_hydrated_force_restores_richer_local_deck(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    practice_dir = tmp_path / "lexicon"
+    pointer_path = tmp_path / "lexicon-practice-deck.pointer.json"
+    release_content = _json_bytes({"counts": {"lexemes": 3}})
+    package = {
+        "schema": "atlas-practice-deck-package",
+        "schemaVersion": 1,
+        "deckVersion": "deck-v1",
+        "files": [{"path": "practice-index.A1.json", "content": release_content.decode("utf-8")}],
+    }
+    package_bytes = _json_bytes(package)
+    gz_bytes = gzip.compress(package_bytes)
+    shard_path = practice_dir / "practice-index.A1.json"
+    shard_path.parent.mkdir(parents=True, exist_ok=True)
+    shard_path.write_bytes(_json_bytes({"counts": {"lexemes": 5}}))
+    _write_pointer(
+        pointer_path,
+        package_bytes=package_bytes,
+        gz_bytes=gz_bytes,
+        shard_bytes=release_content,
+        lexeme_count=3,
+    )
+    _pin_defaults(monkeypatch, practice_dir, pointer_path)
+    monkeypatch.setenv("ATLAS_MANIFEST_FORCE_HYDRATE", "1")
+    monkeypatch.setattr(practice_deck_io.urllib.request, "urlopen", lambda *_args, **_kwargs: io.BytesIO(gz_bytes))
+
+    assert practice_deck_io.ensure_practice_deck_hydrated(practice_dir=practice_dir, pointer_path=pointer_path)
+    assert shard_path.read_bytes() == release_content
 
 
 def test_ensure_practice_deck_hydrated_raises_on_gz_sha256_mismatch(


### PR DESCRIPTION
## Root cause

`load_manifest()` treated a sha-mismatched default manifest as disposable release state. During an intake window, the local file can be intentionally ahead of the published release, so automatic hydration overwrote in-flight work.

## Fix

- Refuse default-manifest hydration when the valid local manifest has more entries or a newer `generated_at` than the verified release target; the error reports both counts and timestamps.
- Permit deliberate restores only with `ATLAS_MANIFEST_FORCE_HYDRATE=1`; absent and provably stale-poorer manifests still hydrate automatically. Explicit `--manifest` paths retain `_read_local` behavior.
- Applied the same force-guard to both practice-deck hydrators discovered in the sibling audit.

## Validation

- `tests/test_manifest_io.py -k refuses_to_clobber_richer_local_manifest`: `1 passed, 9 deselected`.
- Absent + stale-poorer cases: `2 passed, 8 deselected`; force case: `1 passed, 9 deselected`.
- `pytest tests/ -k manifest`: `327 passed, 2 skipped, 10413 deselected`.
- `ruff check` on changed Python files: `All checks passed!`
- `site/tests/unit/hydrate-practice-deck.test.ts`: `13 passed`.

## Sibling audit

- `hydrate-practice-deck.mjs` and `scripts/practice_deck/io.py` had the same release-overwrite flow, and now refuse a richer local practice deck by aggregate index lexeme count. The practice-deck schema has no generation timestamp, so the guard uses its published count contract.
- `hydrate-lexicon-api-shards.ts` only copies/generates local data; it has no release pointer or remote download, so no guard was needed.

Autopsy updated with the Python-twin resolution.

Closes #4937