### PR TITLE
test(audit): invalid-enum rejection coverage for corpus_verification_status adjudication

### DIFF
--- a/tests/test_layerb_apply_adjudication.py
+++ b/tests/test_layerb_apply_adjudication.py
@@ -451,6 +451,27 @@ def test_apply_ruling_custom_sets_corpus_verification_status() -> None:
     }
 
 
+def test_apply_ruling_custom_rejects_invalid_corpus_verification_status() -> None:
+    """A CUSTOM ruling with a value outside the registered enum must be rejected."""
+    draft = {
+        "case_id": "synth-1",
+        "corpus_verification_status": "UNVERIFIED",
+    }
+    left = {"case_id": "synth-1", "corpus_verification_status": "UNVERIFIED"}
+    right = {"case_id": "synth-1", "corpus_verification_status": "UNVERIFIED"}
+    ruling = "CUSTOM:corpus_verification_status=BOGUS_STATUS"
+    digest = {"case_id": "synth-1", "fields": {"corpus_verification_status": {}}}
+
+    with pytest.raises(LabelJoinError, match="must be a registered enum"):
+        apply_ruling(
+            draft,
+            left,
+            right,
+            _decision(ruling),
+            digest,
+        )
+
+
 def test_apply_adjudications_unverified_corpus_status_affects_eligibility_and_custom_overrides_it(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Salvages the one genuinely new piece of duplicate PR #5051: a negative-path test proving a `CUSTOM:corpus_verification_status=BOGUS_STATUS` ruling is rejected with the registered-enum error.

Context: #4983's two requirements were already implemented on main by #5013 (`e394c2513d` — adjudicable field + UNVERIFIED eligibility blockers, verified at `layerb_apply_adjudication.py:479-520`), but the issue stayed open because #5013 used `Refs` not `Closes`. This PR adds the missing coverage and closes the issue.

My verification: full test file 17 passed (raw run below), ruff clean.

```

============================== 17 passed in 1.90s ==============================
```

Closes #4983

🤖 Generated with [Claude Code](https://claude.com/claude-code)
