### PR TITLE
feat(lexicon): relation-promotion safety gate (#4975)

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -77,6 +77,7 @@ from scripts.lexicon.esum_garbled import (
 )
 from scripts.lexicon.heritage_classifier import classify_lemma, compute_warning_severity
 from scripts.lexicon.lemma_normalization import strip_acute_stress
+from scripts.lexicon.load_relation_candidates import load_approved_synonym_verdicts
 from scripts.lexicon.manifest_fingerprint import DEFAULT_FINGERPRINT, write_fingerprint
 from scripts.verification.vesum import verify_lemma, verify_word
 from scripts.wiki.slovnyk_me import primary_synonym_sense_text
@@ -1802,8 +1803,6 @@ def _phraseology_definition_body(definition: str, phrase: str) -> str:
 _FRAZEOLOHICHNYI_FTS_AVAILABLE: dict[str, bool] = {}
 _FRAZEOLOHICHNYI_FTS_WARN_LOGGED = False
 
-_ASCII_LOWER_TABLE = str.maketrans("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz")
-
 
 def _db_cache_key(conn: sqlite3.Connection) -> str | None:
     """Stable per-database cache key: the main DB file path, or ``None`` for
@@ -1831,13 +1830,6 @@ def _cache_verdict(cache: dict[str, bool], key: str | None, verdict: bool) -> bo
     if key is not None:
         cache[key] = verdict
     return verdict
-
-
-def _ascii_lower_contains(text: str, needle: str) -> bool:
-    """Replicate SQLite's ASCII-only ``lower()`` + ``LIKE '%needle%'``
-    semantics — the parity predicate for index-accelerated paths (SQLite's
-    ``lower()`` does not fold Cyrillic)."""
-    return needle in text.translate(_ASCII_LOWER_TABLE)
 
 
 def _is_connection_readonly(conn: sqlite3.Connection) -> bool:
@@ -1917,91 +1909,6 @@ def _ensure_frazeolohichnyi_fts(conn: sqlite3.Connection) -> bool:
             print(f"Warning: Failed to create/populate frazeolohichnyi_fts ({e}). Falling back to LIKE.", file=sys.stderr)
             _FRAZEOLOHICHNYI_FTS_WARN_LOGGED = True
         return _cache_verdict(_FRAZEOLOHICHNYI_FTS_AVAILABLE, key, False)
-
-
-_UKRAJINET_INDEX_AVAILABLE: dict[str, bool] = {}
-_UKRAJINET_INDEX_WARN_LOGGED = False
-
-def _populate_ukrajinet_word_index(conn: sqlite3.Connection) -> None:
-    cursor = conn.execute("SELECT id, words FROM ukrajinet")
-    inserts = []
-    for rowid, words_json in cursor:
-        try:
-            words = json.loads(words_json or "[]")
-        except (TypeError, ValueError):
-            continue
-        for candidate in words:
-            normalized = _normalise_synonym(candidate)
-            tokens = re.findall(rf"[{_CYRILLIC_WORD_CHARS}]+", normalized)
-            for token in tokens:
-                inserts.append((token, rowid))
-
-    if inserts:
-        conn.executemany(
-            "INSERT INTO ukrajinet_word_index (word_key, rowid) VALUES (?, ?)",
-            inserts
-        )
-
-def _ensure_ukrajinet_word_index(conn: sqlite3.Connection) -> bool:
-    global _UKRAJINET_INDEX_WARN_LOGGED
-    key = _db_cache_key(conn)
-    cached = _UKRAJINET_INDEX_AVAILABLE.get(key)
-    if cached is not None:
-        return cached
-
-    try:
-        cur = conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='ukrajinet'")
-        if not cur.fetchone():
-            return _cache_verdict(_UKRAJINET_INDEX_AVAILABLE, key, False)
-    except sqlite3.Error:
-        return _cache_verdict(_UKRAJINET_INDEX_AVAILABLE, key, False)
-
-    try:
-        cur = conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='ukrajinet_word_index'")
-        exists = cur.fetchone() is not None
-    except sqlite3.Error:
-        return _cache_verdict(_UKRAJINET_INDEX_AVAILABLE, key, False)
-
-    if exists:
-        try:
-            row = conn.execute("SELECT COUNT(*) FROM ukrajinet_word_index").fetchone()
-            if row and row[0] == 0:
-                if _is_connection_readonly(conn):
-                    if not _UKRAJINET_INDEX_WARN_LOGGED:
-                        print("Warning: ukrajinet_word_index table is missing and connection is read-only. Falling back to LIKE.", file=sys.stderr)
-                        _UKRAJINET_INDEX_WARN_LOGGED = True
-                    return False
-
-                _populate_ukrajinet_word_index(conn)
-            return _cache_verdict(_UKRAJINET_INDEX_AVAILABLE, key, True)
-        except sqlite3.Error as e:
-            if not _UKRAJINET_INDEX_WARN_LOGGED:
-                print(f"Warning: Failed to verify/populate ukrajinet_word_index ({e}). Falling back to LIKE.", file=sys.stderr)
-                _UKRAJINET_INDEX_WARN_LOGGED = True
-            return False
-
-    if _is_connection_readonly(conn):
-        if not _UKRAJINET_INDEX_WARN_LOGGED:
-            print("Warning: ukrajinet_word_index table is missing and connection is read-only. Falling back to LIKE.", file=sys.stderr)
-            _UKRAJINET_INDEX_WARN_LOGGED = True
-        return _cache_verdict(_UKRAJINET_INDEX_AVAILABLE, key, False)
-
-    try:
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS ukrajinet_word_index ("
-            "word_key TEXT, rowid INTEGER"
-            ")"
-        )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_ukrajinet_word_index_key ON ukrajinet_word_index(word_key)"
-        )
-        _populate_ukrajinet_word_index(conn)
-        return _cache_verdict(_UKRAJINET_INDEX_AVAILABLE, key, True)
-    except sqlite3.Error as e:
-        if not _UKRAJINET_INDEX_WARN_LOGGED:
-            print(f"Warning: Failed to create/populate ukrajinet_word_index ({e}). Falling back to LIKE.", file=sys.stderr)
-            _UKRAJINET_INDEX_WARN_LOGGED = True
-        return _cache_verdict(_UKRAJINET_INDEX_AVAILABLE, key, False)
 
 
 def _idioms_frazeolohichnyi(conn: sqlite3.Connection, lemma: str, *, limit: int = 3) -> dict[str, Any] | None:
@@ -2629,54 +2536,6 @@ def _synonyms_from_wiktionary(conn: sqlite3.Connection, lemma: str, out: list[st
             _add_candidate(out, seen, lemma, str(candidate))
 
 
-def _synonyms_from_ukrajinet(conn: sqlite3.Connection, lemma: str, out: list[str], seen: set[str]) -> None:
-    use_idx = _ensure_ukrajinet_word_index(conn)
-    for variant in _split_lemma_variants(lemma):
-        needle = variant.casefold()
-        indexed = False
-        cursor = None
-        if use_idx:
-            # Derive the lookup token with the SAME normalizer the index was
-            # built with, so build-time and lookup-time keys can never drift.
-            tokens = re.findall(rf"[{_CYRILLIC_WORD_CHARS}]+", _normalise_synonym(variant))
-            if tokens:
-                try:
-                    cursor = conn.execute(
-                        "SELECT words FROM ukrajinet WHERE rowid IN ("
-                        "  SELECT rowid FROM ukrajinet_word_index WHERE word_key = ?"
-                        ")",
-                        (tokens[0],),
-                    )
-                    indexed = True
-                except sqlite3.Error:
-                    cursor = None
-                    indexed = False
-
-        if cursor is None:
-            cursor = conn.execute(
-                "SELECT words FROM ukrajinet WHERE lower(words) LIKE ?",
-                (f"%{needle}%",),
-            )
-
-        rows = cursor.fetchall()
-        for (words_json,) in rows:
-            raw_text = str(words_json or "")
-            # Parity guard: the index folds Cyrillic case (casefold at build
-            # time) but SQLite's lower()+LIKE does not, so the indexed path
-            # can surface rows the fallback never matched. Re-apply the exact
-            # LIKE predicate so both paths emit identical sets.
-            if indexed and not _ascii_lower_contains(raw_text, needle):
-                continue
-            try:
-                words = [str(w).strip() for w in json.loads(words_json or "[]")]
-            except (TypeError, ValueError):
-                continue
-            if not any(_contains_whole_token(_normalise_synonym(word), needle) for word in words):
-                continue
-            for candidate in words:
-                _add_candidate(out, seen, lemma, candidate)
-
-
 def _synonyms_from_balla(conn: sqlite3.Connection, lemma: str, out: list[str], seen: set[str]) -> None:
     allowed = _A1_SENSE_SYNONYMS.get(_lookup_key(lemma), ())
     lookup_words = _BALLA_LOOKUPS.get(_lookup_key(lemma), ())
@@ -3173,27 +3032,6 @@ _SYNONYM_ADDITION_CAP = 8
 _ANTONYM_ADDITION_CAP = 8
 _HOMONYM_ADDITION_CAP = 8
 _PARONYM_ADDITION_CAP = 8
-_COATTESTATION_SUM_OR_GRINCHENKO = frozenset({"СУМ-11", "СУМ-20", "Грінченко"})
-_CONTENT_STEM_STOPWORDS = frozenset(
-    {
-        "бути",
-        "весь",
-        "інший",
-        "кожний",
-        "мати",
-        "один",
-        "особа",
-        "певний",
-        "предмет",
-        "річ",
-        "самий",
-        "такий",
-        "тільки",
-        "той",
-        "це",
-        "який",
-    }
-)
 
 
 def _canonical_synonym_term(value: object) -> str | None:
@@ -3338,6 +3176,42 @@ def _manifest_headwords(manifest: dict[str, Any]) -> dict[str, str]:
             if term:
                 headwords.setdefault(term, term)
     return headwords
+
+
+def _manifest_relation_aliases(manifest: dict[str, Any]) -> dict[str, str]:
+    """Resolve manifest form aliases to their canonical lemma via route slugs.
+
+    Relation-pair rows retain their source lemmas, while the rendered manifest
+    must attach them to canonical Atlas pages.  Form entries carry their target
+    route in ``form_of.url_slug``; resolving through that route keeps relation
+    rendering aligned with the Atlas alias contract rather than guessing from
+    a display string.
+    """
+    canonical_by_slug: dict[str, str] = {}
+    entries = [entry for entry in manifest.get("entries", []) if isinstance(entry, dict)]
+    for entry in entries:
+        if entry.get("form_of"):
+            continue
+        lemma = _canonical_synonym_term(entry.get("lemma"))
+        slug = str(entry.get("url_slug") or "").strip()
+        if lemma and slug:
+            canonical_by_slug[slug] = lemma
+
+    aliases: dict[str, str] = {}
+    for entry in entries:
+        alias = _canonical_synonym_term(entry.get("lemma"))
+        if not alias:
+            continue
+        form_of = entry.get("form_of")
+        target: str | None = None
+        if isinstance(form_of, dict):
+            target = canonical_by_slug.get(str(form_of.get("url_slug") or "").strip())
+            target = target or _canonical_synonym_term(form_of.get("lemma"))
+        if target is None:
+            target = _canonical_synonym_term(entry.get("lemma"))
+        if target:
+            aliases[alias] = target
+    return aliases
 
 
 def _definition_pointer_relations_by_headword(
@@ -3809,19 +3683,20 @@ def _corpus_relation_pairs_by_headword(
 ) -> dict[str, dict[str, list[dict[str, Any]]]]:
     """Read VESUM-gated relation-pair corpus facts for Atlas headwords.
 
-    Candidate artifacts are deliberately permissive during the review period,
-    but both recorded lemmas are re-checked here. This makes the Atlas safe if
-    a stale or manually edited corpus row no longer satisfies the exact-lemma
-    contract. Corpus provenance stays separate from legacy dictionary veins.
+    Only explicitly approved corpus rows are eligible for rendering, and both
+    recorded lemmas are re-checked here. This makes the Atlas safe if a stale
+    or manually edited row no longer satisfies the exact-lemma contract.
+    Corpus provenance stays separate from legacy dictionary veins.
     """
     headwords = _manifest_headwords(manifest)
+    aliases = _manifest_relation_aliases(manifest)
     by_headword: dict[str, dict[str, list[dict[str, Any]]]] = {}
     try:
         rows = conn.execute(
             """
             SELECT relation, word_a, word_b, gloss_a, gloss_b, source, source_url
             FROM relation_pairs
-            WHERE review_status IN ('approved', 'candidate')
+            WHERE review_status = 'approved'
             """
         ).fetchall()
     except sqlite3.Error:
@@ -3835,6 +3710,8 @@ def _corpus_relation_pairs_by_headword(
         word_b = _canonical_synonym_term(word_b_raw)
         if not word_a or not word_b or not (_vesum_valid_synonym(word_a) and _vesum_valid_synonym(word_b)):
             continue
+        word_a = aliases.get(word_a, word_a)
+        word_b = aliases.get(word_b, word_b)
         source = f"relation_pairs/{str(source_raw or '').strip()}"
         if source == "relation_pairs/":
             continue
@@ -3880,184 +3757,11 @@ def _corpus_relation_pairs_by_headword(
             for gloss in dict.fromkeys(gloss for gloss in (gloss_a, gloss_b) if gloss):
                 append(word_a, word_a, gloss)
             continue
+        if word_a == word_b:
+            continue
         append(word_a, word_b, gloss_b)
         append(word_b, word_a, gloss_a)
     return by_headword
-
-
-def _ukrajinet_synsets(conn: sqlite3.Connection, lemma: str) -> list[dict[str, Any]]:
-    """Read matching Ukrajinet synsets without creating the optional SQL index."""
-    term = _canonical_synonym_term(lemma)
-    if not term:
-        return []
-    try:
-        columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(ukrajinet)").fetchall()}
-        if "words" not in columns:
-            return []
-        synset_field = "synset_id" if "synset_id" in columns else "''"
-        source_field = "source" if "source" in columns else "''"
-        has_index = conn.execute(
-            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='ukrajinet_word_index'"
-        ).fetchone()
-        if has_index:
-            rows = conn.execute(
-                f"SELECT {synset_field}, words, {source_field} FROM ukrajinet WHERE rowid IN ("
-                "SELECT rowid FROM ukrajinet_word_index WHERE word_key = ?"
-                ")",
-                (term,),
-            ).fetchall()
-        else:
-            rows = conn.execute(
-                f"SELECT {synset_field}, words, {source_field} FROM ukrajinet WHERE words LIKE ?",
-                (f"%{term}%",),
-            ).fetchall()
-    except sqlite3.Error:
-        return []
-
-    synsets: list[dict[str, Any]] = []
-    for synset_id, words_json, source in rows:
-        try:
-            words = [_canonical_synonym_term(word) for word in json.loads(words_json or "[]")]
-        except (TypeError, ValueError):
-            continue
-        words = [word for word in words if word]
-        if term in words:
-            synsets.append(
-                {
-                    "synset_id": str(synset_id or ""),
-                    "words": list(dict.fromkeys(words)),
-                    "source": str(source or "Ukrajinet WordNet"),
-                }
-            )
-    return synsets
-
-
-def _definition_mentions(text: str, candidate: str) -> bool:
-    return _contains_whole_token(_lookup_key(_strip_stress(text)).casefold(), candidate)
-
-
-def _definition_content_stems(text: str, *, excluded: set[str] | None = None) -> set[str]:
-    """Return VESUM-lemmatized, non-generic content stems from a definition."""
-    excluded = excluded or set()
-    stems: set[str] = set()
-    for raw_token in re.findall(rf"[{_CYRILLIC_WORD_CHARS}]+", _strip_stress(text).casefold()):
-        token = _canonical_synonym_term(raw_token)
-        if not token or len(token) < 4 or token in _CONTENT_STEM_STOPWORDS or token in excluded:
-            continue
-        for lemma, _pos in _vesum_word_analyses(token):
-            stem = _canonical_synonym_term(lemma)
-            if stem and len(stem) >= 4 and stem not in _CONTENT_STEM_STOPWORDS and stem not in excluded:
-                stems.add(stem)
-    return stems
-
-
-def _coattestation_evidence(
-    conn: sqlite3.Connection,
-    lemma: str,
-    candidate: str,
-    *,
-    has_sum11_flags: bool,
-    cache: dict[str, Any] | None = None,
-) -> dict[str, Any] | None:
-    """Return the required local lexicographic evidence, otherwise fail closed."""
-    lemma_rows = _dictionary_definition_rows(
-        conn,
-        lemma,
-        has_sum11_flags=has_sum11_flags,
-        cache=cache,
-        include_grinchenko=True,
-    )
-    candidate_rows = _dictionary_definition_rows(
-        conn,
-        candidate,
-        has_sum11_flags=has_sum11_flags,
-        include_grinchenko=True,
-    )
-    # Sovietized prose is unsafe as evidence for an auto-emitted WordNet pair.
-    # It remains eligible for vein 1: a lexicographer's pointer is safe even
-    # where the surrounding prose has sovietization_risk=2.
-    lemma_rows = [row for row in lemma_rows if int(row.get("sovietization_risk") or 0) != 2]
-    candidate_rows = [row for row in candidate_rows if int(row.get("sovietization_risk") or 0) != 2]
-
-    for direction, rows, mentioned in (
-        ("lemma→candidate", lemma_rows, candidate),
-        ("candidate→lemma", candidate_rows, _canonical_synonym_term(lemma) or lemma),
-    ):
-        for row in rows:
-            if _definition_mentions(str(row["text"]), mentioned):
-                return {
-                    "kind": "definition_mention",
-                    "dictionary": row["source"],
-                    "direction": direction,
-                }
-
-    excluded_stems = {
-        term
-        for term in (_canonical_synonym_term(lemma), _canonical_synonym_term(candidate))
-        if term
-    }
-    for lemma_row in lemma_rows:
-        if lemma_row["source"] not in _COATTESTATION_SUM_OR_GRINCHENKO:
-            continue
-        lemma_stems = _definition_content_stems(str(lemma_row["text"]), excluded=excluded_stems)
-        if not lemma_stems:
-            continue
-        for candidate_row in candidate_rows:
-            if candidate_row["source"] not in _COATTESTATION_SUM_OR_GRINCHENKO:
-                continue
-            shared = lemma_stems.intersection(
-                _definition_content_stems(str(candidate_row["text"]), excluded=excluded_stems)
-            )
-            if shared:
-                return {
-                    "kind": "shared_content_stem",
-                    "dictionaries": [lemma_row["source"], candidate_row["source"]],
-                    "stem": sorted(shared)[0],
-                }
-    return None
-
-
-def _gated_ukrajinet_relations(
-    conn: sqlite3.Connection,
-    lemma: str,
-    *,
-    has_sum11_flags: bool,
-    cache: dict[str, Any] | None = None,
-) -> list[dict[str, Any]]:
-    """Vein 2: WordNet synsets only after the fail-closed lexical gate."""
-    lemma_term = _canonical_synonym_term(lemma)
-    if not lemma_term or not _vesum_valid_synonym(lemma_term):
-        return []
-    relations: list[dict[str, Any]] = []
-    seen: set[str] = set()
-    for synset in _ukrajinet_synsets(conn, lemma_term):
-        for candidate in synset["words"]:
-            if candidate == lemma_term or candidate in seen or not _vesum_valid_synonym(candidate):
-                continue
-            evidence = _coattestation_evidence(
-                conn,
-                lemma_term,
-                candidate,
-                has_sum11_flags=has_sum11_flags,
-                cache=cache,
-            )
-            if not evidence:
-                continue
-            seen.add(candidate)
-            relations.append(
-                {
-                    "item": candidate,
-                    "source": synset["source"],
-                    "pattern": "gated synset",
-                    "vein": 2,
-                    "gate": {
-                        "vesum": "both valid",
-                        "co_attestation": evidence,
-                        "synset_id": synset["synset_id"],
-                    },
-                }
-            )
-    return relations
 
 
 def _relation_source_label(relation: dict[str, Any], item: str) -> str:
@@ -5599,16 +5303,7 @@ def enrich_entry(
             cache=slovnyk_cache,
         )
     )
-    synonym_relations = [*pointer_relations]
-    synonym_relations.extend(
-        _gated_ukrajinet_relations(
-            conn,
-            lemma,
-            has_sum11_flags=has_sum11_flags,
-            cache=slovnyk_cache,
-        )
-    )
-    synonyms = _merge_synonym_relations(synonyms, synonym_relations)
+    synonyms = _merge_synonym_relations(synonyms, pointer_relations)
     if synonyms:
         sections["synonyms"] = synonyms
     antonyms = _antonyms_wiktionary(conn, base, entry_pos=entry_pos)
@@ -5749,6 +5444,11 @@ def enrich() -> tuple[int, int]:
     manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
     _normalize_manifest_entries(manifest)
     kaikki_lookup = _load_kaikki_lookup()
+    # Reviewed synonym verdicts are first-class corpus facts for the manifest,
+    # not an atlas.db-only projection. This import never promotes mined
+    # candidates: it writes only YAML ``approved`` verdict rows with dedicated
+    # provenance before the read-only enrichment pass.
+    load_approved_synonym_verdicts(SOURCES_DB)
     conn = sqlite3.connect(f"file:{SOURCES_DB}?mode=ro", uri=True)
     enriched = 0
     try:

--- a/scripts/lexicon/load_relation_candidates.py
+++ b/scripts/lexicon/load_relation_candidates.py
@@ -19,6 +19,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -32,8 +34,11 @@ from scripts.lexicon.relation_pairs import (
 
 DEFAULT_DB = ROOT / "data" / "sources.db"
 DEFAULT_CANDIDATES_DIR = ROOT / "data" / "lexicon"
+DEFAULT_SYNONYM_VERDICTS = DEFAULT_CANDIDATES_DIR / "synonym_pair_verdicts.yaml"
+SYNONYM_VERDICTS_SOURCE = "synonym_verdicts"
 _CURATED_SOURCE_MARKERS = ("wikipedia", "wiktionary", "miyklas", "ukr-mova", "словник", "dictionary", "zno", "grinchyshyn")
 _GENERATED_SOURCE_MARKERS = ("generated", "llm", "model")
+_EXCLUDED_CANDIDATE_FILENAMES = frozenset({"relation_candidates_sample.json"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -130,6 +135,8 @@ def _normalise_candidate(path: Path, root: dict[str, Any], raw: dict[str, Any]) 
 
 def _iter_candidates(candidates_dir: Path, source_filter: str | None, summary: LoadSummary):
     for path in sorted(candidates_dir.glob("*_candidates_*.json")):
+        if path.name in _EXCLUDED_CANDIDATE_FILENAMES:
+            continue
         root, records = _candidate_records(path)
         for raw in records:
             candidate = _normalise_candidate(path, root, raw)
@@ -143,6 +150,53 @@ def _iter_candidates(candidates_dir: Path, source_filter: str | None, summary: L
                 continue
             summary.accepted += 1
             yield candidate
+
+
+def _approved_synonym_verdict_candidates(verdicts_path: Path) -> list[Candidate]:
+    """Return deterministic corpus rows from reviewed synonym verdicts only.
+
+    The verdict artifact is a human-reviewed approval register, unlike mined
+    ``*_candidates_*.json`` artifacts.  Its rows therefore enter the corpus
+    with an explicit, dedicated provenance rather than inheriting any mining
+    source or candidate status.
+    """
+    try:
+        payload = yaml.safe_load(verdicts_path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        raise ValueError(f"Cannot load synonym verdicts: {verdicts_path}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"Synonym verdicts must be a mapping: {verdicts_path}")
+    approved = payload.get("approved")
+    if not isinstance(approved, list):
+        raise ValueError(f"Synonym verdicts approved section must be a list: {verdicts_path}")
+
+    pairs: set[tuple[str, str]] = set()
+    for index, verdict in enumerate(approved):
+        if not isinstance(verdict, dict):
+            raise ValueError(f"Approved synonym verdict {index} must be a mapping: {verdicts_path}")
+        if str(verdict.get("polarity") or "").strip().casefold() != "synonym":
+            continue
+        word_a = normalize_relation_word(verdict.get("a"))
+        word_b = normalize_relation_word(verdict.get("b"))
+        if not word_a or not word_b:
+            raise ValueError(f"Approved synonym verdict {index} lacks a valid lemma: {verdicts_path}")
+        if word_a != word_b:
+            pairs.add(tuple(sorted((word_a, word_b))))
+
+    return [
+        Candidate(
+            relation="synonym",
+            word_a=word_a,
+            word_b=word_b,
+            gloss_a="",
+            gloss_b="",
+            source=SYNONYM_VERDICTS_SOURCE,
+            source_url="",
+            confidence="high",
+            review_status="approved",
+        )
+        for word_a, word_b in sorted(pairs)
+    ]
 
 
 def _existing_row(conn: sqlite3.Connection, candidate: Candidate) -> tuple[str, str, str, str, str] | None:
@@ -236,6 +290,53 @@ def load_candidates(
     return summary, by_source_relation
 
 
+def load_approved_synonym_verdicts(
+    db_path: Path,
+    verdicts_path: Path = DEFAULT_SYNONYM_VERDICTS,
+    *,
+    dry_run: bool = False,
+) -> LoadSummary:
+    """Import only approved synonym verdicts as durable approved corpus rows.
+
+    This is deliberately separate from mined-candidate ingestion: no candidate
+    row is promoted here, and verdict rows use ``synonym_verdicts`` provenance
+    so their review origin remains visible in rendered manifest sections.
+    """
+    summary = LoadSummary()
+    candidates: list[Candidate] = []
+    for candidate in _approved_synonym_verdict_candidates(verdicts_path):
+        if not (is_exact_vesum_lemma(candidate.word_a) and is_exact_vesum_lemma(candidate.word_b)):
+            summary.skipped_vesum += 1
+            continue
+        summary.accepted += 1
+        candidates.append(candidate)
+    if dry_run:
+        return summary
+
+    conn = sqlite3.connect(db_path)
+    try:
+        ensure_relation_pairs_schema(conn)
+        for candidate in candidates:
+            before = _existing_row(conn, candidate)
+            _upsert(conn, candidate)
+            if before is None:
+                summary.inserted += 1
+            elif before == (
+                candidate.gloss_a,
+                candidate.gloss_b,
+                candidate.source_url,
+                candidate.confidence,
+                candidate.review_status,
+            ):
+                summary.unchanged += 1
+            else:
+                summary.updated += 1
+        conn.commit()
+    finally:
+        conn.close()
+    return summary
+
+
 def _print_summary(summary: LoadSummary, by_source_relation: Counter[tuple[str, str]]) -> None:
     print(
         "relation candidates: "
@@ -251,6 +352,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Load VESUM-gated relation candidate JSON into sources.db.")
     parser.add_argument("--db", type=Path, default=DEFAULT_DB, help="SQLite sources database path.")
     parser.add_argument("--candidates-dir", type=Path, default=DEFAULT_CANDIDATES_DIR, help="Directory containing *_candidates_*.json artifacts.")
+    parser.add_argument("--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS, help="Reviewed synonym verdict YAML.")
     parser.add_argument("--source", dest="source_filter", help="Load only records attributed to this source.")
     parser.add_argument("--dry-run", action="store_true", help="Validate and summarize without creating or changing the database.")
     args = parser.parse_args()
@@ -261,6 +363,17 @@ def main() -> int:
         dry_run=args.dry_run,
     )
     _print_summary(summary, by_source_relation)
+    verdict_summary = load_approved_synonym_verdicts(
+        args.db,
+        args.synonym_verdicts,
+        dry_run=args.dry_run,
+    )
+    print(
+        "approved synonym verdicts: "
+        f"accepted={verdict_summary.accepted} inserted={verdict_summary.inserted} "
+        f"updated={verdict_summary.updated} unchanged={verdict_summary.unchanged} "
+        f"skipped_vesum={verdict_summary.skipped_vesum}"
+    )
     return 0
 
 

--- a/scripts/lexicon/relation_render_diff.py
+++ b/scripts/lexicon/relation_render_diff.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Diff rendered Word Atlas relation sections before manifest promotion.
+
+This gate intentionally compares the manifest that the site renders, rather
+than source database rows. Section caps and merge order can displace visible
+chips even when all raw relation facts remain present.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SECTION_RELATIONS = {
+    "synonyms": "synonym",
+    "antonyms": "antonym",
+    "homonyms": "homonym",
+    "paronyms": "paronym",
+}
+RELATIONS = tuple(SECTION_RELATIONS.values())
+SECTION_CAPS = {relation: 8 for relation in RELATIONS}
+_STRESS_MARK_RE = re.compile("[\u0300\u0301]")
+_ARROW_TARGET_RE = re.compile(r"→\s*(.+?)(?:\s+\[[^\]]*\])?$")
+
+
+@dataclass(frozen=True, slots=True)
+class RenderedEdge:
+    """One relation a learner can see in a rendered manifest section."""
+
+    lemma: str
+    lemma_key: str
+    relation: str
+    displayed_target: str
+    target_key: str
+    order: int
+    provenance: tuple[str, ...]
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        return (self.lemma_key, self.relation, self.target_key)
+
+    @property
+    def source_bucket(self) -> str:
+        source_labels = [label for label in self.provenance if not label.startswith("url: ")]
+        labels = " ".join(source_labels).casefold()
+        if source_labels and "ukrajinet" in labels and all("ukrajinet" in label.casefold() for label in source_labels):
+            return "ukrajinet_only"
+        return "retained_source"
+
+
+def normalized_displayed_target(value: object) -> str:
+    """Normalize visible text for stable relation-edge identity comparison."""
+    text = unicodedata.normalize("NFKD", str(value or ""))
+    text = _STRESS_MARK_RE.sub("", text)
+    text = unicodedata.normalize("NFC", text)
+    text = text.replace("`", "'").replace("’", "'").replace("ʼ", "'")
+    return re.sub(r"\s+", " ", text).strip().casefold()
+
+
+def _displayed_target(relation: str, item: object) -> str | None:
+    if isinstance(item, str):
+        return item.strip() or None
+    if not isinstance(item, dict):
+        return None
+    if relation in {"synonym", "antonym"}:
+        value = item.get("text") or item.get("item")
+        return str(value).strip() or None
+
+    word = str(item.get("word") or item.get("text") or "").strip()
+    if not word:
+        return None
+    detail_key = "gloss" if relation == "homonym" else "distinction"
+    detail = str(item.get(detail_key) or "").strip()
+    return f"{word} — {detail}" if detail else word
+
+
+def _target_specific_source(label: str) -> str | None:
+    match = _ARROW_TARGET_RE.search(label)
+    if not match:
+        return None
+    return normalized_displayed_target(match.group(1).removesuffix(" (reciprocal)"))
+
+
+def _section_provenance(section: dict[str, Any], target_key: str) -> tuple[str, ...]:
+    labels: list[str] = []
+    source = section.get("source")
+    if isinstance(source, str):
+        for label in (part.strip() for part in source.split(" + ")):
+            target = _target_specific_source(label)
+            if label and (target is None or target == target_key or target_key.startswith(f"{target} — ")):
+                labels.append(label)
+    source_urls = section.get("source_urls")
+    if isinstance(source_urls, list):
+        labels.extend(f"url: {url}" for url in source_urls if str(url).strip())
+    return tuple(dict.fromkeys(labels))
+
+
+def rendered_edges(manifest: dict[str, Any]) -> list[RenderedEdge]:
+    """Extract canonical relation edges from display-ready manifest sections."""
+    edges: list[RenderedEdge] = []
+    seen: set[tuple[str, str, str]] = set()
+    for entry in manifest.get("entries", []):
+        if not isinstance(entry, dict):
+            continue
+        lemma = str(entry.get("lemma") or "").strip()
+        lemma_key = normalized_displayed_target(lemma)
+        if not lemma_key:
+            continue
+        sections = entry.get("sections")
+        if not isinstance(sections, dict):
+            continue
+        for section_name, relation in SECTION_RELATIONS.items():
+            section = sections.get(section_name)
+            if not isinstance(section, dict):
+                continue
+            items = section.get("items")
+            if not isinstance(items, list):
+                continue
+            for order, item in enumerate(items):
+                displayed_target = _displayed_target(relation, item)
+                target_key = normalized_displayed_target(displayed_target)
+                if not displayed_target or not target_key:
+                    continue
+                key = (lemma_key, relation, target_key)
+                if key in seen:
+                    continue
+                seen.add(key)
+                provenance = list(_section_provenance(section, target_key))
+                if isinstance(item, dict) and relation == "paronym":
+                    raw_provenance = item.get("exam_provenance")
+                    values = raw_provenance if isinstance(raw_provenance, list) else [raw_provenance]
+                    provenance.extend(str(value).strip() for value in values if str(value).strip())
+                edges.append(
+                    RenderedEdge(
+                        lemma=lemma,
+                        lemma_key=lemma_key,
+                        relation=relation,
+                        displayed_target=displayed_target,
+                        target_key=target_key,
+                        order=order,
+                        provenance=tuple(dict.fromkeys(provenance)),
+                    )
+                )
+    return edges
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Manifest must be a JSON object: {path}")
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError(f"Manifest entries must be a list: {path}")
+    return payload
+
+
+def _edge_map(edges: list[RenderedEdge]) -> dict[tuple[str, str, str], RenderedEdge]:
+    return {edge.key: edge for edge in edges}
+
+
+def _relation_totals(
+    old: dict[tuple[str, str, str], RenderedEdge],
+    new: dict[tuple[str, str, str], RenderedEdge],
+) -> dict[str, dict[str, int]]:
+    return {
+        relation: {
+            "old": sum(edge.relation == relation for edge in old.values()),
+            "new": sum(edge.relation == relation for edge in new.values()),
+            "gained": sum(key not in old and edge.relation == relation for key, edge in new.items()),
+            "lost": sum(key not in new and edge.relation == relation for key, edge in old.items()),
+        }
+        for relation in RELATIONS
+    }
+
+
+def _source_totals(
+    old: dict[tuple[str, str, str], RenderedEdge],
+    new: dict[tuple[str, str, str], RenderedEdge],
+) -> dict[str, dict[str, int]]:
+    totals: dict[str, dict[str, int]] = {}
+    for bucket in ("retained_source", "ukrajinet_only"):
+        totals[bucket] = {
+            "old": sum(edge.source_bucket == bucket for edge in old.values()),
+            "new": sum(edge.source_bucket == bucket for edge in new.values()),
+            "gained": sum(
+                key not in old and edge.source_bucket == bucket for key, edge in new.items()
+            ),
+            "lost": sum(
+                key not in new and edge.source_bucket == bucket for key, edge in old.items()
+            ),
+        }
+    return totals
+
+
+def _per_lemma(
+    old: dict[tuple[str, str, str], RenderedEdge],
+    new: dict[tuple[str, str, str], RenderedEdge],
+) -> list[dict[str, Any]]:
+    keys = set(old) | set(new)
+    lemma_keys = sorted({key[0] for key in keys})
+    results: list[dict[str, Any]] = []
+    for lemma_key in lemma_keys:
+        old_edges = [edge for edge in old.values() if edge.lemma_key == lemma_key]
+        new_edges = [edge for edge in new.values() if edge.lemma_key == lemma_key]
+        gained = [edge for key, edge in new.items() if key not in old and edge.lemma_key == lemma_key]
+        lost = [edge for key, edge in old.items() if key not in new and edge.lemma_key == lemma_key]
+        if not gained and not lost:
+            continue
+        exemplar = (new_edges or old_edges)[0]
+        results.append(
+            {
+                "lemma": exemplar.lemma,
+                "old": len(old_edges),
+                "new": len(new_edges),
+                "gained": [_edge_label(edge) for edge in sorted(gained, key=_edge_sort_key)],
+                "lost": [_edge_label(edge) for edge in sorted(lost, key=_edge_sort_key)],
+            }
+        )
+    return results
+
+
+def _edge_label(edge: RenderedEdge) -> str:
+    return f"{edge.relation} → {edge.displayed_target}"
+
+
+def _edge_sort_key(edge: RenderedEdge) -> tuple[str, str, int, str]:
+    return (edge.lemma_key, edge.relation, edge.order, edge.target_key)
+
+
+def _displaced_by_caps(
+    old: dict[tuple[str, str, str], RenderedEdge],
+    new: dict[tuple[str, str, str], RenderedEdge],
+) -> list[dict[str, Any]]:
+    displaced: list[dict[str, Any]] = []
+    for key, lost_edge in old.items():
+        if key in new:
+            continue
+        replacement_edges = [
+            edge
+            for edge in new.values()
+            if edge.lemma_key == lost_edge.lemma_key and edge.relation == lost_edge.relation
+        ]
+        cap = SECTION_CAPS[lost_edge.relation]
+        if len(replacement_edges) < cap:
+            continue
+        gained = [
+            edge.displayed_target
+            for edge in replacement_edges
+            if edge.key not in old
+        ]
+        displaced.append(
+            {
+                "lemma": lost_edge.lemma,
+                "relation": lost_edge.relation,
+                "lost_target": lost_edge.displayed_target,
+                "cap": cap,
+                "new_targets": [edge.displayed_target for edge in sorted(replacement_edges, key=_edge_sort_key)],
+                "gained_targets": gained,
+            }
+        )
+    return sorted(
+        displaced,
+        key=lambda item: (
+            normalized_displayed_target(item["lemma"]),
+            item["relation"],
+            normalized_displayed_target(item["lost_target"]),
+        ),
+    )
+
+
+def diff_manifests(baseline: dict[str, Any], current: dict[str, Any]) -> dict[str, Any]:
+    """Return deterministic report data for two built manifests."""
+    old = _edge_map(rendered_edges(baseline))
+    new = _edge_map(rendered_edges(current))
+    lost = [edge for key, edge in old.items() if key not in new]
+    emptied = [
+        {"lemma": edges[0].lemma, "old": len(edges), "new": 0}
+        for lemma_key in sorted({edge.lemma_key for edge in old.values()})
+        if (edges := [edge for edge in old.values() if edge.lemma_key == lemma_key])
+        and not any(edge.lemma_key == lemma_key for edge in new.values())
+    ]
+    return {
+        "relations": _relation_totals(old, new),
+        "sources": _source_totals(old, new),
+        "per_lemma": _per_lemma(old, new),
+        "nonempty_to_empty": emptied,
+        "lost_provenance": [
+            {
+                "lemma": edge.lemma,
+                "relation": edge.relation,
+                "target": edge.displayed_target,
+                "provenance": list(edge.provenance),
+            }
+            for edge in sorted(lost, key=_edge_sort_key)
+        ],
+        "cap_displacements": _displaced_by_caps(old, new),
+    }
+
+
+def format_report(report: dict[str, Any]) -> str:
+    """Render a concise human review gate report with all loss evidence."""
+    lines = ["=== RENDERED RELATION DIFF ===", "", "GLOBAL TOTALS"]
+    for relation in RELATIONS:
+        totals = report["relations"][relation]
+        lines.append(
+            f"  {relation:8} old={totals['old']} new={totals['new']} "
+            f"gained={totals['gained']} lost={totals['lost']}"
+        )
+    lines.extend(["", "SOURCE TOTALS"])
+    for bucket, label in (("retained_source", "retained-source"), ("ukrajinet_only", "Ukrajinet-only")):
+        totals = report["sources"][bucket]
+        lines.append(
+            f"  {label:16} old={totals['old']} new={totals['new']} "
+            f"gained={totals['gained']} lost={totals['lost']}"
+        )
+
+    lines.extend(["", "PER-LEMMA CHANGES"])
+    if not report["per_lemma"]:
+        lines.append("  none")
+    for item in report["per_lemma"]:
+        lines.append(f"  {item['lemma']}: old={item['old']} new={item['new']}")
+        if item["gained"]:
+            lines.append(f"    gained: {', '.join(item['gained'])}")
+        if item["lost"]:
+            lines.append(f"    lost: {', '.join(item['lost'])}")
+
+    lines.extend(["", "NONEMPTY → EMPTY"])
+    if not report["nonempty_to_empty"]:
+        lines.append("  none")
+    for item in report["nonempty_to_empty"]:
+        lines.append(f"  {item['lemma']}: old={item['old']} new=0")
+
+    lines.extend(["", "LOST TARGET PROVENANCE"])
+    if not report["lost_provenance"]:
+        lines.append("  none")
+    for item in report["lost_provenance"]:
+        provenance = "; ".join(item["provenance"]) or "<missing rendered provenance>"
+        lines.append(f"  {item['lemma']} → {item['relation']} → {item['target']} [{provenance}]")
+
+    lines.extend(["", "CAP DISPLACEMENTS"])
+    if not report["cap_displacements"]:
+        lines.append("  none")
+    for item in report["cap_displacements"]:
+        gained = ", ".join(item["gained_targets"]) or "none"
+        lines.append(
+            f"  {item['lemma']} → {item['relation']} lost {item['lost_target']}; "
+            f"new section is at cap {item['cap']}; gained={gained}"
+        )
+    return "\n".join(lines)
+
+
+def run(baseline_path: Path, current_path: Path, *, as_json: bool = False) -> dict[str, Any]:
+    report = diff_manifests(_load_manifest(baseline_path), _load_manifest(current_path))
+    print(json.dumps(report, ensure_ascii=False, indent=2) if as_json else format_report(report))
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Diff rendered relation sections between two Atlas manifests.")
+    parser.add_argument("baseline", type=Path, help="Previously built manifest JSON.")
+    parser.add_argument("current", type=Path, help="Newly built manifest JSON.")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable report JSON.")
+    args = parser.parse_args()
+    run(args.baseline, args.current, as_json=args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "fcd9d835253fdf3bba83cd2897be1583e1133e663552b9a337f975671e24611e",
+  "fingerprint": "036aabae5f944d3451dceba79ce00299391c6834de9578ae775451aa87c3d9f6",
   "inputs": {
     "lexicon_code": [
       {
@@ -52,7 +52,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "492b0b006d1bbc69246579fed393a705883e5be4d09b1b8b930543cad15a3aa2"
+        "sha256": "a5e77321061a7d6128e9946ca8b11aedd2ee05fb8e90cd6ec647210a4c54b580"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -100,7 +100,7 @@
       },
       {
         "path": "scripts/lexicon/load_relation_candidates.py",
-        "sha256": "a970db4d2867a6fd182d186176058070b6d090c87a42f1368ef82642aa0d7f69"
+        "sha256": "a5c441ecd45ff470f001c6d430f2968113f94f2ed8465350df444a86d915f5a0"
       },
       {
         "path": "scripts/lexicon/manifest_fingerprint.py",
@@ -139,6 +139,10 @@
         "sha256": "24781db1d0078fd7e83c349477ff764cd409c11b202949a3c615dcf9654d2fa1"
       },
       {
+        "path": "scripts/lexicon/relation_render_diff.py",
+        "sha256": "9a6be21d3fb920bb0fa90f5e594144a65dbf4f2d5c033c3dbbe1aab59a900313"
+      },
+      {
         "path": "scripts/lexicon/repair_plural_noun_aliases.py",
         "sha256": "212d5d59061e2b3709e6f62b0861ccf0c98dfa4e1d63922efa8c5fce3d356416"
       },
@@ -155,6 +159,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 37
+    "lexicon_code_files": 38
   }
 }

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 import pytest
 
 from scripts.lexicon import enrich_manifest as enrich_manifest_module
+from scripts.lexicon import load_relation_candidates as relation_loader
 from scripts.lexicon.enrich_manifest import (
     _BALLA_REVERSE_SOURCE,
     _DROP_ANTONYM_LEMMAS,
@@ -31,7 +32,6 @@ from scripts.lexicon.enrich_manifest import (
     _dmklinger_key,
     _etymology,
     _etymology_lookup_variants,
-    _gated_ukrajinet_relations,
     _homonym_relations,
     _homonym_relations_by_headword,
     _idioms,
@@ -97,10 +97,6 @@ def _conn() -> sqlite3.Connection:
             word TEXT NOT NULL,
             definitions TEXT DEFAULT '',
             synonyms TEXT DEFAULT ''
-        );
-        CREATE TABLE ukrajinet (
-            words TEXT NOT NULL DEFAULT '',
-            text TEXT NOT NULL DEFAULT ''
         );
         CREATE TABLE balla_en_uk (
             word TEXT NOT NULL,
@@ -519,37 +515,11 @@ def test_morphology_form_count_matches_rendered_rows_after_cap(monkeypatch) -> N
     assert morphology["form_count"] == len(morphology["forms"])
 
 
-def test_legacy_synonym_sources_drop_wordnet_and_ukrajinet_noise() -> None:
+def test_legacy_synonym_sources_drop_wordnet_noise() -> None:
     conn = _conn()
     conn.execute(
         "INSERT INTO wiktionary VALUES (?, ?, ?)",
         ("кава", "[]", json.dumps(["кавове зерно", "кофе", "галка"], ensure_ascii=False)),
-    )
-    conn.executemany(
-        "INSERT INTO ukrajinet VALUES (?, ?)",
-        [
-            (json.dumps(["Java", "кава"], ensure_ascii=False), "Синоніми: Java, кава"),
-            (
-                json.dumps(["Палена умбра", "Шоколад", "кава", "темно-коричневий"], ensure_ascii=False),
-                "Синоніми: Палена умбра, Шоколад, кава, темно-коричневий",
-            ),
-            (
-                json.dumps(["hot seat", "електричний стілець", "стілець", "стілець смерті"], ensure_ascii=False),
-                "Синоніми: hot seat, електричний стілець, стілець, стілець смерті",
-            ),
-            (
-                json.dumps(["toppingly", "дивовижний", "жахливо", "чудово"], ensure_ascii=False),
-                "Синоніми: toppingly, дивовижний, жахливо, чудово",
-            ),
-            (
-                json.dumps(["gorgeously", "splendidly", "блискуче", "чудово"], ensure_ascii=False),
-                "Синоніми: gorgeously, splendidly, блискуче, чудово",
-            ),
-            (
-                json.dumps(["Chrysanthemum morifolium", "Хризантема флористів", "мама"], ensure_ascii=False),
-                "Синоніми: Chrysanthemum morifolium, Хризантема флористів, мама",
-            ),
-        ],
     )
     conn.executemany(
         "INSERT INTO balla_en_uk VALUES (?, ?, ?)",
@@ -2912,7 +2882,7 @@ def test_homonym_relation_merge_preserves_gloss_schema_and_source_urls() -> None
     }
 
 
-def test_corpus_relation_pairs_are_vesum_gated_and_attributed(monkeypatch) -> None:
+def test_corpus_relation_pairs_render_only_approved_rows(monkeypatch) -> None:
     conn = _conn()
     conn.executemany(
         """
@@ -2922,21 +2892,30 @@ def test_corpus_relation_pairs_are_vesum_gated_and_attributed(monkeypatch) -> No
         """,
         [
             ("synonym", "гарний", "вродливий", "", "", "miyklas.com.ua", "https://example.invalid/syn", "candidate"),
+            ("synonym", "гарний", "чудовий", "", "", "miyklas.com.ua", "", "approved"),
             ("antonym", "гарний", "поганий", "", "", "uk.wikipedia", "", "approved"),
-            ("paronym", "адрес", "адреса", "привітальний лист", "місце проживання", "ukr-mova.in.ua", "", "candidate"),
-            ("homonym", "ключ", "ключ", "знаряддя для замикання", "джерело води", "uk.wikipedia", "", "candidate"),
+            ("paronym", "адрес", "адреса", "привітальний лист", "місце проживання", "ukr-mova.in.ua", "", "approved"),
+            ("homonym", "ключ", "ключ", "знаряддя для замикання", "джерело води", "uk.wikipedia", "", "approved"),
             ("synonym", "гарний", "вигадка", "", "", "miyklas.com.ua", "", "rejected"),
         ],
     )
-    _patch_synonym_vesum(monkeypatch, {"гарний", "вродливий", "поганий", "адрес", "адреса", "ключ"})
+    _patch_synonym_vesum(monkeypatch, {"гарний", "вродливий", "чудовий", "поганий", "адрес", "адреса", "ключ"})
 
     relations = _corpus_relation_pairs_by_headword(
         conn,
         {"entries": [{"lemma": "гарний"}, {"lemma": "адрес"}, {"lemma": "ключ"}]},
     )
 
-    assert relations["гарний"]["synonym"][0]["item"] == "вродливий"
-    assert relations["гарний"]["synonym"][0]["source"] == "relation_pairs/miyklas.com.ua"
+    assert relations["гарний"]["synonym"] == [
+        {
+            "item": "чудовий",
+            "source": "relation_pairs/miyklas.com.ua",
+            "pattern": "corpus relation pair",
+            "vein": 3,
+            "gate": {"vesum": "both valid"},
+        }
+    ]
+    assert "вродливий" not in [item["item"] for item in relations["гарний"]["synonym"]]
     assert relations["гарний"]["antonym"][0]["item"] == "поганий"
     assert relations["адрес"]["paronym"][0]["distinction"] == "місце проживання"
     assert [item["gloss"] for item in relations["ключ"]["homonym"]] == [
@@ -2949,6 +2928,76 @@ def test_corpus_relation_pairs_are_vesum_gated_and_attributed(monkeypatch) -> No
         {"word": "ключ", "gloss": "знаряддя для замикання"},
         {"word": "ключ", "gloss": "джерело води"},
     ]
+
+
+def test_approved_cafe_verdict_renders_on_both_lemmas_and_resolves_form_aliases(tmp_path, monkeypatch) -> None:
+    verdicts_path = tmp_path / "synonym_pair_verdicts.yaml"
+    verdicts_path.write_text(
+        """approved:
+- a: кафе
+  b: кав'ярня
+  polarity: synonym
+- a: кав'ярня
+  b: кафе
+  polarity: synonym
+- a: крамниці
+  b: магазин
+  polarity: synonym
+- a: кафе
+  b: кафе
+  polarity: synonym
+rejected:
+- a: кафе
+  b: ресторан
+  polarity: synonym
+""",
+        encoding="utf-8",
+    )
+    db_path = tmp_path / "sources.db"
+    monkeypatch.setattr(relation_loader, "is_exact_vesum_lemma", lambda word: True)
+
+    summary = relation_loader.load_approved_synonym_verdicts(db_path, verdicts_path)
+
+    assert summary.accepted == 2
+    assert summary.inserted == 2
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT relation, word_a, word_b, source, review_status FROM relation_pairs ORDER BY word_a"
+    ).fetchall()
+    assert {
+        (relation, frozenset((word_a, word_b)), source, review_status)
+        for relation, word_a, word_b, source, review_status in rows
+    } == {
+        ("synonym", frozenset(("кафе", "кав'ярня")), "synonym_verdicts", "approved"),
+        ("synonym", frozenset(("крамниці", "магазин")), "synonym_verdicts", "approved"),
+    }
+    _patch_synonym_vesum(monkeypatch, {"кафе", "кав'ярня", "крамниці", "крамниця", "магазин"})
+    manifest = {
+        "entries": [
+            {"lemma": "кафе", "url_slug": "cafe"},
+            {"lemma": "кав'ярня", "url_slug": "coffeehouse"},
+            {"lemma": "крамниця", "url_slug": "store"},
+            {"lemma": "магазин", "url_slug": "shop"},
+            {
+                "lemma": "крамниці",
+                "url_slug": "stores",
+                "form_of": {"lemma": "крамниця", "url_slug": "store"},
+            },
+        ]
+    }
+
+    try:
+        relations = _corpus_relation_pairs_by_headword(conn, manifest)
+    finally:
+        conn.close()
+
+    cafe = _merge_synonym_relations(None, relations["кафе"]["synonym"])
+    coffeehouse = _merge_synonym_relations(None, relations["кав'ярня"]["synonym"])
+    assert cafe is not None and cafe["items"] == ["кав'ярня"]
+    assert coffeehouse is not None and coffeehouse["items"] == ["кафе"]
+    assert "relation_pairs/synonym_verdicts" in cafe["source"]
+    assert relations["крамниця"]["synonym"][0]["item"] == "магазин"
+    assert "крамниці" not in relations
 
 
 def test_homonym_fixture_samples_expand_from_zero(monkeypatch) -> None:
@@ -3193,94 +3242,66 @@ def test_definition_pointer_relations_emit_reciprocal_manifest_headword(monkeypa
     assert relations["кав'ярня"][0]["direction"] == "reciprocal"
 
 
-def test_gated_ukrajinet_pair_requires_direct_lexical_coattestation(monkeypatch) -> None:
-    _patch_synonym_vesum(monkeypatch, {"кафе", "кав'ярня"})
+def test_ключ_drops_ukrajinet_targets_and_keeps_karavansky_synonym(monkeypatch) -> None:
+    """The rendered manifest must never reopen the auto-translated WordNet vein."""
+    _patch_synonym_vesum(monkeypatch, {"ключ", "джерело", "живець", "відмикач"})
     conn = _conn()
+    conn.execute("CREATE TABLE ukrajinet (words TEXT NOT NULL, text TEXT NOT NULL)")
     conn.execute(
         "INSERT INTO ukrajinet(words, text) VALUES (?, ?)",
-        ('["кафе", "кав\'ярня"]', "fixture"),
+        ('["ключ", "джерело", "живець"]', "fixture for removed relation vein"),
     )
     conn.execute(
         "INSERT INTO sum11(word, definition) VALUES (?, ?)",
-        ("кафе", "Заклад; те саме, що кав'ярня."),
+        ("ключ", "Знаряддя; джерело води; живець."),
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_slovnyk_cache", lambda lemma: {})
+    monkeypatch.setattr(enrich_manifest_module, "_definition_cards", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "classify_lemma",
+        lambda lemma: {"classification": "standard", "is_russianism": False, "attestations": []},
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_warning_slovnyk", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_curated_calque", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_reverse_calques", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_kaikki_pronunciation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "_synonyms_slovnyk",
+        lambda *args, **kwargs: {
+            "items": ["відмикач"],
+            "source": "slovnyk.me: Словник синонімів Караванського",
+        },
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_antonyms_wiktionary", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_idioms", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_stress_display_form", lambda *args, **kwargs: "")
+    monkeypatch.setattr(enrich_manifest_module, "_kaikki_stress", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_cefr", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_morphology", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_meaning", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_etymology", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_literary_attestation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_wiki_reference", lambda *args, **kwargs: None)
+    monkeypatch.setattr(enrich_manifest_module, "_base_lookup_for_entry", lambda *args, **kwargs: None)
+
+    entry = {"lemma": "ключ", "pos": "noun"}
+    assert enrich_manifest_module.enrich_entry(
+        entry,
+        conn,
+        {},
+        has_sum11_flags=True,
+        pointer_synonym_relations=[],
+        pointer_antonym_relations=[],
+        pointer_homonym_relations=[],
+        pointer_paronym_relations=[],
     )
 
-    relations = _gated_ukrajinet_relations(conn, "кафе", has_sum11_flags=True, cache={})
-
-    assert relations == [
-        {
-            "item": "кав'ярня",
-            "source": "Ukrajinet WordNet",
-            "pattern": "gated synset",
-            "vein": 2,
-            "gate": {
-                "vesum": "both valid",
-                "co_attestation": {
-                    "kind": "definition_mention",
-                    "dictionary": "СУМ-11",
-                    "direction": "lemma→candidate",
-                },
-                "synset_id": "",
-            },
-        }
-    ]
-
-
-def test_gated_ukrajinet_pair_can_use_shared_vesum_content_stem(monkeypatch) -> None:
-    valid = {"школа", "училище", "навчальний", "заклад", "для", "учнів", "навчання"}
-    _patch_synonym_vesum(monkeypatch, valid)
-    conn = _conn()
-    conn.execute(
-        "INSERT INTO ukrajinet(words, text) VALUES (?, ?)",
-        ('["школа", "училище"]', "fixture"),
-    )
-    conn.executemany(
-        "INSERT INTO sum11(word, definition) VALUES (?, ?)",
-        [
-            ("школа", "Навчальний заклад для учнів."),
-            ("училище", "Заклад для навчання."),
-        ],
-    )
-
-    relations = _gated_ukrajinet_relations(conn, "школа", has_sum11_flags=True, cache={})
-
-    assert relations[0]["item"] == "училище"
-    assert relations[0]["gate"]["co_attestation"] == {
-        "kind": "shared_content_stem",
-        "dictionaries": ["СУМ-11", "СУМ-11"],
-        "stem": "заклад",
-    }
-
-
-def test_gated_ukrajinet_pair_fails_closed_without_coattestation(monkeypatch) -> None:
-    _patch_synonym_vesum(monkeypatch, {"глина", "пісок"})
-    conn = _conn()
-    conn.execute(
-        "INSERT INTO ukrajinet(words, text) VALUES (?, ?)",
-        ('["глина", "пісок"]', "fixture"),
-    )
-    conn.executemany(
-        "INSERT INTO sum11(word, definition) VALUES (?, ?)",
-        [("глина", "Мінеральна порода."), ("пісок", "Сипучий матеріал.")],
-    )
-
-    assert _gated_ukrajinet_relations(conn, "глина", has_sum11_flags=True, cache={}) == []
-
-
-def test_sovietized_row_keeps_pointer_but_cannot_open_ukrajinet_gate(monkeypatch) -> None:
-    _patch_synonym_vesum(monkeypatch, {"кафе", "кав'ярня"})
-    conn = _conn()
-    conn.execute(
-        "INSERT INTO ukrajinet(words, text) VALUES (?, ?)",
-        ('["кафе", "кав\'ярня"]', "fixture"),
-    )
-    conn.execute(
-        "INSERT INTO sum11(word, definition, sovietization_risk) VALUES (?, ?, ?)",
-        ("кафе", "Те саме, що кав'ярня.", 2),
-    )
-
-    assert _definition_pointer_relations(conn, "кафе", has_sum11_flags=True, cache={})[0]["item"] == "кав'ярня"
-    assert _gated_ukrajinet_relations(conn, "кафе", has_sum11_flags=True, cache={}) == []
+    items = entry["sections"]["synonyms"]["items"]
+    assert "джерело" not in items
+    assert "живець" not in items
+    assert items == ["відмикач"]
 
 
 def test_synonym_relation_merge_preserves_rendered_schema_deduplicates_and_caps() -> None:
@@ -3289,19 +3310,11 @@ def test_synonym_relation_merge_preserves_rendered_schema_deduplicates_and_caps(
         "source": "existing source",
         "source_urls": ["https://example.invalid/existing"],
     }
-    vein_two_first = {
+    lower_priority_relation = {
         "item": "дев'ятий",
-        "source": "Ukrajinet WordNet",
-        "pattern": "gated synset",
-        "vein": 2,
-        "gate": {
-            "vesum": "both valid",
-            "co_attestation": {
-                "kind": "definition_mention",
-                "dictionary": "СУМ-20",
-                "direction": "lemma→candidate",
-            },
-        },
+        "source": "relation_pairs/synonym_verdicts",
+        "pattern": "corpus relation pair",
+        "vein": 3,
     }
     pointer_items = ["перший", "другий", "третій", "четвертий", "п'ятий", "шостий", "сьомий", "восьмий", "десятий"]
     vein_one = [
@@ -3312,13 +3325,13 @@ def test_synonym_relation_merge_preserves_rendered_schema_deduplicates_and_caps(
         ],
     ]
 
-    merged = _merge_synonym_relations(existing, [vein_two_first, *vein_one])
+    merged = _merge_synonym_relations(existing, [lower_priority_relation, *vein_one])
 
     assert merged is not None
     assert set(merged) == {"items", "source", "source_urls"}
     assert merged["items"] == ["база (рідше)", *pointer_items[:8]]
     assert "СУМ-20: Те саме, що → база" in merged["source"]
-    assert "Ukrajinet WordNet" not in merged["source"]
+    assert "relation_pairs/synonym_verdicts" not in merged["source"]
 
 
 # Fixture-backed VESUM stubs for the xref tests. CI has no data/vesum.db (data/

--- a/tests/test_lexicon_enrich_manifest_perf_optimization.py
+++ b/tests/test_lexicon_enrich_manifest_perf_optimization.py
@@ -1,157 +1,13 @@
-import json
 import sqlite3
 import sys
 
-import pytest
-
 from scripts.lexicon import enrich_manifest as enrich_manifest_module
-from scripts.lexicon.enrich_manifest import (
-    _idioms_frazeolohichnyi,
-    _synonyms_from_ukrajinet,
-)
+from scripts.lexicon.enrich_manifest import _idioms_frazeolohichnyi
 
 
 def _force_like(cache: dict, conn: sqlite3.Connection) -> None:
     """Seed the per-DB availability cache with False so the LIKE path runs."""
     cache[enrich_manifest_module._db_cache_key(conn)] = False
-
-
-def test_ukrajinet_exact_hit_and_parity_and_idempotency(tmp_path, monkeypatch):
-    # Mock candidate_allowed to always return True for this test to focus on lookup/matching
-    monkeypatch.setattr(
-        enrich_manifest_module,
-        "_candidate_allowed",
-        lambda lemma, candidate: True
-    )
-
-    db_path = tmp_path / "test_sources.db"
-    conn = sqlite3.connect(db_path)
-
-    conn.execute("""
-        CREATE TABLE ukrajinet (
-            id INTEGER PRIMARY KEY,
-            words TEXT NOT NULL DEFAULT ''
-        )
-    """)
-
-    conn.execute("INSERT INTO ukrajinet (words) VALUES (?)", (json.dumps(["бігати", "швидко"], ensure_ascii=False),))
-    conn.execute("INSERT INTO ukrajinet (words) VALUES (?)", (json.dumps(["йти", "пішки"], ensure_ascii=False),))
-    conn.execute("INSERT INTO ukrajinet (words) VALUES (?)", (json.dumps(["бігати"], ensure_ascii=False),))
-    conn.commit()
-
-    enrich_manifest_module._UKRAJINET_INDEX_AVAILABLE.clear()
-
-    # Test exact-hit short circuit / index population
-    out_idx = []
-    seen_idx = set()
-    _synonyms_from_ukrajinet(conn, "бігати", out_idx, seen_idx)
-    assert "швидко" in out_idx
-    assert "йти" not in out_idx
-
-    # Check that the index was lazily created and populated
-    cursor = conn.execute("SELECT COUNT(*) FROM ukrajinet_word_index")
-    count1 = cursor.fetchone()[0]
-    assert count1 > 0
-
-    # Test idempotency (calling _ensure_ukrajinet_word_index again should be a no-op)
-    enrich_manifest_module._UKRAJINET_INDEX_AVAILABLE.clear()
-    _synonyms_from_ukrajinet(conn, "йти", out_idx, seen_idx)
-    assert "пішки" in out_idx
-
-    cursor = conn.execute("SELECT COUNT(*) FROM ukrajinet_word_index")
-    count2 = cursor.fetchone()[0]
-    assert count1 == count2
-
-    # Test parity vs LIKE fallback
-    _force_like(enrich_manifest_module._UKRAJINET_INDEX_AVAILABLE, conn)
-    out_like = []
-    seen_like = set()
-    _synonyms_from_ukrajinet(conn, "бігати", out_like, seen_like)
-    assert set(out_like) == {"бігати", "швидко"}
-
-    out_fresh_idx = []
-    seen_fresh_idx = set()
-    enrich_manifest_module._UKRAJINET_INDEX_AVAILABLE.clear()
-    _synonyms_from_ukrajinet(conn, "бігати", out_fresh_idx, seen_fresh_idx)
-
-    out_fresh_like = []
-    seen_fresh_like = set()
-    _force_like(enrich_manifest_module._UKRAJINET_INDEX_AVAILABLE, conn)
-    _synonyms_from_ukrajinet(conn, "бігати", out_fresh_like, seen_fresh_like)
-
-    assert out_fresh_idx == out_fresh_like
-    conn.close()
-
-
-def test_ukrajinet_readonly_degrades(tmp_path, monkeypatch):
-    monkeypatch.setattr(
-        enrich_manifest_module,
-        "_candidate_allowed",
-        lambda lemma, candidate: True
-    )
-
-    db_path = tmp_path / "test_sources.db"
-    conn = sqlite3.connect(db_path)
-    conn.execute("""
-        CREATE TABLE ukrajinet (
-            id INTEGER PRIMARY KEY,
-            words TEXT NOT NULL DEFAULT ''
-        )
-    """)
-    conn.execute("INSERT INTO ukrajinet (words) VALUES (?)", (json.dumps(["бігати"], ensure_ascii=False),))
-    conn.commit()
-    conn.close()
-
-    conn_ro = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
-
-    enrich_manifest_module._UKRAJINET_INDEX_AVAILABLE.clear()
-    enrich_manifest_module._UKRAJINET_INDEX_WARN_LOGGED = False
-
-    captured_stderr = []
-    monkeypatch.setattr(sys, "stderr", type("StderrMock", (object,), {"write": captured_stderr.append, "flush": lambda self: None})())
-
-    out = []
-    seen = set()
-    _synonyms_from_ukrajinet(conn_ro, "бігати", out, seen)
-
-    err_text = "".join(captured_stderr)
-    assert "ukrajinet_word_index table is missing and connection is read-only" in err_text
-    conn_ro.close()
-
-
-def test_ukrajinet_cyrillic_case_parity(tmp_path, monkeypatch):
-    """The sidecar index casefolds Cyrillic at build time; SQLite's ASCII-only
-    lower()+LIKE does not. The indexed path must NOT surface rows the LIKE
-    fallback never matched (capitalized Cyrillic in the raw JSON)."""
-    monkeypatch.setattr(
-        enrich_manifest_module,
-        "_candidate_allowed",
-        lambda lemma, candidate: True
-    )
-
-    db_path = tmp_path / "case_parity.db"
-    conn = sqlite3.connect(db_path)
-    conn.execute("""
-        CREATE TABLE ukrajinet (
-            id INTEGER PRIMARY KEY,
-            words TEXT NOT NULL DEFAULT ''
-        )
-    """)
-    # Capital Б: SQLite lower() leaves 'Брати' untouched → LIKE '%брати%' misses
-    # the row. 'родичі' deliberately does not embed the needle as a substring.
-    conn.execute("INSERT INTO ukrajinet (words) VALUES (?)", (json.dumps(["Брати", "родичі"], ensure_ascii=False),))
-    conn.commit()
-
-    enrich_manifest_module._UKRAJINET_INDEX_AVAILABLE.clear()
-    out_idx, seen_idx = [], set()
-    _synonyms_from_ukrajinet(conn, "брати", out_idx, seen_idx)
-
-    _force_like(enrich_manifest_module._UKRAJINET_INDEX_AVAILABLE, conn)
-    out_like, seen_like = [], set()
-    _synonyms_from_ukrajinet(conn, "брати", out_like, seen_like)
-
-    assert out_idx == out_like == []
-    conn.close()
 
 
 def test_frazeolohichnyi_fts_exact_hit_and_parity_and_idempotency(tmp_path, monkeypatch):
@@ -252,76 +108,6 @@ def test_frazeolohichnyi_fts_limit_crowding_parity(tmp_path, monkeypatch):
     conn.close()
 
 
-def test_index_availability_cached_per_database(tmp_path):
-    """codex #4514 finding 2: DB A's availability verdict must not leak onto
-    DB B in the same process."""
-    db_a = tmp_path / "a.db"
-    db_b = tmp_path / "b.db"
-
-    conn_a = sqlite3.connect(db_a)
-    conn_a.execute("CREATE TABLE ukrajinet (id INTEGER PRIMARY KEY, words TEXT NOT NULL DEFAULT '')")
-    conn_a.execute("INSERT INTO ukrajinet (words) VALUES (?)", (json.dumps(["бігати"], ensure_ascii=False),))
-    conn_a.commit()
-
-    enrich_manifest_module._UKRAJINET_INDEX_AVAILABLE.clear()
-    enrich_manifest_module._UKRAJINET_INDEX_WARN_LOGGED = True  # silence warns
-
-    assert enrich_manifest_module._ensure_ukrajinet_word_index(conn_a) is True
-
-    # DB B: same table shape, NO sidecar index, read-only connection. With the
-    # leaked verdict it would claim True and serve empty indexed results; the
-    # per-DB cache must return False (degrade to LIKE) instead.
-    setup_b = sqlite3.connect(db_b)
-    setup_b.execute("CREATE TABLE ukrajinet (id INTEGER PRIMARY KEY, words TEXT NOT NULL DEFAULT '')")
-    setup_b.execute("INSERT INTO ukrajinet (words) VALUES (?)", (json.dumps(["бігати"], ensure_ascii=False),))
-    setup_b.commit()
-    setup_b.close()
-    conn_b = sqlite3.connect(f"file:{db_b}?mode=ro", uri=True)
-
-    assert enrich_manifest_module._ensure_ukrajinet_word_index(conn_b) is False
-    # And DB A's verdict is untouched.
-    assert enrich_manifest_module._ensure_ukrajinet_word_index(conn_a) is True
-
-    conn_a.close()
-    conn_b.close()
-
-
-def test_pathless_db_verdicts_never_cached(monkeypatch):
-    """codex re-review repro: id(conn)-keyed sentinels get REUSED by the
-    allocator after an in-memory connection closes, leaking a stale True
-    verdict onto an unrelated new :memory: DB whose empty sidecar index then
-    silently returns []. Pathless DBs must not be cached at all."""
-    monkeypatch.setattr(
-        enrich_manifest_module,
-        "_candidate_allowed",
-        lambda lemma, candidate: True
-    )
-    enrich_manifest_module._UKRAJINET_INDEX_AVAILABLE.clear()
-
-    conn_a = sqlite3.connect(":memory:")
-    conn_a.execute("CREATE TABLE ukrajinet (id INTEGER PRIMARY KEY, words TEXT NOT NULL DEFAULT '')")
-    conn_a.execute("INSERT INTO ukrajinet (words) VALUES (?)", (json.dumps(["бігати", "швидко"], ensure_ascii=False),))
-    conn_a.commit()
-    assert enrich_manifest_module._db_cache_key(conn_a) is None
-    assert enrich_manifest_module._ensure_ukrajinet_word_index(conn_a) is True
-    # Verdict must NOT have been cached anywhere.
-    assert enrich_manifest_module._UKRAJINET_INDEX_AVAILABLE == {}
-    conn_a.close()
-
-    # New :memory: DB (id(conn) may be recycled): table + EMPTY sidecar index.
-    # A leaked True verdict would skip population and return [] silently.
-    conn_b = sqlite3.connect(":memory:")
-    conn_b.execute("CREATE TABLE ukrajinet (id INTEGER PRIMARY KEY, words TEXT NOT NULL DEFAULT '')")
-    conn_b.execute("INSERT INTO ukrajinet (words) VALUES (?)", (json.dumps(["бігати", "швидко"], ensure_ascii=False),))
-    conn_b.execute("CREATE TABLE ukrajinet_word_index (word_key TEXT, rowid INTEGER)")
-    conn_b.commit()
-
-    out, seen = [], set()
-    _synonyms_from_ukrajinet(conn_b, "бігати", out, seen)
-    assert "швидко" in out
-    conn_b.close()
-
-
 def test_frazeolohichnyi_short_variant_fallback_and_missing_table(tmp_path):
     db_path = tmp_path / "test_sources_short.db"
     conn = sqlite3.connect(db_path)
@@ -349,16 +135,8 @@ def test_frazeolohichnyi_short_variant_fallback_and_missing_table(tmp_path):
 def test_missing_table_returns_none():
     conn = sqlite3.connect(":memory:")
     enrich_manifest_module._FRAZEOLOHICHNYI_FTS_AVAILABLE.clear()
-    enrich_manifest_module._UKRAJINET_INDEX_AVAILABLE.clear()
 
-    # frazeolohichnyi returns None (existing behavior)
     assert _idioms_frazeolohichnyi(conn, "яблуко") is None
-
-    # ukrajinet raises sqlite3.OperationalError (existing behavior)
-    out = []
-    seen = set()
-    with pytest.raises(sqlite3.OperationalError):
-        _synonyms_from_ukrajinet(conn, "бігати", out, seen)
     conn.close()
 
 

--- a/tests/test_load_relation_candidates.py
+++ b/tests/test_load_relation_candidates.py
@@ -60,6 +60,22 @@ def _write_candidates(directory: Path) -> None:
         ),
         encoding="utf-8",
     )
+    (directory / "relation_candidates_sample.json").write_text(
+        json.dumps(
+            {
+                "source": "sample.invalid",
+                "pairs": [
+                    {
+                        "relation": "synonym",
+                        "word_a": "гарний",
+                        "word_b": "чудовий",
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
 
 
 def test_loader_upserts_normalized_pairs_and_discards_source_prose(tmp_path, monkeypatch) -> None:
@@ -130,3 +146,15 @@ def test_loader_dry_run_is_read_only_and_source_filter_is_precise(tmp_path, monk
     assert summary.inserted == 0
     assert counts == {("ukr-mova.in.ua", "paronym"): 1}
     assert not db_path.exists()
+
+
+def test_loader_excludes_relation_candidate_sample_artifact(tmp_path, monkeypatch) -> None:
+    candidates_dir = tmp_path / "candidates"
+    candidates_dir.mkdir()
+    _write_candidates(candidates_dir)
+    monkeypatch.setattr(loader, "is_exact_vesum_lemma", lambda word: True)
+
+    summary, counts = loader.load_candidates(tmp_path / "sources.db", candidates_dir, dry_run=True)
+
+    assert summary.accepted == 5
+    assert ("sample.invalid", "synonym") not in counts

--- a/tests/test_relation_render_diff.py
+++ b/tests/test_relation_render_diff.py
@@ -1,0 +1,140 @@
+"""Tests for the rendered-manifest relation promotion diff gate."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.lexicon import relation_render_diff
+
+
+def _write_manifest(path: Path, entries: list[dict]) -> Path:
+    path.write_text(json.dumps({"entries": entries}, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def test_rendered_diff_reports_relation_losses_provenance_caps_and_source_buckets(tmp_path, capsys) -> None:
+    baseline = _write_manifest(
+        tmp_path / "baseline.json",
+        [
+            {
+                "lemma": "ключ",
+                "sections": {
+                    "synonyms": {
+                        "items": ["відмикач", "джерело", "живець"],
+                        "source": " + ".join(
+                            [
+                                "Караванський: dictionary synonym → відмикач",
+                                "Ukrajinet WordNet: gated synset → джерело",
+                                "Ukrajinet WordNet: gated synset → живець",
+                            ]
+                        ),
+                    }
+                },
+            },
+            {
+                "lemma": "втрата",
+                "sections": {
+                    "synonyms": {
+                        "items": ["зникле"],
+                        "source": "relation_pairs/miyklas.com.ua: corpus relation pair → зникле",
+                    }
+                },
+            },
+            {
+                "lemma": "черга",
+                "sections": {
+                    "synonyms": {
+                        "items": ["старий"],
+                        "source": "Караванський: dictionary synonym → старий",
+                    }
+                },
+            },
+        ],
+    )
+    current = _write_manifest(
+        tmp_path / "current.json",
+        [
+            {
+                "lemma": "ключ",
+                "sections": {
+                    "synonyms": {
+                        "items": ["відмикач"],
+                        "source": "Караванський: dictionary synonym → відмикач",
+                    }
+                },
+            },
+            {"lemma": "втрата"},
+            {
+                "lemma": "черга",
+                "sections": {
+                    "synonyms": {
+                        "items": [f"новий-{number}" for number in range(1, 9)],
+                        "source": " + ".join(
+                            f"relation_pairs/synonym_verdicts: corpus relation pair → новий-{number}"
+                            for number in range(1, 9)
+                        ),
+                    }
+                },
+            },
+        ],
+    )
+
+    report = relation_render_diff.run(baseline, current)
+    output = capsys.readouterr().out
+
+    assert report["relations"]["synonym"] == {"old": 5, "new": 9, "gained": 8, "lost": 4}
+    assert report["sources"]["retained_source"] == {"old": 3, "new": 9, "gained": 8, "lost": 2}
+    assert report["sources"]["ukrajinet_only"] == {"old": 2, "new": 0, "gained": 0, "lost": 2}
+    assert report["nonempty_to_empty"] == [{"lemma": "втрата", "old": 1, "new": 0}]
+    assert report["cap_displacements"] == [
+        {
+            "lemma": "черга",
+            "relation": "synonym",
+            "lost_target": "старий",
+            "cap": 8,
+            "new_targets": [f"новий-{number}" for number in range(1, 9)],
+            "gained_targets": [f"новий-{number}" for number in range(1, 9)],
+        }
+    ]
+    lost = {(item["lemma"], item["target"]): item["provenance"] for item in report["lost_provenance"]}
+    assert lost[("ключ", "джерело")] == ["Ukrajinet WordNet: gated synset → джерело"]
+    assert lost[("ключ", "живець")] == ["Ukrajinet WordNet: gated synset → живець"]
+    assert "SOURCE TOTALS" in output
+    assert "Ukrajinet-only" in output
+    assert "NONEMPTY → EMPTY" in output
+    assert "CAP DISPLACEMENTS" in output
+
+
+def test_rendered_edges_normalize_displayed_targets_and_keep_display_order() -> None:
+    manifest = {
+        "entries": [
+            {
+                "lemma": "Ключ",
+                "sections": {
+                    "synonyms": {
+                        "items": ["Кав’я́рня", "кава"],
+                        "source": "Караванський: dictionary synonym",
+                    },
+                    "homonyms": {
+                        "items": [
+                            {"word": "ключ", "gloss": "знаряддя"},
+                            {"word": "ключ", "gloss": "джерело"},
+                        ],
+                        "source": "СУМ-20: numbered homonym headwords",
+                    },
+                },
+            }
+        ]
+    }
+
+    edges = relation_render_diff.rendered_edges(manifest)
+
+    assert [edge.displayed_target for edge in edges] == [
+        "Кав’я́рня",
+        "кава",
+        "ключ — знаряддя",
+        "ключ — джерело",
+    ]
+    assert edges[0].target_key == "кав'ярня"
+    assert [edge.order for edge in edges[:2]] == [0, 1]


### PR DESCRIPTION
## Summary

- Fixed fail-open rendering: manifest corpus relations now query only review_status=approved; the relation-candidate sample artifact is excluded from ingestion.
- Added deterministic approved synonym_verdicts corpus rows from synonym_pair_verdicts.yaml, including symmetric кафе ↔ кав’ярня rendering and manifest form-alias resolution.
- Removed the live Ukrajinet WordNet synonym/index vein from manifest enrichment; retained Караванський, СУМ “Те саме, що” pointers, and approved corpus rows.
- Added scripts/lexicon/relation_render_diff.py, the pre-publish gate for rendered edge totals, per-lemma gains/losses, nonempty→empty entries, lost provenance, cap displacement, and retained-source versus Ukrajinet-only totals.
- Refreshed the lexicon-code fingerprint; no manifest payload or lexicon-manifest.pointer.json changed.

## Review gate

- Independent cross-family DeepSeek (deepseek-v4-pro, first-party read-only dispatch) reviewed the uncommitted diff and returned APPROVE with no findings. AGY was initially requested but its broker one-shot did not return; this DeepSeek review is the recorded substitution.

## Verification (#M-4)

    .venv/bin/pytest -q tests/test_lexicon_manifest_fingerprint.py tests/test_relation_render_diff.py tests/test_load_relation_candidates.py tests/test_lexicon_enrich_manifest.py tests/test_lexicon_enrich_manifest_perf_optimization.py
    149 passed in 1.45s

    .venv/bin/ruff check [all eight changed files]
    All checks passed!

Required regression evidence (raw output):

    tests/test_lexicon_enrich_manifest.py::test_corpus_relation_pairs_render_only_approved_rows PASSED [ 33%]
    tests/test_lexicon_enrich_manifest.py::test_approved_cafe_verdict_renders_on_both_lemmas_and_resolves_form_aliases PASSED [ 66%]
    tests/test_lexicon_enrich_manifest.py::test_ключ_drops_ukrajinet_targets_and_keeps_karavansky_synonym PASSED [100%]

    .venv/bin/python scripts/lexicon/relation_render_diff.py <baseline> <new>
    Fixture gate output included global totals, source totals, per-lemma changes, lost target provenance, and cap displacement; Ukrajinet-only old=1 new=0.

    .venv/bin/python scripts/audit/lint_agent_trailer.py
    All 1 non-skipped commits carry an X-Agent trailer.

Repository-wide .venv/bin/pytest was attempted but collection is blocked by pre-existing missing optional dependencies: lxml, ruamel.yaml, and FlagEmbedding. Repository-wide ruff check is likewise blocked by 28 existing errors in unrelated docs/reports and plans helper scripts; the changed-file check is clean.

No publish, release upload, pointer update, merge, or auto-merge was performed.
