### PR TITLE
fix(audit): make corpus_verification_status adjudicable + account for UNVERIFIED in eligibility (Refs #4983)

### DIFF
--- a/scripts/audit/layerb_apply_adjudication.py
+++ b/scripts/audit/layerb_apply_adjudication.py
@@ -27,6 +27,7 @@ from scripts.audit.layerb_keys import _build_event_index
 from scripts.audit.layerb_label_common import LabelJoinError, atomic_write_json, read_json, sha256_file
 from scripts.audit.layerb_label_scaffold import (
     AGGREGATE_RELATIONS,
+    CORPUS_STATUSES,
     FACT_CHECK_DECISIONS,
     LAYER_A_DECISIONS,
     LAYER_A_REASONS,
@@ -42,6 +43,7 @@ CASE_JUDGMENT_FIELDS = {
     "expected_fact_check_decision",
     "expected_layer_a_decision",
     "expected_layer_a_reason",
+    "corpus_verification_status",
 }
 CANDIDATE_JUDGMENT_FIELDS = {"expected_source_relation", "expected_support_spans"}
 CUSTOM_CASE_FIELD_NAMES = {
@@ -49,12 +51,14 @@ CUSTOM_CASE_FIELD_NAMES = {
     "fact_check_decision": "expected_fact_check_decision",
     "layer_a_decision": "expected_layer_a_decision",
     "layer_a_reason": "expected_layer_a_reason",
+    "corpus_verification_status": "corpus_verification_status",
 }
 CUSTOM_CASE_ENUMS = {
     "expected_aggregate_relation": AGGREGATE_RELATIONS,
     "expected_fact_check_decision": FACT_CHECK_DECISIONS,
     "expected_layer_a_decision": LAYER_A_DECISIONS,
     "expected_layer_a_reason": LAYER_A_REASONS,
+    "corpus_verification_status": CORPUS_STATUSES,
 }
 CUSTOM_CANDIDATE_FIELD_NAMES = {
     "candidate.expected_source_relation": "expected_source_relation",
@@ -461,6 +465,7 @@ def apply_adjudications(
 
     final_cases: list[dict[str, Any]] = []
     unresolved_case_ids: list[str] = []
+    unprobed_case_ids: list[str] = []
     agreed = 0
     for case in draft.get("cases", []):
         case_id = str(case["case_id"])
@@ -470,11 +475,17 @@ def apply_adjudications(
             )
             if final_case["adjudication"]["status"] == "UNRESOLVED":
                 unresolved_case_ids.append(case_id)
+            cstat = final_case.get("corpus_verification_status")
+            if cstat in {"UNVERIFIED", "FIXTURE_ATTESTED"}:
+                unprobed_case_ids.append(case_id)
         else:
             final_case = copy.deepcopy(dict(case))
             adjudication = final_case.get("adjudication")
             if not isinstance(adjudication, Mapping) or adjudication.get("status") != "AGREED":
                 raise LabelJoinError(f"non-adjudicated case {case_id} is not already AGREED")
+            cstat = final_case.get("corpus_verification_status")
+            if cstat in {"UNVERIFIED", "FIXTURE_ATTESTED"}:
+                unprobed_case_ids.append(case_id)
             agreed += 1
         final_case.pop("notes", None)
         final_case["annotators"] = list(ANNOTATORS)
@@ -496,21 +507,29 @@ def apply_adjudications(
         raise LabelJoinError(f"unexpected adjudication status counts: {dict(sorted(statuses.items()))}")
 
     final = copy.deepcopy(dict(draft))
-    final["qualification_eligible"] = not unresolved_case_ids
-    final["qualification_blockers"] = (
-        []
-        if not unresolved_case_ids
-        else [
-            f"{len(unresolved_case_ids)} UNRESOLVED cases pending re-adjudication",
-            *[UNRESOLVED_BLOCKER_PREFIX + case_id for case_id in sorted(unresolved_case_ids)],
-        ]
-    )
+    final["qualification_eligible"] = not unresolved_case_ids and not unprobed_case_ids
+    blockers: list[str] = []
+    if unresolved_case_ids:
+        blockers.append(f"{len(unresolved_case_ids)} UNRESOLVED cases pending re-adjudication")
+        blockers.extend(
+            UNRESOLVED_BLOCKER_PREFIX + case_id for case_id in sorted(unresolved_case_ids)
+        )
+    if unprobed_case_ids:
+        n = len(unprobed_case_ids)
+        blockers.append(
+            f"{n} cases with FIXTURE_ATTESTED or UNVERIFIED corpus_verification_status pending re-probe"
+        )
+        blockers.extend(
+            f"corpus_verification_status pending re-probe: {case_id}" for case_id in sorted(unprobed_case_ids)
+        )
+    final["qualification_blockers"] = blockers
     final["cases"] = final_cases
     summary = {
         "cases": len(final_cases),
         "rulings": dict(sorted(Counter(str(decision["ruling"]) for decision in decision_cases.values()).items())),
         "adjudication_statuses": dict(sorted(statuses.items())),
         "unresolved_case_ids": sorted(unresolved_case_ids),
+        "unprobed_corpus_case_ids": sorted(unprobed_case_ids),
     }
     return final, summary
 

--- a/tests/test_layerb_apply_adjudication.py
+++ b/tests/test_layerb_apply_adjudication.py
@@ -422,3 +422,118 @@ def test_apply_adjudications_tolerates_cosmetic_only_merge_report_cases(
         "adjudicator": None,
         "note": "Only cosmetic differences were found.",
     }
+
+
+def test_apply_ruling_custom_sets_corpus_verification_status() -> None:
+    """CUSTOM ruling can override corpus_verification_status (e.g. UNVERIFIED -> NOT_APPLICABLE for synthetic)."""
+    draft = {
+        "case_id": "synth-1",
+        "corpus_verification_status": "UNVERIFIED",
+    }
+    left = {"case_id": "synth-1", "corpus_verification_status": "UNVERIFIED"}
+    right = {"case_id": "synth-1", "corpus_verification_status": "UNVERIFIED"}
+    ruling = "CUSTOM:corpus_verification_status=NOT_APPLICABLE"
+    digest = {"case_id": "synth-1", "fields": {"corpus_verification_status": {}}}
+
+    result = apply_ruling(
+        draft,
+        left,
+        right,
+        _decision(ruling, "Purely synthetic case with no real corpus content fact; status resolved by adjudicator."),
+        digest,
+    )
+
+    assert result["corpus_verification_status"] == "NOT_APPLICABLE"
+    assert result["adjudication"] == {
+        "status": "ADJUDICATED",
+        "adjudicator": ADJUDICATOR,
+        "note": "Purely synthetic case with no real corpus content fact; status resolved by adjudicator.",
+    }
+
+
+def test_apply_adjudications_unverified_corpus_status_affects_eligibility_and_custom_overrides_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """UNVERIFIED corpus status (and FIXTURE_ATTESTED) produces blockers; CUSTOM adjudication to NOT_APPLICABLE removes the blocker and can flip eligibility.
+
+    This covers both required test cases: UNVERIFIED accounted for in eligibility, and UNVERIFIED->NOT_APPLICABLE via tool flips eligibility with no manual edit.
+    """
+    monkeypatch.setattr(adjudication, "validate_annotator_record", lambda _case, _outputs: None)
+    monkeypatch.setattr(adjudication, "_validate_completed_case", lambda _case, _outputs: None)
+
+    # Draft has one case to override via CUSTOM, one AGREED case that stays UNVERIFIED.
+    draft = {
+        "cases": [
+            {"case_id": "synth-override", "corpus_verification_status": "UNVERIFIED"},
+            {
+                "case_id": "uv-agreed",
+                "corpus_verification_status": "UNVERIFIED",
+                "adjudication": {
+                    "status": "AGREED",
+                    "adjudicator": None,
+                    "note": "Independent annotations matched all material fields.",
+                },
+            },
+        ]
+    }
+    decisions = [
+        _case_decision(
+            "synth-override",
+            "CUSTOM:corpus_verification_status=NOT_APPLICABLE",
+            rationale="Synthetic fixture only; no corpus content fact to verify. Adjudicated to NOT_APPLICABLE per rule 12.",
+        ),
+    ]
+    digest = [
+        {"case_id": "synth-override", "fields": {"corpus_verification_status": {}}},
+    ]
+
+    final, summary = adjudication.apply_adjudications(
+        draft,
+        copy.deepcopy(draft),
+        copy.deepcopy(draft),
+        decisions,
+        digest,
+        event_outputs={},
+    )
+
+    override_case = next(c for c in final["cases"] if c["case_id"] == "synth-override")
+    assert override_case["corpus_verification_status"] == "NOT_APPLICABLE"
+    assert override_case["adjudication"]["status"] == "ADJUDICATED"
+    assert "NOT_APPLICABLE" in override_case["adjudication"]["note"] or True  # rationale carried
+
+    agreed_uv = next(c for c in final["cases"] if c["case_id"] == "uv-agreed")
+    assert agreed_uv["corpus_verification_status"] == "UNVERIFIED"
+
+    # Eligibility must reflect the remaining UNVERIFIED (no manual edit path)
+    assert final["qualification_eligible"] is False
+    blockers = final["qualification_blockers"]
+    assert any("UNVERIFIED" in b or "FIXTURE_ATTESTED" in b for b in blockers)
+    assert any("uv-agreed" in b for b in blockers)
+
+    # Summary exposes the unprobed
+    assert "synth-override" not in summary["unprobed_corpus_case_ids"]
+    assert "uv-agreed" in summary["unprobed_corpus_case_ids"]
+
+    # Now a case whose only blocker is UNVERIFIED; CUSTOM to NOT_APPLICABLE must flip to eligible=true
+    draft2 = {"cases": [{"case_id": "only-uv", "corpus_verification_status": "UNVERIFIED"}]}
+    dec2 = [
+        _case_decision(
+            "only-uv",
+            "CUSTOM:corpus_verification_status=NOT_APPLICABLE",
+            rationale="Over-cautious UNVERIFIED on purely synthetic; resolved.",
+        )
+    ]
+    dig2 = [{"case_id": "only-uv", "fields": {"corpus_verification_status": {}}}]
+
+    final2, _ = adjudication.apply_adjudications(
+        draft2,
+        copy.deepcopy(draft2),
+        copy.deepcopy(draft2),
+        dec2,
+        dig2,
+        event_outputs={},
+    )
+
+    assert final2["qualification_eligible"] is True
+    assert final2["qualification_blockers"] == []
+    assert final2["cases"][0]["corpus_verification_status"] == "NOT_APPLICABLE"

--- a/tests/test_layerb_apply_adjudication.py
+++ b/tests/test_layerb_apply_adjudication.py
@@ -499,7 +499,8 @@ def test_apply_adjudications_unverified_corpus_status_affects_eligibility_and_cu
     override_case = next(c for c in final["cases"] if c["case_id"] == "synth-override")
     assert override_case["corpus_verification_status"] == "NOT_APPLICABLE"
     assert override_case["adjudication"]["status"] == "ADJUDICATED"
-    assert "NOT_APPLICABLE" in override_case["adjudication"]["note"] or True  # rationale carried
+    assert "Synthetic fixture only" in override_case["adjudication"]["note"]
+
 
     agreed_uv = next(c for c in final["cases"] if c["case_id"] == "uv-agreed")
     assert agreed_uv["corpus_verification_status"] == "UNVERIFIED"


### PR DESCRIPTION
fix(audit): make corpus_verification_status adjudicable via CUSTOM + account for UNVERIFIED/FIXTURE_ATTESTED in eligibility

- Add `corpus_verification_status` to `CASE_JUDGMENT_FIELDS` and `CUSTOM_CASE_*` so adjudicators can issue rulings like `CUSTOM:corpus_verification_status=NOT_APPLICABLE` (resolves over-cautious `UNVERIFIED` on synthetic cases deterministically as part of `(decisions + records) → gold`).
- Import `CORPUS_STATUSES`; the CUSTOM grammar accepts it exactly like `layer_a_reason`.
- Extend eligibility/blockers derivation in `apply_adjudications`: `qualification_eligible` is now false (with blockers) if any case ends with `UNVERIFIED` or `FIXTURE_ATTESTED` after rulings, in addition to `UNRESOLVED`. Matches annotation guide rule #12 + `corpus_verification_status` decision rule.
- No manual post-edit required for status corrections; gold sidecar is reproducible.
- Two new tests + all prior tests green.

## #M-4 deterministic-evidence preamble

**Verifiable claims + tool backing (all executed in worktree 4983-adjudication-fix @90cc885acd):**

1. `corpus_verification_status` is now an adjudicable case field via CUSTOM rulings.
   - File: `scripts/audit/layerb_apply_adjudication.py:46`
     ```diff
     CASE_JUDGMENT_FIELDS = {
         ...
     +    "corpus_verification_status",
     }
     ```
   - `CUSTOM_CASE_FIELD_NAMES:54` and `CUSTOM_CASE_ENUMS:61` (with `CORPUS_STATUSES`).
   - Quote: `grep -n "corpus_verification_status" scripts/audit/layerb_apply_adjudication.py` (post-edit) lists the three declaration sites + the two derivation sites.

2. CUSTOM adjudication applies `UNVERIFIED → NOT_APPLICABLE` and flips eligibility (no manual edit on gold).
   - Test: `test_apply_ruling_custom_sets_corpus_verification_status` (direct `apply_ruling`)
   - Test: `test_apply_adjudications_unverified_corpus_status_affects_eligibility_and_custom_overrides_it`
   - Raw execution (`.venv/bin/python -c '...' ` exercising `apply_adjudications` + CUSTOM path):
     ```
     === Evidence run: CUSTOM corpus status adjudication + eligibility ===
     final[case][corpus_verification_status]: NOT_APPLICABLE
     qualification_eligible: True
     qualification_blockers: []
     PASS via apply tool (no manual edit).
     ```
   - `pytest ... -q` output:
     ```
     tests/test_layerb_apply_adjudication.py::test_apply_ruling_custom_sets_corpus_verification_status PASSED
     tests/test_layerb_apply_adjudication.py::test_apply_adjudications_unverified_corpus_status_affects_eligibility_and_custom_overrides_it PASSED
     ```

3. Eligibility derivation now accounts for `UNVERIFIED` (and `FIXTURE_ATTESTED` per guide).
   - `scripts/audit/layerb_apply_adjudication.py:499` (post): `final["qualification_eligible"] = not unresolved_case_ids and not unprobed_case_ids`
   - Blockers construction (520-525) adds corpus status lines when present.
   - In the "only-uv" subtest: input `UNVERIFIED` + CUSTOM `NOT_APPLICABLE` → `eligible=True`, `blockers=[]` (flips).
   - Pre-existing `UNRESOLVED` test cases continue to produce identical blocker shape (their mocks have no `corpus_verification_status` key → `.get()` yields None, no extra blockers added).

4. Repro + invariants:
   - `git diff --stat`: only 2 files, 143 insertions.
   - `.venv/bin/ruff check ...` → "All checks passed."
   - `.venv/bin/pytest tests/test_layerb_apply_adjudication.py -q` → "16 passed".
   - Pre-commit hook (on commit) re-ran ruff + the 16 tests and passed.
   - No edits to `layerb_judge_bridge.py`, `layerb_collect_emissions.py`, linter configs, or `.python-version`.
   - No status/audit/review artifacts in diff.
   - `qualification_eligible` / `blockers` written only from `(decisions + draft records)`.

All claims backed by executed commands + file:line + literal stdout above. No behavior asserted without tool run.

Refs #4983