### PR TITLE
feat(lexicon): surface paronym relations

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -3172,6 +3172,7 @@ def _definition_cards(
 _SYNONYM_ADDITION_CAP = 8
 _ANTONYM_ADDITION_CAP = 8
 _HOMONYM_ADDITION_CAP = 8
+_PARONYM_ADDITION_CAP = 8
 _COATTESTATION_SUM_OR_GRINCHENKO = frozenset({"СУМ-11", "СУМ-20", "Грінченко"})
 _CONTENT_STEM_STOPWORDS = frozenset(
     {
@@ -3671,6 +3672,137 @@ def _homonym_relations_by_headword(
     return by_headword
 
 
+def _paronym_pair_members(value: object) -> list[tuple[str, str]]:
+    """Parse semicolon-delimited ``word/word`` pairs from a curated ZNO field."""
+    pairs: list[tuple[str, str]] = []
+    for raw_pair in str(value or "").split(";"):
+        members = [_canonical_synonym_term(member) for member in raw_pair.split("/")]
+        if len(members) != 2 or not all(members) or members[0] == members[1]:
+            continue
+        pairs.append((members[0], members[1]))
+    return pairs
+
+
+def _paronym_cache_distinction(definition: object, target: str) -> str:
+    """Return the cache sentence that distinguishes the confusable target."""
+    text = re.sub(r"\s+", " ", clean_html_entities(str(definition or ""))).strip()
+    if not text:
+        return ""
+    target_re = re.compile(rf"^\s*{re.escape(target)}\s*[—–-]\s*(.+)", flags=re.IGNORECASE)
+    for sentence in re.split(r"(?<=[.!?])\s+", text):
+        match = target_re.match(sentence)
+        if match:
+            return _truncate_text(match.group(1).strip(), 240)
+    return _truncate_text(text, 300)
+
+
+def _paronym_relations(
+    conn: sqlite3.Connection,
+    lemma: str,
+) -> list[dict[str, Any]]:
+    """Emit VESUM-gated paronym pairs from ZNO and the existing open cache.
+
+    ZNO pairs are ordered first because they are exam-validated. The cache can
+    then supplement a pair with a compact semantic distinction; neither source
+    invents a distinction where its raw record does not provide one.
+    """
+    source_term = _canonical_synonym_term(lemma)
+    if not source_term or not _vesum_valid_synonym(source_term):
+        return []
+    relations: list[dict[str, Any]] = []
+
+    try:
+        zno_columns = {
+            str(row[1]) for row in conn.execute("PRAGMA table_info(zno_tasks)").fetchall()
+        }
+        document_columns = {
+            str(row[1]) for row in conn.execute("PRAGMA table_info(zno_documents)").fetchall()
+        }
+        if {"year", "task_no", "task_subtype", "paronym_pair"} <= zno_columns:
+            if {"document_id"} <= zno_columns and "url" in document_columns:
+                rows = conn.execute(
+                    """
+                    SELECT t.year, t.task_no, t.paronym_pair, d.url
+                    FROM zno_tasks AS t
+                    LEFT JOIN zno_documents AS d ON d.id = t.document_id
+                    WHERE t.task_subtype = 'paronym' OR trim(t.paronym_pair) != ''
+                    """
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    """
+                    SELECT year, task_no, paronym_pair, ''
+                    FROM zno_tasks
+                    WHERE task_subtype = 'paronym' OR trim(paronym_pair) != ''
+                    """
+                ).fetchall()
+            for year, task_no, pair_text, source_url in rows:
+                for first, second in _paronym_pair_members(pair_text):
+                    if source_term not in {first, second}:
+                        continue
+                    other = second if source_term == first else first
+                    if not _vesum_valid_synonym(other):
+                        continue
+                    relation: dict[str, Any] = {
+                        "word": other,
+                        "source": "ЗНО",
+                        "pattern": "exam-tested paronym pair",
+                        "vein": 1,
+                        "exam_provenance": f"ЗНО {year}, завдання №{task_no}",
+                        "gate": {"vesum": "both valid"},
+                    }
+                    if str(source_url or "").strip():
+                        relation["source_url"] = str(source_url)
+                    relations.append(relation)
+    except sqlite3.Error:
+        pass
+
+    try:
+        cache_columns = {
+            str(row[1]) for row in conn.execute("PRAGMA table_info(paronyms_cache)").fetchall()
+        }
+        if {"word_a", "word_b", "definition"} <= cache_columns:
+            for first_raw, second_raw, definition in conn.execute(
+                "SELECT word_a, word_b, definition FROM paronyms_cache"
+            ).fetchall():
+                first = _canonical_synonym_term(first_raw)
+                second = _canonical_synonym_term(second_raw)
+                if not first or not second or source_term not in {first, second}:
+                    continue
+                other = second if source_term == first else first
+                if not _vesum_valid_synonym(other):
+                    continue
+                relation = {
+                    "word": other,
+                    "distinction": _paronym_cache_distinction(definition, other),
+                    "source": "paronyms_cache",
+                    "pattern": "cached paronym distinction",
+                    "vein": 2,
+                    "gate": {"vesum": "both valid"},
+                }
+                relations.append(relation)
+    except sqlite3.Error:
+        pass
+    return relations
+
+
+def _paronym_relations_by_headword(
+    conn: sqlite3.Connection,
+    manifest: dict[str, Any],
+) -> dict[str, list[dict[str, Any]]]:
+    """Precompute VESUM-gated ZNO/cache paronym pairs for manifest headwords."""
+    by_headword: dict[str, list[dict[str, Any]]] = {}
+    for entry in manifest.get("entries", []):
+        lemma = str(entry.get("lemma") or "")
+        source_key = _canonical_synonym_term(lemma)
+        if not source_key:
+            continue
+        relations = _paronym_relations(conn, lemma)
+        if relations:
+            by_headword[source_key] = relations
+    return by_headword
+
+
 def _ukrajinet_synsets(conn: sqlite3.Connection, lemma: str) -> list[dict[str, Any]]:
     """Read matching Ukrajinet synsets without creating the optional SQL index."""
     term = _canonical_synonym_term(lemma)
@@ -4013,6 +4145,90 @@ def _merge_homonym_relations(
             items.append({"word": word, "homonym_no": number, "gloss": gloss, "pos": pos})
             additions += 1
         label = f"{relation['source']}: numbered homonym headwords"
+        if label not in source_labels:
+            source_labels.append(label)
+        if relation.get("source_url") and relation["source_url"] not in source_urls:
+            source_urls.append(str(relation["source_url"]))
+
+    if not items:
+        return None
+    if source_labels:
+        original = str(merged.get("source") or "").strip()
+        merged["source"] = " + ".join(part for part in (original, *source_labels) if part)
+    elif not merged.get("source"):
+        merged["source"] = ""
+    merged["items"] = items
+    if source_urls:
+        merged["source_urls"] = list(dict.fromkeys(source_urls))
+    else:
+        merged.pop("source_urls", None)
+    return merged
+
+
+def _paronym_relation_source_label(relation: dict[str, Any]) -> str:
+    """Record paronym provenance without conflating it with a distinction."""
+    exam_provenance = str(relation.get("exam_provenance") or "").strip()
+    if exam_provenance:
+        return exam_provenance
+    return f"{relation['source']}: {relation['pattern']}"
+
+
+def _merge_paronym_relations(
+    existing: dict[str, Any] | None,
+    relations: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    """Merge ordered paronym pairs into the distinction-bearing rendered schema."""
+    merged = dict(existing or {})
+    items: list[dict[str, Any]] = []
+    item_indexes: dict[str, int] = {}
+    for raw_item in merged.get("items", []):
+        if not isinstance(raw_item, dict):
+            continue
+        word = _canonical_synonym_term(raw_item.get("word"))
+        if not word or word in item_indexes:
+            continue
+        item: dict[str, Any] = {"word": word}
+        distinction = str(raw_item.get("distinction") or "").strip()
+        if distinction:
+            item["distinction"] = distinction
+        provenance = raw_item.get("exam_provenance", [])
+        if isinstance(provenance, str):
+            provenance = [provenance]
+        if isinstance(provenance, list):
+            values = [str(value).strip() for value in provenance if str(value).strip()]
+            if values:
+                item["exam_provenance"] = list(dict.fromkeys(values))
+        item_indexes[word] = len(items)
+        items.append(item)
+
+    source_urls = [str(url) for url in merged.get("source_urls", []) if str(url).strip()]
+    source_labels: list[str] = []
+    additions = 0
+    for relation in sorted(
+        relations,
+        key=lambda item: (int(item.get("vein") or 99), str(item.get("word") or "")),
+    ):
+        word = _canonical_synonym_term(relation.get("word"))
+        if not word:
+            continue
+        index = item_indexes.get(word)
+        if index is None:
+            if additions >= _PARONYM_ADDITION_CAP:
+                continue
+            index = len(items)
+            item_indexes[word] = index
+            items.append({"word": word})
+            additions += 1
+        item = items[index]
+        distinction = str(relation.get("distinction") or "").strip()
+        if distinction and not item.get("distinction"):
+            item["distinction"] = distinction
+        exam_provenance = str(relation.get("exam_provenance") or "").strip()
+        if exam_provenance:
+            values = item.setdefault("exam_provenance", [])
+            if exam_provenance not in values:
+                values.append(exam_provenance)
+        label = _paronym_relation_source_label(relation)
         if label not in source_labels:
             source_labels.append(label)
         if relation.get("source_url") and relation["source_url"] not in source_urls:
@@ -5218,6 +5434,7 @@ def enrich_entry(
     pointer_synonym_relations: list[dict[str, Any]] | None = None,
     pointer_antonym_relations: list[dict[str, Any]] | None = None,
     pointer_homonym_relations: list[dict[str, Any]] | None = None,
+    pointer_paronym_relations: list[dict[str, Any]] | None = None,
 ) -> bool:
     """Enrich a single manifest entry in place (dictionary-grounded).
     Returns True if any enrichment was attached. Extracted from enrich() so the
@@ -5326,6 +5543,14 @@ def enrich_entry(
     homonyms = _merge_homonym_relations(None, homonym_relations)
     if homonyms:
         sections["homonyms"] = homonyms
+    paronym_relations = (
+        pointer_paronym_relations
+        if pointer_paronym_relations is not None
+        else _paronym_relations(conn, lemma)
+    )
+    paronyms = _merge_paronym_relations(None, paronym_relations)
+    if paronyms:
+        sections["paronyms"] = paronyms
     idioms = _idioms(conn, lemma, slovnyk_cache)
     if idioms:
         sections["idioms"] = idioms
@@ -5442,6 +5667,7 @@ def enrich() -> tuple[int, int]:
             has_sum11_flags=has_sum11_flags,
         )
         pointer_homonym_relations = _homonym_relations_by_headword(conn, manifest)
+        pointer_paronym_relations = _paronym_relations_by_headword(conn, manifest)
         for entry in manifest["entries"]:
             entry_key = _canonical_synonym_term(str(entry.get("lemma") or ""))
             if enrich_entry(
@@ -5452,6 +5678,7 @@ def enrich() -> tuple[int, int]:
                 pointer_synonym_relations=pointer_synonym_relations.get(entry_key or "", []),
                 pointer_antonym_relations=pointer_antonym_relations.get(entry_key or "", []),
                 pointer_homonym_relations=pointer_homonym_relations.get(entry_key or "", []),
+                pointer_paronym_relations=pointer_paronym_relations.get(entry_key or "", []),
             ):
                 enriched += 1
     finally:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "dcb956fea98b69e8cf7f2fe7be3cf64195e8f4919b4f469e588446d269ca04f9",
+  "fingerprint": "4bfdda88344a0cb5d3c764c5624458e242b9e0bf71e5a600775b7c2ca0a260e3",
   "inputs": {
     "lexicon_code": [
       {
@@ -52,7 +52,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "b75ef92035a67fcd956630c3b11cbb9ac56eadaf9438cd565df79501d44d8bd2"
+        "sha256": "40dc9a32d3d498f4fb70638e7aac02336cd1888f81d4ca18840c2df03ba092ed"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -140,6 +140,11 @@ interface LexiconSections {
     source: string;
     source_urls?: string[];
   };
+  paronyms?: {
+    items: Array<{ word: string; distinction?: string; exam_provenance?: string[] }>;
+    source: string;
+    source_urls?: string[];
+  };
   idioms?: {
     items: Array<{ text?: string; phrase: string; definition: string; source: string; source_url?: string }>;
     source: string;
@@ -436,6 +441,7 @@ function buildStyleNotes() {
 function buildArticleOverview() {
   const synonymCount = (sections?.synonyms?.items.length ?? 0) + (sections?.antonyms?.items.length ?? 0);
   const homonymCount = sections?.homonyms?.items.length ?? 0;
+  const paronymCount = sections?.paronyms?.items.length ?? 0;
   const idiomCount = sections?.idioms?.items.length ?? 0;
   const externalCount = externalGroups.reduce((total, group) => total + group.materials.length, 0);
   const definitionCount = definitionCards.length + (enrichment?.meaning ? 1 : 0) + (phraseHasGloss ? 1 : 0);
@@ -471,6 +477,11 @@ function buildArticleOverview() {
       label: "Омонім",
       ready: homonymCount > 0,
       detail: homonymCount > 0 ? `${homonymCount} позицій` : "очікує джерело",
+    },
+    {
+      label: "Паронім",
+      ready: paronymCount > 0,
+      detail: paronymCount > 0 ? `${paronymCount} позицій` : "очікує джерело",
     },
     {
       label: "Фразеологія",
@@ -549,6 +560,7 @@ function buildSourceList() {
   if (sections?.synonyms?.source) sources.add(sections.synonyms.source);
   if (sections?.antonyms?.source) sources.add(sections.antonyms.source);
   if (sections?.homonyms?.source) sources.add(sections.homonyms.source);
+  if (sections?.paronyms?.source) sources.add(sections.paronyms.source);
   if (sections?.idioms?.source) sources.add(sections.idioms.source);
   if (enrichment?.literary_attestation?.source) sources.add(enrichment.literary_attestation.source);
   if (enrichment?.translation?.source) sources.add(enrichment.translation.source);
@@ -951,6 +963,34 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
             {sections?.homonyms?.source_urls?.length ? (
               <>
                 {" "}Джерела омонімів: {sections.homonyms.source_urls.map((url, index) => (
+                  <>
+                    {index > 0 && " · "}
+                    <a href={url} target="_blank" rel="noopener noreferrer">{sourceHost(url)}</a>
+                  </>
+                ))}
+              </>
+            ) : null}
+          </div>
+        </section>
+      )}
+
+      {(sections?.paronyms?.items.length ?? 0) > 0 && (
+        <section class="atlas-section">
+          <h2>Пароніми</h2>
+          <div class="chip-row">
+            {sections.paronyms.items.map((item) => (
+              <span class="chip">
+                <strong>Не плутати з {item.word}</strong>
+                {item.distinction ? ` — ${item.distinction}` : ""}
+                {item.exam_provenance?.length ? ` (${item.exam_provenance.join("; ")})` : ""}
+              </span>
+            ))}
+          </div>
+          <div class="data-caveat">
+            Пароніми — близькі за формою слова з різними значеннями; розрізняйте їх за контекстом.
+            {sections?.paronyms?.source_urls?.length ? (
+              <>
+                {" "}Джерела паронімів: {sections.paronyms.source_urls.map((url, index) => (
                   <>
                     {index > 0 && " · "}
                     <a href={url} target="_blank" rel="noopener noreferrer">{sourceHost(url)}</a>

--- a/site/tests/unit/atlas-entry-type-templates.test.ts
+++ b/site/tests/unit/atlas-entry-type-templates.test.ts
@@ -98,6 +98,27 @@ function makeHomonymFixture(withHomonyms: boolean): LexiconEntry {
   };
 }
 
+function makeParonymFixture(withParonyms: boolean): LexiconEntry {
+  return {
+    ...makeExpressionLikeFixture('lemma', 'ефективний'),
+    sections: withParonyms
+      ? {
+          paronyms: {
+            items: [
+              {
+                word: 'ефектний',
+                distinction: 'який справляє сильне враження, яскравий',
+                exam_provenance: ['ЗНО 2021, завдання №35'],
+              },
+            ],
+            source: 'ЗНО 2021, завдання №35 + paronyms_cache: cached paronym distinction',
+            source_urls: ['https://example.invalid/zno-2021.pdf'],
+          },
+        }
+      : undefined,
+  };
+}
+
 /** Minimal in-memory atlas.db shaped like the entry-model schema for gate tests. */
 function makeFixtureDb(): InstanceType<typeof Database> {
   const db = new Database(':memory:');
@@ -245,6 +266,27 @@ describe('entry_type-branched article rendering (#4385)', () => {
     expect(html).toContain('Омонім');
     expect(html).not.toContain('<h2>Омоніми</h2>');
     expect(html).not.toContain('Джерела омонімів:');
+  });
+
+  test('renders a paronym distinction, exam provenance, and source', async () => {
+    const html = await renderFixture(makeParonymFixture(true));
+
+    expect(html).toContain('Паронім');
+    expect(html).toContain('<h2>Пароніми</h2>');
+    expect(html).toContain('Не плутати з ефектний');
+    expect(html).toContain('який справляє сильне враження, яскравий');
+    expect(html).toContain('ЗНО 2021, завдання №35');
+    expect(html).toContain('Джерела паронімів:');
+    expect(html).toContain('href="https://example.invalid/zno-2021.pdf"');
+    expect(html).toContain('paronyms_cache: cached paronym distinction');
+  });
+
+  test('keeps the paronym section absent when the entry has no paronym data', async () => {
+    const html = await renderFixture(makeParonymFixture(false));
+
+    expect(html).toContain('Паронім');
+    expect(html).not.toContain('<h2>Пароніми</h2>');
+    expect(html).not.toContain('Джерела паронімів:');
   });
 
   test('lemma baseline remains byte-identical before and after entry-type branching', async () => {

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -44,11 +44,15 @@ from scripts.lexicon.enrich_manifest import (
     _meaning,
     _merge_antonym_relations,
     _merge_homonym_relations,
+    _merge_paronym_relations,
     _merge_slovnyk_warning,
     _merge_synonym_relations,
     _morphology,
     _normalize_manifest_entries,
     _numbered_homonym_members,
+    _paronym_pair_members,
+    _paronym_relations,
+    _paronym_relations_by_headword,
     _parse_translations,
     _prepare_cefr_estimates,
     _proper_noun_wikipedia_meaning,
@@ -144,6 +148,24 @@ def _conn() -> sqlite3.Connection:
             content='literary_texts',
             content_rowid='id',
             tokenize='unicode61'
+        );
+        CREATE TABLE zno_documents (
+            id INTEGER PRIMARY KEY,
+            url TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE zno_tasks (
+            id INTEGER PRIMARY KEY,
+            document_id INTEGER,
+            year INTEGER NOT NULL,
+            task_no INTEGER NOT NULL,
+            task_subtype TEXT NOT NULL DEFAULT '',
+            paronym_pair TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE paronyms_cache (
+            id INTEGER PRIMARY KEY,
+            word_a TEXT NOT NULL,
+            word_b TEXT NOT NULL,
+            definition TEXT NOT NULL
         );
         """
     )
@@ -2909,6 +2931,154 @@ def test_homonym_fixture_samples_expand_from_zero(monkeypatch) -> None:
 
     assert before_counts == {lemma: 0 for lemma in fixtures}
     assert after_numbers == {lemma: expected_numbers for lemma, (_definition, expected_numbers) in fixtures.items()}
+
+
+def test_paronym_pair_members_accepts_only_semicolon_delimited_pairs() -> None:
+    assert _paronym_pair_members("адрес/адреса; ефективний/ефектний") == [
+        ("адрес", "адреса"),
+        ("ефективний", "ефектний"),
+    ]
+    assert _paronym_pair_members("адрес/адреса/адресант; не пара") == []
+
+
+def test_paronym_relations_require_both_vesum_lemmas_and_keep_exam_then_cache(monkeypatch) -> None:
+    conn = _conn()
+    conn.execute("INSERT INTO zno_documents(id, url) VALUES (?, ?)", (1, "https://example.invalid/zno-2021.pdf"))
+    conn.execute(
+        """
+        INSERT INTO zno_tasks(document_id, year, task_no, task_subtype, paronym_pair)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (1, 2021, 35, "paronym", "ефективний/ефектний"),
+    )
+    conn.execute(
+        "INSERT INTO paronyms_cache(word_a, word_b, definition) VALUES (?, ?, ?)",
+        (
+            "ефективний",
+            "ефектний",
+            "Ефективний — який дає потрібний результат, дієвий. "
+            "Ефектний — який справляє сильне враження, яскравий.",
+        ),
+    )
+    _patch_synonym_vesum(monkeypatch, {"ефективний", "ефектний"})
+
+    relations = _paronym_relations(conn, "ефективний")
+
+    assert relations == [
+        {
+            "word": "ефектний",
+            "source": "ЗНО",
+            "pattern": "exam-tested paronym pair",
+            "vein": 1,
+            "exam_provenance": "ЗНО 2021, завдання №35",
+            "gate": {"vesum": "both valid"},
+            "source_url": "https://example.invalid/zno-2021.pdf",
+        },
+        {
+            "word": "ефектний",
+            "distinction": "який справляє сильне враження, яскравий.",
+            "source": "paronyms_cache",
+            "pattern": "cached paronym distinction",
+            "vein": 2,
+            "gate": {"vesum": "both valid"},
+        },
+    ]
+
+    _patch_synonym_vesum(monkeypatch, {"ефективний"})
+    assert _paronym_relations(conn, "ефективний") == []
+
+
+def test_paronym_relations_precompute_reciprocal_manifest_headwords(monkeypatch) -> None:
+    conn = _conn()
+    conn.execute(
+        "INSERT INTO paronyms_cache(word_a, word_b, definition) VALUES (?, ?, ?)",
+        (
+            "адрес",
+            "адреса",
+            "Адрес — урочисте письмове привітання. Адреса — місце проживання чи розташування.",
+        ),
+    )
+    _patch_synonym_vesum(monkeypatch, {"адрес", "адреса"})
+
+    relations = _paronym_relations_by_headword(
+        conn,
+        {"entries": [{"lemma": "адрес"}, {"lemma": "адреса"}]},
+    )
+
+    assert [item["word"] for item in relations["адрес"]] == ["адреса"]
+    assert [item["word"] for item in relations["адреса"]] == ["адрес"]
+
+
+def test_paronym_relation_merge_keeps_distinctions_and_exam_metadata_separate() -> None:
+    relations = [
+        {
+            "word": "змістовний",
+            "source": "ЗНО",
+            "pattern": "exam-tested paronym pair",
+            "vein": 1,
+            "exam_provenance": "ЗНО 2020, завдання №2",
+            "source_url": "https://example.invalid/zno-2020.pdf",
+        },
+        {
+            "word": "ефектний",
+            "distinction": "який справляє сильне враження, яскравий.",
+            "source": "paronyms_cache",
+            "pattern": "cached paronym distinction",
+            "vein": 2,
+        },
+        {
+            "word": "змістовний",
+            "distinction": "який має багато змісту.",
+            "source": "paronyms_cache",
+            "pattern": "cached paronym distinction",
+            "vein": 2,
+        },
+    ]
+
+    merged = _merge_paronym_relations(None, relations)
+
+    assert merged == {
+        "items": [
+            {
+                "word": "змістовний",
+                "distinction": "який має багато змісту.",
+                "exam_provenance": ["ЗНО 2020, завдання №2"],
+            },
+            {
+                "word": "ефектний",
+                "distinction": "який справляє сильне враження, яскравий.",
+            },
+        ],
+        "source": "ЗНО 2020, завдання №2 + paronyms_cache: cached paronym distinction",
+        "source_urls": ["https://example.invalid/zno-2020.pdf"],
+    }
+
+
+def test_paronym_fixture_samples_expand_from_zero(monkeypatch) -> None:
+    fixtures = {
+        "адрес": ("адреса", "Адрес — урочисте письмове привітання. Адреса — місце проживання."),
+        "ефективний": (
+            "ефектний",
+            "Ефективний — який дає потрібний результат. Ефектний — який справляє сильне враження.",
+        ),
+    }
+    _patch_synonym_vesum(
+        monkeypatch,
+        set(fixtures) | {target for target, _definition in fixtures.values()},
+    )
+    conn = _conn()
+    conn.executemany(
+        "INSERT INTO paronyms_cache(word_a, word_b, definition) VALUES (?, ?, ?)",
+        [(lemma, other, definition) for lemma, (other, definition) in fixtures.items()],
+    )
+
+    before_counts = {lemma: 0 for lemma in fixtures}
+    after_items = {
+        lemma: [relation["word"] for relation in _paronym_relations(conn, lemma)] for lemma in fixtures
+    }
+
+    assert before_counts == {lemma: 0 for lemma in fixtures}
+    assert after_items == {lemma: [other] for lemma, (other, _definition) in fixtures.items()}
 
 
 def test_definition_synonym_targets_extracts_stressed_same_as_target() -> None:


### PR DESCRIPTION
## Summary

- Adds a VESUM-gated paronym relation vein to Atlas enrichment, with both members required to be exact valid lemmas.
- Orders exam-validated ЗНО pairs before the existing `paronyms_cache` pairs; cache records add a semantic distinction when one is available.
- Renders a `Пароніми` section and `Паронім` Atlas availability card. Exam provenance is intentionally separate from a lexical distinction.
- Refreshes the required lexicon manifest fingerprint.

Closes #4975

Refs #4506

## Deterministic evidence (#M-4)

### Open-source inputs

Raw `zno_tasks` rows keyed by the implementation (joined to their public `zno_documents.url`):

```text
268 | 2019 | 18 | тактовний/тактичний; численний/чисельний; дослід/дослідження | Д
194 | 2020 | 2  | змістовий/змістовний | В
35  | 2021 | 35 | інформативний/інформаційний | Г
```

The source DB contains 1,646 total `zno_tasks`, with 5 non-empty paronym annotations. The query deliberately uses `trim(paronym_pair) != ''`; the column defaults to an empty string, so `IS NOT NULL` alone would select every task.

slovnyk.me probe result: homepage dictionary index contains no `паронім` or `Гринчишин` listing. `https://slovnyk.me/dict/paronyms/`, `/dict/paronimiv/`, and `/dict/paronimy/` each returned HTTP 404. No Slovnyk paronym source or URL is fabricated; the implementation uses the supplied ZNO rows and existing `paronyms_cache` only.

### VESUM and fixture proof

`verify_words([адрес, адреса, ефективний, ефектний, змістовий, змістовний])` returned 6/6: all are found as exact lemmas (noun, noun, adj, adj, adj, adj respectively).

Small in-memory before/after proof:

```text
before={'адрес': 0, 'ефективний': 0}
after={'адрес': [{'word': 'адреса', 'distinction': 'місце проживання чи розташування.'}], 'ефективний': [{'word': 'ефектний', 'distinction': 'який справляє сильне враження.'}]}
```

Cross-family design input (AGY) confirmed the data model must keep a lexical `distinction` separate from `exam_provenance`; ZNO-only pairs therefore appear with their exam evidence but no invented gloss.

## Validation

- `.venv/bin/python -m pytest tests/test_lexicon_enrich_manifest.py -q` — 129 passed (including synonym, antonym, homonym, and new paronym coverage).
- `cd site && npx vitest run tests/unit/atlas-entry-type-templates.test.ts` — 18 passed.
- `cd site && npx astro build` — passed.
- `.venv/bin/ruff check scripts/lexicon/enrich_manifest.py tests/test_lexicon_enrich_manifest.py` — passed.
- `.venv/bin/python scripts/lexicon/check_manifest_freshness.py` — green.
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — green.

No full re-enrichment or publish was run.

## Independent review

- `deepseek-v4-flash` was dispatched first with a 120-second startup timeout and emitted no response; it was replaced per the repository fallback rule.
- Read-only Grok Build review (`review-4986-grok`) completed against the pushed branch with `NO FINDINGS`.
