### PR TITLE
fix(harness): derive normalized writer/reviewer lineage for stored groundings

### DIFF
--- a/scripts/audit/layerb_shadow.py
+++ b/scripts/audit/layerb_shadow.py
@@ -248,40 +248,131 @@ def normalize_seat_key(seat_arm: Any) -> tuple[str, Mapping[str, Any]]:
     return f"seat-{_sha256_text(_canonical_json(metadata))[:16]}", metadata
 
 
-def _family(value: Any) -> str | None:
-    if not isinstance(value, str):
-        return None
-    normalized = value.strip().casefold()
-    return normalized or None
+_LINEAGE_METADATA_FIELDS = (
+    "family",
+    "vendor",
+    "provider",
+    "pin",
+    "pin_slug",
+    "resolved_model",
+    "model",
+    "model_id",
+    "reviewer_model_id",
+    "writer_model_id",
+)
 
 
-def _first_family(*values: Any) -> str | None:
+def normalize_lineage_family(metadata: Any) -> str | None:
+    """Map seat/pin metadata to a conservative Layer-B lineage family.
+
+    This intentionally differs from the live-reviewer dispatcher's broader
+    routing labels.  Layer B needs one stable equality domain: Google includes
+    Gemma and Gemini; GPT includes OpenAI and Codex; and Grok and Cursor share
+    one fleet-accounting family.  Values outside that domain are not guessed.
+    """
+
+    candidates: set[str] = set()
+
+    def add_text(value: str) -> None:
+        text = value.strip().casefold()
+        if not text:
+            return
+        if re.search(r"(?:^|[^a-z0-9])(google|gemma|gemini)(?:$|[^a-z0-9])", text):
+            candidates.add("google")
+        if re.search(r"(?:^|[^a-z0-9])deepseek(?:$|[^a-z0-9])", text):
+            candidates.add("deepseek")
+        if re.search(r"(?:^|[^a-z0-9])(openai|codex|gpt)(?:$|[^a-z0-9])", text):
+            candidates.add("gpt")
+        if re.search(r"(?:^|[^a-z0-9])(anthropic|claude)(?:$|[^a-z0-9])", text):
+            candidates.add("claude")
+        if re.search(r"(?:^|[^a-z0-9])(grok|cursor|xai)(?:$|[^a-z0-9])", text):
+            candidates.add("grok-cursor")
+
+    def visit(value: Any) -> None:
+        if isinstance(value, str):
+            add_text(value)
+        elif isinstance(value, Mapping):
+            for field in _LINEAGE_METADATA_FIELDS:
+                if field in value:
+                    visit(value[field])
+
+    visit(metadata)
+    return next(iter(candidates)) if len(candidates) == 1 else None
+
+
+def _first_present(*values: Any) -> Any | None:
     for value in values:
-        family = _family(value)
-        if family is not None:
-            return family
+        if isinstance(value, str) and value.strip():
+            return value
+        if isinstance(value, Mapping) and value:
+            return value
     return None
 
 
 def _extract_lineages(
-    artifact: Mapping[str, Any], fact_check: Mapping[str, Any], grounding: Mapping[str, Any]
+    artifact: Mapping[str, Any],
+    fact_check: Mapping[str, Any],
+    grounding: Mapping[str, Any],
+    *,
+    artifact_path: Path | None = None,
 ) -> tuple[str | None, str | None]:
-    """Use only explicitly captured lineages; missing lineage is not inferred."""
+    """Materialize normalized writer and QG-reviewer lineage without mutation."""
+
     payload = artifact.get("payload") if isinstance(artifact.get("payload"), Mapping) else {}
     dispatch = artifact.get("dispatch") if isinstance(artifact.get("dispatch"), Mapping) else {}
