### PR TITLE
feat(research-registry): ADR-011 P3 — task-scoped pointers, bounded cold start, consumption telemetry

### DIFF
--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1457,6 +1457,15 @@ record specifies must match; a task missing a required dimension does not match)
 Disabled → `{"enabled":false,"records":[]}`. Carries its own strong context-scoped
 `ETag`; `If-None-Match` gives a bodyless `304`. Top-5 / ≤1.5 KB; no digest bodies.
 
+### `GET /api/knowledge/cold-start?role=<role>`
+
+Role-only pointer projection from the opt-in `cold_start_roles` announce list —
+**never** the AND matcher above. A bare role has no `task_family`/`track`/
+`owned_path`, so the AND matcher would fail closed on those missing dimensions
+even for a record that explicitly opted in via `cold_start_roles`; this endpoint
+exists precisely so cold start/bootstrap has a role-only path that doesn't hit
+that trap. Same shape, caps, and ETag/304 semantics as `/manifest`.
+
 ### `GET /api/knowledge/record/{id}`
 
 One validated compact digest body as `text/markdown` with an honest per-record
@@ -1468,19 +1477,37 @@ id, an invalid/drifted/`private-local` record, or an over-budget body.
   one privacy-safe consumption telemetry event. Attribution is **response-invariant**:
   a missing/malformed/unknown/finished task changes nothing an unattributed caller
   sees and never reveals whether a task exists — it simply emits no event. A `404`
-  is never a consumption.
+  is never a consumption. A `304` only counts when the same task already has
+  evidence of a matching prior `200` for that record, persisted into the task's own
+  delegate state (no third store) — a caller can't manufacture a consumption event
+  by replaying the record's public `content_hash` as `If-None-Match` without ever
+  having fetched the body.
 
 ### Cold start / bootstrap
 
 - `GET /api/orient?role=<role>` — pointer-only `research` section from the role's
   opt-in `cold_start_roles` announcements (never the AND matcher, never a body).
+  No top-level `fetch` field — the fetch endpoint is the documented, well-known
+  `GET /api/knowledge/record/{id}` above, and omitting it keeps the whole envelope
+  inside the same ≤1.5 KB budget the selector already caps pointers to.
 - Monitor client SDK: `MonitorClient.bootstrap()` is unchanged (`rules` + `session`
-  only); `bootstrap(role=...)` adds a `research` component. `MonitorClient.research(
-  role=…, task_family=…, track=…, owned_paths=…, consumer=…)` fetches the filtered
-  projection, cached under the stable consumer plus a canonical context **fingerprint**
-  (never raw paths/role text) using the projection ETag: cold → first projection
-  surfaces; warm-unchanged → `304`, zero changed pointers, even after an unrelated
-  global registry edit.
+  only). `bootstrap(role=...)` with **no** other context dimension routes through
+  `MonitorClient.cold_start(role=..., consumer=...)` — the role-only
+  `/api/knowledge/cold-start` path, never the AND manifest. `bootstrap(role=...,
+  task_family=...)` (or `track=`/`owned_paths=`) routes through
+  `MonitorClient.research(role=…, task_family=…, track=…, owned_paths=…,
+  consumer=…)` — the full AND-matched `/api/knowledge/manifest` path. Both cache
+  under a fingerprint over the bounded `consumer` plus the canonical context (one
+  full, untruncated SHA-256; never a raw path/role/consumer string in the cache
+  filename) and return **only the added/changed pointers** since the last call for
+  that key — the on-disk cache still stores the complete latest projection so the
+  diff has something to compare against. cold (nothing cached) → the first `200`
+  returns everything; warm+unchanged → `304` returns a valid empty projection
+  (zero changed); warm+changed → the new `200` is diffed against the cached
+  snapshot by canonical pointer content (id/state/content_hash/routing) and only
+  the changed/new records come back. Both methods fail soft to an empty component
+  on any transport or cache read/write failure — an optional boundary that must
+  never crash `bootstrap()`.
 
 ### Dispatch injection
 
@@ -1642,15 +1669,19 @@ orient bundle blindly.
 
 ---
 
-## Bounded Research Discovery — `/api/knowledge/*` (ADR-011 P2, #4982)
+## Bounded Research Discovery — `/api/knowledge/*` (ADR-011 P2 #4982, P3 #4992)
 
 Task-scoped, pointer-only, hash-addressed access to the Project Research
 Registry (`docs/references/research-registry.yaml` + the compact digests
 under `docs/references/research-digests/`). Reuses the P1 validator
 primitives (`scripts/audit/check_research_registry.py`) for the schema,
 canonical digest projection/hash, drift, and path safety — it does not
-re-implement any of them. **P2 exposes the surface; it does not inject any
-research into cold start, orient, bootstrap, or dispatch (that is P3).**
+re-implement any of them. **P2 exposed the bare `/manifest` + `/record/{id}`
+surface with no automatic caller. P3 (this doc's *Research registry* section
+above) wired it into real task discovery: `GET /api/orient?role=`,
+`MonitorClient.bootstrap()`/`cold_start()`/`research()`, and
+`delegate.py dispatch --research-*` all surface pointers automatically now —
+record bodies remain strictly on-demand throughout.**
 
 ### Kill switch (default OFF, instant rollback)
 
@@ -1724,6 +1755,8 @@ before the route). No status or message leaks which of these applied.
 | Total `/api/state/manifest` | < 2048 bytes |
 | `research` manifest component | ≤ 512 bytes |
 | `/api/knowledge/manifest` filtered projection | ≤ 5 records and ≤ 1536 bytes |
+| `/api/knowledge/cold-start` role-only projection | ≤ 5 records and ≤ 1536 bytes |
+| `GET /api/orient?role=` `research` envelope (final emitted bytes) | ≤ 1536 bytes |
 | One `/api/knowledge/record/{id}` body | ≤ 4096 bytes |
 | Automatic selected-body fetch (P3 consumer) | ≤ 8192 bytes total |
 
@@ -1844,11 +1877,23 @@ boot = client.bootstrap()
 rules_md = boot["rules"].body       # ready to drop into a system prompt
 session_md = boot["session"].body   # current-task summary
 
+# Role-only cold start: routes through cold_start_roles, never the AND matcher.
+boot = client.bootstrap(role="quality")
+research_body = boot["research"].body   # changed/new pointers only (see below)
+
 # boot[...].source tells you why you have these bytes:
 #   "cache"         — no network call; local hash matched
-#   "not-modified"  — server replied 304, reused cached body
+#   "not-modified"  — server replied 304; research bodies are a valid EMPTY
+#                      pointer projection (zero changed), other components reuse
+#                      the cached body verbatim
 #   "network"       — first fetch or new ETag, body downloaded
+#   "error:*"       — degraded (transport/cache failure, disabled, or 4xx/5xx);
+#                      body is empty, never raises
 ```
+
+`MonitorClient.cold_start(role=...)` and `MonitorClient.research(role=..., task_family=..., track=..., owned_paths=...)`
+are also callable directly (`bootstrap()` picks between them based on which
+dimensions are given — see *Cold start / bootstrap* above).
 
 The SDK handles:
 

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1440,6 +1440,67 @@ Modules with recent dispatch activity and unfinished publish state.
 }
 ```
 
+## Research registry — `/api/knowledge` (ADR-011)
+
+Bounded, task-scoped discovery of the Project Research Registry
+(`docs/references/research-registry.yaml`). Gated behind the default-off
+`research_registry` kill switch; while disabled every surface below reproduces
+exact pre-registry behavior. **Pointers are automatic; record bodies are strictly
+on demand** — no cold-start, orient, bootstrap, dispatch, or pipeline path ever
+fetches a digest body automatically.
+
+### `GET /api/knowledge/manifest`
+
+Filtered, pointer-only projection for a task context. Pure **AND** matcher over
+`role`, `task_family`, `track`, and repeatable `owned_path` (every dimension a
+record specifies must match; a task missing a required dimension does not match).
+Disabled → `{"enabled":false,"records":[]}`. Carries its own strong context-scoped
+`ETag`; `If-None-Match` gives a bodyless `304`. Top-5 / ≤1.5 KB; no digest bodies.
+
+### `GET /api/knowledge/record/{id}`
+
+One validated compact digest body as `text/markdown` with an honest per-record
+`ETag` (its `content_hash`). Generic `404` for disabled/unknown/malformed/traversal
+id, an invalid/drifted/`private-local` record, or an over-budget body.
+
+- `task=<task-id>` — **optional** consumption attribution. A served `200` or a
+  cache-backed `304` fetched under a validated, still-active delegate task emits
+  one privacy-safe consumption telemetry event. Attribution is **response-invariant**:
+  a missing/malformed/unknown/finished task changes nothing an unattributed caller
+  sees and never reveals whether a task exists — it simply emits no event. A `404`
+  is never a consumption.
+
+### Cold start / bootstrap
+
+- `GET /api/orient?role=<role>` — pointer-only `research` section from the role's
+  opt-in `cold_start_roles` announcements (never the AND matcher, never a body).
+- Monitor client SDK: `MonitorClient.bootstrap()` is unchanged (`rules` + `session`
+  only); `bootstrap(role=...)` adds a `research` component. `MonitorClient.research(
+  role=…, task_family=…, track=…, owned_paths=…, consumer=…)` fetches the filtered
+  projection, cached under the stable consumer plus a canonical context **fingerprint**
+  (never raw paths/role text) using the projection ETag: cold → first projection
+  surfaces; warm-unchanged → `304`, zero changed pointers, even after an unrelated
+  global registry edit.
+
+### Dispatch injection
+
+`delegate.py dispatch` accepts explicit, namespaced context flags — never inferred
+from the prompt, agent, provider, or branch: `--research-role`,
+`--research-task-family`, `--research-track`, and repeatable `--research-owned-path`.
+When set (and the registry is enabled) the dispatch prompt gains a bounded,
+pointer-only block plus an on-demand fetch instruction, and the task state persists
+**only** the pointer ids, filtered ETag, dropped ids, and context fingerprint (never
+raw owned paths, digest/source/prompt text, role, or task family).
+
+### Consumption telemetry (privacy contract)
+
+Two distinct central-emitter events (`scripts/telemetry/emit.py`; no new store):
+`research_pointer_surfaced` (a pointer was shown) and `research_record_consumed`
+(a body was actually fetched under a validated active task). Surfaced ≠ consumed.
+Payload allowlist is exactly `{task_id, research_id, surface, status}` on top of the
+emitter envelope — never a digest body, title, summary, source URL, prompt, role,
+task family, track, owned paths, or context fingerprint.
+
 ## Orientation — `/api/orient`
 
 ### `GET /api/orient`
@@ -1455,6 +1516,12 @@ Query params:
   `session_hints`. Unknown keys return `400`. Omitted = full payload
   (back-compat). Skipped sections are not collected and are omitted
   from both the top-level payload and `meta`.
+- `role=<role>` — **opt-in** ADR-011 P3 cold-start research (see
+  *Research registry* below). Absent → the response is byte-identical to
+  the pre-P3 orient (no `research` key). Present + registry enabled → a
+  pointer-only `research` section (≤5 records / ≤1.5 KB; bodies fetched
+  on demand, never here). Computed fresh per request and never stored in
+  the shared `orient_*` cache, so two roles cannot contaminate each other.
 - `session=<uuid>` or header `X-Session-Id` — per-session context
   telemetry when `LEARN_UKRAINIAN_TELEMETRY_FOOTER=1` (query wins).
 

--- a/scripts/ai_agent_bridge/_monitor_cache.py
+++ b/scripts/ai_agent_bridge/_monitor_cache.py
@@ -94,6 +94,35 @@ def get(key: str, expected_hash: str) -> str | None:
         return None
 
 
+def peek(key: str) -> CacheEntry | None:
+    """Return the cached entry for ``key`` regardless of any expected hash.
+
+    ``get`` requires a manifest-advertised hash to validate against. The ADR-011
+    P3 filtered research projection has no such per-context hash in the manifest —
+    its freshness is carried by its own strong ETag. ``peek`` exposes the last body
+    and its stored ETag/``hash`` so the client can replay it as ``If-None-Match``
+    and reuse the body on a ``304``. Returns ``None`` when nothing is cached or the
+    entry is unreadable/corrupt.
+    """
+    body_path, meta_path = _paths(key)
+    if not body_path.is_file() or not meta_path.is_file():
+        return None
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        body = body_path.read_text(encoding="utf-8")
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(meta, dict):
+        return None
+    return CacheEntry(
+        key=key,
+        body=body,
+        hash=str(meta.get("hash") or ""),
+        url=str(meta.get("url") or ""),
+        fetched_at=str(meta.get("fetched_at") or ""),
+    )
+
+
 def put(key: str, body: str, *, body_hash: str, url: str) -> CacheEntry:
     """Write ``body`` to the cache with its associated hash + URL.
 

--- a/scripts/ai_agent_bridge/monitor_client.py
+++ b/scripts/ai_agent_bridge/monitor_client.py
@@ -23,8 +23,10 @@ Monitor API is always local (localhost:8765), so urllib is plenty.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from typing import Any
@@ -33,6 +35,43 @@ from . import _monitor_cache as cache
 
 DEFAULT_BASE_URL = "http://localhost:8765"
 DEFAULT_TIMEOUT_S = 3.0
+
+_KNOWLEDGE_MANIFEST_PATH = "/api/knowledge/manifest"
+
+
+def _canonical_context(
+    role: str | None,
+    task_family: str | None,
+    track: str | None,
+    owned_paths: list[str] | None,
+) -> dict[str, Any]:
+    """Normalize a task context deterministically (mirrors ``registry.normalize_context``).
+
+    Blank/whitespace scalars collapse to ``None``; owned paths are stripped,
+    de-duplicated, and sorted. Kept dependency-light (no registry import) so the
+    cold-start client stays pure-stdlib.
+    """
+
+    def _norm(value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    paths = sorted({p.strip() for p in (owned_paths or []) if p and p.strip()})
+    return {
+        "role": _norm(role),
+        "task_family": _norm(task_family),
+        "track": _norm(track),
+        "owned_paths": paths,
+    }
+
+
+def _context_fingerprint(context: dict[str, Any]) -> str:
+    """Opaque digest of a canonical context — the cache-key component that keeps
+    raw owned paths / role text out of the on-disk cache filename."""
+    blob = json.dumps(context, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
 
 
 @dataclass
@@ -186,20 +225,109 @@ class MonitorClient:
         cache.put(key, body, body_hash=etag, url=url)
         return ComponentResult(key=key, body=body, hash=etag, source="network")
 
+    # -- ADR-011 P3 filtered research projection --------------------
+
+    def research(
+        self,
+        *,
+        role: str | None = None,
+        task_family: str | None = None,
+        track: str | None = None,
+        owned_paths: list[str] | None = None,
+        consumer: str = "orchestrator",
+    ) -> ComponentResult:
+        """Fetch the task-scoped, pointer-only filtered research projection.
+
+        POINTERS ONLY — this never fetches record bodies; the projection carries
+        IDs/states/hashes/routing, and bodies are pulled on demand elsewhere.
+
+        Caching uses the projection's own strong ETag (there is no per-context hash
+        in the manifest), keyed on the stable ``consumer`` plus a canonical context
+        **fingerprint** — never the raw owned paths or role text. Consequences that
+        satisfy the P3 cache contract:
+
+        * cold (nothing cached for this key) → a plain GET returns the first
+          relevant projection (``source="network"``);
+        * warm + unchanged → ``If-None-Match`` yields a bodyless ``304`` and the
+          cached body is reused (``source="not-modified"``), zero changed pointers —
+          even after an unrelated global registry edit, because the server's
+          filtered ETag only moves for contexts the edited record routes to.
+
+        Fails soft to an empty component (``source="error:*"``) rather than raising,
+        so a cold-start caller never crashes on a degraded/disabled endpoint.
+        """
+        context = _canonical_context(role, task_family, track, owned_paths)
+        fingerprint = _context_fingerprint(context)
+        key = f"research__{consumer}__{fingerprint}"
+
+        params: list[tuple[str, str]] = []
+        if context["role"]:
+            params.append(("role", context["role"]))
+        if context["task_family"]:
+            params.append(("task_family", context["task_family"]))
+        if context["track"]:
+            params.append(("track", context["track"]))
+        params.extend(("owned_path", p) for p in context["owned_paths"])
+        url = _KNOWLEDGE_MANIFEST_PATH
+        if params:
+            url = f"{url}?{urllib.parse.urlencode(params)}"
+
+        cached = cache.peek(key)
+        headers: dict[str, str] = {}
+        if cached is not None and cached.hash:
+            headers["If-None-Match"] = f'"{cached.hash}"'
+
+        status, body, resp_headers = self._get(url, headers=headers)
+        if status == 304 and cached is not None:
+            return ComponentResult(
+                key=key, body=cached.body, hash=cached.hash, source="not-modified"
+            )
+        if status == 304:
+            # 304 with no local body (cache evicted between peek and now):
+            # re-fetch unconditionally so we never return an empty projection.
+            status, body, resp_headers = self._get(url)
+
+        if status >= 400 or not body:
+            return ComponentResult(key=key, body="", hash="", source=f"error:{status}")
+
+        etag = (resp_headers.get("etag") or "").strip('"')
+        cache.put(key, body, body_hash=etag, url=url)
+        return ComponentResult(key=key, body=body, hash=etag, source="network")
+
     # -- convenience bootstrap -------------------------------------
 
-    def bootstrap(self) -> dict[str, ComponentResult]:
+    def bootstrap(
+        self,
+        *,
+        role: str | None = None,
+        task_family: str | None = None,
+        track: str | None = None,
+        owned_paths: list[str] | None = None,
+        consumer: str = "orchestrator",
+    ) -> dict[str, ComponentResult]:
         """One-shot: manifest + every cached component.
 
