### PR TITLE
fix(atlas): backfill related_entries with verified synonym pairs (#4949)

### DIFF
--- a/data/lexicon/synonym_pair_verdicts.yaml
+++ b/data/lexicon/synonym_pair_verdicts.yaml
@@ -1700,6 +1700,13 @@ approved:
   polarity: synonym
   sources:
   - synonyms_karavansky
+- a: кафе
+  b: кав'ярня
+  polarity: synonym
+  sources:
+  - sum20
+  - vts
+  - synonyms
 - a: каштановий
   b: коричневий
   polarity: synonym

--- a/scripts/atlas/atlas_db.py
+++ b/scripts/atlas/atlas_db.py
@@ -28,9 +28,12 @@ import unicodedata
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
 DEFAULT_DB = ROOT / "data" / "atlas.db"
+DEFAULT_SYNONYM_VERDICTS = ROOT / "data" / "lexicon" / "synonym_pair_verdicts.yaml"
 
 ARTICLE_ENTRY_TYPES = {
     "lemma",
@@ -70,6 +73,7 @@ ENRICHMENT_SECTIONS = {
 REVIEW_STATES = {"approved", "needs_review", "rejected"}
 VISIBILITIES = {"public", "private"}
 ENRICHMENT_PHASES = {"migration", "local", "slovnyk", "uncovered"}
+RELATED_PROVENANCES = {"verified", "unverified"}
 
 
 def _sql_enum(values: set[str]) -> str:
@@ -127,9 +131,13 @@ CREATE TABLE IF NOT EXISTS related_entries (
     slug TEXT NOT NULL,
     related_slug TEXT NOT NULL,
     entry_type TEXT,
-    relation TEXT,
+    relation TEXT NOT NULL,
     component_role TEXT,
-    FOREIGN KEY (slug) REFERENCES articles(slug)
+    provenance TEXT NOT NULL CHECK (provenance IN ({_sql_enum(RELATED_PROVENANCES)})),
+    CHECK (slug != related_slug),
+    UNIQUE (slug, related_slug, relation, provenance),
+    FOREIGN KEY (slug) REFERENCES articles(slug),
+    FOREIGN KEY (related_slug) REFERENCES articles(slug)
 );
 CREATE TABLE IF NOT EXISTS enrichment (
     slug TEXT NOT NULL,
@@ -143,6 +151,7 @@ CREATE TABLE IF NOT EXISTS enrichment (
 );
 CREATE INDEX IF NOT EXISTS idx_aliases_target ON aliases(target_slug);
 CREATE INDEX IF NOT EXISTS idx_prov_slug ON article_provenance(slug);
+CREATE INDEX IF NOT EXISTS idx_related_entries_slug_relation ON related_entries(slug, relation);
 CREATE INDEX IF NOT EXISTS idx_enrichment_slug ON enrichment(slug);
 CREATE INDEX IF NOT EXISTS idx_article_payloads_route ON article_payloads(is_public_route, route_order);
 CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
@@ -151,6 +160,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS articles_fts USING fts5(
 """
 
 _STRESS_RE = re.compile("[́̀]")
+_APOSTROPHE_TRANSLATION = str.maketrans({"’": "'", "ʼ": "'"})
 _TRANSLIT = {
     "а": "a", "б": "b", "в": "v", "г": "h", "ґ": "g", "д": "d", "е": "e", "є": "ie",
     "ж": "zh", "з": "z", "и": "y", "і": "i", "ї": "i", "й": "i", "к": "k", "л": "l",
@@ -170,6 +180,101 @@ def unstressed(text: str) -> str:
 
 def transliterate(text: str) -> str:
     return "".join(_TRANSLIT.get(ch, ch) for ch in text.lower())
+
+
+def _relation_lemma_key(lemma: str) -> str:
+    """Normalize a verdict lemma to the same comparison surface as aliases."""
+    return unstressed(lemma).translate(_APOSTROPHE_TRANSLATION).casefold().strip()
+
+
+def _load_verified_synonym_pairs(verdicts_path: Path) -> tuple[list[tuple[str, str]], int]:
+    """Load only approved synonym verdicts; raw candidate sources never enter Atlas.
+
+    The verdict file is the cross-family adjudicated source of truth.  Its
+    ``sources`` tags are intentionally not used as a filter: an approved pair
+    remains verified even when one of several attestations is Ukrajinet's
+    ``synonyms`` source.
+    """
+    data = yaml.safe_load(verdicts_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Synonym verdicts must be a mapping: {verdicts_path}")
+    approved = data.get("approved")
+    if not isinstance(approved, list):
+        raise ValueError(f"Synonym verdicts approved section must be a list: {verdicts_path}")
+
+    pairs: set[tuple[str, str]] = set()
+    self_pairs_skipped = 0
+    for index, verdict in enumerate(approved):
+        if not isinstance(verdict, dict):
+            raise ValueError(f"Approved synonym verdict {index} must be a mapping: {verdicts_path}")
+        if verdict.get("polarity") != "synonym":
+            continue
+        a = _relation_lemma_key(str(verdict.get("a") or ""))
+        b = _relation_lemma_key(str(verdict.get("b") or ""))
+        if not a or not b:
+            raise ValueError(f"Approved synonym verdict {index} lacks a lemma: {verdicts_path}")
+        if a == b:
+            self_pairs_skipped += 1
+            continue
+        pairs.add(tuple(sorted((a, b))))
+    return sorted(pairs), self_pairs_skipped
+
+
+def _relation_targets_by_lemma(cur: sqlite3.Cursor) -> dict[str, tuple[str, ...]]:
+    """Map verdict lemmas to public Atlas slugs through the aliases table.
+
+    Older builds intentionally omit aliases that equal their article slug.  The
+    exact-lemma fallback covers those canonical rows without deriving a slug
+    from source text; non-identical route slugs must still resolve through an
+    emitted alias.
+    """
+    targets: dict[str, set[str]] = {}
+    for alias, target_slug in cur.execute(
+        "SELECT alias, target_slug FROM aliases WHERE visibility = 'public'"
+    ):
+        targets.setdefault(_relation_lemma_key(str(alias)), set()).add(str(target_slug))
+    for lemma, slug in cur.execute(
+        """SELECT lemma, slug FROM articles
+           WHERE review_state = 'approved' AND visibility = 'public'"""
+    ):
+        targets.setdefault(_relation_lemma_key(str(lemma)), set()).add(str(slug))
+    return {lemma: tuple(sorted(slugs)) for lemma, slugs in targets.items()}
+
+
+def _insert_verified_synonym_relations(
+    cur: sqlite3.Cursor,
+    verdicts_path: Path,
+) -> dict[str, int]:
+    """Insert deterministic symmetric edges from approved synonym verdicts."""
+    pairs, self_pairs_skipped = _load_verified_synonym_pairs(verdicts_path)
+    targets_by_lemma = _relation_targets_by_lemma(cur)
+    rows: set[tuple[str, str, str, str]] = set()
+    unresolved_pairs = 0
+
+    for a, b in pairs:
+        a_targets = targets_by_lemma.get(a, ())
+        b_targets = targets_by_lemma.get(b, ())
+        if not a_targets or not b_targets:
+            unresolved_pairs += 1
+            continue
+        for a_slug in a_targets:
+            for b_slug in b_targets:
+                if a_slug == b_slug:
+                    continue
+                rows.add((a_slug, b_slug, "synonym", "verified"))
+                rows.add((b_slug, a_slug, "synonym", "verified"))
+
+    cur.executemany(
+        """INSERT INTO related_entries(slug, related_slug, relation, provenance)
+           VALUES (?, ?, ?, ?)""",
+        sorted(rows),
+    )
+    return {
+        "verified_synonym_pairs": len(pairs),
+        "verified_synonym_pairs_unresolved": unresolved_pairs,
+        "verified_synonym_self_pairs_skipped": self_pairs_skipped,
+        "related_entries": len(rows),
+    }
 
 
 def classify_entry_type(entry: dict[str, Any]) -> str:
@@ -206,13 +311,18 @@ def _insert_manifest_metadata(cur: sqlite3.Cursor, manifest: dict[str, Any]) -> 
             )
 
 
-def migrate_manifest(manifest_path: Path, db_path: Path) -> dict[str, int]:
+def migrate_manifest(
+    manifest_path: Path,
+    db_path: Path,
+    synonym_verdicts_path: Path = DEFAULT_SYNONYM_VERDICTS,
+) -> dict[str, int]:
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     entries = manifest.get("entries", [])
     if db_path.exists():
         db_path.unlink()
     db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA foreign_keys = ON")
     conn.executescript(SCHEMA)
     cur = conn.cursor()
     _insert_manifest_metadata(cur, manifest)
@@ -340,6 +450,8 @@ def migrate_manifest(manifest_path: Path, db_path: Path) -> dict[str, int]:
                 (slug, sec, json.dumps(payload, ensure_ascii=False), src, _iso(e), "migration"),
             )
             counts["enrichment"] += 1
+
+    counts.update(_insert_verified_synonym_relations(cur, synonym_verdicts_path))
 
     # FTS
     cur.execute("DELETE FROM articles_fts")

--- a/tests/test_atlas_db.py
+++ b/tests/test_atlas_db.py
@@ -6,6 +6,7 @@ import json
 import sqlite3
 
 import pytest
+import yaml
 
 from scripts.atlas import atlas_db
 
@@ -82,6 +83,94 @@ def test_alias_helpers():
     assert atlas_db.transliterate("розвідка") == "rozvidka"
     assert atlas_db.classify_entry_type({"lemma": "сліпа зона"}) == "multiword_term"
     assert atlas_db.classify_entry_type({"lemma": "розвідка"}) == "lemma"
+
+
+def test_verified_synonym_relations_are_symmetric_and_resolved_through_aliases(tmp_path):
+    entries = [
+        {"lemma": "краєвид", "url_slug": "landscape", "pos": "noun"},
+        {"lemma": "пейзаж", "url_slug": "scenery", "pos": "noun"},
+        {"lemma": "родина", "url_slug": "family", "pos": "noun"},
+        {"lemma": "сім'я", "url_slug": "family-uk", "pos": "noun"},
+        {"lemma": "кафе", "url_slug": "cafe", "pos": "noun"},
+        {"lemma": "кав'ярня", "url_slug": "coffeehouse", "pos": "noun"},
+    ]
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(json.dumps({"entries": entries}, ensure_ascii=False), encoding="utf-8")
+    verdicts = tmp_path / "synonym_pair_verdicts.yaml"
+    verdicts.write_text(
+        """approved:
+- a: краєвид
+  b: пейзаж
+  polarity: synonym
+  sources: [synonyms]
+- a: родина
+  b: сім'я
+  polarity: synonym
+  sources: [synonyms_karavansky]
+- a: кафе
+  b: кав'ярня
+  polarity: synonym
+  sources: [sum20, vts, synonyms]
+- a: self
+  b: self
+  polarity: synonym
+  sources: [synonyms]
+- a: відсутній
+  b: пейзаж
+  polarity: synonym
+  sources: [synonyms]
+- a: холодний
+  b: гарячий
+  polarity: antonym
+  sources: [synonyms]
+rejected:
+- a: кафе
+  b: ресторан
+  polarity: synonym
+  reason: Different establishments.
+""",
+        encoding="utf-8",
+    )
+    db = tmp_path / "atlas.db"
+
+    counts = atlas_db.migrate_manifest(manifest, db, verdicts)
+
+    conn = sqlite3.connect(db)
+    rows = set(
+        conn.execute(
+            "SELECT slug, related_slug, relation, provenance FROM related_entries ORDER BY slug, related_slug"
+        ).fetchall()
+    )
+    assert rows == {
+        ("cafe", "coffeehouse", "synonym", "verified"),
+        ("coffeehouse", "cafe", "synonym", "verified"),
+        ("family", "family-uk", "synonym", "verified"),
+        ("family-uk", "family", "synonym", "verified"),
+        ("landscape", "scenery", "synonym", "verified"),
+        ("scenery", "landscape", "synonym", "verified"),
+    }
+    assert all(slug != related_slug for slug, related_slug, _, _ in rows)
+    assert all(provenance == "verified" for _, _, _, provenance in rows)
+    assert counts["verified_synonym_pairs"] == 4
+    assert counts["verified_synonym_pairs_unresolved"] == 1
+    assert counts["verified_synonym_self_pairs_skipped"] == 1
+    assert counts["related_entries"] == 6
+    conn.close()
+
+
+def test_cafe_verdict_is_an_approved_synonym_with_attested_sources():
+    verdicts = yaml.safe_load(atlas_db.DEFAULT_SYNONYM_VERDICTS.read_text(encoding="utf-8"))
+    cafe = next(
+        item
+        for item in verdicts["approved"]
+        if item.get("a") == "кафе" and item.get("b") == "кав'ярня"
+    )
+    assert cafe == {
+        "a": "кафе",
+        "b": "кав'ярня",
+        "polarity": "synonym",
+        "sources": ["sum20", "vts", "synonyms"],
+    }
 
 
 def test_alias_validator_reports_actionable_failures(tmp_path, capsys):


### PR DESCRIPTION
## Root cause

`related_entries` was declared by `scripts/atlas/atlas_db.py` but the deterministic Atlas rebuild never inserted any rows, leaving the 8,216-article database with zero relations.

This change makes the builder load only `data/lexicon/synonym_pair_verdicts.yaml` records from `approved` whose `polarity` is `synonym`. It creates symmetric `relation='synonym'` rows with `provenance='verified'`, resolves source lemmas alias-first without slugifying them, skips unresolved pairs deterministically, and storage-enforces no self-loops, unique edges, and valid article targets.

No raw or unverified Ukrajinet WordNet vein was added: the builder never reads WordNet or `sources.db`, and the rebuilt DB contains only `verified` provenance.

## Café attestation

Added the previously absent approved verdict `кафе` ↔ `кав'ярня` with `sum20`, `vts`, and `synonyms` source tags. The reported dictionary attestations are СУМ-20 and Великий тлумачний словник cross-references, plus Ukrajinet synonyms; the existing rejected `кафе` ↔ `ресторан` verdict remains untouched.

## Verification

```text
$ .venv/bin/pytest tests/test_atlas_db.py -q
6 passed in 0.75s

$ .venv/bin/ruff check scripts/atlas/atlas_db.py tests/test_atlas_db.py
All checks passed!

$ npm --prefix site run hydrate:manifest
$ .venv/bin/python -m scripts.atlas.atlas_db --db data/atlas.db
atlas_db migrate: {"articles": 8216, "aliases": 9651, "provenance": 8242, "enrichment": 72386, "form_aliases": 336, "payloads": 8542, "verified_synonym_pairs": 520, "verified_synonym_pairs_unresolved": 0, "verified_synonym_self_pairs_skipped": 0, "related_entries": 1022}
by entry_type: {"multiword_term": 1285, "lemma": 6931}
atlas_db alias validation: {"public_aliases": 9969, "private_aliases": 18, "distinct_public_targets": 8206, "approved_public_articles": 8206, "failures": 0}
```

SQL and raw output:

```sql
SELECT COUNT(*) AS related_entries FROM related_entries;
-- 1022

SELECT src.lemma, dst.lemma, rel.relation, rel.provenance
FROM related_entries AS rel
JOIN articles AS src ON src.slug = rel.slug
JOIN articles AS dst ON dst.slug = rel.related_slug
WHERE (src.lemma = 'краєвид' AND dst.lemma = 'пейзаж')
   OR (src.lemma = 'родина' AND dst.lemma = 'сім''я')
   OR (src.lemma = 'кафе' AND dst.lemma = 'кав''ярня')
ORDER BY src.lemma, dst.lemma;
-- кафе      | кав'ярня | synonym | verified
-- краєвид   | пейзаж   | synonym | verified
-- родина    | сім'я    | synonym | verified

SELECT SUM(CASE WHEN forward.slug = forward.related_slug THEN 1 ELSE 0 END) AS self_loops,
       SUM(CASE WHEN forward.relation != 'synonym' THEN 1 ELSE 0 END) AS non_synonyms,
       SUM(CASE WHEN forward.provenance != 'verified' THEN 1 ELSE 0 END) AS non_verified,
       SUM(CASE WHEN reverse.slug IS NULL THEN 1 ELSE 0 END) AS asymmetric
FROM related_entries AS forward
LEFT JOIN related_entries AS reverse
  ON reverse.slug = forward.related_slug
 AND reverse.related_slug = forward.slug
 AND reverse.relation = forward.relation
 AND reverse.provenance = forward.provenance;
-- 0 | 0 | 0 | 0
```

`ruff check` for the full repository still reports 28 pre-existing violations in untouched `docs/reports/` and `plans/` scripts; scoped Ruff and the pre-commit affected-file checks pass.

## Review

Independent cross-family review: AGY / Gemini 3.1 Pro High, task `review-4949-precommit` — **APPROVE** (no findings).

Fixes #4949
