### PR TITLE
fix(practice): hide stale static error fallback

### DIFF
--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -58,6 +58,18 @@ test('practice matching renders a real round (>=3 pairs) for a fresh learner', a
   await expect.poll(() => page.locator('[data-activity="match-left-tile"]').count()).toBeGreaterThanOrEqual(3);
 });
 
+for (const [path, label] of [
+  ['/words-of-the-day/practice/', 'plain practice page'],
+  ['/words-of-the-day/practice/?lemmaId=%D0%BA%D0%B0%D0%B2%D0%B0', 'deep-link practice page'],
+] as const) {
+  test(`${label} hides the static error fallback after practice loads (#4984, #4946)`, async ({ page }) => {
+    await page.goto(path);
+
+    await expect(page.locator('#lexicon-practice-mount .lexicon-practice')).toBeVisible();
+    await expect(page.locator('#lexicon-practice-fallback')).toBeHidden();
+  });
+}
+
 test('all СУМ-11 definition cards are hidden from word pages (Soviet dictionary)', async ({ page }) => {
   // прапор carries a *flagged* (sovietization_risk>0) СУМ-11 definition card. Assert
   // BOTH the flagged and clean СУМ-11 classes are absent, so a regression that rendered
@@ -96,7 +108,9 @@ test('practice page shows UA fallback when LexiconPractice island chunk fails to
   await page.goto('/words-of-the-day/practice/');
 
   // Expect the static UA fallback (error listener path is fast; no reliance on 10s timeout).
-  await expect(page.getByText('Не вдалося завантажити практику')).toBeVisible({ timeout: 8000 });
+  const fallback = page.locator('#lexicon-practice-fallback');
+  await expect(fallback).toBeVisible({ timeout: 8000 });
+  await expect(fallback).toContainText('Не вдалося завантажити практику');
   const retryBtn = page.getByRole('button', { name: 'Спробувати ще раз' });
   await expect(retryBtn).toBeVisible();
 

--- a/site/src/lexicon/LexiconPracticeMount.astro
+++ b/site/src/lexicon/LexiconPracticeMount.astro
@@ -121,6 +121,9 @@ import LexiconPractice from '../components/LexiconPractice';
   border-radius: 12px;
   background: var(--lu-surface-raised);
 }
+.lexicon-practice-fallback[hidden] {
+  display: none;
+}
 .lexicon-practice-fallback p {
   margin: 0 0 0.5rem;
   color: var(--lu-text);


### PR DESCRIPTION
## Summary

- restore the static practice fallback's `hidden` state with an explicit, more-specific CSS rule
- cover successful plain and `?lemmaId=кава` practice loads, alongside the real island-chunk-fetch failure path

Fixes #4984

Related to #4946: both deep-link and plain URLs share `LexiconPracticeMount.astro`; this fixes the shared static fallback rather than adding a deep-link-only workaround.

## Deterministic evidence (#M-4)

**Root cause — before:**

```css
.lexicon-practice-fallback {
  display: grid;
}
```

The same static fallback was emitted as `<div id="lexicon-practice-fallback" class="lexicon-practice-fallback" hidden>`. The author `display: grid` rule made the initially `hidden` error UI render even though `showFallback()` only removes `hidden` after an island hydration error or the watchdog.

**Load → state trace now:**

1. Initial/default state: fallback has `hidden`; `.lexicon-practice-fallback[hidden] { display: none; }` keeps it out of layout.
2. Success: React renders `#lexicon-practice-mount .lexicon-practice`; `markSuccess()` ends the watchdog while the fallback remains hidden.
3. Real failure: the hydration-error listener or watchdog calls `showFallback()`, which removes `hidden`, hides the mount, and displays the bilingual retry UI.

**Verification:**

- `cd site && npx vitest run tests/unit/LexiconPractice.test.tsx` → `48 passed`.
- `cd site && npm run build` → exit 0; `8973 page(s) built`.
- `cd site && npx playwright test e2e/atlas-practice.spec.ts` → `10 passed`; explicitly covers plain success, `?lemmaId=кава` success, and aborted `LexiconPractice` chunk failure with a visible fallback.
- `npx eslint site/e2e/atlas-practice.spec.ts site/src/lexicon/LexiconPracticeMount.astro` → exit 0 (Astro file has no matching ESLint configuration).
- `git diff --check` → clean.

Independent cross-family review: Grok Build approved the final diff; no blockers.