### PR TITLE
feat(ingest): extract all ZNO online tasks

### DIFF
--- a/scripts/ingest/zno_ingest.py
+++ b/scripts/ingest/zno_ingest.py
@@ -478,14 +478,45 @@ BOOKLETS = [
     },
 ]
 
-# Mapping of Year + Session type to test IDs on zno.osvita.ua for 2019, 2020, 2021
+# Mapping of booklet metadata to the matching interactive test on zno.osvita.ua.
+#
+# Up to 2021, ``ukrainian`` hosted the combined Ukrainian language and literature
+# papers.  The standalone language catalogue, ``ukrmova``, is the authoritative
+# online source for the NMT papers from 2022 onward.  The source is keyed by the
+# complete booklet identity so that a second session cannot accidentally reuse
+# an otherwise similarly named test.
 ONLINE_TEST_MAPPING = {
-    (2019, "osnovna"): 347,
-    (2019, "dodatkova"): 363,
-    (2020, "osnovna"): 401,
-    (2020, "dodatkova"): 429,
-    (2021, "osnovna"): 471,  # maps to combined booklet mova-lit
-    (2021, "dodatkova"): 491,  # maps to combined booklet mova-lit
+    (2010, "sesiya-1", "mova-lit"): ("ukrainian", 15),
+    (2010, "sesiya-2", "mova-lit"): ("ukrainian", 16),
+    (2010, "sesiya-3", "mova-lit"): ("ukrainian", 17),
+    (2011, "sesiya-1", "mova-lit"): ("ukrainian", 13),
+    (2011, "sesiya-2", "mova-lit"): ("ukrainian", 14),
+    (2012, "sesiya-1", "mova-lit"): ("ukrainian", 11),
+    (2012, "sesiya-2", "mova-lit"): ("ukrainian", 12),
+    (2013, "sesiya-1", "mova-lit"): ("ukrainian", 6),
+    (2013, "sesiya-2", "mova-lit"): ("ukrainian", 10),
+    (2014, "sesiya-1", "mova-lit"): ("ukrainian", 132),
+    (2014, "sesiya-2", "mova-lit"): ("ukrainian", 133),
+    (2014, "dodatkova", "mova-lit"): ("ukrainian", 130),
+    (2015, "osnovna", "mova-lit"): ("ukrainian", 143),
+    (2016, "osnovna", "mova-lit"): ("ukrainian", 189),
+    (2017, "osnovna", "mova-lit"): ("ukrainian", 240),
+    (2017, "dodatkova", "mova-lit"): ("ukrainian", 254),
+    (2018, "osnovna", "mova-lit"): ("ukrainian", 299),
+    (2018, "dodatkova", "mova-lit"): ("ukrainian", 309),
+    (2019, "osnovna", "mova-lit"): ("ukrainian", 347),
+    (2019, "dodatkova", "mova-lit"): ("ukrainian", 363),
+    (2020, "osnovna", "mova-lit"): ("ukrainian", 401),
+    (2020, "dodatkova", "mova-lit"): ("ukrainian", 429),
+    (2021, "osnovna", "mova-lit"): ("ukrainian", 471),
+    (2021, "dodatkova", "mova-lit"): ("ukrainian", 491),
+    (2022, "osnovna", "mova"): ("ukrmova", 617),
+    (2023, "sesiya-1", "mova"): ("ukrmova", 619),
+    (2023, "sesiya-2", "mova"): ("ukrmova", 620),
+    (2024, "sesiya-1", "mova"): ("ukrmova", 622),
+    (2024, "sesiya-2", "mova"): ("ukrmova", 623),
+    (2025, "sesiya-1", "mova"): ("ukrmova", 667),
+    (2025, "sesiya-2", "mova"): ("ukrmova", 668),
 }
 
 
@@ -615,6 +646,7 @@ def ingest_documents(conn: sqlite3.Connection):
 
 # Simple global to track the time of the last HTTP request
 _last_request_time = 0.0
+FETCH_TIMEOUT_SECONDS = 30
 
 
 def fetch_page_with_rate_limit(url: str, cache_path: Path, rate_limit: float = 2.0) -> str:
