### PR TITLE
chore(gitignore): ignore sqlite transient sidecars (-journal/-wal/-shm)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,18 @@ npm-debug.log*
 *.db
 *.sqlite
 *.sqlite3
+# SQLite transient sidecars — without these, any in-repo sqlite writer (e.g. the
+# verbatim-overlap shingle index) shows an untracked *-journal mid-transaction,
+# dirtying the primary checkout and blocking write-capable dispatches (#4444 guard).
+*.db-journal
+*.db-wal
+*.db-shm
+*.sqlite-journal
+*.sqlite-wal
+*.sqlite-shm
+*.sqlite3-journal
+*.sqlite3-wal
+*.sqlite3-shm
 
 # Temporary files
 tmp/


### PR DESCRIPTION
## What

Adds sqlite transient sidecar patterns (`-journal`, `-wal`, `-shm` for `*.db`/`*.sqlite`/`*.sqlite3`) to `.gitignore`, next to the existing `*.db` family rules.

## Why

Live incident today: the verbatim-overlap gate (#5019) builds its shingle index at `data/verbatim_shingle_k8.db`. The `.db` is ignored (`*.db`), but sqlite's rollback journal `data/verbatim_shingle_k8.db-journal` is NOT — so for the entire duration of the index build the primary checkout reads as dirty, and the #4444 spawn-guard (correctly) refuses every write-capable dispatch:

```
❌ primary checkout is dirty; refusing write-capable dispatch...
   dirty files: ?? data/verbatim_shingle_k8.db-journal
```

This is the "lanes keep dirtying the primary" recurrence class — except the writer here is legitimate gitignored-runtime-state tooling; only the ignore rule had a gap. A narrow `data/*.db-wal` rule already existed (line 333); this generalizes the class.

## Verification

`git check-ignore -v` on the branch:
```
.gitignore:101:*.db-journal   data/verbatim_shingle_k8.db-journal
.gitignore:333:data/*.db-wal  data/foo.db-wal
.gitignore:109:*.sqlite3-shm  data/bar.sqlite3-shm
```

Refs #4913 (unblocks the staged bug2 per-candidate-resilience dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)