### PR TITLE
chore(gitignore): ignore sqlite rollback-journal sidecars alongside -shm/-wal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -316,12 +316,16 @@ data/corpus_audit/*
 
 .gemini/
 
-# SQLite WAL/SHM sidecars — same exclusion as the .db files themselves.
+# SQLite WAL/SHM/rollback-journal sidecars — same exclusion as the .db files themselves.
+# (-journal appears while a rollback-mode writer, e.g. verbatim_overlap_gate
+# baseline-sweep, holds a transaction — it must not dirty the primary checkout.)
 data/*.db-shm
 data/*.db-wal
-# Test-only SQLite WAL/SHM sidecars (e.g. test_wal.db-* from pytest fixtures)
+data/*.db-journal
+# Test-only SQLite WAL/SHM/rollback-journal sidecars (e.g. test_wal.db-* from pytest fixtures)
 test_*.db-shm
 test_*.db-wal
+test_*.db-journal
 
 # Session-state handoffs that authors marked KEEP_UNTRACKED_UNTIL_PUBLIC_OK
 # (e.g. eval results pending validation) live under a `private/` subdir,


### PR DESCRIPTION
## What
Add `data/*.db-journal` and `test_*.db-journal` to `.gitignore`, mirroring the existing `-shm`/`-wal` sidecar exclusions.

## Why (root cause, hit live today)
`scripts.audit.verbatim_overlap_gate baseline-sweep` (the #4964 gate) writes `data/verbatim_shingle_k8.db` in rollback-journal mode. Its transient `data/verbatim_shingle_k8.db-journal` sidecar is untracked and non-ignored, so while the sweep holds a transaction the primary checkout reads dirty — and `delegate.py` correctly refuses **every write-capable dispatch** ("primary checkout is dirty"). The DB itself is ignored (`*.db`); only the journal sidecar slipped through the 2026 `-shm`/`-wal` exclusion (`.gitignore` L319-324).

Guard note: `guard-primary-checkout-write` (correctly) blocks `.git/info/exclude` as a local workaround, so the tracked `.gitignore` is the right and only fix.

## Follow-up (not this PR)
The shingle-DB writer could open in WAL mode instead (sidecars already ignored, and readers wouldn't block) — worth a note on #4964.

## Evidence
- `git check-ignore -v data/verbatim_shingle_k8.db-journal` on main: no match (the gap).
- `lsof`: pid 36618 `python -m scripts.audit.verbatim_overlap_gate ... baseline-sweep` holding both the DB and the journal while `git status` showed `?? data/verbatim_shingle_k8.db-journal`.
- Two Hramatka #93 dispatches refused with "primary checkout is dirty" on exactly this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)