### PR TITLE
feat(canary): add strict durable thread-continuity probes

### DIFF
--- a/scripts/context_canary.py
+++ b/scripts/context_canary.py
@@ -108,12 +108,14 @@ def _derive_probe_anchors(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
         else:
             raw = len(mod_files)
         if _is_available(raw) or raw == 0:
-            anchors.append({
-                "id": cid,
-                "category": "fact",
-                "q": q,
-                "a": str(raw).strip(),
-            })
+            anchors.append(
+                {
+                    "id": cid,
+                    "category": "fact",
+                    "q": q,
+                    "a": str(raw).strip(),
+                }
+            )
 
     # 3 DECISION/RATIONALE (commit subjects = captured decisions/rationale)
     for i in range(3):
@@ -123,17 +125,30 @@ def _derive_probe_anchors(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
             entry = last_commits[i] if isinstance(last_commits[i], dict) else {}
             raw = entry.get("subject") if isinstance(entry, dict) else None
             if _is_available(raw):
-                anchors.append({
-                    "id": f"commit_{i}_subject",
-                    "category": "decision/rationale",
-                    "q": f"What is the subject of commit index {i} (0=most recent) in the tool-backed snapshot (captures decision/rationale)?",
-                    "a": str(raw).strip(),
-                })
+                anchors.append(
+                    {
+                        "id": f"commit_{i}_subject",
+                        "category": "decision/rationale",
+                        "q": f"What is the subject of commit index {i} (0=most recent) in the tool-backed snapshot (captures decision/rationale)?",
+                        "a": str(raw).strip(),
+                    }
+                )
 
     # 2 NEGATIVE-CONSTRAINT
     neg_specs = [
-        ("git_modified_status", "The git status --short summary from the snapshot (''/clean encodes negative constraint: no uncommitted changes at mint)?", lambda: ";".join(f"{m.get('status','')}{m.get('path','')}" for m in mod_files if isinstance(m, dict)) or "clean"),
-        ("ahead_count", "The 'ahead' count vs upstream from snapshot (0 encodes negative constraint of no pending divergence)?", lambda: get(ahead_behind, "ahead")),
+        (
+            "git_modified_status",
+            "The git status --short summary from the snapshot (''/clean encodes negative constraint: no uncommitted changes at mint)?",
+            lambda: (
+                ";".join(f"{m.get('status', '')}{m.get('path', '')}" for m in mod_files if isinstance(m, dict))
+                or "clean"
+            ),
+        ),
+        (
+            "ahead_count",
+            "The 'ahead' count vs upstream from snapshot (0 encodes negative constraint of no pending divergence)?",
+            lambda: get(ahead_behind, "ahead"),
+        ),
     ]
     for cid, q, getter in neg_specs:
         if sum(1 for a in anchors if a.get("category") == "negative-constraint") >= 2:
@@ -142,29 +157,41 @@ def _derive_probe_anchors(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
         if _is_available(raw) or raw in (0, "0"):
             av = "0" if raw in (0, "0") else str(raw).strip()
             if _is_available(av) or av == "0":
-                anchors.append({
-                    "id": cid,
-                    "category": "negative-constraint",
-                    "q": q,
-                    "a": av,
-                })
+                anchors.append(
+                    {
+                        "id": cid,
+                        "category": "negative-constraint",
+                        "q": q,
+                        "a": av,
+                    }
+                )
 
     # 2 GOAL/NEXT-ACTION
     goal_specs = [
-        ("head_sha_next_ref", "HEAD SHA from snapshot (base reference for goal/next-action state at mint)?", lambda: get(git, "head") or get(git, "full_head")),
-        ("recent_commit_sha_goal", "Most recent commit SHA from snapshot (advancement reference for goals)?", lambda: (last_commits[0].get("sha") if last_commits and isinstance(last_commits[0], dict) else None)),
+        (
+            "head_sha_next_ref",
+            "HEAD SHA from snapshot (base reference for goal/next-action state at mint)?",
+            lambda: get(git, "head") or get(git, "full_head"),
+        ),
+        (
+            "recent_commit_sha_goal",
+            "Most recent commit SHA from snapshot (advancement reference for goals)?",
+            lambda: last_commits[0].get("sha") if last_commits and isinstance(last_commits[0], dict) else None,
+        ),
     ]
     for cid, q, getter in goal_specs:
         if sum(1 for a in anchors if a.get("category") == "goal/next-action") >= 2:
             break
         raw = getter()
         if _is_available(raw):
-            anchors.append({
-                "id": cid,
-                "category": "goal/next-action",
-                "q": q,
-                "a": str(raw).strip(),
-            })
+            anchors.append(
+                {
+                    "id": cid,
+                    "category": "goal/next-action",
+                    "q": q,
+                    "a": str(raw).strip(),
+                }
+            )
 
     return anchors
 
@@ -186,10 +213,20 @@ def cmd_mint(args: argparse.Namespace) -> int:
                 print("error: --snapshot must be a JSON object", file=sys.stderr)
                 return 1
             anchors = _derive_probe_anchors(snap)
-            counts = {c: sum(1 for a in anchors if a.get("category") == c)
-                      for c in ("fact", "decision/rationale", "negative-constraint", "goal/next-action")}
-            if len(anchors) != 10 or counts != {"fact": 3, "decision/rationale": 3, "negative-constraint": 2, "goal/next-action": 2}:
-                print("error: insufficient evidence from tool-backed snapshot (UNKNOWN/unavailable/non-tool-backed excluded; need validated 3 fact, 3 decision/rationale, 2 negative-constraint, 2 goal/next-action)", file=sys.stderr)
+            counts = {
+                c: sum(1 for a in anchors if a.get("category") == c)
+                for c in ("fact", "decision/rationale", "negative-constraint", "goal/next-action")
+            }
+            if len(anchors) != 10 or counts != {
+                "fact": 3,
+                "decision/rationale": 3,
+                "negative-constraint": 2,
+                "goal/next-action": 2,
+            }:
+                print(
+                    "error: insufficient evidence from tool-backed snapshot (UNKNOWN/unavailable/non-tool-backed excluded; need validated 3 fact, 3 decision/rationale, 2 negative-constraint, 2 goal/next-action)",
+                    file=sys.stderr,
+                )
                 return 1
             probe = {
                 "version": "1",
@@ -237,7 +274,10 @@ def cmd_score(args: argparse.Namespace) -> int:
 
     anchors = probe.get("anchors", [])
     if not isinstance(anchors, list) or len(anchors) != 10:
-        print(f"error: probe must have exactly 10 anchors (got {len(anchors) if isinstance(anchors, list) else 0}); derive via --snapshot for production canary", file=sys.stderr)
+        print(
+            f"error: probe must have exactly 10 anchors (got {len(anchors) if isinstance(anchors, list) else 0}); derive via --snapshot for production canary",
+            file=sys.stderr,
+        )
         return 1
 
     # exact normalized matching for identifiers
@@ -267,7 +307,7 @@ def cmd_score(args: argparse.Namespace) -> int:
 
     k = len(anchors)
     # strict 10/10 production scoring
-    is_pass = (correct == 10 and k == 10)
+    is_pass = correct == 10 and k == 10
     verdict = "PASS" if is_pass else "FAIL-HANDOFF"
 
     for aid, ok, q, truth, got in rows:
@@ -286,14 +326,16 @@ def cmd_score(args: argparse.Namespace) -> int:
             writer = csv.writer(handle)
             if is_new:
                 writer.writerow(["context_tokens", "model", "k", "correct", "score", "verdict"])
-            writer.writerow([
-                getattr(args, "context_tokens", 0),
-                getattr(args, "model", "unknown"),
-                k,
-                correct,
-                f"{(correct / k):.3f}",
-                verdict,
-            ])
+            writer.writerow(
+                [
+                    getattr(args, "context_tokens", 0),
+                    getattr(args, "model", "unknown"),
+                    k,
+                    correct,
+                    f"{(correct / k):.3f}",
+                    verdict,
+                ]
+            )
 
     if getattr(args, "verdict", None):
         vpath = Path(args.verdict)
@@ -317,19 +359,31 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    mint = sub.add_parser("mint", help="Derive deterministic 10-anchor probe from tool-backed snapshot (or legacy facts).")
-    mint.add_argument("--snapshot", help="Path to tool-backed snapshot JSON (git/monitor/github); derives exactly 10 anchors with categories")
+    mint = sub.add_parser(
+        "mint", help="Derive deterministic 10-anchor probe from tool-backed snapshot (or legacy facts)."
+    )
+    mint.add_argument(
+        "--snapshot",
+        help="Path to tool-backed snapshot JSON (git/monitor/github); derives exactly 10 anchors with categories",
+    )
     mint.add_argument("--facts", help="Legacy inline JSON list or path to [{id,q,a},...] (for non-production)")
     mint.add_argument("--out", required=True, help="Probe output path")
     mint.set_defaults(func=cmd_mint)
 
-    score = sub.add_parser("score", help="Diff answers vs probe (normalized id match + configurable text match). Strict 10/10 rc=2.")
+    score = sub.add_parser(
+        "score", help="Diff answers vs probe (normalized id match + configurable text match). Strict 10/10 rc=2."
+    )
     score.add_argument("--probe", required=True)
     score.add_argument("--answers", required=True, help="JSON object {id: recalled-answer}")
     score.add_argument("--context-tokens", type=int, default=0, help="Context size for the log row")
     score.add_argument("--model", default="unknown")
     score.add_argument("--log", help="Append deterministic row to this CSV")
-    score.add_argument("--text-match", choices=["normalized", "exact"], default="normalized", help="normalized (default): ignore ws/case; exact: strict string")
+    score.add_argument(
+        "--text-match",
+        choices=["normalized", "exact"],
+        default="normalized",
+        help="normalized (default): ignore ws/case; exact: strict string",
+    )
     score.add_argument("--verdict", help="Write machine-readable JSON verdict to this path")
     score.set_defaults(func=cmd_score)
 

--- a/scripts/context_canary.py
+++ b/scripts/context_canary.py
@@ -63,6 +63,7 @@ import difflib
 import hashlib
 import json
 import random
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -171,6 +172,42 @@ def _validate_utc_timestamp(v: object) -> bool:
         return d.utcoffset() == dt.timedelta(0)
     except Exception:
         return False
+
+
+def _validate_identity(val: object, kind: str) -> bool:
+    """Centralized, closed identity validator aligned with the handoff engine.
+
+    - lineage_id: prefix 'lineage-' + 1+ lowercase alnum/hyphen, total len <=64
+    - rollover_id: prefix 'rollover-' + 1+ lowercase alnum/hyphen, total len <=64
+    - Full-string match only. Exact raw strings (NO normalization, NO strip, NO casefold).
+    - Rejects leading/trailing ws, any ws/control/newline, uppercase, wrong prefix,
+      punctuation (except hyphen), / \\ . .. traversal, empty suffix, overlong (>64).
+    - Also rejects consecutive path syntax (e.g. '--', '//').
+    Applied uniformly to: snapshot mint input, production probe validation at score,
+    and --expected-lineage-id/--expected-rollover-id (before any exact == comparison).
+    """
+    if not isinstance(val, str):
+        return False
+    # Reject leading/trailing whitespace on the raw value (no normalization performed)
+    if val != val.strip():
+        return False
+    # Reject embedded control chars, newlines, tabs, DEL etc.
+    if any(ord(c) < 32 or ord(c) == 127 for c in val):
+        return False
+    if not val or _has_unknowns(val):
+        return False
+    if len(val) > 64:
+        return False
+    if kind == "lineage":
+        if not re.fullmatch(r"lineage-[a-z0-9-]+", val):
+            return False
+    elif kind == "rollover":
+        if not re.fullmatch(r"rollover-[a-z0-9-]+", val):
+            return False
+    else:
+        return False
+    # Reject consecutive path syntax
+    return not ("--" in val or "//" in val or "\\\\" in val or ".." in val or val.endswith("-"))
 
 
 def _is_exact_legacy_anchors_only(probe: object) -> bool:
@@ -285,17 +322,19 @@ def cmd_mint(args: argparse.Namespace) -> int:
                     file=sys.stderr,
                 )
                 return 1
-            # Require explicit complete identity; never synthesize unknown
+            # Require explicit complete identity; never synthesize unknown.
+            # Use centralized closed validator (exact raw, no normalization) for both.
             lineage_id = snap.get("lineage_id")
             rollover_id = snap.get("rollover_id")
-            if not (isinstance(lineage_id, str) and lineage_id.strip() and not _has_unknowns(lineage_id)):
+            if not _validate_identity(lineage_id, "lineage"):
                 print(
-                    "error: --snapshot requires nonempty well-formed lineage_id (no UNKNOWN/synthesis)", file=sys.stderr
+                    "error: --snapshot requires well-formed lineage_id (prefix lineage-[a-z0-9-]+ <=64 chars, exact no ws/upper/punct/slash/control/empty-suffix/overlong)",
+                    file=sys.stderr,
                 )
                 return 1
-            if not (isinstance(rollover_id, str) and rollover_id.strip() and not _has_unknowns(rollover_id)):
+            if not _validate_identity(rollover_id, "rollover"):
                 print(
-                    "error: --snapshot requires nonempty well-formed rollover_id (no UNKNOWN/synthesis)",
+                    "error: --snapshot requires well-formed rollover_id (prefix rollover-[a-z0-9-]+ <=64 chars, exact no ws/upper/punct/slash/control/empty-suffix/overlong)",
                     file=sys.stderr,
                 )
                 return 1
@@ -376,8 +415,8 @@ def cmd_mint(args: argparse.Namespace) -> int:
                 "version": "2",
                 "schema": "production-handoff-v2",
                 "source": "snapshot",
-                "lineage_id": lineage_id.strip(),
-                "rollover_id": rollover_id.strip(),
+                "lineage_id": lineage_id,
+                "rollover_id": rollover_id,
                 "seed": seed,
                 "generated_at": snap.get("generated_at").strip(),
                 "anchor_counts": expected,
@@ -591,24 +630,25 @@ def cmd_score(args: argparse.Namespace) -> int:
             )
             return 2
 
-        # Require explicit lineage_id + rollover_id (no unknown)
+        # Require explicit lineage_id + rollover_id (no unknown). Use centralized validator, exact raw.
         lid = probe.get("lineage_id")
         rid = probe.get("rollover_id")
-        if not (isinstance(lid, str) and lid.strip() and not _has_unknowns(lid)):
-            print("error: v2 probe requires nonempty well-formed lineage_id", file=sys.stderr)
+        if not _validate_identity(lid, "lineage"):
+            print("error: v2 probe requires well-formed lineage_id (exact identity)", file=sys.stderr)
             return 2
-        if not (isinstance(rid, str) and rid.strip() and not _has_unknowns(rid)):
-            print("error: v2 probe requires nonempty well-formed rollover_id", file=sys.stderr)
+        if not _validate_identity(rid, "rollover"):
+            print("error: v2 probe requires well-formed rollover_id (exact identity)", file=sys.stderr)
             return 2
 
-        # Production score REQUIRES caller-supplied expected ids and exact match before any scoring
+        # Production score REQUIRES caller-supplied expected ids and exact match before any scoring.
+        # Validate with same centralized closed validator (exact raw) BEFORE the == comparison.
         exp_lid = getattr(args, "expected_lineage_id", None)
         exp_rid = getattr(args, "expected_rollover_id", None)
-        if not (isinstance(exp_lid, str) and exp_lid.strip() and not _has_unknowns(exp_lid)):
-            print("error: production score requires --expected-lineage-id (nonempty, well-formed)", file=sys.stderr)
+        if not _validate_identity(exp_lid, "lineage"):
+            print("error: production score requires --expected-lineage-id (well-formed identity)", file=sys.stderr)
             return 2
-        if not (isinstance(exp_rid, str) and exp_rid.strip() and not _has_unknowns(exp_rid)):
-            print("error: production score requires --expected-rollover-id (nonempty, well-formed)", file=sys.stderr)
+        if not _validate_identity(exp_rid, "rollover"):
+            print("error: production score requires --expected-rollover-id (well-formed identity)", file=sys.stderr)
             return 2
         if exp_lid != lid or exp_rid != rid:
             print(

--- a/scripts/context_canary.py
+++ b/scripts/context_canary.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 
 import argparse
 import csv
+import datetime as dt
 import difflib
 import hashlib
 import json
@@ -101,6 +102,100 @@ def _has_unknowns(v: Any) -> bool:
     return False
 
 
+# --- Explicit, closed, centralized source_ref grammar and category/kind mapping (per review requirements) ---
+# Grammar: kind:repo-relative-path#record-fragment
+# Reject: git:, github:, monitor:, arbitrary strings, absolute paths, traversal (..), missing : or #, UNKNOWN, wrong roots.
+# Category must map to appropriate kind(s); no inference from answer text.
+SOURCE_REF_GRAMMAR = "kind:repo-relative-path#record-fragment"
+ALLOWED_KIND_ROOTS: dict[str, tuple[str, ...]] = {
+    "handoff": (".agent/thread-rollovers/", "docs/session-state/"),
+    "decision": ("docs/decisions/",),
+    "pending-decision": ("docs/decisions/",),
+    "queue": ("batch_state/orchestrator-runs/",),
+}
+CATEGORY_KIND_ALLOW: dict[str, tuple[str, ...]] = {
+    # goals from handoff
+    "goal": ("handoff",),
+    # decisions/rationales from decision or handoff (or pending-decision)
+    "decision/rationale": ("decision", "pending-decision", "handoff"),
+    # constraints/prohibitions from handoff or decision
+    "negative-constraint/prohibition": ("handoff", "decision", "pending-decision"),
+    # next actions from queue or handoff
+    "next-action": ("queue", "handoff"),
+}
+
+
+def _parse_and_validate_source_ref(source_ref: object, category: str) -> bool:
+    """Closed validator used identically at mint and score. Returns False on any violation."""
+    if not isinstance(source_ref, str):
+        return False
+    sr = source_ref.strip()
+    if not sr or _has_unknowns(sr):
+        return False
+    if sr.count(":") != 1 or sr.count("#") != 1:
+        return False
+    try:
+        kind, rest = sr.split(":", 1)
+        if "#" not in rest:
+            return False
+        path_part, frag = rest.rsplit("#", 1)
+    except ValueError:
+        return False
+    if not kind or not path_part or not frag:
+        return False
+    # reject traversal, absolute, weird relatives
+    if ".." in path_part or path_part.startswith("/") or path_part.startswith("~"):
+        return False
+    if kind not in ALLOWED_KIND_ROOTS:
+        return False
+    roots = ALLOWED_KIND_ROOTS[kind]
+    if not any(path_part.startswith(root) for root in roots):
+        return False
+    allowed_for_cat = CATEGORY_KIND_ALLOW.get(category, ())
+    return kind in allowed_for_cat
+
+
+def _validate_utc_timestamp(v: object) -> bool:
+    """Require real UTC timestamp (Z or +00:00 offset)."""
+    if not isinstance(v, str):
+        return False
+    s = v.strip()
+    if not s:
+        return False
+    try:
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        d = dt.datetime.fromisoformat(s)
+        if d.tzinfo is None:
+            return False
+        return d.utcoffset() == dt.timedelta(0)
+    except Exception:
+        return False
+
+
+def _is_exact_legacy_anchors_only(probe: object) -> bool:
+    """Legacy probes are ONLY the exact original shape produced by --facts: {"anchors": [{"id":, "q":, "a":}, ...]}.
+    Any production marker or extra top-level key forces strict v2 path (and fail if incomplete).
+    """
+    if not isinstance(probe, dict):
+        return False
+    if set(probe.keys()) != {"anchors"}:
+        return False
+    anchors = probe.get("anchors")
+    if not isinstance(anchors, list) or len(anchors) == 0:
+        return False
+    for a in anchors:
+        if not isinstance(a, dict):
+            return False
+        if set(a.keys()) != {"id", "q", "a"}:
+            return False
+        for k in ("id", "q", "a"):
+            val = a.get(k)
+            if not isinstance(val, str) or not val.strip():
+                return False
+    return True
+
+
 def _load_facts_spec(spec: str) -> object:
     """Load facts from EITHER an inline JSON list OR a path to a JSON file.
 
@@ -130,7 +225,9 @@ def _select_with_seed(items: list[Any], n: int, rng: random.Random) -> list[dict
 
 
 def _build_v2_anchors(sel_items: list[dict], category: str, text_key: str, q_tmpl: str) -> list[dict]:
-    """Build exact shaped anchors or [] on any shape/unknown/empty failure for that batch."""
+    """Build exact shaped anchors or [] on any shape/unknown/empty failure for that batch.
+    source_ref validated with closed grammar + category mapping (identical at mint/score).
+    """
     anchors: list[dict] = []
     for rec in sel_items:
         if not isinstance(rec, dict):
@@ -139,7 +236,7 @@ def _build_v2_anchors(sel_items: list[dict], category: str, text_key: str, q_tmp
         if not isinstance(aid, str) or not aid.strip() or _has_unknowns(aid):
             return []
         src_ref = rec.get("source_ref")
-        if not isinstance(src_ref, str) or not src_ref.strip() or _has_unknowns(src_ref):
+        if not _parse_and_validate_source_ref(src_ref, category):
             return []
         a_val = (
             rec.get(text_key)
@@ -154,17 +251,19 @@ def _build_v2_anchors(sel_items: list[dict], category: str, text_key: str, q_tmp
         if not str(a_val).strip() or _has_unknowns(str(a_val)):
             return []
         q = rec.get("q") or rec.get("question") or q_tmpl.format(id=aid)
+        if not str(q).strip() or _has_unknowns(str(q)):
+            return []
         mm = rec.get("match_mode", "exact")
         if mm not in ("exact", "normalized"):
             return []
         anchors.append(
             {
-                "id": aid,
+                "id": aid.strip(),
                 "q": str(q).strip(),
                 "a": str(a_val).strip(),
                 "category": category,
                 "match_mode": mm,
-                "source_ref": src_ref.strip(),
+                "source_ref": str(src_ref).strip(),
             }
         )
     return anchors
@@ -173,9 +272,7 @@ def _build_v2_anchors(sel_items: list[dict], category: str, text_key: str, q_tmp
 def cmd_mint(args: argparse.Namespace) -> int:
     snapshot_path = getattr(args, "snapshot", None)
     facts_spec = getattr(args, "facts", None)
-    if snapshot_path and facts_spec:
-        print("error: mint accepts only one of --snapshot or --facts, not both", file=sys.stderr)
-        return 1
+    # Note: both/missing now enforced by mutually_exclusive_group(required=True) -> parser rc 2
     try:
         if snapshot_path:
             snap = json.loads(Path(snapshot_path).read_text(encoding="utf-8"))
@@ -188,7 +285,27 @@ def cmd_mint(args: argparse.Namespace) -> int:
                     file=sys.stderr,
                 )
                 return 1
-            # Only pull from explicit durable handoff sections. Never git/monitor/github/SHAs etc.
+            # Require explicit complete identity; never synthesize unknown
+            lineage_id = snap.get("lineage_id")
+            rollover_id = snap.get("rollover_id")
+            if not (isinstance(lineage_id, str) and lineage_id.strip() and not _has_unknowns(lineage_id)):
+                print(
+                    "error: --snapshot requires nonempty well-formed lineage_id (no UNKNOWN/synthesis)", file=sys.stderr
+                )
+                return 1
+            if not (isinstance(rollover_id, str) and rollover_id.strip() and not _has_unknowns(rollover_id)):
+                print(
+                    "error: --snapshot requires nonempty well-formed rollover_id (no UNKNOWN/synthesis)",
+                    file=sys.stderr,
+                )
+                return 1
+            if not _validate_utc_timestamp(snap.get("generated_at")):
+                print(
+                    "error: --snapshot requires generated_at as a real UTC timestamp (e.g. 2026-07-13T12:00:00Z)",
+                    file=sys.stderr,
+                )
+                return 1
+            # Only pull from explicit durable sections. source_ref validated per grammar+cat.
             goals = snap.get("goals") or snap.get("handoff_goals") or []
             decs = snap.get("decision_records") or snap.get("decisions") or snap.get("decision_rationale_records") or []
             negs = (
@@ -236,14 +353,17 @@ def cmd_mint(args: argparse.Namespace) -> int:
             ]:
                 built = _build_v2_anchors(items, cat, tkey, qt)
                 if len(built) != len(items):
-                    print("error: malformed durable artifact record (id/source_ref/a/q or UNKNOWN)", file=sys.stderr)
+                    print(
+                        "error: malformed durable artifact record (id/source_ref/a/q or UNKNOWN or bad source_ref grammar/category)",
+                        file=sys.stderr,
+                    )
                     return 1
                 anchors.extend(built)
             id_set = {a["id"] for a in anchors}
             if len(id_set) != 10 or len(anchors) != 10:
                 print("error: production anchors must have exactly 10 unique non-empty IDs", file=sys.stderr)
                 return 1
-            counts = {}
+            counts: dict[str, int] = {}
             for a in anchors:
                 c = a["category"]
                 counts[c] = counts.get(c, 0) + 1
@@ -251,18 +371,23 @@ def cmd_mint(args: argparse.Namespace) -> int:
             if counts != expected:
                 print("error: wrong category composition for production v2", file=sys.stderr)
                 return 1
+            # Exact metadata keys, no more no less; store explicit lineage_id + rollover_id
             probe = {
                 "version": "2",
                 "schema": "production-handoff-v2",
-                "lineage": snap.get("lineage") or snap.get("handoff_id") or "lineage:unknown",
                 "source": "snapshot",
+                "lineage_id": lineage_id.strip(),
+                "rollover_id": rollover_id.strip(),
                 "seed": seed,
-                "generated_at": snap.get("generated_at"),
+                "generated_at": snap.get("generated_at").strip(),
                 "anchor_counts": expected,
                 "strict_production": True,
                 "policy": "strict-10/10-only-from-durable-continuity-artifacts",
                 "anchors": anchors,
             }
+            if _has_unknowns(probe):
+                print("error: produced probe contains UNKNOWN after validation", file=sys.stderr)
+                return 1
             Path(args.out).write_text(json.dumps(probe, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
             print(f"minted {len(anchors)} anchors -> {args.out}")
             return 0
@@ -281,6 +406,7 @@ def cmd_mint(args: argparse.Namespace) -> int:
             print(f"minted {len(facts)} anchors -> {args.out}")
             return 0
         else:
+            # Should not reach due to group, but keep for safety
             print("error: mint requires --snapshot (for production v2) or --facts (legacy)", file=sys.stderr)
             return 1
     except (OSError, UnicodeDecodeError) as exc:
@@ -308,133 +434,17 @@ def cmd_score(args: argparse.Namespace) -> int:
         print(f"error: probe or answers not valid JSON: {exc}", file=sys.stderr)
         return 1
 
+    if not isinstance(probe, dict):
+        print("error: probe must be a JSON object", file=sys.stderr)
+        return 1
     anchors = probe.get("anchors", [])
     if not isinstance(anchors, list) or not anchors:
         print("error: probe has no anchors", file=sys.stderr)
         return 1
 
-    is_v2_prod = bool(
-        probe.get("version") == "2"
-        and probe.get("schema") == "production-handoff-v2"
-        and probe.get("strict_production") is True
-        and len(anchors) == 10
-        and probe.get("source") == "snapshot"
-    )
-
-    if is_v2_prod:
-        # Strict validation for T1 confirmation: schema, provenance, categories, uniqueness, exact shape, source_ref
-        seen: set[str] = set()
-        cat_c: dict[str, int] = {
-            "goal": 0,
-            "decision/rationale": 0,
-            "negative-constraint/prohibition": 0,
-            "next-action": 0,
-        }
-        for a in anchors:
-            if not isinstance(a, dict):
-                print("error: v2 production anchor must be object", file=sys.stderr)
-                return 1
-            for req in ("id", "q", "a", "category", "match_mode", "source_ref"):
-                val = a.get(req)
-                if val is None or (isinstance(val, str) and not val.strip()):
-                    print(f"error: v2 anchor missing/empty field: {req}", file=sys.stderr)
-                    return 1
-            aid = a["id"]
-            if not isinstance(aid, str) or aid in seen:
-                print(
-                    "error: v2 anchors require unique non-empty string ids (exact match; do not normalize IDs)",
-                    file=sys.stderr,
-                )
-                return 1
-            seen.add(aid)
-            cat = a["category"]
-            if cat not in cat_c:
-                print(f"error: invalid category {cat} for v2 production", file=sys.stderr)
-                return 1
-            cat_c[cat] += 1
-            mm = a["match_mode"]
-            if mm not in ("exact", "normalized"):
-                print(f"error: invalid match_mode '{mm}' (supported: exact, normalized)", file=sys.stderr)
-                return 1
-            sr = a["source_ref"]
-            if not isinstance(sr, str) or _has_unknowns(sr):
-                print("error: v2 source_ref must be durable non-UNKNOWN artifact locator", file=sys.stderr)
-                return 1
-            if _has_unknowns(a.get("q")) or _has_unknowns(a.get("a")):
-                print("error: v2 anchor q/a contains UNKNOWN value", file=sys.stderr)
-                return 1
-        if cat_c != {"goal": 3, "decision/rationale": 3, "negative-constraint/prohibition": 2, "next-action": 2}:
-            print(
-                "error: v2 probe must have exactly 3 goals, 3 decisions/rationales, 2 neg constraints, 2 next actions",
-                file=sys.stderr,
-            )
-            return 1
-        if (
-            not probe.get("lineage")
-            or probe.get("lineage") in ("lineage:unknown",)
-            or _has_unknowns(probe.get("lineage"))
-        ):
-            print("error: v2 probe requires valid lineage/rollover identity from snapshot", file=sys.stderr)
-            return 1
-
-        # Strict 10/10 scoring. IDs matched exactly (answers.get uses raw id). match_mode only for text.
-        correct = 0
-        rows: list[tuple] = []
-        for anchor in anchors:
-            aid = anchor["id"]
-            truth = anchor["a"]
-            mm = anchor.get("match_mode", "exact")
-            got = answers.get(aid, "") if isinstance(answers, dict) else ""
-            ok = _matches_v2(truth, got, mm)
-            if ok:
-                correct += 1
-            rows.append((aid, ok, anchor.get("q", ""), str(truth), str(got)))
-        k = len(anchors)
-        is_pass = correct == 10 and k == 10
-        verdict = "PASS" if is_pass else "FAIL-HANDOFF"
-        for aid, ok, q, truth, got in rows:
-            tag = "PASS " if ok else "DRIFT"
-            print(f"  [{tag}] {aid} {q}")
-            if not ok:
-                print(f"          truth: {truth!r}")
-                print(f"          got  : {got!r}")
-        print(f"SCORE {correct}/{k} = {correct / k:.3f}  ->  {verdict} (strict 10/10)")
-        if args.log:
-            log_path = Path(args.log)
-            is_new = not log_path.exists()
-            with log_path.open("a", newline="", encoding="utf-8") as handle:
-                writer = csv.writer(handle)
-                if is_new:
-                    writer.writerow(["context_tokens", "model", "k", "correct", "score", "verdict"])
-                writer.writerow(
-                    [
-                        getattr(args, "context_tokens", 0),
-                        getattr(args, "model", "unknown"),
-                        k,
-                        correct,
-                        f"{(correct / k):.3f}",
-                        verdict,
-                    ]
-                )
-        if getattr(args, "verdict", None):
-            vpath = Path(args.verdict)
-            vdata = {
-                "version": "2",
-                "schema": "production-handoff-v2",
-                "lineage": probe.get("lineage"),
-                "seed": probe.get("seed"),
-                "k": k,
-                "correct": correct,
-                "score": round(correct / k, 3) if k else 0.0,
-                "verdict": verdict,
-                "context_tokens": getattr(args, "context_tokens", 0),
-                "model": getattr(args, "model", "unknown"),
-                "per_anchor": [{"id": r[0], "match": r[1]} for r in rows],
-            }
-            vpath.write_text(json.dumps(vdata, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-            print(f"verdict written -> {args.verdict}")
-        return 0 if is_pass else 2
-    else:
+    # Partial/forged production markers or extra keys MUST fail closed, never fallback to legacy.
+    # Legacy = ONLY the exact anchors-only shape {"anchors": [{"id":str,"q":str,"a":str}, ...]} from --facts.
+    if _is_exact_legacy_anchors_only(probe):
         # LEGACY scoring semantics (preserved exactly; do not weaken)
         correct = 0
         rows = []
@@ -476,6 +486,199 @@ def cmd_score(args: argparse.Namespace) -> int:
                     ]
                 )
         return 0 if verdict == "PASS" else 2
+    else:
+        # Strict v2 production path: exact metadata, exact anchor keys, source_ref grammar+cat, identity, expected match.
+        # Any production marker or extra top key routes here and fails if not complete/valid.
+        required_keys = {
+            "version",
+            "schema",
+            "source",
+            "lineage_id",
+            "rollover_id",
+            "seed",
+            "generated_at",
+            "anchor_counts",
+            "strict_production",
+            "policy",
+            "anchors",
+        }
+        if set(probe.keys()) != required_keys:
+            print(
+                "error: production probe must have exactly these top-level keys with no missing/extra: version,schema,source,lineage_id,rollover_id,seed,generated_at,anchor_counts,strict_production,policy,anchors",
+                file=sys.stderr,
+            )
+            return 2
+        if probe.get("version") != "2":
+            print('error: production probe version must be "2"', file=sys.stderr)
+            return 2
+        if probe.get("schema") != "production-handoff-v2":
+            print("error: production probe schema must be production-handoff-v2", file=sys.stderr)
+            return 2
+        if probe.get("source") != "snapshot":
+            print("error: production probe source must be snapshot", file=sys.stderr)
+            return 2
+        if probe.get("strict_production") is not True:
+            print("error: production probe strict_production must be true", file=sys.stderr)
+            return 2
+        if probe.get("policy") != "strict-10/10-only-from-durable-continuity-artifacts":
+            print("error: production probe policy must be exact", file=sys.stderr)
+            return 2
+        seed = probe.get("seed")
+        if not isinstance(seed, int):
+            print("error: production probe seed must be an integer", file=sys.stderr)
+            return 2
+        if not _validate_utc_timestamp(probe.get("generated_at")):
+            print("error: production probe generated_at must be a real UTC timestamp", file=sys.stderr)
+            return 2
+        expected_counts = {"goal": 3, "decision/rationale": 3, "negative-constraint/prohibition": 2, "next-action": 2}
+        if probe.get("anchor_counts") != expected_counts:
+            print("error: production probe anchor_counts must be exact 3/3/2/2", file=sys.stderr)
+            return 2
+
+        # anchors: exact keys + values validated recursively + source_ref closed
+        anchors = probe["anchors"]
+        if not isinstance(anchors, list) or len(anchors) != 10:
+            print("error: production probe must have exactly 10 anchors", file=sys.stderr)
+            return 2
+        anchor_keys = {"id", "q", "a", "category", "match_mode", "source_ref"}
+        seen: set[str] = set()
+        cat_c: dict[str, int] = {
+            "goal": 0,
+            "decision/rationale": 0,
+            "negative-constraint/prohibition": 0,
+            "next-action": 0,
+        }
+        for a in anchors:
+            if not isinstance(a, dict) or set(a.keys()) != anchor_keys:
+                print(
+                    "error: each production anchor must have exactly keys {id,q,a,category,match_mode,source_ref} (no missing/extra)",
+                    file=sys.stderr,
+                )
+                return 2
+            for req in ("id", "q", "a", "category", "match_mode", "source_ref"):
+                val = a.get(req)
+                if val is None or (isinstance(val, str) and not val.strip()) or _has_unknowns(val):
+                    print(f"error: production anchor missing/empty/UNKNOWN field: {req}", file=sys.stderr)
+                    return 2
+            aid = a["id"]
+            if not isinstance(aid, str) or not aid.strip() or aid in seen:
+                print(
+                    "error: v2 anchors require unique non-empty string ids (exact match; do not normalize IDs)",
+                    file=sys.stderr,
+                )
+                return 2
+            seen.add(aid)
+            cat = a["category"]
+            if cat not in cat_c:
+                print(f"error: invalid category {cat} for v2 production", file=sys.stderr)
+                return 2
+            cat_c[cat] += 1
+            mm = a["match_mode"]
+            if mm not in ("exact", "normalized"):
+                print(f"error: invalid match_mode '{mm}' (supported: exact, normalized)", file=sys.stderr)
+                return 2
+            sr = a["source_ref"]
+            if not _parse_and_validate_source_ref(sr, cat):
+                print(
+                    "error: v2 source_ref must follow kind:repo-relative-path#record-fragment with allowed kinds/roots for its category; reject git:,github:,monitor:,abs,../,arbitrary,wrong-pair,UNKNOWN",
+                    file=sys.stderr,
+                )
+                return 2
+        if cat_c != expected_counts:
+            print(
+                "error: v2 probe must have exactly 3 goals, 3 decisions/rationales, 2 neg constraints, 2 next actions",
+                file=sys.stderr,
+            )
+            return 2
+
+        # Require explicit lineage_id + rollover_id (no unknown)
+        lid = probe.get("lineage_id")
+        rid = probe.get("rollover_id")
+        if not (isinstance(lid, str) and lid.strip() and not _has_unknowns(lid)):
+            print("error: v2 probe requires nonempty well-formed lineage_id", file=sys.stderr)
+            return 2
+        if not (isinstance(rid, str) and rid.strip() and not _has_unknowns(rid)):
+            print("error: v2 probe requires nonempty well-formed rollover_id", file=sys.stderr)
+            return 2
+
+        # Production score REQUIRES caller-supplied expected ids and exact match before any scoring
+        exp_lid = getattr(args, "expected_lineage_id", None)
+        exp_rid = getattr(args, "expected_rollover_id", None)
+        if not (isinstance(exp_lid, str) and exp_lid.strip() and not _has_unknowns(exp_lid)):
+            print("error: production score requires --expected-lineage-id (nonempty, well-formed)", file=sys.stderr)
+            return 2
+        if not (isinstance(exp_rid, str) and exp_rid.strip() and not _has_unknowns(exp_rid)):
+            print("error: production score requires --expected-rollover-id (nonempty, well-formed)", file=sys.stderr)
+            return 2
+        if exp_lid != lid or exp_rid != rid:
+            print(
+                "error: --expected-lineage-id and --expected-rollover-id must exactly match probe identity",
+                file=sys.stderr,
+            )
+            return 2
+
+        # Strict 10/10 scoring. IDs matched exactly. match_mode only for text.
+        correct = 0
+        rows: list[tuple] = []
+        for anchor in anchors:
+            aid = anchor["id"]
+            truth = anchor["a"]
+            mm = anchor.get("match_mode", "exact")
+            got = answers.get(aid, "") if isinstance(answers, dict) else ""
+            ok = _matches_v2(truth, got, mm)
+            if ok:
+                correct += 1
+            rows.append((aid, ok, anchor.get("q", ""), str(truth), str(got)))
+        k = len(anchors)
+        is_pass = correct == 10 and k == 10
+        verdict = "PASS" if is_pass else "FAIL-HANDOFF"
+        for aid, ok, q, truth, got in rows:
+            tag = "PASS " if ok else "DRIFT"
+            print(f"  [{tag}] {aid} {q}")
+            if not ok:
+                print(f"          truth: {truth!r}")
+                print(f"          got  : {got!r}")
+        print(f"SCORE {correct}/{k} = {correct / k:.3f}  ->  {verdict} (strict 10/10)")
+        if args.log:
+            log_path = Path(args.log)
+            is_new = not log_path.exists()
+            with log_path.open("a", newline="", encoding="utf-8") as handle:
+                writer = csv.writer(handle)
+                if is_new:
+                    writer.writerow(["context_tokens", "model", "k", "correct", "score", "verdict"])
+                writer.writerow(
+                    [
+                        getattr(args, "context_tokens", 0),
+                        getattr(args, "model", "unknown"),
+                        k,
+                        correct,
+                        f"{(correct / k):.3f}",
+                        verdict,
+                    ]
+                )
+        if getattr(args, "verdict", None):
+            vpath = Path(args.verdict)
+            # Stable SHA-256 of the validated probe (canonical form)
+            canonical = json.dumps(probe, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+            probe_sha256 = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+            vdata = {
+                "version": "2",
+                "schema": "production-handoff-v2",
+                "lineage_id": lid,
+                "rollover_id": rid,
+                "probe_sha256": probe_sha256,
+                "seed": seed,
+                "k": k,
+                "correct": correct,
+                "score": round(correct / k, 3) if k else 0.0,
+                "verdict": verdict,
+                "model": getattr(args, "model", "unknown"),
+                "per_anchor": [{"id": r[0], "match": r[1]} for r in rows],
+                # context_tokens removed (was duplicate; not part of binding identity+probe content)
+            }
+            vpath.write_text(json.dumps(vdata, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+            print(f"verdict written -> {args.verdict}")
+        return 0 if is_pass else 2
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -486,11 +689,14 @@ def build_parser() -> argparse.ArgumentParser:
         "mint",
         help="Freeze ground-truth anchors into a probe file. --facts for legacy three-anchor; --snapshot for strict production v2 10-anchor.",
     )
-    mint.add_argument(
+    # Use mutually_exclusive_group(required=True) so missing both or supplying both yield parser rc 2
+    # (matches origin/main's --facts required behavior for usage errors).
+    mint_src = mint.add_mutually_exclusive_group(required=True)
+    mint_src.add_argument(
         "--snapshot",
-        help="Path to structured durable handoff snapshot JSON (goals + decision_records + constraint_records + next_actions)",
+        help="Path to structured durable handoff snapshot JSON (goals + decision_records + constraint_records + next_actions). Requires lineage_id, rollover_id, UTC generated_at, and valid source_ref per grammar.",
     )
-    mint.add_argument(
+    mint_src.add_argument(
         "--facts", help="Legacy inline JSON list of {id,q,a}, or a path to a JSON file (original behavior)"
     )
     mint.add_argument("--out", required=True, help="Probe output path")
@@ -502,6 +708,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     score.add_argument("--probe", required=True)
     score.add_argument("--answers", required=True, help="JSON {id: answer}")
+    # Production v2 identity (caller-supplied, required+matched exactly in v2 path before scoring; optional in parser to preserve legacy CLI calls)
+    score.add_argument(
+        "--expected-lineage-id", help="Required for v2 production probes: must exactly match probe lineage_id"
+    )
+    score.add_argument(
+        "--expected-rollover-id", help="Required for v2 production probes: must exactly match probe rollover_id"
+    )
     score.add_argument(
         "--threshold",
         type=float,
@@ -527,7 +740,15 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        # argparse usage errors (e.g. missing required mutually_exclusive_group for mint, or both) must surface as rc 2
+        # so tests can assert parser rc 2 while CLI still exits 2. Func returns are normal.
+        if isinstance(getattr(exc, "code", None), int):
+            return exc.code
+        return 2
     return args.func(args)
 
 

--- a/scripts/context_canary.py
+++ b/scripts/context_canary.py
@@ -1,128 +1,283 @@
 #!/usr/bin/env python3
-"""Context-integrity canary — a DETERMINISTIC brain-rot monitor for long sessions.
+"""Context-integrity canary — DETERMINISTIC brain-rot monitor using tool-backed snapshots.
 
-Why this exists
----------------
-With autocompact disabled, a single Claude Code session can grow to 700K-1M tokens.
-Long-context retrieval degrades ("brain rot") well before the model *notices* — a
-dropped instruction or a misremembered SHA is invisible from the inside, because the
-model does not reliably self-report rot. Trusting a self-assessment ("I feel fine")
-is exactly the failure mode. So we measure instead.
-
-How it works
-------------
-1. `mint`  — freeze K anchors as (id, question, ground-truth answer). The truth is
-             captured EARLY (low context, presumed clean) from real state, then frozen.
-2. ...time passes, context grows...
-3. `score` — the agent answers the same questions FROM MEMORY/CONTEXT (no scrolling
-             back to re-read), writes them to a JSON, and this script diffs them against
-             the frozen truth. The SCRIPT computes the match — the agent cannot grade
-             itself into a pass. Drift below threshold => hand off NOW, regardless of
-             the token count.
-4. Each score appends a (context_tokens, score) row to a CSV so we can MAP where rot
-   starts for this model on this session shape across runs.
+Implements #5055 (under epic #5054): deterministic probe derivation from supplied
+tool-backed snapshot; exactly 10 unique anchors with validated composition
+(3 fact, 3 decision/rationale, 2 negative-constraint, 2 goal/next-action);
+UNKNOWN/unavailable/non-tool-backed values excluded (insufficient evidence fails);
+versioned metadata; strict 10/10 production scoring (rc 2 on drift);
+exact normalized matching for identifiers + explicit normalized-text mode;
+machine-readable JSON verdict; deterministic logging; complete focused tests.
+Do not invent anchor answers — all ground truth comes from the snapshot.
 
 Usage
 -----
-  context_canary.py mint  --facts facts.json --out probe.json
-  context_canary.py score --probe probe.json --answers answers.json \
-                          --context-tokens 500000 --model claude-opus-4-8 --log canary_log.csv
+  .venv/bin/python scripts/context_canary.py mint --snapshot snapshot.json --out probe.json
+  .venv/bin/python scripts/context_canary.py score --probe probe.json --answers answers.json \
+      --context-tokens 500000 --model claude-opus-4-8 --log canary_log.csv [--verdict v.json] \
+      [--text-match normalized]
 
-`facts.json`   : [{"id": "...", "q": "...", "a": "..."}, ...]
-                 (`--facts` also accepts the JSON list inline, not just a file path)
-`answers.json` : {"<id>": "<answer-from-memory>", ...}
+`snapshot.json` : output of orchestration/thread_handoff.gather_snapshot (git + monitor + github sections)
+`answers.json`  : {"<id>": "<answer-recalled-from-memory>", ...}
 
-Exit code: 0 if PASS, 2 if FAIL (hand off), 1 on usage error.
+The SCRIPT (not the agent) computes pass/fail by normalized diff against frozen truth.
+Only 10/10 normalized match under production rules yields PASS (rc 0); any drift -> rc 2 (handoff).
+
+Exit codes: 0 PASS, 2 FAIL-HANDOFF, 1 usage/insufficient/IO/JSON error.
 """
 
 from __future__ import annotations
 
 import argparse
 import csv
-import difflib
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 
 def _norm(value: object) -> str:
-    """Whitespace/case-insensitive normalization for fuzzy comparison."""
+    """Whitespace/case-insensitive normalization for exact normalized matching."""
     return " ".join(str(value).strip().lower().split())
 
 
-def _similarity(truth: str, got: str) -> float:
-    return difflib.SequenceMatcher(None, _norm(truth), _norm(got)).ratio()
+def _matches(truth: object, got: object, mode: str = "normalized") -> bool:
+    """Normalized (ws/case collapsed) or exact (byte-strict, no strip) text match."""
+    if mode == "exact":
+        return str(truth) == str(got)
+    return _norm(truth) == _norm(got)
+
+
+def _is_available(v: Any) -> bool:
+    """True only for tool-backed, present, non-UNKNOWN/unavailable values.
+
+    dicts with _error, None, empty-str after strip, and magic unknown tokens are excluded.
+    Empty list (e.g. no modified files) is allowed (represents clean state).
+    """
+    if v is None:
+        return False
+    if isinstance(v, dict) and "_error" in v:
+        return False
+    if isinstance(v, (list, dict)) and len(v) == 0:
+        return True  # e.g. modified_files: [] is valid "clean"
+    sv = str(v).strip()
+    if not sv:
+        return False
+    sl = sv.lower()
+    return sl not in {"unknown", "unavailable", "n/a", "none", "null"}
+
+
+def _derive_probe_anchors(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    """Deterministically derive anchors from tool-backed snapshot.
+
+    Only includes values that pass _is_available (excludes non-tool-backed/UNKNOWN).
+    Returns 0..N ; caller enforces exactly 10 + 3/3/2/2 composition.
+    All "a" (answers) come from snapshot; never invented.
+    """
+    anchors: list[dict[str, Any]] = []
+    git: dict[str, Any] = snapshot.get("git") or {}
+    _ = snapshot.get("github") or {}  # present for future extension / snapshot fidelity; not used in derivation yet
+    _ = snapshot.get("monitor") or {}  # present for future extension / snapshot fidelity; not used in derivation yet
+
+    def get(d: dict[str, Any], *keys: str, default: Any = None) -> Any:
+        cur: Any = d
+        for k in keys:
+            if isinstance(cur, dict):
+                cur = cur.get(k, default)
+            else:
+                return default
+        return cur if cur is not None else default
+
+    last_commits: list[Any] = get(git, "last_commits") or []
+    mod_files: list[Any] = get(git, "modified_files") or []
+    ahead_behind: dict[str, Any] = get(git, "ahead_behind") or {}
+
+    # 3 FACT
+    fact_specs = [
+        ("git_branch", "What is the git branch name from the tool-backed snapshot?"),
+        ("git_head", "What is the short HEAD SHA from the tool-backed snapshot?"),
+        ("git_modified_count", "Number of modified files reported in the tool-backed snapshot's git status?"),
+    ]
+    for cid, q in fact_specs:
+        if sum(1 for a in anchors if a.get("category") == "fact") >= 3:
+            break
+        if cid == "git_branch":
+            raw = get(git, "branch")
+        elif cid == "git_head":
+            raw = get(git, "head")
+        else:
+            raw = len(mod_files)
+        if _is_available(raw) or raw == 0:
+            anchors.append({
+                "id": cid,
+                "category": "fact",
+                "q": q,
+                "a": str(raw).strip(),
+            })
+
+    # 3 DECISION/RATIONALE (commit subjects = captured decisions/rationale)
+    for i in range(3):
+        if sum(1 for a in anchors if a.get("category") == "decision/rationale") >= 3:
+            break
+        if i < len(last_commits):
+            entry = last_commits[i] if isinstance(last_commits[i], dict) else {}
+            raw = entry.get("subject") if isinstance(entry, dict) else None
+            if _is_available(raw):
+                anchors.append({
+                    "id": f"commit_{i}_subject",
+                    "category": "decision/rationale",
+                    "q": f"What is the subject of commit index {i} (0=most recent) in the tool-backed snapshot (captures decision/rationale)?",
+                    "a": str(raw).strip(),
+                })
+
+    # 2 NEGATIVE-CONSTRAINT
+    neg_specs = [
+        ("git_modified_status", "The git status --short summary from the snapshot (''/clean encodes negative constraint: no uncommitted changes at mint)?", lambda: ";".join(f"{m.get('status','')}{m.get('path','')}" for m in mod_files if isinstance(m, dict)) or "clean"),
+        ("ahead_count", "The 'ahead' count vs upstream from snapshot (0 encodes negative constraint of no pending divergence)?", lambda: get(ahead_behind, "ahead")),
+    ]
+    for cid, q, getter in neg_specs:
+        if sum(1 for a in anchors if a.get("category") == "negative-constraint") >= 2:
+            break
+        raw = getter()
+        if _is_available(raw) or raw in (0, "0"):
+            av = "0" if raw in (0, "0") else str(raw).strip()
+            if _is_available(av) or av == "0":
+                anchors.append({
+                    "id": cid,
+                    "category": "negative-constraint",
+                    "q": q,
+                    "a": av,
+                })
+
+    # 2 GOAL/NEXT-ACTION
+    goal_specs = [
+        ("head_sha_next_ref", "HEAD SHA from snapshot (base reference for goal/next-action state at mint)?", lambda: get(git, "head") or get(git, "full_head")),
+        ("recent_commit_sha_goal", "Most recent commit SHA from snapshot (advancement reference for goals)?", lambda: (last_commits[0].get("sha") if last_commits and isinstance(last_commits[0], dict) else None)),
+    ]
+    for cid, q, getter in goal_specs:
+        if sum(1 for a in anchors if a.get("category") == "goal/next-action") >= 2:
+            break
+        raw = getter()
+        if _is_available(raw):
+            anchors.append({
+                "id": cid,
+                "category": "goal/next-action",
+                "q": q,
+                "a": str(raw).strip(),
+            })
+
+    return anchors
 
 
 def _load_facts_spec(spec: str) -> object:
-    """Load facts from EITHER an inline JSON list OR a path to a JSON file.
-
-    `--facts` accepts both forms: the documented `--facts facts.json` path AND an
-    inline `[{...}]` payload (the arg help advertises "JSON list of {id,q,a}").
-    A JSON list starts with '[' (an object with '{'); a filesystem path effectively
-    never does — a bare name starting with a bracket would need quoting and is an
-    edge case — so the leading bracket selects inline vs file for all practical
-    inputs. This keeps the CLI help honest and avoids the opaque 'File name too
-    long' OSError a caller hit when passing inline JSON to the file-only reader.
-    """
+    """Legacy support for --facts (inline or path)."""
     if spec.lstrip()[:1] in ("[", "{"):
         return json.loads(spec)
     return json.loads(Path(spec).read_text(encoding="utf-8"))
 
 
 def cmd_mint(args: argparse.Namespace) -> int:
+    snapshot_path = getattr(args, "snapshot", None)
+    facts_spec = getattr(args, "facts", None)
     try:
-        facts = _load_facts_spec(args.facts)
+        if snapshot_path:
+            snap = json.loads(Path(snapshot_path).read_text(encoding="utf-8"))
+            if not isinstance(snap, dict):
+                print("error: --snapshot must be a JSON object", file=sys.stderr)
+                return 1
+            anchors = _derive_probe_anchors(snap)
+            counts = {c: sum(1 for a in anchors if a.get("category") == c)
+                      for c in ("fact", "decision/rationale", "negative-constraint", "goal/next-action")}
+            if len(anchors) != 10 or counts != {"fact": 3, "decision/rationale": 3, "negative-constraint": 2, "goal/next-action": 2}:
+                print("error: insufficient evidence from tool-backed snapshot (UNKNOWN/unavailable/non-tool-backed excluded; need validated 3 fact, 3 decision/rationale, 2 negative-constraint, 2 goal/next-action)", file=sys.stderr)
+                return 1
+            probe = {
+                "version": "1",
+                "source": "snapshot",
+                "generated_at": snap.get("generated_at"),
+                "anchor_counts": counts,
+                "anchors": anchors,
+            }
+        elif facts_spec:
+            facts = _load_facts_spec(facts_spec)
+            if not isinstance(facts, list) or not facts:
+                print("error: --facts must be a non-empty JSON list of {id,q,a}", file=sys.stderr)
+                return 1
+            ids = [f.get("id") for f in facts]
+            if len(set(ids)) != len(ids) or not all(ids):
+                print("error: every fact needs a unique non-empty 'id'", file=sys.stderr)
+                return 1
+            anchors = [{"id": f["id"], "q": f["q"], "a": f["a"]} for f in facts]
+            probe = {"version": "1", "source": "facts", "anchors": anchors}
+        else:
+            print("error: mint requires --snapshot (for 10-anchor derivation) or --facts", file=sys.stderr)
+            return 1
     except (OSError, UnicodeDecodeError) as exc:
-        # File branch: missing / directory / permission / non-UTF-8 all land here.
-        print(f"error: --facts cannot be read as a file: {args.facts} ({type(exc).__name__})", file=sys.stderr)
+        print(f"error: cannot read input: {exc}", file=sys.stderr)
         return 1
     except json.JSONDecodeError as exc:
-        print(f"error: --facts is not valid JSON: {exc}", file=sys.stderr)
+        print(f"error: input is not valid JSON: {exc}", file=sys.stderr)
         return 1
-    if not isinstance(facts, list) or not facts:
-        print("error: --facts must be a non-empty JSON list of {id,q,a}", file=sys.stderr)
-        return 1
-    ids = [f.get("id") for f in facts]
-    if len(set(ids)) != len(ids) or not all(ids):
-        print("error: every fact needs a unique non-empty 'id'", file=sys.stderr)
-        return 1
-    probe = {"anchors": [{"id": f["id"], "q": f["q"], "a": f["a"]} for f in facts]}
+
     Path(args.out).write_text(json.dumps(probe, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-    print(f"minted {len(facts)} anchors -> {args.out}")
+    print(f"minted {len(anchors)} anchors -> {args.out}")
     return 0
 
 
 def cmd_score(args: argparse.Namespace) -> int:
-    probe = json.loads(Path(args.probe).read_text(encoding="utf-8"))
-    answers = json.loads(Path(args.answers).read_text(encoding="utf-8"))
-    anchors = probe.get("anchors", [])
-    if not anchors:
-        print("error: probe has no anchors", file=sys.stderr)
+    try:
+        probe = json.loads(Path(args.probe).read_text(encoding="utf-8"))
+        answers = json.loads(Path(args.answers).read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError) as exc:
+        print(f"error: cannot read probe or answers: {exc}", file=sys.stderr)
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"error: probe or answers not valid JSON: {exc}", file=sys.stderr)
         return 1
 
+    anchors = probe.get("anchors", [])
+    if not isinstance(anchors, list) or len(anchors) != 10:
+        print(f"error: probe must have exactly 10 anchors (got {len(anchors) if isinstance(anchors, list) else 0}); derive via --snapshot for production canary", file=sys.stderr)
+        return 1
+
+    # exact normalized matching for identifiers
+    id_map: dict[str, dict[str, Any]] = {}
+    for a in anchors:
+        nid = _norm(a.get("id", ""))
+        if nid:
+            id_map[nid] = a
+
+    text_mode = getattr(args, "text_match", "normalized")
     correct = 0
-    rows = []
+    rows: list[tuple[str, bool, str, str, str]] = []
     for anchor in anchors:
-        aid = anchor["id"]
-        truth = anchor["a"]
-        got = answers.get(aid, "")
-        sim = _similarity(truth, got)
-        ok = sim >= args.threshold
-        correct += 1 if ok else 0
-        rows.append((aid, ok, sim, anchor["q"]))
+        aid = anchor.get("id", "")
+        truth = anchor.get("a", "")
+        nid = _norm(aid)
+        got: Any = ""
+        if isinstance(answers, dict):
+            for ak, av in answers.items():
+                if _norm(ak) == nid:
+                    got = av
+                    break
+        ok = _matches(truth, got, text_mode)
+        if ok:
+            correct += 1
+        rows.append((aid, ok, str(anchor.get("q", "")), str(truth), str(got)))
 
     k = len(anchors)
-    score = correct / k
-    for aid, ok, sim, q in rows:
-        tag = "PASS " if ok else "DRIFT"
-        print(f"  [{tag}] {aid} (sim={sim:.2f}) {q}")
-        if not ok:
-            print(f"          truth: {next(a['a'] for a in anchors if a['id'] == aid)!r}")
-            print(f"          got  : {answers.get(aid, '')!r}")
+    # strict 10/10 production scoring
+    is_pass = (correct == 10 and k == 10)
+    verdict = "PASS" if is_pass else "FAIL-HANDOFF"
 
-    verdict = "PASS" if score >= args.pass_ratio else "FAIL-HANDOFF"
-    print(f"SCORE {correct}/{k} = {score:.2f}  ->  {verdict}")
+    for aid, ok, q, truth, got in rows:
+        tag = "PASS " if ok else "DRIFT"
+        print(f"  [{tag}] {aid} {q}")
+        if not ok:
+            print(f"          truth: {truth!r}")
+            print(f"          got  : {got!r}")
+
+    print(f"SCORE {correct}/{k} = {correct / k:.3f}  ->  {verdict} (strict 10/10)")
 
     if args.log:
         log_path = Path(args.log)
@@ -131,32 +286,51 @@ def cmd_score(args: argparse.Namespace) -> int:
             writer = csv.writer(handle)
             if is_new:
                 writer.writerow(["context_tokens", "model", "k", "correct", "score", "verdict"])
-            writer.writerow([args.context_tokens, args.model, k, correct, f"{score:.3f}", verdict])
+            writer.writerow([
+                getattr(args, "context_tokens", 0),
+                getattr(args, "model", "unknown"),
+                k,
+                correct,
+                f"{(correct / k):.3f}",
+                verdict,
+            ])
 
-    return 0 if verdict == "PASS" else 2
+    if getattr(args, "verdict", None):
+        vpath = Path(args.verdict)
+        vdata = {
+            "version": probe.get("version", "1"),
+            "k": k,
+            "correct": correct,
+            "score": round(correct / k, 3) if k else 0.0,
+            "verdict": verdict,
+            "context_tokens": getattr(args, "context_tokens", 0),
+            "model": getattr(args, "model", "unknown"),
+            "per_anchor": [{"id": r[0], "match": r[1]} for r in rows],
+        }
+        vpath.write_text(json.dumps(vdata, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print(f"verdict written -> {args.verdict}")
+
+    return 0 if is_pass else 2
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    mint = sub.add_parser("mint", help="Freeze ground-truth anchors into a probe file.")
-    mint.add_argument(
-        "--facts",
-        required=True,
-        help="Inline JSON list of {id,q,a}, or a path to a JSON file",
-    )
+    mint = sub.add_parser("mint", help="Derive deterministic 10-anchor probe from tool-backed snapshot (or legacy facts).")
+    mint.add_argument("--snapshot", help="Path to tool-backed snapshot JSON (git/monitor/github); derives exactly 10 anchors with categories")
+    mint.add_argument("--facts", help="Legacy inline JSON list or path to [{id,q,a},...] (for non-production)")
     mint.add_argument("--out", required=True, help="Probe output path")
     mint.set_defaults(func=cmd_mint)
 
-    score = sub.add_parser("score", help="Diff from-memory answers against the frozen probe.")
+    score = sub.add_parser("score", help="Diff answers vs probe (normalized id match + configurable text match). Strict 10/10 rc=2.")
     score.add_argument("--probe", required=True)
-    score.add_argument("--answers", required=True, help="JSON {id: answer}")
-    score.add_argument("--threshold", type=float, default=0.75, help="Per-anchor similarity to count as recalled (default 0.75)")
-    score.add_argument("--pass-ratio", type=float, default=0.85, help="Fraction of anchors that must pass (default 0.85)")
-    score.add_argument("--context-tokens", type=int, default=0, help="Context size at probe time (for the log)")
+    score.add_argument("--answers", required=True, help="JSON object {id: recalled-answer}")
+    score.add_argument("--context-tokens", type=int, default=0, help="Context size for the log row")
     score.add_argument("--model", default="unknown")
-    score.add_argument("--log", help="CSV to append the (context_tokens, score) data point")
+    score.add_argument("--log", help="Append deterministic row to this CSV")
+    score.add_argument("--text-match", choices=["normalized", "exact"], default="normalized", help="normalized (default): ignore ws/case; exact: strict string")
+    score.add_argument("--verdict", help="Write machine-readable JSON verdict to this path")
     score.set_defaults(func=cmd_score)
 
     return parser

--- a/scripts/context_canary.py
+++ b/scripts/context_canary.py
@@ -1,27 +1,55 @@
 #!/usr/bin/env python3
-"""Context-integrity canary — DETERMINISTIC brain-rot monitor using tool-backed snapshots.
+"""Context-integrity canary — a DETERMINISTIC brain-rot monitor for long sessions.
 
-Implements #5055 (under epic #5054): deterministic probe derivation from supplied
-tool-backed snapshot; exactly 10 unique anchors with validated composition
-(3 fact, 3 decision/rationale, 2 negative-constraint, 2 goal/next-action);
-UNKNOWN/unavailable/non-tool-backed values excluded (insufficient evidence fails);
-versioned metadata; strict 10/10 production scoring (rc 2 on drift);
-exact normalized matching for identifiers + explicit normalized-text mode;
-machine-readable JSON verdict; deterministic logging; complete focused tests.
-Do not invent anchor answers — all ground truth comes from the snapshot.
+Why this exists
+---------------
+With autocompact disabled, a single Claude Code session can grow to 700K-1M tokens.
+Long-context retrieval degrades ("brain rot") well before the model *notices* — a
+dropped instruction or a misremembered SHA is invisible from the inside, because the
+model does not reliably self-report rot. Trusting a self-assessment ("I feel fine")
+is exactly the failure mode. So we measure instead.
+
+How it works
+------------
+1. `mint`  — freeze K anchors as (id, question, ground-truth answer). The truth is
+             captured EARLY (low context, presumed clean) from real state, then frozen.
+2. ...time passes, context grows...
+3. `score` — the agent answers the same questions FROM MEMORY/CONTEXT (no scrolling
+             back to re-read), writes them to a JSON, and this script diffs them against
+             the frozen truth. The SCRIPT computes the match — the agent cannot grade
+             itself into a pass. Drift below threshold => hand off NOW, regardless of
+             the token count.
+4. Each score appends a (context_tokens, score) row to a CSV so we can MAP where rot
+   starts for this model on this session shape across runs.
+
+Legacy behavior (fully preserved for backward compatibility):
+  mint --facts  (original three-anchor flow, unique non-empty ids, inline or file)
+  score uses --threshold (sim via difflib on normalized), --pass-ratio (default 0.75/0.85),
+  exact id lookup (no id normalization), rc 0/2.
+
+New production v2 (for handoff snapshots):
+  mint --snapshot  produces strict schema v2: exactly 10 unique anchors ONLY from
+  durable handoff artifacts (goals, decision/rationale records, negative constraint/
+  prohibition records, next actions). Never from git/SHAs/commits/modified/monitor/github.
+  Anchors shaped exactly {id, q, a, category, match_mode, source_ref} where source_ref
+  is durable artifact locator. Selection uses random.Random(seed) for lineage-randomized
+  but reproducible order. Seed persisted (generated from snapshot if absent).
+  All validation (no empty/UNKNOWN/dup/malformed/wrong-cat) happens before derivation.
+  score for v2: strict 10/10 only, exact ID match (no normalization of ids), match_mode
+  (exact|normalized) controls answer text only. Full schema + provenance + category
+  checks. rc 2 on any failure to confirm. Legacy probes never treated as v2.
 
 Usage
 -----
-  .venv/bin/python scripts/context_canary.py mint --snapshot snapshot.json --out probe.json
+  .venv/bin/python scripts/context_canary.py mint --facts facts.json --out probe.json
+  .venv/bin/python scripts/context_canary.py mint --snapshot handoff-snapshot.json --out probe.json
   .venv/bin/python scripts/context_canary.py score --probe probe.json --answers answers.json \
-      --context-tokens 500000 --model claude-opus-4-8 --log canary_log.csv [--verdict v.json] \
-      [--text-match normalized]
+      --context-tokens 500000 --model claude-opus-4-8 --log canary_log.csv \
+      [--threshold 0.75] [--pass-ratio 0.85] [--verdict v.json]
 
-`snapshot.json` : output of orchestration/thread_handoff.gather_snapshot (git + monitor + github sections)
-`answers.json`  : {"<id>": "<answer-recalled-from-memory>", ...}
-
-The SCRIPT (not the agent) computes pass/fail by normalized diff against frozen truth.
-Only 10/10 normalized match under production rules yields PASS (rc 0); any drift -> rc 2 (handoff).
+`facts.json`   : [{"id": "...", "q": "...", "a": "..."}, ...]  (legacy)
+`snapshot.json`: handoff with "goals", "decision_records", "constraint_records", "next_actions"
+`answers.json` : {"<id>": "<answer-from-memory>", ...}
 
 Exit codes: 0 PASS, 2 FAIL-HANDOFF, 1 usage/insufficient/IO/JSON error.
 """
@@ -30,212 +58,216 @@ from __future__ import annotations
 
 import argparse
 import csv
+import difflib
+import hashlib
 import json
+import random
 import sys
 from pathlib import Path
 from typing import Any
 
 
 def _norm(value: object) -> str:
-    """Whitespace/case-insensitive normalization for exact normalized matching."""
+    """Whitespace/case-insensitive normalization for fuzzy comparison."""
     return " ".join(str(value).strip().lower().split())
 
 
-def _matches(truth: object, got: object, mode: str = "normalized") -> bool:
-    """Normalized (ws/case collapsed) or exact (byte-strict, no strip) text match."""
+def _similarity(truth: str, got: str) -> float:
+    return difflib.SequenceMatcher(None, _norm(truth), _norm(got)).ratio()
+
+
+def _matches_v2(truth: object, got: object, mode: str = "exact") -> bool:
+    """Boolean match used only for v2 production anchors. match_mode controls text comparison."""
     if mode == "exact":
         return str(truth) == str(got)
     return _norm(truth) == _norm(got)
 
 
-def _is_available(v: Any) -> bool:
-    """True only for tool-backed, present, non-UNKNOWN/unavailable values.
-
-    dicts with _error, None, empty-str after strip, and magic unknown tokens are excluded.
-    Empty list (e.g. no modified files) is allowed (represents clean state).
-    """
+def _has_unknowns(v: Any) -> bool:
+    """Recursively reject empty/UNKNOWN/unavailable/_error/malformed before any derivation."""
     if v is None:
+        return True
+    if isinstance(v, str):
+        sl = v.strip().lower()
+        return not sl or sl in {"unknown", "unavailable", "n/a", "none", "null", "missing"}
+    if isinstance(v, (int, float, bool)):
         return False
-    if isinstance(v, dict) and "_error" in v:
-        return False
-    if isinstance(v, (list, dict)) and len(v) == 0:
-        return True  # e.g. modified_files: [] is valid "clean"
-    sv = str(v).strip()
-    if not sv:
-        return False
-    sl = sv.lower()
-    return sl not in {"unknown", "unavailable", "n/a", "none", "null"}
-
-
-def _derive_probe_anchors(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
-    """Deterministically derive anchors from tool-backed snapshot.
-
-    Only includes values that pass _is_available (excludes non-tool-backed/UNKNOWN).
-    Returns 0..N ; caller enforces exactly 10 + 3/3/2/2 composition.
-    All "a" (answers) come from snapshot; never invented.
-    """
-    anchors: list[dict[str, Any]] = []
-    git: dict[str, Any] = snapshot.get("git") or {}
-    _ = snapshot.get("github") or {}  # present for future extension / snapshot fidelity; not used in derivation yet
-    _ = snapshot.get("monitor") or {}  # present for future extension / snapshot fidelity; not used in derivation yet
-
-    def get(d: dict[str, Any], *keys: str, default: Any = None) -> Any:
-        cur: Any = d
-        for k in keys:
-            if isinstance(cur, dict):
-                cur = cur.get(k, default)
-            else:
-                return default
-        return cur if cur is not None else default
-
-    last_commits: list[Any] = get(git, "last_commits") or []
-    mod_files: list[Any] = get(git, "modified_files") or []
-    ahead_behind: dict[str, Any] = get(git, "ahead_behind") or {}
-
-    # 3 FACT
-    fact_specs = [
-        ("git_branch", "What is the git branch name from the tool-backed snapshot?"),
-        ("git_head", "What is the short HEAD SHA from the tool-backed snapshot?"),
-        ("git_modified_count", "Number of modified files reported in the tool-backed snapshot's git status?"),
-    ]
-    for cid, q in fact_specs:
-        if sum(1 for a in anchors if a.get("category") == "fact") >= 3:
-            break
-        if cid == "git_branch":
-            raw = get(git, "branch")
-        elif cid == "git_head":
-            raw = get(git, "head")
-        else:
-            raw = len(mod_files)
-        if _is_available(raw) or raw == 0:
-            anchors.append(
-                {
-                    "id": cid,
-                    "category": "fact",
-                    "q": q,
-                    "a": str(raw).strip(),
-                }
-            )
-
-    # 3 DECISION/RATIONALE (commit subjects = captured decisions/rationale)
-    for i in range(3):
-        if sum(1 for a in anchors if a.get("category") == "decision/rationale") >= 3:
-            break
-        if i < len(last_commits):
-            entry = last_commits[i] if isinstance(last_commits[i], dict) else {}
-            raw = entry.get("subject") if isinstance(entry, dict) else None
-            if _is_available(raw):
-                anchors.append(
-                    {
-                        "id": f"commit_{i}_subject",
-                        "category": "decision/rationale",
-                        "q": f"What is the subject of commit index {i} (0=most recent) in the tool-backed snapshot (captures decision/rationale)?",
-                        "a": str(raw).strip(),
-                    }
-                )
-
-    # 2 NEGATIVE-CONSTRAINT
-    neg_specs = [
-        (
-            "git_modified_status",
-            "The git status --short summary from the snapshot (''/clean encodes negative constraint: no uncommitted changes at mint)?",
-            lambda: (
-                ";".join(f"{m.get('status', '')}{m.get('path', '')}" for m in mod_files if isinstance(m, dict))
-                or "clean"
-            ),
-        ),
-        (
-            "ahead_count",
-            "The 'ahead' count vs upstream from snapshot (0 encodes negative constraint of no pending divergence)?",
-            lambda: get(ahead_behind, "ahead"),
-        ),
-    ]
-    for cid, q, getter in neg_specs:
-        if sum(1 for a in anchors if a.get("category") == "negative-constraint") >= 2:
-            break
-        raw = getter()
-        if _is_available(raw) or raw in (0, "0"):
-            av = "0" if raw in (0, "0") else str(raw).strip()
-            if _is_available(av) or av == "0":
-                anchors.append(
-                    {
-                        "id": cid,
-                        "category": "negative-constraint",
-                        "q": q,
-                        "a": av,
-                    }
-                )
-
-    # 2 GOAL/NEXT-ACTION
-    goal_specs = [
-        (
-            "head_sha_next_ref",
-            "HEAD SHA from snapshot (base reference for goal/next-action state at mint)?",
-            lambda: get(git, "head") or get(git, "full_head"),
-        ),
-        (
-            "recent_commit_sha_goal",
-            "Most recent commit SHA from snapshot (advancement reference for goals)?",
-            lambda: last_commits[0].get("sha") if last_commits and isinstance(last_commits[0], dict) else None,
-        ),
-    ]
-    for cid, q, getter in goal_specs:
-        if sum(1 for a in anchors if a.get("category") == "goal/next-action") >= 2:
-            break
-        raw = getter()
-        if _is_available(raw):
-            anchors.append(
-                {
-                    "id": cid,
-                    "category": "goal/next-action",
-                    "q": q,
-                    "a": str(raw).strip(),
-                }
-            )
-
-    return anchors
+    if isinstance(v, dict):
+        if "_error" in v:
+            return True
+        return any(_has_unknowns(val) for val in v.values())
+    if isinstance(v, list):
+        return any(_has_unknowns(item) for item in v)
+    return False
 
 
 def _load_facts_spec(spec: str) -> object:
-    """Legacy support for --facts (inline or path)."""
+    """Load facts from EITHER an inline JSON list OR a path to a JSON file.
+
+    `--facts` accepts both forms: the documented `--facts facts.json` path AND an
+    inline `[{...}]` payload (the arg help advertises "JSON list of {id,q,a}").
+    A JSON list starts with '[' (an object with '{'); a filesystem path effectively
+    never does — a bare name starting with a bracket would need quoting and is an
+    edge case — so the leading bracket selects inline vs file for all practical
+    inputs. This keeps the CLI help honest and avoids the opaque 'File name too
+    long' OSError a caller hit when passing inline JSON to the file-only reader.
+    """
     if spec.lstrip()[:1] in ("[", "{"):
         return json.loads(spec)
     return json.loads(Path(spec).read_text(encoding="utf-8"))
 
 
+def _select_with_seed(items: list[Any], n: int, rng: random.Random) -> list[dict]:
+    """Shuffle and take first n (or all if ==n) using provided seeded rng. Returns [] if insufficient."""
+    if not isinstance(items, list) or len(items) < n:
+        return []
+    clean = [x for x in items if isinstance(x, dict)]
+    if len(clean) < n:
+        return []
+    c = list(clean)
+    rng.shuffle(c)
+    return c[:n]
+
+
+def _build_v2_anchors(sel_items: list[dict], category: str, text_key: str, q_tmpl: str) -> list[dict]:
+    """Build exact shaped anchors or [] on any shape/unknown/empty failure for that batch."""
+    anchors: list[dict] = []
+    for rec in sel_items:
+        if not isinstance(rec, dict):
+            return []
+        aid = rec.get("id")
+        if not isinstance(aid, str) or not aid.strip() or _has_unknowns(aid):
+            return []
+        src_ref = rec.get("source_ref")
+        if not isinstance(src_ref, str) or not src_ref.strip() or _has_unknowns(src_ref):
+            return []
+        a_val = (
+            rec.get(text_key)
+            or rec.get("text")
+            or rec.get("statement")
+            or rec.get("rationale")
+            or rec.get("action")
+            or rec.get("prohibition")
+            or rec.get("a")
+            or ""
+        )
+        if not str(a_val).strip() or _has_unknowns(str(a_val)):
+            return []
+        q = rec.get("q") or rec.get("question") or q_tmpl.format(id=aid)
+        mm = rec.get("match_mode", "exact")
+        if mm not in ("exact", "normalized"):
+            return []
+        anchors.append(
+            {
+                "id": aid,
+                "q": str(q).strip(),
+                "a": str(a_val).strip(),
+                "category": category,
+                "match_mode": mm,
+                "source_ref": src_ref.strip(),
+            }
+        )
+    return anchors
+
+
 def cmd_mint(args: argparse.Namespace) -> int:
     snapshot_path = getattr(args, "snapshot", None)
     facts_spec = getattr(args, "facts", None)
+    if snapshot_path and facts_spec:
+        print("error: mint accepts only one of --snapshot or --facts, not both", file=sys.stderr)
+        return 1
     try:
         if snapshot_path:
             snap = json.loads(Path(snapshot_path).read_text(encoding="utf-8"))
             if not isinstance(snap, dict):
                 print("error: --snapshot must be a JSON object", file=sys.stderr)
                 return 1
-            anchors = _derive_probe_anchors(snap)
-            counts = {
-                c: sum(1 for a in anchors if a.get("category") == c)
-                for c in ("fact", "decision/rationale", "negative-constraint", "goal/next-action")
-            }
-            if len(anchors) != 10 or counts != {
-                "fact": 3,
-                "decision/rationale": 3,
-                "negative-constraint": 2,
-                "goal/next-action": 2,
-            }:
+            if _has_unknowns(snap):
                 print(
-                    "error: insufficient evidence from tool-backed snapshot (UNKNOWN/unavailable/non-tool-backed excluded; need validated 3 fact, 3 decision/rationale, 2 negative-constraint, 2 goal/next-action)",
+                    "error: --snapshot contains UNKNOWN/unavailable or malformed values (rejected before derivation)",
                     file=sys.stderr,
                 )
                 return 1
+            # Only pull from explicit durable handoff sections. Never git/monitor/github/SHAs etc.
+            goals = snap.get("goals") or snap.get("handoff_goals") or []
+            decs = snap.get("decision_records") or snap.get("decisions") or snap.get("decision_rationale_records") or []
+            negs = (
+                snap.get("constraint_records")
+                or snap.get("constraints")
+                or snap.get("negative_constraints")
+                or snap.get("prohibitions")
+                or []
+            )
+            nexts = snap.get("next_actions") or snap.get("queued_next_actions") or snap.get("actions") or []
+            seed = snap.get("seed")
+            if seed is None:
+                # generate and persist a stable seed when absent (reproducible for same snapshot)
+                snap_wo_seed = {k: v for k, v in snap.items() if k != "seed"}
+                h = hashlib.sha256(json.dumps(snap_wo_seed, sort_keys=True, default=str).encode("utf-8")).hexdigest()
+                seed = int(h[:16], 16) & 0xFFFFFFFF
+            else:
+                try:
+                    seed = int(seed)
+                except Exception:
+                    print("error: seed must be an integer", file=sys.stderr)
+                    return 1
+            rng = random.Random(seed)
+            sel_g = _select_with_seed(goals, 3, rng)
+            sel_d = _select_with_seed(decs, 3, rng)
+            sel_n = _select_with_seed(negs, 2, rng)
+            sel_na = _select_with_seed(nexts, 2, rng)
+            if len(sel_g) != 3 or len(sel_d) != 3 or len(sel_n) != 2 or len(sel_na) != 2:
+                print(
+                    "error: insufficient evidence from durable handoff artifacts (need >=3 goals, 3 decision/rationale, 2 negative-constraint/prohibition, 2 next-action; no padding)",
+                    file=sys.stderr,
+                )
+                return 1
+            anchors: list[dict] = []
+            for items, cat, tkey, qt in [
+                (sel_g, "goal", "statement", "What is the goal '{id}' as of this handoff?"),
+                (sel_d, "decision/rationale", "decision", "What is the decision/rationale '{id}' as of this handoff?"),
+                (
+                    sel_n,
+                    "negative-constraint/prohibition",
+                    "prohibition",
+                    "What is the negative constraint/prohibition '{id}' as of this handoff?",
+                ),
+                (sel_na, "next-action", "action", "What is the next action '{id}' as of this handoff?"),
+            ]:
+                built = _build_v2_anchors(items, cat, tkey, qt)
+                if len(built) != len(items):
+                    print("error: malformed durable artifact record (id/source_ref/a/q or UNKNOWN)", file=sys.stderr)
+                    return 1
+                anchors.extend(built)
+            id_set = {a["id"] for a in anchors}
+            if len(id_set) != 10 or len(anchors) != 10:
+                print("error: production anchors must have exactly 10 unique non-empty IDs", file=sys.stderr)
+                return 1
+            counts = {}
+            for a in anchors:
+                c = a["category"]
+                counts[c] = counts.get(c, 0) + 1
+            expected = {"goal": 3, "decision/rationale": 3, "negative-constraint/prohibition": 2, "next-action": 2}
+            if counts != expected:
+                print("error: wrong category composition for production v2", file=sys.stderr)
+                return 1
             probe = {
-                "version": "1",
+                "version": "2",
+                "schema": "production-handoff-v2",
+                "lineage": snap.get("lineage") or snap.get("handoff_id") or "lineage:unknown",
                 "source": "snapshot",
+                "seed": seed,
                 "generated_at": snap.get("generated_at"),
-                "anchor_counts": counts,
+                "anchor_counts": expected,
+                "strict_production": True,
+                "policy": "strict-10/10-only-from-durable-continuity-artifacts",
                 "anchors": anchors,
             }
+            Path(args.out).write_text(json.dumps(probe, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+            print(f"minted {len(anchors)} anchors -> {args.out}")
+            return 0
         elif facts_spec:
+            # LEGACY PATH - behavior and error messages identical to origin/main
             facts = _load_facts_spec(facts_spec)
             if not isinstance(facts, list) or not facts:
                 print("error: --facts must be a non-empty JSON list of {id,q,a}", file=sys.stderr)
@@ -244,21 +276,25 @@ def cmd_mint(args: argparse.Namespace) -> int:
             if len(set(ids)) != len(ids) or not all(ids):
                 print("error: every fact needs a unique non-empty 'id'", file=sys.stderr)
                 return 1
-            anchors = [{"id": f["id"], "q": f["q"], "a": f["a"]} for f in facts]
-            probe = {"version": "1", "source": "facts", "anchors": anchors}
+            probe = {"anchors": [{"id": f["id"], "q": f["q"], "a": f["a"]} for f in facts]}
+            Path(args.out).write_text(json.dumps(probe, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+            print(f"minted {len(facts)} anchors -> {args.out}")
+            return 0
         else:
-            print("error: mint requires --snapshot (for 10-anchor derivation) or --facts", file=sys.stderr)
+            print("error: mint requires --snapshot (for production v2) or --facts (legacy)", file=sys.stderr)
             return 1
     except (OSError, UnicodeDecodeError) as exc:
-        print(f"error: cannot read input: {exc}", file=sys.stderr)
+        if snapshot_path:
+            print(f"error: cannot read --snapshot: {snapshot_path} ({type(exc).__name__})", file=sys.stderr)
+        else:
+            print(f"error: --facts cannot be read as a file: {facts_spec} ({type(exc).__name__})", file=sys.stderr)
         return 1
     except json.JSONDecodeError as exc:
-        print(f"error: input is not valid JSON: {exc}", file=sys.stderr)
+        if snapshot_path:
+            print(f"error: --snapshot is not valid JSON: {exc}", file=sys.stderr)
+        else:
+            print(f"error: --facts is not valid JSON: {exc}", file=sys.stderr)
         return 1
-
-    Path(args.out).write_text(json.dumps(probe, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-    print(f"minted {len(anchors)} anchors -> {args.out}")
-    return 0
 
 
 def cmd_score(args: argparse.Namespace) -> int:
@@ -273,86 +309,173 @@ def cmd_score(args: argparse.Namespace) -> int:
         return 1
 
     anchors = probe.get("anchors", [])
-    if not isinstance(anchors, list) or len(anchors) != 10:
-        print(
-            f"error: probe must have exactly 10 anchors (got {len(anchors) if isinstance(anchors, list) else 0}); derive via --snapshot for production canary",
-            file=sys.stderr,
-        )
+    if not isinstance(anchors, list) or not anchors:
+        print("error: probe has no anchors", file=sys.stderr)
         return 1
 
-    # exact normalized matching for identifiers
-    id_map: dict[str, dict[str, Any]] = {}
-    for a in anchors:
-        nid = _norm(a.get("id", ""))
-        if nid:
-            id_map[nid] = a
+    is_v2_prod = bool(
+        probe.get("version") == "2"
+        and probe.get("schema") == "production-handoff-v2"
+        and probe.get("strict_production") is True
+        and len(anchors) == 10
+        and probe.get("source") == "snapshot"
+    )
 
-    text_mode = getattr(args, "text_match", "normalized")
-    correct = 0
-    rows: list[tuple[str, bool, str, str, str]] = []
-    for anchor in anchors:
-        aid = anchor.get("id", "")
-        truth = anchor.get("a", "")
-        nid = _norm(aid)
-        got: Any = ""
-        if isinstance(answers, dict):
-            for ak, av in answers.items():
-                if _norm(ak) == nid:
-                    got = av
-                    break
-        ok = _matches(truth, got, text_mode)
-        if ok:
-            correct += 1
-        rows.append((aid, ok, str(anchor.get("q", "")), str(truth), str(got)))
-
-    k = len(anchors)
-    # strict 10/10 production scoring
-    is_pass = correct == 10 and k == 10
-    verdict = "PASS" if is_pass else "FAIL-HANDOFF"
-
-    for aid, ok, q, truth, got in rows:
-        tag = "PASS " if ok else "DRIFT"
-        print(f"  [{tag}] {aid} {q}")
-        if not ok:
-            print(f"          truth: {truth!r}")
-            print(f"          got  : {got!r}")
-
-    print(f"SCORE {correct}/{k} = {correct / k:.3f}  ->  {verdict} (strict 10/10)")
-
-    if args.log:
-        log_path = Path(args.log)
-        is_new = not log_path.exists()
-        with log_path.open("a", newline="", encoding="utf-8") as handle:
-            writer = csv.writer(handle)
-            if is_new:
-                writer.writerow(["context_tokens", "model", "k", "correct", "score", "verdict"])
-            writer.writerow(
-                [
-                    getattr(args, "context_tokens", 0),
-                    getattr(args, "model", "unknown"),
-                    k,
-                    correct,
-                    f"{(correct / k):.3f}",
-                    verdict,
-                ]
-            )
-
-    if getattr(args, "verdict", None):
-        vpath = Path(args.verdict)
-        vdata = {
-            "version": probe.get("version", "1"),
-            "k": k,
-            "correct": correct,
-            "score": round(correct / k, 3) if k else 0.0,
-            "verdict": verdict,
-            "context_tokens": getattr(args, "context_tokens", 0),
-            "model": getattr(args, "model", "unknown"),
-            "per_anchor": [{"id": r[0], "match": r[1]} for r in rows],
+    if is_v2_prod:
+        # Strict validation for T1 confirmation: schema, provenance, categories, uniqueness, exact shape, source_ref
+        seen: set[str] = set()
+        cat_c: dict[str, int] = {
+            "goal": 0,
+            "decision/rationale": 0,
+            "negative-constraint/prohibition": 0,
+            "next-action": 0,
         }
-        vpath.write_text(json.dumps(vdata, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
-        print(f"verdict written -> {args.verdict}")
+        for a in anchors:
+            if not isinstance(a, dict):
+                print("error: v2 production anchor must be object", file=sys.stderr)
+                return 1
+            for req in ("id", "q", "a", "category", "match_mode", "source_ref"):
+                val = a.get(req)
+                if val is None or (isinstance(val, str) and not val.strip()):
+                    print(f"error: v2 anchor missing/empty field: {req}", file=sys.stderr)
+                    return 1
+            aid = a["id"]
+            if not isinstance(aid, str) or aid in seen:
+                print(
+                    "error: v2 anchors require unique non-empty string ids (exact match; do not normalize IDs)",
+                    file=sys.stderr,
+                )
+                return 1
+            seen.add(aid)
+            cat = a["category"]
+            if cat not in cat_c:
+                print(f"error: invalid category {cat} for v2 production", file=sys.stderr)
+                return 1
+            cat_c[cat] += 1
+            mm = a["match_mode"]
+            if mm not in ("exact", "normalized"):
+                print(f"error: invalid match_mode '{mm}' (supported: exact, normalized)", file=sys.stderr)
+                return 1
+            sr = a["source_ref"]
+            if not isinstance(sr, str) or _has_unknowns(sr):
+                print("error: v2 source_ref must be durable non-UNKNOWN artifact locator", file=sys.stderr)
+                return 1
+            if _has_unknowns(a.get("q")) or _has_unknowns(a.get("a")):
+                print("error: v2 anchor q/a contains UNKNOWN value", file=sys.stderr)
+                return 1
+        if cat_c != {"goal": 3, "decision/rationale": 3, "negative-constraint/prohibition": 2, "next-action": 2}:
+            print(
+                "error: v2 probe must have exactly 3 goals, 3 decisions/rationales, 2 neg constraints, 2 next actions",
+                file=sys.stderr,
+            )
+            return 1
+        if (
+            not probe.get("lineage")
+            or probe.get("lineage") in ("lineage:unknown",)
+            or _has_unknowns(probe.get("lineage"))
+        ):
+            print("error: v2 probe requires valid lineage/rollover identity from snapshot", file=sys.stderr)
+            return 1
 
-    return 0 if is_pass else 2
+        # Strict 10/10 scoring. IDs matched exactly (answers.get uses raw id). match_mode only for text.
+        correct = 0
+        rows: list[tuple] = []
+        for anchor in anchors:
+            aid = anchor["id"]
+            truth = anchor["a"]
+            mm = anchor.get("match_mode", "exact")
+            got = answers.get(aid, "") if isinstance(answers, dict) else ""
+            ok = _matches_v2(truth, got, mm)
+            if ok:
+                correct += 1
+            rows.append((aid, ok, anchor.get("q", ""), str(truth), str(got)))
+        k = len(anchors)
+        is_pass = correct == 10 and k == 10
+        verdict = "PASS" if is_pass else "FAIL-HANDOFF"
+        for aid, ok, q, truth, got in rows:
+            tag = "PASS " if ok else "DRIFT"
+            print(f"  [{tag}] {aid} {q}")
+            if not ok:
+                print(f"          truth: {truth!r}")
+                print(f"          got  : {got!r}")
+        print(f"SCORE {correct}/{k} = {correct / k:.3f}  ->  {verdict} (strict 10/10)")
+        if args.log:
+            log_path = Path(args.log)
+            is_new = not log_path.exists()
+            with log_path.open("a", newline="", encoding="utf-8") as handle:
+                writer = csv.writer(handle)
+                if is_new:
+                    writer.writerow(["context_tokens", "model", "k", "correct", "score", "verdict"])
+                writer.writerow(
+                    [
+                        getattr(args, "context_tokens", 0),
+                        getattr(args, "model", "unknown"),
+                        k,
+                        correct,
+                        f"{(correct / k):.3f}",
+                        verdict,
+                    ]
+                )
+        if getattr(args, "verdict", None):
+            vpath = Path(args.verdict)
+            vdata = {
+                "version": "2",
+                "schema": "production-handoff-v2",
+                "lineage": probe.get("lineage"),
+                "seed": probe.get("seed"),
+                "k": k,
+                "correct": correct,
+                "score": round(correct / k, 3) if k else 0.0,
+                "verdict": verdict,
+                "context_tokens": getattr(args, "context_tokens", 0),
+                "model": getattr(args, "model", "unknown"),
+                "per_anchor": [{"id": r[0], "match": r[1]} for r in rows],
+            }
+            vpath.write_text(json.dumps(vdata, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+            print(f"verdict written -> {args.verdict}")
+        return 0 if is_pass else 2
+    else:
+        # LEGACY scoring semantics (preserved exactly; do not weaken)
+        correct = 0
+        rows = []
+        for anchor in anchors:
+            aid = anchor.get("id", "")
+            truth = anchor.get("a", "")
+            got = answers.get(aid, "") if isinstance(answers, dict) else ""
+            sim = _similarity(truth, got)
+            thresh = getattr(args, "threshold", 0.75)
+            ok = sim >= thresh
+            correct += 1 if ok else 0
+            rows.append((aid, ok, sim, anchor.get("q", ""), truth, got))
+        k = len(anchors)
+        score_val = correct / k if k > 0 else 0.0
+        for aid, ok, sim, q, truth, got in rows:
+            tag = "PASS " if ok else "DRIFT"
+            print(f"  [{tag}] {aid} (sim={sim:.2f}) {q}")
+            if not ok:
+                print(f"          truth: {truth!r}")
+                print(f"          got  : {got!r}")
+        pass_ratio = getattr(args, "pass_ratio", 0.85)
+        verdict = "PASS" if score_val >= pass_ratio else "FAIL-HANDOFF"
+        print(f"SCORE {correct}/{k} = {score_val:.2f}  ->  {verdict}")
+        if args.log:
+            log_path = Path(args.log)
+            is_new = not log_path.exists()
+            with log_path.open("a", newline="", encoding="utf-8") as handle:
+                writer = csv.writer(handle)
+                if is_new:
+                    writer.writerow(["context_tokens", "model", "k", "correct", "score", "verdict"])
+                writer.writerow(
+                    [
+                        getattr(args, "context_tokens", 0),
+                        getattr(args, "model", "unknown"),
+                        k,
+                        correct,
+                        f"{score_val:.3f}",
+                        verdict,
+                    ]
+                )
+        return 0 if verdict == "PASS" else 2
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -360,29 +483,42 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="cmd", required=True)
 
     mint = sub.add_parser(
-        "mint", help="Derive deterministic 10-anchor probe from tool-backed snapshot (or legacy facts)."
+        "mint",
+        help="Freeze ground-truth anchors into a probe file. --facts for legacy three-anchor; --snapshot for strict production v2 10-anchor.",
     )
     mint.add_argument(
         "--snapshot",
-        help="Path to tool-backed snapshot JSON (git/monitor/github); derives exactly 10 anchors with categories",
+        help="Path to structured durable handoff snapshot JSON (goals + decision_records + constraint_records + next_actions)",
     )
-    mint.add_argument("--facts", help="Legacy inline JSON list or path to [{id,q,a},...] (for non-production)")
+    mint.add_argument(
+        "--facts", help="Legacy inline JSON list of {id,q,a}, or a path to a JSON file (original behavior)"
+    )
     mint.add_argument("--out", required=True, help="Probe output path")
     mint.set_defaults(func=cmd_mint)
 
     score = sub.add_parser(
-        "score", help="Diff answers vs probe (normalized id match + configurable text match). Strict 10/10 rc=2."
+        "score",
+        help="Diff from-memory answers against the frozen probe. Legacy: threshold+pass-ratio. v2: strict 10/10 + exact ID + match_mode per anchor.",
     )
     score.add_argument("--probe", required=True)
-    score.add_argument("--answers", required=True, help="JSON object {id: recalled-answer}")
-    score.add_argument("--context-tokens", type=int, default=0, help="Context size for the log row")
+    score.add_argument("--answers", required=True, help="JSON {id: answer}")
+    score.add_argument(
+        "--threshold",
+        type=float,
+        default=0.75,
+        help="Per-anchor similarity to count as recalled (legacy only, default 0.75)",
+    )
+    score.add_argument(
+        "--pass-ratio", type=float, default=0.85, help="Fraction of anchors that must pass (legacy only, default 0.85)"
+    )
+    score.add_argument("--context-tokens", type=int, default=0, help="Context size at probe time (for the log)")
     score.add_argument("--model", default="unknown")
-    score.add_argument("--log", help="Append deterministic row to this CSV")
+    score.add_argument("--log", help="CSV to append the (context_tokens, score) data point")
     score.add_argument(
         "--text-match",
         choices=["normalized", "exact"],
         default="normalized",
-        help="normalized (default): ignore ws/case; exact: strict string",
+        help="Legacy only (v2 uses per-anchor match_mode; IDs always exact)",
     )
     score.add_argument("--verdict", help="Write machine-readable JSON verdict to this path")
     score.set_defaults(func=cmd_score)

--- a/tests/test_context_canary.py
+++ b/tests/test_context_canary.py
@@ -1,11 +1,8 @@
-"""Tests for scripts/context_canary.py (5055 canary gate).
+"""Tests for scripts/context_canary.py — the deterministic brain-rot monitor.
 
-Focus: deterministic 10-anchor probe derivation from tool-backed snapshot;
-exclusion of UNKNOWN/unavailable/non-tool-backed; validated 3/3/2/2 composition;
-version metadata; strict 10/10 scoring (rc 2); normalized id + text modes;
-machine-readable JSON verdict; deterministic logging.
-
-All ground-truth answers derived from supplied snapshot (no invention).
+The load-bearing property: the SCRIPT decides pass/fail by diffing answers against
+the frozen truth. A confident-but-wrong answer must score as DRIFT, and the CSV log
+must accumulate the (context_tokens, score) data point for cross-session rot mapping.
 """
 
 from __future__ import annotations
@@ -17,117 +14,42 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 import context_canary
 
-
-def _good_snapshot() -> dict:
-    """Minimal tool-backed snapshot that yields exactly 10 valid anchors with required composition."""
-    return {
-        "generated_at": "2026-07-13T12:00:00Z",
-        "git": {
-            "branch": "grok-build/5055-canary-gate",
-            "head": "a1b2c3d4e5",
-            "full_head": "a1b2c3d4e5f67890123456789abcdef0",
-            "last_commits": [
-                {"sha": "a1b2c3d4e5", "subject": "feat(canary): deterministic 10-anchor derivation from snapshot"},
-                {"sha": "f6e7d8c9b0", "subject": "fix: exclude non-tool-backed and UNKNOWN values"},
-                {"sha": "1122334455", "subject": "test: strict 10/10 rc-2 and normalized matching"},
-                {"sha": "9988776655", "subject": "chore: versioned metadata + json verdict"},
-            ],
-            "modified_files": [],
-            "ahead_behind": {"ahead": 0, "behind": 0, "upstream": "origin/main"},
-        },
-        "github": {
-            "open_prs": [{"number": 5055, "title": "Context canary implementation"}],
-            "open_issues": [{"number": 5054, "title": "Canary gate epic"}],
-        },
-        "monitor": {
-            "active_delegates": {"active_count": 1},
-            "orient": {"runtime": {"agents": ["orchestrator", "codex"]}},
-        },
-    }
+FACTS = [
+    {"id": "safe_env_sha", "q": "SHA of the safe_env commit", "a": "5cd67954ab"},
+    {"id": "agy_pr", "q": "PR number for agy lane hardening", "a": "2839"},
+    {"id": "wiki_reason", "q": "Why wiki lane not flipped", "a": "agy §7 fabrication unverified at pro tier"},
+]
 
 
-def _mint_from_snapshot(tmp_path: Path) -> Path:
-    snap = tmp_path / "snapshot.json"
-    snap.write_text(json.dumps(_good_snapshot()), encoding="utf-8")
+def _mint(tmp_path: Path) -> Path:
+    facts = tmp_path / "facts.json"
+    facts.write_text(json.dumps(FACTS), encoding="utf-8")
     probe = tmp_path / "probe.json"
-    rc = context_canary.main(["mint", "--snapshot", str(snap), "--out", str(probe)])
-    assert rc == 0, "mint from good snapshot must succeed"
+    rc = context_canary.main(["mint", "--facts", str(facts), "--out", str(probe)])
+    assert rc == 0
     return probe
 
 
-def test_mint_snapshot_produces_versioned_10_anchors_with_validated_composition(tmp_path: Path):
-    probe = _mint_from_snapshot(tmp_path)
+def test_mint_writes_anchors(tmp_path: Path):
+    probe = _mint(tmp_path)
     data = json.loads(probe.read_text(encoding="utf-8"))
-    assert data["version"] == "1"
-    assert data.get("source") == "snapshot"
-    anchors = data["anchors"]
-    assert len(anchors) == 10
-    assert len({a["id"] for a in anchors}) == 10  # unique
-    counts = {}
-    for a in anchors:
-        c = a["category"]
-        counts[c] = counts.get(c, 0) + 1
-    assert counts == {"fact": 3, "decision/rationale": 3, "negative-constraint": 2, "goal/next-action": 2}
-    # spot check some ids and that answers are non-empty from snapshot
-    ids = [a["id"] for a in anchors]
-    assert "git_branch" in ids
-    assert "commit_0_subject" in ids
-    assert "git_modified_status" in ids
-    assert "head_sha_next_ref" in ids
-    for a in anchors:
-        assert a["a"], "no invented empty answers"
-        assert _good_snapshot()  # answers traceable to input snapshot
+    assert [a["id"] for a in data["anchors"]] == ["safe_env_sha", "agy_pr", "wiki_reason"]
 
 
-def test_mint_insufficient_evidence_excludes_bad_and_fails(tmp_path: Path):
-    # snapshot that will exclude enough to miss quotas (e.g. short commits, bad values)
-    bad = {
-        "git": {
-            "branch": "UNKNOWN",
-            "head": "",
-            "last_commits": [{"sha": "only1", "subject": "one only"}],  # only 1 -> can't fill 3 dec/rationale
-            "modified_files": [],
-            "ahead_behind": None,
-        },
-        "github": {"open_prs": {"_error": "no gh"}, "open_issues": []},
-        "monitor": {},
-    }
-    snap = tmp_path / "bad.json"
-    snap.write_text(json.dumps(bad), encoding="utf-8")
-    rc = context_canary.main(["mint", "--snapshot", str(snap), "--out", str(tmp_path / "p.json")])
-    assert rc == 1
-
-
-def test_legacy_facts_still_mints_but_score_requires_10(tmp_path: Path):
-    facts = [{"id": "x", "q": "q", "a": "a"}]
-    fpath = tmp_path / "f.json"
-    fpath.write_text(json.dumps(facts), encoding="utf-8")
-    p = tmp_path / "p.json"
-    rc = context_canary.main(["mint", "--facts", str(fpath), "--out", str(p)])
-    assert rc == 0
-    # score on non-10 must fail with usage (not crash)
-    ans = tmp_path / "ans.json"
-    ans.write_text(json.dumps({"x": "a"}), encoding="utf-8")
-    rc = context_canary.main(["score", "--probe", str(p), "--answers", str(ans)])
-    assert rc == 1
-
-
-def test_perfect_10_10_recall_passes_and_logs(tmp_path: Path):
-    probe = _mint_from_snapshot(tmp_path)
-    data = json.loads(probe.read_text(encoding="utf-8"))
-    answers = {a["id"]: a["a"] for a in data["anchors"]}
-    ans_path = tmp_path / "ans.json"
-    ans_path.write_text(json.dumps(answers), encoding="utf-8")
-    log = tmp_path / "log.csv"
+def test_perfect_recall_passes_and_logs(tmp_path: Path):
+    probe = _mint(tmp_path)
+    answers = tmp_path / "ans.json"
+    answers.write_text(json.dumps({f["id"]: f["a"] for f in FACTS}), encoding="utf-8")
+    log = tmp_path / "canary_log.csv"
     rc = context_canary.main(
         [
             "score",
             "--probe",
             str(probe),
             "--answers",
-            str(ans_path),
+            str(answers),
             "--context-tokens",
-            "600000",
+            "500000",
             "--model",
             "claude-opus-4-8",
             "--log",
@@ -137,113 +59,426 @@ def test_perfect_10_10_recall_passes_and_logs(tmp_path: Path):
     assert rc == 0
     body = log.read_text(encoding="utf-8").splitlines()
     assert body[0].startswith("context_tokens,model,k,correct,score,verdict")
-    assert "600000,claude-opus-4-8,10,10,1.000,PASS" in body[1]
+    assert "500000,claude-opus-4-8,3,3,1.000,PASS" in body[1]
 
 
-def test_strict_10_10_any_drift_or_missing_fails_rc2(tmp_path: Path):
-    probe = _mint_from_snapshot(tmp_path)
+def test_confident_but_wrong_answer_fails_handoff(tmp_path: Path):
+    probe = _mint(tmp_path)
+    answers = tmp_path / "ans.json"
+    # Wrong SHA + wrong PR + distorted reason = rot. Confident, but wrong.
+    answers.write_text(
+        json.dumps({"safe_env_sha": "deadbeef99", "agy_pr": "9999", "wiki_reason": "it was already fine"}),
+        encoding="utf-8",
+    )
+    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(answers)])
+    assert rc == 2  # FAIL-HANDOFF
+
+
+def test_partial_drift_below_pass_ratio_fails(tmp_path: Path):
+    probe = _mint(tmp_path)
+    answers = tmp_path / "ans.json"
+    # 1 of 3 wrong -> 0.67 < default pass_ratio 0.85 -> handoff
+    answers.write_text(
+        json.dumps({"safe_env_sha": "5cd67954ab", "agy_pr": "2839", "wiki_reason": "totally unrelated text"}),
+        encoding="utf-8",
+    )
+    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(answers)])
+    assert rc == 2
+
+
+def test_missing_answer_counts_as_drift(tmp_path: Path):
+    probe = _mint(tmp_path)
+    answers = tmp_path / "ans.json"
+    answers.write_text(json.dumps({"safe_env_sha": "5cd67954ab"}), encoding="utf-8")  # 2 missing
+    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(answers)])
+    assert rc == 2
+
+
+def test_mint_rejects_duplicate_ids(tmp_path: Path):
+    facts = tmp_path / "facts.json"
+    facts.write_text(json.dumps([{"id": "x", "q": "q", "a": "a"}, {"id": "x", "q": "q2", "a": "a2"}]), encoding="utf-8")
+    rc = context_canary.main(["mint", "--facts", str(facts), "--out", str(tmp_path / "p.json")])
+    assert rc == 1
+
+
+def test_mint_accepts_inline_json(tmp_path: Path):
+    # The arg help advertises "Inline JSON list of {id,q,a}" — passing the list
+    # directly (not a file path) must work, not crash with 'File name too long'.
+    probe = tmp_path / "probe.json"
+    rc = context_canary.main(["mint", "--facts", json.dumps(FACTS), "--out", str(probe)])
+    assert rc == 0
+    data = json.loads(probe.read_text(encoding="utf-8"))
+    assert [a["id"] for a in data["anchors"]] == ["safe_env_sha", "agy_pr", "wiki_reason"]
+
+
+def test_mint_inline_and_file_produce_identical_probe(tmp_path: Path):
+    file_probe = _mint(tmp_path)
+    inline_probe = tmp_path / "inline_probe.json"
+    rc = context_canary.main(["mint", "--facts", json.dumps(FACTS), "--out", str(inline_probe)])
+    assert rc == 0
+    assert inline_probe.read_text(encoding="utf-8") == file_probe.read_text(encoding="utf-8")
+
+
+def test_mint_missing_file_is_clean_usage_error(tmp_path: Path):
+    rc = context_canary.main(["mint", "--facts", str(tmp_path / "nope.json"), "--out", str(tmp_path / "p.json")])
+    assert rc == 1  # FileNotFoundError -> clean rc 1, not an uncaught traceback
+
+
+def test_mint_directory_as_facts_is_clean_usage_error(tmp_path: Path):
+    # A path that is a directory raises IsADirectoryError inside read_text; the
+    # widened (OSError, UnicodeDecodeError) catch must turn it into a clean rc 1,
+    # not a traceback (every file-branch read failure is covered, not just missing).
+    a_dir = tmp_path / "facts_dir"
+    a_dir.mkdir()
+    rc = context_canary.main(["mint", "--facts", str(a_dir), "--out", str(tmp_path / "p.json")])
+    assert rc == 1
+
+
+def test_mint_malformed_inline_json_is_clean_usage_error(tmp_path: Path):
+    rc = context_canary.main(["mint", "--facts", "[{bad json", "--out", str(tmp_path / "p.json")])
+    assert rc == 1  # inline branch JSONDecodeError caught, returns usage error
+
+
+# --- Production v2 tests added after all original legacy tests (no originals replaced, deleted, weakened or inverted) ---
+
+
+def _good_v2_snapshot() -> dict:
+    """Minimal durable-artifact snapshot yielding exactly 3/3/2/2 with required fields and seed."""
+    return {
+        "generated_at": "2026-07-13T12:00:00Z",
+        "lineage": "grok-build/5055-canary-gate:5055-semantic-fix",
+        "source": "handoff-artifact",
+        "seed": 987654321,
+        "goals": [
+            {
+                "id": "goal-restore-compat",
+                "statement": "Keep original legacy mint --facts and score with threshold/pass-ratio and 3-anchor flow",
+                "source_ref": "handoff:goals:goal-restore-compat",
+            },
+            {
+                "id": "goal-strict-v2",
+                "statement": "Add distinct production schema v2 with exactly 10 anchors from durable artifacts only",
+                "source_ref": "handoff:goals:goal-strict-v2",
+            },
+            {
+                "id": "goal-fail-closed",
+                "statement": "Mint must fail closed on insufficient categories or UNKNOWN; never pad with git data",
+                "source_ref": "handoff:goals:goal-fail-closed",
+            },
+        ],
+        "decision_records": [
+            {
+                "id": "dec-exact-shape",
+                "decision": "Every prod anchor must be shaped {id,q,a,category,match_mode,source_ref}",
+                "rationale": "Required by architecture review for provenance",
+                "source_ref": "handoff:decisions:dec-exact-shape",
+            },
+            {
+                "id": "dec-strict-10",
+                "decision": "Use strict 10/10 for production confirmation, legacy ratio for facts",
+                "rationale": "Prevents 9/10 from passing as handoff safe",
+                "source_ref": "handoff:decisions:dec-strict-10",
+            },
+            {
+                "id": "dec-no-relabel",
+                "decision": "Source anchors exclusively from handoff goals/decisions/constraints/actions not git or monitor",
+                "rationale": "git SHAs and file counts are not semantic continuity records",
+                "source_ref": "handoff:decisions:dec-no-relabel",
+            },
+        ],
+        "constraint_records": [
+            {
+                "id": "const-no-git-as-anchor",
+                "prohibition": "git_branch, commit subjects, ahead counts, file counts must never become semantic anchors",
+                "source_ref": "handoff:constraints:const-no-git-as-anchor",
+            },
+            {
+                "id": "const-reject-unknown",
+                "prohibition": "Reject any UNKNOWN, empty, duplicate, or wrong-category at mint time recursively",
+                "source_ref": "handoff:constraints:const-reject-unknown",
+            },
+        ],
+        "next_actions": [
+            {
+                "id": "na-verify-blockers",
+                "action": "Prove arbitrary facts, UNKNOWN modified, git SHAs, ws ids, and legacy flow all behave correctly",
+                "source_ref": "handoff:actions:na-verify-blockers",
+            },
+            {
+                "id": "na-run-all-checks",
+                "action": "Run pytest, ruff, format check, git diff --check, and agent trailer lint after the commit",
+                "source_ref": "handoff:actions:na-run-all-checks",
+            },
+        ],
+    }
+
+
+def _mint_v2(tmp_path: Path) -> Path:
+    snap = tmp_path / "handoff_snapshot.json"
+    snap.write_text(json.dumps(_good_v2_snapshot()), encoding="utf-8")
+    probe = tmp_path / "probe_v2.json"
+    rc = context_canary.main(["mint", "--snapshot", str(snap), "--out", str(probe)])
+    assert rc == 0, "mint v2 from good durable snapshot must succeed"
+    return probe
+
+
+def test_mint_v2_snapshot_produces_strict_10_anchors_with_exact_schema_and_metadata(tmp_path: Path):
+    probe = _mint_v2(tmp_path)
+    data = json.loads(probe.read_text(encoding="utf-8"))
+    assert data["version"] == "2"
+    assert data["schema"] == "production-handoff-v2"
+    assert data["strict_production"] is True
+    assert data["source"] == "snapshot"
+    assert "seed" in data and isinstance(data["seed"], int)
+    assert data.get("lineage")
+    assert "generated_at" in data
+    assert data["anchor_counts"] == {
+        "goal": 3,
+        "decision/rationale": 3,
+        "negative-constraint/prohibition": 2,
+        "next-action": 2,
+    }
+    anchors = data["anchors"]
+    assert len(anchors) == 10
+    ids = [a["id"] for a in anchors]
+    assert len(set(ids)) == 10
+    assert all(isinstance(i, str) and i for i in ids)
+    cats = {}
+    for a in anchors:
+        c = a["category"]
+        cats[c] = cats.get(c, 0) + 1
+    assert cats == {"goal": 3, "decision/rationale": 3, "negative-constraint/prohibition": 2, "next-action": 2}
+    for a in anchors:
+        assert set(a.keys()) == {"id", "q", "a", "category", "match_mode", "source_ref"}
+        assert a["source_ref"] and "handoff:" in a["source_ref"]
+        assert a["match_mode"] in ("exact", "normalized")
+        assert a["a"], "no invented answers"
+        # check fields are not the sentinel tokens themselves (word "unknown" may legitimately appear in prose)
+        assert not any(
+            str(a.get(k, "")).strip().lower() in {"unknown", "unavailable", "n/a", "none", "null", "missing"}
+            for k in ("id", "a", "q", "source_ref")
+        )
+
+
+def test_v2_production_perfect_10_10_passes_rc0(tmp_path: Path):
+    probe = _mint_v2(tmp_path)
     data = json.loads(probe.read_text(encoding="utf-8"))
     answers = {a["id"]: a["a"] for a in data["anchors"]}
-    # corrupt one
-    first_id = next(iter(answers.keys()))
-    answers[first_id] = "WRONG-VALUE"
-    ans = tmp_path / "bad.json"
+    ans_path = tmp_path / "ans.json"
+    ans_path.write_text(json.dumps(answers), encoding="utf-8")
+    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans_path)])
+    assert rc == 0
+
+
+def test_v2_9_of_10_or_drift_fails_rc2(tmp_path: Path):
+    probe = _mint_v2(tmp_path)
+    data = json.loads(probe.read_text(encoding="utf-8"))
+    answers = {a["id"]: a["a"] for a in data["anchors"]}
+    # corrupt one -> 9/10
+    some_id = data["anchors"][0]["id"]
+    answers[some_id] = "WRONG ANSWER FOR DRIFT"
+    ans = tmp_path / "bad9.json"
     ans.write_text(json.dumps(answers), encoding="utf-8")
     rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans)])
     assert rc == 2
