### PR TITLE
fix(canary): mint --facts accepts inline JSON, not just a file path

### DIFF
--- a/scripts/context_canary.py
+++ b/scripts/context_canary.py
@@ -29,6 +29,7 @@ Usage
                           --context-tokens 500000 --model claude-opus-4-8 --log canary_log.csv
 
 `facts.json`   : [{"id": "...", "q": "...", "a": "..."}, ...]
+                 (`--facts` also accepts the JSON list inline, not just a file path)
 `answers.json` : {"<id>": "<answer-from-memory>", ...}
 
 Exit code: 0 if PASS, 2 if FAIL (hand off), 1 on usage error.
@@ -53,8 +54,30 @@ def _similarity(truth: str, got: str) -> float:
     return difflib.SequenceMatcher(None, _norm(truth), _norm(got)).ratio()
 
 
+def _load_facts_spec(spec: str) -> object:
+    """Load facts from EITHER an inline JSON list OR a path to a JSON file.
+
+    `--facts` accepts both forms: the documented `--facts facts.json` path AND an
+    inline `[{...}]` payload (the arg help advertises "JSON list of {id,q,a}").
+    A JSON list starts with '[' (an object with '{'); a filesystem path never
+    does — so the leading bracket unambiguously selects inline vs file. This keeps
+    the CLI help honest and avoids the opaque 'File name too long' OSError a caller
+    hit when passing inline JSON to the file-only reader.
+    """
+    if spec.lstrip()[:1] in ("[", "{"):
+        return json.loads(spec)
+    return json.loads(Path(spec).read_text(encoding="utf-8"))
+
+
 def cmd_mint(args: argparse.Namespace) -> int:
-    facts = json.loads(Path(args.facts).read_text(encoding="utf-8"))
+    try:
+        facts = _load_facts_spec(args.facts)
+    except FileNotFoundError:
+        print(f"error: --facts file not found: {args.facts}", file=sys.stderr)
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"error: --facts is not valid JSON: {exc}", file=sys.stderr)
+        return 1
     if not isinstance(facts, list) or not facts:
         print("error: --facts must be a non-empty JSON list of {id,q,a}", file=sys.stderr)
         return 1
@@ -116,7 +139,11 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     mint = sub.add_parser("mint", help="Freeze ground-truth anchors into a probe file.")
-    mint.add_argument("--facts", required=True, help="JSON list of {id,q,a}")
+    mint.add_argument(
+        "--facts",
+        required=True,
+        help="Inline JSON list of {id,q,a}, or a path to a JSON file",
+    )
     mint.add_argument("--out", required=True, help="Probe output path")
     mint.set_defaults(func=cmd_mint)
 

--- a/scripts/context_canary.py
+++ b/scripts/context_canary.py
@@ -59,10 +59,11 @@ def _load_facts_spec(spec: str) -> object:
 
     `--facts` accepts both forms: the documented `--facts facts.json` path AND an
     inline `[{...}]` payload (the arg help advertises "JSON list of {id,q,a}").
