### PR TITLE
docs: privacy sweep — role-neutral phrasing across session records

### DIFF
--- a/docs/design/dimensional-review.md
+++ b/docs/design/dimensional-review.md
@@ -279,7 +279,7 @@ If user/the native reviewer bandwidth permits: have her mark errors independentl
 
 - Phase 1: ~50 calls total, ~1 day
 - Phase 2: 5 artifacts × 3 versions × 3 agents × 4 dims × 3 reruns ≈ 540 calls, bounded over 1-2 nights
-- the native reviewer validation: 3 artifacts, ~1 week real-world turnaround depending on her schedule
+- the native reviewer validation: 3 artifacts, ~1 week real-world turnaround depending on reviewer availability
 
 **Do not freeze agent assignments or thresholds before Phase 2 completes.**
 

--- a/docs/handoffs/SESSION-HANDOFF-2026-03-25b.md
+++ b/docs/handoffs/SESSION-HANDOFF-2026-03-25b.md
@@ -45,7 +45,7 @@ The new 4-tab lesson design exists as disconnected pieces. **The pipeline does N
 - A1.2+: graduated Ukrainian introduction
 
 ### Issues created
-- #1040: Scrape МійКлас grammar (the native reviewer's find)
+- #1040: Scrape МійКлас grammar (community-recommended source)
 - #1041-#1044: Activity System V2 (all closed)
 
 ### Closed: #1031 (Figma — not needed)

--- a/docs/personal-name-audit.md
+++ b/docs/personal-name-audit.md
@@ -47,7 +47,7 @@ calibrators, reviewers, or teaching-material owners.
 | `docs/wiki-rebuild-plan.md` | 228 | "hand articles to teacher {N1}" | "hand articles to a native-speaker reviewer" |
 | `docs/style-guide.md` | 121 | "Teacher {N1} or Teacher {N2} on the…" | "a native-speaker reviewer" |
 | `docs/session-state/2026-04-21-evening.md` | 10 hits | reviewer references | (session-state — historical record; consider just deleting the file post-reboot since V6 sessions are obsolete reference) |
-| `docs/session-state/2026-04-21-morning-handoff.md` | 2 hits | "Native teacher signed off (Alona...)" | "a native teacher" |
+| `docs/session-state/2026-04-21-morning-handoff.md` | 2 hits | "Native teacher signed off (name masked — see this audit's purpose)" | "a native teacher" |
 | `docs/session-state/2026-04-21-evening-strategic-audit.md` | 3 hits | various | scrub or delete file |
 | `docs/architecture/2026-04-21-pilot-readiness-audit.md` | 13 hits | reviewer authority references | "native reviewer" |
 | `docs/architecture/adr/adr-008-uk-native-track-destination.md` | 8 hits | "{N2} reviews it..." | "the native reviewer reviews it..." |