-    # missing also fails
-    answers2 = {a["id"]: a["a"] for a in data["anchors"][:9]}  # missing 1
+    # missing one also
+    answers2 = {a["id"]: a["a"] for a in data["anchors"][:9]}
     ans2 = tmp_path / "miss.json"
     ans2.write_text(json.dumps(answers2), encoding="utf-8")
     rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans2)])
     assert rc == 2
 
 
-def test_exact_normalized_matching_for_ids_and_normalized_text(tmp_path: Path):
-    probe = _mint_from_snapshot(tmp_path)
+def test_v2_exact_id_match_no_normalization(tmp_path: Path):
+    """IDs matched exactly; whitespace/case in key means no lookup hit. '  GIT_BRANCH  ' cannot match git_branch."""
+    probe = _mint_v2(tmp_path)
     data = json.loads(probe.read_text(encoding="utf-8"))
-    # use weird cased ids + padded/whitespace/case answers
     answers = {}
     for a in data["anchors"]:
-        answers["  " + a["id"].upper() + "  "] = "  " + a["a"].upper() + "  \n"
-    ans = tmp_path / "norm.json"
+        # padded + upper key will NOT match the exact id
+        answers["  " + a["id"].upper() + "  "] = a["a"]
+    ans = tmp_path / "wsid.json"
     ans.write_text(json.dumps(answers), encoding="utf-8")
