### PR TITLE
fix(rules): stream-scoped session sweeps — track sessions own-stream-only

### DIFF
--- a/agents_extensions/shared/rules/workflow.md
+++ b/agents_extensions/shared/rules/workflow.md
@@ -115,18 +115,26 @@ when CI settles, nobody babysits. Dispatched agents still do NOT self-enable aut
 **Stream-scoped sweeps (user directive 2026-07-13 — parallel-stream chaos fix; supersedes the
 2026-07-07 one-hour out-of-lane backstop for TRACK sessions).** Multiple streams run in parallel, so a
 session's start/end sweep is **OWN-STREAM ONLY**: it may review, review-route, arm auto-merge, or merge
-**only** PRs in its own stream. A PR is **in-stream** iff it matches the session's assigned stream
-(named in its handoff) by (a) branch prefix, (b) a `Closes/Refs #<epic>` link, or (c) a stream label.
-**Anything else is another stream's PR → hands-off: no exceptions, no time threshold** — do NOT
-shepherd, review-route, or arm auto-merge on it. Rationale: the old one-hour timer could not tell an
-*abandoned* PR from an *owner-paused* one, so with parallel streams it made two sessions grab the same
-PR, or one session merge another live stream's paused PR.
+**only** PRs in its own stream.
 
-The **cross-stream out-of-lane backstop belongs to exactly ONE owner: the repo-wide integration
-orchestrator (Codex-main — roster: owns the repo-wide queue, integration, and final merge judgment).**
-Only it runs a cross-stream sweep, and only on PRs that have sat green (CI passing + review gate passed)
-idle for MORE THAN 1 HOUR (the rare abandoned-PR net). No other session runs one. Per-lane `--auto`
-merge already keeps in-stream PRs from sitting, so this backstop is a safety net, not the primary path.
+**Stream membership is AUTHORITATIVE + FAIL-CLOSED.** A PR is *in-stream* iff its linked issue resolves
+to the session's stream-epic in the issue→epic membership registry — `/api/issues/streams` (from
+`scripts.orchestration.issue_stream_audit`). **Branch prefixes (`codex/`, `claude/`, `agy/`) are AUTHOR
+lanes, NOT streams — never use them for membership.** If a PR does not resolve to exactly one
+stream-epic there (no link, multiple/conflicting `Closes/Refs`, or not yet indexed), it is
+**out-of-stream → hands-off** for every track session. Out-of-stream = another stream's PR → do NOT
+shepherd, review-route, or arm auto-merge on it: **no time threshold, no exception.** Rationale: the old
+one-hour timer could not tell an *abandoned* PR from an *owner-paused* one, so with parallel streams it
+made two sessions grab the same PR, or one merge another live stream's paused PR.
+
+**The cross-stream abandoned-PR net has exactly ONE owner — the INTEGRATION-OWNER ROLE** (default
+holder: Codex-main; a ROLE, not a hardcoded session/model — the roster owns repo-wide queue +
+integration + final merge judgment). Only that role sweeps out-of-stream PRs, and only ones sat green
+(CI + review gate passed) idle for MORE THAN 1 HOUR. **To avoid a liveness gap** (a down role-holder
+stranding a green PR forever), this net MUST run as a **scheduled integration sweep** owned by the role
+— it must not depend on any interactive session being live. (Until that scheduled sweep is wired, the
+role-holder runs it at session start/end — see follow-up.) Per-lane `--auto` merge already keeps
+in-stream PRs from sitting, so this net is a rare safety valve, not the primary path.
 
 ## Two-tier handoffs (epic #1865 item #1, shipped 2026-05-11)
 

--- a/agents_extensions/shared/rules/workflow.md
+++ b/agents_extensions/shared/rules/workflow.md
@@ -122,8 +122,9 @@ to the session's stream-epic in the issue→epic membership registry — `/api/i
 `scripts.orchestration.issue_stream_audit`). **Branch prefixes (`codex/`, `claude/`, `agy/`) are AUTHOR
 lanes, NOT streams — never use them for membership.** If a PR does not resolve to exactly one
 stream-epic there (no link, multiple/conflicting `Closes/Refs`, or not yet indexed), it is