-        Returns a dict with keys ``rules`` and ``session``, each a
-        ``ComponentResult``. Use this at the start of a session:
+        With no arguments this returns **exactly** ``{"rules", "session"}`` — the
+        pre-P3 shape, byte-for-byte. Passing any research context (``role`` or a
+        finer dimension) opts in an extra ``"research"`` key carrying the filtered,
+        pointer-only projection for that context. Absent a role, no research call is
+        made at all.
 
             client = MonitorClient()
-            boot = client.bootstrap()
-            rules_md = boot["rules"].body
+            boot = client.bootstrap()                     # rules + session only
+            boot = client.bootstrap(role="quality")       # + research pointers
         """
         man = self.manifest()
-        return {
+        result = {
             "rules": self.rules(manifest=man),
             "session": self.session(manifest=man),
         }
+        if role or task_family or track or owned_paths:
+            result["research"] = self.research(
+                role=role,
+                task_family=task_family,
+                track=track,
+                owned_paths=owned_paths,
+                consumer=consumer,
+            )
+        return result

--- a/scripts/ai_agent_bridge/monitor_client.py
+++ b/scripts/ai_agent_bridge/monitor_client.py
@@ -37,6 +37,10 @@ DEFAULT_BASE_URL = "http://localhost:8765"
 DEFAULT_TIMEOUT_S = 3.0
 
 _KNOWLEDGE_MANIFEST_PATH = "/api/knowledge/manifest"
+_KNOWLEDGE_COLD_START_PATH = "/api/knowledge/cold-start"
+
+# Bound the consumer label before it ever reaches a hash or a filesystem path.
+_MAX_CONSUMER_LEN = 128
 
 
 def _canonical_context(
@@ -67,11 +71,77 @@ def _canonical_context(
     }
 
 
-def _context_fingerprint(context: dict[str, Any]) -> str:
-    """Opaque digest of a canonical context — the cache-key component that keeps
-    raw owned paths / role text out of the on-disk cache filename."""
-    blob = json.dumps(context, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
-    return hashlib.sha256(blob.encode("utf-8")).hexdigest()[:16]
+def _bounded_consumer(consumer: str | None) -> str:
+    """Cap + sanitize the consumer label before it ever reaches a hash or a
+    filesystem path. Never used verbatim in a cache key/filename (ADR-011 P3)."""
+    if not isinstance(consumer, str):
+        return ""
+    return consumer.strip()[:_MAX_CONSUMER_LEN]
+
+
+def _context_fingerprint(consumer: str | None, context: dict[str, Any]) -> str:
+    """One full SHA-256 fingerprint over the bounded consumer + canonical context.
+
+    Folds ``consumer`` into the same digest as the context rather than splicing
+    the raw string into the cache key — a cache filename must never carry the raw
+    consumer, role, or owned paths (ADR-011 P3 privacy contract). Uses the full
+    64-hex digest, never a truncated prefix: a truncated digest is a needless
+    collision risk once enough distinct (consumer, context) pairs accumulate.
+    """
+    payload = {"consumer": _bounded_consumer(consumer), "context": context}
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _parse_projection(body: str) -> dict[str, Any]:
+    """Best-effort parse of a ``{"enabled":bool,"records":[...]}`` projection body.
+
+    Malformed/non-JSON/non-dict input degrades to the empty, disabled shape rather
+    than raising — this feeds a diff, not a validator.
+    """
+    try:
+        data = json.loads(body)
+    except (json.JSONDecodeError, TypeError):
+        return {"enabled": False, "records": []}
+    if not isinstance(data, dict):
+        return {"enabled": False, "records": []}
+    records = data.get("records")
+    return {
+        "enabled": bool(data.get("enabled")),
+        "records": [rec for rec in records if isinstance(rec, dict)] if isinstance(records, list) else [],
+    }
+
+
+def _serialize_projection(enabled: bool, records: list[dict[str, Any]]) -> str:
+    return json.dumps(
+        {"enabled": enabled, "records": records}, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+
+
+def _diff_changed_pointers(*, previous_body: str | None, new_body: str) -> str:
+    """New/changed pointers only, diffed by canonical pointer content (the only
+    fields a projection carries: id/state/content_hash/routing).
+
+    ``previous_body`` is ``None`` on a cold fetch (nothing cached yet) — every
+    pointer in the fresh projection counts as changed/new. A record present in
+    ``previous_body`` but absent from ``new_body`` (removed, or no longer matches
+    this context) is NOT surfaced as a change — ADR-011 P3 defines no tombstone
+    contract; the caller's cache write below still drops it from the stored
+    snapshot, so it simply stops appearing in future diffs.
+    """
+    new_proj = _parse_projection(new_body)
+    if previous_body is None:
+        changed = new_proj["records"]
+    else:
+        previous_by_id = {rec.get("id"): rec for rec in _parse_projection(previous_body)["records"]}
+        changed = [rec for rec in new_proj["records"] if previous_by_id.get(rec.get("id")) != rec]
+    return _serialize_projection(new_proj["enabled"], changed)
+
+
+def _empty_changed_projection(cached_body: str) -> str:
+    """Zero-changed-pointers projection for a warm, unchanged (``304``) fetch."""
+    proj = _parse_projection(cached_body)
+    return _serialize_projection(proj["enabled"], [])
 
 
 @dataclass
@@ -227,6 +297,65 @@ class MonitorClient:
 
     # -- ADR-011 P3 filtered research projection --------------------
 
+    def _fetch_changed_projection(self, *, key: str, url: str) -> ComponentResult:
+        """Shared fetch/diff/cache path for a filtered or cold-start pointer
+        projection. The on-disk cache stores the COMPLETE latest projection; the
+        returned ``ComponentResult.body`` carries only the added/changed pointers.
+
+        Contract (ADR-011 P3):
+
+        * cold (nothing cached for this key) → the first ``200`` returns every
+          pointer in the fresh projection (``source="network"``, all "changed").
+        * warm + unchanged → ``If-None-Match`` yields a bodyless ``304``; the
+          returned body is a valid EMPTY pointer projection (zero changed) —
+          even after an unrelated global registry edit, because the server's
+          filtered ETag only moves for contexts the edited record routes to.
+        * warm + changed → a fresh ``200`` diffs the new projection's pointers
+          against the previously cached full snapshot by canonical content
+          (id/state/content_hash/routing — the only fields a pointer carries) and
+          returns only the new/changed ones, then replaces the cached full
+          snapshot with the fresh one. A record that disappeared (removed, or no
+          longer matches) updates the cache but is NOT surfaced as a change — P3
+          defines no tombstone contract.
+
+        Fails soft to an empty component (``source="error:*"``) on any transport
+        failure (including unreachable-server ``URLError``, a superclass HTTPError
+        doesn't cover) or cache read/write failure — this is an optional boundary
+        and must never crash ``bootstrap()``.
+        """
+        try:
+            cached = cache.peek(key)
+            headers: dict[str, str] = {}
+            if cached is not None and cached.hash:
+                headers["If-None-Match"] = f'"{cached.hash}"'
+
+            status, body, resp_headers = self._get(url, headers=headers)
+            if status == 304:
+                if cached is None:
+                    # Defensive only — unreachable in practice: we only ever send
+                    # If-None-Match when `cached` is populated, so the server has
+                    # no ETag to 304 against otherwise (Gemini review, dead branch).
+                    return ComponentResult(key=key, body="", hash="", source="error:304-no-cache")
+                return ComponentResult(
+                    key=key,
+                    body=_empty_changed_projection(cached.body),
+                    hash=cached.hash,
+                    source="not-modified",
+                )
+
+            if status >= 400 or not body:
+                return ComponentResult(key=key, body="", hash="", source=f"error:{status}")
+
+            etag = (resp_headers.get("etag") or "").strip('"')
+            changed_body = _diff_changed_pointers(
+                previous_body=cached.body if cached is not None else None,
+                new_body=body,
+            )
+            cache.put(key, body, body_hash=etag, url=url)
+            return ComponentResult(key=key, body=changed_body, hash=etag, source="network")
+        except Exception as exc:
+            return ComponentResult(key=key, body="", hash="", source=f"error:{type(exc).__name__}")
+
     def research(
         self,
         *,
@@ -239,26 +368,20 @@ class MonitorClient:
         """Fetch the task-scoped, pointer-only filtered research projection.
 
         POINTERS ONLY — this never fetches record bodies; the projection carries
-        IDs/states/hashes/routing, and bodies are pulled on demand elsewhere.
+        IDs/states/hashes/routing, and bodies are pulled on demand elsewhere. This
+        is the full **AND**-matcher context (``/api/knowledge/manifest``) — use it
+        when at least one of ``task_family``/``track``/``owned_paths`` is known. A
+        ``role``-only context with none of those has no family/track/path for the
+        AND matcher to satisfy and belongs in :meth:`cold_start` instead.
 
-        Caching uses the projection's own strong ETag (there is no per-context hash
-        in the manifest), keyed on the stable ``consumer`` plus a canonical context
-        **fingerprint** — never the raw owned paths or role text. Consequences that
-        satisfy the P3 cache contract:
-
-        * cold (nothing cached for this key) → a plain GET returns the first
-          relevant projection (``source="network"``);
-        * warm + unchanged → ``If-None-Match`` yields a bodyless ``304`` and the
-          cached body is reused (``source="not-modified"``), zero changed pointers —
-          even after an unrelated global registry edit, because the server's
-          filtered ETag only moves for contexts the edited record routes to.
-
-        Fails soft to an empty component (``source="error:*"``) rather than raising,
-        so a cold-start caller never crashes on a degraded/disabled endpoint.
+        Caching is keyed on a fingerprint over the bounded ``consumer`` plus the
+        canonical context — never raw owned paths or role text — and returns only
+        the changed/new pointers since the last call for this exact key (see
+        :meth:`_fetch_changed_projection`).
         """
         context = _canonical_context(role, task_family, track, owned_paths)
-        fingerprint = _context_fingerprint(context)
-        key = f"research__{consumer}__{fingerprint}"
+        fingerprint = _context_fingerprint(consumer, context)
+        key = f"research__{fingerprint}"
 
         params: list[tuple[str, str]] = []
         if context["role"]:
@@ -272,27 +395,32 @@ class MonitorClient:
         if params:
             url = f"{url}?{urllib.parse.urlencode(params)}"
 
-        cached = cache.peek(key)
-        headers: dict[str, str] = {}
-        if cached is not None and cached.hash:
-            headers["If-None-Match"] = f'"{cached.hash}"'
+        return self._fetch_changed_projection(key=key, url=url)
 
-        status, body, resp_headers = self._get(url, headers=headers)
-        if status == 304 and cached is not None:
-            return ComponentResult(
-                key=key, body=cached.body, hash=cached.hash, source="not-modified"
-            )
-        if status == 304:
-            # 304 with no local body (cache evicted between peek and now):
-            # re-fetch unconditionally so we never return an empty projection.
-            status, body, resp_headers = self._get(url)
+    def cold_start(self, *, role: str, consumer: str = "orchestrator") -> ComponentResult:
+        """Fetch the role-only cold-start pointer projection (``cold_start_roles``).
 
-        if status >= 400 or not body:
-            return ComponentResult(key=key, body="", hash="", source=f"error:{status}")
+        Distinct from :meth:`research`: this NEVER runs the AND matcher. It hits
+        the dedicated ``GET /api/knowledge/cold-start`` announcer, which matches
+        solely on the role's opt-in ``cold_start_roles`` list — a record that only
+        declares ``cold_start_roles`` (and not ``routing.roles``/``task_families``/
+        ...) still announces here even though it would fail the AND matcher on the
+        missing family/track/path dimensions a bare role can't supply.
 
-        etag = (resp_headers.get("etag") or "").strip('"')
-        cache.put(key, body, body_hash=etag, url=url)
-        return ComponentResult(key=key, body=body, hash=etag, source="network")
+        Cached + diffed the same way as :meth:`research` (changed pointers only,
+        full snapshot cached) under its own key prefix so it never shares a cache
+        entry with an AND-matched ``research()`` call for the same role text.
+        """
+        normalized_role = (role or "").strip()
+        context = {"role": normalized_role, "task_family": None, "track": None, "owned_paths": []}
+        fingerprint = _context_fingerprint(consumer, context)
+        key = f"cold_start__{fingerprint}"
+
+        url = _KNOWLEDGE_COLD_START_PATH
+        if normalized_role:
+            url = f"{url}?{urllib.parse.urlencode([('role', normalized_role)])}"
+
+        return self._fetch_changed_projection(key=key, url=url)
 
     # -- convenience bootstrap -------------------------------------
 
@@ -308,21 +436,26 @@ class MonitorClient:
         """One-shot: manifest + every cached component.
 
         With no arguments this returns **exactly** ``{"rules", "session"}`` — the