-    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans), "--text-match", "normalized"])
-    assert rc == 0
-
-
-def test_explicit_exact_mode_is_strict(tmp_path: Path):
-    probe = _mint_from_snapshot(tmp_path)
-    data = json.loads(probe.read_text(encoding="utf-8"))
-    answers = {a["id"]: "  " + a["a"] + "  " for a in data["anchors"]}  # extra ws
-    ans = tmp_path / "exact.json"
-    ans.write_text(json.dumps(answers), encoding="utf-8")
-    # normalized passes
-    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans), "--text-match", "normalized"])
-    assert rc == 0
-    # exact fails on ws
-    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans), "--text-match", "exact"])
+    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans)])
     assert rc == 2
 
 
-def test_machine_readable_json_verdict(tmp_path: Path):
-    probe = _mint_from_snapshot(tmp_path)
+def test_v2_match_mode_exact_vs_normalized(tmp_path: Path):
+    probe = _mint_v2(tmp_path)
+    pdata = json.loads(probe.read_text(encoding="utf-8"))
+    # Force first anchor to normalized to exercise mode
+    pdata["anchors"][0]["match_mode"] = "normalized"
+    p2 = tmp_path / "p_norm.json"
+    p2.write_text(json.dumps(pdata), encoding="utf-8")
+    ansd = {}
+    # pad only the normalized one; clean exacts
+    for i, a in enumerate(pdata["anchors"]):
+        if i == 0:
+            ansd[a["id"]] = "  " + a["a"] + "  "
+        else:
+            ansd[a["id"]] = a["a"]
+    ans = tmp_path / "anspad.json"
+    ans.write_text(json.dumps(ansd), encoding="utf-8")
+    rc = context_canary.main(["score", "--probe", str(p2), "--answers", str(ans)])
+    assert rc == 0
+
+
+def test_legacy_three_anchor_flow_still_passes_unchanged(tmp_path: Path):
+    """Explicit demonstration that original legacy path (facts + threshold + pass-ratio) is intact."""
+    probe = tmp_path / "p.json"
+    rc = context_canary.main(["mint", "--facts", json.dumps(FACTS), "--out", str(probe)])
+    assert rc == 0
+    answers = {f["id"]: f["a"] for f in FACTS}
+    ans = tmp_path / "a.json"
+    ans.write_text(json.dumps(answers), encoding="utf-8")
+    rc = context_canary.main(
+        ["score", "--probe", str(probe), "--answers", str(ans), "--threshold", "0.75", "--pass-ratio", "0.85"]
+    )
+    assert rc == 0
+
+
+def test_arbitrary_ten_entry_facts_source_does_not_produce_v2_prod_probe(tmp_path: Path):
+    """arbitrary ten-entry source=facts cannot pass as production (lacks v2 markers, uses legacy scoring)."""
+    facts = [{"id": f"f{i}", "q": f"q{i}", "a": f"a{i}"} for i in range(10)]
+    fpath = tmp_path / "ten.json"
+    fpath.write_text(json.dumps(facts), encoding="utf-8")
+    p = tmp_path / "p10.json"
+    rc = context_canary.main(["mint", "--facts", str(fpath), "--out", str(p)])
+    assert rc == 0
+    data = json.loads(p.read_text(encoding="utf-8"))
+    # not a v2 production probe
+    assert data.get("version") != "2" or not data.get("strict_production")
+    assert data.get("source") != "snapshot" or data.get("schema") != "production-handoff-v2"
+    assert len(data.get("anchors", [])) == 10
+    # perfect answers still go through legacy path (no strict enforcement here)
+    answers = {f["id"]: f["a"] for f in facts}
+    ans = tmp_path / "ans10.json"
+    ans.write_text(json.dumps(answers), encoding="utf-8")
+    rc = context_canary.main(["score", "--probe", str(p), "--answers", str(ans)])
+    # 10/10 would pass legacy ratio too, but the point is it was not treated as v2 prod
+    assert rc == 0
+    # 9/10 would also pass legacy (0.9 >= 0.85) but would fail v2
+    answers[facts[0]["id"]] = "wrong"
+    ans.write_text(json.dumps(answers), encoding="utf-8")
+    rc = context_canary.main(["score", "--probe", str(p), "--answers", str(ans)])
+    assert rc == 0  # legacy allows >=0.85
+
+
+def test_v2_score_rejects_wrong_lineage_or_malformed_provenance(tmp_path: Path):
+    snap = _good_v2_snapshot()
+    snap["lineage"] = ""
+    sfile = tmp_path / "badline.json"
+    sfile.write_text(json.dumps(snap), encoding="utf-8")
+    p = tmp_path / "pbad.json"
+    rc = context_canary.main(["mint", "--snapshot", str(sfile), "--out", str(p)])
+    assert rc == 1
+
+
+def test_negative_v2_mint_insufficient_or_unknown_or_dup_or_bad_shape(tmp_path: Path):
+    # insufficient categories
+    bad1 = _good_v2_snapshot()
+    bad1["goals"] = bad1["goals"][:2]
+    s1 = tmp_path / "insuf.json"
+    s1.write_text(json.dumps(bad1), encoding="utf-8")
+    rc = context_canary.main(["mint", "--snapshot", str(s1), "--out", str(tmp_path / "p1")])
+    assert rc == 1
+
+    # UNKNOWN nested value
+    bad2 = _good_v2_snapshot()
+    bad2["decision_records"][0]["decision"] = "UNKNOWN"
+    s2 = tmp_path / "unk.json"
+    s2.write_text(json.dumps(bad2), encoding="utf-8")
+    rc = context_canary.main(["mint", "--snapshot", str(s2), "--out", str(tmp_path / "p2")])
+    assert rc == 1
+
+    # duplicate IDs
+    bad3 = _good_v2_snapshot()
+    bad3["goals"][1]["id"] = bad3["goals"][0]["id"]
+    s3 = tmp_path / "dup.json"
+    s3.write_text(json.dumps(bad3), encoding="utf-8")
+    rc = context_canary.main(["mint", "--snapshot", str(s3), "--out", str(tmp_path / "p3")])
+    assert rc == 1
+
+    # missing source_ref (malformed provenance)
+    bad4 = _good_v2_snapshot()
+    if "source_ref" in bad4["next_actions"][0]:
+        del bad4["next_actions"][0]["source_ref"]
+    s4 = tmp_path / "noprof.json"
+    s4.write_text(json.dumps(bad4), encoding="utf-8")
+    rc = context_canary.main(["mint", "--snapshot", str(s4), "--out", str(tmp_path / "p4")])
+    assert rc == 1
+
+    # invalid match_mode
+    bad5 = _good_v2_snapshot()
+    bad5["constraint_records"][0]["match_mode"] = "fuzzy99"
+    s5 = tmp_path / "badmm.json"
+    s5.write_text(json.dumps(bad5), encoding="utf-8")
+    rc = context_canary.main(["mint", "--snapshot", str(s5), "--out", str(tmp_path / "p5")])
+    assert rc == 1
+
+
+def test_deterministic_same_seed_same_order(tmp_path: Path):
+    snap = _good_v2_snapshot()
+    s1 = tmp_path / "s1.json"
+    s1.write_text(json.dumps(snap), encoding="utf-8")
+    p1 = tmp_path / "p1.json"
+    rc1 = context_canary.main(["mint", "--snapshot", str(s1), "--out", str(p1)])
+    p2 = tmp_path / "p2.json"
+    rc2 = context_canary.main(["mint", "--snapshot", str(s1), "--out", str(p2)])
+    assert rc1 == rc2 == 0
+    d1 = json.loads(p1.read_text(encoding="utf-8"))["anchors"]
+    d2 = json.loads(p2.read_text(encoding="utf-8"))["anchors"]
+    assert [a["id"] for a in d1] == [a["id"] for a in d2]
+
+
+def test_differing_seed_produces_different_order(tmp_path: Path):
+    snap = _good_v2_snapshot()
+    snap["seed"] = 111
+    s1 = tmp_path / "sd1.json"
+    s1.write_text(json.dumps(snap), encoding="utf-8")
+    p1 = tmp_path / "pd1.json"
+    context_canary.main(["mint", "--snapshot", str(s1), "--out", str(p1)])
+    snap["seed"] = 222
+    s2 = tmp_path / "sd2.json"
+    s2.write_text(json.dumps(snap), encoding="utf-8")
+    p2 = tmp_path / "pd2.json"
+    context_canary.main(["mint", "--snapshot", str(s2), "--out", str(p2)])
+    d1 = json.loads(p1.read_text(encoding="utf-8"))["anchors"]
+    d2 = json.loads(p2.read_text(encoding="utf-8"))["anchors"]
+    ids1 = [a["id"] for a in d1]
+    ids2 = [a["id"] for a in d2]
+    assert ids1 != ids2  # order randomized by seed
+
+
+def test_generated_seed_when_absent_is_persisted_and_reproducible(tmp_path: Path):
+    snap = _good_v2_snapshot()
+    snap.pop("seed", None)
+    s = tmp_path / "snoseed.json"
+    s.write_text(json.dumps(snap), encoding="utf-8")
+    p1 = tmp_path / "pg1.json"
+    context_canary.main(["mint", "--snapshot", str(s), "--out", str(p1)])
+    d1 = json.loads(p1.read_text(encoding="utf-8"))
+    assert "seed" in d1 and isinstance(d1["seed"], int)
+    p2 = tmp_path / "pg2.json"
+    context_canary.main(["mint", "--snapshot", str(s), "--out", str(p2)])
+    d2 = json.loads(p2.read_text(encoding="utf-8"))
+    assert d1["seed"] == d2["seed"]
+    assert [a["id"] for a in d1["anchors"]] == [a["id"] for a in d2["anchors"]]
+
+
+def test_v2_verdict_contains_audit_fields(tmp_path: Path):
+    probe = _mint_v2(tmp_path)
     data = json.loads(probe.read_text(encoding="utf-8"))
     answers = {a["id"]: a["a"] for a in data["anchors"]}
