### PR TITLE
feat(lexicon): generate reviewable relation candidates

### DIFF
--- a/scripts/lexicon/generate_antonym_candidates.py
+++ b/scripts/lexicon/generate_antonym_candidates.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Generate review-only morphological-negation antonym candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.lexicon.relation_candidate_common import (
+    DEFAULT_ARTIFACT,
+    DEFAULT_SOURCES_DB,
+    DEFAULT_VESUM_DB,
+    FrequencySource,
+    VesumIndex,
+    load_artifact,
+    merge_rows,
+    normalize_word,
+    summarize_rows,
+    write_artifact,
+)
+
+AFFIXES = ("не-", "без-", "анти-", "проти-")
+ALLOWED_POSITIONS = ("adj", "adv", "noun")
+DEFAULT_MIN_FREQUENCY = 2
+
+
+def generate(
+    *,
+    vesum_db: Path = DEFAULT_VESUM_DB,
+    corpus_db: Path | None = DEFAULT_SOURCES_DB,
+    frequency_json: Path | None = None,
+    min_frequency: int = DEFAULT_MIN_FREQUENCY,
+    sample_seed: int = 4975,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    vesum = VesumIndex(vesum_db)
+    try:
+        exact = vesum.exact_lemmas(ALLOWED_POSITIONS)
+        bases = sorted(exact)
+        possible: list[tuple[str, str, str, str]] = []
+        for base in bases:
+            for affix in AFFIXES:
+                prefix = affix[:-1]
+                if base.startswith(prefix):
+                    continue
+                negated = normalize_word(prefix + base)
+                common_positions = sorted(exact.get(base, set()) & exact.get(negated, set()))
+                for pos in common_positions:
+                    possible.append((base, negated, affix, pos))
+
+        frequency = FrequencySource(vesum=vesum, corpus_db=corpus_db, frequency_json=frequency_json)
+        frequencies = frequency.count({word for base, negated, _affix, _pos in possible for word in (base, negated)})
+        rows: list[dict[str, Any]] = []
+        for base, negated, affix, pos in possible:
+            freq_base = frequencies.get(base)
+            freq_negated = frequencies.get(negated)
+            base_is_rare = freq_base is None or freq_base < min_frequency
+            negated_is_rare = freq_negated is None or freq_negated < min_frequency
+            confidence = "high" if not base_is_rare and not negated_is_rare else "low"
+            rows.append(
+                {
+                    "relation": "antonym",
+                    "word": base,
+                    "antonym": negated,
+                    "affix": affix,
+                    "pos": pos,
+                    "confidence": confidence,
+                    "freq_word": freq_base,
+                    "freq_antonym": freq_negated,
+                    "frequency_source": frequency.source,
+                    "source": "vesum+morphological_negation",
+                    "gate": {
+                        "vesum_exact_lemma": base in exact and negated in exact,
+                        "same_pos": pos in exact.get(base, set()) and pos in exact.get(negated, set()),
+                        "base_is_real_lemma": vesum.verify_exact(base, pos),
+                        "negative_is_real_lemma": vesum.verify_exact(negated, pos),
+                        "base_not_prefixed_with_affix": not base.startswith(affix[:-1]),
+                    },
+                    "evidence": {
+                        "algorithm": "valid VESUM lemma + valid VESUM prefixed lemma with shared POS",
+                        "frequency_floor": min_frequency,
+                        "rare_base_or_negative": base_is_rare or negated_is_rare,
+                    },
+                }
+            )
+        summary = {
+            "candidate_pairs_before_frequency_review": len(rows),
+            "affix_distribution": {affix: sum(row["affix"] == affix for row in rows) for affix in AFFIXES},
+            "pos_distribution": {pos: sum(row["pos"] == pos for row in rows) for pos in ALLOWED_POSITIONS},
+            "confidence_distribution": {level: sum(row["confidence"] == level for row in rows) for level in ("high", "low")},
+            "frequency_source": frequency.source,
+            "min_frequency": min_frequency,
+            **summarize_rows(rows, sample_seed=sample_seed),
+        }
+        return rows, summary
+    finally:
+        vesum.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vesum-db", type=Path, default=DEFAULT_VESUM_DB)
+    parser.add_argument("--corpus-db", type=Path, default=DEFAULT_SOURCES_DB)
+    parser.add_argument("--frequency-json", type=Path)
+    parser.add_argument("--min-frequency", type=int, default=DEFAULT_MIN_FREQUENCY)
+    parser.add_argument("--sample-seed", type=int, default=4975)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    args = parser.parse_args()
+    rows, summary = generate(
+        vesum_db=args.vesum_db,
+        corpus_db=args.corpus_db,
+        frequency_json=args.frequency_json,
+        min_frequency=args.min_frequency,
+        sample_seed=args.sample_seed,
+    )
+    payload = load_artifact(args.out)
+    payload["relations"]["antonyms"] = [
+        row for row in payload["relations"]["antonyms"] if row.get("source") != "vesum+morphological_negation"
+    ]
+    added = merge_rows(payload, "antonyms", rows)
+    payload.setdefault("metadata", {})["antonym_generator"] = {
+        "config": {"min_frequency": args.min_frequency, "sample_seed": args.sample_seed},
+        "summary": {key: value for key, value in summary.items() if key != "samples"},
+    }
+    write_artifact(payload, args.out)
+    print(json.dumps({"added": added, **summary}, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lexicon/generate_paronym_candidates.py
+++ b/scripts/lexicon/generate_paronym_candidates.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Generate review-only paronym candidates from VESUM and corpus frequency.
+
+The output is intentionally not consumed by ``enrich_manifest.py``.  Every
+generated row carries the gates and evidence needed for a human review pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.lexicon.relation_candidate_common import (
+    DEFAULT_ARTIFACT,
+    DEFAULT_SOURCES_DB,
+    DEFAULT_VESUM_DB,
+    FrequencySource,
+    VesumIndex,
+    iter_edit_pairs,
+    levenshtein,
+    load_artifact,
+    merge_rows,
+    normalize_word,
+    orthographic_variant,
+    shared_prefix_length,
+    summarize_rows,
+    write_artifact,
+)
+
+DEFAULT_MIN_FREQUENCY = 100
+DEFAULT_SEED_DISTANCE = 2
+PARONYM_POSITIONS = ("adj", "adv", "noun", "verb")
+
+
+def _parse_pair(value: object) -> list[tuple[str, str]]:
+    pairs: list[tuple[str, str]] = []
+    for raw_pair in str(value or "").split(";"):
+        members = [normalize_word(part) for part in raw_pair.split("/")]
+        if len(members) == 2 and all(members) and members[0] != members[1]:
+            pairs.append((members[0], members[1]))
+    return pairs
+
+
+def load_confirmed_seeds(sources_db: Path) -> list[tuple[str, str, str]]:
+    """Read only the existing ZNO/cache seed relations; do not invent seeds."""
+    if not sources_db.exists():
+        return []
+    seeds: list[tuple[str, str, str]] = []
+    conn = sqlite3.connect(str(sources_db))
+    try:
+        columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(zno_tasks)")}
+        if {"task_subtype", "paronym_pair"} <= columns:
+            rows = conn.execute(
+                "SELECT paronym_pair FROM zno_tasks WHERE task_subtype = 'paronym' OR trim(paronym_pair) != ''"
+            )
+            for (value,) in rows:
+                seeds.extend((first, second, "ЗНО") for first, second in _parse_pair(value))
+        columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(paronyms_cache)")}
+        if {"word_a", "word_b"} <= columns:
+            rows = conn.execute("SELECT word_a, word_b FROM paronyms_cache")
+            seeds.extend(
+                (normalize_word(first), normalize_word(second), "paronyms_cache")
+                for first, second in rows
+                if normalize_word(first) and normalize_word(second)
+            )
+    finally:
+        conn.close()
+    deduplicated: dict[tuple[str, str], str] = {}
+    for first, second, source in seeds:
+        key = tuple(sorted((first, second)))
+        deduplicated.setdefault(key, source)
+    return [(first, second, source) for (first, second), source in sorted(deduplicated.items())]
+
+
+def seed_matches(
+    first: str,
+    second: str,
+    seeds: list[tuple[str, str, str]],
+    *,
+    radius: int = DEFAULT_SEED_DISTANCE,
+) -> list[dict[str, Any]]:
+    matches: list[dict[str, Any]] = []
+    for seed_first, seed_second, source in seeds:
+        left = min(levenshtein(first, seed_first, cutoff=radius), levenshtein(first, seed_second, cutoff=radius))
+        right = min(levenshtein(second, seed_first, cutoff=radius), levenshtein(second, seed_second, cutoff=radius))
+        if left <= radius and right <= radius:
+            matches.append({"pair": [seed_first, seed_second], "source": source, "distance": [left, right]})
+    return matches
+
+
+def generate(
+    *,
+    vesum_db: Path = DEFAULT_VESUM_DB,
+    sources_db: Path = DEFAULT_SOURCES_DB,
+    corpus_db: Path | None = DEFAULT_SOURCES_DB,
+    frequency_json: Path | None = None,
+    min_frequency: int = DEFAULT_MIN_FREQUENCY,
+    seed_distance: int = DEFAULT_SEED_DISTANCE,
+    sample_seed: int = 4975,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    vesum = VesumIndex(vesum_db)
+    try:
+        exact = {
+            word: positions
+            for word, positions in vesum.exact_lemmas(PARONYM_POSITIONS).items()
+            if len(word) >= 3
+        }
+        frequency = FrequencySource(vesum=vesum, corpus_db=corpus_db, frequency_json=frequency_json)
+        exact_frequencies = frequency.count_exact_lemmas(exact)
+        eligible = {
+            word: positions
+            for word, positions in exact.items()
+            if exact_frequencies.get(word) is not None and exact_frequencies[word] >= min_frequency
+        }
+        pairs = list(iter_edit_pairs(eligible, max_distance=2))
+        candidate_lemmas = {word for first, second, _pos, _distance in pairs for word in (first, second)}
+        frequencies = {word: exact_frequencies.get(word) for word in candidate_lemmas}
+        seeds = load_confirmed_seeds(sources_db)
+        rows: list[dict[str, Any]] = []
+        for first, second, pos, distance in pairs:
+            freq_first = frequencies.get(first)
+            freq_second = frequencies.get(second)
+            seed_evidence = seed_matches(first, second, seeds, radius=seed_distance)
+            prefix_len = shared_prefix_length(first, second)
+            suffix_len = 0
+            for left, right in zip(reversed(first), reversed(second), strict=False):
+                if left != right:
+                    break
+                suffix_len += 1
+            gate = {
+                "vesum_exact_lemma": first in exact and second in exact,
+                "same_pos": pos in exact.get(first, set()) and pos in exact.get(second, set()),
+                "not_inflectional_variant": not vesum.are_inflectional_variants(first, second),
+                "frequency_floor": freq_first is not None and freq_second is not None and freq_first >= min_frequency and freq_second >= min_frequency,
+                "not_orthographic_variant": not orthographic_variant(first, second),
+                "confusable_stem_or_seed": max(prefix_len, suffix_len) >= 4 or bool(seed_evidence),
+            }
+            if not all(gate.values()):
+                continue
+            confidence = "medium" if seed_evidence else "low"
+            rows.append(
+                {
+                    "relation": "paronym",
+                    "word_a": first,
+                    "word_b": second,
+                    "edit_distance": distance,
+                    "shared_prefix_len": prefix_len,
+                    "shared_suffix_len": suffix_len,
+                    "pos": pos,
+                    "freq_a": freq_first,
+                    "freq_b": freq_second,
+                    "frequency_source": frequency.source,
+                    "frequency_measure": "exact lemma spelling occurrences in literary_texts",
+                    "confidence": confidence,
+                    "source": "vesum+literary_corpus",
+                    "gate": gate,
+                    "evidence": {
+                        "algorithm": "same-POS exact VESUM lemmas within Levenshtein distance 1-2",
+                        "seed_neighborhood": seed_evidence,
+                        "frequency_floor": min_frequency,
+                        "confusable_similarity_floor": 4,
+                    },
+                }
+            )
+        summary = {
+            "candidate_pairs_before_gates": len(pairs),
+            "candidate_lemmas": len(candidate_lemmas),
+            "seeds": len(seeds),
+            "frequency_source": frequency.source,
+            "frequency_measure": "exact lemma spelling occurrences in literary_texts",
+            "min_frequency": min_frequency,
+            "edit_distance_distribution": {str(distance): sum(row["edit_distance"] == distance for row in rows) for distance in (1, 2)},
+            "confidence_distribution": {level: sum(row["confidence"] == level for row in rows) for level in ("high", "medium", "low")},
+            **summarize_rows(rows, sample_seed=sample_seed),
+        }
+        return rows, summary
+    finally:
+        vesum.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vesum-db", type=Path, default=DEFAULT_VESUM_DB)
+    parser.add_argument("--sources-db", type=Path, default=DEFAULT_SOURCES_DB)
+    parser.add_argument("--corpus-db", type=Path, default=DEFAULT_SOURCES_DB)
+    parser.add_argument("--frequency-json", type=Path)
+    parser.add_argument("--min-frequency", type=int, default=DEFAULT_MIN_FREQUENCY)
+    parser.add_argument("--seed-distance", type=int, default=DEFAULT_SEED_DISTANCE)
+    parser.add_argument("--sample-seed", type=int, default=4975)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    args = parser.parse_args()
+    rows, summary = generate(
+        vesum_db=args.vesum_db,
+        sources_db=args.sources_db,
+        corpus_db=args.corpus_db,
+        frequency_json=args.frequency_json,
+        min_frequency=args.min_frequency,
+        seed_distance=args.seed_distance,
+        sample_seed=args.sample_seed,
+    )
+    payload = load_artifact(args.out)
+    payload["relations"]["paronyms"] = [
+        row for row in payload["relations"]["paronyms"] if row.get("source") != "vesum+literary_corpus"
+    ]
+    added = merge_rows(payload, "paronyms", rows)
+    payload.setdefault("metadata", {})["paronym_generator"] = {
+        "config": {"min_frequency": args.min_frequency, "seed_distance": args.seed_distance, "sample_seed": args.sample_seed},
+        "summary": {key: value for key, value in summary.items() if key != "samples"},
+    }
+    write_artifact(payload, args.out)
+    print(json.dumps({"added": added, **summary}, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lexicon/mine_wikipedia_relations.py
+++ b/scripts/lexicon/mine_wikipedia_relations.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Mine curated Ukrainian Wikipedia/Wiktionary relation examples.
+
+Only exact VESUM lemmas with a shared POS survive.  The output is a review
+artifact; it is never wired into manifest enrichment by this script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.lexicon.relation_candidate_common import (
+    DEFAULT_ARTIFACT,
+    DEFAULT_VESUM_DB,
+    VesumIndex,
+    is_single_word,
+    load_artifact,
+    merge_rows,
+    normalize_word,
+    summarize_rows,
+    write_artifact,
+)
+
+WIKIPEDIA_API = "https://uk.wikipedia.org/w/api.php"
+WIKTIONARY_API = "https://uk.wiktionary.org/w/api.php"
+USER_AGENT = "learn-ukrainian-relation-miner/1.0 (offline candidate extraction; contact repo maintainers)"
+ARTICLE_RELATIONS = {
+    "Пароніми": "paronym",
+    "Синоніми": "synonym",
+    "Антоніми": "antonym",
+    "Омоніми": "homonym",
+}
+CATEGORIES = {
+    "paronym": "Категорія:Пароніми",
+    "homonym": "Категорія:Омоніми",
+    "antonym": "Категорія:Антоніми",
+    "synonym": "Категорія:Синоніми",
+}
+WORD_RE = re.compile(r"[А-Яа-яЄєІіЇїҐґ]+(?:['’ʼ-][А-Яа-яЄєІіЇїҐґ]+)*")
+WORD_CHAR_CLASS = "A-Za-zА-Яа-яЄєІіЇїҐґ'’ʼ-"
+PAIR_RE = re.compile(
+    rf"(?<![{WORD_CHAR_CLASS}])(?P<first>{WORD_RE.pattern})(?![{WORD_CHAR_CLASS}])"
+    rf"\s*(?:\([^)]*\)|«[^»]*»|\"[^\"]*\")?\s*[—–]\s*"
+    rf"(?<![{WORD_CHAR_CLASS}])(?P<second>{WORD_RE.pattern})(?![{WORD_CHAR_CLASS}])"
+)
+HEADING_RE = re.compile(r"^(={2,6})\s*(.*?)\s*\1\s*$")
+RELATION_HEADING_RE = re.compile(r"(паронім|синонім|антонім|омонім)", re.IGNORECASE)
+WIKILINK_RE = re.compile(r"\[\[(?:[^|\]]+\|)?([^\]]+)\]\]")
+
+
+def _api_get(endpoint: str, params: dict[str, Any]) -> dict[str, Any]:
+    query = urllib.parse.urlencode(params, doseq=True)
+    request = urllib.request.Request(f"{endpoint}?{query}", headers={"User-Agent": USER_AGENT})
+    for attempt in range(6):
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:  # nosec B310 — fixed Wikimedia endpoints
+                payload = json.load(response)
+            break
+        except urllib.error.HTTPError as error:
+            if error.code != 429 or attempt == 5:
+                raise
+            retry_after = int(error.headers.get("Retry-After", "0") or 0)
+            time.sleep(min(60, max(retry_after, 2**attempt)))
+    else:  # pragma: no cover - loop either breaks or raises
+        raise RuntimeError("Wikimedia API retry loop exhausted")
+    if "error" in payload:
+        raise RuntimeError(f"Wikimedia API error: {payload['error']}")
+    return payload
+
+
+def _clean_wikitext(text: str) -> str:
+    text = re.sub(r"<!--.*?-->", " ", text, flags=re.DOTALL)
+    text = re.sub(r"<ref[^>]*>.*?</ref>", " ", text, flags=re.DOTALL | re.IGNORECASE)
+    text = re.sub(r"<[^>]+>", " ", text)
+    for _ in range(4):
+        new_text = re.sub(r"\{\{[^{}]*\}\}", " ", text)
+        if new_text == text:
+            break
+        text = new_text
+    text = re.sub(r"\[\[([^]|]+)\|([^]]+)\]\]", r"\2", text)
+    text = re.sub(r"\[\[([^]]+)\]\]", r"\1", text)
+    text = re.sub(r"\[https?://[^ ]+\s+([^]]+)\]", r"\1", text)
+    text = re.sub(r"'''?([^']+)'''?", r"\1", text)
+    cleaned = html.unescape(text).replace("&nbsp;", " ").replace("\u0301", "").replace("\u0300", "")
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def _inside_parentheses(line: str, index: int) -> bool:
+    """Treat a leading list label such as ``б)`` as non-structural."""
+    if ":" in line:
+        context_start = line.index(":") + 1
+        prefix = line[context_start:index]
+    else:
+        prefix = line[:index]
+    return prefix.count("(") > prefix.count(")")
+
+
+def _headword_pairs(text: str) -> list[tuple[str, str, str, str]]:
+    """Extract raw adjacent ``word — word`` spans from relation examples."""
+    pairs: list[tuple[str, str, str, str]] = []
+    lines = text.replace("\r", "").splitlines()
+    section = "lead"
+    for raw_line in lines:
+        heading = HEADING_RE.match(raw_line.strip())
+        if heading:
+            section = _clean_wikitext(heading.group(2)) or section
+            continue
+        line = _clean_wikitext(raw_line)
+        if not line or line.startswith(("[[Категорія:", "{{")):
+            continue
+        for match in PAIR_RE.finditer(line):
+            if _inside_parentheses(line, match.start()):
+                continue
+            if re.search(r"не\s+(?:мають|можна\s+вважати|є)\s+антонім", line.casefold()):
+                continue
+            first, second = normalize_word(match.group("first")), normalize_word(match.group("second"))
+            if first != second and second not in {"омографія", "омонімія", "паронімія", "синонімія", "антонімія"}:
+                pairs.append((first, second, section, line[:600]))
+    return pairs
+
+
+def _relations_for_pair(default_relation: str, section: str, evidence: str) -> set[str]:
+    if section in {"paronym", "synonym", "antonym", "homonym"}:
+        return {section}
+    relations = {default_relation}
+    if default_relation == "paronym":
+        lowered = f"{section} {evidence}".casefold()
+        if "синонім" in lowered:
+            relations.add("synonym")
+        if "антонім" in lowered:
+            relations.add("antonym")
+    return relations
+
+
+def _source_url(title: str, *, wiki: str = "wikipedia") -> str:
+    host = "uk.wiktionary.org" if wiki == "wiktionary" else "uk.wikipedia.org"
+    return f"https://{host}/wiki/{urllib.parse.quote(title.replace(' ', '_'), safe="()'" )}"
+
+
+def _gated_rows(
+    raw_pairs: list[tuple[str, str, str, str]],
+    *,
+    default_relation: str,
+    source: str,
+    source_url: str,
+    article: str,
+    vesum: VesumIndex,
+    confidence: str,
+    category: str | None = None,
+) -> tuple[list[dict[str, Any]], set[str]]:
+    words = {word for first, second, _section, _evidence in raw_pairs for word in (first, second)}
+    exact = vesum.exact_members(words)
+    rows: list[dict[str, Any]] = []
+    for first, second, section, evidence in raw_pairs:
+        if source == "uk.wikipedia" and "російськ" in section.casefold():
+            continue
+        positions = sorted(exact.get(first, set()) & exact.get(second, set()))
+        if not positions:
+            continue
+        for pos in positions:
+            for relation in sorted(_relations_for_pair(default_relation, section, evidence)):
+                row: dict[str, Any] = {
+                    "relation": relation,
+                    "word_a": first,
+                    "word_b": second,
+                    "pos": pos,
+                    "confidence": confidence,
+                    "source": source,
+                    "source_url": source_url,
+                    "article": article,
+                    "section": section,
+                    "evidence_text": evidence,
+                    "gate": {
+                        "vesum_exact_lemma": first in exact and second in exact,
+                        "same_pos": True,
+                    },
+                    "license": "CC BY-SA 4.0" if source == "uk.wikipedia" else "CC BY-SA 4.0 / Wiktionary",
+                    "attribution": "Українська Вікіпедія" if source == "uk.wikipedia" else "Український Вікісловник",
+                }
+                if category:
+                    row["category"] = category
+                gloss = _extract_gloss(first, second, evidence)
+                if gloss:
+                    row["distinction"] = gloss
+                rows.append(row)
+    return rows, words
+
+
+def _extract_gloss(first: str, second: str, evidence: str) -> str | None:
+    text = evidence
+    first_match = re.search(re.escape(first), text, re.IGNORECASE)
+    second_match = re.search(re.escape(second), text, re.IGNORECASE)
+    if not first_match or not second_match:
+        return None
+    remainder = text[first_match.end() : second_match.start()]
+    if not remainder.strip(" \t,;:()[]«»\"'—–-"):
+        return None
+    cleaned = re.sub(r"\s+", " ", remainder).strip(" \t,;:()[]«»\"'—–-")
+    return cleaned[:500] if cleaned else None
+
+
+def fetch_article(title: str) -> str:
+    payload = _api_get(
+        WIKIPEDIA_API,
+        {"action": "parse", "page": title, "prop": "wikitext", "format": "json", "formatversion": "2", "redirects": "1"},
+    )
+    return str(payload.get("parse", {}).get("wikitext", ""))
+
+
+def fetch_category_members(category: str) -> list[str]:
+    payload = _api_get(
+        WIKIPEDIA_API,
+        {"action": "query", "list": "categorymembers", "cmtitle": category, "cmlimit": "500", "cmtype": "page|subcat", "format": "json", "formatversion": "2"},
+    )
+    return [str(item["title"]) for item in payload.get("query", {}).get("categorymembers", []) if item.get("title")]
+
+
+def fetch_wiktionary_pages(titles: list[str]) -> dict[str, str]:
+    pages: dict[str, str] = {}
+    for start in range(0, len(titles), 50):
+        batch = titles[start : start + 50]
+        payload = _api_get(
+            WIKTIONARY_API,
+            {"action": "query", "prop": "revisions", "titles": "|".join(batch), "rvprop": "content", "rvslots": "main", "format": "json", "formatversion": "2"},
+        )
+        for page in payload.get("query", {}).get("pages", []):
+            revisions = page.get("revisions") or []
+            if revisions:
+                content = revisions[0].get("slots", {}).get("main", {}).get("content", "")
+                pages[str(page.get("title", ""))] = str(content)
+    return pages
+
+
+def _wiktionary_pairs(title: str, text: str) -> list[tuple[str, str, str, str]]:
+    pairs: list[tuple[str, str, str, str]] = []
+    current: str | None = None
+    for raw_line in text.replace("\r", "").splitlines():
+        heading = HEADING_RE.match(raw_line.strip())
+        if heading:
+            found = RELATION_HEADING_RE.search(_clean_wikitext(heading.group(2)))
+            relation_by_stem = {
+                "паронім": "paronym",
+                "синонім": "synonym",
+                "антонім": "antonym",
+                "омонім": "homonym",
+            }
+            current = relation_by_stem.get(found.group(1).casefold()) if found else None
+            continue
+        if not current or not raw_line.lstrip().startswith(("*", "#")):
+            continue
+        linked = [normalize_word(_clean_wikitext(match.group(1))) for match in WIKILINK_RE.finditer(raw_line)]
+        linked = [word for word in linked if is_single_word(word) and word != normalize_word(title)]
+        cleaned = _clean_wikitext(raw_line).lstrip("*# ").strip()
+        for target in dict.fromkeys(linked):
+            pairs.append((normalize_word(title), target, current, cleaned[:600]))
+    return pairs
+
+
+def mine(
+    *,
+    vesum_db: Path = DEFAULT_VESUM_DB,
+    sample_seed: int = 4975,
+    wiktionary_limit: int = 100,
+    sleep_seconds: float = 1.0,
+) -> tuple[dict[str, list[dict[str, Any]]], dict[str, Any]]:
+    vesum = VesumIndex(vesum_db)
+    try:
+        rows_by_relation: dict[str, list[dict[str, Any]]] = {relation: [] for relation in ("paronyms", "synonyms", "antonyms", "homonyms")}
+        category_report: dict[str, list[str]] = {}
+        seed_words: set[str] = set()
+        for article, default_relation in ARTICLE_RELATIONS.items():
+            text = fetch_article(article)
+            rows, words = _gated_rows(
+                _headword_pairs(text),
+                default_relation=default_relation,
+                source="uk.wikipedia",
+                source_url=_source_url(article),
+                article=article,
+                vesum=vesum,
+                confidence="high",
+            )
+            seed_words.update(words)
+            for row in rows:
+                rows_by_relation[row["relation"] + "s"].append(row)
+            time.sleep(sleep_seconds)
+
+        category_pages: list[tuple[str, str]] = []
+        for default_relation, category in CATEGORIES.items():
+            members = fetch_category_members(category)
+            category_report[category] = members
+            category_pages.extend((default_relation, title) for title in members if not title.startswith("Категорія:"))
+            time.sleep(sleep_seconds)
+        for default_relation, title in sorted(set(category_pages)):
+            text = fetch_article(title)
+            rows, _words = _gated_rows(
+                _headword_pairs(text),
+                default_relation=default_relation,
+                source="uk.wikipedia",
+                source_url=_source_url(title),
+                article=title,
+                vesum=vesum,
+                confidence="high",
+                category=CATEGORIES[default_relation],
+            )
+            for row in rows:
+                rows_by_relation[row["relation"] + "s"].append(row)
+            time.sleep(sleep_seconds)
+
+        wiktionary_titles = sorted(seed_words)[:wiktionary_limit]
+        wiktionary_rows = 0
+        if wiktionary_titles:
+            pages = fetch_wiktionary_pages(wiktionary_titles)
+            for title, text in sorted(pages.items()):
+                rows, _words = _gated_rows(
+                    _wiktionary_pairs(title, text),
+                    default_relation="paronym",
+                    source="uk.wiktionary",
+                    source_url=_source_url(title, wiki="wiktionary"),
+                    article=title,
+                    vesum=vesum,
+                    confidence="medium",
+                )
+                for row in rows:
+                    rows_by_relation[row["relation"] + "s"].append(row)
+                    wiktionary_rows += 1
+
+        flat = [row for rows in rows_by_relation.values() for row in rows]
+        summary: dict[str, Any] = {
+            "article_rows": sum(len(rows) for rows in rows_by_relation.values()),
+            "wiktionary_rows": wiktionary_rows,
+            "category_pages": sum(len(values) for values in category_report.values()),
+            "category_report": category_report,
+            "wiktionary_pages_checked": len(wiktionary_titles),
+            "relation_counts": {relation: len(rows_by_relation[relation]) for relation in rows_by_relation},
+            "confidence_distribution": {level: sum(row["confidence"] == level for row in flat) for level in ("high", "medium")},
+            **summarize_rows(flat, sample_seed=sample_seed),
+        }
+        return rows_by_relation, summary
+    finally:
+        vesum.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--vesum-db", type=Path, default=DEFAULT_VESUM_DB)
+    parser.add_argument("--sample-seed", type=int, default=4975)
+    parser.add_argument("--wiktionary-limit", type=int, default=100)
+    parser.add_argument("--sleep-seconds", type=float, default=1.0)
+    parser.add_argument("--out", type=Path, default=DEFAULT_ARTIFACT)
+    args = parser.parse_args()
+    rows_by_relation, summary = mine(
+        vesum_db=args.vesum_db,
+        sample_seed=args.sample_seed,
+        wiktionary_limit=args.wiktionary_limit,
+        sleep_seconds=args.sleep_seconds,
+    )
+    payload = load_artifact(args.out)
+    added = 0
+    for relation, rows in rows_by_relation.items():
+        payload["relations"][relation] = [
+            row for row in payload["relations"][relation] if row.get("source") not in {"uk.wikipedia", "uk.wiktionary"}
+        ]
+        added += merge_rows(payload, relation, rows)
+    payload.setdefault("metadata", {})["wikipedia_miner"] = {
+        "license": "CC BY-SA 4.0",
+        "attribution": "Українська Вікіпедія; Український Вікісловник",
+        "article_urls": [_source_url(title) for title in ARTICLE_RELATIONS],
+        "category_urls": [_source_url(category) for category in CATEGORIES.values()],
+        "summary": {key: value for key, value in summary.items() if key != "samples"},
+    }
+    write_artifact(payload, args.out)
+    print(json.dumps({"added": added, **summary}, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lexicon/relation_candidate_common.py
+++ b/scripts/lexicon/relation_candidate_common.py
@@ -1,0 +1,367 @@
+"""Shared offline helpers for reviewable lexical-relation candidates.
+
+The generators in this directory deliberately stop at a candidate artifact.
+Nothing here mutates the Atlas manifest or treats a generated relation as
+learner-facing truth.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import unicodedata
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Iterator, Mapping
+from itertools import pairwise
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ARTIFACT = PROJECT_ROOT / "data" / "lexicon" / "relation_candidates.json"
+DEFAULT_VESUM_DB = PROJECT_ROOT / "data" / "vesum.db"
+DEFAULT_SOURCES_DB = PROJECT_ROOT / "data" / "sources.db"
+
+RELATIONS = ("paronyms", "synonyms", "antonyms", "homonyms")
+UK_WORD_RE = re.compile(r"[A-Za-zА-Яа-яЄєІіЇїҐґ]+(?:['’ʼ-][A-Za-zА-Яа-яЄєІіЇїҐґ]+)*")
+CORPUS_TOKEN_RE = re.compile(r"[А-Яа-яЄєІіЇїҐґ]+(?:['’ʼ-][А-Яа-яЄєІіЇїҐґ]+)*")
+APOSTROPHE_TRANSLATION = str.maketrans({"’": "'", "ʼ": "'", "`": "'", "′": "'"})
+
+
+def normalize_word(value: object) -> str:
+    """Normalize a lemma without guessing at morphology."""
+    text = unicodedata.normalize("NFKC", str(value or "")).strip().casefold()
+    text = text.translate(APOSTROPHE_TRANSLATION)
+    text = "".join(char for char in unicodedata.normalize("NFD", text) if char not in "\u0300\u0301")
+    return unicodedata.normalize("NFC", text)
+
+
+def is_single_word(value: object) -> bool:
+    text = normalize_word(value)
+    return bool(text and UK_WORD_RE.fullmatch(text))
+
+
+def shared_prefix_length(first: str, second: str) -> int:
+    length = 0
+    for left, right in zip(first, second, strict=False):
+        if left != right:
+            break
+        length += 1
+    return length
+
+
+def levenshtein(first: str, second: str, cutoff: int | None = None) -> int:
+    """Return Levenshtein distance, stopping once a row exceeds ``cutoff``."""
+    if first == second:
+        return 0
+    if len(first) > len(second):
+        first, second = second, first
+    if cutoff is not None and len(second) - len(first) > cutoff:
+        return cutoff + 1
+    previous = list(range(len(first) + 1))
+    for right_index, right in enumerate(second, 1):
+        current = [right_index]
+        row_min = right_index
+        for left_index, left in enumerate(first, 1):
+            value = min(
+                current[-1] + 1,
+                previous[left_index] + 1,
+                previous[left_index - 1] + (left != right),
+            )
+            current.append(value)
+            row_min = min(row_min, value)
+        if cutoff is not None and row_min > cutoff:
+            return cutoff + 1
+        previous = current
+    return previous[-1]
+
+
+class VesumIndex:
+    """Small, read-only exact-lemma index over the VESUM SQLite artifact."""
+
+    def __init__(self, db_path: Path = DEFAULT_VESUM_DB) -> None:
+        self.db_path = Path(db_path)
+        self.conn = sqlite3.connect(str(self.db_path))
+        self.conn.row_factory = sqlite3.Row
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def __enter__(self) -> VesumIndex:
+        return self
+
+    def __exit__(self, _exc_type: object, _exc_value: object, _traceback: object) -> None:
+        self.close()
+
+    def exact_lemmas(self, positions: Iterable[str] | None = None) -> dict[str, set[str]]:
+        query = "SELECT lemma, pos FROM forms WHERE word_form = lemma"
+        params: list[str] = []
+        allowed = sorted(set(positions or ()))
+        if allowed:
+            query += " AND pos IN (" + ",".join("?" for _ in allowed) + ")"
+            params.extend(allowed)
+        rows = self.conn.execute(query, params)
+        result: dict[str, set[str]] = defaultdict(set)
+        for row in rows:
+            lemma = normalize_word(row["lemma"])
+            if is_single_word(lemma):
+                result[lemma].add(str(row["pos"]))
+        return dict(result)
+
+    def exact_members(self, words: Iterable[str]) -> dict[str, set[str]]:
+        normalized = sorted({normalize_word(word) for word in words if is_single_word(word)})
+        if not normalized:
+            return {}
+        result: dict[str, set[str]] = defaultdict(set)
+        for start in range(0, len(normalized), 800):
+            batch = normalized[start : start + 800]
+            placeholders = ",".join("?" for _ in batch)
+            rows = self.conn.execute(
+                f"SELECT lemma, pos FROM forms WHERE word_form = lemma AND word_form IN ({placeholders})",
+                batch,
+            )
+            for row in rows:
+                result[normalize_word(row["lemma"])].add(str(row["pos"]))
+        return dict(result)
+
+    def forms_for_lemmas(self, lemmas: Iterable[str]) -> dict[str, dict[str, set[str]]]:
+        normalized = sorted({normalize_word(lemma) for lemma in lemmas if is_single_word(lemma)})
+        result: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+        for start in range(0, len(normalized), 800):
+            batch = normalized[start : start + 800]
+            placeholders = ",".join("?" for _ in batch)
+            rows = self.conn.execute(
+                f"SELECT word_form, lemma, pos FROM forms WHERE lemma IN ({placeholders})",
+                batch,
+            )
+            for row in rows:
+                result[normalize_word(row["lemma"])][normalize_word(row["word_form"])].add(str(row["pos"]))
+        return {lemma: dict(forms) for lemma, forms in result.items()}
+
+    def are_inflectional_variants(self, first: str, second: str) -> bool:
+        row = self.conn.execute(
+            """
+            SELECT 1 FROM forms
+            WHERE (word_form = ? AND lemma = ?)
+               OR (word_form = ? AND lemma = ?)
+            LIMIT 1
+            """,
+            (first, second, second, first),
+        ).fetchone()
+        return row is not None
+
+    def verify_exact(self, word: str, pos: str | None = None) -> bool:
+        normalized = normalize_word(word)
+        query = "SELECT 1 FROM forms WHERE word_form = lemma AND word_form = ?"
+        params: list[str] = [normalized]
+        if pos:
+            query += " AND pos = ?"
+            params.append(pos)
+        return self.conn.execute(query, params).fetchone() is not None
+
+
+class FrequencySource:
+    """Deterministic frequency evidence from a supplied map or literary corpus."""
+
+    def __init__(
+        self,
+        *,
+        vesum: VesumIndex,
+        corpus_db: Path | None = DEFAULT_SOURCES_DB,
+        frequency_json: Path | None = None,
+    ) -> None:
+        self.vesum = vesum
+        self.corpus_db = Path(corpus_db) if corpus_db else None
+        self.frequency_json = Path(frequency_json) if frequency_json else None
+        self.source = "none"
+        self._map: dict[str, int] | None = None
+
+    def _load_map(self) -> dict[str, int]:
+        if self._map is not None:
+            return self._map
+        if self.frequency_json:
+            payload = json.loads(self.frequency_json.read_text(encoding="utf-8"))
+            if not isinstance(payload, Mapping):
+                raise ValueError("frequency JSON must be an object keyed by lemma")
+            values: dict[str, int] = {}
+            for raw_word, raw_value in payload.items():
+                value = raw_value.get("freq") if isinstance(raw_value, Mapping) else raw_value
+                try:
+                    values[normalize_word(raw_word)] = int(value)
+                except (TypeError, ValueError):
+                    continue
+            self.source = "frequency_json"
+            self._map = values
+            return values
+        self._map = {}
+        return self._map
+
+    def count(self, lemmas: Iterable[str]) -> dict[str, int | None]:
+        requested = sorted({normalize_word(lemma) for lemma in lemmas if is_single_word(lemma)})
+        if not requested:
+            return {}
+        values = self._load_map()
+        if values:
+            return {lemma: values.get(lemma, 0) for lemma in requested}
+        if not self.corpus_db or not self.corpus_db.exists():
+            return {lemma: None for lemma in requested}
+
+        forms_by_lemma = self.vesum.forms_for_lemmas(requested)
+        surface_to_lemmas: dict[str, set[str]] = defaultdict(set)
+        for lemma, forms in forms_by_lemma.items():
+            for surface in forms:
+                surface_to_lemmas[surface].add(lemma)
+        return self._count_surface_map(surface_to_lemmas, requested)
+
+    def count_exact_lemmas(self, lemmas: Iterable[str]) -> dict[str, int | None]:
+        """Count exact lemma spellings, a fast corpus floor for candidate mining."""
+        requested = sorted({normalize_word(lemma) for lemma in lemmas if is_single_word(lemma)})
+        if not requested:
+            return {}
+        values = self._load_map()
+        if values:
+            return {lemma: values.get(lemma, 0) for lemma in requested}
+        if not self.corpus_db or not self.corpus_db.exists():
+            return {lemma: None for lemma in requested}
+        surface_to_lemmas = {lemma: {lemma} for lemma in requested}
+        return self._count_surface_map(surface_to_lemmas, requested)
+
+    def _count_surface_map(self, surface_to_lemmas: Mapping[str, set[str]], requested: list[str]) -> dict[str, int]:
+        counts: Counter[str] = Counter()
+        conn = sqlite3.connect(str(self.corpus_db))
+        try:
+            for (text,) in conn.execute("SELECT text FROM literary_texts WHERE text != ''"):
+                for token in CORPUS_TOKEN_RE.findall(str(text)):
+                    key = token.casefold()
+                    if "’" in key or "ʼ" in key or "`" in key or "′" in key:
+                        key = key.translate(APOSTROPHE_TRANSLATION)
+                    for lemma in surface_to_lemmas.get(key, ()):
+                        counts[lemma] += 1
+        finally:
+            conn.close()
+        self.source = "literary_texts"
+        return {lemma: counts.get(lemma, 0) for lemma in requested}
+
+
+def _deletion_signatures(word: str, max_deletions: int = 2) -> Iterator[tuple[str, int]]:
+    """Yield exact deletion signatures used for edit-distance candidate lookup."""
+    seen: set[tuple[str, int]] = set()
+    for deletion_count in range(max_deletions + 1):
+        if deletion_count == 0:
+            variants = (word,)
+        elif deletion_count == 1:
+            variants = (word[:index] + word[index + 1 :] for index in range(len(word)))
+        else:
+            variants = (
+                word[:first] + word[first + 1 : second] + word[second + 1 :]
+                for first in range(len(word))
+                for second in range(first + 1, len(word))
+            )
+        for signature in variants:
+            key = (signature, deletion_count)
+            if key not in seen:
+                seen.add(key)
+                yield signature, deletion_count
+
+
+def iter_edit_pairs(
+    exact_lemmas: Mapping[str, set[str]],
+    *,
+    max_distance: int = 2,
+) -> Iterator[tuple[str, str, str, int]]:
+    """Yield unique same-POS lemma pairs within the requested edit radius."""
+    words_by_pos: dict[str, list[str]] = defaultdict(list)
+    for word, positions in exact_lemmas.items():
+        for pos in sorted(positions):
+            words_by_pos[pos].append(word)
+    for pos in sorted(words_by_pos):
+        words = sorted(set(words_by_pos[pos]))
+        signatures: dict[str, list[tuple[str, int]]] = defaultdict(list)
+        for word in words:
+            for signature, deletion_count in _deletion_signatures(word, max_distance):
+                signatures[signature].append((word, deletion_count))
+        seen: set[tuple[str, str, str]] = set()
+        for candidates in signatures.values():
+            if len(candidates) < 2:
+                continue
+            for index, (first, first_deletions) in enumerate(candidates):
+                for second, second_deletions in candidates[index + 1 :]:
+                    if first == second or first > second or abs(len(first) - len(second)) > max_distance:
+                        continue
+                    if abs(first_deletions - second_deletions) > max_distance:
+                        continue
+                    pair = (first, second, pos)
+                    if pair in seen:
+                        continue
+                    distance = levenshtein(first, second, cutoff=max_distance)
+                    if distance <= max_distance:
+                        seen.add(pair)
+                        yield first, second, pos, distance
+
+
+def orthographic_variant(first: str, second: str) -> bool:
+    """Reject only normalization-equivalent spelling variants."""
+    return normalize_word(first) == normalize_word(second)
+
+
+def load_artifact(path: Path = DEFAULT_ARTIFACT) -> dict[str, Any]:
+    if path.exists():
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"relation artifact must be an object: {path}")
+    else:
+        payload = {}
+    payload.setdefault("schema_version", 1)
+    payload.setdefault("artifact", "reviewable_relation_candidates")
+    payload.setdefault("relations", {})
+    if not isinstance(payload["relations"], dict):
+        raise ValueError("relation artifact relations must be an object")
+    for relation in RELATIONS:
+        payload["relations"].setdefault(relation, [])
+    return payload
+
+
+def _row_key(row: Mapping[str, Any]) -> str:
+    relation = str(row.get("relation") or "")
+    first = normalize_word(row.get("word_a", row.get("word", "")))
+    second = normalize_word(row.get("word_b", row.get("antonym", "")))
+    source = str(row.get("source") or "")
+    url = str(row.get("source_url") or "")
+    affix = str(row.get("affix") or "")
+    pos = str(row.get("pos") or "")
+    return "\x1f".join((relation, first, second, pos, source, url, affix))
+
+
+def merge_rows(payload: dict[str, Any], relation: str, rows: Iterable[Mapping[str, Any]]) -> int:
+    if relation not in RELATIONS:
+        raise ValueError(f"unknown relation: {relation}")
+    existing = payload["relations"].setdefault(relation, [])
+    if not isinstance(existing, list):
+        raise ValueError(f"artifact relation {relation} must be a list")
+    known = {_row_key(row) for row in existing if isinstance(row, Mapping)}
+    added = 0
+    for raw in rows:
+        row = dict(raw)
+        row.setdefault("relation", relation[:-1] if relation.endswith("s") else relation)
+        key = _row_key(row)
+        if key in known:
+            continue
+        existing.append(row)
+        known.add(key)
+        added += 1
+    existing.sort(key=lambda row: _row_key(row) if isinstance(row, Mapping) else "")
+    return added
+
+
+def write_artifact(payload: Mapping[str, Any], path: Path = DEFAULT_ARTIFACT) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def summarize_rows(rows: list[Mapping[str, Any]], *, sample_seed: int, sample_size: int = 20) -> dict[str, Any]:
+    import random
+
+    rng = random.Random(sample_seed)
+    sample = list(rows)
+    rng.shuffle(sample)
+    return {"count": len(rows), "samples": sample[:sample_size]}

--- a/tests/test_relation_candidate_generators.py
+++ b/tests/test_relation_candidate_generators.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from scripts.lexicon.generate_antonym_candidates import generate as generate_antonyms
+from scripts.lexicon.generate_paronym_candidates import generate as generate_paronyms
+from scripts.lexicon.mine_wikipedia_relations import (
+    _gated_rows,
+    _headword_pairs,
+    _wiktionary_pairs,
+)
+from scripts.lexicon.relation_candidate_common import (
+    VesumIndex,
+    iter_edit_pairs,
+    load_artifact,
+    merge_rows,
+    write_artifact,
+)
+
+
+def _vesum_db(path: Path, rows: list[tuple[str, str, str]]) -> Path:
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE forms (word_form TEXT NOT NULL, lemma TEXT NOT NULL, tags TEXT NOT NULL, pos TEXT NOT NULL)")
+    conn.executemany("INSERT INTO forms VALUES (?, ?, ?, ?)", rows)
+    conn.commit()
+    conn.close()
+    return path
+
+
+def _frequency_json(path: Path, words: list[str], value: int = 5) -> Path:
+    path.write_text(json.dumps({word: value for word in words}, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def test_paronym_generator_applies_same_pos_frequency_and_seed_gates(tmp_path: Path) -> None:
+    db = _vesum_db(
+        tmp_path / "vesum.db",
+        [
+            ("адресант", "адресант", "noun:anim:m:v_naz", "noun"),
+            ("адресат", "адресат", "noun:anim:m:v_naz", "noun"),
+            ("адресанти", "адресант", "noun:anim:p:v_naz", "noun"),
+            ("адресати", "адресат", "noun:anim:p:v_naz", "noun"),
+            ("адресанта", "адресант", "noun:anim:m:v_rod", "noun"),
+        ],
+    )
+    sources = tmp_path / "sources.db"
+    conn = sqlite3.connect(sources)
+    conn.execute("CREATE TABLE zno_tasks (task_subtype TEXT, paronym_pair TEXT)")
+    conn.execute("CREATE TABLE paronyms_cache (word_a TEXT, word_b TEXT)")
+    conn.execute("INSERT INTO paronyms_cache VALUES ('адресант', 'адресат')")
+    conn.commit()
+    conn.close()
+    frequency = _frequency_json(tmp_path / "frequency.json", ["адресант", "адресат"])
+
+    rows, summary = generate_paronyms(
+        vesum_db=db,
+        sources_db=sources,
+        corpus_db=None,
+        frequency_json=frequency,
+        min_frequency=2,
+    )
+
+    assert [(row["word_a"], row["word_b"], row["pos"]) for row in rows] == [("адресант", "адресат", "noun")]
+    assert rows[0]["confidence"] == "medium"
+    assert rows[0]["gate"] == {
+        "vesum_exact_lemma": True,
+        "same_pos": True,
+        "not_inflectional_variant": True,
+        "frequency_floor": True,
+        "not_orthographic_variant": True,
+        "confusable_stem_or_seed": True,
+    }
+    assert summary["edit_distance_distribution"] == {"1": 1, "2": 0}
+
+
+def test_paronym_generator_rejects_missing_frequency_and_inflection_variant(tmp_path: Path) -> None:
+    db = _vesum_db(
+        tmp_path / "vesum.db",
+        [
+            ("книга", "книга", "noun:f:v_naz", "noun"),
+            ("книги", "книга", "noun:p:v_naz", "noun"),
+            ("книжа", "книжа", "noun:f:v_naz", "noun"),
+        ],
+    )
+    rows, summary = generate_paronyms(
+        vesum_db=db,
+        sources_db=tmp_path / "missing-sources.db",
+        corpus_db=None,
+        frequency_json=None,
+    )
+    assert rows == []
+    assert summary["frequency_source"] == "none"
+
+
+def test_antonym_generator_requires_both_exact_lemmas_and_flags_rare_forms(tmp_path: Path) -> None:
+    db = _vesum_db(
+        tmp_path / "vesum.db",
+        [
+            ("можливий", "можливий", "adj:m:v_naz", "adj"),
+            ("неможливий", "неможливий", "adj:m:v_naz", "adj"),
+            ("нехтувати", "нехтувати", "verb:inf", "verb"),
+        ],
+    )
+    frequency = _frequency_json(tmp_path / "frequency.json", ["можливий"], 5)
+    rows, summary = generate_antonyms(
+        vesum_db=db,
+        corpus_db=None,
+        frequency_json=frequency,
+    )
+    assert len(rows) == 1
+    assert rows[0]["word"] == "можливий"
+    assert rows[0]["antonym"] == "неможливий"
+    assert rows[0]["affix"] == "не-"
+    assert rows[0]["confidence"] == "low"
+    assert summary["affix_distribution"]["не-"] == 1
+
+
+def test_wikipedia_parser_preserves_gloss_and_cross_tags(tmp_path: Path) -> None:
+    db = _vesum_db(
+        tmp_path / "vesum.db",
+        [
+            ("ефектний", "ефектний", "adj:m:v_naz", "adj"),
+            ("ефективний", "ефективний", "adj:m:v_naz", "adj"),
+            ("прогрес", "прогрес", "noun:m:v_naz", "noun"),
+            ("регрес", "регрес", "noun:m:v_naz", "noun"),
+        ],
+    )
+    text = """'''Пароніми'''\n\n* '''Антонімічні''': прогрес — регрес;\n* ефектний («вражаючий») — ефективний («з позитивними наслідками»)."""
+    raw = _headword_pairs(text)
+    with VesumIndex(db) as vesum:  # type: ignore[attr-defined]
+        rows, _ = _gated_rows(
+            raw,
+            default_relation="paronym",
+            source="uk.wikipedia",
+            source_url="https://uk.wikipedia.org/wiki/Пароніми",
+            article="Пароніми",
+            vesum=vesum,
+            confidence="high",
+        )
+    assert {row["word_a"] for row in rows} == {"ефектний", "прогрес"}
+    antonym = next(row for row in rows if row["word_a"] == "прогрес")
+    assert antonym["relation"] == "antonym"
+    assert "uk.wikipedia.org" in antonym["source_url"]
+    assert next(row for row in rows if row["word_a"] == "ефектний")["distinction"] == "вражаючий"
+
+
+def test_wiktionary_relation_sections_map_to_relation_names() -> None:
+    raw = _wiktionary_pairs(
+        "ефектний",
+        """=== Синоніми ===\n* [[ефектний]]: [[видовищний]]\n=== Антоніми ===\n* [[неефектний]]""",
+    )
+    assert ("ефектний", "видовищний", "synonym", "ефектний: видовищний") in raw
+    assert ("ефектний", "неефектний", "antonym", "неефектний") in raw
+
+
+def test_relation_artifact_is_stable_and_deduplicated(tmp_path: Path) -> None:
+    path = tmp_path / "relations.json"
+    payload = load_artifact(path)
+    row = {"relation": "antonym", "word": "можливий", "antonym": "неможливий", "source": "test"}
+    assert merge_rows(payload, "antonyms", [row, row]) == 1
+    write_artifact(payload, path)
+    assert json.loads(path.read_text(encoding="utf-8"))["relations"]["antonyms"] == [row]
+
+
+def test_edit_neighbour_index_covers_substitution_and_insertion() -> None:
+    pairs = {(first, second, distance) for first, second, _pos, distance in iter_edit_pairs({"книга": {"noun"}, "книги": {"noun"}, "краса": {"noun"}})}
+    assert ("книга", "книги", 1) in pairs
+    assert not any(first == "книга" and second == "краса" for first, second, _distance in pairs)


### PR DESCRIPTION
Refs #4975

## Summary

This PR adds offline, review-only relation candidate generation. It does not modify `enrich_manifest.py`, the Atlas manifest, or learner-facing relation veins.

- Artifact: `data/lexicon/relation_candidates.json` (single merged review artifact).
- Wikipedia/Wiktionary pass: 608 raw gated rows; after source/POS dedup: 589 Wikimedia rows (Wikipedia 151, Wiktionary 438). Wikipedia rows all carry URL, CC BY-SA attribution, confidence, and VESUM gates.
- Final artifact rows: **16103**.
- Independent cross-family review: AGY final `PASS` after fixes for link-only Wiktionary parsing, POS-aware deduplication, and stale-source purging.

### Generator counts

| generator | rows emitted | distribution |
| --- | ---: | --- |
| Paronym expansion | 5,256 | edit distance 1: 1,254; 2: 4,002; confidence medium: 16, low: 5,240; min exact-lemma corpus frequency: 100; seed pairs: 11 |
| Antonym expansion | 10,258 | `не-`: 7,521; `без-`: 1,478; `анти-`: 950; `проти-`: 309; adj: 6,157; adv: 1,282; noun: 2,819; high: 2,845; low: 7,413 |

Paronym frequency is the exact lemma-spelling occurrence count in the local `literary_texts` corpus; it is intentionally conservative and does not treat inflected forms as evidence for the floor. Paronym expansion also requires a shared prefix/suffix of at least four characters or confirmed seed-neighborhood support. Antonym rows are emitted even when corpus evidence is rare, but are explicitly marked low confidence.

## Deterministic paronym samples (seed 4975)

Gate legend: `V` exact VESUM lemmas; `S` same POS; `I` not an inflectional variant; `F` frequency floor; `O` not a normalized orthographic variant; `C` confusable stem/seed gate.

| a | b | d | POS | freq a/b | conf. | gates |
| --- | --- | ---: | --- | ---: | --- | --- |
| деколи | інколи | 2 | adv | 318/1266 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| вінок | дзвінок | 2 | noun | 530/299 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| жахливо | щасливо | 2 | adv | 129/783 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| переведення | переселення | 2 | noun | 180/209 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| табор | табори | 1 | noun | 441/178 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| битися | братися | 2 | verb | 738/169 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| постав | пристав | 2 | noun | 427/494 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| повідати | повісити | 2 | verb | 109/111 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| ворог | ворона | 2 | noun | 1568/317 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| вдома | дома | 1 | adv | 1332/2992 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| бувати | чувати | 1 | verb | 153/126 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| олесь | олеся | 1 | noun | 357/1074 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| рабство | царство | 2 | noun | 265/1567 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| гула | гулак | 1 | noun | 107/143 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| всередині | посередині | 2 | adv | 759/621 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| вінець | донець | 2 | noun | 449/178 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| вхопити | захопити | 2 | verb | 149/412 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| забирати | набрати | 2 | verb | 159/187 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| ярославль | ярославна | 2 | noun | 205/358 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| франц | франція | 2 | noun | 1132/267 | low | V/S/I/F/O/C=T/T/T/T/T/T |

Observed likely false positives in this intentionally review-only bucket include `вуста—уста` (possible lexicalized/spelling-variant issue), `темна—темне` (looks form-like), and `арсенал—арсенія` (proper-name/lexical confusability). These remain candidates, not learner-facing pairs.

## Deterministic antonym samples (seed 4975)

Gate legend: `V` exact VESUM lemmas; `S` same POS; `I` base is a real exact lemma; `F` emitted frequency evidence is present/flagged separately; `O` negative lemma is real; `C` base is not already prefixed with the affix.

| word | antonym | affix | POS | freq word/antonym | conf. | gates |
| --- | --- | --- | --- | ---: | --- | --- |
| довготривалий | недовготривалий | не- | adj | 96/10 | high | V/S/I/F/O/C=T/T/T/T/T/T |
| ковідний | нековідний | не- | adj | 0/0 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| депресивний | недепресивний | не- | adj | 4/0 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| життєво | безжиттєво | без- | adv | 28/3 | high | V/S/I/F/O/C=T/T/T/T/T/T |
| правоздатний | неправоздатний | не- | adj | 1/0 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| імперіалістичний | антиімперіалістичний | анти- | adj | 79/6 | high | V/S/I/F/O/C=T/T/T/T/T/T |
| вихідний | безвихідний | без- | adj | 467/130 | high | V/S/I/F/O/C=T/T/T/T/T/T |
| людніше | безлюдніше | без- | adv | 7/0 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| передання | непередання | не- | noun | 35/0 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| зашорений | незашорений | не- | adj | 0/0 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| одривний | неодривний | не- | adj | 1/0 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| гніздовий | безгніздовий | без- | adj | 4/0 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| запальність | незапальність | не- | noun | 19/0 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| докучливо | недокучливо | не- | adv | 7/0 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| стійко | нестійко | не- | adv | 35/0 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| інфекційний | протиінфекційний | проти- | adj | 7/0 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| благословенний | неблагословенний | не- | adj | 434/5 | high | V/S/I/F/O/C=T/T/T/T/T/T |
| стандартний | нестандартний | не- | adj | 95/6 | high | V/S/I/F/O/C=T/T/T/T/T/T |
| подійний | безподійний | без- | adj | 1/0 | low | V/S/I/F/O/C=T/T/T/T/T/T |
| участь | неучасть | не- | noun | 6062/4 | high | V/S/I/F/O/C=T/T/T/T/T/T |

Obvious low-confidence false-positive classes visible in these samples include neologism/technical forms such as `ковідний↔нековідний`, rare base/negative pairs such as `правоздатний↔неправоздатний`, and prefix strings that are valid morphology but not necessarily lexical antonymy. The low-confidence flag is intentional and is the review gate.

## Verification

Commands run:

```text
.venv/bin/ruff check scripts/lexicon/relation_candidate_common.py scripts/lexicon/generate_paronym_candidates.py scripts/lexicon/generate_antonym_candidates.py scripts/lexicon/mine_wikipedia_relations.py tests/test_relation_candidate_generators.py
.venv/bin/pytest -q tests/test_relation_candidate_generators.py  # 7 passed
.venv/bin/python scripts/verification/vesum.py words вуста уста виклад виклик можливий неможливий законний незаконний --json
.venv/bin/python scripts/audit/lint_agent_trailer.py  # PASS
```

VESUM spot confirmation returned exact lemma/POS rows for all eight queried words, including `вуста/уста`, `виклад/виклик`, `можливий/неможливий`, and `законний/незаконний`.

The full repository pytest collection was also attempted: 10,649 passed, 135 skipped, 11 xfailed, with 38 unrelated failures and 58 environment/setup errors (missing pre-existing optional dependencies such as MCP, rapidfuzz, lxml, ruamel.yaml, FlagEmbedding, and the separate embed-venv). No failure was in the new relation-generator test file.
