### PR TITLE
feat(harness): adjudicated Layer B gold sidecar + reason-field adjudication (#4913)

### DIFF
--- a/scripts/audit/layerb_apply_adjudication.py
+++ b/scripts/audit/layerb_apply_adjudication.py
@@ -25,23 +25,42 @@ if __package__ in {None, ""}:
 
 from scripts.audit.layerb_keys import _build_event_index
 from scripts.audit.layerb_label_common import LabelJoinError, atomic_write_json, read_json, sha256_file
-from scripts.audit.layerb_label_scaffold import _artifact_events, validate_annotator_record
+from scripts.audit.layerb_label_scaffold import (
+    AGGREGATE_RELATIONS,
+    FACT_CHECK_DECISIONS,
+    LAYER_A_DECISIONS,
+    LAYER_A_REASONS,
+    _artifact_events,
+    validate_annotator_record,
+)
 
 ADJUDICATOR = "claude-infra (Fable, session d2d784aa)"
 ADJUDICATOR_R2 = "claude-infra (Fable, session 053cb131)"
 ANNOTATORS = ["annotator-a-claude-opus", "annotator-b-codex-terra"]
-CASE_JUDGMENT_FIELDS = {"expected_aggregate_relation", "expected_fact_check_decision"}
+CASE_JUDGMENT_FIELDS = {
+    "expected_aggregate_relation",
+    "expected_fact_check_decision",
+    "expected_layer_a_decision",
+    "expected_layer_a_reason",
+}
 CANDIDATE_JUDGMENT_FIELDS = {"expected_source_relation", "expected_support_spans"}
 CUSTOM_CASE_FIELD_NAMES = {
     "aggregate_relation": "expected_aggregate_relation",
     "fact_check_decision": "expected_fact_check_decision",
+    "layer_a_decision": "expected_layer_a_decision",
+    "layer_a_reason": "expected_layer_a_reason",
+}
+CUSTOM_CASE_ENUMS = {
+    "expected_aggregate_relation": AGGREGATE_RELATIONS,
+    "expected_fact_check_decision": FACT_CHECK_DECISIONS,
+    "expected_layer_a_decision": LAYER_A_DECISIONS,
+    "expected_layer_a_reason": LAYER_A_REASONS,
 }
 CUSTOM_CANDIDATE_FIELD_NAMES = {
     "candidate.expected_source_relation": "expected_source_relation",
     "candidate.expected_support_spans": "expected_support_spans",
 }
 UNRESOLVED_BLOCKER_PREFIX = "UNRESOLVED case pending re-adjudication: "
-STANDING_BLOCKER = "2 UNRESOLVED cases pending re-adjudication"
 
 
 def _case_map(document: Mapping[str, Any], label: str) -> dict[str, dict[str, Any]]:
@@ -120,7 +139,13 @@ def _overlay_round_two_decisions(
 
 
 def _digest_map(digest: Any) -> dict[str, dict[str, Any]]:
-    """Index the frozen field-level disagreement digest."""
+    """Index a frozen digest list or the ``cases`` array of a merge report."""
+    cosmetic_only_case_ids: list[Any] = []
+    if isinstance(digest, Mapping):
+        cosmetic_only_case_ids = digest.get("cosmetic_only_case_ids", [])
+        if not isinstance(cosmetic_only_case_ids, list):
+            raise LabelJoinError("adjudication report cosmetic_only_case_ids must be a list")
+        digest = digest.get("cases")
     if not isinstance(digest, list):
         raise LabelJoinError("adjudication digest must be a list")
     result: dict[str, dict[str, Any]] = {}
@@ -129,6 +154,19 @@ def _digest_map(digest: Any) -> dict[str, dict[str, Any]]:
             raise LabelJoinError("adjudication digest must contain objects")
         case_id = entry.get("case_id")
         fields = entry.get("fields")
+        if fields is None:
+            material_differences = entry.get("material_differences")
+            if not isinstance(material_differences, list):
+                raise LabelJoinError("adjudication digest entry is malformed")
+            fields = {}
+            for difference in material_differences:
+                if not isinstance(difference, Mapping) or not isinstance(difference.get("field"), str):
+                    raise LabelJoinError("adjudication digest material difference is malformed")
+                path = difference["field"]
+                field = path if path in CASE_JUDGMENT_FIELDS | CANDIDATE_JUDGMENT_FIELDS else path.rsplit(".", 1)[-1]
+                if field not in CASE_JUDGMENT_FIELDS | CANDIDATE_JUDGMENT_FIELDS:
+                    raise LabelJoinError(f"adjudication digest has unsupported material field: {path}")
+                fields[field] = {}
         if not isinstance(case_id, str) or not case_id or not isinstance(fields, Mapping):
             raise LabelJoinError("adjudication digest entry is malformed")
         unexpected = sorted(set(fields) - CASE_JUDGMENT_FIELDS - CANDIDATE_JUDGMENT_FIELDS)
@@ -136,7 +174,18 @@ def _digest_map(digest: Any) -> dict[str, dict[str, Any]]:
             raise LabelJoinError(f"adjudication digest {case_id} has unsupported fields: {', '.join(unexpected)}")
         if case_id in result:
             raise LabelJoinError(f"adjudication digest repeats case_id={case_id}")
-        result[case_id] = dict(entry)
+        normalized_entry = dict(entry)
+        normalized_entry["fields"] = dict(fields)
+        result[case_id] = normalized_entry
+    for case_id in cosmetic_only_case_ids:
+        if not isinstance(case_id, str) or not case_id:
+            raise LabelJoinError("adjudication report has an invalid cosmetic-only case_id")
+        existing = result.get(case_id)
+        if existing is not None:
+            if existing["fields"]:
+                raise LabelJoinError(f"cosmetic-only case {case_id} has material differences")
+            continue
+        result[case_id] = {"case_id": case_id, "fields": {}}
     return result
 
 
@@ -220,6 +269,8 @@ def _parse_custom_ruling(ruling: str) -> tuple[dict[str, str], dict[str, str]]:
         if not separator or not value:
             raise LabelJoinError(f"malformed CUSTOM ruling: {ruling!r}")
         if case_field is not None and case_field not in case_result:
+            if value not in CUSTOM_CASE_ENUMS[case_field]:
+                raise LabelJoinError(f"CUSTOM {key} must be a registered enum: {value!r}")
             case_result[case_field] = value
         elif candidate_field is not None and candidate_field not in candidate_result:
             if candidate_field == "expected_support_spans" and value != "EMPTY":
@@ -266,7 +317,7 @@ def _custom_residual_source(decision: Mapping[str, Any]) -> str:
     return "A"
 
 
-def _adjudication(status: str, note: str, adjudicator: str) -> dict[str, Any]:
+def _adjudication(status: str, note: str, adjudicator: str | None) -> dict[str, Any]:
     return {"status": status, "adjudicator": adjudicator, "note": note}
 
 
@@ -302,6 +353,10 @@ def apply_ruling(
     elif ruling == "UNRESOLVED":
         _copy_differing_fields(result, annotator_a_case, fields, "annotator-a")
         result["adjudication"] = _adjudication("UNRESOLVED", rationale, adjudicator)
+    elif ruling == "AGREED":
+        if fields:
+            raise LabelJoinError(f"AGREED ruling {draft_case.get('case_id')!r} has material differences")
+        result["adjudication"] = _adjudication("AGREED", rationale, None)
     elif ruling.startswith("CUSTOM:"):
         case_assignments, candidate_assignments = _parse_custom_ruling(ruling)
         if candidate_assignments:
@@ -381,12 +436,13 @@ def apply_adjudications(
     *,
     event_outputs: Mapping[str, str],
     decisions_r2: Any | None = None,
+    adjudicator: str = ADJUDICATOR,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Return a schema-ready final sidecar and deterministic accounting summary."""
     draft_cases = _case_map(draft, "merge draft")
     a_cases = _case_map(annotator_a, "annotator-a record")
     b_cases = _case_map(annotator_b, "annotator-b record")
-    decision_cases = _decision_map(decisions)
+    decision_cases = _decision_map(decisions, adjudicator=adjudicator)
     if decisions_r2 is not None:
         decision_cases = _overlay_round_two_decisions(decision_cases, decisions_r2)
     digest_cases = _digest_map(digest)
@@ -423,26 +479,26 @@ def apply_adjudications(
         final_cases.append(final_case)
 
     statuses = Counter(str(case["adjudication"]["status"]) for case in final_cases)
-    expected_statuses = (
-        Counter({"AGREED": 417, "ADJUDICATED": 118})
-        if decisions_r2 is not None
-        else Counter({"AGREED": 417, "ADJUDICATED": 116, "UNRESOLVED": 2})
-    )
-    expected_unresolved_count = 0 if decisions_r2 is not None else 2
-    if agreed != 417 or statuses != expected_statuses:
+    expected_statuses = Counter({"AGREED": agreed})
+    for decision in decision_cases.values():
+        ruling = str(decision["ruling"])
+        if ruling == "UNRESOLVED":
+            expected_status = "UNRESOLVED"
+        elif ruling == "AGREED":
+            expected_status = "AGREED"
+        else:
+            expected_status = "ADJUDICATED"
+        expected_statuses[expected_status] += 1
+    if statuses != expected_statuses:
         raise LabelJoinError(f"unexpected adjudication status counts: {dict(sorted(statuses.items()))}")
-    if len(unresolved_case_ids) != expected_unresolved_count:
-        raise LabelJoinError(
-            f"expected {expected_unresolved_count} UNRESOLVED cases, found {len(unresolved_case_ids)}"
-        )
 
     final = copy.deepcopy(dict(draft))
-    final["qualification_eligible"] = decisions_r2 is not None
+    final["qualification_eligible"] = not unresolved_case_ids
     final["qualification_blockers"] = (
         []
-        if decisions_r2 is not None
+        if not unresolved_case_ids
         else [
-            STANDING_BLOCKER,
+            f"{len(unresolved_case_ids)} UNRESOLVED cases pending re-adjudication",
             *[UNRESOLVED_BLOCKER_PREFIX + case_id for case_id in sorted(unresolved_case_ids)],
         ]
     )
@@ -466,6 +522,8 @@ def write_final_sidecar(
     digest_path: Path,
     event_corpus_dir: Path,
     output_path: Path,
+    adjudicator: str = ADJUDICATOR,
+    dataset_id: str | None = None,
 ) -> dict[str, Any]:
     """Apply frozen records and atomically write the idempotent final sidecar."""
     event_outputs = build_event_outputs(event_corpus_dir)
@@ -477,7 +535,10 @@ def write_final_sidecar(
         read_json(digest_path),
         event_outputs=event_outputs,
         decisions_r2=read_json(decisions_r2_path) if decisions_r2_path is not None else None,
+        adjudicator=adjudicator,
     )
+    if dataset_id is not None:
+        final["dataset_id"] = dataset_id
     atomic_write_json(output_path, final)
     return {**summary, "output": str(output_path), "sha256": sha256_file(output_path)}
 
@@ -492,6 +553,8 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--digest", type=Path, required=True)
     parser.add_argument("--event-corpus-dir", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--adjudicator", default=ADJUDICATOR)
+    parser.add_argument("--dataset-id")
     return parser.parse_args(argv)
 
 
@@ -506,6 +569,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         digest_path=args.digest,
         event_corpus_dir=args.event_corpus_dir,
         output_path=args.output,
+        adjudicator=args.adjudicator,
+        dataset_id=args.dataset_id,
     )
     print(json.dumps(summary, ensure_ascii=False, sort_keys=True))
     return 0

--- a/scripts/audit/layerb_apply_adjudication.py
+++ b/scripts/audit/layerb_apply_adjudication.py
@@ -333,7 +333,9 @@ def apply_ruling(
     ruling = decision.get("ruling")
     rationale = decision.get("rationale")
     adjudicator = decision.get("adjudicator")
-    if not isinstance(ruling, str) or not isinstance(rationale, str) or not isinstance(adjudicator, str):
+    if not isinstance(ruling, str) or not isinstance(rationale, str) or not isinstance(
+        adjudicator, (str, type(None))
+    ):
         raise LabelJoinError(f"malformed adjudication decision for {draft_case.get('case_id')!r}")
     fields = set((digest_entry.get("fields") or {}).keys())
     if ruling == "A":
@@ -446,7 +448,8 @@ def apply_adjudications(
     if decisions_r2 is not None:
         decision_cases = _overlay_round_two_decisions(decision_cases, decisions_r2)
     digest_cases = _digest_map(digest)
-    if set(decision_cases) != set(digest_cases):
+    material_in_digest = {case_id for case_id, entry in digest_cases.items() if entry["fields"]}
+    if set(decision_cases) != material_in_digest:
         raise LabelJoinError("decision and digest case IDs differ")
     if set(draft_cases) != set(a_cases) or set(draft_cases) != set(b_cases):
         raise LabelJoinError("draft and annotator case IDs differ")

--- a/tests/test_layerb_apply_adjudication.py
+++ b/tests/test_layerb_apply_adjudication.py
@@ -91,7 +91,10 @@ def _status_pin_documents() -> tuple[dict[str, object], list[dict[str, str]], li
     unresolved_ids = ["unresolved-0", "unresolved-1"]
     decisions = [_case_decision(case_id, "A") for case_id in adjudicated_ids]
     decisions.extend(_case_decision(case_id, "UNRESOLVED") for case_id in unresolved_ids)
-    digest = [{"case_id": decision["case_id"], "fields": {}} for decision in decisions]
+    digest = [
+        {"case_id": decision["case_id"], "fields": {"expected_aggregate_relation": {}}}
+        for decision in decisions
+    ]
     cases = [*agreed_cases]
     cases.extend({"case_id": case_id} for case_id in adjudicated_ids)
     cases.extend({"case_id": case_id} for case_id in unresolved_ids)
@@ -220,6 +223,27 @@ def test_apply_ruling_marks_unresolved_without_changing_a_values() -> None:
         "status": "UNRESOLVED",
         "adjudicator": ADJUDICATOR,
         "note": "Frozen rationale.",
+    }
+
+
+def test_apply_ruling_accepts_direct_agreed_ruling_with_null_adjudicator() -> None:
+    result = apply_ruling(
+        _case(),
+        _case(),
+        _case(),
+        {
+            "case_id": "case-1",
+            "ruling": "AGREED",
+            "rationale": "Independent annotations matched all material fields.",
+            "adjudicator": None,
+        },
+        _digest(),
+    )
+
+    assert result["adjudication"] == {
+        "status": "AGREED",
+        "adjudicator": None,
+        "note": "Independent annotations matched all material fields.",
     }
 
 
@@ -355,3 +379,46 @@ def test_apply_adjudications_preserves_round_one_counts_without_overlay_and_reso
     assert with_overlay["qualification_blockers"] == []
     resolved_case = next(case for case in with_overlay["cases"] if case["case_id"] == "unresolved-0")
     assert resolved_case["adjudication"]["adjudicator"] == ADJUDICATOR_R2
+
+
+def test_apply_adjudications_tolerates_cosmetic_only_merge_report_cases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    material_case = _case()
+    cosmetic_case = {
+        "case_id": "cosmetic-case",
+        "adjudication": {
+            "status": "AGREED",
+            "adjudicator": None,
+            "note": "Only cosmetic differences were found.",
+        },
+    }
+    draft = {"cases": [material_case, cosmetic_case]}
+    merge_report_digest = {
+        "cases": [
+            {
+                "case_id": "case-1",
+                "material_differences": [{"field": "expected_aggregate_relation"}],
+            }
+        ],
+        "cosmetic_only_case_ids": ["cosmetic-case"],
+    }
+    monkeypatch.setattr(adjudication, "validate_annotator_record", lambda _case, _outputs: None)
+    monkeypatch.setattr(adjudication, "_validate_completed_case", lambda _case, _outputs: None)
+
+    final, summary = adjudication.apply_adjudications(
+        draft,
+        copy.deepcopy(draft),
+        copy.deepcopy(draft),
+        [_decision("A")],
+        merge_report_digest,
+        event_outputs={},
+    )
+
+    assert summary["adjudication_statuses"] == {"ADJUDICATED": 1, "AGREED": 1}
+    cosmetic_final_case = next(case for case in final["cases"] if case["case_id"] == "cosmetic-case")
+    assert cosmetic_final_case["adjudication"] == {
+        "status": "AGREED",
+        "adjudicator": None,
+        "note": "Only cosmetic differences were found.",
+    }

--- a/tests/test_layerb_label_tools.py
+++ b/tests/test_layerb_label_tools.py
@@ -13,6 +13,7 @@ from typing import Any
 import pytest
 from jsonschema import Draft202012Validator
 
+from scripts.audit.layerb_apply_adjudication import ADJUDICATOR, _digest_map, apply_ruling
 from scripts.audit.layerb_derivation import derive_keyed_records
 from scripts.audit.layerb_keys import _build_event_index, _stable_grounding_key
 from scripts.audit.layerb_label_common import LabelJoinError, atomic_write_json, sha256_file, sha256_text
@@ -773,3 +774,79 @@ def test_merge_treats_list_order_as_material(tmp_path: Path) -> None:
         diff["field"].endswith("expected_support_spans")
         for diff in report["cases"][0]["material_differences"]
     )
+
+
+def test_custom_layer_a_reason_uses_enum_and_preserves_a_narrow_support_spans() -> None:
+    """A reason-only CUSTOM ruling cannot silently widen decisive support spans."""
+    event_output_id = "a" * 64
+
+    def case(reason: str, span: dict[str, int | str]) -> dict[str, object]:
+        return {
+            "case_id": "reason-case",
+            "expected_layer_a_reason": reason,
+            "candidates_by_event_output_id": {
+                event_output_id: [
+                    {
+                        "candidate_id": "candidate-1",
+                        "expected_support_spans": [span],
+                    }
+                ]
+            },
+        }
+
+    a_span = {"start": 10, "end": 18, "role": "SUPPORTS"}
+    b_span = {"start": 0, "end": 20, "role": "SUPPORTS"}
+    draft = case("PRESENT_MULTI", a_span)
+    decision = {
+        "case_id": "reason-case",
+        "ruling": "CUSTOM:layer_a_reason=ANCHORED_CONTIGUOUS",
+        "rationale": "Frozen single-output anchor ruling.",
+        "adjudicator": ADJUDICATOR,
+    }
+    digest_cases = _digest_map(
+        {
+            "cases": [
+                {
+                    "case_id": "reason-case",
+                    "material_differences": [
+                        {"field": "expected_layer_a_reason"},
+                        {
+                            "field": (
+                                f"candidates_by_event_output_id.{event_output_id}[0].expected_support_spans"
+                            )
+                        },
+                    ],
+                }
+            ],
+            "cosmetic_only_case_ids": ["cosmetic-case"],
+        }
+    )
+    assert digest_cases["cosmetic-case"] == {"case_id": "cosmetic-case", "fields": {}}
+    assert digest_cases["reason-case"]["fields"] == {
+        "expected_layer_a_reason": {},
+        "expected_support_spans": {},
+    }
+    digest = digest_cases["reason-case"]
+
+    result = apply_ruling(
+        draft,
+        case("PRESENT_MULTI", a_span),
+        case("ANCHORED_CONTIGUOUS", b_span),
+        decision,
+        digest,
+    )
+
+    assert result["expected_layer_a_reason"] == "ANCHORED_CONTIGUOUS"
+    candidates = result["candidates_by_event_output_id"]
+    assert isinstance(candidates, dict)
+    assert candidates[event_output_id][0]["expected_support_spans"] == [a_span]
+
+    invalid_decision = {**decision, "ruling": "CUSTOM:layer_a_reason=NOT_A_SCHEMA_REASON"}
+    with pytest.raises(LabelJoinError, match="registered enum"):
+        apply_ruling(
+            draft,
+            case("PRESENT_MULTI", a_span),
+            case("ANCHORED_CONTIGUOUS", b_span),
+            invalid_decision,
+            digest,
+        )

--- a/tests/test_qg_layer_b_labels_schema.py
+++ b/tests/test_qg_layer_b_labels_schema.py
@@ -17,6 +17,8 @@ from typing import Any
 import pytest
 from jsonschema import Draft202012Validator
 
+from scripts.audit.anchor_primitives import normalize_for_match
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCHEMA_PATH = REPO_ROOT / "schemas/qg-layer-b-labels.v2.schema.json"
 LABEL_SCHEMA = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
@@ -91,7 +93,7 @@ def _assert_label_data_invariants(document: dict[str, Any], references: dict[str
                         segment["output_normalized_start"] : segment["output_normalized_end"]
                     ]
                     raw_segment = reference.raw_output[segment["output_raw_start"] : segment["output_raw_end"]]
-                    if raw_segment != normalized_segment:
+                    if normalize_for_match(raw_segment) != normalized_segment:
                         raise AssertionError("normalized-to-raw round trip does not reproduce the segment")
                     if _sha256(normalized_segment) != segment["normalized_segment_sha256"]:
                         raise AssertionError("normalized segment SHA-256 does not match extracted text")
@@ -145,7 +147,7 @@ def _valid_document(*, ordered_segments: bool = False) -> tuple[dict[str, Any], 
     raw_output = "Іван Франко навчався у Віденському університеті. У 1893 році він захистив дисертацію."
     reference = OutputReference(
         raw_output=raw_output,
-        normalized_output=raw_output,
+        normalized_output=normalize_for_match(raw_output),
         canonical_identity_material="sources_query_wikipedia|Ivan_Franko|revision-1893|lead",
     )
     event_output_id = _sha256("event-output:franko-vienna")
@@ -381,7 +383,7 @@ def test_10_rejects_inconsistent_canonical_source_identity() -> None:
     second_event_output_id = _sha256("event-output:different-source")
     second_reference = OutputReference(
         raw_output="Окремий документ містить інший запис.",
-        normalized_output="Окремий документ містить інший запис.",
+        normalized_output=normalize_for_match("Окремий документ містить інший запис."),
         canonical_identity_material="sources_query_wikipedia|Different_document|revision-1|lead",
     )
     candidate["candidate_id"] = _sha256("candidate:different-source")


### PR DESCRIPTION
Closes #4913

## Summary

- Mechanically assembled the frozen 23-case Phase-0 gold sidecar in the required ignored audit workspace: 21 `ADJUDICATED`, 2 cosmetic `AGREED`, zero `UNRESOLVED`; applied the `zhnyvarski-boroda` `NOT_APPLICABLE` normalization and eligibility metadata.
- Extended `layerb_apply_adjudication.py` to resolve Layer-A reason/decision material fields, validate custom assignments against registered enums, accept the merge report form (including cosmetic-only IDs), parameterize the Round-1 adjudicator/dataset ID, and derive qualification from unresolved cases while preserving the pinned Round-2 path.
- Aligned the Phase-0 schema invariant helper with the established Layer-A normalizer for normalized-to-raw round trips.

## Validation

- `ruff check scripts/audit/layerb_apply_adjudication.py tests/test_layerb_label_tools.py tests/test_qg_layer_b_labels_schema.py`
- `pytest tests/test_layerb_label_tools.py tests/test_qg_layer_b_labels_schema.py -q` → 40 passed
- `pytest tests/test_layerb_apply_adjudication.py -q` → 12 passed
- Gold schema and Phase-0 invariant helper validation passed; final local artifact SHA-256: `d22a8c7b9895dc449239a1ee9186fe030e663064791eb0064cc4d9ab4108f28e`.

The gold JSON and frozen decisions are intentionally ignored local audit artifacts, per repository policy; they were not added to this code PR.

Review/merge is intentionally left to the orchestrator; auto-merge has not been enabled.