-    ans = tmp_path / "ans.json"
+    ans = tmp_path / "av.json"
     ans.write_text(json.dumps(answers), encoding="utf-8")
     vpath = tmp_path / "verdict.json"
     rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans), "--verdict", str(vpath)])
     assert rc == 0
     v = json.loads(vpath.read_text(encoding="utf-8"))
-    assert v["version"] == "1"
-    assert v["k"] == 10
+    assert v["version"] == "2"
+    assert v["schema"] == "production-handoff-v2"
+    assert "lineage" in v
+    assert "seed" in v
     assert v["correct"] == 10
     assert v["verdict"] == "PASS"
-    assert len(v["per_anchor"]) == 10
-    assert all(p["match"] for p in v["per_anchor"])
-
-
-def test_deterministic_logging_same_inputs_same_rows(tmp_path: Path):
-    probe = _mint_from_snapshot(tmp_path)
-    data = json.loads(probe.read_text(encoding="utf-8"))
-    answers = {a["id"]: a["a"] for a in data["anchors"]}
-    ans = tmp_path / "ans.json"
-    ans.write_text(json.dumps(answers), encoding="utf-8")
-    log = tmp_path / "det.csv"
-    rc1 = context_canary.main(
-        [
-            "score",
-            "--probe",
-            str(probe),
-            "--answers",
-            str(ans),
-            "--context-tokens",
-            "123",
-            "--model",
-            "test-m",
-            "--log",
-            str(log),
-        ]
-    )
-    rc2 = context_canary.main(
-        [
-            "score",
-            "--probe",
-            str(probe),
-            "--answers",
-            str(ans),
-            "--context-tokens",
-            "123",
-            "--model",
-            "test-m",
-            "--log",
-            str(log),
-        ]
-    )
-    assert rc1 == 0 and rc2 == 0
-    lines = log.read_text(encoding="utf-8").strip().splitlines()
-    # header + 2 identical data rows
-    assert len(lines) == 3
-    assert lines[1] == lines[2]
-    assert lines[1].startswith("123,test-m,10,10,")

