### PR TITLE
fix(bridge): value-shape gate stops secret redactor mangling benign code diffs

### DIFF
--- a/scripts/secret_redactor.py
+++ b/scripts/secret_redactor.py
@@ -1,4 +1,14 @@
-"""Best-effort secret redaction for agent egress paths."""
+"""Best-effort secret redaction for agent egress paths.
+
+Accepted gap: an *unquoted* assignment to a secret-named key whose value is a
+whitespace-separated passphrase with no code punctuation (e.g.
+``PASSWORD=correct horse battery staple``) is redacted, but one that cannot be
+told apart from prose is not the concern here — quoted and JSON forms are always
+covered. The unquoted value-shape gate (see ``_value_is_secret_shaped``)
+deliberately errs toward passing code through, because corrupting a reviewed
+diff is the failure mode we are fixing; real single-token secrets in env dumps
+(``FOO_TOKEN=ghp_...``) still pass the shape gate and remain redacted.
+"""
 
 from __future__ import annotations
 
@@ -32,6 +42,19 @@ _BLOCK_PATTERNS = (
         re.DOTALL,
     ),
 )
+
+# Value-shape gate for the UNQUOTED assignment pattern only. `_ASSIGNMENT_PATTERNS[1]`
+# matches any `key = <rest of line>`, so a secret-*named* LHS identifier
+# (token_verdicts, secret_keys, tokens, ...) used to nuke a benign RHS such as
+# `vesum_gate.check_tokens(sentence)` or `[t for t in words if len(t) > 1]`,
+# corrupting reviewed diffs and producing bogus "blocking" review findings
+# (2026-07-12 burn). Best practice (gitleaks/trufflehog): require a secret-*shaped*
+# value, not just a secret-named key. We accept either a single opaque token or a
+# bare whitespace-separated passphrase, and reject anything containing code
+# punctuation — ()[]{}, . operators — which is exactly what function calls,
+# attribute-access-with-call, comprehensions, and literals carry.
+_SECRET_VALUE_TOKEN = re.compile(r"^[A-Za-z0-9_\-+/=.~:]{8,}$")
+_SECRET_VALUE_PASSPHRASE = re.compile(r"^[A-Za-z0-9]+(?: [A-Za-z0-9]+)+$")
 
 _TOKEN_PATTERNS = (
     re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
@@ -99,9 +122,24 @@ def _is_secret_key(key: str) -> bool:
     return bool(parts and parts[-1] == "APIKEY")
 
 
+def _value_is_secret_shaped(value: str) -> bool:
+    """True when an unquoted RHS looks like a credential, not a code expression."""
+    candidate = value.strip()
+    return bool(
+        _SECRET_VALUE_TOKEN.match(candidate)
+        or _SECRET_VALUE_PASSPHRASE.match(candidate)
+    )
+
+
 def _redact_assignment_match(match: re.Match[str]) -> str:
     if not _is_secret_key(match.group("key")):
         return match.group(0)
 
     quote = match.groupdict().get("quote") or ""
+    # Quoted / JSON forms (quote present) stay fail-closed: a literal assigned to a
+    # secret-named key is plausibly a secret. The unquoted pattern (no quote) must
+    # clear the value-shape gate, else benign code expressions get mangled.
+    if not quote and not _value_is_secret_shaped(match.group("value")):
+        return match.group(0)
+
     return f"{match.group('prefix')}{quote}{REDACTION}{quote}"

--- a/scripts/secret_redactor.py
+++ b/scripts/secret_redactor.py
@@ -1,13 +1,26 @@
 """Best-effort secret redaction for agent egress paths.
 
-Accepted gap: an *unquoted* assignment to a secret-named key whose value is a
-whitespace-separated passphrase with no code punctuation (e.g.
-``PASSWORD=correct horse battery staple``) is redacted, but one that cannot be
-told apart from prose is not the concern here — quoted and JSON forms are always
-covered. The unquoted value-shape gate (see ``_value_is_secret_shaped``)
-deliberately errs toward passing code through, because corrupting a reviewed
-diff is the failure mode we are fixing; real single-token secrets in env dumps
-(``FOO_TOKEN=ghp_...``) still pass the shape gate and remain redacted.
+This is a security control, so the unquoted-assignment gate fails CLOSED: a
+secret-named key is redacted unless the value is *unambiguously* a code
+expression. The only pass-through is a *spaced* assignment (``key = value``,
+code / INI style) whose value carries call/subscript/collection punctuation
+(``( ) [ ] { }`` or a comma) — exactly what corrupted reviewed diffs in the
+2026-07-12 burn (function calls, comprehensions, set/list literals). A *tight*
+assignment (``KEY=value`` with no whitespace around ``=`` — env / shell / .env /
+docker-compose style) is ALWAYS redacted, because env dumps are the canonical
+place real secrets leak and are virtually never PEP8-spaced.
+
+Two accepted, deliberate gaps (both err toward NOT leaking secrets):
+
+- Spaced bare identifiers / dotted refs assigned to a secret-named key
+  (``token_fn = vesum_gate.check_tokens``) stay REDACTED — they lack code
+  punctuation, so they fail closed. A rare mangled code line is acceptable; a
+  leaked secret is not.
+- Spaced INI-style secret values (``password = hunter2``) are redacted. That is
+  the correct side of the trade for a security control.
+
+Quoted (``key = 'secret'``) and JSON (``{"key": "secret"}``) forms are always
+covered, unconditionally.
 """
 
 from __future__ import annotations
@@ -43,18 +56,18 @@ _BLOCK_PATTERNS = (
     ),
 )
 
