### PR TITLE
fix(atlas): document full-manifest relation publish path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ atlas:
 	$(PYTHON) scripts/lexicon/enrich_manifest.py
 	$(PYTHON) -m scripts.audit.generate_search_index
 	$(PYTHON) scripts/lexicon/export_open_dataset.py
-	$(PYTHON) scripts/audit/generate_daily_pool.py
+	$(PYTHON) -m scripts.audit.generate_daily_pool
 	$(PYTHON) scripts/lexicon/verify_manifest.py
 
 atlas-publish: atlas

--- a/docs/bug-autopsies/INDEX.md
+++ b/docs/bug-autopsies/INDEX.md
@@ -4,7 +4,8 @@ One-liner per bug. Grep for symptoms or categories to find relevant detail files
 
 <!-- INDEX-START -->
 | Date | Issue | Category | Summary |
-|------|-------|----------|---------|
+| --- | --- | --- | --- |
+| 2026-07-13 | #4975 | atlas-build / source-split | `make atlas` starts with the course-vocabulary builder, but the 8,552-entry live Atlas also contains 3,376 promoted grow/source-inventory entries. A relation-only run therefore replaces the full release with a smaller, non-equivalent set. Hydrate the pointer asset and re-enrich in place; `make atlas-publish` is unsafe for this path. Detail in [atlas-manifest-source-split.md](atlas-manifest-source-split.md). |
 | 2026-07-10 | #4857 | git-discipline | Read-only review delegate ran `gh pr checkout 4849` at repo root → primary checkout left on `pr-4849` (~7 min, silently wrong code for all repo-root readers). delegate.py neither prevents nor detects children moving primary HEAD; guard hook covers interactive shells only. Prior fossils: `pr-4397/4556/4557`. Fix = runtime enforcement (worktree-default reviews + branch assert-on-exit), tracked #4857. Detail in `git-discipline.md`. |
 | 2026-07-09 | #4797 | gate-false-accept | QG grounding gate v2 false-accepted near-copy fabrications (real «1722» → fabricated «1900» anchored at default τ=0.75) despite green CI + 153 tests + solo review. Fuzzy char-similarity + `any()` guard can't ground swapped factual tokens; a test pinned τ=0.9 masking the shipped behavior; edit-distance can't separate UK inflection (Львова/Львів dist 2) from name-swap (Мирко/Марко dist 1) — only lemma can; a perf-cap then introduced a truncation false-accept. Fixed via positional opcode-`equal` alignment of salient tokens (dep-free) + truncation-fails-closed. 5 cross-family review rounds. Detail in `qg-grounding-gate-fuzzy-false-accept.md`. |
 | 2026-04-05 | #1150 | score-parsing | Wiki review loop stuck at 8/10 — regex `(\d+)` can't match decimal scores like `8.8/10` |

--- a/docs/bug-autopsies/INDEX.md
+++ b/docs/bug-autopsies/INDEX.md
@@ -4,6 +4,7 @@ One-liner per bug. Grep for symptoms or categories to find relevant detail files
 
 <!-- INDEX-START -->
 | Date | Issue | Category | Summary |
+|------|-------|----------|---------|
 | --- | --- | --- | --- |
 | 2026-07-13 | #4975 | atlas-build / source-split | `make atlas` starts with the course-vocabulary builder, but the 8,552-entry live Atlas also contains 3,376 promoted grow/source-inventory entries. A relation-only run therefore replaces the full release with a smaller, non-equivalent set. Hydrate the pointer asset and re-enrich in place; `make atlas-publish` is unsafe for this path. Detail in [atlas-manifest-source-split.md](atlas-manifest-source-split.md). |
 | 2026-07-10 | #4857 | git-discipline | Read-only review delegate ran `gh pr checkout 4849` at repo root → primary checkout left on `pr-4849` (~7 min, silently wrong code for all repo-root readers). delegate.py neither prevents nor detects children moving primary HEAD; guard hook covers interactive shells only. Prior fossils: `pr-4397/4556/4557`. Fix = runtime enforcement (worktree-default reviews + branch assert-on-exit), tracked #4857. Detail in `git-discipline.md`. |

