### PR TITLE
feat(lexicon): add durable relation-pair corpus

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -3803,6 +3803,88 @@ def _paronym_relations_by_headword(
     return by_headword
 
 
+def _corpus_relation_pairs_by_headword(
+    conn: sqlite3.Connection,
+    manifest: dict[str, Any],
+) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    """Read VESUM-gated relation-pair corpus facts for Atlas headwords.
+
+    Candidate artifacts are deliberately permissive during the review period,
+    but both recorded lemmas are re-checked here. This makes the Atlas safe if
+    a stale or manually edited corpus row no longer satisfies the exact-lemma
+    contract. Corpus provenance stays separate from legacy dictionary veins.
+    """
+    headwords = _manifest_headwords(manifest)
+    by_headword: dict[str, dict[str, list[dict[str, Any]]]] = {}
+    try:
+        rows = conn.execute(
+            """
+            SELECT relation, word_a, word_b, gloss_a, gloss_b, source, source_url
+            FROM relation_pairs
+            WHERE review_status IN ('approved', 'candidate')
+            """
+        ).fetchall()
+    except sqlite3.Error:
+        return by_headword
+
+    for relation_raw, word_a_raw, word_b_raw, gloss_a_raw, gloss_b_raw, source_raw, source_url_raw in rows:
+        relation = str(relation_raw or "").strip().casefold()
+        if relation not in {"synonym", "antonym", "paronym", "homonym"}:
+            continue
+        word_a = _canonical_synonym_term(word_a_raw)
+        word_b = _canonical_synonym_term(word_b_raw)
+        if not word_a or not word_b or not (_vesum_valid_synonym(word_a) and _vesum_valid_synonym(word_b)):
+            continue
+        source = f"relation_pairs/{str(source_raw or '').strip()}"
+        if source == "relation_pairs/":
+            continue
+        source_url = str(source_url_raw or "").strip()
+        gloss_a = str(gloss_a_raw or "").strip()
+        gloss_b = str(gloss_b_raw or "").strip()
+
+        def append(
+            headword: str,
+            other: str,
+            other_gloss: str,
+            *,
+            corpus_relation: str = relation,
+            corpus_source: str = source,
+            corpus_source_url: str = source_url,
+        ) -> None:
+            if headword not in headwords:
+                return
+            relation_data: dict[str, Any] = {
+                "source": corpus_source,
+                "pattern": "corpus relation pair",
+                "vein": 3,
+                "gate": {"vesum": "both valid"},
+            }
+            if corpus_source_url:
+                relation_data["source_url"] = corpus_source_url
+            if corpus_relation in {"synonym", "antonym"}:
+                relation_data["item"] = other
+            elif corpus_relation == "paronym":
+                relation_data["word"] = other
+                if other_gloss:
+                    relation_data["distinction"] = other_gloss
+            elif not other_gloss:
+                # A homonym needs an independently authored gloss to be useful;
+                # do not manufacture a number or a part of speech for the UI.
+                return
+            else:
+                relation_data["word"] = other
+                relation_data["gloss"] = other_gloss
+            by_headword.setdefault(headword, {}).setdefault(corpus_relation, []).append(relation_data)
+
+        if relation == "homonym" and word_a == word_b:
+            for gloss in dict.fromkeys(gloss for gloss in (gloss_a, gloss_b) if gloss):
+                append(word_a, word_a, gloss)
+            continue
+        append(word_a, word_b, gloss_b)
+        append(word_b, word_a, gloss_a)
+    return by_headword
+
+
 def _ukrajinet_synsets(conn: sqlite3.Connection, lemma: str) -> list[dict[str, Any]]:
     """Read matching Ukrajinet synsets without creating the optional SQL index."""
     term = _canonical_synonym_term(lemma)
@@ -4099,10 +4181,10 @@ def _merge_homonym_relations(
     existing: dict[str, Any] | None,
     relations: list[dict[str, Any]],
 ) -> dict[str, Any] | None:
-    """Merge numbered homonym siblings into the gloss-bearing rendered schema."""
+    """Merge numbered and explicitly glossed corpus homonym relations."""
     merged = dict(existing or {})
     items: list[dict[str, Any]] = []
-    seen: set[tuple[str, int]] = set()
+    seen: set[tuple[str, int | None, str]] = set()
     for raw_item in merged.get("items", []):
         if not isinstance(raw_item, dict):
             continue
@@ -4110,41 +4192,57 @@ def _merge_homonym_relations(
         try:
             number = int(raw_item.get("homonym_no"))
         except (TypeError, ValueError):
-            continue
+            number = None
         gloss = str(raw_item.get("gloss") or "").strip()
         pos = str(raw_item.get("pos") or "").strip()
-        if not word or number < 1 or not gloss or not pos:
+        if not word or not gloss or (number is not None and (number < 1 or not pos)) or (number is None and pos):
             continue
-        key = (word, number)
+        key = (word, number, gloss)
         if key in seen:
             continue
         seen.add(key)
-        items.append({"word": word, "homonym_no": number, "gloss": gloss, "pos": pos})
+        item: dict[str, Any] = {"word": word, "gloss": gloss}
+        if number is not None:
+            item["homonym_no"] = number
+            item["pos"] = pos
+        items.append(item)
 
     source_urls = [str(url) for url in merged.get("source_urls", []) if str(url).strip()]
     source_labels: list[str] = []
     additions = 0
-    for relation in sorted(
-        relations,
-        key=lambda item: (int(item.get("vein") or 99), int(item.get("homonym_no") or 0)),
-    ):
+    def relation_order(item: dict[str, Any]) -> tuple[int, int]:
+        try:
+            number = int(item.get("homonym_no"))
+        except (TypeError, ValueError):
+            number = 0
+        return (int(item.get("vein") or 99), number)
+
+    for relation in sorted(relations, key=relation_order):
         word = _canonical_synonym_term(relation.get("word"))
         try:
             number = int(relation.get("homonym_no"))
         except (TypeError, ValueError):
-            continue
+            number = None
         gloss = str(relation.get("gloss") or "").strip()
         pos = str(relation.get("pos") or "").strip()
-        if not word or number < 1 or not gloss or not pos:
+        if not word or not gloss or (number is not None and (number < 1 or not pos)) or (number is None and pos):
             continue
-        key = (word, number)
+        key = (word, number, gloss)
         if key not in seen:
             if additions >= _HOMONYM_ADDITION_CAP:
                 continue
             seen.add(key)
-            items.append({"word": word, "homonym_no": number, "gloss": gloss, "pos": pos})
+            item = {"word": word, "gloss": gloss}
+            if number is not None:
+                item["homonym_no"] = number
+                item["pos"] = pos
+            items.append(item)
             additions += 1
-        label = f"{relation['source']}: numbered homonym headwords"
+        label = (
+            _relation_source_label(relation, word)
+            if relation.get("pattern") == "corpus relation pair"
+            else f"{relation['source']}: numbered homonym headwords"
+        )
         if label not in source_labels:
             source_labels.append(label)
         if relation.get("source_url") and relation["source_url"] not in source_urls:
@@ -5668,17 +5766,31 @@ def enrich() -> tuple[int, int]:
         )
         pointer_homonym_relations = _homonym_relations_by_headword(conn, manifest)
         pointer_paronym_relations = _paronym_relations_by_headword(conn, manifest)
+        corpus_relations = _corpus_relation_pairs_by_headword(conn, manifest)
         for entry in manifest["entries"]:
             entry_key = _canonical_synonym_term(str(entry.get("lemma") or ""))
+            corpus_for_entry = corpus_relations.get(entry_key or "", {})
             if enrich_entry(
                 entry,
                 conn,
                 kaikki_lookup,
                 has_sum11_flags=has_sum11_flags,
-                pointer_synonym_relations=pointer_synonym_relations.get(entry_key or "", []),
-                pointer_antonym_relations=pointer_antonym_relations.get(entry_key or "", []),
-                pointer_homonym_relations=pointer_homonym_relations.get(entry_key or "", []),
-                pointer_paronym_relations=pointer_paronym_relations.get(entry_key or "", []),
+                pointer_synonym_relations=[
+                    *pointer_synonym_relations.get(entry_key or "", []),
+                    *corpus_for_entry.get("synonym", []),
+                ],
+                pointer_antonym_relations=[
+                    *pointer_antonym_relations.get(entry_key or "", []),
+                    *corpus_for_entry.get("antonym", []),
+                ],
+                pointer_homonym_relations=[
+                    *pointer_homonym_relations.get(entry_key or "", []),
+                    *corpus_for_entry.get("homonym", []),
+                ],
+                pointer_paronym_relations=[
+                    *pointer_paronym_relations.get(entry_key or "", []),
+                    *corpus_for_entry.get("paronym", []),
+                ],
             ):
                 enriched += 1
     finally:

--- a/scripts/lexicon/load_relation_candidates.py
+++ b/scripts/lexicon/load_relation_candidates.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Load VESUM-gated relation candidate artifacts into ``relation_pairs``.
+
+Candidate artifacts contain relation facts and provenance only.  Miner-provided
+``distinction`` prose is intentionally not imported: source glosses may be
+copyrighted.  Only explicitly supplied project-authored ``gloss_a`` and
+``gloss_b`` fields may enter the corpus.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.lexicon.relation_pairs import (
+    RELATION_TYPES,
+    ensure_relation_pairs_schema,
+    is_exact_vesum_lemma,
+    normalize_relation_word,
+)
+
+DEFAULT_DB = ROOT / "data" / "sources.db"
+DEFAULT_CANDIDATES_DIR = ROOT / "data" / "lexicon"
+_CURATED_SOURCE_MARKERS = ("wikipedia", "wiktionary", "miyklas", "ukr-mova", "словник", "dictionary", "zno", "grinchyshyn")
+_GENERATED_SOURCE_MARKERS = ("generated", "llm", "model")
+
+
+@dataclass(frozen=True, slots=True)
+class Candidate:
+    relation: str
+    word_a: str
+    word_b: str
+    gloss_a: str
+    gloss_b: str
+    source: str
+    source_url: str
+    confidence: str
+    review_status: str
+
+
+@dataclass(slots=True)
+class LoadSummary:
+    accepted: int = 0
+    skipped_invalid: int = 0
+    skipped_vesum: int = 0
+    inserted: int = 0
+    updated: int = 0
+    unchanged: int = 0
+
+
+def _infer_relation(path: Path, payload: object) -> str | None:
+    if isinstance(payload, dict):
+        relation = str(payload.get("relation") or "").strip().casefold()
+        if relation in RELATION_TYPES:
+            return relation
+    return "paronym" if "paronym" in path.stem.casefold() else None
+
+
+def _confidence_for(source: str, supplied: object) -> str:
+    value = str(supplied or "").strip().casefold()
+    if value in {"high", "medium", "low"}:
+        return value
+    source_key = source.casefold()
+    if any(marker in source_key for marker in _GENERATED_SOURCE_MARKERS):
+        return "low"
+    if any(marker in source_key for marker in _CURATED_SOURCE_MARKERS):
+        return "high"
+    return "medium"
+
+
+def _candidate_records(path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        return {}, [item for item in payload if isinstance(item, dict)]
+    if not isinstance(payload, dict):
+        return {}, []
+    values = payload.get("pairs") or payload.get("relations") or payload.get("items") or []
+    return payload, [item for item in values if isinstance(item, dict)] if isinstance(values, list) else []
+
+
+def _project_authored_gloss(raw: dict[str, Any], root: dict[str, Any], key: str) -> str:
+    """Accept a gloss only when its artifact explicitly attests its origin."""
+    is_project_authored = raw.get("glosses_are_project_authored", root.get("glosses_are_project_authored", False))
+    return str(raw.get(key) or "").strip() if is_project_authored is True else ""
+
+
+def _normalise_candidate(path: Path, root: dict[str, Any], raw: dict[str, Any]) -> Candidate | None:
+    relation = str(raw.get("relation") or root.get("relation") or _infer_relation(path, root) or "").strip().casefold()
+    if relation not in RELATION_TYPES:
+        return None
+    word_a = normalize_relation_word(raw.get("word_a") or raw.get("lemma_a"))
+    word_b = normalize_relation_word(raw.get("word_b") or raw.get("lemma_b"))
+    source = str(raw.get("source") or root.get("source") or "").strip()
+    if not word_a or not word_b or not source:
+        return None
+
+    # Relation pairs are undirected. Keep the gloss paired with its lemma while
+    # canonicalizing the database key so reversed miner output deduplicates.
+    gloss_a = _project_authored_gloss(raw, root, "gloss_a")
+    gloss_b = _project_authored_gloss(raw, root, "gloss_b")
+    if word_b < word_a:
+        word_a, word_b = word_b, word_a
+        gloss_a, gloss_b = gloss_b, gloss_a
+    status = str(raw.get("review_status") or "candidate").strip().casefold()
+    if status not in {"candidate", "approved", "rejected"}:
+        status = "candidate"
+    return Candidate(
+        relation=relation,
+        word_a=word_a,
+        word_b=word_b,
+        gloss_a=gloss_a,
+        gloss_b=gloss_b,
+        source=source,
+        source_url=str(raw.get("source_url") or raw.get("source_page") or raw.get("url") or root.get("source_url") or "").strip(),
+        confidence=_confidence_for(source, raw.get("confidence") or root.get("confidence")),
+        review_status=status,
+    )
+
+
+def _iter_candidates(candidates_dir: Path, source_filter: str | None, summary: LoadSummary):
+    for path in sorted(candidates_dir.glob("*_candidates_*.json")):
+        root, records = _candidate_records(path)
+        for raw in records:
+            candidate = _normalise_candidate(path, root, raw)
+            if candidate is None:
+                summary.skipped_invalid += 1
+                continue
+            if source_filter and candidate.source != source_filter:
+                continue
+            if not (is_exact_vesum_lemma(candidate.word_a) and is_exact_vesum_lemma(candidate.word_b)):
+                summary.skipped_vesum += 1
+                continue
+            summary.accepted += 1
+            yield candidate
+
+
+def _existing_row(conn: sqlite3.Connection, candidate: Candidate) -> tuple[str, str, str, str, str] | None:
+    return conn.execute(
+        """
+        SELECT gloss_a, gloss_b, source_url, confidence, review_status
+        FROM relation_pairs
+        WHERE relation = ? AND word_a = ? AND word_b = ? AND source = ?
+        """,
+        (candidate.relation, candidate.word_a, candidate.word_b, candidate.source),
+    ).fetchone()
+
+
+def _upsert(conn: sqlite3.Connection, candidate: Candidate) -> None:
+    conn.execute(
+        """
+        INSERT INTO relation_pairs(
+            relation, word_a, word_b, gloss_a, gloss_b, source, source_url,
+            confidence, review_status, added_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(relation, word_a, word_b, source) DO UPDATE SET
+            gloss_a = CASE WHEN excluded.gloss_a != '' THEN excluded.gloss_a ELSE relation_pairs.gloss_a END,
+            gloss_b = CASE WHEN excluded.gloss_b != '' THEN excluded.gloss_b ELSE relation_pairs.gloss_b END,
+            source_url = CASE WHEN excluded.source_url != '' THEN excluded.source_url ELSE relation_pairs.source_url END,
+            confidence = excluded.confidence,
+            review_status = CASE
+                WHEN relation_pairs.review_status IN ('approved', 'rejected')
+                    AND excluded.review_status = 'candidate'
+                THEN relation_pairs.review_status
+                ELSE excluded.review_status
+            END
+        """,
+        (
+            candidate.relation,
+            candidate.word_a,
+            candidate.word_b,
+            candidate.gloss_a,
+            candidate.gloss_b,
+            candidate.source,
+            candidate.source_url,
+            candidate.confidence,
+            candidate.review_status,
+            datetime.now(UTC).isoformat(),
+        ),
+    )
+
+
+def load_candidates(
+    db_path: Path,
+    candidates_dir: Path,
+    *,
+    source_filter: str | None = None,
+    dry_run: bool = False,
+) -> tuple[LoadSummary, Counter[tuple[str, str]]]:
+    """Load all matching candidates and return result counts by source/relation."""
+    summary = LoadSummary()
+    by_source_relation: Counter[tuple[str, str]] = Counter()
+    candidates = list(_iter_candidates(candidates_dir, source_filter, summary))
+    for candidate in candidates:
+        by_source_relation[(candidate.source, candidate.relation)] += 1
+    if dry_run:
+        return summary, by_source_relation
+
+    conn = sqlite3.connect(db_path)
+    try:
+        ensure_relation_pairs_schema(conn)
+        for candidate in candidates:
+            before = _existing_row(conn, candidate)
+            review_status = (
+                before[4]
+                if before and before[4] in {"approved", "rejected"} and candidate.review_status == "candidate"
+                else candidate.review_status
+            )
+            after = (
+                candidate.gloss_a or (before[0] if before else ""),
+                candidate.gloss_b or (before[1] if before else ""),
+                candidate.source_url or (before[2] if before else ""),
+                candidate.confidence,
+                review_status,
+            )
+            _upsert(conn, candidate)
+            if before is None:
+                summary.inserted += 1
+            elif before == after:
+                summary.unchanged += 1
+            else:
+                summary.updated += 1
+        conn.commit()
+    finally:
+        conn.close()
+    return summary, by_source_relation
+
+
+def _print_summary(summary: LoadSummary, by_source_relation: Counter[tuple[str, str]]) -> None:
+    print(
+        "relation candidates: "
+        f"accepted={summary.accepted} inserted={summary.inserted} updated={summary.updated} "
+        f"unchanged={summary.unchanged} skipped_invalid={summary.skipped_invalid} "
+        f"skipped_vesum={summary.skipped_vesum}"
+    )
+    for (source, relation), count in sorted(by_source_relation.items()):
+        print(f"  {source} | {relation}: {count}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Load VESUM-gated relation candidate JSON into sources.db.")
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB, help="SQLite sources database path.")
+    parser.add_argument("--candidates-dir", type=Path, default=DEFAULT_CANDIDATES_DIR, help="Directory containing *_candidates_*.json artifacts.")
+    parser.add_argument("--source", dest="source_filter", help="Load only records attributed to this source.")
+    parser.add_argument("--dry-run", action="store_true", help="Validate and summarize without creating or changing the database.")
+    args = parser.parse_args()
+    summary, by_source_relation = load_candidates(
+        args.db,
+        args.candidates_dir,
+        source_filter=args.source_filter,
+        dry_run=args.dry_run,
+    )
+    _print_summary(summary, by_source_relation)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lexicon/relation_pairs.py
+++ b/scripts/lexicon/relation_pairs.py
@@ -1,0 +1,67 @@
+"""Shared schema and normalization helpers for relation-pair corpus data."""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+import unicodedata
+from collections.abc import Callable
+
+from scripts.lexicon.lemma_normalization import strip_acute_stress
+from scripts.verification.vesum import verify_word
+
+RELATION_TYPES = frozenset({"synonym", "antonym", "paronym", "homonym"})
+_UKRAINIAN_WORD_RE = re.compile(r"^[А-Яа-яЄєІіЇїҐґ'’ʼ-]+$")
+_STRESS_MARK_RE = re.compile("[\u0300\u0301]")
+
+
+def ensure_relation_pairs_schema(conn: sqlite3.Connection) -> None:
+    """Create the durable, provenance-preserving relation-pair corpus schema."""
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS relation_pairs (
+            id INTEGER PRIMARY KEY,
+            relation TEXT NOT NULL CHECK (relation IN ('synonym', 'antonym', 'paronym', 'homonym')),
+            word_a TEXT NOT NULL,
+            word_b TEXT NOT NULL,
+            gloss_a TEXT DEFAULT '',
+            gloss_b TEXT DEFAULT '',
+            source TEXT NOT NULL,
+            source_url TEXT DEFAULT '',
+            confidence TEXT DEFAULT 'medium' CHECK (confidence IN ('high', 'medium', 'low')),
+            review_status TEXT DEFAULT 'candidate' CHECK (review_status IN ('candidate', 'approved', 'rejected')),
+            added_at TEXT
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_relation_pairs_pair_source
+            ON relation_pairs(relation, word_a, word_b, source);
+        CREATE INDEX IF NOT EXISTS idx_relation_pairs_relation_word_a
+            ON relation_pairs(relation, word_a);
+        CREATE INDEX IF NOT EXISTS idx_relation_pairs_relation_word_b
+            ON relation_pairs(relation, word_b);
+        """
+    )
+
+
+def normalize_relation_word(value: object) -> str | None:
+    """Return a single Ukrainian lemma key with VESUM-compatible apostrophes."""
+    text = unicodedata.normalize("NFKD", str(value or ""))
+    text = _STRESS_MARK_RE.sub("", text)
+    text = unicodedata.normalize("NFC", text)
+    text = strip_acute_stress(text).replace("`", "'").replace("’", "'").replace("ʼ", "'")
+    text = re.sub(r"\s+", " ", text).strip().casefold()
+    return text if _UKRAINIAN_WORD_RE.fullmatch(text) else None
+
+
+def is_exact_vesum_lemma(
+    word: str,
+    *,
+    verifier: Callable[[str], list[dict]] = verify_word,
+) -> bool:
+    """Fail closed unless VESUM records ``word`` exactly as a lemma."""
+    normalized = normalize_relation_word(word)
+    if not normalized:
+        return False
+    try:
+        return any(normalize_relation_word(row.get("lemma")) == normalized for row in verifier(normalized))
+    except Exception:
+        return False

--- a/scripts/wiki/build_sources_db.py
+++ b/scripts/wiki/build_sources_db.py
@@ -246,6 +246,33 @@ CREATE TABLE IF NOT EXISTS style_guide (
 );
 CREATE INDEX IF NOT EXISTS idx_style_word ON style_guide(word COLLATE NOCASE);
 
+-- === Lexical relation corpus (populated by scripts/lexicon/load_relation_candidates.py) ===
+--
+-- This durable fact corpus is rebuilt from versioned/mined candidate artifacts
+-- after a full source build, just as ZNO task tables are re-ingested separately.
+-- One row is retained per normalized pair and provenance source so source URLs
+-- and confidence remain attributable without serializing a source list.
+
+CREATE TABLE IF NOT EXISTS relation_pairs (
+    id INTEGER PRIMARY KEY,
+    relation TEXT NOT NULL CHECK (relation IN ('synonym', 'antonym', 'paronym', 'homonym')),
+    word_a TEXT NOT NULL,
+    word_b TEXT NOT NULL,
+    gloss_a TEXT DEFAULT '',
+    gloss_b TEXT DEFAULT '',
+    source TEXT NOT NULL,
+    source_url TEXT DEFAULT '',
+    confidence TEXT DEFAULT 'medium' CHECK (confidence IN ('high', 'medium', 'low')),
+    review_status TEXT DEFAULT 'candidate' CHECK (review_status IN ('candidate', 'approved', 'rejected')),
+    added_at TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_relation_pairs_pair_source
+    ON relation_pairs(relation, word_a, word_b, source);
+CREATE INDEX IF NOT EXISTS idx_relation_pairs_relation_word_a
+    ON relation_pairs(relation, word_a);
+CREATE INDEX IF NOT EXISTS idx_relation_pairs_relation_word_b
+    ON relation_pairs(relation, word_b);
+
 -- === Wikipedia passthrough (populated by scripts/wiki/fetch_wikipedia.py) ===
 --
 -- These tables own the Wikipedia cache that the MCP sources server queries

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "4bfdda88344a0cb5d3c764c5624458e242b9e0bf71e5a600775b7c2ca0a260e3",
+  "fingerprint": "0c9ca9ca1ff2a37b49aefef70a58437c6217b663db08add46523dfb26e5b870b",
   "inputs": {
     "lexicon_code": [
       {
@@ -52,7 +52,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "40dc9a32d3d498f4fb70638e7aac02336cd1888f81d4ca18840c2df03ba092ed"
+        "sha256": "492b0b006d1bbc69246579fed393a705883e5be4d09b1b8b930543cad15a3aa2"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -91,6 +91,10 @@
         "sha256": "d99d41aff8ffb52fc40ca9ac55a79a2eee8090dac4a57b32aabdcbdfc1374c7b"
       },
       {
+        "path": "scripts/lexicon/load_relation_candidates.py",
+        "sha256": "a970db4d2867a6fd182d186176058070b6d090c87a42f1368ef82642aa0d7f69"
+      },
+      {
         "path": "scripts/lexicon/manifest_fingerprint.py",
         "sha256": "06db0476943928e3440767172e3bb9f91718d4504580dc156867e66b5535b5fb"
       },
@@ -119,6 +123,10 @@
         "sha256": "28c72082c388ae5b301acc006eeed4e585c9fbbda48b805d1ff543d31862745d"
       },
       {
+        "path": "scripts/lexicon/relation_pairs.py",
+        "sha256": "24781db1d0078fd7e83c349477ff764cd409c11b202949a3c615dcf9654d2fa1"
+      },
+      {
         "path": "scripts/lexicon/repair_plural_noun_aliases.py",
         "sha256": "212d5d59061e2b3709e6f62b0861ccf0c98dfa4e1d63922efa8c5fce3d356416"
       },
@@ -135,6 +143,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 32
+    "lexicon_code_files": 34
   }
 }

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -136,7 +136,7 @@ interface LexiconSections {
   synonyms?: { items: string[]; source: string; source_urls?: string[] };
   antonyms?: { items: string[]; source: string; source_urls?: string[] };
   homonyms?: {
-    items: Array<{ word: string; gloss: string; pos: string; homonym_no: number }>;
+    items: Array<{ word: string; gloss: string; pos?: string; homonym_no?: number }>;
     source: string;
     source_urls?: string[];
   };
@@ -954,7 +954,8 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
           <div class="chip-row">
             {sections.homonyms.items.map((item) => (
               <span class="chip">
-                <strong>{item.word}<sup>{item.homonym_no}</sup></strong> ({item.pos}) — {item.gloss}
+                <strong>{item.word}{item.homonym_no ? <sup>{item.homonym_no}</sup> : null}</strong>
+                {item.pos ? ` (${item.pos})` : ""} — {item.gloss}
               </span>
             ))}
           </div>

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -19,6 +19,7 @@ from scripts.lexicon.enrich_manifest import (
     _build_paradigm,
     _cefr,
     _clean_synonym_candidate,
+    _corpus_relation_pairs_by_headword,
     _curated_calque,
     _definition_antonym_relations,
     _definition_antonym_relations_by_headword,
@@ -166,6 +167,19 @@ def _conn() -> sqlite3.Connection:
             word_a TEXT NOT NULL,
             word_b TEXT NOT NULL,
             definition TEXT NOT NULL
+        );
+        CREATE TABLE relation_pairs (
+            id INTEGER PRIMARY KEY,
+            relation TEXT NOT NULL,
+            word_a TEXT NOT NULL,
+            word_b TEXT NOT NULL,
+            gloss_a TEXT DEFAULT '',
+            gloss_b TEXT DEFAULT '',
+            source TEXT NOT NULL,
+            source_url TEXT DEFAULT '',
+            confidence TEXT DEFAULT 'medium',
+            review_status TEXT DEFAULT 'candidate',
+            added_at TEXT
         );
         """
     )
@@ -2896,6 +2910,45 @@ def test_homonym_relation_merge_preserves_gloss_schema_and_source_urls() -> None
         "source": "СУМ-20: numbered homonym headwords",
         "source_urls": ["https://example.invalid/sum20/kosa"],
     }