--- a/docs/session-state/2026-06-13-claude-agy-retire-atlas-pairfix-quality-queue.md
+++ b/docs/session-state/2026-06-13-claude-agy-retire-atlas-pairfix-quality-queue.md
@@ -52,7 +52,7 @@ Dispatch cap discipline: 2 codex + 2 agy + 2 claude in flight; check `/api/deleg
 Run several in parallel; the fleet has been idle.
 
 ## 📨 Open / awaiting-user
-- **Лепетун (ukr-mova.in.ua)** outreach draft ready: `docs/outreach/lepetun-collaboration-draft.md` (gitignored). **User to review/send** (assistant won't send). robots.txt permissive for content + sitemap. Read slovnyk/Лепетун `/policy` once before any pull. Use ULP-pattern (private gitignored reference, verify, re-express, never verbatim; link + attribute). Citation ≠ permission.
+- **Лепетун (ukr-mova.in.ua)** collaboration material prepared (local gitignored file, **user-owned next step**). robots.txt permissive for content + sitemap. Read slovnyk/Лепетун `/policy` once before any pull. Use ULP-pattern (private gitignored reference, verify, re-express, never verbatim; link + attribute). Citation ≠ permission.
 - Calibration kernel (#2156 lean) — fire as a parallel dispatch whenever a routing decision (#3087) needs evidence.
 
 ## ⚠️ Lessons this session

--- a/docs/session-state/archive/2026-04-12-overnight-report.md
+++ b/docs/session-state/archive/2026-04-12-overnight-report.md
@@ -43,7 +43,7 @@ Tonight's main deliverable was unblocking a clean B1/A1/A2 rebuild. That ladder 
 | **#1082** | OPEN | Posted status: 16 test files / 315 tests passing. 4 ACs done, 3 ACs open (a11y, Playwright e2e, CI). Recommended split or close-with-followups. |
 | **#1086** | OPEN (stale note added) | Filed 16+ days ago, zero activity. Recommend close as "wontfix until learners". |
 | **#1087** | OPEN (stale note added) | Same. Auto-deploy was disabled intentionally. Recommend close as "wontfix / deferred". |
-| **#1084** | OPEN (stale note added) | Has some recent activity (2026-04-10). Blocked on human reviewer (the native reviewer). Keep open with note. |
+| **#1084** | OPEN (stale note added) | Has some recent activity (2026-04-10). Blocked on the native-review step. Keep open with note. |
 | **#1191** | OPEN | Cloze 1-based indexing fix — fully specced, 30-min Codex task. **Queued for tonight.** |
 | **#1192** | C.1 ✅ shipped | Phase C epic. C.2 dispatched to Codex while writing this report. |
 | **#1193** | CLOSED | Pyright tech debt cleanup — Codex implementation, Gemini PASS. |

--- a/docs/session-state/archive/2026-04-23-overnight-scale-batch-1.md
+++ b/docs/session-state/archive/2026-04-23-overnight-scale-batch-1.md
@@ -24,7 +24,7 @@ Main at **`4f0fae3c0b`** — 7 PRs landed in the late-night session, all roadmap
 - ✅ CI clean
 - ✅ Gemini bridge unblocked (subscription always)
 - ⏳ A.8 canary measurement — **ready to run** (not yet executed; user runs builds per memory rule)
-- ⏳ Native reviewer engagement (A.7) — user-owned
+- ⏳ Native review step (A.7) — user-owned
 
 ## Active dispatches — overnight scale batch 1
 

--- a/docs/session-state/archive/2026-04-25-evening-reboot-decision.md
+++ b/docs/session-state/archive/2026-04-25-evening-reboot-decision.md
@@ -86,9 +86,8 @@ A published lesson has 4 tabs in this order:
 
 ## Sacred-name policy (security)
 
-User's two private contacts (the teachers): names stay in `memory/MEMORY.md`,
-NOT in any committed file. Fresh sessions inherit MY memory (so I know who
-they are without naming them in chat). Phase 1 sub-task includes scrubbing
+Reviewer contact details stay out of committed files (standing rule).
+Phase 1 sub-task includes scrubbing
 personal references across `curriculum/`, `wiki/`, `docs/` — distinguish
 PERSONAL references from generic dialogue uses (the names are also common
 Ukrainian first names; characters can still be called that).

--- a/docs/session-state/archive/2026-04-26-phase-2-driving-overnight.md
+++ b/docs/session-state/archive/2026-04-26-phase-2-driving-overnight.md
@@ -66,7 +66,7 @@ Phase 3 lesson schema work.
 Checkpoint commits before user-initiated wiki rebuild:
 
 - `.gitignore` — added `data/*.db.bak-*`, `/*.diff`, `/*.patch`
-  patterns; renamed `data/alona-lessons/` → `data/native-reviewer-lessons/`
+  patterns; renamed the legacy personal-named lessons dir → `data/native-reviewer-lessons/`
   on disk to match existing role-anonymous gitignore pattern (privacy
   rule + saved 113 MB from accidental commit risk).
 - Wiki content snapshot — 1137 files / +83 K lines preserved as the


### PR DESCRIPTION
Acts on the fleet privacy sweep (user-ordered). 8 docs edited: name-audit quote masked, legacy dir reference masked, reviewer availability/engagement phrasing made role-neutral, coordination notes reduced to user-owned pointers. Touches docs/session-state/ archives (main's territory) — cross-lane privacy scrub under explicit user order; main may re-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)