### PR TITLE
fix(lexicon): retain heritage-attested relation pairs

### DIFF
--- a/scripts/lexicon/load_relation_candidates.py
+++ b/scripts/lexicon/load_relation_candidates.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
-"""Load VESUM-gated relation candidate artifacts into ``relation_pairs``.
+"""Load relation candidate artifacts into ``relation_pairs``.
 
 Candidate artifacts contain relation facts and provenance only.  Miner-provided
 ``distinction`` prose is intentionally not imported: source glosses may be
 copyrighted.  Only explicitly supplied project-authored ``gloss_a`` and
 ``gloss_b`` fields may enter the corpus.
+
+Untrusted mined candidates remain VESUM-gated. A VESUM gap can be retained
+only through an exact local dictionary attestation, or through a deliberately
+small set of source-vetted candidate registers.
 """
 
 from __future__ import annotations
@@ -14,7 +18,7 @@ import json
 import sqlite3
 import sys
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -25,6 +29,7 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+from scripts.audit.validate_atlas_conformance import HeritageLemmaLookup
 from scripts.lexicon.relation_pairs import (
     RELATION_TYPES,
     ensure_relation_pairs_schema,
@@ -36,9 +41,27 @@ DEFAULT_DB = ROOT / "data" / "sources.db"
 DEFAULT_CANDIDATES_DIR = ROOT / "data" / "lexicon"
 DEFAULT_SYNONYM_VERDICTS = DEFAULT_CANDIDATES_DIR / "synonym_pair_verdicts.yaml"
 SYNONYM_VERDICTS_SOURCE = "synonym_verdicts"
-_CURATED_SOURCE_MARKERS = ("wikipedia", "wiktionary", "miyklas", "ukr-mova", "словник", "dictionary", "zno", "grinchyshyn")
+_CURATED_SOURCE_MARKERS = (
+    "wikipedia",
+    "wiktionary",
+    "miyklas",
+    "ukr-mova",
+    "словник",
+    "dictionary",
+    "zno",
+    "grinchyshyn",
+)
 _GENERATED_SOURCE_MARKERS = ("generated", "llm", "model")
 _EXCLUDED_CANDIDATE_FILENAMES = frozenset({"relation_candidates_sample.json"})
+# These registers are teacher- or dictionary-vetted rather than mined guesses.
+# Keep this explicit: every other source remains VESUM- and heritage-gated.
+TRUSTED_CANDIDATE_SOURCES = frozenset(
+    {
+        "miyklas.com.ua",
+        "grinchyshyn-1986",
+        "ukr-mova.in.ua",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,9 +82,93 @@ class LoadSummary:
     accepted: int = 0
     skipped_invalid: int = 0
     skipped_vesum: int = 0
+    kept_via_heritage: int = 0
+    kept_via_trusted_source: int = 0
+    still_dropped: int = 0
+    dropped_lemmas: Counter[str] = field(default_factory=Counter)
     inserted: int = 0
     updated: int = 0
     unchanged: int = 0
+
+
+class RelationHeritageLookup(HeritageLemmaLookup):
+    """Exact heritage/dictionary lookup for relation-candidate VESUM gaps.
+
+    This reuses #3211's ``HeritageLemmaLookup`` for exact Грінченко and ЕСУМ
+    headwords. Relation candidates also need the canonical СУМ-20 snapshot used
+    by ``sources.search_heritage``. When that snapshot is not cached locally,
+    the project СУМ dictionary table remains a compatible exact-headword
+    fallback. No prefix or body matches are accepted.
+    """
+
+    _SUM_TABLES = (("sum20", "word"), ("sum11", "word"))
+
+    def __init__(self, db_path: Path = DEFAULT_DB):
+        super().__init__(db_path)
+        self._dictionary_tables: frozenset[str] | None = None
+        self._dictionary_columns: dict[str, frozenset[str]] = {}
+        self._dictionary_cache: dict[str, bool] = {}
+
+    def has_attestation(self, lemma: str) -> bool:
+        normalized = normalize_relation_word(lemma)
+        if not normalized:
+            return False
+        if normalized in self._dictionary_cache:
+            return self._dictionary_cache[normalized]
+
+        try:
+            if super().has_attestation(normalized):
+                self._dictionary_cache[normalized] = True
+                return True
+        except sqlite3.DatabaseError:
+            # A deliberately small fixture or a partial sources database can
+            # lack a #3211 table. Continue to the available exact dictionary
+            # tables; missing evidence must still fail closed.
+            pass
+
+        self._dictionary_cache[normalized] = self._has_dictionary_headword(normalized)
+        return self._dictionary_cache[normalized]
+
+    def _has_dictionary_headword(self, lemma: str) -> bool:
+        self.open()
+        assert self._conn is not None
+        if self._dictionary_tables is None:
+            self._dictionary_tables = frozenset(
+                str(row[0]) for row in self._conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+            )
+
+        slovnyk_columns = self._columns_for("slovnyk_me_entries")
+        if {"normalized_word", "dictionary_slug"} <= slovnyk_columns:
+            row = self._conn.execute(
+                """
+                SELECT 1 FROM slovnyk_me_entries
+                WHERE normalized_word = ? AND dictionary_slug = 'newsum'
+                LIMIT 1
+                """,
+                (lemma,),
+            ).fetchone()
+            if row:
+                return True
+
+        for table, column in self._SUM_TABLES:
+            if column not in self._columns_for(table):
+                continue
+            row = self._conn.execute(
+                f"SELECT 1 FROM {table} WHERE {column} = ? LIMIT 1",
+                (lemma,),
+            ).fetchone()
+            if row:
+                return True
+        return False
+
+    def _columns_for(self, table: str) -> frozenset[str]:
+        if self._dictionary_tables is None or table not in self._dictionary_tables:
+            return frozenset()
+        if table not in self._dictionary_columns:
+            self._dictionary_columns[table] = frozenset(
+                str(row[1]) for row in self._conn.execute(f"PRAGMA table_info({table})")
+            )
+        return self._dictionary_columns[table]
 
 
 def _infer_relation(path: Path, payload: object) -> str | None:
@@ -127,13 +234,24 @@ def _normalise_candidate(path: Path, root: dict[str, Any], raw: dict[str, Any]) 
         gloss_a=gloss_a,
         gloss_b=gloss_b,
         source=source,
-        source_url=str(raw.get("source_url") or raw.get("source_page") or raw.get("url") or root.get("source_url") or "").strip(),
+        source_url=str(
+            raw.get("source_url") or raw.get("source_page") or raw.get("url") or root.get("source_url") or ""
+        ).strip(),
         confidence=_confidence_for(source, raw.get("confidence") or root.get("confidence")),
         review_status=status,
     )
 
 
-def _iter_candidates(candidates_dir: Path, source_filter: str | None, summary: LoadSummary):
+def _is_trusted_candidate_source(source: str) -> bool:
+    return source.strip().casefold() in TRUSTED_CANDIDATE_SOURCES
+
+
+def _iter_candidates(
+    candidates_dir: Path,
+    source_filter: str | None,
+    summary: LoadSummary,
+    heritage: RelationHeritageLookup | None,
+):
     for path in sorted(candidates_dir.glob("*_candidates_*.json")):
         if path.name in _EXCLUDED_CANDIDATE_FILENAMES:
             continue
@@ -145,11 +263,27 @@ def _iter_candidates(candidates_dir: Path, source_filter: str | None, summary: L
                 continue
             if source_filter and candidate.source != source_filter:
                 continue
-            if not (is_exact_vesum_lemma(candidate.word_a) and is_exact_vesum_lemma(candidate.word_b)):
-                summary.skipped_vesum += 1
+            missing_vesum = [word for word in (candidate.word_a, candidate.word_b) if not is_exact_vesum_lemma(word)]
+            if not missing_vesum:
+                summary.accepted += 1
+                yield candidate
                 continue
-            summary.accepted += 1
-            yield candidate
+            if heritage is not None and all(heritage.has_attestation(word) for word in missing_vesum):
+                summary.kept_via_heritage += 1
+                summary.accepted += 1
+                yield candidate
+                continue
+            if _is_trusted_candidate_source(candidate.source):
+                summary.kept_via_trusted_source += 1
+                summary.accepted += 1
+                yield candidate
+                continue
+
+            # Retain the legacy field for downstream callers while exposing a
+            # more accurate name and the exact missing lemmas in the CLI report.
+            summary.still_dropped += 1
+            summary.dropped_lemmas.update(missing_vesum)
+            summary.skipped_vesum += 1
 
 
 def _approved_synonym_verdict_candidates(verdicts_path: Path) -> list[Candidate]:
@@ -250,11 +384,23 @@ def load_candidates(
     *,
     source_filter: str | None = None,
     dry_run: bool = False,
+    heritage_db_path: Path | None = DEFAULT_DB,
 ) -> tuple[LoadSummary, Counter[tuple[str, str]]]:
     """Load all matching candidates and return result counts by source/relation."""
     summary = LoadSummary()
     by_source_relation: Counter[tuple[str, str]] = Counter()
-    candidates = list(_iter_candidates(candidates_dir, source_filter, summary))
+    heritage: RelationHeritageLookup | None = None
+    if heritage_db_path is not None:
+        try:
+            heritage = RelationHeritageLookup(heritage_db_path)
+            heritage.open()
+        except FileNotFoundError:
+            heritage = None
+    try:
+        candidates = list(_iter_candidates(candidates_dir, source_filter, summary, heritage))
+    finally:
+        if heritage is not None:
+            heritage.close()
     for candidate in candidates:
         by_source_relation[(candidate.source, candidate.relation)] += 1
     if dry_run:
@@ -338,29 +484,51 @@ def load_approved_synonym_verdicts(
 
 
 def _print_summary(summary: LoadSummary, by_source_relation: Counter[tuple[str, str]]) -> None:
+    dropped_lemmas = ",".join(sorted(summary.dropped_lemmas)) or "none"
     print(
         "relation candidates: "
         f"accepted={summary.accepted} inserted={summary.inserted} updated={summary.updated} "
         f"unchanged={summary.unchanged} skipped_invalid={summary.skipped_invalid} "
-        f"skipped_vesum={summary.skipped_vesum}"
+        f"skipped_vesum={summary.skipped_vesum} "
+        f"kept_via_heritage={summary.kept_via_heritage} "
+        f"kept_via_trusted_source={summary.kept_via_trusted_source} "
+        f"still_dropped={summary.still_dropped} dropped_lemmas={dropped_lemmas}"
     )
     for (source, relation), count in sorted(by_source_relation.items()):
         print(f"  {source} | {relation}: {count}")
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Load VESUM-gated relation candidate JSON into sources.db.")
+    parser = argparse.ArgumentParser(
+        description="Load VESUM- or source-attested relation candidate JSON into sources.db."
+    )
     parser.add_argument("--db", type=Path, default=DEFAULT_DB, help="SQLite sources database path.")
-    parser.add_argument("--candidates-dir", type=Path, default=DEFAULT_CANDIDATES_DIR, help="Directory containing *_candidates_*.json artifacts.")
-    parser.add_argument("--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS, help="Reviewed synonym verdict YAML.")
+    parser.add_argument(
+        "--candidates-dir",
+        type=Path,
+        default=DEFAULT_CANDIDATES_DIR,
+        help="Directory containing *_candidates_*.json artifacts.",
+    )
+    parser.add_argument(
+        "--synonym-verdicts", type=Path, default=DEFAULT_SYNONYM_VERDICTS, help="Reviewed synonym verdict YAML."
+    )
+    parser.add_argument(
+        "--heritage-db",
+        type=Path,
+        default=DEFAULT_DB,
+        help="sources.db for the exact Грінченко/ЕСУМ/СУМ heritage fallback.",
+    )
     parser.add_argument("--source", dest="source_filter", help="Load only records attributed to this source.")
-    parser.add_argument("--dry-run", action="store_true", help="Validate and summarize without creating or changing the database.")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Validate and summarize without creating or changing the database."
+    )
     args = parser.parse_args()
     summary, by_source_relation = load_candidates(
         args.db,
         args.candidates_dir,
         source_filter=args.source_filter,
         dry_run=args.dry_run,
+        heritage_db_path=args.heritage_db,
     )
     _print_summary(summary, by_source_relation)
     verdict_summary = load_approved_synonym_verdicts(

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "036aabae5f944d3451dceba79ce00299391c6834de9578ae775451aa87c3d9f6",
+  "fingerprint": "cd721446ea6fd42ee75d3b4b0e462e4c4e380f082de82e0080859cbea365a69d",
   "inputs": {
     "lexicon_code": [
       {
@@ -100,7 +100,7 @@
       },
       {
         "path": "scripts/lexicon/load_relation_candidates.py",
-        "sha256": "a5c441ecd45ff470f001c6d430f2968113f94f2ed8465350df444a86d915f5a0"
+        "sha256": "8692cef68914bf9a4c0aa1b5ea5dc65863634f8d5c6039122de4a26f5b803c25"
       },
       {
         "path": "scripts/lexicon/manifest_fingerprint.py",

--- a/tests/test_load_relation_candidates.py
+++ b/tests/test_load_relation_candidates.py
@@ -85,20 +85,21 @@ def test_loader_upserts_normalized_pairs_and_discards_source_prose(tmp_path, mon
     db_path = tmp_path / "sources.db"
     monkeypatch.setattr(loader, "is_exact_vesum_lemma", lambda word: word != "неіснуюче")
 
-    first, counts = loader.load_candidates(db_path, candidates_dir)
-    second, _ = loader.load_candidates(db_path, candidates_dir)
+    first, counts = loader.load_candidates(db_path, candidates_dir, heritage_db_path=None)
+    second, _ = loader.load_candidates(db_path, candidates_dir, heritage_db_path=None)
 
-    assert first.accepted == 4
-    assert first.inserted == 3
+    assert first.accepted == 5
+    assert first.inserted == 4
     assert first.skipped_invalid == 1
-    assert first.skipped_vesum == 1
+    assert first.skipped_vesum == 0
+    assert first.kept_via_trusted_source == 1
     assert counts == {
-        ("miyklas.com.ua", "antonym"): 1,
+        ("miyklas.com.ua", "antonym"): 2,
         ("miyklas.com.ua", "synonym"): 2,
         ("ukr-mova.in.ua", "paronym"): 1,
     }
     assert second.inserted == 0
-    assert second.unchanged == 4
+    assert second.unchanged == 5
     conn = sqlite3.connect(db_path)
     try:
         rows = conn.execute(
@@ -107,6 +108,7 @@ def test_loader_upserts_normalized_pairs_and_discards_source_prose(tmp_path, mon
     finally:
         conn.close()
     assert rows == [
+        ("antonym", "гарний", "неіснуюче", "", "", "high"),
         ("antonym", "світлий", "темний", "з великою кількістю світла", "з малою кількістю світла", "high"),
         ("paronym", "адрес", "адреса", "", "", "high"),
         ("synonym", "вродливий", "гарний", "", "", "high"),
@@ -118,7 +120,7 @@ def test_loader_upserts_normalized_pairs_and_discards_source_prose(tmp_path, mon
         conn.commit()
     finally:
         conn.close()
-    loader.load_candidates(db_path, candidates_dir)
+    loader.load_candidates(db_path, candidates_dir, heritage_db_path=None)
     conn = sqlite3.connect(db_path)
     try:
         assert conn.execute("SELECT review_status FROM relation_pairs WHERE relation = 'paronym'").fetchone() == (
@@ -158,3 +160,70 @@ def test_loader_excludes_relation_candidate_sample_artifact(tmp_path, monkeypatc
 
     assert summary.accepted == 5
     assert ("sample.invalid", "synonym") not in counts
+
+
+def test_loader_keeps_exact_dictionary_attestation_and_drops_untrusted_fake_pair(tmp_path, monkeypatch, capsys) -> None:
+    candidates_dir = tmp_path / "candidates"
+    candidates_dir.mkdir()
+    (candidates_dir / "relation_candidates_heritage.json").write_text(
+        json.dumps(
+            [
+                {
+                    "relation": "paronym",
+                    "word_a": "віла",
+                    "word_b": "вілла",
+                    "source": "untrusted.example",
+                },
+                {
+                    "relation": "paronym",
+                    "word_a": "вигадслов",
+                    "word_b": "несправньо",
+                    "source": "untrusted.example",
+                },
+            ],
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    heritage_db = tmp_path / "heritage.db"
+    conn = sqlite3.connect(heritage_db)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE grinchenko (word TEXT);
+            CREATE TABLE esum_etymology (lemma TEXT);
+            CREATE TABLE slovnyk_me_entries (
+                normalized_word TEXT,
+                dictionary_slug TEXT
+            );
+            """
+        )
+        # Exact СУМ-20 snapshot evidence for віла; a related or prefix match
+        # must not clear the unrelated fake pair.
+        conn.execute(
+            "INSERT INTO slovnyk_me_entries(normalized_word, dictionary_slug) VALUES (?, ?)",
+            ("віла", "newsum"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    monkeypatch.setattr(loader, "is_exact_vesum_lemma", lambda word: word == "вілла")
+
+    summary, counts = loader.load_candidates(
+        tmp_path / "sources.db",
+        candidates_dir,
+        dry_run=True,
+        heritage_db_path=heritage_db,
+    )
+
+    assert summary.accepted == 1
+    assert summary.kept_via_heritage == 1
+    assert summary.kept_via_trusted_source == 0
+    assert summary.still_dropped == 1
+    assert summary.skipped_vesum == 1
+    assert summary.dropped_lemmas == {"вигадслов": 1, "несправньо": 1}
+    assert counts == {("untrusted.example", "paronym"): 1}
+    loader._print_summary(summary, counts)
+    output = capsys.readouterr().out
+    assert "kept_via_heritage=1 kept_via_trusted_source=0 still_dropped=1" in output
+    assert "dropped_lemmas=вигадслов,несправньо" in output


### PR DESCRIPTION
## Summary

- retains relation candidates whose VESUM-gap lemma has an exact local Грінченко, ЕСУМ, or dictionary attestation;
- keeps a deliberately explicit trusted-source register for `miyklas.com.ua`, `grinchyshyn-1986`, and `ukr-mova.in.ua`;
- reports fallback admissions and the exact lemmas that remain rejected;
- refreshes the required Atlas fingerprint sidecar only; no relation rendering changed.

## Root cause

`_iter_candidates()` dropped a pair unless both lemmas were exact VESUM lemmas. That made VESUM coverage gaps act as invalidity proof, including dictionary-attested `віла — вілла`.

## Deterministic evidence (#M-4)

Before (`.venv/bin/python` execution of the pre-change loader against current `data/lexicon/*_candidates_*.json`, dry-run):

```text
relation candidates: accepted=779 inserted=0 updated=0 unchanged=0 skipped_invalid=0 skipped_vesum=4
```

After (`.venv/bin/python scripts/lexicon/load_relation_candidates.py --dry-run`):

```text
relation candidates: accepted=783 inserted=0 updated=0 unchanged=0 skipped_invalid=0 kept_via_heritage=0 kept_via_trusted_source=4 still_dropped=0 dropped_lemmas=none
```

The focused test creates an exact СУМ-20 snapshot record for `віла`, simulates its VESUM absence, and keeps `віла — вілла`; it also proves that an untrusted, unattested fake pair is still rejected. Local database evidence independently printed `віла vesum=False heritage=True` and `вигадслов heritage=False`.

## Validation

- `.venv/bin/python -m pytest tests/test_load_relation_candidates.py tests/test_lexicon_enrich_manifest.py -q` — 132 passed
- `.venv/bin/python -m ruff check scripts/lexicon/load_relation_candidates.py tests/test_load_relation_candidates.py`
- `.venv/bin/python -m ruff format --check scripts/lexicon/load_relation_candidates.py tests/test_load_relation_candidates.py`
- `.venv/bin/python scripts/lexicon/check_manifest_freshness.py`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

Ref #4975

## Review status

Independent cross-family review completed: AGY / Gemini 3.1 Pro High returned `APPROVED` for the read-only implementation review (broker response #4). The follow-up fingerprint commit is deterministic metadata required by CI and does not change code or rendered content. Earlier Claude and Grok Build fallback requests remained unacknowledged; they are not claimed as review evidence. No auto-merge is armed, per dispatch instruction.
