### PR TITLE
fix(guardrails): restore stripped-flavor imports broken by the #4931 relocation (dispatch lane down)

### DIFF
--- a/scripts/audit/decision_lineage.py
+++ b/scripts/audit/decision_lineage.py
@@ -14,7 +14,13 @@ from typing import Any
 
 import yaml
 
-from scripts.common.git_context import sanitized_git_env
+# Dual-flavor import: audit modules are importable as ``audit.*`` with only
+# ``scripts/`` on sys.path — keep both flavors resolvable (cf. #4931 fallout
+# in guardrails.worktree_containment).
+try:
+    from scripts.common.git_context import sanitized_git_env
+except ImportError:  # scripts/ on sys.path (stripped flavor)
+    from common.git_context import sanitized_git_env  # type: ignore[no-redef]
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 DECISIONS_DIR = Path("docs/decisions")

--- a/scripts/guardrails/worktree_containment.py
+++ b/scripts/guardrails/worktree_containment.py
@@ -40,7 +40,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-from scripts.common.git_context import GIT_REDIRECT_ENV_KEYS, sanitized_git_env
+# Dual-flavor import: the delegate worker and build entrypoints put only
+# ``scripts/`` on sys.path and import this module as
+# ``guardrails.worktree_containment`` — a hard ``scripts.*`` import there
+# broke every write-capable dispatch spawn (fail-closed refusal) after the
+# #4931 relocation. Keep both flavors resolvable.
+try:
+    from scripts.common.git_context import GIT_REDIRECT_ENV_KEYS, sanitized_git_env
+except ImportError:  # scripts/ on sys.path (stripped flavor)
+    from common.git_context import GIT_REDIRECT_ENV_KEYS, sanitized_git_env  # type: ignore[no-redef]
 
 __all__ = [
     "PROTECTED_BRANCHES",

--- a/scripts/path_safety.py
+++ b/scripts/path_safety.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from scripts.common.release_layout import LIVE_DATA_PATHS, MANIFEST_NAME, is_release_root
+# Dual-flavor import: several consumers load this module as top-level
+# ``path_safety`` with only ``scripts/`` on sys.path (test sys.path-hack,
+# build entrypoints) — a hard ``scripts.*`` import breaks that flavor.
+try:
+    from scripts.common.release_layout import LIVE_DATA_PATHS, MANIFEST_NAME, is_release_root
+except ImportError:  # scripts/ on sys.path (stripped flavor)
+    from common.release_layout import LIVE_DATA_PATHS, MANIFEST_NAME, is_release_root  # type: ignore[no-redef]
 
 
 def _validate_component(value: str) -> None:

--- a/tests/test_stripped_flavor_imports.py
+++ b/tests/test_stripped_flavor_imports.py
@@ -1,0 +1,59 @@
+"""Pin the stripped-flavor import contract (#4444 spawn guard, #4931 fallout).
+
+The delegate worker and build entrypoints put only ``scripts/`` on sys.path
+and import shared modules WITHOUT the ``scripts.`` prefix (e.g.
+``guardrails.worktree_containment``, ``path_safety``, ``audit.*``). A hard
+``from scripts...`` import inside any of those modules breaks that flavor —
+which broke every write-capable dispatch spawn (fail-closed refusal in
+``agent_runtime.runner._ensure_write_cwd_isolated``) after the #4931
+relocation of ``git_context``/``release_layout`` into ``scripts/common/``.
+
+These tests import the stripped flavors in a subprocess whose sys.path
+contains ONLY the stdlib/site-packages and ``scripts/`` — exactly the worker
+environment — so a future hard ``scripts.*`` import fails here first.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+
+STRIPPED_MODULES = (
+    "guardrails.worktree_containment",
+    "path_safety",
+    "audit.decision_lineage",
+    "common.git_context",
+    "common.release_layout",
+)
+
+
+@pytest.mark.parametrize("module_name", STRIPPED_MODULES)
+def test_module_imports_with_only_scripts_on_sys_path(module_name: str) -> None:
+    probe = (
+        "import sys\n"
+        # Drop the repo root and any cwd-derived entries; keep stdlib AND
+        # site-packages (the venv lives under the repo, so filter by name).
+        "sys.path = [p for p in sys.path if p and ('learn-ukrainian' not in p or 'site-packages' in p)]\n"
+        f"sys.path.insert(0, {str(SCRIPTS_DIR)!r})\n"
+        f"import importlib; importlib.import_module({module_name!r})\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        cwd="/",  # never let the repo-root cwd leak onto sys.path
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"stripped-flavor import of {module_name!r} failed — this breaks the "
+        f"delegate worker's write-capable spawn guard (fail-closed refusal):\n"
+        f"{result.stderr}"
+    )
+    assert result.stdout.strip() == "OK"


### PR DESCRIPTION
**Every write-capable agent task currently refuses to start on main.** The task launcher's isolation check (`guardrails.worktree_containment`) became unimportable in the launcher's own environment after #4931 moved its dependency into `scripts/common/` — the guard correctly failed closed, so all danger-mode dispatches die at spawn with 'cannot verify worktree isolation'. Hit live firing the next qualification-arc build.

**Why CI didn't catch it**: the launcher imports these modules WITHOUT the `scripts.` prefix (only `scripts/` on its path); pytest always has the repo root on the path, so both flavors resolved there.

**Fix**: dual-flavor imports (with stripped fallback) in the three affected modules + a regression test that reproduces the launcher's exact import environment in a subprocess for all five stripped modules — this class now fails in CI first.

My verify: reproduced the break in a clean subprocess before the fix; 40 tests green after (regression + release-snapshot + orient suites).

Refs #4707 (fleet reliability) · fallout from #4931.

🤖 Generated with [Claude Code](https://claude.com/claude-code)