### PR TITLE
feat(orchestration): harden thread rollover lineage

### DIFF
--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -20,6 +20,7 @@ import subprocess
 import urllib.error
 import urllib.request
 import uuid
+from collections.abc import Mapping
 from contextlib import closing
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -58,12 +59,46 @@ def repo_root_from_file() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
+def canonical_state_root(repo_root: Path) -> Path:
+    """Find the primary checkout that owns shared rollover runtime state.
+
+    Linked worktrees have their own working-tree root but share Git's common
+    directory, which lives at ``<primary-checkout>/.git``.  Rollover leases
+    must be visible to every worktree in that repository, so default state is
+    rooted at the primary checkout rather than the invoking worktree.
+    """
+    result = run_command(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        cwd=repo_root,
+        env=git_environment(),
+    )
+    if result.returncode != 0 or not result.stdout:
+        detail = result.stderr or result.stdout or "git did not report a common directory"
+        raise ValueError(f"cannot discover canonical Git common directory: {detail}")
+    common_dir = Path(result.stdout)
+    if not common_dir.is_absolute() or common_dir.name != ".git":
+        raise ValueError(f"cannot derive canonical checkout root from Git common directory: {result.stdout!r}")
+    return common_dir.parent.resolve()
+
+
+def resolve_roots(repo_root_arg: Path | None) -> tuple[Path, Path]:
+    """Return the active checkout and the root that owns rollover runtime state.
+
+    An explicit ``--repo-root`` deliberately keeps fixtures and isolated
+    operator invocations self-contained.  The default requires canonical Git
+    discovery and never falls back to a worktree-local ``.agent`` directory.
+    """
+    if repo_root_arg is not None:
+        repo_root = repo_root_arg.resolve()
+        return repo_root, repo_root
+    repo_root = repo_root_from_file().resolve()
+    return repo_root, canonical_state_root(repo_root)
+
+
 def normalize_agent_name(value: str | None) -> str:
     agent = (value or DEFAULT_AGENT).strip().lower()
     if not AGENT_NAME_RE.fullmatch(agent):
-        raise ValueError(
-            "agent names must match [a-z][a-z0-9-]* so handoff paths cannot escape the repo"
-        )
+        raise ValueError("agent names must match [a-z][a-z0-9-]* so handoff paths cannot escape the repo")
     return agent
 
 
@@ -77,9 +112,7 @@ def argparse_agent_name(value: str) -> str:
 def normalize_lineage_id(value: str) -> str:
     lineage_id = value.strip().lower()
     if not LINEAGE_ID_RE.fullmatch(lineage_id):
-        raise ValueError(
-            "lineage ids must match [a-z][a-z0-9-]{0,63} so runtime paths cannot escape the repo"
-        )
+        raise ValueError("lineage ids must match [a-z][a-z0-9-]{0,63} so runtime paths cannot escape the repo")
     return lineage_id
 
 
@@ -166,11 +199,25 @@ def repo_local_path(repo_root: Path, value: Path) -> Path:
     return candidate
 
 
+def resolve_state_path(
+    *,
+    repo_root: Path,
+    state_root: Path,
+    supplied_state_file: Path | None,
+    default_path: Path,
+) -> Path:
+    """Resolve an explicit fixture path or a canonical default runtime path."""
+    if supplied_state_file is not None:
+        return repo_local_path(repo_root, supplied_state_file)
+    return repo_local_path(state_root, default_path)
+
+
 def run_command(
     args: list[str],
     *,
     cwd: Path,
     timeout_s: int = 10,
+    env: Mapping[str, str] | None = None,
 ) -> CommandResult:
     try:
         completed = subprocess.run(
@@ -180,6 +227,7 @@ def run_command(
             text=True,
             timeout=timeout_s,
             check=False,
+            env=env,
         )
     except FileNotFoundError as exc:
         return CommandResult(returncode=127, stdout="", stderr=str(exc))
@@ -202,8 +250,22 @@ def run_command(
     )
 
 
+def git_environment() -> dict[str, str]:
+    """Keep inherited hook state from redirecting Git away from ``cwd``."""
+    redirecting_variables = {
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_DIR",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_PREFIX",
+        "GIT_WORK_TREE",
+    }
+    return {key: value for key, value in os.environ.items() if key not in redirecting_variables}
+
+
 def git_output(repo_root: Path, *args: str, timeout_s: int = 10) -> str:
-    result = run_command(["git", *args], cwd=repo_root, timeout_s=timeout_s)
+    result = run_command(["git", *args], cwd=repo_root, timeout_s=timeout_s, env=git_environment())
     if result.returncode != 0:
         return ""
     return result.stdout
@@ -240,10 +302,12 @@ def parse_git_log(raw: str) -> list[dict[str, str]]:
         parts = line.split("\t", 1)
         if not parts or not parts[0]:
             continue
-        commits.append({
-            "sha": parts[0],
-            "subject": parts[1] if len(parts) > 1 else "",
-        })
+        commits.append(
+            {
+                "sha": parts[0],
+                "subject": parts[1] if len(parts) > 1 else "",
+            }
+        )
     return commits
 
 
@@ -252,10 +316,12 @@ def parse_status(raw: str) -> list[dict[str, str]]:
     for line in raw.splitlines():
         if not line:
             continue
-        files.append({
-            "status": line[:2].strip() or line[:2],
-            "path": line[3:] if len(line) > 3 else "",
-        })
+        files.append(
+            {
+                "status": line[:2].strip() or line[:2],
+                "path": line[3:] if len(line) > 3 else "",
+            }
+        )
     return files
 
 
@@ -289,9 +355,7 @@ def gather_git_state(repo_root: Path) -> dict[str, Any]:
         "head": head,
         "full_head": full_head,
         "ahead_behind": ahead_behind,
-        "last_commits": parse_git_log(
-            git_output(repo_root, "log", "-5", "--pretty=format:%h%x09%s")
-        ),
+        "last_commits": parse_git_log(git_output(repo_root, "log", "-5", "--pretty=format:%h%x09%s")),
         "modified_files": parse_status(git_output(repo_root, "status", "--short")),
     }
 
@@ -308,26 +372,32 @@ def gather_monitor_state(base_url: str) -> dict[str, Any]:
 
 def gather_github_state(repo_root: Path) -> dict[str, Any]:
     return {
-        "open_prs": gh_json(repo_root, [
-            "pr",
-            "list",
-            "--state",
-            "open",
-            "--json",
-            "number,title,headRefName,mergeStateStatus,statusCheckRollup,url,updatedAt,isDraft,reviewDecision",
-            "--limit",
-            "20",
-        ]),
-        "open_issues": gh_json(repo_root, [
-            "issue",
-            "list",
-            "--state",
-            "open",
-            "--json",
-            "number,title,url,updatedAt,labels",
-            "--limit",
-            "10",
-        ]),
+        "open_prs": gh_json(
+            repo_root,
+            [
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--json",
+                "number,title,headRefName,mergeStateStatus,statusCheckRollup,url,updatedAt,isDraft,reviewDecision",
+                "--limit",
+                "20",
+            ],
+        ),
+        "open_issues": gh_json(
+            repo_root,
+            [
+                "issue",
+                "list",
+                "--state",
+                "open",
+                "--json",
+                "number,title,url,updatedAt,labels",
+                "--limit",
+                "10",
+            ],
+        ),
     }
 
 
