### PR TITLE
fix(atlas): conformance gate counts marked_forms as renderable morphology (red-main unblock)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,12 @@ jobs:
               # test_source_inventory_intake::test_committed_source_inventory_files_are_valid
               # globs every file here — data-only edits must run pytest too.
               - 'data/lexicon/source-inventory/**'
+              # Same class again (2026-07-10, #4936 — 3rd manifestation after
+              # #3873/#4888): test_atlas_conformance reads the committed Atlas
+              # manifest; a data(atlas) publish PR skipped pytest and turned
+              # main red for every subsequent code PR.
+              - 'site/src/data/lexicon-manifest.json'
+              - 'site/src/data/lexicon-manifest.fingerprint.json'
             frontend:
               - '.github/workflows/ci.yml'
               - 'site/**'

--- a/scripts/audit/validate_atlas_conformance.py
+++ b/scripts/audit/validate_atlas_conformance.py
@@ -544,7 +544,16 @@ def _section_has_content(section_name: str, section: object) -> bool:
     if section_name == "meaning":
         return _definitions_have_content(section.get("definitions"))
     if section_name == "morphology":
-        return _list_has_content(section.get("forms")) or _mapping_has_content(section.get("paradigm"))
+        # marked_forms are renderable content: WordAtlasArticle.astro renders
+        # style/register-marked forms in their own subsection (#4891), so a
+        # marked-forms-only morphology (VESUM has no unmarked modern paradigm —
+        # slang/variant lemmas like «баг») is NOT an empty section. Gate went
+        # stale when #4891 added the renderer; detonated on the #4936 publish.
+        return (
+            _list_has_content(section.get("forms"))
+            or _mapping_has_content(section.get("paradigm"))
+            or _list_has_content(section.get("marked_forms"))
+        )
     if section_name == "definition_cards":
         return False
     if section_name == "etymology":

--- a/tests/test_atlas_conformance.py
+++ b/tests/test_atlas_conformance.py
@@ -225,6 +225,51 @@ def test_section_omitted_not_empty_flags_empty_section():
     assert _gates_for(entry) == ["section_omitted_not_empty"]
 
 
+def test_morphology_marked_forms_only_is_renderable_content():
+    """#4891 renders marked_forms in their own subsection: a marked-forms-only
+    morphology (VESUM has no unmarked modern paradigm — slang/variant lemmas
+    like «баг») must NOT flag section_omitted_not_empty. Detonated on the
+    #4936 publish (29 lemmas, red main)."""
+    entry = _entry(
+        enrichment={
+            "morphology": {
+                "pos": "іменник",
+                "form_count": 0,
+                "forms": [],
+                "source": "VESUM",
+                "marked_forms": [
+                    {
+                        "form": "багові",
+                        "label": "чол., давальний",
+                        "marker": "slang",
+                        "marker_label": "сленгова форма",
+                    }
+                ],
+            }
+        }
+    )
+
+    assert _gates_for(entry) == []
+
+
+def test_morphology_all_form_containers_empty_still_flags():
+    """Truly empty morphology (forms, paradigm, AND marked_forms empty) keeps
+    failing the gate — the marked-forms allowance must not fail-open."""
+    entry = _entry(
+        enrichment={
+            "morphology": {
+                "pos": "іменник",
+                "form_count": 0,
+                "forms": [],
+                "marked_forms": [],
+                "source": "VESUM",
+            }
+        }
+    )
+
+    assert _gates_for(entry) == ["section_omitted_not_empty"]
+
+
 def test_synonyms_section_requires_source_and_items():
     entry = _entry(
         sections={


### PR DESCRIPTION
**Main is RED at b9a3163823** — `test_real_lexicon_manifest_conforms_to_atlas_gates` fails with 29 `section_omitted_not_empty` violations, blocking every code PR behind the CI Gate (#4942 already hit it).

## Root cause
- #4891 added the marked-forms renderer + updated `audit_atlas_poc_richness` (counts `marked_forms` as content) but `validate_atlas_conformance._section_has_content` still required `forms`/`paradigm`.
- The #4936 atlas publish shipped 29 marked-forms-only lemmas (VESUM covers slang/variant lemmas only with markers).
- #4936 was a data-only PR: the manifest path was in the `frontend` CI filter but NOT `python` → pytest skipped → landmine detonated on the next code PR. **3rd manifestation of the #3873/#4888 class.**

## Fix (both layers)
1. Gate predicate: `marked_forms` with content = renderable morphology (mirrors the renderer + richness auditor). Fail-open guarded: all-containers-empty still flags.
2. Systemic: `python` CI filter gains `site/src/data/lexicon-manifest{,.fingerprint}.json`.

## Evidence (my runs)
- `tests/test_atlas_conformance.py`: **32 passed, 1 skipped** — including the real-manifest test that is red on main, plus 2 new regression tests.
- ruff clean. Sibling sweep: richness auditor already counts marked_forms; no other stale predicate.

Unblocks: #4942, #4931 merge train. Atlas lane notified.

Refs #4891 #4936 #4387

🤖 Generated with [Claude Code](https://claude.com/claude-code)