### PR TITLE
fix(orchestration): support direct thread handoff CLI

### DIFF
--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -27,7 +27,12 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-from scripts.orchestration import thread_handoff_canary
+try:
+    from scripts.orchestration import thread_handoff_canary
+except ModuleNotFoundError as exc:
+    if __package__ or exc.name != "scripts":
+        raise
+    import thread_handoff_canary
 
 SCHEMA_VERSION = 2
 DEFAULT_MONITOR_BASE_URL = "http://127.0.0.1:8765"

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -90,6 +90,27 @@ def resumed_with_proof(tmp_path: Path, state: dict, thread_id: str = "new-thread
     return resumed, proof_path
 
 
+def test_direct_script_help_from_repository_root():
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env.pop("CODEX_THREAD_ID", None)
+    env.pop("CODEX_SESSION_ID", None)
+
+    completed = subprocess.run(
+        [".venv/bin/python", "scripts/orchestration/thread_handoff.py", "--help"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Prepare and guard agent-specific thread handoffs." in completed.stdout
+    for command in ("prepare", "confirm-started", "resume", "check", "audit"):
+        assert command in completed.stdout
+
+
 def test_prepare_state_requires_confirmation_before_cleanup(tmp_path: Path):
     now = datetime(2026, 5, 30, 8, 0, tzinfo=UTC)
     state = prepared()


### PR DESCRIPTION
## Summary

- make `thread_handoff.py` directly executable from the repository root without requiring an installed package
- keep the packaged import path unchanged
- add a real subprocess regression test with Codex identity variables removed

## Verification

- `env -u CODEX_THREAD_ID -u CODEX_SESSION_ID .venv/bin/python scripts/orchestration/thread_handoff.py --help`
- `env -u CODEX_THREAD_ID -u CODEX_SESSION_ID .venv/bin/python -m pytest tests/orchestration/test_thread_handoff.py -q` — 32 passed
- Ruff check and format check
- `git diff --check origin/main...HEAD`
- `.venv/bin/python scripts/audit/lint_agent_trailer.py`

## Review gate

Independent cross-family Grok review: **PASS**. It verified the fallback is limited to `ModuleNotFoundError.name == "scripts"` during direct execution, unrelated import errors are re-raised, no `sys.path` mutation exists, and the subprocess regression exercises the real CLI.

Fixes #5056