### PR TITLE
docs(architecture): keep public continuity contract provider-neutral

### DIFF
--- a/docs/decisions/INDEX.md
+++ b/docs/decisions/INDEX.md
@@ -5,8 +5,9 @@ One-liner per decision. Full details in `decisions.yaml`.
 Staleness check: `.venv/bin/python scripts/check_decisions.py`
 
 | ID | Date | Expires | Scope | Status | Title |
-|----|------|---------|-------|--------|-------|
-| dec-011 | 2026-07-11 | 2027-07-11 | architecture | active | Static-first forever: github.io canonical, backend = progressive enhancement, split at defined trigger |
+| ---- | ------ | --------- | ------- | -------- | ------- |
+| dec-012 | 2026-07-12 | 2027-07-12 | architecture | active | Static delivery is canonical; learning works without dynamic services |
+| dec-011 | 2026-07-11 | 2027-07-11 | architecture | superseded | Static-first forever: github.io canonical, backend = progressive enhancement, split at defined trigger |
 | dec-010 | 2026-07-10 | 2026-10-08 | harness | active | Grammar + word-choice gate priority; finetuning parked |
 | dec-009 | 2026-07-07 | 2026-10-05 | benchmark-2156 | active | Public benchmark release (epic #4639) parked; deploy-first |
 | dec-008 | 2026-06-14 | 2026-09-12 | content | active | A1/A2 live maintenance favors workbook enrichment over rebuilds |

--- a/docs/decisions/decisions.yaml
+++ b/docs/decisions/decisions.yaml
@@ -242,11 +242,14 @@ decisions:
     depends_on: []
 
   - id: dec-011
-    status: active
+    status: superseded
     date: 2026-07-11
     expires: 2027-07-11
     scope: architecture
     title: "Static-first forever: github.io site is canonical; backend is progressive enhancement; serverless stays the maintained fallback"
+    superseded_note: >-
+      The product invariant of static delivery survives, while current operational
+      details have moved to a non-public control-plane record.
     reasoning: >-
       User decision 2026-07-11 (continuity requirement: the site must keep working at
       github.io even if the maintainer becomes unavailable). (1) The static GitHub Pages
@@ -264,3 +267,27 @@ decisions:
       remains backend-only - never attempted statically.
     review_signal: >-
       Revisit at backend design kickoff (#4920) or when the #4966 size report crosses 600MB.
+    superseded_by: dec-012
+    depends_on: []
+
+  - id: dec-012
+    status: active
+    date: 2026-07-12
+    expires: 2027-07-12
+    scope: architecture
+    title: "Static delivery is canonical; learning works without dynamic services"
+    reasoning: >-
+      (1) Static delivery is canonical; learning works without dynamic services. (2) Content
+      may be partitioned behind versioned provider-neutral static-origin manifests.
+      (3) Dynamic services implement the same public JSON contracts as optional
+      progressive enhancement. (4) Backend absence cannot break learning. (5) Implementation
+      topology, capacity, providers, budgets, and operational triggers are intentionally
+      outside the public decision.
+    evidence: "User direction 2026-07-12; issue #5015"
+    alternatives:
+      - option: "Require centralized backend servers for core features"
+        rejected_because: "Contradicts the core requirement that learning capability must run off static pages"
+    review_signal: >-
+      Revisit only when a public schema or learner-visible continuity contract changes.
+    superseded_by: null
+    depends_on: []


### PR DESCRIPTION
Closes #5015.

## Scope

- Preserve the original architecture decision as immutable, disclosed history and mark it superseded.
- Add a current public product contract containing only learner-visible guarantees and provider-neutral integration requirements.
- Keep static delivery canonical, make dynamic services optional, and require backend absence not to break learning.
- Keep implementation topology, capacity planning, providers, budgets, and operational triggers outside the public decision.

## Validation

- Decision journal validator passed: 6 active, 11 total, no stale decisions.
- `git diff --check` passed.
- Agent trailer validation passed.
- CI and security checks are green.

## Disclosure boundary

No private repository paths, operational runbooks, provider evaluation, live identifiers, credentials, or new infrastructure details are introduced. Previously published historical details remain treated as disclosed rather than represented as secret.

## Fleet

AGY drafted the public decision, Codex rejected the overbroad first draft and integrated the corrected immutable-decision form. Independent cross-family review remains required before merge.