### PR TITLE
fix(practice): keep mode switches out of prior sessions

### DIFF
--- a/site/e2e/atlas-practice.spec.ts
+++ b/site/e2e/atlas-practice.spec.ts
@@ -58,6 +58,22 @@ test('practice matching renders a real round (>=3 pairs) for a fresh learner', a
   await expect.poll(() => page.locator('[data-activity="match-left-tile"]').count()).toBeGreaterThanOrEqual(3);
 });
 
+test('practice mode switch starts the selected mode without inheriting the unfinished one', async ({ page }) => {
+  await page.goto('/words-of-the-day/practice/');
+
+  await page.locator('button[data-mode="matching"]').click();
+  await expect(page.locator('[data-testid="practice-matching"]')).toBeVisible();
+  await page.getByRole('button', { name: /Додому/ }).click();
+
+  // An unfinished matching session remains available only through its matching control.
+  await expect(page.locator('button[data-resume-mode="matching"]')).toBeVisible();
+  await page.locator('button[data-mode="flashcards"]').click();
+
+  await expect(page.locator('[data-activity="flashcard"]')).toBeVisible();
+  await expect(page.locator('[data-testid="practice-matching"]')).toBeHidden();
+  await expect(page.locator('[data-testid="practice-session-progress"]')).toContainText('0/');
+});
+
 for (const [path, label] of [
   ['/words-of-the-day/practice/', 'plain practice page'],
   ['/words-of-the-day/practice/?lemmaId=%D0%BA%D0%B0%D0%B2%D0%B0', 'deep-link practice page'],

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -8,6 +8,7 @@ import {
   PUBLISHED_PRACTICE_LEVELS,
   SRS_STORAGE_FULL_WARNING,
   buildSessionPoolConstraintState,
+  clearPracticeSessionSnapshots,
   combinePracticeShards,
   extendWithLowerDecks,
   itemIdPresentInDeck,
@@ -26,7 +27,7 @@ import {
   rateCard,
   resolveSessionCompletion,
   readNewCardsDailyState,
-  readPracticeSessionSnapshot,
+  readPracticeSessionSnapshots,
   selectNextPracticeItem,
   seededAnswerIndex,
   sessionPoolAllowsCandidate,
@@ -47,6 +48,7 @@ import {
   type PracticeRating,
   type PracticeSelection,
   type PracticeSessionSnapshot,
+  type PracticeSessionSnapshots,
   type ReviewLogEntry,
   type SelectionHistoryItem,
   type SessionBudget,
@@ -888,7 +890,7 @@ function LexiconPracticeIsland({
   const [sessionCorrect, setSessionCorrect] = useState(0);
   const [sessionLapsed, setSessionLapsed] = useState(0);
   const [advancedToReview, setAdvancedToReview] = useState<string[]>([]);
-  const [resumeSnapshot, setResumeSnapshot] = useState<PracticeSessionSnapshot | null>(null);
+  const [resumeSnapshots, setResumeSnapshots] = useState<PracticeSessionSnapshots>({});
   const [learnerLevel, setLearnerLevel] = useState<CefrLevel>(() =>
     readLearnerLevel(normalizeCefrLevel(deckLevel)),
   );
@@ -985,12 +987,15 @@ function LexiconPracticeIsland({
       if (target) {
         // Keep #4744's single reactive auto-start path: initialize the resolved focus,
         // then let the focusedLemmaId effect below create the session exactly once.
-        writePracticeSessionSnapshot(null);
-        setResumeSnapshot(null);
+        clearPracticeSessionSnapshots();
+        setResumeSnapshots({});
         void initializeFocusedPractice(target);
       } else {
-        const snapshot = readPracticeSessionSnapshot();
-        setResumeSnapshot(isPracticeSessionResumable(snapshot) ? snapshot : null);
+        const snapshots = readPracticeSessionSnapshots();
+        const resumableSnapshots = Object.fromEntries(
+          Object.entries(snapshots).filter(([, snapshot]) => isPracticeSessionResumable(snapshot)),
+        ) as PracticeSessionSnapshots;
+        setResumeSnapshots(resumableSnapshots);
       }
     }
   }, []);
@@ -1027,7 +1032,7 @@ function LexiconPracticeIsland({
     sessionStartedAtRef.current = Date.now();
     setHistory([]);
     const reviewSlots = sessionBudget === 'until-zero' ? plan.dueReviews : Math.min(plan.dueReviews, sessionBudget);
-    writePracticeSessionSnapshot({
+    const snapshot: PracticeSessionSnapshot = {
       sessionSeed: nextSeed,
       history: [],
       budget: sessionBudget,
@@ -1042,7 +1047,9 @@ function LexiconPracticeIsland({
       plannedTotal: plan.plannedTotal,
       reviewsCompleted: 0,
       unresolvedCardKeys: [],
-    });
+    };
+    writePracticeSessionSnapshot(mode, snapshot);
+    setResumeSnapshots((snapshots) => ({ ...snapshots, [mode]: snapshot }));
   }, [autoStart, focusedLemmaId, dailyNewCount, deck, mode, plannedTotal, sessionBudget, learnerLevel]);
 
   useEffect(() => {
@@ -1524,12 +1531,28 @@ function LexiconPracticeIsland({
     };
   }
 
+  function clearResumeSnapshot(nextMode: PracticeModeFilter) {
+    writePracticeSessionSnapshot(nextMode, null);
+    setResumeSnapshots((snapshots) => {
+      const nextSnapshots = { ...snapshots };
+      delete nextSnapshots[nextMode];
+      return nextSnapshots;
+    });
+  }
+
+  function clearResumeSnapshots() {
+    clearPracticeSessionSnapshots();
+    setResumeSnapshots({});
+  }
+
   function persistSessionSnapshot(
     overrides: Partial<PracticeSessionSnapshot> = {},
     options: { force?: boolean } = {},
   ) {
     if (!options.force && sessionPhase !== 'active') return;
-    writePracticeSessionSnapshot(buildSessionSnapshot(overrides));
+    const snapshot = buildSessionSnapshot(overrides);
+    writePracticeSessionSnapshot(mode, snapshot);
+    setResumeSnapshots((snapshots) => ({ ...snapshots, [mode]: snapshot }));
   }
 
   function effectiveSessionTarget(): number {
@@ -1538,8 +1561,7 @@ function LexiconPracticeIsland({
 
   function openSummary(deferred: PracticeLexeme[] = deferredLemmas) {
     if (deferred.length) setDeferredLemmas(deferred);
-    writePracticeSessionSnapshot(null);
-    setResumeSnapshot(null);
+    clearResumeSnapshot(mode);
     setSessionPhase('summary');
   }
 
@@ -1554,6 +1576,10 @@ function LexiconPracticeIsland({
     // design and is intentionally NOT persisted to `PracticeSessionSnapshot`.
     focus: WeakArea | null = null,
   ) {
+    // A pinned selection is only valid within the session that created it. Without this
+    // reset, returning home with an empty history lets the selector reuse the previous
+    // mode's card when the learner starts a different mode.
+    committedSelectionRef.current = null;
     setMode(nextMode);
     setSessionBudget(budget);
     setError(null);
@@ -1584,8 +1610,7 @@ function LexiconPracticeIsland({
     ) {
       setFocusWeakness(null);
       setFeedback('Немає вправ для цього фокуса — колода оновиться після практики');
-      writePracticeSessionSnapshot(null);
-      setResumeSnapshot(null);
+      clearResumeSnapshot(nextMode);
       setSessionPhase('idle');
       return;
     }
@@ -1616,7 +1641,7 @@ function LexiconPracticeIsland({
     }
     setSessionPhase('active');
     const reviewSlots = budget === 'until-zero' ? plan.dueReviews : Math.min(plan.dueReviews, budget);
-    writePracticeSessionSnapshot({
+    const snapshot: PracticeSessionSnapshot = {
       sessionSeed: nextSeed,
       history: resume?.history ?? [],
       budget,
@@ -1631,7 +1656,9 @@ function LexiconPracticeIsland({
       plannedTotal: resume?.plannedTotal ?? plan.plannedTotal,
       reviewsCompleted: resume?.reviewsCompleted ?? 0,
       unresolvedCardKeys: resume?.unresolvedCardKeys ?? [],
-    });
+    };
+    writePracticeSessionSnapshot(nextMode, snapshot);
+    setResumeSnapshots((snapshots) => ({ ...snapshots, [nextMode]: snapshot }));
   }
 
   async function startSession(
@@ -1639,16 +1666,16 @@ function LexiconPracticeIsland({
     nextMode: PracticeModeFilter = 'mixed',
     focus: WeakArea | null = null,
   ) {
-    writePracticeSessionSnapshot(null);
-    setResumeSnapshot(null);
+    clearResumeSnapshot(nextMode);
     await beginSession(nextMode, budget, undefined, focus);
   }
 
-  async function resumeSession() {
-    if (!resumeSnapshot) return;
+  async function resumeSession(nextMode: PracticeModeFilter) {
+    const snapshot = resumeSnapshots[nextMode];
+    if (!snapshot || snapshot.modeFilter !== nextMode || !isPracticeSessionResumable(snapshot)) return;
     // A resumed session starts with NO focus: the weakness is session-transient (never
     // persisted to the snapshot), so `beginSession(..., focus=null)` clears `focusWeakness`.
-    await beginSession(resumeSnapshot.modeFilter, resumeSnapshot.budget, resumeSnapshot, null);
+    await beginSession(nextMode, snapshot.budget, snapshot, null);
   }
 
   async function startFocusMode(nextMode: PracticeModeFilter) {
@@ -1672,8 +1699,7 @@ function LexiconPracticeIsland({
     setDeck(null);
     setDueIndex(null);
     committedSelectionRef.current = null;
-    writePracticeSessionSnapshot(null);
-    setResumeSnapshot(null);
+    clearResumeSnapshots();
     setSessionPhase('idle');
   }
 
@@ -1684,8 +1710,7 @@ function LexiconPracticeIsland({
     setClozeLoaded(false);
     setHistory([]);
     committedSelectionRef.current = null;
-    writePracticeSessionSnapshot(null);
-    setResumeSnapshot(null);
+    clearResumeSnapshots();
     if (sessionPhase === 'active') {
       await ensureDeck(shouldLoadCloze(mode), { level: nextLevel, force: true });
     } else {
@@ -1942,7 +1967,6 @@ function LexiconPracticeIsland({
     setHistory([]);
     setDeck(null);
     setClozeLoaded(false);
-    writePracticeSessionSnapshot(null);
   }
 
   return (
@@ -2084,14 +2108,16 @@ function LexiconPracticeIsland({
                 <span className="btn-sub">{SESSION_LABELS_A1.startSession}</span>
               ) : null}
             </button>
-            {resumeSnapshot ? (
+            {resumeSnapshots.mixed ? (
               <button
                 type="button"
                 className="btn lexicon-session-resume"
                 data-testid="practice-resume-session"
-                onClick={() => void resumeSession()}
+                data-resume-mode="mixed"
+                onClick={() => void resumeSession('mixed')}
               >
-                Продовжити сесію ({resumeSnapshot.completed}/{resumeSnapshot.plannedTotal ?? resumeSnapshot.budget})
+                Продовжити сесію «Мікс» ({resumeSnapshots.mixed.completed}/
+                {resumeSnapshots.mixed.plannedTotal ?? resumeSnapshots.mixed.budget})
                 {showEnglishSubtitles ? (
                   <span className="btn-sub">{SESSION_LABELS_A1.continueSession}</span>
                 ) : null}
@@ -2166,26 +2192,42 @@ function LexiconPracticeIsland({
                   shouldShowFocusModeCard(practiceMode, deck, indexForStats),
               ).map((practiceMode) => {
                 const meta = MODE_META[practiceMode];
+                const resumeSnapshot = resumeSnapshots[practiceMode];
                 return (
-                  <button
-                    type="button"
-                    key={practiceMode}
-                    className="mode-card"
-                    data-mode={practiceMode}
-                    data-accent={meta.accent}
-                    onClick={() => void startFocusMode(practiceMode)}
-                  >
-                    <div className="mc-top">
-                      <span className="mc-ico">
-                        <ModeIcon mode={practiceMode} />
-                      </span>
-                      <span>
-                        <span className="mc-title">{meta.title}</span>
-                        {showEnglishSubtitles ? <span className="mc-en">{meta.en}</span> : null}
-                      </span>
-                    </div>
-                    <span className="mc-desc">{meta.description}</span>
-                  </button>
+                  <div className="mode-card-stack" key={practiceMode}>
+                    <button
+                      type="button"
+                      className="mode-card"
+                      data-mode={practiceMode}
+                      data-accent={meta.accent}
+                      onClick={() => void startFocusMode(practiceMode)}
+                    >
+                      <div className="mc-top">
+                        <span className="mc-ico">
+                          <ModeIcon mode={practiceMode} />
+                        </span>
+                        <span>
+                          <span className="mc-title">{meta.title}</span>
+                          {showEnglishSubtitles ? <span className="mc-en">{meta.en}</span> : null}
+                        </span>
+                      </div>
+                      <span className="mc-desc">{meta.description}</span>
+                    </button>
+                    {resumeSnapshot ? (
+                      <button
+                        type="button"
+                        className="btn mode-card-resume"
+                        data-resume-mode={practiceMode}
+                        onClick={() => void resumeSession(practiceMode)}
+                      >
+                        Продовжити ({resumeSnapshot.completed}/
+                        {resumeSnapshot.plannedTotal ?? resumeSnapshot.budget})
+                        {showEnglishSubtitles ? (
+                          <span className="btn-sub">{SESSION_LABELS_A1.continueSession}</span>
+                        ) : null}
+                      </button>
+                    ) : null}
+                  </div>
                 );
               })}
             </div>

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -430,6 +430,17 @@ export interface PracticeSessionSnapshot {
   unresolvedCardKeys?: string[];
 }
 
+/**
+ * Unfinished sessions are isolated by mode. This prevents the selection, history, and
+ * progress of one drill from being restored into another drill's session.
+ */
+export type PracticeSessionSnapshots = Partial<Record<PracticeModeFilter, PracticeSessionSnapshot>>;
+
+interface PersistedPracticeSessionSnapshots {
+  version: 1;
+  byMode: PracticeSessionSnapshots;
+}
+
 export interface NewCardsDailyState {
   date: string;
   count: number;
@@ -2053,19 +2064,21 @@ export function previewRatingIntervals(
   return previews;
 }
 
-export function readPracticeSessionSnapshot(
-  storage: StorageLike = resolveStorage(),
-): PracticeSessionSnapshot | null {
+function isPracticeModeFilter(value: unknown): value is PracticeModeFilter {
+  return value === 'mixed' || isPracticeMode(value);
+}
+
+function parsePracticeSessionSnapshot(value: unknown): PracticeSessionSnapshot | null {
   try {
-    const raw = storage.getItem(PRACTICE_SESSION_STORAGE_KEY);
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as Partial<PracticeSessionSnapshot>;
+    const parsed = value as Partial<PracticeSessionSnapshot>;
     if (
+      !parsed ||
+      typeof parsed !== 'object' ||
       typeof parsed.sessionSeed !== 'number' ||
       !Array.isArray(parsed.history) ||
       (typeof parsed.budget !== 'number' && parsed.budget !== 'until-zero') ||
       typeof parsed.completed !== 'number' ||
-      typeof parsed.modeFilter !== 'string' ||
+      !isPracticeModeFilter(parsed.modeFilter) ||
       typeof parsed.level !== 'string' ||
       typeof parsed.startedAt !== 'number'
     ) {
@@ -2077,16 +2090,78 @@ export function readPracticeSessionSnapshot(
   }
 }
 
+/**
+ * Read the mode-indexed session store. A pre-mode-scoping legacy snapshot is accepted
+ * and placed under its own stored mode; the next write upgrades it to the v1 envelope.
+ */
+export function readPracticeSessionSnapshots(
+  storage: StorageLike = resolveStorage(),
+): PracticeSessionSnapshots {
+  try {
+    const raw = storage.getItem(PRACTICE_SESSION_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    const legacySnapshot = parsePracticeSessionSnapshot(parsed);
+    if (legacySnapshot) return { [legacySnapshot.modeFilter]: legacySnapshot };
+
+    const persisted = parsed as Partial<PersistedPracticeSessionSnapshots>;
+    if (
+      !persisted ||
+      typeof persisted !== 'object' ||
+      persisted.version !== 1 ||
+      !persisted.byMode ||
+      typeof persisted.byMode !== 'object' ||
+      Array.isArray(persisted.byMode)
+    ) {
+      return {};
+    }
+
+    const snapshots: PracticeSessionSnapshots = {};
+    for (const [mode, candidate] of Object.entries(persisted.byMode)) {
+      if (!isPracticeModeFilter(mode)) continue;
+      const snapshot = parsePracticeSessionSnapshot(candidate);
+      if (snapshot?.modeFilter === mode) snapshots[mode] = snapshot;
+    }
+    return snapshots;
+  } catch {
+    return {};
+  }
+}
+
+export function readPracticeSessionSnapshot(
+  mode: PracticeModeFilter,
+  storage: StorageLike = resolveStorage(),
+): PracticeSessionSnapshot | null {
+  return readPracticeSessionSnapshots(storage)[mode] ?? null;
+}
+
 export function writePracticeSessionSnapshot(
+  mode: PracticeModeFilter,
   snapshot: PracticeSessionSnapshot | null,
   storage: StorageLike = resolveStorage(),
 ): void {
   try {
-    if (!snapshot) {
+    const snapshots = readPracticeSessionSnapshots(storage);
+    if (snapshot && snapshot.modeFilter !== mode) return;
+    if (snapshot) {
+      snapshots[mode] = snapshot;
+    } else {
+      delete snapshots[mode];
+    }
+    if (Object.keys(snapshots).length === 0) {
       storage.removeItem(PRACTICE_SESSION_STORAGE_KEY);
       return;
     }
-    storage.setItem(PRACTICE_SESSION_STORAGE_KEY, JSON.stringify(snapshot));
+    const persisted: PersistedPracticeSessionSnapshots = { version: 1, byMode: snapshots };
+    storage.setItem(PRACTICE_SESSION_STORAGE_KEY, JSON.stringify(persisted));
+  } catch {
+    // Best-effort persistence.
+  }
+}
+
+export function clearPracticeSessionSnapshots(storage: StorageLike = resolveStorage()): void {
+  try {
+    storage.removeItem(PRACTICE_SESSION_STORAGE_KEY);
   } catch {
     // Best-effort persistence.
   }

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -447,7 +447,13 @@ const frontmatter = {
     margin-top: 0.35rem;
   }
 
+  :global(.mode-card-stack) {
+    display: grid;
+    gap: 0.5rem;
+  }
+
   :global(.mode-card) {
+    width: 100%;
     position: relative;
     display: flex;
     min-height: 44px;
@@ -461,6 +467,10 @@ const frontmatter = {
     box-shadow: var(--lu-shadow);
     text-align: left;
     transition: transform 0.14s ease, border-color 0.14s ease, box-shadow 0.14s ease;
+  }
+
+  :global(.mode-card-resume) {
+    justify-self: start;
   }
 
   :global(.mode-card:hover),

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -885,8 +885,8 @@ describe('LexiconPractice', () => {
 
       const startedSnapshot = JSON.parse(snapshotWrites[0][1]);
       expect(startedSnapshot).not.toBeNull();
-      expect(startedSnapshot.modeFilter).toBe('mixed');
-      expect(startedSnapshot.budget).toBe(10);
+      expect(startedSnapshot.byMode.mixed.modeFilter).toBe('mixed');
+      expect(startedSnapshot.byMode.mixed.budget).toBe(10);
     } finally {
       window.location = new URL('http://localhost/') as any;
       vi.restoreAllMocks();
@@ -1402,10 +1402,10 @@ describe('LexiconPractice', () => {
     await user.click(await screen.findByTestId('practice-weak-chip-accusative'));
     await screen.findByTestId('practice-cloze');
 
-    // The persisted snapshot carries the mode but no focus weakness — transiency by design.
+    // The mode-indexed snapshot carries the mode but no focus weakness — transiency by design.
     const raw = localStorage.getItem('lu-practice-session');
     expect(raw).not.toBeNull();
-    const snapshot = JSON.parse(raw as string);
+    const snapshot = JSON.parse(raw as string).byMode.cloze;
     expect(snapshot.modeFilter).toBe('cloze');
     expect(snapshot).not.toHaveProperty('focusWeakness');
     expect(raw).not.toContain('focus');
@@ -1415,8 +1415,47 @@ describe('LexiconPractice', () => {
     // stranded focus-filtered one.
     first.unmount();
     render(<LexiconPractice initialDeck={sampleDeck()} />);
-    await user.click(await screen.findByTestId('practice-resume-session'));
+    await user.click(await screen.findByRole('button', { name: /Продовжити \(0\// }));
     expect(await screen.findByTestId('practice-cloze')).toBeInTheDocument();
+  });
+
+  test('switching modes starts a fresh selected session and preserves only its own continuation', async () => {
+    const deck = sampleDeck();
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('practice-index.A1.json')) {
+        return okJson({ deckVersion: deck.deckVersion, level: deck.level, items: deck.index });
+      }
+      if (url.includes('practice-lexemes.A1.json')) {
+        return okJson({ deckVersion: deck.deckVersion, level: deck.level, lexemes: deck.lexemes });
+      }
+      return notFoundResponse();
+    });
+    const user = userEvent.setup();
+    const { container } = render(<LexiconPractice initialDeck={deck} />);
+
+    // Leave a matching session unfinished, then return to the hub exactly as a learner does.
+    await user.click(container.querySelector<HTMLButtonElement>('[data-mode="matching"]')!);
+    await screen.findByTestId('practice-matching');
+    await user.click(screen.getByRole('button', { name: /Додому/ }));
+
+    // The matching continuation belongs to matching, never to the next mode selected.
+    await screen.findByRole('button', { name: /Продовжити \(0\// });
+    await user.click(container.querySelector<HTMLButtonElement>('[data-mode="flashcards"]')!);
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-activity="flashcard"]')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('practice-matching')).not.toBeInTheDocument();
+    expect(screen.getByTestId('practice-session-progress')).toHaveTextContent('0/');
+
+    const snapshots = JSON.parse(localStorage.getItem('lu-practice-session')!);
+    expect(snapshots.byMode.matching).toMatchObject({ modeFilter: 'matching', completed: 0 });
+    expect(snapshots.byMode.flashcards).toMatchObject({
+      modeFilter: 'flashcards',
+      completed: 0,
+      history: [],
+    });
   });
 
   test('double-Enter during dwell advances exactly once (no double completion)', async () => {

--- a/site/tests/unit/practice-session.test.ts
+++ b/site/tests/unit/practice-session.test.ts
@@ -215,7 +215,7 @@ describe('practice session helpers', () => {
     const history: SelectionHistoryItem[] = [
       { itemId: 'alpha:flashcards', lemmaId: 'alpha', mode: 'flashcards' },
     ];
-    writePracticeSessionSnapshot({
+    writePracticeSessionSnapshot('flashcards', {
       sessionSeed: 424242,
       history,
       budget: 10,
@@ -231,7 +231,7 @@ describe('practice session helpers', () => {
       extensionUsed: 0,
       unresolvedCardKeys: [],
     });
-    const snapshot = readPracticeSessionSnapshot();
+    const snapshot = readPracticeSessionSnapshot('flashcards');
     expect(snapshot).toMatchObject({
       sessionSeed: 424242,
       history,
@@ -283,7 +283,7 @@ describe('practice session helpers', () => {
   });
 
   test('expired snapshot is not resumable', () => {
-    writePracticeSessionSnapshot({
+    writePracticeSessionSnapshot('mixed', {
       sessionSeed: 1,
       history: [],
       budget: 10,
@@ -293,7 +293,7 @@ describe('practice session helpers', () => {
       startedAt: NOW.getTime() - 7 * 60 * 60_000,
       plannedTotal: 10,
     });
-    expect(isPracticeSessionResumable(readPracticeSessionSnapshot(), NOW)).toBe(false);
+    expect(isPracticeSessionResumable(readPracticeSessionSnapshot('mixed'), NOW)).toBe(false);
     localStorage.removeItem(PRACTICE_SESSION_STORAGE_KEY);
     localStorage.removeItem(SRS_STORAGE_KEY);
   });


### PR DESCRIPTION
## Root cause

The direct focus-mode card already calls the fresh-start path, so the persisted resume snapshot was not the event that reproduced this exact flow. The actual leak was `committedSelectionRef`:

- `finishPractice()` at `site/src/components/LexiconPractice.tsx:1964-1970` returned to the hub with `history = []` but retained the pinned selection.
- The selector stabilization branch at `site/src/components/LexiconPractice.tsx:1155-1165` accepts a pinned selection when its saved history length equals the current history length. A new mode also begins with history length 0, so starting Flashcards after an unfinished Matching session returned Matching’s old selection (including its mode and item).

The existing persisted-session boundary was also mode-ambiguous: `PRACTICE_SESSION_STORAGE_KEY` is `lu-practice-session` (`site/src/lib/lexicon/srs.ts:16`). Its legacy flat JSON shape is `PracticeSessionSnapshot` (`:415-431`): required `sessionSeed`, `history`, `budget`, `completed`, `modeFilter`, `level`, `startedAt`; optional `extensionUsed`, `sessionNewIntroduced`, `plannedReviews`, `plannedNew`, `plannedTotal`, `reviewsCompleted`, and `unresolvedCardKeys`.

## Fix

- Clear the in-flight selection pin at the `beginSession()` boundary (`LexiconPractice.tsx:1579-1582`), so it can never cross into a new mode or newly resumed session.
- Store resumable sessions per mode in a versioned envelope at the same key:

  `{ "version": 1, "byMode": { "matching": { ...PracticeSessionSnapshot } } }`

  Legacy flat snapshots remain readable and are upgraded on the next write.
- Offer Continue only on the matching mode card (and only for Mixed in the main CTA); a new mode-card click always starts a fresh session. `← Додому` now preserves an unfinished session for its own mode.

This also fixes the mirror contamination: a new mode receives empty history and `completed: 0`, while the old mode’s history/progress stay only in that mode’s snapshot.

## Verification

### Unit regression: fail before the session-boundary reset

```text
$ cd site && npx vitest run tests/unit/LexiconPractice.test.tsx --reporter=verbose -t "switching modes starts a fresh"

FAIL  tests/unit/LexiconPractice.test.tsx > LexiconPractice > switching modes starts a fresh selected session and preserves only its own continuation
Error: expect(received).toBeInTheDocument()
received value must be an HTMLElement or an SVGElement.
Received has value: null

❯ tests/unit/LexiconPractice.test.tsx:1447:70
Test Files  1 failed (1)
Tests  1 failed | 48 skipped (49)
```

### Unit regression: pass after the fix

```text
$ cd site && npx vitest run tests/unit/LexiconPractice.test.tsx --reporter=verbose -t "switching modes starts a fresh"
✓ tests/unit/LexiconPractice.test.tsx > LexiconPractice > switching modes starts a fresh selected session and preserves only its own continuation 72ms

Test Files  1 passed (1)
Tests  1 passed | 48 skipped (49)
```

### Relevant unit suite

```text
$ cd site && npx vitest run tests/unit/LexiconPractice.test.tsx tests/unit/practice-session.test.ts --reporter=dot

Test Files  2 passed (2)
Tests  62 passed (62)
```

The suite retains pre-existing `ECONNREFUSED`/React `act(...)` diagnostics but exits green.

### Browser regression

```text
$ cd site && CI=1 npx playwright test e2e/atlas-practice.spec.ts --project=chromium --grep "practice mode switch starts" --reporter=list
[WebServer] npm notice run astro preview --host 127.0.0.1 --port 4321
```

The command completed successfully; the regression exercises Matching → Додому → Flashcards and asserts the Flashcard stage, no matching stage, and `0/` session progress.

### Build

```text
$ cd site && npm run build
✓ hydrated manifest 83.4 MB from 11.4 MB release asset
atlas_db alias validation: {"public_aliases":9969,"private_aliases":18,"distinct_public_targets":8206,"approved_public_articles":8206,"failures":0}
✓ hydrated practice deck atlas-practice-v1-fa1f37b28c7aa8cd from 0.6 MB release asset
01:38:36 [build] ✓ Completed in 739ms.
```

Independent cross-family review: DeepSeek v4 Flash — APPROVE (no findings).

No auto-merge has been enabled.