+
+
+def test_corpus_relation_pairs_are_vesum_gated_and_attributed(monkeypatch) -> None:
+    conn = _conn()
+    conn.executemany(
+        """
+        INSERT INTO relation_pairs(
+            relation, word_a, word_b, gloss_a, gloss_b, source, source_url, review_status
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            ("synonym", "гарний", "вродливий", "", "", "miyklas.com.ua", "https://example.invalid/syn", "candidate"),
+            ("antonym", "гарний", "поганий", "", "", "uk.wikipedia", "", "approved"),
+            ("paronym", "адрес", "адреса", "привітальний лист", "місце проживання", "ukr-mova.in.ua", "", "candidate"),
+            ("homonym", "ключ", "ключ", "знаряддя для замикання", "джерело води", "uk.wikipedia", "", "candidate"),
+            ("synonym", "гарний", "вигадка", "", "", "miyklas.com.ua", "", "rejected"),
+        ],
+    )
+    _patch_synonym_vesum(monkeypatch, {"гарний", "вродливий", "поганий", "адрес", "адреса", "ключ"})
+
+    relations = _corpus_relation_pairs_by_headword(
+        conn,
+        {"entries": [{"lemma": "гарний"}, {"lemma": "адрес"}, {"lemma": "ключ"}]},
+    )
+
+    assert relations["гарний"]["synonym"][0]["item"] == "вродливий"
+    assert relations["гарний"]["synonym"][0]["source"] == "relation_pairs/miyklas.com.ua"
+    assert relations["гарний"]["antonym"][0]["item"] == "поганий"
+    assert relations["адрес"]["paronym"][0]["distinction"] == "місце проживання"
+    assert [item["gloss"] for item in relations["ключ"]["homonym"]] == [
+        "знаряддя для замикання",
+        "джерело води",
+    ]
+    merged = _merge_homonym_relations(None, relations["ключ"]["homonym"])
+    assert merged is not None
+    assert merged["items"] == [
+        {"word": "ключ", "gloss": "знаряддя для замикання"},
+        {"word": "ключ", "gloss": "джерело води"},
+    ]
 
 
 def test_homonym_fixture_samples_expand_from_zero(monkeypatch) -> None:

--- a/tests/test_load_relation_candidates.py
+++ b/tests/test_load_relation_candidates.py
@@ -1,0 +1,132 @@
+import json
+import sqlite3
+from pathlib import Path
+
+from scripts.lexicon import load_relation_candidates as loader
+
+
+def _write_candidates(directory: Path) -> None:
+    (directory / "paronym_candidates_fixture.json").write_text(
+        json.dumps(
+            {
+                "source": "ukr-mova.in.ua",
+                "pairs": [
+                    {
+                        "word_a": "Адреса",
+                        "word_b": "адрес",
+                        "source_page": "https://example.invalid/address",
+                        "site_distinction": "This copyrighted source text must not be retained.",
+                    },
+                    {"word_a": "invalid token", "word_b": "адрес", "source_page": "https://example.invalid/bad"},
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    (directory / "relation_candidates_fixture.json").write_text(
+        json.dumps(
+            [
+                {
+                    "relation": "synonym",
+                    "word_a": "гарний",
+                    "word_b": "вродливий",
+                    "source": "miyklas.com.ua",
+                    "distinction": "This source prose must not be retained.",
+                },
+                {
+                    "relation": "synonym",
+                    "word_a": "вродливий",
+                    "word_b": "гарний",
+                    "source": "miyklas.com.ua",
+                },
+                {
+                    "relation": "antonym",
+                    "word_a": "гарний",
+                    "word_b": "неіснуюче",
+                    "source": "miyklas.com.ua",
+                },
+                {
+                    "relation": "antonym",
+                    "word_a": "світлий",
+                    "word_b": "темний",
+                    "gloss_a": "з великою кількістю світла",
+                    "gloss_b": "з малою кількістю світла",
+                    "glosses_are_project_authored": True,
+                    "source": "miyklas.com.ua",
+                },
+            ],
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_loader_upserts_normalized_pairs_and_discards_source_prose(tmp_path, monkeypatch) -> None:
+    candidates_dir = tmp_path / "candidates"
+    candidates_dir.mkdir()
+    _write_candidates(candidates_dir)
+    db_path = tmp_path / "sources.db"
+    monkeypatch.setattr(loader, "is_exact_vesum_lemma", lambda word: word != "неіснуюче")
+
+    first, counts = loader.load_candidates(db_path, candidates_dir)
+    second, _ = loader.load_candidates(db_path, candidates_dir)
+
+    assert first.accepted == 4
+    assert first.inserted == 3
+    assert first.skipped_invalid == 1
+    assert first.skipped_vesum == 1
+    assert counts == {
+        ("miyklas.com.ua", "antonym"): 1,
+        ("miyklas.com.ua", "synonym"): 2,
+        ("ukr-mova.in.ua", "paronym"): 1,
+    }
+    assert second.inserted == 0
+    assert second.unchanged == 4
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT relation, word_a, word_b, gloss_a, gloss_b, confidence FROM relation_pairs ORDER BY relation, word_a"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows == [
+        ("antonym", "світлий", "темний", "з великою кількістю світла", "з малою кількістю світла", "high"),
+        ("paronym", "адрес", "адреса", "", "", "high"),
+        ("synonym", "вродливий", "гарний", "", "", "high"),
+    ]
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("UPDATE relation_pairs SET review_status = 'approved' WHERE relation = 'paronym'")
+        conn.commit()
+    finally:
+        conn.close()
+    loader.load_candidates(db_path, candidates_dir)
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("SELECT review_status FROM relation_pairs WHERE relation = 'paronym'").fetchone() == (
+            "approved",
+        )
+    finally:
+        conn.close()
+
+
+def test_loader_dry_run_is_read_only_and_source_filter_is_precise(tmp_path, monkeypatch) -> None:
+    candidates_dir = tmp_path / "candidates"
+    candidates_dir.mkdir()
+    _write_candidates(candidates_dir)
+    db_path = tmp_path / "sources.db"
+    monkeypatch.setattr(loader, "is_exact_vesum_lemma", lambda word: word != "неіснуюче")
+
+    summary, counts = loader.load_candidates(
+        db_path,
+        candidates_dir,
+        source_filter="ukr-mova.in.ua",
+        dry_run=True,
+    )
+
+    assert summary.accepted == 1
+    assert summary.inserted == 0
+    assert counts == {("ukr-mova.in.ua", "paronym"): 1}
+    assert not db_path.exists()


### PR DESCRIPTION
## Summary

Implements #4975: a durable, attributed `relation_pairs` corpus in `data/sources.db`, an idempotent VESUM-gated candidate loader, and Atlas enrichment reads for synonym, antonym, paronym, and safe glossed homonym pairs.

## Evidence

- Loaded referenced candidate artifacts: 290 stored rows after normalized `(relation, word_a, word_b, source)` dedup.
- Stored rows by relation/source: antonym miyklas 27; homonym miyklas 67; paronym miyklas 14 + ukr-mova 41; synonym miyklas 141.
- Ten sampled rows were inspected with source, confidence, and review status; all stored generated-artifact gloss fields are empty, so no source prose was copied.
- Re-running the loader: `accepted=292 inserted=0 updated=0 unchanged=292`; no duplicate rows.
- Live corpus reader query returned Atlas relations for `адрес` (two paronym sources) and `великий` (one antonym). Hermetic enrichment fixture covers all four relation types, VESUM failure, rejected rows, and glossed homonyms.
- Verification: `.venv/bin/python -m pytest tests/test_load_relation_candidates.py tests/test_lexicon_enrich_manifest.py tests/test_sources_db.py -q` (154 passed); targeted ruff passed; manifest freshness passed; agent-trailer lint passed.

## Review

Independent Gemini-family review requested through AGY (task `review-4975b`); no auto-merge has been enabled.