-        pre-P3 shape, byte-for-byte. Passing any research context (``role`` or a
-        finer dimension) opts in an extra ``"research"`` key carrying the filtered,
-        pointer-only projection for that context. Absent a role, no research call is
-        made at all.
+        pre-P3 shape, byte-for-byte. Passing any research context opts in an extra
+        ``"research"`` key. A ``role`` given ALONE (no ``task_family``/``track``/
+        ``owned_paths``) routes through the role-only cold-start pointer path
+        (:meth:`cold_start` — ``cold_start_roles``, never the AND matcher, which
+        would silently under-match cold-start-only records given a bare role with
+        no other dimension). Any other combination routes through the full
+        AND-matched :meth:`research` context.
 
             client = MonitorClient()
             boot = client.bootstrap()                     # rules + session only
-            boot = client.bootstrap(role="quality")       # + research pointers
+            boot = client.bootstrap(role="quality")       # + cold-start pointers
         """
         man = self.manifest()
         result = {
             "rules": self.rules(manifest=man),
             "session": self.session(manifest=man),
         }
-        if role or task_family or track or owned_paths:
+        if role and not (task_family or track or owned_paths):
+            result["research"] = self.cold_start(role=role, consumer=consumer)
+        elif role or task_family or track or owned_paths:
             result["research"] = self.research(
                 role=role,
                 task_family=task_family,

--- a/scripts/api/knowledge_router.py
+++ b/scripts/api/knowledge_router.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, HTTPException, Query, Request, Response
 
+from scripts.research import consumption
 from scripts.research import registry as reg
 
 from .rules_router import _matches_etag
@@ -71,13 +72,24 @@ def knowledge_manifest(
 
 
 @router.get("/record/{record_id}")
-def knowledge_record(request: Request, record_id: str):
+def knowledge_record(
+    request: Request,
+    record_id: str,
+    task: str | None = Query(default=None),
+):
     """One validated compact digest body as ``text/markdown`` with an honest ETag.
 
     Returns a generic 404 for a disabled feature, an unknown/malformed/traversal
     id, an invalid/drifted/``private-local`` record, an unsafe digest path, or an
     over-budget body — never a leaking status. ``content_hash`` is the ETag for the
     exact normalized body; ``If-None-Match`` gives a bodyless 304.
+
+    ADR-011 P3 consumption telemetry: an optional ``task`` id attributes an actual
+    on-demand fetch (a served 200 or a cache-backed 304) to a validated, still-active
+    delegate task. Attribution is best-effort and **response-invariant** — a missing,
+    malformed, unknown, or finished task changes nothing an unattributed caller sees
+    and never reveals whether a task exists; it just emits no consumption event. A
+    404 (no record served) is never a consumption.
     """
     if not reg.is_enabled():
         raise HTTPException(status_code=404, detail=_NOT_FOUND)
@@ -90,5 +102,7 @@ def knowledge_record(request: Request, record_id: str):
     body, etag_hex = result
     etag = f'"{etag_hex}"'
     if _matches_etag(request.headers.get("If-None-Match"), etag_hex):
+        consumption.record_consumption(task, record_id, status=304)
         return Response(status_code=304, headers={"ETag": etag})
+    consumption.record_consumption(task, record_id, status=200)
     return Response(content=body, media_type=_MARKDOWN_MEDIA, headers={"ETag": etag})

--- a/scripts/api/knowledge_router.py
+++ b/scripts/api/knowledge_router.py
@@ -1,10 +1,15 @@
-"""Knowledge API router — ADR-011 P2 bounded research discovery.
+"""Knowledge API router — ADR-011 P2/P3 bounded research discovery.
 
-Mounted at ``/api/knowledge`` in ``main.py``. Two endpoints, both gated behind the
+Mounted at ``/api/knowledge`` in ``main.py``. Three endpoints, all gated behind the
 default-off ``research_registry`` kill switch (``scripts/research/registry.py``):
 
     GET /api/knowledge/manifest             Filtered, task-scoped pointer list with
                                             its own strong ETag (no digest bodies).
+                                            Pure AND matcher over role/task_family/
+                                            track/owned_path.
+    GET /api/knowledge/cold-start           Role-only pointer list from the opt-in
+                                            ``cold_start_roles`` announce list —
+                                            NEVER the AND matcher (P3).
     GET /api/knowledge/record/{record_id}   One compact digest body as text/markdown
                                             with an honest per-record ETag.
 
@@ -71,6 +76,32 @@ def knowledge_manifest(
     return _json_response(result.body, result.etag_hex)
 
 
+@router.get("/cold-start")
+def knowledge_cold_start(
+    request: Request,
+    role: str | None = Query(default=None, max_length=reg.MAX_QUERY_VALUE_LEN),
+):
+    """Role-only cold-start research pointers (ADR-011 P3 ``cold_start_roles``).
+
+    Distinct from ``/manifest``: this NEVER runs the AND matcher over
+    role/task_family/track/owned_path — a missing family/track/path context would
+    fail that matcher closed even for a record that explicitly opted in via
+    ``cold_start_roles``. Disabled → HTTP 200 ``{"enabled":false,"records":[]}``.
+    Enabled → pointers from ``cold_start_roles`` only, top-5 / ≤1.5 KB, sorted by
+    record id, strong ETag over the exact response bytes, ``If-None-Match`` gives a
+    bodyless 304.
+    """
+    if not reg.is_enabled():
+        return _json_response(reg.disabled_manifest_bytes())
+
+    runtime = reg.load_runtime_safe()
+    result = reg.empty_manifest_response() if runtime is None else reg.filtered_cold_start(runtime, role)
+
+    if _matches_etag(request.headers.get("If-None-Match"), result.etag_hex):
+        return Response(status_code=304, headers={"ETag": f'"{result.etag_hex}"'})
+    return _json_response(result.body, result.etag_hex)
+
+
 @router.get("/record/{record_id}")
 def knowledge_record(
     request: Request,
@@ -89,7 +120,11 @@ def knowledge_record(
     delegate task. Attribution is best-effort and **response-invariant** — a missing,
     malformed, unknown, or finished task changes nothing an unattributed caller sees
     and never reveals whether a task exists; it just emits no consumption event. A
-    404 (no record served) is never a consumption.
+    404 (no record served) is never a consumption. A `304` only counts as
+    consumption when the same task already has evidence of a matching prior `200`
+    (see ``consumption.record_consumption``) — replaying the record's public
+    ``content_hash`` as ``If-None-Match`` without ever fetching the body does not
+    manufacture a consumption event.
     """
     if not reg.is_enabled():
         raise HTTPException(status_code=404, detail=_NOT_FOUND)
@@ -102,7 +137,7 @@ def knowledge_record(
     body, etag_hex = result
     etag = f'"{etag_hex}"'
     if _matches_etag(request.headers.get("If-None-Match"), etag_hex):
-        consumption.record_consumption(task, record_id, status=304)
+        consumption.record_consumption(task, record_id, status=304, etag=etag_hex)
         return Response(status_code=304, headers={"ETag": etag})
-    consumption.record_consumption(task, record_id, status=200)
+    consumption.record_consumption(task, record_id, status=200, etag=etag_hex)
     return Response(content=body, media_type=_MARKDOWN_MEDIA, headers={"ETag": etag})

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -27,6 +27,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 
 from scripts.guardrails import worktree_containment
+from scripts.research import registry as reg
 
 try:
     from path_safety import safe_join  # scripts/ on sys.path (test sys.path-hack)
@@ -729,6 +730,11 @@ async def orient(
         None,
         description="Comma-separated subset of orient sections to collect.",
     ),
+    role: str | None = Query(
+        None,
+        max_length=reg.MAX_QUERY_VALUE_LEN,
+        description="Opt-in ADR-011 P3 cold-start research role. Adds pointer-only research.",
+    ),
 ):
     """One-shot agent orientation.
 
@@ -740,6 +746,13 @@ async def orient(
             120 s for ``issues``/``wiki``). Reviewer BLOCKER B3 / #1309.
         sections: comma-separated list of section keys to collect. Unknown
             keys return 400. Omitted = full payload (back-compat).
+        role: ADR-011 P3 opt-in. Absent → the response is byte-identical to
+            the pre-P3 orient (no research key, no shared-cache contamination).
+            Present + registry enabled → a pointer-only ``research`` section of
+            the role's ``cold_start_roles`` announcements (≤5 / ≤1.5 KB, bodies
+            fetched on demand). Computed fresh per request and never stored in
+            the shared ``orient_*`` cache, so two roles can never contaminate
+            each other's pointers.
     """
     if fresh:
         cache_invalidate("orient_")
@@ -803,7 +816,34 @@ async def orient(
         issues_info = section_data["issues"]
         if isinstance(issues_info, dict) and issues_info.get("error"):
             response["issues_error"] = issues_info["error"]
+
+    _attach_cold_start_research(response, role)
     return add_json_telemetry(response, session_id=session_id_from_request(request))
+
+
+def _attach_cold_start_research(response: dict[str, Any], role: str | None) -> None:
+    """Add the ADR-011 P3 pointer-only research section for an opt-in role.
+
+    No-op (leaving the response byte-identical to the pre-P3 orient) when no role
+    is given, the kill switch is off, or the registry cannot be exposed — fail-open,
+    never a 500. POINTERS ONLY: it calls the role-only cold-start selector, never
+    ``select_bodies``; record bodies are fetched on demand from ``fetch``. Computed
+    inline, never cached at the orient layer, so role-specific pointers never share
+    a cache key.
+    """
+    if not role or not role.strip():
+        return
+    if not reg.is_enabled():
+        return
+    runtime = reg.load_runtime_safe()
+    if runtime is None:
+        return
+    pointers, _dropped = reg.select_cold_start_pointers(runtime, role)
+    response["research"] = {
+        "enabled": True,
+        "records": pointers,
+        "fetch": "/api/knowledge/record/{id}",
+    }
 
 
 @app.get("/api/config")

--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -825,25 +825,34 @@ def _attach_cold_start_research(response: dict[str, Any], role: str | None) -> N
     """Add the ADR-011 P3 pointer-only research section for an opt-in role.
 
     No-op (leaving the response byte-identical to the pre-P3 orient) when no role
-    is given, the kill switch is off, or the registry cannot be exposed — fail-open,
-    never a 500. POINTERS ONLY: it calls the role-only cold-start selector, never
-    ``select_bodies``; record bodies are fetched on demand from ``fetch``. Computed
-    inline, never cached at the orient layer, so role-specific pointers never share
-    a cache key.
+    is given, the kill switch is off, the registry cannot be exposed, or anything
+    in the selector/loader path raises unexpectedly — fail-open, never a 500 for
+    orient as a whole. POINTERS ONLY: it calls the role-only cold-start selector
+    (``cold_start_roles``, never the AND matcher), never ``select_bodies``; record
+    bodies are fetched on demand from the documented, well-known
+    ``GET /api/knowledge/record/{id}`` (see ``docs/MONITOR-API.md``) — omitted here
+    rather than repeated per response so the envelope stays inside the same
+    ``MAX_FILTERED_BYTES`` (1536 B) budget the selector already caps pointers to.
+    Computed inline, never cached at the orient layer, so role-specific pointers
+    never share a cache key.
     """
     if not role or not role.strip():
         return
-    if not reg.is_enabled():
-        return
-    runtime = reg.load_runtime_safe()
-    if runtime is None:
-        return
-    pointers, _dropped = reg.select_cold_start_pointers(runtime, role)
-    response["research"] = {
-        "enabled": True,
-        "records": pointers,
-        "fetch": "/api/knowledge/record/{id}",
-    }
+    try:
+        if not reg.is_enabled():
+            return
+        runtime = reg.load_runtime_safe()
+        if runtime is None:
+            return
+        pointers, _dropped = reg.select_cold_start_pointers(runtime, role)
+        response["research"] = {"enabled": True, "records": pointers}
+    except Exception:
+        logger.warning(
+            "orient: cold-start research selector failed unexpectedly for role %r; omitting research section",
+            role,
+            exc_info=True,
+        )
+        response.pop("research", None)
 
 
 @app.get("/api/config")

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1359,6 +1359,115 @@ def _augment_prompt_with_worktree(prompt: str, worktree_path: Path | None) -> st
     )
 
 