@@ -572,7 +642,9 @@ def confirm_started(
     return confirmed
 
 
-def resume_state(state: dict[str, Any], *, rollover_id: str, replacement_thread_id: str, now: datetime) -> dict[str, Any]:
+def resume_state(
+    state: dict[str, Any], *, rollover_id: str, replacement_thread_id: str, now: datetime
+) -> dict[str, Any]:
     """Bind exactly one new thread to a prepared local packet, without provider history."""
     if state.get("schema_version") != SCHEMA_VERSION:
         raise ValueError("schema v2 state is required; run prepare with --migrate-v1 first")
@@ -607,10 +679,7 @@ def format_table(rows: list[list[str]], headers: list[str]) -> str:
             widths[idx] = max(widths[idx], len(value))
     header_line = "| " + " | ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers)) + " |"
     sep_line = "| " + " | ".join("-" * widths[idx] for idx in range(len(headers))) + " |"
-    row_lines = [
-        "| " + " | ".join(value.ljust(widths[idx]) for idx, value in enumerate(row)) + " |"
-        for row in rows
-    ]
+    row_lines = ["| " + " | ".join(value.ljust(widths[idx]) for idx, value in enumerate(row)) + " |" for row in rows]
     return "\n".join([header_line, sep_line, *row_lines])
 
 
@@ -619,13 +688,15 @@ def summarize_prs(open_prs: Any) -> str:
         return f"_Unavailable: {open_prs['_error']}_"
     rows = []
     for pr in open_prs if isinstance(open_prs, list) else []:
-        rows.append([
-            f"#{pr.get('number')}",
-            str(pr.get("headRefName") or ""),
-            str(pr.get("mergeStateStatus") or ""),
-            "yes" if pr.get("isDraft") else "no",
-            str(pr.get("title") or ""),
-        ])
+        rows.append(
+            [
+                f"#{pr.get('number')}",
+                str(pr.get("headRefName") or ""),
+                str(pr.get("mergeStateStatus") or ""),
+                "yes" if pr.get("isDraft") else "no",
+                str(pr.get("title") or ""),
+            ]
+        )
     return format_table(rows, ["PR", "Branch", "Merge", "Draft", "Title"])
 
 
@@ -634,11 +705,13 @@ def summarize_issues(open_issues: Any) -> str:
         return f"_Unavailable: {open_issues['_error']}_"
     rows = []
     for issue in open_issues if isinstance(open_issues, list) else []:
-        rows.append([
-            f"#{issue.get('number')}",
-            str(issue.get("updatedAt") or ""),
-            str(issue.get("title") or ""),
-        ])
+        rows.append(
+            [
+                f"#{issue.get('number')}",
+                str(issue.get("updatedAt") or ""),
+                str(issue.get("title") or ""),
+            ]
+        )
     return format_table(rows, ["Issue", "Updated", "Title"])
 
 
@@ -649,12 +722,14 @@ def summarize_tasks(tasks_payload: Any) -> str:
         return f"_Unavailable: {tasks_payload['_error']}_"
     rows = []
     for task in tasks_payload.get("tasks") or []:
-        rows.append([
-            str(task.get("task_id") or ""),
-            str(task.get("agent") or ""),
-            str(task.get("status") or ""),
-            str(task.get("age_s") or task.get("duration_s") or ""),
-        ])
+        rows.append(
+            [
+                str(task.get("task_id") or ""),
+                str(task.get("agent") or ""),
+                str(task.get("status") or ""),
+                str(task.get("age_s") or task.get("duration_s") or ""),
+            ]
+        )
     return format_table(rows, ["Task", "Agent", "Status", "Age/Duration"])
 
 
@@ -703,6 +778,7 @@ def render_bootstrap_prompt(
     router_path: Path = DEFAULT_ROUTER_PATH,
     handoff_path: Path | None = None,
     role_handoff_path: Path | None = None,
+    state_root: Path | None = None,
     context_threshold: float,
 ) -> str:
     git = snapshot["git"]
@@ -719,64 +795,71 @@ def render_bootstrap_prompt(
     replacement_generation = replacement.get("generation") or "unknown"
     rollover_id = replacement.get("rollover_id") or "unknown"
     canary_challenge = replacement.get("canary_challenge") or "unknown"
-    canary_proof_path = replacement.get("canary_proof_path") or "unknown"
+    canary_proof_path = Path(replacement.get("canary_proof_path") or "unknown")
+    if state_root is not None:
+        canary_proof_path = repo_local_path(state_root, canary_proof_path)
     context_percent = (state.get("last_handoff") or {}).get("context_percent")
     agent_label = "Codex orchestrator" if agent == "orchestrator" else agent
 
-    return "\n".join([
-        f"Work locally in {git.get('repo_root')}.",
-        "",
-        f"You are the replacement {agent_label} thread.",
-        f"Replacement generation: {replacement_generation}",
-        f"Rollover id: {rollover_id}",
-        f"Previous active generation: {active_generation}",
-        f"Role handoff: {handoff_text}",
-        f"Thread handoff: {thread_handoff_text}",
-        "",
-        "Read first:",
-        f"- {thread_handoff_text}",
-        f"- {handoff_text}",
-        "- AGENTS.md",
-        "- docs/best-practices/agent-cooperation.md",
-        "- docs/best-practices/codex-thread-handoff.md",
-        "",
-        "Rules:",
-        "- Continue from the durable packet exactly; do not fork, continue, or resume provider conversation history.",
-        "- Keep the main checkout read-only; thread rollover state belongs in gitignored .agent/ files.",
-        "- Use dispatch worktrees for implementation work: .worktrees/dispatch/<agent>/<task>/.",
-        "- Do not edit generated status/audit/review artifacts, linter configs, or .python-version.",
-        "- Do not write docs/session-state/current.md for thread rollover.",
-        "- Do not delete or migrate the old heartbeat automation until the confirm-started command below has succeeded.",
-        "",
-        *first_turn_checklist_lines(
-            repo_root=str(git.get("repo_root")),
-            thread_handoff_text=thread_handoff_text,
-            role_handoff_text=handoff_text,
-        ),
-        "",
-        "Local monitor follow-up:",
-        "```bash",
-        "curl -sS http://127.0.0.1:8765/api/delegate/active",
-        "curl -sS http://127.0.0.1:8765/api/worktrees",
-        ".venv/bin/python scripts/orchestration/orchestrator_control.py inbox --recent 20 --include-results",
-        "```",
-        "",
-        "Bind this new thread to this exact rollover, then create its local canary PASS proof:",
-        "```bash",
-        f".venv/bin/python scripts/orchestration/thread_handoff.py resume --agent {agent} --lineage-id {replacement.get('lineage_id', 'unknown')} --rollover-id {rollover_id} --replacement-thread-id <replacement-thread-id>",
-        f".venv/bin/python scripts/orchestration/thread_handoff_canary.py --rollover-id {rollover_id} --replacement-thread-id <replacement-thread-id> --challenge {canary_challenge} --proof-file {canary_proof_path}",
-        f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --lineage-id {replacement.get('lineage_id', 'unknown')} --rollover-id {rollover_id} --new-thread-id <replacement-thread-id> --canary-proof {canary_proof_path}",
-        "```",
-        "",
-        "Only after that command reports old_automation_ready_to_delete=true may the old heartbeat automation be deleted or paused.",
-        "",
-        "Current snapshot:",
-        f"- Branch: {git.get('branch')} @ {git.get('head')}",
-        f"- {context_line(float(context_percent) if context_percent is not None else None, context_threshold)}",
-        f"- Active delegates: {(monitor.get('active_delegates') or {}).get('total', 'unknown') if isinstance(monitor.get('active_delegates'), dict) else 'unknown'}",
-        f"- Open PRs: {len(github.get('open_prs')) if isinstance(github.get('open_prs'), list) else 'unknown'}",
-        f"- Bootstrap prompt source: {prompt_path}",
-    ]) + "\n"
+    return (
+        "\n".join(
+            [
+                f"Work locally in {git.get('repo_root')}.",
+                "",
+                f"You are the replacement {agent_label} thread.",
+                f"Replacement generation: {replacement_generation}",
+                f"Rollover id: {rollover_id}",
+                f"Previous active generation: {active_generation}",
+                f"Role handoff: {handoff_text}",
+                f"Thread handoff: {thread_handoff_text}",
+                "",
+                "Read first:",
+                f"- {thread_handoff_text}",
+                f"- {handoff_text}",
+                "- AGENTS.md",
+                "- docs/best-practices/agent-cooperation.md",
+                "- docs/best-practices/codex-thread-handoff.md",
+                "",
+                "Rules:",
+                "- Continue from the durable packet exactly; do not fork, continue, or resume provider conversation history.",
+                "- Keep the main checkout read-only; thread rollover state belongs in gitignored .agent/ files.",
+                "- Use dispatch worktrees for implementation work: .worktrees/dispatch/<agent>/<task>/.",
+                "- Do not edit generated status/audit/review artifacts, linter configs, or .python-version.",
+                "- Do not write docs/session-state/current.md for thread rollover.",
+                "- Do not delete or migrate the old heartbeat automation until the confirm-started command below has succeeded.",
+                "",
+                *first_turn_checklist_lines(
+                    repo_root=str(git.get("repo_root")),
+                    thread_handoff_text=thread_handoff_text,
+                    role_handoff_text=handoff_text,
+                ),
+                "",
+                "Local monitor follow-up:",
+                "```bash",
+                "curl -sS http://127.0.0.1:8765/api/delegate/active",
+                "curl -sS http://127.0.0.1:8765/api/worktrees",
+                ".venv/bin/python scripts/orchestration/orchestrator_control.py inbox --recent 20 --include-results",
+                "```",
+                "",
+                "Bind this new thread to this exact rollover, then create its script-proven canary PASS proof:",
+                "```bash",
+                f".venv/bin/python scripts/orchestration/thread_handoff.py resume --agent {agent} --lineage-id {replacement.get('lineage_id', 'unknown')} --rollover-id {rollover_id} --replacement-thread-id <replacement-thread-id>",
+                f".venv/bin/python scripts/orchestration/thread_handoff_canary.py --rollover-id {rollover_id} --replacement-thread-id <replacement-thread-id> --challenge {canary_challenge} --proof-file {canary_proof_path.as_posix()}",
+                f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --lineage-id {replacement.get('lineage_id', 'unknown')} --rollover-id {rollover_id} --new-thread-id <replacement-thread-id> --canary-proof {canary_proof_path.as_posix()}",
+                "```",
+                "",
+                "Only after that command reports old_automation_ready_to_delete=true may the old heartbeat automation be deleted or paused.",
+                "",
+                "Current snapshot:",
+                f"- Branch: {git.get('branch')} @ {git.get('head')}",
+                f"- {context_line(float(context_percent) if context_percent is not None else None, context_threshold)}",
+                f"- Active delegates: {(monitor.get('active_delegates') or {}).get('total', 'unknown') if isinstance(monitor.get('active_delegates'), dict) else 'unknown'}",
+                f"- Open PRs: {len(github.get('open_prs')) if isinstance(github.get('open_prs'), list) else 'unknown'}",
+                f"- Bootstrap prompt source: {prompt_path}",
+            ]
+        )
+        + "\n"
+    )
 
 
 def render_current_markdown(
@@ -785,6 +868,7 @@ def render_current_markdown(
     *,
     agent: str = DEFAULT_AGENT,
     role_handoff_path: Path | None = None,
+    state_root: Path | None = None,
     context_threshold: float,
 ) -> str:
     git = snapshot["git"]
@@ -796,6 +880,9 @@ def render_current_markdown(
     handoff = state.get("last_handoff") or {}
     prompt_path = replacement.get("bootstrap_prompt_path") or "unknown"
     thread_handoff_text = replacement.get("handoff_path") or "unknown"
+    canary_proof_path = Path(replacement.get("canary_proof_path") or "unknown")
+    if state_root is not None:
+        canary_proof_path = repo_local_path(state_root, canary_proof_path)
     role_handoff = (role_handoff_path or default_handoff_path(agent)).as_posix()
     title_agent = "Orchestrator" if agent == "orchestrator" else agent.title()
 
@@ -889,8 +976,8 @@ def render_current_markdown(
         "",
         "```bash",
         f".venv/bin/python scripts/orchestration/thread_handoff.py resume --agent {agent} --lineage-id {replacement.get('lineage_id', '<lineage-id>')} --rollover-id {replacement.get('rollover_id', '<rollover-id>')} --replacement-thread-id <replacement-thread-id>",
-        f".venv/bin/python scripts/orchestration/thread_handoff_canary.py --rollover-id {replacement.get('rollover_id', '<rollover-id>')} --replacement-thread-id <replacement-thread-id> --challenge {replacement.get('canary_challenge', '<canary-challenge>')} --proof-file {replacement.get('canary_proof_path', '<canary-proof-path>')}",
-        f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --lineage-id {replacement.get('lineage_id', '<lineage-id>')} --rollover-id {replacement.get('rollover_id', '<rollover-id>')} --new-thread-id <replacement-thread-id> --canary-proof {replacement.get('canary_proof_path', '<canary-proof-path>')}",
+        f".venv/bin/python scripts/orchestration/thread_handoff_canary.py --rollover-id {replacement.get('rollover_id', '<rollover-id>')} --replacement-thread-id <replacement-thread-id> --challenge {replacement.get('canary_challenge', '<canary-challenge>')} --proof-file {canary_proof_path.as_posix()}",
+        f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --lineage-id {replacement.get('lineage_id', '<lineage-id>')} --rollover-id {replacement.get('rollover_id', '<rollover-id>')} --new-thread-id <replacement-thread-id> --canary-proof {canary_proof_path.as_posix()}",
         "```",
         "",
         "Do not delete the old heartbeat automation before this confirmation.",
@@ -915,16 +1002,18 @@ def render_router_markdown(
     ]
     for agent in agents:
         lines.append(f"- {agent}: {default_handoff_path(agent).as_posix()}")
-    lines.extend([
-        "",
-        f"Default-Agent: {default_agent}",
-        f"Generated-At: {generated_at}",
-        "",
-        "This file is a small compatibility router. Durable role state lives in",
-        "the mapped Agent-Handoff files. Thread rollover packets live under",
-        "`.agent/<agent>-thread-handoff.md` unless explicitly overridden.",
-        "",
-    ])
+    lines.extend(
+        [
+            "",
+            f"Default-Agent: {default_agent}",
+            f"Generated-At: {generated_at}",
+            "",
+            "This file is a small compatibility router. Durable role state lives in",
+            "the mapped Agent-Handoff files. Thread rollover packets live under",
+            "`.agent/<agent>-thread-handoff.md` unless explicitly overridden.",
+            "",
+        ]
+    )
     return "\n".join(lines)
 
 
@@ -937,10 +1026,7 @@ def inspect_codex_home(codex_home: Path) -> dict[str, Any]:
     }
     automations_dir = codex_home / "automations"
     if automations_dir.exists():
-        result["automation_toml_files"] = [
-            str(path)
-            for path in sorted(automations_dir.glob("**/automation.toml"))
-        ]
+        result["automation_toml_files"] = [str(path) for path in sorted(automations_dir.glob("**/automation.toml"))]
     else:
         result["automation_toml_files"] = []
 
@@ -951,8 +1037,7 @@ def inspect_codex_home(codex_home: Path) -> dict[str, Any]:
         try:
             with closing(sqlite3.connect(db_path)) as conn:
                 tables = [
-                    row[0]
-                    for row in conn.execute("select name from sqlite_master where type='table' order by name")
+                    row[0] for row in conn.execute("select name from sqlite_master where type='table' order by name")
                 ]
                 result["latest_state_db"] = str(db_path)
                 result["tables"] = tables
@@ -1014,22 +1099,35 @@ def check_state(
 
 
 def cmd_prepare(args: argparse.Namespace) -> int:
-    repo_root = Path(args.repo_root).resolve()
+    try:
+        repo_root, state_root = resolve_roots(args.repo_root)
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}, indent=2))
+        return 2
     now = utc_now()
     agent = normalize_agent_name(args.agent)
     active_thread_id = args.active_thread_id or active_thread_id_from_env()
     if not active_thread_id:
-        print(json.dumps({
-            "error": "--active-thread-id (or CODEX_THREAD_ID) is required for a v2 rollover",
-            "agent": agent,
-        }, indent=2))
+        print(
+            json.dumps(
+                {
+                    "error": "--active-thread-id (or CODEX_THREAD_ID) is required for a v2 rollover",
+                    "agent": agent,
+                },
+                indent=2,
+            )
+        )
         return 2
     lineage_id = args.lineage_id or lineage_id_for(agent, active_thread_id)
-    state_file = args.state_file or default_state_path(agent, lineage_id)
     role_handoff_file = default_handoff_path(agent)
     router_file = args.current_file or DEFAULT_ROUTER_PATH
     try:
-        state_path = repo_local_path(repo_root, state_file)
+        state_path = resolve_state_path(
+            repo_root=repo_root,
+            state_root=state_root,
+            supplied_state_file=args.state_file,
+            default_path=default_state_path(agent, lineage_id),
+        )
         router_path = repo_local_path(repo_root, router_file)
     except ValueError as exc:
         print(json.dumps({"error": str(exc), "agent": agent}, indent=2))
@@ -1037,16 +1135,21 @@ def cmd_prepare(args: argparse.Namespace) -> int:
     role_handoff_path = repo_root / role_handoff_file
 
     if args.write_current and not args.allow_git_router:
-        print(json.dumps({
-            "error": "--write-current is disabled by default because docs/session-state/current.md is git-tracked. "
-            "Use the default .agent/ handoff files for thread rollover, or pass --allow-git-router only for an explicitly approved compatibility-router update.",
-            "agent": agent,
-            "state_file": rel(state_path, repo_root),
-        }, indent=2))
+        print(
+            json.dumps(
+                {
+                    "error": "--write-current is disabled by default because docs/session-state/current.md is git-tracked. "
+                    "Use the default .agent/ handoff files for thread rollover, or pass --allow-git-router only for an explicitly approved compatibility-router update.",
+                    "agent": agent,
+                    "state_file": rel(state_path, state_root),
+                },
+                indent=2,
+            )
+        )
         return 2
 
     state = load_state(state_path)
-    state_error = state_error_payload(state, state_path, repo_root)
+    state_error = state_error_payload(state, state_path, state_root)
     if state_error and not args.force_reset_state:
         print(json.dumps(state_error, indent=2))
         return 2
@@ -1062,19 +1165,29 @@ def cmd_prepare(args: argparse.Namespace) -> int:
         try:
             state = migrate_v1_state(state, agent=agent, lineage_id=lineage_id, now=now)
         except ValueError as exc:
-            print(json.dumps({"error": str(exc), "state_file": rel(state_path, repo_root)}, indent=2))
+            print(json.dumps({"error": str(exc), "state_file": rel(state_path, state_root)}, indent=2))
             return 2
     if state.get("agent") and state["agent"] != agent:
-        print(json.dumps({
-            "error": "state agent does not match --agent",
-            "state_file": rel(state_path, repo_root),
-        }, indent=2))
+        print(
+            json.dumps(
+                {
+                    "error": "state agent does not match --agent",
+                    "state_file": rel(state_path, state_root),
+                },
+                indent=2,
+            )
+        )
         return 2
     if state.get("lineage_id") and state["lineage_id"] != lineage_id:
-        print(json.dumps({
-            "error": "state lineage does not match --lineage-id/active thread identity",
-            "state_file": rel(state_path, repo_root),
-        }, indent=2))
+        print(
+            json.dumps(
+                {
+                    "error": "state lineage does not match --lineage-id/active thread identity",
+                    "state_file": rel(state_path, state_root),
+                },
+                indent=2,
+            )
+        )
         return 2
     try:
         prepared_state = prepare_state(
@@ -1087,11 +1200,11 @@ def cmd_prepare(args: argparse.Namespace) -> int:
             force_new_replacement=args.force_new_replacement,
         )
     except ValueError as exc:
-        print(json.dumps({"error": str(exc), "state_file": rel(state_path, repo_root)}, indent=2))
+        print(json.dumps({"error": str(exc), "state_file": rel(state_path, state_root)}, indent=2))
         return 2
     replacement = prepared_state["replacement"]
-    bootstrap_path = repo_root / replacement["bootstrap_prompt_path"]
-    handoff_path = repo_root / replacement["handoff_path"]
+    bootstrap_path = repo_local_path(state_root, Path(replacement["bootstrap_prompt_path"]))
+    handoff_path = repo_local_path(state_root, Path(replacement["handoff_path"]))
     snapshot = gather_snapshot(repo_root, args.monitor_base_url)
     prompt = render_bootstrap_prompt(
         snapshot,
@@ -1100,6 +1213,7 @@ def cmd_prepare(args: argparse.Namespace) -> int:
         router_path=Path(router_file),
         handoff_path=Path(replacement["handoff_path"]),
         role_handoff_path=Path(role_handoff_file),
+        state_root=state_root,
         context_threshold=args.context_threshold,
     )
     handoff_md = render_current_markdown(
@@ -1107,6 +1221,7 @@ def cmd_prepare(args: argparse.Namespace) -> int:
         prepared_state,
         agent=agent,
         role_handoff_path=Path(role_handoff_file),
+        state_root=state_root,
         context_threshold=args.context_threshold,
     )
     router_md = render_router_markdown(
@@ -1121,10 +1236,10 @@ def cmd_prepare(args: argparse.Namespace) -> int:
             "agent": agent,
             "lineage_id": lineage_id,
             "rollover_id": replacement["rollover_id"],
-            "state_file": rel(state_path, repo_root),
-            "bootstrap_file": rel(bootstrap_path, repo_root),
-            "handoff_file": rel(handoff_path, repo_root),
-            "thread_handoff_file": rel(handoff_path, repo_root),
+            "state_file": rel(state_path, state_root),
+            "bootstrap_file": rel(bootstrap_path, state_root),
+            "handoff_file": rel(handoff_path, state_root),
+            "thread_handoff_file": rel(handoff_path, state_root),
             "role_handoff_file": role_handoff_path.as_posix(),
             "router_file": router_path.as_posix(),
             "current_file": router_path.as_posix(),
@@ -1148,10 +1263,10 @@ def cmd_prepare(args: argparse.Namespace) -> int:
         "lineage_id": lineage_id,
         "rollover_id": replacement["rollover_id"],
         "runtime_path": replacement["runtime_path"],
-        "state_file": rel(state_path, repo_root),
-        "bootstrap_file": rel(bootstrap_path, repo_root),
-        "handoff_file": rel(handoff_path, repo_root),
-        "thread_handoff_file": rel(handoff_path, repo_root),
+        "state_file": rel(state_path, state_root),
+        "bootstrap_file": rel(bootstrap_path, state_root),
+        "handoff_file": rel(handoff_path, state_root),
+        "thread_handoff_file": rel(handoff_path, state_root),
         "role_handoff_file": rel(role_handoff_path, repo_root),
         "router_file": rel(router_path, repo_root) if wrote_router else None,
         "current_file": rel(router_path, repo_root) if wrote_router else None,
@@ -1163,28 +1278,43 @@ def cmd_prepare(args: argparse.Namespace) -> int:
 
 
 def cmd_confirm_started(args: argparse.Namespace) -> int:
-    repo_root = Path(args.repo_root).resolve()
+    try:
+        repo_root, state_root = resolve_roots(args.repo_root)
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}, indent=2))
+        return 2
     agent = normalize_agent_name(args.agent)
     if not args.lineage_id and not args.state_file:
-        print(json.dumps({"error": "--lineage-id or --state-file is required to locate an isolated rollover"}, indent=2))
+        print(
+            json.dumps({"error": "--lineage-id or --state-file is required to locate an isolated rollover"}, indent=2)
+        )
         return 2
     lineage_id = args.lineage_id
     try:
-        state_path = repo_local_path(repo_root, args.state_file or default_state_path(agent, lineage_id))
+        state_path = resolve_state_path(
+            repo_root=repo_root,
+            state_root=state_root,
+            supplied_state_file=args.state_file,
+            default_path=default_state_path(agent, lineage_id),
+        )
     except ValueError as exc:
         print(json.dumps({"error": str(exc), "agent": agent}, indent=2))
         return 2
     state = load_state(state_path)
-    state_error = state_error_payload(state, state_path, repo_root)
+    state_error = state_error_payload(state, state_path, state_root)
     if state_error:
         print(json.dumps(state_error, indent=2))
         return 2
-    if args.rollover_id != (state.get("replacement") or {}).get("rollover_id"):
+    replacement = state.get("replacement") or {}
+    if not replacement:
+        print(json.dumps({"error": "run prepare first"}, indent=2))
+        return 2
+    if args.rollover_id != replacement.get("rollover_id"):
         print(json.dumps({"error": "--rollover-id does not match the isolated pending rollover"}, indent=2))
         return 2
-    expected_proof = repo_local_path(repo_root, Path(state["replacement"]["canary_proof_path"]))
+    expected_proof = repo_local_path(state_root, Path(state["replacement"]["canary_proof_path"]))
     try:
-        supplied_proof = repo_local_path(repo_root, args.canary_proof)
+        supplied_proof = repo_local_path(state_root, args.canary_proof)
     except ValueError as exc:
         print(json.dumps({"error": str(exc), "agent": agent}, indent=2))
         return 2
@@ -1204,31 +1334,47 @@ def cmd_confirm_started(args: argparse.Namespace) -> int:
         print(json.dumps({"error": str(exc)}, indent=2))
         return 2
     write_json_atomic(state_path, confirmed)
-    print(json.dumps({
-        "agent": agent,
-        "lineage_id": confirmed.get("lineage_id"),
-        "rollover_id": confirmed["replacement"]["rollover_id"],
-        "state_file": rel(state_path, repo_root),
-        "replacement_status": confirmed["replacement"]["status"],
-        "replacement_thread_id": confirmed["replacement"]["thread_id"],
-        "old_automation_ready_to_delete": confirmed["cleanup"]["old_automation_ready_to_delete"],
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "agent": agent,
+                "lineage_id": confirmed.get("lineage_id"),
+                "rollover_id": confirmed["replacement"]["rollover_id"],
+                "state_file": rel(state_path, state_root),
+                "replacement_status": confirmed["replacement"]["status"],
+                "replacement_thread_id": confirmed["replacement"]["thread_id"],
+                "old_automation_ready_to_delete": confirmed["cleanup"]["old_automation_ready_to_delete"],
+            },
+            indent=2,
+        )
+    )
     return 0
 
 
 def cmd_resume(args: argparse.Namespace) -> int:
-    repo_root = Path(args.repo_root).resolve()
+    try:
+        repo_root, state_root = resolve_roots(args.repo_root)
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}, indent=2))
+        return 2
     agent = normalize_agent_name(args.agent)
     if not args.lineage_id and not args.state_file:
-        print(json.dumps({"error": "--lineage-id or --state-file is required to locate an isolated rollover"}, indent=2))
+        print(
+            json.dumps({"error": "--lineage-id or --state-file is required to locate an isolated rollover"}, indent=2)
+        )
         return 2
     try:
-        state_path = repo_local_path(repo_root, args.state_file or default_state_path(agent, args.lineage_id))
+        state_path = resolve_state_path(
+            repo_root=repo_root,
+            state_root=state_root,
+            supplied_state_file=args.state_file,
+            default_path=default_state_path(agent, args.lineage_id),
+        )
     except ValueError as exc:
         print(json.dumps({"error": str(exc), "agent": agent}, indent=2))
         return 2
     state = load_state(state_path)
-    state_error = state_error_payload(state, state_path, repo_root)
+    state_error = state_error_payload(state, state_path, state_root)
     if state_error:
         print(json.dumps(state_error, indent=2))
         return 2
@@ -1240,29 +1386,45 @@ def cmd_resume(args: argparse.Namespace) -> int:
             now=utc_now(),
         )
     except ValueError as exc:
-        print(json.dumps({"error": str(exc), "state_file": rel(state_path, repo_root)}, indent=2))
+        print(json.dumps({"error": str(exc), "state_file": rel(state_path, state_root)}, indent=2))
         return 2
     write_json_atomic(state_path, resumed)
     replacement = resumed["replacement"]
-    print(json.dumps({
-        "agent": agent,
-        "lineage_id": resumed.get("lineage_id"),
-        "rollover_id": replacement["rollover_id"],
-        "replacement_thread_id": replacement["resumed_thread_id"],
-        "canary_proof_file": replacement["canary_proof_path"],
-        "status": replacement["status"],
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "agent": agent,
+                "lineage_id": resumed.get("lineage_id"),
+                "rollover_id": replacement["rollover_id"],
+                "replacement_thread_id": replacement["resumed_thread_id"],
+                "canary_proof_file": replacement["canary_proof_path"],
+                "status": replacement["status"],
+            },
+            indent=2,
+        )
+    )
     return 0
 
 
 def cmd_check(args: argparse.Namespace) -> int:
-    repo_root = Path(args.repo_root).resolve()
+    try:
+        repo_root, state_root = resolve_roots(args.repo_root)
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}, indent=2))
+        return 2
     agent = normalize_agent_name(args.agent)
     if not args.lineage_id and not args.state_file:
-        print(json.dumps({"error": "--lineage-id or --state-file is required to locate an isolated rollover"}, indent=2))
+        print(
+            json.dumps({"error": "--lineage-id or --state-file is required to locate an isolated rollover"}, indent=2)
+        )
         return 2
     try:
