### PR TITLE
fix(hooks): fix direct-push pytest guard and stamp hook defects

### DIFF
--- a/agents_extensions/codex/hooks.json
+++ b/agents_extensions/codex/hooks.json
@@ -98,6 +98,25 @@
         ]
       }
     ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "^(Bash|apply_patch|Edit|Write)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/tool-timing.sh\"",
+            "timeout": 1,
+            "statusMessage": "Recording tool timing"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/stamp-pytest.sh\"",
+            "timeout": 3,
+            "statusMessage": "Stamping pytest telemetry"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/agents_extensions/shared/hooks/guard-push-pytest.py
+++ b/agents_extensions/shared/hooks/guard-push-pytest.py
@@ -211,6 +211,18 @@ def _contains_git_push(command: str) -> bool:
     return any(_git_push_args(seg) is not None for seg in _segments(command))
 
 
+def _has_inline_skip(command: str) -> bool:
+    """Check if the command includes inline SKIP_PYTEST_HOOK=1 override before a git push."""
+    for seg in _segments(command):
+        if _git_push_args(seg) is not None:
+            for tok in seg:
+                if tok == "git":
+                    break
+                if tok in {"SKIP_PYTEST_HOOK=1", "SKIP_PYTEST_HOOK=\"1\"", "SKIP_PYTEST_HOOK=\x271\x27"}:
+                    return True
+    return False
+
+
 def _current_branch() -> str | None:
     try:
         out = subprocess.run(
@@ -267,9 +279,9 @@ def _marker_is_fresh(path: Path) -> bool | None:
         return None
 
 
-def _block_msg(marker: Path) -> str:
+def _block_msg(branch: str, marker: Path) -> str:
     return (
-        "BLOCKED by guard-push-pytest (#M-7): direct push from `main` includes "
+        f"BLOCKED by guard-push-pytest (#M-7): direct push from `{branch}` includes "
         "Python/test-trigger changes, but no recent local pytest stamp was found.\n\n"
         f"Marker path: {marker}\n"
         "Run `.venv/bin/python -m pytest ...` locally, then push again within "
@@ -287,6 +299,9 @@ def main() -> int:
     if not command or not _contains_git_push(command):
         return 0
 
+    if _has_inline_skip(command):
+        return 0
+
     branch = _current_branch()
     if branch != "main":
         return 0
@@ -300,7 +315,7 @@ def main() -> int:
     if fresh is None or fresh:
         return 0
 
-    sys.stderr.write(_block_msg(marker))
+    sys.stderr.write(_block_msg(branch, marker))
     return 2
 
 

--- a/agents_extensions/shared/hooks/stamp-pytest.sh
+++ b/agents_extensions/shared/hooks/stamp-pytest.sh
@@ -16,6 +16,11 @@ while [ "$DIR" != "/" ] && [ ! -f "$DIR/package.json" ]; do
 done
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$DIR}"
 PYTHON="$PROJECT_DIR/.venv/bin/python"
+# The embedded parser is pure stdlib — any python3 works. Without this fallback
+# the PostToolUseFailure path silently no-ops wherever the project venv is not
+# resolvable (e.g. worktrees without a linked .venv), which made the compound-
+# failure fix environment-dependent.
+[ -x "$PYTHON" ] || PYTHON="$(command -v python3 || true)"
 
 HAS_PYTEST=1
 if [ -x "$PYTHON" ]; then
@@ -129,7 +134,9 @@ matches = list(pytest_summary_pattern.finditer(output_str))
 if matches:
     last_match = matches[-1]
     counts = last_match.group("counts")
-    if "failed" not in counts and "error" not in counts:
+    # Require a positive "passed" signal: "no tests ran in 0.12s" and stray
+    # "<word> in N.Ns" lines from other tools must NOT count as a green run.
+    if "passed" in counts and "failed" not in counts and "error" not in counts:
         sys.exit(0)
 
 sys.exit(1)

--- a/agents_extensions/shared/hooks/stamp-pytest.sh
+++ b/agents_extensions/shared/hooks/stamp-pytest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Hook: PostToolUse - stamp recent pytest runs for the #M-7 push guard.
+# Hook: PostToolUse / PostToolUseFailure - stamp recent pytest runs for the #M-7 push guard.
 
 set -u
 
@@ -9,18 +9,42 @@ INPUT=$(</dev/stdin)
 COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
 [ -n "$COMMAND" ] || exit 0
 
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# Resolve project root robustly by walking up until package.json is found
+DIR="$(cd "$(dirname "$0")" && pwd)"
+while [ "$DIR" != "/" ] && [ ! -f "$DIR/package.json" ]; do
+  DIR="$(dirname "$DIR")"
+done
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$DIR}"
 PYTHON="$PROJECT_DIR/.venv/bin/python"
 
 HAS_PYTEST=1
 if [ -x "$PYTHON" ]; then