-**out-of-stream → hands-off** for every track session. Out-of-stream = another stream's PR → do NOT
-shepherd, review-route, or arm auto-merge on it: **no time threshold, no exception.** Rationale: the old
+**out-of-stream → hands-off** for every track session. Out-of-stream — another stream's PR, OR any PR
+with no / multiple / conflicting / not-yet-indexed stream-epic membership (the fail-closed default) —
+means do NOT shepherd, review-route, or arm auto-merge on it: **no time threshold, no exception.** Rationale: the old
 one-hour timer could not tell an *abandoned* PR from an *owner-paused* one, so with parallel streams it
 made two sessions grab the same PR, or one merge another live stream's paused PR.
 

--- a/agents_extensions/shared/rules/workflow.md
+++ b/agents_extensions/shared/rules/workflow.md
@@ -110,10 +110,23 @@ hours). Every lane: the moment a PR's review gate passes (cross-family review ev
 requested changes), run `gh pr merge <N> --auto --squash --delete-branch` — GitHub merges it
 when CI settles, nobody babysits. Dispatched agents still do NOT self-enable auto-merge
 (review gate first — unchanged). `--auto` waits for green and never bypasses blocking checks
-(#M-0.5 semantics unchanged). Orchestrator session sweeps remain the backstop — but ONLY for
-out-of-lane PRs that have sat green (CI passing + review gate passed) idle for MORE THAN
-1 HOUR (user directive 2026-07-07): a fresh PR belongs to its lane. Do not shepherd,
-review-route, or arm auto-merge on another lane's PR before that threshold.
+(#M-0.5 semantics unchanged).
+
+**Stream-scoped sweeps (user directive 2026-07-13 — parallel-stream chaos fix; supersedes the
+2026-07-07 one-hour out-of-lane backstop for TRACK sessions).** Multiple streams run in parallel, so a
+session's start/end sweep is **OWN-STREAM ONLY**: it may review, review-route, arm auto-merge, or merge
+**only** PRs in its own stream. A PR is **in-stream** iff it matches the session's assigned stream
+(named in its handoff) by (a) branch prefix, (b) a `Closes/Refs #<epic>` link, or (c) a stream label.
+**Anything else is another stream's PR → hands-off: no exceptions, no time threshold** — do NOT
+shepherd, review-route, or arm auto-merge on it. Rationale: the old one-hour timer could not tell an
+*abandoned* PR from an *owner-paused* one, so with parallel streams it made two sessions grab the same
+PR, or one session merge another live stream's paused PR.
+
+The **cross-stream out-of-lane backstop belongs to exactly ONE owner: the repo-wide integration
+orchestrator (Codex-main — roster: owns the repo-wide queue, integration, and final merge judgment).**
+Only it runs a cross-stream sweep, and only on PRs that have sat green (CI passing + review gate passed)
+idle for MORE THAN 1 HOUR (the rare abandoned-PR net). No other session runs one. Per-lane `--auto`
+merge already keeps in-stream PRs from sitting, so this backstop is a safety net, not the primary path.
 
 ## Two-tier handoffs (epic #1865 item #1, shipped 2026-05-11)
 

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -70,16 +70,21 @@ does not micromanage that track.
 | State | `docs/session-state/codex-orchestrator-handoff.md` and router | Track handoff (gitignored local), e.g. `.claude/bio-epic/CLAUDE-DRIVER-HANDOFF.md` — not in git/PRs |
 | Work selection | Repo-wide priorities, A1 spine, tooling, infra, tech debt, issues | Track backlog, batches, reviews, content quality |
 | Agent dispatch | Cross-track/tooling agents | Track-local writers/reviewers, including headless Codex |
-| Merge authority | Final reconcile on cross-track/contested merges; sweep backstop for out-of-lane PRs sitting green >1h (#4703) | Open PRs, route track feedback; self-merge own-track PRs after cross-family review + green CI (#M-12 grant, user 2026-06-16); arm `gh pr merge --auto --squash --delete-branch` at review-gate-pass |
+| Merge authority | Final reconcile on cross-track/contested merges; SOLE cross-stream sweeper (integration-owner role) for abandoned out-of-stream PRs green+reviewed idle >1h, via scheduled sweep (#4703; stream-scoped 2026-07-13). Track PRs = own-stream-only, membership authoritative via `/api/issues/streams` | Open PRs, route track feedback; self-merge own-track PRs after cross-family review + green CI (#M-12 grant, user 2026-06-16); arm `gh pr merge --auto --squash --delete-branch` at review-gate-pass |
 
 **Boundary rule:** if a track orchestrator exists, the main orchestrator treats
 that track's PRs and delegates as awareness-only unless the track orchestrator
 asks for help. This keeps one owner per workstream and prevents duplicate
-triage. The only exception is the merge-sweep backstop (user directive
-2026-07-07, #4703): an out-of-lane PR that has sat GREEN (CI passing + review
-gate passed) idle for more than 1 hour may be picked up by any orchestrator
-sweep. Fresh out-of-lane PRs are hands-off — do not shepherd, review-route, or
-arm auto-merge on them before that threshold.
+triage. Stream membership is AUTHORITATIVE + FAIL-CLOSED via the issue→epic
+registry (`/api/issues/streams`, from `issue_stream_audit`); branch prefixes are
+AUTHOR lanes, not streams. A track session touches ONLY its own stream's PRs —
+an out-of-stream PR (or one that doesn't resolve to exactly one stream-epic) is
+hands-off with **no time threshold**. The one cross-stream exception is the
+abandoned-PR net, owned by the **INTEGRATION-OWNER ROLE alone** (default:
+Codex-main; a role, NOT any orchestrator), for a green+reviewed out-of-stream PR
+idle >1h — ideally run as a scheduled integration sweep so a down role-holder
+cannot strand it (user directive 2026-07-13, supersedes the 2026-07-07
+any-orchestrator backstop). See workflow.md § Merge policy for the full rule.
 
 ### Track ↔ main communication protocol
 

--- a/docs/best-practices/agent-cooperation.md
+++ b/docs/best-practices/agent-cooperation.md
@@ -82,8 +82,9 @@ an out-of-stream PR (or one that doesn't resolve to exactly one stream-epic) is
 hands-off with **no time threshold**. The one cross-stream exception is the
 abandoned-PR net, owned by the **INTEGRATION-OWNER ROLE alone** (default:
 Codex-main; a role, NOT any orchestrator), for a green+reviewed out-of-stream PR
-idle >1h — ideally run as a scheduled integration sweep so a down role-holder
-cannot strand it (user directive 2026-07-13, supersedes the 2026-07-07
+idle >1h — which MUST run as a scheduled integration sweep (not gated on any
+live session) so a down role-holder cannot strand it (user directive
+2026-07-13, supersedes the 2026-07-07
 any-orchestrator backstop). See workflow.md § Merge policy for the full rule.
 
 ### Track ↔ main communication protocol


### PR DESCRIPTION
## Problem (user report)
After a restart, a Claude session starts working on **green PRs from other streams**. With ≥3 parallel streams active, this is a chaos risk — agents touching each other's PRs.

## Root cause (traced, not a hook)
No hook/cron auto-sweeps on restart. It's purely the rule in `agents_extensions/shared/rules/workflow.md` §"Merge policy" (served at `/api/rules`):

> *Orchestrator session sweeps remain the backstop — but ONLY for out-of-lane PRs that have sat green … idle for MORE THAN 1 HOUR … Do not shepherd, review-route, or arm auto-merge on another lane's PR before that threshold.*

That was written (2026-07-07) for a **single** orchestrator catching genuinely abandoned PRs. It breaks with parallel streams: every session applies it on cold-start, and the 1-hour timer can't distinguish an *abandoned* PR from an *owner-paused* one → two sessions grab the same PR, or one merges another live stream's paused PR.

## Fix
- **Track/stream sessions = OWN-STREAM ONLY.** Review / review-route / arm-auto-merge / merge **only** PRs in the session's own stream. In-stream = branch prefix, `Closes/Refs #<epic>`, or a stream label matching the session's assigned stream. Anything else is hands-off — **no exceptions, no time threshold**.
- **The cross-stream out-of-lane backstop belongs to exactly ONE owner: Codex-main** (roster: repo-wide queue + integration + final merge judgment), and only for PRs green+reviewed idle >1h (the rare abandoned-PR net).
- Per-lane `--auto` merge already stops in-stream PRs from sitting, so the backstop is a safety net, not the primary path.

Single-file change to the served source; `.claude/` is a gitignored deploy target (rule is served from source via `/api/rules`).

## Review
Cross-family (author = Claude) — checking the policy wording + that it can't silently strand a truly-abandoned PR.