-        state_path = repo_local_path(repo_root, args.state_file or default_state_path(agent, args.lineage_id))
+        state_path = resolve_state_path(
+            repo_root=repo_root,
+            state_root=state_root,
+            supplied_state_file=args.state_file,
+            default_path=default_state_path(agent, args.lineage_id),
+        )
     except ValueError as exc:
         print(json.dumps({"error": str(exc), "agent": agent}, indent=2))
         return 2
@@ -1274,7 +1436,7 @@ def cmd_check(args: argparse.Namespace) -> int:
         context_percent=args.context_percent,
         context_threshold=args.context_threshold,
     )
-    payload = {"agent": agent, "facts": facts, "warnings": warnings, "state_file": rel(state_path, repo_root)}
+    payload = {"agent": agent, "facts": facts, "warnings": warnings, "state_file": rel(state_path, state_root)}
     print(json.dumps(payload, indent=2))
     return 2 if warnings else 0
 
@@ -1289,13 +1451,17 @@ def cmd_audit(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--repo-root", type=Path, default=repo_root_from_file())
+    parser.add_argument("--repo-root", type=Path)
     parser.add_argument("--monitor-base-url", default=os.environ.get("MONITOR_API_BASE_URL", DEFAULT_MONITOR_BASE_URL))
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     prepare = subparsers.add_parser("prepare", help="Prepare a rollover handoff and bootstrap prompt.")
     prepare.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
-    prepare.add_argument("--lineage-id", type=argparse_lineage_id, help="Optional stable isolation key; otherwise derived from --active-thread-id.")
+    prepare.add_argument(
+        "--lineage-id",
+        type=argparse_lineage_id,
+        help="Optional stable isolation key; otherwise derived from --active-thread-id.",
+    )
     prepare.add_argument("--state-file", type=Path)
     prepare.add_argument("--current-file", type=Path, help="Override the shared docs/session-state/current.md router.")
     prepare.add_argument("--active-thread-id")
@@ -1303,7 +1469,9 @@ def build_parser() -> argparse.ArgumentParser:
     prepare.add_argument("--context-percent", type=float)
     prepare.add_argument("--context-threshold", type=float, default=DEFAULT_CONTEXT_THRESHOLD)
     prepare.add_argument("--force-new-replacement", action="store_true")
-    prepare.add_argument("--migrate-v1", action="store_true", help="Explicitly migrate a v1 lease into a fresh v2 rollover.")
+    prepare.add_argument(
+        "--migrate-v1", action="store_true", help="Explicitly migrate a v1 lease into a fresh v2 rollover."
+    )
     prepare.add_argument(
         "--force-reset-state",
         action="store_true",

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -11,6 +11,7 @@ until the replacement thread is explicitly confirmed.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -18,17 +19,21 @@ import sqlite3
 import subprocess
 import urllib.error
 import urllib.request
+import uuid
 from contextlib import closing
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = 1
+from scripts.orchestration import thread_handoff_canary
+
+SCHEMA_VERSION = 2
 DEFAULT_MONITOR_BASE_URL = "http://127.0.0.1:8765"
 DEFAULT_AGENT = "orchestrator"
 DEFAULT_ROUTER_AGENTS = ("orchestrator", "codex", "claude", "gemini")
 AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+LINEAGE_ID_RE = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
 DEFAULT_ROUTER_PATH = Path("docs/session-state/current.md")
 ORCHESTRATOR_HANDOFF_PATH = Path("docs/session-state/codex-orchestrator-handoff.md")
 DEFAULT_STALE_HOURS = 12
@@ -69,16 +74,42 @@ def argparse_agent_name(value: str) -> str:
         raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
-def default_state_path(agent: str) -> Path:
-    return Path(f".agent/{agent}-thread-lease.json")
+def normalize_lineage_id(value: str) -> str:
+    lineage_id = value.strip().lower()
+    if not LINEAGE_ID_RE.fullmatch(lineage_id):
+        raise ValueError(
+            "lineage ids must match [a-z][a-z0-9-]{0,63} so runtime paths cannot escape the repo"
+        )
+    return lineage_id
 
 
-def default_bootstrap_path(agent: str) -> Path:
-    return Path(f".agent/{agent}-thread-bootstrap.md")
+def argparse_lineage_id(value: str) -> str:
+    try:
+        return normalize_lineage_id(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
-def default_thread_handoff_path(agent: str) -> Path:
-    return Path(f".agent/{agent}-thread-handoff.md")
+def lineage_id_for(agent: str, active_thread_id: str) -> str:
+    """Derive a stable, path-safe lineage for one active runtime thread."""
+    digest = hashlib.sha256(f"{agent}\0{active_thread_id.strip()}".encode()).hexdigest()
+    return f"lineage-{digest[:24]}"
+
+
+def runtime_dir(agent: str, lineage_id: str, generation: int, rollover_id: str) -> Path:
+    return Path(".agent/thread-rollovers") / agent / lineage_id / f"generation-{generation:04d}" / rollover_id
+
+
+def default_state_path(agent: str, lineage_id: str) -> Path:
+    return Path(".agent/thread-rollovers") / agent / lineage_id / "lease.json"
+
+
+def default_bootstrap_path(agent: str, lineage_id: str, generation: int, rollover_id: str) -> Path:
+    return runtime_dir(agent, lineage_id, generation, rollover_id) / "bootstrap.md"
+
+
+def default_thread_handoff_path(agent: str, lineage_id: str, generation: int, rollover_id: str) -> Path:
+    return runtime_dir(agent, lineage_id, generation, rollover_id) / "handoff.md"
 
 
 def default_handoff_path(agent: str) -> Path:
@@ -123,6 +154,16 @@ def rel(path: Path, root: Path) -> str:
         return path.resolve().relative_to(root.resolve()).as_posix()
     except ValueError:
         return path.as_posix()
+
+
+def repo_local_path(repo_root: Path, value: Path) -> Path:
+    """Resolve an operator-supplied path only when it remains inside this repository."""
+    candidate = (repo_root / value).resolve()
+    try:
+        candidate.relative_to(repo_root.resolve())
+    except ValueError as exc:
+        raise ValueError(f"path must stay under the repository root: {value}") from exc
+    return candidate
 
 
 def run_command(
@@ -311,7 +352,13 @@ def load_state(path: Path) -> dict[str, Any]:
         }
     if not isinstance(data, dict):
         return {"schema_version": SCHEMA_VERSION, "state_error": f"state file is not a JSON object: {path}"}
-    data.setdefault("schema_version", SCHEMA_VERSION)
+    schema_version = data.get("schema_version", 1)
+    if schema_version not in {1, SCHEMA_VERSION}:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "state_error": f"unsupported state schema version {schema_version!r}: {path}",
+        }
+    data["schema_version"] = schema_version
     return data
 
 
@@ -333,13 +380,57 @@ def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
     os.replace(tmp, path)
 
 
+def write_text_atomic(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
+
+
 def active_thread_id_from_env() -> str | None:
     return os.environ.get("CODEX_THREAD_ID") or os.environ.get("CODEX_SESSION_ID")
 
 
-def generation_id(prefix: str, now: datetime) -> str:
-    stamp = now.strftime("%Y%m%dT%H%M%SZ")
-    return f"{prefix}-{stamp}"
+def new_rollover_id() -> str:
+    return f"rollover-{uuid.uuid4().hex}"
+
+
+def new_canary_challenge() -> str:
+    return uuid.uuid4().hex + uuid.uuid4().hex
+
+
+def migration_error(state: dict[str, Any], state_path: Path, repo_root: Path) -> dict[str, Any]:
+    return {
+        "error": "schema v1 state requires an explicit migration before it can be used",
+        "state_file": rel(state_path, repo_root),
+        "hint": "Rerun prepare with --migrate-v1. Legacy pending replacements are discarded and replaced by a fresh v2 rollover.",
+    }
+
+
+def migrate_v1_state(state: dict[str, Any], *, agent: str, lineage_id: str, now: datetime) -> dict[str, Any]:
+    """Safely migrate durable active identity while discarding unverifiable v1 replacement state."""
+    active_v1 = dict(state.get("active") or {})
+    active_thread_id = str(active_v1.get("thread_id") or "").strip()
+    if not active_thread_id:
+        raise ValueError("schema v1 state has no active thread id; choose a new --lineage-id and prepare afresh")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "agent": agent,
+        "lineage_id": lineage_id,
+        "active": {
+            "thread_id": active_thread_id,
+            "automation_id": active_v1.get("automation_id"),
+            "generation": 0,
+            "lineage_id": lineage_id,
+            "started_at": active_v1.get("started_at") or isoformat_z(now),
+            "last_seen_at": active_v1.get("last_seen_at") or isoformat_z(now),
+        },
+        "cleanup": {
+            "old_automation_ready_to_delete": False,
+            "reason": "v1 state migrated; every legacy replacement is unverified",
+        },
+        "migrated_from_v1_at": isoformat_z(now),
+    }
 
 
 def prepare_state(
@@ -349,40 +440,79 @@ def prepare_state(
     now: datetime,
     active_thread_id: str | None,
     active_automation_id: str | None,
-    bootstrap_path: Path,
     context_percent: float | None,
     force_new_replacement: bool,
 ) -> dict[str, Any]:
+    if state.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("schema v2 state is required; migrate v1 explicitly before preparing")
+    if not active_thread_id:
+        raise ValueError("--active-thread-id (or CODEX_THREAD_ID) is required for a v2 rollover")
+
     prepared = dict(state)
     prepared["schema_version"] = SCHEMA_VERSION
     prepared["agent"] = agent
 
     active = dict(prepared.get("active") or {})
-    if not active.get("generation"):
-        active["generation"] = generation_id(agent, now)
-        active["started_at"] = isoformat_z(now)
-    if active_thread_id:
-        active["thread_id"] = active_thread_id
-    elif active_thread_id_from_env() and not active.get("thread_id"):
-        active["thread_id"] = active_thread_id_from_env()
+    requested_thread_id = active_thread_id.strip()
+    lineage_id = str(prepared.get("lineage_id") or lineage_id_for(agent, requested_thread_id))
+    if (
+        active.get("thread_id")
+        and active["thread_id"] != requested_thread_id
+        and (prepared.get("replacement") or {}).get("status") != "started"
+    ):
+        raise ValueError("--active-thread-id does not match the active thread recorded for this lineage")
+    if not active:
+        active = {
+            "thread_id": requested_thread_id,
+            "generation": 0,
+            "lineage_id": lineage_id,
+            "started_at": isoformat_z(now),
+        }
+    active.setdefault("generation", 0)
+    active["lineage_id"] = lineage_id
     if active_automation_id:
         active["automation_id"] = active_automation_id
     active["last_seen_at"] = isoformat_z(now)
     prepared["active"] = active
+    prepared["lineage_id"] = lineage_id
 
     replacement = dict(prepared.get("replacement") or {})
-    if force_new_replacement or replacement.get("status") not in {"pending_start", "started"}:
-        replacement = {
-            "generation": generation_id(f"{agent}-next", now),
-            "status": "pending_start",
-            "prepared_at": isoformat_z(now),
-            "thread_id": None,
-            "bootstrap_prompt_path": bootstrap_path.as_posix(),
+    if replacement.get("status") in {"pending_start", "resumed"} and not force_new_replacement:
+        raise ValueError(
+            f"pending rollover {replacement.get('rollover_id', 'unknown')} already exists; "
+            "use --force-new-replacement to supersede it explicitly"
+        )
+    if replacement.get("status") == "started":
+        active = {
+            "thread_id": replacement["thread_id"],
+            "automation_id": replacement.get("automation_id"),
+            "generation": replacement["generation"],
+            "lineage_id": lineage_id,
+            "started_at": replacement.get("confirmed_at", isoformat_z(now)),
+            "last_seen_at": isoformat_z(now),
         }
-    else:
-        replacement["prepared_at"] = isoformat_z(now)
-        replacement["bootstrap_prompt_path"] = bootstrap_path.as_posix()
+        if requested_thread_id != active["thread_id"]:
+            raise ValueError("--active-thread-id must be the last confirmed replacement thread")
+        prepared["active"] = active
+
+    generation = int((prepared["active"] or {}).get("generation", 0)) + 1
+    rollover_id = new_rollover_id()
+    packet_dir = runtime_dir(agent, lineage_id, generation, rollover_id)
+    replacement = {
+        "rollover_id": rollover_id,
+        "lineage_id": lineage_id,
+        "generation": generation,
+        "runtime_path": packet_dir.as_posix(),
+        "status": "pending_start",
+        "prepared_at": isoformat_z(now),
+        "thread_id": None,
+        "bootstrap_prompt_path": (packet_dir / "bootstrap.md").as_posix(),
+        "handoff_path": (packet_dir / "handoff.md").as_posix(),
+        "canary_proof_path": (packet_dir / "canary-pass.json").as_posix(),
+        "canary_challenge": new_canary_challenge(),
+    }
     prepared["replacement"] = replacement
+    prepared["rollover_id"] = rollover_id
 
     cleanup = dict(prepared.get("cleanup") or {})
     cleanup["old_automation_ready_to_delete"] = False
@@ -403,19 +533,33 @@ def confirm_started(
     new_automation_id: str | None,
     confirmed_by: str,
     now: datetime,
+    canary_proof: Path,
 ) -> dict[str, Any]:
     if not new_thread_id.strip():
         raise ValueError("--new-thread-id is required")
-    if not state.get("replacement"):
+    if state.get("schema_version") != SCHEMA_VERSION or not state.get("replacement"):
         raise ValueError("no pending replacement exists; run prepare first")
 
     confirmed = dict(state)
     replacement = dict(confirmed["replacement"])
+    if replacement.get("status") != "resumed":
+        raise ValueError("replacement must be resumed through the rollover packet before confirmation")
+    if replacement.get("resumed_thread_id") != new_thread_id.strip():
+        raise ValueError("--new-thread-id does not match the thread that resumed this rollover")
+    proof, proof_error = thread_handoff_canary.load_and_validate_pass_proof(
+        canary_proof,
+        rollover_id=str(replacement.get("rollover_id") or ""),
+        replacement_thread_id=new_thread_id.strip(),
+        challenge=str(replacement.get("canary_challenge") or ""),
+    )
+    if proof_error:
+        raise ValueError(f"script-proven canary PASS is required: {proof_error}")
     replacement["status"] = "started"
     replacement["thread_id"] = new_thread_id.strip()
     replacement["confirmed_at"] = isoformat_z(now)
     if new_automation_id:
         replacement["automation_id"] = new_automation_id
+    replacement["canary_proof"] = proof
     confirmed["replacement"] = replacement
 
     cleanup = dict(confirmed.get("cleanup") or {})
@@ -426,6 +570,32 @@ def confirm_started(
     confirmed["cleanup"] = cleanup
     confirmed["updated_at"] = isoformat_z(now)
     return confirmed
+
+
+def resume_state(state: dict[str, Any], *, rollover_id: str, replacement_thread_id: str, now: datetime) -> dict[str, Any]:
+    """Bind exactly one new thread to a prepared local packet, without provider history."""
+    if state.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("schema v2 state is required; run prepare with --migrate-v1 first")
+    replacement = dict(state.get("replacement") or {})
+    if replacement.get("status") not in {"pending_start", "resumed"}:
+        raise ValueError("no pending rollover is available to resume")
+    if replacement.get("rollover_id") != rollover_id:
+        raise ValueError("--rollover-id does not match the pending rollover")
+    thread_id = replacement_thread_id.strip()
+    if not thread_id:
+        raise ValueError("--replacement-thread-id is required")
+    existing = replacement.get("resumed_thread_id")
+    if existing and existing != thread_id:
+        raise ValueError("pending rollover is already bound to a different replacement thread")
+    if existing == thread_id:
+        return state
+    replacement["status"] = "resumed"
+    replacement["resumed_thread_id"] = thread_id
+    replacement.setdefault("resumed_at", isoformat_z(now))
+    resumed = dict(state)
+    resumed["replacement"] = replacement
+    resumed["updated_at"] = isoformat_z(now)
+    return resumed
 
 
 def format_table(rows: list[list[str]], headers: list[str]) -> str:
@@ -540,13 +710,16 @@ def render_bootstrap_prompt(
     github = snapshot["github"]
     active = state.get("active") or {}
     replacement = state.get("replacement") or {}
-    prompt_path = replacement.get("bootstrap_prompt_path") or default_bootstrap_path(agent).as_posix()
-    handoff_path = handoff_path or default_thread_handoff_path(agent)
+    prompt_path = replacement.get("bootstrap_prompt_path") or "unknown"
+    handoff_path = handoff_path or Path(replacement.get("handoff_path") or "unknown")
     role_handoff_path = role_handoff_path or default_handoff_path(agent)
     handoff_text = role_handoff_path.as_posix()
     thread_handoff_text = handoff_path.as_posix()
     active_generation = active.get("generation") or "unknown"
     replacement_generation = replacement.get("generation") or "unknown"
+    rollover_id = replacement.get("rollover_id") or "unknown"
+    canary_challenge = replacement.get("canary_challenge") or "unknown"
+    canary_proof_path = replacement.get("canary_proof_path") or "unknown"
     context_percent = (state.get("last_handoff") or {}).get("context_percent")
     agent_label = "Codex orchestrator" if agent == "orchestrator" else agent
 
@@ -555,6 +728,7 @@ def render_bootstrap_prompt(
         "",
         f"You are the replacement {agent_label} thread.",
         f"Replacement generation: {replacement_generation}",
+        f"Rollover id: {rollover_id}",
         f"Previous active generation: {active_generation}",
         f"Role handoff: {handoff_text}",
         f"Thread handoff: {thread_handoff_text}",
@@ -567,7 +741,7 @@ def render_bootstrap_prompt(
         "- docs/best-practices/codex-thread-handoff.md",
         "",
         "Rules:",
-        "- Continue from the handoff exactly; do not restart from scratch.",
+        "- Continue from the durable packet exactly; do not fork, continue, or resume provider conversation history.",
         "- Keep the main checkout read-only; thread rollover state belongs in gitignored .agent/ files.",
         "- Use dispatch worktrees for implementation work: .worktrees/dispatch/<agent>/<task>/.",
         "- Do not edit generated status/audit/review artifacts, linter configs, or .python-version.",
@@ -587,9 +761,11 @@ def render_bootstrap_prompt(
         ".venv/bin/python scripts/orchestration/orchestrator_control.py inbox --recent 20 --include-results",
         "```",
         "",
-        "After the replacement thread is actually running, confirm it from the repo root:",
+        "Bind this new thread to this exact rollover, then create its local canary PASS proof:",
         "```bash",
-        f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --new-thread-id <replacement-thread-id>",
+        f".venv/bin/python scripts/orchestration/thread_handoff.py resume --agent {agent} --lineage-id {replacement.get('lineage_id', 'unknown')} --rollover-id {rollover_id} --replacement-thread-id <replacement-thread-id>",
+        f".venv/bin/python scripts/orchestration/thread_handoff_canary.py --rollover-id {rollover_id} --replacement-thread-id <replacement-thread-id> --challenge {canary_challenge} --proof-file {canary_proof_path}",
+        f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --lineage-id {replacement.get('lineage_id', 'unknown')} --rollover-id {rollover_id} --new-thread-id <replacement-thread-id> --canary-proof {canary_proof_path}",
         "```",
         "",
         "Only after that command reports old_automation_ready_to_delete=true may the old heartbeat automation be deleted or paused.",
@@ -618,8 +794,8 @@ def render_current_markdown(
     replacement = state.get("replacement") or {}
     cleanup = state.get("cleanup") or {}
     handoff = state.get("last_handoff") or {}
-    prompt_path = replacement.get("bootstrap_prompt_path") or default_bootstrap_path(agent).as_posix()
-    thread_handoff_text = default_thread_handoff_path(agent).as_posix()
+    prompt_path = replacement.get("bootstrap_prompt_path") or "unknown"
+    thread_handoff_text = replacement.get("handoff_path") or "unknown"
     role_handoff = (role_handoff_path or default_handoff_path(agent)).as_posix()
     title_agent = "Orchestrator" if agent == "orchestrator" else agent.title()
 
@@ -636,6 +812,9 @@ def render_current_markdown(
         f"- Active thread id: `{active.get('thread_id', 'unknown')}`",
         f"- Active automation id: `{active.get('automation_id', 'unknown')}`",
         f"- Replacement generation: `{replacement.get('generation', 'unknown')}`",
+        f"- Rollover id: `{replacement.get('rollover_id', 'unknown')}`",
+        f"- Lineage id: `{replacement.get('lineage_id', state.get('lineage_id', 'unknown'))}`",
+        f"- Replacement runtime path: `{replacement.get('runtime_path', 'unknown')}`",
         f"- Replacement status: `{replacement.get('status', 'unknown')}`",
         f"- Replacement thread id: `{replacement.get('thread_id') or 'not-confirmed'}`",
         f"- Old automation ready to delete: `{cleanup.get('old_automation_ready_to_delete', False)}`",
@@ -705,11 +884,13 @@ def render_current_markdown(
         "",
         "## Replacement Bootstrap Prompt",
         "",
-        "Paste the generated bootstrap prompt into the new Codex thread, or use the Codex app `create_thread` tool when available.",
-        "After the new thread is actually running, run:",
+        "Paste the generated bootstrap prompt into a new thread. This protocol does not fork, continue, or resume provider conversation history.",
+        "After the new thread is actually running, bind and prove this exact rollover:",
         "",
         "```bash",
-        f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --new-thread-id <replacement-thread-id>",
+        f".venv/bin/python scripts/orchestration/thread_handoff.py resume --agent {agent} --lineage-id {replacement.get('lineage_id', '<lineage-id>')} --rollover-id {replacement.get('rollover_id', '<rollover-id>')} --replacement-thread-id <replacement-thread-id>",
+        f".venv/bin/python scripts/orchestration/thread_handoff_canary.py --rollover-id {replacement.get('rollover_id', '<rollover-id>')} --replacement-thread-id <replacement-thread-id> --challenge {replacement.get('canary_challenge', '<canary-challenge>')} --proof-file {replacement.get('canary_proof_path', '<canary-proof-path>')}",
+        f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --lineage-id {replacement.get('lineage_id', '<lineage-id>')} --rollover-id {replacement.get('rollover_id', '<rollover-id>')} --new-thread-id <replacement-thread-id> --canary-proof {replacement.get('canary_proof_path', '<canary-proof-path>')}",
         "```",
         "",
         "Do not delete the old heartbeat automation before this confirmation.",
@@ -786,10 +967,7 @@ def inspect_codex_home(codex_home: Path) -> dict[str, Any]:
         except sqlite3.Error as exc:
             result["sqlite_error"] = f"{type(exc).__name__}: {exc}"
 
-    codex_help = run_command(["codex", "exec", "resume", "--help"], cwd=Path.cwd(), timeout_s=5)
-    result["codex_exec_resume_available"] = codex_help.returncode == 0
-    if codex_help.returncode != 0:
-        result["codex_exec_resume_error"] = codex_help.stderr or codex_help.stdout
+    result["history_resume_used"] = False
     return result
 
 
@@ -811,6 +989,8 @@ def check_state(
         warnings.append(str(state["state_error"]))
 
     facts.append(f"active_generation={active.get('generation', 'unknown')}")
+    facts.append(f"lineage_id={state.get('lineage_id', 'unknown')}")
+    facts.append(f"rollover_id={replacement.get('rollover_id', 'none')}")
     facts.append(f"replacement_status={replacement.get('status', 'none')}")
     facts.append(f"old_automation_ready_to_delete={cleanup.get('old_automation_ready_to_delete', False)}")
 
@@ -837,24 +1017,31 @@ def cmd_prepare(args: argparse.Namespace) -> int:
     repo_root = Path(args.repo_root).resolve()
     now = utc_now()
     agent = normalize_agent_name(args.agent)
-    state_file = args.state_file or default_state_path(agent)
-    bootstrap_file = args.bootstrap_file or default_bootstrap_path(agent)
-    handoff_file = args.handoff_file or default_thread_handoff_path(agent)
+    active_thread_id = args.active_thread_id or active_thread_id_from_env()
+    if not active_thread_id:
+        print(json.dumps({
+            "error": "--active-thread-id (or CODEX_THREAD_ID) is required for a v2 rollover",
+            "agent": agent,
+        }, indent=2))
+        return 2
+    lineage_id = args.lineage_id or lineage_id_for(agent, active_thread_id)
+    state_file = args.state_file or default_state_path(agent, lineage_id)
     role_handoff_file = default_handoff_path(agent)
     router_file = args.current_file or DEFAULT_ROUTER_PATH
-    state_path = repo_root / state_file
-    bootstrap_path = repo_root / bootstrap_file
-    handoff_path = repo_root / handoff_file
+    try:
+        state_path = repo_local_path(repo_root, state_file)
+        router_path = repo_local_path(repo_root, router_file)
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc), "agent": agent}, indent=2))
+        return 2
     role_handoff_path = repo_root / role_handoff_file
-    router_path = repo_root / router_file
 
     if args.write_current and not args.allow_git_router:
         print(json.dumps({
             "error": "--write-current is disabled by default because docs/session-state/current.md is git-tracked. "
             "Use the default .agent/ handoff files for thread rollover, or pass --allow-git-router only for an explicitly approved compatibility-router update.",
             "agent": agent,
-            "thread_handoff_file": rel(handoff_path, repo_root),
-            "bootstrap_file": rel(bootstrap_path, repo_root),
+            "state_file": rel(state_path, repo_root),
         }, indent=2))
         return 2
 
@@ -868,23 +1055,50 @@ def cmd_prepare(args: argparse.Namespace) -> int:
             "schema_version": SCHEMA_VERSION,
             "reset_from_error": state_error["error"],
         }
-    prepared_state = prepare_state(
-        state,
-        agent=agent,
-        now=now,
-        active_thread_id=args.active_thread_id,
-        active_automation_id=args.active_automation_id,
-        bootstrap_path=Path(bootstrap_file),
-        context_percent=args.context_percent,
-        force_new_replacement=args.force_new_replacement,
-    )
+    if state.get("schema_version") == 1:
+        if not args.migrate_v1:
+            print(json.dumps(migration_error(state, state_path, repo_root), indent=2))
+            return 2
+        try:
+            state = migrate_v1_state(state, agent=agent, lineage_id=lineage_id, now=now)
+        except ValueError as exc:
+            print(json.dumps({"error": str(exc), "state_file": rel(state_path, repo_root)}, indent=2))
+            return 2
+    if state.get("agent") and state["agent"] != agent:
+        print(json.dumps({
+            "error": "state agent does not match --agent",
+            "state_file": rel(state_path, repo_root),
+        }, indent=2))
+        return 2
+    if state.get("lineage_id") and state["lineage_id"] != lineage_id:
+        print(json.dumps({
+            "error": "state lineage does not match --lineage-id/active thread identity",
+            "state_file": rel(state_path, repo_root),
+        }, indent=2))
+        return 2
+    try:
+        prepared_state = prepare_state(
+            state,
+            agent=agent,
+            now=now,
+            active_thread_id=active_thread_id,
+            active_automation_id=args.active_automation_id,
+            context_percent=args.context_percent,
+            force_new_replacement=args.force_new_replacement,
+        )
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc), "state_file": rel(state_path, repo_root)}, indent=2))
+        return 2
+    replacement = prepared_state["replacement"]
+    bootstrap_path = repo_root / replacement["bootstrap_prompt_path"]
+    handoff_path = repo_root / replacement["handoff_path"]
     snapshot = gather_snapshot(repo_root, args.monitor_base_url)
     prompt = render_bootstrap_prompt(
         snapshot,
         prepared_state,
         agent=agent,
         router_path=Path(router_file),
-        handoff_path=Path(handoff_file),
+        handoff_path=Path(replacement["handoff_path"]),
         role_handoff_path=Path(role_handoff_file),
         context_threshold=args.context_threshold,
     )
@@ -905,10 +1119,12 @@ def cmd_prepare(args: argparse.Namespace) -> int:
         output = {
             "dry_run": True,
             "agent": agent,
-            "state_file": state_path.as_posix(),
-            "bootstrap_file": bootstrap_path.as_posix(),
-            "handoff_file": handoff_path.as_posix(),
-            "thread_handoff_file": handoff_path.as_posix(),
+            "lineage_id": lineage_id,
+            "rollover_id": replacement["rollover_id"],
+            "state_file": rel(state_path, repo_root),
+            "bootstrap_file": rel(bootstrap_path, repo_root),
+            "handoff_file": rel(handoff_path, repo_root),
+            "thread_handoff_file": rel(handoff_path, repo_root),
             "role_handoff_file": role_handoff_path.as_posix(),
             "router_file": router_path.as_posix(),
             "current_file": router_path.as_posix(),
@@ -919,19 +1135,19 @@ def cmd_prepare(args: argparse.Namespace) -> int:
         print(json.dumps(output, indent=2))
         return 0
 
-    bootstrap_path.parent.mkdir(parents=True, exist_ok=True)
-    bootstrap_path.write_text(prompt, encoding="utf-8")
-    handoff_path.parent.mkdir(parents=True, exist_ok=True)
-    handoff_path.write_text(handoff_md, encoding="utf-8")
+    write_text_atomic(bootstrap_path, prompt)
+    write_text_atomic(handoff_path, handoff_md)
     write_json_atomic(state_path, prepared_state)
     wrote_router = False
     if args.write_current:
-        router_path.parent.mkdir(parents=True, exist_ok=True)
-        router_path.write_text(router_md, encoding="utf-8")
+        write_text_atomic(router_path, router_md)
         wrote_router = True
 
     output = {
         "agent": agent,
+        "lineage_id": lineage_id,
+        "rollover_id": replacement["rollover_id"],
+        "runtime_path": replacement["runtime_path"],
         "state_file": rel(state_path, repo_root),
         "bootstrap_file": rel(bootstrap_path, repo_root),
         "handoff_file": rel(handoff_path, repo_root),
@@ -949,11 +1165,31 @@ def cmd_prepare(args: argparse.Namespace) -> int:
 def cmd_confirm_started(args: argparse.Namespace) -> int:
     repo_root = Path(args.repo_root).resolve()
     agent = normalize_agent_name(args.agent)
-    state_path = repo_root / (args.state_file or default_state_path(agent))
+    if not args.lineage_id and not args.state_file:
+        print(json.dumps({"error": "--lineage-id or --state-file is required to locate an isolated rollover"}, indent=2))
+        return 2
+    lineage_id = args.lineage_id
+    try:
+        state_path = repo_local_path(repo_root, args.state_file or default_state_path(agent, lineage_id))
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc), "agent": agent}, indent=2))
+        return 2
     state = load_state(state_path)
     state_error = state_error_payload(state, state_path, repo_root)
     if state_error:
         print(json.dumps(state_error, indent=2))
+        return 2
+    if args.rollover_id != (state.get("replacement") or {}).get("rollover_id"):
+        print(json.dumps({"error": "--rollover-id does not match the isolated pending rollover"}, indent=2))
+        return 2
+    expected_proof = repo_local_path(repo_root, Path(state["replacement"]["canary_proof_path"]))
+    try:
+        supplied_proof = repo_local_path(repo_root, args.canary_proof)
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc), "agent": agent}, indent=2))
+        return 2
+    if supplied_proof != expected_proof:
+        print(json.dumps({"error": "--canary-proof must be the proof path reserved by this rollover"}, indent=2))
         return 2
     try:
         confirmed = confirm_started(
@@ -962,6 +1198,7 @@ def cmd_confirm_started(args: argparse.Namespace) -> int:
             new_automation_id=args.new_automation_id,
             confirmed_by=args.confirmed_by,
             now=utc_now(),
+            canary_proof=supplied_proof,
         )
     except ValueError as exc:
         print(json.dumps({"error": str(exc)}, indent=2))
