### PR TITLE
fix(practice): clear stale load-error when the deep-link init ultimately succeeds (Refs #4946)

### DIFF
--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: ce1099110a99f6a7f538e25642902a4e321056294ac8be58efa1d843931c40cb
+  components_sha256: 48b22a075b262d3dbf4f770a32cd148f8b9adf386ea9d84d539f43135ba30002
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -1254,7 +1254,10 @@ function LexiconPracticeIsland({
     const level = options.level ?? learnerLevel;
     const force = options.force ?? false;
     const current = force ? null : deck;
-    if (current && (!includeCloze || clozeLoaded)) return current;
+    if (current && (!includeCloze || clozeLoaded)) {
+      setError(null);
+      return current;
+    }
     const requestId = ++deckRequestId.current;
     setLoading(true);
     setError(null);
@@ -1400,6 +1403,7 @@ function LexiconPracticeIsland({
       if (deckRequestId.current !== requestId) return nextDeck!;
       setDeck(nextDeck!);
       setClozeLoaded(nextClozeLoaded);
+      setError(null);
       return nextDeck!;
     } catch {
       if (deckRequestId.current === requestId) {
@@ -1447,9 +1451,14 @@ function LexiconPracticeIsland({
       // The cumulative index is small. Load only the resolved level's core deck next,
       // retaining the progressive lower-level loading strategy for practice content.
       const matchedLevel = normalizeCefrLevel(matchedIndexItem.cefr, learnerLevel);
-      const loadedDeck = initialMatch
+      let loadedDeck = initialMatch
         ? initialDeck
         : await ensureDeck(shouldLoadCloze('mixed'), { level: matchedLevel, force: true });
+      if (!loadedDeck && !initialMatch) {
+        // A failed shared shard promise is evicted by getShardJson. Retry the focused
+        // deck once so a transient init failure cannot outlive the successful exercise.
+        loadedDeck = await ensureDeck(shouldLoadCloze('mixed'), { level: matchedLevel, force: true });
+      }
       if (!loadedDeck) return;
 
       const resolvedItem = resolvePracticeIndexItem(loadedDeck.index, target);
@@ -1461,6 +1470,7 @@ function LexiconPracticeIsland({
         return;
       }
 
+      setError(null);
       setFocusedLemmaId(resolvedItem.lemmaId);
       setMode('mixed');
       setSessionBudget(10);
@@ -2184,7 +2194,7 @@ function LexiconPracticeIsland({
       )}
 
       {loading && <p className="lexicon-practice-muted">Завантажуємо…</p>}
-      {error && (
+      {error && !selection && (
         <div className="lexicon-practice-fallback" data-testid="practice-fetch-error">
           <p className="lexicon-practice-warning">
             <BilingualPracticeMessage uk={error} en={PRACTICE_LOAD_ERROR_EN} />

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -931,8 +931,69 @@ describe('LexiconPractice', () => {
         await screen.findByRole('button', { name: /кафе.*натисніть, щоб перевернути/ }),
       ).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /книга.*натисніть, щоб перевернути/ })).not.toBeInTheDocument();
+      expect(screen.queryByTestId('practice-fetch-error')).not.toBeInTheDocument();
     } finally {
       window.location = new URL(originalSearch ? `http://localhost${originalSearch}` : 'http://localhost/') as any;
+    }
+  });
+
+  test('focused deep link clears a transient deck-load error after its retry renders the exercise', async () => {
+    const originalSearch = window.location.search;
+    delete (window as any).location;
+    window.location = new URL('http://localhost/words-of-the-day/practice/?lemmaId=%D0%BA%D0%B0%D1%84%D0%B5') as any;
+
+    try {
+      const cafe = lexeme('kafe', 'кафе', 'cafe', {
+        nominative: 'кафе',
+        accusative: 'кафе',
+        locative: 'кафе',
+      });
+      let failFirstLexemeRequest = true;
+      const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        const match = url.match(
+          /practice-(index|lexemes|cloze|stress|classify|paradigm|synonym|heritage)\.([ABC][12])\.json/,
+        );
+        if (!match || match[2] !== 'A1') return notFoundResponse();
+        const kind = match[1];
+        if (kind === 'index') {
+          return okJson({
+            deckVersion: 'v-A1',
+            level: 'A1',
+            items: [{
+              lemmaId: cafe.lemmaId,
+              lemma: cafe.lemma,
+              cefr: 'A1',
+              modes: ['flashcards'],
+              hasCloze: false,
+              clozeIds: [],
+              newOrder: 0,
+            }],
+          });
+        }
+        if (kind === 'lexemes') {
+          if (failFirstLexemeRequest) {
+            failFirstLexemeRequest = false;
+            throw new Error('transient lexeme failure');
+          }
+          return okJson({ deckVersion: 'v-A1', level: 'A1', lexemes: [cafe] });
+        }
+        return okJson({ [kind]: [] });
+      });
+      vi.spyOn(globalThis, 'fetch').mockImplementation(fetchMock);
+
+      render(<LexiconPractice autoStart={false} />);
+
+      expect(
+        await screen.findByRole('button', { name: /кафе.*натисніть, щоб перевернути/ }),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId('practice-fetch-error')).not.toBeInTheDocument();
+      expect(
+        fetchMock.mock.calls.filter(([url]) => String(url).includes('practice-lexemes.A1.json')),
+      ).toHaveLength(2);
+    } finally {
+      window.location = new URL(originalSearch ? `http://localhost${originalSearch}` : 'http://localhost/') as any;
+      vi.restoreAllMocks();
     }
   });
 


### PR DESCRIPTION
## Summary

- Clear a stale practice load error after a successful cached deck, focused deck, or resolved focused exercise.
- Retry one transient focused deck load after the rejected shard promise is evicted.
- Suppress the ordinary fetch fallback whenever an exercise selection is mounted.
- Add deep-link coverage for the happy path, transient failure → success, and retain total-failure coverage.

## Root cause

The focused initializer could retain `error` from an earlier failed deck request after a later successful load activated the exercise. The fallback rendered solely from that stale state, independently of exercise content.

## Validation

- `site/`: `npx vitest run tests/unit/LexiconPractice.test.tsx` — **48 passed**, exit 0.
- `site/`: `npx tsc --noEmit` — exit 2 only from pre-existing workspace diagnostics in `packages/activity-kit` (missing React type resolution) plus unrelated `atlas-db-read` manifest and `hydrate-practice-deck` fixture diagnostics; neither changed file is named.
- Pre-commit gates, schema-drift fingerprint, `git diff --check`, and `.venv/bin/python scripts/audit/lint_agent_trailer.py` passed.

## Review

Independent cross-family review: Grok Build approved the exact diff. Gemini review was unavailable because local Gemini OAuth configuration is absent; the initial DeepSeek fallback stalled at its 60-second startup timeout, then Grok Build completed the replacement review.

No auto-merge has been enabled. Driver owns the final gate.

Refs #4946