### PR TITLE
feat(research-registry): ADR-011 P6 measured pilot and rollout decision

### DIFF
--- a/agents_extensions/shared/rules/workflow.md
+++ b/agents_extensions/shared/rules/workflow.md
@@ -32,6 +32,9 @@ curl -s http://localhost:8765/api/state/manifest         # ~1 KB index
 curl -s http://localhost:8765/api/rules?format=markdown  # only if hash changed
 curl -s 'http://localhost:8765/api/session/current?agent=orchestrator'  # only if hash changed
 curl -s http://localhost:8765/api/orient                 # always-fresh, has meta
+# Known functional role only: replace `quality` with the assigned role.
+curl -s 'http://localhost:8765/api/knowledge/cold-start?role=quality'  # role-scoped pointers
+# Generic or genuinely role-unknown session: skip the role-scoped request; remain pointer-free.
 curl -s 'http://localhost:8765/api/comms/inbox?agent=claude'  # unread messages
 ```
 

--- a/agents_extensions/shared/rules/workflow.md
+++ b/agents_extensions/shared/rules/workflow.md
@@ -4,15 +4,26 @@
 
 ## Cold-start sequence (do this first every session)
 
-Use the Monitor API instead of reading files. One-shot bootstrap:
+Use the Monitor API instead of reading files. A session with a known assigned
+functional role opts into that role's bounded pointer-only cold start:
 
 ```python
-  # Python one-liner equivalent — see scripts/monitor_client.py
 from ai_agent_bridge.monitor_client import MonitorClient
-boot = MonitorClient().bootstrap()
-  # boot["rules"].body    — condensed rules markdown
-  # boot["session"].body  — condensed session summary
+boot = MonitorClient().bootstrap(role="quality")
+  # boot["rules"].body     — condensed rules markdown
+  # boot["session"].body   — condensed session summary
+  # boot["research"].body  — role-scoped pointers only, if enabled
 ```
+
+Generic or genuinely role-unknown startup stays pointer-free:
+
+```python
+boot = MonitorClient().bootstrap()
+```
+
+There is no hidden default role. `bootstrap()` remains the generic, silent
+path; add `role="..."` only when the session already has that known assigned
+functional role.
 
 Shell equivalent:
 

--- a/docs/MONITOR-API.md
+++ b/docs/MONITOR-API.md
@@ -1935,6 +1935,11 @@ research_body = boot["research"].body   # changed/new pointers only (see below)
 #                      body is empty, never raises
 ```
 
+Use `bootstrap(role="...")` only when the session already has a known assigned
+functional role. `bootstrap()` remains the generic or genuinely role-unknown
+startup path and deliberately has no hidden default role, so it remains
+pointer-free.
+
 `MonitorClient.cold_start(role=...)` and `MonitorClient.research(role=..., task_family=..., track=..., owned_paths=...)`
 are also callable directly (`bootstrap()` picks between them based on which
 dimensions are given — see *Cold start / bootstrap* above).

--- a/docs/architecture/adr/adr-011-project-research-registry.md
+++ b/docs/architecture/adr/adr-011-project-research-registry.md
@@ -127,6 +127,28 @@ Changing one registry record flips the global manifest hash and that record's pe
 
 **Runtime kill switch (rollout safety).** A single default-safe configuration flag — `research_registry.enabled` (config, env-overridable) — gates the entire feature. **Default during rollout: `false`** (manifest omits the research component; `/api/knowledge/*` returns an empty/disabled projection; the router surfaces zero pointers), reproducing exact current behavior. Flipping it `true` enables the feature without a code change; flipping it back `false` is an instant, in-place disable — **no revert PR and no redeploy required**. This makes rollback a config toggle, not a deploy, and lets the pilot run behind the flag while unrelated agents are wholly unaffected.
 