@@ -969,6 +1206,8 @@ def cmd_confirm_started(args: argparse.Namespace) -> int:
     write_json_atomic(state_path, confirmed)
     print(json.dumps({
         "agent": agent,
+        "lineage_id": confirmed.get("lineage_id"),
+        "rollover_id": confirmed["replacement"]["rollover_id"],
         "state_file": rel(state_path, repo_root),
         "replacement_status": confirmed["replacement"]["status"],
         "replacement_thread_id": confirmed["replacement"]["thread_id"],
@@ -977,10 +1216,56 @@ def cmd_confirm_started(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_resume(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).resolve()
+    agent = normalize_agent_name(args.agent)
+    if not args.lineage_id and not args.state_file:
+        print(json.dumps({"error": "--lineage-id or --state-file is required to locate an isolated rollover"}, indent=2))
+        return 2
+    try:
+        state_path = repo_local_path(repo_root, args.state_file or default_state_path(agent, args.lineage_id))
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc), "agent": agent}, indent=2))
+        return 2
+    state = load_state(state_path)
+    state_error = state_error_payload(state, state_path, repo_root)
+    if state_error:
+        print(json.dumps(state_error, indent=2))
+        return 2
+    try:
+        resumed = resume_state(
+            state,
+            rollover_id=args.rollover_id,
+            replacement_thread_id=args.replacement_thread_id,
+            now=utc_now(),
+        )
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc), "state_file": rel(state_path, repo_root)}, indent=2))
+        return 2
+    write_json_atomic(state_path, resumed)
+    replacement = resumed["replacement"]
+    print(json.dumps({
+        "agent": agent,
+        "lineage_id": resumed.get("lineage_id"),
+        "rollover_id": replacement["rollover_id"],
+        "replacement_thread_id": replacement["resumed_thread_id"],
+        "canary_proof_file": replacement["canary_proof_path"],
+        "status": replacement["status"],
+    }, indent=2))
+    return 0
+
+
 def cmd_check(args: argparse.Namespace) -> int:
     repo_root = Path(args.repo_root).resolve()
     agent = normalize_agent_name(args.agent)
