### PR TITLE
feat(review): add canonical versioned post-build review (#5020)

### DIFF
--- a/agents_extensions/shared/skills/post-build-review/SKILL.md
+++ b/agents_extensions/shared/skills/post-build-review/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: post-build-review
+description: Run the canonical read-only, versioned review of a built Ukrainian curriculum module by composing deterministic audit evidence, track policy, the correct core or seminar semantic prompt, and fail-closed combined disposition. Use for short requests such as "Use $post-build-review for bio/oleksandr-bilash", for post-build quality gates, for reproducing a prior versioned review, or before declaring a module ready.
+---
+
+# Post-build review
+
+Keep all repository files unchanged. Write packets and results only under `/tmp`.
+Do not create curriculum `audit/`, `review/`, `status/`, telemetry, or published
+artifacts. Report findings; do not fix the module during this invocation.
+
+## Workflow
+
+1. Parse the argument as `track/slug`. Do not infer an unknown track.
+2. Record the current reviewer agent, model family, exact model id, and effort.
+3. Run deterministic preparation:
+
+   ```bash
+   .venv/bin/python scripts/audit/post_build_review.py prepare \
+     <track/slug> \
+     --reviewer-agent <agent> \
+     --reviewer-family <family> \
+     --reviewer-model <model> \
+     --reviewer-effort <effort> \
+     --output /tmp/post-build-review-packet.json
+   ```
+
+4. Read `/tmp/post-build-review-packet.json`. Follow its `semantic_prompt`
+   exactly. Read every path in `target.files`; use the project source tools for
+   Ukrainian, factual, attribution, and quotation claims. Never guess a
+   Ukrainian fact. If required tools or evidence are unavailable, return
+   `INCOMPLETE`.
+5. Create `/tmp/post-build-review-semantic.json` with the shape required at the
+   end of the effective prompt. Use `apply_patch`, not a shell heredoc.
+6. Finalize and validate:
+
+   ```bash
+   .venv/bin/python scripts/audit/post_build_review.py finalize \
+     --packet /tmp/post-build-review-packet.json \
+     --semantic-result /tmp/post-build-review-semantic.json \
+     --output /tmp/post-build-review-result.json
+   ```
+
+7. Read the result back, report the combined disposition and material findings,
+   and cite `/tmp/post-build-review-result.json`. A non-zero finalize exit means
+   `BLOCK`, `REVISE`, or `INCOMPLETE`; it is a review outcome, not a tool crash.
+8. Verify `git status --short` is unchanged from before the invocation.
+
+## Canonical resources
+
+- Deterministic contract: [contracts/deterministic-audit-contract.md](contracts/deterministic-audit-contract.md)
+- Disposition policy: [contracts/combined-disposition-policy.md](contracts/combined-disposition-policy.md)
+- Size policy: [contracts/evidence-derived-size-policy-contract.md](contracts/evidence-derived-size-policy-contract.md)
+- Track configuration: [config/track-policy.v1.yaml](config/track-policy.v1.yaml)
+- Output schema: [schema/review-result.v1.schema.json](schema/review-result.v1.schema.json)
+
+The runner assembles the common prompt plus exactly one family prompt. Do not
+manually concatenate or substitute other review prompts.
+
+## Safety and maintenance
+
+- Never use `scripts/audit_module.py`, `scripts/audit_module.sh`, `--output` on
+  the track audit, or `--run-mdx-generation-validate`; those paths may write to
+  the repository.
+- Never let semantic `PASS` override a deterministic blocker/high finding.
+- Never reuse a result after any `source_hashes` value changes.
+- Maintain this skill only through the bug-fix workflow in
+  `docs/runbooks/post-build-review.md`; bump the responsible version and deploy
+  mirrors from this canonical directory.

--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,0 +1,72 @@
+review_protocol_version: 1.0.0
+deterministic_contract_version: 1.0.0
+semantic_prompt_version: 1.0.0
+track_policy_version: 1.0.0
+
+families:
+  core:
+    semantic_prompt: agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
+    semantic_requirements:
+      claim_coverage: not_applicable
+      verify_ukrainian_with_project_sources: true
+      review_plan_pedagogy_activities: true
+    size_policy_blocking_statuses: [invalid_size_policy, plan_review_needed]
+    mechanical_checks:
+      connects_to_sequence:
+        severity: high
+      forbidden_placeholders:
+        - path: portrait_fallback.license
+          values: [VERIFY, TODO, TBD, UNKNOWN]
+          category: unresolved_rights
+          severity: high
+          message: Public-media rights remain unresolved.
+    skip_policy:
+      llm_qg: superseded_by_semantic
+      mdx_generation_validate: accepted_read_only_omission
+      external_resource_liveness: advisory_external
+  seminar:
+    semantic_prompt: agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
+    semantic_requirements:
+      claim_coverage: exhaustive
+      verify_ukrainian_with_project_sources: true
+      verify_every_factual_claim: true
+      decolonization_review: required
+    size_policy_blocking_statuses: [invalid_size_policy, plan_review_needed, missing_research_dossier]
+    mechanical_checks:
+      connects_to_sequence:
+        severity: high
+      forbidden_placeholders:
+        - path: portrait_fallback.license
+          values: [VERIFY, TODO, TBD, UNKNOWN]
+          category: unresolved_rights
+          severity: high
+          message: Public-media rights remain unresolved; use text-only until cleared.
+    skip_policy:
+      llm_qg: superseded_by_semantic
+      mdx_generation_validate: accepted_read_only_omission
+      external_resource_liveness: advisory_external
+
+tracks:
+  a1: {family: core}
+  a2: {family: core}
+  b1: {family: core}
+  b2: {family: core}
+  c1: {family: core}
+  c2: {family: core}
+  folk: {family: seminar}
+  hist: {family: seminar}
+  history: {family: seminar}
+  bio: {family: seminar, semantic_mode: biography}
+  istorio: {family: seminar}
+  lit: {family: seminar}
+  lit-crimea: {family: seminar}
+  lit-doc: {family: seminar}
+  lit-drama: {family: seminar}
+  lit-essay: {family: seminar}
+  lit-fantastika: {family: seminar}
+  lit-hist-fic: {family: seminar}
+  lit-humor: {family: seminar}
+  lit-war: {family: seminar}
+  lit-youth: {family: seminar}
+  oes: {family: seminar}
+  ruth: {family: seminar}

--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,5 +1,5 @@
 review_protocol_version: 1.0.1
-deterministic_contract_version: 1.0.0
+deterministic_contract_version: 1.0.1
 semantic_prompt_version: 1.0.0
 track_policy_version: 1.0.0
 

--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,4 +1,4 @@
-review_protocol_version: 1.0.0
+review_protocol_version: 1.0.1
 deterministic_contract_version: 1.0.0
 semantic_prompt_version: 1.0.0
 track_policy_version: 1.0.0

--- a/agents_extensions/shared/skills/post-build-review/contracts/combined-disposition-policy.md
+++ b/agents_extensions/shared/skills/post-build-review/contracts/combined-disposition-policy.md
@@ -1,0 +1,25 @@
+# Combined disposition policy
+
+Review protocol version: `1.0.0`
+
+Apply disposition in this order:
+
+1. `INCOMPLETE`: deterministic/size command error; required or unclassified
+   skip; source drift; missing provenance/version/hash/reviewer fields; schema
+   failure; unavailable required source tooling; incomplete semantic coverage.
+2. `BLOCK`: any blocker from deterministic, track-policy, or semantic evidence;
+   any high mechanical finding; semantic `BLOCK`.
+3. `REVISE`: semantic `REVISE`; semantic high/medium finding; other actionable
+   non-mechanical medium finding.
+4. `PASS`: deterministic stages completed, all skips were policy-classified,
+   semantic coverage completed or is correctly not applicable, and only
+   low/info findings remain.
+
+Semantic `PASS` never overrides deterministic or track-policy findings. A count
+above the size-policy advisory ceiling is not an automatic failure; the
+semantic reviewer decides whether the excess is sourced density or padding.
+The combined result is immutable evidence for the hashed inputs only.
+
+Canonical severity is `blocker | high | medium | low | info`, matching the
+deterministic audit and code-review verifier. Adapters normalize legacy
+`critical → blocker`, `major → high`, `warning/minor → medium`, and `nit → low`.

--- a/agents_extensions/shared/skills/post-build-review/contracts/combined-disposition-policy.md
+++ b/agents_extensions/shared/skills/post-build-review/contracts/combined-disposition-policy.md
@@ -1,6 +1,6 @@
 # Combined disposition policy
 
-Review protocol version: `1.0.0`
+Review protocol version: `1.0.1`
 
 Apply disposition in this order:
 

--- a/agents_extensions/shared/skills/post-build-review/contracts/deterministic-audit-contract.md
+++ b/agents_extensions/shared/skills/post-build-review/contracts/deterministic-audit-contract.md
@@ -1,6 +1,6 @@
 # Deterministic audit contract
 
-Deterministic contract version: `1.0.0`
+Deterministic contract version: `1.0.1`
 
 The canonical deterministic stage composes, without reimplementing:
 
@@ -21,7 +21,7 @@ path, and configuration version. Never persist a machine-local interpreter
 path. Hash every resolved source file. A command error, malformed JSON, unknown skip, missing
 required evidence, or changed source hash fails closed as `INCOMPLETE`.
 
-Allowed deterministic skips must remain explicit in the result. Version 1.0.0
+Allowed deterministic skips must remain explicit in the result. Version 1.0.1
 accepts the read-only omission of MDX regeneration validation, supersedes the
 excluded legacy LLM-QG with the semantic stage, and records network liveness as
 an external advisory. None may disappear silently.

--- a/agents_extensions/shared/skills/post-build-review/contracts/deterministic-audit-contract.md
+++ b/agents_extensions/shared/skills/post-build-review/contracts/deterministic-audit-contract.md
@@ -1,0 +1,27 @@
+# Deterministic audit contract
+
+Deterministic contract version: `1.0.0`
+
+The canonical deterministic stage composes, without reimplementing:
+
+1. `.venv/bin/python scripts/audit/track_deterministic_audit.py --track
+   <track> --slugs <slug> --format json --fail-on never`
+2. `.venv/bin/python scripts/audit/module_size_policy_audit.py --tracks
+   <track> --slugs <slug> --built-only --format json`
+3. Mechanical rules from `config/track-policy.v1.yaml`.
+
+`--fail-on never` preserves structured output; combined disposition applies the
+severity threshold. Never pass `--output` or
+`--run-mdx-generation-validate`. Never substitute the legacy module audit or
+shell wrapper, which write audit/status/log artifacts and may update caches.
+
+Record canonical argv twice (`argv` and the privacy-safe `executed_argv`),
+repository-relative cwd, exit code, stdout and stderr SHA-256, configuration
+path, and configuration version. Never persist a machine-local interpreter
+path. Hash every resolved source file. A command error, malformed JSON, unknown skip, missing
+required evidence, or changed source hash fails closed as `INCOMPLETE`.
+
+Allowed deterministic skips must remain explicit in the result. Version 1.0.0
+accepts the read-only omission of MDX regeneration validation, supersedes the
+excluded legacy LLM-QG with the semantic stage, and records network liveness as
+an external advisory. None may disappear silently.

--- a/agents_extensions/shared/skills/post-build-review/contracts/evidence-derived-size-policy-contract.md
+++ b/agents_extensions/shared/skills/post-build-review/contracts/evidence-derived-size-policy-contract.md
@@ -1,0 +1,25 @@
+# Evidence-derived size-policy contract
+
+Size-policy contract version: `1.0.0`
+
+Consume the existing structured record from
+`scripts/audit/module_size_policy_audit.py` and the implementation in
+`scripts/build/module_size_policy.py`. Do not duplicate density thresholds in
+prompts, track policy, or this contract.
+
+- `word_target` and a valid reviewed `size_policy.floor_words` are deterministic
+  floors, not targets to pad toward with unsupported material.
+- The recommended range and advisory ceiling express evidence/pedagogical
+  pressure. Crossing the ceiling triggers semantic inspection; it is not an
+  automatic fail.
+- Source-backed density and necessary pedagogy are acceptable. Repeated framing,
+  generic exposition, uncited interpretation, and inflated transitions are
+  padding evidence.
+- If grounded material runs out before the floor, surface a plan-policy mismatch
+  instead of inventing depth.
+- Invalid reviewed policy or missing required dossier evidence blocks automatic
+  expansion.
+
+Oleksandr Bilash is the first exemplar only. Its current range, ceiling,
+headings, evidence density, and conclusion belong to its plan/result fixture,
+not to BIO or seminar defaults.

--- a/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
@@ -1,0 +1,64 @@
+# Common semantic post-build review prompt
+
+Semantic prompt version: `1.0.0`
+
+Review the resolved built module, not an imagined template. Deterministic facts
+and mechanically verifiable track rules are already in the resolved context;
+do not re-score them or negotiate them down. Investigate the residual judgments
+that code cannot decide.
+
+## Evidence rules
+
+- Read every resolved source file before judging it.
+- Cite exact locations and concise evidence for each finding.
+- Verify Ukrainian word, stress, morphology, grammar, Russicism, false-friend,
+  and calque claims with project source tools. Never infer them from intuition.
+- Verify factual, quotation, and attribution claims with the appropriate
+  authoritative project sources. Plausible but unattested is not supported.
+- Treat missing tools, missing source support, or incomplete review coverage as
+  `INCOMPLETE`, not `PASS`.
+- Inspect activities for actual learner behavior: answer correctness,
+  distractor validity, task clarity, progression, and whether they test the
+  intended language or analysis rather than trivia.
+- Inspect pedagogy, plan adherence, coherence, learner register, cognitive
+  load, naturalness, engagement, and source-backed density. Do not turn a word
+  count or Bilash-specific structure into a universal rule.
+
+## Severity and verdict
+
+Use only `blocker`, `high`, `medium`, `low`, or `info`.
+
+- `blocker`: false teaching, fabricated/contradicted fact, unsafe rights or
+  provenance failure, or a defect that makes the module unshippable.
+- `high`: material correction required before readiness.
+- `medium`: actionable quality defect requiring revision.
+- `low`/`info`: non-blocking polish or observation.
+
+Verdicts are `PASS`, `REVISE`, `BLOCK`, or `INCOMPLETE`. `PASS` permits only
+low/info findings and complete required coverage.
+
+## Semantic result shape
+
+Return one JSON object and no Markdown wrapper:
+
+```json
+{
+  "verdict": "PASS|REVISE|BLOCK|INCOMPLETE",
+  "summary": "concise evidence-backed summary",
+  "claim_coverage": {
+    "status": "complete|incomplete|not_applicable",
+    "claims_total": 0,
+    "claims_verified": 0
+  },
+  "findings": [
+    {
+      "id": "stable-kebab-id",
+      "category": "pedagogy|language|activity|factuality|grounding|decolonization|rights|size|other",
+      "severity": "blocker|high|medium|low|info",
+      "message": "what is wrong and why it matters",
+      "evidence": "exact text plus source/tool support",
+      "location": "repo-relative path and locator"
+    }
+  ]
+}
+```

--- a/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
@@ -1,0 +1,21 @@
+# Core semantic post-build review prompt
+
+Semantic prompt version: `1.0.0`
+
+Apply this only to A1-C2 core tracks, after the common prompt.
+
+- Calibrate language, grammar scope, scaffolding, activity demand, and teaching
+  sequence to the resolved CEFR level and module position.
+- Preserve A1 English scaffolding. From A2 onward never recommend increasing
+  English or lowering Ukrainian immersion; use the repository's current banded
+  policy rather than remembered thresholds.
+- Verify grammar explanations and examples against Ukrainian sources. Check
+  agreement, government, aspect, case, word order, stress, and register where
+  relevant.
+- Evaluate whether examples precede abstraction, practice follows introduced
+  material, and activities use only knowledge available to the learner.
+- Compare plan objectives and required vocabulary with prose and activities,
+  but do not invent hard counts or headings not supplied by current policy.
+- Set `claim_coverage.status` to `not_applicable` unless the module makes
+  factual claims that require explicit verification; then use `complete` or
+  `incomplete` and report the counts.

--- a/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
@@ -1,0 +1,36 @@
+# Seminar semantic post-build review prompt
+
+Semantic prompt version: `1.0.0`
+
+Apply this only to FOLK, HIST, BIO, ISTORIO, LIT and subtracks, OES, or RUTH,
+after the common prompt.
+
+## Exhaustive claim ledger
+
+Extract every checkable factual claim as an atomic item: people, dates, places,
+events, works, categories, typologies, periods, etymologies, quotations,
+attributions, causal claims presented as fact, image/rights claims, and source
+claims. Verify every item. Record total and verified counts. Any unchecked item
+makes claim coverage incomplete.
+
+Classify evidence internally as supported, contradicted, imprecise, unattested,
+or unverifiable. A contradicted teaching claim is a blocker. Confidently
+specific but unattested material is at least high and may be a blocker when a
+named source/person/event should be findable.
+
+## Track-sensitive judgment
+
+- Center Ukrainian agency and Ukrainian scholarly categories. Detect Russian-
+  imperial, Soviet, common-heritage, colonial, and Western-centrist framing.
+- Distinguish evidence from interpretation, and interpretation from praise.
+  Reject hagiography and unsupported moral/psychological narratives.
+- For BIO, verify education, roles, relationships, chronology, works, awards,
+  repression/recognition claims, quotations, and image rights. Do not treat
+  Oleksandr Bilash's headings, length range, works, or final disposition as a
+  global BIO template.
+- For literary and historical-language tracks, verify textual evidence,
+  edition/source identity, dating, genre, and anachronism risks.
+- For FOLK, enforce decolonized framing and distinguish documented practice
+  from occult belief claims or demonizing ethnographic language.
+- Set `claim_coverage.status` to `complete` only when every extracted claim was
+  checked with attributable evidence.

--- a/agents_extensions/shared/skills/post-build-review/schema/review-result.v1.schema.json
+++ b/agents_extensions/shared/skills/post-build-review/schema/review-result.v1.schema.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://learn-ukrainian.github.io/schemas/post-build-review.result.v1.schema.json",
+  "title": "Post-build review result v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "review_protocol_version",
+    "deterministic_contract_version",
+    "semantic_prompt_version",
+    "track_policy_version",
+    "prompt_sha256",
+    "reproducibility_key",
+    "target",
+    "source_hashes",
+    "reviewer",
+    "deterministic",
+    "semantic",
+    "findings",
+    "combined_disposition"
+  ],
+  "properties": {
+    "schema_version": {"const": "post-build-review.result.v1"},
+    "review_protocol_version": {"$ref": "#/$defs/semver"},
+    "deterministic_contract_version": {"$ref": "#/$defs/semver"},
+    "semantic_prompt_version": {"$ref": "#/$defs/semver"},
+    "track_policy_version": {"$ref": "#/$defs/semver"},
+    "prompt_sha256": {"$ref": "#/$defs/sha256"},
+    "reproducibility_key": {"$ref": "#/$defs/sha256"},
+    "target": {"$ref": "#/$defs/target"},
+    "source_hashes": {
+      "type": "object",
+      "minProperties": 2,
+      "additionalProperties": {"$ref": "#/$defs/sha256"}
+    },
+    "reviewer": {"$ref": "#/$defs/reviewer"},
+    "deterministic": {"$ref": "#/$defs/deterministic"},
+    "semantic": {"$ref": "#/$defs/semantic"},
+    "findings": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/finding"}
+    },
+    "combined_disposition": {"$ref": "#/$defs/disposition"}
+  },
+  "$defs": {
+    "semver": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "nonempty": {"type": "string", "minLength": 1},
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["track", "slug", "semantic_family", "layout", "files"],
+      "properties": {
+        "track": {"$ref": "#/$defs/nonempty"},
+        "slug": {"$ref": "#/$defs/nonempty"},
+        "semantic_family": {"enum": ["core", "seminar"]},
+        "layout": {"enum": ["directory", "flat"]},
+        "files": {
+          "type": "object",
+          "required": ["plan", "content"],
+          "additionalProperties": {"$ref": "#/$defs/nonempty"}
+        }
+      }
+    },
+    "reviewer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["agent", "family", "model", "effort"],
+      "properties": {
+        "agent": {"$ref": "#/$defs/nonempty"},
+        "family": {"$ref": "#/$defs/nonempty"},
+        "model": {"$ref": "#/$defs/nonempty"},
+        "effort": {"$ref": "#/$defs/nonempty"}
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["argv", "executed_argv", "cwd", "exit_code", "stdout_sha256", "stderr_sha256", "config_path", "config_version"],
+      "properties": {
+        "argv": {"type": "array", "minItems": 2, "items": {"$ref": "#/$defs/nonempty"}},
+        "executed_argv": {"type": "array", "minItems": 2, "items": {"$ref": "#/$defs/nonempty"}},
+        "cwd": {"const": "."},
+        "exit_code": {"type": "integer"},
+        "stdout_sha256": {"$ref": "#/$defs/sha256"},
+        "stderr_sha256": {"$ref": "#/$defs/sha256"},
+        "config_path": {"$ref": "#/$defs/nonempty"},
+        "config_version": {"$ref": "#/$defs/nonempty"}
+      }
+    },
+    "stage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "provenance", "result", "error"],
+      "properties": {
+        "status": {"enum": ["complete", "error"]},
+        "provenance": {"$ref": "#/$defs/provenance"},
+        "result": {"type": ["object", "null"], "additionalProperties": true},
+        "error": {"type": ["string", "null"]}
+      }
+    },
+    "skip": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["category", "disposition", "reason"],
+      "properties": {
+        "category": {"$ref": "#/$defs/nonempty"},
+        "disposition": {"$ref": "#/$defs/nonempty"},
+        "reason": {"type": "string"}
+      }
+    },
+    "deterministic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["track_audit", "size_policy", "policy_findings", "skip_assessments", "aggregate"],
+      "properties": {
+        "track_audit": {"$ref": "#/$defs/stage"},
+        "size_policy": {"$ref": "#/$defs/stage"},
+        "policy_findings": {"type": "array", "items": {"$ref": "#/$defs/finding"}},
+        "skip_assessments": {"type": "array", "items": {"$ref": "#/$defs/skip"}},
+        "aggregate": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "findings_by_severity", "reasons"],
+          "properties": {
+            "status": {"enum": ["clear", "review", "block", "incomplete"]},
+            "findings_by_severity": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["blocker", "high", "medium", "low", "info"],
+              "properties": {
+                "blocker": {"type": "integer", "minimum": 0},
+                "high": {"type": "integer", "minimum": 0},
+                "medium": {"type": "integer", "minimum": 0},
+                "low": {"type": "integer", "minimum": 0},
+                "info": {"type": "integer", "minimum": 0}
+              }
+            },
+            "reasons": {"type": "array", "items": {"$ref": "#/$defs/nonempty"}}
+          }
+        }
+      }
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "source", "category", "severity", "message", "evidence", "location"],
+      "properties": {
+        "id": {"$ref": "#/$defs/nonempty"},
+        "source": {"enum": ["deterministic", "track_policy", "semantic"]},
+        "category": {"$ref": "#/$defs/nonempty"},
+        "severity": {"enum": ["blocker", "high", "medium", "low", "info"]},
+        "message": {"$ref": "#/$defs/nonempty"},
+        "evidence": {"type": "string"},
+        "location": {"type": ["string", "null"]}
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "claims_total", "claims_verified"],
+      "properties": {
+        "status": {"enum": ["complete", "incomplete", "not_applicable"]},
+        "claims_total": {"type": "integer", "minimum": 0},
+        "claims_verified": {"type": "integer", "minimum": 0}
+      }
+    },
+    "semantic": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["family", "verdict", "summary", "claim_coverage", "findings"],
+      "properties": {
+        "family": {"enum": ["core", "seminar"]},
+        "verdict": {"enum": ["PASS", "REVISE", "BLOCK", "INCOMPLETE"]},
+        "summary": {"type": "string"},
+        "claim_coverage": {"$ref": "#/$defs/coverage"},
+        "findings": {"type": "array", "items": {"$ref": "#/$defs/finding"}}
+      }
+    },
+    "disposition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "reasons"],
+      "properties": {
+        "status": {"enum": ["PASS", "REVISE", "BLOCK", "INCOMPLETE"]},
+        "reasons": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/nonempty"}}
+      }
+    }
+  }
+}