+### P6 pilot result and rollout decision
+
+The real three-record UNLP pilot is recorded in
+[`research-registry-pilot.md`](../../references/research-registry-pilot.md).
+It protects five explicit task contexts, exact canonical UTF-8 payload/body
+measurements, state-manifest delta, and endpoint-level warm-cache `304` reads in
+`scripts/audit/check_research_registry_pilot.py`. The result is **GO for a
+controlled local rollout when a task supplies explicit scoped context or a
+session already knows its assigned functional role**. `MonitorClient().bootstrap()`
+without a role remains generic and pointer-free; there is no hidden default role.
+
+The compiled feature default remains fail-safe disabled. The gitignored live flag
+is a local opt-in, and rollback is setting it false or removing it — no source
+revert, task-store rewrite, or telemetry deletion. This decision does not switch
+every environment on. New research ingestion remains schema/adoption-gated.
+
+**P5 remains NO-GO / condition not triggered.** The three bounded digests are
+sufficient, CEFR adoption shipped without raw transport, and deferred TTS/GEC
+work is blocked by ownership/product/licensing. Reopen only for a specific missing
+datum plus a blocked routed task, proof that digest/public manual access is
+insufficient, repeated need, and rights allowing automated caching.
+
 ### P4 — strict adoption gate: cache authority window and partial-metric semantics
 
 **Cache authority window.** `scripts/audit/check_research_registry.py --strict-adoption` and `GET /api/knowledge/monitor` both gate ownership/issue-consumer proof on a membership cache (`batch_state/issue_stream_audit.json`, gitignored, written by `scripts/orchestration/issue_stream_audit.py`), never the network directly. A cache is authoritative only when:

--- a/docs/references/research-registry-pilot.md
+++ b/docs/references/research-registry-pilot.md
@@ -72,9 +72,10 @@ full-coverage 30-day monitor sample, lifecycle was 3 total records: 1 adopted,
 was 1 of 3 (0.3333); dead consumers were 0. Discovery status was enabled for this
 local operational measurement.
 
-The separate live surfaced-to-consumed measurement was complete (`partial:
-false`): 1 surfaced pair, 1 consumed pair, 2 consumed events, 0 pending, and
-0 surfaced-but-never-consumed pairs. The sole observed record ID was
+The separate live surfaced-to-consumed measurement was a point-in-time
+`2026-07-12` measurement and was complete (`partial: false`): 1 surfaced pair,
+1 consumed pair, 2 consumed events, 0 pending, and 0 surfaced-but-never-consumed
+pairs. The sole observed record ID was
 `unlp-2026-cefr-assessment`. This report intentionally excludes task IDs, event
 rows, prompts, paths, source contents, and raw telemetry.
 

