### PR TITLE
feat(research-registry): ADR-011 P2 — bounded discovery API

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1575,6 +1575,93 @@ orient bundle blindly.
 
 ---
 
+## Bounded Research Discovery — `/api/knowledge/*` (ADR-011 P2, #4982)
+
+Task-scoped, pointer-only, hash-addressed access to the Project Research
+Registry (`docs/references/research-registry.yaml` + the compact digests
+under `docs/references/research-digests/`). Reuses the P1 validator
+primitives (`scripts/audit/check_research_registry.py`) for the schema,
+canonical digest projection/hash, drift, and path safety — it does not
+re-implement any of them. **P2 exposes the surface; it does not inject any
+research into cold start, orient, bootstrap, or dispatch (that is P3).**
+
+### Kill switch (default OFF, instant rollback)
+
+The whole surface is gated by `research_registry.enabled`, resolved
+**dynamically per request**, most-specific layer wins:
+
+1. env `LEARN_UK_RESEARCH_REGISTRY_ENABLED` — strict `true/false`, `1/0`,
+   `yes/no`, `on/off` (case-insensitive);
+2. live gitignored file `<LIVE_REPO_ROOT>/.runtime/api/research-registry.json`
+   with shape `{"research_registry":{"enabled":false}}`;
+3. compiled default `false`.
+
+An invalid higher-precedence value (bad env spelling, malformed/unreadable
+live file) logs a warning and resolves to `false` — it never falls through
+to a lower, possibly-enabled layer. Flipping the live file is an immediate,
+in-place enable/disable — no revert PR, no redeploy. Loading is **fail-open**:
+while disabled the registry is never parsed; enabled with a missing/malformed/
+invalid registry yields an empty surface and a logged warning, never a 500. A
+drifted or provenance-broken record is excluded individually; healthy records
+keep routing.
+
+### `GET /api/knowledge/manifest?role=&task_family=&track=&owned_path=`
+
+Filtered, task-scoped **pointers** for the given context (no digest bodies).
+Query context: single `role`, `task_family`, `track`, and repeated
+`owned_path`. Matching is a strict **AND** across every dimension the record
+declares — a dimension omitted from the record is a wildcard; a dimension the
+record requires but the request lacks fails the match (so a `core`-track
+record scoped to `difficulty-gate` will **not** surface for a `core`-track
+`module-build` task). `owned_path` intersects the record's globs by
+deterministic case-sensitive glob. **No task context → zero records** (never
+"show all"). Repeated/duplicate/reordered query values are normalized so
+semantically identical contexts produce byte-identical output and ETag.
+
+- Disabled → HTTP 200 `{"enabled":false,"records":[]}` (loader never invoked).
+- Enabled → `{"enabled":true,"records":[…]}`, each record an allowlisted
+  pointer `{"id","state","content_hash","routing"}` — never summary, digest
+  path/body, source URL, ownership, timestamps, the global hash, or telemetry.
+- Bounded: **top 5 records** (sorted by record id) and **≤ 1536 serialized
+  UTF-8 bytes**. If the byte cap drops records, every dropped id is logged —
+  never a silent truncation.
+- Strong **ETag** over the exact response bytes for this context (not the
+  global hash, not `generated_at`). This is what keeps an unrelated warm
+  client at zero research tokens even while the global manifest hash churns:
+  after any record edit flips the global hash, a context whose filtered set is
+  unchanged still gets a bodyless `304` on `If-None-Match`, while a context
+  routing to the edited record gets `200` and a new ETag. Honors strong/weak/
+  `*`/comma-list `If-None-Match` (shared `_matches_etag` semantics).
+- Request caps: ≤ 64 `owned_path` values, each ≤ 512 chars; `role`/
+  `task_family`/`track` ≤ 128 chars. Excess → `422`.
+
+### `GET /api/knowledge/record/{record_id}`
+
+The one validated compact digest **body** as `text/markdown; charset=utf-8`,
+capped at **4096 serialized UTF-8 bytes**. The P1 `content_hash` is the ETag
+for the exact normalized body (an honest ETag: if the returned bytes ever
+differed from the hashed projection, the ETag is computed over the response
+bytes instead). Unchanged `If-None-Match` → bodyless `304`; a
+changed/reconciled digest → `200` with a new ETag.
+
+Lookup resolves only through validated registry ids — never a direct path
+join. A generic **404** covers a disabled feature, an unknown/malformed/
+traversal id, an invalid/drifted/`private-local` record, an unsafe digest
+path, or an over-budget body (Starlette answers encoded traversal with `403`
+before the route). No status or message leaks which of these applied.
+
+### Budgets (normative = serialized UTF-8 bytes; tokens = `ceil(bytes/2)`)
+
+| Surface | Budget |
+|---|---|
+| Total `/api/state/manifest` | < 2048 bytes |
+| `research` manifest component | ≤ 512 bytes |
+| `/api/knowledge/manifest` filtered projection | ≤ 5 records and ≤ 1536 bytes |
+| One `/api/knowledge/record/{id}` body | ≤ 4096 bytes |
+| Automatic selected-body fetch (P3 consumer) | ≤ 8192 bytes total |
+
+Any runtime budget drop logs the affected record ids, never digest bodies.
+
 ## Cold-Start Consolidation — `/api/state/manifest`, `/api/rules`, `/api/session/current`, `/api/comms/inbox` (#1309)
 
 Per the Agent Quick Start above, these four endpoints are the
@@ -1603,6 +1690,16 @@ hashes against its local cache and only refetches what changed.
   already carries per-section `meta` with its own `generated_at` +
   `cache` + `source` fields, and `/api/comms/inbox` is always
   point-in-time.
+- `research` — **optional, ADR-011 P2.** Present only when the research
+  registry kill switch is on *and* the registry is exposable; a compact
+  `{"hash": "<64-hex>", "url": "/api/knowledge/manifest"}` (≤ 512 bytes,
+  no summary/note/timestamp). `hash` is a single global hash over the
+  routing-relevant projection of the whole registry (states, content
+  hashes, per-record validity, and routing metadata — never digest
+  bodies or YAML formatting). Any record edit flips it for all clients.
+  With the switch off or on a missing/malformed registry the key is
+  **absent**, so pre-P2 clients are byte-for-byte unaffected. See
+  *Bounded Research Discovery* below.
 - When `LEARN_UKRAINIAN_TELEMETRY_FOOTER=1`, this JSON response also
   includes top-level `_telemetry` derived from transcript JSONL. It
   never appends text to the manifest body.

--- a/scripts/api/knowledge_router.py
+++ b/scripts/api/knowledge_router.py
@@ -1,0 +1,94 @@
+"""Knowledge API router — ADR-011 P2 bounded research discovery.
+
+Mounted at ``/api/knowledge`` in ``main.py``. Two endpoints, both gated behind the
+default-off ``research_registry`` kill switch (``scripts/research/registry.py``):
+
+    GET /api/knowledge/manifest             Filtered, task-scoped pointer list with
+                                            its own strong ETag (no digest bodies).
+    GET /api/knowledge/record/{record_id}   One compact digest body as text/markdown
+                                            with an honest per-record ETag.
+
+Everything is deterministic and fail-open: disabled or a failed registry load
+yields an empty/disabled projection, never a 500. The runtime layer does all the
+loading, matching, projection, and budgeting; this module only maps it to HTTP,
+including the shared ``_matches_etag`` 304 semantics.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query, Request, Response
+
+from scripts.research import registry as reg
+
+from .rules_router import _matches_etag
+
+router = APIRouter(tags=["knowledge"])
+
+_JSON_MEDIA = "application/json"
+_MARKDOWN_MEDIA = "text/markdown; charset=utf-8"
+_NOT_FOUND = "Not Found"
+
+
+def _json_response(body: bytes, etag_hex: str | None = None, status_code: int = 200) -> Response:
+    headers = {"ETag": f'"{etag_hex}"'} if etag_hex is not None else None
+    return Response(content=body, media_type=_JSON_MEDIA, status_code=status_code, headers=headers)
+
+
+@router.get("/manifest")
+def knowledge_manifest(
+    request: Request,
+    role: str | None = Query(default=None, max_length=reg.MAX_QUERY_VALUE_LEN),
+    task_family: str | None = Query(default=None, max_length=reg.MAX_QUERY_VALUE_LEN),
+    track: str | None = Query(default=None, max_length=reg.MAX_QUERY_VALUE_LEN),
+    owned_path: list[str] = Query(default=[]),
+):
+    """Filtered, task-scoped research pointers for the given context.
+
+    Disabled → HTTP 200 ``{"enabled":false,"records":[]}`` (loader never invoked).
+    Enabled → the pure AND matcher over ``{role, task_family, track, owned_path}``,
+    top-5 / ≤1.5 KB pointers, sorted by record id, with a strong ETag over the exact
+    response bytes. No task context yields zero records. Supports ``If-None-Match``
+    for a bodyless 304.
+    """
+    if not reg.is_enabled():
+        return _json_response(reg.disabled_manifest_bytes())
+
+    if len(owned_path) > reg.MAX_OWNED_PATHS:
+        raise HTTPException(status_code=422, detail="too many owned_path values")
+    if any(len(path) > reg.MAX_OWNED_PATH_LEN for path in owned_path):
+        raise HTTPException(status_code=422, detail="owned_path value too long")
+
+    runtime = reg.load_runtime()
+    if runtime is None:
+        result = reg.empty_manifest_response()
+    else:
+        ctx = reg.normalize_context(role, task_family, track, owned_path)
+        result = reg.filtered_manifest(runtime, ctx)
+
+    if _matches_etag(request.headers.get("If-None-Match"), result.etag_hex):
+        return Response(status_code=304, headers={"ETag": f'"{result.etag_hex}"'})
+    return _json_response(result.body, result.etag_hex)
+
+
+@router.get("/record/{record_id}")
+def knowledge_record(request: Request, record_id: str):
+    """One validated compact digest body as ``text/markdown`` with an honest ETag.
+
+    Returns a generic 404 for a disabled feature, an unknown/malformed/traversal
+    id, an invalid/drifted/``private-local`` record, an unsafe digest path, or an
+    over-budget body — never a leaking status. ``content_hash`` is the ETag for the
+    exact normalized body; ``If-None-Match`` gives a bodyless 304.
+    """
+    if not reg.is_enabled():
+        raise HTTPException(status_code=404, detail=_NOT_FOUND)
+    runtime = reg.load_runtime()
+    if runtime is None:
+        raise HTTPException(status_code=404, detail=_NOT_FOUND)
+    result = reg.record_body(runtime, record_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail=_NOT_FOUND)
+    body, etag_hex = result
+    etag = f'"{etag_hex}"'
+    if _matches_etag(request.headers.get("If-None-Match"), etag_hex):
+        return Response(status_code=304, headers={"ETag": etag})
+    return Response(content=body, media_type=_MARKDOWN_MEDIA, headers={"ETag": etag})

--- a/scripts/api/knowledge_router.py
+++ b/scripts/api/knowledge_router.py
@@ -58,7 +58,7 @@ def knowledge_manifest(
     if any(len(path) > reg.MAX_OWNED_PATH_LEN for path in owned_path):
         raise HTTPException(status_code=422, detail="owned_path value too long")
 
-    runtime = reg.load_runtime()
+    runtime = reg.load_runtime_safe()
     if runtime is None:
         result = reg.empty_manifest_response()
     else:
@@ -81,7 +81,7 @@ def knowledge_record(request: Request, record_id: str):
     """
     if not reg.is_enabled():
         raise HTTPException(status_code=404, detail=_NOT_FOUND)