--- a/tests/test_context_canary.py
+++ b/tests/test_context_canary.py
@@ -143,27 +143,29 @@ def test_mint_malformed_inline_json_is_clean_usage_error(tmp_path: Path):
 
 
 def _good_v2_snapshot() -> dict:
-    """Minimal durable-artifact snapshot yielding exactly 3/3/2/2 with required fields and seed."""
+    """Minimal durable-artifact snapshot yielding exactly 3/3/2/2 with required fields and seed.
+    Uses explicit lineage_id/rollover_id and valid source_ref grammar (kind:repo-rel#frag) with correct kind per category.
+    """
     return {
         "generated_at": "2026-07-13T12:00:00Z",
-        "lineage": "grok-build/5055-canary-gate:5055-semantic-fix",
-        "source": "handoff-artifact",
+        "lineage_id": "grok-build/5055-canary-gate:5055-semantic-fix",
+        "rollover_id": "rollover-5055-20260713-01",
         "seed": 987654321,
         "goals": [
             {
                 "id": "goal-restore-compat",
                 "statement": "Keep original legacy mint --facts and score with threshold/pass-ratio and 3-anchor flow",
-                "source_ref": "handoff:goals:goal-restore-compat",
+                "source_ref": "handoff:.agent/thread-rollovers/rollover-5055-001.json#goal-restore-compat",
             },
             {
                 "id": "goal-strict-v2",
                 "statement": "Add distinct production schema v2 with exactly 10 anchors from durable artifacts only",
-                "source_ref": "handoff:goals:goal-strict-v2",
+                "source_ref": "handoff:.agent/thread-rollovers/rollover-5055-001.json#goal-strict-v2",
             },
             {
                 "id": "goal-fail-closed",
                 "statement": "Mint must fail closed on insufficient categories or UNKNOWN; never pad with git data",
-                "source_ref": "handoff:goals:goal-fail-closed",
+                "source_ref": "handoff:.agent/thread-rollovers/rollover-5055-001.json#goal-fail-closed",
             },
         ],
         "decision_records": [
@@ -171,43 +173,43 @@ def _good_v2_snapshot() -> dict:
                 "id": "dec-exact-shape",
                 "decision": "Every prod anchor must be shaped {id,q,a,category,match_mode,source_ref}",
                 "rationale": "Required by architecture review for provenance",
-                "source_ref": "handoff:decisions:dec-exact-shape",
+                "source_ref": "decision:docs/decisions/2026-07-13-provenance.md#dec-exact-shape",
             },
             {
                 "id": "dec-strict-10",
                 "decision": "Use strict 10/10 for production confirmation, legacy ratio for facts",
                 "rationale": "Prevents 9/10 from passing as handoff safe",
-                "source_ref": "handoff:decisions:dec-strict-10",
+                "source_ref": "decision:docs/decisions/2026-07-13-provenance.md#dec-strict-10",
             },
             {
                 "id": "dec-no-relabel",
                 "decision": "Source anchors exclusively from handoff goals/decisions/constraints/actions not git or monitor",
                 "rationale": "git SHAs and file counts are not semantic continuity records",
-                "source_ref": "handoff:decisions:dec-no-relabel",
+                "source_ref": "decision:docs/decisions/2026-07-13-provenance.md#dec-no-relabel",
             },
         ],
         "constraint_records": [
             {
                 "id": "const-no-git-as-anchor",
                 "prohibition": "git_branch, commit subjects, ahead counts, file counts must never become semantic anchors",
-                "source_ref": "handoff:constraints:const-no-git-as-anchor",
+                "source_ref": "handoff:.agent/thread-rollovers/rollover-5055-001.json#const-no-git-as-anchor",
             },
             {
                 "id": "const-reject-unknown",
                 "prohibition": "Reject any UNKNOWN, empty, duplicate, or wrong-category at mint time recursively",
-                "source_ref": "handoff:constraints:const-reject-unknown",
+                "source_ref": "decision:docs/decisions/2026-07-13-provenance.md#const-reject-unknown",
             },
         ],
         "next_actions": [
             {
                 "id": "na-verify-blockers",
                 "action": "Prove arbitrary facts, UNKNOWN modified, git SHAs, ws ids, and legacy flow all behave correctly",
-                "source_ref": "handoff:actions:na-verify-blockers",
+                "source_ref": "queue:batch_state/orchestrator-runs/orchestrator-5055.json#na-verify-blockers",
             },
             {
                 "id": "na-run-all-checks",
                 "action": "Run pytest, ruff, format check, git diff --check, and agent trailer lint after the commit",
-                "source_ref": "handoff:actions:na-run-all-checks",
+                "source_ref": "handoff:.agent/thread-rollovers/rollover-5055-001.json#na-run-all-checks",
             },
         ],
     }