@@ -633,7 +665,7 @@ def fetch_page_with_rate_limit(url: str, cache_path: Path, rate_limit: float = 2
 
     # Fetch page
     req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
-    with urllib.request.urlopen(req) as response:
+    with urllib.request.urlopen(req, timeout=FETCH_TIMEOUT_SECONDS) as response:
         html = response.read().decode("utf-8")
 
     _last_request_time = time.time()
@@ -643,6 +675,37 @@ def fetch_page_with_rate_limit(url: str, cache_path: Path, rate_limit: float = 2
     cache_path.write_text(html, encoding="utf-8")
 
     return html
+
+
+def derive_task_metadata(prompt: str, options_json: str, correct_json: str, task_format: str) -> tuple[str, str]:
+    """Derive only task metadata that is explicit in the source page.
+
+    Paronym pairs require a reviewed lexical analysis and are applied separately
+    with ``apply_zno_annotations.py``.  The source page itself unambiguously
+    identifies synonym, antonym, and lexical-error prompts, while a
+    single-choice наголос prompt identifies its target through the published
+    correct answer.
+    """
+    prompt_normalized = prompt.casefold()
+    task_subtype = ""
+    if "антонім" in prompt_normalized:
+        task_subtype = "antonym"
+    elif "синонім" in prompt_normalized:
+        task_subtype = "synonym"
+    elif "лексичн" in prompt_normalized and "помилк" in prompt_normalized:
+        task_subtype = "lexical_error"
+
+    stress_word = ""
+    if task_format == "single-choice" and "наголос" in prompt_normalized:
+        try:
+            options = json.loads(options_json)
+        except json.JSONDecodeError:
+            options = []
+        answer_index = {"А": 0, "Б": 1, "В": 2, "Г": 3, "Д": 4}.get(correct_json)
+        if isinstance(options, list) and answer_index is not None and answer_index < len(options):
+            stress_word = options[answer_index]
+
+    return task_subtype, stress_word
 
 
 def parse_and_insert_tasks(conn: sqlite3.Connection, html: str, doc_id: int, year: int, exam: str, session: str):
@@ -678,6 +741,8 @@ def parse_and_insert_tasks(conn: sqlite3.Connection, html: str, doc_id: int, yea
         # Stem
         q_div = card.find(class_="question")
         stem = q_div.get_text(separator="\n", strip=True) if q_div else ""
+        prompt_parts = q_div.find_all("p", recursive=False) if q_div else []
+        task_prompt = prompt_parts[-1].get_text(separator=" ", strip=True) if prompt_parts else stem
 
         # Topic tag verbatim
         exp = card.find(class_="explanation")
@@ -802,16 +867,45 @@ def parse_and_insert_tasks(conn: sqlite3.Connection, html: str, doc_id: int, yea
             options_json = "[]"
             correct_json = ""
 
-        # Insert or replace task
+        task_subtype, stress_word = derive_task_metadata(task_prompt, options_json, correct_json, task_format)
+
+        # Keep manually reviewed annotations on a refresh.  ``INSERT OR
+        # REPLACE`` deletes the previous row before inserting a new one, which
+        # silently clears topic_norm, task_subtype, paronym_pair, and
+        # stress_word.  An upsert updates parsed source fields in place instead.
         conn.execute(
             """
-            INSERT OR REPLACE INTO zno_tasks(
+            INSERT INTO zno_tasks(
                 document_id, year, exam, session, task_no, subject, task_format,
-                stem, options_json, correct_json, topic_tag
+                stem, options_json, correct_json, topic_tag, task_subtype, stress_word
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(document_id, task_no) DO UPDATE SET
+                year=excluded.year,
+                exam=excluded.exam,
+                session=excluded.session,
+                subject=excluded.subject,
+                task_format=excluded.task_format,
+                stem=excluded.stem,
+                options_json=excluded.options_json,
+                correct_json=excluded.correct_json,
+                topic_tag=excluded.topic_tag
         """,
-            (doc_id, year, exam, session, task_no, subject, task_format, stem, options_json, correct_json, topic_tag),
+            (
+                doc_id,
+                year,
+                exam,
+                session,
+                task_no,
+                subject,
+                task_format,
+                stem,
+                options_json,
+                correct_json,
+                topic_tag,
+                task_subtype,
+                stress_word,
+            ),
         )
         inserted += 1
 
@@ -820,26 +914,21 @@ def parse_and_insert_tasks(conn: sqlite3.Connection, html: str, doc_id: int, yea
 
 def ingest_tasks(conn: sqlite3.Connection, cache_dir: Path):
     """
-    Extract and ingest tasks for years 2019, 2020, 2021 from zno.osvita.ua test pages.
+    Extract and ingest tasks from the matching zno.osvita.ua test pages.
     """
-    # Find the document IDs for the target years & sessions
+    # Find the document IDs that have a verified interactive source.
     cursor = conn.execute("SELECT id, year, exam, session, subject_scope FROM zno_documents")
     docs = cursor.fetchall()
 
     total_inserted = 0
     for doc_id, year, exam, session, subject_scope in docs:
-        if year not in [2019, 2020, 2021]:
-            continue
-        # We only crawl combined mova-lit sessions from the web (since there is no separate mova-only online page)
-        if subject_scope != "mova-lit":
+        source = ONLINE_TEST_MAPPING.get((year, session, subject_scope))
+        if not source:
             continue
 
-        test_id = ONLINE_TEST_MAPPING.get((year, session))
-        if not test_id:
-            continue
-
-        url = f"https://zno.osvita.ua/ukrainian/{test_id}/"
-        cache_path = cache_dir / f"{test_id}_main.html"
+        catalogue, test_id = source
+        url = f"https://zno.osvita.ua/{catalogue}/{test_id}/"
+        cache_path = cache_dir / f"{catalogue}_{test_id}.html"
 
         print(f"Fetching tasks for {year} {session} (test_id: {test_id}) from {url}...")
         html = fetch_page_with_rate_limit(url, cache_path)

--- a/tests/ingest/test_zno_ingest.py
+++ b/tests/ingest/test_zno_ingest.py
@@ -1,13 +1,25 @@
 from __future__ import annotations
 
+import io
 import json
 import os
 import sqlite3
+import urllib.request
 from pathlib import Path
 
 import pytest
 
-from scripts.ingest.zno_ingest import ingest, ingest_documents, init_db, parse_and_insert_tasks
+from scripts.ingest import zno_ingest
+from scripts.ingest.zno_ingest import (
+    FETCH_TIMEOUT_SECONDS,
+    ONLINE_TEST_MAPPING,
+    derive_task_metadata,
+    fetch_page_with_rate_limit,
+    ingest,
+    ingest_documents,
+    init_db,
+    parse_and_insert_tasks,
+)
 
 
 @pytest.fixture
@@ -133,15 +145,172 @@ def test_task_extraction_from_fixtures(db_path: Path) -> None:
         conn.close()
 
 
+def test_online_mapping_covers_every_booklet_with_a_clean_interactive_source() -> None:
+    assert ONLINE_TEST_MAPPING == {
+        (2010, "sesiya-1", "mova-lit"): ("ukrainian", 15),
+        (2010, "sesiya-2", "mova-lit"): ("ukrainian", 16),
+        (2010, "sesiya-3", "mova-lit"): ("ukrainian", 17),
+        (2011, "sesiya-1", "mova-lit"): ("ukrainian", 13),
+        (2011, "sesiya-2", "mova-lit"): ("ukrainian", 14),
+        (2012, "sesiya-1", "mova-lit"): ("ukrainian", 11),
+        (2012, "sesiya-2", "mova-lit"): ("ukrainian", 12),
+        (2013, "sesiya-1", "mova-lit"): ("ukrainian", 6),
+        (2013, "sesiya-2", "mova-lit"): ("ukrainian", 10),
+        (2014, "sesiya-1", "mova-lit"): ("ukrainian", 132),
+        (2014, "sesiya-2", "mova-lit"): ("ukrainian", 133),
+        (2014, "dodatkova", "mova-lit"): ("ukrainian", 130),
+        (2015, "osnovna", "mova-lit"): ("ukrainian", 143),
+        (2016, "osnovna", "mova-lit"): ("ukrainian", 189),
+        (2017, "osnovna", "mova-lit"): ("ukrainian", 240),
+        (2017, "dodatkova", "mova-lit"): ("ukrainian", 254),
+        (2018, "osnovna", "mova-lit"): ("ukrainian", 299),
+        (2018, "dodatkova", "mova-lit"): ("ukrainian", 309),
+        (2019, "osnovna", "mova-lit"): ("ukrainian", 347),
+        (2019, "dodatkova", "mova-lit"): ("ukrainian", 363),
+        (2020, "osnovna", "mova-lit"): ("ukrainian", 401),
+        (2020, "dodatkova", "mova-lit"): ("ukrainian", 429),
+        (2021, "osnovna", "mova-lit"): ("ukrainian", 471),
+        (2021, "dodatkova", "mova-lit"): ("ukrainian", 491),
+        (2022, "osnovna", "mova"): ("ukrmova", 617),
+        (2023, "sesiya-1", "mova"): ("ukrmova", 619),
+        (2023, "sesiya-2", "mova"): ("ukrmova", 620),
+        (2024, "sesiya-1", "mova"): ("ukrmova", 622),
+        (2024, "sesiya-2", "mova"): ("ukrmova", 623),
+        (2025, "sesiya-1", "mova"): ("ukrmova", 667),
+        (2025, "sesiya-2", "mova"): ("ukrmova", 668),
+    }
+
+
+def test_task_refresh_preserves_reviewed_annotations(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        init_db(conn)
+        html = (Path(__file__).parent / "fixtures" / "347_trimmed.html").read_text(encoding="utf-8")
+        parse_and_insert_tasks(conn, html, 14, 2019, "zno", "osnovna")
+        conn.execute(
+            """
+            UPDATE zno_tasks
+            SET topic_norm = ?, task_subtype = ?, paronym_pair = ?, stress_word = ?
+            WHERE document_id = ? AND task_no = ?
+            """,
+            ("lexical_norm", "paronym", "saved-pair", "saved-word", 14, 1),
+        )
+
+        parse_and_insert_tasks(conn, html, 14, 2019, "zno", "osnovna")
+        refreshed = conn.execute(
+            """
+            SELECT topic_norm, task_subtype, paronym_pair, stress_word
+            FROM zno_tasks WHERE document_id = ? AND task_no = ?
+            """,
+            (14, 1),
+        ).fetchone()
+
+        assert refreshed == ("lexical_norm", "paronym", "saved-pair", "saved-word")
+        assert conn.execute("SELECT count(*) FROM zno_tasks").fetchone()[0] == 4
+    finally:
+        conn.close()
+
+
+def test_derive_task_metadata_uses_explicit_prompt_and_answer() -> None:
+    assert derive_task_metadata(
+        "Антонімами є слова в рядку",
+        json.dumps(["перший", "другий"], ensure_ascii=False),
+        "",
+        "single-choice",
+    ) == ("antonym", "")
+    assert derive_task_metadata(
+        "На перший склад падає наголос у слові",
+        json.dumps(["слово А", "слово Б"], ensure_ascii=False),
+        "Б",
+        "single-choice",
+    ) == ("", "слово Б")
+    assert derive_task_metadata(
+        "Лексичну помилку допущено в рядку",
+        "[]",
+        "",
+        "single-choice",
+    ) == ("lexical_error", "")
+
+
+def test_parser_classifies_the_question_prompt_not_source_text(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        init_db(conn)
+        html = """
+        <div class="task-card" id="q1">
+          <input name="q[tip]" value="1">
+          <div class="question">
+            <p>У тексті вжито слово «синонім».</p>
+            <p>Визначте головну думку тексту.</p>
+          </div>
+          <div class="answer"><span class="marker">А</span>перша</div>
+          <div class="answer"><span class="marker">Б</span>друга</div>
+          <input name="result" value="a">
+        </div>
+        """
+        parse_and_insert_tasks(conn, html, 14, 2019, "zno", "osnovna")
+
+        assert conn.execute("SELECT task_subtype FROM zno_tasks").fetchone() == ("",)
+    finally:
+        conn.close()
+
+
+def test_fetch_page_uses_bounded_request_timeout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    timeouts: list[int] = []
+
+    class Response:
+        def __enter__(self) -> Response:
+            return self
+
+        def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return io.BytesIO("<html>тест</html>".encode()).read()
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int) -> Response:
+        assert request.full_url == "https://example.invalid/test/"
+        timeouts.append(timeout)
+        return Response()
+
+    monkeypatch.setattr(zno_ingest.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(zno_ingest, "_last_request_time", 0.0)
+
+    html = fetch_page_with_rate_limit("https://example.invalid/test/", tmp_path / "page.html", rate_limit=0)
+
+    assert html == "<html>тест</html>"
+    assert timeouts == [FETCH_TIMEOUT_SECONDS]
+
+
 @pytest.mark.skipif(os.getenv("ZNO_LIVE") != "1", reason="Requires ZNO_LIVE=1 env var")
 def test_task_extraction_live(db_path: Path, cache_dir: Path) -> None:
     total_tasks = ingest(db_path, cache_dir)
-    assert total_tasks == 366
+    assert total_tasks == 1646
 
     conn = sqlite3.connect(db_path)
     try:
         tasks_count = conn.execute("SELECT count(*) FROM zno_tasks").fetchone()[0]
-        assert tasks_count == 366
+        assert tasks_count == 1646
+
+        year_counts = dict(conn.execute("SELECT year, count(*) FROM zno_tasks GROUP BY year"))
+        assert year_counts == {
+            2010: 183,
+            2011: 122,
+            2012: 122,
+            2013: 122,
+            2014: 183,
+            2015: 58,
+            2016: 58,
+            2017: 116,
+            2018: 116,
+            2019: 116,
+            2020: 116,
+            2021: 134,
+            2022: 20,
+            2023: 60,
+            2024: 60,
+            2025: 60,
+        }
 
         # Check real counts for all 6 documents
         q19_count = conn.execute("SELECT count(*) FROM zno_tasks WHERE year = 2019 AND session = 'osnovna'").fetchone()[0]


### PR DESCRIPTION
Closes #4975

Refs #4702

## Summary

- Mapped every 2010–2025 booklet document to its matching clean interactive
  ZNO-ONLINE page: combined papers use `/ukrainian/<id>/`; NMT language papers
  use `/ukrmova/<id>/`.
- Replaced `INSERT OR REPLACE` with a conflict upsert. Refreshing a task now
  updates source-derived fields without clearing reviewed `topic_norm`,
  `task_subtype`, `paronym_pair`, or `stress_word` annotations.
- Added source-deterministic metadata extraction: explicit synonym / antonym /
  lexical-error prompts receive `task_subtype`; single-choice наголос tasks
  receive the answer-key-selected `stress_word`. Reviewed `paronym_pair` values
  remain exclusively owned by the annotation applier; the parser does not
  guess lexical pairs.
- Added a 30-second request timeout after an observed stalled HTTP request.

`data/sources.db` and cached HTML are ignored and are not in this PR.

## Live coverage evidence

Actual live run (fresh ignored database and cache):

```text
.venv/bin/python scripts/ingest/zno_ingest.py \
  --db tmp/4975-zno-evidence/sources.db \
  --cache-dir tmp/4975-zno-evidence/cache
Successfully ingested 1646 tasks.
```

| Year | Tasks extracted | Status |
| --- | ---: | --- |
| 2010 | 183 | covered |
| 2011 | 122 | covered |
| 2012 | 122 | covered |
| 2013 | 122 | covered |
| 2014 | 183 | covered |
| 2015 | 58 | covered |
| 2016 | 58 | covered |
| 2017 | 116 | covered |
| 2018 | 116 | covered |
| 2019 | 116 | covered; existing |
| 2020 | 116 | covered; existing |
| 2021 | 134 | covered; existing |
| 2022 | 20 | covered |
| 2023 | 60 | covered |
| 2024 | 60 | covered |
| 2025 | 60 | covered |

No year is marked BLOCKED: each listed booklet session has a source page with
clean `task-card` HTML and its published correct-answer input.

### Faithful extracted samples

**2014, session 1, task 1**

> Stem: «М ’який знак треба писати на місці обох пропусків у рядку»
>
> Options: А `їдал..ня не працює, далеке майбут..нє`; Б `ткац..кий верстат,
> срібний лан..цюжок`; В `на тонкій жердин..ці, стан..те поруч`; Г
> `обчислювал..ний прилад, дон..чине свято`.
>
> Correct: `Г`.

**2022, основна сесія, task 5**

> Stem: «На перший склад падає наголос у слові»
>
> Options: А `зручний`; Б `проміжок`; В `перекис`; Г `експерт`; Д `фаховий`.
>
> Correct: `А`.

**2025, session 1, task 1**

> Stem: «Однаковий звук позначають букви, виділені в кожному слові рядка»
>
> Options: А `боротьба, дзвеніти, подія`; Б `анекдот, ґречний, екзотика`; В
> `сміється, утіха, шістсот`; Г `кігтик, легко, подруга`.
>
> Correct: `Б`.

## Idempotence evidence

A temporary database seeded with the primary database's 366 existing 2019–2021
rows was rerun from the cache. The logical snapshot covered every task field,
including all four reviewed annotation columns.

```text
before_count=366 after_count=366
before_sha256=f95c13ce67737af0048da291f65dad01238a2cf340ffc9b0b964605174e21c71
after_sha256=f95c13ce67737af0048da291f65dad01238a2cf340ffc9b0b964605174e21c71
Idempotence check: unchanged.
```

## Validation

```text
.venv/bin/ruff check scripts/ingest/zno_ingest.py tests/ingest/test_zno_ingest.py
All checks passed!

.venv/bin/python -m pytest tests/ingest/test_zno_ingest.py -q
8 passed, 1 skipped
```

## Independent review

**APPROVE** — native `grok-build` independently reviewed the uncommitted diff,
the live-source cache, mapping/session correspondence, annotation-preserving
upsert, prompt-vs-passage guard, and the targeted test suite.

The default first-party `deepseek-v4-flash` review dispatch timed out at its
180-second initial-response guard with zero output; the required Grok fallback
completed successfully in 139.5 seconds. Its recorded result is
`review-4975-zno-extraction-grok`.
