### PR TITLE
fix(hooks): goal-driver-stop — anchor cwd to project root before python -m

### DIFF
--- a/agents_extensions/shared/hooks/goal-driver-stop.sh
+++ b/agents_extensions/shared/hooks/goal-driver-stop.sh
@@ -24,4 +24,10 @@ if [ ! -x "$PYTHON" ]; then
   exit 0
 fi
 
+# `python -m` resolves the module against the CURRENT working directory, so a
+# session whose cwd is not the repo root (worktree, other dir) hits
+# "ModuleNotFoundError: No module named 'scripts'". Anchor cwd to the project
+# root first; fail open if it is unreachable. (cwd-drift bug family: #4912/#4899.)
+cd "$PROJECT_DIR" || exit 0
+
 exec "$PYTHON" -m scripts.goal_driver.stop_hook


### PR DESCRIPTION
Stop-hook noise reported by user: `ModuleNotFoundError: No module named 'scripts'` on sessions whose cwd ≠ repo root. Root cause: `exec "$PYTHON" -m scripts.goal_driver.stop_hook` resolves the module against the current working directory; the hook never cd'd. Fix: `cd "$PROJECT_DIR" || exit 0` before exec (fail-open preserved).

Verified end-to-end:
- from /tmp (failing case): exit 0, no error — previously printed the ModuleNotFoundError
- from repo root: unchanged, exit 0

Deploy note: `.claude/hooks/` copy is gitignored local state — refreshed separately on the driver machine after merge. cwd-drift bug family: refs #4912, #4899.

🤖 Generated with [Claude Code](https://claude.com/claude-code)