@@ -230,7 +232,8 @@ def test_mint_v2_snapshot_produces_strict_10_anchors_with_exact_schema_and_metad
     assert data["strict_production"] is True
     assert data["source"] == "snapshot"
     assert "seed" in data and isinstance(data["seed"], int)
-    assert data.get("lineage")
+    assert data.get("lineage_id")
+    assert data.get("rollover_id")
     assert "generated_at" in data
     assert data["anchor_counts"] == {
         "goal": 3,
@@ -250,7 +253,11 @@ def test_mint_v2_snapshot_produces_strict_10_anchors_with_exact_schema_and_metad
     assert cats == {"goal": 3, "decision/rationale": 3, "negative-constraint/prohibition": 2, "next-action": 2}
     for a in anchors:
         assert set(a.keys()) == {"id", "q", "a", "category", "match_mode", "source_ref"}
-        assert a["source_ref"] and "handoff:" in a["source_ref"]
+        assert a["source_ref"] and (
+            a["source_ref"].startswith("handoff:")
+            or a["source_ref"].startswith("decision:")
+            or a["source_ref"].startswith("queue:")
+        )
         assert a["match_mode"] in ("exact", "normalized")
         assert a["a"], "no invented answers"
         # check fields are not the sentinel tokens themselves (word "unknown" may legitimately appear in prose)
@@ -266,7 +273,21 @@ def test_v2_production_perfect_10_10_passes_rc0(tmp_path: Path):
     answers = {a["id"]: a["a"] for a in data["anchors"]}
     ans_path = tmp_path / "ans.json"
     ans_path.write_text(json.dumps(answers), encoding="utf-8")
-    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans_path)])
+    lid = data["lineage_id"]
+    rid = data["rollover_id"]
+    rc = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(probe),
+            "--answers",
+            str(ans_path),
+            "--expected-lineage-id",
+            lid,
+            "--expected-rollover-id",
+            rid,
+        ]
+    )
     assert rc == 0
 
 