--- a/docs/runbooks/post-build-review.md
+++ b/docs/runbooks/post-build-review.md
@@ -1,0 +1,124 @@
+# Post-build review runbook
+
+The canonical protocol lives only at
+`agents_extensions/shared/skills/post-build-review/`. Deployed agent directories
+are mirrors. Do not maintain an independent Codex, Claude, Gemini, `.agent`, or
+dispatch-prompt copy.
+
+## Operator invocation
+
+Use the short prompt:
+
+```text
+Use $post-build-review for bio/oleksandr-bilash.
+```
+
+The skill runs deterministic preparation, selects the core or seminar semantic
+family from versioned track policy, requires a source-backed semantic result,
+and combines both layers into `/tmp/post-build-review-result.json`. It must not
+write curriculum audit/status/review files or telemetry.
+
+## Responsibility boundaries
+
+| Responsibility | Canonical location |
+| --- | --- |
+| Deterministic facts and aggregation | `scripts/audit/post_build_review.py` plus existing audit code |
+| Mechanically verifiable track rules | `post-build-review/config/track-policy.v1.yaml` |
+| Semantic judgment | `post-build-review/prompts/*.md` |
+| Orchestration order | `post-build-review/SKILL.md` |
+| Output shape | `post-build-review/schema/review-result.v1.schema.json` |
+| Operator maintenance | This runbook |
+
+The evidence-derived size contract consumes the existing size-policy audit. It
+does not duplicate thresholds. Bilash is the first BIO exemplar; its range,
+headings, and disposition are local evidence, never global BIO policy.
+
+## Versioning
+
+Every result records:
+
+- `review_protocol_version`
+- `deterministic_contract_version`
+- `semantic_prompt_version`
+- `track_policy_version`
+- effective `prompt_sha256`
+- reviewer agent, family, exact model, and effort
+- deterministic argv/cwd/exit/output hashes/config provenance
+- source-file hashes and a normalized reproducibility key
+
+Bump the version responsible for a behavior change:
+
+| Change | Version to bump |
+| --- | --- |
+| Aggregation, command composition, disposition order | `review_protocol_version` |
+| Deterministic evidence/provenance semantics | `deterministic_contract_version` |
+| Common/core/seminar judgment instruction | `semantic_prompt_version` |
+| Track mapping, mechanical rule, skip classification | `track_policy_version` |
+
+Use semantic versioning. A breaking schema change requires a new schema id/file
+and review protocol major version. Prompt hashes change automatically from the
+exact assembled common + family + resolved context.
+
+## Bug-fix workflow
+
+For every review defect:
+
+1. Reproduce it with a failing fixture in
+   `tests/fixtures/post_build_review/regressions.v1.yaml`.
+2. Classify the responsible layer: deterministic code, track policy, semantic
+   prompt, disposition, schema, or orchestration.
+3. Patch the single canonical source for that layer.
+4. Add or extend a regression test that fails before the patch.
+5. Increment the applicable protocol version above.
+6. Regenerate mirrors with `npm run agents:deploy` (or
+   `scripts/deploy_prompts.sh`) and never edit a mirror directly.
+7. Run all affected fixtures, schema/prompt/track/read-only tests, deployment
+   drift checks, and the Bilash exemplar.
+8. Obtain an independent review from outside the author's model family. Resolve
+   all material findings; internal same-family helpers do not satisfy the gate.
+9. Commit with an `X-Agent` trailer and merge through one scoped PR. Close the
+   linked stream issue with command/output evidence and clean the worktree.
+
+`.agent/` is preserve-by-default because it contains runtime state. A skill
+rename/removal therefore requires an explicit post-deploy check for the old
+`.agent/skills/<name>` mirror and removal of that stale mirror only; never clean
+unrelated `.agent/` state.
+
+## Validation
+
+From the issue worktree:
+
+```bash
+.venv/bin/python -m pytest tests/audit/test_post_build_review.py -q
+.venv/bin/python -m pytest tests/test_deploy_script_idempotency.py -q
+.venv/bin/python scripts/lint/lint_agent_skills.py
+.venv/bin/python "${CODEX_HOME:-$HOME/.codex}/skills/.system/skill-creator/scripts/quick_validate.py" \
+  agents_extensions/shared/skills/post-build-review
+scripts/deploy_prompts.sh
+bash scripts/check_rules_deployment.sh
+git diff --check
+```
+
+Then forward-test the exact short prompt in a fresh agent. Validate the emitted
+result with:
+
+```bash
+.venv/bin/python scripts/audit/post_build_review.py validate \
+  /tmp/post-build-review-result.json
+```
+
+Compare `reproducibility_key`, version fields, prompt hash, source hashes,
+deterministic findings, size-policy evidence, and combined disposition with the
+versioned Bilash exemplar. Reviewer identity is expected to differ across
+independent agents.
+
+## Read-only and failure behavior
+
+- Outputs inside the repository are rejected.
+- Unknown tracks, ambiguous/missing targets, malformed audit JSON, incomplete
+  seminar claim coverage, source drift, required skips, and missing provenance
+  fail closed.
+- `finalize` exits zero only for `PASS`; `BLOCK`, `REVISE`, and `INCOMPLETE`
+  return non-zero after writing a valid structured result.
+- Never use the legacy module audit/shell wrapper or opt into MDX regeneration
+  from this protocol; those paths can write generated artifacts.

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -559,11 +559,12 @@ def assemble_semantic_prompt(
     family_rel = str(track_policy["semantic_prompt"])
     paths = [common_rel, family_rel]
     pieces = [(repo_root / path).read_text(encoding="utf-8").rstrip() for path in paths]
+    track_result = deterministic["track_audit"].get("result") or {}
     context = {
         "target": target,
         "source_hashes": source_hashes,
-        "deterministic_summary": deterministic["track_audit"].get("result", {}).get("summary"),
-        "deterministic_findings": deterministic["track_audit"].get("result", {}).get("findings"),
+        "deterministic_summary": track_result.get("summary"),
+        "deterministic_findings": track_result.get("findings"),
         "mechanical_policy_findings": deterministic.get("policy_findings"),
         "skip_assessments": deterministic.get("skip_assessments"),
         "size_policy": deterministic["size_policy"].get("result"),

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -1,0 +1,911 @@
+#!/usr/bin/env python3
+"""Compose deterministic and semantic post-build review evidence.
+
+The command is deliberately read-only with respect to the repository. It runs
+the existing track deterministic audit without its mutating opt-ins, resolves
+mechanical track policy, assembles the effective semantic prompt, and combines
+an agent-authored semantic result into the canonical JSON schema.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+from collections.abc import Callable, Mapping, Sequence
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
+SKILL_ROOT = PROJECT_ROOT / "agents_extensions" / "shared" / "skills" / "post-build-review"
+POLICY_PATH = SKILL_ROOT / "config" / "track-policy.v1.yaml"
+SCHEMA_PATH = SKILL_ROOT / "schema" / "review-result.v1.schema.json"
+TRACK_AUDIT_CONFIG = PROJECT_ROOT / "scripts" / "audit" / "track_deterministic_audit_config.yaml"
+
+CANONICAL_SEVERITIES = ("blocker", "high", "medium", "low", "info")
+SEVERITY_ALIASES = {
+    "critical": "blocker",
+    "major": "high",
+    "warning": "medium",
+    "minor": "medium",
+    "nit": "low",
+}
+CONNECTS_TO_RE = re.compile(r"^(?P<track>[a-z0-9-]+)-(?P<sequence>\d+)-(?P<slug>[a-z0-9-]+)$")
+
+
+class ReviewProtocolError(RuntimeError):
+    """Raised when protocol inputs cannot be resolved safely."""
+
+
+def _stable_json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def display_path(path: Path, repo_root: Path = PROJECT_ROOT) -> str:
+    return path.resolve().relative_to(repo_root.resolve()).as_posix()
+
+
+def resolve_repo_path(value: str, *, repo_root: Path = PROJECT_ROOT) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        raise ReviewProtocolError(f"Repository path must be relative: {value!r}")
+    resolved = (repo_root / path).resolve()
+    try:
+        resolved.relative_to(repo_root.resolve())
+    except ValueError as exc:
+        raise ReviewProtocolError(f"Repository path escapes the checkout: {value!r}") from exc
+    return resolved
+
+
+def read_yaml(path: Path) -> dict[str, Any]:
+    value = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ReviewProtocolError(f"Expected YAML mapping: {display_path(path)}")
+    return value
+
+
+def load_track_policy(path: Path = POLICY_PATH) -> dict[str, Any]:
+    policy = read_yaml(path)
+    required = {
+        "review_protocol_version",
+        "deterministic_contract_version",
+        "semantic_prompt_version",
+        "track_policy_version",
+        "families",
+        "tracks",
+    }
+    missing = sorted(required - set(policy))
+    if missing:
+        raise ReviewProtocolError(f"Track policy missing: {', '.join(missing)}")
+    return policy
+
+
+def resolve_track_policy(track: str, policy: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = track.strip().lower()
+    tracks = policy.get("tracks")
+    if not isinstance(tracks, Mapping) or normalized not in tracks:
+        raise ReviewProtocolError(f"Unknown track: {track!r}")
+    track_config = tracks[normalized]
+    if not isinstance(track_config, Mapping):
+        raise ReviewProtocolError(f"Track policy must be a mapping: {normalized}")
+    family_name = str(track_config.get("family") or "")
+    families = policy.get("families")
+    if not isinstance(families, Mapping) or family_name not in families:
+        raise ReviewProtocolError(f"Unknown semantic family {family_name!r} for {normalized}")
+    family_config = families[family_name]
+    if not isinstance(family_config, Mapping):
+        raise ReviewProtocolError(f"Family policy must be a mapping: {family_name}")
+    merged = deepcopy(dict(family_config))
+    for key, value in track_config.items():
+        if key != "family":
+            merged[key] = deepcopy(value)
+    merged["family"] = family_name
+    merged["track"] = normalized
+    return merged
+
+
+def _single_existing(candidates: Sequence[Path], label: str) -> Path | None:
+    existing = sorted({path.resolve() for path in candidates if path.exists()})
+    if len(existing) > 1:
+        shown = ", ".join(path.as_posix() for path in existing)
+        raise ReviewProtocolError(f"Ambiguous {label}: {shown}")
+    return existing[0] if existing else None
+
+
+def resolve_target(
+    selector: str, *, repo_root: Path = PROJECT_ROOT, policy: Mapping[str, Any] | None = None
+) -> dict[str, Any]:
+    if "/" not in selector.strip("/"):
+        raise ReviewProtocolError("Target must be track/slug")
+    track, slug = selector.strip("/").split("/", 1)
+    track = track.lower()
+    if not re.fullmatch(r"[a-z0-9-]+", track) or not re.fullmatch(r"[a-z0-9-]+", slug):
+        raise ReviewProtocolError(f"Invalid target selector: {selector!r}")
+    policy = policy or load_track_policy(repo_root / POLICY_PATH.relative_to(PROJECT_ROOT))
+    track_policy = resolve_track_policy(track, policy)
+    curriculum = repo_root / "curriculum" / "l2-uk-en"
+    plan = curriculum / "plans" / track / f"{slug}.yaml"
+    if not plan.exists():
+        raise ReviewProtocolError(f"Missing plan: {display_path(plan, repo_root)}")
+
+    track_dir = curriculum / track
+    module_dir = track_dir / slug
+    content = _single_existing(
+        [module_dir / "module.md", track_dir / f"{slug}.md", *track_dir.glob(f"[0-9]*-{slug}.md")],
+        "module content",
+    )
+    if content is None:
+        raise ReviewProtocolError(f"No built content for {track}/{slug}")
+    nested = content.name == "module.md" and content.parent == module_dir
+    candidates: dict[str, Sequence[Path]] = {
+        "activities": [module_dir / "activities.yaml"] if nested else [track_dir / "activities" / f"{slug}.yaml"],
+        "vocabulary": [module_dir / "vocabulary.yaml"] if nested else [track_dir / "vocabulary" / f"{slug}.yaml"],
+        "resources": [module_dir / "resources.yaml"] if nested else [track_dir / "resources" / f"{slug}.yaml"],
+        "meta": [module_dir / "meta.yaml", track_dir / "meta" / f"{slug}.yaml"],
+    }
+    files: dict[str, str] = {
+        "plan": display_path(plan, repo_root),
+        "content": display_path(content, repo_root),
+    }
+    for name, paths in candidates.items():
+        resolved = _single_existing(paths, name)
+        if resolved is not None:
+            files[name] = display_path(resolved, repo_root)
+    return {
+        "track": track,
+        "slug": slug,
+        "semantic_family": track_policy["family"],
+        "layout": "directory" if nested else "flat",
+        "files": files,
+    }
+
+
+def hash_target_files(target: Mapping[str, Any], *, repo_root: Path = PROJECT_ROOT) -> dict[str, str]:
+    files = target.get("files")
+    if not isinstance(files, Mapping):
+        raise ReviewProtocolError("Target files must be a mapping")
+    return {
+        str(name): sha256_file(resolve_repo_path(str(path), repo_root=repo_root))
+        for name, path in sorted(files.items())
+    }
+
+
+def resolve_venv_python(repo_root: Path = PROJECT_ROOT) -> Path:
+    direct = repo_root / ".venv" / "bin" / "python"
+    if direct.exists():
+        return direct.resolve()
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if result.returncode == 0:
+        common_dir = Path(result.stdout.strip()).resolve()
+        shared = common_dir.parent / ".venv" / "bin" / "python"
+        if shared.exists():
+            return shared.resolve()
+    raise ReviewProtocolError("Repository .venv/bin/python is unavailable")
+
+
+RunCommand = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _command_provenance(
+    canonical_argv: list[str],
+    executed_argv: list[str],
+    result: subprocess.CompletedProcess[str],
+    *,
+    config_path: str,
+    config_version: str,
+) -> dict[str, Any]:
+    return {
+        "argv": canonical_argv,
+        "executed_argv": executed_argv,
+        "cwd": ".",
+        "exit_code": result.returncode,
+        "stdout_sha256": sha256_text(result.stdout),
+        "stderr_sha256": sha256_text(result.stderr),
+        "config_path": config_path,
+        "config_version": config_version,
+    }
+
+
+def _run_json_command(
+    canonical_argv: list[str],
+    *,
+    repo_root: Path,
+    config_path: str,
+    config_version: str,
+    runner: RunCommand = subprocess.run,
+) -> tuple[Any | None, dict[str, Any], str | None]:
+    python = resolve_venv_python(repo_root)
+    executed_argv = [str(python), *canonical_argv[1:]]
+    result = runner(executed_argv, cwd=repo_root, capture_output=True, check=False, text=True)
+    provenance = _command_provenance(
+        canonical_argv,
+        canonical_argv,
+        result,
+        config_path=config_path,
+        config_version=config_version,
+    )
+    if result.returncode != 0:
+        return None, provenance, f"command_exit_{result.returncode}: {result.stderr[-500:]}"
+    try:
+        return json.loads(result.stdout), provenance, None
+    except json.JSONDecodeError as exc:
+        return None, provenance, f"invalid_json: {exc}"
+
+
+def run_existing_deterministic_audits(
+    target: Mapping[str, Any],
+    *,
+    repo_root: Path = PROJECT_ROOT,
+    policy: Mapping[str, Any],
+    runner: RunCommand = subprocess.run,
+) -> dict[str, Any]:
+    track = str(target["track"])
+    slug = str(target["slug"])
+    audit_config = read_yaml(repo_root / TRACK_AUDIT_CONFIG.relative_to(PROJECT_ROOT))
+    audit_config_version = str(audit_config.get("version"))
+    audit_argv = [
+        ".venv/bin/python",
+        "scripts/audit/track_deterministic_audit.py",
+        "--track",
+        track,
+        "--slugs",
+        slug,
+        "--format",
+        "json",
+        "--fail-on",
+        "never",
+    ]
+    audit_data, audit_provenance, audit_error = _run_json_command(
+        audit_argv,
+        repo_root=repo_root,
+        config_path="scripts/audit/track_deterministic_audit_config.yaml",
+        config_version=audit_config_version,
+        runner=runner,
+    )
+
+    size_argv = [
+        ".venv/bin/python",
+        "scripts/audit/module_size_policy_audit.py",
+        "--tracks",
+        track,
+        "--slugs",
+        slug,
+        "--built-only",
+        "--format",
+        "json",
+    ]
+    size_data, size_provenance, size_error = _run_json_command(
+        size_argv,
+        repo_root=repo_root,
+        config_path="agents_extensions/shared/skills/post-build-review/contracts/evidence-derived-size-policy-contract.md",
+        config_version=str(policy["deterministic_contract_version"]),
+        runner=runner,
+    )
+    size_record = size_data[0] if isinstance(size_data, list) and len(size_data) == 1 else None
+    if size_data is not None and size_record is None:
+        size_error = "expected exactly one size-policy record"
+    return {
+        "track_audit": {
+            "status": "complete" if audit_error is None else "error",
+            "provenance": audit_provenance,
+            "result": audit_data,
+            "error": audit_error,
+        },
+        "size_policy": {
+            "status": "complete" if size_error is None else "error",
+            "provenance": size_provenance,
+            "result": size_record,
+            "error": size_error,
+        },
+    }
+
+
+def normalize_severity(value: str) -> str:
+    normalized = value.strip().lower()
+    normalized = SEVERITY_ALIASES.get(normalized, normalized)
+    if normalized not in CANONICAL_SEVERITIES:
+        raise ReviewProtocolError(f"Unknown severity: {value!r}")
+    return normalized
+
+
+def _policy_finding(
+    finding_id: str, category: str, severity: str, message: str, *, evidence: str, location: str | None = None
+) -> dict[str, Any]:
+    return {
+        "id": finding_id,
+        "source": "track_policy",
+        "category": category,
+        "severity": normalize_severity(severity),
+        "message": message,
+        "evidence": evidence,
+        "location": location,
+    }
+
+
+def _check_size_policy_status(
+    target: Mapping[str, Any],
+    track_policy: Mapping[str, Any],
+    size_record: Mapping[str, Any] | None,
+) -> list[dict[str, Any]]:
+    blocking_size_statuses = {str(value) for value in track_policy.get("size_policy_blocking_statuses") or []}
+    if size_record is None or str(size_record.get("status")) not in blocking_size_statuses:
+        return []
+    return [
+        _policy_finding(
+            "size-policy-blocking-status",
+            "size_policy",
+            "high",
+            "Evidence-derived size policy is not ready for module approval.",
+            evidence=f"status={size_record.get('status')}; notes={size_record.get('notes')}",
+            location=str(target["files"]["plan"]),
+        )
+    ]
+
+
+def _check_connects_to(
+    plan: Mapping[str, Any],
+    plan_path: Path,
+    spec: object,
+    *,
+    repo_root: Path,
+) -> list[dict[str, Any]]:
+    if not spec:
+        return []
+    severity = str(spec.get("severity", "high")) if isinstance(spec, Mapping) else "high"
+    findings: list[dict[str, Any]] = []
+    for index, raw in enumerate(plan.get("connects_to") or []):
+        if not isinstance(raw, str):
+            findings.append(
+                _policy_finding(
+                    f"connects-to-shape-{index}",
+                    "crosslink_integrity",
+                    severity,
+                    "connects_to entries must be strings.",
+                    evidence=repr(raw),
+                    location=display_path(plan_path, repo_root),
+                )
+            )
+            continue
+        match = CONNECTS_TO_RE.fullmatch(raw)
+        if not match:
+            findings.append(
+                _policy_finding(
+                    f"connects-to-format-{index}",
+                    "crosslink_integrity",
+                    severity,
+                    "connects_to entry does not match track-sequence-slug.",
+                    evidence=raw,
+                    location=display_path(plan_path, repo_root),
+                )
+            )
+            continue
+        linked_plan = repo_root / "curriculum" / "l2-uk-en" / "plans" / match["track"] / f"{match['slug']}.yaml"
+        if not linked_plan.exists():
+            findings.append(
+                _policy_finding(
+                    f"connects-to-missing-{index}",
+                    "crosslink_integrity",
+                    severity,
+                    "connects_to target plan does not exist.",
+                    evidence=raw,
+                    location=display_path(plan_path, repo_root),
+                )
+            )
+            continue
+        actual = read_yaml(linked_plan).get("sequence")
+        if str(actual) != str(int(match["sequence"])):
+            findings.append(
+                _policy_finding(
+                    f"connects-to-sequence-{index}",
+                    "crosslink_integrity",
+                    severity,
+                    "connects_to sequence does not match the target plan.",
+                    evidence=f"declared={raw}; target_sequence={actual}",
+                    location=display_path(plan_path, repo_root),
+                )
+            )
+    return findings
+
+
+def _dotted_value(mapping: Mapping[str, Any], dotted: str) -> Any:
+    value: Any = mapping
+    for part in dotted.split("."):
+        if not isinstance(value, Mapping) or part not in value:
+            return None
+        value = value[part]
+    return value
+
+
+def _check_forbidden_placeholders(
+    plan: Mapping[str, Any],
+    plan_path: Path,
+    specs: object,
+    *,
+    repo_root: Path,
+) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    for index, spec in enumerate(specs or []):
+        if not isinstance(spec, Mapping):
+            raise ReviewProtocolError("forbidden_placeholders entries must be mappings")
+        dotted = str(spec.get("path") or "")
+        value = _dotted_value(plan, dotted)
+        forbidden = {str(item).strip().upper() for item in spec.get("values") or []}
+        if value is not None and str(value).strip().upper() in forbidden:
+            findings.append(
+                _policy_finding(
+                    f"forbidden-placeholder-{index}",
+                    str(spec.get("category") or "unresolved_placeholder"),
+                    str(spec.get("severity") or "high"),
+                    str(spec.get("message") or f"Unresolved placeholder at {dotted}."),
+                    evidence=f"{dotted}={value}",
+                    location=display_path(plan_path, repo_root),
+                )
+            )
+    return findings
+
+
+def evaluate_mechanical_track_policy(
+    target: Mapping[str, Any],
+    track_policy: Mapping[str, Any],
+    *,
+    repo_root: Path = PROJECT_ROOT,
+    size_record: Mapping[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    plan_path = resolve_repo_path(str(target["files"]["plan"]), repo_root=repo_root)
+    plan = read_yaml(plan_path)
+    checks = track_policy.get("mechanical_checks")
+    if not isinstance(checks, Mapping):
+        return []
+    return [
+        *_check_size_policy_status(target, track_policy, size_record),
+        *_check_connects_to(plan, plan_path, checks.get("connects_to_sequence"), repo_root=repo_root),
+        *_check_forbidden_placeholders(
+            plan,
+            plan_path,
+            checks.get("forbidden_placeholders"),
+            repo_root=repo_root,
+        ),
+    ]
+
+
+def assess_skips(track_result: Mapping[str, Any], track_policy: Mapping[str, Any]) -> list[dict[str, Any]]:
+    allowed = track_policy.get("skip_policy")
+    if not isinstance(allowed, Mapping):
+        allowed = {}
+    assessments: list[dict[str, Any]] = []
+    for skipped in track_result.get("skipped") or []:
+        category = str(skipped.get("category") or "unknown")
+        disposition = str(allowed.get(category) or "unclassified")
+        assessments.append(
+            {
+                "category": category,
+                "disposition": disposition,
+                "reason": str(skipped.get("reason") or ""),
+            }
+        )
+    return assessments
+
+
+def aggregate_deterministic(deterministic: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a pure, fail-closed summary of deterministic review evidence."""
+    severities = {severity: 0 for severity in CANONICAL_SEVERITIES}
+    track_result = deterministic.get("track_audit", {}).get("result") or {}
+    for finding in track_result.get("findings") or []:
+        severities[normalize_severity(str(finding.get("severity") or ""))] += 1
+    for finding in deterministic.get("policy_findings") or []:
+        severities[normalize_severity(str(finding.get("severity") or ""))] += 1
+
+    reasons: list[str] = []
+    for stage_name in ("track_audit", "size_policy"):
+        if deterministic.get(stage_name, {}).get("status") != "complete":
+            reasons.append(f"{stage_name} did not complete")
+    required_skips = sorted(
+        {
+            str(item.get("category"))
+            for item in deterministic.get("skip_assessments") or []
+            if item.get("disposition") in {"required", "unclassified"}
+        }
+    )
+    if required_skips:
+        reasons.append("required or unclassified skips: " + ", ".join(required_skips))
+    if reasons:
+        status = "incomplete"
+    elif severities["blocker"] or severities["high"]:
+        status = "block"
+    elif severities["medium"]:
+        status = "review"
+    else:
+        status = "clear"
+    return {
+        "status": status,
+        "findings_by_severity": severities,
+        "reasons": reasons,
+    }
+
+
+def assemble_semantic_prompt(
+    target: Mapping[str, Any],
+    track_policy: Mapping[str, Any],
+    deterministic: Mapping[str, Any],
+    source_hashes: Mapping[str, str],
+    *,
+    repo_root: Path = PROJECT_ROOT,
+) -> tuple[str, list[str]]:
+    common_rel = "agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md"
+    family_rel = str(track_policy["semantic_prompt"])
+    paths = [common_rel, family_rel]
+    pieces = [(repo_root / path).read_text(encoding="utf-8").rstrip() for path in paths]
+    context = {
+        "target": target,
+        "source_hashes": source_hashes,
+        "deterministic_summary": deterministic["track_audit"].get("result", {}).get("summary"),
+        "deterministic_findings": deterministic["track_audit"].get("result", {}).get("findings"),
+        "mechanical_policy_findings": deterministic.get("policy_findings"),
+        "skip_assessments": deterministic.get("skip_assessments"),
+        "size_policy": deterministic["size_policy"].get("result"),
+        "resolved_track_policy": {
+            "family": track_policy.get("family"),
+            "track": track_policy.get("track"),
+            "semantic_requirements": track_policy.get("semantic_requirements"),
+            "mechanical_checks": track_policy.get("mechanical_checks"),
+            "size_policy_blocking_statuses": track_policy.get("size_policy_blocking_statuses"),
+            "skip_policy": track_policy.get("skip_policy"),
+        },
+    }
+    pieces.append(
+        "# Resolved review context\n\n```json\n"
+        + json.dumps(context, ensure_ascii=False, indent=2, sort_keys=True)
+        + "\n```"
+    )
+    return "\n\n---\n\n".join(pieces) + "\n", paths
+
+
+def prepare_review(
+    selector: str,
+    reviewer: Mapping[str, str],
+    *,
+    repo_root: Path = PROJECT_ROOT,
+    runner: RunCommand = subprocess.run,
+) -> dict[str, Any]:
+    policy_path = repo_root / POLICY_PATH.relative_to(PROJECT_ROOT)
+    policy = load_track_policy(policy_path)
+    target = resolve_target(selector, repo_root=repo_root, policy=policy)
+    track_policy = resolve_track_policy(str(target["track"]), policy)
+    source_hashes = hash_target_files(target, repo_root=repo_root)
+    deterministic = run_existing_deterministic_audits(target, repo_root=repo_root, policy=policy, runner=runner)
+    track_result = deterministic["track_audit"].get("result") or {}
+    deterministic["policy_findings"] = evaluate_mechanical_track_policy(
+        target,
+        track_policy,
+        repo_root=repo_root,
+        size_record=deterministic["size_policy"].get("result"),
+    )
+    deterministic["skip_assessments"] = assess_skips(track_result, track_policy)
+    deterministic["aggregate"] = aggregate_deterministic(deterministic)
+    prompt_text, prompt_paths = assemble_semantic_prompt(
+        target, track_policy, deterministic, source_hashes, repo_root=repo_root
+    )
+    return {
+        "packet_version": "post-build-review.packet.v1",
+        "review_protocol_version": str(policy["review_protocol_version"]),
+        "deterministic_contract_version": str(policy["deterministic_contract_version"]),
+        "semantic_prompt_version": str(policy["semantic_prompt_version"]),
+        "track_policy_version": str(policy["track_policy_version"]),
+        "prompt_sha256": sha256_text(prompt_text),
+        "prompt_paths": prompt_paths,
+        "semantic_prompt": prompt_text,
+        "target": target,
+        "source_hashes": source_hashes,
+        "reviewer": dict(reviewer),
+        "deterministic": deterministic,
+    }
+
+
+def source_drift_findings(packet: Mapping[str, Any], *, repo_root: Path = PROJECT_ROOT) -> list[dict[str, Any]]:
+    current = hash_target_files(packet["target"], repo_root=repo_root)
+    expected = packet.get("source_hashes") or {}
+    findings: list[dict[str, Any]] = []
+    for name in sorted(set(current) | set(expected)):
+        if current.get(name) != expected.get(name):
+            findings.append(
+                _policy_finding(
+                    f"source-drift-{name}",
+                    "source_drift",
+                    "blocker",
+                    f"{name} changed after deterministic preparation.",
+                    evidence=f"expected={expected.get(name)} current={current.get(name)}",
+                    location=str(packet["target"]["files"].get(name)),
+                )
+            )
+    return findings
+
+
+def packet_integrity_findings(packet: Mapping[str, Any], *, repo_root: Path = PROJECT_ROOT) -> list[dict[str, Any]]:
+    policy = load_track_policy(repo_root / POLICY_PATH.relative_to(PROJECT_ROOT))
+    track_policy = resolve_track_policy(str(packet["target"]["track"]), policy)
+    expected_prompt, expected_paths = assemble_semantic_prompt(
+        packet["target"],
+        track_policy,
+        packet["deterministic"],
+        packet["source_hashes"],
+        repo_root=repo_root,
+    )
+    failures: list[str] = []
+    actual_prompt = str(packet.get("semantic_prompt") or "")
+    if sha256_text(actual_prompt) != packet.get("prompt_sha256"):
+        failures.append("semantic_prompt does not match prompt_sha256")
+    if actual_prompt != expected_prompt or packet.get("prompt_paths") != expected_paths:
+        failures.append("semantic prompt does not match current canonical assembly")
+    for key in (
+        "review_protocol_version",
+        "deterministic_contract_version",
+        "semantic_prompt_version",
+        "track_policy_version",
+    ):
+        if str(packet.get(key)) != str(policy[key]):
+            failures.append(f"{key} does not match current policy")
+    return [
+        _policy_finding(
+            f"packet-integrity-{index}",
+            "packet_integrity",
+            "blocker",
+            message,
+            evidence="Prepared packet is stale or was modified after preparation.",
+        )
+        for index, message in enumerate(failures)
+    ]
+
+
+def normalize_semantic_result(value: Mapping[str, Any], family: str) -> dict[str, Any]:
+    verdict = str(value.get("verdict") or "").upper()
+    if verdict not in {"PASS", "REVISE", "BLOCK", "INCOMPLETE"}:
+        raise ReviewProtocolError(f"Invalid semantic verdict: {verdict!r}")
+    findings = []
+    for index, raw in enumerate(value.get("findings") or []):
+        if not isinstance(raw, Mapping):
+            raise ReviewProtocolError("Semantic findings must be mappings")
+        findings.append(
+            {
+                "id": str(raw.get("id") or f"semantic-{index + 1}"),
+                "source": "semantic",
+                "category": str(raw.get("category") or "other"),
+                "severity": normalize_severity(str(raw.get("severity") or "")),
+                "message": str(raw.get("message") or ""),
+                "evidence": str(raw.get("evidence") or ""),
+                "location": str(raw["location"]) if raw.get("location") is not None else None,
+            }
+        )
+    coverage = value.get("claim_coverage")
+    if not isinstance(coverage, Mapping):
+        raise ReviewProtocolError("semantic claim_coverage is required")
+    status = str(coverage.get("status") or "")
+    allowed_status = {"complete", "incomplete", "not_applicable"}
+    if status not in allowed_status:
+        raise ReviewProtocolError(f"Invalid claim coverage status: {status!r}")
+    if family == "seminar" and status == "not_applicable":
+        raise ReviewProtocolError("Seminar review requires exhaustive claim coverage")
+    claims_total = int(coverage.get("claims_total") or 0)
+    claims_verified = int(coverage.get("claims_verified") or 0)
+    if claims_verified > claims_total:
+        raise ReviewProtocolError("claims_verified cannot exceed claims_total")
+    if family == "seminar" and status == "complete" and claims_total == 0:
+        raise ReviewProtocolError("Complete seminar review must enumerate factual claims")
+    return {
+        "family": family,
+        "verdict": verdict,
+        "summary": str(value.get("summary") or ""),
+        "claim_coverage": {
+            "status": status,
+            "claims_total": claims_total,
+            "claims_verified": claims_verified,
+        },
+        "findings": findings,
+    }
+
+
+def _deterministic_findings(packet: Mapping[str, Any]) -> list[dict[str, Any]]:
+    deterministic = packet["deterministic"]
+    findings: list[dict[str, Any]] = []
+    track_result = deterministic["track_audit"].get("result") or {}
+    for index, raw in enumerate(track_result.get("findings") or []):
+        findings.append(
+            {
+                "id": f"deterministic-{index + 1}",
+                "source": "deterministic",
+                "category": str(raw.get("category") or "other"),
+                "severity": normalize_severity(str(raw.get("severity") or "")),
+                "message": str(raw.get("message") or ""),
+                "evidence": str(raw.get("evidence") or ""),
+                "location": str(raw["file"]) if raw.get("file") is not None else None,
+            }
+        )
+    findings.extend(deepcopy(deterministic.get("policy_findings") or []))
+    return findings
+
+
+def combine_disposition(
+    deterministic: Mapping[str, Any],
+    semantic: Mapping[str, Any],
+    findings: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    aggregate = deterministic.get("aggregate") or aggregate_deterministic(deterministic)
+    reasons.extend(str(reason) for reason in aggregate.get("reasons") or [])
+    coverage = semantic["claim_coverage"]
+    if coverage["status"] == "incomplete" or coverage["claims_verified"] < coverage["claims_total"]:
+        reasons.append("semantic claim coverage is incomplete")
+    if semantic["verdict"] == "INCOMPLETE":
+        reasons.append("semantic reviewer reported incomplete")
+    integrity_categories = {item.get("category") for item in findings}
+    if "source_drift" in integrity_categories:
+        reasons.append("source files changed after deterministic preparation")
+    if "packet_integrity" in integrity_categories:
+        reasons.append("prepared packet failed integrity validation")
+    if reasons:
+        return {"status": "INCOMPLETE", "reasons": reasons}
+
+    severities = {str(item["severity"]) for item in findings}
+    if "blocker" in severities or semantic["verdict"] == "BLOCK":
+        return {"status": "BLOCK", "reasons": ["blocking finding is unresolved"]}
+    deterministic_high = any(
+        item["source"] in {"deterministic", "track_policy"} and item["severity"] == "high" for item in findings
+    )
+    if deterministic_high:
+        return {"status": "BLOCK", "reasons": ["high-severity mechanical finding is unresolved"]}
+    if semantic["verdict"] == "REVISE" or severities.intersection({"high", "medium"}):
+        return {"status": "REVISE", "reasons": ["actionable semantic finding is unresolved"]}
+    return {"status": "PASS", "reasons": ["deterministic and semantic review passed"]}
+
+
+def validate_result(result: Mapping[str, Any], *, schema_path: Path = SCHEMA_PATH) -> None:
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    Draft202012Validator(schema).validate(result)
+
+
+def finalize_review(
+    packet: Mapping[str, Any],
+    semantic_input: Mapping[str, Any],
+    *,
+    repo_root: Path = PROJECT_ROOT,
+) -> dict[str, Any]:
+    family = str(packet["target"]["semantic_family"])
+    semantic = normalize_semantic_result(semantic_input, family)
+    drift = source_drift_findings(packet, repo_root=repo_root)
+    integrity = packet_integrity_findings(packet, repo_root=repo_root)
+    deterministic = deepcopy(packet["deterministic"])
+    deterministic["policy_findings"] = [
+        *(deterministic.get("policy_findings") or []),
+        *drift,
+        *integrity,
+    ]
+    deterministic["aggregate"] = aggregate_deterministic(deterministic)
+    normalized_packet = {**packet, "deterministic": deterministic}
+    findings = [*_deterministic_findings(normalized_packet), *semantic["findings"]]
+    disposition = combine_disposition(deterministic, semantic, findings)
+    result: dict[str, Any] = {
+        "schema_version": "post-build-review.result.v1",
+        "review_protocol_version": str(packet["review_protocol_version"]),
+        "deterministic_contract_version": str(packet["deterministic_contract_version"]),
+        "semantic_prompt_version": str(packet["semantic_prompt_version"]),
+        "track_policy_version": str(packet["track_policy_version"]),
+        "prompt_sha256": str(packet["prompt_sha256"]),
+        "target": deepcopy(packet["target"]),
+        "source_hashes": deepcopy(packet["source_hashes"]),
+        "reviewer": deepcopy(packet["reviewer"]),
+        "deterministic": deterministic,
+        "semantic": semantic,
+        "findings": findings,
+        "combined_disposition": disposition,
+    }
+    reproducible = {
+        key: deepcopy(result[key])
+        for key in (
+            "schema_version",
+            "review_protocol_version",
+            "deterministic_contract_version",
+            "semantic_prompt_version",
+            "track_policy_version",
+            "prompt_sha256",
+            "target",
+            "source_hashes",
+            "deterministic",
+            "semantic",
+            "findings",
+            "combined_disposition",
+        )
+    }
+    result["reproducibility_key"] = sha256_text(_stable_json(reproducible))
+    validate_result(result, schema_path=repo_root / SCHEMA_PATH.relative_to(PROJECT_ROOT))
+    return result
+
+
+def ensure_output_outside_repo(path: Path, *, repo_root: Path = PROJECT_ROOT) -> None:
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(repo_root.resolve())
+    except ValueError:
+        return
+    raise ReviewProtocolError("Review outputs must be written outside the repository")
+
+
+def _write_or_print(value: object, output: Path | None, *, repo_root: Path) -> None:
+    text = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if output is None:
+        print(text, end="")
+        return
+    ensure_output_outside_repo(output, repo_root=repo_root)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(text, encoding="utf-8")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the canonical read-only post-build review protocol.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prepare = subparsers.add_parser("prepare", help="Run deterministic stages and assemble the semantic prompt.")
+    prepare.add_argument("target", help="track/slug, e.g. bio/oleksandr-bilash")
+    prepare.add_argument("--reviewer-agent", required=True)
+    prepare.add_argument("--reviewer-family", required=True)
+    prepare.add_argument("--reviewer-model", required=True)
+    prepare.add_argument("--reviewer-effort", required=True)
+    prepare.add_argument("--output", type=Path)
+
+    finalize = subparsers.add_parser("finalize", help="Combine semantic JSON with a prepared packet.")
+    finalize.add_argument("--packet", type=Path, required=True)
+    finalize.add_argument("--semantic-result", type=Path, required=True)
+    finalize.add_argument("--output", type=Path)
+
+    validate = subparsers.add_parser("validate", help="Validate an existing canonical result.")
+    validate.add_argument("result", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "prepare":
+        reviewer = {
+            "agent": args.reviewer_agent,
+            "family": args.reviewer_family,
+            "model": args.reviewer_model,
+            "effort": args.reviewer_effort,
+        }
+        packet = prepare_review(args.target, reviewer)
+        _write_or_print(packet, args.output, repo_root=PROJECT_ROOT)
+        return 0
+    if args.command == "finalize":
+        packet = json.loads(args.packet.read_text(encoding="utf-8"))
+        semantic = json.loads(args.semantic_result.read_text(encoding="utf-8"))
+        result = finalize_review(packet, semantic)
+        _write_or_print(result, args.output, repo_root=PROJECT_ROOT)
+        return 0 if result["combined_disposition"]["status"] == "PASS" else 1
+    result = json.loads(args.result.read_text(encoding="utf-8"))
+    validate_result(result)
+    print("post-build-review result is valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -192,7 +192,9 @@ def hash_target_files(target: Mapping[str, Any], *, repo_root: Path = PROJECT_RO
 def resolve_venv_python(repo_root: Path = PROJECT_ROOT) -> Path:
     direct = repo_root / ".venv" / "bin" / "python"
     if direct.exists():
-        return direct.resolve()
+        # Preserve the venv entrypoint path. Resolving its interpreter symlink
+        # bypasses pyvenv.cfg on symlink-based Linux environments.
+        return direct
     result = subprocess.run(
         ["git", "-C", str(repo_root), "rev-parse", "--path-format=absolute", "--git-common-dir"],
         capture_output=True,
@@ -203,7 +205,7 @@ def resolve_venv_python(repo_root: Path = PROJECT_ROOT) -> Path:
         common_dir = Path(result.stdout.strip()).resolve()
         shared = common_dir.parent / ".venv" / "bin" / "python"
         if shared.exists():
-            return shared.resolve()
+            return shared
     raise ReviewProtocolError("Repository .venv/bin/python is unavailable")
 
 

--- a/scripts/check_rules_deployment.sh
+++ b/scripts/check_rules_deployment.sh
@@ -18,11 +18,17 @@ check_pair() {
     shift 2
 
     local diff_args=(-rq -x .DS_Store)
-    local orphan
+    local orphan normalized
     for orphan in "$@"; do
-        diff_args+=(-x "${orphan%/}")
-        if [[ "$orphan" == */* ]]; then
-            diff_args+=(-x "${orphan##*/}")
+        normalized="${orphan%/}"
+        # A subtree declaration such as skills/* must exclude the subtree
+        # root. Passing its basename ("*") to diff would mask every path.
+        if [[ "$normalized" == */\* ]]; then
+            normalized="${normalized%/\*}"
+        fi
+        diff_args+=(-x "$normalized")
+        if [[ "$normalized" == */* ]]; then
+            diff_args+=(-x "${normalized##*/}")
         fi
     done
 
@@ -85,6 +91,70 @@ check_overlay() {
     echo "OK: $src -> $dst"
 }
 
+check_shared_skill_pairs() {
+    local shared_skill skill_name failed=0
+    for shared_skill in agents_extensions/shared/skills/*; do
+        [[ -d "$shared_skill" ]] || continue
+        skill_name="$(basename "$shared_skill")"
+        check_pair "$shared_skill" ".gemini/skills/$skill_name" || failed=1
+    done
+    return "$failed"
+}
+
+check_gemini_provider_skill_pairs() {
+    local provider_skill skill_name failed=0
+    for provider_skill in gemini_extensions/skills/*; do
+        [[ -d "$provider_skill" ]] || continue
+        skill_name="$(basename "$provider_skill")"
+        check_pair "$provider_skill" ".gemini/skills/$skill_name" || failed=1
+    done
+    return "$failed"
+}
+
+check_gemini_skill_owners() {
+    local deployed_skill skill_name failed=0
+    [[ -d .gemini/skills ]] || return 0
+    for deployed_skill in .gemini/skills/*; do
+        [[ -d "$deployed_skill" ]] || continue
+        skill_name="$(basename "$deployed_skill")"
+        if [[ ! -d "agents_extensions/shared/skills/$skill_name" && ! -d "gemini_extensions/skills/$skill_name" ]]; then
+            echo "::error::Unowned deployed Gemini skill: .gemini/skills/$skill_name"
+            failed=1
+        fi
+    done
+    return "$failed"
+}
+
+gemini_path_is_declared_orphan() {
+    local relative="$1" orphan normalized
+    for orphan in $ORPHAN_PATHS_GEMINI; do
+        normalized="${orphan%/}"
+        if [[ "$relative" == "$normalized" || "$relative" == "$normalized/"* ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+check_gemini_file_owners() {
+    local deployed_file relative failed=0
+    [[ -d .gemini ]] || return 0
+    while IFS= read -r deployed_file; do
+        relative="${deployed_file#.gemini/}"
+        if [[ "$relative" == skills/* || "$relative" == rules/* ]]; then
+            continue
+        fi
+        if gemini_path_is_declared_orphan "$relative"; then
+            continue
+        fi
+        if [[ ! -e "gemini_extensions/$relative" ]]; then
+            echo "::error::Unowned deployed Gemini file: .gemini/$relative"
+            failed=1
+        fi
+    done < <(find .gemini \( -type f -o -type l \) -print | sort)
+    return "$failed"
+}
+
 drift=0
 
 # Orphan exclusions must stay in lock-step with scripts/deploy_orphan_paths.sh
@@ -110,7 +180,15 @@ check_overlay "agents_extensions/codex" ".codex" || drift=1
 # shellcheck disable=SC2086
 check_pair "agents_extensions/shared/skills" ".agents/skills" $ORPHAN_PATHS_AGENTS || drift=1
 # shellcheck disable=SC2086
-check_pair "gemini_extensions" ".gemini" $ORPHAN_PATHS_GEMINI || drift=1
+check_pair \
+    "gemini_extensions" \
+    ".gemini" \
+    $ORPHAN_PATHS_GEMINI \
+    $GEMINI_SHARED_SKILL_OVERLAY_PATHS || drift=1
+check_gemini_provider_skill_pairs || drift=1
+check_shared_skill_pairs || drift=1
+check_gemini_skill_owners || drift=1
+check_gemini_file_owners || drift=1
 check_pair "agents_extensions/shared/rules" ".gemini/rules" || drift=1
 
 exit "$drift"

--- a/scripts/deploy_orphan_paths.sh
+++ b/scripts/deploy_orphan_paths.sh
@@ -58,6 +58,12 @@ CODEX_OVERLAY_PATHS="hooks.json memory"
 #        It disables GitHub PR reviews while preserving local Gemini CLI tooling.
 ORPHAN_PATHS_GEMINI="config.yaml docs/ rules/ tmp/"
 
+# Shared skills overlay into .gemini/skills. Gemini-specific skills remain
+# sourced from gemini_extensions/skills; shared skill names are overlaid after
+# that sync. The glob is a preflight/diff exclusion only and MUST NOT be passed
+# to the gemini_extensions rsync --exclude list.
+GEMINI_SHARED_SKILL_OVERLAY_PATHS="skills/*"
+
 # --- deploy-owned: Claude autoload excludes (checker mirrors for .claude drift) ---
 # Claude Code auto-loads every unscoped file in `.claude/rules/` into the system
 # prompt. These always-load rules are served by the Monitor API and must not be

--- a/scripts/deploy_prompts.sh
+++ b/scripts/deploy_prompts.sh
@@ -44,6 +44,14 @@ build_excludes() {
     echo "$args"
 }
 
+build_shared_skill_overlay_excludes() {
+    local shared_skill
+    for shared_skill in "$SHARED_EXTENSIONS"/skills/*; do
+        [[ -d "$shared_skill" ]] || continue
+        echo "--exclude=/skills/$(basename "$shared_skill")/"
+    done
+}
+
 remove_claude_autoload_rules() {
     local p
     for p in "${CLAUDE_RULE_AUTOLOAD_EXCLUDES[@]}"; do
@@ -81,6 +89,20 @@ check_orphans() {
     return 0
 }
 
+check_shared_skill_collisions() {
+    local shared_skill skill_name
+    for shared_skill in "$SHARED_EXTENSIONS"/skills/*; do
+        [[ -d "$shared_skill" ]] || continue
+        skill_name="$(basename "$shared_skill")"
+        if [[ -e "gemini_extensions/skills/$skill_name" ]]; then
+            echo "  ⚠️  shared/Gemini skill collision: $skill_name"
+            echo "     Keep one canonical source; rename or remove the provider-specific duplicate."
+            return 1
+        fi
+    done
+    return 0
+}
+
 # Step 0: Preflight — assert no undeclared orphan paths in destinations
 echo "=== Preflight (orphan-path guard) ==="
 orphan_fail=false
@@ -90,8 +112,9 @@ check_orphans "$SHARED_EXTENSIONS" ".claude" "$ORPHAN_PATHS_CLAUDE" "$SHARED_EXT
 # is overlaid; everything else in .agent/ is left alone.
 check_orphans "$SHARED_EXTENSIONS/skills" ".agents/skills" "$ORPHAN_PATHS_AGENTS" "$SHARED_EXTENSIONS/skills → .agents/skills" || orphan_fail=true
 check_orphans "$SHARED_EXTENSIONS" ".codex" "$ORPHAN_PATHS_CODEX $CODEX_OVERLAY_PATHS" "$SHARED_EXTENSIONS → .codex" || orphan_fail=true
-check_orphans "gemini_extensions" ".gemini" "$ORPHAN_PATHS_GEMINI" "gemini_extensions → .gemini" || orphan_fail=true
+check_orphans "gemini_extensions" ".gemini" "$ORPHAN_PATHS_GEMINI $GEMINI_SHARED_SKILL_OVERLAY_PATHS" "gemini_extensions → .gemini" || orphan_fail=true
 check_orphans "$SHARED_EXTENSIONS/rules" ".gemini/rules" "" "$SHARED_EXTENSIONS/rules → .gemini/rules" || orphan_fail=true
+check_shared_skill_collisions || orphan_fail=true
 if [[ "$orphan_fail" == true ]]; then
     echo ""
     echo "❌ Deploy aborted: undeclared orphan paths would be deleted."
@@ -127,11 +150,18 @@ diff_dirs() {
     # Use diff -rq for a brief summary; ignore .DS_Store and declared orphan
     # paths (they'd always show as "Only in <dst>..." noise)
     local diff_args=(-rq --exclude='.DS_Store')
+    local normalized
     for p in $orphans; do
         # Strip trailing slash for diff --exclude
-        diff_args+=(--exclude="${p%/}")
-        if [[ "$p" == */* ]]; then
-            diff_args+=(--exclude="${p##*/}")
+        normalized="${p%/}"
+        # A subtree declaration such as skills/* must exclude the subtree
+        # root. Passing its basename ("*") to diff would mask every path.
+        if [[ "$normalized" == */\* ]]; then
+            normalized="${normalized%/\*}"
+        fi
+        diff_args+=(--exclude="$normalized")
+        if [[ "$normalized" == */* ]]; then
+            diff_args+=(--exclude="${normalized##*/}")
         fi
     done
     local diff_out
@@ -182,6 +212,32 @@ diff_overlay_files() {
     fi
 }
 
+diff_shared_skill_overlays() {
+    local shared_skill skill_name
+    for shared_skill in "$SHARED_EXTENSIONS"/skills/*; do
+        [[ -d "$shared_skill" ]] || continue
+        skill_name="$(basename "$shared_skill")"
+        diff_dirs \
+            "$shared_skill" \
+            ".gemini/skills/$skill_name" \
+            "$shared_skill → .gemini/skills/$skill_name" \
+            ""
+    done
+}
+
+diff_gemini_skill_owners() {
+    local deployed_skill skill_name
+    [[ -d .gemini/skills ]] || return 0
+    for deployed_skill in .gemini/skills/*; do
+        [[ -d "$deployed_skill" ]] || continue
+        skill_name="$(basename "$deployed_skill")"
+        if [[ ! -d "$SHARED_EXTENSIONS/skills/$skill_name" && ! -d "gemini_extensions/skills/$skill_name" ]]; then
+            echo "  .gemini/skills: stale unowned skill '$skill_name' (will be removed)"
+            has_changes=true
+        fi
+    done
+}
+
 diff_dirs \
     "$SHARED_EXTENSIONS" \
     ".claude" \
@@ -194,7 +250,9 @@ diff_dirs "$SHARED_EXTENSIONS" ".codex" "$SHARED_EXTENSIONS → .codex" "$ORPHAN
 if [[ -d "$CODEX_EXTENSIONS" ]]; then
     diff_overlay_files "$CODEX_EXTENSIONS" ".codex" "$CODEX_EXTENSIONS → .codex"
 fi
-diff_dirs "gemini_extensions" ".gemini" "gemini_extensions → .gemini" "$ORPHAN_PATHS_GEMINI"
+diff_overlay_files "gemini_extensions" ".gemini" "gemini_extensions → .gemini"
+diff_shared_skill_overlays
+diff_gemini_skill_owners
 diff_dirs "$SHARED_EXTENSIONS/rules" ".gemini/rules" "$SHARED_EXTENSIONS/rules → .gemini/rules" ""
 echo ""
 
@@ -230,7 +288,16 @@ fi
 mkdir -p .agents
 rsync -av --delete $(build_excludes "$ORPHAN_PATHS_AGENTS") "$SHARED_EXTENSIONS/skills/" .agents/skills/
 # shellcheck disable=SC2046
-rsync -av --delete $(build_excludes "$ORPHAN_PATHS_GEMINI") gemini_extensions/ .gemini/
+rsync -av --delete \
+    $(build_excludes "$ORPHAN_PATHS_GEMINI") \
+    $(build_shared_skill_overlay_excludes) \
+    gemini_extensions/ .gemini/
+for shared_skill in "$SHARED_EXTENSIONS"/skills/*; do
+    [[ -d "$shared_skill" ]] || continue
+    skill_name="$(basename "$shared_skill")"
+    mkdir -p ".gemini/skills/$skill_name"
+    rsync -av --delete "$shared_skill/" ".gemini/skills/$skill_name/"
+done
 rsync -av --delete "$SHARED_EXTENSIONS/rules/" .gemini/rules/
 echo ""
 echo "Deploy complete."

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -78,6 +78,20 @@ def test_track_resolution_covers_every_versioned_track() -> None:
         pbr.resolve_track_policy("unknown", policy)
 
 
+def test_venv_python_resolution_preserves_symlink_entrypoint(tmp_path: Path) -> None:
+    """The command path must stay inside .venv so Python loads pyvenv.cfg."""
+    runtime_python = tmp_path / "runtime-python"
+    runtime_python.write_text("runtime placeholder\n", encoding="utf-8")
+    venv_python = tmp_path / ".venv" / "bin" / "python"
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(runtime_python)
+
+    resolved = pbr.resolve_venv_python(tmp_path)
+
+    assert resolved == venv_python
+    assert resolved.is_symlink()
+
+
 def test_track_policy_covers_curriculum_manifest_and_api_registry() -> None:
     from scripts.api.config import SEMINAR_TRACK_IDS
 
@@ -364,8 +378,8 @@ def test_skill_forbids_mutating_legacy_paths() -> None:
 def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
-    assert catalog["catalog_version"] == "1.0.1"
-    assert len(rows) == 11
+    assert catalog["catalog_version"] == "1.0.2"
+    assert len(rows) == 12
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",
@@ -379,3 +393,8 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
     null_result = next(row for row in rows if row["bug_id"] == "deterministic-stage-null-result-crash")
     assert null_result["responsible_layer"] == "orchestration"
     assert null_result["fixed_in_version"] == "1.0.1"
+    assert null_result["version_field"] == "review_protocol_version"
+    venv_symlink = next(row for row in rows if row["bug_id"] == "venv-python-symlink-bypassed-environment")
+    assert venv_symlink["responsible_layer"] == "deterministic_code"
+    assert venv_symlink["fixed_in_version"] == "1.0.1"
+    assert venv_symlink["version_field"] == "deterministic_contract_version"

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -120,6 +120,36 @@ def test_effective_prompt_uses_common_plus_exactly_one_family(bilash_packet: dic
     assert pbr.sha256_text(changed) != bilash_packet["prompt_sha256"]
 
 
+def test_failed_deterministic_stage_renders_incomplete_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A null result from a failed audit must remain evidence, not crash prompt assembly."""
+    deterministic = {
+        "track_audit": {
+            "status": "error",
+            "result": None,
+            "error": "synthetic deterministic failure",
+            "provenance": {},
+        },
+        "size_policy": {
+            "status": "complete",
+            "result": None,
+            "error": None,
+            "provenance": {},
+        },
+    }
+    monkeypatch.setattr(
+        pbr,
+        "run_existing_deterministic_audits",
+        lambda *args, **kwargs: copy.deepcopy(deterministic),
+    )
+
+    packet = pbr.prepare_review("bio/oleksandr-bilash", _reviewer())
+
+    assert packet["deterministic"]["aggregate"]["status"] == "incomplete"
+    assert packet["deterministic"]["track_audit"]["result"] is None
+    assert '"deterministic_summary": null' in packet["semantic_prompt"]
+    assert '"deterministic_findings": null' in packet["semantic_prompt"]
+
+
 def test_prompt_versions_match_track_policy() -> None:
     policy = pbr.load_track_policy()
     marker = f"Semantic prompt version: `{policy['semantic_prompt_version']}`"
@@ -334,8 +364,8 @@ def test_skill_forbids_mutating_legacy_paths() -> None:
 def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
-    assert catalog["catalog_version"] == "1.0.0"
-    assert len(rows) == 10
+    assert catalog["catalog_version"] == "1.0.1"
+    assert len(rows) == 11
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",
@@ -345,4 +375,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
         "schema",
         "orchestration",
     }
-    assert all(row["fixed_in_version"] == "1.0.0" for row in rows)
+    assert {row["fixed_in_version"] for row in rows} == {"1.0.0", "1.0.1"}
+    null_result = next(row for row in rows if row["bug_id"] == "deterministic-stage-null-result-crash")
+    assert null_result["responsible_layer"] == "orchestration"
+    assert null_result["fixed_in_version"] == "1.0.1"

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -1,0 +1,348 @@
+"""Contract, regression, and exemplar tests for post-build-review."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema import ValidationError
+
+from scripts.audit import post_build_review as pbr
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL = ROOT / "agents_extensions" / "shared" / "skills" / "post-build-review"
+FIXTURES = ROOT / "tests" / "fixtures" / "post_build_review"
+BILASH_GOLDEN = FIXTURES / "bio-oleksandr-bilash.result.v1.json"
+REGRESSIONS = FIXTURES / "regressions.v1.yaml"
+CORE_EXEMPLAR = FIXTURES / "core-semantic-exemplar.v1.json"
+
+
+def _reviewer() -> dict[str, str]:
+    return {
+        "agent": "fixture",
+        "family": "fixture",
+        "model": "fixture-model",
+        "effort": "high",
+    }
+
+
+def _artifact_snapshot() -> dict[str, tuple[int, int, str]]:
+    paths: list[Path] = []
+    bundle = ROOT / "curriculum" / "l2-uk-en" / "bio" / "oleksandr-bilash"
+    paths.extend(path for path in bundle.rglob("*") if path.is_file())
+    paths.append(ROOT / "curriculum" / "l2-uk-en" / "plans" / "bio" / "oleksandr-bilash.yaml")
+    for dirname in ("audit", "review", "status"):
+        directory = ROOT / "curriculum" / "l2-uk-en" / "bio" / dirname
+        if directory.exists():
+            paths.extend(path for path in directory.glob("*oleksandr-bilash*") if path.is_file())
+    return {
+        pbr.display_path(path): (path.stat().st_size, path.stat().st_mtime_ns, pbr.sha256_file(path))
+        for path in sorted(set(paths))
+    }
+
+
+@pytest.fixture(scope="module")
+def bilash_packet() -> dict:
+    before_status = subprocess.run(
+        ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+        cwd=ROOT,
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout
+    before_artifacts = _artifact_snapshot()
+    packet = pbr.prepare_review("bio/oleksandr-bilash", _reviewer())
+    after_status = subprocess.run(
+        ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+        cwd=ROOT,
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout
+    assert after_status == before_status
+    assert _artifact_snapshot() == before_artifacts
+    return packet
+
+
+def test_track_resolution_covers_every_versioned_track() -> None:
+    policy = pbr.load_track_policy()
+    for track, config in policy["tracks"].items():
+        resolved = pbr.resolve_track_policy(track.upper(), policy)
+        assert resolved["family"] == config["family"]
+        assert resolved["semantic_prompt"].endswith("-semantic-review-prompt.md")
+    with pytest.raises(pbr.ReviewProtocolError, match="Unknown track"):
+        pbr.resolve_track_policy("unknown", policy)
+
+
+def test_track_policy_covers_curriculum_manifest_and_api_registry() -> None:
+    from scripts.api.config import SEMINAR_TRACK_IDS
+
+    policy = pbr.load_track_policy()
+    manifest = yaml.safe_load((ROOT / "curriculum" / "l2-uk-en" / "curriculum.yaml").read_text(encoding="utf-8"))
+    for track, config in manifest["levels"].items():
+        assert track in policy["tracks"], f"manifest track missing from review policy: {track}"
+        expected = "core" if config["type"] == "core" else "seminar"
+        assert policy["tracks"][track]["family"] == expected
+    assert set(policy["tracks"]) >= SEMINAR_TRACK_IDS
+    assert all(policy["tracks"][track]["family"] == "seminar" for track in SEMINAR_TRACK_IDS)
+
+
+def test_target_resolution_routes_core_and_bio_families() -> None:
+    core = pbr.resolve_target("a1/sounds-letters-and-hello")
+    seminar = pbr.resolve_target("bio/oleksandr-bilash")
+    assert core["semantic_family"] == "core"
+    assert seminar["semantic_family"] == "seminar"
+    assert core["files"]["content"].endswith("a1/sounds-letters-and-hello/module.md")
+    assert seminar["files"]["content"].endswith("bio/oleksandr-bilash/module.md")
+
+
+def test_core_semantic_exemplar_uses_core_family() -> None:
+    exemplar = json.loads(CORE_EXEMPLAR.read_text(encoding="utf-8"))
+    target = pbr.resolve_target(exemplar["target"])
+    semantic = pbr.normalize_semantic_result(exemplar["semantic_result"], target["semantic_family"])
+    assert target["semantic_family"] == exemplar["expected_family"] == "core"
+    assert semantic["claim_coverage"]["status"] == "not_applicable"
+
+
+def test_effective_prompt_uses_common_plus_exactly_one_family(bilash_packet: dict) -> None:
+    prompt = bilash_packet["semantic_prompt"]
+    assert "Common semantic post-build review prompt" in prompt
+    assert "Seminar semantic post-build review prompt" in prompt
+    assert "Core semantic post-build review prompt" not in prompt
+    assert "exhaustive claim ledger" in prompt.lower()
+    assert pbr.sha256_text(prompt) == bilash_packet["prompt_sha256"]
+
+    changed = prompt.replace("Exhaustive claim ledger", "Complete claim ledger", 1)
+    assert pbr.sha256_text(changed) != bilash_packet["prompt_sha256"]
+
+
+def test_prompt_versions_match_track_policy() -> None:
+    policy = pbr.load_track_policy()
+    marker = f"Semantic prompt version: `{policy['semantic_prompt_version']}`"
+    for path in (SKILL / "prompts").glob("*-semantic-review-prompt.md"):
+        assert marker in path.read_text(encoding="utf-8")
+
+
+def test_bilash_mechanical_regressions_are_detected(bilash_packet: dict) -> None:
+    findings = bilash_packet["deterministic"]["policy_findings"]
+    categories = [finding["category"] for finding in findings]
+    assert categories.count("crosslink_integrity") == 3
+    assert categories.count("unresolved_rights") == 1
+    assert {finding["severity"] for finding in findings} == {"high"}
+
+
+def test_deterministic_provenance_and_skips_are_explicit(bilash_packet: dict) -> None:
+    deterministic = bilash_packet["deterministic"]
+    argv = deterministic["track_audit"]["provenance"]["argv"]
+    assert argv[0] == ".venv/bin/python"
+    assert deterministic["track_audit"]["provenance"]["executed_argv"] == argv
+    assert "--run-mdx-generation-validate" not in argv
+    assert "--output" not in argv
+    assert deterministic["track_audit"]["provenance"]["config_version"] == "1"
+    skips = {item["category"]: item["disposition"] for item in deterministic["skip_assessments"]}
+    assert skips == {
+        "llm_qg": "superseded_by_semantic",
+        "mdx_generation_validate": "accepted_read_only_omission",
+        "external_resource_liveness": "advisory_external",
+    }
+
+
+def test_bilash_size_policy_is_exemplar_only(bilash_packet: dict) -> None:
+    size = bilash_packet["deterministic"]["size_policy"]["result"]
+    assert size["actual_words"] == 2428
+    assert [size["band_min"], size["band_max"]] == [2200, 2800]
+    assert size["advisory_ceiling"] == 4000
+    policy_text = (SKILL / "config" / "track-policy.v1.yaml").read_text(encoding="utf-8")
+    assert "2200" not in policy_text
+    assert "4000" not in policy_text
+
+
+def test_semantic_pass_cannot_override_mechanical_high(bilash_packet: dict) -> None:
+    semantic = {
+        "verdict": "PASS",
+        "summary": "Semantic review completed.",
+        "claim_coverage": {"status": "complete", "claims_total": 5, "claims_verified": 5},
+        "findings": [],
+    }
+    result = pbr.finalize_review(bilash_packet, semantic)
+    assert result["combined_disposition"]["status"] == "BLOCK"
+    assert any(finding["source"] == "track_policy" for finding in result["findings"])
+    pbr.validate_result(result)
+
+
+@pytest.mark.parametrize(
+    ("stage_status", "severity", "skip_disposition", "expected"),
+    [
+        ("complete", None, None, "clear"),
+        ("complete", "medium", None, "review"),
+        ("complete", "high", None, "block"),
+        ("error", None, None, "incomplete"),
+        ("complete", None, "required", "incomplete"),
+    ],
+)
+def test_deterministic_aggregation(
+    stage_status: str,
+    severity: str | None,
+    skip_disposition: str | None,
+    expected: str,
+) -> None:
+    deterministic = {
+        "track_audit": {
+            "status": stage_status,
+            "result": {"findings": []},
+        },
+        "size_policy": {"status": "complete", "result": {}},
+        "policy_findings": [],
+        "skip_assessments": [],
+    }
+    if severity:
+        deterministic["policy_findings"].append({"severity": severity})
+    if skip_disposition:
+        deterministic["skip_assessments"].append({"category": "required-check", "disposition": skip_disposition})
+    assert pbr.aggregate_deterministic(deterministic)["status"] == expected
+
+
+@pytest.mark.parametrize(
+    ("semantic_verdict", "severity", "expected"),
+    [
+        ("PASS", None, "PASS"),
+        ("REVISE", "medium", "REVISE"),
+        ("PASS", "high", "REVISE"),
+        ("BLOCK", "blocker", "BLOCK"),
+        ("INCOMPLETE", None, "INCOMPLETE"),
+    ],
+)
+def test_combined_disposition_precedence(semantic_verdict: str, severity: str | None, expected: str) -> None:
+    deterministic = {
+        "track_audit": {"status": "complete"},
+        "size_policy": {"status": "complete"},
+        "skip_assessments": [],
+        "aggregate": {"status": "clear", "reasons": []},
+    }
+    semantic = {
+        "verdict": semantic_verdict,
+        "claim_coverage": {"status": "complete", "claims_total": 1, "claims_verified": 1},
+    }
+    findings = []
+    if severity:
+        findings.append({"source": "semantic", "severity": severity})
+    assert pbr.combine_disposition(deterministic, semantic, findings)["status"] == expected
+
+
+def test_incomplete_coverage_fails_closed() -> None:
+    deterministic = {
+        "track_audit": {"status": "complete"},
+        "size_policy": {"status": "complete"},
+        "skip_assessments": [],
+        "aggregate": {"status": "clear", "reasons": []},
+    }
+    semantic = {
+        "verdict": "PASS",
+        "claim_coverage": {"status": "incomplete", "claims_total": 8, "claims_verified": 7},
+    }
+    assert pbr.combine_disposition(deterministic, semantic, [])["status"] == "INCOMPLETE"
+
+
+def test_seminar_complete_requires_nonzero_claim_ledger() -> None:
+    with pytest.raises(pbr.ReviewProtocolError, match="enumerate factual claims"):
+        pbr.normalize_semantic_result(
+            {
+                "verdict": "PASS",
+                "summary": "",
+                "claim_coverage": {
+                    "status": "complete",
+                    "claims_total": 0,
+                    "claims_verified": 0,
+                },
+                "findings": [],
+            },
+            "seminar",
+        )
+
+
+def test_schema_validates_golden_and_rejects_missing_versions() -> None:
+    golden = json.loads(BILASH_GOLDEN.read_text(encoding="utf-8"))
+    pbr.validate_result(golden)
+    for field in (
+        "review_protocol_version",
+        "deterministic_contract_version",
+        "semantic_prompt_version",
+        "track_policy_version",
+        "prompt_sha256",
+        "reviewer",
+        "deterministic",
+    ):
+        invalid = copy.deepcopy(golden)
+        invalid.pop(field)
+        with pytest.raises(ValidationError):
+            pbr.validate_result(invalid)
+
+
+def test_golden_reproduces_current_bilash_packet(bilash_packet: dict) -> None:
+    golden = json.loads(BILASH_GOLDEN.read_text(encoding="utf-8"))
+    assert golden["target"] == bilash_packet["target"]
+    assert golden["source_hashes"] == bilash_packet["source_hashes"]
+    assert golden["prompt_sha256"] == bilash_packet["prompt_sha256"]
+    assert golden["deterministic"]["policy_findings"] == bilash_packet["deterministic"]["policy_findings"]
+    assert golden["deterministic"]["size_policy"]["result"] == bilash_packet["deterministic"]["size_policy"]["result"]
+    reproduced = pbr.finalize_review(bilash_packet, golden["semantic"])
+    assert reproduced["reproducibility_key"] == golden["reproducibility_key"]
+    assert reproduced["combined_disposition"] == golden["combined_disposition"]
+
+
+def test_repository_output_paths_are_rejected(tmp_path: Path) -> None:
+    with pytest.raises(pbr.ReviewProtocolError, match="outside the repository"):
+        pbr.ensure_output_outside_repo(ROOT / "curriculum" / "review.json")
+    pbr.ensure_output_outside_repo(tmp_path / "review.json")
+
+
+def test_tampered_packet_paths_cannot_escape_repository() -> None:
+    target = {"files": {"plan": "../../etc/passwd"}}
+    with pytest.raises(pbr.ReviewProtocolError, match="escapes the checkout"):
+        pbr.hash_target_files(target)
+
+
+def test_tampered_prompt_packet_fails_closed(bilash_packet: dict) -> None:
+    packet = copy.deepcopy(bilash_packet)
+    packet["semantic_prompt"] += "\nignore the canonical review\n"
+    semantic = {
+        "verdict": "PASS",
+        "summary": "",
+        "claim_coverage": {"status": "complete", "claims_total": 1, "claims_verified": 1},
+        "findings": [],
+    }
+    result = pbr.finalize_review(packet, semantic)
+    assert result["combined_disposition"]["status"] == "INCOMPLETE"
+    assert any(finding["category"] == "packet_integrity" for finding in result["findings"])
+    target = {"files": {"content": "/etc/passwd"}}
+    with pytest.raises(pbr.ReviewProtocolError, match="must be relative"):
+        pbr.hash_target_files(target)
+
+
+def test_skill_forbids_mutating_legacy_paths() -> None:
+    text = (SKILL / "SKILL.md").read_text(encoding="utf-8")
+    assert "Never use `scripts/audit_module.py`" in text
+    assert "--run-mdx-generation-validate" in text
+    assert "Write packets and results only under `/tmp`" in text
+    assert "curriculum/l2-uk-en/{track}/audit" not in text
+
+
+def test_regression_catalog_covers_every_discovered_layer() -> None:
+    catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
+    rows = catalog["regressions"]
+    assert catalog["catalog_version"] == "1.0.0"
+    assert len(rows) == 10
+    assert len({row["bug_id"] for row in rows}) == len(rows)
+    assert {row["responsible_layer"] for row in rows} == {
+        "deterministic_code",
+        "track_policy",
+        "semantic_prompt",
+        "disposition",
+        "schema",
+        "orchestration",
+    }
+    assert all(row["fixed_in_version"] == "1.0.0" for row in rows)

--- a/tests/fixtures/post_build_review/bio-oleksandr-bilash.result.v1.json
+++ b/tests/fixtures/post_build_review/bio-oleksandr-bilash.result.v1.json
@@ -1,0 +1,371 @@
+{
+  "combined_disposition": {
+    "reasons": [
+      "high-severity mechanical finding is unresolved"
+    ],
+    "status": "BLOCK"
+  },
+  "deterministic": {
+    "aggregate": {
+      "findings_by_severity": {
+        "blocker": 0,
+        "high": 4,
+        "info": 0,
+        "low": 0,
+        "medium": 0
+      },
+      "reasons": [],
+      "status": "block"
+    },
+    "policy_findings": [
+      {
+        "category": "crosslink_integrity",
+        "evidence": "declared=bio-137-dmytro-pavlychko; target_sequence=159",
+        "id": "connects-to-sequence-0",
+        "location": "curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml",
+        "message": "connects_to sequence does not match the target plan.",
+        "severity": "high",
+        "source": "track_policy"
+      },
+      {
+        "category": "crosslink_integrity",
+        "evidence": "declared=bio-39-taras-shevchenko; target_sequence=61",
+        "id": "connects-to-sequence-1",
+        "location": "curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml",
+        "message": "connects_to sequence does not match the target plan.",
+        "severity": "high",
+        "source": "track_policy"
+      },
+      {
+        "category": "crosslink_integrity",
+        "evidence": "declared=bio-149-volodymyr-ivasyuk; target_sequence=171",
+        "id": "connects-to-sequence-2",
+        "location": "curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml",
+        "message": "connects_to sequence does not match the target plan.",
+        "severity": "high",
+        "source": "track_policy"
+      },
+      {
+        "category": "unresolved_rights",
+        "evidence": "portrait_fallback.license=VERIFY",
+        "id": "forbidden-placeholder-0",
+        "location": "curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml",
+        "message": "Public-media rights remain unresolved; use text-only until cleared.",
+        "severity": "high",
+        "source": "track_policy"
+      }
+    ],
+    "size_policy": {
+      "error": null,
+      "provenance": {
+        "argv": [
+          ".venv/bin/python",
+          "scripts/audit/module_size_policy_audit.py",
+          "--tracks",
+          "bio",
+          "--slugs",
+          "oleksandr-bilash",
+          "--built-only",
+          "--format",
+          "json"
+        ],
+        "config_path": "agents_extensions/shared/skills/post-build-review/contracts/evidence-derived-size-policy-contract.md",
+        "config_version": "1.0.0",
+        "cwd": ".",
+        "executed_argv": [
+          ".venv/bin/python",
+          "scripts/audit/module_size_policy_audit.py",
+          "--tracks",
+          "bio",
+          "--slugs",
+          "oleksandr-bilash",
+          "--built-only",
+          "--format",
+          "json"
+        ],
+        "exit_code": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "b23a9b0022a8eea8d5bbe761092226410e2dcc061ea520970aecd9f5aeadac48"
+      },
+      "result": {
+        "actual_words": 2428,
+        "advisory_ceiling": 4000,
+        "band_max": 2800,
+        "band_min": 2200,
+        "basis": "explicit_plan_size_policy",
+        "density_band": "reviewed_plan_override",
+        "dossier_path": "docs/research/bio/oleksandr-bilash.md",
+        "effective_min": 2200,
+        "metrics": {
+          "contested_markers": 6,
+          "headings": 12,
+          "primary_markers": 14,
+          "source_refs": 13,
+          "variant_markers": 3,
+          "words": 1846
+        },
+        "module_path": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md",
+        "notes": [
+          "A reviewed explicit plan size policy override replaces generic density-band limits.",
+          "Review basis: human_reviewed_rebuild_plus_research_dossier",
+          "Saturation evidence: current_module_padding_review_and_bounded_primary_packet",
+          "Above the explicit advisory ceiling, exceptional justification is required."
+        ],
+        "plan_floor": 2200,
+        "plan_outline_words": 2200,
+        "plan_path": "curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml",
+        "slug": "oleksandr-bilash",
+        "status": "explicit_override",
+        "track": "bio"
+      },
+      "status": "complete"
+    },
+    "skip_assessments": [
+      {
+        "category": "llm_qg",
+        "disposition": "superseded_by_semantic",
+        "reason": "excluded pending issue #2156; old LLM-QG rows are not read or recreated"
+      },
+      {
+        "category": "mdx_generation_validate",
+        "disposition": "accepted_read_only_omission",
+        "reason": "skipped by default because generate_mdx.py rewrites site MDX before validating"
+      },
+      {
+        "category": "external_resource_liveness",
+        "disposition": "advisory_external",
+        "reason": "skipped by default because live URL checks are network-dependent"
+      }
+    ],
+    "track_audit": {
+      "error": null,
+      "provenance": {
+        "argv": [
+          ".venv/bin/python",
+          "scripts/audit/track_deterministic_audit.py",
+          "--track",
+          "bio",
+          "--slugs",
+          "oleksandr-bilash",
+          "--format",
+          "json",
+          "--fail-on",
+          "never"
+        ],
+        "config_path": "scripts/audit/track_deterministic_audit_config.yaml",
+        "config_version": "1",
+        "cwd": ".",
+        "executed_argv": [
+          ".venv/bin/python",
+          "scripts/audit/track_deterministic_audit.py",
+          "--track",
+          "bio",
+          "--slugs",
+          "oleksandr-bilash",
+          "--format",
+          "json",
+          "--fail-on",
+          "never"
+        ],
+        "exit_code": 0,
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "stdout_sha256": "d4861b77259214b20f938c9142bb56323b5282afba14a928c59263be4ed8d3da"
+      },
+      "result": {
+        "findings": [],
+        "modules": [
+          {
+            "built": true,
+            "module_dir": "curriculum/l2-uk-en/bio/oleksandr-bilash",
+            "module_num": 374,
+            "slug": "oleksandr-bilash",
+            "title": "Олександр Білаш: Між словом і мелодією"
+          }
+        ],
+        "skipped": [
+          {
+            "category": "llm_qg",
+            "module_num": null,
+            "reason": "excluded pending issue #2156; old LLM-QG rows are not read or recreated",
+            "slug": null,
+            "track": "bio"
+          },
+          {
+            "category": "mdx_generation_validate",
+            "module_num": 374,
+            "reason": "skipped by default because generate_mdx.py rewrites site MDX before validating",
+            "slug": "oleksandr-bilash",
+            "track": "bio"
+          },
+          {
+            "category": "external_resource_liveness",
+            "module_num": 374,
+            "reason": "skipped by default because live URL checks are network-dependent",
+            "slug": "oleksandr-bilash",
+            "track": "bio"
+          }
+        ],
+        "summary": {
+          "auto_fixable_findings": 0,
+          "deterministic_failures": 0,
+          "findings_by_category": {},
+          "findings_by_severity": {
+            "blocker": 0,
+            "high": 0,
+            "info": 0,
+            "low": 0,
+            "medium": 0
+          },
+          "findings_total": 0,
+          "judgement_required_content_work": 0,
+          "llm_qg_excluded_pending_2156": true,
+          "modules_built": 1,
+          "modules_not_built": 0,
+          "modules_selected": 1,
+          "modules_with_findings": 0,
+          "remediation_only_findings": 0,
+          "skipped_checks": 3
+        },
+        "track": "bio"
+      },
+      "status": "complete"
+    }
+  },
+  "deterministic_contract_version": "1.0.0",
+  "findings": [
+    {
+      "category": "crosslink_integrity",
+      "evidence": "declared=bio-137-dmytro-pavlychko; target_sequence=159",
+      "id": "connects-to-sequence-0",
+      "location": "curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml",
+      "message": "connects_to sequence does not match the target plan.",
+      "severity": "high",
+      "source": "track_policy"
+    },
+    {
+      "category": "crosslink_integrity",
+      "evidence": "declared=bio-39-taras-shevchenko; target_sequence=61",
+      "id": "connects-to-sequence-1",
+      "location": "curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml",
+      "message": "connects_to sequence does not match the target plan.",
+      "severity": "high",
+      "source": "track_policy"
+    },
+    {
+      "category": "crosslink_integrity",
+      "evidence": "declared=bio-149-volodymyr-ivasyuk; target_sequence=171",
+      "id": "connects-to-sequence-2",
+      "location": "curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml",
+      "message": "connects_to sequence does not match the target plan.",
+      "severity": "high",
+      "source": "track_policy"
+    },
+    {
+      "category": "unresolved_rights",
+      "evidence": "portrait_fallback.license=VERIFY",
+      "id": "forbidden-placeholder-0",
+      "location": "curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml",
+      "message": "Public-media rights remain unresolved; use text-only until cleared.",
+      "severity": "high",
+      "source": "track_policy"
+    },
+    {
+      "category": "language",
+      "evidence": "The plan says «потребує критичного співставлення». Project source tool search_ua_gec_errors returned a human-annotated native-author pair: error «співставлення», correction «зіставлення», tag F/Calque.",
+      "id": "ua-calque-spivstavlennia",
+      "location": "curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml:208",
+      "message": "Replace the learner-facing calque «співставлення» with standard «зіставлення».",
+      "severity": "medium",
+      "source": "semantic"
+    },
+    {
+      "category": "activity",
+      "evidence": "The activity asks learners to compare «Баяніст із Градизька» with the 2026 concert, and its model answer requires «однієї пісні у двох версіях». Official Mediateka metadata specifically names «Впали роси на покоси» and «Смерека»; YouTube metadata for P6_-jd0nvRU lists 16 chapters, including «Ясени» and «Два кольори», but neither named archive performance. The supplied materials do not identify any overlap or archive timestamp, so learners cannot reliably perform the required same-song comparison from the packet.",
+      "id": "comparison-shared-recording-not-established",
+      "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/activities.yaml:76",
+      "message": "Identify a song demonstrably present in both recordings, with usable timestamps, or provide a different archival recording; the current workbook comparison does not establish the common object required by its model answer.",
+      "severity": "medium",
+      "source": "semantic"
+    },
+    {
+      "category": "language",
+      "evidence": "GRAC returned no concordance for the exact phrase «межа певності», while «ступінь певності» returned seven concordance examples. The uncorroborated phrase is promoted as a vocabulary lemma and rubric term, so it merits source-aligned polishing even though its intended meaning is understandable.",
+      "id": "certainty-metalanguage-not-attested",
+      "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/vocabulary.yaml:26",
+      "message": "Prefer attested «ступінь певності» (or another source-checked formulation) over repeatedly teaching «межа певності» as a fixed noun phrase.",
+      "severity": "low",
+      "source": "semantic"
+    }
+  ],
+  "prompt_sha256": "64ef1f69fa272995a545671ed03d092a9977e928a977cc3b4e9b1c88c8900aaa",
+  "reproducibility_key": "1fd508cab122b105c044a4c065b72900618f4f16ca6fcddfa5587052c3b43e8a",
+  "review_protocol_version": "1.0.0",
+  "reviewer": {
+    "agent": "codex-subagent",
+    "effort": "runtime-unreported",
+    "family": "openai-gpt",
+    "model": "runtime-unreported"
+  },
+  "schema_version": "post-build-review.result.v1",
+  "semantic": {
+    "claim_coverage": {
+      "claims_total": 74,
+      "claims_verified": 74,
+      "status": "complete"
+    },
+    "family": "seminar",
+    "findings": [
+      {
+        "category": "language",
+        "evidence": "The plan says «потребує критичного співставлення». Project source tool search_ua_gec_errors returned a human-annotated native-author pair: error «співставлення», correction «зіставлення», tag F/Calque.",
+        "id": "ua-calque-spivstavlennia",
+        "location": "curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml:208",
+        "message": "Replace the learner-facing calque «співставлення» with standard «зіставлення».",
+        "severity": "medium",
+        "source": "semantic"
+      },
+      {
+        "category": "activity",
+        "evidence": "The activity asks learners to compare «Баяніст із Градизька» with the 2026 concert, and its model answer requires «однієї пісні у двох версіях». Official Mediateka metadata specifically names «Впали роси на покоси» and «Смерека»; YouTube metadata for P6_-jd0nvRU lists 16 chapters, including «Ясени» and «Два кольори», but neither named archive performance. The supplied materials do not identify any overlap or archive timestamp, so learners cannot reliably perform the required same-song comparison from the packet.",
+        "id": "comparison-shared-recording-not-established",
+        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/activities.yaml:76",
+        "message": "Identify a song demonstrably present in both recordings, with usable timestamps, or provide a different archival recording; the current workbook comparison does not establish the common object required by its model answer.",
+        "severity": "medium",
+        "source": "semantic"
+      },
+      {
+        "category": "language",
+        "evidence": "GRAC returned no concordance for the exact phrase «межа певності», while «ступінь певності» returned seven concordance examples. The uncorroborated phrase is promoted as a vocabulary lemma and rubric term, so it merits source-aligned polishing even though its intended meaning is understandable.",
+        "id": "certainty-metalanguage-not-attested",
+        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/vocabulary.yaml:26",
+        "message": "Prefer attested «ступінь певності» (or another source-checked formulation) over repeatedly teaching «межа певності» as a fixed noun phrase.",
+        "severity": "low",
+        "source": "semantic"
+      }
+    ],
+    "summary": "All 74 atomic factual/source claims were checked against ESU, VUE, the NBU for Children bibliography, Suspilne/Mediateka metadata, Ukrainian Wikipedia, the project research dossier, VESUM, the literary corpus, UA-GEC, and GRAC. The module is careful about evidence limits and decolonization, but it contains one source-confirmed Ukrainian calque and a workbook comparison whose supplied resources do not establish the shared performance needed by its model answer.",
+    "verdict": "REVISE"
+  },
+  "semantic_prompt_version": "1.0.0",
+  "source_hashes": {
+    "activities": "90548efda024b3ce722fa2548a7a92e8645cf39963a479fac0bd827ea04dd05b",
+    "content": "81b01bf7fb52a120c2d9d283817ee7b0399c5530ef95aa0773443258a4f2bfd8",
+    "plan": "7c9d3623533452f3c96fdd97c26e8b926c74643d030c05838f4e9a8577ca1625",
+    "resources": "6558ce471e000a317fa4887107ecb2e1cbfd458ccb2f397ac89c0008f70ebc6a",
+    "vocabulary": "50c20da1c4216d2353ec752fad78092f3e959d7f8af718643d3ee362ef6d761e"
+  },
+  "target": {
+    "files": {
+      "activities": "curriculum/l2-uk-en/bio/oleksandr-bilash/activities.yaml",
+      "content": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md",
+      "plan": "curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml",
+      "resources": "curriculum/l2-uk-en/bio/oleksandr-bilash/resources.yaml",
+      "vocabulary": "curriculum/l2-uk-en/bio/oleksandr-bilash/vocabulary.yaml"
+    },
+    "layout": "directory",
+    "semantic_family": "seminar",
+    "slug": "oleksandr-bilash",
+    "track": "bio"
+  },
+  "track_policy_version": "1.0.0"
+}

--- a/tests/fixtures/post_build_review/bio-oleksandr-bilash.result.v1.json
+++ b/tests/fixtures/post_build_review/bio-oleksandr-bilash.result.v1.json
@@ -70,7 +70,7 @@
           "json"
         ],
         "config_path": "agents_extensions/shared/skills/post-build-review/contracts/evidence-derived-size-policy-contract.md",
-        "config_version": "1.0.0",
+        "config_version": "1.0.1",
         "cwd": ".",
         "executed_argv": [
           ".venv/bin/python",
@@ -231,7 +231,7 @@
       "status": "complete"
     }
   },
-  "deterministic_contract_version": "1.0.0",
+  "deterministic_contract_version": "1.0.1",
   "findings": [
     {
       "category": "crosslink_integrity",
@@ -298,7 +298,7 @@
     }
   ],
   "prompt_sha256": "64ef1f69fa272995a545671ed03d092a9977e928a977cc3b4e9b1c88c8900aaa",
-  "reproducibility_key": "96f271179cf0ccb3b13a69c82689c187c0250ccd3dcb2f65187c66e85aa6f0f6",
+  "reproducibility_key": "cbcd2ef8546b6058ee14c8b5df9a35e61d5195d20e8dec1aa63f5f09e0940d4b",
   "review_protocol_version": "1.0.1",
   "reviewer": {
     "agent": "codex-subagent",

--- a/tests/fixtures/post_build_review/bio-oleksandr-bilash.result.v1.json
+++ b/tests/fixtures/post_build_review/bio-oleksandr-bilash.result.v1.json
@@ -298,8 +298,8 @@
     }
   ],
   "prompt_sha256": "64ef1f69fa272995a545671ed03d092a9977e928a977cc3b4e9b1c88c8900aaa",
-  "reproducibility_key": "1fd508cab122b105c044a4c065b72900618f4f16ca6fcddfa5587052c3b43e8a",
-  "review_protocol_version": "1.0.0",
+  "reproducibility_key": "96f271179cf0ccb3b13a69c82689c187c0250ccd3dcb2f65187c66e85aa6f0f6",
+  "review_protocol_version": "1.0.1",
   "reviewer": {
     "agent": "codex-subagent",
     "effort": "runtime-unreported",

--- a/tests/fixtures/post_build_review/core-semantic-exemplar.v1.json
+++ b/tests/fixtures/post_build_review/core-semantic-exemplar.v1.json
@@ -1,0 +1,14 @@
+{
+  "target": "a1/sounds-letters-and-hello",
+  "expected_family": "core",
+  "semantic_result": {
+    "verdict": "PASS",
+    "summary": "Core exemplar with non-factual beginner content and no material semantic findings.",
+    "claim_coverage": {
+      "status": "not_applicable",
+      "claims_total": 0,
+      "claims_verified": 0
+    },
+    "findings": []
+  }
+}

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -1,4 +1,4 @@
-catalog_version: 1.0.0
+catalog_version: 1.0.1
 regressions:
   - bug_id: bilash-evening-school-location-role
     responsible_layer: semantic_prompt
@@ -53,3 +53,8 @@ regressions:
     fixed_in_version: 1.0.0
     input: Bilash range 2200-2800 and ceiling 4000
     expected: Values remain exemplar/plan evidence and are never BIO defaults.
+  - bug_id: deterministic-stage-null-result-crash
+    responsible_layer: orchestration
+    fixed_in_version: 1.0.1
+    input: Deterministic track audit status error with result null.
+    expected: Prompt assembly preserves null evidence and aggregate status INCOMPLETE without raising AttributeError.

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -1,0 +1,55 @@
+catalog_version: 1.0.0
+regressions:
+  - bug_id: bilash-evening-school-location-role
+    responsible_layer: semantic_prompt
+    fixed_in_version: 1.0.0
+    input: Poltava evening school together with the Mayboroda brothers
+    expected: Verify Kyiv evening school and teacher roles against sources; never infer peers.
+  - bug_id: bilash-stale-connects-to-sequences
+    responsible_layer: track_policy
+    fixed_in_version: 1.0.0
+    input:
+      - bio-137-dmytro-pavlychko
+      - bio-39-taras-shevchenko
+      - bio-149-volodymyr-ivasyuk
+    expected: Three high crosslink_integrity findings.
+  - bug_id: bilash-unresolved-portrait-license
+    responsible_layer: track_policy
+    fixed_in_version: 1.0.0
+    input: portrait_fallback.license=VERIFY
+    expected: One high unresolved_rights finding and text-only fallback.
+  - bug_id: bio-routed-to-core-spot-check
+    responsible_layer: orchestration
+    fixed_in_version: 1.0.0
+    input: bio/oleksandr-bilash
+    expected: Route to seminar prompt with exhaustive claim ledger.
+  - bug_id: mdx-validation-created-missing-output
+    responsible_layer: deterministic_code
+    fixed_in_version: 1.0.0
+    input: --run-mdx-generation-validate with initially missing MDX
+    expected: The canonical read-only command never enables the mutating opt-in.
+  - bug_id: semantic-pass-overrode-mechanical-blocker
+    responsible_layer: disposition
+    fixed_in_version: 1.0.0
+    input: semantic PASS plus deterministic high
+    expected: Combined disposition BLOCK.
+  - bug_id: missing-review-provenance
+    responsible_layer: schema
+    fixed_in_version: 1.0.0
+    input: Result without version, prompt hash, reviewer, or command provenance.
+    expected: JSON Schema validation failure.
+  - bug_id: generated-review-written-to-curriculum-audit
+    responsible_layer: orchestration
+    fixed_in_version: 1.0.0
+    input: curriculum/l2-uk-en/bio/audit/generated-review.md
+    expected: Reject repository output paths; use /tmp.
+  - bug_id: render-skip-silently-green
+    responsible_layer: track_policy
+    fixed_in_version: 1.0.0
+    input: mdx_generation_validate skipped
+    expected: Explicit accepted_read_only_omission assessment remains in the result.
+  - bug_id: bilash-size-policy-globalized
+    responsible_layer: semantic_prompt
+    fixed_in_version: 1.0.0
+    input: Bilash range 2200-2800 and ceiling 4000
+    expected: Values remain exemplar/plan evidence and are never BIO defaults.

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -1,4 +1,4 @@
-catalog_version: 1.0.1
+catalog_version: 1.0.2
 regressions:
   - bug_id: bilash-evening-school-location-role
     responsible_layer: semantic_prompt
@@ -56,5 +56,12 @@ regressions:
   - bug_id: deterministic-stage-null-result-crash
     responsible_layer: orchestration
     fixed_in_version: 1.0.1
+    version_field: review_protocol_version
     input: Deterministic track audit status error with result null.
     expected: Prompt assembly preserves null evidence and aggregate status INCOMPLETE without raising AttributeError.
+  - bug_id: venv-python-symlink-bypassed-environment
+    responsible_layer: deterministic_code
+    fixed_in_version: 1.0.1
+    version_field: deterministic_contract_version
+    input: Repository .venv/bin/python is a symlink to a host interpreter.
+    expected: Execute through the .venv entrypoint path so pyvenv.cfg and project dependencies remain active.

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -61,8 +61,7 @@ def _copy_repo_subset(target: Path) -> None:
     bin_dir.mkdir(parents=True, exist_ok=True)
     python_wrapper = bin_dir / "python"
     python_wrapper.write_text(
-        "#!/usr/bin/env bash\n"
-        f"exec {shlex.quote(str(PROJECT_PYTHON))} \"$@\"\n",
+        f'#!/usr/bin/env bash\nexec {shlex.quote(str(PROJECT_PYTHON))} "$@"\n',
         encoding="utf-8",
     )
     python_wrapper.chmod(0o755)
@@ -107,8 +106,7 @@ def test_fresh_deploy_produces_synced_output(tmp_path: Path) -> None:
 
     check_result = _run(repo, CHECK_SCRIPT)
     assert check_result.returncode == 0, (
-        "drift check failed after fresh deploy:\n"
-        f"stdout: {check_result.stdout}\nstderr: {check_result.stderr}"
+        f"drift check failed after fresh deploy:\nstdout: {check_result.stdout}\nstderr: {check_result.stderr}"
     )
     assert (repo / CODEX_HOOK_TARGET).exists()
     assert (repo / CODEX_HOOKS_CONFIG).exists()
@@ -117,9 +115,9 @@ def test_fresh_deploy_produces_synced_output(tmp_path: Path) -> None:
     ).read_text(encoding="utf-8")
     assert (repo / ".codex" / "memory" / "MEMORY.md").exists()
     assert (repo / ".gemini/config.yaml").exists()
-    deployed_claude_rules = sorted(
-        path.name for path in (repo / ".claude" / "rules").glob("*.md")
-    )
+    assert (repo / ".gemini/skills/final-review/SKILL.md").exists()
+    assert (repo / ".gemini/skills/post-build-review/SKILL.md").exists()
+    deployed_claude_rules = sorted(path.name for path in (repo / ".claude" / "rules").glob("*.md"))
     assert deployed_claude_rules == sorted(CLAUDE_RULE_FILES)
     for filename in UNSCOPED_RULE_FILES:
         assert not (repo / ".claude" / "rules" / filename).exists()
@@ -132,8 +130,7 @@ def test_fresh_deploy_produces_synced_output(tmp_path: Path) -> None:
         ["diff", "-rq", "agents_extensions/shared/hooks", ".codex/hooks"],
     )
     assert codex_hooks_diff.returncode == 0, (
-        "Codex hooks drift after fresh deploy:\n"
-        f"stdout: {codex_hooks_diff.stdout}\nstderr: {codex_hooks_diff.stderr}"
+        f"Codex hooks drift after fresh deploy:\nstdout: {codex_hooks_diff.stdout}\nstderr: {codex_hooks_diff.stderr}"
     )
 
 
@@ -258,6 +255,102 @@ def test_missing_codex_hooks_json_is_drift(tmp_path: Path) -> None:
     assert check_result.returncode != 0
     assert "Deploy-script drift between agents_extensions/codex and .codex" in combined_output
     assert "Missing deployed overlay file: .codex/hooks.json" in combined_output
+
+
+def test_gemini_shared_skill_overlay_is_checked_without_deleting_provider_skills(
+    tmp_path: Path,
+) -> None:
+    """Shared skills overlay into Gemini without replacing Gemini-only skills."""
+    repo = _init_checkout(tmp_path)
+    deploy_result = _run(repo, DEPLOY_SCRIPT)
+    assert deploy_result.returncode == 0, deploy_result.stderr
+
+    shared = repo / ".gemini" / "skills" / "post-build-review" / "SKILL.md"
+    provider = repo / ".gemini" / "skills" / "final-review" / "SKILL.md"
+    assert shared.exists()
+    assert provider.exists()
+
+    unauthorized = repo / ".gemini" / "unauthorized-target-file.txt"
+    unauthorized.write_text("not source-owned\n", encoding="utf-8")
+    unauthorized_check = _run(repo, CHECK_SCRIPT)
+    unauthorized_output = f"{unauthorized_check.stdout}\n{unauthorized_check.stderr}"
+    assert unauthorized_check.returncode != 0
+    assert "Unowned deployed Gemini file" in unauthorized_output
+    assert "unauthorized-target-file.txt" in unauthorized_output
+    unauthorized.unlink()
+
+    shared.write_text(shared.read_text(encoding="utf-8") + "\n# drift\n", encoding="utf-8")
+    check_result = _run(repo, CHECK_SCRIPT)
+    combined_output = f"{check_result.stdout}\n{check_result.stderr}"
+    assert check_result.returncode != 0
+    assert ("agents_extensions/shared/skills/post-build-review and .gemini/skills/post-build-review") in combined_output
+
+    shutil.copy2(
+        repo / "agents_extensions" / "shared" / "skills" / "post-build-review" / "SKILL.md",
+        shared,
+    )
+    provider.write_text(provider.read_text(encoding="utf-8") + "\n# provider drift\n", encoding="utf-8")
+    provider_check = _run(repo, CHECK_SCRIPT)
+    provider_output = f"{provider_check.stdout}\n{provider_check.stderr}"
+    assert provider_check.returncode != 0
+    assert ("gemini_extensions/skills/final-review and .gemini/skills/final-review") in provider_output
+    assert "SKILL.md" in provider_output
+
+    provider_source = repo / "gemini_extensions" / "skills" / "final-review" / "SKILL.md"
+    provider_source.write_text(
+        provider_source.read_text(encoding="utf-8") + "\n# provider source update\n",
+        encoding="utf-8",
+    )
+    redeploy = _run(repo, DEPLOY_SCRIPT)
+    assert redeploy.returncode == 0, redeploy.stderr
+    assert "deleting skills/post-build-review" not in redeploy.stdout
+    assert shared.exists()
+
+    stale = shared.parent / "stale-resource.txt"
+    stale.write_text("stale shared mirror file\n", encoding="utf-8")
+    stale_redeploy = _run(repo, DEPLOY_SCRIPT)
+    assert stale_redeploy.returncode == 0, stale_redeploy.stderr
+    assert not stale.exists()
+
+    shutil.rmtree(repo / "agents_extensions" / "shared" / "skills" / "post-build-review")
+    for mirror in (".claude/skills", ".agent/skills", ".agents/skills", ".codex/skills"):
+        shutil.rmtree(repo / mirror / "post-build-review", ignore_errors=True)
+    removed_redeploy = _run(repo, DEPLOY_SCRIPT)
+    assert removed_redeploy.returncode == 0, removed_redeploy.stderr
+    assert not shared.parent.exists()
+    assert provider.exists()
+
+
+def test_gemini_shared_skill_exclusion_does_not_mask_root_drift(tmp_path: Path) -> None:
+    """The skills/* overlay exclusion must not become diff's match-all '*'."""
+    repo = _init_checkout(tmp_path)
+    deploy_result = _run(repo, DEPLOY_SCRIPT)
+    assert deploy_result.returncode == 0, deploy_result.stderr
+
+    settings = repo / ".gemini" / "settings.json"
+    settings.write_text(
+        settings.read_text(encoding="utf-8") + "\n",
+        encoding="utf-8",
+    )
+
+    check_result = _run(repo, CHECK_SCRIPT)
+    combined_output = f"{check_result.stdout}\n{check_result.stderr}"
+    assert check_result.returncode != 0
+    assert "Deploy-script drift between gemini_extensions and .gemini" in combined_output
+    assert "settings.json" in combined_output
+
+
+def test_gemini_shared_skill_name_collision_fails_closed(tmp_path: Path) -> None:
+    """A provider-specific duplicate cannot shadow the canonical shared skill."""
+    repo = _init_checkout(tmp_path)
+    duplicate = repo / "gemini_extensions" / "skills" / "post-build-review" / "SKILL.md"
+    duplicate.parent.mkdir(parents=True)
+    duplicate.write_text("provider duplicate\n", encoding="utf-8")
+
+    deploy_result = _run(repo, DEPLOY_SCRIPT)
+    combined_output = f"{deploy_result.stdout}\n{deploy_result.stderr}"
+    assert deploy_result.returncode != 0
+    assert "shared/Gemini skill collision: post-build-review" in combined_output
 
 
 def test_codex_orphan_is_caught(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add the canonical shared `$post-build-review` skill with versioned deterministic, semantic, policy, disposition, size, and JSON-schema contracts
- add read-only prepare/finalize/validate orchestration, track resolution, provenance hashing, Bilash/core exemplars, and regression catalog
- deploy exact shared-skill mirrors through the established workflow, including Gemini coexistence with provider-owned skills and fail-closed drift/collision/ownership checks
- document the nine-step maintenance and bug-fix workflow in `docs/runbooks/post-build-review.md`

## Reproducibility

A fresh agent invoked exactly `Use $post-build-review for bio/oleksandr-bilash.` and reproduced the checked result:

- review protocol and deterministic contract: `1.0.1`; semantic prompt and track policy: `1.0.0`
- prompt SHA-256: `64ef1f69fa272995a545671ed03d092a9977e928a977cc3b4e9b1c88c8900aaa`
- reproducibility key: `cbcd2ef8546b6058ee14c8b5df9a35e61d5195d20e8dec1aa63f5f09e0940d4b`
- semantic coverage: 74/74 claims
- combined disposition: `BLOCK`

Bilash content repairs are deliberately outside this infrastructure PR and tracked in linked BIO sub-issue #5023.

## Verification

- `76 passed`: post-build review, deploy idempotency, deterministic track audit, module size policy, writer size policy
- focused post-build/deploy rerun: `45 passed`
- Ruff check + format, py_compile, bash syntax, prompt lint, skill lint, skill validator
- JSON/YAML parse; Markdownlint 8 files / 0 errors
- live deploy, deployment drift checker, dry-run, `git diff --check`
- mandatory pre-submit audit: 19 scoped files; protected configs unchanged; no generated status/review/telemetry artifacts; no `sys.executable`, skips, or weakened assertions
- commit trailer audit: PASS

## Review gate

Independent AGY/Gemini cross-family implementation re-review: **PASS**, no findings. The first CI run exposed a null-result orchestration crash; it was cataloged, fixed fail-closed, and bumped to review protocol `1.0.1`. The second trace revealed the root cause: resolving a symlink-based `.venv/bin/python` bypassed `pyvenv.cfg` on Linux. The deterministic command layer now preserves the venv entrypoint, is bumped to contract `1.0.1`, and has a symlink regression. Both fixes were re-forward-tested byte-for-byte and independently re-reviewed **PASS**. Earlier Grok/AGY findings exposed stale-mirror and diff-exclusion bugs; both were reproduced, fixed at the canonical deployment layer, and regression-tested. Claude was at 95% weekly use, so AGY/Grok were used as the documented cross-family substitution.

## Pre-submit checklist

- [x] `.python-version` remains `3.12.8`
- [x] `.yamllint` and `.markdownlint.json` unchanged
- [x] no generated status/audit/review/telemetry artifacts
- [x] no `sys.executable` or weakened/skipped tests
- [x] every changed file is in scope; total files changed = 19
- [x] affected code and fixtures execute without import/name/key errors

Fixes #5020