### PR TITLE
fix(practice): resolve atlas deep-links by lemma; bilingual fallbacks; no false load-error (Fixes #4946)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 1891e707363e1235febffb2679ddc25279457eb4615a7c2072f2b1026fd15145
+  components_sha256: ce1099110a99f6a7f538e25642902a4e321056294ac8be58efa1d843931c40cb
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -108,6 +108,13 @@ const STREAK_KEY = 'lu-lexicon-practice-streak';
 const MASTERED_THRESHOLD = 21;
 type SessionPhase = 'idle' | 'active' | 'summary';
 
+const PRACTICE_LOAD_ERROR_UK = 'Не вдалося завантажити практику.';
+const PRACTICE_LOAD_ERROR_EN = 'We couldn’t load practice.';
+const PRACTICE_RETRY_UK = 'Спробувати ще раз';
+const PRACTICE_RETRY_EN = 'Try again';
+const PRACTICE_POOL_MISS_UK = 'Це слово ще не в тренажері.';
+const PRACTICE_POOL_MISS_EN = 'This word is not in the practice pool yet.';
+
 const SESSION_LABELS_A1: Record<string, string> = {
   startSession: 'Start session',
   continueSession: 'Continue session',
@@ -802,6 +809,30 @@ function mergeDecks(decks: PracticeDeckData[], level: CefrLevel): PracticeDeckDa
   return extendWithLowerDecks(base, rest);
 }
 
+/** Resolve either a practice item id or the bare lemma that Atlas links provide. */
+function resolvePracticeIndexItem(
+  index: PracticeIndexItem[],
+  target: string,
+): PracticeIndexItem | null {
+  const normalizedTarget = czNorm(target);
+  if (!normalizedTarget) return null;
+
+  return (
+    [...index]
+      .reverse()
+      .find((item) => item.lemmaId === target || czNorm(item.lemma) === normalizedTarget) ?? null
+  );
+}
+
+function BilingualPracticeMessage({ uk, en }: { uk: string; en: string }) {
+  return (
+    <>
+      <span lang="uk">{uk}</span>{' '}
+      <span lang="en">/ {en}</span>
+    </>
+  );
+}
+
 /** Deduped fetch for a practice shard JSON by URL. Concurrent or repeated callers share the promise. */
 async function getShardJson<T>(url: string, cache: Map<string, Promise<unknown>>): Promise<T> {
   let p = cache.get(url) as Promise<T> | undefined;
@@ -862,6 +893,7 @@ function LexiconPracticeIsland({
     readLearnerLevel(normalizeCefrLevel(deckLevel)),
   );
   const [focusedLemmaId, setFocusedLemmaId] = useState<string | null>(null);
+  const [focusLookupMiss, setFocusLookupMiss] = useState(false);
   // §6b weak-area focus: when set, the session poolFilter is narrowed to this weakness.
   const [focusWeakness, setFocusWeakness] = useState<WeakArea | null>(null);
   const [reviewLog, setReviewLog] = useState<ReviewLogEntry[]>([]);
@@ -951,15 +983,11 @@ function LexiconPracticeIsland({
       const params = new URLSearchParams(window.location.search);
       const target = params.get('lemmaId');
       if (target) {
-        // Clear snapshot and resume state
+        // Keep #4744's single reactive auto-start path: initialize the resolved focus,
+        // then let the focusedLemmaId effect below create the session exactly once.
         writePracticeSessionSnapshot(null);
         setResumeSnapshot(null);
-
-        setFocusedLemmaId(target);
-        setMode('mixed');
-        setSessionBudget(10);
-        setSessionPhase('active');
-        void ensureDeck(shouldLoadCloze('mixed'));
+        void initializeFocusedPractice(target);
       } else {
         const snapshot = readPracticeSessionSnapshot();
         setResumeSnapshot(isPracticeSessionResumable(snapshot) ? snapshot : null);
@@ -1375,11 +1403,75 @@ function LexiconPracticeIsland({
       return nextDeck!;
     } catch {
       if (deckRequestId.current === requestId) {
-        setError('Не вдалося завантажити колоду для практики.');
+        setError(PRACTICE_LOAD_ERROR_UK);
       }
       return null;
     } finally {
       if (deckRequestId.current === requestId) setLoading(false);
+    }
+  }
+
+  async function initializeFocusedPractice(target: string) {
+    setLoading(true);
+    setError(null);
+    setFocusLookupMiss(false);
+
+    try {
+      const initialDeck = deck;
+      const initialMatch = initialDeck
+        ? resolvePracticeIndexItem(initialDeck.index, target)
+        : null;
+      let matchedIndexItem = initialMatch;
+      if (!matchedIndexItem) {
+        const indexShards = await Promise.all(
+          levelsUpTo(learnerLevel).map((level) =>
+            getShardJson<PracticeIndexShard>(
+              `${shardBaseUrl}/practice-index.${level}.json`,
+              shardJsonCacheRef.current,
+            ),
+          ),
+        );
+        matchedIndexItem = resolvePracticeIndexItem(
+          indexShards.flatMap((shard) => shard.items ?? []),
+          target,
+        );
+      }
+
+      if (!matchedIndexItem) {
+        setFocusedLemmaId(null);
+        setFocusLookupMiss(true);
+        setSessionPhase('idle');
+        return;
+      }
+
+      // The cumulative index is small. Load only the resolved level's core deck next,
+      // retaining the progressive lower-level loading strategy for practice content.
+      const matchedLevel = normalizeCefrLevel(matchedIndexItem.cefr, learnerLevel);
+      const loadedDeck = initialMatch
+        ? initialDeck
+        : await ensureDeck(shouldLoadCloze('mixed'), { level: matchedLevel, force: true });
+      if (!loadedDeck) return;
+
+      const resolvedItem = resolvePracticeIndexItem(loadedDeck.index, target);
+      if (!resolvedItem) {
+        // An index/lexeme deploy mismatch is a real data-load fault, not a word that
+        // simply is not in the learner's available practice pool.
+        setError(PRACTICE_LOAD_ERROR_UK);
+        setSessionPhase('idle');
+        return;
+      }
+
+      setFocusedLemmaId(resolvedItem.lemmaId);
+      setMode('mixed');
+      setSessionBudget(10);
+      setSessionPhase('active');
+    } catch {
+      // Only request failures reach the load fallback. A completed lookup miss remains
+      // a usable hub with a concise bilingual notice.
+      setError(PRACTICE_LOAD_ERROR_UK);
+      setSessionPhase('idle');
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -1455,6 +1547,7 @@ function LexiconPracticeIsland({
     setMode(nextMode);
     setSessionBudget(budget);
     setError(null);
+    setFocusLookupMiss(false);
     let loadedDeck = await ensureDeck(shouldLoadCloze(nextMode));
     if (!loadedDeck) return;
     if (focusedLemmaId) {
@@ -1564,6 +1657,7 @@ function LexiconPracticeIsland({
 
   function clearFocus() {
     setFocusedLemmaId(null);
+    setFocusLookupMiss(false);
     setFocusWeakness(null);
     setDeck(null);
     setDueIndex(null);
@@ -1854,6 +1948,12 @@ function LexiconPracticeIsland({
 
       {storageWarning && <p className="lexicon-practice-warning">{storageWarning}</p>}
 
+      {focusLookupMiss && (
+        <p className="lexicon-practice-warning" role="status" data-testid="practice-lemma-missing">
+          <BilingualPracticeMessage uk={PRACTICE_POOL_MISS_UK} en={PRACTICE_POOL_MISS_EN} />
+        </p>
+      )}
+
       {sessionPhase === 'idle' && (
         <div className="lexicon-practice-home">
           {focusedLemmaId && (
@@ -2086,9 +2186,12 @@ function LexiconPracticeIsland({
       {loading && <p className="lexicon-practice-muted">Завантажуємо…</p>}
       {error && (
         <div className="lexicon-practice-fallback" data-testid="practice-fetch-error">
-          <p className="lexicon-practice-warning">{error}</p>
+          <p className="lexicon-practice-warning">
+            <BilingualPracticeMessage uk={error} en={PRACTICE_LOAD_ERROR_EN} />
+          </p>
           <button type="button" className="btn btn-accent" onClick={() => window.location.reload()}>
-            Спробувати ще раз
+            <span lang="uk">{PRACTICE_RETRY_UK}</span>{' '}
+            <span className="btn-sub" lang="en">{PRACTICE_RETRY_EN}</span>
           </button>
         </div>
       )}

--- a/site/src/components/PracticeErrorBoundary.tsx
+++ b/site/src/components/PracticeErrorBoundary.tsx
@@ -27,10 +27,12 @@ export default class PracticeErrorBoundary extends Component<
       return (
         <div className="lexicon-practice-fallback" role="alert" data-testid="practice-error-fallback">
           <p className="lexicon-practice-warning">
-            Не вдалося завантажити практику. Спробуйте оновити сторінку.
+            <span lang="uk">Не вдалося завантажити практику. Спробуйте оновити сторінку.</span>{' '}
+            <span lang="en">/ We couldn’t load practice. Try reloading the page.</span>
           </p>
           <button type="button" className="btn btn-accent" onClick={() => window.location.reload()}>
-            Спробувати ще раз
+            <span lang="uk">Спробувати ще раз</span>{' '}
+            <span className="btn-sub" lang="en">Try again</span>
           </button>
         </div>
       );

--- a/site/src/lexicon/LexiconPracticeMount.astro
+++ b/site/src/lexicon/LexiconPracticeMount.astro
@@ -7,8 +7,14 @@ import LexiconPractice from '../components/LexiconPractice';
 </div>
 
 <div id="lexicon-practice-fallback" class="lexicon-practice-fallback" hidden>
-  <p>Не вдалося завантажити практику.</p>
-  <button type="button" onclick="location.reload()">Спробувати ще раз</button>
+  <p>
+    <span lang="uk">Не вдалося завантажити практику.</span>
+    <span lang="en">/ We couldn’t load practice.</span>
+  </p>
+  <button type="button" onclick="location.reload()">
+    <span lang="uk">Спробувати ще раз</span>
+    <span class="btn-sub" lang="en">Try again</span>
+  </button>
 </div>
 
 <script is:inline>

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -3,6 +3,7 @@ import { State } from 'ts-fsrs';
 import { act, render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LexiconPractice from '@site/src/components/LexiconPractice';
+import PracticeErrorBoundary from '@site/src/components/PracticeErrorBoundary';
 import {
   SRS_STORAGE_KEY,
   cardKey,
@@ -18,6 +19,10 @@ import {
 import { LEARNER_LEVEL_STORAGE_KEY, type CefrLevel } from '@site/src/lib/lexicon/levels';
 
 const NOW = new Date('2026-06-23T12:00:00.000Z');
+
+function ThrowPracticeError(): never {
+  throw new Error('practice render failed');
+}
 
 function okJson(body: unknown): Response {
   return { ok: true, json: async () => body } as unknown as Response;
@@ -463,6 +468,21 @@ beforeEach(() => {
 });
 
 describe('LexiconPractice', () => {
+  test('practice render fallback is bilingual', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    render(
+      <PracticeErrorBoundary>
+        <ThrowPracticeError />
+      </PracticeErrorBoundary>,
+    );
+
+    const fallback = screen.getByTestId('practice-error-fallback');
+    expect(fallback).toHaveTextContent('Не вдалося завантажити практику. Спробуйте оновити сторінку.');
+    expect(fallback).toHaveTextContent('We couldn’t load practice. Try reloading the page.');
+    expect(screen.getByRole('button', { name: /Спробувати ще раз\s*Try again/ })).toBeInTheDocument();
+  });
+
   test('eager-loads only the index (not lexemes/cloze) before a mode starts', async () => {
     const { fn, requested } = mockShardFetch({ A1: 2 });
     vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
@@ -831,10 +851,10 @@ describe('LexiconPractice', () => {
     expect(link).toHaveAttribute('href', '/lexicon/dim/');
   });
 
-  test('focus deep-link: deck filtered to the lemma, no double session start', async () => {
+  test('focus deep-link: a bare Atlas lemma resolves to its item with no double session start', async () => {
     const originalSearch = window.location.search;
     delete (window as any).location;
-    window.location = new URL('http://localhost/lexicon/practice/?lemmaId=dim') as any;
+    window.location = new URL('http://localhost/lexicon/practice/?lemmaId=%D0%B4%D1%96%D0%BC') as any;
 
     try {
       const setItemSpy = vi.spyOn(localStorage, 'setItem');
@@ -869,6 +889,149 @@ describe('LexiconPractice', () => {
       expect(startedSnapshot.budget).toBe(10);
     } finally {
       window.location = new URL('http://localhost/') as any;
+      vi.restoreAllMocks();
+    }
+  });
+
+  test('bare in-pool Atlas lemma opens that lemma’s practice', async () => {
+    const originalSearch = window.location.search;
+    delete (window as any).location;
+    window.location = new URL('http://localhost/words-of-the-day/practice/?lemmaId=%D0%BA%D0%B0%D1%84%D0%B5') as any;
+
+    try {
+      const cafe = lexeme('kafe', 'кафе', 'cafe', {
+        nominative: 'кафе',
+        accusative: 'кафе',
+        locative: 'кафе',
+      });
+      const book = lexeme('knyha', 'книга', 'book', {
+        nominative: 'книга',
+        accusative: 'книгу',
+        locative: 'книзі',
+      });
+      const deck: PracticeDeckData = {
+        deckVersion: 'test-atlas-lemma',
+        level: 'A1',
+        lexemes: [cafe, book],
+        index: [cafe, book].map((entry, newOrder) => ({
+          lemmaId: entry.lemmaId,
+          lemma: entry.lemma,
+          cefr: 'A1',
+          modes: ['flashcards'],
+          hasCloze: false,
+          clozeIds: [],
+          newOrder,
+        })),
+        cloze: [],
+      };
+
+      render(<LexiconPractice initialDeck={deck} autoStart={false} />);
+
+      expect(
+        await screen.findByRole('button', { name: /кафе.*натисніть, щоб перевернути/ }),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /книга.*натисніть, щоб перевернути/ })).not.toBeInTheDocument();
+    } finally {
+      window.location = new URL(originalSearch ? `http://localhost${originalSearch}` : 'http://localhost/') as any;
+    }
+  });
+
+  test('bare Atlas lemma outside the initial deck resolves from cumulative shards', async () => {
+    const originalSearch = window.location.search;
+    delete (window as any).location;
+    window.location = new URL('http://localhost/words-of-the-day/practice/?lemmaId=%D0%BA%D0%B0%D1%84%D0%B5') as any;
+    localStorage.setItem(LEARNER_LEVEL_STORAGE_KEY, 'B1');
+
+    try {
+      const cafe = lexeme('kafe', 'кафе', 'cafe', {
+        nominative: 'кафе',
+        accusative: 'кафе',
+        locative: 'кафе',
+      });
+      const requested: string[] = [];
+      const fn = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        requested.push(url);
+        const match = url.match(
+          /practice-(index|lexemes|cloze|stress|classify|paradigm|synonym|heritage)\.([ABC][12])\.json/,
+        );
+        if (!match) return notFoundResponse();
+        const kind = match[1];
+        const level = match[2] as CefrLevel;
+        if (kind === 'index') {
+          return okJson({
+            deckVersion: `v-${level}`,
+            level,
+            items: level === 'A1'
+              ? [{ lemmaId: cafe.lemmaId, lemma: cafe.lemma, cefr: 'A1', modes: ['flashcards'], hasCloze: false, clozeIds: [], newOrder: 0 }]
+              : [],
+          });
+        }
+        if (kind === 'lexemes') {
+          return okJson({ deckVersion: `v-${level}`, level, lexemes: level === 'A1' ? [cafe] : [] });
+        }
+        return okJson({ [kind]: [] });
+      });
+      vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+
+      render(<LexiconPractice initialDeck={sampleDeck()} autoStart={false} />);
+
+      expect(
+        await screen.findByRole('button', { name: /кафе.*натисніть, щоб перевернути/ }),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId('practice-lemma-missing')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('practice-fetch-error')).not.toBeInTheDocument();
+      expect(requested.filter((url) => url.includes('practice-index.A1.json'))).toHaveLength(1);
+      expect(requested.filter((url) => url.includes('practice-lexemes.A1.json'))).toHaveLength(1);
+    } finally {
+      window.location = new URL(originalSearch ? `http://localhost${originalSearch}` : 'http://localhost/') as any;
+      vi.restoreAllMocks();
+    }
+  });
+
+  test('out-of-pool Atlas lemma keeps the hub usable without retrying its lookup', async () => {
+    const originalSearch = window.location.search;
+    delete (window as any).location;
+    window.location = new URL('http://localhost/words-of-the-day/practice/?lemmaId=%D0%BF%D0%BE%D0%B7%D0%B0%D0%BF%D1%83%D0%BB%D0%BE%D0%BC') as any;
+
+    try {
+      const user = userEvent.setup();
+      const { fn, requested } = mockShardFetch({ A1: 2 });
+      vi.spyOn(globalThis, 'fetch').mockImplementation(fn);
+
+      render(<LexiconPractice />);
+
+      const notice = await screen.findByTestId('practice-lemma-missing');
+      expect(notice).toHaveTextContent('Це слово ще не в тренажері.');
+      expect(notice).toHaveTextContent('This word is not in the practice pool yet.');
+      expect(screen.queryByTestId('practice-fetch-error')).not.toBeInTheDocument();
+      await user.click(screen.getByTestId('practice-start-session'));
+      expect(await screen.findByTestId('practice-session-progress')).toHaveTextContent('0/6');
+      expect(screen.queryByTestId('practice-fetch-error')).not.toBeInTheDocument();
+      expect(requested.filter((url) => url.includes('practice-index.A1.json'))).toHaveLength(1);
+      expect(requested.filter((url) => url.includes('practice-lexemes.A1.json'))).toHaveLength(1);
+    } finally {
+      window.location = new URL(originalSearch ? `http://localhost${originalSearch}` : 'http://localhost/') as any;
+      vi.restoreAllMocks();
+    }
+  });
+
+  test('a real deep-link fetch failure renders bilingual practice fallback', async () => {
+    const originalSearch = window.location.search;
+    delete (window as any).location;
+    window.location = new URL('http://localhost/words-of-the-day/practice/?lemmaId=%D0%BA%D0%B0%D1%84%D0%B5') as any;
+
+    try {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network offline'));
+
+      render(<LexiconPractice />);
+
+      const fallback = await screen.findByTestId('practice-fetch-error');
+      expect(fallback).toHaveTextContent('Не вдалося завантажити практику.');
+      expect(fallback).toHaveTextContent('We couldn’t load practice.');
+      expect(screen.getByRole('button', { name: /Спробувати ще раз\s*Try again/ })).toBeInTheDocument();
+    } finally {
+      window.location = new URL(originalSearch ? `http://localhost${originalSearch}` : 'http://localhost/') as any;
       vi.restoreAllMocks();
     }
   });


### PR DESCRIPTION
## Summary

- Resolve Atlas `?lemmaId=` links by bare Ukrainian lemma across cumulative practice-index shards, while preserving #4744’s reactive single-start path.
- Treat a completed lookup miss as a usable hub with the required bilingual pool notice; reserve the load fallback for real request failures.
- Make all practice fallback/retry surfaces bilingual and add regression coverage for in-pool, cumulative-initial-deck, out-of-pool, fetch-failure, and render-boundary paths.

## Root cause

Atlas passes a bare lemma such as `кафе`, whereas practice cards are keyed by a slug/id such as `kafe`. The previous initialization installed the raw value as the focus id and exact-filtered the deck, turning a lookup mismatch into an apparent load failure.

## Validation

- `site/`: `npx vitest run tests/unit/LexiconPractice.test.tsx` — **47 passed**, exit 0.
- `site/`: `npx tsc --noEmit` — exits 2 on pre-existing workspace diagnostics: unresolved React types under `packages/activity-kit`, missing `@site/src/data/lexicon-manifest.json`, and an unrelated `hydrate-practice-deck` fixture type mismatch. No changed file is named.
- Pre-commit gates and `scripts/audit/lint_agent_trailer.py` passed. The schema gate required the included one-line `docs/lesson-schema.yaml` fingerprint refresh.

## Review

Independent cross-family implementation review via AGY / Gemini 3.1 Pro: initial block (initial-deck cumulative lookup gap) fixed; re-gate **APPROVE**. Atlas driver retains the final gate. Auto-merge is intentionally not enabled.

Fixes #4946