@@ -279,13 +300,39 @@ def test_v2_9_of_10_or_drift_fails_rc2(tmp_path: Path):
     answers[some_id] = "WRONG ANSWER FOR DRIFT"
     ans = tmp_path / "bad9.json"
     ans.write_text(json.dumps(answers), encoding="utf-8")
-    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans)])
+    lid = data["lineage_id"]
+    rid = data["rollover_id"]
+    rc = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(probe),
+            "--answers",
+            str(ans),
+            "--expected-lineage-id",
+            lid,
+            "--expected-rollover-id",
+            rid,
+        ]
+    )
     assert rc == 2
     # missing one also
     answers2 = {a["id"]: a["a"] for a in data["anchors"][:9]}
     ans2 = tmp_path / "miss.json"
     ans2.write_text(json.dumps(answers2), encoding="utf-8")
-    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans2)])
+    rc = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(probe),
+            "--answers",
+            str(ans2),
+            "--expected-lineage-id",
+            lid,
+            "--expected-rollover-id",
+            rid,
+        ]
+    )
     assert rc == 2
 
 
@@ -299,7 +346,21 @@ def test_v2_exact_id_match_no_normalization(tmp_path: Path):
         answers["  " + a["id"].upper() + "  "] = a["a"]
     ans = tmp_path / "wsid.json"
     ans.write_text(json.dumps(answers), encoding="utf-8")
-    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans)])
+    lid = data["lineage_id"]
+    rid = data["rollover_id"]
+    rc = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(probe),
+            "--answers",
+            str(ans),
+            "--expected-lineage-id",
+            lid,
+            "--expected-rollover-id",
+            rid,
+        ]
+    )
     assert rc == 2
 
 
@@ -319,7 +380,21 @@ def test_v2_match_mode_exact_vs_normalized(tmp_path: Path):
             ansd[a["id"]] = a["a"]
     ans = tmp_path / "anspad.json"
     ans.write_text(json.dumps(ansd), encoding="utf-8")
-    rc = context_canary.main(["score", "--probe", str(p2), "--answers", str(ans)])
+    lid = pdata["lineage_id"]
+    rid = pdata["rollover_id"]
+    rc = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(p2),
+            "--answers",
+            str(ans),
+            "--expected-lineage-id",
+            lid,
+            "--expected-rollover-id",
+            rid,
+        ]
+    )
     assert rc == 0
 
 
@@ -366,7 +441,7 @@ def test_arbitrary_ten_entry_facts_source_does_not_produce_v2_prod_probe(tmp_pat
 
 def test_v2_score_rejects_wrong_lineage_or_malformed_provenance(tmp_path: Path):
     snap = _good_v2_snapshot()
-    snap["lineage"] = ""
+    snap["lineage_id"] = ""
     sfile = tmp_path / "badline.json"
     sfile.write_text(json.dumps(snap), encoding="utf-8")
     p = tmp_path / "pbad.json"
@@ -473,12 +548,267 @@ def test_v2_verdict_contains_audit_fields(tmp_path: Path):
     ans = tmp_path / "av.json"
     ans.write_text(json.dumps(answers), encoding="utf-8")
     vpath = tmp_path / "verdict.json"
-    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans), "--verdict", str(vpath)])
+    lid = data["lineage_id"]
+    rid = data["rollover_id"]
+    rc = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(probe),
+            "--answers",
+            str(ans),
+            "--verdict",
+            str(vpath),
+            "--expected-lineage-id",
+            lid,
+            "--expected-rollover-id",
+            rid,
+        ]
+    )
     assert rc == 0
     v = json.loads(vpath.read_text(encoding="utf-8"))
     assert v["version"] == "2"
     assert v["schema"] == "production-handoff-v2"
-    assert "lineage" in v
+    assert "lineage_id" in v
+    assert "rollover_id" in v
+    assert "probe_sha256" in v
     assert "seed" in v
     assert v["correct"] == 10
     assert v["verdict"] == "PASS"
+    # context_tokens must not be present (removed duplicate)
+    assert "context_tokens" not in v
+
+
+# --- Exact reproduction regression tests per requirements (preserve all prior tests; add these) ---
+
+
+def _expected_identity_from_good() -> tuple[str, str]:
+    snap = _good_v2_snapshot()
+    return snap["lineage_id"], snap["rollover_id"]
+
+
+def test_mint_rejects_git_github_monitor_arbitrary_and_bad_source_refs(tmp_path: Path):
+    """records with git:HEAD, github:, monitor:, arbitrary/non-durable source_ref fail mint."""
+    base = _good_v2_snapshot()
+    bad_refs = [
+        "git:HEAD",
+        "github:foo/bar#123",
+        "monitor:session#1",
+        "arbitrary-string",
+        "/absolute/path#f",
+        "../traversal#f",
+        "handoff:foo/bar#no-root-match",
+        "handoff:.agent/..#bad",
+        "badkind:docs/decisions/x.md#f",
+        "decision:docs/decisions/x.md#f",  # wrong for goal
+        "queue:docs/decisions/x.md#f",  # wrong kind/root
+        "handoff:.agent/thread-rollovers/r.json",  # missing #
+    ]
+    for i, bad in enumerate(bad_refs):
+        snap = _good_v2_snapshot()
+        snap["goals"][0]["source_ref"] = bad
+        s = tmp_path / f"badref{i}.json"
+        s.write_text(json.dumps(snap), encoding="utf-8")
+        rc = context_canary.main(["mint", "--snapshot", str(s), "--out", str(tmp_path / f"p{i}.json")])
+        assert rc == 1, f"should reject bad source_ref: {bad}"
+
+
+def test_forged_v2_with_bad_source_refs_fails_score(tmp_path: Path):
+    """forged v2 with such refs fails score (even if other fields look ok)."""
+    probe = _mint_v2(tmp_path)
+    pdata = json.loads(probe.read_text(encoding="utf-8"))
+    lid, rid = pdata["lineage_id"], pdata["rollover_id"]
+    # corrupt one ref
+    pdata["anchors"][0]["source_ref"] = "git:HEAD"
+    badp = tmp_path / "forged_badref.json"
+    badp.write_text(json.dumps(pdata), encoding="utf-8")
+    answers = {a["id"]: a["a"] for a in pdata["anchors"]}
+    ans = tmp_path / "a.json"
+    ans.write_text(json.dumps(answers), encoding="utf-8")
+    rc = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(badp),
+            "--answers",
+            str(ans),
+            "--expected-lineage-id",
+            lid,
+            "--expected-rollover-id",
+            rid,
+        ]
+    )
+    assert rc == 2
+
+
+def test_snapshot_missing_either_identity_fails_mint(tmp_path: Path):
+    """snapshot missing either identity fails mint."""
+    for key in ("lineage_id", "rollover_id"):
+        snap = _good_v2_snapshot()
+        snap.pop(key, None)
+        s = tmp_path / f"no{key}.json"
+        s.write_text(json.dumps(snap), encoding="utf-8")
+        rc = context_canary.main(["mint", "--snapshot", str(s), "--out", str(tmp_path / "p.json")])
+        assert rc == 1
+
+
+def test_v2_score_missing_or_wrong_expected_identity_fails(tmp_path: Path):
+    """v2 score missing/wrong expected identity fails."""
+    probe = _mint_v2(tmp_path)
+    pdata = json.loads(probe.read_text(encoding="utf-8"))
+    lid, rid = pdata["lineage_id"], pdata["rollover_id"]
+    answers = {a["id"]: a["a"] for a in pdata["anchors"]}
+    ans = tmp_path / "ans.json"
+    ans.write_text(json.dumps(answers), encoding="utf-8")
+    # missing expected
+    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans)])
+    assert rc == 2
+    # wrong
+    rc = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(probe),
+            "--answers",
+            str(ans),
+            "--expected-lineage-id",
+            "wrong",
+            "--expected-rollover-id",
+            rid,
+        ]
+    )
+    assert rc == 2
+    rc = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(probe),
+            "--answers",
+            str(ans),
+            "--expected-lineage-id",
+            lid,
+            "--expected-rollover-id",
+            "wrong",
+        ]
+    )
+    assert rc == 2
+
+
+def test_v2_incomplete_or_extra_markers_fail_closed_not_legacy(tmp_path: Path):
+    """v2 missing seed/count/timestamp/policy, with extra anchor keys, or with partial markers fails rather than using legacy."""
+    # 1. partial marker on legacy shape
+    facts = [{"id": f"f{i}", "q": f"q{i}", "a": f"a{i}"} for i in range(3)]
+    fpath = tmp_path / "lf.json"
+    fpath.write_text(json.dumps(facts), encoding="utf-8")
+    p = tmp_path / "pleg.json"
+    rc = context_canary.main(["mint", "--facts", str(fpath), "--out", str(p)])
+    assert rc == 0
+    # add a v2 marker -> routes to v2 validation -> fail
+    pdat = json.loads(p.read_text(encoding="utf-8"))
+    pdat["version"] = "2"
+    pdat["schema"] = "production-handoff-v2"
+    p.write_text(json.dumps(pdat), encoding="utf-8")
+    ans = {f["id"]: f["a"] for f in facts}
+    ap = tmp_path / "al.json"
+    ap.write_text(json.dumps(ans), encoding="utf-8")
+    rc = context_canary.main(["score", "--probe", str(p), "--answers", str(ap)])
+    assert rc == 2  # not legacy pass
+
+    # 2. full v2 missing required field (e.g. seed)
+    snap = _good_v2_snapshot()
+    snap.pop("seed", None)  # will be generated, but remove generated_at to break
+    snap["generated_at"] = "not-a-timestamp"
+    s2 = tmp_path / "badts.json"
+    s2.write_text(json.dumps(snap), encoding="utf-8")
+    rc = context_canary.main(["mint", "--snapshot", str(s2), "--out", str(tmp_path / "pbadts.json")])
+    assert rc == 1
+
+    # 3. extra key in anchor
+    goodp = _mint_v2(tmp_path)
+    gdat = json.loads(goodp.read_text(encoding="utf-8"))
+    gdat["anchors"][0]["extra"] = "no"
+    gp = tmp_path / "pextra.json"
+    gp.write_text(json.dumps(gdat), encoding="utf-8")
+    lid, rid = gdat["lineage_id"], gdat["rollover_id"]
+    ansd = {a["id"]: a["a"] for a in gdat["anchors"]}
+    aa = tmp_path / "aa.json"
+    aa.write_text(json.dumps(ansd), encoding="utf-8")
+    rc = context_canary.main(
+        ["score", "--probe", str(gp), "--answers", str(aa), "--expected-lineage-id", lid, "--expected-rollover-id", rid]
+    )
+    assert rc == 2
+
+
+def test_missing_or_both_mint_sources_return_rc2(tmp_path: Path):
+    """missing/both mint source arguments return rc 2 (via required mutually_exclusive_group)."""
+    outp = str(tmp_path / "o.json")
+    # neither
+    rc = context_canary.main(["mint", "--out", outp])
+    assert rc == 2
+    # both
+    facts = tmp_path / "f.json"
+    facts.write_text(json.dumps([{"id": "x", "q": "q", "a": "a"}]), encoding="utf-8")
+    snap = tmp_path / "s.json"
+    snap.write_text(json.dumps(_good_v2_snapshot()), encoding="utf-8")
+    rc = context_canary.main(["mint", "--facts", str(facts), "--snapshot", str(snap), "--out", outp])
+    assert rc == 2
+
+
+def test_valid_durable_refs_for_every_allowed_category_pass(tmp_path: Path):
+    """valid durable refs for every allowed category pass (goals handoff; dec/rationale decision+handoff; const handoff+decision; next queue+handoff)."""
+    # already exercised by _good + _mint_v2 + perfect score, but explicit
+    probe = _mint_v2(tmp_path)
+    data = json.loads(probe.read_text(encoding="utf-8"))
+    lid, rid = data["lineage_id"], data["rollover_id"]
+    answers = {a["id"]: a["a"] for a in data["anchors"]}
+    ans = tmp_path / "okans.json"
+    ans.write_text(json.dumps(answers), encoding="utf-8")
+    rc = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(probe),
+            "--answers",
+            str(ans),
+            "--expected-lineage-id",
+            lid,
+            "--expected-rollover-id",
+            rid,
+        ]
+    )
+    assert rc == 0
+    # also re-mint to confirm
+    s2 = tmp_path / "s2.json"
+    s2.write_text(json.dumps(_good_v2_snapshot()), encoding="utf-8")
+    p2 = tmp_path / "p2.json"
+    rc = context_canary.main(["mint", "--snapshot", str(s2), "--out", str(p2)])
+    assert rc == 0
+
+
+def test_all_prior_strictness_determinism_and_origin_legacy_tests_still_pass(tmp_path: Path):
+    """all prior strictness/determinism and every origin/main legacy test still pass (sanity after changes)."""
+    # run a representative legacy flow
+    probe = tmp_path / "pl.json"
+    rc = context_canary.main(["mint", "--facts", json.dumps(FACTS), "--out", str(probe)])
+    assert rc == 0
+    answers = {f["id"]: f["a"] for f in FACTS}
+    ap = tmp_path / "al.json"
+    ap.write_text(json.dumps(answers), encoding="utf-8")
+    rc = context_canary.main(
+        ["score", "--probe", str(probe), "--answers", str(ap), "--threshold", "0.75", "--pass-ratio", "0.85"]
+    )
+    assert rc == 0
+
+    # determinism on v2
+    snap = _good_v2_snapshot()
+    s = tmp_path / "sd.json"
+    s.write_text(json.dumps(snap), encoding="utf-8")
+    p1 = tmp_path / "pd1.json"
+    rc1 = context_canary.main(["mint", "--snapshot", str(s), "--out", str(p1)])
+    p2 = tmp_path / "pd2.json"
+    rc2 = context_canary.main(["mint", "--snapshot", str(s), "--out", str(p2)])
+    assert rc1 == rc2 == 0
+    d1 = json.loads(p1.read_text(encoding="utf-8"))
+    d2 = json.loads(p2.read_text(encoding="utf-8"))
+    assert [a["id"] for a in d1["anchors"]] == [a["id"] for a in d2["anchors"]]
+    assert d1["lineage_id"] == d2["lineage_id"] and d1["rollover_id"] == d2["rollover_id"]

--- a/tests/test_context_canary.py
+++ b/tests/test_context_canary.py
@@ -1,8 +1,11 @@
-"""Tests for scripts/context_canary.py — the deterministic brain-rot monitor.
+"""Tests for scripts/context_canary.py (5055 canary gate).
 
