### PR TITLE
feat(harness): scaffold selection for full-corpus annotation (Refs #4913)

### DIFF
--- a/scripts/audit/layerb_label_scaffold.py
+++ b/scripts/audit/layerb_label_scaffold.py
@@ -245,11 +245,32 @@ def _source_artifact_path(corpus_dir: Path, artifact_name: str) -> str:
     return artifact_name
 
 
-def _fixture_sha256(fixture_id: str) -> str:
+def _fixture_source(
+    fixture_id: str,
+    *,
+    corpus_dir: Path,
+    artifact_name: str,
+    corpus: Mapping[str, Mapping[str, Any]],
+    selection_mode: str | None,
+) -> dict[str, str]:
+    """Pin a canonical fixture or an explicitly embedded corpus fixture."""
     fixture_path = Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "qg_bakeoff" / f"{fixture_id}.json"
-    if not fixture_path.is_file():
+    if fixture_path.is_file():
+        return {"path": str(fixture_path), "sha256": sha256_file(fixture_path)}
+    if selection_mode != "select-all-from-source-artifacts":
         raise LabelJoinError(f"fixture file required for scaffold source hashes is absent: {fixture_path}")
-    return sha256_file(fixture_path)
+    artifact = corpus.get(artifact_name)
+    fixture = artifact.get("fixture") if isinstance(artifact, Mapping) else None
+    if not isinstance(fixture, Mapping) or fixture.get("slug") != fixture_id:
+        raise LabelJoinError(
+            f"embedded fixture source does not match {fixture_id!r} in corpus artifact {artifact_name!r}"
+        )
+    artifact_path = corpus_dir / artifact_name
+    return {
+        "path": str(artifact_path),
+        "sha256": sha256_file(artifact_path),
+        "provenance": "embedded-corpus-artifact",
+    }
 
 
 def _case_from_row(
@@ -440,12 +461,17 @@ def build_scaffold(
     ordered_pairs = sorted(zip(cases, packets, strict=True), key=lambda pair: str(pair[0]["case_id"]))
     cases = [case for case, _packet in ordered_pairs]
     packets = [packet for _case, packet in ordered_pairs]
+    selection_mode = (keyed_document.get("keying") or {}).get("mode")
     source_artifacts = [
         {
             "artifact_sha256": sha256_file(corpus_dir / artifact_name),
-            "fixture_set_sha256": _fixture_sha256(
-                str(next(case for case in cases if case["case_id"].startswith(artifact_name + "#"))["fixture_id"])
-            ),
+            "fixture_set_sha256": _fixture_source(
+                str(next(case for case in cases if case["case_id"].startswith(artifact_name + "#"))["fixture_id"]),
+                corpus_dir=corpus_dir,
+                artifact_name=artifact_name,
+                corpus=corpus,
+                selection_mode=selection_mode if isinstance(selection_mode, str) else None,
+            )["sha256"],
         }
         for artifact_name in sorted(used_artifacts)
     ]
@@ -505,6 +531,26 @@ def write_scaffold(
         resume=resume,
     )
     used_artifacts = sorted({str(case["case_id"]).split("#fact_checks[", maxsplit=1)[0] for case in scaffold["cases"]})
+    corpus = load_corpus(corpus_dir)
+    selection_mode = (keyed_document.get("keying") or {}).get("mode")
+    fixture_sets: dict[str, dict[str, str]] = {}
+    for fixture_id in sorted({str(case["fixture_id"]) for case in scaffold["cases"]}):
+        artifact_names = sorted(
+            {
+                str(case["case_id"]).split("#fact_checks[", maxsplit=1)[0]
+                for case in scaffold["cases"]
+                if case["fixture_id"] == fixture_id
+            }
+        )
+        if not artifact_names:
+            raise LabelJoinError(f"scaffold has no source artifact for fixture {fixture_id!r}")
+        fixture_sets[fixture_id] = _fixture_source(
+            fixture_id,
+            corpus_dir=corpus_dir,
+            artifact_name=artifact_names[0],
+            corpus=corpus,
+            selection_mode=selection_mode if isinstance(selection_mode, str) else None,
+        )
     manifest = {
         "manifest_version": "qg-layer-b-scaffold-manifest.v2",
         "inputs": {
@@ -513,15 +559,7 @@ def write_scaffold(
             "corpus_artifacts": {
                 artifact_name: sha256_file(corpus_dir / artifact_name) for artifact_name in used_artifacts
             },
-            "fixture_sets": {
-                fixture_id: {
-                    "path": str(
-                        Path(__file__).resolve().parents[2] / "tests" / "fixtures" / "qg_bakeoff" / f"{fixture_id}.json"
-                    ),
-                    "sha256": _fixture_sha256(fixture_id),
-                }
-                for fixture_id in sorted({str(case["fixture_id"]) for case in scaffold["cases"]})
-            },
+            "fixture_sets": fixture_sets,
         },
         "join_report": report["join_report"],
         "counts": {key: value for key, value in report.items() if key != "join_report"},

--- a/scripts/audit/layerb_label_union.py
+++ b/scripts/audit/layerb_label_union.py
@@ -4,7 +4,9 @@
 ``rederive`` is the authoritative path: it emits keys while walking the raw
 corpus, proves that the 1,310 non-key records have not drifted, and hands those
 keyed records to ``derive``.  ``derive`` selects the flag-derived union and
-fresh deterministic controls without any shadow-row join.
+fresh deterministic controls without any shadow-row join.  ``select-all`` is
+the separate, source-to-keyed-input path for a self-contained corpus whose
+annotation set deliberately includes every row.
 
 ``attach`` remains available solely for inputs whose duplicate groups resolve
 under its strict D2 invariant.  It is unsafe for ambiguous groups and is never
@@ -51,6 +53,7 @@ DEFAULT_REDERIVE_EXPECTED_ROWS = 1310
 KEY_FIELDS = frozenset({"grounding_key", "fact_check_index"})
 CATEGORY_NAMES = frozenset({"recovered", "regression", "abstain"})
 CATEGORY_ORDER = ("recovered", "regression", "abstain", "control_both_accept", "control_both_reject")
+SELECT_ALL_SOURCE_FIELDS = ("fixture", "claim", "excerpt", "grounding_key", "fact_check_index")
 
 
 def _rows_document(
@@ -179,6 +182,20 @@ def _ordered_categories(categories: set[str]) -> list[str]:
 def _stable_pool_order(row: Mapping[str, Any], index: int) -> tuple[str, str, str, str, int]:
     key = structural_key_from_union(row)
     return (*key, index)
+
+
+def _validate_keyed_derivation_rows(rows: Sequence[Mapping[str, Any]], *, operation: str) -> list[str]:
+    """Require source-emitted keys before any selection mode can proceed."""
+    for row in rows:
+        grounding_key = row.get("grounding_key")
+        if not isinstance(grounding_key, str) or not grounding_key:
+            raise LabelJoinError(f"{operation} requires source-keyed derivation records")
+        if row.get("fact_check_index") != fact_check_index_from_key(grounding_key):
+            raise LabelJoinError(f"keyed derivation fact_check_index is invalid: {grounding_key!r}")
+    grounding_keys = [str(row["grounding_key"]) for row in rows]
+    if len(grounding_keys) != len(set(grounding_keys)):
+        raise LabelJoinError("keyed derivation contains duplicate grounding keys")
+    return grounding_keys
 
 
 def _without_key_fields(row: Mapping[str, Any]) -> dict[str, Any]:
@@ -316,15 +333,7 @@ def derive_union(
     derivations = derivation_rows(derivation_document)
     if control_per_stratum < 1:
         raise LabelJoinError("control_per_stratum must be positive")
-    for row in derivations:
-        grounding_key = row.get("grounding_key")
-        if not isinstance(grounding_key, str) or not grounding_key:
-            raise LabelJoinError("derive requires source-keyed derivation records")
-        if row.get("fact_check_index") != fact_check_index_from_key(grounding_key):
-            raise LabelJoinError(f"keyed derivation fact_check_index is invalid: {grounding_key!r}")
-    grounding_keys = [str(row["grounding_key"]) for row in derivations]
-    if len(grounding_keys) != len(set(grounding_keys)):
-        raise LabelJoinError("keyed derivation contains duplicate grounding keys")
+    _validate_keyed_derivation_rows(derivations, operation="derive")
     selected_categories: dict[int, set[str]] = {
         index: _category_names(row) for index, row in enumerate(derivations) if _category_names(row)
     }
@@ -394,6 +403,56 @@ def derive_union(
     return document, report
 
 
+def select_all_corpus(artifacts_dir: Path, *, tau: float = DEFAULT_TAU) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build a minimal keyed input that selects every raw corpus fact check.
+
+    This intentionally does not accept a frozen derivation, flag categories,
+    control seed, or fixture truth lookup. It shares the normal raw source
+    walker so every grounding key is emitted by :mod:`layerb_keys` at the same
+    point as the phase-1 shadow runner.
+    """
+    derivations = derive_keyed_records(artifacts_dir, fixtures_dir=None, tau=tau)
+    grounding_keys = _validate_keyed_derivation_rows(derivations, operation="select-all")
+    keyed_rows: list[dict[str, Any]] = []
+    for index in sorted(range(len(derivations)), key=lambda value: (str(derivations[value]["grounding_key"]), value)):
+        source = derivations[index]
+        missing = [field for field in SELECT_ALL_SOURCE_FIELDS if field not in source or source[field] in (None, "")]
+        if missing:
+            raise LabelJoinError(f"select-all source row lacks required fields at index {index}: {', '.join(missing)}")
+        row = {field: source[field] for field in SELECT_ALL_SOURCE_FIELDS}
+        row["source_index"] = index
+        row["union_categories"] = []
+        keyed_rows.append(row)
+    report: dict[str, Any] = {
+        "mode": "select-all-from-source-artifacts",
+        "selection": "all-corpus-rows",
+        "artifacts_dir": str(artifacts_dir),
+        "tau": tau,
+        "keyed_derivation_rows": len(derivations),
+        "matched_rows": len(keyed_rows),
+        "grounding_keys_unique": len(set(grounding_keys)),
+        "source_keyed_derivation_required": True,
+        "fixture_truth_lookup_used": False,
+        "flag_categories_used": False,
+        "control_sampling_used": False,
+        "control_resampled": False,
+        "frozen_derivation_verified": False,
+        "projected_row_fields": [*SELECT_ALL_SOURCE_FIELDS, "source_index", "union_categories"],
+    }
+    document = {
+        "kind": "qg-layer-b-label-union-input",
+        "version": 3,
+        "total_rows": len(keyed_rows),
+        "rows": keyed_rows,
+        "keying": {
+            "mode": "select-all-from-source-artifacts",
+            "note": "Every source-keyed corpus row is selected; no flags, controls, or fixture truth labels are used.",
+            "join_report": report,
+        },
+    }
+    return document, report
+
+
 def _write_outputs(
     document: Mapping[str, Any], report: Mapping[str, Any], output: Path, report_path: Path | None
 ) -> None:
@@ -422,33 +481,41 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     rederive.add_argument("--fixtures-dir", type=Path, default=Path("tests/fixtures/qg_bakeoff"))
     rederive.add_argument("--tau", type=float, default=DEFAULT_TAU)
     rederive.add_argument("--expected-rows", type=int, default=DEFAULT_REDERIVE_EXPECTED_ROWS)
+    select_all = subparsers.add_parser("select-all")
+    select_all.add_argument("--artifacts-dir", type=Path, required=True)
+    select_all.add_argument("--output", type=Path, required=True)
+    select_all.add_argument("--report", type=Path)
+    select_all.add_argument("--tau", type=float, default=DEFAULT_TAU)
     return parser.parse_args(argv)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
-    derivation_document = read_json(args.derivation)
-    if args.mode == "attach":
-        document, report = attach_keys(
-            read_json(args.union), derivation_document, read_json(args.shadow), corpus_dir=args.corpus_dir
-        )
-    elif args.mode == "derive":
-        document, report = derive_union(
-            derivation_document,
-            frozen_union_document=read_json(args.frozen_union),
-            seed=args.seed,
-            control_per_stratum=args.control_per_stratum,
-        )
+    if args.mode == "select-all":
+        document, report = select_all_corpus(args.artifacts_dir, tau=args.tau)
     else:
-        document, report = rederive_keyed_derivation(
-            artifacts_dir=args.artifacts_dir,
-            fixtures_dir=args.fixtures_dir,
-            frozen_derivation_document=derivation_document,
-            tau=args.tau,
-            expected_rows=args.expected_rows,
-        )
-        report["frozen_derivation"] = {"path": str(args.derivation), "sha256": sha256_file(args.derivation)}
-        document["metadata"]["frozen_derivation"] = dict(report["frozen_derivation"])
+        derivation_document = read_json(args.derivation)
+        if args.mode == "attach":
+            document, report = attach_keys(
+                read_json(args.union), derivation_document, read_json(args.shadow), corpus_dir=args.corpus_dir
+            )
+        elif args.mode == "derive":
+            document, report = derive_union(
+                derivation_document,
+                frozen_union_document=read_json(args.frozen_union),
+                seed=args.seed,
+                control_per_stratum=args.control_per_stratum,
+            )
+        else:
+            document, report = rederive_keyed_derivation(
+                artifacts_dir=args.artifacts_dir,
+                fixtures_dir=args.fixtures_dir,
+                frozen_derivation_document=derivation_document,
+                tau=args.tau,
+                expected_rows=args.expected_rows,
+            )
+            report["frozen_derivation"] = {"path": str(args.derivation), "sha256": sha256_file(args.derivation)}
+            document["metadata"]["frozen_derivation"] = dict(report["frozen_derivation"])
     _write_outputs(document, report, args.output, args.report)
     return 0
 

--- a/tests/test_layerb_label_tools.py
+++ b/tests/test_layerb_label_tools.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import copy
 import json
 import subprocess
-import sys
 from collections.abc import Mapping
 from hashlib import sha256
 from pathlib import Path
@@ -16,7 +15,7 @@ from jsonschema import Draft202012Validator
 
 from scripts.audit.layerb_derivation import derive_keyed_records
 from scripts.audit.layerb_keys import _build_event_index, _stable_grounding_key
-from scripts.audit.layerb_label_common import LabelJoinError, sha256_text
+from scripts.audit.layerb_label_common import LabelJoinError, atomic_write_json, sha256_file, sha256_text
 from scripts.audit.layerb_label_merge import merge_annotator_sidecars
 from scripts.audit.layerb_label_scaffold import (
     JUDGMENT_CASE_FIELDS,
@@ -30,13 +29,17 @@ from scripts.audit.layerb_label_union import (
     attach_keys,
     derive_union,
     rederive_keyed_derivation,
+    select_all_corpus,
 )
+from scripts.audit.layerb_shadow import ShadowRunner
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
 SCHEMA = json.loads((REPO_ROOT / "schemas" / "qg-layer-b-labels.v2.schema.json").read_text(encoding="utf-8"))
 VALIDATOR = Draft202012Validator(SCHEMA)
 RAW_OUTPUT = "source evidence used for deterministic label checks"
 EXCERPT = "source evidence"
+ADVERSARIAL_CORPUS_DIR = REPO_ROOT / "tests" / "fixtures" / "curriculum_qg" / "layer_b_adversarial"
 
 
 def _sha(value: str) -> str:
@@ -229,6 +232,22 @@ def _frozen_category_union(keyed_derivation: Mapping[str, Any]) -> dict[str, Any
         ]
         rows.append(frozen_row)
     return {"kind": "qg-layer-b-label-union-input", "rows": rows, "total_rows": len(rows)}
+
+
+def _assert_scaffold_judgments_are_null(cases: list[Mapping[str, Any]]) -> None:
+    for case in cases:
+        assert all(case[field] is None for field in JUDGMENT_CASE_FIELDS)
+        for candidates in case["candidates_by_event_output_id"].values():
+            for candidate in candidates:
+                assert candidate["expected_source_relation"] is None
+                assert candidate["expected_support_spans"] is None
+
+
+def _tree_sha256(directory: Path) -> dict[str, str]:
+    return {
+        str(path.relative_to(directory)): sha256_file(path)
+        for path in sorted(path for path in directory.rglob("*") if path.is_file())
+    }
 
 
 def _raw_rederive_inputs(tmp_path: Path) -> tuple[Path, Path, dict[str, Any]]:
@@ -431,6 +450,73 @@ def test_keyed_union_is_byte_identical_and_matches_frozen_category_fixture(tmp_p
     assert first_report["frozen_control_sample_reproduction_guaranteed"] is False
 
 
+def test_select_all_uses_every_source_key_and_projects_no_judgment_fields(tmp_path: Path) -> None:
+    corpus_dir, _fixtures_dir, _frozen = _raw_rederive_inputs(tmp_path)
+    source_records = derive_keyed_records(corpus_dir, fixtures_dir=None)
+
+    first, first_report = select_all_corpus(corpus_dir)
+    second, second_report = select_all_corpus(corpus_dir)
+
+    assert first == second
+    assert first_report == second_report
+    assert first["total_rows"] == first_report["matched_rows"] == len(source_records) == 2
+    assert first_report["mode"] == "select-all-from-source-artifacts"
+    assert first_report["flag_categories_used"] is False
+    assert first_report["control_sampling_used"] is False
+    assert first_report["fixture_truth_lookup_used"] is False
+    assert {row["grounding_key"] for row in first["rows"]} == {row["grounding_key"] for row in source_records}
+    assert all(set(row) == set(first_report["projected_row_fields"]) for row in first["rows"])
+    assert all(row["union_categories"] == [] for row in first["rows"])
+    assert all("gold_is_true" not in row for row in first["rows"])
+
+
+def test_adversarial_corpus_select_all_scaffolds_all_cases_without_proposed_labels(tmp_path: Path) -> None:
+    shadow_dir = tmp_path / "shadow"
+    shadow_report = ShadowRunner(artifacts_dir=ADVERSARIAL_CORPUS_DIR, audit_dir=shadow_dir).run()
+    shadow_path = shadow_dir / "phase1-shadow.json"
+    keyed_document, selection_report = select_all_corpus(ADVERSARIAL_CORPUS_DIR)
+    keyed_path = tmp_path / "keyed-select-all.json"
+    atomic_write_json(keyed_path, keyed_document)
+
+    first_dir = tmp_path / "scaffold-first"
+    second_dir = tmp_path / "scaffold-second"
+    first, first_manifest = write_scaffold(
+        keyed_path,
+        shadow_path,
+        corpus_dir=ADVERSARIAL_CORPUS_DIR,
+        output_dir=first_dir,
+    )
+    second, second_manifest = write_scaffold(
+        keyed_path,
+        shadow_path,
+        corpus_dir=ADVERSARIAL_CORPUS_DIR,
+        output_dir=second_dir,
+    )
+
+    assert shadow_report["summary"]["groundings_processed"] == 23
+    assert selection_report["matched_rows"] == keyed_document["total_rows"] == 23
+    assert len(first["cases"]) == len(second["cases"]) == 23
+    assert first_manifest["counts"]["keyed_rows"] == first_manifest["counts"]["cases"] == 23
+    assert first_manifest["counts"]["segment_verified_candidates"] > 0
+    assert first_manifest["counts"]["judgment_fields_prefilled"] == 0
+    _assert_scaffold_judgments_are_null(first["cases"])
+    _assert_scaffold_judgments_are_null(second["cases"])
+    packet_cases = [
+        json.loads(line)["case"]
+        for packet_path in sorted((first_dir / "packets").glob("shard-*.jsonl"))
+        for line in packet_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert len(packet_cases) == 23
+    _assert_scaffold_judgments_are_null(packet_cases)
+    assert _tree_sha256(first_dir) == _tree_sha256(second_dir)
+    assert first_manifest["scaffold_sha256"] == second_manifest["scaffold_sha256"]
+    fixture_source = first_manifest["inputs"]["fixture_sets"]["layer-b-adversarial-fixture"]
+    assert fixture_source["path"] == str(ADVERSARIAL_CORPUS_DIR / "adversarial-layer-b-fixture.json")
+    assert fixture_source["provenance"] == "embedded-corpus-artifact"
+    assert fixture_source["sha256"] == first_manifest["inputs"]["corpus_artifacts"]["adversarial-layer-b-fixture.json"]
+    assert all("PROPOSED" not in path.read_text(encoding="utf-8") for path in first_dir.rglob("*") if path.is_file())
+
+
 def test_rederive_no_drift_positive_and_synthetic_drift_hard_fail(tmp_path: Path) -> None:
     corpus_dir, fixtures_dir, frozen = _raw_rederive_inputs(tmp_path)
     regenerated = derive_keyed_records(corpus_dir, fixtures_dir=fixtures_dir)
@@ -467,7 +553,6 @@ def test_rederive_cli_is_byte_identical_for_two_source_walks(tmp_path: Path) -> 
     first_path = tmp_path / "keyed-first.json"
     second_path = tmp_path / "keyed-second.json"
     command = [
-        sys.executable,
         "scripts/audit/layerb_label_union.py",
         "rederive",
         "--derivation",
@@ -481,7 +566,7 @@ def test_rederive_cli_is_byte_identical_for_two_source_walks(tmp_path: Path) -> 
     ]
     for output in (first_path, second_path):
         completed = subprocess.run(
-            [*command, "--output", str(output)],
+            [str(VENV_PYTHON), *command, "--output", str(output)],
             cwd=REPO_ROOT,
             check=False,
             capture_output=True,
@@ -599,7 +684,7 @@ def test_label_tool_imports_do_not_load_runtime_reviewer_dispatch(module: str) -
         "raise SystemExit('scripts.audit.llm_reviewer_dispatch' in sys.modules)"
     )
     completed = subprocess.run(
-        [sys.executable, "-c", command],
+        [str(VENV_PYTHON), "-c", command],
         cwd=REPO_ROOT,
         check=False,
         capture_output=True,


### PR DESCRIPTION
## Summary

- Adds `layerb_label_union.py select-all`, a direct raw-corpus keyed-input builder that validates the existing grounding-key contract and selects every row without flag categories, controls, fixture truth lookup, or a manifest join.
- Preserves the existing scaffold implementation and makes its fixture pin explicit when a select-all corpus embeds the fixture in its source artifact.
- Covers both the selection mode and the full 23-case adversarial corpus, including packet determinism, segment re-verification, null judgments, and proposed-label exclusion.

## Evidence

Implementation locations: `scripts/audit/layerb_label_union.py:406-453`, `scripts/audit/layerb_label_scaffold.py:248-273`, `scripts/audit/layerb_label_scaffold.py:464-568`, `tests/test_layerb_label_tools.py:453-517`.

Raw focused verification from `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/4913-adversarial-scaffold`:

```text
All checks passed!
collected 28 items

tests/test_layerb_label_tools.py ........................                [ 85%]
tests/test_layer_b_adversarial_corpus.py ....                            [100%]

============================== 28 passed in 2.87s ==============================
```

Raw frozen generation ran twice into the gitignored main-checkout audit target:

```json
{"counts":{"candidates":27,"cases":23,"judgment_fields_prefilled":0,"keyed_rows":23,"segment_verified_candidates":27,"shards":4},"keyed_union_sha256":"59da576466b9773b9ace2bcae20a98a5e037934bf4da2a6250ec93814517b465","run":"first","scaffold_sha256":"74e83960affd2e60f5d929166435de87e5996935bfa47bdfeb65dc7bf823237b","scaffold_tree_sha256":"f467874d319614fb4224e7ce8d8ae8abe03dea003a4a0157c9742d58f5d284c6"}
{"counts":{"candidates":27,"cases":23,"judgment_fields_prefilled":0,"keyed_rows":23,"segment_verified_candidates":27,"shards":4},"keyed_union_sha256":"59da576466b9773b9ace2bcae20a98a5e037934bf4da2a6250ec93814517b465","run":"second","scaffold_sha256":"74e83960affd2e60f5d929166435de87e5996935bfa47bdfeb65dc7bf823237b","scaffold_tree_sha256":"f467874d319614fb4224e7ce8d8ae8abe03dea003a4a0157c9742d58f5d284c6"}
```

Raw post-generation verification:

```json
{"candidate_judgment_fields_all_null":true,"case_judgment_fields_all_null":true,"case_rows":23,"key_sets_equal":true,"keyed_rows":23,"manifest_segment_verified_candidates":27,"packet_case_ids_exact":true,"packet_case_rows":23,"packet_done_markers_valid":true,"proposed_token_absent_from_scaffold":true,"scaffold_sha256":"74e83960affd2e60f5d929166435de87e5996935bfa47bdfeb65dc7bf823237b","segment_verified_candidates":27,"shadow_rows":23,"source_rows":23}
```

## Review handoff

No auto-merge. The orchestrator should regenerate the frozen scaffold from `audit/2026-07-11-layerb-adversarial-annotation/keyed-union-select-all.json` plus `shadow/phase1-shadow.json`, confirm the quoted hashes/counts, and route the independent PR review before starting annotators A/B.