### PR TITLE
feat(activity-kit): render quiz/mark-the-words and existing widgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -876,7 +876,7 @@ jobs:
         run: |
           python -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
-          .venv/bin/python -m pip install jsonschema
+          .venv/bin/python -m pip install jsonschema PyYAML
 
       - name: Restore Atlas lexicon manifest cache
         id: atlas-manifest-cache
@@ -935,6 +935,7 @@ jobs:
       run: |
         python -m venv .venv
         .venv/bin/python -m pip install --upgrade pip
+        .venv/bin/python -m pip install PyYAML
 
     - name: Restore Atlas lexicon manifest cache
       id: atlas-manifest-cache

--- a/docs/lesson-schema.yaml
+++ b/docs/lesson-schema.yaml
@@ -2,7 +2,7 @@ schema_version: "1.0"
 generator_version: "1.0.0"
 generated_from:
   components_dir: site/src/components/{*.tsx, *.astro}
-  components_sha256: 48b22a075b262d3dbf4f770a32cd148f8b9adf386ea9d84d539f43135ba30002
+  components_sha256: 2237e61f61465c870e064ef2bca6cec1637b7d47130798178653e430431b9635
   config_tables_sha256: 00ac63a789f8f4a8d347ec407a03d6103f53d23a40205f74309ff438c1547a1c
   lesson_contract_sha256: 917ee4abd1a74c5df17f9d19e743f23c376f43d8f1b9a68e12fb30ad6b535024
 components:

--- a/packages/activity-kit/src/ActivityPlayer.tsx
+++ b/packages/activity-kit/src/ActivityPlayer.tsx
@@ -1,11 +1,65 @@
 import Cloze from './components/Cloze';
+import ErrorCorrection from './components/ErrorCorrection';
+import EssayResponse from './components/EssayResponse';
+import FillIn from './components/FillIn';
+import MarkTheWords, { MarkTheWordsActivity } from './components/MarkTheWords';
 import MatchUp from './components/MatchUp';
+import Quiz from './components/Quiz';
+import ReadingActivity from './components/ReadingActivity';
 import TrueFalse from './components/TrueFalse';