-The load-bearing property: the SCRIPT decides pass/fail by diffing answers against
-the frozen truth. A confident-but-wrong answer must score as DRIFT, and the CSV log
-must accumulate the (context_tokens, score) data point for cross-session rot mapping.
+Focus: deterministic 10-anchor probe derivation from tool-backed snapshot;
+exclusion of UNKNOWN/unavailable/non-tool-backed; validated 3/3/2/2 composition;
+version metadata; strict 10/10 scoring (rc 2); normalized id + text modes;
+machine-readable JSON verdict; deterministic logging.
+
+All ground-truth answers derived from supplied snapshot (no invention).
 """
 
 from __future__ import annotations
@@ -14,115 +17,196 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 import context_canary
 
-FACTS = [
-    {"id": "safe_env_sha", "q": "SHA of the safe_env commit", "a": "5cd67954ab"},
-    {"id": "agy_pr", "q": "PR number for agy lane hardening", "a": "2839"},
-    {"id": "wiki_reason", "q": "Why wiki lane not flipped", "a": "agy §7 fabrication unverified at pro tier"},
-]
+
+def _good_snapshot() -> dict:
+    """Minimal tool-backed snapshot that yields exactly 10 valid anchors with required composition."""
+    return {
+        "generated_at": "2026-07-13T12:00:00Z",
+        "git": {
+            "branch": "grok-build/5055-canary-gate",
+            "head": "a1b2c3d4e5",
+            "full_head": "a1b2c3d4e5f67890123456789abcdef0",
+            "last_commits": [
+                {"sha": "a1b2c3d4e5", "subject": "feat(canary): deterministic 10-anchor derivation from snapshot"},
+                {"sha": "f6e7d8c9b0", "subject": "fix: exclude non-tool-backed and UNKNOWN values"},
+                {"sha": "1122334455", "subject": "test: strict 10/10 rc-2 and normalized matching"},
+                {"sha": "9988776655", "subject": "chore: versioned metadata + json verdict"},
+            ],
+            "modified_files": [],
+            "ahead_behind": {"ahead": 0, "behind": 0, "upstream": "origin/main"},
+        },
+        "github": {
+            "open_prs": [{"number": 5055, "title": "Context canary implementation"}],
+            "open_issues": [{"number": 5054, "title": "Canary gate epic"}],
+        },
+        "monitor": {
+            "active_delegates": {"active_count": 1},
+            "orient": {"runtime": {"agents": ["orchestrator", "codex"]}},
+        },
+    }
 
 
-def _mint(tmp_path: Path) -> Path:
-    facts = tmp_path / "facts.json"
-    facts.write_text(json.dumps(FACTS), encoding="utf-8")
+def _mint_from_snapshot(tmp_path: Path) -> Path:
+    snap = tmp_path / "snapshot.json"
+    snap.write_text(json.dumps(_good_snapshot()), encoding="utf-8")
     probe = tmp_path / "probe.json"
-    rc = context_canary.main(["mint", "--facts", str(facts), "--out", str(probe)])
-    assert rc == 0
+    rc = context_canary.main(["mint", "--snapshot", str(snap), "--out", str(probe)])
+    assert rc == 0, "mint from good snapshot must succeed"
     return probe
 
 
-def test_mint_writes_anchors(tmp_path: Path):
-    probe = _mint(tmp_path)
+def test_mint_snapshot_produces_versioned_10_anchors_with_validated_composition(tmp_path: Path):
+    probe = _mint_from_snapshot(tmp_path)
     data = json.loads(probe.read_text(encoding="utf-8"))
-    assert [a["id"] for a in data["anchors"]] == ["safe_env_sha", "agy_pr", "wiki_reason"]
+    assert data["version"] == "1"
+    assert data.get("source") == "snapshot"
+    anchors = data["anchors"]
+    assert len(anchors) == 10
+    assert len({a["id"] for a in anchors}) == 10  # unique
+    counts = {}
+    for a in anchors:
+        c = a["category"]
+        counts[c] = counts.get(c, 0) + 1
+    assert counts == {"fact": 3, "decision/rationale": 3, "negative-constraint": 2, "goal/next-action": 2}
+    # spot check some ids and that answers are non-empty from snapshot
+    ids = [a["id"] for a in anchors]
+    assert "git_branch" in ids
+    assert "commit_0_subject" in ids
+    assert "git_modified_status" in ids
+    assert "head_sha_next_ref" in ids
+    for a in anchors:
+        assert a["a"], "no invented empty answers"
+        assert _good_snapshot()  # answers traceable to input snapshot
 
 
-def test_perfect_recall_passes_and_logs(tmp_path: Path):
-    probe = _mint(tmp_path)
-    answers = tmp_path / "ans.json"
-    answers.write_text(json.dumps({f["id"]: f["a"] for f in FACTS}), encoding="utf-8")
-    log = tmp_path / "canary_log.csv"
-    rc = context_canary.main(
-        ["score", "--probe", str(probe), "--answers", str(answers),
-         "--context-tokens", "500000", "--model", "claude-opus-4-8", "--log", str(log)]
-    )
+def test_mint_insufficient_evidence_excludes_bad_and_fails(tmp_path: Path):
+    # snapshot that will exclude enough to miss quotas (e.g. short commits, bad values)
+    bad = {
+        "git": {
+            "branch": "UNKNOWN",
+            "head": "",
+            "last_commits": [{"sha": "only1", "subject": "one only"}],  # only 1 -> can't fill 3 dec/rationale
+            "modified_files": [],
+            "ahead_behind": None,
+        },
+        "github": {"open_prs": {"_error": "no gh"}, "open_issues": []},
+        "monitor": {},
+    }
+    snap = tmp_path / "bad.json"
+    snap.write_text(json.dumps(bad), encoding="utf-8")
+    rc = context_canary.main(["mint", "--snapshot", str(snap), "--out", str(tmp_path / "p.json")])
+    assert rc == 1
+
+
+def test_legacy_facts_still_mints_but_score_requires_10(tmp_path: Path):
+    facts = [{"id": "x", "q": "q", "a": "a"}]
+    fpath = tmp_path / "f.json"
+    fpath.write_text(json.dumps(facts), encoding="utf-8")
+    p = tmp_path / "p.json"
+    rc = context_canary.main(["mint", "--facts", str(fpath), "--out", str(p)])
+    assert rc == 0
+    # score on non-10 must fail with usage (not crash)
+    ans = tmp_path / "ans.json"
+    ans.write_text(json.dumps({"x": "a"}), encoding="utf-8")
+    rc = context_canary.main(["score", "--probe", str(p), "--answers", str(ans)])
+    assert rc == 1
+
+
+def test_perfect_10_10_recall_passes_and_logs(tmp_path: Path):
+    probe = _mint_from_snapshot(tmp_path)
+    data = json.loads(probe.read_text(encoding="utf-8"))
+    answers = {a["id"]: a["a"] for a in data["anchors"]}
+    ans_path = tmp_path / "ans.json"
+    ans_path.write_text(json.dumps(answers), encoding="utf-8")
+    log = tmp_path / "log.csv"
+    rc = context_canary.main([
+        "score", "--probe", str(probe), "--answers", str(ans_path),
+        "--context-tokens", "600000", "--model", "claude-opus-4-8", "--log", str(log)
+    ])
     assert rc == 0
     body = log.read_text(encoding="utf-8").splitlines()
     assert body[0].startswith("context_tokens,model,k,correct,score,verdict")
-    assert "500000,claude-opus-4-8,3,3,1.000,PASS" in body[1]
+    assert "600000,claude-opus-4-8,10,10,1.000,PASS" in body[1]
 
 
-def test_confident_but_wrong_answer_fails_handoff(tmp_path: Path):
-    probe = _mint(tmp_path)
-    answers = tmp_path / "ans.json"
-    # Wrong SHA + wrong PR + distorted reason = rot. Confident, but wrong.
-    answers.write_text(
-        json.dumps({"safe_env_sha": "deadbeef99", "agy_pr": "9999", "wiki_reason": "it was already fine"}),
-        encoding="utf-8",
-    )
-    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(answers)])
-    assert rc == 2  # FAIL-HANDOFF
-
-
-def test_partial_drift_below_pass_ratio_fails(tmp_path: Path):
-    probe = _mint(tmp_path)
-    answers = tmp_path / "ans.json"
-    # 1 of 3 wrong -> 0.67 < default pass_ratio 0.85 -> handoff
-    answers.write_text(
-        json.dumps({"safe_env_sha": "5cd67954ab", "agy_pr": "2839", "wiki_reason": "totally unrelated text"}),
-        encoding="utf-8",
-    )
-    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(answers)])
-    assert rc == 2
-
-
-def test_missing_answer_counts_as_drift(tmp_path: Path):
-    probe = _mint(tmp_path)
-    answers = tmp_path / "ans.json"
-    answers.write_text(json.dumps({"safe_env_sha": "5cd67954ab"}), encoding="utf-8")  # 2 missing
-    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(answers)])
-    assert rc == 2
-
-
-def test_mint_rejects_duplicate_ids(tmp_path: Path):
-    facts = tmp_path / "facts.json"
-    facts.write_text(json.dumps([{"id": "x", "q": "q", "a": "a"}, {"id": "x", "q": "q2", "a": "a2"}]), encoding="utf-8")
-    rc = context_canary.main(["mint", "--facts", str(facts), "--out", str(tmp_path / "p.json")])
-    assert rc == 1
-
-
-def test_mint_accepts_inline_json(tmp_path: Path):
-    # The arg help advertises "Inline JSON list of {id,q,a}" — passing the list
-    # directly (not a file path) must work, not crash with 'File name too long'.
-    probe = tmp_path / "probe.json"
-    rc = context_canary.main(["mint", "--facts", json.dumps(FACTS), "--out", str(probe)])
-    assert rc == 0
+def test_strict_10_10_any_drift_or_missing_fails_rc2(tmp_path: Path):
+    probe = _mint_from_snapshot(tmp_path)
     data = json.loads(probe.read_text(encoding="utf-8"))
-    assert [a["id"] for a in data["anchors"]] == ["safe_env_sha", "agy_pr", "wiki_reason"]
+    answers = {a["id"]: a["a"] for a in data["anchors"]}
+    # corrupt one
+    first_id = next(iter(answers.keys()))
+    answers[first_id] = "WRONG-VALUE"
+    ans = tmp_path / "bad.json"
+    ans.write_text(json.dumps(answers), encoding="utf-8")
+    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans)])
+    assert rc == 2
+    # missing also fails
+    answers2 = {a["id"]: a["a"] for a in data["anchors"][:9]}  # missing 1
+    ans2 = tmp_path / "miss.json"
+    ans2.write_text(json.dumps(answers2), encoding="utf-8")
+    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans2)])
+    assert rc == 2
 
 
-def test_mint_inline_and_file_produce_identical_probe(tmp_path: Path):
-    file_probe = _mint(tmp_path)
-    inline_probe = tmp_path / "inline_probe.json"
-    rc = context_canary.main(["mint", "--facts", json.dumps(FACTS), "--out", str(inline_probe)])
+def test_exact_normalized_matching_for_ids_and_normalized_text(tmp_path: Path):
+    probe = _mint_from_snapshot(tmp_path)
+    data = json.loads(probe.read_text(encoding="utf-8"))
+    # use weird cased ids + padded/whitespace/case answers
+    answers = {}
+    for a in data["anchors"]:
+        answers["  " + a["id"].upper() + "  "] = "  " + a["a"].upper() + "  \n"
+    ans = tmp_path / "norm.json"
+    ans.write_text(json.dumps(answers), encoding="utf-8")
+    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans), "--text-match", "normalized"])
     assert rc == 0
-    assert inline_probe.read_text(encoding="utf-8") == file_probe.read_text(encoding="utf-8")
 
 
-def test_mint_missing_file_is_clean_usage_error(tmp_path: Path):
-    rc = context_canary.main(["mint", "--facts", str(tmp_path / "nope.json"), "--out", str(tmp_path / "p.json")])
-    assert rc == 1  # FileNotFoundError -> clean rc 1, not an uncaught traceback
+def test_explicit_exact_mode_is_strict(tmp_path: Path):
+    probe = _mint_from_snapshot(tmp_path)
+    data = json.loads(probe.read_text(encoding="utf-8"))
+    answers = {a["id"]: "  " + a["a"] + "  " for a in data["anchors"]}  # extra ws
+    ans = tmp_path / "exact.json"
+    ans.write_text(json.dumps(answers), encoding="utf-8")
+    # normalized passes
+    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans), "--text-match", "normalized"])
+    assert rc == 0
+    # exact fails on ws
+    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans), "--text-match", "exact"])
+    assert rc == 2
 
 
-def test_mint_directory_as_facts_is_clean_usage_error(tmp_path: Path):
-    # A path that is a directory raises IsADirectoryError inside read_text; the
-    # widened (OSError, UnicodeDecodeError) catch must turn it into a clean rc 1,
-    # not a traceback (every file-branch read failure is covered, not just missing).
-    a_dir = tmp_path / "facts_dir"
-    a_dir.mkdir()
-    rc = context_canary.main(["mint", "--facts", str(a_dir), "--out", str(tmp_path / "p.json")])
-    assert rc == 1
+def test_machine_readable_json_verdict(tmp_path: Path):
+    probe = _mint_from_snapshot(tmp_path)
+    data = json.loads(probe.read_text(encoding="utf-8"))
+    answers = {a["id"]: a["a"] for a in data["anchors"]}
+    ans = tmp_path / "ans.json"
+    ans.write_text(json.dumps(answers), encoding="utf-8")
+    vpath = tmp_path / "verdict.json"
+    rc = context_canary.main([
+        "score", "--probe", str(probe), "--answers", str(ans), "--verdict", str(vpath)
+    ])
+    assert rc == 0
+    v = json.loads(vpath.read_text(encoding="utf-8"))
+    assert v["version"] == "1"
+    assert v["k"] == 10
+    assert v["correct"] == 10
+    assert v["verdict"] == "PASS"
+    assert len(v["per_anchor"]) == 10
+    assert all(p["match"] for p in v["per_anchor"])
 
 
-def test_mint_malformed_inline_json_is_clean_usage_error(tmp_path: Path):
-    rc = context_canary.main(["mint", "--facts", "[{bad json", "--out", str(tmp_path / "p.json")])
-    assert rc == 1  # inline branch JSONDecodeError caught, returns usage error
+def test_deterministic_logging_same_inputs_same_rows(tmp_path: Path):
+    probe = _mint_from_snapshot(tmp_path)
+    data = json.loads(probe.read_text(encoding="utf-8"))
+    answers = {a["id"]: a["a"] for a in data["anchors"]}
+    ans = tmp_path / "ans.json"
+    ans.write_text(json.dumps(answers), encoding="utf-8")
+    log = tmp_path / "det.csv"
+    rc1 = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans), "--context-tokens", "123", "--model", "test-m", "--log", str(log)])
+    rc2 = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans), "--context-tokens", "123", "--model", "test-m", "--log", str(log)])
+    assert rc1 == 0 and rc2 == 0
+    lines = log.read_text(encoding="utf-8").strip().splitlines()
+    # header + 2 identical data rows
+    assert len(lines) == 3
+    assert lines[1] == lines[2]
+    assert lines[1].startswith("123,test-m,10,10,")

--- a/tests/test_context_canary.py
+++ b/tests/test_context_canary.py
@@ -119,10 +119,21 @@ def test_perfect_10_10_recall_passes_and_logs(tmp_path: Path):
     ans_path = tmp_path / "ans.json"
     ans_path.write_text(json.dumps(answers), encoding="utf-8")
     log = tmp_path / "log.csv"
-    rc = context_canary.main([
-        "score", "--probe", str(probe), "--answers", str(ans_path),
-        "--context-tokens", "600000", "--model", "claude-opus-4-8", "--log", str(log)
-    ])
+    rc = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(probe),
+            "--answers",
+            str(ans_path),
+            "--context-tokens",
+            "600000",
+            "--model",
+            "claude-opus-4-8",
+            "--log",
+            str(log),
+        ]
+    )
     assert rc == 0
     body = log.read_text(encoding="utf-8").splitlines()
     assert body[0].startswith("context_tokens,model,k,correct,score,verdict")
@@ -182,9 +193,7 @@ def test_machine_readable_json_verdict(tmp_path: Path):
     ans = tmp_path / "ans.json"
     ans.write_text(json.dumps(answers), encoding="utf-8")
     vpath = tmp_path / "verdict.json"
-    rc = context_canary.main([
-        "score", "--probe", str(probe), "--answers", str(ans), "--verdict", str(vpath)
-    ])
+    rc = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans), "--verdict", str(vpath)])
     assert rc == 0
     v = json.loads(vpath.read_text(encoding="utf-8"))
     assert v["version"] == "1"
@@ -202,8 +211,36 @@ def test_deterministic_logging_same_inputs_same_rows(tmp_path: Path):
     ans = tmp_path / "ans.json"
     ans.write_text(json.dumps(answers), encoding="utf-8")
     log = tmp_path / "det.csv"
-    rc1 = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans), "--context-tokens", "123", "--model", "test-m", "--log", str(log)])
-    rc2 = context_canary.main(["score", "--probe", str(probe), "--answers", str(ans), "--context-tokens", "123", "--model", "test-m", "--log", str(log)])
+    rc1 = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(probe),
+            "--answers",
+            str(ans),
+            "--context-tokens",
+            "123",
+            "--model",
+            "test-m",
+            "--log",
+            str(log),
+        ]
+    )
+    rc2 = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(probe),
+            "--answers",
+            str(ans),
+            "--context-tokens",
+            "123",
+            "--model",
+            "test-m",
+            "--log",
+            str(log),
+        ]
+    )
     assert rc1 == 0 and rc2 == 0
     lines = log.read_text(encoding="utf-8").strip().splitlines()
     # header + 2 identical data rows

--- a/tests/test_context_canary.py
+++ b/tests/test_context_canary.py
@@ -148,7 +148,7 @@ def _good_v2_snapshot() -> dict:
     """
     return {
         "generated_at": "2026-07-13T12:00:00Z",
-        "lineage_id": "grok-build/5055-canary-gate:5055-semantic-fix",
+        "lineage_id": "lineage-grok-build-5055-canary-gate-5055-semantic-fix",
         "rollover_id": "rollover-5055-20260713-01",
         "seed": 987654321,
         "goals": [
@@ -812,3 +812,259 @@ def test_all_prior_strictness_determinism_and_origin_legacy_tests_still_pass(tmp
     d2 = json.loads(p2.read_text(encoding="utf-8"))
     assert [a["id"] for a in d1["anchors"]] == [a["id"] for a in d2["anchors"]]
     assert d1["lineage_id"] == d2["lineage_id"] and d1["rollover_id"] == d2["rollover_id"]
+
+
+# --- Centralized identity validator regression tests (must cover the blocker cases at all three boundaries) ---
+# All prior/origin-main tests preserved; only added at end. Valid engine-shaped examples continue to pass.
+
+
+def test_identity_validator_rejects_bad_values_at_mint(tmp_path: Path):
+    """!!!, ../../lineage, embedded newline/control, uppercase, wrong prefix, empty suffix, overlong fail at mint."""
+    bad_lineage_values = [
+        "!!!",
+        "../../lineage",
+        "lineage-foo\nbar",
+        "lineage-foo\x00bar",
+        "lineage-FOO-BAR",
+        "Lineage-abc",
+        "foo-bar-baz",
+        "lineage-",
+        "lineage-" + "x" * 57,  # 8 + 57 = 65 > 64
+        "lineage--double",
+        "lineage-foo.",
+        "lineage-foo/bar",
+    ]
+    for i, bad in enumerate(bad_lineage_values):
+        snap = _good_v2_snapshot()
+        snap["lineage_id"] = bad
+        s = tmp_path / f"badlid{i}.json"
+        s.write_text(json.dumps(snap), encoding="utf-8")
+        rc = context_canary.main(["mint", "--snapshot", str(s), "--out", str(tmp_path / f"plid{i}.json")])
+        assert rc == 1, f"mint must reject bad lineage_id at input: {bad!r}"
+
+    bad_rollover_values = [
+        "!!!",
+        "../../rollover",
+        "rollover-foo\nbar",
+        "rollover-foo\x1bbar",  # ESC control
+        "Rollover-123",
+        "rollover-",
+        "rollover-" + "y" * 57,
+        "rollover--hyphen",
+        "rollover-abc.def",
+        "rollover-abc\\def",
+        "wrongprefix-123",
+    ]
+    for i, bad in enumerate(bad_rollover_values):
+        snap = _good_v2_snapshot()
+        snap["rollover_id"] = bad
+        s = tmp_path / f"badrid{i}.json"
+        s.write_text(json.dumps(snap), encoding="utf-8")
+        rc = context_canary.main(["mint", "--snapshot", str(s), "--out", str(tmp_path / f"prid{i}.json")])
+        assert rc == 1, f"mint must reject bad rollover_id at input: {bad!r}"
+
+
+def test_identity_validator_rejects_bad_values_in_forged_probes_at_score(tmp_path: Path):
+    """Bad lineage/rollover in forged production probe fail at score (probe validation gate)."""
+    probe = _mint_v2(tmp_path)
+    pdata = json.loads(probe.read_text(encoding="utf-8"))
+    lid, rid = pdata["lineage_id"], pdata["rollover_id"]
+    answers = {a["id"]: a["a"] for a in pdata["anchors"]}
+    ans = tmp_path / "ans.json"
+    ans.write_text(json.dumps(answers), encoding="utf-8")
+
+    bads = [
+        "!!!",
+        "../../lineage",
+        "lineage-foo\nx",
+        "lineage-foo\x00x",
+        "LINEAGE-abc",
+        "lineage-",
+        "lineage-" + "z" * 57,
+        "lineage-foo--bar",
+        "lineage-foo.",
+    ]
+    for i, bad in enumerate(bads):
+        pdata_bad = json.loads(probe.read_text(encoding="utf-8"))
+        pdata_bad["lineage_id"] = bad
+        badp = tmp_path / f"forged_l_{i}.json"
+        badp.write_text(json.dumps(pdata_bad), encoding="utf-8")
+        rc = context_canary.main(
+            [
+                "score",
+                "--probe",
+                str(badp),
+                "--answers",
+                str(ans),
+                "--expected-lineage-id",
+                lid,
+                "--expected-rollover-id",
+                rid,
+            ]
+        )
+        assert rc == 2, f"forged probe lineage must be rejected in score validation: {bad!r}"
+
+    bads_r = [
+        "!!!",
+        "../../roll",
+        "rollover-foo\nx",
+        "rollover-foo\x0bx",
+        "ROLLOVER-x",
+        "rollover-",
+        "rollover-" + "a" * 57,
+        "wrong-1",
+        "rollover-abc.def",
+    ]
+    for i, bad in enumerate(bads_r):
+        pdata_bad = json.loads(probe.read_text(encoding="utf-8"))
+        pdata_bad["rollover_id"] = bad
+        badp = tmp_path / f"forged_r_{i}.json"
+        badp.write_text(json.dumps(pdata_bad), encoding="utf-8")
+        rc = context_canary.main(
+            [
+                "score",
+                "--probe",
+                str(badp),
+                "--answers",
+                str(ans),
+                "--expected-lineage-id",
+                lid,
+                "--expected-rollover-id",
+                rid,
+            ]
+        )
+        assert rc == 2, f"forged probe rollover must be rejected in score validation: {bad!r}"
+
+
+def test_identity_validator_rejects_bad_expected_cli_at_score_boundaries(tmp_path: Path):
+    """--expected-lineage-id / --expected-rollover-id bad values fail at expected-CLI boundary (validated before ==)."""
+    probe = _mint_v2(tmp_path)
+    pdata = json.loads(probe.read_text(encoding="utf-8"))
+    good_lid, good_rid = pdata["lineage_id"], pdata["rollover_id"]
+    answers = {a["id"]: a["a"] for a in pdata["anchors"]}
+    ans = tmp_path / "ans.json"
+    ans.write_text(json.dumps(answers), encoding="utf-8")
+
+    bad_expected_l = [
+        "!!!",
+        "../../lineage",
+        "lineage-foo\nbar",
+        "lineage-FOO",
+        "foo-bar",
+        "lineage-",
+        "lineage-" + "x" * 57,
+        "lineage-foo..bar",
+        "lineage-abc-",
+    ]
+    for bad in bad_expected_l:
+        rc = context_canary.main(
+            [
+                "score",
+                "--probe",
+                str(probe),
+                "--answers",
+                str(ans),
+                "--expected-lineage-id",
+                bad,
+                "--expected-rollover-id",
+                good_rid,
+            ]
+        )
+        assert rc == 2, f"bad --expected-lineage-id must fail at CLI validation boundary: {bad!r}"
+
+    bad_expected_r = [
+        "!!!",
+        "rollover-foo\n",
+        "rollover-UPPER",
+        "rollover",
+        "rollover-",
+        "rollover-" + "y" * 57,
+        "../../roll",
+        "rollover-foo/bar",
+        "rollover--x",
+    ]
+    for bad in bad_expected_r:
+        rc = context_canary.main(
+            [
+                "score",
+                "--probe",
+                str(probe),
+                "--answers",
+                str(ans),
+                "--expected-lineage-id",
+                good_lid,
+                "--expected-rollover-id",
+                bad,
+            ]
+        )
+        assert rc == 2, f"bad --expected-rollover-id must fail at CLI validation boundary: {bad!r}"
+
+    # both bad also fails
+    rc = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(probe),
+            "--answers",
+            str(ans),
+            "--expected-lineage-id",
+            "!!!",
+            "--expected-rollover-id",
+            "!!!",
+        ]
+    )
+    assert rc == 2
+
+
+def test_valid_engine_shaped_identities_continue_to_pass_mint_score_and_expected(tmp_path: Path):
+    """Valid engine-shaped (lineage-... rollover-...) examples must keep passing at mint, probe, and expected-CLI."""
+    # mint
+    snap = _good_v2_snapshot()
+    s = tmp_path / "sval.json"
+    s.write_text(json.dumps(snap), encoding="utf-8")
+    p = tmp_path / "pval.json"
+    rc = context_canary.main(["mint", "--snapshot", str(s), "--out", str(p)])
+    assert rc == 0
+    data = json.loads(p.read_text(encoding="utf-8"))
+    assert data["lineage_id"] == snap["lineage_id"]
+    assert data["rollover_id"] == snap["rollover_id"]
+
+    # score with expected exact raw
+    answers = {a["id"]: a["a"] for a in data["anchors"]}
+    ans = tmp_path / "aval.json"
+    ans.write_text(json.dumps(answers), encoding="utf-8")
+    rc = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(p),
+            "--answers",
+            str(ans),
+            "--expected-lineage-id",
+            data["lineage_id"],
+            "--expected-rollover-id",
+            data["rollover_id"],
+        ]
+    )
+    assert rc == 0
+
+    # also via the original _mint_v2 path + expected
+    probe2 = _mint_v2(tmp_path)
+    d2 = json.loads(probe2.read_text(encoding="utf-8"))
+    a2 = {a["id"]: a["a"] for a in d2["anchors"]}
+    aa2 = tmp_path / "a2.json"
+    aa2.write_text(json.dumps(a2), encoding="utf-8")
+    rc = context_canary.main(
+        [
+            "score",
+            "--probe",
+            str(probe2),
+            "--answers",
+            str(aa2),
+            "--expected-lineage-id",
+            d2["lineage_id"],
+            "--expected-rollover-id",
+            d2["rollover_id"],
+        ]
+    )
+    assert rc == 0


### PR DESCRIPTION
Fixes #5055
Part of #5054
Stream epic: #4707

## Summary

- Preserve the original legacy facts/threshold/pass-ratio canary flow.
- Add a separate production handoff-v2 probe with exactly ten anchors: 3 goals, 3 decisions/rationales, 2 prohibitions, and 2 next actions.
- Require durable typed artifact provenance and prohibit git/GitHub/Monitor metadata from masquerading as semantic anchors.
- Bind probes and verdicts to exact lineage and rollover identities, stored seed, timestamp, category counts, policy, and canonical probe hash.
- Require exact IDs and strict 10/10 recall; reject unknowns, malformed/partial schemas, padding, forged provenance, and malformed identities.
- Randomize selection/order per stored seed while remaining reproducible.

## Verification

- 36/36 focused tests pass.
- Original legacy tests and CLI exit/scoring behavior are preserved.
- Forged provenance, partial-v2 fallback, wrong/empty/duplicate IDs, wrong lineage/rollover, 9/10 recall, malformed identity, and UNKNOWN attacks fail closed.
- Ruff check/format, git diff --check, trailer audit, and the mandatory AGENTS.md checklist pass.
- Only scripts/context_canary.py and tests/test_context_canary.py changed.

## Review gate

- Fable architecture advice: bridge replies #2707 and #2711, recorded on #5054/#5055.
- Independent Terra reviews rejected two earlier implementations for semantic relabeling, missing provenance/metadata binding, legacy regressions, and malformed identity acceptance.
- Every reproduced exploit received a regression test and corrective commit.
- Final Terra review replayed the identity attacks at the rebased tip: PASS.