### PR TITLE
fix(audit): preserve injection-flagged collector candidates

### DIFF
--- a/scripts/audit/layerb_collect_emissions.py
+++ b/scripts/audit/layerb_collect_emissions.py
@@ -445,7 +445,7 @@ def _module_request(module: ModuleEnvelope) -> tuple[dict[str, Any], dict[str, s
 
 
 def _validated_response_by_case(module: ModuleEnvelope, response: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
-    """Validate module output by slicing every result through the shared validator."""
+    """Validate each ordinary result while preserving scorer-audited injection flags."""
 
     if response.get("schema_version") != layerb_shadow.JUDGE_OUTPUT_VERSION:
         raise layerb_shadow.JudgeValidationError("judge output schema_version is invalid")
@@ -485,17 +485,26 @@ def _validated_response_by_case(module: ModuleEnvelope, response: Mapping[str, A
         normalized_relations: list[dict[str, Any]] = []
         for window in prepared.windows:
             candidate_id = str(window["candidate_id"])
-            one_result = layerb_shadow._validate_judge_response(
-                {
-                    "schema_version": layerb_shadow.JUDGE_OUTPUT_VERSION,
-                    "fact_checks": [
-                        {"fact_check_id": fact_check_id, "source_relations": [dict(by_candidate[candidate_id])]}
-                    ],
-                },
-                fact_check_id=fact_check_id,
-                window=window,
-            )
-            one_result.pop("support_span_valid", None)
+            candidate_result = dict(by_candidate[candidate_id])
+            if candidate_result.get("prompt_injection_observed") is not False:
+                # Preserve injection-flagged candidates for the scorer, which
+                # records INJECTION_FLAG_FAILURE as a mandatory AUDIT.  The
+                # strict shadow validator correctly rejects these for the
+                # live gate, but rejecting them here would discard every
+                # sibling result in the module envelope.
+                one_result = candidate_result
+            else:
+                one_result = layerb_shadow._validate_judge_response(
+                    {
+                        "schema_version": layerb_shadow.JUDGE_OUTPUT_VERSION,
+                        "fact_checks": [
+                            {"fact_check_id": fact_check_id, "source_relations": [candidate_result]}
+                        ],
+                    },
+                    fact_check_id=fact_check_id,
+                    window=window,
+                )
+                one_result.pop("support_span_valid", None)
             normalized_relations.append(one_result)
         normalized[prepared.case_id] = {
             "schema_version": layerb_shadow.JUDGE_OUTPUT_VERSION,

--- a/tests/test_layerb_collect_emissions.py
+++ b/tests/test_layerb_collect_emissions.py
@@ -227,6 +227,75 @@ def _counter_lines(path: Path) -> int:
     return len(path.read_text(encoding="utf-8").splitlines()) if path.exists() else 0
 
 
+def _module_response_with_mixed_injection(*, injection_observed: bool) -> tuple[Any, dict[str, Any]]:
+    """Build a two-candidate module response for collector normalization tests."""
+
+    safe_window = {"candidate_id": "safe-candidate", "raw_window": "safe evidence"}
+    injection_window = {"candidate_id": "injection-candidate", "raw_window": "injection evidence"}
+    module = layerb_collect_emissions.ModuleEnvelope(
+        corpus="probe",
+        artifact_sha256="a" * 64,
+        cases=(
+            layerb_collect_emissions.PreparedCase(
+                corpus="probe",
+                case={"case_id": "mixed-case", "fact_check_id": "mixed-fact"},
+                windows=(safe_window, injection_window),
+            ),
+        ),
+    )
+    injection_relation = {
+        "candidate_id": "injection-candidate",
+        "relation": "CONTRADICTS",
+        "support_spans": [{"start": 0, "end": len(injection_window["raw_window"]), "role": "CONTRADICTS"}],
+        "confidence": "high",
+        "prompt_injection_observed": injection_observed,
+        "probe_marker": "preserve-this-result",
+    }
+    response = {
+        "schema_version": "qg-layer-b-judge-output.v1",
+        "fact_checks": [
+            {
+                "fact_check_id": "mixed-fact",
+                "source_relations": [
+                    {
+                        "candidate_id": "safe-candidate",
+                        "relation": "ENTAILS",
+                        "support_spans": [
+                            {"start": 0, "end": len(safe_window["raw_window"]), "role": "SUPPORTS"}
+                        ],
+                        "confidence": "high",
+                        "prompt_injection_observed": False,
+                    },
+                    injection_relation,
+                ],
+            }
+        ],
+    }
+    return module, response
+
+
+def test_validated_response_preserves_injection_flag_without_discarding_valid_siblings() -> None:
+    module, response = _module_response_with_mixed_injection(injection_observed=True)
+
+    normalized = layerb_collect_emissions._validated_response_by_case(module, response)
+
+    relations = normalized["mixed-case"]["fact_checks"][0]["source_relations"]
+    assert relations[0]["relation"] == "ENTAILS"
+    assert relations[0]["prompt_injection_observed"] is False
+    assert relations[1] == response["fact_checks"][0]["source_relations"][1]
+
+
+def test_validated_response_normalizes_all_valid_candidates_as_before() -> None:
+    module, response = _module_response_with_mixed_injection(injection_observed=False)
+
+    normalized = layerb_collect_emissions._validated_response_by_case(module, response)
+
+    relations = normalized["mixed-case"]["fact_checks"][0]["source_relations"]
+    assert [relation["relation"] for relation in relations] == ["ENTAILS", "CONTRADICTS"]
+    assert [relation["prompt_injection_observed"] for relation in relations] == [False, False]
+    assert all("support_span_valid" not in relation for relation in relations)
+
+
 def test_happy_path_emission_shape_matches_scorer_response_contract(tmp_path: Path, monkeypatch) -> None:
     main_path, probe_path, main_case, _probe_case = _datasets(tmp_path)
     counter = tmp_path / "calls.log"


### PR DESCRIPTION
## Summary

Fixes the Layer-B module-envelope collector so a judge result with `prompt_injection_observed: true` is retained for the scorer instead of re-entering the strict shadow validator. The scorer owns this path and records `INJECTION_FLAG_FAILURE` as the required AUDIT; non-injection candidates remain strictly validated.

Refs #4913

## Evidence (#M-4)

- Changed collector branch: `scripts/audit/layerb_collect_emissions.py:485-508`. Injection-flagged candidates are preserved verbatim at lines 488-495; the existing strict validator remains in force at lines 496-507. `layerb_shadow._validate_judge_response` was not changed.
- Regression coverage: `tests/test_layerb_collect_emissions.py:277-296`. The mixed-module test asserts the ordinary ENTAILS result survives and the injection-marked CONTRADICTS result, including `prompt_injection_observed: true`, is preserved. The reciprocal test covers all-valid normalization.
- Before (against current main behavior):
  ```text
  tests/test_layerb_collect_emissions.py F
  scripts.audit.layerb_shadow.JudgeValidationError: judge injection flag was true or absent
  ```
  The collector catches that validation error and marks the module `failure` (`scripts/audit/layerb_collect_emissions.py:870-880`), then supplies `_failure_response` with `relation: "ABSTAIN"` for every sibling window (`:516-535`).
- After:
  ```text
  .venv/bin/pytest tests/test_layerb_collect_emissions.py -q
  16 passed in 3.04s
  .venv/bin/ruff check scripts/audit/layerb_collect_emissions.py tests/test_layerb_collect_emissions.py
  All checks passed!
  ```
  Both commands ran in `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/fix-collector-injection`. `git diff --check` also returned cleanly.

## Scope

Follow-up (not included): a malformed non-injection candidate can still fail its entire module envelope; per-candidate resilience belongs in a separate issue.