-# Value-shape gate for the UNQUOTED assignment pattern only. `_ASSIGNMENT_PATTERNS[1]`
+# Code-shape VETO for the UNQUOTED assignment pattern only. `_ASSIGNMENT_PATTERNS[1]`
 # matches any `key = <rest of line>`, so a secret-*named* LHS identifier
-# (token_verdicts, secret_keys, tokens, ...) used to nuke a benign RHS such as
+# (token_verdicts, secret_keys, ...) used to nuke a benign RHS such as
 # `vesum_gate.check_tokens(sentence)` or `[t for t in words if len(t) > 1]`,
 # corrupting reviewed diffs and producing bogus "blocking" review findings
-# (2026-07-12 burn). Best practice (gitleaks/trufflehog): require a secret-*shaped*
-# value, not just a secret-named key. We accept either a single opaque token or a
-# bare whitespace-separated passphrase, and reject anything containing code
-# punctuation — ()[]{}, . operators — which is exactly what function calls,
-# attribute-access-with-call, comprehensions, and literals carry.
-_SECRET_VALUE_TOKEN = re.compile(r"^[A-Za-z0-9_\-+/=.~:]{8,}$")
-_SECRET_VALUE_PASSPHRASE = re.compile(r"^[A-Za-z0-9]+(?: [A-Za-z0-9]+)+$")
+# (2026-07-12 burn). We do NOT allowlist secret-*shaped* values — that under-
+# redacted real env secrets carrying `@`, `$`, `!`, or trailing comments (the
+# PR #5047 regression). Instead we redact by default and veto only a *spaced*
+# assignment whose value carries these call/subscript/collection characters,
+# which is exactly what function calls, comprehensions, and set/list/dict
+# literals — and virtually no env-dump secret value — contain.
+_CODE_EXPRESSION_CHARS = frozenset("()[]{},")
 
 _TOKEN_PATTERNS = (
     re.compile(r"\bgithub_pat_[A-Za-z0-9_]{20,}\b"),
@@ -122,13 +135,9 @@ def _is_secret_key(key: str) -> bool:
     return bool(parts and parts[-1] == "APIKEY")
 
 
-def _value_is_secret_shaped(value: str) -> bool:
-    """True when an unquoted RHS looks like a credential, not a code expression."""
-    candidate = value.strip()
-    return bool(
-        _SECRET_VALUE_TOKEN.match(candidate)
-        or _SECRET_VALUE_PASSPHRASE.match(candidate)
-    )
+def _is_code_expression(value: str) -> bool:
+    """True when an unquoted RHS carries call/subscript/collection punctuation."""
+    return any(char in _CODE_EXPRESSION_CHARS for char in value)
 
 
 def _redact_assignment_match(match: re.Match[str]) -> str:
@@ -136,10 +145,14 @@ def _redact_assignment_match(match: re.Match[str]) -> str:
         return match.group(0)
 
     quote = match.groupdict().get("quote") or ""
-    # Quoted / JSON forms (quote present) stay fail-closed: a literal assigned to a
-    # secret-named key is plausibly a secret. The unquoted pattern (no quote) must
-    # clear the value-shape gate, else benign code expressions get mangled.
-    if not quote and not _value_is_secret_shaped(match.group("value")):
-        return match.group(0)
+    if not quote:
+        # Unquoted assignment. Read the spacing around `=` off the prefix group,
+        # which captured `key\s*=\s*` — no line re-scan needed. A tight `KEY=value`
+        # (no surrounding whitespace) is env / shell / .env / compose style and is
+        # ALWAYS redacted. A spaced `key = value` is code / INI style: redact by
+        # default, veto only when the value is unambiguously a code expression.
+        spaced = bool(re.search(r"\s", match.group("prefix")))
+        if spaced and _is_code_expression(match.group("value")):
+            return match.group(0)
 
     return f"{match.group('prefix')}{quote}{REDACTION}{quote}"

--- a/tests/test_secret_redactor.py
+++ b/tests/test_secret_redactor.py
@@ -51,6 +51,60 @@ def test_redact_text_handles_env_dump_and_known_token_shapes():
     assert "normal text" in redacted
 
 
+def test_redact_text_leaves_benign_code_with_secret_named_lhs_untouched():
+    # Regression for the 2026-07-12 diff-corruption burn: a secret-*named*
+    # identifier on the LHS must not nuke a benign code RHS (function call, list
+    # comprehension, set literal). These must survive byte-identical.
+    lines = [
+        "token_verdicts = vesum_gate.check_tokens(sentence)",
+        "tokens = [t for t in words if len(t) > 1]",
+        "secret_keys = set(pairwise(parts))",
+    ]
+
+    for line in lines:
+        assert redact_text(line) == line, line
+
+    joined = "\n".join(lines)
+    assert redact_text(joined) == joined
+    assert REDACTION not in redact_text(joined)
+
+
+def test_redact_text_still_redacts_real_secret_shaped_assignments():
+    cases = {
+        "GITHUB_TOKEN=ghp_abcdefghijklmnopqrstuvwxyz1234567890": "ghp_",
+        "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY": "wJalrXUtn",
+    }
+
+    for line, marker in cases.items():
+        redacted = redact_text(line)
+        assert marker not in redacted, line
+        assert REDACTION in redacted, line
+
+
+def test_redact_text_still_redacts_quoted_and_json_secret_values():
+    assert "sk-ant-" not in redact_text("api_key = 'sk-ant-abcdefghijklmnop1234'")
+    assert REDACTION in redact_text('{"password": "hunter2secret"}')
+    assert "hunter2secret" not in redact_text('{"password": "hunter2secret"}')
+
+
+def test_redact_text_still_redacts_known_token_shapes_anywhere():
+    jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123def456"
+    assert "eyJ" not in redact_text(f"the token is {jwt} in prose")
+    assert REDACTION in redact_text(f"the token is {jwt} in prose")
+
+
+def test_redact_text_redacts_unquoted_passphrase_but_not_code():
+    # Documented narrow allowance: a bare whitespace-separated passphrase assigned
+    # to a secret-named key is redacted (fail-closed), while code expressions —
+    # which always carry () [] {} , . operators — pass through.
+    redacted = redact_text("PASSWORD=correct horse battery staple")
+    assert "correct horse" not in redacted
+    assert REDACTION in redacted
+
+    code = "secret = compute(a, b) + other[0]"
+    assert redact_text(code) == code
+
+
 def test_redact_value_recursively_redacts_secret_keys_and_values():
     value = {
         "nested": {

--- a/tests/test_secret_redactor.py
+++ b/tests/test_secret_redactor.py
@@ -105,6 +105,71 @@ def test_redact_text_redacts_unquoted_passphrase_but_not_code():
     assert redact_text(code) == code
 
 
+# --- Decision-boundary pins (PR #5047 rework) ------------------------------
+#
+# The unquoted-assignment gate was inverted from a secret-shape ALLOWLIST (which
+# leaked real env secrets carrying @ $ ! or comments) to a code-shape VETO with a
+# spacing signal:
+#   * tight `KEY=value`  (env/shell/.env/compose) -> ALWAYS redact
+#   * spaced `key = value` (code/INI)             -> redact unless the value is
+#                                                    unambiguously a code
+#                                                    expression (() [] {} or ,)
+# The three tests below pin that boundary in BOTH directions plus the accepted
+# fail-closed over-redaction. All secrets here are throwaway fakes.
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        # Findings 1-3: tight env secrets with @ / $ / ! that the old shape
+        # allowlist let leak — must be redacted again.
+        "POSTGRES_PASSWORD=p@ssw0rdwithat123456",
+        "DB_PASS=my$uper$ecretlongvalue1234",
+        "FOO_TOKEN=verylongwith!exclaim12345",
+        # Finding: tight passphrase with a trailing comment / double spaces.
+        "PASSWORD=correct horse battery staple # production",
+        "MY_SECRET=word1  word2 word3",
+        # Finding 6-ish: spaced INI-style bare value (no code punctuation) stays
+        # redacted — correct side of the trade for a security control.
+        "password = hunter2captain",
+    ],
+)
+def test_redact_text_still_redacts_secret_assignments(line):
+    redacted = redact_text(line)
+    assert REDACTION in redacted, line
+    # The secret material must be gone.
+    for leak in ("p@ssw0rd", "my$uper", "!exclaim", "correct horse", "word1", "hunter2"):
+        assert leak not in redacted, line
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        # The three original burn lines (regression) ...
+        "token_verdicts = vesum_gate.check_tokens(sentence)",
+        "tokens = [t for t in words if len(t) > 1]",
+        "secret_keys = set(pairwise(parts))",
+        # ... plus mixed-operator and dict-comprehension forms.
+        "secret = compute(a, b) + other[0]",
+        "tokens = {t: 1 for t in words}",
+    ],
+)
+def test_redact_text_leaves_spaced_code_expressions_byte_identical(code):
+    assert redact_text(code) == code, code
+    assert REDACTION not in redact_text(code), code
+
+
+def test_redact_text_expected_fail_closed_over_redacts_spaced_dotted_ref():
+    # EXPECTED FAIL-CLOSED: a spaced bare dotted reference assigned to a
+    # secret-named key has no code punctuation (() [] {} ,), so it cannot be told
+    # apart from an INI-style secret value. We accept the over-redaction — a rare
+    # mangled code line beats a leaked secret.
+    line = "token_fn = vesum_gate.check_tokens"
+    redacted = redact_text(line)
+    assert REDACTION in redacted
+    assert "vesum_gate" not in redacted
+
+
 def test_redact_value_recursively_redacts_secret_keys_and_values():
     value = {
         "nested": {


### PR DESCRIPTION
## Problem

The bridge redacts message bodies/attachments before sending diffs to external
cross-family reviewers. `_ASSIGNMENT_PATTERNS[1]` matches unquoted
`key = <rest of line>`, and `_redact_assignment_match` redacted the **entire**
value whenever `_is_secret_key(key)` was true — based on the key name alone.
That mangled benign Python in reviewed diffs (real burn 2026-07-12: 3 bogus
"blocking" findings because `token_verdicts = vesum_gate.check_tokens(...)` was
nuked).

The **first** fix attempt (secret-shape ALLOWLIST) was the wrong direction for a
security control and the grok-build cross-family review **rejected** it: real
env-style secrets carrying `@` / `$` / `!` or trailing comments matched no allowed
shape and **leaked**. Under-redaction on a control that guards every bridge egress
is worse than the diff-mangling being fixed.

## Fix (rework — invert the gate)

Flip from a secret-shape **allowlist** to a code-shape **VETO** with a spacing
signal, on the **unquoted pattern only**:

- **Tight `KEY=value`** (no whitespace around `=` — env / shell / .env /
  docker-compose style) → **ALWAYS redact**. Env dumps are the canonical place
  secrets leak and are virtually never PEP8-spaced.
- **Spaced `key = value`** (code / INI style) → redact **by default**, pass
  through **only** when the value is unambiguously a code expression: it carries
  `( ) [ ] { }` or a comma (function calls, comprehensions, set/list/dict
  literals). Spacing is read straight off the `prefix` group (`key\s*=\s*`), no
  line re-scan.
- Quoted (`key = 'secret'`) and JSON (`{"key": "secret"}`) forms: unchanged,
  fail-closed.

### Accepted, documented fail-closed gaps (both in the module docstring)

- Spaced bare identifiers / dotted refs assigned to a secret-named key
  (`token_fn = vesum_gate.check_tokens`) stay **redacted** — no code punctuation,
  so they fail closed. A rare mangled code line beats a leaked secret. (Supersedes
  the earlier follow-up nit that wanted these passed through.)
- Spaced INI-style secret values (`password = hunter2`) are **redacted** — the
  correct side of the trade for a security control.

## Verification

### pytest — all green (25 in the redactor suite + 199 bridge consumer tests)

```
$ .venv/bin/pytest tests/test_secret_redactor.py -q
collected 25 items
tests/test_secret_redactor.py .........................                  [100%]
============================== 25 passed in 0.23s ==============================

$ .venv/bin/pytest tests/ai_agent_bridge tests/test_bridge_channels.py \
    tests/test_bridge_inbox.py tests/test_codex_bridge.py -q
================== 199 passed, 1 skipped, 1 warning in 7.30s ==================
```

`.venv/bin/ruff check scripts/secret_redactor.py tests/test_secret_redactor.py` → `All checks passed!`

### before/after probe — every review finding (throwaway fake secrets)

`pre` = the rejected shape-allowlist commit (`3ad1e27`); `NEW` = this rework.

| Finding | Input | pre (allowlist) | NEW |
|---|---|---|---|
| 1 | `POSTGRES_PASSWORD=p@ssw0rdwithat123456` | **passed-through (LEAK)** | REDACTED |
| 2 | `DB_PASS=my$uper$ecretlongvalue1234` | **passed-through (LEAK)** | REDACTED |
| 3 | `FOO_TOKEN=verylongwith!exclaim12345` | **passed-through (LEAK)** | REDACTED |
| 4 | `PASSWORD=correct horse battery staple # production` | **passed-through (LEAK)** | REDACTED |
| 4 | `MY_SECRET=word1  word2 word3` | **passed-through (LEAK)** | REDACTED |
| 3 (over-redact, accepted) | `token_fn = vesum_gate.check_tokens` | REDACTED | REDACTED |
| boundary | `password = hunter2captain` (spaced INI) | REDACTED | REDACTED |
| code | `token_verdicts = vesum_gate.check_tokens(sentence)` | passed-through | passed-through |
| code | `tokens = [t for t in words if len(t) > 1]` | passed-through | passed-through |
| code | `secret_keys = set(pairwise(parts))` | passed-through | passed-through |
| code | `secret = compute(a, b) + other[0]` | passed-through | passed-through |
| code | `tokens = {t: 1 for t in words}` | passed-through | passed-through |

Findings 1–5 (LEAK) are closed; the benign code lines stay byte-identical; the
accepted over-redaction cases stay fail-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
