### PR TITLE
fix(deps): repin pydantic_core 2.46.4 — unbreak red main CI

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -129,7 +129,7 @@ pycookiecheat==0.8.0
 pycparser==3.0
 pydantic-settings==2.14.2
 pydantic==2.13.4
-pydantic_core==2.41.5
+pydantic_core==2.46.4
 pyee==13.0.1
 Pygments==2.20.0
 PyJWT==2.13.0


### PR DESCRIPTION
Main CI is red since #5039 merged: dependabot bumped `pydantic==2.13.4` but left `pydantic_core==2.41.5` stale in `requirements-lock.txt`. pydantic 2.13.4 requires pydantic-core 2.46.4, so pytest setup dies with:

```
SystemError: The installed pydantic-core version (2.41.5) is incompatible with the current pydantic version, which requires 2.46.4.
```

(evidence: main run 29232849922; same failure on unrelated PR #5047)

One-line lock repin. Resolver compat verified locally via `pip install --dry-run pydantic==2.13.4 pydantic_core==2.46.4 pydantic-settings==2.14.2 fastapi==0.139.0` (clean). CI on this PR is the end-to-end verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)