### PR TITLE
docs(research-registry): require orchestrator routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,21 @@ bind as part of this contract.
 
 ---
 
+## Project Research Registry — Orchestrator Duty (binding)
+
+Before every delegated task, the accountable orchestrator must deliberately classify
+its functional role, task family, track, and owned paths. For scoped work, pass every
+known dimension through `--research-role`, `--research-task-family`,
+`--research-track`, and repeatable `--research-owned-path`; never infer them from the
+provider or agent name. A genuinely generic or unknown task omits all research flags
+and remains pointer-free. A surfaced pointer is not proof of consumption: research
+claimed as used requires an attributed record fetch while the task is active. Registry
+delivery remains fail-open, but forgetting this classification is not an acceptable
+generic-task classification. Full contract and examples:
+`agents_extensions/shared/rules/workflow.md` § Project Research Registry.
+
+---
+
 ## Work Intake — Stream Epics (binding for ALL orchestrators; #4708)
 
 Every open GH issue belongs to **exactly one stream epic** — registry:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,20 @@ repo hard gates bind.
 
 ---
 
+## Project Research Registry — Orchestrator Duty (binding)
+
+Before every delegated task, classify its functional role, task family, track, and
+owned paths. Pass every known dimension through `--research-role`,
+`--research-task-family`, `--research-track`, and repeatable
+`--research-owned-path`; never infer context from the provider or agent name. A
+genuinely generic or unknown task omits all research flags and remains pointer-free.
+A surfaced pointer is not proof of consumption, so research claimed as used requires
+an attributed record fetch while the task is active. Registry delivery remains
+fail-open, but the classification duty is mandatory. Canonical contract and examples:
+`agents_extensions/shared/rules/workflow.md` § Project Research Registry.
+
+---
+
 ## Best Practices Reference
 
 Detailed standards in `docs/best-practices/`. Read the relevant doc before working in that area.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -22,6 +22,18 @@ verified, never guessed) · clean code + current docs · **max UA immersion EXCE
 English scaffolding is by design; from A2 never raise English) · drive, don't defer · repo
 hard gates bind.
 
+## Project Research Registry — Orchestrator Duty (binding)
+
+Before every delegated task, classify its functional role, task family, track, and
+owned paths. Pass every known dimension through `--research-role`,
+`--research-task-family`, `--research-track`, and repeatable
+`--research-owned-path`; never infer context from the provider or agent name. A
+genuinely generic or unknown task omits all research flags and remains pointer-free.
+A surfaced pointer is not proof of consumption, so research claimed as used requires
+an attributed record fetch while the task is active. Registry delivery remains
+fail-open, but the classification duty is mandatory. Canonical contract and examples:
+`agents_extensions/shared/rules/workflow.md` § Project Research Registry.
+
 ## Work Intake — Stream Epics (binding; #4708)
 
 Every open GH issue belongs to **exactly one stream epic** — registry:

