### PR TITLE
feat(lexicon): enrich antonyms from dictionary pointers

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -1632,6 +1632,10 @@ def _antonyms_wiktionary(
     if not _wiktionary_has_antonyms_column(conn):
         return None
 
+    source_term = _canonical_synonym_term(lemma)
+    if not source_term or not _vesum_valid_synonym(source_term):
+        return None
+
     # #3197 — per-lemma pedagogy filter over the raw Вікісловник antonym column.
     base_key = _base_lemma(lemma).casefold().replace("’", "'").replace("ʼ", "'").replace("`", "'")
     if base_key in _DROP_ANTONYM_LEMMAS:
@@ -1656,7 +1660,7 @@ def _antonyms_wiktionary(
                 continue
             for candidate in candidates:
                 term = _clean_atlas_chip_candidate(str(candidate), lemma)
-                if not term or term in seen:
+                if not term or term in seen or not _vesum_valid_synonym(term):
                     continue
                 if wrong_terms:
                     normalized = term.replace("’", "'").replace("ʼ", "'").replace("`", "'")
@@ -2803,6 +2807,12 @@ _DEFINITION_SAME_AS_RE = re.compile(
     r"\bте\s+саме\s*,?\s+що\s+(?P<target>[А-Яа-яЄєІіЇїҐґ'’ʼ-]+)(?=\s*(?:[.;]|$))",
     flags=re.IGNORECASE,
 )
+_DEFINITION_ANTONYM_RE = re.compile(
+    r"(?:^|[.;])\s*(?P<marker>протилежне|прот\.)\s+(?!до\b)(?P<targets>"
+    r"[А-Яа-яЄєІіЇїҐґ'’ʼ-]+(?:\s*,\s*[А-Яа-яЄєІіЇїҐґ'’ʼ-]+){0,2})"
+    r"(?=\s*(?:[.;(]|$))",
+    flags=re.IGNORECASE,
+)
 # Grammar abbreviations that may sit between the headword echo and «див.» in a
 # cross-reference-only entry (e.g. «ЗАХОВАТИ, док. див. заховувати»); any other
 # word before «див.» means the card carries real definitional text → not xref-only.
@@ -2888,6 +2898,23 @@ def _definition_synonym_targets(body: str, lemma: str) -> list[tuple[str, str]]:
         same_as_targets = _normalise_xref_targets(match.group("target"))
         if len(same_as_targets) == 1:
             targets.append((same_as_targets[0], "Те саме, що"))
+    return list(dict.fromkeys(targets))
+
+
+def _definition_antonym_targets(body: str) -> list[tuple[str, str]]:
+    """Extract explicit ``протилежне`` / ``прот.`` lemma pointers.
+
+    СУМ-20 and СУМ-11 spell the relation as ``протилежне X``; VTS abbreviates
+    it as ``прот. X``. A target is accepted only when it ends at a definition
+    boundary, and ``протилежне до`` is deliberately excluded because it is
+    ordinary prose rather than a lexicographer's antonym pointer.
+    """
+    targets: list[tuple[str, str]] = []
+    for match in _DEFINITION_ANTONYM_RE.finditer(_strip_stress(body)):
+        marker = match.group("marker").casefold()
+        pattern = "прот." if marker == "прот." else "протилежне"
+        for target in _normalise_xref_targets(match.group("targets")):
+            targets.append((target, pattern))
     return list(dict.fromkeys(targets))
 
 
@@ -3143,6 +3170,7 @@ def _definition_cards(
 
 
 _SYNONYM_ADDITION_CAP = 8
+_ANTONYM_ADDITION_CAP = 8
 _COATTESTATION_SUM_OR_GRINCHENKO = frozenset({"СУМ-11", "СУМ-20", "Грінченко"})
 _CONTENT_STEM_STOPWORDS = frozenset(
     {
@@ -3259,9 +3287,10 @@ def _dictionary_definition_rows(
 
 
 def _vesum_valid_synonym(term: str) -> bool:
-    """Fail closed unless VESUM recognizes the emitted synonym form."""
+    """Fail closed unless VESUM recognizes the emitted term as its own lemma."""
     try:
-        return bool(verify_word(term))
+        term_key = _lookup_key(term)
+        return any(_lookup_key(str(row.get("lemma") or "")) == term_key for row in verify_word(term))
     except Exception:
         return False
 
@@ -3333,6 +3362,74 @@ def _definition_pointer_relations_by_headword(
         for relation in relations:
             target_key = str(relation["item"])
             if target_key not in headwords or not _vesum_valid_synonym(source_key):
+                continue
+            reciprocal = dict(relation)
+            reciprocal["item"] = headwords[source_key]
+            reciprocal["direction"] = "reciprocal"
+            by_headword.setdefault(target_key, []).append(reciprocal)
+    return by_headword
+
+
+def _definition_antonym_relations(
+    conn: sqlite3.Connection,
+    lemma: str,
+    *,
+    has_sum11_flags: bool,
+    cache: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Lexicographer-authored antonym pointers, VESUM-gated at both ends."""
+    source_term = _canonical_synonym_term(lemma)
+    if not source_term or not _vesum_valid_synonym(source_term):
+        return []
+
+    relations: list[dict[str, Any]] = []
+    for row in _dictionary_definition_rows(
+        conn,
+        lemma,
+        has_sum11_flags=has_sum11_flags,
+        cache=cache,
+    ):
+        for target, pattern in _definition_antonym_targets(str(row["text"])):
+            item = _canonical_synonym_term(target)
+            if not item or item == source_term or not _vesum_valid_synonym(item):
+                continue
+            relation: dict[str, Any] = {
+                "item": item,
+                "source": row["source"],
+                "pattern": pattern,
+                "vein": 1,
+                "gate": {"vesum": "both valid"},
+            }
+            if row.get("source_url"):
+                relation["source_url"] = row["source_url"]
+            relations.append(relation)
+    return relations
+
+
+def _definition_antonym_relations_by_headword(
+    conn: sqlite3.Connection,
+    manifest: dict[str, Any],
+    *,
+    has_sum11_flags: bool,
+) -> dict[str, list[dict[str, Any]]]:
+    """Precompute explicit antonym pointers and symmetric manifest-headword pairs."""
+    headwords = _manifest_headwords(manifest)
+    by_headword: dict[str, list[dict[str, Any]]] = {}
+    for entry in manifest.get("entries", []):
+        lemma = str(entry.get("lemma") or "")
+        source_key = _canonical_synonym_term(lemma)
+        if not source_key:
+            continue
+        relations = _definition_antonym_relations(
+            conn,
+            lemma,
+            has_sum11_flags=has_sum11_flags,
+        )
+        if relations:
+            by_headword.setdefault(source_key, []).extend(relations)
+        for relation in relations:
+            target_key = str(relation["item"])
+            if target_key not in headwords:
                 continue
             reciprocal = dict(relation)
             reciprocal["item"] = headwords[source_key]
@@ -3560,6 +3657,54 @@ def _merge_synonym_relations(
         item_was_present = item in seen
         if not item_was_present:
             if additions >= _SYNONYM_ADDITION_CAP:
+                continue
+            seen.add(item)
+            items.append(item)
+            additions += 1
+        label = _relation_source_label(relation, item)
+        if label not in source_labels:
+            source_labels.append(label)
+        if relation.get("source_url") and relation["source_url"] not in source_urls:
+            source_urls.append(str(relation["source_url"]))
+
+    if not items:
+        return None
+    if source_labels:
+        original = str(merged.get("source") or "").strip()
+        merged["source"] = " + ".join(part for part in (original, *source_labels) if part)
+    elif not merged.get("source"):
+        merged["source"] = ""
+    merged["items"] = items
+    if source_urls:
+        merged["source_urls"] = list(dict.fromkeys(source_urls))
+    else:
+        merged.pop("source_urls", None)
+    return merged
+
+
+def _merge_antonym_relations(
+    existing: dict[str, Any] | None,
+    relations: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Merge VESUM-gated antonym pointers into the rendered section schema."""
+    merged = dict(existing or {})
+    items = [str(item) for item in merged.get("items", []) if str(item).strip()]
+    seen = {
+        key
+        for item in items
+        if (key := _canonical_synonym_term(_base_word(item))) is not None
+    }
+    source_urls = [str(url) for url in merged.get("source_urls", []) if str(url).strip()]
+    source_labels: list[str] = []
+    additions = 0
+
+    for relation in sorted(relations, key=lambda item: int(item.get("vein") or 99)):
+        item = _canonical_synonym_term(relation.get("item"))
+        if not item:
+            continue
+        item_was_present = item in seen
+        if not item_was_present:
+            if additions >= _ANTONYM_ADDITION_CAP:
                 continue
             seen.add(item)
             items.append(item)
@@ -4768,6 +4913,7 @@ def enrich_entry(
     *,
     has_sum11_flags,
     pointer_synonym_relations: list[dict[str, Any]] | None = None,
+    pointer_antonym_relations: list[dict[str, Any]] | None = None,
 ) -> bool:
     """Enrich a single manifest entry in place (dictionary-grounded).
     Returns True if any enrichment was attached. Extracted from enrich() so the
@@ -4851,6 +4997,17 @@ def enrich_entry(
         antonyms = _antonyms_wiktionary(conn, fallback_base, entry_pos=entry_pos)
         if antonyms:
             antonyms = _with_base_source_label(antonyms, fallback_base)
+    antonym_relations = (
+        pointer_antonym_relations
+        if pointer_antonym_relations is not None
+        else _definition_antonym_relations(
+            conn,
+            lemma,
+            has_sum11_flags=has_sum11_flags,
+            cache=slovnyk_cache,
+        )
+    )
+    antonyms = _merge_antonym_relations(antonyms, antonym_relations)
     if antonyms:
         sections["antonyms"] = antonyms
     idioms = _idioms(conn, lemma, slovnyk_cache)
@@ -4963,6 +5120,11 @@ def enrich() -> tuple[int, int]:
             manifest,
             has_sum11_flags=has_sum11_flags,
         )
+        pointer_antonym_relations = _definition_antonym_relations_by_headword(
+            conn,
+            manifest,
+            has_sum11_flags=has_sum11_flags,
+        )
         for entry in manifest["entries"]:
             entry_key = _canonical_synonym_term(str(entry.get("lemma") or ""))
             if enrich_entry(
@@ -4971,6 +5133,7 @@ def enrich() -> tuple[int, int]:
                 kaikki_lookup,
                 has_sum11_flags=has_sum11_flags,
                 pointer_synonym_relations=pointer_synonym_relations.get(entry_key or "", []),
+                pointer_antonym_relations=pointer_antonym_relations.get(entry_key or "", []),
             ):
                 enriched += 1
     finally:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "c3e9599c543b19f76fd7b590536be25d78c9d5185c7ef8f440e43e37109fa2f8",
+  "fingerprint": "2745a4a73c67015d2af58bea1c32e5fd68b64dc5af4156acd79d52a7e02f5245",
   "inputs": {
     "lexicon_code": [
       {
@@ -52,7 +52,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "ce20132ff9bb7b641cd30527a28a8a653a4a63ad488233b6e54ab612eb1eb0d5"
+        "sha256": "b3e4f1ef6c6ab7f1fe2601ac98e192443d3b69283ace1a5de953b9b771934fd2"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -20,6 +20,9 @@ from scripts.lexicon.enrich_manifest import (
     _cefr,
     _clean_synonym_candidate,
     _curated_calque,
+    _definition_antonym_relations,
+    _definition_antonym_relations_by_headword,
+    _definition_antonym_targets,
     _definition_cards,
     _definition_pointer_relations,
     _definition_pointer_relations_by_headword,
@@ -37,6 +40,7 @@ from scripts.lexicon.enrich_manifest import (
     _literary_attestation,
     _literary_excerpt,
     _meaning,
+    _merge_antonym_relations,
     _merge_slovnyk_warning,
     _merge_synonym_relations,
     _morphology,
@@ -69,6 +73,11 @@ def _patch_vesum_analyses(monkeypatch, pos_by_word: dict[str, str]) -> None:
         return ((word, pos),) if pos else ()
 
     monkeypatch.setattr(enrich_manifest_module, "_vesum_word_analyses", fake_analyses)
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "verify_word",
+        lambda word: [{"lemma": word, "pos": pos_by_word[word]}] if word in pos_by_word else [],
+    )
 
 
 def _conn() -> sqlite3.Connection:
@@ -969,7 +978,7 @@ def test_wiktionary_antonyms_filter_wrong_terms_keep_valid(monkeypatch) -> None:
     )
     _patch_vesum_analyses(
         monkeypatch,
-        {"син": "noun", "мати": "noun", "матка": "noun", "матуся": "noun"},
+        {"дочка": "noun", "син": "noun", "мати": "noun", "матка": "noun", "матуся": "noun"},
     )
 
     section = _antonyms_wiktionary(conn, "дочка", entry_pos="noun")
@@ -2076,11 +2085,7 @@ def test_enrich_populates_antonyms_phraseology_and_variant_etymology(monkeypatch
     monkeypatch.setattr(enrich_manifest_module, "_meaning", lambda *args, **kwargs: None)
     monkeypatch.setattr(enrich_manifest_module, "_literary_attestation", lambda *args, **kwargs: None)
     monkeypatch.setattr(enrich_manifest_module, "_translation", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        enrich_manifest_module,
-        "_vesum_word_analyses",
-        lambda word: ((word, "noun"),) if word in {"воля", "ув'язнення"} else (),
-    )
+    _patch_vesum_analyses(monkeypatch, {"воля": "noun", "ув'язнення": "noun"})
 
     assert enrich_manifest_module.enrich() == (1, 1)
 
@@ -2529,6 +2534,176 @@ def _patch_synonym_vesum(monkeypatch, valid_terms: set[str], stems: dict[str, st
         "_vesum_word_analyses",
         lambda word: [(stems.get(word, word), "noun")] if word in valid_terms else [],
     )
+
+
+def test_definition_antonym_targets_extract_strict_sum_and_vts_pointers() -> None:
+    assert _definition_antonym_targets(
+        "ВЕЛИ́КИЙ, а, е. Значний розмірами; протилежне малий."
+    ) == [("малий", "протилежне")]
+    assert _definition_antonym_targets(
+        "висо́кий -а, -е. Значний за висотою; прот. низький."
+    ) == [("низький", "прот.")]
+    assert _definition_antonym_targets(
+        "СИ́ЛЬНИЙ, а, е. Міцний; протилежне слабкий, слабий."
+    ) == [("слабкий", "протилежне"), ("слабий", "протилежне")]
+    # Ordinary prose and a grammatical continuation are not dictionary pointers.
+    assert _definition_antonym_targets("Слова з протилежним значенням називають антонімами.") == []
+    assert _definition_antonym_targets("Напрям, протилежне до руху.") == []
+
+
+def test_definition_antonym_relations_keep_dictionary_provenance_and_vesum_gate(monkeypatch) -> None:
+    _patch_synonym_vesum(monkeypatch, {"великий", "малий"})
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO sum11(word, definition) VALUES (?, ?)",
+        ("великий", "ВЕЛИ́КИЙ, а, е. Значний за розмірами; протилежне малий."),
+    )
+    cache = {
+        "lookups": {
+            "newsum": {
+                "word": "великий",
+                "text": "великий ВЕЛИ́КИЙ, а, е. Значний за розмірами; протилежне малий.",
+                "source_url": "https://example.invalid/sum20/velykyi",
+            },
+            "vts": {
+                "word": "великий",
+                "text": "великий вели́кий -а, -е. Значний за розмірами; прот. малий.",
+                "source_url": "https://example.invalid/vts/velykyi",
+            },
+        }
+    }
+
+    relations = _definition_antonym_relations(
+        conn, "великий", has_sum11_flags=True, cache=cache
+    )
+
+    assert [(row["item"], row["source"], row["pattern"]) for row in relations] == [
+        ("малий", "СУМ-20", "протилежне"),
+        ("малий", "ВТС", "прот."),
+        ("малий", "СУМ-11", "протилежне"),
+    ]
+    assert all(row["gate"] == {"vesum": "both valid"} for row in relations)
+    assert [row.get("source_url") for row in relations] == [
+        "https://example.invalid/sum20/velykyi",
+        "https://example.invalid/vts/velykyi",
+        None,
+    ]
+
+    _patch_synonym_vesum(monkeypatch, {"малий"})
+    assert _definition_antonym_relations(conn, "великий", has_sum11_flags=True, cache=cache) == []
+
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "verify_word",
+        lambda word: [{"lemma": "великий", "pos": "adj"}]
+        if word == "великий"
+        else [{"lemma": "малий", "pos": "adj"}]
+        if word == "малого"
+        else [],
+    )
+    inflected_cache = {
+        "lookups": {
+            "newsum": {
+                "word": "великий",
+                "text": "великий ВЕЛИ́КИЙ, а, е. Значний за розмірами; протилежне малого.",
+            }
+        }
+    }
+    assert _definition_antonym_relations(
+        conn, "великий", has_sum11_flags=True, cache=inflected_cache
+    ) == []
+
+
+def test_definition_antonym_relations_are_reciprocal_for_manifest_headwords(monkeypatch) -> None:
+    _patch_synonym_vesum(monkeypatch, {"великий", "малий"})
+    monkeypatch.setattr(enrich_manifest_module, "_read_cached_slovnyk_rows", lambda lemma: {})
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO sum11(word, definition) VALUES (?, ?)",
+        ("великий", "ВЕЛИ́КИЙ, а, е. Значний за розмірами; протилежне малий."),
+    )
+    manifest = {"entries": [{"lemma": "великий"}, {"lemma": "малий"}]}
+
+    relations = _definition_antonym_relations_by_headword(
+        conn, manifest, has_sum11_flags=True
+    )
+
+    assert relations["великий"][0]["item"] == "малий"
+    assert relations["малий"][0]["item"] == "великий"
+    assert relations["малий"][0]["direction"] == "reciprocal"
+
+
+def test_antonym_relation_merge_preserves_rendered_schema_and_source_urls() -> None:
+    existing = {
+        "items": ["малий"],
+        "source": "Вікісловник: explicit antonym list",
+        "source_urls": ["https://example.invalid/wiktionary/velykyi"],
+    }
+    relations = [
+        {
+            "item": "малий",
+            "source": "СУМ-20",
+            "pattern": "протилежне",
+            "vein": 1,
+            "gate": {"vesum": "both valid"},
+            "source_url": "https://example.invalid/sum20/velykyi",
+        },
+        {
+            "item": "низький",
+            "source": "ВТС",
+            "pattern": "прот.",
+            "vein": 1,
+            "gate": {"vesum": "both valid"},
+            "source_url": "https://example.invalid/vts/velykyi",
+        },
+    ]
+
+    merged = _merge_antonym_relations(existing, relations)
+
+    assert merged == {
+        "items": ["малий", "низький"],
+        "source": (
+            "Вікісловник: explicit antonym list + СУМ-20: протилежне → малий + "
+            "ВТС: прот. → низький"
+        ),
+        "source_urls": [
+            "https://example.invalid/wiktionary/velykyi",
+            "https://example.invalid/sum20/velykyi",
+            "https://example.invalid/vts/velykyi",
+        ],
+    }
+
+
+def test_antonym_fixture_samples_expand_from_zero(monkeypatch) -> None:
+    pairs = {
+        "великий": "малий",
+        "день": "ніч",
+        "білий": "чорний",
+        "високий": "низький",
+    }
+    _patch_synonym_vesum(monkeypatch, set(pairs) | set(pairs.values()))
+    conn = _conn()
+    conn.executemany(
+        "INSERT INTO sum11(word, definition) VALUES (?, ?)",
+        [
+            (lemma, f"{lemma.upper()}. Тестова дефініція; протилежне {antonym}.")
+            for lemma, antonym in pairs.items()
+        ],
+    )
+
+    before_counts = {lemma: 0 for lemma in pairs}
+    after_items = {
+        lemma: [
+            relation["item"]
+            for relation in _definition_antonym_relations(
+                conn, lemma, has_sum11_flags=True, cache={}
+            )
+        ]
+        for lemma in pairs
+    }
+
+    assert before_counts == {lemma: 0 for lemma in pairs}
+    assert after_items == {lemma: [antonym] for lemma, antonym in pairs.items()}
 
 
 def test_definition_synonym_targets_extracts_stressed_same_as_target() -> None:


### PR DESCRIPTION
Refs #4975

## Summary

- Adds strict, clause-bounded СУМ-20 / ВТС / СУМ-11 antonym-pointer extraction for `протилежне <lemma>` and VTS `прот. <lemma>` markers.
- VESUM-gates both endpoints as their own lemmas, including retained Вікісловник pairs; extracts symmetric relation entries when both headwords are in the manifest.
- Merges pointer results into the existing `sections["antonyms"]` shape with `{source, items, source_urls}` and preserves Wiktionary attribution.
- Does not run a full re-enrichment or publish any generated manifest/cache artifact.

## Deterministic evidence

### Raw definition markers

- СУМ-11 `великий`: `ВЕЛИ́КИЙ, а, е. 1. Значний своїми розмірами, величиною; протилежне малий.`
- СУМ-11 `високий`: `ВИСО́КИЙ, а, е. 1. Який має велику відстань знизу вгору; протилежне низький.`
- СУМ-11 `сильний`: `СИ́ЛЬНИЙ, а, е. 1. Який має велику фізичну силу ...; протилежне слабкий, слабий.`
- СУМ-20 [великий](https://slovnyk.me/dict/newsum/%D0%B2%D0%B5%D0%BB%D0%B8%D0%BA%D0%B8%D0%B9): `... Значний своїми розмірами, величиною; протилежне малий .`
- ВТС [великий](https://slovnyk.me/dict/vts/%D0%B2%D0%B5%D0%BB%D0%B8%D0%BA%D0%B8%D0%B9): `... Значний за розмірами, величиною; прот. малий.`

`rg` found no source slug named `synonyms_antonyms`; it is an audit coverage label only. Direct Slovnyk probes for `/dict/synonyms_antonyms/<lemma>` and `/dict/antonyms/<lemma>` returned 404, so no nonexistent dictionary was integrated.

### VESUM own-lemma gate

Read-only `verify_word` output (first analysis) confirmed each endpoint:

- `великий` → `lemma=великий, pos=adj, tags=adj:m:v_naz:compb`; `малий` → `lemma=малий, pos=adj, tags=adj:m:v_naz:compb`
- `день` → `lemma=день, pos=noun, tags=noun:inanim:m:v_naz`; `ніч` → `lemma=ніч, pos=noun, tags=noun:inanim:f:v_naz`
- `білий` → `lemma=білий, pos=adj, tags=adj:m:v_naz:compb`; `чорний` → `lemma=чорний, pos=adj, tags=adj:m:v_naz:compb`
- `високий` → `lemma=високий, pos=adj, tags=adj:m:v_naz:compb`; `низький` → `lemma=низький, pos=adj, tags=adj:m:v_naz:compb`

The gate rejects inflected forms: `verify_word("чорне")` resolves to lemma `чорний`, so it is not emitted as an antonym chip.

### Small read-only probe (not a full enrichment)

| Lemma | Before | Pointer items | After |
| --- | ---: | --- | ---: |
| великий | 0 | малий | 1 |
| день | 1 | — | 1 |
| білий | 0 | чорний, червоний | 2 |
| високий | 1 | низький | 1 |

## Validation

- `.venv/bin/pytest -q tests/test_lexicon_enrich_manifest.py` → `118 passed`
- `.venv/bin/ruff check scripts/lexicon/enrich_manifest.py tests/test_lexicon_enrich_manifest.py` → passed
- `git diff --check` → passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` → passed

## Review and handoff

Agy / Gemini cross-family review approved the final diff. An additional DeepSeek Flash reviewer attempt was terminated by its 60-second initial-response guard with no verdict; it is not relied upon.

Driver next action: review this code-only PR, then run the separately authorized re-enrichment / publish workflow. Auto-merge is intentionally not armed.