### PR TITLE
feat(lexicon): enrich numbered homonyms

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -3171,6 +3171,7 @@ def _definition_cards(
 
 _SYNONYM_ADDITION_CAP = 8
 _ANTONYM_ADDITION_CAP = 8
+_HOMONYM_ADDITION_CAP = 8
 _COATTESTATION_SUM_OR_GRINCHENKO = frozenset({"СУМ-11", "СУМ-20", "Грінченко"})
 _CONTENT_STEM_STOPWORDS = frozenset(
     {
@@ -3435,6 +3436,238 @@ def _definition_antonym_relations_by_headword(
             reciprocal["item"] = headwords[source_key]
             reciprocal["direction"] = "reciprocal"
             by_headword.setdefault(target_key, []).append(reciprocal)
+    return by_headword
+
+
+# СУМ-11 encodes lexical homonyms as consecutive, explicitly numbered heads in
+# one ``definition`` value (for example ``КОСА́¹ … КОСА́² …``), rather than as
+# separate database rows. The source data uses Unicode superscript digits.
+# Keep this separate from ordinary sense numbers (``1.``, ``2.``): only a
+# superscript immediately following an all-capital headword is a homonym marker.
+_HOMONYM_SUPERSCRIPT_TO_INT = {
+    "¹": 1,
+    "²": 2,
+    "³": 3,
+    "⁴": 4,
+    "⁵": 5,
+    "⁶": 6,
+    "⁷": 7,
+    "⁸": 8,
+    "⁹": 9,
+}
+HOMONYM_DIGIT_RE = re.compile(r"(?P<homonym_no>[¹²³⁴⁵⁶⁷⁸⁹])")
+_HOMONYM_HEADWORD_RE = re.compile(
+    rf"(?P<surface>(?:[А-ЯҐІЇЄ'’ʼ-][\u0300\u0301]?)+)\s*{HOMONYM_DIGIT_RE.pattern}"
+    r"(?=\s*(?:[,.;:—-]|$))"
+)
+_HOMONYM_NOUN_RE = re.compile(r",\s*(?P<gender>ч|ж|с|мн)\.(?P<body>.*)", flags=re.IGNORECASE | re.DOTALL)
+_HOMONYM_POS_RE = re.compile(
+    r"\b(?P<marker>прикм|присл|числ|займ|прийм|спол|част|виг|док|недок)\.(?P<body>.*)",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+_HOMONYM_POS_LABELS = {
+    "прикм": "прикметник",
+    "присл": "прислівник",
+    "числ": "числівник",
+    "займ": "займенник",
+    "прийм": "прийменник",
+    "спол": "сполучник",
+    "част": "частка",
+    "виг": "вигук",
+    "док": "дієслово",
+    "недок": "дієслово",
+}
+_HOMONYM_LEADING_QUALIFIERS_RE = re.compile(
+    r"^\s*(?:,\s*)?(?:(?:діал|заст|розм|рідко|спец|поет|перен|розмовне|мет)\.\s*)*",
+    flags=re.IGNORECASE,
+)
+_HOMONYM_LEADING_SENSE_NO_RE = re.compile(r"^\s*\d+\s*\.\s*")
+_HOMONYM_LEADING_GRAMMAR_RE = re.compile(
+    r"^\s*(?:род|дав|знах|ор|місц|клич)\.\s*[А-Яа-яЄєІіЇїҐґ\u0300\u0301]+\.\s*",
+    flags=re.IGNORECASE,
+)
+
+
+def _homonym_pos_and_gloss(fragment: str) -> tuple[str, str] | None:
+    """Extract a dictionary POS and short first-definition gloss from one block.
+
+    Membership is accepted only when both values are explicit. This deliberately
+    declines malformed number runs instead of turning an ordinary polysemous
+    sense list into a homonym relation.
+    """
+    pos = ""
+    body = ""
+    noun_match = _HOMONYM_NOUN_RE.search(fragment)
+    if noun_match:
+        gender = noun_match.group("gender").casefold()
+        if gender == "мн":
+            pos = "іменник, множина"
+        else:
+            gender_label = {"ч": "чол.", "ж": "жін.", "с": "сер."}[gender]
+            pos = f"іменник, {gender_label} р."
+        body = noun_match.group("body")
+    else:
+        pos_match = _HOMONYM_POS_RE.search(fragment)
+        if not pos_match:
+            # Adjective heads normally use the compact ``-ий, а, е.`` form.
+            adjective_match = re.match(r"\s*,\s*[^.]{0,48},\s*[аеєі]\.\s*(?P<body>.*)", fragment)
+            if adjective_match:
+                pos = "прикметник"
+                body = adjective_match.group("body")
+            else:
+                return None
+        else:
+            marker = pos_match.group("marker").casefold()
+            pos = _HOMONYM_POS_LABELS[marker]
+            body = pos_match.group("body")
+
+    # The source can place a register marker before its first sense number
+    # (``мет. 1. …``) or a case-government note after it (``1. род. а. …``).
+    # Peel only these header conventions, never prose inside the definition.
+    for _ in range(3):
+        body = _HOMONYM_LEADING_QUALIFIERS_RE.sub("", body)
+        body = _HOMONYM_LEADING_SENSE_NO_RE.sub("", body)
+        body = _HOMONYM_LEADING_GRAMMAR_RE.sub("", body)
+    if not body:
+        return None
+    gloss = re.split(r"(?<=[.!?])\s+(?=[А-ЯҐІЇЄ])", body, maxsplit=1)[0].strip()
+    gloss = _truncate_text(gloss, 180)
+    return (pos, gloss) if gloss else None
+
+
+def _numbered_homonym_members(text: str, surface: str) -> list[dict[str, Any]]:
+    """Parse one dictionary article's explicitly numbered same-surface heads."""
+    surface_key = _canonical_synonym_term(surface)
+    if not surface_key:
+        return []
+    matches = [
+        match
+        for match in _HOMONYM_HEADWORD_RE.finditer(text)
+        if _canonical_synonym_term(_strip_stress(match.group("surface"))) == surface_key
+    ]
+    members: list[dict[str, Any]] = []
+    seen_numbers: set[int] = set()
+    for index, match in enumerate(matches):
+        number = _HOMONYM_SUPERSCRIPT_TO_INT[match.group("homonym_no")]
+        if number in seen_numbers:
+            return []
+        seen_numbers.add(number)
+        block_end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        pos_and_gloss = _homonym_pos_and_gloss(text[match.end() : block_end])
+        if pos_and_gloss is None:
+            return []
+        pos, gloss = pos_and_gloss
+        members.append(
+            {
+                "word": surface_key,
+                "homonym_no": number,
+                "gloss": gloss,
+                "pos": pos,
+            }
+        )
+    return members if len(members) >= 2 else []
+
+
+def _homonym_dictionary_rows(
+    conn: sqlite3.Connection,
+    lemma: str,
+    *,
+    cache: dict[str, Any] | None = None,
+) -> list[dict[str, str]]:
+    """Return full local СУМ rows; never fetch or mutate a slovnyk cache.
+
+    Unlike ordinary definition cards, a homonym set cannot be truncated at the
+    first 900 characters: later numbered heads are part of the same evidence.
+    """
+    cache = cache if cache is not None else _read_cached_slovnyk_rows(lemma)
+    rows: list[dict[str, str]] = []
+    sum20 = _cache_lookup(cache, "newsum")
+    if sum20 and sum20.get("text"):
+        rows.append(
+            {
+                "source": "СУМ-20",
+                "text": _definition_body(sum20["text"], limit=20_000),
+                "source_url": str(sum20.get("source_url") or ""),
+            }
+        )
+    try:
+        for variant in _split_lemma_variants(lemma):
+            for definition, text in conn.execute(
+                "SELECT definition, text FROM sum11 WHERE word = ? AND definition != ''",
+                (variant,),
+            ).fetchall():
+                raw = str(definition or text or "")
+                if raw:
+                    rows.append({"source": "СУМ-11", "text": raw, "source_url": ""})
+    except sqlite3.Error:
+        pass
+    return rows
+
+
+def _homonym_relations(
+    conn: sqlite3.Connection,
+    lemma: str,
+    *,
+    cache: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Emit numbered lexical-homonym siblings, gated by dictionary and VESUM.
+
+    СУМ numbering establishes the semantic set. VESUM does not encode those
+    homonym indices, so it can honestly gate only the shared surface as a valid
+    lemma; an invented ``two VESUM lemmas`` threshold would reject the recorded
+    sets for ``ключ``, ``лист``, and ``стан``.
+    """
+    source_term = _canonical_synonym_term(lemma)
+    if not source_term:
+        return []
+    best_row: dict[str, str] | None = None
+    best_members: list[dict[str, Any]] = []
+    for row in _homonym_dictionary_rows(conn, lemma, cache=cache):
+        members = _numbered_homonym_members(row["text"], source_term)
+        if len(members) > len(best_members):
+            best_row = row
+            best_members = members
+    if not best_row:
+        return []
+    if not all(_vesum_valid_synonym(str(member["word"])) for member in best_members):
+        return []
+
+    # An unnumbered Atlas entry names the lead (lowest-numbered) dictionary
+    # head. The relation lists only the other numbered lexical headwords. Use
+    # the source with the most complete numbered run: a stale СУМ-20 cache can
+    # contain only the first two heads where local СУМ-11 records all of them.
+    lead_number = min(int(member["homonym_no"]) for member in best_members)
+    relations: list[dict[str, Any]] = []
+    for member in best_members:
+        if int(member["homonym_no"]) == lead_number:
+            continue
+        relation: dict[str, Any] = {
+            **member,
+            "source": best_row["source"],
+            "pattern": "numbered homonym headword",
+            "vein": 1,
+            "gate": {"vesum": "valid lemma"},
+        }
+        if best_row["source_url"]:
+            relation["source_url"] = best_row["source_url"]
+        relations.append(relation)
+    return relations
+
+
+def _homonym_relations_by_headword(
+    conn: sqlite3.Connection,
+    manifest: dict[str, Any],
+) -> dict[str, list[dict[str, Any]]]:
+    """Precompute each manifest headword's dictionary-numbered homonym set."""
+    by_headword: dict[str, list[dict[str, Any]]] = {}
+    for entry in manifest.get("entries", []):
+        lemma = str(entry.get("lemma") or "")
+        source_key = _canonical_synonym_term(lemma)
+        if not source_key:
+            continue
+        relations = _homonym_relations(conn, lemma)
+        if relations:
+            by_headword[source_key] = relations
     return by_headword
 
 
@@ -3710,6 +3943,76 @@ def _merge_antonym_relations(
             items.append(item)
             additions += 1
         label = _relation_source_label(relation, item)
+        if label not in source_labels:
+            source_labels.append(label)
+        if relation.get("source_url") and relation["source_url"] not in source_urls:
+            source_urls.append(str(relation["source_url"]))
+
+    if not items:
+        return None
+    if source_labels:
+        original = str(merged.get("source") or "").strip()
+        merged["source"] = " + ".join(part for part in (original, *source_labels) if part)
+    elif not merged.get("source"):
+        merged["source"] = ""
+    merged["items"] = items
+    if source_urls:
+        merged["source_urls"] = list(dict.fromkeys(source_urls))
+    else:
+        merged.pop("source_urls", None)
+    return merged
+
+
+def _merge_homonym_relations(
+    existing: dict[str, Any] | None,
+    relations: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Merge numbered homonym siblings into the gloss-bearing rendered schema."""
+    merged = dict(existing or {})
+    items: list[dict[str, Any]] = []
+    seen: set[tuple[str, int]] = set()
+    for raw_item in merged.get("items", []):
+        if not isinstance(raw_item, dict):
+            continue
+        word = _canonical_synonym_term(raw_item.get("word"))
+        try:
+            number = int(raw_item.get("homonym_no"))
+        except (TypeError, ValueError):
+            continue
+        gloss = str(raw_item.get("gloss") or "").strip()
+        pos = str(raw_item.get("pos") or "").strip()
+        if not word or number < 1 or not gloss or not pos:
+            continue
+        key = (word, number)
+        if key in seen:
+            continue
+        seen.add(key)
+        items.append({"word": word, "homonym_no": number, "gloss": gloss, "pos": pos})
+
+    source_urls = [str(url) for url in merged.get("source_urls", []) if str(url).strip()]
+    source_labels: list[str] = []
+    additions = 0
+    for relation in sorted(
+        relations,
+        key=lambda item: (int(item.get("vein") or 99), int(item.get("homonym_no") or 0)),
+    ):
+        word = _canonical_synonym_term(relation.get("word"))
+        try:
+            number = int(relation.get("homonym_no"))
+        except (TypeError, ValueError):
+            continue
+        gloss = str(relation.get("gloss") or "").strip()
+        pos = str(relation.get("pos") or "").strip()
+        if not word or number < 1 or not gloss or not pos:
+            continue
+        key = (word, number)
+        if key not in seen:
+            if additions >= _HOMONYM_ADDITION_CAP:
+                continue
+            seen.add(key)
+            items.append({"word": word, "homonym_no": number, "gloss": gloss, "pos": pos})
+            additions += 1
+        label = f"{relation['source']}: numbered homonym headwords"
         if label not in source_labels:
             source_labels.append(label)
         if relation.get("source_url") and relation["source_url"] not in source_urls:
@@ -4914,6 +5217,7 @@ def enrich_entry(
     has_sum11_flags,
     pointer_synonym_relations: list[dict[str, Any]] | None = None,
     pointer_antonym_relations: list[dict[str, Any]] | None = None,
+    pointer_homonym_relations: list[dict[str, Any]] | None = None,
 ) -> bool:
     """Enrich a single manifest entry in place (dictionary-grounded).
     Returns True if any enrichment was attached. Extracted from enrich() so the
@@ -5010,6 +5314,18 @@ def enrich_entry(
     antonyms = _merge_antonym_relations(antonyms, antonym_relations)
     if antonyms:
         sections["antonyms"] = antonyms
+    homonym_relations = (
+        pointer_homonym_relations
+        if pointer_homonym_relations is not None
+        else _homonym_relations(
+            conn,
+            lemma,
+            cache=slovnyk_cache,
+        )
+    )
+    homonyms = _merge_homonym_relations(None, homonym_relations)
+    if homonyms:
+        sections["homonyms"] = homonyms
     idioms = _idioms(conn, lemma, slovnyk_cache)
     if idioms:
         sections["idioms"] = idioms
@@ -5125,6 +5441,7 @@ def enrich() -> tuple[int, int]:
             manifest,
             has_sum11_flags=has_sum11_flags,
         )
+        pointer_homonym_relations = _homonym_relations_by_headword(conn, manifest)
         for entry in manifest["entries"]:
             entry_key = _canonical_synonym_term(str(entry.get("lemma") or ""))
             if enrich_entry(
@@ -5134,6 +5451,7 @@ def enrich() -> tuple[int, int]:
                 has_sum11_flags=has_sum11_flags,
                 pointer_synonym_relations=pointer_synonym_relations.get(entry_key or "", []),
                 pointer_antonym_relations=pointer_antonym_relations.get(entry_key or "", []),
+                pointer_homonym_relations=pointer_homonym_relations.get(entry_key or "", []),
             ):
                 enriched += 1
     finally:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "2745a4a73c67015d2af58bea1c32e5fd68b64dc5af4156acd79d52a7e02f5245",
+  "fingerprint": "dcb956fea98b69e8cf7f2fe7be3cf64195e8f4919b4f469e588446d269ca04f9",
   "inputs": {
     "lexicon_code": [
       {
@@ -52,7 +52,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "b3e4f1ef6c6ab7f1fe2601ac98e192443d3b69283ace1a5de953b9b771934fd2"
+        "sha256": "b75ef92035a67fcd956630c3b11cbb9ac56eadaf9438cd565df79501d44d8bd2"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -135,6 +135,11 @@ interface HeritageStatus {
 interface LexiconSections {
   synonyms?: { items: string[]; source: string; source_urls?: string[] };
   antonyms?: { items: string[]; source: string; source_urls?: string[] };
+  homonyms?: {
+    items: Array<{ word: string; gloss: string; pos: string; homonym_no: number }>;
+    source: string;
+    source_urls?: string[];
+  };
   idioms?: {
     items: Array<{ text?: string; phrase: string; definition: string; source: string; source_url?: string }>;
     source: string;
@@ -430,6 +435,7 @@ function buildStyleNotes() {
 
 function buildArticleOverview() {
   const synonymCount = (sections?.synonyms?.items.length ?? 0) + (sections?.antonyms?.items.length ?? 0);
+  const homonymCount = sections?.homonyms?.items.length ?? 0;
   const idiomCount = sections?.idioms?.items.length ?? 0;
   const externalCount = externalGroups.reduce((total, group) => total + group.materials.length, 0);
   const definitionCount = definitionCards.length + (enrichment?.meaning ? 1 : 0) + (phraseHasGloss ? 1 : 0);
@@ -460,6 +466,11 @@ function buildArticleOverview() {
       label: "Синонімія",
       ready: synonymCount > 0,
       detail: synonymCount > 0 ? `${synonymCount} позицій` : "очікує джерело",
+    },
+    {
+      label: "Омонім",
+      ready: homonymCount > 0,
+      detail: homonymCount > 0 ? `${homonymCount} позицій` : "очікує джерело",
     },
     {
       label: "Фразеологія",
@@ -537,6 +548,7 @@ function buildSourceList() {
   if (enrichment?.etymology?.source) sources.add(enrichment.etymology.source);
   if (sections?.synonyms?.source) sources.add(sections.synonyms.source);
   if (sections?.antonyms?.source) sources.add(sections.antonyms.source);
+  if (sections?.homonyms?.source) sources.add(sections.homonyms.source);
   if (sections?.idioms?.source) sources.add(sections.idioms.source);
   if (enrichment?.literary_attestation?.source) sources.add(enrichment.literary_attestation.source);
   if (enrichment?.translation?.source) sources.add(enrichment.translation.source);
@@ -913,6 +925,32 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
             {sections?.antonyms?.source_urls?.length ? (
               <>
                 {" "}Джерела антонімів: {sections.antonyms.source_urls.map((url, index) => (
+                  <>
+                    {index > 0 && " · "}
+                    <a href={url} target="_blank" rel="noopener noreferrer">{sourceHost(url)}</a>
+                  </>
+                ))}
+              </>
+            ) : null}
+          </div>
+        </section>
+      )}
+
+      {(sections?.homonyms?.items.length ?? 0) > 0 && (
+        <section class="atlas-section">
+          <h2>Омоніми</h2>
+          <div class="chip-row">
+            {sections.homonyms.items.map((item) => (
+              <span class="chip">
+                <strong>{item.word}<sup>{item.homonym_no}</sup></strong> ({item.pos}) — {item.gloss}
+              </span>
+            ))}
+          </div>
+          <div class="data-caveat">
+            Омоніми показано за нумерованими словниковими заголовками; звіряйте значення з контекстом.
+            {sections?.homonyms?.source_urls?.length ? (
+              <>
+                {" "}Джерела омонімів: {sections.homonyms.source_urls.map((url, index) => (
                   <>
                     {index > 0 && " · "}
                     <a href={url} target="_blank" rel="noopener noreferrer">{sourceHost(url)}</a>

--- a/site/tests/unit/atlas-entry-type-templates.test.ts
+++ b/site/tests/unit/atlas-entry-type-templates.test.ts
@@ -76,6 +76,28 @@ function makeExpressionLikeFixture(entry_type: string, lemma: string): LexiconEn
   };
 }
 
+function makeHomonymFixture(withHomonyms: boolean): LexiconEntry {
+  return {
+    ...makeExpressionLikeFixture('lemma', 'коса'),
+    sections: withHomonyms
+      ? {
+          homonyms: {
+            items: [
+              {
+                word: 'коса',
+                homonym_no: 2,
+                pos: 'ж.',
+                gloss: 'сільськогосподарське знаряддя для косіння трави',
+              },
+            ],
+            source: 'СУМ-20',
+            source_urls: ['https://slovnyk.me/dict/newsum/коса'],
+          },
+        }
+      : undefined,
+  };
+}
+
 /** Minimal in-memory atlas.db shaped like the entry-model schema for gate tests. */
 function makeFixtureDb(): InstanceType<typeof Database> {
   const db = new Database(':memory:');
@@ -203,6 +225,26 @@ describe('entry_type-branched article rendering (#4385)', () => {
     expect(html).toContain('href="/lexicon/dim/"');
     expect(html).not.toContain('href="/lexicon/у/"');
     expect(html).not.toContain('href="/lexicon/до́мі/"');
+  });
+
+  test('renders a numbered homonym with its gloss and source', async () => {
+    const html = await renderFixture(makeHomonymFixture(true));
+
+    expect(html).toContain('Омонім');
+    expect(html).toContain('<h2>Омоніми</h2>');
+    expect(html).toContain('коса<sup>2</sup>');
+    expect(html).toContain('сільськогосподарське знаряддя для косіння трави');
+    expect(html).toContain('Джерела омонімів:');
+    expect(html).toContain('href="https://slovnyk.me/dict/newsum/коса"');
+    expect(html).toContain('<span class="src">СУМ-20</span>');
+  });
+
+  test('keeps the homonym section absent when the entry has no homonym data', async () => {
+    const html = await renderFixture(makeHomonymFixture(false));
+
+    expect(html).toContain('Омонім');
+    expect(html).not.toContain('<h2>Омоніми</h2>');
+    expect(html).not.toContain('Джерела омонімів:');
   });
 
   test('lemma baseline remains byte-identical before and after entry-type branching', async () => {

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -31,6 +31,8 @@ from scripts.lexicon.enrich_manifest import (
     _etymology,
     _etymology_lookup_variants,
     _gated_ukrajinet_relations,
+    _homonym_relations,
+    _homonym_relations_by_headword,
     _idioms,
     _idioms_frazeolohichnyi,
     _idioms_slovnyk,
@@ -41,10 +43,12 @@ from scripts.lexicon.enrich_manifest import (
     _literary_excerpt,
     _meaning,
     _merge_antonym_relations,
+    _merge_homonym_relations,
     _merge_slovnyk_warning,
     _merge_synonym_relations,
     _morphology,
     _normalize_manifest_entries,
+    _numbered_homonym_members,
     _parse_translations,
     _prepare_cefr_estimates,
     _proper_noun_wikipedia_meaning,
@@ -2704,6 +2708,207 @@ def test_antonym_fixture_samples_expand_from_zero(monkeypatch) -> None:
 
     assert before_counts == {lemma: 0 for lemma in pairs}
     assert after_items == {lemma: [antonym] for lemma, antonym in pairs.items()}
+
+
+def test_numbered_homonym_members_extract_same_surface_glosses_and_pos() -> None:
+    members = _numbered_homonym_members(
+        "КОСА́¹, и, ж. Заплетене волосся. КОСА́², и, ж. Сільськогосподарське знаряддя для косіння трави.",
+        "коса",
+    )
+
+    assert members == [
+        {
+            "word": "коса",
+            "homonym_no": 1,
+            "gloss": "Заплетене волосся.",
+            "pos": "іменник, жін. р.",
+        },
+        {
+            "word": "коса",
+            "homonym_no": 2,
+            "gloss": "Сільськогосподарське знаряддя для косіння трави.",
+            "pos": "іменник, жін. р.",
+        },
+    ]
+    spaced = _numbered_homonym_members(
+        "ЛИСТ ¹ , ч. 1 . Орган рослини. ЛИСТ ² , а, ч. 1 . Шматок паперу.",
+        "лист",
+    )
+    assert [member["gloss"] for member in spaced] == ["Орган рослини.", "Шматок паперу."]
+    apostrophized = _numbered_homonym_members(
+        "В'ЯЗ¹, а, ч. В'язальний вузол. В'ЯЗ², а, ч. Низка дерев.",
+        "в'яз",
+    )
+    assert [member["word"] for member in apostrophized] == ["в'яз", "в'яз"]
+    plural_only = _numbered_homonym_members(
+        "НОЖИЦІ¹, мн. Інструмент для різання. НОЖИЦІ², мн. Форма орнаменту.",
+        "ножиці",
+    )
+    assert [member["pos"] for member in plural_only] == ["іменник, множина", "іменник, множина"]
+
+
+def test_homonym_relations_require_numbering_and_an_exact_vesum_lemma(monkeypatch) -> None:
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO sum11(word, definition) VALUES (?, ?)",
+        (
+            "коса",
+            "КОСА́¹, и, ж. Заплетене волосся. КОСА́², и, ж. Сільськогосподарське знаряддя для косіння трави.",
+        ),
+    )
+    _patch_synonym_vesum(monkeypatch, {"коса"})
+
+    relations = _homonym_relations(conn, "коса", cache={})
+
+    assert relations == [
+        {
+            "word": "коса",
+            "homonym_no": 2,
+            "gloss": "Сільськогосподарське знаряддя для косіння трави.",
+            "pos": "іменник, жін. р.",
+            "source": "СУМ-11",
+            "pattern": "numbered homonym headword",
+            "vein": 1,
+            "gate": {"vesum": "valid lemma"},
+        }
+    ]
+
+    _patch_synonym_vesum(monkeypatch, set())
+    assert _homonym_relations(conn, "коса", cache={}) == []
+
+    _patch_synonym_vesum(monkeypatch, {"коса"})
+    conn.execute(
+        "INSERT INTO sum11(word, definition) VALUES (?, ?)",
+        ("коса", "КОСА́¹, и, ж. Заплетене волосся."),
+    )
+    # A malformed source row must not supplement a complete, dictionary-numbered set.
+    assert _homonym_relations(conn, "коса", cache={}) == relations
+
+
+def test_homonym_relations_precompute_by_manifest_headword(monkeypatch) -> None:
+    _patch_synonym_vesum(monkeypatch, {"коса"})
+    monkeypatch.setattr(enrich_manifest_module, "_read_cached_slovnyk_rows", lambda lemma: {})
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO sum11(word, definition) VALUES (?, ?)",
+        (
+            "коса",
+            "КОСА́¹, и, ж. Заплетене волосся. КОСА́², и, ж. Сільськогосподарське знаряддя для косіння трави.",
+        ),
+    )
+
+    relations = _homonym_relations_by_headword(conn, {"entries": [{"lemma": "коса"}]})
+
+    assert [(item["word"], item["homonym_no"]) for item in relations["коса"]] == [("коса", 2)]
+
+
+def test_homonym_relations_choose_the_most_complete_numbered_source(monkeypatch) -> None:
+    _patch_synonym_vesum(monkeypatch, {"коса"})
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO sum11(word, definition) VALUES (?, ?)",
+        (
+            "коса",
+            "КОСА́¹, и, ж. Заплетене волосся. КОСА́², и, ж. Знаряддя для косіння. "
+            "КОСА́³, и, ж. Намивна смуга суходолу.",
+        ),
+    )
+    cache = {
+        "lookups": {
+            "newsum": {
+                "text": "КОСА́ ¹, и, ж. Заплетене волосся. КОСА́ ², и, ж. Знаряддя для косіння.",
+                "source_url": "https://example.invalid/sum20/kosa",
+            }
+        }
+    }
+
+    relations = _homonym_relations(conn, "коса", cache=cache)
+
+    assert [(item["source"], item["homonym_no"]) for item in relations] == [
+        ("СУМ-11", 2),
+        ("СУМ-11", 3),
+    ]
+
+
+def test_homonym_relation_merge_preserves_gloss_schema_and_source_urls() -> None:
+    relations = [
+        {
+            "word": "коса",
+            "homonym_no": 2,
+            "gloss": "Знаряддя для косіння.",
+            "pos": "іменник, жін. р.",
+            "source": "СУМ-20",
+            "pattern": "numbered homonym headword",
+            "vein": 1,
+            "source_url": "https://example.invalid/sum20/kosa",
+        },
+        {
+            "word": "коса",
+            "homonym_no": 3,
+            "gloss": "Намивна смуга суходолу.",
+            "pos": "іменник, жін. р.",
+            "source": "СУМ-20",
+            "pattern": "numbered homonym headword",
+            "vein": 1,
+            "source_url": "https://example.invalid/sum20/kosa",
+        },
+    ]
+
+    merged = _merge_homonym_relations(None, relations)
+
+    assert merged == {
+        "items": [
+            {
+                "word": "коса",
+                "homonym_no": 2,
+                "gloss": "Знаряддя для косіння.",
+                "pos": "іменник, жін. р.",
+            },
+            {
+                "word": "коса",
+                "homonym_no": 3,
+                "gloss": "Намивна смуга суходолу.",
+                "pos": "іменник, жін. р.",
+            },
+        ],
+        "source": "СУМ-20: numbered homonym headwords",
+        "source_urls": ["https://example.invalid/sum20/kosa"],
+    }
+
+
+def test_homonym_fixture_samples_expand_from_zero(monkeypatch) -> None:
+    fixtures = {
+        "коса": (
+            "КОСА́¹, и, ж. Заплетене волосся. КОСА́², и, ж. Сільськогосподарське знаряддя для косіння трави.",
+            [2],
+        ),
+        "ключ": (
+            "КЛЮЧ¹, а, ч. Знаряддя для замикання. КЛЮЧ², а, ч. Джерело води.",
+            [2],
+        ),
+        "лист": (
+            "ЛИСТ¹, ч. Орган рослини. ЛИСТ², а, ч. Шматок паперу або металу.",
+            [2],
+        ),
+        "стан": (
+            "СТАН¹, у, ч. Тулуб людини. СТАН², у, ч. Тимчасовий табір. СТАН³, у, ч. Обставини існування.",
+            [2, 3],
+        ),
+    }
+    _patch_synonym_vesum(monkeypatch, set(fixtures))
+    conn = _conn()
+    conn.executemany(
+        "INSERT INTO sum11(word, definition) VALUES (?, ?)",
+        [(lemma, definition) for lemma, (definition, _numbers) in fixtures.items()],
+    )
+
+    before_counts = {lemma: 0 for lemma in fixtures}
+    after_numbers = {
+        lemma: [relation["homonym_no"] for relation in _homonym_relations(conn, lemma, cache={})] for lemma in fixtures
+    }
+
+    assert before_counts == {lemma: 0 for lemma in fixtures}
+    assert after_numbers == {lemma: expected_numbers for lemma, (_definition, expected_numbers) in fixtures.items()}
 
 
 def test_definition_synonym_targets_extracts_stressed_same_as_target() -> None:


### PR DESCRIPTION
## Summary

Adds the Word Atlas омоніми vein for dictionary-numbered lexical homonyms.

- Parses explicitly numbered, same-surface СУМ-20 / СУМ-11 heads; it never infers a set from ordinary polysemy.
- Gates every emitted numbered member against an exact VESUM lemma analysis, preserves a gloss and POS, caps additions at eight, and picks the most complete numbered source when a cached source is partial.
- Adds `sections.homonyms` with source provenance and renders an `Омонім` Atlas availability card plus an `Омоніми` sibling list.
- Regenerates the required lexicon manifest fingerprint. No full re-enrichment or publish was run.

Closes #4975.

## Deterministic evidence

### Raw numbered source rows

```sql
SELECT id, word, substr(definition, 1, 180)
FROM sum11
WHERE word IN ('коса', 'ключ', 'лист', 'стан');
```

Observed local rows:

- `42019 | коса | КОСА́¹, и, ж. ...`; its subsequent raw block starts `КОСА́², и, ж. Сільськогосподарське знаряддя для косіння трави...`.
- `40023 | ключ | КЛЮЧ¹, а́, ч. ...`; its subsequent raw block starts `КЛЮЧ², а́, ч., рідко. Те саме, що джерело́ 1.`
- `45018 | лист | ЛИСТ¹, ч. 1. род. а́. Орган повітряного живлення...`.
- `106688 | стан | СТАН¹, у, ч. 1. Тулуб, корпус людини; торс...`.

The DB has one normalized `sum11.word` row per surface and no homonym-number column; all numbered heads are embedded in `definition` with Unicode superscripts. The implementation therefore parses those source-authored headers. It does not fabricate `ключ³`: the local numbered source has `ключ¹/²`.

### VESUM + fixture proof

`verify_word` reported exact lemmas for all four surfaces:

```text
коса  exact=['коса']
ключ  exact=['ключ']
лист  exact=['лист']
стан  exact=['стан']
```

VESUM does not encode the dictionaries' homonym indexes as separate lemma strings. A literal distinct-string threshold would suppress authoritative `ключ`, `лист`, and `стан` sets, so dictionary numbering is the membership authority and VESUM verifies each emitted member's shared surface as an exact lemma.

Small-set result, without modifying the manifest:

```text
коса: before=0 → коса² (scythe), коса³ (sandbar), коса⁴ (spleen)
ключ: before=0 → ключ² (spring/source)
лист: before=0 → лист² (sheet/material)
стан: before=0 → стан² (camp), стан³ (state/condition), стан⁴ (metalworking machine)
```

## Validation

- `.venv/bin/python -m pytest tests/test_lexicon_enrich_manifest.py tests/test_lexicon_manifest_fingerprint.py -q` — 135 passed.
- `.venv/bin/ruff check scripts/lexicon/enrich_manifest.py tests/test_lexicon_enrich_manifest.py` — passed.
- `.venv/bin/python scripts/lexicon/check_manifest_freshness.py` — green.
- `ATLAS_DB_PATH=/Users/krisztiankoos/projects/learn-ukrainian/data/atlas.db npm exec vitest run tests/unit/atlas-entry-type-templates.test.ts` — 16 passed.
- Direct `npm exec astro build` reached the site build but is blocked in this worktree by the intentionally absent hydrated `site/src/data/lexicon-manifest.json`; the renderer test ran against the read-only Atlas DB. No generated search sidecars are in this PR.

## Review

Cross-family AGY review identified apostrophe/hyphen headword and plural-only-noun parser gaps. Both are fixed with regression tests. The configured local Gemini CLI was unavailable for a follow-up; Poolside and Grok fallback workers were also unavailable, so this substitution is recorded here rather than silently omitted.