-    runtime = reg.load_runtime()
+    runtime = reg.load_runtime_safe()
     if runtime is None:
         raise HTTPException(status_code=404, detail=_NOT_FOUND)
     result = reg.record_body(runtime, record_id)

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -69,6 +69,7 @@ from .governance_router import router as governance_router
 from .hermes_cron_router import router as hermes_cron_router
 from .images_router import router as images_router
 from .issues_router import router as issues_router
+from .knowledge_router import router as knowledge_router
 from .preload import preload_all
 from .rag_router import router as rag_router
 from .resilience import get_resilience_snapshot, resilience_middleware
@@ -156,6 +157,7 @@ app.include_router(hermes_cron_router, prefix="/api/hermes-cron", tags=["hermes-
 app.include_router(build_events_router, prefix="/api/build/events")
 app.include_router(images_router, prefix="/api/images")
 app.include_router(issues_router, prefix="/api/issues", tags=["issues"])
+app.include_router(knowledge_router, prefix="/api/knowledge", tags=["knowledge"])
 app.include_router(rag_router, prefix="/api/rag")
 # GH #1529 P3 — reviewer-ghost telemetry nested under /api/state so clients
 # can discover it alongside the other state-query endpoints.

--- a/scripts/api/preload.py
+++ b/scripts/api/preload.py
@@ -45,6 +45,8 @@ PRELOAD_MODULES = [
     "agent_runtime.adapters.gemini",
     "research_quality",
     "research.research_markdown_utils",
+    "scripts.research.registry",
+    "scripts.audit.check_research_registry",
 ]
 
 # Heavy or optional dependencies (try/except ImportError, record skipped)

--- a/scripts/api/route_contracts.py
+++ b/scripts/api/route_contracts.py
@@ -468,6 +468,21 @@ ROUTE_CONTRACTS: tuple[RouteContract, ...] = (
         "keep cold-start source of truth",
     ),
     RouteContract(
+        "/api/knowledge", "prefix", "http",
+        "ADR-011 bounded Project Research Registry discovery: task-scoped pointer "
+        "manifest and per-record compact digest bodies.",
+        "docs/references/research-registry.yaml + docs/references/research-digests/** "
+        "via the P1 validator primitives (scripts/audit/check_research_registry.py).",
+        "No route cache; per-request deterministic registry load. Strong ETags: a "
+        "context-scoped ETag on /manifest and the P1 content_hash on /record/{id}. "
+        "Disabled by default behind the research_registry kill switch.",
+        ("agents", "dispatch", "cold-start tooling"),
+        "Pointer index for /api/state/manifest's research component; bodies never "
+        "enter cold start.",
+        "low; disabled or a failed load degrades to an empty/disabled projection",
+        "keep as the research discovery surface",
+    ),
+    RouteContract(
         "/api/state/manifest", "exact", "http",
         "Tiny cold-start manifest with hashes and URLs.",
         "Rules/session hash helpers plus static endpoint metadata.",

--- a/scripts/api/state_router.py
+++ b/scripts/api/state_router.py
@@ -48,6 +48,8 @@ try:
 except ImportError:
     from ..path_safety import safe_join  # scripts.api package import (production)
 
+from scripts.research.registry import research_manifest_component
+
 from . import delegate_router as delegate_api
 from .codexbar_usage import get_provider_usage_data, refresh_provider_usage_data
 from .config import CURRICULUM_ROOT, LEVELS
@@ -1828,34 +1830,38 @@ async def manifest(request: Request):
     state to one tiny call.
     """
     session_id = session_id_from_request(request)
-    return add_json_telemetry(
-        {
-            "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
-            "rules": {
-                "hash": rules_hash(),
-                "url": "/api/rules?format=markdown",
-                "format": "markdown",
-                "note": "Condensed critical + non-negotiable + workflow rules. Drop straight into a system prompt.",
-            },
-            "session": {
-                "hash": session_hash(),
-                "url": "/api/session/current?agent=orchestrator&format=markdown",
-                "format": "markdown",
-                "note": "Current.md + recent session-state handoff filenames.",
-            },
-            "orient": {
-                "url": "/api/orient",
-                "fresh_param": "?fresh=true",
-                "note": "Per-section TTL cache + meta. Most agents only need the sections whose TTL has elapsed.",
-            },
-            "inbox": {
-                "url_template": "/api/comms/inbox?agent={name}",
-                "note": "Read-only view of unread channel deliveries for one agent.",
-            },
-            "activity": {
-                "url": "/api/comms/agent-activity",
-                "note": "Compact channel delivery/event snapshot for orchestration.",
-            },
+    body = {
+        "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+        "rules": {
+            "hash": rules_hash(),
+            "url": "/api/rules?format=markdown",
+            "format": "markdown",
+            "note": "Condensed critical + non-negotiable + workflow rules. Drop straight into a system prompt.",
         },
-        session_id=session_id,
-    )
+        "session": {
+            "hash": session_hash(),
+            "url": "/api/session/current?agent=orchestrator&format=markdown",
+            "format": "markdown",
+            "note": "Current.md + recent session-state handoff filenames.",
+        },
+        "orient": {
+            "url": "/api/orient",
+            "fresh_param": "?fresh=true",
+            "note": "Per-section TTL cache + meta. Most agents only need the sections whose TTL has elapsed.",
+        },
+        "inbox": {
+            "url_template": "/api/comms/inbox?agent={name}",
+            "note": "Read-only view of unread channel deliveries for one agent.",
+        },
+        "activity": {
+            "url": "/api/comms/agent-activity",
+            "note": "Compact channel delivery/event snapshot for orchestration.",
+        },
+    }
+    # ADR-011 P2: compact {hash, url} research pointer, present only when the
+    # research-registry kill switch is on and the registry is exposable. Absent
+    # otherwise, preserving the exact pre-P2 manifest for existing clients.
+    research = research_manifest_component()
+    if research is not None:
+        body["research"] = research
+    return add_json_telemetry(body, session_id=session_id)

--- a/scripts/research/registry.py
+++ b/scripts/research/registry.py
@@ -12,9 +12,15 @@ Runtime contract (ADR-011 §"Runtime kill switch", §"Failure / degradation"):
 
 * **Disabled by default.** While disabled the registry is never loaded or parsed.
 * **Fail-open.** Enabled + a missing/malformed/invalid registry yields *no*
-  research surface and a logged warning — never a boot or API 500.
-* **Per-record isolation.** A drifted or provenance-broken record is excluded
-  individually; healthy records keep routing.
+  research surface and a logged warning — never a boot or API 500. An unexpected
+  exception anywhere in the load path degrades the same way, via
+  :func:`load_runtime_safe`.
+* **Per-record isolation is drift-only.** ADR-011 grants isolation to a single
+  invariant: a ``content_hash`` that no longer matches its digest. That record is
+  excluded while healthy records keep routing. Any other semantic defect P1
+  reports (broken provenance, a lifecycle/consumer/ownership violation, a
+  duplicate id, a supersession cycle, an over-cap cold-start role) hides the
+  *whole* registry — it is not safe to isolate per record.
 * **No side effects at request time.** No GitHub, subprocess, network,
   ``sources.db``, or embeddings access — only local file reads.
 
@@ -233,51 +239,66 @@ class RegistryRuntime:
         return sha256(canonical_json_bytes(items)).hexdigest()
 
 
-def _record_is_valid(record: dict[str, Any], root: Path) -> bool:
-    """Runtime validity: provenance resolves safely and the digest has not drifted.
-
-    These are the two invariants that can go stale *after* a record passes CI (a
-    digest edited without ``--reconcile`` → drift; a digest path broken → bad
-    provenance). Lifecycle/ownership/consumer invariants are CI-gated and do not
-    affect the safety of the routed projection, so they are not re-litigated here.
-    """
-    try:
-        if crr.validate_provenance(record, root):
-            return False
-        if record["content_hash"] != crr.expected_content_hash(record, root):
-            return False
-    except Exception as exc:  # pragma: no cover - defensive; P1 raises ProvenanceError
-        logger.warning("research registry: record %r failed runtime validity (%s)", record.get("id"), exc)
-        return False
-    return True
-
-
 def load_runtime(*, root: Path | None = None) -> RegistryRuntime | None:
-    """Load + schema-validate the registry, computing per-record validity.
+    """Load the registry and validate it via P1's ``validate_registry`` — the single
+    semantic authority for schema, lifecycle, supersession, consumer, ownership, and
+    digest-policy invariants (this module never duplicates that logic).
 
     Returns ``None`` (fail-open: omit the whole research surface) when the file is
-    missing, unreadable, not a mapping, or structurally schema-invalid. Individual
-    invalid records are kept in ``pairs`` with ``valid=False`` so the global hash
-    stays sensitive to their validity while they are excluded from routing.
+    missing/unreadable/malformed, or when P1 reports any *non-drift* error — a
+    structural schema violation, broken provenance, a lifecycle/consumer/ownership
+    violation, a duplicate id, a supersession cycle, or an over-cap cold-start role.
+    ADR-011 grants per-record isolation only to ``content_hash`` drift: when P1
+    reports drift and nothing else, the runtime is still built and only the drifted
+    ids are marked ``valid=False`` so healthy records keep routing.
     """
     root = root if root is not None else _live_repo_root()
     path = _registry_path(root)
     try:
-        _raw, data = crr.load_registry(path)
-    except (OSError, ValueError, yaml.YAMLError) as exc:
+        raw, data = crr.load_registry(path)
+    except (OSError, ValueError, yaml.YAMLError, RecursionError) as exc:
         logger.warning("research registry: cannot load %s (%s); no research surface", path, exc)
         return None
     try:
-        schema = crr.load_schema()
-    except (OSError, ValueError) as exc:  # pragma: no cover - schema ships with code
-        logger.warning("research registry: cannot load schema (%s); no research surface", exc)
+        result = crr.validate_registry(data, project_root=root, raw_text=raw)
+    except (OSError, ValueError, yaml.YAMLError, RecursionError, KeyError, TypeError) as exc:
+        logger.warning(
+            "research registry: %s failed validation (%s); no research surface",
+            path,
+            type(exc).__name__,
+        )
         return None
-    if crr.validate_schema(data, schema):
-        logger.warning("research registry: %s fails structural schema; no research surface", path)
+    if result.errors:
+        logger.warning(
+            "research registry: %s fails semantic validation (%d error(s)); no research surface",
+            path,
+            len(result.errors),
+        )
         return None
     records = data.get("records") or []
-    pairs = tuple((rec, _record_is_valid(rec, root)) for rec in records)
+    drifted = set(result.drift)
+    pairs = tuple((rec, rec["id"] not in drifted) for rec in records)
     return RegistryRuntime(root=root, pairs=pairs)
+
+
+def load_runtime_safe(*, root: Path | None = None) -> RegistryRuntime | None:
+    """Fail-open boundary around :func:`load_runtime` for every HTTP-facing caller.
+
+    ``load_runtime`` already turns known-bad input (missing file, malformed YAML,
+    semantic errors) into ``None``, but a pathological/injected failure (e.g. a
+    parser resource error we didn't anticipate, or a defect in a future P1 change)
+    must still never surface as an API 500. Catches any unexpected ``Exception``
+    and logs only the exception type — never registry or digest contents. Callers
+    must check :func:`is_enabled` first; this function does not gate on the flag.
+    """
+    try:
+        return load_runtime(root=root)
+    except Exception as exc:
+        logger.warning(
+            "research registry: unexpected %s loading runtime; no research surface",
+            type(exc).__name__,
+        )
+        return None
 
 
 def research_manifest_component(*, root: Path | None = None) -> dict[str, str] | None:
@@ -289,7 +310,7 @@ def research_manifest_component(*, root: Path | None = None) -> dict[str, str] |
     """
     if not is_enabled(root=root):
         return None
-    runtime = load_runtime(root=root)
+    runtime = load_runtime_safe(root=root)
     if runtime is None:
         return None
     return {"hash": runtime.global_hash(), "url": KNOWLEDGE_MANIFEST_URL}
@@ -478,18 +499,20 @@ def record_body(runtime: RegistryRuntime, record_id: str) -> tuple[str, str] | N
             MAX_RECORD_BYTES,
         )
         return None
-    # ``content_hash`` is an honest ETag only if it addresses the exact bytes we
-    # return; otherwise compute the ETag over the response bytes so we never serve
-    # a stale-body ETag.
-    expected = crr.compute_content_hash(body)
+    # The digest is re-read from disk on every call, but ``record`` (and its
+    # ``content_hash``) is a snapshot captured at load_runtime() time. If the
+    # digest changed on disk in between (a TOCTOU window), the freshly-read body
+    # no longer matches that snapshot hash — refuse rather than inventing a new
+    # ETag and serving unreconciled bytes. A fresh load_runtime() call would
+    # exclude this record entirely; this call must not do less.
     stored = record["content_hash"]
-    # ``content_hash`` addresses the exact bytes for a valid (non-drifted) record;
-    # the fallback is belt-and-suspenders so we never serve a stale-body ETag.
-    if expected == stored:  # noqa: SIM108 - keep the defensive branch explicit
-        etag_hex = stored.split(":", 1)[1]
-    else:
-        etag_hex = sha256(body_bytes).hexdigest()
-    return body, etag_hex
+    if crr.compute_content_hash(body) != stored:
+        logger.warning(
+            "research registry: record %r content changed since load_runtime(); refusing to serve",
+            record_id,
+        )
+        return None
+    return body, stored.split(":", 1)[1]
 
 
 # --------------------------------------------------------------------------- #

--- a/scripts/research/registry.py
+++ b/scripts/research/registry.py
@@ -1,0 +1,525 @@
+"""ADR-011 P2 — Project Research Registry runtime layer.
+
+P1 (``scripts/audit/check_research_registry.py``) is the source of truth for the
+schema, the canonical digest projection/hash, drift detection, lifecycle, path
+safety, and record validity. This module is the *runtime* layer that the bounded
+discovery API (``scripts/api/knowledge_router.py``) and the cold-start manifest
+component build on. It deliberately **reuses** P1's primitives — it does not
+re-implement a second normalization, fence parser, schema, or content-hash
+algorithm.
+
+Runtime contract (ADR-011 §"Runtime kill switch", §"Failure / degradation"):
+
+* **Disabled by default.** While disabled the registry is never loaded or parsed.
+* **Fail-open.** Enabled + a missing/malformed/invalid registry yields *no*
+  research surface and a logged warning — never a boot or API 500.
+* **Per-record isolation.** A drifted or provenance-broken record is excluded
+  individually; healthy records keep routing.
+* **No side effects at request time.** No GitHub, subprocess, network,
+  ``sources.db``, or embeddings access — only local file reads.
+
+Everything here is deterministic: identical inputs → identical bytes → identical
+ETag.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import logging
+import math
+import os
+import re
+from dataclasses import dataclass
+from hashlib import sha256
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.audit import check_research_registry as crr
+
+logger = logging.getLogger("research.registry")
+
+# --------------------------------------------------------------------------- #
+# Kill switch (ADR-011 §"Runtime kill switch")
+# --------------------------------------------------------------------------- #
+ENV_FLAG = "LEARN_UK_RESEARCH_REGISTRY_ENABLED"
+LIVE_FLAG_RELATIVE = Path(".runtime") / "api" / "research-registry.json"
+
+# Strict boolean spellings for the environment override. Case-insensitive.
+_ENV_TRUE = frozenset({"true", "1", "yes", "on"})
+_ENV_FALSE = frozenset({"false", "0", "no", "off"})
+
+# --------------------------------------------------------------------------- #
+# Budgets (ADR-011 §"Budgets and selection helper"). Serialized UTF-8 bytes are
+# the normative gate; tokens are a pinned ceil(bytes/2) estimate.
+# --------------------------------------------------------------------------- #
+MAX_STATE_MANIFEST_BYTES = 2048  # total /api/state/manifest response
+MAX_RESEARCH_COMPONENT_BYTES = 512  # the {hash,url} manifest component
+MAX_FILTERED_BYTES = 1536  # /api/knowledge/manifest filtered projection
+MAX_FILTERED_RECORDS = 5  # top-N pointers per context
+MAX_RECORD_BYTES = 4096  # one /api/knowledge/record/{id} body (mirrors P1)
+MAX_SELECTED_BODIES_BYTES = 8192  # automatic selected-body helper total (P3 consumer)
+
+# Request-side caps (ADR-011 §"Pure AND context matcher": bound the work).
+MAX_QUERY_VALUE_LEN = 128
+MAX_OWNED_PATH_LEN = 512
+MAX_OWNED_PATHS = 64
+
+KNOWLEDGE_MANIFEST_URL = "/api/knowledge/manifest"
+
+# Record-id shape — mirrors the JSON Schema ``slug`` pattern. Used to reject
+# traversal/slash/junk ids before any registry lookup.
+_SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+# Test/consumer seam: override the live repo root without importing the API config.
+_ROOT_OVERRIDE: Path | None = None
+
+
+def est_tokens(utf8_bytes: int) -> int:
+    """Pinned conservative token estimate: ``ceil(utf8_bytes / 2)`` (ADR-011)."""
+    return math.ceil(utf8_bytes / 2)
+
+
+def _live_repo_root() -> Path:
+    """The live git checkout that hosts the registry and the runtime flag file.
+
+    Uses the API's ``LIVE_REPO_ROOT`` (the real checkout, where ``docs/`` is a
+    real directory rather than a release-snapshot symlink), unless a test sets an
+    explicit override. The import is lazy so non-API consumers of the pure matcher
+    do not pull in the API config.
+    """
+    if _ROOT_OVERRIDE is not None:
+        return _ROOT_OVERRIDE
+    from scripts.api.config import LIVE_REPO_ROOT  # lazy-ok: decouple matcher from API config
+
+    return LIVE_REPO_ROOT
+
+
+def _registry_path(root: Path) -> Path:
+    return root / "docs" / "references" / "research-registry.yaml"
+
+
+def _live_flag_path(root: Path) -> Path:
+    return root / LIVE_FLAG_RELATIVE
+
+
+def _parse_bool_strict(raw: str) -> bool | None:
+    """Return True/False for an accepted spelling, or None for anything else."""
+    value = raw.strip().lower()
+    if value in _ENV_TRUE:
+        return True
+    if value in _ENV_FALSE:
+        return False
+    return None
+
+
+def is_enabled(*, root: Path | None = None) -> bool:
+    """Resolve the feature flag dynamically, most-specific layer wins.
+
+    1. environment variable ``LEARN_UK_RESEARCH_REGISTRY_ENABLED`` (strict);
+    2. live gitignored file ``<root>/.runtime/api/research-registry.json``;
+    3. compiled default ``False``.
+
+    An invalid higher-precedence value (bad env spelling, malformed/unreadable
+    live file) warns and resolves to ``False`` — it never falls through to a
+    lower, possibly-enabled layer.
+    """
+    env_value = os.environ.get(ENV_FLAG)
+    if env_value is not None:
+        parsed = _parse_bool_strict(env_value)
+        if parsed is None:
+            logger.warning(
+                "research registry: invalid %s=%r; treating as disabled", ENV_FLAG, env_value
+            )
+            return False
+        return parsed
+
+    root = root if root is not None else _live_repo_root()
+    flag_path = _live_flag_path(root)
+    if not flag_path.exists():
+        return False
+    try:
+        raw = flag_path.read_text("utf-8")
+        data = json.loads(raw)
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            "research registry: live flag %s is unreadable/malformed (%s); disabled",
+            flag_path,
+            exc,
+        )
+        return False
+    try:
+        value = data["research_registry"]["enabled"]
+    except (KeyError, TypeError):
+        logger.warning(
+            "research registry: live flag %s missing research_registry.enabled; disabled",
+            flag_path,
+        )
+        return False
+    if isinstance(value, bool):
+        return value
+    logger.warning(
+        "research registry: live flag %s enabled is not a boolean (%r); disabled",
+        flag_path,
+        value,
+    )
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Deterministic JSON serialization (single source for body bytes + ETag)
+# --------------------------------------------------------------------------- #
+def canonical_json_bytes(payload: Any) -> bytes:
+    """Serialize deterministically: sorted keys, compact separators, UTF-8.
+
+    The knowledge endpoints send exactly these bytes and compute their ETag over
+    them, so byte-identical projections for two unrelated contexts produce a
+    byte-identical response and a matching ETag.
+    """
+    return json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# Runtime loading + per-record validity (reuses P1)
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class RegistryRuntime:
+    """A loaded, schema-valid registry snapshot with per-record validity flags."""
+
+    root: Path
+    pairs: tuple[tuple[dict[str, Any], bool], ...]  # (record, is_valid)
+
+    @property
+    def valid_records(self) -> list[dict[str, Any]]:
+        return [rec for rec, valid in self.pairs if valid]
+
+    def valid_by_id(self, record_id: str) -> dict[str, Any] | None:
+        for rec, valid in self.pairs:
+            if valid and rec["id"] == record_id:
+                return rec
+        return None
+
+    def global_hash(self) -> str:
+        """Single registry-wide hash over the routing-relevant projection.
+
+        Covers each record's id, state, stored ``content_hash``, runtime validity,
+        access class, and routing dimensions — never digest bodies, YAML
+        formatting/ordering, or ``generated_at``. Editing any record's routed
+        metadata, state, content hash, or validity flips it; a pure YAML
+        reorder/reformat does not.
+        """
+        items = []
+        for rec, valid in self.pairs:
+            routing = rec.get("routing") or {}
+            items.append(
+                {
+                    "id": rec["id"],
+                    "state": rec["state"],
+                    "content_hash": rec["content_hash"],
+                    "valid": valid,
+                    "access_class": rec["access_class"],
+                    "cold_start_roles": sorted(rec.get("cold_start_roles") or []),
+                    "roles": sorted(routing.get("roles") or []),
+                    "task_families": sorted(routing.get("task_families") or []),
+                    "tracks": sorted(routing.get("tracks") or []),
+                    "owned_paths": sorted(routing.get("owned_paths") or []),
+                }
+            )
+        items.sort(key=lambda item: item["id"])
+        return sha256(canonical_json_bytes(items)).hexdigest()
+
+
+def _record_is_valid(record: dict[str, Any], root: Path) -> bool:
+    """Runtime validity: provenance resolves safely and the digest has not drifted.
+
+    These are the two invariants that can go stale *after* a record passes CI (a
+    digest edited without ``--reconcile`` → drift; a digest path broken → bad
+    provenance). Lifecycle/ownership/consumer invariants are CI-gated and do not
+    affect the safety of the routed projection, so they are not re-litigated here.
+    """
+    try:
+        if crr.validate_provenance(record, root):
+            return False
+        if record["content_hash"] != crr.expected_content_hash(record, root):
+            return False
+    except Exception as exc:  # pragma: no cover - defensive; P1 raises ProvenanceError
+        logger.warning("research registry: record %r failed runtime validity (%s)", record.get("id"), exc)
+        return False
+    return True
+
+
+def load_runtime(*, root: Path | None = None) -> RegistryRuntime | None:
+    """Load + schema-validate the registry, computing per-record validity.
+
+    Returns ``None`` (fail-open: omit the whole research surface) when the file is
+    missing, unreadable, not a mapping, or structurally schema-invalid. Individual
+    invalid records are kept in ``pairs`` with ``valid=False`` so the global hash
+    stays sensitive to their validity while they are excluded from routing.
+    """
+    root = root if root is not None else _live_repo_root()
+    path = _registry_path(root)
+    try:
+        _raw, data = crr.load_registry(path)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        logger.warning("research registry: cannot load %s (%s); no research surface", path, exc)
+        return None
+    try:
+        schema = crr.load_schema()
+    except (OSError, ValueError) as exc:  # pragma: no cover - schema ships with code
+        logger.warning("research registry: cannot load schema (%s); no research surface", exc)
+        return None
+    if crr.validate_schema(data, schema):
+        logger.warning("research registry: %s fails structural schema; no research surface", path)
+        return None
+    records = data.get("records") or []
+    pairs = tuple((rec, _record_is_valid(rec, root)) for rec in records)
+    return RegistryRuntime(root=root, pairs=pairs)
+
+
+def research_manifest_component(*, root: Path | None = None) -> dict[str, str] | None:
+    """The ``{hash, url}`` research component for ``/api/state/manifest``.
+
+    Returns ``None`` (omit the component, preserving pre-P2 clients) when the
+    feature is disabled or the registry cannot be exposed. Never loads the
+    registry while disabled.
+    """
+    if not is_enabled(root=root):
+        return None
+    runtime = load_runtime(root=root)
+    if runtime is None:
+        return None
+    return {"hash": runtime.global_hash(), "url": KNOWLEDGE_MANIFEST_URL}
+
+
+# --------------------------------------------------------------------------- #
+# Pure AND context matcher (ADR-011 §"Routing algebra")
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class Context:
+    """A normalized task context. Single role/family/track, a set of owned paths."""
+
+    role: str | None
+    task_family: str | None
+    track: str | None
+    owned_paths: tuple[str, ...]
+
+    def is_empty(self) -> bool:
+        return (
+            self.role is None
+            and self.task_family is None
+            and self.track is None
+            and not self.owned_paths
+        )
+
+
+def normalize_context(
+    role: str | None,
+    task_family: str | None,
+    track: str | None,
+    owned_paths: list[str] | None,
+) -> Context:
+    """Deduplicate/reorder so semantically identical contexts are byte-identical."""
+
+    def _norm(value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    paths = sorted({p.strip() for p in (owned_paths or []) if p and p.strip()})
+    return Context(_norm(role), _norm(task_family), _norm(track), tuple(paths))
+
+
+def matches(routing: dict[str, Any], ctx: Context) -> bool:
+    """Conjunctive match: every dimension present on the record must be satisfied.
+
+    A dimension omitted from the record is a wildcard. A record dimension the
+    context lacks fails the match (track alone never surfaces a family-scoped
+    record). ``owned_paths`` intersect via deterministic, case-sensitive globbing.
+    """
+    roles = routing.get("roles")
+    if roles is not None and (ctx.role is None or ctx.role not in roles):
+        return False
+    families = routing.get("task_families")
+    if families is not None and (ctx.task_family is None or ctx.task_family not in families):
+        return False
+    tracks = routing.get("tracks")
+    if tracks is not None and (ctx.track is None or ctx.track not in tracks):
+        return False
+    globs = routing.get("owned_paths")
+    if globs is not None:
+        if not ctx.owned_paths:
+            return False
+        if not any(fnmatch.fnmatchcase(path, glob) for path in ctx.owned_paths for glob in globs):
+            return False
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# Projections (allowlisted — never leak bodies/summaries/prose)
+# --------------------------------------------------------------------------- #
+def pointer(record: dict[str, Any]) -> dict[str, Any]:
+    """The bounded, allowlisted filtered-manifest pointer for one record.
+
+    IDs, lifecycle state, P1 content hash, and routing metadata only — never
+    summary, digest path/body, source URL, ownership prose, timestamps, the global
+    hash, or telemetry.
+    """
+    routing = record.get("routing") or {}
+    routing_out = {
+        key: sorted(routing[key])
+        for key in ("roles", "task_families", "tracks", "owned_paths")
+        if key in routing
+    }
+    return {
+        "id": record["id"],
+        "state": record["state"],
+        "content_hash": record["content_hash"],
+        "routing": routing_out,
+    }
+
+
+def select_pointers(runtime: RegistryRuntime, ctx: Context) -> tuple[list[dict[str, Any]], list[str]]:
+    """Return (pointers, dropped_ids). No context → zero records (never "show all").
+
+    Deterministically sorted by record id, capped at ``MAX_FILTERED_RECORDS`` and
+    ``MAX_FILTERED_BYTES`` measured on the exact serialized response. Every dropped
+    id is logged — never a silent truncation.
+    """
+    if ctx.is_empty():
+        return [], []
+    matched = sorted(
+        (rec for rec in runtime.valid_records if matches(rec.get("routing") or {}, ctx)),
+        key=lambda rec: rec["id"],
+    )
+    dropped: list[str] = []
+    if len(matched) > MAX_FILTERED_RECORDS:
+        dropped.extend(rec["id"] for rec in matched[MAX_FILTERED_RECORDS:])
+        matched = matched[:MAX_FILTERED_RECORDS]
+    pointers = [pointer(rec) for rec in matched]
+    while pointers and len(canonical_json_bytes(_manifest_payload(pointers))) > MAX_FILTERED_BYTES:
+        dropped.append(pointers[-1]["id"])
+        pointers = pointers[:-1]
+    if dropped:
+        logger.warning(
+            "research registry: knowledge manifest dropped record id(s) over budget: %s",
+            ", ".join(dropped),
+        )
+    return pointers, dropped
+
+
+def _manifest_payload(pointers: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"enabled": True, "records": pointers}
+
+
+@dataclass(frozen=True)
+class ManifestResponse:
+    body: bytes
+    etag_hex: str
+    dropped: tuple[str, ...]
+
+
+def filtered_manifest(runtime: RegistryRuntime, ctx: Context) -> ManifestResponse:
+    """Build the exact response bytes + strong ETag for a filtered manifest."""
+    pointers, dropped = select_pointers(runtime, ctx)
+    body = canonical_json_bytes(_manifest_payload(pointers))
+    return ManifestResponse(body=body, etag_hex=sha256(body).hexdigest(), dropped=tuple(dropped))
+
+
+def disabled_manifest_bytes() -> bytes:
+    """The deterministic disabled projection ``{"enabled":false,"records":[]}``."""
+    return canonical_json_bytes({"enabled": False, "records": []})
+
+
+def empty_manifest_response() -> ManifestResponse:
+    """Enabled-but-no-surface projection (registry failed to load), still 200."""
+    body = canonical_json_bytes(_manifest_payload([]))
+    return ManifestResponse(body=body, etag_hex=sha256(body).hexdigest(), dropped=())
+
+
+# --------------------------------------------------------------------------- #
+# Per-record compact body + honest ETag (ADR-011 §"Per-record endpoint")
+# --------------------------------------------------------------------------- #
+def _slug_ok(record_id: str) -> bool:
+    """Accept only the P1 slug shape; reject traversal, slashes, and junk."""
+    return _SLUG_RE.fullmatch(record_id) is not None
+
+
+def record_body(runtime: RegistryRuntime, record_id: str) -> tuple[str, str] | None:
+    """Return (markdown_body, etag_hex) for a record, or ``None`` if unavailable.
+
+    ``None`` (→ generic 404 at the API) covers: malformed id, unknown/invalid/
+    drifted record, ``private-local`` access class, an unsafe digest path, or an
+    over-budget body. Lookup resolves only through validated registry ids — never
+    a direct path join.
+    """
+    if not _slug_ok(record_id):
+        return None
+    record = runtime.valid_by_id(record_id)
+    if record is None:
+        return None
+    if record.get("access_class") == "private-local":
+        return None
+    try:
+        raw_projection = crr._record_projection(record, runtime.root)
+        body = crr.normalize_digest_projection(raw_projection)
+    except crr.ProvenanceError:
+        return None
+    body_bytes = body.encode("utf-8")
+    if len(body_bytes) > MAX_RECORD_BYTES:
+        logger.warning(
+            "research registry: record %r body is %d bytes (max %d); refusing",
+            record_id,
+            len(body_bytes),
+            MAX_RECORD_BYTES,
+        )
+        return None
+    # ``content_hash`` is an honest ETag only if it addresses the exact bytes we
+    # return; otherwise compute the ETag over the response bytes so we never serve
+    # a stale-body ETag.
+    expected = crr.compute_content_hash(body)
+    stored = record["content_hash"]
+    # ``content_hash`` addresses the exact bytes for a valid (non-drifted) record;
+    # the fallback is belt-and-suspenders so we never serve a stale-body ETag.
+    if expected == stored:  # noqa: SIM108 - keep the defensive branch explicit
+        etag_hex = stored.split(":", 1)[1]
+    else:
+        etag_hex = sha256(body_bytes).hexdigest()
+    return body, etag_hex
+
+
+# --------------------------------------------------------------------------- #
+# Automatic selected-body helper (ADR-011 §"Budgets and selection helper").
+# P3 is its first runtime consumer; implemented + tested here so the budget is
+# proven in P2.
+# --------------------------------------------------------------------------- #
+def select_bodies(runtime: RegistryRuntime, record_ids: list[str]) -> tuple[list[dict[str, str]], list[str]]:
+    """Return (selected, dropped_ids); total body bytes ≤ ``MAX_SELECTED_BODIES_BYTES``.
+
+    Preserves request order, never truncates a body, and logs every dropped id
+    (unavailable record or budget exhaustion) — never the body content.
+    """
+    selected: list[dict[str, str]] = []
+    dropped: list[str] = []
+    total = 0
+    for record_id in record_ids:
+        result = record_body(runtime, record_id)
+        if result is None:
+            dropped.append(record_id)
+            continue
+        body, _etag = result
+        size = len(body.encode("utf-8"))
+        if total + size > MAX_SELECTED_BODIES_BYTES:
+            dropped.append(record_id)
+            continue
+        total += size
+        selected.append({"id": record_id, "body": body})
+    if dropped:
+        logger.warning(
+            "research registry: select_bodies dropped record id(s): %s", ", ".join(dropped)
+        )
+    return selected, dropped

--- a/tests/test_manifest_api.py
+++ b/tests/test_manifest_api.py
@@ -10,6 +10,7 @@ Covered:
 from __future__ import annotations
 
 import hashlib
+import json
 import sqlite3
 
 import pytest
@@ -286,6 +287,32 @@ def test_manifest_stays_small():
     assert len(resp.content) < 2048, (
         f"manifest grew to {len(resp.content)} bytes; keep it lean or agents will stop using it"
     )
+
+
+def test_manifest_omits_research_when_flag_off(monkeypatch):
+    """ADR-011 P2: with the kill switch off, the manifest is exactly the pre-P2
+    shape — no ``research`` key — so existing clients are untouched."""
+    monkeypatch.setenv("LEARN_UK_RESEARCH_REGISTRY_ENABLED", "false")
+    resp = client.get("/api/state/manifest")
+    assert resp.status_code == 200
+    assert "research" not in resp.json()
+
+
+@pytest.mark.parametrize("telemetry", ["0", "1"])
+def test_manifest_with_research_stays_within_budget(monkeypatch, telemetry):
+    """Enabled research component ≤ 512 bytes and total manifest < 2 KB, with and
+    without the telemetry footer. Uses the real committed 3-record registry."""
+    monkeypatch.setenv("LEARN_UK_RESEARCH_REGISTRY_ENABLED", "true")
+    monkeypatch.setenv("LEARN_UKRAINIAN_TELEMETRY_FOOTER", telemetry)
+    # Unresolvable session → bounded, deterministic telemetry block (no sidecar).
+    resp = client.get("/api/state/manifest?session=00000000-0000-0000-0000-000000000000")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["research"]["url"] == "/api/knowledge/manifest"
+    assert len(body["research"]["hash"]) == 64
+    component = json.dumps(body["research"], separators=(",", ":")).encode("utf-8")
+    assert len(component) <= 512, f"research component grew to {len(component)} bytes"
+    assert len(resp.content) < 2048, f"manifest grew to {len(resp.content)} bytes"
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_research_registry_api.py
+++ b/tests/test_research_registry_api.py
@@ -95,6 +95,16 @@ def reg_root(tmp_path, monkeypatch):
     return tmp_path
 
 
+def _stub_path_consumer(root: Path, rel: str = "scripts/audit/text_difficulty.py") -> None:
+    """Write a stub file so an ``{"kind": "path", "ref": rel}`` consumer resolves
+    under the synthetic ``root`` -- P1's ``validate_consumer`` requires the ref to
+    exist on disk under ``project_root``, which for these tests is ``reg_root``,
+    not the real repository."""
+    stub = root / rel
+    stub.parent.mkdir(parents=True, exist_ok=True)
+    stub.write_text("# stub consumer target for tests\n", "utf-8")
+
+
 # --------------------------------------------------------------------------- #
 # 1. Kill switch: precedence + strict parsing
 # --------------------------------------------------------------------------- #
@@ -262,6 +272,7 @@ def test_global_hash_sensitive_to_routed_fields(reg_root, mutate):
     r1b = json.loads(json.dumps(r1))  # deep copy
     mutate(r1b)
     if r1b["state"] == "adopted":  # keep it schema/lifecycle sane for the loader
+        _stub_path_consumer(reg_root)
         r1b["consumer"] = {"kind": "path", "ref": "scripts/audit/text_difficulty.py"}
     _write_registry(reg_root, [r1b])
     assert reg.load_runtime(root=reg_root).global_hash() != h1
@@ -355,6 +366,7 @@ def test_context_normalization_shares_etag(reg_root):
 # 7. Pointer field allowlist (no body/summary/source path)
 # --------------------------------------------------------------------------- #
 def test_pointer_allowlist(reg_root):
+    _stub_path_consumer(reg_root)
     r1 = _make_record(reg_root, "aaa", routing={"roles": ["quality"]}, state="adopted")
     r1["consumer"] = {"kind": "path", "ref": "scripts/audit/text_difficulty.py"}
     _write_registry(reg_root, [r1])
@@ -494,15 +506,22 @@ def test_est_tokens(n, expected):
 
 
 def test_record_body_size_boundary(reg_root):
-    # Single line of N 'x' + newline normalizes to exactly N bytes.
-    ok = _make_record(reg_root, "aaa", digest_body="x" * reg.MAX_RECORD_BYTES + "\n")
+    # A single unterminated line of exactly N 'x' has an identical raw and
+    # normalized length (no trailing whitespace/newline for normalization to
+    # strip) -- exactly N bytes, at P1's own digest-policy ceiling too.
+    ok = _make_record(reg_root, "aaa", digest_body="x" * reg.MAX_RECORD_BYTES)
     _write_registry(reg_root, [ok])
     body = reg.record_body(reg.load_runtime(root=reg_root), "aaa")
     assert body is not None and len(body[0].encode("utf-8")) == reg.MAX_RECORD_BYTES
 
-    over = _make_record(reg_root, "aaa", digest_body="x" * (reg.MAX_RECORD_BYTES + 1) + "\n")
+    # One byte over trips P1's digest-policy ceiling (raw projection size) at
+    # load_runtime() time -- a non-drift semantic error hides the whole registry
+    # (ADR-011: only hash drift gets per-record isolation), so record_body is
+    # never reached; assert the same generic 404 refusal at the API surface.
+    over = _make_record(reg_root, "aaa", digest_body="x" * (reg.MAX_RECORD_BYTES + 1))
     _write_registry(reg_root, [over])
-    assert reg.record_body(reg.load_runtime(root=reg_root), "aaa") is None
+    assert reg.load_runtime(root=reg_root) is None
+    assert client.get("/api/knowledge/record/aaa").status_code == 404
     assert client.get("/api/knowledge/record/aaa").status_code == 404
 
 
@@ -591,3 +610,182 @@ def test_no_network_or_subprocess_imports():
                 imported.add(node.module.split(".")[0])
         leaked = imported & forbidden
         assert not leaked, f"{rel} imports forbidden modules: {leaked}"
+
+
+# --------------------------------------------------------------------------- #
+# 16. Fix 1 (PR #4988 review): TOCTOU — a runtime snapshot must never serve
+# post-load digest drift under an invented fallback ETag.
+# --------------------------------------------------------------------------- #
+def test_record_body_refuses_post_load_drift(reg_root, caplog):
+    r1 = _make_record(reg_root, "aaa")
+    _write_registry(reg_root, [r1])
+    runtime = reg.load_runtime(root=reg_root)
+    assert runtime.valid_by_id("aaa") is not None  # sanity: healthy at load time
+
+    # Mutate the digest on disk WITHOUT reconciling content_hash or rewriting the
+    # registry -- the already-loaded `runtime` still carries the old, now-stale
+    # content_hash for "aaa".
+    (reg_root / r1["provenance"]["digest"]).write_text(
+        _digest_body("aaa", extra="\nCHANGED-AFTER-LOAD\n"), "utf-8"
+    )
+
+    with caplog.at_level("WARNING"):
+        result = reg.record_body(runtime, "aaa")
+    assert result is None
+    assert "aaa" in caplog.text  # record id logged...
+    assert "CHANGED-AFTER-LOAD" not in caplog.text  # ...never the changed content
+
+    # A fresh load correctly excludes the now-drifted record too.
+    assert reg.load_runtime(root=reg_root).valid_by_id("aaa") is None
+
+    # The API surface (which always loads fresh per request) never leaks the
+    # changed bytes either -- generic 404.
+    resp = client.get("/api/knowledge/record/aaa")
+    assert resp.status_code == 404
+    assert b"CHANGED-AFTER-LOAD" not in resp.content
+
+
+def test_select_bodies_inherits_toctou_refusal(reg_root):
+    r1 = _make_record(reg_root, "aaa")
+    _write_registry(reg_root, [r1])
+    runtime = reg.load_runtime(root=reg_root)
+    (reg_root / r1["provenance"]["digest"]).write_text(
+        _digest_body("aaa", extra="\nCHANGED-AFTER-LOAD\n"), "utf-8"
+    )
+    selected, dropped = reg.select_bodies(runtime, ["aaa"])
+    assert selected == []
+    assert dropped == ["aaa"]
+
+
+# --------------------------------------------------------------------------- #
+# 17. Fix 2 (PR #4988 review): fail-open containment — a pathological parser
+# failure or an unexpected loader exception must never surface as an API 500.
+# --------------------------------------------------------------------------- #
+def test_enabled_deeply_nested_yaml_recursion_fails_open_not_500(reg_root):
+    refs = reg_root / "docs" / "references"
+    refs.mkdir(parents=True, exist_ok=True)
+    depth = 20000
+    (refs / "research-registry.yaml").write_text("[" * depth + "]" * depth, "utf-8")
+
+    assert reg.load_runtime(root=reg_root) is None
+
+    km = client.get("/api/knowledge/manifest")
+    assert km.status_code == 200
+    assert km.json() == {"enabled": True, "records": []}
+
+    assert client.get("/api/knowledge/record/anything").status_code == 404
+
+    sm = client.get("/api/state/manifest")
+    assert sm.status_code == 200
+    assert "research" not in sm.json()
+
+
+def test_enabled_injected_loader_exception_fails_open_not_500(reg_root, monkeypatch):
+    def _boom(**_kwargs):
+        raise RuntimeError("injected failure")
+
+    monkeypatch.setattr(reg, "load_runtime", _boom)
+
+    km = client.get("/api/knowledge/manifest")
+    assert km.status_code == 200
+    assert km.json() == {"enabled": True, "records": []}
+
+    assert client.get("/api/knowledge/record/anything").status_code == 404
+
+    sm = client.get("/api/state/manifest")
+    assert sm.status_code == 200
+    assert "research" not in sm.json()
+
+    assert reg.load_runtime_safe(root=reg_root) is None
+
+
+def test_rules_session_orient_unaffected_by_research_registry_failure(reg_root, monkeypatch):
+    """A broken research registry must not degrade unrelated cold-start surfaces."""
+    monkeypatch.setattr(reg, "load_runtime", lambda **_kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
+    assert client.get("/api/rules").status_code == 200
+    assert client.get("/api/session/current").status_code == 200
+    assert client.get("/api/orient").status_code == 200
+
+
+# --------------------------------------------------------------------------- #
+# 18. Fix 3 (PR #4988 review): P1's validate_registry is the semantic
+# authority. Non-drift semantic errors hide the whole registry; only hash
+# drift gets ADR-011's per-record isolation.
+# --------------------------------------------------------------------------- #
+def test_adopted_null_consumer_hides_whole_registry(reg_root):
+    """Schema-valid but P1-semantically invalid (adopted + no consumer) must not
+    silently route -- the whole registry fails closed, not just that record."""
+    healthy = _make_record(reg_root, "aaa", routing={"roles": ["quality"]})
+    bad = _make_record(reg_root, "bbb", state="adopted")
+    bad["consumer"] = None
+    bad["reason"] = None
+    _write_registry(reg_root, [healthy, bad])
+
+    assert reg.load_runtime(root=reg_root) is None
+    assert reg.research_manifest_component() is None
+    resp = client.get("/api/knowledge/manifest?role=quality")
+    assert resp.status_code == 200
+    assert resp.json() == {"enabled": True, "records": []}
+    assert client.get("/api/knowledge/record/aaa").status_code == 404
+
+
+def test_duplicate_record_id_hides_whole_registry(reg_root):
+    r1 = _make_record(reg_root, "aaa", routing={"roles": ["quality"]})
+    r2 = _make_record(reg_root, "aaa", routing={"roles": ["quality"]})  # duplicate id
+    _write_registry(reg_root, [r1, r2])
+
+    assert reg.load_runtime(root=reg_root) is None
+    assert reg.research_manifest_component() is None
+    resp = client.get("/api/knowledge/manifest?role=quality")
+    assert resp.json() == {"enabled": True, "records": []}
+    assert client.get("/api/knowledge/record/aaa").status_code == 404
+
+
+def test_single_drift_still_isolates_and_serves_healthy_record(reg_root):
+    """Sanity companion to test_record_drift_excluded_but_healthy_served: proves
+    Fix 3's reuse of validate_registry() preserves the ONE case ADR-011 grants
+    per-record isolation for -- pure content_hash drift, nothing else wrong."""
+    healthy = _make_record(reg_root, "aaa", routing={"roles": ["quality"]})
+    drifted = _make_record(reg_root, "bbb", routing={"roles": ["quality"]})
+    _write_registry(reg_root, [healthy, drifted])
+    (reg_root / drifted["provenance"]["digest"]).write_text(_digest_body("bbb", extra="\ndrift\n"), "utf-8")
+
+    runtime = reg.load_runtime(root=reg_root)
+    assert runtime is not None  # drift alone never hides the whole registry
+    assert [r["id"] for r in runtime.valid_records] == ["aaa"]
+    assert client.get("/api/knowledge/record/aaa").status_code == 200
+    assert client.get("/api/knowledge/record/bbb").status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# 19. Additional hardening: end-to-end state-manifest hash + unrelated-context
+# ETag stability across a routing-relevant, reconciled record edit.
+# --------------------------------------------------------------------------- #
+def test_state_manifest_hash_tracks_runtime_and_unrelated_projection_stable(reg_root):
+    matched = _make_record(reg_root, "aaa", routing={"roles": ["quality"]})
+    other = _make_record(reg_root, "zzz", routing={"roles": ["tts"]})
+    _write_registry(reg_root, [matched, other])
+
+    sm0 = client.get("/api/state/manifest")
+    assert sm0.status_code == 200
+    body0 = sm0.json()
+    assert body0["research"]["hash"] == reg.load_runtime(root=reg_root).global_hash()
+
+    other_resp0 = client.get("/api/knowledge/manifest?role=tts")
+    etag_other0 = other_resp0.headers["etag"]
+
+    # Routing-relevant, reconciled edit to "aaa" -> global hash (and therefore
+    # /api/state/manifest.research.hash) changes.
+    matched_edit = _make_record(reg_root, "aaa", routing={"roles": ["quality"], "tracks": ["core"]})
+    _write_registry(reg_root, [matched_edit, other])
+
+    sm1 = client.get("/api/state/manifest")
+    body1 = sm1.json()
+    assert body1["research"]["hash"] != body0["research"]["hash"]
+    assert body1["research"]["hash"] == reg.load_runtime(root=reg_root).global_hash()
+
+    # The unrelated ("tts") filtered projection is byte-identical -> the old
+    # If-None-Match still yields a bodyless 304 with the same ETag.
+    other_resp1 = client.get("/api/knowledge/manifest?role=tts", headers={"If-None-Match": etag_other0})
+    assert other_resp1.status_code == 304
+    assert other_resp1.headers["etag"] == etag_other0

--- a/tests/test_research_registry_api.py
+++ b/tests/test_research_registry_api.py
@@ -1,0 +1,593 @@
+"""ADR-011 P2 — bounded research discovery API + runtime layer contract tests.
+
+Hermetic: every test builds a synthetic registry under ``tmp_path`` and points the
+runtime at it via ``registry._ROOT_OVERRIDE`` (never the operator's live ``.runtime``
+state). No GitHub, network, subprocess, ``sources.db``, or embeddings access.
+
+Covers the required P2 matrix: the kill switch (env/live-file precedence and strict
+parsing), disabled-mode exactness, fail-open loading, the global routing hash, the
+pure AND matcher, context normalization, the two-tier 304 proof, per-record ETag
+semantics, drift/traversal/private/oversize refusal, byte/token budgets, and a
+static no-side-effects guard.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+import scripts.api.main as api_main
+from scripts.audit import check_research_registry as crr
+from scripts.research import registry as reg
+
+client = TestClient(api_main.app, raise_server_exceptions=False)
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic registry builder
+# --------------------------------------------------------------------------- #
+def _digest_body(rid: str, *, extra: str = "") -> str:
+    return (
+        f"# {rid}\n\n"
+        f"Source: https://example.org/{rid}\n\n"
+        f"Paraphrase-only compact digest for {rid}. No verbatim passages.\n{extra}"
+    )
+
+
+def _make_record(
+    root: Path,
+    rid: str,
+    *,
+    routing: dict[str, Any] | None = None,
+    state: str = "deferred",
+    access_class: str = "tracked-digest",
+    cold_start_roles: list[str] | None = None,
+    digest_body: str | None = None,
+    title: str | None = None,
+    summary: str | None = None,
+) -> dict[str, Any]:
+    """Write the record's digest and return a schema-valid, drift-free record dict."""
+    digest_rel = f"docs/references/research-digests/{rid}.md"
+    digest_path = root / digest_rel
+    digest_path.parent.mkdir(parents=True, exist_ok=True)
+    digest_path.write_text(digest_body if digest_body is not None else _digest_body(rid), "utf-8")
+
+    record: dict[str, Any] = {
+        "id": rid,
+        "title": title or f"Title {rid}",
+        "summary": summary or f"Summary {rid}",
+        "content_hash": "sha256:" + "0" * 64,
+        "state": state,
+        "provenance": {
+            "digest": digest_rel,
+            "digest_anchor": None,
+            "source_url": f"https://example.org/{rid}",
+        },
+        "routing": routing if routing is not None else {"roles": ["quality"]},
+        "cold_start_roles": cold_start_roles or [],
+        "ownership": None,
+        "consumer": None,
+        "reason": "Deferred for the test." if state == "deferred" else None,
+        "replacement": None,
+        "access_class": access_class,
+    }
+    record["content_hash"] = crr.expected_content_hash(record, root)
+    return record
+
+
+def _write_registry(root: Path, records: list[dict[str, Any]], *, header: str = "") -> None:
+    refs = root / "docs" / "references"
+    refs.mkdir(parents=True, exist_ok=True)
+    doc = yaml.safe_dump({"schema_version": 1, "records": records}, sort_keys=False, allow_unicode=True)
+    (refs / "research-registry.yaml").write_text(header + doc, "utf-8")
+
+
+@pytest.fixture
+def reg_root(tmp_path, monkeypatch):
+    """Point the runtime at a hermetic tmp root and force the feature ON via env."""
+    monkeypatch.setattr(reg, "_ROOT_OVERRIDE", tmp_path)
+    monkeypatch.setenv(reg.ENV_FLAG, "true")
+    return tmp_path
+
+
+# --------------------------------------------------------------------------- #
+# 1. Kill switch: precedence + strict parsing
+# --------------------------------------------------------------------------- #
+def test_flag_default_off(tmp_path, monkeypatch):
+    monkeypatch.setattr(reg, "_ROOT_OVERRIDE", tmp_path)
+    monkeypatch.delenv(reg.ENV_FLAG, raising=False)
+    assert reg.is_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "on", "TRUE", "On", "YES"])
+def test_env_true_spellings(tmp_path, monkeypatch, value):
+    monkeypatch.setattr(reg, "_ROOT_OVERRIDE", tmp_path)
+    monkeypatch.setenv(reg.ENV_FLAG, value)
+    assert reg.is_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off", "FALSE", "Off"])
+def test_env_false_spellings(tmp_path, monkeypatch, value):
+    monkeypatch.setattr(reg, "_ROOT_OVERRIDE", tmp_path)
+    monkeypatch.setenv(reg.ENV_FLAG, value)
+    assert reg.is_enabled() is False
+
+
+def test_env_invalid_resolves_false_never_falls_through(tmp_path, monkeypatch):
+    # Live file says enabled, but an invalid *higher-precedence* env must not fall
+    # through to it — it resolves to False.
+    flag = tmp_path / ".runtime" / "api" / "research-registry.json"
+    flag.parent.mkdir(parents=True, exist_ok=True)
+    flag.write_text(json.dumps({"research_registry": {"enabled": True}}), "utf-8")
+    monkeypatch.setattr(reg, "_ROOT_OVERRIDE", tmp_path)
+    monkeypatch.setenv(reg.ENV_FLAG, "maybe")
+    assert reg.is_enabled() is False
+
+
+def test_live_file_toggle_true_then_false(tmp_path, monkeypatch):
+    flag = tmp_path / ".runtime" / "api" / "research-registry.json"
+    flag.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(reg, "_ROOT_OVERRIDE", tmp_path)
+    monkeypatch.delenv(reg.ENV_FLAG, raising=False)
+
+    flag.write_text(json.dumps({"research_registry": {"enabled": True}}), "utf-8")
+    assert reg.is_enabled() is True
+    # Same process, flip the file — the change is immediate (dynamic per call).
+    flag.write_text(json.dumps({"research_registry": {"enabled": False}}), "utf-8")
+    assert reg.is_enabled() is False
+
+
+def test_env_overrides_live_file(tmp_path, monkeypatch):
+    flag = tmp_path / ".runtime" / "api" / "research-registry.json"
+    flag.parent.mkdir(parents=True, exist_ok=True)
+    flag.write_text(json.dumps({"research_registry": {"enabled": False}}), "utf-8")
+    monkeypatch.setattr(reg, "_ROOT_OVERRIDE", tmp_path)
+    monkeypatch.setenv(reg.ENV_FLAG, "true")
+    assert reg.is_enabled() is True
+
+
+@pytest.mark.parametrize(
+    "content",
+    ["{ not json", json.dumps({"research_registry": {}}), json.dumps({"other": 1}),
+     json.dumps({"research_registry": {"enabled": "true"}})],
+)
+def test_live_file_malformed_resolves_false(tmp_path, monkeypatch, content):
+    flag = tmp_path / ".runtime" / "api" / "research-registry.json"
+    flag.parent.mkdir(parents=True, exist_ok=True)
+    flag.write_text(content, "utf-8")
+    monkeypatch.setattr(reg, "_ROOT_OVERRIDE", tmp_path)
+    monkeypatch.delenv(reg.ENV_FLAG, raising=False)
+    assert reg.is_enabled() is False
+
+
+# --------------------------------------------------------------------------- #
+# 2. Disabled mode is exact + loader is not invoked
+# --------------------------------------------------------------------------- #
+def test_disabled_mode_exact(tmp_path, monkeypatch):
+    monkeypatch.setattr(reg, "_ROOT_OVERRIDE", tmp_path)
+    monkeypatch.setenv(reg.ENV_FLAG, "false")
+
+    km = client.get("/api/knowledge/manifest")
+    assert km.status_code == 200
+    assert km.json() == {"enabled": False, "records": []}
+
+    rec = client.get("/api/knowledge/record/anything")
+    assert rec.status_code == 404
+
+
+def test_disabled_loader_not_invoked(tmp_path, monkeypatch):
+    monkeypatch.setattr(reg, "_ROOT_OVERRIDE", tmp_path)
+    monkeypatch.setenv(reg.ENV_FLAG, "false")
+
+    def _boom(**_kwargs):
+        raise AssertionError("load_runtime must not be called while disabled")
+
+    monkeypatch.setattr(reg, "load_runtime", _boom)
+    assert client.get("/api/knowledge/manifest").status_code == 200
+    assert client.get("/api/knowledge/record/x").status_code == 404
+    assert reg.research_manifest_component() is None
+
+
+# --------------------------------------------------------------------------- #
+# 3. Fail-open: enabled + missing/malformed registry or loader exception
+# --------------------------------------------------------------------------- #
+def test_enabled_missing_registry_fails_open(reg_root):
+    # No registry file written at all.
+    km = client.get("/api/knowledge/manifest?role=quality")
+    assert km.status_code == 200
+    assert km.json() == {"enabled": True, "records": []}
+    assert client.get("/api/knowledge/record/anything").status_code == 404
+    assert reg.research_manifest_component() is None
+
+
+def test_enabled_malformed_registry_fails_open(reg_root):
+    refs = reg_root / "docs" / "references"
+    refs.mkdir(parents=True, exist_ok=True)
+    (refs / "research-registry.yaml").write_text("this: [is not: valid: yaml", "utf-8")
+    assert reg.load_runtime(root=reg_root) is None
+    assert client.get("/api/knowledge/manifest").status_code == 200
+
+
+def test_enabled_schema_invalid_fails_open(reg_root):
+    _write_registry(reg_root, [{"id": "x", "not": "a valid record"}])
+    assert reg.load_runtime(root=reg_root) is None
+    assert reg.research_manifest_component() is None
+
+
+# --------------------------------------------------------------------------- #
+# 4. Global hash determinism + sensitivity
+# --------------------------------------------------------------------------- #
+def test_global_hash_stable_under_yaml_reorder_and_format(reg_root):
+    r1 = _make_record(reg_root, "aaa", routing={"roles": ["quality"], "tracks": ["core"]})
+    r2 = _make_record(reg_root, "bbb", routing={"roles": ["tts"]})
+    _write_registry(reg_root, [r1, r2])
+    h1 = reg.load_runtime(root=reg_root).global_hash()
+
+    # Reorder records + add a comment header + trailing whitespace: hash unchanged.
+    _write_registry(reg_root, [r2, r1], header="# a comment\n\n\n")
+    h2 = reg.load_runtime(root=reg_root).global_hash()
+    assert h1 == h2
+
+
+def test_global_hash_insensitive_to_summary_and_title(reg_root):
+    r1 = _make_record(reg_root, "aaa")
+    _write_registry(reg_root, [r1])
+    h1 = reg.load_runtime(root=reg_root).global_hash()
+    r1b = dict(r1, title="A completely different title", summary="different summary")
+    _write_registry(reg_root, [r1b])
+    assert reg.load_runtime(root=reg_root).global_hash() == h1
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda r: r.__setitem__("state", "adopted"),
+        lambda r: r.__setitem__("access_class", "public-url"),
+        lambda r: r.__setitem__("cold_start_roles", ["quality"]),
+        lambda r: r["routing"].__setitem__("roles", ["quality", "pedagogy"]),
+        lambda r: r["routing"].__setitem__("task_families", ["difficulty-gate"]),
+        lambda r: r["routing"].__setitem__("tracks", ["core"]),
+        lambda r: r["routing"].__setitem__("owned_paths", ["scripts/audit/**"]),
+    ],
+)
+def test_global_hash_sensitive_to_routed_fields(reg_root, mutate):
+    r1 = _make_record(reg_root, "aaa", routing={"roles": ["quality"]}, state="deferred")
+    _write_registry(reg_root, [r1])
+    h1 = reg.load_runtime(root=reg_root).global_hash()
+    r1b = json.loads(json.dumps(r1))  # deep copy
+    mutate(r1b)
+    if r1b["state"] == "adopted":  # keep it schema/lifecycle sane for the loader
+        r1b["consumer"] = {"kind": "path", "ref": "scripts/audit/text_difficulty.py"}
+    _write_registry(reg_root, [r1b])
+    assert reg.load_runtime(root=reg_root).global_hash() != h1
+
+
+def test_global_hash_sensitive_to_content_hash(reg_root):
+    r1 = _make_record(reg_root, "aaa", digest_body=_digest_body("aaa"))
+    _write_registry(reg_root, [r1])
+    h1 = reg.load_runtime(root=reg_root).global_hash()
+    # Change the digest AND reconcile the stored hash (a real content edit).
+    r1b = _make_record(reg_root, "aaa", digest_body=_digest_body("aaa", extra="\nA new paraphrased line.\n"))
+    _write_registry(reg_root, [r1b])
+    assert reg.load_runtime(root=reg_root).global_hash() != h1
+
+
+def test_global_hash_sensitive_to_validity_drift(reg_root):
+    r1 = _make_record(reg_root, "aaa")
+    _write_registry(reg_root, [r1])
+    h1 = reg.load_runtime(root=reg_root).global_hash()
+    # Edit the digest WITHOUT reconciling → drift → validity flips → hash changes.
+    (reg_root / r1["provenance"]["digest"]).write_text(_digest_body("aaa", extra="\ndrifted\n"), "utf-8")
+    runtime = reg.load_runtime(root=reg_root)
+    assert runtime.global_hash() != h1
+    assert runtime.valid_records == []  # the drifted record is excluded
+
+
+# --------------------------------------------------------------------------- #
+# 5-6. Pure AND matcher: positives, negatives, normalization
+# --------------------------------------------------------------------------- #
+def _ctx(role=None, family=None, track=None, paths=None):
+    return reg.normalize_context(role, family, track, paths)
+
+
+def test_and_matcher_full_positive():
+    routing = {
+        "roles": ["quality"],
+        "task_families": ["difficulty-gate"],
+        "tracks": ["core"],
+        "owned_paths": ["scripts/audit/**"],
+    }
+    ctx = _ctx("quality", "difficulty-gate", "core", ["scripts/audit/text_difficulty.py"])
+    assert reg.matches(routing, ctx) is True
+
+
+def test_and_matcher_same_track_wrong_family_negative():
+    routing = {"task_families": ["difficulty-gate"], "tracks": ["core"]}
+    ctx = _ctx(track="core", family="module-build")  # track intersects, family does not
+    assert reg.matches(routing, ctx) is False
+
+
+def test_and_matcher_missing_dimension_negative():
+    routing = {"roles": ["quality"], "task_families": ["difficulty-gate"]}
+    ctx = _ctx(role="quality")  # request lacks task_family the record requires
+    assert reg.matches(routing, ctx) is False
+
+
+def test_and_matcher_omitted_dimension_is_wildcard():
+    routing = {"roles": ["quality"]}  # no track requirement
+    assert reg.matches(routing, _ctx(role="quality", track="anything")) is True
+
+
+def test_and_matcher_owned_path_glob():
+    routing = {"owned_paths": ["scripts/audit/**"]}
+    assert reg.matches(routing, _ctx(paths=["scripts/audit/text_difficulty.py"])) is True
+    assert reg.matches(routing, _ctx(paths=["scripts/build/x.py"])) is False
+    assert reg.matches(routing, _ctx(paths=[])) is False  # record requires a path, none given
+
+
+def test_no_context_yields_zero_records(reg_root):
+    r1 = _make_record(reg_root, "aaa", routing={})  # all-wildcard routing
+    _write_registry(reg_root, [r1])
+    runtime = reg.load_runtime(root=reg_root)
+    pointers, dropped = reg.select_pointers(runtime, _ctx())
+    assert pointers == [] and dropped == []
+
+
+def test_context_normalization_shares_etag(reg_root):
+    r1 = _make_record(reg_root, "aaa", routing={"owned_paths": ["scripts/audit/**"]})
+    _write_registry(reg_root, [r1])
+    a = client.get("/api/knowledge/manifest?owned_path=scripts/audit/a.py&owned_path=scripts/audit/b.py")
+    b = client.get(
+        "/api/knowledge/manifest?owned_path=scripts/audit/b.py"
+        "&owned_path=scripts/audit/a.py&owned_path=scripts/audit/a.py"
+    )
+    assert a.status_code == b.status_code == 200
+    assert a.content == b.content
+    assert a.headers["etag"] == b.headers["etag"]
+
+
+# --------------------------------------------------------------------------- #
+# 7. Pointer field allowlist (no body/summary/source path)
+# --------------------------------------------------------------------------- #
+def test_pointer_allowlist(reg_root):
+    r1 = _make_record(reg_root, "aaa", routing={"roles": ["quality"]}, state="adopted")
+    r1["consumer"] = {"kind": "path", "ref": "scripts/audit/text_difficulty.py"}
+    _write_registry(reg_root, [r1])
+    resp = client.get("/api/knowledge/manifest?role=quality")
+    assert resp.status_code == 200
+    records = resp.json()["records"]
+    assert len(records) == 1
+    pointer = records[0]
+    assert set(pointer) == {"id", "state", "content_hash", "routing"}
+    assert "summary" not in pointer and "provenance" not in pointer
+    # No digest path, source URL, ownership, or timestamp leaks anywhere in the body.
+    blob = resp.text
+    for leak in ("summary", "digest", "source_url", "ownership", "generated_at", "consumer"):
+        assert leak not in blob
+
+
+# --------------------------------------------------------------------------- #
+# 8-9. Two-tier 304 + ETag semantics
+# --------------------------------------------------------------------------- #
+def test_two_tier_304_unrelated_context(reg_root):
+    matched = _make_record(reg_root, "aaa", routing={"roles": ["quality"]})
+    other = _make_record(reg_root, "zzz", routing={"roles": ["tts"]})
+    _write_registry(reg_root, [matched, other])
+
+    # Context A matches 'aaa'; context B (reviewer) matches nothing.
+    a0 = client.get("/api/knowledge/manifest?role=quality")
+    b0 = client.get("/api/knowledge/manifest?role=reviewer")
+    etag_a0, etag_b0 = a0.headers["etag"], b0.headers["etag"]
+    global0 = reg.load_runtime(root=reg_root).global_hash()
+
+    # Edit the matched record's routing → global hash changes AND ctx-A projection changes.
+    matched_edit = _make_record(reg_root, "aaa", routing={"roles": ["quality"], "tracks": ["core"]})
+    _write_registry(reg_root, [matched_edit, other])
+    assert reg.load_runtime(root=reg_root).global_hash() != global0
+
+    # Unrelated context B: byte-identical, old If-None-Match → bodyless 304.
+    b1 = client.get("/api/knowledge/manifest?role=reviewer", headers={"If-None-Match": etag_b0})
+    assert b1.status_code == 304
+    assert b1.content == b""
+    assert b1.headers["etag"] == etag_b0
+
+    # Matching context A: 200 with a new ETag.
+    a1 = client.get("/api/knowledge/manifest?role=quality", headers={"If-None-Match": etag_a0})
+    assert a1.status_code == 200
+    assert a1.headers["etag"] != etag_a0
+
+
+@pytest.mark.parametrize("header_tmpl", ['"{h}"', 'W/"{h}"', "*", 'W/"other", "{h}"'])
+def test_manifest_etag_variants_yield_304(reg_root, header_tmpl):
+    r1 = _make_record(reg_root, "aaa", routing={"roles": ["quality"]})
+    _write_registry(reg_root, [r1])
+    base = client.get("/api/knowledge/manifest?role=quality")
+    etag_hex = base.headers["etag"].strip('"')
+    resp = client.get(
+        "/api/knowledge/manifest?role=quality",
+        headers={"If-None-Match": header_tmpl.format(h=etag_hex)},
+    )
+    assert resp.status_code == 304
+    assert resp.content == b""
+
+
+def test_manifest_nonmatching_etag_is_200(reg_root):
+    r1 = _make_record(reg_root, "aaa", routing={"roles": ["quality"]})
+    _write_registry(reg_root, [r1])
+    resp = client.get("/api/knowledge/manifest?role=quality", headers={"If-None-Match": '"deadbeef"'})
+    assert resp.status_code == 200
+
+
+# --------------------------------------------------------------------------- #
+# 10-11. Per-record endpoint: 304, invalidation, drift/traversal/private/oversize
+# --------------------------------------------------------------------------- #
+def test_record_body_and_304(reg_root):
+    r1 = _make_record(reg_root, "aaa")
+    _write_registry(reg_root, [r1])
+    resp = client.get("/api/knowledge/record/aaa")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/markdown")
+    # ETag is the P1 content hash for the exact normalized body.
+    assert resp.headers["etag"].strip('"') == r1["content_hash"].split(":", 1)[1]
+    again = client.get("/api/knowledge/record/aaa", headers={"If-None-Match": resp.headers["etag"]})
+    assert again.status_code == 304
+    assert again.content == b""
+
+
+def test_record_body_changed_invalidates_etag(reg_root):
+    r1 = _make_record(reg_root, "aaa")
+    _write_registry(reg_root, [r1])
+    old = client.get("/api/knowledge/record/aaa").headers["etag"]
+    # Reconcile a real content edit (new digest + new stored hash).
+    r1b = _make_record(reg_root, "aaa", digest_body=_digest_body("aaa", extra="\nAdded a paraphrase.\n"))
+    _write_registry(reg_root, [r1b])
+    new = client.get("/api/knowledge/record/aaa")
+    assert new.status_code == 200
+    assert new.headers["etag"] != old
+
+
+def test_record_drift_excluded_but_healthy_served(reg_root):
+    healthy = _make_record(reg_root, "aaa")
+    drifted = _make_record(reg_root, "bbb")
+    _write_registry(reg_root, [healthy, drifted])
+    # Silently edit bbb's digest → drift, without touching aaa.
+    (reg_root / drifted["provenance"]["digest"]).write_text(_digest_body("bbb", extra="\ndrift\n"), "utf-8")
+    assert client.get("/api/knowledge/record/aaa").status_code == 200
+    assert client.get("/api/knowledge/record/bbb").status_code == 404
+    # Healthy record still routes; drifted one does not.
+    runtime = reg.load_runtime(root=reg_root)
+    assert [r["id"] for r in runtime.valid_records] == ["aaa"]
+
+
+@pytest.mark.parametrize("bad_id", ["../etc/passwd", "unknown-id", "UPPER", "has space", "a/b"])
+def test_record_bad_ids_are_404(reg_root, bad_id):
+    r1 = _make_record(reg_root, "aaa")
+    _write_registry(reg_root, [r1])
+    assert client.get(f"/api/knowledge/record/{bad_id}").status_code == 404
+
+
+def test_record_encoded_traversal_is_refused(reg_root):
+    r1 = _make_record(reg_root, "aaa")
+    _write_registry(reg_root, [r1])
+    # Starlette rejects encoded traversal with 403 before the route; 404 is the
+    # in-route refusal. Either is a non-leaking refusal.
+    assert client.get("/api/knowledge/record/%2e%2e%2fpasswd").status_code in (403, 404)
+
+
+def test_record_private_local_is_404(reg_root):
+    r1 = _make_record(reg_root, "aaa", access_class="private-local")
+    _write_registry(reg_root, [r1])
+    assert client.get("/api/knowledge/record/aaa").status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# 12. Budgets: boundary+1, Cyrillic, token estimate, top-5, drop logging
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("n,expected", [(0, 0), (1, 1), (2, 1), (4096, 2048), (4097, 2049)])
+def test_est_tokens(n, expected):
+    assert reg.est_tokens(n) == expected
+
+
+def test_record_body_size_boundary(reg_root):
+    # Single line of N 'x' + newline normalizes to exactly N bytes.
+    ok = _make_record(reg_root, "aaa", digest_body="x" * reg.MAX_RECORD_BYTES + "\n")
+    _write_registry(reg_root, [ok])
+    body = reg.record_body(reg.load_runtime(root=reg_root), "aaa")
+    assert body is not None and len(body[0].encode("utf-8")) == reg.MAX_RECORD_BYTES
+
+    over = _make_record(reg_root, "aaa", digest_body="x" * (reg.MAX_RECORD_BYTES + 1) + "\n")
+    _write_registry(reg_root, [over])
+    assert reg.record_body(reg.load_runtime(root=reg_root), "aaa") is None
+    assert client.get("/api/knowledge/record/aaa").status_code == 404
+
+
+def test_record_body_cyrillic(reg_root):
+    # Cyrillic is 2 UTF-8 bytes/char; ensure bytes + honest hash are correct.
+    body_text = "# Заголовок\n\nUkrainian paraphrase: приклад тексту.\n"
+    r1 = _make_record(reg_root, "aaa", digest_body=body_text)
+    _write_registry(reg_root, [r1])
+    resp = client.get("/api/knowledge/record/aaa")
+    assert resp.status_code == 200
+    assert "приклад" in resp.content.decode("utf-8")
+    assert resp.headers["etag"].strip('"') == r1["content_hash"].split(":", 1)[1]
+
+
+def test_filtered_top5_and_drop_logging(reg_root, caplog):
+    records = [
+        _make_record(reg_root, f"rec-{i:02d}", routing={"roles": ["quality"]})
+        for i in range(7)
+    ]
+    _write_registry(reg_root, records)
+    with caplog.at_level("WARNING"):
+        resp = client.get("/api/knowledge/manifest?role=quality")
+    ids = [r["id"] for r in resp.json()["records"]]
+    assert ids == ["rec-00", "rec-01", "rec-02", "rec-03", "rec-04"]  # lowest-5 by id
+    assert "dropped record id" in caplog.text
+    assert "rec-05" in caplog.text and "rec-06" in caplog.text
+
+
+def test_filtered_byte_cap_drops_with_logging(reg_root, caplog):
+    # Inflate each pointer via a large *matching* roles list (role=quality still
+    # matches) so the ≤1536 byte cap bites before the 5-record cap.
+    padded_roles = ["quality"] + [f"padrole-{i}-" + "z" * 60 for i in range(3)]
+    records = [
+        _make_record(reg_root, f"rec-{i:02d}", routing={"roles": padded_roles})
+        for i in range(5)
+    ]
+    _write_registry(reg_root, records)
+    with caplog.at_level("WARNING"):
+        resp = client.get("/api/knowledge/manifest?role=quality")
+    assert len(resp.content) <= reg.MAX_FILTERED_BYTES
+    assert len(resp.json()["records"]) < 5
+    assert "dropped record id" in caplog.text
+
+
+def test_select_bodies_total_cap(reg_root, caplog):
+    # Each body ~3 KB; only two fit under the 8 KB selected-body budget.
+    body = "y" * 3000 + "\n"
+    records = [_make_record(reg_root, f"rec-{i}", digest_body=body) for i in range(4)]
+    _write_registry(reg_root, records)
+    runtime = reg.load_runtime(root=reg_root)
+    with caplog.at_level("WARNING"):
+        selected, dropped = reg.select_bodies(runtime, ["rec-0", "rec-1", "rec-2", "rec-3"])
+    total = sum(len(item["body"].encode("utf-8")) for item in selected)
+    assert total <= reg.MAX_SELECTED_BODIES_BYTES
+    assert dropped  # at least one dropped
+    assert "select_bodies dropped" in caplog.text
+
+
+def test_request_caps_reject_excess(reg_root):
+    r1 = _make_record(reg_root, "aaa")
+    _write_registry(reg_root, [r1])
+    many = "&".join(f"owned_path=p{i}" for i in range(reg.MAX_OWNED_PATHS + 1))
+    assert client.get(f"/api/knowledge/manifest?{many}").status_code == 422
+    long_path = "x" * (reg.MAX_OWNED_PATH_LEN + 1)
+    assert client.get(f"/api/knowledge/manifest?owned_path={long_path}").status_code == 422
+    long_role = "r" * (reg.MAX_QUERY_VALUE_LEN + 1)
+    assert client.get(f"/api/knowledge/manifest?role={long_role}").status_code == 422
+
+
+# --------------------------------------------------------------------------- #
+# 15. No side effects: static guard over the P2 modules
+# --------------------------------------------------------------------------- #
+def test_no_network_or_subprocess_imports():
+    """Static proof: neither P2 module imports network/subprocess/db machinery."""
+    import ast
+
+    forbidden = {"subprocess", "socket", "sqlite3", "requests", "httpx", "urllib", "http"}
+    root = Path(__file__).resolve().parents[1]
+    for rel in ("scripts/research/registry.py", "scripts/api/knowledge_router.py"):
+        tree = ast.parse((root / rel).read_text("utf-8"))
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name.split(".")[0] for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module.split(".")[0])
+        leaked = imported & forbidden
+        assert not leaked, f"{rel} imports forbidden modules: {leaked}"