--- a/docs/references/research-registry-pilot.md
+++ b/docs/references/research-registry-pilot.md
@@ -1,0 +1,93 @@
+# ADR-011 Research Registry P6 Pilot
+
+## Decision
+
+**GO for a controlled local rollout with explicit task-scoped context or a known
+functional role.** Generic and genuinely role-unknown startup remains silent:
+`MonitorClient().bootstrap()` has no hidden default role and receives no research
+pointers. New research ingestion remains schema- and adoption-gated. The compiled
+default remains disabled; the gitignored local live flag is the local opt-in.
+
+Rollback is immediate: set that live flag to `false` or remove it. No source
+revert, task-store rewrite, or telemetry deletion is required.
+
+## Method
+
+`scripts/audit/check_research_registry_pilot.py` uses the three committed UNLP
+records in `docs/references/research-registry.yaml`; it does not create synthetic
+records. It builds each filtered payload with the production canonical JSON
+serializer, measures `len(payload_bytes)`, and compares explicit expected sets.
+It also uses an isolated FastAPI `TestClient` harness with a frozen manifest time
+and response telemetry disabled. The harness sets the registry flag only in its
+own process and restores all changed process state afterwards.
+`tests/test_research_registry_p6.py` invokes this checker, so the existing pytest
+CI path keeps these invariants durable without a separate workflow.
+
+The checker protects the production caps from `scripts.research.registry`:
+filtered pointers are at most 1,536 bytes, a record body at most 4,096 bytes, the
+research manifest component at most 512 bytes, and the whole state manifest under
+2,048 bytes. It has no dependency on mutable consumption telemetry or task state.
+
+## Five-case discovery result
+
+| Context | Expected record IDs | Serialized UTF-8 bytes |
+| --- | --- | ---: |
+| quality · difficulty-gate · core · `scripts/audit/text_difficulty.py` | `unlp-2026-cefr-assessment` | 342 |
+| tts · tts · `scripts/tts/**` | `unlp-2025-stress-tts` | 251 |
+| reviewer · reviewer-prompt · `agents_extensions/**` | `unlp-2026-gec-minimal-edit` | 280 |
+| unrelated UI | none | 29 |
+| unrelated CI | none | 29 |
+
+The explicit-set confusion matrix is **TP 3, FP 0, FN 0**: precision is
+`3 / (3 + 0) = 1.0` and recall is `3 / (3 + 0) = 1.0`. The zero-result controls
+are measured responses, not denominator exclusions.
+
+## Byte and warm-cache measurements
+
+| Surface | Exact serialized UTF-8 bytes |
+| --- | ---: |
+| CEFR record body | 2,630 |
+| TTS record body | 2,629 |
+| GEC record body | 3,483 |
+| State-manifest `research` component | 107 |
+| State manifest, registry disabled | 912 |
+| State manifest, registry enabled | 1,031 |
+| Enabled-minus-disabled manifest delta | 119 |
+
+The API proof is end-to-end, not a helper-only check:
+
+- quality filtered manifest: `200 / 342`, then `304 / 0`;
+- CEFR record body: `200 / 2630`, then `304 / 0`;
+- a UI context offered the quality ETag returns its own `200 / 29` before its
+  own repeat returns `304 / 0`. Context A therefore cannot borrow context B's
+  ETag.
+
+## P4 lifecycle, adoption, and live evidence
+
+The ordinary registry check and strict-adoption gate both passed against a freshly
+refreshed authoritative membership cache. The monitor is deliberately ungated and
+reports only safe aggregate lifecycle and consumption fields. At the measured
+full-coverage 30-day monitor sample, lifecycle was 3 total records: 1 adopted,
+2 deferred, 0 stale, 0 orphaned, 0 superseded, and 0 invalid. Effective adoption
+was 1 of 3 (0.3333); dead consumers were 0. Discovery status was enabled for this
+local operational measurement.
+
+The separate live surfaced-to-consumed measurement was complete (`partial:
+false`): 1 surfaced pair, 1 consumed pair, 2 consumed events, 0 pending, and
+0 surfaced-but-never-consumed pairs. The sole observed record ID was
+`unlp-2026-cefr-assessment`. This report intentionally excludes task IDs, event
+rows, prompts, paths, source contents, and raw telemetry.
+
+## P5 disposition and limits
+
+**NO-GO / condition not triggered.** All three bounded digests are sufficient;
+CEFR adoption shipped without raw transport; and deferred TTS/GEC work remains
+blocked by ownership, product, and licensing constraints. P5 may reopen only
+when all of these are evidenced: a specific missing datum, a blocked routed task,
+proof that the digest and public/manual access are insufficient, repeated need,
+and rights that permit automated caching.
+
+The pilot does not claim that keyword/path routing is semantic retrieval, that a
+single local measurement predicts every environment, or that a pointer is a
+consumption. The strict registry gate and the monitor remain the checks for
+future lifecycle/adoption rot.