-  printf '%s' "$COMMAND" | "$PYTHON" -c '
+  # Pass the entire JSON input to python to parse tool_output/tool_response if needed
+  printf '%s' "$INPUT" | "$PYTHON" -c '
 from __future__ import annotations
 
+import json
+import re
 import shlex
 import sys
+from typing import Any
 
-command = sys.stdin.read()
+payload_str = sys.stdin.read()
+command = ""
+payload = {}
+try:
+    payload = json.loads(payload_str)
+    if isinstance(payload, dict):
+        command = (payload.get("tool_input") or {}).get("command") or payload.get("command") or ""
+except Exception:
+    command = payload_str
+
+if not command:
+    command = payload_str
+
+if not isinstance(command, str) or not command.strip():
+    sys.exit(1)
+
 try:
     tokens = shlex.split(command, posix=True)
 except ValueError:
@@ -39,26 +63,87 @@ if current:
     segments.append(current)
 
 wrappers = {"sudo", "time", "env", "nohup"}
+has_pytest = False
 for seg in segments:
     i = 0
     while i < len(seg) and seg[i] in wrappers:
         i += 1
     if i >= len(seg):
         continue
-    if seg[i] in {".venv/bin/python", "./.venv/bin/python"} and seg[i + 1 : i + 3] == ["-m", "pytest"]:
-        sys.exit(0)
+    # Support absolute path python pytest runs (e.g. /abs/path/.venv/bin/python)
+    is_python = seg[i] == ".venv/bin/python" or seg[i].endswith("/.venv/bin/python")
+    if is_python and seg[i + 1 : i + 3] == ["-m", "pytest"]:
+        has_pytest = True
+        break
     if seg[i] == "pytest":
-        sys.exit(0)
+        has_pytest = True
+        break
     if seg[i : i + 3] == ["dagger", "call", "pytest"]:
+        has_pytest = True
+        break
+
+if not has_pytest:
+    sys.exit(1)
+
+# If the overall command succeeded (PostToolUse) or event name is empty (tests/fallback),
+# we can touch the stamp immediately.
+event_name = (payload.get("hook_event_name") if isinstance(payload, dict) else "") or ""
+if event_name in ("PostToolUse", ""):
+    sys.exit(0)
+
+# If the overall command failed (PostToolUseFailure), we check if the pytest segment
+# itself succeeded by parsing the tool output/stdout for a passing pytest summary.
+# This prevents compound command failures (e.g. pytest && failing-cmd) from blocking pushes.
+def _find_command_output(val: Any) -> str:
+    if isinstance(val, str):
+        return val
+    if isinstance(val, dict):
+        for key in ("tool_output", "output", "result", "stdout", "stderr"):
+            o = val.get(key)
+            if isinstance(o, str) and o:
+                return o
+        for key in ("tool_response", "tool_input", "tool_result"):
+            o = _find_command_output(val.get(key))
+            if o:
+                return o
+        parts = []
+        for v in val.values():
+            o = _find_command_output(v)
+            if o:
+                parts.append(o)
+        return "\n".join(parts)
+    if isinstance(val, list):
+        parts = []
+        for item in val:
+            o = _find_command_output(item)
+            if o:
+                parts.append(o)
+        return "\n".join(parts)
+    return ""
+
+output_str = _find_command_output(payload)
+pytest_summary_pattern = re.compile(
+    r"(?:={2,}\s+)?(?:(?P<counts>[0-9a-zA-Z\s,]+)\s+in\s+(?P<duration>[0-9.]+)s)(?:\s+=+)?"
+)
+matches = list(pytest_summary_pattern.finditer(output_str))
+if matches:
+    last_match = matches[-1]
+    counts = last_match.group("counts")
+    if "failed" not in counts and "error" not in counts:
         sys.exit(0)
+
 sys.exit(1)
 '
   HAS_PYTEST=$?
 else