-    A JSON list starts with '[' (an object with '{'); a filesystem path never
-    does — so the leading bracket unambiguously selects inline vs file. This keeps
-    the CLI help honest and avoids the opaque 'File name too long' OSError a caller
-    hit when passing inline JSON to the file-only reader.
+    A JSON list starts with '[' (an object with '{'); a filesystem path effectively
+    never does — a bare name starting with a bracket would need quoting and is an
+    edge case — so the leading bracket selects inline vs file for all practical
+    inputs. This keeps the CLI help honest and avoids the opaque 'File name too
+    long' OSError a caller hit when passing inline JSON to the file-only reader.
     """
     if spec.lstrip()[:1] in ("[", "{"):
         return json.loads(spec)
@@ -72,8 +73,9 @@ def _load_facts_spec(spec: str) -> object:
 def cmd_mint(args: argparse.Namespace) -> int:
     try:
         facts = _load_facts_spec(args.facts)
-    except FileNotFoundError:
-        print(f"error: --facts file not found: {args.facts}", file=sys.stderr)
+    except (OSError, UnicodeDecodeError) as exc:
+        # File branch: missing / directory / permission / non-UTF-8 all land here.
+        print(f"error: --facts cannot be read as a file: {args.facts} ({type(exc).__name__})", file=sys.stderr)
         return 1
     except json.JSONDecodeError as exc:
         print(f"error: --facts is not valid JSON: {exc}", file=sys.stderr)

--- a/tests/test_context_canary.py
+++ b/tests/test_context_canary.py
@@ -110,9 +110,19 @@ def test_mint_inline_and_file_produce_identical_probe(tmp_path: Path):
 
 def test_mint_missing_file_is_clean_usage_error(tmp_path: Path):
     rc = context_canary.main(["mint", "--facts", str(tmp_path / "nope.json"), "--out", str(tmp_path / "p.json")])
-    assert rc == 1  # not an uncaught traceback
+    assert rc == 1  # FileNotFoundError -> clean rc 1, not an uncaught traceback
+
+
+def test_mint_directory_as_facts_is_clean_usage_error(tmp_path: Path):
+    # A path that is a directory raises IsADirectoryError inside read_text; the
+    # widened (OSError, UnicodeDecodeError) catch must turn it into a clean rc 1,
+    # not a traceback (every file-branch read failure is covered, not just missing).
+    a_dir = tmp_path / "facts_dir"
+    a_dir.mkdir()
+    rc = context_canary.main(["mint", "--facts", str(a_dir), "--out", str(tmp_path / "p.json")])
+    assert rc == 1
 
 
 def test_mint_malformed_inline_json_is_clean_usage_error(tmp_path: Path):
     rc = context_canary.main(["mint", "--facts", "[{bad json", "--out", str(tmp_path / "p.json")])
-    assert rc == 1  # JSONDecodeError caught, returns usage error
+    assert rc == 1  # inline branch JSONDecodeError caught, returns usage error

--- a/tests/test_context_canary.py
+++ b/tests/test_context_canary.py
@@ -88,3 +88,31 @@ def test_mint_rejects_duplicate_ids(tmp_path: Path):
     facts.write_text(json.dumps([{"id": "x", "q": "q", "a": "a"}, {"id": "x", "q": "q2", "a": "a2"}]), encoding="utf-8")
     rc = context_canary.main(["mint", "--facts", str(facts), "--out", str(tmp_path / "p.json")])
     assert rc == 1
+
+
+def test_mint_accepts_inline_json(tmp_path: Path):
+    # The arg help advertises "Inline JSON list of {id,q,a}" — passing the list
+    # directly (not a file path) must work, not crash with 'File name too long'.
+    probe = tmp_path / "probe.json"
+    rc = context_canary.main(["mint", "--facts", json.dumps(FACTS), "--out", str(probe)])
+    assert rc == 0
+    data = json.loads(probe.read_text(encoding="utf-8"))
+    assert [a["id"] for a in data["anchors"]] == ["safe_env_sha", "agy_pr", "wiki_reason"]
+
+
+def test_mint_inline_and_file_produce_identical_probe(tmp_path: Path):
+    file_probe = _mint(tmp_path)
+    inline_probe = tmp_path / "inline_probe.json"
+    rc = context_canary.main(["mint", "--facts", json.dumps(FACTS), "--out", str(inline_probe)])
+    assert rc == 0
+    assert inline_probe.read_text(encoding="utf-8") == file_probe.read_text(encoding="utf-8")
+
+
+def test_mint_missing_file_is_clean_usage_error(tmp_path: Path):
+    rc = context_canary.main(["mint", "--facts", str(tmp_path / "nope.json"), "--out", str(tmp_path / "p.json")])
+    assert rc == 1  # not an uncaught traceback
+
+
+def test_mint_malformed_inline_json_is_clean_usage_error(tmp_path: Path):
+    rc = context_canary.main(["mint", "--facts", "[{bad json", "--out", str(tmp_path / "p.json")])
+    assert rc == 1  # JSONDecodeError caught, returns usage error


### PR DESCRIPTION
## Problem
`context_canary.py mint --facts` arg help says **"JSON list of {id,q,a}"**, implying you can pass the list inline. But the code only did `Path(args.facts).read_text()` — passing inline JSON crashed with an opaque `OSError: File name too long`. Every agent mints a canary at cold-start reading that help, so the help/impl mismatch is a fleet-wide papercut (hit live this session during cold-start).

## Root cause
A file-only reader sitting behind a help string that advertises inline input.

## Fix
- `_load_facts_spec(spec)` selects inline-vs-file by the leading JSON bracket (a filesystem path never starts with `[`/`{`), so **both** documented forms work.
- `cmd_mint` now returns a clean usage error (rc 1) on a missing file or malformed JSON instead of an uncaught traceback.
- Arg help + module docstring corrected to state both forms.

## Tests (10/10 pass, ruff clean)
- `test_mint_accepts_inline_json` — the exact inline form that crashed now works
- `test_mint_inline_and_file_produce_identical_probe` — byte-identical output both ways
- `test_mint_missing_file_is_clean_usage_error` / `test_mint_malformed_inline_json_is_clean_usage_error` — rc 1, no traceback

Docs-adjacent tooling fix; no runtime/API surface. In-lane (infra tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)