### PR TITLE
fix(practice): advance matching-board prompt after match (#4924)

### DIFF
--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -629,6 +629,20 @@ function matchingPairs(selection: PracticeSelection, deck: PracticeDeckData) {
   }));
 }
 
+export function nextMatchingPromptIndex(
+  currentPromptIndex: number | null,
+  matchedPairIndexes: ReadonlySet<number>,
+  pairCount: number,
+): number | null {
+  if (currentPromptIndex === null || !matchedPairIndexes.has(currentPromptIndex)) {
+    return currentPromptIndex;
+  }
+  for (let index = 0; index < pairCount; index += 1) {
+    if (!matchedPairIndexes.has(index)) return index;
+  }
+  return null;
+}
+
 function choicePrompt(selection: PracticeSelection): string {
   if (selection.choicePolarity === 'word-to-meaning') {
     return `Що означає «${selection.lemma.lemma}»?`;
@@ -2282,6 +2296,7 @@ function LexiconPracticeIsland({
               {selection ? (
                 <>
                   <PracticeItem
+                    key={selection.cardKey}
                     selection={selection}
                     deck={deck}
                     pairs={pairs}
@@ -2379,6 +2394,9 @@ function PracticeItem({
   onMatchingMatch?: (pairIndex: number, rating: PracticeRating) => void;
   onClozeSubmit(value: string, source: 'typed' | 'chip'): void;
 }) {
+  const [matchingPromptIndex, setMatchingPromptIndex] = useState<number | null>(0);
+  const matchedPairIndexesRef = useRef<Set<number>>(new Set());
+
   if (selection.mode === 'flashcards') {
     const intervalPreviews = previewRatingIntervals(
       selection.lemma.lemmaId,
@@ -2449,14 +2467,25 @@ function PracticeItem({
     if (!pairs.length) {
       return <p className="lexicon-practice-muted">Зараз немає карток для добору пар.</p>;
     }
+    const promptedPair = matchingPromptIndex === null ? null : pairs[matchingPromptIndex] ?? null;
     return (
       <div data-testid="practice-matching">
         <MatchUp
           key={selection.cardKey}
           pairs={pairs}
-          instruction={`Доберіть пару для «${selection.lemma.lemma}»`}
+          instruction={promptedPair ? `Доберіть пару для «${promptedPair.left}»` : undefined}
           onComplete={onMatchingComplete}
-          onMatch={onMatchingMatch}
+          onMatch={(pairIndex, rating) => {
+            matchedPairIndexesRef.current.add(pairIndex);
+            setMatchingPromptIndex((currentPromptIndex) => {
+              return nextMatchingPromptIndex(
+                currentPromptIndex,
+                matchedPairIndexesRef.current,
+                pairs.length,
+              );
+            });
+            onMatchingMatch?.(pairIndex, rating);
+          }}
         />
       </div>
     );

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { State } from 'ts-fsrs';
 import { act, render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import LexiconPractice from '@site/src/components/LexiconPractice';
+import LexiconPractice, { nextMatchingPromptIndex } from '@site/src/components/LexiconPractice';
 import PracticeErrorBoundary from '@site/src/components/PracticeErrorBoundary';
 import {
   SRS_STORAGE_KEY,
@@ -1619,6 +1619,36 @@ describe('LexiconPractice', () => {
       cloze: [],
     };
   }
+
+  test('matching prompt advances in board order and clears after the final match', async () => {
+    const user = userEvent.setup();
+    const deck = matchingDeck();
+    const { container } = render(<LexiconPractice initialDeck={deck} autoStart initialMode="matching" />);
+    const leftColumn = container.querySelector('[data-activity="match-left-column"]');
+    const rightColumn = container.querySelector('[data-activity="match-right-column"]');
+    expect(leftColumn).toBeInTheDocument();
+    expect(rightColumn).toBeInTheDocument();
+
+    const pairs = within(leftColumn as HTMLElement).getAllByRole('button').map((button, index) => {
+      const left = button.textContent?.trim() ?? '';
+      const right = within(rightColumn as HTMLElement)
+        .getAllByRole('button')
+        .find((candidate) => candidate.getAttribute('data-original-index') === String(index));
+      return { left, right };
+    });
+
+    const initialPrompt = screen.getByText(/Доберіть пару для/);
+    expect(initialPrompt).toHaveTextContent(`«${pairs[0].left}»`);
+
+    await user.click(within(leftColumn as HTMLElement).getByRole('button', { name: pairs[0].left }));
+    await user.click(pairs[0].right!);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Доберіть пару для/)).toHaveTextContent(`«${pairs[1].left}»`);
+    });
+
+    expect(nextMatchingPromptIndex(2, new Set([0, 1, 2]), 3)).toBeNull();
+  });
 
   test('matching mode rates every matched pair with proper ratings', async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary

Advances the matching-board instruction to the first unmatched pair in the deterministic left-column order.

## Root cause

`site/src/components/LexiconPractice.tsx:1141-1179` pins `selection` and `pairs` for the entire board. `MatchUp` owns the matched set, but `PracticeItem` at `site/src/components/LexiconPractice.tsx:2467-2488` previously rendered the instruction from immutable `selection.lemma`, so it remained stale after that pair was disabled.

## Fix

- Keep a board-local prompt index and matched-index set, reset by `selection.cardKey`.
- On every successful match, advance only when the currently prompted pair was matched; scan the deterministic `pairs` order for the first unmatched index.
- Omit the instruction when no prompted pair remains.
- Add the #4924 regression test for prompt advancement plus the terminal no-prompt state.

Retry assessment: no matching-board retry button exists. Wrong pairs receive transient feedback and then allow in-place continuation, so no secondary change was needed.

## Validation (#M-4)

### Fail before fix

```text
 FAIL  tests/unit/LexiconPractice.test.tsx > LexiconPractice > matching prompt advances in board order and clears after the final match
Expected element to have text content:
  «книга»
Received:
  Доберіть пару для «робота»

Test Files  1 failed (1)
Tests  1 failed | 49 passed (50)
```

### Pass after fix

```text
$ cd site && npx vitest run tests/unit/LexiconPractice.test.tsx
Test Files  1 passed (1)
Tests  50 passed (50)
```

`cd site && npm run test:unit` is not defined in `site/package.json`; the focused Vitest command above ran the requested unit suite.

```text
$ cd site && npm run build
[build] ✓ Completed in 40.00s.
[@astrojs/sitemap] `sitemap-index.xml` created at `dist`
[build] 8973 page(s) built in 42.11s
[build] Complete!
```

Full `npm test` result: 588 passed; one unrelated `atlas-db-read.test.ts` case timed out after hydration (no task files implicated).

## Review

Independent Gemini 3.1 Pro pre-commit review: APPROVE (bridge task `review-4924-precommit-sync`, response #5).

Closes #4924