### PR DESCRIPTION
## What

P2 of epic #4969 / accepted ADR-011: expose the already-merged P1 Project Research Registry through a **disabled-by-default, bounded, deterministic** discovery API with three cache tiers. Reuses the P1 validator primitives (`scripts/audit/check_research_registry.py`) — no second schema, normalization, fence parser, or content-hash algorithm; **P1 is unchanged**.

`Closes #4982` · `Refs #4969` · ADR-011 P2

## Surface (9 files, all in scope)

- `scripts/research/registry.py` — runtime loader (fail-open, per-record drift isolation), live kill switch, global routing hash, pure AND matcher, allowlisted projections, byte/token budget helpers.
- `scripts/api/knowledge_router.py` — `/api/knowledge/manifest` + `/api/knowledge/record/{id}`.
- `scripts/api/state_router.py` — conditional compact `research` manifest component only.
- `scripts/api/main.py` — router mount; `route_contracts.py` — `/api/knowledge` contract; `preload.py` — import pinning.
- `tests/test_research_registry_api.py` (new, 73 cases) + `tests/test_manifest_api.py` (flag-off compat + enabled budget) + `docs/MONITOR-API.md`.

## Frozen decisions honored

- **Kill switch** default `false`; precedence env `LEARN_UK_RESEARCH_REGISTRY_ENABLED` (strict `true/false/1/0/yes/no/on/off`) → `<LIVE_REPO_ROOT>/.runtime/api/research-registry.json` → compiled `false`. Invalid higher layer → `false`, never falls through. Resolved dynamically per request → live true→false flip is immediate. Loader **not invoked** while disabled.
- **Fail-open**: enabled + missing/malformed/invalid registry → empty surface, logged warning, never 500. Drifted/provenance-broken record excluded individually; healthy records keep routing.
- **Global hash** over the routing-relevant projection (state, content hash, per-record validity, routing) — sensitive to every routed field/validity/content-hash, invariant under YAML reorder/format.
- **Pure AND matcher** (present dims conjunctive, omitted = wildcard, no-context → zero). Same-track/wrong-family negative proven.
- **Two-tier 304**: after a record edit flips the global manifest hash, an unrelated context is byte-identical → bodyless 304 with the same ETag; a matching context → 200 + new ETag. Reuses `rules_router._matches_etag` (strong/weak/`*`/comma-list).
- **Honest per-record ETag** = P1 `content_hash` for the exact normalized body (falls back to over-bytes on mismatch). Generic 404 for unknown/malformed/traversal/`private-local`/drifted/oversize; no path disclosure.
- **No P3 scope**: no cold-start announcer, no orient/bootstrap/dispatch injection, no telemetry. The pure matcher + selected-body helper are included because P2's ETag proof and budget matrix require them.