-    state_path = repo_root / (args.state_file or default_state_path(agent))
+    if not args.lineage_id and not args.state_file:
+        print(json.dumps({"error": "--lineage-id or --state-file is required to locate an isolated rollover"}, indent=2))
+        return 2
+    try:
+        state_path = repo_local_path(repo_root, args.state_file or default_state_path(agent, args.lineage_id))
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc), "agent": agent}, indent=2))
+        return 2
     state = load_state(state_path)
     facts, warnings = check_state(
         state,
@@ -1010,15 +1295,15 @@ def build_parser() -> argparse.ArgumentParser:
 
     prepare = subparsers.add_parser("prepare", help="Prepare a rollover handoff and bootstrap prompt.")
     prepare.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    prepare.add_argument("--lineage-id", type=argparse_lineage_id, help="Optional stable isolation key; otherwise derived from --active-thread-id.")
     prepare.add_argument("--state-file", type=Path)
-    prepare.add_argument("--bootstrap-file", type=Path)
-    prepare.add_argument("--handoff-file", type=Path, help="Override the local thread rollover handoff path.")
     prepare.add_argument("--current-file", type=Path, help="Override the shared docs/session-state/current.md router.")
     prepare.add_argument("--active-thread-id")
     prepare.add_argument("--active-automation-id")
     prepare.add_argument("--context-percent", type=float)
     prepare.add_argument("--context-threshold", type=float, default=DEFAULT_CONTEXT_THRESHOLD)
     prepare.add_argument("--force-new-replacement", action="store_true")
+    prepare.add_argument("--migrate-v1", action="store_true", help="Explicitly migrate a v1 lease into a fresh v2 rollover.")
     prepare.add_argument(
         "--force-reset-state",
         action="store_true",
@@ -1039,14 +1324,29 @@ def build_parser() -> argparse.ArgumentParser:
 
     confirm = subparsers.add_parser("confirm-started", help="Confirm that the replacement agent thread is running.")
     confirm.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    confirm.add_argument("--lineage-id", type=argparse_lineage_id)
     confirm.add_argument("--state-file", type=Path)
+    confirm.add_argument("--rollover-id", required=True)
     confirm.add_argument("--new-thread-id", required=True)
     confirm.add_argument("--new-automation-id")
+    confirm.add_argument("--canary-proof", type=Path, required=True)
     confirm.add_argument("--confirmed-by", default=os.environ.get("USER", "operator"))
     confirm.set_defaults(func=cmd_confirm_started)
 
+    resume = subparsers.add_parser(
+        "resume",
+        help="Bind a new thread to a prepared local rollover packet; never provider conversation history.",
+    )
+    resume.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    resume.add_argument("--lineage-id", type=argparse_lineage_id)
+    resume.add_argument("--state-file", type=Path)
+    resume.add_argument("--rollover-id", required=True)
+    resume.add_argument("--replacement-thread-id", required=True)
+    resume.set_defaults(func=cmd_resume)
+
     check = subparsers.add_parser("check", help="Detect stale or unsafe handoff state.")
     check.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    check.add_argument("--lineage-id", type=argparse_lineage_id)
     check.add_argument("--state-file", type=Path)
     check.add_argument("--stale-hours", type=float, default=DEFAULT_STALE_HOURS)
     check.add_argument("--context-percent", type=float)

--- a/scripts/orchestration/thread_handoff_canary.py
+++ b/scripts/orchestration/thread_handoff_canary.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+"""Create and validate local proof for a thread-handoff replacement.
+
+This is deliberately a small, offline protocol.  It proves that the new
+thread supplied the challenge contained in its own rollover packet; it never
+forks, continues, or resumes a provider conversation or its history.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+STATUS_PASS = "PASS"
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC).replace(microsecond=0)
+
+
+def isoformat_z(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def challenge_digest(challenge: str) -> str:
+    return hashlib.sha256(challenge.encode("utf-8")).hexdigest()
+
+
+def build_pass_proof(
+    *,
+    rollover_id: str,
+    replacement_thread_id: str,
+    challenge: str,
+    now: datetime,
+) -> dict[str, Any]:
+    if not rollover_id.strip() or not replacement_thread_id.strip() or not challenge.strip():
+        raise ValueError("rollover id, replacement thread id, and challenge are required")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": STATUS_PASS,
+        "rollover_id": rollover_id.strip(),
+        "replacement_thread_id": replacement_thread_id.strip(),
+        "challenge_sha256": challenge_digest(challenge.strip()),
+        "proven_at": isoformat_z(now),
+        "proven_by": "scripts/orchestration/thread_handoff_canary.py",
+    }
+
+
+def validate_pass_proof(
+    payload: Any,
+    *,
+    rollover_id: str,
+    replacement_thread_id: str,
+    challenge: str,
+) -> str | None:
+    if not isinstance(payload, dict):
+        return "canary proof must be a JSON object"
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        return "canary proof schema version is unsupported"
+    if payload.get("status") != STATUS_PASS:
+        return "canary proof did not report PASS"
+    if payload.get("proven_by") != "scripts/orchestration/thread_handoff_canary.py":
+        return "canary proof was not produced by the thread handoff canary script"
+    if payload.get("rollover_id") != rollover_id:
+        return "canary proof rollover_id does not match the pending rollover"
+    if payload.get("replacement_thread_id") != replacement_thread_id:
+        return "canary proof replacement_thread_id does not match --new-thread-id"
+    if payload.get("challenge_sha256") != challenge_digest(challenge):
+        return "canary proof challenge does not match the pending rollover"
+    return None
+
+
+def load_and_validate_pass_proof(
+    path: Path,
+    *,
+    rollover_id: str,
+    replacement_thread_id: str,
+    challenge: str,
+) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"cannot read canary proof: {type(exc).__name__}: {exc}"
+    error = validate_pass_proof(
+        payload,
+        rollover_id=rollover_id,
+        replacement_thread_id=replacement_thread_id,
+        challenge=challenge,
+    )
+    return payload if error is None else None, error
+
+
+def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rollover-id", required=True)
+    parser.add_argument("--replacement-thread-id", required=True)
+    parser.add_argument("--challenge", required=True)
+    parser.add_argument("--proof-file", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        proof = build_pass_proof(
+            rollover_id=args.rollover_id,
+            replacement_thread_id=args.replacement_thread_id,
+            challenge=args.challenge,
+            now=utc_now(),
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
+    write_json_atomic(args.proof_file, proof)
+    print(json.dumps({"status": STATUS_PASS, "proof_file": args.proof_file.as_posix()}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
+import subprocess
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -15,21 +17,501 @@ def sample_snapshot(tmp_path: Path) -> dict:
     return {
         "generated_at": "2026-05-30T08:00:00Z",
         "git": {
-            "repo_root": str(tmp_path), "branch": "main", "head": "abc123def0",
-            "full_head": "abc123def0456789", "ahead_behind": None,
-            "last_commits": [], "modified_files": [],
+            "repo_root": str(tmp_path),
+            "branch": "main",
+            "head": "abc123def0",
+            "full_head": "abc123def0456789",
+            "ahead_behind": {"ahead": 1, "behind": 0, "upstream": "origin/main"},
+            "last_commits": [
+                {"sha": "abc123def0", "subject": "docs(session): handoff"},
+                {"sha": "1111111111", "subject": "feat(api): monitor"},
+            ],
+            "modified_files": [
+                {"status": "M", "path": "docs/session-state/current.md"},
+            ],
         },
-        "monitor": {"base_url": "http://127.0.0.1:8765", "orient": {}, "active_delegates": {"total": 0, "tasks": []}, "completed_delegates": {"total": 0, "tasks": []}, "worktrees": {"count": 0, "worktrees": []}},
-        "github": {"open_prs": [], "open_issues": []},
+        "monitor": {
+            "base_url": "http://127.0.0.1:8765",
+            "orient": {"git": {"head": "abc123def0"}},
+            "active_delegates": {"total": 0, "tasks": []},
+            "completed_delegates": {
+                "total": 1,
+                "tasks": [{"task_id": "codex/example", "agent": "codex", "status": "done", "duration_s": 42}],
+            },
+            "worktrees": {"count": 2, "worktrees": []},
+        },
+        "github": {
+            "open_prs": [
+                {
+                    "number": 12,
+                    "title": "feat: example",
+                    "headRefName": "codex/example",
+                    "mergeStateStatus": "CLEAN",
+                    "isDraft": False,
+                }
+            ],
+            "open_issues": [
+                {"number": 34, "title": "Need handoff", "updatedAt": "2026-05-30T07:00:00Z"},
+            ],
+        },
     }
 
 
 def prepared(*, agent: str = "orchestrator", thread_id: str = "old-thread") -> dict:
     return th.prepare_state(
-        {"schema_version": th.SCHEMA_VERSION}, agent=agent,
-        now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC), active_thread_id=thread_id,
-        active_automation_id="old-auto", context_percent=86.0, force_new_replacement=False,
+        {"schema_version": th.SCHEMA_VERSION},
+        agent=agent,
+        now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC),
+        active_thread_id=thread_id,
+        active_automation_id="old-auto",
+        context_percent=86.0,
+        force_new_replacement=False,
     )
+
+
+def resumed_with_proof(tmp_path: Path, state: dict, thread_id: str = "new-thread") -> tuple[dict, Path]:
+    replacement = state["replacement"]
+    resumed = th.resume_state(
+        state,
+        rollover_id=replacement["rollover_id"],
+        replacement_thread_id=thread_id,
+        now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
+    )
+    proof_path = tmp_path / "canary-pass.json"
+    canary.write_json_atomic(
+        proof_path,
+        canary.build_pass_proof(
+            rollover_id=replacement["rollover_id"],
+            replacement_thread_id=thread_id,
+            challenge=replacement["canary_challenge"],
+            now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
+        ),
+    )
+    return resumed, proof_path
+
+
+def test_prepare_state_requires_confirmation_before_cleanup(tmp_path: Path):
+    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
+    state = prepared()
+
+    assert state["active"]["thread_id"] == "old-thread"
+    assert state["active"]["automation_id"] == "old-auto"
+    assert state["replacement"]["status"] == "pending_start"
+    assert state["cleanup"]["old_automation_ready_to_delete"] is False
+
+    resumed, proof_path = resumed_with_proof(tmp_path, state)
+    confirmed = th.confirm_started(
+        resumed,
+        new_thread_id="new-thread",
+        new_automation_id=None,
+        confirmed_by="tester",
+        now=now + timedelta(minutes=2),
+        canary_proof=proof_path,
+    )
+    assert confirmed["replacement"]["status"] == "started"
+    assert confirmed["replacement"]["thread_id"] == "new-thread"
+    assert confirmed["cleanup"]["old_automation_ready_to_delete"] is True
+
+
+def test_confirm_started_rejects_missing_pending_replacement():
+    with pytest.raises(ValueError, match="run prepare first"):
+        th.confirm_started(
+            {},
+            new_thread_id="new-thread",
+            new_automation_id=None,
+            confirmed_by="tester",
+            now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC),
+            canary_proof=Path("missing-proof.json"),
+        )
+
+
+def test_render_bootstrap_prompt_contains_guardrails(tmp_path: Path):
+    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
+    state = prepared()
+    prompt = th.render_bootstrap_prompt(sample_snapshot(tmp_path), state, context_threshold=82.0)
+
+    assert "You are the replacement Codex orchestrator thread." in prompt
+    assert "Role handoff: docs/session-state/codex-orchestrator-handoff.md" in prompt
+    assert "Thread handoff: .agent/thread-rollovers/" in prompt
+    assert "Global router:" not in prompt
+    assert "Do not write docs/session-state/current.md for thread rollover." in prompt
+    assert "git status --short --branch" in prompt
+    assert "issue_stream_audit.py --json" in prompt
+    assert "git worktree list" in prompt
+    assert "confirm-started --agent orchestrator --lineage-id" in prompt
+    assert "Only after that command reports old_automation_ready_to_delete=true" in prompt
+    assert "Context estimate: 86.0% (ROLL OVER NOW; threshold 82.0%)." in prompt
+    assert "orchestrator_control.py inbox --recent 20 --include-results" in prompt
+
+
+def test_render_current_markdown_includes_required_handoff_sections(tmp_path: Path):
+    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
+    state = prepared()
+    rendered = th.render_current_markdown(sample_snapshot(tmp_path), state, context_threshold=82.0)
+
+    assert "## Thread Lease" in rendered
+    assert "## Git State" in rendered
+    assert "### Last 5 Commits" in rendered
+    assert "### Modified Files" in rendered
+    assert "## Open PRs" in rendered
+    assert "## Delegated Tasks" in rendered
+    assert "## First-Turn Checklist" in rendered
+    assert "issue_stream_audit.py --json" in rendered
+    assert "confirm-started --agent orchestrator --lineage-id" in rendered
+    assert "orchestrator_control.py inbox --recent 20 --include-results" in rendered
+    assert "Durable role handoff: `docs/session-state/codex-orchestrator-handoff.md`" in rendered
+
+
+def test_render_bootstrap_prompt_for_codex_uses_orchestrator_pointer(tmp_path: Path):
+    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
+    state = prepared(agent="codex")
+    prompt = th.render_bootstrap_prompt(
+        sample_snapshot(tmp_path),
+        state,
+        agent="codex",
+        context_threshold=82.0,
+    )
+
+    assert "You are the replacement codex thread." in prompt
+    assert "Role handoff: docs/session-state/current.orchestrator.md" in prompt
+    assert "Thread handoff: .agent/thread-rollovers/" in prompt
+    assert "issue_stream_audit.py --json" in prompt
+    assert "git worktree list" in prompt
+
+
+def test_render_current_markdown_for_codex_uses_orchestrator_pointer(tmp_path: Path):
+    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
+    state = prepared(agent="codex")
+    rendered = th.render_current_markdown(
+        sample_snapshot(tmp_path),
+        state,
+        agent="codex",
+        context_threshold=82.0,
+    )
+
+    assert "## First-Turn Checklist" in rendered
+    assert "Durable role handoff: `docs/session-state/current.orchestrator.md`" in rendered
+    assert "confirm-started --agent codex --lineage-id" in rendered
+
+
+def test_render_router_markdown_contains_parseable_markers():
+    rendered = th.render_router_markdown(
+        generated_at="2026-05-30T08:00:00Z",
+        default_agent="orchestrator",
+        agents=["orchestrator", "codex", "claude", "gemini"],
+    )
+
+    assert "Latest-Brief: docs/session-state/codex-orchestrator-handoff.md" in rendered
+    assert "Agent-Handoff:" in rendered
+    assert "- orchestrator: docs/session-state/codex-orchestrator-handoff.md" in rendered
+    assert "- codex: docs/session-state/current.orchestrator.md" in rendered
+    assert len(rendered.encode("utf-8")) < 1200
+
+
+def test_default_agent_paths_are_agent_specific():
+    lineage_id = th.lineage_id_for("claude", "old-thread")
+    rollover_id = "rollover-example"
+    expected_runtime = Path(".agent/thread-rollovers/claude") / lineage_id / "generation-0001" / rollover_id
+    assert th.default_state_path("claude", lineage_id) == (
+        Path(".agent/thread-rollovers/claude") / lineage_id / "lease.json"
+    )
+    assert th.default_bootstrap_path("claude", lineage_id, 1, rollover_id) == expected_runtime / "bootstrap.md"
+    assert th.default_thread_handoff_path("claude", lineage_id, 1, rollover_id) == expected_runtime / "handoff.md"
+    assert th.default_handoff_path("orchestrator") == Path("docs/session-state/codex-orchestrator-handoff.md")
+    assert th.default_handoff_path("codex") == Path("docs/session-state/current.orchestrator.md")
+    assert th.default_handoff_path("claude") == Path("docs/session-state/current.claude.md")
+
+
+def test_prepare_orchestrator_writes_only_local_thread_handoff_by_default(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+):
+    monkeypatch.setattr(th, "gather_snapshot", lambda repo_root, base_url: sample_snapshot(repo_root))
+
+    rc = th.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "prepare",
+            "--agent",
+            "orchestrator",
+            "--context-percent",
+            "86",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["agent"] == "orchestrator"
+    assert payload["state_file"].startswith(".agent/thread-rollovers/orchestrator/")
+    assert payload["bootstrap_file"].endswith("/bootstrap.md")
+    assert payload["handoff_file"].endswith("/handoff.md")
+    assert payload["thread_handoff_file"] == payload["handoff_file"]
+    assert payload["role_handoff_file"] == "docs/session-state/codex-orchestrator-handoff.md"
+    assert payload["router_file"] is None
+    assert not (tmp_path / "docs/session-state/current.md").exists()
+    assert "## Thread Lease" in (tmp_path / payload["handoff_file"]).read_text(encoding="utf-8")
+
+
+def test_prepare_rejects_write_current_without_explicit_router_unlock(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+):
+    monkeypatch.setattr(th, "gather_snapshot", lambda repo_root, base_url: sample_snapshot(repo_root))
+
+    rc = th.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "prepare",
+            "--agent",
+            "orchestrator",
+            "--active-thread-id",
+            "old-thread",
+            "--write-current",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert "--write-current is disabled by default" in payload["error"]
+    assert payload["state_file"].startswith(".agent/thread-rollovers/orchestrator/")
+    assert not (tmp_path / "docs/session-state/current.md").exists()
+    assert not (tmp_path / payload["state_file"]).exists()
+
+
+def test_prepare_writes_router_only_when_explicitly_unlocked(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+):
+    monkeypatch.setattr(th, "gather_snapshot", lambda repo_root, base_url: sample_snapshot(repo_root))
+
+    rc = th.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "prepare",
+            "--agent",
+            "orchestrator",
+            "--active-thread-id",
+            "old-thread",
+            "--write-current",
+            "--allow-git-router",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["router_file"] == "docs/session-state/current.md"
+    assert "Latest-Brief: docs/session-state/codex-orchestrator-handoff.md" in (
+        tmp_path / "docs/session-state/current.md"
+    ).read_text(encoding="utf-8")
+
+
+def test_prepare_non_orchestrator_does_not_clobber_router_or_orchestrator_handoff(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+):
+    session_dir = tmp_path / "docs/session-state"
+    session_dir.mkdir(parents=True)
+    router_path = session_dir / "current.md"
+    orchestrator_path = session_dir / "codex-orchestrator-handoff.md"
+    claude_path = session_dir / "current.claude.md"
+    router_path.write_text("router stays\n", encoding="utf-8")
+    orchestrator_path.write_text("orchestrator stays\n", encoding="utf-8")
+    claude_path.write_text("claude role stays\n", encoding="utf-8")
+    monkeypatch.setattr(th, "gather_snapshot", lambda repo_root, base_url: sample_snapshot(repo_root))
+
+    rc = th.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "prepare",
+            "--agent",
+            "claude",
+            "--active-thread-id",
+            "old-thread",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["agent"] == "claude"
+    assert payload["router_file"] is None
+    assert router_path.read_text(encoding="utf-8") == "router stays\n"
+    assert orchestrator_path.read_text(encoding="utf-8") == "orchestrator stays\n"
+    assert claude_path.read_text(encoding="utf-8") == "claude role stays\n"
+    assert (tmp_path / payload["handoff_file"]).is_file()
+    assert (tmp_path / payload["state_file"]).is_file()
+    assert (tmp_path / payload["bootstrap_file"]).is_file()
+
+
+def test_confirm_started_is_scoped_to_selected_agent(tmp_path: Path, capsys):
+    orchestrator_state = prepared(thread_id="old-orchestrator")
+    claude_state = prepared(agent="claude", thread_id="old-claude")
+    orchestrator_path = tmp_path / th.default_state_path("orchestrator", orchestrator_state["lineage_id"])
+    claude_path = tmp_path / th.default_state_path("claude", claude_state["lineage_id"])
+    th.write_json_atomic(orchestrator_path, orchestrator_state)
+    resumed = th.resume_state(
+        claude_state,
+        rollover_id=claude_state["replacement"]["rollover_id"],
+        replacement_thread_id="new-claude",
+        now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
+    )
+    proof_path = tmp_path / resumed["replacement"]["canary_proof_path"]
+    canary.write_json_atomic(
+        proof_path,
+        canary.build_pass_proof(
+            rollover_id=resumed["replacement"]["rollover_id"],
+            replacement_thread_id="new-claude",
+            challenge=resumed["replacement"]["canary_challenge"],
+            now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
+        ),
+    )
+    th.write_json_atomic(claude_path, resumed)
+
+    rc = th.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "confirm-started",
+            "--agent",
+            "claude",
+            "--lineage-id",
+            resumed["lineage_id"],
+            "--rollover-id",
+            resumed["replacement"]["rollover_id"],
+            "--new-thread-id",
+            "new-claude",
+            "--canary-proof",
+            str(proof_path),
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["agent"] == "claude"
+    assert payload["state_file"] == claude_path.relative_to(tmp_path).as_posix()
+    confirmed_claude = json.loads(claude_path.read_text(encoding="utf-8"))
+    untouched_orchestrator = json.loads(orchestrator_path.read_text(encoding="utf-8"))
+    assert confirmed_claude["replacement"]["thread_id"] == "new-claude"
+    assert confirmed_claude["cleanup"]["old_automation_ready_to_delete"] is True
+    assert untouched_orchestrator["cleanup"]["old_automation_ready_to_delete"] is False
+
+
+def test_confirm_started_missing_agent_prepare_is_safe(tmp_path: Path, capsys):
+    rc = th.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "confirm-started",
+            "--agent",
+            "gemini",
+            "--lineage-id",
+            "lineage-missing",
+            "--rollover-id",
+            "rollover-missing",
+            "--new-thread-id",
+            "new-gemini",
+            "--canary-proof",
+            ".agent/missing-proof.json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert "run prepare first" in payload["error"]
+    assert not (tmp_path / th.default_state_path("gemini", "lineage-missing")).exists()
+
+
+def test_check_state_flags_pending_and_stale_replacement():
+    prepared_at = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
+    state = {
+        "active": {"generation": "orchestrator-1", "last_seen_at": th.isoformat_z(prepared_at)},
+        "replacement": {"status": "pending_start", "prepared_at": th.isoformat_z(prepared_at)},
+        "cleanup": {"old_automation_ready_to_delete": False},
+    }
+
+    facts, warnings = th.check_state(
+        state,
+        now=prepared_at + timedelta(hours=13),
+        stale_after=timedelta(hours=12),
+        context_percent=83.0,
+        context_threshold=82.0,
+    )
+
+    assert "active_generation=orchestrator-1" in facts
+    assert any("pending_start" in warning for warning in warnings)
+    assert any("context estimate 83.0%" in warning for warning in warnings)
+    assert any("replacement has been pending" in warning for warning in warnings)
+
+
+def test_check_state_flags_corrupted_state_file():
+    facts, warnings = th.check_state(
+        {"schema_version": th.SCHEMA_VERSION, "state_error": "unreadable state file: bad json"},
+        now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC),
+        stale_after=timedelta(hours=12),
+        context_percent=None,
+        context_threshold=82.0,
+    )
+
+    assert "replacement_status=none" in facts
+    assert warnings == ["unreadable state file: bad json"]
+
+
+def test_prepare_refuses_to_overwrite_corrupted_state_file(tmp_path: Path, capsys, monkeypatch):
+    state_file = Path(".agent/orchestrator-thread-lease.json")
+    state_path = tmp_path / state_file
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text("{not-json", encoding="utf-8")
+    monkeypatch.setattr(th, "gather_snapshot", lambda repo_root, base_url: sample_snapshot(repo_root))
+
+    rc = th.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "prepare",
+            "--state-file",
+            str(state_file),
+            "--active-thread-id",
+            "old-thread",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert "unreadable state file" in payload["error"]
+    assert state_path.read_text(encoding="utf-8") == "{not-json"
+    assert not list((tmp_path / ".agent/thread-rollovers").glob("**/bootstrap.md"))
+
+
+def test_parse_ahead_behind_reports_malformed_output():
+    parsed = th.parse_ahead_behind("not-a-count", "origin/main")
+
+    assert parsed == {
+        "upstream": "origin/main",
+        "parse_error": "unexpected rev-list output: 'not-a-count'",
+    }
+
+
+def test_inspect_codex_home_reports_thread_metadata(tmp_path: Path):
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    db = codex_home / "state_1.sqlite"
+    with sqlite3.connect(db) as conn:
+        conn.execute("create table threads (id text, title text, cwd text, archived integer, updated_at integer)")
+        conn.execute("insert into threads values ('thread-1', 'Example', '/tmp/repo', 0, 100)")
+
+    audit = th.inspect_codex_home(codex_home)
+
+    assert audit["latest_state_db"] == str(db)
+    assert audit["thread_count"] == 1
+    assert audit["recent_threads"][0]["id"] == "thread-1"
+    assert audit["automation_toml_files"] == []
 
 
 def test_v2_state_has_unique_rollover_and_lineage_runtime_paths():
@@ -40,8 +522,7 @@ def test_v2_state_has_unique_rollover_and_lineage_runtime_paths():
     assert replacement["rollover_id"].startswith("rollover-")
     assert replacement["lineage_id"] == th.lineage_id_for("orchestrator", "old-thread")
     assert replacement["runtime_path"] == (
-        ".agent/thread-rollovers/orchestrator/"
-        f"{replacement['lineage_id']}/generation-0001/{replacement['rollover_id']}"
+        f".agent/thread-rollovers/orchestrator/{replacement['lineage_id']}/generation-0001/{replacement['rollover_id']}"
     )
     assert replacement["bootstrap_prompt_path"].startswith(replacement["runtime_path"])
     assert replacement["handoff_path"].startswith(replacement["runtime_path"])
@@ -51,14 +532,22 @@ def test_pending_prepare_refuses_unless_explicitly_forced():
     state = prepared()
     with pytest.raises(ValueError, match="pending rollover"):
         th.prepare_state(
-            state, agent="orchestrator", now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
-            active_thread_id="old-thread", active_automation_id=None, context_percent=None,
+            state,
+            agent="orchestrator",
+            now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
+            active_thread_id="old-thread",
+            active_automation_id=None,
+            context_percent=None,
             force_new_replacement=False,
         )
 
     forced = th.prepare_state(
-        state, agent="orchestrator", now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
-        active_thread_id="old-thread", active_automation_id=None, context_percent=None,
+        state,
+        agent="orchestrator",
+        now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
+        active_thread_id="old-thread",
+        active_automation_id=None,
+        context_percent=None,
         force_new_replacement=True,
     )
     assert forced["replacement"]["rollover_id"] != state["replacement"]["rollover_id"]
@@ -68,194 +557,326 @@ def test_resume_is_deterministic_and_refuses_a_different_thread():
     state = prepared()
     rollover_id = state["replacement"]["rollover_id"]
     resumed = th.resume_state(
-        state, rollover_id=rollover_id, replacement_thread_id="new-thread",
+        state,
+        rollover_id=rollover_id,
+        replacement_thread_id="new-thread",
         now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
     )
     repeated = th.resume_state(
-        resumed, rollover_id=rollover_id, replacement_thread_id="new-thread",
+        resumed,
+        rollover_id=rollover_id,
+        replacement_thread_id="new-thread",
         now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
     )
 
     assert repeated == resumed
     with pytest.raises(ValueError, match="different replacement thread"):
         th.resume_state(
-            resumed, rollover_id=rollover_id, replacement_thread_id="other-thread",
+            resumed,
+            rollover_id=rollover_id,
+            replacement_thread_id="other-thread",
             now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
         )
 
 
 def test_confirm_requires_matching_script_proven_canary_pass(tmp_path: Path):
     state = prepared()
-    replacement = state["replacement"]
-    resumed = th.resume_state(
-        state, rollover_id=replacement["rollover_id"], replacement_thread_id="new-thread",
-        now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
-    )
-    proof_path = tmp_path / "canary-pass.json"
-    canary.write_json_atomic(proof_path, canary.build_pass_proof(
-        rollover_id=replacement["rollover_id"], replacement_thread_id="new-thread",
-        challenge=replacement["canary_challenge"], now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
-    ))
-
+    resumed, proof_path = resumed_with_proof(tmp_path, state)
     confirmed = th.confirm_started(
-        resumed, new_thread_id="new-thread", new_automation_id=None, confirmed_by="tester",
-        now=datetime(2026, 5, 30, 8, 3, tzinfo=UTC), canary_proof=proof_path,
+        resumed,
+        new_thread_id="new-thread",
+        new_automation_id=None,
+        confirmed_by="tester",
+        now=datetime(2026, 5, 30, 8, 3, tzinfo=UTC),
+        canary_proof=proof_path,
     )
     assert confirmed["replacement"]["status"] == "started"
     assert confirmed["cleanup"]["old_automation_ready_to_delete"] is True
 
     wrong_proof = tmp_path / "wrong.json"
-    canary.write_json_atomic(wrong_proof, canary.build_pass_proof(
-        rollover_id="other-rollover", replacement_thread_id="new-thread",
-        challenge=replacement["canary_challenge"], now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
-    ))
+    canary.write_json_atomic(
+        wrong_proof,
+        canary.build_pass_proof(
+            rollover_id="other-rollover",
+            replacement_thread_id="new-thread",
+            challenge=state["replacement"]["canary_challenge"],
+            now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
+        ),
+    )
     with pytest.raises(ValueError, match="script-proven canary PASS"):
         th.confirm_started(
-            resumed, new_thread_id="new-thread", new_automation_id=None, confirmed_by="tester",
-            now=datetime(2026, 5, 30, 8, 3, tzinfo=UTC), canary_proof=wrong_proof,
+            resumed,
+            new_thread_id="new-thread",
+            new_automation_id=None,
+            confirmed_by="tester",
+            now=datetime(2026, 5, 30, 8, 3, tzinfo=UTC),
+            canary_proof=wrong_proof,
         )
 
 
-def test_confirm_refuses_unresumed_or_identity_mismatch(tmp_path: Path):
-    state = prepared()
-    proof_path = tmp_path / "proof.json"
-    replacement = state["replacement"]
-    canary.write_json_atomic(proof_path, canary.build_pass_proof(
-        rollover_id=replacement["rollover_id"], replacement_thread_id="new-thread",
-        challenge=replacement["canary_challenge"], now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
-    ))
-    with pytest.raises(ValueError, match="must be resumed"):
-        th.confirm_started(
-            state, new_thread_id="new-thread", new_automation_id=None, confirmed_by="tester",
-            now=datetime(2026, 5, 30, 8, 3, tzinfo=UTC), canary_proof=proof_path,
-        )
-
-
-def test_v1_state_requires_explicit_migration_and_discards_unverified_replacement(tmp_path: Path, capsys, monkeypatch):
+def test_v1_state_requires_explicit_migration(tmp_path: Path, capsys, monkeypatch):
     state_path = tmp_path / ".agent/legacy.json"
     state_path.parent.mkdir(parents=True)
-    state_path.write_text(json.dumps({"schema_version": 1, "active": {"thread_id": "old-thread"}, "replacement": {"status": "pending_start"}}), encoding="utf-8")
+    state_path.write_text(
+        json.dumps({"schema_version": 1, "active": {"thread_id": "old-thread"}}),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
-    base = ["--repo-root", str(tmp_path), "prepare", "--state-file", ".agent/legacy.json", "--active-thread-id", "old-thread"]
+    command = [
+        "--repo-root",
+        str(tmp_path),
+        "prepare",
+        "--state-file",
+        ".agent/legacy.json",
+        "--active-thread-id",
+        "old-thread",
+    ]
 
-    assert th.main(base) == 2
+    assert th.main(command) == 2
     assert "requires an explicit migration" in json.loads(capsys.readouterr().out)["error"]
-    assert th.main([*base, "--migrate-v1"]) == 0
-    payload = json.loads(capsys.readouterr().out)
-    migrated = json.loads(state_path.read_text(encoding="utf-8"))
-    assert payload["rollover_id"] == migrated["replacement"]["rollover_id"]
-    assert migrated["schema_version"] == 2
-    assert migrated["migrated_from_v1_at"]
+    assert th.main([*command, "--migrate-v1"]) == 0
+    assert json.loads(state_path.read_text(encoding="utf-8"))["schema_version"] == 2
 
 
-def test_prepare_parallel_lineages_do_not_collide(tmp_path: Path, capsys, monkeypatch):
+def test_cli_requires_exact_rollover_and_reserved_canary_proof(tmp_path: Path, capsys, monkeypatch):
     monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
-    outputs = []
-    for thread_id in ("old-a", "old-b"):
-        assert th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", thread_id]) == 0
-        outputs.append(json.loads(capsys.readouterr().out))
-
-    assert outputs[0]["lineage_id"] != outputs[1]["lineage_id"]
-    assert outputs[0]["state_file"] != outputs[1]["state_file"]
-    assert outputs[0]["runtime_path"] != outputs[1]["runtime_path"]
-    assert (tmp_path / outputs[0]["bootstrap_file"]).is_file()
-    assert (tmp_path / outputs[1]["bootstrap_file"]).is_file()
-
-
-def test_cli_requires_the_exact_rollover_and_canary_proof(tmp_path: Path, capsys, monkeypatch):
-    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
-    assert th.main([
-        "--repo-root", str(tmp_path), "prepare", "--active-thread-id", "old-thread",
-    ]) == 0
+    assert th.main(["--repo-root", str(tmp_path), "prepare", "--active-thread-id", "old-thread"]) == 0
     prepared_payload = json.loads(capsys.readouterr().out)
     state_path = tmp_path / prepared_payload["state_file"]
     state = json.loads(state_path.read_text(encoding="utf-8"))
 
-    assert th.main([
-        "--repo-root", str(tmp_path), "resume", "--lineage-id", prepared_payload["lineage_id"],
-        "--rollover-id", prepared_payload["rollover_id"], "--replacement-thread-id", "new-thread",
-    ]) == 0
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "resume",
+                "--lineage-id",
+                prepared_payload["lineage_id"],
+                "--rollover-id",
+                prepared_payload["rollover_id"],
+                "--replacement-thread-id",
+                "new-thread",
+            ]
+        )
+        == 0
+    )
     capsys.readouterr()
     proof_path = tmp_path / state["replacement"]["canary_proof_path"]
-    assert canary.main([
-        "--rollover-id", prepared_payload["rollover_id"], "--replacement-thread-id", "new-thread",
-        "--challenge", state["replacement"]["canary_challenge"], "--proof-file", str(proof_path),
-    ]) == 0
+    assert (
+        canary.main(
+            [
+                "--rollover-id",
+                prepared_payload["rollover_id"],
+                "--replacement-thread-id",
+                "new-thread",
+                "--challenge",
+                state["replacement"]["canary_challenge"],
+                "--proof-file",
+                str(proof_path),
+            ]
+        )
+        == 0
+    )
     capsys.readouterr()
 
-    assert th.main([
-        "--repo-root", str(tmp_path), "confirm-started", "--lineage-id", prepared_payload["lineage_id"],
-        "--rollover-id", prepared_payload["rollover_id"], "--new-thread-id", "new-thread",
-        "--canary-proof", state["replacement"]["canary_proof_path"],
-    ]) == 0
-    confirmed_payload = json.loads(capsys.readouterr().out)
-    assert confirmed_payload["old_automation_ready_to_delete"] is True
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "confirm-started",
+                "--lineage-id",
+                prepared_payload["lineage_id"],
+                "--rollover-id",
+                prepared_payload["rollover_id"],
+                "--new-thread-id",
+                "new-thread",
+                "--canary-proof",
+                state["replacement"]["canary_proof_path"],
+            ]
+        )
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out)["old_automation_ready_to_delete"] is True
 
 
-def test_prepare_retains_router_guard(tmp_path: Path, capsys, monkeypatch):
+def test_default_runtime_root_is_shared_by_real_linked_worktree(tmp_path: Path, capsys, monkeypatch):
+    primary = tmp_path / "primary"
+    linked = tmp_path / "linked"
+    primary.mkdir()
+    git_env = {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    for command in (
+        ["git", "init"],
+        ["git", "config", "user.email", "test@example.invalid"],
+        ["git", "config", "user.name", "Test"],
+    ):
+        subprocess.run(command, cwd=primary, check=True, capture_output=True, text=True, env=git_env)
+    (primary / "README.md").write_text("fixture\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=primary, check=True, capture_output=True, text=True, env=git_env)
+    subprocess.run(
+        ["git", "commit", "-m", "fixture"], cwd=primary, check=True, capture_output=True, text=True, env=git_env
+    )
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "linked", str(linked)],
+        cwd=primary,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=git_env,
+    )
+
+    assert th.canonical_state_root(primary) == primary.resolve()
+    assert th.canonical_state_root(linked) == primary.resolve()
     monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
-    rc = th.main(["--repo-root", str(tmp_path), "prepare", "--active-thread-id", "old-thread", "--write-current"])
-    payload = json.loads(capsys.readouterr().out)
+    monkeypatch.setattr(th, "repo_root_from_file", lambda: linked)
+    assert th.main(["prepare", "--active-thread-id", "same-thread"]) == 0
+    linked_payload = json.loads(capsys.readouterr().out)
+    monkeypatch.setattr(th, "repo_root_from_file", lambda: primary)
+    assert th.main(["prepare", "--active-thread-id", "same-thread"]) == 2
+    primary_payload = json.loads(capsys.readouterr().out)
 
-    assert rc == 2
-    assert "disabled by default" in payload["error"]
-    assert not (tmp_path / "docs/session-state/current.md").exists()
+    expected_lineage = th.lineage_id_for("orchestrator", "same-thread")
+    linked_state_path = th.resolve_state_path(
+        repo_root=linked,
+        state_root=th.canonical_state_root(linked),
+        supplied_state_file=None,
+        default_path=th.default_state_path("orchestrator", expected_lineage),
+    )
+    primary_state_path = th.resolve_state_path(
+        repo_root=primary,
+        state_root=th.canonical_state_root(primary),
+        supplied_state_file=None,
+        default_path=th.default_state_path("orchestrator", expected_lineage),
+    )
+    assert linked_state_path == primary_state_path
+    assert linked_payload["state_file"] == primary_payload["state_file"]
+    assert (primary / linked_payload["state_file"]).is_file()
+    assert (primary / linked_payload["bootstrap_file"]).is_file()
+    assert not (linked / ".agent").exists()
 
 
-def test_prepare_refuses_corrupted_state_without_overwrite(tmp_path: Path, capsys, monkeypatch):
-    state_path = tmp_path / ".agent/corrupt.json"
-    state_path.parent.mkdir(parents=True)
-    state_path.write_text("{not-json", encoding="utf-8")
+def test_canonical_discovery_failure_refuses_fallback_and_explicit_root_is_isolated(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(
+        th,
+        "run_command",
+        lambda *args, **kwargs: th.CommandResult(128, "", "not a repository"),
+    )
+    with pytest.raises(ValueError, match="cannot discover canonical Git common directory"):
+        th.canonical_state_root(tmp_path)
+
+    assert th.resolve_roots(tmp_path) == (tmp_path.resolve(), tmp_path.resolve())
+
+
+def test_parallel_lineages_do_not_collide_in_an_explicit_fixture(tmp_path: Path, capsys, monkeypatch):
     monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    payloads = []
+    for thread_id in ("old-a", "old-b"):
+        assert (
+            th.main(
+                [
+                    "--repo-root",
+                    str(tmp_path),
+                    "prepare",
+                    "--agent",
+                    "codex",
+                    "--active-thread-id",
+                    thread_id,
+                ]
+            )
+            == 0
+        )
+        payloads.append(json.loads(capsys.readouterr().out))
 
-    rc = th.main(["--repo-root", str(tmp_path), "prepare", "--state-file", ".agent/corrupt.json", "--active-thread-id", "old-thread"])
-    assert rc == 2
-    assert "unreadable state file" in json.loads(capsys.readouterr().out)["error"]
-    assert state_path.read_text(encoding="utf-8") == "{not-json"
+    assert payloads[0]["lineage_id"] != payloads[1]["lineage_id"]
+    assert payloads[0]["state_file"] != payloads[1]["state_file"]
+    assert payloads[0]["runtime_path"] != payloads[1]["runtime_path"]
 
 
-def test_bootstrap_explicitly_forbids_history_resume_and_contains_proof_protocol(tmp_path: Path):
+def test_bootstrap_uses_resume_canary_confirm_without_history_resume(tmp_path: Path):
     state = prepared()
-    prompt = th.render_bootstrap_prompt(sample_snapshot(tmp_path), state, context_threshold=82.0)
+    state_root = tmp_path / "canonical"
+    prompt = th.render_bootstrap_prompt(
+        sample_snapshot(tmp_path),
+        state,
+        state_root=state_root,
+        context_threshold=82.0,
+    )
 
     assert "do not fork, continue, or resume provider conversation history" in prompt
+    assert "thread_handoff.py resume" in prompt
     assert "thread_handoff_canary.py" in prompt
-    assert state["replacement"]["rollover_id"] in prompt
-    assert state["replacement"]["canary_challenge"] in prompt
+    assert "thread_handoff.py confirm-started" in prompt
+    assert str(state_root / state["replacement"]["canary_proof_path"]) in prompt
 
 
-def test_check_state_flags_pending_stale_and_corrupt_state():
-    state = prepared()
-    facts, warnings = th.check_state(
-        state, now=datetime(2026, 5, 31, 8, 0, tzinfo=UTC), stale_after=timedelta(hours=12),
-        context_percent=90.0, context_threshold=82.0,
-    )
-    assert any(fact.startswith("rollover_id=rollover-") for fact in facts)
-    assert any("pending_start" in warning for warning in warnings)
-    assert any("context estimate" in warning for warning in warnings)
-
-
-def test_atomic_writer_and_canary_validation_reject_tampering(tmp_path: Path):
+def test_canary_proof_rejects_tampering_after_atomic_write(tmp_path: Path):
     proof_path = tmp_path / "proof.json"
     payload = canary.build_pass_proof(
-        rollover_id="rollover-1", replacement_thread_id="new-thread", challenge="challenge",
+        rollover_id="rollover-1",
+        replacement_thread_id="new-thread",
+        challenge="challenge",
         now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC),
     )
     canary.write_json_atomic(proof_path, payload)
-    assert canary.load_and_validate_pass_proof(proof_path, rollover_id="rollover-1", replacement_thread_id="new-thread", challenge="challenge")[1] is None
+    assert (
+        canary.load_and_validate_pass_proof(
+            proof_path,
+            rollover_id="rollover-1",
+            replacement_thread_id="new-thread",
+            challenge="challenge",
+        )[1]
+        is None
+    )
+
     payload["status"] = "FAIL"
     canary.write_json_atomic(proof_path, payload)
-    assert "did not report PASS" in canary.load_and_validate_pass_proof(proof_path, rollover_id="rollover-1", replacement_thread_id="new-thread", challenge="challenge")[1]
+    assert (
+        "did not report PASS"
+        in canary.load_and_validate_pass_proof(
+            proof_path,
+            rollover_id="rollover-1",
+            replacement_thread_id="new-thread",
+            challenge="challenge",
+        )[1]
+    )
 
 
-def test_inspect_codex_home_does_not_use_history_resume(tmp_path: Path):
-    codex_home = tmp_path / ".codex"
-    codex_home.mkdir()
-    db = codex_home / "state_1.sqlite"
-    with sqlite3.connect(db) as conn:
-        conn.execute("create table threads (id text, title text, cwd text, archived integer, updated_at integer)")
-        conn.execute("insert into threads values ('thread-1', 'Example', '/tmp/repo', 0, 100)")
+def test_confirmation_refuses_unresumed_and_identity_mismatched_rollovers(tmp_path: Path):
+    state = prepared()
+    replacement = state["replacement"]
+    proof_path = tmp_path / "proof.json"
+    canary.write_json_atomic(
+        proof_path,
+        canary.build_pass_proof(
+            rollover_id=replacement["rollover_id"],
+            replacement_thread_id="new-thread",
+            challenge=replacement["canary_challenge"],
+            now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
+        ),
+    )
+    with pytest.raises(ValueError, match="must be resumed"):
+        th.confirm_started(
+            state,
+            new_thread_id="new-thread",
+            new_automation_id=None,
+            confirmed_by="tester",
+            now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
+            canary_proof=proof_path,
+        )
 
-    audit = th.inspect_codex_home(codex_home)
-    assert audit["thread_count"] == 1
-    assert audit["history_resume_used"] is False
+    resumed = th.resume_state(
+        state,
+        rollover_id=replacement["rollover_id"],
+        replacement_thread_id="bound-thread",
+        now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
+    )
+    with pytest.raises(ValueError, match="does not match the thread"):
+        th.confirm_started(
+            resumed,
+            new_thread_id="new-thread",
+            new_automation_id=None,
+            confirmed_by="tester",
+            now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
+            canary_proof=proof_path,
+        )

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -236,6 +236,8 @@ def test_prepare_orchestrator_writes_only_local_thread_handoff_by_default(
             "prepare",
             "--agent",
             "orchestrator",
+            "--active-thread-id",
+            "old-thread",
             "--context-percent",
             "86",
         ]

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -8,486 +8,254 @@ from pathlib import Path
 import pytest
 
 from scripts.orchestration import thread_handoff as th
+from scripts.orchestration import thread_handoff_canary as canary
 
 
 def sample_snapshot(tmp_path: Path) -> dict:
     return {
         "generated_at": "2026-05-30T08:00:00Z",
         "git": {
-            "repo_root": str(tmp_path),
-            "branch": "main",
-            "head": "abc123def0",
-            "full_head": "abc123def0456789",
-            "ahead_behind": {"ahead": 1, "behind": 0, "upstream": "origin/main"},
-            "last_commits": [
-                {"sha": "abc123def0", "subject": "docs(session): handoff"},
-                {"sha": "1111111111", "subject": "feat(api): monitor"},
-            ],
-            "modified_files": [
-                {"status": "M", "path": "docs/session-state/current.md"},
-            ],
+            "repo_root": str(tmp_path), "branch": "main", "head": "abc123def0",
+            "full_head": "abc123def0456789", "ahead_behind": None,
+            "last_commits": [], "modified_files": [],
         },
-        "monitor": {
-            "base_url": "http://127.0.0.1:8765",
-            "orient": {"git": {"head": "abc123def0"}},
-            "active_delegates": {"total": 0, "tasks": []},
-            "completed_delegates": {
-                "total": 1,
-                "tasks": [{"task_id": "codex/example", "agent": "codex", "status": "done", "duration_s": 42}],
-            },
-            "worktrees": {"count": 2, "worktrees": []},
-        },
-        "github": {
-            "open_prs": [
-                {
-                    "number": 12,
-                    "title": "feat: example",
-                    "headRefName": "codex/example",
-                    "mergeStateStatus": "CLEAN",
-                    "isDraft": False,
-                }
-            ],
-            "open_issues": [
-                {"number": 34, "title": "Need handoff", "updatedAt": "2026-05-30T07:00:00Z"},
-            ],
-        },
+        "monitor": {"base_url": "http://127.0.0.1:8765", "orient": {}, "active_delegates": {"total": 0, "tasks": []}, "completed_delegates": {"total": 0, "tasks": []}, "worktrees": {"count": 0, "worktrees": []}},
+        "github": {"open_prs": [], "open_issues": []},
     }
 
 
-def test_prepare_state_requires_confirmation_before_cleanup(tmp_path: Path):
-    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
-    state = th.prepare_state(
-        {},
-        now=now,
-        active_thread_id="old-thread",
-        active_automation_id="old-auto",
-        bootstrap_path=Path(".agent/bootstrap.md"),
-        context_percent=86.0,
-        force_new_replacement=False,
+def prepared(*, agent: str = "orchestrator", thread_id: str = "old-thread") -> dict:
+    return th.prepare_state(
+        {"schema_version": th.SCHEMA_VERSION}, agent=agent,
+        now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC), active_thread_id=thread_id,
+        active_automation_id="old-auto", context_percent=86.0, force_new_replacement=False,
     )
 
-    assert state["active"]["thread_id"] == "old-thread"
-    assert state["active"]["automation_id"] == "old-auto"
-    assert state["replacement"]["status"] == "pending_start"
-    assert state["cleanup"]["old_automation_ready_to_delete"] is False
 
-    confirmed = th.confirm_started(
-        state,
-        new_thread_id="new-thread",
-        new_automation_id=None,
-        confirmed_by="tester",
-        now=now + timedelta(minutes=2),
+def test_v2_state_has_unique_rollover_and_lineage_runtime_paths():
+    state = prepared()
+    replacement = state["replacement"]
+
+    assert state["schema_version"] == 2
+    assert replacement["rollover_id"].startswith("rollover-")
+    assert replacement["lineage_id"] == th.lineage_id_for("orchestrator", "old-thread")
+    assert replacement["runtime_path"] == (
+        ".agent/thread-rollovers/orchestrator/"
+        f"{replacement['lineage_id']}/generation-0001/{replacement['rollover_id']}"
     )
-    assert confirmed["replacement"]["status"] == "started"
-    assert confirmed["replacement"]["thread_id"] == "new-thread"
-    assert confirmed["cleanup"]["old_automation_ready_to_delete"] is True
+    assert replacement["bootstrap_prompt_path"].startswith(replacement["runtime_path"])
+    assert replacement["handoff_path"].startswith(replacement["runtime_path"])
 
 
-def test_confirm_started_rejects_missing_pending_replacement():
-    with pytest.raises(ValueError, match="run prepare first"):
-        th.confirm_started(
-            {},
-            new_thread_id="new-thread",
-            new_automation_id=None,
-            confirmed_by="tester",
-            now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC),
+def test_pending_prepare_refuses_unless_explicitly_forced():
+    state = prepared()
+    with pytest.raises(ValueError, match="pending rollover"):
+        th.prepare_state(
+            state, agent="orchestrator", now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
+            active_thread_id="old-thread", active_automation_id=None, context_percent=None,
+            force_new_replacement=False,
+        )
+
+    forced = th.prepare_state(
+        state, agent="orchestrator", now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
+        active_thread_id="old-thread", active_automation_id=None, context_percent=None,
+        force_new_replacement=True,
+    )
+    assert forced["replacement"]["rollover_id"] != state["replacement"]["rollover_id"]
+
+
+def test_resume_is_deterministic_and_refuses_a_different_thread():
+    state = prepared()
+    rollover_id = state["replacement"]["rollover_id"]
+    resumed = th.resume_state(
+        state, rollover_id=rollover_id, replacement_thread_id="new-thread",
+        now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
+    )
+    repeated = th.resume_state(
+        resumed, rollover_id=rollover_id, replacement_thread_id="new-thread",
+        now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
+    )
+
+    assert repeated == resumed
+    with pytest.raises(ValueError, match="different replacement thread"):
+        th.resume_state(
+            resumed, rollover_id=rollover_id, replacement_thread_id="other-thread",
+            now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
         )
 
 
-def test_render_bootstrap_prompt_contains_guardrails(tmp_path: Path):
-    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
-    state = th.prepare_state(
-        {},
-        now=now,
-        active_thread_id="old-thread",
-        active_automation_id="old-auto",
-        bootstrap_path=Path(".agent/bootstrap.md"),
-        context_percent=90.0,
-        force_new_replacement=False,
+def test_confirm_requires_matching_script_proven_canary_pass(tmp_path: Path):
+    state = prepared()
+    replacement = state["replacement"]
+    resumed = th.resume_state(
+        state, rollover_id=replacement["rollover_id"], replacement_thread_id="new-thread",
+        now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
     )
-    prompt = th.render_bootstrap_prompt(sample_snapshot(tmp_path), state, context_threshold=82.0)
+    proof_path = tmp_path / "canary-pass.json"
+    canary.write_json_atomic(proof_path, canary.build_pass_proof(
+        rollover_id=replacement["rollover_id"], replacement_thread_id="new-thread",
+        challenge=replacement["canary_challenge"], now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
+    ))
 
-    assert "You are the replacement Codex orchestrator thread." in prompt
-    assert "Role handoff: docs/session-state/codex-orchestrator-handoff.md" in prompt
-    assert "Thread handoff: .agent/orchestrator-thread-handoff.md" in prompt
-    assert "Global router:" not in prompt
-    assert "Do not write docs/session-state/current.md for thread rollover." in prompt
-    assert "git status --short --branch" in prompt
-    assert "issue_stream_audit.py --json" in prompt
-    assert "git worktree list" in prompt
-    assert "confirm-started --agent orchestrator --new-thread-id <replacement-thread-id>" in prompt
-    assert "Only after that command reports old_automation_ready_to_delete=true" in prompt
-    assert "Context estimate: 90.0% (ROLL OVER NOW; threshold 82.0%)." in prompt
-    assert "orchestrator_control.py inbox --recent 20 --include-results" in prompt
-
-
-def test_render_current_markdown_includes_required_handoff_sections(tmp_path: Path):
-    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
-    state = th.prepare_state(
-        {},
-        now=now,
-        active_thread_id="old-thread",
-        active_automation_id=None,
-        bootstrap_path=Path(".agent/bootstrap.md"),
-        context_percent=None,
-        force_new_replacement=False,
+    confirmed = th.confirm_started(
+        resumed, new_thread_id="new-thread", new_automation_id=None, confirmed_by="tester",
+        now=datetime(2026, 5, 30, 8, 3, tzinfo=UTC), canary_proof=proof_path,
     )
-    rendered = th.render_current_markdown(sample_snapshot(tmp_path), state, context_threshold=82.0)
+    assert confirmed["replacement"]["status"] == "started"
+    assert confirmed["cleanup"]["old_automation_ready_to_delete"] is True
 
-    assert "## Thread Lease" in rendered
-    assert "## Git State" in rendered
-    assert "### Last 5 Commits" in rendered
-    assert "### Modified Files" in rendered
-    assert "## Open PRs" in rendered
-    assert "## Delegated Tasks" in rendered
-    assert "## First-Turn Checklist" in rendered
-    assert "issue_stream_audit.py --json" in rendered
-    assert "confirm-started --agent orchestrator --new-thread-id <replacement-thread-id>" in rendered
-    assert "orchestrator_control.py inbox --recent 20 --include-results" in rendered
-    assert "Durable role handoff: `docs/session-state/codex-orchestrator-handoff.md`" in rendered
-
-
-def test_render_bootstrap_prompt_for_codex_uses_orchestrator_pointer(tmp_path: Path):
-    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
-    state = th.prepare_state(
-        {},
-        agent="codex",
-        now=now,
-        active_thread_id="old-thread",
-        active_automation_id="old-auto",
-        bootstrap_path=Path(".agent/bootstrap.md"),
-        context_percent=90.0,
-        force_new_replacement=False,
-    )
-    prompt = th.render_bootstrap_prompt(
-        sample_snapshot(tmp_path),
-        state,
-        agent="codex",
-        context_threshold=82.0,
-    )
-
-    assert "You are the replacement codex thread." in prompt
-    assert "Role handoff: docs/session-state/current.orchestrator.md" in prompt
-    assert "Thread handoff: .agent/codex-thread-handoff.md" in prompt
-    assert "issue_stream_audit.py --json" in prompt
-    assert "git worktree list" in prompt
+    wrong_proof = tmp_path / "wrong.json"
+    canary.write_json_atomic(wrong_proof, canary.build_pass_proof(
+        rollover_id="other-rollover", replacement_thread_id="new-thread",
+        challenge=replacement["canary_challenge"], now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
+    ))
+    with pytest.raises(ValueError, match="script-proven canary PASS"):
+        th.confirm_started(
+            resumed, new_thread_id="new-thread", new_automation_id=None, confirmed_by="tester",
+            now=datetime(2026, 5, 30, 8, 3, tzinfo=UTC), canary_proof=wrong_proof,
+        )
 
 
-def test_render_current_markdown_for_codex_uses_orchestrator_pointer(tmp_path: Path):
-    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
-    state = th.prepare_state(
-        {},
-        agent="codex",
-        now=now,
-        active_thread_id="old-thread",
-        active_automation_id=None,
-        bootstrap_path=Path(".agent/bootstrap.md"),
-        context_percent=None,
-        force_new_replacement=False,
-    )
-    rendered = th.render_current_markdown(
-        sample_snapshot(tmp_path),
-        state,
-        agent="codex",
-        context_threshold=82.0,
-    )
-
-    assert "## First-Turn Checklist" in rendered
-    assert "Durable role handoff: `docs/session-state/current.orchestrator.md`" in rendered
-    assert "confirm-started --agent codex --new-thread-id <replacement-thread-id>" in rendered
+def test_confirm_refuses_unresumed_or_identity_mismatch(tmp_path: Path):
+    state = prepared()
+    proof_path = tmp_path / "proof.json"
+    replacement = state["replacement"]
+    canary.write_json_atomic(proof_path, canary.build_pass_proof(
+        rollover_id=replacement["rollover_id"], replacement_thread_id="new-thread",
+        challenge=replacement["canary_challenge"], now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
+    ))
+    with pytest.raises(ValueError, match="must be resumed"):
+        th.confirm_started(
+            state, new_thread_id="new-thread", new_automation_id=None, confirmed_by="tester",
+            now=datetime(2026, 5, 30, 8, 3, tzinfo=UTC), canary_proof=proof_path,
+        )
 
 
-def test_render_router_markdown_contains_parseable_markers():
-    rendered = th.render_router_markdown(
-        generated_at="2026-05-30T08:00:00Z",
-        default_agent="orchestrator",
-        agents=["orchestrator", "codex", "claude", "gemini"],
-    )
+def test_v1_state_requires_explicit_migration_and_discards_unverified_replacement(tmp_path: Path, capsys, monkeypatch):
+    state_path = tmp_path / ".agent/legacy.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(json.dumps({"schema_version": 1, "active": {"thread_id": "old-thread"}, "replacement": {"status": "pending_start"}}), encoding="utf-8")
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    base = ["--repo-root", str(tmp_path), "prepare", "--state-file", ".agent/legacy.json", "--active-thread-id", "old-thread"]
 
-    assert "Latest-Brief: docs/session-state/codex-orchestrator-handoff.md" in rendered
-    assert "Agent-Handoff:" in rendered
-    assert "- orchestrator: docs/session-state/codex-orchestrator-handoff.md" in rendered
-    assert "- codex: docs/session-state/current.orchestrator.md" in rendered
-    assert len(rendered.encode("utf-8")) < 1200
-
-
-def test_default_agent_paths_are_agent_specific():
-    assert th.default_state_path("claude") == Path(".agent/claude-thread-lease.json")
-    assert th.default_bootstrap_path("claude") == Path(".agent/claude-thread-bootstrap.md")
-    assert th.default_thread_handoff_path("claude") == Path(".agent/claude-thread-handoff.md")
-    assert th.default_handoff_path("orchestrator") == Path("docs/session-state/codex-orchestrator-handoff.md")
-    assert th.default_handoff_path("codex") == Path("docs/session-state/current.orchestrator.md")
-    assert th.default_handoff_path("claude") == Path("docs/session-state/current.claude.md")
-
-
-def test_prepare_orchestrator_writes_only_local_thread_handoff_by_default(
-    tmp_path: Path,
-    capsys,
-    monkeypatch,
-):
-    monkeypatch.setattr(th, "gather_snapshot", lambda repo_root, base_url: sample_snapshot(repo_root))
-
-    rc = th.main([
-        "--repo-root",
-        str(tmp_path),
-        "prepare",
-        "--agent",
-        "orchestrator",
-        "--context-percent",
-        "86",
-    ])
+    assert th.main(base) == 2
+    assert "requires an explicit migration" in json.loads(capsys.readouterr().out)["error"]
+    assert th.main([*base, "--migrate-v1"]) == 0
     payload = json.loads(capsys.readouterr().out)
-
-    assert rc == 0
-    assert payload["agent"] == "orchestrator"
-    assert payload["state_file"] == ".agent/orchestrator-thread-lease.json"
-    assert payload["bootstrap_file"] == ".agent/orchestrator-thread-bootstrap.md"
-    assert payload["handoff_file"] == ".agent/orchestrator-thread-handoff.md"
-    assert payload["thread_handoff_file"] == ".agent/orchestrator-thread-handoff.md"
-    assert payload["role_handoff_file"] == "docs/session-state/codex-orchestrator-handoff.md"
-    assert payload["router_file"] is None
-    assert not (tmp_path / "docs/session-state/current.md").exists()
-    assert "## Thread Lease" in (
-        tmp_path / ".agent/orchestrator-thread-handoff.md"
-    ).read_text(encoding="utf-8")
+    migrated = json.loads(state_path.read_text(encoding="utf-8"))
+    assert payload["rollover_id"] == migrated["replacement"]["rollover_id"]
+    assert migrated["schema_version"] == 2
+    assert migrated["migrated_from_v1_at"]
 
 
-def test_prepare_rejects_write_current_without_explicit_router_unlock(
-    tmp_path: Path,
-    capsys,
-    monkeypatch,
-):
-    monkeypatch.setattr(th, "gather_snapshot", lambda repo_root, base_url: sample_snapshot(repo_root))
+def test_prepare_parallel_lineages_do_not_collide(tmp_path: Path, capsys, monkeypatch):
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    outputs = []
+    for thread_id in ("old-a", "old-b"):
+        assert th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", thread_id]) == 0
+        outputs.append(json.loads(capsys.readouterr().out))
 
-    rc = th.main([
-        "--repo-root",
-        str(tmp_path),
-        "prepare",
-        "--agent",
-        "orchestrator",
-        "--write-current",
-    ])
+    assert outputs[0]["lineage_id"] != outputs[1]["lineage_id"]
+    assert outputs[0]["state_file"] != outputs[1]["state_file"]
+    assert outputs[0]["runtime_path"] != outputs[1]["runtime_path"]
+    assert (tmp_path / outputs[0]["bootstrap_file"]).is_file()
+    assert (tmp_path / outputs[1]["bootstrap_file"]).is_file()
+
+
+def test_cli_requires_the_exact_rollover_and_canary_proof(tmp_path: Path, capsys, monkeypatch):
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    assert th.main([
+        "--repo-root", str(tmp_path), "prepare", "--active-thread-id", "old-thread",
+    ]) == 0
+    prepared_payload = json.loads(capsys.readouterr().out)
+    state_path = tmp_path / prepared_payload["state_file"]
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+
+    assert th.main([
+        "--repo-root", str(tmp_path), "resume", "--lineage-id", prepared_payload["lineage_id"],
+        "--rollover-id", prepared_payload["rollover_id"], "--replacement-thread-id", "new-thread",
+    ]) == 0
+    capsys.readouterr()
+    proof_path = tmp_path / state["replacement"]["canary_proof_path"]
+    assert canary.main([
+        "--rollover-id", prepared_payload["rollover_id"], "--replacement-thread-id", "new-thread",
+        "--challenge", state["replacement"]["canary_challenge"], "--proof-file", str(proof_path),
+    ]) == 0
+    capsys.readouterr()
+
+    assert th.main([
+        "--repo-root", str(tmp_path), "confirm-started", "--lineage-id", prepared_payload["lineage_id"],
+        "--rollover-id", prepared_payload["rollover_id"], "--new-thread-id", "new-thread",
+        "--canary-proof", state["replacement"]["canary_proof_path"],
+    ]) == 0
+    confirmed_payload = json.loads(capsys.readouterr().out)
+    assert confirmed_payload["old_automation_ready_to_delete"] is True
+
+
+def test_prepare_retains_router_guard(tmp_path: Path, capsys, monkeypatch):
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    rc = th.main(["--repo-root", str(tmp_path), "prepare", "--active-thread-id", "old-thread", "--write-current"])
     payload = json.loads(capsys.readouterr().out)
 
     assert rc == 2
-    assert "--write-current is disabled by default" in payload["error"]
-    assert payload["thread_handoff_file"] == ".agent/orchestrator-thread-handoff.md"
+    assert "disabled by default" in payload["error"]
     assert not (tmp_path / "docs/session-state/current.md").exists()
-    assert not (tmp_path / ".agent/orchestrator-thread-handoff.md").exists()
 
 
-def test_prepare_writes_router_only_when_explicitly_unlocked(
-    tmp_path: Path,
-    capsys,
-    monkeypatch,
-):
-    monkeypatch.setattr(th, "gather_snapshot", lambda repo_root, base_url: sample_snapshot(repo_root))
-
-    rc = th.main([
-        "--repo-root",
-        str(tmp_path),
-        "prepare",
-        "--agent",
-        "orchestrator",
-        "--write-current",
-        "--allow-git-router",
-    ])
-    payload = json.loads(capsys.readouterr().out)
-
-    assert rc == 0
-    assert payload["router_file"] == "docs/session-state/current.md"
-    assert "Latest-Brief: docs/session-state/codex-orchestrator-handoff.md" in (
-        tmp_path / "docs/session-state/current.md"
-    ).read_text(encoding="utf-8")
-
-
-def test_prepare_non_orchestrator_does_not_clobber_router_or_orchestrator_handoff(
-    tmp_path: Path,
-    capsys,
-    monkeypatch,
-):
-    session_dir = tmp_path / "docs/session-state"
-    session_dir.mkdir(parents=True)
-    router_path = session_dir / "current.md"
-    orchestrator_path = session_dir / "codex-orchestrator-handoff.md"
-    claude_path = session_dir / "current.claude.md"
-    router_path.write_text("router stays\n", encoding="utf-8")
-    orchestrator_path.write_text("orchestrator stays\n", encoding="utf-8")
-    claude_path.write_text("claude role stays\n", encoding="utf-8")
-    monkeypatch.setattr(th, "gather_snapshot", lambda repo_root, base_url: sample_snapshot(repo_root))
-
-    rc = th.main([
-        "--repo-root",
-        str(tmp_path),
-        "prepare",
-        "--agent",
-        "claude",
-    ])
-    payload = json.loads(capsys.readouterr().out)
-
-    assert rc == 0
-    assert payload["agent"] == "claude"
-    assert payload["router_file"] is None
-    assert router_path.read_text(encoding="utf-8") == "router stays\n"
-    assert orchestrator_path.read_text(encoding="utf-8") == "orchestrator stays\n"
-    assert claude_path.read_text(encoding="utf-8") == "claude role stays\n"
-    assert (tmp_path / ".agent/claude-thread-handoff.md").is_file()
-    assert (tmp_path / ".agent/claude-thread-lease.json").is_file()
-    assert (tmp_path / ".agent/claude-thread-bootstrap.md").is_file()
-
-
-def test_confirm_started_is_scoped_to_selected_agent(tmp_path: Path, capsys):
-    now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
-    agent_dir = tmp_path / ".agent"
-    agent_dir.mkdir()
-    th.write_json_atomic(
-        agent_dir / "orchestrator-thread-lease.json",
-        th.prepare_state(
-            {},
-            agent="orchestrator",
-            now=now,
-            active_thread_id="old-orchestrator",
-            active_automation_id=None,
-            bootstrap_path=Path(".agent/orchestrator-thread-bootstrap.md"),
-            context_percent=None,
-            force_new_replacement=False,
-        ),
-    )
-    th.write_json_atomic(
-        agent_dir / "claude-thread-lease.json",
-        th.prepare_state(
-            {},
-            agent="claude",
-            now=now,
-            active_thread_id="old-claude",
-            active_automation_id=None,
-            bootstrap_path=Path(".agent/claude-thread-bootstrap.md"),
-            context_percent=None,
-            force_new_replacement=False,
-        ),
-    )
-
-    rc = th.main([
-        "--repo-root",
-        str(tmp_path),
-        "confirm-started",
-        "--agent",
-        "claude",
-        "--new-thread-id",
-        "new-claude",
-    ])
-    payload = json.loads(capsys.readouterr().out)
-
-    assert rc == 0
-    assert payload["agent"] == "claude"
-    assert payload["state_file"] == ".agent/claude-thread-lease.json"
-    claude_state = json.loads((agent_dir / "claude-thread-lease.json").read_text(encoding="utf-8"))
-    orchestrator_state = json.loads((agent_dir / "orchestrator-thread-lease.json").read_text(encoding="utf-8"))
-    assert claude_state["replacement"]["thread_id"] == "new-claude"
-    assert claude_state["cleanup"]["old_automation_ready_to_delete"] is True
-    assert orchestrator_state["cleanup"]["old_automation_ready_to_delete"] is False
-
-
-def test_confirm_started_missing_agent_prepare_is_safe(tmp_path: Path, capsys):
-    rc = th.main([
-        "--repo-root",
-        str(tmp_path),
-        "confirm-started",
-        "--agent",
-        "gemini",
-        "--new-thread-id",
-        "new-gemini",
-    ])
-    payload = json.loads(capsys.readouterr().out)
-
-    assert rc == 2
-    assert "run prepare first" in payload["error"]
-    assert not (tmp_path / ".agent/gemini-thread-lease.json").exists()
-
-
-def test_check_state_flags_pending_and_stale_replacement():
-    prepared_at = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
-    state = {
-        "active": {"generation": "orchestrator-1", "last_seen_at": th.isoformat_z(prepared_at)},
-        "replacement": {"status": "pending_start", "prepared_at": th.isoformat_z(prepared_at)},
-        "cleanup": {"old_automation_ready_to_delete": False},
-    }
-
-    facts, warnings = th.check_state(
-        state,
-        now=prepared_at + timedelta(hours=13),
-        stale_after=timedelta(hours=12),
-        context_percent=83.0,
-        context_threshold=82.0,
-    )
-
-    assert "active_generation=orchestrator-1" in facts
-    assert any("pending_start" in warning for warning in warnings)
-    assert any("context estimate 83.0%" in warning for warning in warnings)
-    assert any("replacement has been pending" in warning for warning in warnings)
-
-
-def test_check_state_flags_corrupted_state_file():
-    facts, warnings = th.check_state(
-        {"schema_version": th.SCHEMA_VERSION, "state_error": "unreadable state file: bad json"},
-        now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC),
-        stale_after=timedelta(hours=12),
-        context_percent=None,
-        context_threshold=82.0,
-    )
-
-    assert "replacement_status=none" in facts
-    assert warnings == ["unreadable state file: bad json"]
-
-
-def test_prepare_refuses_to_overwrite_corrupted_state_file(tmp_path: Path, capsys, monkeypatch):
-    state_file = Path(".agent/orchestrator-thread-lease.json")
-    state_path = tmp_path / state_file
+def test_prepare_refuses_corrupted_state_without_overwrite(tmp_path: Path, capsys, monkeypatch):
+    state_path = tmp_path / ".agent/corrupt.json"
     state_path.parent.mkdir(parents=True)
     state_path.write_text("{not-json", encoding="utf-8")
-    monkeypatch.setattr(th, "gather_snapshot", lambda repo_root, base_url: sample_snapshot(repo_root))
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
 
-    rc = th.main([
-        "--repo-root",
-        str(tmp_path),
-        "prepare",
-        "--state-file",
-        str(state_file),
-        "--bootstrap-file",
-        ".agent/bootstrap.md",
-    ])
-    payload = json.loads(capsys.readouterr().out)
-
+    rc = th.main(["--repo-root", str(tmp_path), "prepare", "--state-file", ".agent/corrupt.json", "--active-thread-id", "old-thread"])
     assert rc == 2
-    assert "unreadable state file" in payload["error"]
+    assert "unreadable state file" in json.loads(capsys.readouterr().out)["error"]
     assert state_path.read_text(encoding="utf-8") == "{not-json"
-    assert not (tmp_path / ".agent/bootstrap.md").exists()
 
 
-def test_parse_ahead_behind_reports_malformed_output():
-    parsed = th.parse_ahead_behind("not-a-count", "origin/main")
+def test_bootstrap_explicitly_forbids_history_resume_and_contains_proof_protocol(tmp_path: Path):
+    state = prepared()
+    prompt = th.render_bootstrap_prompt(sample_snapshot(tmp_path), state, context_threshold=82.0)
 
-    assert parsed == {
-        "upstream": "origin/main",
-        "parse_error": "unexpected rev-list output: 'not-a-count'",
-    }
+    assert "do not fork, continue, or resume provider conversation history" in prompt
+    assert "thread_handoff_canary.py" in prompt
+    assert state["replacement"]["rollover_id"] in prompt
+    assert state["replacement"]["canary_challenge"] in prompt
 
 
-def test_inspect_codex_home_reports_thread_metadata(tmp_path: Path):
+def test_check_state_flags_pending_stale_and_corrupt_state():
+    state = prepared()
+    facts, warnings = th.check_state(
+        state, now=datetime(2026, 5, 31, 8, 0, tzinfo=UTC), stale_after=timedelta(hours=12),
+        context_percent=90.0, context_threshold=82.0,
+    )
+    assert any(fact.startswith("rollover_id=rollover-") for fact in facts)
+    assert any("pending_start" in warning for warning in warnings)
+    assert any("context estimate" in warning for warning in warnings)
+
+
+def test_atomic_writer_and_canary_validation_reject_tampering(tmp_path: Path):
+    proof_path = tmp_path / "proof.json"
+    payload = canary.build_pass_proof(
+        rollover_id="rollover-1", replacement_thread_id="new-thread", challenge="challenge",
+        now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC),
+    )
+    canary.write_json_atomic(proof_path, payload)
+    assert canary.load_and_validate_pass_proof(proof_path, rollover_id="rollover-1", replacement_thread_id="new-thread", challenge="challenge")[1] is None
+    payload["status"] = "FAIL"
+    canary.write_json_atomic(proof_path, payload)
+    assert "did not report PASS" in canary.load_and_validate_pass_proof(proof_path, rollover_id="rollover-1", replacement_thread_id="new-thread", challenge="challenge")[1]
+
+
+def test_inspect_codex_home_does_not_use_history_resume(tmp_path: Path):
     codex_home = tmp_path / ".codex"
     codex_home.mkdir()
     db = codex_home / "state_1.sqlite"
     with sqlite3.connect(db) as conn:
-        conn.execute(
-            "create table threads (id text, title text, cwd text, archived integer, updated_at integer)"
-        )
-        conn.execute(
-            "insert into threads values ('thread-1', 'Example', '/tmp/repo', 0, 100)"
-        )
+        conn.execute("create table threads (id text, title text, cwd text, archived integer, updated_at integer)")
+        conn.execute("insert into threads values ('thread-1', 'Example', '/tmp/repo', 0, 100)")
 
     audit = th.inspect_codex_home(codex_home)
-
-    assert audit["latest_state_db"] == str(db)
     assert audit["thread_count"] == 1
-    assert audit["recent_threads"][0]["id"] == "thread-1"
-    assert audit["automation_toml_files"] == []
+    assert audit["history_resume_used"] is False


### PR DESCRIPTION
Fixes #5056
Part of #5054
Stream epic: #4707

## Summary

- Add schema-v2 rollover leases with explicit v1 migrate-or-refuse behavior.
- Mint unique lineage and rollover identities with immutable packet paths.
- Add deterministic one-thread resume binding and refuse duplicate pending replacements.
- Require exact identity plus script-proven canary PASS before confirmation permits predecessor cleanup.
- Resolve the default runtime state through Git's common directory so linked worktrees share one canonical primary-checkout state root.
- Preserve atomic writes, corrupt-state refusal, tracked-router guards, and no-history-resume rules.

## Verification

- 31/31 handoff tests pass with CODEX_THREAD_ID and CODEX_SESSION_ID explicitly unset.
- Real temporary Git linked-worktree test proves identical canonical state paths and no linked-worktree .agent writes.
- Ruff check and format check pass for all changed Python files.
- git diff --check and X-Agent trailer audit pass.
- Mandatory AGENTS.md forbidden-file/config checklist passes.

## Review gate

- Fable architecture advice: bridge reply #2707, recorded on #5054.
- Independent Grok review found the original worktree-local root and deleted-test blockers.
- Corrected branch re-review verified canonical-root, identity/canary, migration, router, corruption, parallel-isolation, and no-history guarantees.
- Final Grok tip review verified the environment-isolation follow-up and 31/31 clean-environment tests: PASS.

Hook, runbook, skill, and restart integration are deliberately owned by #5058 and remain blocking for the epic, but are outside this engine PR's file scope.