--- a/docs/bug-autopsies/atlas-manifest-source-split.md
+++ b/docs/bug-autopsies/atlas-manifest-source-split.md
@@ -1,0 +1,118 @@
+# Atlas manifest source split silently shrinks a relation-only rebuild
+
+**Date:** 2026-07-13
+**Issue:** #4975
+**Category:** atlas-build / source-split
+**Affected commands:** `make atlas`, `make atlas-publish`, and the release
+relation workflow
+
+## Outcome
+
+The 8,552-entry released manifest is an intentional superset of the
+course-vocabulary builder's output. It contains promoted content and source
+inventory entries that `scripts.lexicon.build_data_manifest` never reads.
+Running `make atlas` before a relation-only publication replaces that superset
+with the course-only layer; it is not a reproducing release build.
+
+This is not a recent regression in the builder or a false comparison. It is an
+old source-boundary mismatch that the stale release instructions obscured. No
+published data was lost: the pointer still resolves to the 8,552-entry release
+asset, and the re-enrichment must start by hydrating that asset.
+
+## Evidence
+
+`87cc0772ce259cb91f6f19f06fa202cace3d668b` (2026-07-10) records the
+8,552-entry Phase-A publish. Its commit message states that a promoted
+8,706-entry manifest received a course-usage backfill and then
+`park_thin_entries --limit 154`, resulting in 8,552 live entries.
+
+`58a00e70e18b97178209586d7503a9a72705b579` (2026-07-11) moved the pointer to
+the current `27e87936efb4…` asset after re-enriching **all 8,552 entries** with
+antonym, homonym, and paronym relations. The current pointer pins raw JSON SHA
+`27e87936efb4beb23a15a25fa548766fb7aa519741e21f52a8a0b9a67dff4fa1`; its
+gzip SHA is `99fee5e9b01cd8e5d8d8c0ab8e78eefdd8effee623fe4a0a12f30d35a8239bbe`.
+
+The release asset has 8,552 `entries`, 8,552 unique normalized lemma keys, and
+`stats.lemmas_total == 8552`. Its primary-source composition is:
+
+| Source | Entries |
+| --- | ---: |
+| `built_vocabulary` | 4,793 |
+| `built_vocabulary_form` | 336 |
+| `built_vocabulary_normalized` | 36 |
+| `built_vocabulary_canonicalized` | 4 |
+| `content_lexicon_grow` | 2,857 |
+| `source_inventory_grow` | 519 |
+| `heritage_status_seed` | 4 |
+| `surzhyk_to_avoid` | 3 |
+
+`build_data_manifest` enumerates only built `vocabulary.yaml` records and its
+seed sets. `enrich_manifest` enriches the entries already present; it cannot
+recreate the 3,376 promoted grow/source-inventory records.
+
+This was not introduced between the Phase-A publish and #4975: the Phase-A
+commit and current `HEAD` resolve `scripts/lexicon/build_data_manifest.py` to
+the same blob (`1c385c3da9a1c9db1c85a2c030fed983cc366390`) and `Makefile` to the
+same blob (`f642eb31d3243aac4e9e48842cf9e90602c55441`).
+
+## Count and set comparison
+
+The reported data-enabled run was 6,852 entries (6,841 built plus 13 seeds),
+which is 1,700 fewer than the release. The source-only builder invoked directly
+in this dispatch's `HEAD` returned 6,823 entries (6,812 built plus 13 seeds),
+so that exact 6,852 run has a separate 29-entry input-state discrepancy. It
+does not change the conclusion: neither course-only result contains the
+promoted source layer.
+
+For the current checked-out inputs and the pointer-pinned asset, a deterministic
+comparison produced 5,004 shared normalized lemma keys, 3,548 release-only
+keys, and 1,819 builder-only keys. The count-only difference is therefore not a
+membership delta: overwriting the release would discard 3,548 existing entries
+while adding 1,819 different course entries, for a net 1,729-entry shrink in
+this checkout.
+
+The raw manifest is intentionally gitignored and absent from the `87cc077` tree;
+the committed pointer is the reproducible source for the released bytes. Thus
+the exact 6,852 membership delta is not recoverable from committed files alone.
+To reproduce the current comparison without writing a manifest, download the
+pointer asset, call `build_manifest()`, and compare each entry's normalized
+`lemma` key. Verify the downloaded JSON SHA against the pointer before using
+the result.
+
+## Guard semantics
+
+`manifest_io._entry_count()` compares `len(manifest["entries"])` when it is a
+list. The builder emits that same list shape, and the released asset has unique
+lemma keys, so this is not an apples-to-oranges guard.
+
+`_refuse_richer_local()` has a narrower purpose than its name may suggest: it
+raises only if the local manifest has more entries than the release or a newer
+timestamp. A poorer 6,852-entry local manifest is hydrated over by the pinned
+8,552-entry release; `tests/test_manifest_io.py::test_load_manifest_hydrates_stale_poorer_local_manifest`
+covers that behavior. The safety outcome is correct, but it is not a direct
+"refuse 6,852 over 8,552" publish check.
+
+## Correct publish preparation
+
+Do not run `make atlas-publish` for relation-only work: it first runs the
+course-only builder. In a primary checkout with the required local data, use:
+
+```bash
+.venv/bin/python -c \
+  "from scripts.lexicon.manifest_io import load_manifest; print(len(load_manifest()['entries']))"
+.venv/bin/python scripts/lexicon/enrich_manifest.py
+.venv/bin/python -m scripts.audit.generate_search_index
+.venv/bin/python scripts/lexicon/export_open_dataset.py
+.venv/bin/python -m scripts.audit.generate_daily_pool
+.venv/bin/python scripts/lexicon/verify_manifest.py
+.venv/bin/python -m scripts.lexicon.publish_manifest
+```
+
+`load_manifest()` hydrates a missing or poorer local file and refuses to clobber
+an in-flight richer/newer intake manifest. The final command performs the
+external publish and is intentionally not run for this diagnosis.
+
+For a deliberately superseding growth release, hydrate first, run the reviewed
+grow-candidate promotion and any required course-usage backfill/thin-entry park,
+then continue from `enrich_manifest.py` in the sequence above. That preserves
+the existing asset as the base rather than rebuilding only the curriculum layer.