-    model = artifact.get("model") if isinstance(artifact.get("model"), Mapping) else {}
-    writer_family = _first_family(
+    model = artifact.get("model")
+    if not isinstance(model, (Mapping, str)):
+        model = {}
+
+    explicit_writer = _first_present(
         grounding.get("writer_family"),
         fact_check.get("writer_family"),
         artifact.get("writer_family"),
         payload.get("writer_family"),
     )
-    qg_reviewer_family = _first_family(
+    writer_metadata = _first_present(
+        grounding.get("writer_seat"),
+        fact_check.get("writer_seat"),
+        artifact.get("writer_seat"),
+        grounding.get("writer"),
+        fact_check.get("writer"),
+        artifact.get("writer"),
+        artifact.get("seat_arm"),
+        artifact.get("seat"),
+        model,
+    )
+    writer_family = (
+        normalize_lineage_family(explicit_writer)
+        if explicit_writer is not None
+        else normalize_lineage_family(writer_metadata)
+    )
+    if writer_family is None and explicit_writer is None and writer_metadata is None and artifact_path is not None:
+        writer_family = normalize_lineage_family(artifact_path.name)
+
+    explicit_reviewer = _first_present(
         grounding.get("qg_reviewer_family"),
         fact_check.get("qg_reviewer_family"),
+        artifact.get("qg_reviewer_family"),
         payload.get("qg_reviewer_family"),
+    )
+    reviewer_metadata = _first_present(
+        grounding.get("qg_reviewer_seat"),
+        fact_check.get("qg_reviewer_seat"),
+        artifact.get("qg_reviewer_seat"),
+        payload.get("qg_reviewer_seat"),
+        grounding.get("qg_reviewer"),
+        fact_check.get("qg_reviewer"),
+        artifact.get("qg_reviewer"),
+        payload.get("qg_reviewer"),
         dispatch.get("reviewer_family"),
-        model.get("family"),
+        dispatch.get("reviewer_model_id"),
+        artifact.get("reviewer"),
+        model,
+    )
+    qg_reviewer_family = (
+        normalize_lineage_family(explicit_reviewer)
+        if explicit_reviewer is not None
+        else normalize_lineage_family(reviewer_metadata)
     )
     return writer_family, qg_reviewer_family
 
@@ -556,7 +647,16 @@ def _select_route(
     if writer_family is None or reviewer_family is None:
         return None
     excluded = {writer_family, reviewer_family}
-    return next((route for route in routes if route.qualified and _family(route.family) not in excluded), None)
+    return next(
+        (
+            route
+            for route in routes
+            if route.qualified
+            and (route_family := normalize_lineage_family(route.family)) is not None
+            and route_family not in excluded
+        ),
+        None,
+    )
 
 
 def _load_labels(path: Path | None) -> tuple[Mapping[str, Any], dict[str, Any]]:
@@ -850,6 +950,7 @@ class ShadowRunner:
         reviewer_verdict = str(fact_check.get("reviewer_verdict") or fact_check.get("verdict") or "UNKNOWN")
         key = _stable_grounding_key(path, fact_index, fact_check)
         label = self.labels.get(key) or self.labels.get(str(fact_check.get("fact_check_id") or ""))
+        writer_family, reviewer_family = _extract_lineages(artifact, fact_check, grounding, artifact_path=path)
         record: dict[str, Any] = {
             "grounding_key": key,
             "artifact": path.name,
@@ -864,6 +965,7 @@ class ShadowRunner:
             "candidate_details": [],
             "aggregate_relation": None,
             "final_decision": None,
+            "lineage": {"writer_family": writer_family, "qg_reviewer_family": reviewer_family},
             "labels": {
                 "present": isinstance(label, Mapping),
                 "outcome_only": not isinstance(label, Mapping),
@@ -938,8 +1040,6 @@ class ShadowRunner:
                 )
             return record
         record["b1"] = "ELIGIBLE"
-        writer_family, reviewer_family = _extract_lineages(artifact, fact_check, grounding)
-        record["lineage"] = {"writer_family": writer_family, "qg_reviewer_family": reviewer_family}
         event_index = _build_event_index(events)
         details = [
             self._route_candidate(
@@ -1162,16 +1262,39 @@ class ShadowRunner:
         _atomic_write_json(self.audit_dir / f"{stem}.json", report)
         (self.audit_dir / f"{stem}.md").write_text(_markdown_report(report), encoding="utf-8")
 
-    def run(self, *, resume: bool = False) -> dict[str, Any]:
+    def _artifacts_and_groundings(
+        self,
+    ) -> tuple[list[tuple[Path, Mapping[str, Any]]], list[tuple[Path, Mapping[str, Any], int, Mapping[str, Any]]]]:
         artifacts = _read_artifacts(self.artifacts_dir)
         if not artifacts:
             raise ValueError(f"No qg_bakeoff_run.* artifact JSON files in {self.artifacts_dir}")
-        all_groundings = [
+        groundings = [
             (path, artifact, index, fact_check)
             for path, artifact in artifacts
             for index, fact_check in enumerate(_artifact_fact_checks(artifact))
             if isinstance(fact_check, Mapping) and isinstance(fact_check.get("grounding"), Mapping)
         ]
+        return artifacts, groundings
+
+    def validate_judged_replay_lineage(self) -> None:
+        """Reject live judged replay unless every stored grounding has both lineages."""
+
+        _artifacts, groundings = self._artifacts_and_groundings()
+        unresolved_by_artifact: Counter[str] = Counter()
+        for path, artifact, _index, fact_check in groundings:
+            grounding = fact_check["grounding"]
+            writer_family, reviewer_family = _extract_lineages(artifact, fact_check, grounding, artifact_path=path)
+            if writer_family is None or reviewer_family is None:
+                unresolved_by_artifact[path.name] += 1
+        if unresolved_by_artifact:
+            details = ", ".join(f"{artifact}={count}" for artifact, count in sorted(unresolved_by_artifact.items()))
+            raise ValueError(
+                "judged replay requires known writer and qg reviewer lineage; "
+                f"unresolved grounding rows by artifact: {details}"
+            )
+
+    def run(self, *, resume: bool = False) -> dict[str, Any]:
+        artifacts, all_groundings = self._artifacts_and_groundings()
         input_identity = _artifact_input_identity(artifacts)
         state = self._load_state(input_identity, resume)
         processed = state.setdefault("processed", {})
@@ -1283,6 +1406,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             dry_run=args.dry_run,
             baseline_path=args.baseline,
         )
+        if args.judge_command is not None:
+            runner.validate_judged_replay_lineage()
         previous_handlers = {
             kind: signal.signal(kind, lambda _signum, _frame: (_ for _ in ()).throw(KeyboardInterrupt()))
             for kind in (signal.SIGINT, signal.SIGTERM)

--- a/scripts/audit/layerb_shadow.py
+++ b/scripts/audit/layerb_shadow.py
@@ -313,10 +313,20 @@ def _extract_lineages(
     artifact: Mapping[str, Any],
     fact_check: Mapping[str, Any],
     grounding: Mapping[str, Any],
-    *,
-    artifact_path: Path | None = None,
 ) -> tuple[str | None, str | None]:
-    """Materialize normalized writer and QG-reviewer lineage without mutation."""
+    """Materialize normalized writer and QG-reviewer lineage without mutation.
+
+    Writer lineage never derives from a QG-reviewer seat, arm, model, or
+    artifact filename: those fields identify the reviewer under test, not the
+    model that wrote the content being evaluated.  A recorded writer-specific
+    field is authoritative.  Otherwise, a mapping-valued ``fixture`` marks
+    synthetic or ``source_module_dir`` fixture content, whose manifest records
+    no model writer; its writer family is the non-model sentinel ``fixture``.
+    The sentinel excludes no judge family because the third-family constraint
+    protects against model self-preference, which human/synthetic fixtures do
+    not have.  A non-fixture artifact without an explicit writer remains
+    unknown and fails closed.
+    """
 
     payload = artifact.get("payload") if isinstance(artifact.get("payload"), Mapping) else {}
     dispatch = artifact.get("dispatch") if isinstance(artifact.get("dispatch"), Mapping) else {}
@@ -337,25 +347,19 @@ def _extract_lineages(
         grounding.get("writer"),
         fact_check.get("writer"),
         artifact.get("writer"),
-        artifact.get("seat_arm"),
-        artifact.get("seat"),
-        model,
     )
-    writer_family = (
-        normalize_lineage_family(explicit_writer)
-        if explicit_writer is not None
-        else normalize_lineage_family(writer_metadata)
-    )
-    if writer_family is None and explicit_writer is None and writer_metadata is None and artifact_path is not None:
-        writer_family = normalize_lineage_family(artifact_path.name)
+    writer_source = _first_present(explicit_writer, writer_metadata)
+    writer_family = normalize_lineage_family(writer_source) if writer_source is not None else None
+    if writer_source is None and isinstance(artifact.get("fixture"), Mapping):
+        writer_family = "fixture"
 
-    explicit_reviewer = _first_present(
+    reviewer_metadata = _first_present(
+        dispatch.get("reviewer_family"),
+        dispatch.get("reviewer_model_id"),
         grounding.get("qg_reviewer_family"),
         fact_check.get("qg_reviewer_family"),
         artifact.get("qg_reviewer_family"),
         payload.get("qg_reviewer_family"),
-    )
-    reviewer_metadata = _first_present(
         grounding.get("qg_reviewer_seat"),
         fact_check.get("qg_reviewer_seat"),
         artifact.get("qg_reviewer_seat"),
@@ -364,16 +368,10 @@ def _extract_lineages(
         fact_check.get("qg_reviewer"),
         artifact.get("qg_reviewer"),
         payload.get("qg_reviewer"),
-        dispatch.get("reviewer_family"),
-        dispatch.get("reviewer_model_id"),
         artifact.get("reviewer"),
         model,
     )
-    qg_reviewer_family = (
-        normalize_lineage_family(explicit_reviewer)
-        if explicit_reviewer is not None
-        else normalize_lineage_family(reviewer_metadata)
-    )
+    qg_reviewer_family = normalize_lineage_family(reviewer_metadata)
     return writer_family, qg_reviewer_family
 
 
@@ -646,7 +644,7 @@ def _select_route(
 ) -> JudgeRoute | None:
     if writer_family is None or reviewer_family is None:
         return None
-    excluded = {writer_family, reviewer_family}
+    excluded = {family for family in (writer_family, reviewer_family) if family != "fixture"}
     return next(
         (
             route
@@ -950,7 +948,7 @@ class ShadowRunner:
         reviewer_verdict = str(fact_check.get("reviewer_verdict") or fact_check.get("verdict") or "UNKNOWN")
         key = _stable_grounding_key(path, fact_index, fact_check)
         label = self.labels.get(key) or self.labels.get(str(fact_check.get("fact_check_id") or ""))
-        writer_family, reviewer_family = _extract_lineages(artifact, fact_check, grounding, artifact_path=path)
+        writer_family, reviewer_family = _extract_lineages(artifact, fact_check, grounding)
         record: dict[str, Any] = {
             "grounding_key": key,
             "artifact": path.name,
@@ -1283,7 +1281,7 @@ class ShadowRunner:
         unresolved_by_artifact: Counter[str] = Counter()
         for path, artifact, _index, fact_check in groundings:
             grounding = fact_check["grounding"]
-            writer_family, reviewer_family = _extract_lineages(artifact, fact_check, grounding, artifact_path=path)
+            writer_family, reviewer_family = _extract_lineages(artifact, fact_check, grounding)
             if writer_family is None or reviewer_family is None:
                 unresolved_by_artifact[path.name] += 1
         if unresolved_by_artifact:

--- a/tests/test_layerb_shadow.py
+++ b/tests/test_layerb_shadow.py
@@ -157,6 +157,56 @@ def test_route_selection_treats_gemma_writer_and_gemini_judge_as_same_family() -
     assert route == claude
 
 
+def test_route_selection_ignores_fixture_writer_sentinel() -> None:
+    gemini = JudgeRoute("gemini", "gemini-3.1-pro")
+    claude = JudgeRoute("claude", "claude-opus-4-6")
+
+    route = _select_route((gemini, claude), writer_family="fixture", reviewer_family="deepseek")
+
+    assert route == gemini
+
+
+@pytest.mark.parametrize(
+    ("artifact_overrides", "expected"),
+    (
+        ({}, ("fixture", "google")),
+        (
+            {"writer_family": "openai", "dispatch": {"reviewer_family": "deepseek"}},
+            ("gpt", "deepseek"),
+        ),
+        (
+            {"writer_seat": {"family": "anthropic", "pin": "claude-opus-4-6"}},
+            ("claude", "google"),
+        ),
+        (
+            {
+                "fixture": None,
+                "seat_arm": {"family": "google", "pin": "synthetic-google-qg"},
+                "seat": {"family": "google", "pin": "synthetic-google-qg"},
+                "model": {"family": "google", "pin": "synthetic-google-qg"},
+            },
+            (None, "google"),
+        ),
+        (
+            {
+                "fixture": None,
+                "dispatch": {},
+                "model": {"family": "deepseek", "pin": "deepseek-v4"},
+            },
+            (None, "deepseek"),
+        ),
+    ),
+)
+def test_extract_lineages_preserves_writer_and_reviewer_semantics(
+    artifact_overrides: dict[str, Any], expected: tuple[str | None, str | None]
+) -> None:
+    artifact = _artifact([_fact_check("fc-lineage")], writer_family=None)
+    artifact.update(artifact_overrides)
+    fact_check = artifact["payload"]["fact_checks"][0]
+
+    assert _extract_lineages(artifact, fact_check, fact_check["grounding"]) == expected
+
+
 def test_relation_verdict_table_is_exhaustive_and_defaults_to_audit() -> None:
     relations = (
         "ENTAILS",
@@ -238,6 +288,7 @@ def test_runner_executes_b0_to_b4_with_fake_judge_and_emits_all_stat_groups(tmp_
 
 def test_unknown_writer_lineage_and_prompt_injection_are_audited_without_judge(tmp_path: Path) -> None:
     unknown_artifact = _artifact([_fact_check("fc-unknown")], writer_family=None)
+    unknown_artifact.pop("fixture")
     unknown_artifact["seat_arm"] = {"family": "unmapped", "pin": "local/mystery-model"}
     unknown_artifact["model"] = {"family": "unmapped", "pin": "local/mystery-model"}
     unknown_artifacts = _write_artifacts(tmp_path / "unknown", unknown_artifact)
@@ -272,6 +323,7 @@ def test_judged_replay_refuses_artifact_with_unknown_lineage(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     artifact = _artifact([_fact_check("fc-unknown")], writer_family=None)
+    artifact.pop("fixture")
     artifact["seat_arm"] = {"family": "unmapped", "pin": "local/mystery-model"}
     artifact["model"] = {"family": "unmapped", "pin": "local/mystery-model"}
     artifacts = _write_artifacts(tmp_path / "unknown", artifact)
@@ -315,13 +367,13 @@ def test_stored_corpus_lineage_resolves_all_groundings_when_available() -> None:
         if isinstance(fact_check, dict) and isinstance(fact_check.get("grounding"), dict)
     ]
     lineages = [
-        _extract_lineages(artifact, fact_check, fact_check["grounding"], artifact_path=path)
-        for path, artifact, fact_check in rows
+        _extract_lineages(artifact, fact_check, fact_check["grounding"]) for _path, artifact, fact_check in rows
     ]
 
     assert len(rows) == 1310
     assert all(writer is not None and reviewer is not None for writer, reviewer in lineages)
-    assert Counter(writer for writer, _reviewer in lineages) == {"deepseek": 892, "google": 418}
+    assert Counter(writer for writer, _reviewer in lineages) == {"fixture": 1310}
+    assert Counter(reviewer for _writer, reviewer in lineages) == {"deepseek": 892, "google": 418}
 
 
 def test_b2_rejects_incompatible_claim_number_without_deterministic_entailment(tmp_path: Path) -> None:

--- a/tests/test_layerb_shadow.py
+++ b/tests/test_layerb_shadow.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+from collections import Counter
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -14,11 +16,17 @@ from scripts.audit.layerb_shadow import (
     JudgeRoute,
     ShadowRunner,
     _aggregate_relations,
+    _artifact_fact_checks,
     _build_event_index,
+    _extract_lineages,
     _judge_window,
+    _read_artifacts,
+    _select_route,
     _serialize_untrusted_window,
     _validate_judge_response,
     final_decision,
+    main,
+    normalize_lineage_family,
     normalize_seat_key,
 )
 
@@ -125,6 +133,30 @@ def test_seat_key_is_canonical_not_python_dict_order() -> None:
     assert first_metadata == second_metadata
 
 
+def test_normalize_lineage_family_uses_conservative_vendor_families() -> None:
+    cases = (
+        ({"family": "deepseek", "pin": "openrouter/deepseek/deepseek-v4-flash"}, "deepseek"),
+        ({"family": "google", "pin": "openrouter/google/gemma-4-31b-it"}, "google"),
+        ({"family": "openai", "pin": "gpt-5.6-terra"}, "gpt"),
+        ({"family": "anthropic", "pin": "claude-opus-4-6"}, "claude"),
+        ({"family": "cursor", "pin": "grok-4"}, "grok-cursor"),
+        ({"family": "google", "pin": "openrouter/deepseek/deepseek-v4-pro"}, None),
+        ({"family": "unmapped", "pin": "local/mystery-model"}, None),
+    )
+
+    for metadata, expected in cases:
+        assert normalize_lineage_family(metadata) == expected
+
+
+def test_route_selection_treats_gemma_writer_and_gemini_judge_as_same_family() -> None:
+    gemini = JudgeRoute("gemini", "gemini-3.1-pro")
+    claude = JudgeRoute("claude", "claude-opus-4-6")
+
+    route = _select_route((gemini, claude), writer_family="google", reviewer_family="gpt")
+
+    assert route == claude
+
+
 def test_relation_verdict_table_is_exhaustive_and_defaults_to_audit() -> None:
     relations = (
         "ENTAILS",
@@ -205,9 +237,10 @@ def test_runner_executes_b0_to_b4_with_fake_judge_and_emits_all_stat_groups(tmp_
 
 
 def test_unknown_writer_lineage_and_prompt_injection_are_audited_without_judge(tmp_path: Path) -> None:
-    unknown_artifacts = _write_artifacts(
-        tmp_path / "unknown", _artifact([_fact_check("fc-unknown")], writer_family=None)
-    )
+    unknown_artifact = _artifact([_fact_check("fc-unknown")], writer_family=None)
+    unknown_artifact["seat_arm"] = {"family": "unmapped", "pin": "local/mystery-model"}
+    unknown_artifact["model"] = {"family": "unmapped", "pin": "local/mystery-model"}
+    unknown_artifacts = _write_artifacts(tmp_path / "unknown", unknown_artifact)
     unknown_report = _runner(unknown_artifacts, tmp_path / "unknown-audit").run()
     unknown_detail = unknown_report["records"][0]["candidate_details"][0]
     assert unknown_detail["relation"] == "AUDIT"
@@ -233,6 +266,62 @@ def test_unknown_writer_lineage_and_prompt_injection_are_audited_without_judge(t
     fake_delimiter_detail = fake_delimiter_report["records"][0]["candidate_details"][0]
     assert fake_delimiter_detail["relation"] == "AUDIT"
     assert fake_delimiter_detail["failure_class"] == "PROMPT_INJECTION"
+
+
+def test_judged_replay_refuses_artifact_with_unknown_lineage(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    artifact = _artifact([_fact_check("fc-unknown")], writer_family=None)
+    artifact["seat_arm"] = {"family": "unmapped", "pin": "local/mystery-model"}
+    artifact["model"] = {"family": "unmapped", "pin": "local/mystery-model"}
+    artifacts = _write_artifacts(tmp_path / "unknown", artifact)
+
+    exit_code = main(
+        [
+            "--artifacts-dir",
+            str(artifacts),
+            "--audit-dir",
+            str(tmp_path / "audit"),
+            "--judge-command",
+            "must-not-run",
+            "--judge-family",
+            "claude",
+            "--judge-model",
+            "test",
+        ]
+    )
+
+    assert exit_code == 2
+    assert "synthetic.json=1" in capsys.readouterr().err
+
+
+def test_stored_corpus_lineage_resolves_all_groundings_when_available() -> None:
+    worktree_root = Path(__file__).resolve().parents[1]
+    common_git_dir = subprocess.run(
+        ["git", "-C", str(worktree_root), "rev-parse", "--git-common-dir"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    corpus_dir = Path(common_git_dir).resolve().parent / "audit" / "2026-07-06-qg-bakeoff-multirun"
+    artifacts = _read_artifacts(corpus_dir)
+    if not artifacts:
+        pytest.skip("the frozen, gitignored Layer-B corpus is unavailable in this checkout")
+
+    rows = [
+        (path, artifact, fact_check)
+        for path, artifact in artifacts
+        for fact_check in _artifact_fact_checks(artifact)
+        if isinstance(fact_check, dict) and isinstance(fact_check.get("grounding"), dict)
+    ]
+    lineages = [
+        _extract_lineages(artifact, fact_check, fact_check["grounding"], artifact_path=path)
+        for path, artifact, fact_check in rows
+    ]
+
+    assert len(rows) == 1310
+    assert all(writer is not None and reviewer is not None for writer, reviewer in lineages)
+    assert Counter(writer for writer, _reviewer in lineages) == {"deepseek": 892, "google": 418}
 
 
 def test_b2_rejects_incompatible_claim_number_without_deterministic_entailment(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Corrects stored-grounding lineage so QG reviewer identity is never recorded as the content writer.
- Keeps judged replay fail-closed for missing writer or reviewer lineage.
- Leaves frozen bakeoff artifacts unchanged.

## Root cause

The prior derivation incorrectly treated the QG bakeoff seat, arm, model, and filename as writer provenance. In this corpus those identify the QG reviewer under test; the fixture content is what that reviewer evaluated. That made the route exclusion set coincidentally correct for the current corpus but wrote false writer lineage into attestation records.

## Corrected lineage ruling

- Writer: normalize only explicit writer-specific fields. If those are absent and the artifact has mapping-valued fixture metadata, record writer_family as the non-model sentinel fixture. Otherwise record null and fail closed.
- Fixture rationale: fixture content is synthetic hand-crafted content or a source_module_dir copy, with no model writer recorded. The fixture sentinel therefore excludes no judge family: the third-family requirement protects against model self-preference, which these human or synthetic fixtures do not have.
- Reviewer: use dispatch.reviewer_family or dispatch.reviewer_model_id first, then retained explicit QG reviewer fields, with model as the reviewer-seat fallback.
- Writer derivation never uses seat_arm, seat, model, or the artifact filename.

## Frozen-corpus evidence and route eligibility

Read-only derivation over audit/2026-07-06-qg-bakeoff-multirun resolves all 1,310 rows:

- writer: fixture 1,310
- stored QG reviewer: deepseek 892; google 418

Consequently, Gemini is eligible to judge rows reviewed by DeepSeek, and Claude plus GPT are eligible on all rows. The fixture writer sentinel itself excludes no judge family; only the reviewer family applies to this corpus.

## Validation

- .venv/bin/ruff check scripts/audit/layerb_shadow.py tests/test_layerb_shadow.py
- .venv/bin/ruff format --check scripts/audit/layerb_shadow.py tests/test_layerb_shadow.py
- .venv/bin/pytest -q tests/test_layerb_shadow.py tests/test_layerb_label_tools.py: 45 passed
- Commit pre-commit hook: affected tests 23 passed; ruff, gitleaks, and repository guards passed
- .venv/bin/python scripts/audit/lint_agent_trailer.py: 2/2 commits passed
- Independent Claude Opus 4.6 cross-family review: APPROVE, no findings. Gemini was unavailable locally because its OAuth credentials were absent, so Claude was used as the documented cross-family fallback.

## Handoff

The PR remains draft by design. Do not enable auto-merge.

Refs #4913