--- a/agents_extensions/shared/rules/workflow.md
+++ b/agents_extensions/shared/rules/workflow.md
@@ -38,6 +38,49 @@ curl -s 'http://localhost:8765/api/knowledge/cold-start?role=quality'  # role-sc
 curl -s 'http://localhost:8765/api/comms/inbox?agent=claude'  # unread messages
 ```
 
+### Project Research Registry — orchestrator dispatch duty
+
+Cold-start awareness is not enough. Before **every** `delegate.py dispatch`, the
+accountable orchestrator must classify the task from its issue/brief and record
+one of these outcomes in the brief or orchestration note:
+
+- **Scoped:** pass every known task dimension with `--research-role`,
+  `--research-task-family`, `--research-track`, and repeatable
+  `--research-owned-path`. These describe the task's functional context, never
+  the provider or agent identity. The registry matcher is conjunctive: a missing
+  dimension required by a record safely produces no match. Never invent a value
+  to force a pointer; split a dispatch that spans incompatible single-value
+  roles, families, or tracks.
+- **Genuinely generic or unknown:** omit all `--research-*` flags and keep the
+  dispatch pointer-free. This must be a deliberate classification, not the
+  accidental result of forgetting the registry.
+
+Example scoped dispatch fragment:
+
+```bash
+.venv/bin/python scripts/delegate.py dispatch \
+  --agent codex --task-id quality-4952 \
+  --prompt-file docs/dispatch-briefs/quality-4952.md --worktree \
+  --mode danger \
+  --research-role quality \
+  --research-task-family difficulty-gate \
+  --research-track core \
+  --research-owned-path scripts/audit/text_difficulty.py
+```
+
+The injected block contains pointers only. A worker that relies on a record must
+fetch it while the task is active with
+`GET /api/knowledge/record/{id}?task=<task-id>`. A surfaced pointer is not proof
+of consumption: do not claim research was used without attributed fetch evidence,
+and do not fetch an irrelevant record merely to manufacture adoption. Before
+final disposition, the orchestrator checks the task's consumption evidence and
+the privacy-safe aggregate `/api/knowledge/monitor`; any relevant surfaced but
+unconsumed pointer must be explained, not silently counted as adopted.
+
+Classification is mandatory; delivery remains fail-open. A disabled or degraded
+registry must not block the delegated task, and it does not justify fabricating
+context or weakening the generic pointer-free contract.
+
 **Do NOT read `CLAUDE.md`, `agents_extensions/shared/rules/*.md`, or
 `docs/session-state/current.md` directly on cold start.** Those are
 the source of truth the endpoints above serve. Reading them separately

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -457,22 +457,63 @@ Additional audit guardrails:
 
 ### Agent runtime
 
-`scripts/agent_runtime/` is the universal adapter layer for Claude, Gemini, and Codex CLI invocations. See [`docs/agent-runtime-guide.md`](agent-runtime-guide.md).
+`scripts/agent_runtime/` is the universal adapter layer for the dispatchable agent
+lanes. See [`docs/agent-runtime-guide.md`](agent-runtime-guide.md). Gemini-family
+work uses AGY; the legacy Gemini CLI route is unsupported.
 
 ### Delegate to background workers
 
 ```bash
 .venv/bin/python scripts/delegate.py dispatch \
-  --agent {codex|gemini|claude} \
+  --agent {codex|claude|agy|grok|grok-build|deepseek|cursor} \
   --task-id <id> \
   --prompt-file <file> \
-  --worktree .worktrees/<agent>-<task-id> \
+  --worktree \
   --mode danger
 ```
 
 Fire-and-forget **execution** with status polling and completion artifacts. This is the right tool when you need another agent to write code, run commands, and commit — not to hold a conversation. For discussion, reviews, or Q&A see [Inter-Agent Communication](#inter-agent-communication) below (`ai_agent_bridge` channel bridge, `ask-*`).
 
 For write-capable delegation, prefer `--worktree`. `delegate.py` creates the worktree if missing and records its path in the task state. `--mode danger` now requires `--worktree` so background agents cannot switch branches in the main checkout by accident.
+
+#### Project Research Registry — orchestrator dispatch duty
+
+Before every dispatch, the orchestrator classifies the task by functional role,
+task family, track, and owned paths. Pass every known dimension explicitly; the
+dispatcher never infers research context from the prompt, provider, agent, branch,
+or task ID:
+
+```bash
+.venv/bin/python scripts/delegate.py dispatch \
+  --agent codex \
+  --task-id quality-4952 \
+  --prompt-file docs/dispatch-briefs/quality-4952.md \
+  --worktree \
+  --mode danger \
+  --research-role quality \
+  --research-task-family difficulty-gate \
+  --research-track core \
+  --research-owned-path scripts/audit/text_difficulty.py
+```
+
+`--research-role`, `--research-task-family`, and `--research-track` are
+single-valued; repeat `--research-owned-path` when the task owns multiple paths.
+Matching is conjunctive, so omitting a dimension required by a registry record
+safely produces no pointer. Never invent a value to force a match. If the task is
+genuinely generic or unknown, omit all `--research-*` flags and record that
+classification in the brief or orchestration note.
+
+The worker receives bounded pointers, not record bodies. When it relies on one,
+it fetches `GET /api/knowledge/record/{id}?task=<task-id>` while the delegated
+task is active. This creates attributed consumption evidence in the task state;
+`GET /api/knowledge/monitor?window_days=30` exposes only privacy-safe aggregate
+surface/consumption health. A surfaced pointer is not proof of consumption, and
+workers must not fetch irrelevant records merely to inflate adoption metrics.
+Registry delivery is fail-open when disabled or degraded; task classification
+remains an orchestrator responsibility.
+
+Gemini-family work routes through `--agent agy`; the legacy `gemini` dispatcher
+choice remains compatibility-only and should not be used for new work.
 
 ---
 
@@ -1208,7 +1249,7 @@ When the delegated task may edit files or run git commands:
   --agent codex \
   --task-id issue-1383-smoke \
   --prompt-file /tmp/prompt.md \
-  --worktree .worktrees/codex-issue-1383-smoke \
+  --worktree \
   --mode danger
 ```
 

--- a/tests/test_research_registry_p6.py
+++ b/tests/test_research_registry_p6.py
@@ -55,3 +55,48 @@ def test_known_role_bootstrap_contract_is_explicit_in_source() -> None:
     assert content.index('MonitorClient().bootstrap(role="quality")') < content.index(
         "Generic or genuinely role-unknown startup stays pointer-free:"
     )
+
+
+def test_orchestrator_dispatch_duty_reaches_every_agent_entry_point() -> None:
+    root = Path(__file__).resolve().parents[1]
+    required_flags = (
+        "--research-role",
+        "--research-task-family",
+        "--research-track",
+        "--research-owned-path",
+    )
+    entry_points = (
+        "AGENTS.md",
+        "CLAUDE.md",
+        "GEMINI.md",
+        "agents_extensions/shared/rules/workflow.md",
+        "docs/SCRIPTS.md",
+    )
+
+    for relative_path in entry_points:
+        content = (root / relative_path).read_text(encoding="utf-8")
+        normalized = " ".join(content.lower().split())
+        assert "Project Research Registry" in content, f"{relative_path} lost registry awareness"
+        assert "orchestrator" in normalized, f"{relative_path} lost orchestrator ownership"
+        for flag in required_flags:
+            assert flag in content, f"{relative_path} lost {flag}"
+        assert "genuinely generic or unknown" in normalized, (
+            f"{relative_path} lost the deliberate pointer-free classification"
+        )
+        assert "surfaced pointer is not proof of consumption" in normalized, (
+            f"{relative_path} now conflates surfacing with consumption"
+        )
+
+    workflow = (root / "agents_extensions/shared/rules/workflow.md").read_text(encoding="utf-8")
+    workflow_normalized = " ".join(workflow.split())
+    assert "never the provider or agent identity" in workflow_normalized
+    assert "Classification is mandatory; delivery remains fail-open." in workflow
+    assert workflow.index("Before **every** `delegate.py dispatch`") < workflow.index(
+        "**Genuinely generic or unknown:**"
+    )
+
+    scripts_doc = (root / "docs/SCRIPTS.md").read_text(encoding="utf-8")
+    assert "--agent {codex|claude|agy|grok|grok-build|deepseek|cursor}" in scripts_doc
+    assert "--worktree .worktrees/<agent>-<task-id>" not in scripts_doc
+    assert "--worktree .worktrees/codex-issue-1383-smoke" not in scripts_doc
+    assert "GET /api/knowledge/record/{id}?task=<task-id>" in scripts_doc


### PR DESCRIPTION
## Summary

- make research-registry classification an explicit orchestrator duty in the canonical shared workflow
- carry a compact binding digest in AGENTS.md, CLAUDE.md, and GEMINI.md
- document exact scoped-dispatch flags, intentional generic fallback, attributed consumption, current agent lanes, and subtree worktrees in docs/SCRIPTS.md
- add regression coverage across every required agent entry point

## Design

Claude Opus 4.8 independently confirmed the adoption gap: runtime machinery existed, but the orchestrator duty was absent from the root entry points and scripts guide. The contract keeps role-only cold start separate from task-scoped dispatch. Classification is mandatory; registry delivery remains fail-open. Context is never inferred from provider identity, and a surfaced pointer is never counted as consumption without an attributed body fetch.

## Verification

- 59 focused tests passed: P3 routing/consumption, P6 pilot/wiring, deployment idempotency
- Ruff clean; git diff check clean
- research registry ordinary validation clean (3 records)
- issue-stream audit clean (113 open issues, 11 streams)
- measured P6 pilot unchanged: precision=1.0, recall=1.0, warm 304 behavior intact
- deployment drift clean for shared→Claude/Agent/Codex, Codex overlay, skills, Gemini, and shared Gemini rules
- mandatory pre-submit scope checks passed; 6 related files, no protected/generated/telemetry artifacts

## Known baseline failures

- full prompt deploy remains blocked by the same 58 pre-existing PERSONA_IN_RESEARCH errors; this diff adds none
- markdownlint reports the same 29 pre-existing errors on origin/main and this branch; this diff adds none

Fixes #5007