-import type { LuActivityType, LuActivityV1 } from './lu.activity.v1.generated';
+import type { LuActivityV1 } from './lu.activity.v1.generated';
+
+/**
+ * Activity shapes emitted by the activities-b1/activity-v2 pipeline.
+ *
+ * The public lesson-document envelope has a separately versioned schema, so
+ * these source activities intentionally remain a small, explicit union rather
+ * than widening LuActivityV1 with unvalidated `unknown` payloads.
+ */
+export type ActivitySourceActivity =
+  | {
+    id?: string;
+    type: 'quiz';
+    title?: string;
+    instruction: string;
+    items: Array<{ question: string; options: string[]; correct: number; explanation?: string }>;
+  }
+  | {
+    id?: string;
+    type: 'mark-the-words';
+    title?: string;
+    instruction: string;
+    text: string;
+    target_words: string[];
+    criteria?: string;
+  }
+  | {
+    id?: string;
+    type: 'error-correction';
+    title?: string;
+    instruction: string;
+    items: Array<{
+      sentence: string;
+      error: string;
+      correction: string;
+      options?: string[];
+      explanation?: string;
+    }>;
+  }
+  | {
+    id?: string;
+    type: 'fill-in';
+    title?: string;
+    instruction: string;
+    items: Array<{ sentence: string; answer: string; options?: string[] }>;
+  };
+
+export type ActivityPlayerActivity = LuActivityV1 | ActivitySourceActivity;
+type ActivityPlayerActivityType = ActivityPlayerActivity['type'];
 
 export interface ActivityCompletionEvent {
   activityId: string;
-  activityType: LuActivityType;
+  activityType: ActivityPlayerActivityType;
 }
 
 export interface ActivityEditOperation {
@@ -16,7 +70,7 @@ export interface ActivityEditOperation {
 }
 
 export interface ActivityPlayerProps {
-  activity: LuActivityV1;
+  activity: ActivityPlayerActivity;
   onComplete?: (event: ActivityCompletionEvent) => void;
   /**
    * Reserved for controlled editor integrations. This player has no editor UI
@@ -28,12 +82,14 @@ export interface ActivityPlayerProps {
 
 export function ActivityPlayer({ activity, onComplete, isUkrainian }: ActivityPlayerProps) {
   const complete = () => {
-    onComplete?.({ activityId: activity.id, activityType: activity.type });
+    onComplete?.({ activityId: activity.id ?? activity.type, activityType: activity.type });
   };
 
+  const title = activity.title ?? activity.type;
+
   return (
-    <section data-activity-player={activity.type} aria-label={activity.title}>
-      <h2>{activity.title}</h2>
+    <section data-activity-player={activity.type} aria-label={title}>
+      <h2>{title}</h2>
       {activity.type === 'true-false' && (
         <TrueFalse
           items={activity.payload.items.map(({ statement, correct, explanation }) => ({
@@ -67,7 +123,121 @@ export function ActivityPlayer({ activity, onComplete, isUkrainian }: ActivityPl
           onComplete={complete}
         />
       )}
-      {!['true-false', 'cloze', 'match-up'].includes(activity.type) && (
+      {activity.type === 'quiz' && (
+        <Quiz
+          questions={activity.items.map(({ question, options, correct, explanation }) => ({
+            question,
+            options: options.map((text, index) => ({ text, correct: index === correct })),
+            explanation,
+          }))}
+          instruction={activity.instruction}
+          isUkrainian={isUkrainian}
+        />
+      )}
+      {activity.type === 'mark-the-words' && (
+        <MarkTheWords isUkrainian={isUkrainian}>
+          <MarkTheWordsActivity
+            text={activity.text}
+            correctWords={activity.target_words.flatMap((word) => word.split(/\s+/).filter(Boolean))}
+            instruction={[activity.instruction, activity.criteria].filter(Boolean).join(' ')}
+            isUkrainian={isUkrainian}
+          />
+        </MarkTheWords>
+      )}
+      {activity.type === 'error-correction' && 'items' in activity && (
+        <ErrorCorrection
+          items={activity.items.map(({ sentence, error, correction, options, explanation }) => ({
+            sentence,
+            errorWord: error,
+            correctForm: correction,
+            options: options ?? [],
+            explanation: explanation ?? '',
+          }))}
+          instruction={activity.instruction}
+          isUkrainian={isUkrainian}
+        />
+      )}
+      {activity.type === 'error-correction' && 'payload' in activity && (
+        <ErrorCorrection
+          items={activity.payload.items.map((sentence, index) => ({
+            sentence,
+            errorWord: sentence,
+            correctForm: activity.answer_key.items[index] ?? '',
+            options: [],
+            explanation: '',
+          }))}
+          instruction={activity.payload.instruction}
+          isUkrainian={isUkrainian}
+        />
+      )}
+      {activity.type === 'fill-in' && (
+        <FillIn
+          items={activity.items.map(({ sentence, answer, options }) => ({
+            sentence: sentence.replace(/\{[^{}]+\}/g, '___'),
+            answer,
+            options: options ?? [answer],
+          }))}
+          instruction={activity.instruction}
+          isUkrainian={isUkrainian}
+        />
+      )}
+      {activity.type === 'multiple-choice' && (
+        <Quiz
+          questions={activity.payload.items.map(({ prompt, options }, index) => {
+            const correct = activity.answer_key.items.find((item) => item.index === index)?.correct;
+            return {
+              question: prompt,
+              options: options.map((text) => ({
+                text,
+                correct: text === correct || text.startsWith(`${correct})`),
+              })),
+            };
+          })}
+          instruction={activity.payload.instruction}
+          isUkrainian={isUkrainian}
+        />
+      )}
+      {activity.type === 'text-questions' && (
+        <>
+          <ReadingActivity
+            title={title}
+            context={activity.payload.instruction}
+            tasks={activity.payload.items}
+            activityType="text-questions"
+            isUkrainian={isUkrainian}
+          />
+          <aside data-activity-teacher-guidance="text-questions">
+            <strong>{isUkrainian ? 'Для обговорення / оцінювання:' : 'For discussion / grading:'}</strong>{' '}
+            {activity.answer_key.guidance}
+          </aside>
+        </>
+      )}
+      {activity.type === 'short-writing' && (
+        <>
+          <EssayResponse
+            title={title}
+            prompt={activity.payload.prompt}
+            activityType="short-writing"
+            isUkrainian={isUkrainian}
+          />
+          <aside data-activity-teacher-guidance="short-writing">
+            <strong>{isUkrainian ? 'Для обговорення / оцінювання:' : 'For discussion / grading:'}</strong>{' '}
+            {activity.answer_key.guidance}
+          </aside>
+        </>
+      )}
+      {![
+        'true-false',
+        'cloze',
+        'match-up',
+        'quiz',
+        'mark-the-words',
+        'error-correction',
+        'fill-in',
+        'multiple-choice',
+        'text-questions',
+        'short-writing',
+      ].includes(activity.type) && (
         <p data-activity-placeholder={activity.type}>тип поки без віджета</p>
       )}
     </section>

--- a/packages/activity-kit/src/components/Activities.module.css
+++ b/packages/activity-kit/src/components/Activities.module.css
@@ -1,16 +1,16 @@
-/* Shared shell for the public activity-kit slice. */
+/* ============= ACTIVITY CONTAINER ============= */
 .activityContainer {
-  border: 2px solid var(--ifm-color-emphasis-200, #d9dee8);
+  border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 12px;
   padding: 22px;
   margin: 22px 0;
-  background: var(--ifm-card-background-color, #fff);
-  box-shadow: 0 2px 8px rgb(0 0 0 / 8%);
+  background: var(--ifm-card-background-color);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   transition: all 0.2s ease;
 }
 
 .activityContainer:hover {
-  box-shadow: 0 4px 16px rgb(0 0 0 / 12%);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
 }
 
 .activityHeader {
@@ -28,8 +28,8 @@
   border-radius: 4px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: #fff;
-  background: var(--ifm-color-primary, #0057b7);
+  color: white;
+  background: var(--ifm-color-primary);
 }
 
 .activityContent {
@@ -38,17 +38,130 @@
   gap: 1.5rem;
 }
 
+/* Remove top padding from the first question/item in every activity type.
+ * Gap handles inter-item spacing; padding-top on the first item just creates
+ * unwanted extra space between the header and the first piece of content. */
 .activityContent > *:first-child {
   padding-top: 0;
 }
 
 .instruction {
   font-size: 13px;
-  color: var(--ifm-color-emphasis-600, #4f5b6c);
+  color: var(--ifm-color-emphasis-600);
   margin-bottom: 14px;
   font-style: italic;
 }
 
+/* ============= READING ============= */
+.readingContext {
+  font-size: 15px;
+  line-height: 1.9;
+  margin-bottom: 14px;
+  padding: 20px;
+  background: white;
+  border-radius: 12px;
+  border: 2px solid var(--ifm-color-emphasis-200);
+  white-space: pre-wrap;
+}
+
+.readingTasks {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 2px solid var(--ifm-color-emphasis-200);
+}
+
+.taskList {
+  list-style-type: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.taskItem {
+  padding: 1rem;
+  background: var(--ifm-background-color);
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  font-weight: 500;
+}
+
+/* ============= QUIZ ============= */
+.quizQuestion {
+  margin-bottom: 14px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.quizQuestion:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.questionText {
+  font-weight: 600;
+  font-size: 15px;
+  margin-bottom: 8px;
+  color: var(--ifm-heading-color);
+}
+
+.options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.option {
+  display: inline-block;
+  padding: 7px 14px;
+  text-align: left;
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  background: white;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.option:hover:not(:disabled) {
+  border-color: var(--ifm-color-primary);
+  background: var(--lu-state-active);
+}
+
+.option.selected {
+  border-color: var(--ifm-color-primary);
+  background: var(--lu-state-active);
+}
+
+.option.correct {
+  border-color: var(--lu-state-correct-fg) !important;
+  background: var(--lu-state-correct-bg) !important;
+  color: var(--lu-state-correct-fg);
+  font-weight: 600;
+  position: relative;
+}
+
+.option.correct::after {
+  content: '';
+}
+
+.option.incorrect {
+  border-color: var(--lu-state-wrong-fg) !important;
+  background: var(--lu-state-wrong-bg) !important;
+  color: var(--lu-state-wrong-fg);
+  position: relative;
+}
+
+.option.incorrect::after {
+  content: '';
+}
+
+.option:disabled {
+  cursor: default;
+}
+
+/* ============= FEEDBACK ============= */
 .feedback {
   margin-top: 10px;
   padding: 10px 14px;
@@ -74,15 +187,15 @@
 }
 
 .feedbackCorrect {
-  background: var(--lu-state-correct-bg, #e8f6ed);
-  color: var(--lu-state-correct-fg, #1e7a3c);
-  border: 1px solid var(--lu-state-correct-fg, #1e7a3c);
+  background: var(--lu-state-correct-bg);
+  color: var(--lu-state-correct-fg);
+  border: 1px solid var(--lu-state-correct-fg);
 }
 
 .feedbackIncorrect {
-  background: var(--lu-state-wrong-bg, #fdecea);
-  color: var(--lu-state-wrong-fg, #b3261e);
-  border: 1px solid var(--lu-state-wrong-fg, #b3261e);
+  background: var(--lu-state-wrong-bg);
+  color: var(--lu-state-wrong-fg);
+  border: 1px solid var(--lu-state-wrong-fg);
 }
 
 .explanation {
@@ -92,7 +205,114 @@
   opacity: 0.9;
 }
 
-/* MatchUp */
+/* ============= FILL-IN ============= */
+.fillInQuestion {
+  padding: 1.25rem 0;
+}
+
+.sentenceWithBlank {
+  font-size: 15px;
+  line-height: 2;
+}
+
+.blank {
+  display: inline-block;
+  min-width: 80px;
+  padding: 2px 8px;
+  margin: 0 0.3rem;
+  border-bottom: 2px dashed var(--ifm-color-primary);
+  text-align: center;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  transition: all 0.2s ease;
+}
+
+.blank.correct {
+  border-bottom-style: solid;
+  border-color: var(--lu-state-correct-fg);
+  background: var(--lu-state-correct-bg);
+  color: var(--lu-state-correct-fg);
+  border-radius: 4px;
+}
+
+.blank.incorrect {
+  border-color: var(--lu-state-wrong-fg);
+  background: var(--lu-state-wrong-bg);
+  color: var(--lu-state-wrong-fg);
+}
+
+.optionChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 1.25rem;
+}
+
+.chip {
+  padding: 7px 14px;
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  background: white;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.chip:hover {
+  border-color: var(--ifm-color-primary);
+  background: var(--lu-state-active);
+}
+
+.chipDraggable {
+  padding: 6px 14px;
+  border: 1px solid var(--lu-state-drag);
+  border-radius: 20px;
+  background: var(--lu-state-drag);
+  cursor: grab;
+  transition: all 0.2s ease;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.chipDraggable:hover {
+  background: var(--lu-state-drag);
+  color: var(--lu-text);
+}
+
+.chipDraggable:active {
+  cursor: grabbing;
+}
+
+.blankDropZone {
+  display: inline-block;
+  padding: 0.4rem 1rem;
+  border: 2px dashed var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  background: var(--lu-state-active);
+  color: var(--ifm-color-emphasis-500);
+  font-style: italic;
+  min-width: 80px;
+  text-align: center;
+  transition: all 0.2s ease;
+}
+
+.blankDropZone:hover {
+  background: var(--lu-state-active);
+  border-color: var(--ifm-color-primary);
+}
+
+.blankDropZone.correct {
+  border-color: var(--lu-state-correct-fg);
+  border-style: solid;
+}
+
+.blankDropZone.incorrect {
+  border-color: var(--lu-state-wrong-fg);
+  border-style: solid;
+}
+
+/* ============= MATCH UP ============= */
 .matchUpContainer {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
@@ -118,29 +338,31 @@
   text-align: center;
 }
 
+/* Left column items */
 .matchColumn:first-child .matchItem {
-  background: var(--lu-state-active, #e8f1ff);
+  background: var(--lu-state-active);
   text-align: right;
 }
 
+/* Right column items */
 .matchColumn:last-child .matchItem {
-  background: var(--lu-match-right, #fff1db);
+  background: var(--lu-match-right);
 }
 
 .matchItem:hover:not(:disabled) {
-  border-color: var(--ifm-color-primary, #0057b7);
+  border-color: var(--ifm-color-primary);
 }
 
 .matchItem.selected {
-  border-color: var(--ifm-color-primary, #0057b7);
-  box-shadow: 0 0 0 2px var(--lu-state-active, #e8f1ff);
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 2px var(--lu-state-active);
 }
 
 .matchItem.matched {
   --match-pair-hue: 142;
-  --match-pair-bg: hsl(var(--match-pair-hue) 68% 43% / 14%);
+  --match-pair-bg: hsl(var(--match-pair-hue) 68% 43% / 0.14);
   --match-pair-border: hsl(var(--match-pair-hue) 72% 35%);
-  --match-pair-fg: var(--lu-text, #1c2430);
+  --match-pair-fg: var(--lu-text);
 
   border-color: var(--match-pair-border);
   background: var(--match-pair-bg);
@@ -159,13 +381,18 @@
   color: var(--match-pair-fg);
 }
 
+.matchItem.matched::after {
+  content: '';
+}
+
 .matchItem.wrong {
-  border-color: var(--lu-state-wrong-fg, #b3261e);
-  background: var(--lu-state-wrong-bg, #fdecea);
+  border-color: var(--lu-state-wrong-fg);
+  background: var(--lu-state-wrong-bg);
   animation: shake 0.5s ease;
 }
 
 @keyframes shake {
+
   0%,
   100% {
     transform: translateX(0);
@@ -188,7 +415,7 @@
   }
 }
 
-/* TrueFalse */
+/* ============= TRUE/FALSE ============= */
 .trueFalseQuestion {
   padding: 1.25rem 0;
 }
@@ -208,9 +435,9 @@
 
 .tfButton {
   padding: 5px 14px;
-  border: 2px solid var(--ifm-color-emphasis-200, #d9dee8);
+  border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 6px;
-  background: #fff;
+  background: white;
   cursor: pointer;
   font-size: 13px;
   font-weight: 600;
@@ -218,70 +445,217 @@
 }
 
 .tfButton:hover:not(:disabled) {
-  border-color: var(--ifm-color-primary, #0057b7);
+  border-color: var(--ifm-color-primary);
 }
 
 .trueButton:hover:not(:disabled) {
-  border-color: var(--lu-state-correct-fg, #1e7a3c);
-  background: var(--lu-state-correct-bg, #e8f6ed);
-  color: var(--lu-state-correct-fg, #1e7a3c);
+  border-color: var(--lu-state-correct-fg);
+  background: var(--lu-state-correct-bg);
+  color: var(--lu-state-correct-fg);
 }
 
 .falseButton:hover:not(:disabled) {
-  border-color: var(--lu-state-wrong-fg, #b3261e);
-  background: var(--lu-state-wrong-bg, #fdecea);
-  color: var(--lu-state-wrong-fg, #b3261e);
+  border-color: var(--lu-state-wrong-fg);
+  background: var(--lu-state-wrong-bg);
+  color: var(--lu-state-wrong-fg);
 }
 
 .tfButton.correct {
-  border-color: var(--lu-state-correct-fg, #1e7a3c) !important;
-  background: var(--lu-state-correct-bg, #e8f6ed) !important;
-  color: var(--lu-state-correct-fg, #1e7a3c);
+  border-color: var(--lu-state-correct-fg) !important;
+  background: var(--lu-state-correct-bg) !important;
+  color: var(--lu-state-correct-fg);
 }
 
 .tfButton.incorrect {
-  border-color: var(--lu-state-wrong-fg, #b3261e) !important;
-  background: var(--lu-state-wrong-bg, #fdecea) !important;
-  color: var(--lu-state-wrong-fg, #b3261e);
+  border-color: var(--lu-state-wrong-fg) !important;
+  background: var(--lu-state-wrong-bg) !important;
+  color: var(--lu-state-wrong-fg);
 }
 
-/* Cloze */
-.clozePassage {
-  font-size: 15px;
-  line-height: 2;
-  margin-bottom: 1.5rem;
-  padding: 16px;
-  background: var(--ifm-color-emphasis-100, #f4f6f9);
+/* ============= ANAGRAM ============= */
+.anagramQuestion {
+  padding: 1.25rem 0;
+  text-align: center;
+}
+
+/* Answer Zone for drag targets */
+.answerZone {
+  min-height: 52px;
+  padding: 6px;
+  border: 2px dashed var(--ifm-color-emphasis-300);
   border-radius: 8px;
+  margin-bottom: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: center;
+  align-items: center;
+  transition: all 0.2s ease;
 }
 
-.clozeSelect {
-  display: inline-block;
-  padding: 4px 8px;
-  margin: 0 2px;
-  border: 2px solid var(--ifm-color-primary, #0057b7);
-  border-radius: 6px;
-  background: var(--lu-state-active, #e8f1ff);
-  font-size: 14px;
-  font-family: inherit;
+.answerZone:hover {
+  border-color: var(--ifm-color-primary);
+}
+
+.answerZone.correct {
+  border-color: #2E7D32;
+  background: var(--lu-state-correct-bg);
+}
+
+.answerZone.incorrect {
+  border-color: #C62828;
+  background: var(--lu-state-wrong-bg);
+}
+
+/* Letter Bank */
+.letterBank {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: center;
+  margin-bottom: 10px;
+  min-height: 50px;
+  padding: 0.75rem;
+  border: 2px dashed var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  background: var(--ifm-background-surface-color);
+}
+
+.scrambledWord {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: center;
+  margin-bottom: 10px;
+}
+
+.letterTile {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0;
+  border: 2px solid var(--ifm-color-primary);
+  border-radius: 8px;
+  background: var(--lu-state-active);
+  font-size: 18px;
+  font-weight: 700;
+  transition: all 0.15s ease;
   cursor: pointer;
-  min-width: 70px;
+  user-select: none;
 }
 
-.clozeSelect:focus {
+.letterTile:hover:not(:disabled) {
+  background: var(--ifm-color-primary);
+  color: white;
+  transform: scale(1.1);
+}
+
+.letterTile:active {
+  cursor: grabbing;
+}
+
+.hint {
+  text-align: center;
+  color: var(--ifm-color-emphasis-600);
+  font-style: italic;
+  margin-bottom: 1.25rem;
+  font-size: 0.95rem;
+}
+
+.inputRow {
+  display: flex;
+  gap: 0.75rem;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+.textInput {
+  flex: 1;
+  padding: 10px 14px;
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  font-size: 15px;
+  font-family: inherit;
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  transition: border-color 0.2s ease;
+}
+
+.textInput:focus {
   outline: none;
+  border-color: var(--ifm-color-primary);
 }
 
-.clozeSelect.correct {
-  border-color: var(--lu-state-correct-fg, #1e7a3c);
-  background: var(--lu-state-correct-bg, #e8f6ed);
-  color: var(--lu-state-correct-fg, #1e7a3c);
-  font-weight: 600;
+/* ============= UNJUMBLE ============= */
+.unjumbleQuestion {
+  padding: 1.25rem 0;
 }
 
-.clozeSelect.incorrect {
-  border-color: var(--lu-state-wrong-fg, #b3261e);
-  background: var(--lu-state-wrong-bg, #fdecea);
+.sentenceBuilder {
+  min-height: 44px;
+  padding: 8px 12px;
+  border: 2px dashed var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  margin-bottom: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  background: var(--ifm-background-surface-color);
+  transition: all 0.2s ease;
+}
+
+.sentenceBuilder:hover {
+  border-color: var(--ifm-color-primary);
+}
+
+.sentenceBuilder.correct {
+  border-color: #2E7D32;
+  background: var(--lu-state-correct-bg);
+}
+
+.sentenceBuilder.incorrect {
+  border-color: #C62828;
+  background: var(--lu-state-wrong-bg);
+}
+
+.placeholder {
+  color: var(--ifm-color-emphasis-500);
+  font-style: italic;
+}
+
+.wordBank {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+  justify-content: center;
+}
+
+.wordTile {
+  padding: 6px 14px;
+  border: 2px solid var(--ifm-color-primary);
+  border-radius: 8px;
+  background: white;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.wordTile:hover:not(:disabled) {
+  background: var(--ifm-color-primary);
+  color: white;
+}
+
+.wordTile:active {
+  cursor: grabbing;
+}
+
+.wordTile.selectedWord {
+  background: rgba(0, 87, 183, 0.12);
 }
 
 .buttonRow {
@@ -293,7 +667,7 @@
 .submitButton,
 .resetButton {
   padding: 7px 20px;
-  border: 2px solid var(--ifm-color-emphasis-200, #d9dee8);
+  border: 2px solid var(--ifm-color-emphasis-200);
   border-radius: 8px;
   font-size: 14px;
   font-weight: 600;
@@ -302,9 +676,9 @@
 }
 
 .submitButton {
-  background: var(--ifm-color-primary, #0057b7);
-  color: #fff;
-  border-color: var(--ifm-color-primary, #0057b7);
+  background: var(--ifm-color-primary);
+  color: white;
+  border-color: var(--ifm-color-primary);
 }
 
 .submitButton:hover:not(:disabled) {
@@ -317,15 +691,623 @@
 }
 
 .resetButton {
-  background: var(--ifm-color-emphasis-200, #d9dee8);
-  color: var(--ifm-font-color-base, #1c2430);
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-font-color-base);
 }
 
 .resetButton:hover {
-  background: var(--ifm-color-emphasis-300, #c4ccd8);
+  background: var(--ifm-color-emphasis-300);
 }
 
-/* Help */
+/* ============= GROUP SORT ============= */
+.groupSortContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.wordPool {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 12px;
+  border: 2px dashed var(--ifm-color-emphasis-300);
+  border-radius: 12px;
+  background: var(--ifm-background-surface-color);
+  min-height: 60px;
+  justify-content: center;
+  transition: all 0.2s ease;
+}
+
+.wordPool.dropTarget {
+  border-color: #6A1B9A;
+  background: rgba(106, 27, 154, 0.05);
+}
+
+.poolEmpty {
+  color: var(--ifm-color-emphasis-500);
+  font-style: italic;
+  width: 100%;
+  text-align: center;
+}
+
+.groupContainers {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.groupBucket {
+  border: 2px dashed var(--ifm-color-emphasis-300);
+  border-radius: 12px;
+  padding: 12px;
+  min-height: 100px;
+  background: var(--ifm-background-surface-color);
+  text-align: center;
+  transition: all 0.2s ease;
+}
+
+.groupBucket.dropTarget {
+  border-color: #6A1B9A;
+  background: var(--lu-state-drag);
+}
+
+.groupTitle {
+  margin: 0 0 8px 0;
+  padding-bottom: 0;
+  border-bottom: none;
+  color: #6A1B9A;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+/* #6A1B9A is the light-mode purple — unreadable on the dark drop-zone.
+   Use the dark-mode purple variant (matches --lu-purple in [data-theme=dark]). */
+[data-theme='dark'] .groupTitle {
+  color: #C58BFF;
+}
+
+[data-theme='dark'] .groupBucket.dropTarget {
+  border-color: #C58BFF;
+}
+
+.groupItems {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 40px;
+  justify-content: center;
+}
+
+.bucketPlaceholder {
+  /* --ifm-color-emphasis-400 is undefined in this theme (fell back to a
+     low-contrast gray). Use the defined muted token — readable in both modes. */
+  color: var(--lu-text-muted);
+  font-style: italic;
+  font-size: 0.9rem;
+}
+
+/* ============= ERROR CORRECTION ============= */
+.errorCorrectionItem {
+  padding: 1.25rem 0;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.errorCorrectionItem:last-child {
+  border-bottom: none;
+}
+
+.stepIndicator {
+  margin-bottom: 1rem;
+}
+
+.stepBadge {
+  display: inline-block;
+  padding: 3px 10px;
+  background: var(--ifm-color-primary);
+  color: white;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* --ifm-color-primary (= --lu-blue) goes pale in dark mode → white text fails.
+   Use a fixed mid-azure so the white label stays readable. */
+[data-theme='dark'] .stepBadge {
+  background: #1A6FD4;
+}
+
+.stepBadgeComplete {
+  display: inline-block;
+  padding: 3px 10px;
+  background: #2E7D32;
+  color: white;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.errorSentence {
+  font-size: 15px;
+  line-height: 1.8;
+  margin-bottom: 10px;
+  padding: 12px 16px;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+}
+
+.clickableWord {
+  transition: all 0.2s ease;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.wordHoverable {
+  cursor: pointer;
+}
+
+.wordHoverable:hover {
+  background: rgba(0, 87, 183, 0.15);
+  color: var(--ifm-color-primary);
+}
+
+.wordWrong {
+  background: var(--lu-state-wrong-bg);
+  color: #C62828;
+  text-decoration: underline wavy #C62828;
+  animation: shake 0.3s ease;
+}
+
+@keyframes wrongPulse {
+  0% {
+    background: rgba(198, 40, 40, 0.15);
+  }
+  100% {
+    background: var(--lu-state-wrong-bg);
+  }
+}
+
+.wordSelected {
+  background: rgba(0, 87, 183, 0.15);
+  font-weight: 600;
+}
+
+.wordError {
+  color: #C62828;
+}
+
+.correctedWord s {
+  color: #C62828;
+  text-decoration: line-through;
+  opacity: 0.7;
+}
+
+.correctedWord {
+  color: #2E7D32;
+  font-weight: 600;
+}
+
+.noErrorButton {
+  display: block;
+  margin-top: 10px;
+  padding: 7px 14px;
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  background: white;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.noErrorButton:hover {
+  border-color: #2E7D32;
+  background: var(--lu-state-correct-bg);
+  color: #2E7D32;
+}
+
+.noErrorWrong {
+  border-color: #C62828 !important;
+  background: var(--lu-state-wrong-bg) !important;
+  animation: shake 0.3s ease;
+}
+
+.fixOptions {
+  margin-top: 14px;
+  padding: 1rem;
+  background: var(--ifm-background-surface-color);
+  border-radius: 8px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.fixPrompt {
+  margin-bottom: 0.75rem;
+  font-size: 0.95rem;
+}
+
+/* ============= SELECT (MULTI-CHECKBOX) ============= */
+.selectQuestion {
+  padding: 1.25rem 0;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.selectQuestion:last-child {
+  border-bottom: none;
+}
+
+.checkboxOptions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.checkboxOption {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 7px 14px;
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.checkboxOption:hover {
+  border-color: var(--ifm-color-primary);
+  background: rgba(0, 87, 183, 0.05);
+}
+
+.checkboxOption.checked {
+  border-color: var(--ifm-color-primary);
+  background: var(--lu-state-active);
+}
+
+.checkboxOption.correctAnswer {
+  border-color: #2E7D32 !important;
+  background: var(--lu-state-correct-bg) !important;
+}
+
+.checkboxOption.wrongAnswer {
+  border-color: #C62828 !important;
+  background: var(--lu-state-wrong-bg) !important;
+}
+
+.checkboxOption.missedAnswer {
+  border-color: #FBBC04 !important;
+  background: var(--lu-state-missed) !important;
+}
+
+.checkboxOption.missedAnswer::after {
+  content: '\2190 missed';
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: #B06000;
+  font-weight: 600;
+}
+
+.checkbox {
+  width: 22px;
+  height: 22px;
+  border: 2px solid var(--ifm-color-emphasis-400);
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+
+.checkbox.checked {
+  background: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+  color: white;
+}
+
+.checkboxLabel {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+/* ============= TRANSLATE ============= */
+.translateItem {
+  padding: 14px 0;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.translateItem:last-child {
+  border-bottom: none;
+}
+
+.sourceText {
+  font-size: 15px;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.translateOptions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.translateOption {
+  display: block;
+  width: 100%;
+  padding: 10px 14px;
+  text-align: left;
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  background: white;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-size: 14px;
+}
+
+.translateOption:hover:not(:disabled) {
+  border-color: var(--ifm-color-primary);
+  background: rgba(0, 87, 183, 0.05);
+}
+
+.translateOption.selected {
+  border-color: var(--ifm-color-primary);
+  background: var(--lu-state-active);
+}
+
+.translateOption.correct {
+  border-color: #2E7D32 !important;
+  background: var(--lu-state-correct-bg) !important;
+}
+
+.translateOption.incorrect {
+  border-color: #C62828 !important;
+  background: var(--lu-state-wrong-bg) !important;
+}
+
+/* ============= CLOZE ============= */
+.clozePassage {
+  font-size: 15px;
+  line-height: 2;
+  margin-bottom: 1.5rem;
+  padding: 16px;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+}
+
+.clozeSelect {
+  display: inline-block;
+  padding: 4px 8px;
+  margin: 0 2px;
+  border: 2px solid var(--ifm-color-primary);
+  border-radius: 6px;
+  background: var(--lu-state-active);
+  font-size: 14px;
+  font-family: inherit;
+  cursor: pointer;
+  min-width: 70px;
+}
+
+.clozeSelect:focus {
+  outline: none;
+}
+
+.clozeSelect.correct {
+  border-color: #2E7D32;
+  background: var(--lu-state-correct-bg);
+  color: #2E7D32;
+  font-weight: 600;
+}
+
+.clozeSelect.incorrect {
+  border-color: #C62828;
+  background: var(--lu-state-wrong-bg);
+}
+
+/* ============= MARK THE WORDS ============= */
+.activityInstruction {
+  font-size: 13px;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 14px;
+  font-style: italic;
+}
+
+.markWordsText {
+  font-size: 15px;
+  line-height: 2.2;
+  margin-bottom: 1.5rem;
+  padding: 16px;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+}
+
+.markableWord {
+  display: inline;
+  padding: 2px 4px;
+  margin: 0 0.1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.markableWord:hover {
+  background: var(--lu-state-active);
+}
+
+.markableWord.marked {
+  background: var(--ifm-color-primary);
+  color: white;
+}
+
+.markableWord.correctMark {
+  background: var(--lu-state-correct-bg);
+  border: 2px solid #2E7D32;
+  font-weight: 600;
+}
+
+.markableWord.missedMark {
+  background: var(--lu-state-correct-bg);
+  border: 2px dashed #2E7D32;
+}
+
+.markableWord.wrongMark {
+  background: var(--lu-state-wrong-bg);
+  border: 2px solid #C62828;
+  text-decoration: line-through;
+}
+
+/* ============= HIGHLIGHT MORPHEMES ============= */
+.morphemeHighlighted {
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-color: var(--ifm-color-primary);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 2px;
+}
+
+/* ============= DIALOGUE REORDER ============= */
+.dialogueContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.dialogueLine {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 10px 14px;
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  background: white;
+  cursor: grab;
+  transition: all 0.2s ease;
+}
+
+.dialogueLine:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.dialogueLine:active {
+  cursor: grabbing;
+}
+
+.dialogueLine.dragging {
+  opacity: 0.5;
+  transform: scale(0.98);
+}
+
+.dialogueLine.correct {
+  border-color: #2E7D32;
+  background: var(--lu-state-correct-bg);
+}
+
+.dialogueLine.incorrect {
+  border-color: #C62828;
+  background: var(--lu-state-wrong-bg);
+}
+
+.speakerLabel {
+  flex-shrink: 0;
+  padding: 0.3rem 0.8rem;
+  background: var(--ifm-color-primary);
+  color: white;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.dialogueText {
+  flex: 1;
+  font-size: 15px;
+}
+
+.orderNumber {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: var(--ifm-color-emphasis-200);
+  border-radius: 50%;
+  font-weight: 600;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+/* ============= OBSERVE (Pattern Discovery) ============= */
+.observeContainer {
+  padding: 1rem 0;
+}
+
+.observeExamples {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 14px;
+  padding: 18px;
+  background: var(--lu-state-active);
+  border-radius: 12px;
+}
+
+.observeExample {
+  padding: 10px 14px;
+  background: white;
+  border-radius: 8px;
+  text-align: center;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
+.exampleNumber {
+  color: var(--ifm-color-primary);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.observePrompt {
+  margin-top: 14px;
+  font-style: italic;
+  color: var(--ifm-color-primary);
+  font-weight: 600;
+  font-size: 15px;
+}
+
+.observeIcon {
+  font-size: 1.4rem;
+}
+
+.revealButton {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.85rem;
+  background: var(--ifm-color-primary-lightest);
+  color: var(--ifm-color-primary-dark);
+  border: 1px solid var(--ifm-color-primary-light);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.revealButton:hover {
+  background: var(--ifm-color-primary-light);
+  color: white;
+}
+
+[data-theme='dark'] .observeExamples {
+  background: rgba(0, 87, 183, 0.15);
+}
+
+[data-theme='dark'] .observePrompt {
+  color: #78b8ff;
+}
+
+/* ============= HELP TOOLTIP ============= */
 .helpContainer {
   position: relative;
   display: inline-flex;
@@ -336,9 +1318,9 @@
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  border: 2px solid var(--ifm-color-primary, #0057b7);
+  border: 2px solid var(--ifm-color-primary);
   background: transparent;
-  color: var(--ifm-color-primary, #0057b7);
+  color: var(--ifm-color-primary);
   font-size: 14px;
   font-weight: 700;
   cursor: pointer;
@@ -346,18 +1328,21 @@
   align-items: center;
   justify-content: center;
   transition: all 0.2s ease;
-  -webkit-text-fill-color: var(--ifm-color-primary, #0057b7);
+  -webkit-text-fill-color: var(--ifm-color-primary);
 }
 
 .helpButton:hover {
-  background: var(--ifm-color-primary, #0057b7);
-  color: #fff;
-  -webkit-text-fill-color: #fff;
+  background: var(--ifm-color-primary);
+  color: white;
+  -webkit-text-fill-color: white;
 }
 
 .helpOverlay {
   position: fixed;
-  inset: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
   z-index: 100;
 }
 
@@ -367,10 +1352,10 @@
   right: 0;
   width: 280px;
   padding: 1rem;
-  background: var(--ifm-card-background-color, #fff);
-  border: 1px solid var(--ifm-color-emphasis-200, #d9dee8);
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgb(0 0 0 / 8%);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   z-index: 101;
   animation: fadeIn 0.2s ease;
 }
@@ -380,7 +1365,6 @@
     opacity: 0;
     transform: translateY(-4px);
   }
-
   to {
     opacity: 1;
     transform: translateY(0);
@@ -390,55 +1374,250 @@
 .helpTitle {
   font-size: 0.95rem;
   font-weight: 700;
-  color: var(--ifm-color-primary, #0057b7);
-  -webkit-text-fill-color: var(--ifm-color-primary, #0057b7);
+  color: var(--ifm-color-primary);
+  -webkit-text-fill-color: var(--ifm-color-primary);
   margin-bottom: 0.5rem;
 }
 
 .helpDescription {
   font-size: 0.85rem;
   line-height: 1.5;
-  color: var(--ifm-font-color-base, #1c2430);
-  -webkit-text-fill-color: var(--ifm-font-color-base, #1c2430);
-}
-
-[data-theme='dark'] .tfButton {
-  background: var(--ifm-background-color, #1c2430);
-}
-
-[data-theme='dark'] .matchColumn:first-child .matchItem,
-[data-theme='dark'] .matchItem.selected {
-  background: var(--lu-state-active, #e8f1ff);
-}
-
-[data-theme='dark'] .matchColumn:last-child .matchItem {
-  background: var(--lu-match-right, #fff1db);
-}
-
-[data-theme='dark'] .matchColumn .matchItem.matched {
-  --match-pair-bg: hsl(var(--match-pair-hue) 82% 65% / 24%);
-  --match-pair-border: hsl(var(--match-pair-hue) 82% 75%);
-}
-
-[data-theme='dark'] .trueButton:hover:not(:disabled),
-[data-theme='dark'] .tfButton.correct,
-[data-theme='dark'] .clozeSelect.correct {
-  background: var(--lu-state-correct-bg, #e8f6ed) !important;
-  color: var(--lu-state-correct-fg, #1e7a3c);
-}
-
-[data-theme='dark'] .matchItem.wrong,
-[data-theme='dark'] .falseButton:hover:not(:disabled),
-[data-theme='dark'] .tfButton.incorrect,
-[data-theme='dark'] .clozeSelect.incorrect {
-  background: var(--lu-state-wrong-bg, #fdecea) !important;
-  color: var(--lu-state-wrong-fg, #b3261e);
+  color: var(--ifm-font-color-base);
+  -webkit-text-fill-color: var(--ifm-font-color-base);
 }
 
 [data-theme='dark'] .helpTooltip {
-  box-shadow: 0 4px 16px rgb(0 0 0 / 40%);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
 }
 
+/* ============= SOURCE EVALUATION ============= */
+.metadataBox {
+  padding: 1rem;
+  background: var(--ifm-background-surface-color);
+  border-radius: 8px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  margin-bottom: 1rem;
+}
+
+.metadataTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.5rem;
+}
+
+.metadataTable td {
+  padding: 0.4rem 0.75rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  font-size: 14px;
+}
+
+.metadataTable td:first-child {
+  width: 120px;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.criteriaBox {
+  margin-bottom: 1rem;
+}
+
+.criteriaTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.criteriaTag {
+  display: inline-block;
+  padding: 3px 10px;
+  background: var(--ifm-color-primary);
+  color: white;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+/* ============= DEBATE ============= */
+.debateQuestion {
+  padding: 16px 20px;
+  background: var(--lu-state-drag);
+  border-radius: 12px;
+  border-left: 4px solid #6A1B9A;
+  margin-bottom: 14px;
+}
+
+.debateQuestion .questionText {
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-top: 0.5rem;
+  margin-bottom: 0;
+}
+
+.positionsContainer {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.positionCard {
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  padding: 16px;
+  background: var(--ifm-background-color);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.positionCard:hover {
+  border-color: var(--ifm-color-primary);
+}
+
+.positionHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.positionNumber {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: var(--ifm-color-primary);
+  color: white;
+  border-radius: 50%;
+  font-weight: 700;
+  font-size: 0.9rem;
+  flex-shrink: 0;
+}
+
+.positionName {
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--ifm-heading-color);
+  flex: 1;
+}
+
+.expandIcon {
+  color: var(--ifm-color-emphasis-500);
+  font-size: 0.85rem;
+}
+
+.positionProponents {
+  font-size: 13px;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 0.75rem;
+  padding-left: 2.75rem;
+}
+
+.positionArgument {
+  padding-left: 2.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.positionArgument p {
+  margin: 0.5rem 0 0 0;
+  line-height: 1.6;
+}
+
+.positionDetails {
+  padding-left: 2.75rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.positionEvidence {
+  margin-bottom: 1rem;
+}
+
+.positionEvidence ul,
+.positionWeaknesses ul {
+  margin: 0.5rem 0 0 0;
+  padding-left: 1.25rem;
+}
+
+.positionEvidence li,
+.positionWeaknesses li {
+  margin-bottom: 0.4rem;
+  font-size: 0.95rem;
+}
+
+.positionWeaknesses {
+  color: var(--ifm-color-danger-dark);
+}
+
+/* ============= ESSAY / MODEL ANSWER SHARED ============= */
+.essayPrompt {
+  padding: 16px 20px;
+  background: var(--lu-state-drag);
+  border-radius: 12px;
+  border-left: 4px solid #6A1B9A;
+  margin-bottom: 14px;
+}
+
+.essayInputArea {
+  margin-bottom: 1rem;
+}
+
+.inputLabel {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  color: var(--ifm-heading-color);
+}
+
+.essayTextarea {
+  width: 100%;
+  padding: 14px;
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  font-size: 15px;
+  font-family: inherit;
+  line-height: 1.6;
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  resize: vertical;
+  transition: border-color 0.2s ease;
+}
+
+.essayTextarea:focus {
+  outline: none;
+  border-color: #6A1B9A;
+}
+
+.modelAnswer {
+  margin-top: 1rem;
+}
+
+.collapsibleHeader {
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+  margin-bottom: 0.75rem;
+  font-size: 1rem;
+}
+
+.modelContent {
+  font-size: 15px;
+  line-height: 1.7;
+}
+
+.modelContent ol,
+.modelContent ul {
+  margin: 0.5rem 0;
+  padding-left: 1.5rem;
+}
+
+.modelContent li {
+  margin-bottom: 0.5rem;
+}
+
+/* ============= RESPONSIVE ============= */
 @media (max-width: 768px) {
   .matchUpContainer {
     grid-template-columns: 1fr;
@@ -447,4 +1626,1106 @@
   .trueFalseButtons {
     flex-direction: column;
   }
+
+  .groupContainers {
+    grid-template-columns: 1fr;
+  }
+
+  .letterTile {
+    width: 36px;
+    height: 36px;
+    font-size: 16px;
+  }
+
+  .positionsContainer {
+    grid-template-columns: 1fr;
+  }
+
+  .observeExamples {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ============= ETYMOLOGY TRACE ============= */
+.etymologyList {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding: 14px;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+}
+
+.etymologyItem {
+  text-align: center;
+  padding: 10px 16px;
+  background: white;
+  border-radius: 8px;
+  border: 2px solid var(--ifm-color-emphasis-300);
+  transition: all 0.2s ease;
+  cursor: pointer;
+}
+
+.etymologyItem:hover {
+  border-color: var(--ifm-color-primary);
+  transform: translateY(-2px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.etymologyHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.etymologyWords {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.etymologyOriginal {
+  font-family: 'Noto Serif', serif;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.etymologyArrow {
+  font-size: 24px;
+  color: var(--ifm-color-emphasis-300);
+}
+
+.etymologyModern {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.etymologyEvolution {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--ifm-color-emphasis-300);
+  color: var(--ifm-color-emphasis-800);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+/* ============= GRAMMAR IDENTIFY ============= */
+.grammarList {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.grammarItem {
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 12px;
+  padding: 1.25rem;
+  border-left: 4px solid var(--ifm-color-warning);
+}
+
+.grammarText {
+  font-size: 15px;
+  margin-bottom: 0.5rem;
+}
+
+.oesText {
+  font-family: 'Noto Serif', serif;
+  font-style: italic;
+  color: var(--ifm-color-primary-dark);
+}
+
+.grammarTask {
+  color: var(--ifm-color-emphasis-700);
+  margin-bottom: 0.75rem;
+}
+
+.grammarInput {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.grammarInput input {
+  padding: 10px 14px;
+  font-size: 15px;
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  transition: border-color 0.2s ease;
+}
+
+.grammarInput input:focus {
+  outline: none;
+  border-color: var(--ifm-color-primary);
+}
+
+.grammarInput input.correct {
+  border-color: #2E7D32;
+  background: var(--lu-state-correct-bg);
+}
+
+.grammarInput input.incorrect {
+  border-color: #C62828;
+  background: var(--lu-state-wrong-bg);
+}
+
+.correctAnswer {
+  color: #2E7D32;
+  font-size: 0.9rem;
+  padding: 0.5rem;
+  background: var(--lu-state-correct-bg);
+  border-radius: 6px;
+}
+
+.secondaryButton {
+  padding: 7px 14px;
+  font-size: 14px;
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-800);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.secondaryButton:hover {
+  background: var(--ifm-color-emphasis-300);
+}
+
+/* ============= TRANSCRIPTION ACTIVITY ============= */
+.transcriptionOriginal {
+  background: rgba(255, 215, 0, 0.12);
+  border: 2px solid #FFD700;
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 14px;
+  text-align: center;
+  font-family: 'Georgia', serif;
+  font-size: 18px;
+  line-height: 1.8;
+  letter-spacing: 0.5px;
+}
+
+.archaicText {
+  font-family: 'Old Standard TT', 'Times New Roman', Georgia, serif;
+  font-size: 1.75rem;
+  line-height: 1.8;
+  color: #3d2b1f;
+  letter-spacing: 0.05em;
+}
+
+.historicalKeyboard {
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.keyboardLabel {
+  display: block;
+  font-size: 12px;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.charButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.charButton {
+  min-width: 2.5rem;
+  height: 2.5rem;
+  font-size: 1.25rem;
+  font-family: 'Old Standard TT', serif;
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.charButton:hover {
+  background: var(--lu-state-active);
+  border-color: var(--ifm-color-primary);
+}
+
+.charButton:active {
+  transform: translateY(0);
+}
+
+.transcriptionInput textarea {
+  width: 100%;
+  min-height: 80px;
+  padding: 14px;
+  font-size: 15px;
+  font-family: 'Old Standard TT', serif;
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  resize: vertical;
+  transition: border-color 0.2s ease;
+}
+
+.transcriptionInput textarea:focus {
+  outline: none;
+  border-color: var(--ifm-color-primary);
+}
+
+.transcriptionInput textarea.correct {
+  border-color: #2E7D32;
+  background: rgba(46, 125, 50, 0.05);
+}
+
+.transcriptionInput textarea.incorrect {
+  border-color: #C62828;
+  background: rgba(198, 40, 40, 0.05);
+}
+
+.hintsList {
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.hintsList ul {
+  margin: 0;
+  padding-left: 1.5rem;
+}
+
+.hintsList li {
+  margin-bottom: 0.5rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+/* ============= PALEOGRAPHY ANALYSIS ============= */
+.paleographyContainer {
+  margin-bottom: 1.5rem;
+}
+
+.manuscriptWrapper {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+  max-width: 100%;
+  border: 3px solid #8D6E63;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #F5F0E6;
+}
+
+.manuscriptImage {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.hotspot {
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--ifm-color-primary);
+  color: white;
+  border: 3px solid white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transform: translate(-50%, -50%);
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hotspot:hover {
+  transform: translate(-50%, -50%) scale(1.15);
+}
+
+.hotspotActive {
+  background: var(--ifm-color-warning);
+  transform: translate(-50%, -50%) scale(1.2);
+  box-shadow: 0 0 0 4px rgba(255, 193, 7, 0.3);
+}
+
+.hotspotCorrect {
+  background: #2E7D32 !important;
+}
+
+.hotspotIncorrect {
+  background: #C62828 !important;
+}
+
+.hotspotPanel {
+  background: var(--ifm-background-surface-color);
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  padding: 1.25rem;
+  margin-top: 1rem;
+}
+
+.hotspotPanel h4 {
+  margin: 0 0 1rem 0;
+  color: var(--ifm-color-primary);
+}
+
+.hotspotExplanation {
+  margin-top: 0.75rem;
+  padding: 1rem;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+}
+
+.hotspotExplanation strong {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: var(--ifm-color-primary);
+}
+
+.hotspotExplanation p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.featureSelect {
+  width: 100%;
+  padding: 10px 14px;
+  font-size: 15px;
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  background: var(--ifm-background-color);
+  cursor: pointer;
+  margin-bottom: 1rem;
+}
+
+.featureSelect:focus {
+  outline: none;
+  border-color: var(--ifm-color-primary);
+}
+
+.featureInput {
+  width: 100%;
+  padding: 10px 14px;
+  font-size: 15px;
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  background: var(--ifm-background-color);
+  margin-bottom: 1rem;
+}
+
+.featureInput:focus {
+  outline: none;
+  border-color: var(--ifm-color-primary);
+}
+
+.instructionText {
+  text-align: center;
+  color: var(--ifm-color-emphasis-600);
+  font-style: italic;
+  padding: 1rem;
+}
+
+/* ============= DIALECT COMPARISON ============= */
+.dialectSplit {
+  display: flex;
+  gap: 0;
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 14px;
+}
+
+.dialectPane {
+  flex: 1;
+  padding: 1.25rem;
+  background: var(--ifm-background-surface-color);
+}
+
+.dialectPane:first-child {
+  border-right: none;
+}
+
+.dialectLabel {
+  margin: 0 0 0.75rem 0;
+  font-size: 14px;
+  color: var(--ifm-color-primary);
+  font-weight: 700;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid var(--ifm-color-emphasis-200);
+}
+
+.dialectText {
+  font-size: 15px;
+  line-height: 1.8;
+}
+
+.dialectDivider {
+  width: 2px;
+  background: var(--ifm-color-emphasis-200);
+}
+
+.dialectHighlight {
+  background: rgba(255, 193, 7, 0.3);
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+  font-weight: 600;
+}
+
+.featureTable {
+  overflow-x: auto;
+  margin-bottom: 14px;
+}
+
+.featureTable table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.featureTable th,
+.featureTable td {
+  padding: 10px 14px;
+  text-align: left;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.featureTable th {
+  background: var(--ifm-color-emphasis-100);
+  font-weight: 700;
+  color: var(--ifm-heading-color);
+}
+
+.featureTable tr:hover {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.featureTable tr.featureSelected {
+  background: var(--lu-state-active);
+}
+
+.dialectValueA {
+  color: var(--ifm-color-primary-dark);
+  font-weight: 500;
+}
+
+.dialectValueB {
+  color: var(--ifm-color-success-dark);
+  font-weight: 500;
+}
+
+@media (max-width: 768px) {
+  .dialectSplit {
+    flex-direction: column;
+  }
+
+  .dialectDivider {
+    width: 100%;
+    height: 2px;
+  }
+
+  .dialectPane:first-child {
+    border-right: none;
+    border-bottom: none;
+  }
+}
+
+/* ============= TRANSLATION CRITIQUE ============= */
+.originalTextSection {
+  margin-bottom: 14px;
+}
+
+.originalTextSection h4 {
+  margin: 0 0 0.75rem 0;
+  color: var(--ifm-heading-color);
+}
+
+.focusPointsSection {
+  margin-bottom: 14px;
+  padding: 1rem;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+}
+
+.focusPointsList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.focusPointTag {
+  display: inline-block;
+  padding: 3px 10px;
+  background: var(--ifm-color-primary);
+  color: white;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.focusHighlight {
+  background: rgba(255, 193, 7, 0.4);
+  padding: 0.1rem 0.2rem;
+  border-radius: 3px;
+}
+
+.translationsSection h4 {
+  margin: 0 0 1rem 0;
+  color: var(--ifm-heading-color);
+}
+
+.translationCards {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.translationCard {
+  border: 2px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  padding: 14px 18px;
+  background: var(--ifm-background-color);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.translationCard:hover {
+  border-color: var(--ifm-color-primary);
+}
+
+.translationSelected {
+  border-color: var(--ifm-color-primary);
+  background: rgba(0, 87, 183, 0.05);
+}
+
+.translationHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.translatorName {
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--ifm-heading-color);
+}
+
+.accuracyScore {
+  padding: 3px 10px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.scoreHigh {
+  background: var(--lu-state-correct-bg);
+  color: #2E7D32;
+}
+
+.scoreMedium {
+  background: rgba(251, 188, 4, 0.2);
+  color: #B06000;
+}
+
+.scoreLow {
+  background: var(--lu-state-wrong-bg);
+  color: #C62828;
+}
+
+.translationText {
+  font-size: 15px;
+  line-height: 1.7;
+  margin-bottom: 0.75rem;
+  font-style: italic;
+}
+
+.expertVerdict {
+  margin-top: 1rem;
+  padding: 1rem;
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 8px;
+  border-left: 4px solid var(--ifm-color-primary);
+}
+
+.expertVerdict strong {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: var(--ifm-color-primary);
+}
+
+.expertVerdict p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+/* ============= OBSERVE BOX (from POC) ============= */
+.observeBox {
+  background: var(--lu-state-active);
+  border-radius: 12px;
+  padding: 18px;
+  margin: 14px 0;
+}
+
+.observePairs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.observeItem {
+  padding: 10px 14px;
+  background: white;
+  border-radius: 8px;
+  text-align: center;
+  font-size: 15px;
+}
+
+.observeQuestion {
+  margin-top: 14px;
+  font-style: italic;
+  color: var(--ifm-color-primary);
+  font-weight: 600;
+}
+
+/* ============= VOCAB TABLE (from POC) ============= */
+.vocabTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 18px 0;
+  background: white;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.vocabTable th {
+  background: var(--ifm-color-primary);
+  color: white;
+  padding: 10px 14px;
+  text-align: left;
+  font-size: 13px;
+}
+
+.vocabTable td {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  font-size: 14px;
+}
+
+.vocabTable tr:last-child td {
+  border-bottom: none;
+}
+
+.vocabTable tr:hover td {
+  background: var(--lu-state-active);
+}
+
+/* ============= FOLK TEXT LAYER ============= */
+.exerciseBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  padding: 0.1875rem 0.5625rem;
+  border-radius: 10px;
+  color: #fff;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.badgeRitual {
+  background: #e67e22;
+}
+
+.badgeVariant {
+  background: #00897b;
+}
+
+.badgeMotif {
+  background: #1976d2;
+}
+
+.badgePerform {
+  background: #2e7d32;
+}
+
+.ritualSequencingGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.ritualTimeline {
+  counter-reset: ritual-step;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-height: 5rem;
+  margin: 0.375rem 0 0;
+}
+
+.ritualAnswerZone {
+  border: 1px dashed var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  padding: 0.75rem;
+}
+
+.ritualAnswerZone.correct {
+  border-color: #2e7d32;
+  background: var(--lu-state-correct-bg);
+}
+
+.ritualAnswerZone.incorrect {
+  border-color: #c62828;
+  background: var(--lu-state-wrong-bg);
+}
+
+.ritualStepButton {
+  position: relative;
+  display: block;
+  width: 100%;
+  min-height: 2.75rem;
+  padding: 0.625rem 0.875rem 0.625rem 2.75rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.ritualStepButton::before {
+  counter-increment: ritual-step;
+  content: counter(ritual-step);
+  position: absolute;
+  left: 0.625rem;
+  top: 50%;
+  display: flex;
+  width: 1.5rem;
+  height: 1.5rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--ifm-color-primary);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  transform: translateY(-50%);
+}
+
+.ritualStepButton:disabled {
+  cursor: default;
+}
+
+.variantCards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.variantCard {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  padding: 0.75rem;
+  background: var(--ifm-background-color);
+}
+
+.variantLabel {
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+}
+
+.variantMeta,
+.variantSource {
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.8125rem;
+}
+
+.variantText {
+  margin-top: 0.5rem;
+  line-height: 1.6;
+}
+
+.variantTableWrap {
+  overflow-x: auto;
+}
+
+.variantTable {
+  width: 100%;
+  min-width: 32rem;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.variantTable th {
+  padding: 0.4375rem 0.625rem;
+  background: rgba(0, 137, 123, 0.12);
+  text-align: left;
+}
+
+.variantTable td {
+  padding: 0.375rem 0.5rem;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+  vertical-align: top;
+}
+
+.variantTable input {
+  width: 100%;
+  min-height: 2.25rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+  padding: 0.375rem 0.5rem;
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  font: inherit;
+}
+
+.motifPassage {
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  background: var(--ifm-color-emphasis-100);
+  font-style: italic;
+  line-height: 1.9;
+}
+
+.formula {
+  display: inline;
+  border: 0;
+  border-bottom: 2px solid #fbc02d;
+  background: rgba(251, 192, 45, 0.22);
+  color: inherit;
+  font: inherit;
+  font-style: inherit;
+  padding: 0.0625rem 0.125rem;
+  cursor: pointer;
+}
+
+.formula:hover,
+.formulaSelected {
+  background: rgba(251, 192, 45, 0.45);
+}
+
+.performanceFragment {
+  margin: 1rem 0;
+}
+
+.performanceFragment blockquote {
+  margin: 0.5rem 0 0;
+  border-left: 3px solid var(--ifm-color-primary);
+  padding-left: 1rem;
+  font-style: italic;
+}
+
+.recButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 2.75rem;
+  border: 0;
+  border-radius: 24px;
+  padding: 0.625rem 1.125rem;
+  background: var(--ifm-color-primary);
+  color: #fff;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.performanceChecklist {
+  margin-top: 1rem;
+}
+
+.performanceCheckItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+  line-height: 1.5;
+}
+
+@media (max-width: 760px) {
+  .ritualSequencingGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .variantTable {
+    min-width: 28rem;
+  }
+}
+
+/* Dark mode adjustments */
+[data-theme='dark'] .manuscriptWrapper {
+  background: linear-gradient(135deg, #2d2a26 0%, #3d3830 100%);
+  border-color: var(--ifm-color-emphasis-400);
+}
+
+[data-theme='dark'] .hotspot {
+  border-color: var(--ifm-color-emphasis-600);
+}
+
+[data-theme='dark'] .dialectHighlight,
+[data-theme='dark'] .focusHighlight {
+  background: var(--lu-state-missed);
+}
+
+[data-theme='dark'] .scoreHigh {
+  background: var(--lu-state-correct-bg);
+  color: var(--lu-state-correct-fg);
+}
+
+[data-theme='dark'] .scoreMedium {
+  background: var(--lu-state-missed);
+  color: var(--lu-text);
+}
+
+[data-theme='dark'] .scoreLow {
+  background: var(--lu-state-wrong-bg);
+  color: var(--lu-state-wrong-fg);
+}
+
+[data-theme='dark'] .option,
+[data-theme='dark'] .chip,
+[data-theme='dark'] .translateOption,
+[data-theme='dark'] .tfButton,
+[data-theme='dark'] .noErrorButton,
+[data-theme='dark'] .wordTile,
+[data-theme='dark'] .dialogueLine,
+[data-theme='dark'] .translationCard,
+[data-theme='dark'] .readingContext {
+  background: var(--ifm-background-color);
+}
+
+[data-theme='dark'] .observeExamples,
+[data-theme='dark'] .observeBox {
+  background: var(--lu-state-active);
+}
+
+[data-theme='dark'] .observeExample,
+[data-theme='dark'] .observeItem {
+  background: var(--ifm-background-color);
+}
+
+[data-theme='dark'] .vocabTable {
+  background: var(--ifm-background-color);
+}
+
+/* ============================================================
+   DARK-MODE STATE TINTS  [activity-darkmode-contrast]
+   Light-mode state backgrounds are tuned for a light surface; on the
+   dark theme the same selectors need the shared dual-mode state tokens
+   so hover / selection / match / correct / wrong feedback stays legible.
+   ============================================================ */
+
+/* neutral · hover · selected → blue */
+[data-theme='dark'] .option:hover:not(:disabled),
+[data-theme='dark'] .option.selected,
+[data-theme='dark'] .chip:hover,
+[data-theme='dark'] .blankDropZone:hover,
+[data-theme='dark'] .matchColumn:first-child .matchItem,
+[data-theme='dark'] .matchItem.selected,
+[data-theme='dark'] .letterTile,
+[data-theme='dark'] .wordTile.selectedWord,
+[data-theme='dark'] .wordHoverable:hover,
+[data-theme='dark'] .wordSelected,
+[data-theme='dark'] .checkboxOption:hover,
+[data-theme='dark'] .checkboxOption.checked,
+[data-theme='dark'] .translateOption:hover:not(:disabled),
+[data-theme='dark'] .translateOption.selected,
+[data-theme='dark'] .markableWord:hover,
+[data-theme='dark'] .charButton:hover,
+[data-theme='dark'] .featureTable tr.featureSelected,
+[data-theme='dark'] .translationSelected,
+[data-theme='dark'] .vocabTable tr:hover td {
+  background: var(--lu-state-active);
+}
+
+[data-theme='dark'] .blankDropZone {
+  background: var(--lu-state-active);
+}
+
+/* match-up right column → amber-orange (distinct from the blue left) */
+[data-theme='dark'] .matchColumn:last-child .matchItem {
+  background: var(--lu-match-right);
+}
+
+[data-theme='dark'] .matchColumn .matchItem.matched {
+  --match-pair-bg: hsl(var(--match-pair-hue) 82% 65% / 0.24);
+  --match-pair-border: hsl(var(--match-pair-hue) 82% 75%);
+
+  border-color: var(--match-pair-border);
+  background: var(--match-pair-bg);
+  color: var(--lu-text);
+}
+
+/* drag pools · prompts → violet */
+[data-theme='dark'] .chipDraggable,
+[data-theme='dark'] .wordPool.dropTarget,
+[data-theme='dark'] .debateQuestion,
+[data-theme='dark'] .essayPrompt {
+  background: var(--lu-state-drag);
+}
+
+/* correct → green (+ legible text) */
+[data-theme='dark'] .option.correct,
+[data-theme='dark'] .blank.correct,
+[data-theme='dark'] .trueButton:hover:not(:disabled),
+[data-theme='dark'] .tfButton.correct,
+[data-theme='dark'] .answerZone.correct,
+[data-theme='dark'] .sentenceBuilder.correct,
+[data-theme='dark'] .noErrorButton:hover,
+[data-theme='dark'] .checkboxOption.correctAnswer,
+[data-theme='dark'] .translateOption.correct,
+[data-theme='dark'] .clozeSelect.correct,
+[data-theme='dark'] .markableWord.correctMark,
+[data-theme='dark'] .markableWord.missedMark,
+[data-theme='dark'] .dialogueLine.correct,
+[data-theme='dark'] .grammarInput input.correct,
+[data-theme='dark'] .correctAnswer,
+[data-theme='dark'] .transcriptionInput textarea.correct {
+  background: var(--lu-state-correct-bg) !important;
+  color: var(--lu-state-correct-fg);
+}
+
+/* incorrect · wrong → red (+ legible text) */
+[data-theme='dark'] .option.incorrect,
+[data-theme='dark'] .blank.incorrect,
+[data-theme='dark'] .matchItem.wrong,
+[data-theme='dark'] .falseButton:hover:not(:disabled),
+[data-theme='dark'] .tfButton.incorrect,
+[data-theme='dark'] .answerZone.incorrect,
+[data-theme='dark'] .sentenceBuilder.incorrect,
+[data-theme='dark'] .wordWrong,
+[data-theme='dark'] .noErrorWrong,
+[data-theme='dark'] .checkboxOption.wrongAnswer,
+[data-theme='dark'] .translateOption.incorrect,
+[data-theme='dark'] .clozeSelect.incorrect,
+[data-theme='dark'] .markableWord.wrongMark,
+[data-theme='dark'] .dialogueLine.incorrect,
+[data-theme='dark'] .grammarInput input.incorrect,
+[data-theme='dark'] .transcriptionInput textarea.incorrect {
+  background: var(--lu-state-wrong-bg) !important;
+  color: var(--lu-state-wrong-fg);
+}
+
+/* missed answer · transcription highlight → amber */
+[data-theme='dark'] .checkboxOption.missedAnswer,
+[data-theme='dark'] .transcriptionOriginal {
+  background: var(--lu-state-missed);
 }

--- a/packages/activity-kit/src/components/ActivityHelp.tsx
+++ b/packages/activity-kit/src/components/ActivityHelp.tsx
@@ -1,45 +1,168 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 import styles from './Activities.module.css';
 
 interface ActivityHelpProps {
-  activityType: 'true-false' | 'cloze' | 'match-up';
+  activityType: string;
   isUkrainian?: boolean;
 }
 
-const HELP_TEXT = {
+const HELP_TEXT: Record<string, { title: string; description: string }> = {
+  'quiz': {
+    title: 'Multiple Choice',
+    description: 'Select the correct answer from the options provided. Only one answer is correct.',
+  },
+  'fill-in': {
+    title: 'Fill in the Blank',
+    description: 'Choose the correct word or phrase to complete each sentence from the dropdown options.',
+  },
   'match-up': {
     title: 'Match the Pairs',
-    description: 'Connect items from the left column with their matching items on the right by clicking them.',
+    description: 'Connect items from the left column with their matching items on the right by clicking or dragging.',
   },
   'true-false': {
     title: 'True or False',
-    description: 'Decide whether each statement is true or false based on what you have learned.',
+    description: 'Decide whether each statement is true or false based on what you\'ve learned.',
   },
-  cloze: {
+  'anagram': {
+    title: 'Unscramble the Letters',
+    description: 'Rearrange the scrambled letters to form the correct Ukrainian word.',
+  },
+  'unjumble': {
+    title: 'Build the Sentence',
+    description: 'Drag or click the words to arrange them in the correct order to form a grammatically correct sentence.',
+  },
+  'group-sort': {
+    title: 'Sort into Groups',
+    description: 'Drag each word from the pool into the correct category bucket. You can also drag words between buckets to change your answer.',
+  },
+  'error-correction': {
+    title: 'Find & Fix the Error',
+    description: 'Each sentence contains an error. Find the incorrect word and select the correct form from the options.',
+  },
+  'cloze': {
     title: 'Complete the Passage',
-    description: 'Read the passage and fill in each blank by selecting the correct word.',
+    description: 'Read the passage and fill in the blanks by selecting the correct word from each dropdown.',
   },
-} as const;
+  'mark-the-words': {
+    title: 'Mark the Words',
+    description: 'Click on all the words in the text that match the given criteria (e.g., nouns, verbs, specific case).',
+  },
+  'select': {
+    title: 'Select All That Apply',
+    description: 'Choose ALL correct answers. Multiple options may be correct.',
+  },
+  'translate': {
+    title: 'Choose the Translation',
+    description: 'Select the correct translation of the given sentence or phrase.',
+  },
+  'observe': {
+    title: 'Observe the Pattern',
+    description: 'Study the examples carefully and try to discover the grammar pattern before it\'s explained. Look for similarities in word endings, structure, or meaning.',
+  },
+  'essay-response': {
+    title: 'Essay Response',
+    description: 'Write a structured essay in response to the prompt. Use the rubric to guide your writing and compare with the model answer.',
+  },
+  'comparative-study': {
+    title: 'Comparative Study',
+    description: 'Analyze and compare the provided materials. Identify similarities, differences, and patterns.',
+  },
+  'reading': {
+    title: 'Reading Comprehension',
+    description: 'Read the text carefully and answer the questions or complete the tasks that follow.',
+  },
+  'critical-analysis': {
+    title: 'Critical Analysis',
+    description: 'Analyze the text critically, considering context, bias, and implications.',
+  },
+  'authorial-intent': {
+    title: 'Authorial Intent',
+    description: 'Examine the author\'s purpose, tone, and stylistic choices.',
+  },
+};
 
-const HELP_TEXT_UA = {
+const HELP_TEXT_UA: Record<string, { title: string; description: string }> = {
+  'quiz': {
+    title: 'Вибір відповіді',
+    description: 'Виберіть правильну відповідь із запропонованих варіантів. Лише одна відповідь є правильною.',
+  },
+  'fill-in': {
+    title: 'Заповніть пропуски',
+    description: 'Виберіть правильне слово або фразу з випадаючого списку, щоб доповнити речення.',
+  },
   'match-up': {
     title: 'Знайдіть пару',
-    description: "З'єднайте елементи лівої колонки з відповідними елементами праворуч, натискаючи на них.",
+    description: 'З’єднайте елементи з лівої колонки з відповідними елементами праворуч, натискаючи на них.',
   },
   'true-false': {
     title: 'Правда чи хибність',
     description: 'Визначте, чи є кожне твердження правдивим чи хибним на основі вивченого матеріалу.',
   },
-  cloze: {
-    title: 'Заповніть текст',
-    description: 'Прочитайте текст і заповніть пропуски, вибираючи правильне слово.',
+  'anagram': {
+    title: 'Переставте літери',
+    description: 'Переставте переплутані літери, щоб утворити правильне українське слово.',
   },
-} as const;
+  'unjumble': {
+    title: 'Складіть речення',
+    description: 'Натискайте на слова, щоб розташувати їх у правильному порядку та утворити граматично правильне речення.',
+  },
+  'group-sort': {
+    title: 'Розподіліть за категоріями',
+    description: 'Перетягніть або натисніть на кожне слово, щоб помістити його у відповідний кошик категорії.',
+  },
+  'error-correction': {
+    title: 'Знайдіть і виправте помилку',
+    description: 'Кожне речення містить помилку. Знайдіть неправильне слово та виберіть правильну форму з варіантів.',
+  },
+  'cloze': {
+    title: 'Заповніть текст',
+    description: 'Прочитайте текст і заповніть пропуски, вибираючи правильне слово з кожного випадаючого списку.',
+  },
+  'mark-the-words': {
+    title: 'Відмітьте слова',
+    description: 'Натисніть на всі слова в тексті, які відповідають заданим критеріям (наприклад, іменники, дієслова, певний відмінок).',
+  },
+  'select': {
+    title: 'Виберіть усі варіанти',
+    description: 'Виберіть УСІ правильні відповіді. Правильних варіантів може бути декілька.',
+  },
+  'translate': {
+    title: 'Виберіть переклад',
+    description: 'Виберіть правильний переклад поданого речення або фрази.',
+  },
+  'observe': {
+    title: 'Спостереження за мовою',
+    description: 'Уважно вивчіть приклади та спробуйте самостійно знайти граматичну закономірність. Звертайте увагу на закінчення слів, структуру або значення.',
+  },
+  'essay-response': {
+    title: 'Есе-відповідь',
+    description: 'Напишіть структуроване есе у відповідь на завдання. Використовуйте критерії оцінювання та порівняйте свою відповідь зі зразком.',
+  },
+  'comparative-study': {
+    title: 'Порівняльний аналіз',
+    description: 'Проаналізуйте та порівняйте надані матеріали. Визначте схожості, відмінності та закономірності.',
+  },
+  'reading': {
+    title: 'Читання',
+    description: 'Уважно прочитайте текст та дайте відповіді на запитання або виконайте завдання.',
+  },
+  'critical-analysis': {
+    title: 'Критичний аналіз',
+    description: 'Проаналізуйте текст критично, враховуючи контекст, упередження та наслідки.',
+  },
+  'authorial-intent': {
+    title: 'Авторський задум',
+    description: 'Дослідіть мету автора, тон та стилістичні засоби.',
+  },
+};
 
 export default function ActivityHelp({ activityType, isUkrainian }: ActivityHelpProps) {
   const [isOpen, setIsOpen] = useState(false);
+
   const help = isUkrainian ? HELP_TEXT_UA[activityType] : HELP_TEXT[activityType];
-  const buttonTitle = isUkrainian ? 'Як працює ця вправа?' : 'How does this activity work?';
+  if (!help) return null;
+
+  const btnTitle = isUkrainian ? 'Як працює ця вправа?' : 'How does this activity work?';
 
   return (
     <div className={styles.helpContainer}>
@@ -47,13 +170,17 @@ export default function ActivityHelp({ activityType, isUkrainian }: ActivityHelp
         className={styles.helpButton}
         onClick={() => setIsOpen(!isOpen)}
         aria-label="Activity help"
-        title={buttonTitle}
+        title={btnTitle}
       >
         ?
       </button>
+
       {isOpen && (
         <>
-          <div className={styles.helpOverlay} onClick={() => setIsOpen(false)} />
+          <div
+            className={styles.helpOverlay}
+            onClick={() => setIsOpen(false)}
+          />
           <div className={styles.helpTooltip}>
             <div className={styles.helpTitle}>{help.title}</div>
             <div className={styles.helpDescription}>{help.description}</div>

--- a/packages/activity-kit/src/components/ErrorCorrection.tsx
+++ b/packages/activity-kit/src/components/ErrorCorrection.tsx
@@ -1,0 +1,366 @@
+import React, { useState, useMemo } from 'react';
+import styles from './Activities.module.css';
+import ActivityHelp from './ActivityHelp';
+import { shuffle } from './utils';
+
+interface ErrorCorrectionItemProps {
+  /**
+   * @schemaDescription Sentence shown to the learner.
+   * @ukrainianText true
+   */
+  sentence: string;
+  /**
+   * @schemaDescription Error Word value consumed by this component.
+   * @ukrainianText true
+   */
+  errorWord: string | null;  // null = no error
+  /**
+   * @schemaDescription Correct Form value consumed by this component.
+   * @ukrainianText true
+   */
+  correctForm: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
+  options: string[];
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
+  explanation: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
+  isUkrainian?: boolean;
+}
+
+type Step = 'identify' | 'fix' | 'complete';
+
+export function ErrorCorrectionItem({
+  sentence,
+  errorWord,
+  correctForm,
+  options,
+  explanation,
+  isUkrainian
+}: ErrorCorrectionItemProps) {
+  // Shuffle options on mount
+  const shuffledOptions = useMemo(() => shuffle([...options]), [options]);
+
+  const [step, setStep] = useState<Step>('identify');
+  const [selectedWord, setSelectedWord] = useState<string | null>(null);
+  const [selectedFix, setSelectedFix] = useState<string | null>(null);
+  const [wrongAttempts, setWrongAttempts] = useState<string[]>([]);
+  const [revealedCorrection, setRevealedCorrection] = useState(false);
+
+  // Split sentence into words while preserving punctuation
+  const words = sentence.match(/[\wа-яіїєґА-ЯІЇЄҐ']+|[^\s\wа-яіїєґА-ЯІЇЄҐ']+|\s+/gi) || [];
+
+  const handleWordKeyDown = (e: React.KeyboardEvent, word: string) => {
+    // Enter and Space activate the span-as-button, matching native
+    // <button> keyboard semantics. preventDefault on Space blocks the
+    // default scroll behaviour.
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleWordClick(word);
+    }
+  };
+
+  const handleWordClick = (word: string) => {
+    if (step !== 'identify') return;
+
+    // Clean word for comparison (remove punctuation)
+    const cleanWord = word.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '');
+
+    if (errorWord) {
+      // For multi-word errors, check if the clicked word is part of the error phrase
+      const errorWords = errorWord.split(/\s+/);
+      const cleanErrorWords = errorWords.map(w => w.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '').toLowerCase());
+
+      if (cleanErrorWords.includes(cleanWord.toLowerCase())) {
+        // Correct word/phrase identified
+        setSelectedWord(errorWord); // Store the full error phrase
+        setStep('fix');
+      } else if (cleanWord.trim()) {
+        // Wrong word selected
+        setWrongAttempts(prev => [...prev, cleanWord]);
+      }
+    }
+  };
+
+  const handleNoError = () => {
+    if (step !== 'identify') return;
+
+    if (errorWord === null) {
+      // Correct - there was no error
+      setStep('complete');
+    } else {
+      // Wrong - there was an error
+      setWrongAttempts(prev => [...prev, '__no_error__']);
+    }
+  };
+
+  const handleFixSelect = (fix: string) => {
+    if (step !== 'fix') return;
+
+    setRevealedCorrection(false);
+    setSelectedFix(fix);
+    setStep('complete');
+  };
+
+  const handleRevealCorrection = () => {
+    if (step !== 'fix' || shuffledOptions.length > 0) return;
+
+    setRevealedCorrection(true);
+    setSelectedFix(correctForm);
+    setStep('complete');
+  };
+
+  const handleReset = () => {
+    setStep('identify');
+    setSelectedWord(null);
+    setSelectedFix(null);
+    setWrongAttempts([]);
+    setRevealedCorrection(false);
+  };
+
+  const isFixCorrect = selectedFix === correctForm;
+  const isNoErrorCorrect = errorWord === null && step === 'complete';
+  const isCorrectionShown = revealedCorrection && step === 'complete';
+
+  const step1Label = isUkrainian ? 'Крок 1: Знайдіть помилку' : 'Step 1: Find the error';
+  const step2Label = isUkrainian ? 'Крок 2: Оберіть правильну форму' : 'Step 2: Choose the correct form';
+  const completeLabel = isUkrainian ? 'Завершено' : 'Complete';
+  const noErrorLabel = isUkrainian ? '✓ У цьому реченні немає помилок' : '✓ No error in this sentence';
+  const fixPromptLabel = isUkrainian ? 'Оберіть правильну форму для' : 'Choose the correct form for';
+  const revealCorrectionLabel = isUkrainian ? 'Показати виправлення' : 'Show correction';
+  const retryBtnLabel = isUkrainian ? 'Спробувати знову' : 'Try Again';
+
+  return (
+    <div className={styles.errorCorrectionItem} data-activity="error-correction-item" data-step={step}>
+      {/* Step indicator */}
+      <div className={styles.stepIndicator}>
+        {step === 'identify' && <span className={styles.stepBadge}>{step1Label}</span>}
+        {step === 'fix' && <span className={styles.stepBadge}>{step2Label}</span>}
+        {step === 'complete' && <span className={styles.stepBadgeComplete}>{completeLabel}</span>}
+      </div>
+
+      {/* Sentence with clickable words */}
+      <p className={styles.errorSentence} data-activity="error-correction-sentence">
+        {words.map((word, idx) => {
+          const cleanWord = word.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '');
+
+          // Check if this word is part of a multi-word error
+          const errorWords = errorWord ? errorWord.split(/\s+/).map(w => w.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '').toLowerCase()) : [];
+          const isError = errorWords.includes(cleanWord.toLowerCase());
+          const isWrongAttempt = wrongAttempts.includes(cleanWord);
+          const isSelected = selectedWord && errorWords.includes(cleanWord.toLowerCase()) && step !== 'identify';
+
+          // Non-word tokens (punctuation, spaces)
+          if (!cleanWord) {
+            return <span key={idx}>{word}</span>;
+          }
+
+          // For complete step, show strikethrough for all error words, replacement after last error word
+          const isLastErrorWord = errorWord && isError && idx === words.findLastIndex(w => {
+            const cw = w.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '');
+            return errorWords.includes(cw.toLowerCase());
+          });
+
+          return (
+            <span
+              key={idx}
+              className={`
+                ${styles.clickableWord}
+                ${step === 'identify' ? styles.wordHoverable : ''}
+                ${isWrongAttempt ? styles.wordWrong : ''}
+                ${isSelected ? styles.wordSelected : ''}
+                ${step === 'complete' && isError ? styles.wordError : ''}
+              `}
+              data-activity="error-correction-word"
+              data-word={cleanWord}
+              data-is-error={isError ? 'true' : 'false'}
+              onClick={() => handleWordClick(word)}
+              onKeyDown={(e) => handleWordKeyDown(e, word)}
+              role="button"
+              tabIndex={step === 'identify' ? 0 : -1}
+              aria-label={step === 'identify' ? `Click to flag "${cleanWord}" as the error` : undefined}
+            >
+              {step === 'complete' && isError ? (
+                <>
+                  <s>{word}</s>
+                  {isLastErrorWord && selectedFix ? ` ${selectedFix}` : ''}
+                </>
+              ) : (
+                word
+              )}
+            </span>
+          );
+        })}
+      </p>
+
+      {/* No Error button - only in identify step */}
+      {step === 'identify' && (
+        <button
+          className={`${styles.noErrorButton} ${wrongAttempts.includes('__no_error__') ? styles.noErrorWrong : ''}`}
+          data-activity="error-correction-no-error"
+          onClick={handleNoError}
+        >
+          {noErrorLabel}
+        </button>
+      )}
+
+      {/* Options - only in fix step */}
+      {step === 'fix' && shuffledOptions.length > 0 && (
+        <div className={styles.fixOptions} data-activity="error-correction-fix-options">
+          <p className={styles.fixPrompt}>{fixPromptLabel} "<strong>{errorWord}</strong>":</p>
+          <div className={styles.optionChips}>
+            {shuffledOptions.map((option, idx) => (
+              <button
+                key={idx}
+                className={styles.chip}
+                data-activity="error-correction-fix-chip"
+                onClick={() => handleFixSelect(option)}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Sentence-level rewrites can intentionally omit multiple-choice chips. */}
+      {step === 'fix' && shuffledOptions.length === 0 && (
+        <div className={styles.fixOptions} data-activity="error-correction-reveal-panel">
+          <p className={styles.fixPrompt}>{fixPromptLabel} "<strong>{errorWord}</strong>":</p>
+          <div className={styles.optionChips}>
+            <button
+              className={styles.chip}
+              data-activity="error-correction-reveal"
+              onClick={handleRevealCorrection}
+            >
+              {revealCorrectionLabel}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Result feedback */}
+      {step === 'complete' && (
+        <>
+          <div
+            className={`${styles.feedback} ${(isFixCorrect || isNoErrorCorrect || isCorrectionShown) ? styles.feedbackCorrect : styles.feedbackIncorrect}`}
+            data-activity="error-correction-feedback"
+            data-correct={(isFixCorrect || isNoErrorCorrect || isCorrectionShown) ? 'true' : 'false'}
+          >
+            {isNoErrorCorrect ? (
+              isUkrainian ? '✓ Правильно! У цьому реченні не було помилок.' : '✓ Correct! There was no error in this sentence.'
+            ) : isCorrectionShown ? (
+              `✓ ${isUkrainian ? 'Виправлення:' : 'Correction:'} "${errorWord}" → "${correctForm}"`
+            ) : isFixCorrect ? (
+              `✓ ${isUkrainian ? 'Правильно!' : 'Correct!'} "${errorWord}" → "${correctForm}"`
+            ) : (
+              `${isUkrainian ? '✗ Правильна відповідь:' : '✗ The correct answer is:'} "${errorWord}" → "${correctForm}"`
+            )}
+            {explanation && (
+              <div className={styles.explanation}>{explanation}</div>
+            )}
+          </div>
+          <div className={styles.buttonRow}>
+            <button className={styles.resetButton} onClick={handleReset}>
+              {retryBtnLabel}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+interface ErrorCorrectionItemData {
+  /**
+   * @schemaDescription Sentence shown to the learner.
+   * @ukrainianText true
+   */
+  sentence: string;
+  /**
+   * @schemaDescription Error Word value consumed by this component.
+   * @ukrainianText true
+   */
+  errorWord: string | null;
+  /**
+   * @schemaDescription Correct Form value consumed by this component.
+   * @ukrainianText true
+   */
+  correctForm: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
+  options: string[];
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
+  explanation: string;
+}
+
+interface ErrorCorrectionProps {
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
+  items?: ErrorCorrectionItemData[];
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
+  children?: React.ReactNode;
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
+  instruction?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
+  isUkrainian?: boolean;
+}
+
+export default function ErrorCorrection({ items, children, instruction, isUkrainian }: ErrorCorrectionProps) {
+  const headerLabel = isUkrainian ? 'Знайдіть і виправте помилку' : 'Find and Fix';
+
+  return (
+    <div className={styles.activityContainer} data-activity="error-correction">
+      <div className={styles.activityHeader}>
+        <span className={styles.activityIcon}>🔍</span>
+        <span>{headerLabel}</span>
+        <ActivityHelp activityType="error-correction" isUkrainian={isUkrainian} />
+      </div>
+      {instruction && (
+        <p className={styles.instruction}><strong>{instruction}</strong></p>
+      )}
+      <div className={styles.activityContent}>
+        {items ? items.map((item, index) => (
+          <ErrorCorrectionItem
+            key={index}
+            sentence={item.sentence}
+            errorWord={item.errorWord}
+            correctForm={item.correctForm}
+            options={item.options}
+            explanation={item.explanation}
+            isUkrainian={isUkrainian}
+          />
+        )) : React.Children.map(children, (child) => {
+          if (React.isValidElement(child)) {
+            return React.cloneElement(child as React.ReactElement<{ isUkrainian?: boolean }>, { isUkrainian });
+          }
+          return child;
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/activity-kit/src/components/EssayResponse.tsx
+++ b/packages/activity-kit/src/components/EssayResponse.tsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react';
+import styles from './Activities.module.css';
+import ActivityHelp from './ActivityHelp';
+import { parseMarkdown } from './utils';
+
+interface EssayResponseProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
+  title: string;
+  /**
+   * @schemaDescription Prompt shown to guide the learner response.
+   * @ukrainianText true
+   */
+  prompt: string;
+  /**
+   * @schemaDescription Model answer for review or self-check.
+   * @ukrainianText true
+   */
+  modelAnswer?: string;
+  /**
+   * @schemaDescription Evaluation rubric for the response.
+   * @ukrainianText true
+   */
+  rubric?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
+  isUkrainian?: boolean;
+  /** Stable activity marker when the component is rendered through the kit. */
+  activityType?: string;
+}
+
+export default function EssayResponse({
+  title,
+  prompt,
+  modelAnswer,
+  rubric,
+  isUkrainian,
+  activityType = 'essay-response'
+}: EssayResponseProps) {
+  const [response, setResponse] = useState('');
+  const [showModel, setShowModel] = useState(false);
+  const [showRubric, setShowRubric] = useState(false);
+
+  const wordCount = response.trim() ? response.trim().split(/\s+/).length : 0;
+
+  const headerLabel = isUkrainian ? 'Есе-відповідь' : 'Essay Response';
+  const yourResponseLabel = isUkrainian ? 'Ваша відповідь:' : 'Your Response:';
+  const wordCountLabel = isUkrainian ? 'Слів:' : 'Word count:';
+  const modelAnswerBtnLabel = isUkrainian ?
+    (showModel ? 'Приховати зразок' : 'Показати зразок') :
+    (showModel ? 'Hide Model Answer' : 'Show Model Answer');
+  const rubricBtnLabel = isUkrainian ?
+    (showRubric ? 'Приховати критерії' : 'Показати критерії') :
+    (showRubric ? 'Hide Rubric' : 'Show Rubric');
+  const placeholderText = isUkrainian ? 'Пишіть тут...' : 'Type your essay here...';
+
+  return (
+    <div className={styles.activityContainer} data-activity={activityType}>
+      <div className={styles.activityHeader}>
+        <span className={styles.activityIcon}>✍️</span>
+        <span>{title || headerLabel}</span>
+        <ActivityHelp activityType="essay-response" isUkrainian={isUkrainian} />
+      </div>
+      <div className={styles.activityContent}>
+        <div className={styles.essayPrompt}>
+          {parseMarkdown(prompt)}
+        </div>
+
+        <div className={styles.essayInputArea}>
+          <label className={styles.inputLabel}>{yourResponseLabel}</label>
+          <textarea
+            className={styles.essayTextarea}
+            value={response}
+            onChange={(e) => setResponse(e.target.value)}
+            placeholder={placeholderText}
+            rows={10}
+          />
+          <div className={styles.wordCounter}>
+            {wordCountLabel} {wordCount}
+          </div>
+        </div>
+
+        <div className={styles.buttonRow}>
+          {rubric && (
+            <button
+              className={styles.secondaryButton}
+              onClick={() => setShowRubric(!showRubric)}
+            >
+              {rubricBtnLabel}
+            </button>
+          )}
+          {modelAnswer && (
+            <button
+              className={styles.submitButton}
+              onClick={() => setShowModel(!showModel)}
+            >
+              {modelAnswerBtnLabel}
+            </button>
+          )}
+        </div>
+
+        {showRubric && rubric && (
+          <div className={styles.rubricContainer}>
+            <div className={styles.collapsibleHeader}>{isUkrainian ? 'Критерії оцінювання' : 'Rubric'}</div>
+            <div className={styles.rubricContent}>
+              {parseMarkdown(rubric)}
+            </div>
+          </div>
+        )}
+
+        {showModel && modelAnswer && (
+          <div className={`${styles.feedback} ${styles.modelAnswer}`}>
+            <div className={styles.collapsibleHeader}>{isUkrainian ? 'Зразок відповіді' : 'Model Answer'}</div>
+            <div className={styles.modelContent}>
+              {parseMarkdown(modelAnswer)}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/activity-kit/src/components/FillIn.tsx
+++ b/packages/activity-kit/src/components/FillIn.tsx
@@ -1,0 +1,264 @@
+import React, { useState, useMemo } from 'react';
+import styles from './Activities.module.css';
+import { parseMarkdown, shuffle } from './utils';
+import ActivityHelp from './ActivityHelp';
+
+// Generate consistent colors for option chips
+const CHIP_COLORS = [
+  '#E53935', '#D81B60', '#8E24AA', '#5E35B1', '#3949AB',
+  '#1E88E5', '#039BE5', '#00ACC1', '#00897B', '#43A047',
+  '#7CB342', '#FB8C00', '#F4511E', '#6D4C41'
+];
+
+function getChipColor(text: string, index: number): string {
+  const charSum = text.split('').reduce((sum, char) => sum + char.charCodeAt(0), 0);
+  return CHIP_COLORS[(charSum + index) % CHIP_COLORS.length];
+}
+
+interface FillInQuestionProps {
+  /**
+   * @schemaDescription Sentence shown to the learner.
+   * @ukrainianText true
+   */
+  sentence: string;
+  /**
+   * @schemaDescription Correct answer used for validation and feedback.
+   * @ukrainianText true
+   */
+  answer: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
+  options?: string[];
+}
+
+export function FillInQuestion({ sentence, answer, options = [] }: FillInQuestionProps) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const [showResult, setShowResult] = useState(false);
+  const [draggedOption, setDraggedOption] = useState<string | null>(null);
+
+  // Shuffle and create colored option chips
+  const coloredOptions = useMemo(() => {
+    const shuffled = shuffle([...options]);
+    return shuffled.map((opt, idx) => ({
+      text: opt,
+      color: getChipColor(opt, idx)
+    }));
+  }, [options]);
+
+  const handleSelect = (option: string) => {
+    if (showResult) return;
+    setSelected(option);
+    setShowResult(true);
+  };
+
+  const handleDragStart = (e: React.DragEvent, option: string) => {
+    setDraggedOption(option);
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (draggedOption && !showResult) {
+      setSelected(draggedOption);
+      setShowResult(true);
+    }
+    setDraggedOption(null);
+  };
+
+  const handleReset = () => {
+    setSelected(null);
+    setShowResult(false);
+  };
+
+  const isCorrect = selected === answer;
+
+  // Parse sentence - look for ___ or [blank]
+  const parts = sentence.split(/___|\\[blank\\]/);
+  const selectedColor = coloredOptions.find(o => o.text === selected)?.color;
+
+  return (
+    <div className={styles.fillInQuestion} data-activity="fillin-question">
+      <p className={styles.sentenceWithBlank}>
+        {parseMarkdown(parts[0])}
+        <span
+          className={`${styles.blankDropZone} ${showResult ? (isCorrect ? styles.correct : styles.incorrect) : ''}`}
+          data-activity="fillin-blank"
+          onDragOver={handleDragOver}
+          onDrop={handleDrop}
+          style={selected && selectedColor ? {
+            backgroundColor: selectedColor,
+            color: 'white',
+            borderStyle: 'solid'
+          } : undefined}
+        >
+          {selected || 'drag here'}
+        </span>
+        {parseMarkdown(parts[1] || '')}
+      </p>
+
+      {options.length > 0 && !showResult && (
+        <div className={styles.optionChips} data-activity="fillin-chips">
+          {coloredOptions.map((option, index) => (
+            <button
+              key={index}
+              className={styles.chipDraggable}
+              style={{
+                backgroundColor: option.color,
+                color: 'white'
+              }}
+              draggable
+              onDragStart={(e) => handleDragStart(e, option.text)}
+              onClick={() => handleSelect(option.text)}
+            >
+              {option.text}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {showResult && (
+        <div className={styles.buttonRow}>
+          <button className={styles.resetButton} onClick={handleReset}>
+            Try Again
+          </button>
+        </div>
+      )}
+
+      {showResult && (
+        <div
+          className={`${styles.feedback} ${isCorrect ? styles.feedbackCorrect : styles.feedbackIncorrect}`}
+          data-activity="fillin-feedback"
+          data-correct={isCorrect ? 'true' : 'false'}
+        >
+          {isCorrect ? '✓ Correct!' : `✗ The answer is: ${answer}`}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface FillInItem {
+  /**
+   * @schemaDescription Sentence shown to the learner.
+   * @ukrainianText true
+   */
+  sentence: string;
+  /**
+   * @schemaDescription Correct answer used for validation and feedback.
+   * @ukrainianText true
+   */
+  answer: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
+  options?: string[];
+}
+
+interface FillInProps {
+  /**
+   * @schemaDescription Array of activity items rendered by the component.
+   * @ukrainianText true
+   */
+  items: FillInItem[];
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
+  instruction?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
+  isUkrainian?: boolean;
+}
+
+export default function FillIn({ items, instruction, isUkrainian }: FillInProps) {
+  const [answers, setAnswers] = useState<Record<number, string>>({});
+  const [showResults, setShowResults] = useState(false);
+
+  const handleSelect = (index: number, value: string) => {
+    setAnswers({ ...answers, [index]: value });
+  };
+
+  const allAnswered = Object.keys(answers).length === items.length;
+  const headerLabel = isUkrainian ? 'Заповніть пропуски' : 'Fill in the Blank';
+  const checkBtnLabel = isUkrainian ? 'Перевірити' : 'Check Answers';
+  const retryBtnLabel = isUkrainian ? 'Спробувати знову' : 'Try Again';
+
+  return (
+    <div className={styles.activityContainer} data-activity="fill-in">
+      <div className={styles.activityHeader}>
+        <span className={styles.activityIcon}>✍️</span>
+        <span>{headerLabel}</span>
+        <ActivityHelp activityType="fill-in" isUkrainian={isUkrainian} />
+      </div>
+      {instruction && (
+        <p className={styles.instruction}><strong>{instruction}</strong></p>
+      )}
+      <div className={styles.activityContent}>
+        {items.map((item, index) => {
+          const parts = item.sentence.split(/_{3,}/);  // Match 3+ underscores
+          const isCorrect = answers[index] === item.answer;
+
+          return (
+            <div key={index} className={styles.fillInRow} data-activity="fillin-row">
+              <span className={styles.fillInText}>
+                {parseMarkdown(parts[0])}
+                <select
+                  className={`${styles.fillInSelect} ${showResults ? (isCorrect ? styles.correct : styles.incorrect) : ''
+                    }`}
+                  value={answers[index] || ''}
+                  onChange={(e) => handleSelect(index, e.target.value)}
+                  disabled={showResults}
+                >
+                  <option value=""></option>
+                  {shuffle(item.options || []).map((opt, i) => (
+                    <option key={i} value={opt}>
+                      {opt}
+                    </option>
+                  ))}
+                </select>
+                {parseMarkdown(parts[1])}
+              </span>
+              {showResults && !isCorrect && (
+                <span className={styles.correctHint}>
+                  {isUkrainian ? 'Правильно:' : 'Correct:'} {item.answer}
+                </span>
+              )}
+            </div>
+          );
+        })}
+
+        <div className={styles.controls}>
+          {!showResults ? (
+            <button
+              className={styles.checkButton}
+              onClick={() => setShowResults(true)}
+              disabled={!allAnswered}
+            >
+              {checkBtnLabel}
+            </button>
+          ) : (
+            <button
+              className={styles.retryButton}
+              onClick={() => {
+                setShowResults(false);
+                setAnswers({});
+              }}
+            >
+              {retryBtnLabel}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/activity-kit/src/components/MarkTheWords.tsx
+++ b/packages/activity-kit/src/components/MarkTheWords.tsx
@@ -1,0 +1,205 @@
+import React, { useState } from 'react';
+import styles from './Activities.module.css';
+import ActivityHelp from './ActivityHelp';
+
+interface MarkTheWordsActivityProps {
+  /**
+   * @schemaDescription Text passage shown to the learner.
+   * @ukrainianText true
+   */
+  text: string;
+  /**
+   * @schemaDescription Correct Words value consumed by this component.
+   * @ukrainianText true
+   */
+  correctWords: string[];
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
+  instruction?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
+  isUkrainian?: boolean;
+}
+
+export function MarkTheWordsActivity({ text, correctWords, instruction, isUkrainian }: MarkTheWordsActivityProps) {
+  const [markedIndices, setMarkedIndices] = useState<Set<number>>(new Set());
+  const [submitted, setSubmitted] = useState(false);
+
+  // Split text into words while preserving punctuation and spaces
+  const tokens = text.match(/[\wа-яіїєґА-ЯІЇЄҐ']+|[^\s\wа-яіїєґА-ЯІЇЄҐ']+|\s+/gi) || [];
+
+  // Normalize for comparison
+  const normalizedCorrect = correctWords.map(w => w.toLowerCase().trim());
+
+  const handleWordClick = (idx: number) => {
+    if (submitted) return;
+
+    const token = tokens[idx];
+    const cleanWord = token.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '');
+    if (!cleanWord) return;
+
+    const newMarked = new Set(markedIndices);
+    if (newMarked.has(idx)) {
+      newMarked.delete(idx);
+    } else {
+      newMarked.add(idx);
+    }
+    setMarkedIndices(newMarked);
+  };
+
+  const handleSubmit = () => {
+    setSubmitted(true);
+  };
+
+  const handleReset = () => {
+    setMarkedIndices(new Set());
+    setSubmitted(false);
+  };
+
+  const isWordCorrect = (word: string) => {
+    const cleanWord = word.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '').toLowerCase();
+    return normalizedCorrect.includes(cleanWord);
+  };
+
+  const getWordClass = (token: string, idx: number) => {
+    const cleanWord = token.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '');
+    if (!cleanWord) return '';
+
+    const isMarked = markedIndices.has(idx);
+    const isCorrect = isWordCorrect(token);
+
+    if (!submitted) {
+      return isMarked ? styles.marked : '';
+    }
+
+    // After submission
+    if (isMarked && isCorrect) return styles.correctMark;
+    if (isMarked && !isCorrect) return styles.wrongMark;
+    if (!isMarked && isCorrect) return styles.missedMark;
+    return '';
+  };
+
+  // Calculate score
+  const markedArray = Array.from(markedIndices);
+  const correctMarks = markedArray.filter(idx => isWordCorrect(tokens[idx])).length;
+  const wrongMarks = markedArray.filter(idx => !isWordCorrect(tokens[idx])).length;
+
+  // Total instances of correct words available in the text
+  const totalCorrectInstances = tokens.filter(t => {
+    const clean = t.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '');
+    return clean && isWordCorrect(t);
+  }).length;
+
+  const missedMarks = totalCorrectInstances - correctMarks;
+
+  const isFullyCorrect = correctMarks === totalCorrectInstances && wrongMarks === 0;
+
+  const checkBtnLabel = isUkrainian ? 'Перевірити' : 'Check Answer';
+  const retryBtnLabel = isUkrainian ? 'Спробувати знову' : 'Try Again';
+  const successLabel = isUkrainian ? '✓ Чудово! Ви знайшли всі правильні слова.' : '✓ Perfect! You found all the correct words.';
+  const correctPlural = isUkrainian ? 'правильно' : 'correct';
+  const incorrectPlural = isUkrainian ? 'неправильно' : 'incorrect';
+  const missedLabel = isUkrainian ? 'Пропущено' : 'Missed';
+  const correctWordsLabel = isUkrainian ? 'Правильні слова:' : 'Correct words:';
+
+  return (
+    <div>
+      {instruction && (
+        <p className={styles.instruction}><strong>{instruction}</strong></p>
+      )}
+      <p className={styles.markWordsText}>
+        {tokens.map((token, idx) => {
+          const cleanWord = token.replace(/[^\wа-яіїєґА-ЯІЇЄҐ']/gi, '');
+
+          // Non-word tokens (punctuation, spaces)
+          if (!cleanWord) {
+            return <span key={idx}>{token}</span>;
+          }
+
+          return (
+            <span
+              key={idx}
+              className={`${styles.markableWord} ${getWordClass(token, idx)}`}
+              onClick={() => handleWordClick(idx)}
+            >
+              {token}
+            </span>
+          );
+        })}
+      </p>
+
+      {!submitted && (
+        <div className={styles.buttonRow}>
+          <button
+            className={styles.submitButton}
+            onClick={handleSubmit}
+          >
+            {checkBtnLabel}
+          </button>
+        </div>
+      )}
+
+      {submitted && (
+        <>
+          <div className={`${styles.feedback} ${isFullyCorrect ? styles.feedbackCorrect : styles.feedbackIncorrect}`}>
+            {isFullyCorrect ? (
+              successLabel
+            ) : (
+              <>
+                {correctMarks > 0 && <span>✓ {correctMarks} {correctPlural}. </span>}
+                {wrongMarks > 0 && <span>✗ {wrongMarks} {incorrectPlural}. </span>}
+                {missedMarks > 0 && <span>{missedLabel}: {missedMarks}. </span>}
+                <br />
+                <span>{correctWordsLabel} <strong>{correctWords.join(', ')}</strong></span>
+              </>
+            )}
+          </div>
+          <div className={styles.buttonRow}>
+            <button className={styles.resetButton} onClick={handleReset}>
+              {retryBtnLabel}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+interface MarkTheWordsProps {
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
+  children: React.ReactNode;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
+  isUkrainian?: boolean;
+}
+
+export default function MarkTheWords({ children, isUkrainian }: MarkTheWordsProps) {
+  const headerLabel = isUkrainian ? 'Відмітьте слова' : 'Mark the Words';
+
+  return (
+    <div className={styles.activityContainer} data-activity="mark-the-words">
+      <div className={styles.activityHeader}>
+        <span className={styles.activityIcon}>🎯</span>
+        <span>{headerLabel}</span>
+        <ActivityHelp activityType="mark-the-words" isUkrainian={isUkrainian} />
+      </div>
+      <div className={styles.activityContent}>
+        {React.Children.map(children, (child) => {
+          if (React.isValidElement(child)) {
+            return React.cloneElement(child as React.ReactElement<{ isUkrainian?: boolean }>, { isUkrainian });
+          }
+          return child;
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/activity-kit/src/components/Quiz.tsx
+++ b/packages/activity-kit/src/components/Quiz.tsx
@@ -1,0 +1,178 @@
+import React, { useState, useMemo } from 'react';
+import styles from './Activities.module.css';
+import { parseMarkdown, shuffle } from './utils';
+import ActivityHelp from './ActivityHelp';
+
+interface QuizQuestionProps {
+  /**
+   * @schemaDescription Question value consumed by this component.
+   * @ukrainianText true
+   */
+  question: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
+  options: string[];
+  /**
+   * @schemaDescription Zero-based index of the correct option.
+   * @ukrainianText false
+   */
+  correctIndex: number;
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
+  explanation?: string;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
+  isUkrainian?: boolean;
+}
+
+export function QuizQuestion({ question, options, correctIndex, explanation, isUkrainian }: QuizQuestionProps) {
+  // Shuffle options on mount, tracking original indices
+  const shuffledOptions = useMemo(() => {
+    const indexed = options.map((opt, i) => ({ opt, originalIndex: i }));
+    return shuffle(indexed);
+  }, [options]);
+
+  const [selected, setSelected] = useState<number | null>(null);
+  const [showResult, setShowResult] = useState(false);
+
+  const handleSelect = (shuffledIndex: number) => {
+    if (showResult) return;
+    setSelected(shuffledIndex);
+    setShowResult(true);
+  };
+
+  // Find the shuffled index of the correct answer
+  const correctShuffledIndex = shuffledOptions.findIndex(o => o.originalIndex === correctIndex);
+  const isCorrect = selected === correctShuffledIndex;
+
+  const correctLabel = isUkrainian ? '✓ Правильно!' : '✓ Correct!';
+  const incorrectLabel = isUkrainian ? '✗ Неправильно. Відповідь:' : '✗ Incorrect. The answer is:';
+
+  return (
+    <div className={styles.quizQuestion} data-activity="quiz-question">
+      <p className={styles.questionText}>{parseMarkdown(question)}</p>
+      <div className={styles.options} data-activity="quiz-options">
+        {shuffledOptions.map((item, index) => (
+          <button
+            key={index}
+            className={`${styles.option} ${showResult
+              ? index === correctShuffledIndex
+                ? styles.correct
+                : index === selected
+                  ? styles.incorrect
+                  : ''
+              : ''
+              } ${selected === index ? styles.selected : ''}`}
+            onClick={() => handleSelect(index)}
+            disabled={showResult}
+          >
+            {parseMarkdown(item.opt)}
+          </button>
+        ))}
+      </div>
+      {showResult && (
+        <div
+          className={`${styles.feedback} ${isCorrect ? styles.feedbackCorrect : styles.feedbackIncorrect}`}
+          data-activity="quiz-feedback"
+          data-correct={isCorrect ? 'true' : 'false'}
+        >
+          {isCorrect ? correctLabel : `${incorrectLabel} ${options[correctIndex]}`}
+          {explanation && <p className={styles.explanation}>{explanation}</p>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface QuizQuestionItem {
+  /**
+   * @schemaDescription Question value consumed by this component.
+   * @ukrainianText true
+   */
+  question: string;
+  /**
+   * @schemaDescription Answer options shown to the learner.
+   * @ukrainianText true
+   */
+  options: Array<{ text: string; correct: boolean }>;
+  /**
+   * @schemaDescription Feedback explanation shown after the learner answers.
+   * @ukrainianText true
+   */
+  explanation?: string;
+}
+
+interface QuizProps {
+  /**
+   * @schemaDescription Array of questions rendered by the component.
+   * @ukrainianText true
+   */
+  questions?: QuizQuestionItem[];
+  /**
+   * @schemaDescription Instruction shown to the learner above the activity.
+   * @ukrainianText true
+   */
+  instruction?: string;
+  /**
+   * @schemaDescription Nested MDX content rendered inside the component.
+   * @ukrainianText false
+   */
+  children?: React.ReactNode;
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
+  isUkrainian?: boolean;
+}
+
+export default function Quiz({ questions, instruction, children, isUkrainian }: QuizProps) {
+  const headerLabel = isUkrainian ? 'Тест' : 'Quiz';
+
+  return (
+    <div className={styles.activityContainer} data-activity="quiz">
+      <div className={styles.activityHeader}>
+        <span className={styles.activityIcon}>📝</span>
+        <span>{headerLabel}</span>
+        <ActivityHelp activityType="quiz" isUkrainian={isUkrainian} />
+      </div>
+      {instruction && (
+        <p className={styles.instruction}><strong>{instruction}</strong></p>
+      )}
+      <div className={styles.activityContent}>
+        {questions ? questions.map((item, index) => {
+          // Transform options format: {text, correct} -> string[] + correctIndex
+          const optionTexts = item.options.map(o => o.text);
+          const correctIndex = item.options.findIndex(o => o.correct);
+          if (correctIndex < 0) {
+            // Graceful degradation — fall back to index 0 so the lesson
+            // still renders, but surface the data bug loudly in the
+            // browser console so content authors notice it during dev.
+            // Server-side validation (in the activity renderer) should
+            // catch this before publish, so seeing this warn in prod is
+            // a sign that the build pipeline missed a malformed question.
+            console.warn(
+              `[Quiz] Question "${item.question}" has no option with correct:true. ` +
+              `Falling back to index 0. This is a content-data bug — please fix the source.`
+            );
+          }
+          return (
+            <QuizQuestion
+              key={index}
+              question={item.question}
+              options={optionTexts}
+              correctIndex={correctIndex >= 0 ? correctIndex : 0}
+              explanation={item.explanation}
+              isUkrainian={isUkrainian}
+            />
+          );
+        }) : children}
+      </div>
+    </div>
+  );
+}

--- a/packages/activity-kit/src/components/ReadingActivity.tsx
+++ b/packages/activity-kit/src/components/ReadingActivity.tsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react';
+import styles from './Activities.module.css';
+import ActivityHelp from './ActivityHelp';
+import { parseMarkdown } from './utils';
+
+interface ReadingProps {
+  /**
+   * @schemaDescription Display title shown above the component.
+   * @ukrainianText true
+   */
+  title: string;
+  /**
+   * @schemaDescription Context value consumed by this component.
+   * @ukrainianText true
+   */
+  context?: string;
+  /**
+   * @schemaDescription Text passage shown to the learner.
+   * @ukrainianText true
+   */
+  text?: string;  // Seminar: inline primary source text
+  /**
+   * @schemaDescription Source value consumed by this component.
+   * @ukrainianText false
+   */
+  source?: string;  // Seminar: attribution (e.g., 'Тарас Шевченко (1845)')
+  resource?: {
+    /**
+     * @schemaDescription Type value consumed by this component.
+     * @ukrainianText false
+     */
+    type?: string;
+    /**
+     * @schemaDescription External URL for the embedded or linked resource.
+     * @ukrainianText false
+     */
+    url?: string;
+    /**
+     * @schemaDescription Display title shown above the component.
+     * @ukrainianText true
+     */
+    title?: string;
+  };
+  /**
+   * @schemaDescription Tasks value consumed by this component.
+   * @ukrainianText true
+   */
+  tasks: string[];
+  /**
+   * @schemaDescription UI language flag for Ukrainian labels and feedback.
+   * @ukrainianText false
+   */
+  isUkrainian?: boolean;
+  /** Stable activity marker when the component is rendered through the kit. */
+  activityType?: string;
+}
+
+export default function ReadingActivity({
+  title,
+  context = '',
+  text = '',
+  source = '',
+  resource,
+  tasks,
+  isUkrainian,
+  activityType = 'reading'
+}: ReadingProps) {
+  const [showTasks, setShowTasks] = useState(false);
+
+  const headerLabel = isUkrainian ? 'Читання' : 'Reading';
+  const showTasksLabel = isUkrainian ?
+    (showTasks ? 'Приховати завдання' : 'Показати завдання') :
+    (showTasks ? 'Hide Tasks' : 'Show Tasks');
+
+  // If no title provided, use default
+  const displayTitle = title || headerLabel;
+
+  return (
+    <div className={styles.activityContainer} data-activity={activityType}>
+      <div className={styles.activityHeader}>
+        <span className={styles.activityIcon}>📖</span>
+        <span>{displayTitle}</span>
+        <ActivityHelp activityType="reading" isUkrainian={isUkrainian} />
+      </div>
+      <div className={styles.activityContent}>
+        <div className={styles.readingContext}>
+          {text ? (
+            // Seminar mode: inline primary source text
+            <div className={styles.primarySource}>
+              {parseMarkdown(text)}
+              {source && (
+                <p className={styles.sourceAttribution}>
+                  <em>— {source}</em>
+                </p>
+              )}
+            </div>
+          ) : context ? (
+            parseMarkdown(context)
+          ) : resource?.url ? (
+            <div className={styles.externalResource}>
+              <p>
+                {isUkrainian ? 'Прочитайте матеріал за посиланням:' : 'Read the material at the link:'}
+              </p>
+              <a href={resource.url} target="_blank" rel="noopener noreferrer" className={styles.resourceLink}>
+                📄 {resource.title || resource.url}
+              </a>
+              {resource.type && (
+                <p className={styles.resourceType}>
+                  <em>({resource.type})</em>
+                </p>
+              )}
+            </div>
+          ) : (
+            <p className={styles.emptyContext}>
+              {isUkrainian ? 'Немає тексту для читання' : 'No reading text provided'}
+            </p>
+          )}
+        </div>
+
+        <div className={styles.buttonRow}>
+            <button
+              className={styles.submitButton}
+              onClick={() => setShowTasks(!showTasks)}
+            >
+              {showTasksLabel}
+            </button>
+        </div>
+
+        {showTasks && (
+          <div className={styles.readingTasks}>
+            <ul className={styles.taskList}>
+              {tasks.map((task, index) => (
+                <li key={index} className={styles.taskItem}>
+                  {parseMarkdown(task)}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/activity-kit/src/index.ts
+++ b/packages/activity-kit/src/index.ts
@@ -2,6 +2,8 @@ import './components/Activities.module.css';
 
 export { ActivityPlayer } from './ActivityPlayer';
 export type {
+  ActivityPlayerActivity,
+  ActivitySourceActivity,
   ActivityCompletionEvent,
   ActivityEditOperation,
   ActivityPlayerProps,

--- a/site/tests/unit/ActivityKit.contract.test.tsx
+++ b/site/tests/unit/ActivityKit.contract.test.tsx
@@ -7,6 +7,7 @@ import fixtures from '../../../packages/activity-kit/src/fixtures/lu.activity.v1
 import lessonFixture from '../../../packages/activity-kit/src/fixtures/lu.lesson.v1.fixture.json';
 import { ActivityPlayer } from '../../../packages/activity-kit/src/ActivityPlayer';
 import type { ActivityEditOperation, LuActivityV1, LuLessonV1 } from '../../../packages/activity-kit/src';
+import type { ActivitySourceActivity } from '../../../packages/activity-kit/src/ActivityPlayer';
 
 const repoRoot = resolve(process.cwd(), '..');
 const kitRoot = join(repoRoot, 'packages/activity-kit');
@@ -83,6 +84,45 @@ function sourceFiles(directory: string): string[] {
   });
 }
 
+const sourceActivities: ActivitySourceActivity[] = [
+  {
+    id: 'quiz-render',
+    type: 'quiz',
+    title: 'Тест',
+    instruction: 'Оберіть правильну відповідь.',
+    items: [{ question: 'Яке слово правильне?', options: ['книга', 'книгу'], correct: 0 }],
+  },
+  {
+    id: 'mark-the-words-render',
+    type: 'mark-the-words',
+    title: 'Позначте слова',
+    instruction: 'Позначте іменники.',
+    text: 'Книга лежить на столі.',
+    target_words: ['Книга', 'столі'],
+    criteria: 'Називний або місцевий відмінок.',
+  },
+  {
+    id: 'error-correction-render',
+    type: 'error-correction',
+    title: 'Виправте помилку',
+    instruction: 'Знайдіть помилку.',
+    items: [{
+      sentence: 'Це моя стіл.',
+      error: 'моя',
+      correction: 'мій',
+      options: ['мій', 'моє'],
+      explanation: 'Стіл — чоловічого роду.',
+    }],
+  },
+  {
+    id: 'fill-in-render',
+    type: 'fill-in',
+    title: 'Вставте слово',
+    instruction: 'Оберіть форму.',
+    items: [{ sentence: 'Це {правильна форма}.', answer: 'книга', options: ['книга', 'книгу'] }],
+  },
+];
+
 describe('activity-kit contract', () => {
   test('generates the TypeScript discriminated union from the v1 schema', () => {
     execFileSync('node', ['scripts/generate-types.mjs'], { cwd: kitRoot });
@@ -133,16 +173,32 @@ describe('activity-kit contract', () => {
     });
   });
 
-  test('shows the editor placeholder for a valid type without a widget', () => {
-    const activity = lessonFixture.blocks.find((block) => block.type === 'text-questions')?.activity;
+  test.each([
+    ...sourceActivities.map((activity) => ({ activity, type: activity.type })),
+    ...(['text-questions', 'short-writing'] as const).map((type) => ({
+      activity: lessonFixture.blocks.find((block) => block.type === type)?.activity as LuActivityV1,
+      type,
+    })),
+  ])('renders $type through its existing widget instead of the placeholder', ({ activity, type }) => {
     expect(activity).toBeDefined();
 
-    const { container } = render(<ActivityPlayer activity={activity as LuActivityV1} isUkrainian />);
+    const { container } = render(<ActivityPlayer activity={activity} isUkrainian />);
 
-    expect(container.querySelector('[data-activity-placeholder="text-questions"]')).toHaveTextContent(
-      'тип поки без віджета',
-    );
+    expect(container.querySelector(`[data-activity="${type}"]`)).toBeInTheDocument();
+    expect(container.querySelector(`[data-activity-placeholder="${type}"]`)).not.toBeInTheDocument();
   });
+
+  test.each(['text-questions', 'short-writing'] as const)(
+    '%s renders its teacher-facing discuss/grade guidance without auto-grading',
+    (type) => {
+      const activity = lessonFixture.blocks.find((block) => block.type === type)?.activity;
+      expect(activity).toBeDefined();
+
+      render(<ActivityPlayer activity={activity as LuActivityV1} isUkrainian />);
+
+      expect(screen.getByText('Для обговорення / оцінювання:')).toBeInTheDocument();
+    },
+  );
 
   test('publishes the structured edit-operation contract', () => {
     const operation: ActivityEditOperation = {


### PR DESCRIPTION
## Summary

Wires existing widgets into `ActivityPlayer` while keeping the publishable kit independent of `site/src`:

- renders `quiz`, `mark-the-words`, `error-correction`, and `fill-in` from activities-b1/activity-v2 source shapes
- renders lesson-envelope `text-questions` through `ReadingActivity` and `short-writing` through `EssayResponse`, with explicit discuss/grade guidance and no auto-grading
- also renders the already-versioned `multiple-choice` envelope through `Quiz`
- ports the existing widget implementations, styles, and help content into activity-kit; no site-internal imports

## Placeholder status

Now rendered: `true-false`, `cloze`, `match-up`, `quiz`, `mark-the-words`, `error-correction`, `fill-in`, `multiple-choice`, `text-questions`, `short-writing`.

Still placeholder (no corresponding component): `glossary`, `form-build`, `paraphrase`, `continue-sentence`, `roleplay-dialog`.

## Verification

- `cd site && npx vitest run tests/unit/ActivityKit.contract.test.tsx` — 39 passed
- `npx eslint packages/activity-kit/src/ActivityPlayer.tsx packages/activity-kit/src/components/ActivityHelp.tsx packages/activity-kit/src/components/Quiz.tsx packages/activity-kit/src/components/MarkTheWords.tsx packages/activity-kit/src/components/ErrorCorrection.tsx packages/activity-kit/src/components/FillIn.tsx packages/activity-kit/src/components/EssayResponse.tsx packages/activity-kit/src/components/ReadingActivity.tsx site/tests/unit/ActivityKit.contract.test.tsx` — passed
- `cd site && npm run build` — passed (Astro static build)
- `cd site && npx tsc --noEmit` remains blocked by pre-existing `tests/unit/hydrate-practice-deck.test.ts(157)` manifest `counts` typing; the activity-kit sources introduced no TypeScript diagnostics.

Cross-family review was requested through the AGY/Gemini route; no auto-merge has been enabled.