### PR TITLE
feat(harness): adjudication round-2 overlay — resolve the 2 UNRESOLVED cases

### DIFF
--- a/scripts/audit/layerb_apply_adjudication.py
+++ b/scripts/audit/layerb_apply_adjudication.py
@@ -28,12 +28,17 @@ from scripts.audit.layerb_label_common import LabelJoinError, atomic_write_json,
 from scripts.audit.layerb_label_scaffold import _artifact_events, validate_annotator_record
 
 ADJUDICATOR = "claude-infra (Fable, session d2d784aa)"
+ADJUDICATOR_R2 = "claude-infra (Fable, session 053cb131)"
 ANNOTATORS = ["annotator-a-claude-opus", "annotator-b-codex-terra"]
 CASE_JUDGMENT_FIELDS = {"expected_aggregate_relation", "expected_fact_check_decision"}
 CANDIDATE_JUDGMENT_FIELDS = {"expected_source_relation", "expected_support_spans"}
-CUSTOM_FIELD_NAMES = {
+CUSTOM_CASE_FIELD_NAMES = {
     "aggregate_relation": "expected_aggregate_relation",
     "fact_check_decision": "expected_fact_check_decision",
+}
+CUSTOM_CANDIDATE_FIELD_NAMES = {
+    "candidate.expected_source_relation": "expected_source_relation",
+    "candidate.expected_support_spans": "expected_support_spans",
 }
 UNRESOLVED_BLOCKER_PREFIX = "UNRESOLVED case pending re-adjudication: "
 STANDING_BLOCKER = "2 UNRESOLVED cases pending re-adjudication"
@@ -55,25 +60,62 @@ def _case_map(document: Mapping[str, Any], label: str) -> dict[str, dict[str, An
     return result
 
 
-def _decision_map(decisions: Any) -> dict[str, dict[str, Any]]:
+def _decision_map(
+    decisions: Any,
+    *,
+    label: str = "adjudication",
+    adjudicator: str = ADJUDICATOR,
+) -> dict[str, dict[str, Any]]:
     """Index frozen rulings and reject malformed or duplicate decisions."""
     if not isinstance(decisions, list):
-        raise LabelJoinError("adjudication decisions must be a list")
+        raise LabelJoinError(f"{label} decisions must be a list")
     result: dict[str, dict[str, Any]] = {}
     for decision in decisions:
         if not isinstance(decision, Mapping):
-            raise LabelJoinError("adjudication decisions must contain objects")
+            raise LabelJoinError(f"{label} decisions must contain objects")
         case_id = decision.get("case_id")
         rationale = decision.get("rationale")
         if not isinstance(case_id, str) or not case_id:
-            raise LabelJoinError("adjudication decision has no non-empty case_id")
+            raise LabelJoinError(f"{label} decision has no non-empty case_id")
         if not isinstance(rationale, str) or not rationale:
-            raise LabelJoinError(f"adjudication decision {case_id} has no rationale")
-        if decision.get("adjudicator") != ADJUDICATOR:
-            raise LabelJoinError(f"adjudication decision {case_id} has an unexpected adjudicator")
+            raise LabelJoinError(f"{label} decision {case_id} has no rationale")
+        if decision.get("adjudicator") != adjudicator:
+            raise LabelJoinError(f"{label} decision {case_id} has an unexpected adjudicator")
         if case_id in result:
-            raise LabelJoinError(f"adjudication decisions repeat case_id={case_id}")
+            raise LabelJoinError(f"{label} decisions repeat case_id={case_id}")
         result[case_id] = dict(decision)
+    return result
+
+
+def _round_two_decision_map(decisions: Any) -> dict[str, dict[str, Any]]:
+    """Index and validate frozen Round-2 decisions before applying an overlay."""
+    result = _decision_map(
+        decisions,
+        label="round-2 adjudication",
+        adjudicator=ADJUDICATOR_R2,
+    )
+    for case_id, decision in result.items():
+        if decision.get("round") != 2:
+            raise LabelJoinError(f"round-2 adjudication decision {case_id} must carry round=2")
+        if decision.get("supersedes_ruling") != "UNRESOLVED":
+            raise LabelJoinError(
+                f"round-2 adjudication decision {case_id} must supersede UNRESOLVED"
+            )
+    return result
+
+
+def _overlay_round_two_decisions(
+    round_one: Mapping[str, dict[str, Any]], decisions_r2: Any
+) -> dict[str, dict[str, Any]]:
+    """Replace only Round-1 UNRESOLVED rulings with validated Round-2 records."""
+    result = dict(round_one)
+    for case_id, decision in _round_two_decision_map(decisions_r2).items():
+        previous = round_one.get(case_id)
+        if previous is None or previous.get("ruling") != "UNRESOLVED":
+            raise LabelJoinError(
+                f"round-2 adjudication decision {case_id} does not target a Round-1 UNRESOLVED case"
+            )
+        result[case_id] = decision
     return result
 
 
@@ -164,19 +206,50 @@ def _union_support_spans(target: dict[str, Any], left: Mapping[str, Any], right:
             target_candidate["expected_support_spans"] = union
 
 
-def _parse_custom_ruling(ruling: str) -> dict[str, str]:
-    """Translate frozen CUSTOM keys to the corresponding sidecar field names."""
+def _parse_custom_ruling(ruling: str) -> tuple[dict[str, str], dict[str, str]]:
+    """Translate frozen CUSTOM assignments into case and candidate changes."""
     if not ruling.startswith("CUSTOM:"):
         raise LabelJoinError(f"not a CUSTOM ruling: {ruling!r}")
     assignments = ruling.removeprefix("CUSTOM:").split(",")
-    result: dict[str, str] = {}
+    case_result: dict[str, str] = {}
+    candidate_result: dict[str, str] = {}
     for assignment in assignments:
         key, separator, value = assignment.partition("=")
-        field = CUSTOM_FIELD_NAMES.get(key)
-        if not separator or field is None or not value or field in result:
+        case_field = CUSTOM_CASE_FIELD_NAMES.get(key)
+        candidate_field = CUSTOM_CANDIDATE_FIELD_NAMES.get(key)
+        if not separator or not value:
             raise LabelJoinError(f"malformed CUSTOM ruling: {ruling!r}")
-        result[field] = value
-    return result
+        if case_field is not None and case_field not in case_result:
+            case_result[case_field] = value
+        elif candidate_field is not None and candidate_field not in candidate_result:
+            if candidate_field == "expected_support_spans" and value != "EMPTY":
+                raise LabelJoinError(f"candidate CUSTOM spans must be literal EMPTY: {ruling!r}")
+            candidate_result[candidate_field] = value
+        else:
+            raise LabelJoinError(f"malformed CUSTOM ruling: {ruling!r}")
+    return case_result, candidate_result
+
+
+def _single_candidate_for_custom(case: dict[str, Any]) -> dict[str, Any]:
+    """Return the sole candidate required for a candidate-level CUSTOM ruling."""
+    candidates: list[dict[str, Any]] = []
+    for event_output_id, group in _candidate_groups(case, "CUSTOM target").items():
+        if not isinstance(group, list):
+            raise LabelJoinError(f"candidate group {event_output_id} is not a list")
+        for candidate in group:
+            if not isinstance(candidate, dict):
+                raise LabelJoinError(f"candidate group {event_output_id} contains a non-object")
+            candidates.append(candidate)
+    if len(candidates) != 1:
+        raise LabelJoinError(f"candidate-level CUSTOM requires exactly one candidate, found {len(candidates)}")
+    return candidates[0]
+
+
+def _apply_candidate_custom_assignments(case: dict[str, Any], assignments: Mapping[str, str]) -> None:
+    """Set explicit candidate CUSTOM assignments without selecting an annotator residual."""
+    candidate = _single_candidate_for_custom(case)
+    for field, value in assignments.items():
+        candidate[field] = [] if field == "expected_support_spans" else value
 
 
 def _custom_residual_source(decision: Mapping[str, Any]) -> str:
@@ -193,8 +266,8 @@ def _custom_residual_source(decision: Mapping[str, Any]) -> str:
     return "A"
 
 
-def _adjudication(status: str, note: str) -> dict[str, Any]:
-    return {"status": status, "adjudicator": ADJUDICATOR, "note": note}
+def _adjudication(status: str, note: str, adjudicator: str) -> dict[str, Any]:
+    return {"status": status, "adjudicator": adjudicator, "note": note}
 
 
 def apply_ruling(
@@ -208,30 +281,49 @@ def apply_ruling(
     result = copy.deepcopy(dict(draft_case))
     ruling = decision.get("ruling")
     rationale = decision.get("rationale")
-    if not isinstance(ruling, str) or not isinstance(rationale, str):
+    adjudicator = decision.get("adjudicator")
+    if not isinstance(ruling, str) or not isinstance(rationale, str) or not isinstance(adjudicator, str):
         raise LabelJoinError(f"malformed adjudication decision for {draft_case.get('case_id')!r}")
     fields = set((digest_entry.get("fields") or {}).keys())
     if ruling == "A":
         _copy_differing_fields(result, annotator_a_case, fields, "annotator-a")
-        result["adjudication"] = _adjudication("ADJUDICATED", rationale)
+        result["adjudication"] = _adjudication("ADJUDICATED", rationale, adjudicator)
     elif ruling == "B":
         _copy_differing_fields(result, annotator_b_case, fields, "annotator-b")
-        result["adjudication"] = _adjudication("ADJUDICATED", rationale)
+        result["adjudication"] = _adjudication("ADJUDICATED", rationale, adjudicator)
     elif ruling == "UNION":
         _copy_differing_fields(result, annotator_a_case, fields - {"expected_support_spans"}, "annotator-a")
         _union_support_spans(result, annotator_a_case, annotator_b_case)
         result["adjudication"] = _adjudication(
-            "ADJUDICATED", rationale + " [UNION: A then B support spans, exact duplicates removed.]"
+            "ADJUDICATED",
+            rationale + " [UNION: A then B support spans, exact duplicates removed.]",
+            adjudicator,
         )
     elif ruling == "UNRESOLVED":
         _copy_differing_fields(result, annotator_a_case, fields, "annotator-a")
-        result["adjudication"] = _adjudication("UNRESOLVED", rationale)
+        result["adjudication"] = _adjudication("UNRESOLVED", rationale, adjudicator)
     elif ruling.startswith("CUSTOM:"):
-        source = annotator_b_case if _custom_residual_source(decision) == "B" else annotator_a_case
-        _copy_differing_fields(result, source, fields, "annotator-b" if source is annotator_b_case else "annotator-a")
-        for field, value in _parse_custom_ruling(ruling).items():
+        case_assignments, candidate_assignments = _parse_custom_ruling(ruling)
+        if candidate_assignments:
+            _copy_differing_fields(
+                result,
+                annotator_a_case,
+                fields - CANDIDATE_JUDGMENT_FIELDS,
+                "annotator-a",
+            )
+        else:
+            source = annotator_b_case if _custom_residual_source(decision) == "B" else annotator_a_case
+            _copy_differing_fields(
+                result,
+                source,
+                fields,
+                "annotator-b" if source is annotator_b_case else "annotator-a",
+            )
+        for field, value in case_assignments.items():
             result[field] = value
-        result["adjudication"] = _adjudication("ADJUDICATED", rationale)
+        if candidate_assignments:
+            _apply_candidate_custom_assignments(result, candidate_assignments)
+        result["adjudication"] = _adjudication("ADJUDICATED", rationale, adjudicator)
     else:
         raise LabelJoinError(f"unsupported ruling {ruling!r} for {draft_case.get('case_id')!r}")
     return result
@@ -288,12 +380,15 @@ def apply_adjudications(
     digest: Any,
     *,
     event_outputs: Mapping[str, str],
+    decisions_r2: Any | None = None,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Return a schema-ready final sidecar and deterministic accounting summary."""
     draft_cases = _case_map(draft, "merge draft")
     a_cases = _case_map(annotator_a, "annotator-a record")
     b_cases = _case_map(annotator_b, "annotator-b record")
     decision_cases = _decision_map(decisions)
+    if decisions_r2 is not None:
+        decision_cases = _overlay_round_two_decisions(decision_cases, decisions_r2)
     digest_cases = _digest_map(digest)
     if set(decision_cases) != set(digest_cases):
         raise LabelJoinError("decision and digest case IDs differ")
@@ -328,17 +423,29 @@ def apply_adjudications(
         final_cases.append(final_case)
 
     statuses = Counter(str(case["adjudication"]["status"]) for case in final_cases)
-    if agreed != 417 or statuses != Counter({"AGREED": 417, "ADJUDICATED": 116, "UNRESOLVED": 2}):
+    expected_statuses = (
+        Counter({"AGREED": 417, "ADJUDICATED": 118})
+        if decisions_r2 is not None
+        else Counter({"AGREED": 417, "ADJUDICATED": 116, "UNRESOLVED": 2})
+    )
+    expected_unresolved_count = 0 if decisions_r2 is not None else 2
+    if agreed != 417 or statuses != expected_statuses:
         raise LabelJoinError(f"unexpected adjudication status counts: {dict(sorted(statuses.items()))}")
-    if len(unresolved_case_ids) != 2:
-        raise LabelJoinError(f"expected 2 UNRESOLVED cases, found {len(unresolved_case_ids)}")
+    if len(unresolved_case_ids) != expected_unresolved_count:
+        raise LabelJoinError(
+            f"expected {expected_unresolved_count} UNRESOLVED cases, found {len(unresolved_case_ids)}"
+        )
 
     final = copy.deepcopy(dict(draft))
-    final["qualification_eligible"] = False
-    final["qualification_blockers"] = [
-        STANDING_BLOCKER,
-        *[UNRESOLVED_BLOCKER_PREFIX + case_id for case_id in sorted(unresolved_case_ids)],
-    ]
+    final["qualification_eligible"] = decisions_r2 is not None
+    final["qualification_blockers"] = (
+        []
+        if decisions_r2 is not None
+        else [
+            STANDING_BLOCKER,
+            *[UNRESOLVED_BLOCKER_PREFIX + case_id for case_id in sorted(unresolved_case_ids)],
+        ]
+    )
     final["cases"] = final_cases
     summary = {
         "cases": len(final_cases),
@@ -352,6 +459,7 @@ def apply_adjudications(
 def write_final_sidecar(
     *,
     decisions_path: Path,
+    decisions_r2_path: Path | None = None,
     merge_draft_path: Path,
     annotator_a_path: Path,
     annotator_b_path: Path,
@@ -368,6 +476,7 @@ def write_final_sidecar(
         read_json(decisions_path),
         read_json(digest_path),
         event_outputs=event_outputs,
+        decisions_r2=read_json(decisions_r2_path) if decisions_r2_path is not None else None,
     )
     atomic_write_json(output_path, final)
     return {**summary, "output": str(output_path), "sha256": sha256_file(output_path)}
@@ -376,6 +485,7 @@ def write_final_sidecar(
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--decisions", type=Path, required=True)
+    parser.add_argument("--decisions-r2", type=Path)
     parser.add_argument("--merge-draft", type=Path, required=True)
     parser.add_argument("--annotator-a", type=Path, required=True)
     parser.add_argument("--annotator-b", type=Path, required=True)
@@ -389,6 +499,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     summary = write_final_sidecar(
         decisions_path=args.decisions,
+        decisions_r2_path=args.decisions_r2,
         merge_draft_path=args.merge_draft,
         annotator_a_path=args.annotator_a,
         annotator_b_path=args.annotator_b,

--- a/tests/test_layerb_apply_adjudication.py
+++ b/tests/test_layerb_apply_adjudication.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from scripts.audit.layerb_apply_adjudication import ADJUDICATOR, apply_ruling
+import copy
+
+import pytest
+
+import scripts.audit.layerb_apply_adjudication as adjudication
+from scripts.audit.layerb_apply_adjudication import ADJUDICATOR, ADJUDICATOR_R2, apply_ruling
+from scripts.audit.layerb_label_common import LabelJoinError
 
 EVENT_OUTPUT_ID = "a" * 64
 
@@ -35,11 +41,29 @@ def _case(
 
 
 def _decision(ruling: str, rationale: str = "Frozen rationale.") -> dict[str, str]:
+    return _case_decision("case-1", ruling, rationale=rationale)
+
+
+def _case_decision(
+    case_id: str,
+    ruling: str,
+    *,
+    rationale: str = "Frozen rationale.",
+    adjudicator: str = ADJUDICATOR,
+) -> dict[str, str]:
     return {
-        "case_id": "case-1",
+        "case_id": case_id,
         "ruling": ruling,
         "rationale": rationale,
-        "adjudicator": ADJUDICATOR,
+        "adjudicator": adjudicator,
+    }
+
+
+def _round_two_decision(case_id: str, ruling: str = "B") -> dict[str, object]:
+    return {
+        **_case_decision(case_id, ruling, adjudicator=ADJUDICATOR_R2),
+        "round": 2,
+        "supersedes_ruling": "UNRESOLVED",
     }
 
 
@@ -55,6 +79,23 @@ def _candidate(case: dict[str, object]) -> dict[str, object]:
     candidate = candidates[0]
     assert isinstance(candidate, dict)
     return candidate
+
+
+def _status_pin_documents() -> tuple[dict[str, object], list[dict[str, str]], list[dict[str, object]]]:
+    """Build lightweight cases for accounting tests; record validation is patched there."""
+    agreed_cases = [
+        {"case_id": f"agreed-{index}", "adjudication": {"status": "AGREED"}}
+        for index in range(417)
+    ]
+    adjudicated_ids = [f"adjudicated-{index}" for index in range(116)]
+    unresolved_ids = ["unresolved-0", "unresolved-1"]
+    decisions = [_case_decision(case_id, "A") for case_id in adjudicated_ids]
+    decisions.extend(_case_decision(case_id, "UNRESOLVED") for case_id in unresolved_ids)
+    digest = [{"case_id": decision["case_id"], "fields": {}} for decision in decisions]
+    cases = [*agreed_cases]
+    cases.extend({"case_id": case_id} for case_id in adjudicated_ids)
+    cases.extend({"case_id": case_id} for case_id in unresolved_ids)
+    return {"cases": cases}, decisions, digest
 
 
 def test_apply_ruling_copies_selected_a_or_b_judgment_fields() -> None:
@@ -180,3 +221,137 @@ def test_apply_ruling_marks_unresolved_without_changing_a_values() -> None:
         "adjudicator": ADJUDICATOR,
         "note": "Frozen rationale.",
     }
+
+
+def test_apply_ruling_custom_sets_single_candidate_and_empty_spans_without_residual_heuristic() -> None:
+    draft = _case(source_relation="ENTAILS", spans=[_span(1)])
+    left = _case(source_relation="NO_RELATION")
+    right = _case(source_relation="CONTRADICTS", spans=[_span(7, "CONTRADICTS")])
+    ruling = (
+        "CUSTOM:candidate.expected_source_relation=INSUFFICIENT_CONTEXT,"
+        "candidate.expected_support_spans=EMPTY,aggregate_relation=INSUFFICIENT_CONTEXT,"
+        "fact_check_decision=AUDIT"
+    )
+
+    result = apply_ruling(
+        draft,
+        left,
+        right,
+        _decision(ruling, "B's srel right, but the candidate custom is explicit."),
+        _digest(
+            "expected_aggregate_relation",
+            "expected_fact_check_decision",
+            "expected_source_relation",
+            "expected_support_spans",
+        ),
+    )
+
+    assert result["expected_aggregate_relation"] == "INSUFFICIENT_CONTEXT"
+    assert result["expected_fact_check_decision"] == "AUDIT"
+    assert _candidate(result)["expected_source_relation"] == "INSUFFICIENT_CONTEXT"
+    assert _candidate(result)["expected_support_spans"] == []
+
+
+def test_apply_ruling_candidate_custom_rejects_multiple_candidates_and_nonempty_spans() -> None:
+    draft = _case()
+    groups = draft["candidates_by_event_output_id"]
+    assert isinstance(groups, dict)
+    groups["b" * 64] = [
+        {
+            "candidate_id": "candidate-2",
+            "expected_source_relation": "NO_RELATION",
+            "expected_support_spans": [],
+        }
+    ]
+    candidate_ruling = "CUSTOM:candidate.expected_source_relation=INSUFFICIENT_CONTEXT"
+
+    with pytest.raises(LabelJoinError, match="requires exactly one candidate"):
+        apply_ruling(draft, _case(), _case(), _decision(candidate_ruling), _digest("expected_source_relation"))
+
+    with pytest.raises(LabelJoinError, match="literal EMPTY"):
+        apply_ruling(
+            _case(),
+            _case(),
+            _case(),
+            _decision("CUSTOM:candidate.expected_support_spans=NOT_EMPTY"),
+            _digest("expected_support_spans"),
+        )
+
+
+def test_round_two_overlay_rejects_non_unresolved_targets() -> None:
+    with pytest.raises(LabelJoinError, match="does not target a Round-1 UNRESOLVED case"):
+        adjudication._overlay_round_two_decisions(
+            {"case-1": _case_decision("case-1", "A")},
+            [_round_two_decision("case-1")],
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("adjudicator", "not-the-frozen-adjudicator", "unexpected adjudicator"),
+        ("round", 1, "must carry round=2"),
+        ("supersedes_ruling", "A", "must supersede UNRESOLVED"),
+    ],
+)
+def test_round_two_overlay_requires_frozen_metadata(field: str, value: object, message: str) -> None:
+    decision = _round_two_decision("case-1")
+    decision[field] = value
+
+    with pytest.raises(LabelJoinError, match=message):
+        adjudication._overlay_round_two_decisions(
+            {"case-1": _case_decision("case-1", "UNRESOLVED")},
+            [decision],
+        )
+
+
+def test_apply_adjudications_preserves_round_one_counts_without_overlay_and_resolves_with_overlay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    draft, decisions, digest = _status_pin_documents()
+    monkeypatch.setattr(adjudication, "validate_annotator_record", lambda _case, _outputs: None)
+    monkeypatch.setattr(adjudication, "_validate_completed_case", lambda _case, _outputs: None)
+
+    without_overlay, summary_without_overlay = adjudication.apply_adjudications(
+        draft,
+        copy.deepcopy(draft),
+        copy.deepcopy(draft),
+        decisions,
+        digest,
+        event_outputs={},
+    )
+
+    assert summary_without_overlay["adjudication_statuses"] == {
+        "ADJUDICATED": 116,
+        "AGREED": 417,
+        "UNRESOLVED": 2,
+    }
+    assert without_overlay["qualification_eligible"] is False
+    assert without_overlay["qualification_blockers"] == [
+        "2 UNRESOLVED cases pending re-adjudication",
+        "UNRESOLVED case pending re-adjudication: unresolved-0",
+        "UNRESOLVED case pending re-adjudication: unresolved-1",
+    ]
+
+    with_overlay, summary_with_overlay = adjudication.apply_adjudications(
+        draft,
+        copy.deepcopy(draft),
+        copy.deepcopy(draft),
+        decisions,
+        digest,
+        event_outputs={},
+        decisions_r2=[
+            _round_two_decision("unresolved-0", "B"),
+            _round_two_decision(
+                "unresolved-1",
+                "CUSTOM:aggregate_relation=INSUFFICIENT_CONTEXT,fact_check_decision=AUDIT",
+            ),
+        ],
+    )
+
+    assert summary_with_overlay["adjudication_statuses"] == {"ADJUDICATED": 118, "AGREED": 417}
+    assert summary_with_overlay["unresolved_case_ids"] == []
+    assert with_overlay["qualification_eligible"] is True
+    assert with_overlay["qualification_blockers"] == []
+    resolved_case = next(case for case in with_overlay["cases"] if case["case_id"] == "unresolved-0")
+    assert resolved_case["adjudication"]["adjudicator"] == ADJUDICATOR_R2


### PR DESCRIPTION
## Summary

- Adds strict optional `--decisions-r2` overlay validation: exact Round-2 adjudicator, `round: 2`, `supersedes_ruling: UNRESOLVED`, and only Round-1 UNRESOLVED targets.
- Resolves the frozen Khreshchennia Rusi case with ruling `B`, preserving Round-2 adjudicator provenance in the final sidecar.
- Adds single-candidate CUSTOM assignments used by the Ruska Triitsia case: `INSUFFICIENT_CONTEXT`, empty support spans, aggregate `INSUFFICIENT_CONTEXT`, and `AUDIT`; multiple candidates and non-literal span directives hard-fail.

## Evidence

- `pytest tests/test_layerb_apply_adjudication.py -k adjudic -q`: **12 passed**.
- `ruff check scripts/audit/layerb_apply_adjudication.py tests/test_layerb_apply_adjudication.py`: **All checks passed**.
- Independent no-overlay regeneration exactly reproduced the prior final sidecar: `5082f4305c0b10e05be5434a841ad72e7e6fd8fca5b815e1cafb7de90f1a558a`.
- Round-2 regeneration wrote the gitignored final sidecar with `AGREED: 417`, `ADJUDICATED: 118`, `UNRESOLVED: 0`, `qualification_eligible: true`, `qualification_blockers: []`, SHA-256 `871337e5bd4560365371822237fb2846cdcc8eb28811ecd64efe7b39a25c9001`.
- `Draft202012Validator(schemas/qg-layer-b-labels.v2.schema.json)`: `valid: true`, `error_count: 0`.

Refs #4913