-  if [[ "$COMMAND" =~ (^|[[:space:];|&])(\./)?\.venv/bin/python[[:space:]]+-m[[:space:]]+pytest($|[[:space:]]) ]] || \
-     [[ "$COMMAND" =~ (^|[[:space:];|&])pytest($|[[:space:]]) ]] || \
-     [[ "$COMMAND" =~ (^|[[:space:];|&])dagger[[:space:]]+call[[:space:]]+pytest($|[[:space:]]) ]]; then
-    HAS_PYTEST=0
+  # Bash fallback if python is not available (only matches command on success event or empty event)
+  EVENT_NAME=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // empty' 2>/dev/null)
+  if [ -z "$EVENT_NAME" ] || [ "$EVENT_NAME" = "PostToolUse" ]; then
+    if [[ "$COMMAND" =~ (^|[[:space:];|&])[^[:space:]]*\.venv/bin/python[[:space:]]+-m[[:space:]]+pytest($|[[:space:]]) ]] || \
+       [[ "$COMMAND" =~ (^|[[:space:];|&])pytest($|[[:space:]]) ]] || \
+       [[ "$COMMAND" =~ (^|[[:space:];|&])dagger[[:space:]]+call[[:space:]]+pytest($|[[:space:]]) ]]; then
+      HAS_PYTEST=0
+    fi
   fi
 fi
 

--- a/agents_extensions/shared/settings.json
+++ b/agents_extensions/shared/settings.json
@@ -715,6 +715,11 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/tool-timing.sh",
             "timeout": 1
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/stamp-pytest.sh",
+            "timeout": 3
           }
         ]
       }

--- a/tests/test_guard_push_pytest.py
+++ b/tests/test_guard_push_pytest.py
@@ -290,6 +290,28 @@ def test_stamp_pytest_compound_command_segment_success(tmp_path):
     assert result.returncode == 0
     assert not marker.exists()
 