--- a/docs/bug-autopsies/atlas-manifest-source-split.md
+++ b/docs/bug-autopsies/atlas-manifest-source-split.md
@@ -8,8 +8,12 @@ relation workflow
 
 ## Outcome
 
-The 8,552-entry released manifest is an intentional superset of the
-course-vocabulary builder's output. It contains promoted content and source
+**Symptom:** running `make atlas` before a relation-only publication rebuilds
+only the course layer (≈6.8K entries) and replaces the released 8,552-entry
+manifest — the release silently shrinks by ~1,700 entries.
+
+**Root cause:** the 8,552-entry released manifest is an intentional superset of
+the course-vocabulary builder's output. It contains promoted content and source
 inventory entries that `scripts.lexicon.build_data_manifest` never reads.
 Running `make atlas` before a relation-only publication replaces that superset
 with the course-only layer; it is not a reproducing release build.
@@ -94,8 +98,9 @@ covers that behavior. The safety outcome is correct, but it is not a direct
 
 ## Correct publish preparation
 
-Do not run `make atlas-publish` for relation-only work: it first runs the
-course-only builder. In a primary checkout with the required local data, use:
+**Prevention:** never run `make atlas-publish` for relation-only work: it first
+runs the course-only builder. Hydrate the pointer asset first and follow the
+sequence below. In a primary checkout with the required local data, use:
 
 ```bash
 .venv/bin/python -c \

--- a/scripts/lexicon/README.md
+++ b/scripts/lexicon/README.md
@@ -1,34 +1,73 @@
 # Word Atlas Lexicon Pipeline
 
-`make atlas` is the release command for refreshing the static Word Atlas data:
+## Course-vocabulary rebuild
+
+`make atlas` rebuilds a **course-vocabulary-only** manifest from every
+`curriculum/l2-uk-en/*/*/vocabulary.yaml` plus the small warning and heritage
+seed sets:
 
 ```bash
 make atlas
 ```
 
-The target runs `scripts.lexicon.build_data_manifest`, `scripts/lexicon/enrich_manifest.py`,
-and `scripts/lexicon/verify_manifest.py`. It writes the committed Atlas data files:
+It is appropriate when deliberately constructing that source layer. It is not
+the release command for an existing full Atlas manifest: its first step,
+`scripts.lexicon.build_data_manifest`, replaces the manifest and therefore
+does not retain entries promoted by `content_lexicon_grow` or
+`source_inventory_grow`.
+
+The target runs `scripts.lexicon.build_data_manifest`,
+`scripts.lexicon/enrich_manifest.py`, and `scripts.lexicon/verify_manifest.py`.
+It writes the derived local Atlas data files:
 
 - `site/src/data/lexicon-manifest.json`
 - `site/src/data/lexicon-manifest.fingerprint.json`
+
+`make atlas-publish` depends on this target, so do not use it for a
+relation-only or other in-place re-enrichment of a published full manifest.
+
+## Re-enrich and publish the full manifest
+
+For relation changes or any update that must retain the promoted Atlas layer,
+run this sequence from a data-enabled primary checkout. The first command
+hydrates the content-addressed release pointer when the local manifest is
+missing or poorer. It refuses to overwrite a richer or newer local intake
+manifest, so do not set `ATLAS_MANIFEST_FORCE_HYDRATE=1` for this workflow.
+
+```bash
+.venv/bin/python -c \
+  "from scripts.lexicon.manifest_io import load_manifest; print(len(load_manifest()['entries']))"
+.venv/bin/python scripts/lexicon/enrich_manifest.py
+.venv/bin/python -m scripts.audit.generate_search_index
+.venv/bin/python scripts/lexicon/export_open_dataset.py
+.venv/bin/python -m scripts.audit.generate_daily_pool
+.venv/bin/python scripts/lexicon/verify_manifest.py
+.venv/bin/python -m scripts.lexicon.publish_manifest
+```
+
+The last command publishes a Release asset and must run only when publishing is
+authorized. See `docs/bug-autopsies/atlas-manifest-source-split.md` for the
+2026-07-13 evidence behind this split.
 
 ## Module Release Recipe
 
 When a module release adds or changes `curriculum/l2-uk-en/*/*/vocabulary.yaml`:
 
 1. Promote or edit the module files.
-2. Run `make atlas`.
-3. Commit the module changes plus the updated manifest and fingerprint.
+2. Use the full-manifest recipe above when the published Atlas already contains
+   promoted growth entries; use `make atlas` only for an intentionally
+   course-only reconstruction.
+3. Commit the module changes plus the updated fingerprint and pointer files.
 4. Open the PR and let CI run the Atlas freshness and vocabulary coverage gates.
-5. After merge, publish with the manual `deploy-pages.yml` `workflow_dispatch`.
+5. After merge, publish with the authorized Atlas publish flow.
 
 Push-to-main deploy remains intentionally disabled in `.github/workflows/deploy-pages.yml`.
 Re-enabling automatic deploy is a separate owner decision, not part of the Atlas refresh.
 
 For module promotions, `scripts/sync/promote_module.py --refresh-atlas ...` can run
-`make atlas` after `vocabulary.yaml` is promoted and include the manifest outputs in the
-promotion commit. Use it only on machines with the local dictionary data and caches needed
-by Atlas enrichment.
+`make atlas` after `vocabulary.yaml` is promoted. Use it only for an intentionally
+course-only reconstruction on machines with the local dictionary data and caches
+needed by Atlas enrichment; it is not a replacement for the full-manifest recipe.
 
 ## Source Inventory Candidate Intake
 

--- a/scripts/lexicon/README.md
+++ b/scripts/lexicon/README.md
@@ -17,7 +17,7 @@ does not retain entries promoted by `content_lexicon_grow` or
 `source_inventory_grow`.
 
 The target runs `scripts.lexicon.build_data_manifest`,
-`scripts.lexicon/enrich_manifest.py`, and `scripts.lexicon/verify_manifest.py`.
+`scripts/lexicon/enrich_manifest.py`, and `scripts/lexicon/verify_manifest.py`.
 It writes the derived local Atlas data files:
 
 - `site/src/data/lexicon-manifest.json`


### PR DESCRIPTION
## Summary

- Run the daily Atlas pool generator as a package module, fixing its `ModuleNotFoundError`.
- Document why the 8,552-entry release cannot be rebuilt by the course-only `make atlas` target and record the verified source-set evidence.
- Document the safe pointer-hydrate → in-place re-enrich publish preparation for relation-only releases.

## Diagnosis evidence

- `87cc0772ce` published 8,552 entries after a promoted 8,706-entry manifest, backfill, and 154 thin-entry parks.
- `58a00e70e` re-enriched all 8,552 entries and moved the relation release pointer to `27e87936efb4`.
- The pointer asset has 8,552 unique lemma keys; 2,857 are `content_lexicon_grow` and 519 are `source_inventory_grow`, neither of which the builder reads.
- Release/current builder and Makefile blobs are identical, so this is a source-boundary mismatch rather than a recent regression.

## Verification

- `.venv/bin/python -m pytest tests/test_lexicon_build_manifest.py tests/test_generate_daily_pool.py tests/test_manifest_io.py -q` — 34 passed
- `npx --no-install markdownlint-cli2 docs/bug-autopsies/atlas-manifest-source-split.md docs/bug-autopsies/INDEX.md scripts/lexicon/README.md` — 0 errors
- `make -n atlas` confirms the daily-pool command is now `.venv/bin/python -m scripts.audit.generate_daily_pool`
- Direct script invocation reproduced `ModuleNotFoundError`; module invocation produced a 300-row pool from the pointer-pinned asset.

## Review and release safety

- Independent Poolside review: APPROVE (task `review-4975-atlas-manifest-source-split-final`).
- No manifest asset was published and no deployment was run.

Refs #4975
Refs #4220