--- a/scripts/audit/check_research_registry_pilot.py
+++ b/scripts/audit/check_research_registry_pilot.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Deterministic P6 acceptance checker for ADR-011's real UNLP seed records.
+
+This checker deliberately exercises the committed registry rather than synthetic
+fixtures.  It measures canonical serialized UTF-8 response bytes, proves the
+five P6 routing cases, and drives the actual FastAPI endpoints in an isolated
+in-process harness.  It never reads or writes consumption telemetry and never
+prints task identifiers, digest bodies, or runtime flag contents.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+# A bare script invocation puts ``scripts/audit`` (not the repository root) on
+# sys.path.  Keep the documented ``.venv/bin/python scripts/audit/...`` command
+# usable without caller-specific PYTHONPATH configuration.  Remove that audit
+# directory first: its ``config.py`` would otherwise shadow ``scripts/config.py``
+# while importing the audit package.
+AUDIT_DIR = Path(__file__).resolve().parent
+sys.path[:] = [entry for entry in sys.path if Path(entry or ".").resolve() != AUDIT_DIR]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from fastapi.testclient import TestClient
+
+import scripts.api.main as api_main
+import scripts.api.state_router as state_router
+from scripts.research import registry as reg
+
+EXPECTED_CASES = (
+    (
+        "quality_difficulty_core",
+        ("quality", "difficulty-gate", "core", ["scripts/audit/text_difficulty.py"]),
+        {"unlp-2026-cefr-assessment"},
+        342,
+    ),
+    (
+        "tts",
+        ("tts", "tts", None, ["scripts/tts/engine.py"]),
+        {"unlp-2025-stress-tts"},
+        251,
+    ),
+    (
+        "reviewer_prompt",
+        (
+            "reviewer",
+            "reviewer-prompt",
+            None,
+            ["agents_extensions/shared/rules/workflow.md"],
+        ),
+        {"unlp-2026-gec-minimal-edit"},
+        280,
+    ),
+    ("unrelated_ui", ("frontend", "ui", None, ["site/src/app.ts"]), set(), 29),
+    ("unrelated_ci", ("infra", "ci", None, [".github/workflows/ci.yml"]), set(), 29),
+)
+
+EXPECTED_BODIES = {
+    "unlp-2026-cefr-assessment": 2630,
+    "unlp-2025-stress-tts": 2629,
+    "unlp-2026-gec-minimal-edit": 3483,
+}
+EXPECTED_RESEARCH_COMPONENT_BYTES = 107
+EXPECTED_STATE_MANIFEST_BYTES = {"disabled": 912, "enabled": 1031}
+
+
+@contextmanager
+def _isolated_api(root: Path) -> Iterator[TestClient]:
+    """Force an isolated, deterministic API process view for byte assertions."""
+    prior_root = reg._ROOT_OVERRIDE
+    prior_datetime = state_router.datetime
+    prior_flag = os.environ.get(reg.ENV_FLAG)
+    prior_footer = os.environ.get("LEARN_UKRAINIAN_TELEMETRY_FOOTER")
+
+    class _FrozenDateTime:
+        @staticmethod
+        def now(tz: Any = None) -> datetime:
+            return datetime(2026, 7, 11, 12, 0, 0, 123456, tzinfo=tz or UTC)
+
+    reg._ROOT_OVERRIDE = root
+    state_router.datetime = _FrozenDateTime  # type: ignore[assignment]
+    os.environ["LEARN_UKRAINIAN_TELEMETRY_FOOTER"] = "0"
+    try:
+        with TestClient(api_main.app, raise_server_exceptions=False) as client:
+            yield client
+    finally:
+        reg._ROOT_OVERRIDE = prior_root
+        state_router.datetime = prior_datetime
+        if prior_flag is None:
+            os.environ.pop(reg.ENV_FLAG, None)
+        else:
+            os.environ[reg.ENV_FLAG] = prior_flag
+        if prior_footer is None:
+            os.environ.pop("LEARN_UKRAINIAN_TELEMETRY_FOOTER", None)
+        else:
+            os.environ["LEARN_UKRAINIAN_TELEMETRY_FOOTER"] = prior_footer
+
+
+def _assert_equal(actual: Any, expected: Any, label: str) -> None:
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def run(root: Path = PROJECT_ROOT) -> dict[str, Any]:
+    """Run all P6 checks and return only report-safe aggregate measurements."""
+    runtime = reg.load_runtime(root=root)
+    if runtime is None:
+        raise AssertionError("committed research registry is not runtime-exposable")
+
+    tp = fp = fn = 0
+    cases: dict[str, dict[str, Any]] = {}
+    for name, args, expected, expected_bytes in EXPECTED_CASES:
+        response = reg.filtered_manifest(runtime, reg.normalize_context(*args))
+        actual = {pointer["id"] for pointer in json.loads(response.body)["records"]}
+        _assert_equal(actual, expected, f"{name} record ids")
+        _assert_equal(len(response.body), expected_bytes, f"{name} serialized UTF-8 bytes")
+        tp += len(actual & expected)
+        fp += len(actual - expected)
+        fn += len(expected - actual)
+        cases[name] = {"records": sorted(actual), "bytes": len(response.body)}
+
+    if tp + fp == 0 or tp + fn == 0:
+        raise AssertionError("pilot metrics require explicit non-zero positive denominators")
+    precision = tp / (tp + fp)
+    recall = tp / (tp + fn)
+    _assert_equal(precision, 1.0, "precision")
+    _assert_equal(recall, 1.0, "recall")
+
+    record_bytes: dict[str, int] = {}
+    for record_id, expected_bytes in EXPECTED_BODIES.items():
+        result = reg.record_body(runtime, record_id)
+        if result is None:
+            raise AssertionError(f"{record_id}: body unavailable")
+        body, _etag = result
+        actual_bytes = len(body.encode("utf-8"))
+        _assert_equal(actual_bytes, expected_bytes, f"{record_id} normalized UTF-8 bytes")
+        if actual_bytes > reg.MAX_RECORD_BYTES:
+            raise AssertionError(f"{record_id}: production record cap exceeded")
+        record_bytes[record_id] = actual_bytes
+
+    manifest_sizes: dict[str, int] = {}
+    with _isolated_api(root) as client:
+        os.environ[reg.ENV_FLAG] = "false"
+        disabled = client.get("/api/state/manifest")
+        _assert_equal(disabled.status_code, 200, "disabled state manifest status")
+        manifest_sizes["disabled"] = len(disabled.content)
+        _assert_equal(
+            manifest_sizes["disabled"], EXPECTED_STATE_MANIFEST_BYTES["disabled"], "disabled state manifest bytes"
+        )
+
+        os.environ[reg.ENV_FLAG] = "true"
+        enabled = client.get("/api/state/manifest")
+        _assert_equal(enabled.status_code, 200, "enabled state manifest status")
+        manifest_sizes["enabled"] = len(enabled.content)
+        _assert_equal(
+            manifest_sizes["enabled"], EXPECTED_STATE_MANIFEST_BYTES["enabled"], "enabled state manifest bytes"
+        )
+        _assert_equal(
+            manifest_sizes["enabled"] - manifest_sizes["disabled"],
+            119,
+            "research state-manifest delta",
+        )
+        if manifest_sizes["enabled"] >= reg.MAX_STATE_MANIFEST_BYTES:
+            raise AssertionError("production state manifest cap exceeded")
+        component = enabled.json()["research"]
+        component_bytes = len(reg.canonical_json_bytes(component))
+        _assert_equal(component_bytes, EXPECTED_RESEARCH_COMPONENT_BYTES, "research manifest component bytes")
+        if component_bytes > reg.MAX_RESEARCH_COMPONENT_BYTES:
+            raise AssertionError("production research component cap exceeded")
+
+        quality_params = {
+            "role": "quality",
+            "task_family": "difficulty-gate",
+            "track": "core",
+            "owned_path": "scripts/audit/text_difficulty.py",
+        }
+        first = client.get("/api/knowledge/manifest", params=quality_params)
+        _assert_equal((first.status_code, len(first.content)), (200, 342), "quality manifest first read")
+        quality_etag = first.headers["etag"]
+        repeated = client.get("/api/knowledge/manifest", params=quality_params, headers={"If-None-Match": quality_etag})
+        _assert_equal((repeated.status_code, len(repeated.content)), (304, 0), "quality manifest warm read")
+
+        control_params = {"role": "frontend", "task_family": "ui", "owned_path": "site/src/app.ts"}
+        isolated = client.get("/api/knowledge/manifest", params=control_params, headers={"If-None-Match": quality_etag})
+        _assert_equal((isolated.status_code, len(isolated.content)), (200, 29), "context-isolated manifest read")
+        control_etag = isolated.headers["etag"]
+        control_warm = client.get(
+            "/api/knowledge/manifest", params=control_params, headers={"If-None-Match": control_etag}
+        )
+        _assert_equal((control_warm.status_code, len(control_warm.content)), (304, 0), "control manifest warm read")
+
+        body = client.get("/api/knowledge/record/unlp-2026-cefr-assessment")
+        _assert_equal((body.status_code, len(body.content)), (200, 2630), "CEFR record first read")
+        body_warm = client.get(
+            "/api/knowledge/record/unlp-2026-cefr-assessment",
+            headers={"If-None-Match": body.headers["etag"]},
+        )
+        _assert_equal((body_warm.status_code, len(body_warm.content)), (304, 0), "CEFR record warm read")
+
+    return {
+        "ok": True,
+        "cases": cases,
+        "metrics": {"tp": tp, "fp": fp, "fn": fn, "precision": precision, "recall": recall},
+        "record_body_bytes": record_bytes,
+        "research_manifest_component_bytes": EXPECTED_RESEARCH_COMPONENT_BYTES,
+        "state_manifest_bytes": manifest_sizes,
+        "warm_reads": {
+            "quality_manifest": [200, 342, 304, 0],
+            "record_body": [200, 2630, 304, 0],
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check ADR-011 P6 real-record pilot invariants.")
+    parser.add_argument("--json", action="store_true", help="Print safe aggregate measurements as JSON.")
+    args = parser.parse_args(argv)
+    try:
+        report = run()
+    except AssertionError as exc:
+        print(f"research-registry pilot FAILED: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(report, sort_keys=True, indent=2))
+    else:
+        print("research-registry pilot: 5 cases, precision=1.0, recall=1.0")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/check_research_registry_pilot.py
+++ b/scripts/audit/check_research_registry_pilot.py
@@ -11,11 +11,12 @@ prints task identifiers, digest bodies, or runtime flag contents.
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
 import sys
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stdout
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -91,7 +92,10 @@ def _isolated_api(root: Path) -> Iterator[TestClient]:
     state_router.datetime = _FrozenDateTime  # type: ignore[assignment]
     os.environ["LEARN_UKRAINIAN_TELEMETRY_FOOTER"] = "0"
     try:
-        with TestClient(api_main.app, raise_server_exceptions=False) as client:
+        # The in-process app emits preload diagnostics while TestClient enters.
+        # They are incidental to this checker's API harness and would corrupt
+        # the machine-readable output produced by ``main(--json)``.
+        with redirect_stdout(io.StringIO()), TestClient(api_main.app, raise_server_exceptions=False) as client:
             yield client
     finally:
         reg._ROOT_OVERRIDE = prior_root

--- a/tests/test_research_registry_p6.py
+++ b/tests/test_research_registry_p6.py
@@ -44,6 +44,11 @@ def test_known_role_bootstrap_contract_is_explicit_in_source() -> None:
     assert 'MonitorClient().bootstrap(role="quality")' in content
     assert "Generic or genuinely role-unknown startup stays pointer-free:" in content
     assert "MonitorClient().bootstrap()" in content
+    assert "http://localhost:8765/api/knowledge/cold-start?role=quality" in content
+    assert "replace `quality` with the assigned role" in content
+    assert "Generic or genuinely role-unknown session: skip the role-scoped request; remain pointer-free." in content
+    assert "curl -s http://localhost:8765/api/orient                 # always-fresh, has meta" in content
+    assert "/api/orient?role=" not in content
 
     # Deployment is verified separately by scripts/check_rules_deployment.sh;
     # this source assertion prevents future edits from dropping either behavior.

--- a/tests/test_research_registry_p6.py
+++ b/tests/test_research_registry_p6.py
@@ -7,7 +7,10 @@ it does not inspect mutable consumption events or live task state.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+
+import pytest
 
 from scripts.audit import check_research_registry_pilot as pilot
 
@@ -21,6 +24,16 @@ def test_real_seeded_pilot_checker_is_green() -> None:
         "quality_manifest": [200, 342, 304, 0],
         "record_body": [200, 2630, 304, 0],
     }
+
+
+def test_json_cli_output_is_a_single_parseable_document(capsys: pytest.CaptureFixture[str]) -> None:
+    assert pilot.main(["--json"]) == 0
+
+    output = capsys.readouterr().out
+    report = json.loads(output)
+
+    assert report["ok"] is True
+    assert report["metrics"] == {"tp": 3, "fp": 0, "fn": 0, "precision": 1.0, "recall": 1.0}
 
 
 def test_known_role_bootstrap_contract_is_explicit_in_source() -> None:

--- a/tests/test_research_registry_p6.py
+++ b/tests/test_research_registry_p6.py
@@ -1,0 +1,39 @@
+"""P6 real-record pilot regressions for ADR-011.
+
+The checker is intentionally run against the real three-record registry.  Its
+API harness freezes only response-local time and disables response telemetry;
+it does not inspect mutable consumption events or live task state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.audit import check_research_registry_pilot as pilot
+
+
+def test_real_seeded_pilot_checker_is_green() -> None:
+    report = pilot.run(Path(__file__).resolve().parents[1])
+
+    assert report["metrics"] == {"tp": 3, "fp": 0, "fn": 0, "precision": 1.0, "recall": 1.0}
+    assert report["state_manifest_bytes"] == {"disabled": 912, "enabled": 1031}
+    assert report["warm_reads"] == {
+        "quality_manifest": [200, 342, 304, 0],
+        "record_body": [200, 2630, 304, 0],
+    }
+
+
+def test_known_role_bootstrap_contract_is_explicit_in_source() -> None:
+    root = Path(__file__).resolve().parents[1]
+    source = root / "agents_extensions/shared/rules/workflow.md"
+    content = source.read_text(encoding="utf-8")
+
+    assert 'MonitorClient().bootstrap(role="quality")' in content
+    assert "Generic or genuinely role-unknown startup stays pointer-free:" in content
+    assert "MonitorClient().bootstrap()" in content
+
+    # Deployment is verified separately by scripts/check_rules_deployment.sh;
+    # this source assertion prevents future edits from dropping either behavior.
+    assert content.index('MonitorClient().bootstrap(role="quality")') < content.index(
+        "Generic or genuinely role-unknown startup stays pointer-free:"
+    )


### PR DESCRIPTION
## Summary

Completes ADR-011 P6 with a deterministic measured UNLP pilot, role-aware
cold-start correction, privacy-safe live surfaced→consumed evidence, explicit
P5 no-go, and a controlled rollout/rollback decision.

Closes #5000. Refs #4969.

## Measured pilot

- Five real task contexts over the three seeded records: TP/FP/FN = `3/0/0`,
  precision = `1.0`, recall = `1.0`; two irrelevant UI/CI controls return no
  pointers.
- Filtered payloads: `342 / 251 / 280` bytes; empty controls: `29 / 29`.
- Record bodies: `2630 / 2629 / 3483` bytes; research component: `107` bytes.
- Full state manifest: `912` disabled, `1031` enabled (`+119`).
- Endpoint proofs: manifest `200/342 → 304/0`; body `200/2630 → 304/0`;
  cross-context ETag reuse returns the control's own `200/29` before `304/0`.
- `--json` is a single machine-parseable document; the regression catches
  incidental TestClient startup output.

## Live operational proof

Against merged P4 with discovery explicitly enabled, one active scoped dispatch
received exactly `unlp-2026-cefr-assessment`. The safe monitor aggregate showed
one surfaced pair, one consumed pair, two consumption events (200 + 304), zero
pending, and full coverage. Lifecycle was 1 adopted / 2 deferred / 0 invalid;
effective adoption `1/3` (`0.3333`); no stale, orphaned, dead, or unverified
records. No task IDs, raw event rows, telemetry files, prompts, or source content
are committed. Durable evidence: #5000 issue comment.

## Cold start, P5, rollout

- Known-role Python and shell sessions explicitly request role-scoped pointers;
  generic/role-unknown startup remains pointer-free with no hidden default.
- P5 is **NO-GO / condition not triggered**: bounded digests are sufficient;
  CEFR adoption shipped without raw transport; TTS/GEC are blocked by
  ownership/product/licensing. Reopening requires a specific missing datum,
  blocked routed task, digest/manual insufficiency, repeated need, and rights.
- Rollout is **GO for controlled local opt-in**. The compiled default stays
  disabled; the gitignored live flag enables locally. Rollback is setting the
  flag false/removing it—no code revert or telemetry deletion.

## Verification

- 267 focused P1–P6/API/session/deployment/monitor tests passed.
- P6 checker exact measurements passed; P6 CLI JSON parsed through `jq`.
- Ruff, `git diff --check`, forbidden-artifact/file-count guards passed.
- Registry normal check and fresh-cache strict-adoption check: `ok: true`.
- ADR audit: 11 ADRs clean; X-Agent trailer lint: 3/3 passed.
- Independent Gemini 3.1 Pro High: initial shell-symmetry blocker fixed; final
  delta `APPROVE`.
- Independent Claude Opus: full review `APPROVE`; corrective delta `APPROVE`.

The worktree's full deploy command encountered 58 pre-existing prompt-lint
violations before sync; no lint thresholds/configs were changed. The isolated
deployment/idempotency suite passed, and GitHub's Rules Deployment Check remains
required. The canonical tracked rule is in this PR; live gitignored provider
copies will be synced after merge.
