### PR TITLE
fix(deploy): install PyYAML for Pages build

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           python -m venv .venv
           .venv/bin/python -m pip install --upgrade pip
+          .venv/bin/python -m pip install PyYAML==6.0.3
 
       - name: Restore Atlas lexicon manifest cache
         id: atlas-manifest-cache

--- a/tests/test_deploy_pages_workflow.py
+++ b/tests/test_deploy_pages_workflow.py
@@ -1,0 +1,25 @@
+"""Regression checks for the GitHub Pages deployment workflow."""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "deploy-pages.yml"
+REQUIREMENTS_LOCK = REPO_ROOT / "requirements-lock.txt"
+
+
+def test_pages_build_installs_atlas_python_dependencies() -> None:
+    """The deploy venv must satisfy imports used by ``npm run build:full``."""
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["deploy"]["steps"]
+    create_venv = next(step for step in steps if step.get("name") == "Create Python venv")
+    build_site = next(step for step in steps if step.get("name") == "Build Site")
+    locked_pyyaml = next(
+        line
+        for line in REQUIREMENTS_LOCK.read_text(encoding="utf-8").splitlines()
+        if line.startswith("PyYAML==")
+    )
+
+    assert f".venv/bin/python -m pip install {locked_pyyaml}" in create_venv["run"]
+    assert steps.index(create_venv) < steps.index(build_site)


### PR DESCRIPTION
## Summary

- install the lockfile-pinned PyYAML release in the GitHub Pages build venv
- add a regression test that ties the workflow install to requirements-lock.txt and verifies it precedes the site build

## Root cause

The Pages workflow created .venv but installed only pip. npm run build:full now invokes scripts/atlas/atlas_db.py, which imports yaml, so production deploys failed with ModuleNotFoundError: No module named yaml.

## Verification

- scripts/audit/check_workflows.sh .github/workflows/deploy-pages.yml — passed (actionlint 1.7.12)
- .venv/bin/pytest tests/test_actionlint_workflow.py tests/test_deploy_pages_workflow.py -q — 9 passed
- .venv/bin/python scripts/audit/lint_agent_trailer.py — passed
- git diff --check origin/main...HEAD — passed

## Independent review

DeepSeek v4 Flash independently traced the complete build/import chain and returned NO FINDINGS. AGY/Gemini was attempted first but unavailable because local OAuth was not configured; DeepSeek was the recorded cross-family substitution. No provider/model substitution occurred within the DeepSeek dispatch.

## Impact

After merge, the workflow-file path trigger will launch a fresh Pages deployment; the Bilash module and other queued site changes can then publish.