+class ResearchContextError(ValueError):
+    """A --research-* flag violated a request-side bound (mirrors the API 422s)."""
+
+
+def _build_research_context(args: argparse.Namespace):
+    """Return a normalized research ``Context`` from the explicit --research-* flags.
+
+    Returns ``None`` when no flag was given (the no-flags path stays byte-identical
+    to a pre-P3 dispatch). Never infers a value from the prompt, agent, provider, or
+    branch — ADR-011 P3 requires explicit dimensions and fails closed on the rest.
+    Validates the same request-side caps the FastAPI query layer enforces so a
+    direct CLI caller cannot smuggle an oversize/over-count context past the API.
+    """
+    role = getattr(args, "research_role", None)
+    family = getattr(args, "research_task_family", None)
+    track = getattr(args, "research_track", None)
+    owned = getattr(args, "research_owned_path", None) or []
+    if not (role or family or track or owned):
+        return None
+
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+    from scripts.research import registry as reg
+
+    for label, value in (
+        ("--research-role", role),
+        ("--research-task-family", family),
+        ("--research-track", track),
+    ):
+        if value is not None and len(value) > reg.MAX_QUERY_VALUE_LEN:
+            raise ResearchContextError(f"{label} value too long (max {reg.MAX_QUERY_VALUE_LEN} chars)")
+    if len(owned) > reg.MAX_OWNED_PATHS:
+        raise ResearchContextError(
+            f"too many --research-owned-path values ({len(owned)} > {reg.MAX_OWNED_PATHS})"
+        )
+    for path in owned:
+        if len(path) > reg.MAX_OWNED_PATH_LEN:
+            raise ResearchContextError(
+                f"--research-owned-path value too long (max {reg.MAX_OWNED_PATH_LEN} chars)"
+            )
+    return reg.normalize_context(role, family, track, owned)
+
+
+def _render_research_prompt_block(pointers: list[dict[str, Any]]) -> str:
+    """Render the bounded, POINTER-ONLY research block appended to a delegated prompt.
+
+    Never contains a digest body/summary/source — only ids, states, and content
+    hashes plus the on-demand fetch instruction. The pointer set is already capped
+    (top-5 / ≤1.5 KB) by the selector.
+    """
+    lines = [
+        "",
+        "[project research pointers — ADR-011 P3]",
+        "These research-registry records match this task's context. Bodies are NOT",
+        "included; fetch one on demand only if you need it:",
+        "  GET /api/knowledge/record/{id}?task={your-task-id}",
+    ]
+    for ptr in pointers:
+        lines.append(f"- {ptr['id']} [{ptr['state']}] content_hash={ptr['content_hash']}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _resolve_research_injection(ctx, task_id: str) -> tuple[str, dict[str, Any] | None]:
+    """Fail-open pointer resolution for a dispatch context.
+
+    Returns ``(prompt_block, persist_state)``. ``persist_state`` records ONLY the
+    pointer ids, filtered projection ETag, dropped ids, and a context fingerprint —
+    never raw owned paths, digest/source/prompt text, role, or task family. Any
+    disabled/malformed/unexpected registry condition degrades to ``("", None)`` so a
+    dispatch is never blocked by the research surface. Emits one surface (not
+    consumption) telemetry event per injected pointer, attributed to ``task_id``.
+    """
+    if str(_REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(_REPO_ROOT))
+    from scripts.research import consumption
+    from scripts.research import registry as reg
+
+    try:
+        if not reg.is_enabled(root=_REPO_ROOT):
+            return "", None
+        runtime = reg.load_runtime_safe(root=_REPO_ROOT)
+        if runtime is None:
+            return "", None
+        pointers, dropped = reg.select_pointers(runtime, ctx)
+        etag = reg.filtered_manifest(runtime, ctx).etag_hex
+        persist_state = {
+            "pointer_ids": [ptr["id"] for ptr in pointers],
+            "filtered_etag": etag,
+            "dropped_ids": list(dropped),
+            "context_fingerprint": reg.context_fingerprint(ctx),
+        }
+        if not pointers:
+            return "", persist_state
+        for ptr in pointers:
+            consumption.emit_surface(
+                research_id=ptr["id"],
+                surface=consumption.SURFACE_DISPATCH,
+                task_id=task_id,
+            )
+        return _render_research_prompt_block(pointers), persist_state
+    except Exception as exc:  # fail-open: research never blocks a dispatch
+        print(
+            f"[delegate] WARNING: research pointer injection skipped: {type(exc).__name__}",
+            file=sys.stderr,
+        )
+        return "", None
+
+
 # ---------------------------------------------------------------------------
 # Worker entrypoint — runs inside the detached subprocess
 # ---------------------------------------------------------------------------
@@ -1835,6 +1944,15 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         print("❌ --prompt or --prompt-file is required", file=sys.stderr)
         return 2
 
+    # ADR-011 P3 research context — explicit --research-* flags only. Validate the
+    # request-side caps up front (fail fast, before any worktree side effect) so a
+    # direct CLI caller is bounded exactly like the API query layer.
+    try:
+        research_ctx = _build_research_context(args)
+    except ResearchContextError as exc:
+        print(f"❌ {exc}", file=sys.stderr)
+        return 2
+
     if str(_REPO_ROOT) not in sys.path:
         sys.path.insert(0, str(_REPO_ROOT))
     from scripts.ai_agent_bridge.routing_guard import (
@@ -1927,6 +2045,16 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
 
     cwd = str(worktree_path or (Path(args.cwd) if args.cwd else _REPO_ROOT))
     prompt = _augment_prompt_with_worktree(prompt, worktree_path)
+
+    # POINTERS ONLY: inject bounded research pointers + an on-demand fetch
+    # instruction (never digest bodies) when an explicit context was supplied and
+    # the registry is enabled. Fail-open — a disabled/malformed registry leaves the
+    # prompt and state untouched.
+    research_state: dict[str, Any] | None = None
+    if research_ctx is not None:
+        research_block, research_state = _resolve_research_injection(research_ctx, task_id)
+        prompt = prompt + research_block
+
     start_telemetry = resolve_dispatch_start_telemetry(
         agent_name=dispatch_agent,
         requested_model=args.model,
@@ -1970,6 +2098,10 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "returncode": None,
         "returncode_reason": None,
         "substitution": None,
+        # ADR-011 P3: pointer ids / filtered ETag / dropped ids / context
+        # fingerprint only — never raw owned paths, digest/source/prompt text,
+        # role, or task family. ``None`` when no --research-* context was given.
+        "research": research_state,
     }
     _write_state_atomic(state_path, initial_state)
 
@@ -2775,6 +2907,39 @@ def build_parser() -> argparse.ArgumentParser:
             "Optional Claude Code dollar cap for this dispatch. Only Claude "
             "translates this to a CLI flag; non-Claude adapters warn and "
             "ignore it. Omit to run uncapped."
+        ),
+    )
+    d.add_argument(
+        "--research-role",
+        default=None,
+        metavar="ROLE",
+        help=(
+            "ADR-011 P3 research context: the task's single role (e.g. quality). "
+            "Explicit only — never inferred from the prompt, agent, provider, or "
+            "branch. Combined with the other --research-* flags, injects bounded, "
+            "pointer-only research pointers (bodies fetched on demand)."
+        ),
+    )
+    d.add_argument(
+        "--research-task-family",
+        default=None,
+        metavar="FAMILY",
+        help="ADR-011 P3 research context: the task's single task family (e.g. difficulty-gate).",
+    )
+    d.add_argument(
+        "--research-track",
+        default=None,
+        metavar="TRACK",
+        help="ADR-011 P3 research context: the task's single track (e.g. core).",
+    )
+    d.add_argument(
+        "--research-owned-path",
+        action="append",
+        default=None,
+        metavar="GLOB",
+        help=(
+            "ADR-011 P3 research context: an owned/changed path for the task. "
+            "Repeatable. Matched against each record's owned_paths globs."
         ),
     )
     d.set_defaults(func=cmd_dispatch)

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -1422,6 +1422,22 @@ def _render_research_prompt_block(pointers: list[dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
+def _with_optional_research_state(
+    state: dict[str, Any], research_state: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Add ``"research"`` to ``state`` only when ``research_state`` is non-``None``.
+
+    ADR-011 P3 default-compatibility: a no-flags dispatch, a disabled registry, or
+    a degraded/failed injection must persist byte-identical pre-P3 state — the key
+    is OMITTED, never present as ``"research": null``. Pointer ids / filtered ETag
+    / dropped ids / context fingerprint only when present — never raw owned paths,
+    digest/source/prompt text, role, or task family.
+    """
+    if research_state is not None:
+        state["research"] = research_state
+    return state
+
+
 def _resolve_research_injection(ctx, task_id: str) -> tuple[str, dict[str, Any] | None]:
     """Fail-open pointer resolution for a dispatch context.
 
@@ -2098,11 +2114,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "returncode": None,
         "returncode_reason": None,
         "substitution": None,
-        # ADR-011 P3: pointer ids / filtered ETag / dropped ids / context
-        # fingerprint only — never raw owned paths, digest/source/prompt text,
-        # role, or task family. ``None`` when no --research-* context was given.
-        "research": research_state,
     }
+    initial_state = _with_optional_research_state(initial_state, research_state)
     _write_state_atomic(state_path, initial_state)
 
     # Fix 5 (#1476 AC 5) — dispatch-start telemetry.

--- a/scripts/research/consumption.py
+++ b/scripts/research/consumption.py
@@ -1,0 +1,154 @@
+"""ADR-011 P3 — privacy-safe research consumption + surfacing telemetry.
+
+Two distinct signals, both routed through the *existing* central JSONL emitter
+(``scripts/telemetry/emit.py``) — this module creates no new event store and no
+new task store:
+
+* **Surfacing** (``research_pointer_surfaced``): a bounded pointer was injected
+  into a task/prompt/cold-start context. It says "the agent was *shown* this id".
+* **Consumption** (``research_record_consumed``): the agent actually fetched a
+  record body on demand (``/api/knowledge/record/{id}`` → 200 or a cache-backed
+  304) *and* the request carried a validated, still-active task id. It says "the
+  agent *used* this id". Surfaced ≠ consumed.
+
+Task correlation is validated **conservatively** and fails closed. An invalid,
+missing, finished, or unknown task never raises, never changes the HTTP response
+(the caller serves per its own API policy regardless), and never reveals whether
+a task exists — it simply produces no consumption event. The task store reused is
+the delegate task store as read by ``scripts.api.delegate_router`` (imported
+lazily so non-API callers that only emit surface events pay nothing).
+
+Payload allowlist (ADR-011 P3 privacy contract): exactly
+``{task_id, research_id, surface, status}`` on top of the emitter's required
+envelope. Never a digest body, title, summary, source URL, prompt, role,
+task family, track, owned paths, or context fingerprint.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+try:  # package-path tolerant, mirrors emit.py's own import guard
+    from scripts.telemetry.emit import emit_event
+except ImportError:  # pragma: no cover - alternate import path
+    from telemetry.emit import emit_event
+
+# Event types (stable strings; consumers key on these).
+CONSUMED_EVENT = "research_record_consumed"
+SURFACED_EVENT = "research_pointer_surfaced"
+
+# The only surfaces P3 distinguishes. "record" is reserved for consumption.
+SURFACE_COLD_START = "cold_start"
+SURFACE_DISPATCH = "dispatch"
+_CONSUMED_SURFACE = "record"
+
+# Task-id validation: bounded length + a conservative safe shape. Slugs, agent
+# prefixes, and dashed ids pass; traversal (``..``), whitespace, and control
+# characters do not. The exact stored-id match below is the real authority — this
+# only bounds work and rejects obviously hostile input before any file lookup.
+MAX_TASK_ID_LEN = 128
+_TASK_ID_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9._/-]{0,126}[A-Za-z0-9])?$")
+
+# Only these derived states count as an active, attributable task. "spawning" and
+# "running" are live; "zombie" (running status with a dead pid), "done", and every
+# terminal state are rejected so a finished task cannot be spoofed for attribution.
+_ACTIVE_STATES = frozenset({"spawning", "running"})
+
+
+def _looks_like_task_id(task_id: str) -> bool:
+    if not isinstance(task_id, str):
+        return False
+    if len(task_id) > MAX_TASK_ID_LEN:
+        return False
+    if ".." in task_id:
+        return False
+    return _TASK_ID_RE.fullmatch(task_id) is not None
+
+
+def validate_active_task(task_id: str | None) -> str | None:
+    """Return the task id iff it names a real, still-active delegate task.
+
+    Fails closed to ``None`` for: absent/blank id, oversize/malformed id, an id
+    whose sanitized state file is missing or corrupt, a stored ``task_id`` that
+    does not match the request byte-for-byte (defeats collisions and path games),
+    or a task not in an active spawning/running state (defeats finished-task
+    spoofing). Never raises and never distinguishes "no such task" from "inactive
+    task" to the caller — both simply return ``None``.
+    """
+    if not task_id or not _looks_like_task_id(task_id):
+        return None
+    try:
+        # Lazy import: only the API record endpoint validates tasks; surface-only
+        # emitters (delegate) never pull the API package in.
+        from scripts.api.delegate_router import (
+            _derived_task_status,
+            _read_task_state,
+            _task_state_path,
+        )
+
+        state = _read_task_state(_task_state_path(task_id))
+        if not isinstance(state, dict):
+            return None
+        if state.get("task_id") != task_id:
+            return None
+        derived_status, _alive = _derived_task_status(state)
+        if derived_status not in _ACTIVE_STATES:
+            return None
+    except Exception:
+        # Attribution is best-effort observability: any unexpected failure means
+        # "no consumption event", never a broken record fetch.
+        return None
+    return task_id
+
+
+def _allowlisted(payload: dict[str, Any]) -> dict[str, Any]:
+    allowed = {"task_id", "research_id", "surface", "status"}
+    return {key: value for key, value in payload.items() if key in allowed and value is not None}
+
+
+def emit_consumption(*, task_id: str, research_id: str, status: int) -> None:
+    """Emit one consumption event for a validated active task. Best-effort."""
+    emit_event(
+        CONSUMED_EVENT,
+        _allowlisted(
+            {
+                "task_id": task_id,
+                "research_id": research_id,
+                "surface": _CONSUMED_SURFACE,
+                "status": status,
+            }
+        ),
+    )
+
+
+def record_consumption(task_id: str | None, research_id: str, *, status: int) -> str | None:
+    """Validate ``task_id`` then emit a consumption event; return the attributed id.
+
+    The one call site the record endpoint needs: it validates, emits on success,
+    and reports back the attributed task id (or ``None``) purely for logging/tests
+    — the HTTP response must not branch on it.
+    """
+    attributed = validate_active_task(task_id)
+    if attributed is not None:
+        emit_consumption(task_id=attributed, research_id=research_id, status=status)
+    return attributed
+
+
+def emit_surface(*, research_id: str, surface: str, task_id: str | None = None) -> None:
+    """Emit one pointer-surfaced event (distinct from consumption). Best-effort.
+
+    Surfacing does not require an active-task check — it records that a pointer was
+    shown, not used. ``task_id`` is included only when the surface knows it
+    (dispatch does; cold start does not).
+    """
+    emit_event(
+        SURFACED_EVENT,
+        _allowlisted(
+            {
+                "task_id": task_id,
+                "research_id": research_id,
+                "surface": surface,
+            }
+        ),
+    )

--- a/scripts/research/consumption.py
+++ b/scripts/research/consumption.py
@@ -15,8 +15,17 @@ Task correlation is validated **conservatively** and fails closed. An invalid,
 missing, finished, or unknown task never raises, never changes the HTTP response
 (the caller serves per its own API policy regardless), and never reveals whether
 a task exists — it simply produces no consumption event. The task store reused is
-the delegate task store as read by ``scripts.api.delegate_router`` (imported
-lazily so non-API callers that only emit surface events pay nothing).
+the delegate task store as read/written by ``scripts.api.delegate_router`` (imported
+lazily so non-API callers that only emit surface events pay nothing) — no third
+store is created.
+
+A public ``content_hash``/ETag alone is not proof of consumption: a caller who
+merely *saw* a pointer (via ``/api/knowledge/manifest`` or the cold-start
+projection) already knows the record's ETag and could replay it as
+``If-None-Match`` to manufacture a `304` without ever fetching the body. A `200`
+therefore persists minimal evidence (``{research_id: etag}``) into the same
+validated task's state file; a `304` only counts as consumption when that
+evidence already shows a matching prior `200` for the same record.
 
 Payload allowlist (ADR-011 P3 privacy contract): exactly
 ``{task_id, research_id, surface, status}`` on top of the emitter's required
@@ -26,6 +35,8 @@ task family, track, owned paths, or context fingerprint.
 
 from __future__ import annotations
 
+import json
+import os
 import re
 from typing import Any
 
@@ -38,8 +49,12 @@ except ImportError:  # pragma: no cover - alternate import path
 CONSUMED_EVENT = "research_record_consumed"
 SURFACED_EVENT = "research_pointer_surfaced"
 
-# The only surfaces P3 distinguishes. "record" is reserved for consumption.
-SURFACE_COLD_START = "cold_start"
+# Task-attributed surfacing begins at dispatch, where a real task_id exists.
+# Cold-start orient (``GET /api/orient?role=``) has no task in flight yet — there
+# is nothing trustworthy to attribute a surface event to — so it never calls
+# ``emit_surface``; only the dispatch path does. If a future surface gains a real
+# task correlation, add its constant here rather than fabricating one now.
+# "record" is reserved for consumption.
 SURFACE_DISPATCH = "dispatch"
 _CONSUMED_SURFACE = "record"
 
@@ -72,9 +87,12 @@ def validate_active_task(task_id: str | None) -> str | None:
     Fails closed to ``None`` for: absent/blank id, oversize/malformed id, an id
     whose sanitized state file is missing or corrupt, a stored ``task_id`` that
     does not match the request byte-for-byte (defeats collisions and path games),
-    or a task not in an active spawning/running state (defeats finished-task
-    spoofing). Never raises and never distinguishes "no such task" from "inactive
-    task" to the caller — both simply return ``None``.
+    a task not in an active spawning/running state (defeats finished-task
+    spoofing), or a spawning/running task with no live PID (defeats a state file
+    that never got a real worker attached — the parent writes the Popen PID into
+    the state file immediately after spawn, so a genuinely active task always has
+    one; see ``_derived_task_status``). Never raises and never distinguishes "no
+    such task" from "inactive task" to the caller — both simply return ``None``.
     """
     if not task_id or not _looks_like_task_id(task_id):
         return None
@@ -92,8 +110,8 @@ def validate_active_task(task_id: str | None) -> str | None:
             return None
         if state.get("task_id") != task_id:
             return None
-        derived_status, _alive = _derived_task_status(state)
-        if derived_status not in _ACTIVE_STATES:
+        derived_status, alive = _derived_task_status(state)
+        if derived_status not in _ACTIVE_STATES or not alive:
             return None
     except Exception:
         # Attribution is best-effort observability: any unexpected failure means
@@ -122,17 +140,79 @@ def emit_consumption(*, task_id: str, research_id: str, status: int) -> None:
     )
 
 
-def record_consumption(task_id: str | None, research_id: str, *, status: int) -> str | None:
+_EVIDENCE_FIELD = "research_consumption_evidence"
+
+
+def _persist_200_evidence(task_id: str, research_id: str, etag: str) -> None:
+    """Record ``{research_id: etag}`` in the task's own state file (best-effort).
+
+    Reuses the existing delegate task-state JSON — no third store — via the same
+    write-rename atomic pattern ``delegate.py`` already uses for that file. Never
+    raises: a lost write under a concurrent worker update just means a later `304`
+    for this record isn't attributable, which is the safe (fail-closed) direction.
+    """
+    try:
+        from scripts.api.delegate_router import _read_task_state, _task_state_path
+
+        path = _task_state_path(task_id)
+        state = _read_task_state(path)
+        if not isinstance(state, dict):
+            return
+        evidence = state.get(_EVIDENCE_FIELD)
+        if not isinstance(evidence, dict):
+            evidence = {}
+        evidence[research_id] = etag
+        state[_EVIDENCE_FIELD] = evidence
+        tmp = path.with_suffix(f".json.tmp.{os.getpid()}")
+        tmp.write_text(json.dumps(state, indent=2, default=str))
+        os.replace(tmp, path)
+    except Exception:
+        pass
+
+
+def _has_prior_200_evidence(task_id: str, research_id: str, etag: str) -> bool:
+    """True iff this task's state already records a matching prior `200` fetch."""
+    try:
+        from scripts.api.delegate_router import _read_task_state, _task_state_path
+
+        state = _read_task_state(_task_state_path(task_id))
+        if not isinstance(state, dict):
+            return False
+        evidence = state.get(_EVIDENCE_FIELD)
+        if not isinstance(evidence, dict):
+            return False
+        return evidence.get(research_id) == etag
+    except Exception:
+        return False
+
+
+def record_consumption(task_id: str | None, research_id: str, *, status: int, etag: str) -> str | None:
     """Validate ``task_id`` then emit a consumption event; return the attributed id.
 
     The one call site the record endpoint needs: it validates, emits on success,
     and reports back the attributed task id (or ``None``) purely for logging/tests
-    — the HTTP response must not branch on it.
+    — the HTTP response must not branch on it and is computed before this call.
+
+    A `200` always counts (the caller demonstrably received the body) and persists
+    ``etag`` as evidence for this task/record. A `304` only counts when this same
+    task already has matching `200` evidence for ``research_id`` — otherwise a
+    caller could replay the record's publicly-visible ``content_hash`` as
+    ``If-None-Match`` and manufacture a consumption event without ever fetching the
+    body ("manufactured 304").
     """
     attributed = validate_active_task(task_id)
-    if attributed is not None:
-        emit_consumption(task_id=attributed, research_id=research_id, status=status)
-    return attributed
+    if attributed is None:
+        return None
+    if status == 200:
+        emit_consumption(task_id=attributed, research_id=research_id, status=200)
+        _persist_200_evidence(attributed, research_id, etag)
+        return attributed
+    if status == 304:
+        if not _has_prior_200_evidence(attributed, research_id, etag):
+            return None
+        emit_consumption(task_id=attributed, research_id=research_id, status=304)
+        return attributed
+    return None
 
 
 def emit_surface(*, research_id: str, surface: str, task_id: str | None = None) -> None:

--- a/scripts/research/registry.py
+++ b/scripts/research/registry.py
@@ -404,19 +404,16 @@ def pointer(record: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def select_pointers(runtime: RegistryRuntime, ctx: Context) -> tuple[list[dict[str, Any]], list[str]]:
-    """Return (pointers, dropped_ids). No context → zero records (never "show all").
+def _apply_caps(matched: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[str]]:
+    """The single deterministic cap renderer shared by every pointer selector.
 
-    Deterministically sorted by record id, capped at ``MAX_FILTERED_RECORDS`` and
-    ``MAX_FILTERED_BYTES`` measured on the exact serialized response. Every dropped
-    id is logged — never a silent truncation.
+    Takes an already-sorted list of matched records; returns (pointers, dropped_ids)
+    honouring ``MAX_FILTERED_RECORDS`` (top-N) then ``MAX_FILTERED_BYTES`` (measured
+    on the exact serialized response). Both the dispatch AND matcher and the
+    role-only cold-start announcer route through here so the two surfaces cannot
+    drift apart on cap semantics. Logging the drop is the caller's job so the log
+    line names which surface truncated.
     """
-    if ctx.is_empty():
-        return [], []
-    matched = sorted(
-        (rec for rec in runtime.valid_records if matches(rec.get("routing") or {}, ctx)),
-        key=lambda rec: rec["id"],
-    )
     dropped: list[str] = []
     if len(matched) > MAX_FILTERED_RECORDS:
         dropped.extend(rec["id"] for rec in matched[MAX_FILTERED_RECORDS:])
@@ -425,12 +422,77 @@ def select_pointers(runtime: RegistryRuntime, ctx: Context) -> tuple[list[dict[s
     while pointers and len(canonical_json_bytes(_manifest_payload(pointers))) > MAX_FILTERED_BYTES:
         dropped.append(pointers[-1]["id"])
         pointers = pointers[:-1]
+    return pointers, dropped
+
+
+def select_pointers(runtime: RegistryRuntime, ctx: Context) -> tuple[list[dict[str, Any]], list[str]]:
+    """Return (pointers, dropped_ids). No context → zero records (never "show all").
+
+    Deterministically sorted by record id, capped via the shared
+    :func:`_apply_caps` renderer. Every dropped id is logged — never a silent
+    truncation.
+    """
+    if ctx.is_empty():
+        return [], []
+    matched = sorted(
+        (rec for rec in runtime.valid_records if matches(rec.get("routing") or {}, ctx)),
+        key=lambda rec: rec["id"],
+    )
+    pointers, dropped = _apply_caps(matched)
     if dropped:
         logger.warning(
             "research registry: knowledge manifest dropped record id(s) over budget: %s",
             ", ".join(dropped),
         )
     return pointers, dropped
+
+
+def select_cold_start_pointers(
+    runtime: RegistryRuntime, role: str | None
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Return (pointers, dropped_ids) for the role-only cold-start announcer.
+
+    ADR-011 §"Cold-start algebra (role only)": cold start has no task family,
+    track, or owned paths, so it MUST NOT run the full AND matcher (which would
+    fail closed on the missing dimensions anyway). It uses **only** the opt-in
+    top-level ``cold_start_roles`` allow-list: a record announces a pointer to a
+    role solely when it lists that role. A missing/blank role, or a role no record
+    opts into, yields zero pointers. Bodies are never announced — pointers only.
+    Shares the exact deterministic cap renderer with :func:`select_pointers`.
+    """
+    role = (role or "").strip()
+    if not role:
+        return [], []
+    matched = sorted(
+        (rec for rec in runtime.valid_records if role in (rec.get("cold_start_roles") or [])),
+        key=lambda rec: rec["id"],
+    )
+    pointers, dropped = _apply_caps(matched)
+    if dropped:
+        logger.warning(
+            "research registry: cold-start pointers dropped record id(s) over budget for role %r: %s",
+            role,
+            ", ".join(dropped),
+        )
+    return pointers, dropped
+
+
+def context_fingerprint(ctx: Context) -> str:
+    """A stable, opaque digest of a normalized context for cache keys / persistence.
+
+    Hashes the canonical ``{role, task_family, track, owned_paths}`` projection so
+    two byte-identical contexts share a fingerprint and two different ones do not.
+    Because only the digest is ever persisted or used as a cache-key component, the
+    raw owned paths never leave the caller — ADR-011 P3 forbids persisting or
+    keying on raw paths, role, or task text.
+    """
+    payload = {
+        "role": ctx.role,
+        "task_family": ctx.task_family,
+        "track": ctx.track,
+        "owned_paths": list(ctx.owned_paths),
+    }
+    return sha256(canonical_json_bytes(payload)).hexdigest()
 
 
 def _manifest_payload(pointers: list[dict[str, Any]]) -> dict[str, Any]:

--- a/scripts/research/registry.py
+++ b/scripts/research/registry.py
@@ -513,6 +513,18 @@ def filtered_manifest(runtime: RegistryRuntime, ctx: Context) -> ManifestRespons
     return ManifestResponse(body=body, etag_hex=sha256(body).hexdigest(), dropped=tuple(dropped))
 
 
+def filtered_cold_start(runtime: RegistryRuntime, role: str | None) -> ManifestResponse:
+    """Build the exact response bytes + strong ETag for the role-only cold-start
+    pointer projection (:func:`select_cold_start_pointers` — ``cold_start_roles``
+    only, never the AND matcher). Mirrors :func:`filtered_manifest`'s shape and cap
+    semantics so the two surfaces stay byte-comparable, but routes through the
+    role-only selector so a record that only opts in via ``cold_start_roles`` (and
+    not ``routing.roles``/``task_families``/...) still announces at cold start."""
+    pointers, dropped = select_cold_start_pointers(runtime, role)
+    body = canonical_json_bytes(_manifest_payload(pointers))
+    return ManifestResponse(body=body, etag_hex=sha256(body).hexdigest(), dropped=tuple(dropped))
+
+
 def disabled_manifest_bytes() -> bytes:
     """The deterministic disabled projection ``{"enabled":false,"records":[]}``."""
     return canonical_json_bytes({"enabled": False, "records": []})

--- a/tests/test_research_registry_p3.py
+++ b/tests/test_research_registry_p3.py
@@ -18,6 +18,8 @@ proof.
 from __future__ import annotations
 
 import json
+import os
+import urllib.error
 from pathlib import Path
 from typing import Any
 
@@ -161,9 +163,49 @@ def test_orient_role_adds_pointer_only_research(reg_root):
     body = _orient({"role": "quality"}).json()
     assert body["research"]["enabled"] is True
     assert [p["id"] for p in body["research"]["records"]] == ["r1"]
-    assert body["research"]["fetch"] == "/api/knowledge/record/{id}"
+    # No top-level `fetch` field: it is redundant with the documented, well-known
+    # GET /api/knowledge/record/{id} and would push the envelope over budget.
+    assert "fetch" not in body["research"]
+    assert set(body["research"]) == {"enabled", "records"}
     for ptr in body["research"]["records"]:
         assert set(ptr) == {"id", "state", "content_hash", "routing"}
+
+
+def test_orient_research_envelope_fits_budget_without_fetch_field(reg_root):
+    # 5 records (P1's per-role cold_start_roles cap) each padded with routing
+    # metadata to push the pointer set close to the byte budget — proves the
+    # *final emitted* envelope (no extra top-level `fetch` appended after
+    # capping) still respects MAX_FILTERED_BYTES end to end.
+    records = [
+        _make_record(
+            reg_root,
+            f"cs-{i}",
+            cold_start_roles=["quality"],
+            routing={
+                "roles": ["quality"],
+                "task_families": [f"family-{i}-{j}" for j in range(6)],
+                "owned_paths": [f"scripts/pkg-{i}/module-{j}/**" for j in range(6)],
+            },
+        )
+        for i in range(5)
+    ]
+    _write_registry(reg_root, records)
+    research = _orient({"role": "quality"}).json()["research"]
+    assert "fetch" not in research
+    envelope_bytes = len(json.dumps(research, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+    assert envelope_bytes <= reg.MAX_FILTERED_BYTES
+
+
+def test_orient_fail_open_when_cold_start_selector_raises(reg_root, monkeypatch):
+    _write_registry(reg_root, [_make_record(reg_root, "r1", cold_start_roles=["quality"])])
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(reg, "select_cold_start_pointers", _boom)
+    resp = _orient({"role": "quality"})
+    assert resp.status_code == 200
+    assert "research" not in resp.json()
 
 
 def test_orient_roles_do_not_share_cache(reg_root):
@@ -196,6 +238,51 @@ def test_orient_role_never_calls_record_endpoint_body(reg_root):
 
 
 # --------------------------------------------------------------------------- #
+# 2b. /api/knowledge/cold-start: dedicated role-only endpoint (never the AND
+#     matcher) — the bootstrap routing-algebra bug reproduced against the HTTP
+#     surface, not just the pure selector.
+# --------------------------------------------------------------------------- #
+def test_cold_start_endpoint_uses_cold_start_roles_not_routing(reg_root):
+    # routing.roles-only, no cold_start_roles → must NOT announce.
+    routed_only = _make_record(reg_root, "routed-only", routing={"roles": ["quality"]}, cold_start_roles=[])
+    # cold_start_roles=["quality"] but routing requires a task_family the
+    # role-only request can never supply → must STILL announce (cold start is
+    # role-only algebra, never the AND matcher).
+    announced = _make_record(
+        reg_root,
+        "announced",
+        routing={"roles": ["pedagogy"], "task_families": ["difficulty-gate"]},
+        cold_start_roles=["quality"],
+    )
+    _write_registry(reg_root, [routed_only, announced])
+    resp = client.get("/api/knowledge/cold-start", params={"role": "quality"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is True
+    assert [r["id"] for r in body["records"]] == ["announced"]
+
+
+def test_cold_start_endpoint_disabled_and_missing_role(tmp_path, monkeypatch):
+    monkeypatch.setattr(reg, "_ROOT_OVERRIDE", tmp_path)
+    monkeypatch.setenv(reg.ENV_FLAG, "false")
+    _write_registry(tmp_path, [_make_record(tmp_path, "r1", cold_start_roles=["quality"])])
+    assert client.get("/api/knowledge/cold-start", params={"role": "quality"}).json() == {
+        "enabled": False,
+        "records": [],
+    }
+
+
+def test_cold_start_endpoint_etag_304(reg_root):
+    _write_registry(reg_root, [_make_record(reg_root, "r1", cold_start_roles=["quality"])])
+    first = client.get("/api/knowledge/cold-start", params={"role": "quality"})
+    etag = first.headers["ETag"]
+    second = client.get(
+        "/api/knowledge/cold-start", params={"role": "quality"}, headers={"If-None-Match": etag}
+    )
+    assert second.status_code == 304
+
+
+# --------------------------------------------------------------------------- #
 # 3. Consumption telemetry: attribution vs surfacing, allowlist, validation
 # --------------------------------------------------------------------------- #
 @pytest.fixture
@@ -218,23 +305,42 @@ def task_store(tmp_path, monkeypatch):
 
 def test_valid_active_task_emits_consumption_on_200(reg_root, emit_sink, task_store):
     _write_registry(reg_root, [_make_record(reg_root, "r1")])
-    task_store("job-1", status="spawning")
+    task_store("job-1", status="spawning", pid=os.getpid())
     resp = client.get("/api/knowledge/record/r1", params={"task": "job-1"})
     assert resp.status_code == 200
     consumed = [p for t, p in emit_sink if t == consumption.CONSUMED_EVENT]
     assert consumed == [{"task_id": "job-1", "research_id": "r1", "surface": "record", "status": 200}]
 
 
-def test_cache_backed_304_emits_consumption(reg_root, emit_sink, task_store):
+def test_cache_backed_304_emits_consumption_after_prior_200(reg_root, emit_sink, task_store):
+    # ADR-011 P3: a 304 only counts as consumption when this task already has
+    # evidence of a matching prior 200 for this exact record.
     _write_registry(reg_root, [_make_record(reg_root, "r1")])
-    task_store("job-1")
-    etag = client.get("/api/knowledge/record/r1").headers["ETag"]
+    task_store("job-1", pid=os.getpid())
+    first = client.get("/api/knowledge/record/r1", params={"task": "job-1"})
+    etag = first.headers["ETag"]
     resp = client.get(
         "/api/knowledge/record/r1", params={"task": "job-1"}, headers={"If-None-Match": etag}
     )
     assert resp.status_code == 304
     consumed = [p for t, p in emit_sink if t == consumption.CONSUMED_EVENT]
-    assert consumed[0]["status"] == 304
+    assert [c["status"] for c in consumed] == [200, 304]
+
+
+def test_manufactured_304_without_prior_fetch_emits_nothing(reg_root, emit_sink, task_store):
+    # A caller can learn a record's content_hash/ETag from the public filtered
+    # manifest/pointer projection WITHOUT ever fetching the body. Replaying that
+    # publicly-known ETag as If-None-Match under an active task must not
+    # manufacture a consumption event — there is no proof the task ever consumed
+    # the body. The HTTP response (304) is unaffected regardless of attribution.
+    _write_registry(reg_root, [_make_record(reg_root, "r1")])
+    task_store("job-1", pid=os.getpid())
+    etag = client.get("/api/knowledge/record/r1").headers["ETag"]  # unattributed fetch
+    resp = client.get(
+        "/api/knowledge/record/r1", params={"task": "job-1"}, headers={"If-None-Match": etag}
+    )
+    assert resp.status_code == 304
+    assert not [p for t, p in emit_sink if t == consumption.CONSUMED_EVENT]
 
 
 def test_no_task_no_consumption_but_still_serves(reg_root, emit_sink, task_store):
@@ -246,7 +352,7 @@ def test_no_task_no_consumption_but_still_serves(reg_root, emit_sink, task_store
 
 def test_404_is_never_consumption(reg_root, emit_sink, task_store):
     _write_registry(reg_root, [_make_record(reg_root, "r1")])
-    task_store("job-1")
+    task_store("job-1", pid=os.getpid())
     resp = client.get("/api/knowledge/record/does-not-exist", params={"task": "job-1"})
     assert resp.status_code == 404
     assert not [p for t, p in emit_sink if t == consumption.CONSUMED_EVENT]
@@ -254,7 +360,7 @@ def test_404_is_never_consumption(reg_root, emit_sink, task_store):
 
 def test_response_invariant_to_task_validity(reg_root, task_store):
     _write_registry(reg_root, [_make_record(reg_root, "r1")])
-    task_store("live", status="running", pid=1)  # pid=1 always alive
+    task_store("live", status="running", pid=os.getpid())
     valid = client.get("/api/knowledge/record/r1", params={"task": "live"})
     invalid = client.get("/api/knowledge/record/r1", params={"task": "ghost"})
     assert valid.status_code == invalid.status_code == 200
@@ -269,6 +375,8 @@ def test_response_invariant_to_task_validity(reg_root, task_store):
         ("finished", "done", None),  # finished-task spoof
         ("zombie", "running", 999999),  # running status, dead pid → zombie
         ("a" * 129, "spawning", None),  # oversize
+        ("half-spawned", "spawning", None),  # spawning with no PID yet → no attribution
+        ("half-spawned-dead", "spawning", 999999),  # spawning with a dead PID
     ],
 )
 def test_invalid_or_inactive_task_no_consumption(reg_root, emit_sink, task_store, task_id, status, pid):
@@ -280,6 +388,24 @@ def test_invalid_or_inactive_task_no_consumption(reg_root, emit_sink, task_store
     assert not [p for t, p in emit_sink if t == consumption.CONSUMED_EVENT]
 
 
+def test_validate_active_task_requires_live_pid(task_store):
+    # ADR-011 P3: spawning AND running both require a live PID (mirrors the
+    # existing delegate zombie-detection semantics for "running", extended to
+    # "spawning" — the parent writes the real Popen PID into the state file
+    # immediately after spawn, so a genuinely active task always has one).
+    task_store("alive", status="running", pid=os.getpid())
+    assert consumption.validate_active_task("alive") == "alive"
+
+    task_store("spawning-alive", status="spawning", pid=os.getpid())
+    assert consumption.validate_active_task("spawning-alive") == "spawning-alive"
+
+    task_store("spawning-no-pid", status="spawning", pid=None)
+    assert consumption.validate_active_task("spawning-no-pid") is None
+
+    task_store("spawning-dead-pid", status="spawning", pid=999999)
+    assert consumption.validate_active_task("spawning-dead-pid") is None
+
+
 def test_task_id_collision_requires_exact_stored_match(reg_root, emit_sink, task_store):
     # A state file exists at a sanitized path, but its stored task_id differs from
     # the request → no attribution (defeats collisions via path sanitization).
@@ -287,7 +413,7 @@ def test_task_id_collision_requires_exact_stored_match(reg_root, emit_sink, task
     from scripts.api import delegate_router
 
     (delegate_router.TASKS_DIR / "collide.json").write_text(
-        json.dumps({"task_id": "other-id", "status": "running", "pid": 1}), "utf-8"
+        json.dumps({"task_id": "other-id", "status": "running", "pid": os.getpid()}), "utf-8"
     )
     resp = client.get("/api/knowledge/record/r1", params={"task": "collide"})
     assert resp.status_code == 200
@@ -303,7 +429,7 @@ def test_surface_event_is_distinct_from_consumption(emit_sink):
 
 def test_telemetry_payloads_carry_no_forbidden_fields(emit_sink):
     consumption.emit_consumption(task_id="job-1", research_id="r1", status=200)
-    consumption.emit_surface(research_id="r1", surface=consumption.SURFACE_COLD_START)
+    consumption.emit_surface(research_id="r1", surface=consumption.SURFACE_DISPATCH, task_id="job-1")
     forbidden = {"body", "title", "summary", "source", "source_url", "prompt", "role",
                  "task_family", "track", "owned_paths", "context", "context_fingerprint"}
     for _t, payload in emit_sink:
@@ -311,31 +437,60 @@ def test_telemetry_payloads_carry_no_forbidden_fields(emit_sink):
         assert not (set(payload) & forbidden)
 
 
+def test_surface_cold_start_constant_was_removed_not_fabricated():
+    # ADR-011 P3: cold-start orient has no trustworthy task id to attribute a
+    # surface event to, and never calls emit_surface. The old unused
+    # SURFACE_COLD_START constant implied telemetry that doesn't exist —
+    # removed rather than left dangling. Task-attributed surfacing begins at
+    # dispatch (SURFACE_DISPATCH), which IS wired to a real task id.
+    assert not hasattr(consumption, "SURFACE_COLD_START")
+    assert consumption.SURFACE_DISPATCH == "dispatch"
+
+
 # --------------------------------------------------------------------------- #
 # 4. Monitor client: filtered projection caching + bootstrap default compat
 # --------------------------------------------------------------------------- #
-def test_monitor_research_first_surfaces_then_304_reuses(tmp_path, monkeypatch):
+def test_monitor_research_first_all_then_304_empty_then_changed_only(tmp_path, monkeypatch):
+    # ADR-011 P3 changed-pointer semantics: the on-disk cache stores the complete
+    # latest projection, but research()/cold_start() return only added/changed
+    # pointers. [a, b] -> 304 (empty) -> only 'a' changes -> returns only 'a'.
     from scripts.ai_agent_bridge import monitor_client as mc
 
     monkeypatch.setenv("MONITOR_CACHE_DIR", str(tmp_path / "cache"))
     cli = mc.MonitorClient(base_url="http://test")
-    calls: list[dict[str, str]] = []
+
+    full_ab = (
+        '{"enabled":true,"records":['
+        '{"id":"a","state":"active","content_hash":"sha256:aa","routing":{}},'
+        '{"id":"b","state":"active","content_hash":"sha256:bb","routing":{}}]}'
+    )
+    a_changed = (
+        '{"enabled":true,"records":['
+        '{"id":"a","state":"active","content_hash":"sha256:ZZ","routing":{}},'
+        '{"id":"b","state":"active","content_hash":"sha256:bb","routing":{}}]}'
+    )
+    state = {"body": full_ab, "etag": "e1"}
 
     def _fake_get(path, *, headers=None):
-        calls.append(headers or {})
-        if headers and "If-None-Match" in headers:
-            return 304, "", {"etag": '"abc"'}
-        return 200, '{"enabled":true,"records":[{"id":"r1"}]}', {"etag": '"abc"'}
+        if headers and headers.get("If-None-Match") == f'"{state["etag"]}"':
+            return 304, "", {"etag": f'"{state["etag"]}"'}
+        return 200, state["body"], {"etag": f'"{state["etag"]}"'}
 
     monkeypatch.setattr(cli, "_get", _fake_get)
 
     first = cli.research(role="quality")
     assert first.source == "network"
-    assert "r1" in first.body
+    assert {r["id"] for r in json.loads(first.body)["records"]} == {"a", "b"}
+
     second = cli.research(role="quality")
     assert second.source == "not-modified"
-    assert second.body == first.body  # warm reuse, zero changed pointers
-    assert "If-None-Match" in calls[1]
+    assert json.loads(second.body) == {"enabled": True, "records": []}  # valid, empty
+
+    state["body"] = a_changed
+    state["etag"] = "e2"
+    third = cli.research(role="quality")
+    assert third.source == "network"
+    assert [r["id"] for r in json.loads(third.body)["records"]] == ["a"]  # only 'a', never 'b'
 
 
 def test_monitor_research_context_isolation_by_fingerprint(tmp_path, monkeypatch):
@@ -352,23 +507,135 @@ def test_monitor_research_context_isolation_by_fingerprint(tmp_path, monkeypatch
     c = cli.research(role="quality", owned_paths=["scripts/secret/path.py"])
     assert "scripts/secret/path.py" not in c.key
     assert cache.peek(c.key) is not None
+    # different consumer -> different key, even for the identical context
+    d = cli.research(role="quality", consumer="a-different-consumer")
+    assert d.key != a.key
 
 
-def test_bootstrap_default_is_exactly_rules_and_session(monkeypatch):
+def test_monitor_cache_key_never_embeds_raw_consumer_and_is_full_sha256(tmp_path, monkeypatch):
+    from scripts.ai_agent_bridge import monitor_client as mc
+
+    monkeypatch.setenv("MONITOR_CACHE_DIR", str(tmp_path / "cache"))
+    cli = mc.MonitorClient(base_url="http://test")
+    monkeypatch.setattr(cli, "_get", lambda path, headers=None: (200, '{"enabled":true,"records":[]}', {"etag": '"e"'}))
+
+    result = cli.research(role="quality", consumer="some-secret-consumer-name")
+    assert "some-secret-consumer-name" not in result.key
+    fingerprint = result.key.split("__", 1)[1]
+    assert len(fingerprint) == 64  # full sha256 hex, never the old 16-char truncation
+
+    # A 300-char consumer (over any reasonable bound) must not raise and must
+    # still be bounded before hashing, never embedded raw in the key.
+    long_consumer = "c" * 300
+    result2 = cli.research(role="quality", consumer=long_consumer)
+    assert long_consumer not in result2.key
+    assert len(result2.key.split("__", 1)[1]) == 64
+
+
+def test_monitor_research_fails_open_on_transport_urlerror(tmp_path, monkeypatch):
+    from scripts.ai_agent_bridge import monitor_client as mc
+
+    monkeypatch.setenv("MONITOR_CACHE_DIR", str(tmp_path / "cache"))
+    cli = mc.MonitorClient(base_url="http://test")
+
+    def _raise(path, *, headers=None):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(cli, "_get", _raise)
+    result = cli.research(role="quality")
+    assert result.source.startswith("error:")
+    assert result.body == ""
+
+
+def test_monitor_research_fails_open_on_cache_oserror(tmp_path, monkeypatch):
+    from scripts.ai_agent_bridge import _monitor_cache as cache
+    from scripts.ai_agent_bridge import monitor_client as mc
+
+    monkeypatch.setenv("MONITOR_CACHE_DIR", str(tmp_path / "cache"))
+    cli = mc.MonitorClient(base_url="http://test")
+    monkeypatch.setattr(cli, "_get", lambda path, headers=None: (200, '{"enabled":true,"records":[]}', {"etag": '"e"'}))
+
+    def _boom(_key):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(cache, "peek", _boom)
+    result = cli.research(role="quality")
+    assert result.source.startswith("error:")
+    assert result.body == ""
+
+
+def test_monitor_defensive_304_without_cache_degrades_safely(tmp_path, monkeypatch):
+    # Gemini review: the old "304 with no cached body -> re-fetch unconditionally"
+    # branch was unreachable (we only ever send If-None-Match when a cached
+    # snapshot exists, so the server has no ETag to 304 against otherwise).
+    # Removed in favor of an explicit, safe fallback for a rogue/buggy server.
+    from scripts.ai_agent_bridge import monitor_client as mc
+
+    monkeypatch.setenv("MONITOR_CACHE_DIR", str(tmp_path / "cache"))
+    cli = mc.MonitorClient(base_url="http://test")
+    monkeypatch.setattr(cli, "_get", lambda path, headers=None: (304, "", {}))
+    result = cli.research(role="quality")
+    assert result.source == "error:304-no-cache"
+    assert result.body == ""
+
+
+# --------------------------------------------------------------------------- #
+# 4b. Monitor client: cold_start() dedicated role-only path + bootstrap routing
+# --------------------------------------------------------------------------- #
+def test_monitor_cold_start_hits_dedicated_endpoint_not_and_manifest(tmp_path, monkeypatch):
+    from scripts.ai_agent_bridge import monitor_client as mc
+
+    monkeypatch.setenv("MONITOR_CACHE_DIR", str(tmp_path / "cache"))
+    cli = mc.MonitorClient(base_url="http://test")
+    seen_paths: list[str] = []
+
+    def _fake_get(path, *, headers=None):
+        seen_paths.append(path)
+        return (
+            200,
+            '{"enabled":true,"records":[{"id":"r1","state":"active","content_hash":"sha256:aa","routing":{}}]}',
+            {"etag": '"e1"'},
+        )
+
+    monkeypatch.setattr(cli, "_get", _fake_get)
+    result = cli.cold_start(role="quality")
+    assert result.source == "network"
+    assert seen_paths[0].startswith("/api/knowledge/cold-start")
+    assert "manifest" not in seen_paths[0]
+
+
+def test_bootstrap_role_only_routes_to_cold_start_never_and_manifest(monkeypatch):
     from scripts.ai_agent_bridge import monitor_client as mc
 
     cli = mc.MonitorClient(base_url="http://test")
     monkeypatch.setattr(cli, "manifest", lambda: {})
-    stub = mc.ComponentResult(key="x", body="b", hash="h", source="cache")
+    stub = mc.ComponentResult(key="x", body="{}", hash="h", source="cache")
     monkeypatch.setattr(cli, "rules", lambda *, manifest=None: stub)
     monkeypatch.setattr(cli, "session", lambda *, manifest=None: stub)
-    called = {"research": False}
-    monkeypatch.setattr(cli, "research", lambda **_kw: called.__setitem__("research", True) or stub)
+    calls = {"cold_start": 0, "research": 0}
+    monkeypatch.setattr(
+        cli, "cold_start", lambda **_kw: calls.__setitem__("cold_start", calls["cold_start"] + 1) or stub
+    )
+    monkeypatch.setattr(
+        cli, "research", lambda **_kw: calls.__setitem__("research", calls["research"] + 1) or stub
+    )
 
     assert set(cli.bootstrap()) == {"rules", "session"}
-    assert called["research"] is False
+    assert calls == {"cold_start": 0, "research": 0}
+
+    # role ALONE -> the dedicated cold-start path, never the AND manifest.
     assert set(cli.bootstrap(role="quality")) == {"rules", "session", "research"}
-    assert called["research"] is True
+    assert calls == {"cold_start": 1, "research": 0}
+
+    # role PLUS another dimension -> the full AND-matched context.
+    assert set(cli.bootstrap(role="quality", task_family="difficulty-gate")) == {
+        "rules", "session", "research",
+    }
+    assert calls == {"cold_start": 1, "research": 1}
+
+    # a dimension with no role -> still the AND-matched context (never cold-start).
+    assert set(cli.bootstrap(task_family="difficulty-gate")) == {"rules", "session", "research"}
+    assert calls == {"cold_start": 1, "research": 2}
 
 
 # --------------------------------------------------------------------------- #
@@ -397,6 +664,25 @@ def _args(**over):
 def test_delegate_no_flags_yields_no_context():
     delegate = _delegate()
     assert delegate._build_research_context(_args()) is None
+
+
+def test_delegate_state_never_persists_research_null():
+    # ADR-011 P3 default compatibility: a no-flags dispatch, a disabled registry,
+    # or a degraded injection all resolve research_state to None; the persisted
+    # state dict must OMIT the "research" key entirely — never "research": null.
+    delegate = _delegate()
+    base_state = {"task_id": "t", "status": "spawning"}
+
+    no_flags = delegate._with_optional_research_state(dict(base_state), None)
+    assert "research" not in no_flags
+    assert no_flags == base_state
+
+    with_context = delegate._with_optional_research_state(
+        dict(base_state), {"pointer_ids": ["r1"], "filtered_etag": "e", "dropped_ids": [], "context_fingerprint": "f"}
+    )
+    assert with_context["research"] == {
+        "pointer_ids": ["r1"], "filtered_etag": "e", "dropped_ids": [], "context_fingerprint": "f",
+    }
 
 
 def test_delegate_rejects_oversize_and_overcount():

--- a/tests/test_research_registry_p3.py
+++ b/tests/test_research_registry_p3.py
@@ -1,0 +1,471 @@
+"""ADR-011 P3 — task-scoped pointers, bounded cold start, consumption telemetry.
+
+Hermetic: every test builds a synthetic registry under ``tmp_path`` and points the
+runtime at it via ``registry._ROOT_OVERRIDE`` (never the operator's live state). The
+central telemetry emitter is monkeypatched to an in-memory sink; the delegate task
+store is redirected to ``tmp_path`` — no GitHub, network, subprocess, or real event
+log is touched.
+
+Covers the P3 matrix: role-only cold-start selection (uses ``cold_start_roles``,
+never the AND matcher), default orient/bootstrap byte compatibility, cache isolation
+across roles/contexts, consumption attribution (200/304 with a validated active
+task) vs surfacing, conservative task-id validation (traversal / collision /
+finished-task spoof), telemetry payload allowlist, delegate flag validation +
+pointer-only injection + privacy-safe persistence, and the automatic-body-bytes-zero
+proof.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+import scripts.api.main as api_main
+from scripts.audit import check_research_registry as crr
+from scripts.research import consumption
+from scripts.research import registry as reg
+
+client = TestClient(api_main.app, raise_server_exceptions=False)
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic registry builder (mirrors the P2 API test builder)
+# --------------------------------------------------------------------------- #
+def _digest_body(rid: str) -> str:
+    return (
+        f"# {rid}\n\n"
+        f"Source: https://example.org/{rid}\n\n"
+        f"Paraphrase-only compact digest for {rid}. No verbatim passages.\n"
+    )
+
+
+def _make_record(
+    root: Path,
+    rid: str,
+    *,
+    routing: dict[str, Any] | None = None,
+    state: str = "deferred",
+    access_class: str = "tracked-digest",
+    cold_start_roles: list[str] | None = None,
+) -> dict[str, Any]:
+    digest_rel = f"docs/references/research-digests/{rid}.md"
+    digest_path = root / digest_rel
+    digest_path.parent.mkdir(parents=True, exist_ok=True)
+    digest_path.write_text(_digest_body(rid), "utf-8")
+    record: dict[str, Any] = {
+        "id": rid,
+        "title": f"Title {rid}",
+        "summary": f"Summary {rid}",
+        "content_hash": "sha256:" + "0" * 64,
+        "state": state,
+        "provenance": {
+            "digest": digest_rel,
+            "digest_anchor": None,
+            "source_url": f"https://example.org/{rid}",
+        },
+        "routing": routing if routing is not None else {"roles": ["quality"]},
+        "cold_start_roles": cold_start_roles or [],
+        "ownership": None,
+        "consumer": None,
+        "reason": "Deferred for the test." if state == "deferred" else None,
+        "replacement": None,
+        "access_class": access_class,
+    }
+    record["content_hash"] = crr.expected_content_hash(record, root)
+    return record
+
+
+def _write_registry(root: Path, records: list[dict[str, Any]]) -> None:
+    refs = root / "docs" / "references"
+    refs.mkdir(parents=True, exist_ok=True)
+    doc = yaml.safe_dump({"schema_version": 1, "records": records}, sort_keys=False, allow_unicode=True)
+    (refs / "research-registry.yaml").write_text(doc, "utf-8")
+
+
+@pytest.fixture
+def reg_root(tmp_path, monkeypatch):
+    """Hermetic tmp root with the feature forced ON via env."""
+    monkeypatch.setattr(reg, "_ROOT_OVERRIDE", tmp_path)
+    monkeypatch.setenv(reg.ENV_FLAG, "true")
+    return tmp_path
+
+
+@pytest.fixture
+def emit_sink(monkeypatch):
+    """Capture central telemetry events in memory (event_type, payload)."""
+    events: list[tuple[str, dict[str, Any]]] = []
+
+    def _fake_emit(event_type: str, payload: dict[str, Any], **_kw: Any) -> None:
+        events.append((event_type, dict(payload)))
+
+    monkeypatch.setattr(consumption, "emit_event", _fake_emit)
+    return events
+
+
+# --------------------------------------------------------------------------- #
+# 1. Cold-start selector: cold_start_roles only, never the AND matcher
+# --------------------------------------------------------------------------- #
+def test_cold_start_uses_cold_start_roles_not_routing(reg_root):
+    # routing.roles=[quality] but cold_start_roles empty → NOT announced at cold start.
+    rec = _make_record(reg_root, "routed-only", routing={"roles": ["quality"]}, cold_start_roles=[])
+    ann = _make_record(reg_root, "announced", routing={"roles": ["pedagogy"]}, cold_start_roles=["quality"])
+    _write_registry(reg_root, [rec, ann])
+    runtime = reg.load_runtime_safe()
+    pointers, dropped = reg.select_cold_start_pointers(runtime, "quality")
+    assert [p["id"] for p in pointers] == ["announced"]
+    assert dropped == []
+
+
+def test_cold_start_unknown_and_missing_role_yield_none(reg_root):
+    _write_registry(reg_root, [_make_record(reg_root, "r1", cold_start_roles=["quality"])])
+    runtime = reg.load_runtime_safe()
+    assert reg.select_cold_start_pointers(runtime, "nobody") == ([], [])
+    assert reg.select_cold_start_pointers(runtime, None) == ([], [])
+    assert reg.select_cold_start_pointers(runtime, "   ") == ([], [])
+
+
+def test_cold_start_deterministic_order_and_pointer_fields_only(reg_root):
+    # P1 caps cold_start_roles at 5/role, so the max valid set is 5; the selector
+    # returns them deterministically sorted by id, pointer-fields only.
+    five = [_make_record(reg_root, f"cs-{i}", cold_start_roles=["quality"]) for i in (2, 0, 4, 1, 3)]
+    _write_registry(reg_root, five)
+    runtime = reg.load_runtime_safe()
+    pointers, dropped = reg.select_cold_start_pointers(runtime, "quality")
+    assert [p["id"] for p in pointers] == ["cs-0", "cs-1", "cs-2", "cs-3", "cs-4"]
+    assert dropped == []
+    # allowlisted pointer fields only — no title/summary/body/source/provenance.
+    for ptr in pointers:
+        assert set(ptr) == {"id", "state", "content_hash", "routing"}
+
+
+# --------------------------------------------------------------------------- #
+# 2. Orient: role opt-in, default byte compatibility, no shared cache
+# --------------------------------------------------------------------------- #
+def _orient(params: dict[str, str] | None = None):
+    return client.get("/api/orient", params={"sections": "health", **(params or {})})
+
+
+def test_orient_default_has_no_research_key(reg_root):
+    _write_registry(reg_root, [_make_record(reg_root, "r1", cold_start_roles=["quality"])])
+    body = _orient().json()
+    assert "research" not in body
+
+
+def test_orient_role_adds_pointer_only_research(reg_root):
+    _write_registry(reg_root, [_make_record(reg_root, "r1", cold_start_roles=["quality"])])
+    body = _orient({"role": "quality"}).json()
+    assert body["research"]["enabled"] is True
+    assert [p["id"] for p in body["research"]["records"]] == ["r1"]
+    assert body["research"]["fetch"] == "/api/knowledge/record/{id}"
+    for ptr in body["research"]["records"]:
+        assert set(ptr) == {"id", "state", "content_hash", "routing"}
+
+
+def test_orient_roles_do_not_share_cache(reg_root):
+    _write_registry(
+        reg_root,
+        [
+            _make_record(reg_root, "q-rec", cold_start_roles=["quality"]),
+            _make_record(reg_root, "t-rec", cold_start_roles=["tts"]),
+        ],
+    )
+    quality = _orient({"role": "quality"}).json()["research"]["records"]
+    tts = _orient({"role": "tts"}).json()["research"]["records"]
+    assert [p["id"] for p in quality] == ["q-rec"]
+    assert [p["id"] for p in tts] == ["t-rec"]  # would be contaminated by a shared cache
+
+
+def test_orient_disabled_has_no_research_even_with_role(tmp_path, monkeypatch):
+    monkeypatch.setattr(reg, "_ROOT_OVERRIDE", tmp_path)
+    monkeypatch.setenv(reg.ENV_FLAG, "false")
+    _write_registry(tmp_path, [_make_record(tmp_path, "r1", cold_start_roles=["quality"])])
+    assert "research" not in _orient({"role": "quality"}).json()
+
+
+def test_orient_role_never_calls_record_endpoint_body(reg_root):
+    # Cold start announces pointers, never bodies: the response carries no digest text.
+    _write_registry(reg_root, [_make_record(reg_root, "r1", cold_start_roles=["quality"])])
+    body = _orient({"role": "quality"}).json()
+    blob = json.dumps(body)
+    assert "Paraphrase-only" not in blob and "digest" not in blob
+
+
+# --------------------------------------------------------------------------- #
+# 3. Consumption telemetry: attribution vs surfacing, allowlist, validation
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def task_store(tmp_path, monkeypatch):
+    """Redirect the delegate task store (read via delegate_router) to tmp_path."""
+    from scripts.api import delegate_router
+
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(delegate_router, "TASKS_DIR", tasks_dir)
+
+    def _put(task_id: str, *, status: str = "spawning", pid: int | None = None) -> None:
+        safe = task_id.replace("/", "_").replace("\\", "_")
+        (tasks_dir / f"{safe}.json").write_text(
+            json.dumps({"task_id": task_id, "status": status, "pid": pid}), "utf-8"
+        )
+
+    return _put
+
+
+def test_valid_active_task_emits_consumption_on_200(reg_root, emit_sink, task_store):
+    _write_registry(reg_root, [_make_record(reg_root, "r1")])
+    task_store("job-1", status="spawning")
+    resp = client.get("/api/knowledge/record/r1", params={"task": "job-1"})
+    assert resp.status_code == 200
+    consumed = [p for t, p in emit_sink if t == consumption.CONSUMED_EVENT]
+    assert consumed == [{"task_id": "job-1", "research_id": "r1", "surface": "record", "status": 200}]
+
+
+def test_cache_backed_304_emits_consumption(reg_root, emit_sink, task_store):
+    _write_registry(reg_root, [_make_record(reg_root, "r1")])
+    task_store("job-1")
+    etag = client.get("/api/knowledge/record/r1").headers["ETag"]
+    resp = client.get(
+        "/api/knowledge/record/r1", params={"task": "job-1"}, headers={"If-None-Match": etag}
+    )
+    assert resp.status_code == 304
+    consumed = [p for t, p in emit_sink if t == consumption.CONSUMED_EVENT]
+    assert consumed[0]["status"] == 304
+
+
+def test_no_task_no_consumption_but_still_serves(reg_root, emit_sink, task_store):
+    _write_registry(reg_root, [_make_record(reg_root, "r1")])
+    resp = client.get("/api/knowledge/record/r1")
+    assert resp.status_code == 200
+    assert not [p for t, p in emit_sink if t == consumption.CONSUMED_EVENT]
+
+
+def test_404_is_never_consumption(reg_root, emit_sink, task_store):
+    _write_registry(reg_root, [_make_record(reg_root, "r1")])
+    task_store("job-1")
+    resp = client.get("/api/knowledge/record/does-not-exist", params={"task": "job-1"})
+    assert resp.status_code == 404
+    assert not [p for t, p in emit_sink if t == consumption.CONSUMED_EVENT]
+
+
+def test_response_invariant_to_task_validity(reg_root, task_store):
+    _write_registry(reg_root, [_make_record(reg_root, "r1")])
+    task_store("live", status="running", pid=1)  # pid=1 always alive
+    valid = client.get("/api/knowledge/record/r1", params={"task": "live"})
+    invalid = client.get("/api/knowledge/record/r1", params={"task": "ghost"})
+    assert valid.status_code == invalid.status_code == 200
+    assert valid.content == invalid.content
+    assert valid.headers["ETag"] == invalid.headers["ETag"]
+
+
+@pytest.mark.parametrize(
+    "task_id,status,pid",
+    [
+        ("../../etc/passwd", "spawning", None),  # traversal
+        ("finished", "done", None),  # finished-task spoof
+        ("zombie", "running", 999999),  # running status, dead pid → zombie
+        ("a" * 129, "spawning", None),  # oversize
+    ],
+)
+def test_invalid_or_inactive_task_no_consumption(reg_root, emit_sink, task_store, task_id, status, pid):
+    _write_registry(reg_root, [_make_record(reg_root, "r1")])
+    if "/" not in task_id and len(task_id) <= 200:
+        task_store(task_id, status=status, pid=pid)
+    resp = client.get("/api/knowledge/record/r1", params={"task": task_id})
+    assert resp.status_code == 200
+    assert not [p for t, p in emit_sink if t == consumption.CONSUMED_EVENT]
+
+
+def test_task_id_collision_requires_exact_stored_match(reg_root, emit_sink, task_store):
+    # A state file exists at a sanitized path, but its stored task_id differs from
+    # the request → no attribution (defeats collisions via path sanitization).
+    _write_registry(reg_root, [_make_record(reg_root, "r1")])
+    from scripts.api import delegate_router
+
+    (delegate_router.TASKS_DIR / "collide.json").write_text(
+        json.dumps({"task_id": "other-id", "status": "running", "pid": 1}), "utf-8"
+    )
+    resp = client.get("/api/knowledge/record/r1", params={"task": "collide"})
+    assert resp.status_code == 200
+    assert not [p for t, p in emit_sink if t == consumption.CONSUMED_EVENT]
+
+
+def test_surface_event_is_distinct_from_consumption(emit_sink):
+    consumption.emit_surface(research_id="r1", surface=consumption.SURFACE_DISPATCH, task_id="job-1")
+    assert emit_sink == [
+        (consumption.SURFACED_EVENT, {"task_id": "job-1", "research_id": "r1", "surface": "dispatch"})
+    ]
+
+
+def test_telemetry_payloads_carry_no_forbidden_fields(emit_sink):
+    consumption.emit_consumption(task_id="job-1", research_id="r1", status=200)
+    consumption.emit_surface(research_id="r1", surface=consumption.SURFACE_COLD_START)
+    forbidden = {"body", "title", "summary", "source", "source_url", "prompt", "role",
+                 "task_family", "track", "owned_paths", "context", "context_fingerprint"}
+    for _t, payload in emit_sink:
+        assert set(payload) <= {"task_id", "research_id", "surface", "status"}
+        assert not (set(payload) & forbidden)
+
+
+# --------------------------------------------------------------------------- #
+# 4. Monitor client: filtered projection caching + bootstrap default compat
+# --------------------------------------------------------------------------- #
+def test_monitor_research_first_surfaces_then_304_reuses(tmp_path, monkeypatch):
+    from scripts.ai_agent_bridge import monitor_client as mc
+
+    monkeypatch.setenv("MONITOR_CACHE_DIR", str(tmp_path / "cache"))
+    cli = mc.MonitorClient(base_url="http://test")
+    calls: list[dict[str, str]] = []
+
+    def _fake_get(path, *, headers=None):
+        calls.append(headers or {})
+        if headers and "If-None-Match" in headers:
+            return 304, "", {"etag": '"abc"'}
+        return 200, '{"enabled":true,"records":[{"id":"r1"}]}', {"etag": '"abc"'}
+
+    monkeypatch.setattr(cli, "_get", _fake_get)
+
+    first = cli.research(role="quality")
+    assert first.source == "network"
+    assert "r1" in first.body
+    second = cli.research(role="quality")
+    assert second.source == "not-modified"
+    assert second.body == first.body  # warm reuse, zero changed pointers
+    assert "If-None-Match" in calls[1]
+
+
+def test_monitor_research_context_isolation_by_fingerprint(tmp_path, monkeypatch):
+    from scripts.ai_agent_bridge import _monitor_cache as cache
+    from scripts.ai_agent_bridge import monitor_client as mc
+
+    monkeypatch.setenv("MONITOR_CACHE_DIR", str(tmp_path / "cache"))
+    cli = mc.MonitorClient(base_url="http://test")
+    monkeypatch.setattr(cli, "_get", lambda path, headers=None: (200, '{"records":[]}', {"etag": '"e"'}))
+    a = cli.research(role="quality")
+    b = cli.research(role="tts")
+    assert a.key != b.key  # different fingerprints → different cache keys
+    # neither key leaks a raw path
+    c = cli.research(role="quality", owned_paths=["scripts/secret/path.py"])
+    assert "scripts/secret/path.py" not in c.key
+    assert cache.peek(c.key) is not None
+
+
+def test_bootstrap_default_is_exactly_rules_and_session(monkeypatch):
+    from scripts.ai_agent_bridge import monitor_client as mc
+
+    cli = mc.MonitorClient(base_url="http://test")
+    monkeypatch.setattr(cli, "manifest", lambda: {})
+    stub = mc.ComponentResult(key="x", body="b", hash="h", source="cache")
+    monkeypatch.setattr(cli, "rules", lambda *, manifest=None: stub)
+    monkeypatch.setattr(cli, "session", lambda *, manifest=None: stub)
+    called = {"research": False}
+    monkeypatch.setattr(cli, "research", lambda **_kw: called.__setitem__("research", True) or stub)
+
+    assert set(cli.bootstrap()) == {"rules", "session"}
+    assert called["research"] is False
+    assert set(cli.bootstrap(role="quality")) == {"rules", "session", "research"}
+    assert called["research"] is True
+
+
+# --------------------------------------------------------------------------- #
+# 5. Delegate: flag validation, pointer-only injection, privacy-safe persistence
+# --------------------------------------------------------------------------- #
+def _delegate():
+    import sys
+
+    sys.path.insert(0, str(Path(reg.__file__).resolve().parents[2] / "scripts"))
+    import delegate
+
+    return delegate
+
+
+def _args(**over):
+    import argparse
+
+    ns = argparse.Namespace(
+        research_role=None, research_task_family=None, research_track=None, research_owned_path=None
+    )
+    for key, value in over.items():
+        setattr(ns, key, value)
+    return ns
+
+
+def test_delegate_no_flags_yields_no_context():
+    delegate = _delegate()
+    assert delegate._build_research_context(_args()) is None
+
+
+def test_delegate_rejects_oversize_and_overcount():
+    delegate = _delegate()
+    with pytest.raises(delegate.ResearchContextError):
+        delegate._build_research_context(_args(research_role="x" * (reg.MAX_QUERY_VALUE_LEN + 1)))
+    with pytest.raises(delegate.ResearchContextError):
+        delegate._build_research_context(
+            _args(research_owned_path=["p"] * (reg.MAX_OWNED_PATHS + 1))
+        )
+    with pytest.raises(delegate.ResearchContextError):
+        delegate._build_research_context(
+            _args(research_owned_path=["x" * (reg.MAX_OWNED_PATH_LEN + 1)])
+        )
+
+
+def test_delegate_injection_is_pointer_only_and_persists_safely(reg_root, monkeypatch):
+    delegate = _delegate()
+    monkeypatch.setattr(reg, "_ROOT_OVERRIDE", reg_root)
+    monkeypatch.setattr(delegate, "_REPO_ROOT", reg_root)
+    _write_registry(
+        reg_root,
+        [
+            _make_record(
+                reg_root,
+                "cefr",
+                routing={"roles": ["quality"], "task_families": ["difficulty-gate"]},
+            )
+        ],
+    )
+    surfaced: list[tuple[str, dict]] = []
+    monkeypatch.setattr(consumption, "emit_event", lambda t, p, **k: surfaced.append((t, p)))
+
+    ctx = reg.normalize_context("quality", "difficulty-gate", None, [])
+    block, state = delegate._resolve_research_injection(ctx, "task-9")
+
+    # pointer-only prompt block: ids + fetch instruction, never a digest body
+    assert "cefr" in block and "/api/knowledge/record/{id}" in block
+    assert "Paraphrase-only" not in block
+    # persistence allowlist: ids / etag / dropped / fingerprint only
+    assert set(state) == {"pointer_ids", "filtered_etag", "dropped_ids", "context_fingerprint"}
+    assert state["pointer_ids"] == ["cefr"]
+    assert "owned_paths" not in state and "role" not in state
+    # a surface (not consumption) event was emitted for the injected pointer
+    assert surfaced == [
+        (consumption.SURFACED_EVENT, {"task_id": "task-9", "research_id": "cefr", "surface": "dispatch"})
+    ]
+
+
+def test_delegate_injection_fail_open_when_disabled(reg_root, monkeypatch):
+    delegate = _delegate()
+    monkeypatch.setattr(delegate, "_REPO_ROOT", reg_root)
+    monkeypatch.setenv(reg.ENV_FLAG, "false")
+    ctx = reg.normalize_context("quality", "difficulty-gate", None, [])
+    assert delegate._resolve_research_injection(ctx, "t") == ("", None)
+
+
+# --------------------------------------------------------------------------- #
+# 6. Byte measurement: automatic body bytes are zero; bounded pointer payloads
+# --------------------------------------------------------------------------- #
+def test_automatic_surface_never_injects_body_bytes(reg_root):
+    _write_registry(
+        reg_root,
+        [_make_record(reg_root, "r1", routing={"roles": ["quality"]}, cold_start_roles=["quality"])],
+    )
+    # Cold-start orient projection carries pointers, never the digest body bytes.
+    body = _orient({"role": "quality"}).json()["research"]
+    projection = json.dumps(body).encode("utf-8")
+    digest = (reg_root / "docs/references/research-digests/r1.md").read_text("utf-8")
+    assert digest.strip() not in json.dumps(body)
+    # And it stays well within the filtered budget.
+    assert len(projection) <= reg.MAX_FILTERED_BYTES


### PR DESCRIPTION
## What

Implements **ADR-011 P3** (`Closes #4992`, `Refs #4969`) on top of the P2 squash `1bdb9cc6`. Integrates P2's deterministic matcher into real task discovery **without growing default cold start**. Pointers are automatic; record bodies stay strictly on demand.

## How (per frozen decisions)

- **registry.py** — new role-only `select_cold_start_pointers(runtime, role)` using **only** `cold_start_roles` (never the AND matcher with missing dimensions); one shared deterministic `_apply_caps` cap renderer for both selectors; opaque `context_fingerprint(ctx)` for cache keys / persistence. Reuses P2 `Context`, `normalize_context`, `matches`, `select_pointers`, filtered ETags, loader, caps.
- **consumption.py** (new) — privacy-safe telemetry over the **existing central emitter** (`scripts/telemetry/emit.py`); no third task store (reuses the delegate task store as read by `delegate_router`). `research_record_consumed` (validated active task, 200 or cache-backed 304) vs `research_pointer_surfaced` — surfaced ≠ consumed. Conservative task-id validation: `<=128`, safe pattern (rejects traversal), **exact stored `task_id` match**, active spawning/running only (rejects finished/zombie). Payload allowlist **exactly** `{task_id, research_id, surface, status}`.
- **knowledge_router.py** — optional `task=` on `/record/{id}`; consumption emitted on 200/304. **Response is invariant to task validity** and never reveals task existence; a 404 is never a consumption.
- **main.py** — opt-in `/api/orient?role=` pointer-only research section, computed fresh (**no shared orient cache** → roles can't contaminate each other), byte-identical default with no role.
- **monitor_client.py / _monitor_cache.py** — `peek()` + `research()` filtered-projection caching keyed on stable consumer + canonical context **fingerprint** (never raw paths) via the projection ETag: cold → first projection surfaces; warm-unchanged → filtered 304, zero changed pointers even after unrelated global edits. `bootstrap()` default stays **exactly** rules+session.
- **delegate.py** — namespaced `--research-role`, `--research-task-family`, `--research-track`, repeatable `--research-owned-path` (**never inferred**); direct-caller cap validation mirroring the API 422s; pointer-only prompt injection + on-demand fetch instruction; persists **only** pointer ids / filtered ETag / dropped ids / context fingerprint (no raw paths, digest/source/prompt text, role, or family); surface telemetry. **Fail-open** everywhere.
- **docs/MONITOR-API.md** — new Research registry section + orient `?role=` param.

## Measured evidence

| Surface | Records | Bytes | est_tokens |
|---|---|---|---|
| cold-start `role=quality` | 1 | 342 | 171 |
| cold-start `role=tts` | 1 | 251 | 126 |
| cold-start `role=reviewer` | 1 | 280 | 140 |
| cold-start `role=frontend` (unaffected) | 0 | 29 | 15 |
| dispatch AND positive (`quality·difficulty-gate·core·scripts/audit/**`) | 1 | 342 | — |

- **Automatic body bytes = 0**: no cold-start/orient/bootstrap/dispatch/pipeline path calls `select_bodies`/`record_body` (grep-proven; only the on-demand `/record/{id}` endpoint does). Automatic projection provably contains no digest body substring.
- Same-track/wrong-family dispatch context returns **zero** pointers (AND proof).

## Tests

- New `tests/test_research_registry_p3.py` (28 tests): cold-start selector (cold_start_roles not routing; unknown/missing→none; deterministic order; pointer-fields-only), orient role opt-in + default/disabled compat + cache isolation, consumption 200/304 vs no-task/404, response-invariance, task-id validation matrix (traversal / oversize / finished-spoof / zombie / collision), telemetry allowlist, monitor `research()` 304 reuse + fingerprint isolation, `bootstrap()` default compat, delegate flag validation + pointer-only injection + privacy-safe persistence + fail-open, automatic-body-bytes-zero.
- Regressions green: P1 `test_research_registry.py`, P2 `test_research_registry_api.py`, manifest/orient/monitor-cache/monitor-sdk/route-contracts/delegate-api/dispatch-telemetry/telemetry-emit (234 passed together).
- Audits: P1 registry `--check` (3 records clean), `check_adrs.py` (clean), `git diff --check` clean, ruff clean on all changed Python, 9 changed files (<20).

## Boundaries respected

No P4 observability/adoption endpoint, no P5 raw sources / private symlinks, no `sources.db` / embeddings / prompt-corpus ingestion, no automatic body injection. P2 kill switch remains default false — disabled reproduces exact pre-registry behavior.

## Review / merge

Codex owns integration/review/merge. I hold **no merge authority** and have not armed auto-merge. Independent cross-family review required before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)