### PR TITLE
fix(test): make TestRouterMounting use OpenAPI paths for reliable detection

### DIFF
--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -230,10 +230,16 @@ class TestDashboardOverviewEndpoint:
 
 
 class TestRouterMounting:
-    """All routers are properly mounted in the app."""
+    """All routers are properly mounted in the app.
+
+    Uses the generated OpenAPI spec to reliably detect mounted paths
+    (app.routes introspection misses prefixed sub-router paths).
+    """
 
     def _route_paths(self) -> set[str]:
-        return {r.path for r in app.routes if hasattr(r, "path")}
+        # OpenAPI paths are the source of truth for what the app actually serves.
+        spec = app.openapi()
+        return set(spec.get("paths", {}).keys())
 
     def test_dashboard_router_mounted(self):
         paths = self._route_paths()


### PR DESCRIPTION
The `_route_paths` helper used `app.routes` introspection which does not surface paths from included sub-routers (with prefixes). This caused 6 mounting assertions (dashboard, state, comms, blue, gold, admin) to fail even though the endpoints were live and other tests exercising them passed.

Switched to `app.openapi()["paths"]` which is the complete and accurate list of mounted routes.

This also unblocks the remaining Dependabot PRs (#5038, #5039) whose pytest runs were hitting these asserts.

Changes:
- tests/test_api_endpoints.py

X-Agent: grok/resolve-dependabot-and-scans