## Measured budgets (serialized UTF-8; tokens = `ceil(bytes/2)`)

| Surface | Budget | Measured |
|---|---|---|
| `/api/state/manifest` total (enabled) | < 2048 | **1031** |
| `/api/state/manifest` total (disabled) | = pre-P2 | **912** (no `research` key) |
| `research` component | ≤ 512 | **107** |
| `/api/knowledge/manifest` filtered (1 rec) | ≤ 1536, ≤ 5 rec | **342** |
| `/api/knowledge/record/{id}` body | ≤ 4096 | **2630** (ETag == `content_hash`) |

## Verification

- `tests/test_research_registry_api.py` (73) + `tests/test_manifest_api.py` (24) — **97 passed** (pre-commit affected-file pytest).
- `tests/test_monitor_route_contracts.py`, `tests/api/test_import_pinning.py`, `tests/test_research_registry.py` (P1), `tests/test_monitor_client_sdk.py`, `tests/test_orient_api.py` — all green (phase boundary intact).
- `scripts/audit/check_research_registry.py --check` → `3 records — all clean` (P1 no regression).
- `ruff check` clean on all changed Python; `git diff --check` clean; 9 files (<20).

Independent cross-family review + disposition owned by the Codex orchestrator — not self-approving, merging, or enabling auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)