+    # 3. "no tests ran" must NOT stamp: a wrong test path in a failing compound
+    # produces a summary with no positive "passed" signal.
+    payload_no_tests = json.dumps({
+        "hook_event_name": "PostToolUseFailure",
+        "tool_input": {
+            "command": ".venv/bin/python -m pytest tests/nonexistent && exit 1"
+        },
+        "tool_output": "============================= no tests ran in 0.12s ==============================",
+    })
+
+    result = subprocess.run(
+        [str(STAMP_PATH)],
+        cwd=repo,
+        input=payload_no_tests,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert not marker.exists()
+
 
 def test_inline_skip_allows(monkeypatch):
     assert _run(monkeypatch, "SKIP_PYTEST_HOOK=1 git push origin main") == 0

--- a/tests/test_guard_push_pytest.py
+++ b/tests/test_guard_push_pytest.py
@@ -184,3 +184,121 @@ def test_wrapper_assignment_brace_push_detected(cmd):
 
 def test_unclosed_heredoc_does_not_hide_push():
     assert guard._contains_git_push("cat <<'NOEND'\nnote\ngit push origin main")
+
+
+# --- Tests for 4945 defects ---
+
+def test_stamp_pytest_absolute_path_venv(tmp_path):
+    branch = "testbranch"
+    git_env = os.environ.copy()
+    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX"):
+        git_env.pop(key, None)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", branch], cwd=repo, env=git_env, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, env=git_env, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, env=git_env, check=True)
+    (repo / "README.md").write_text("test repo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, env=git_env, check=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=repo, env=git_env, check=True)
+
+    marker = tmp_path / f"learn-uk-pytest.{branch}.stamp"
+
+    # Test absolute path /abs/path/.venv/bin/python -m pytest
+    payload = json.dumps({
+        "tool_input": {
+            "command": "/abs/path/.venv/bin/python -m pytest tests/test_guard_push_pytest.py -q"
+        }
+    })
+    env = git_env.copy()
+    env["TMPDIR"] = str(tmp_path)
+
+    result = subprocess.run(
+        [str(STAMP_PATH)],
+        cwd=repo,
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert marker.exists()
+
+
+def test_stamp_pytest_compound_command_segment_success(tmp_path):
+    branch = "testbranch"
+    git_env = os.environ.copy()
+    for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_PREFIX"):
+        git_env.pop(key, None)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", branch], cwd=repo, env=git_env, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, env=git_env, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, env=git_env, check=True)
+    (repo / "README.md").write_text("test repo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo, env=git_env, check=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=repo, env=git_env, check=True)
+
+    env = git_env.copy()
+    env["TMPDIR"] = str(tmp_path)
+
+    # 1. Success case: pytest segment succeeds, compound fails (PostToolUseFailure)
+    marker = tmp_path / f"learn-uk-pytest.{branch}.stamp"
+    payload_success = json.dumps({
+        "hook_event_name": "PostToolUseFailure",
+        "tool_input": {
+            "command": ".venv/bin/python -m pytest tests/ -v && exit 1"
+        },
+        "tool_output": "============================= 20 passed in 0.65s =============================="
+    })
+
+    result = subprocess.run(
+        [str(STAMP_PATH)],
+        cwd=repo,
+        input=payload_success,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert marker.exists()
+
+    # 2. Failure case: pytest segment fails, compound fails (PostToolUseFailure)
+    marker.unlink()
+    payload_fail = json.dumps({
+        "hook_event_name": "PostToolUseFailure",
+        "tool_input": {
+            "command": ".venv/bin/python -m pytest tests/ -v && exit 1"
+        },
+        "tool_output": "============================= 1 failed, 19 passed in 0.65s =============================="
+    })
+
+    result = subprocess.run(
+        [str(STAMP_PATH)],
+        cwd=repo,
+        input=payload_fail,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert not marker.exists()
+
+
+def test_inline_skip_allows(monkeypatch):
+    assert _run(monkeypatch, "SKIP_PYTEST_HOOK=1 git push origin main") == 0
+    assert _run(monkeypatch, "SKIP_PYTEST_HOOK=\"1\" git push origin main") == 0
+    assert _run(monkeypatch, "SKIP_PYTEST_HOOK='1' git push origin main") == 0
+
+
+def test_block_msg_interpolates_actual_branch():
+    msg = guard._block_msg("some-feature-branch", Path("/tmp/marker"))
+    assert "direct push from `some-feature-branch`" in msg
+    assert "from `main`" not in msg
+


### PR DESCRIPTION
# Pull Request: fix defects in direct-push pytest guard and stamp hook

Fixes all four defects in the `#M-7` push-guard hook pair, resolving issue #4945.

Closes #4945

## Verifiable Claims & Tool Run Backing

### 1. Test Pass Counts
All 24 unit tests pass successfully.
**Raw test output:**
```
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.1.1, pluggy-1.6.0 -- /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/agy/fix-4945-push-guard-hooks/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/agy/fix-4945-push-guard-hooks
configfile: pyproject.toml
plugins: cov-7.1.0, anyio-4.14.1
collecting ... collected 24 items

tests/test_guard_push_pytest.py::test_push_to_main_with_trigger_path_and_stale_marker_blocks PASSED [  4%]
tests/test_guard_push_pytest.py::test_push_to_main_with_fresh_marker_allows PASSED [  8%]
tests/test_guard_push_pytest.py::test_non_main_branch_allows PASSED      [ 12%]
tests/test_guard_push_pytest.py::test_non_push_command_allows PASSED     [ 16%]
tests/test_guard_push_pytest.py::test_skip_env_allows PASSED             [ 20%]
tests/test_guard_push_pytest.py::test_quoted_push_in_commit_body_allows PASSED [ 25%]
tests/test_guard_push_pytest.py::test_dry_run_push_allows PASSED         [ 29%]
tests/test_guard_push_pytest.py::test_non_trigger_diff_allows PASSED     [ 33%]
tests/test_guard_push_pytest.py::test_hook_errors_fail_open PASSED       [ 37%]
tests/test_guard_push_pytest.py::test_stamp_pytest_bash_smoke PASSED     [ 41%]
tests/test_guard_push_pytest.py::test_glued_operator_push_detected[true 2>&1 | head -1; git push origin main] PASSED [ 45%]
tests/test_guard_push_pytest.py::test_glued_operator_push_detected[echo done\ngit push origin main] PASSED [ 50%]
tests/test_guard_push_pytest.py::test_glued_operator_push_detected[true;git push origin main] PASSED [ 54%]
tests/test_guard_push_pytest.py::test_glued_operator_push_detected[git add -A && git commit -m 'x'; git push] PASSED [ 58%]
tests/test_guard_push_pytest.py::test_heredoc_push_mention_not_detected PASSED [ 62%]
tests/test_guard_push_pytest.py::test_backslash_continuation_push_detected PASSED [ 66%]
tests/test_guard_push_pytest.py::test_wrapper_assignment_brace_push_detected[env FOO=1 git push origin main] PASSED [ 70%]
tests/test_guard_push_pytest.py::test_wrapper_assignment_brace_push_detected[FOO=1 git push origin main] PASSED [ 75%]
tests/test_guard_push_pytest.py::test_wrapper_assignment_brace_push_detected[{ git push origin main; }] PASSED [ 79%]
tests/test_guard_push_pytest.py::test_unclosed_heredoc_does_not_hide_push PASSED [ 83%]
tests/test_guard_push_pytest.py::test_stamp_pytest_absolute_path_venv PASSED [ 87%]
tests/test_guard_push_pytest.py::test_stamp_pytest_compound_command_segment_success PASSED [ 91%]
tests/test_guard_push_pytest.py::test_inline_skip_allows PASSED          [ 95%]
tests/test_guard_push_pytest.py::test_block_msg_interpolates_actual_branch PASSED [100%]

============================== 24 passed in 0.69s ==============================
```

### 2. Red-on-Old Proof (Failing Assertions)
- **Defect 1 (Absolute Path)**: `test_stamp_pytest_absolute_path_venv` failed under the old code since `/abs/path/.venv/bin/python` did not match the relative-only check.
  *Old Failure:* `AssertionError: assert False` where `False = PosixPath('/tmp/.../learn-uk-pytest.testbranch.stamp').exists()`
- **Defect 2 (Compound Success)**: `test_stamp_pytest_compound_command_segment_success` failed under the old code since the stamp hook was not wired into `PostToolUseFailure` and could not inspect output of compound runs.
  *Old Failure:* `AssertionError: assert False` where `False = PosixPath('/tmp/.../learn-uk-pytest.testbranch.stamp').exists()`
- **Defect 3 (Inline Override)**: `test_inline_skip_allows` would fail (returning exit code 2/blocked) on old code because `os.environ` check on the hook process does not see command string variables.
- **Defect 4 (Dynamic Branch)**: `test_block_msg_interpolates_actual_branch` failed on old code with a `TypeError` because `_block_msg` was defined with a single parameter `marker` and hardcoded `"main"`.

### 3. Regex Behavior
The bash regex walk-up matching was verified using `bash -c`:
```bash
COMMAND="/abs/path/.venv/bin/python -m pytest tests/"
if [[ "$COMMAND" =~ (^|[[:space:];|&])[^[:space:]]*\.venv/bin/python[[:space:]]+-m[[:space:]]+pytest($|[[:space:]]) ]]; then
  echo "Regex matched absolute path"
fi
```
**Raw output:** `Regex matched absolute path`

### 4. Deploy-Target Sync Verification
Diff between source `agents_extensions/shared/` and deploy targets (e.g. `.claude/`) returns nothing:
```bash
$ diff agents_extensions/shared/hooks/guard-push-pytest.py .claude/hooks/guard-push-pytest.py
$ diff agents_extensions/shared/hooks/stamp-pytest.sh .claude/hooks/stamp-pytest.sh
```

## Before / After Defect Overview

### Defect 1: stamp-pytest.sh absolute path
- **Before**: Python block checked `seg[i] in {".venv/bin/python", "./.venv/bin/python"}` and Bash regex checked `(\./)?\.venv/bin/python`. This failed to match absolute paths such as `/abs/path/.venv/bin/python`.
- **After**: Checks if `seg[i] == ".venv/bin/python"` or `seg[i].endswith("/.venv/bin/python")`, and Bash regex uses `[^[:space:]]*\.venv/bin/python`.

### Defect 2: compound command success
- **Before**: Only ran on `PostToolUse` (overall command success). If a compound `pytest ... && failing-command` failed, the hook did not run, leaving the stamp stale despite all tests passing.
- **After**: Hook is registered in both `PostToolUse` and `PostToolUseFailure`. When running on `PostToolUseFailure`, it parses the command output to verify if the pytest segment succeeded (looks for standard pytest summary indicating no failing or error tests).

### Defect 3: inline SKIP_PYTEST_HOOK=1 override
- **Before**: The hook process env was checked, meaning `SKIP_PYTEST_HOOK=1 git push` never bypassed the hook since the environment was not inherited.
- **After**: Inspected command segments are parsed to check for leading inline assignments of `SKIP_PYTEST_HOOK=1`.

### Defect 4: Dynamic Branch Interpolation
- **Before**: `_block_msg` hardcoded `"main"` in its block warning message.
- **After**: `_block_msg` takes the branch name as a parameter and interpolates it dynamically (e.g. `f"BLOCKED ... direct push from \`{branch}\` ..."`).
