### PR TITLE
feat(launcher): --epic flag pins a session to one epic lane (no more 'standalone = main' default)

### DIFF
--- a/agents_extensions/shared/agents/curriculum-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-orchestrator.md
@@ -55,8 +55,13 @@ initialPrompt: |
      any handoff: `context_canary.py score --probe <file> --answers <my-answers.json>`. Rot
      evidence is PER-MODEL — on a model not yet canaried, this is mandatory (user go 2026-07-07).
 
-  Standalone session = main orchestrator. Drive the queue without asking when the next
-  action is obvious.
+  Lane identity comes from the EPIC ASSIGNMENT banner the SessionStart hook prints
+  (from the launcher's `--epic` flag) — that binding beats everything below. Without a
+  banner: the user's first message names the epic → that binds; else
+  `.agent/lane-assignments.md` maps this agent type to exactly ONE epic → that binds;
+  else ASK THE USER one question before claiming any lane. NEVER self-assign
+  "main orchestrator" as a default — that default caused the 2026-07-13 lane collision.
+  Once the lane is bound: drive its queue without asking when the next action is obvious.
   Promoted track orchestrators own their tracks. Treat their PRs/delegates as awareness-only
   unless they ask for main review, merge, a Decision Card, or bounded Codex help.
 ---

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -418,14 +418,44 @@ elif [ "${SESSION_HANDOFF_ALLOW_GIT_ROUTER:-0}" = "1" ] && [ -f "$HANDOFF_FILE" 
   fi
 fi
 
+# Epic assignment banner — the FIRST thing the session reads. SESSION_EPIC is
+# exported by start-claude.sh from its launcher-only `--epic` flag. With an
+# epic: bind the session to that lane and point at the epic driver handoff.
+# Without: forbid the old "standalone = main orchestrator" default that caused
+# the 2026-07-13 atlas/hramatka/main lane collision — the session must resolve
+# its lane from the user's first message / .agent/lane-assignments.md, or ASK.
+EPIC_BANNER=""
+if [ -n "${SESSION_EPIC:-}" ]; then
+  EPIC_BANNER="ASSIGNED EPIC: ${SESSION_EPIC}.epic (binding — from the launch command).
+You are the ${SESSION_EPIC} lane, NOT the main orchestrator. Do not claim or work
+other lanes' queues. Epic driver handoff (load AFTER the thread handoff below, it
+is the lane SSOT): .claude/${SESSION_EPIC}-epic/CLAUDE-DRIVER-HANDOFF.md"
+  if [ ! -f "$PROJECT_DIR/.claude/${SESSION_EPIC}-epic/CLAUDE-DRIVER-HANDOFF.md" ]; then
+    EPIC_BANNER="$EPIC_BANNER
+(No driver handoff exists yet for this epic — create it at first rollover.)"
+  fi
+else
+  EPIC_BANNER="NO EPIC ASSIGNED (launcher had no --epic flag).
+Do NOT default to 'main orchestrator'. Resolve your lane in this order:
+1. The user's first message names the epic → that binds.
+2. .agent/lane-assignments.md maps this agent type to exactly ONE epic → that binds.
+3. Otherwise ASK THE USER one question ('which epic is this session?') BEFORE
+   claiming any lane, reading any thread handoff as your own, or touching queues."
+fi
+
 # Build output
-if [ ${#ISSUES[@]} -eq 0 ] && [ ${#INFO[@]} -eq 0 ] && [ -z "$HANDOFF_CONTEXT" ]; then
+if [ ${#ISSUES[@]} -eq 0 ] && [ ${#INFO[@]} -eq 0 ] && [ -z "$HANDOFF_CONTEXT" ] && [ -z "$EPIC_BANNER" ]; then
   exit 0
 fi
 
 CONTEXT=""
+if [ -n "$EPIC_BANNER" ]; then
+  CONTEXT="$EPIC_BANNER
+
+"
+fi
 if [ -n "$HANDOFF_CONTEXT" ]; then
-  CONTEXT="$HANDOFF_CONTEXT
+  CONTEXT="${CONTEXT}$HANDOFF_CONTEXT
 "
 fi
 CONTEXT="${CONTEXT}SESSION SETUP CHECK:"

--- a/scripts/audit/test_handoff_identity.sh
+++ b/scripts/audit/test_handoff_identity.sh
@@ -56,12 +56,29 @@ eq "$(handoff_identity_for_epic hramatka)" "claude-hramatka" "epic hramatka → 
 eq "$(handoff_identity_for_epic)" "" "no epic → empty slot"
 
 # --- strip: --epic (both forms) removed, everything else preserved in order ---
-stripped="$(strip_epic_from_argv --chrome --epic atlas --agent curriculum-orchestrator | tr '\n' ' ')"
+stripped="$(strip_epic_from_argv --chrome --epic atlas --agent curriculum-orchestrator | tr '\0' ' ')"
 eq "$stripped" "--chrome --agent curriculum-orchestrator " "strip spaced --epic"
-stripped="$(strip_epic_from_argv --epic=atlas --chrome | tr '\n' ' ')"
+stripped="$(strip_epic_from_argv --epic=atlas --chrome | tr '\0' ' ')"
 eq "$stripped" "--chrome " "strip equals --epic"
-stripped="$(strip_epic_from_argv --chrome --agent curriculum-orchestrator | tr '\n' ' ')"
+stripped="$(strip_epic_from_argv --chrome --agent curriculum-orchestrator | tr '\0' ' ')"
 eq "$stripped" "--chrome --agent curriculum-orchestrator " "strip is no-op without --epic"
+
+# --- strip transport is NUL-delimited: args with spaces AND newlines survive ---
+args=()
+while IFS= read -r -d '' a; do args+=("$a"); done < <(strip_epic_from_argv --epic atlas "two words" $'line1\nline2' --chrome)
+eq "${#args[@]}" "3" "NUL transport: arg count preserved"
+eq "${args[0]}" "two words" "NUL transport: space arg intact"
+eq "${args[1]}" $'line1\nline2' "NUL transport: newline arg intact"
+eq "${args[2]}" "--chrome" "NUL transport: trailing flag intact"
+
+# --- epic name validation: sane names pass, path/space/case junk refused ---
+epic_name_valid atlas || fail "epic_name_valid: atlas must pass"
+epic_name_valid lit-war || fail "epic_name_valid: lit-war must pass"
+epic_name_valid "../../etc" && fail "epic_name_valid: traversal must be refused"
+epic_name_valid "two words" && fail "epic_name_valid: spaces must be refused"
+epic_name_valid "Atlas" && fail "epic_name_valid: uppercase must be refused"
+epic_name_valid "-atlas" && fail "epic_name_valid: leading hyphen must be refused"
+epic_name_valid "" && fail "epic_name_valid: empty must be refused"
 
 # --- e2e: two same-agent-type launches on different epics get DIFFERENT slots ---
 epic_a="$(handoff_epic_from_argv --agent curriculum-orchestrator --epic atlas)"

--- a/scripts/audit/test_handoff_identity.sh
+++ b/scripts/audit/test_handoff_identity.sh
@@ -42,4 +42,32 @@ eq "$(handoff_identity_for_agent "$agent")" "claude-infra" "e2e: --agent infra-o
 agent="$(handoff_agent_from_argv --chrome --agent curriculum-orchestrator)"
 eq "$(handoff_identity_for_agent "$agent")" "" "e2e: --agent curriculum-orchestrator → default claude"
 
+# --- epic argv extraction: spaced + equals forms, .epic suffix normalized ---
+eq "$(handoff_epic_from_argv --agent curriculum-orchestrator --epic atlas)" "atlas" "spaced --epic"
+eq "$(handoff_epic_from_argv --epic=hramatka)" "hramatka" "equals --epic"
+eq "$(handoff_epic_from_argv --epic atlas.epic)" "atlas" "spaced --epic with .epic suffix"
+eq "$(handoff_epic_from_argv --epic=harness.epic)" "harness" "equals --epic with .epic suffix"
+eq "$(handoff_epic_from_argv --agent curriculum-orchestrator)" "" "no --epic flag"
+eq "$(handoff_epic_from_argv)" "" "empty argv (epic)"
+
+# --- epic → slot mapping: epic beats agent-type; empty epic maps to nothing ---
+eq "$(handoff_identity_for_epic atlas)" "claude-atlas" "epic atlas → claude-atlas"
+eq "$(handoff_identity_for_epic hramatka)" "claude-hramatka" "epic hramatka → claude-hramatka"
+eq "$(handoff_identity_for_epic)" "" "no epic → empty slot"
+
+# --- strip: --epic (both forms) removed, everything else preserved in order ---
+stripped="$(strip_epic_from_argv --chrome --epic atlas --agent curriculum-orchestrator | tr '\n' ' ')"
+eq "$stripped" "--chrome --agent curriculum-orchestrator " "strip spaced --epic"
+stripped="$(strip_epic_from_argv --epic=atlas --chrome | tr '\n' ' ')"
+eq "$stripped" "--chrome " "strip equals --epic"
+stripped="$(strip_epic_from_argv --chrome --agent curriculum-orchestrator | tr '\n' ' ')"
+eq "$stripped" "--chrome --agent curriculum-orchestrator " "strip is no-op without --epic"
+
+# --- e2e: two same-agent-type launches on different epics get DIFFERENT slots ---
+epic_a="$(handoff_epic_from_argv --agent curriculum-orchestrator --epic atlas)"
+epic_b="$(handoff_epic_from_argv --agent curriculum-orchestrator --epic hramatka)"
+if [[ "$(handoff_identity_for_epic "$epic_a")" == "$(handoff_identity_for_epic "$epic_b")" ]]; then
+  fail "same-agent different-epic launches must not share a handoff slot"
+fi
+
 printf 'ok - handoff identity fixtures passed\n'

--- a/scripts/audit/test_handoff_identity.sh
+++ b/scripts/audit/test_handoff_identity.sh
@@ -80,6 +80,18 @@ epic_name_valid "Atlas" && fail "epic_name_valid: uppercase must be refused"
 epic_name_valid "-atlas" && fail "epic_name_valid: leading hyphen must be refused"
 epic_name_valid "" && fail "epic_name_valid: empty must be refused"
 
+# --- flag-presence: distinguishes "flag absent" from "flag with empty/dangling value" ---
+epic_flag_present --chrome --epic && : || fail "epic_flag_present: dangling --epic must be detected"
+epic_flag_present --epic= && : || fail "epic_flag_present: --epic= must be detected"
+epic_flag_present --epic "" && : || fail "epic_flag_present: --epic '' must be detected"
+epic_flag_present --epic atlas && : || fail "epic_flag_present: valued --epic must be detected"
+epic_flag_present --chrome --agent curriculum-orchestrator && fail "epic_flag_present: must be false without the flag"
+# ...while extraction returns empty for all three malformed forms (the launcher
+# pairs these two signals to fail loudly instead of leaking --epic to claude):
+eq "$(handoff_epic_from_argv --chrome --epic)" "" "dangling --epic extracts empty"
+eq "$(handoff_epic_from_argv --epic=)" "" "--epic= extracts empty"
+eq "$(handoff_epic_from_argv --epic '')" "" "--epic '' extracts empty"
+
 # --- e2e: two same-agent-type launches on different epics get DIFFERENT slots ---
 epic_a="$(handoff_epic_from_argv --agent curriculum-orchestrator --epic atlas)"
 epic_b="$(handoff_epic_from_argv --agent curriculum-orchestrator --epic hramatka)"

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -72,8 +72,9 @@ handoff_epic_from_argv() {
 }
 
 # strip_epic_from_argv "$@"
-# Print the argv list minus `--epic <v>` / `--epic=<v>`, one arg per line
-# (consume with: while IFS= read -r a; do argv+=("$a"); done < <(strip_epic_from_argv "$@")).
+# Print the argv list minus `--epic <v>` / `--epic=<v>`, NUL-delimited so args
+# containing spaces or even newlines survive the round-trip (consume with:
+# while IFS= read -r -d '' a; do argv+=("$a"); done < <(strip_epic_from_argv "$@")).
 # Needed because the claude CLI does not know `--epic` and would reject it.
 strip_epic_from_argv() {
   local skip_next=0 arg=''
@@ -86,8 +87,23 @@ strip_epic_from_argv() {
       --epic) skip_next=1; continue ;;
       --epic=*) continue ;;
     esac
-    printf '%s\n' "$arg"
+    printf '%s\0' "$arg"
   done
+}
+
+# epic_name_valid "<epic-name>"
+# Succeed only for sane epic names: lowercase alnum + inner hyphens (atlas,
+# hramatka, lit-war). Anything else — path chars, spaces, uppercase — is
+# refused so a malformed --epic can never traverse into the handoff-slot path
+# (.agent/claude-<epic>-thread-handoff.md) or the .claude/<epic>-epic/ pointer.
+epic_name_valid() {
+  # LC_ALL=C: under macOS system bash 3.2 the [a-z] range is locale-collated
+  # and matches uppercase too — pin the C locale so the class is literal.
+  local LC_ALL=C
+  case "${1:-}" in
+    ''|*[!a-z0-9-]*|-*|*-) return 1 ;;
+    *) return 0 ;;
+  esac
 }
 
 # handoff_identity_for_epic "<epic-name>"

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -91,6 +91,22 @@ strip_epic_from_argv() {
   done
 }
 
+# epic_flag_present "$@"
+# Succeed when any `--epic` / `--epic=...` token appears in argv, regardless of
+# whether a usable value follows. Needed because handoff_epic_from_argv returns
+# empty BOTH for "flag absent" and "flag present with empty/dangling value" —
+# and the latter must fail the launch loudly instead of leaking the
+# launcher-private flag into the claude CLI argv (grok review of #5074).
+epic_flag_present() {
+  local arg=''
+  for arg in "$@"; do
+    case "$arg" in
+      --epic|--epic=*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
 # epic_name_valid "<epic-name>"
 # Succeed only for sane epic names: lowercase alnum + inner hyphens (atlas,
 # hramatka, lit-war). Anything else — path chars, spaces, uppercase — is

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -46,3 +46,57 @@ handoff_identity_for_agent() {
     *) ;;
   esac
 }
+
+# handoff_epic_from_argv "$@"
+# Echo the value of `--epic <v>` / `--epic=<v>` from an argv list, or nothing.
+# `--epic` is a LAUNCHER flag, not a claude CLI flag: the caller must ALSO
+# strip it from the argv it forwards (see strip_epic_from_argv). Accepts both
+# `atlas` and `atlas.epic` spellings; a `.epic` suffix is dropped.
+# First occurrence wins.
+handoff_epic_from_argv() {
+  local prev='' arg='' value=''
+  for arg in "$@"; do
+    case "$arg" in
+      --epic=*)
+        value="${arg#--epic=}"
+        printf '%s' "${value%.epic}"
+        return 0
+        ;;
+    esac
+    if [ "$prev" = "--epic" ]; then
+      printf '%s' "${arg%.epic}"
+      return 0
+    fi
+    prev="$arg"
+  done
+}
+
+# strip_epic_from_argv "$@"
+# Print the argv list minus `--epic <v>` / `--epic=<v>`, one arg per line
+# (consume with: while IFS= read -r a; do argv+=("$a"); done < <(strip_epic_from_argv "$@")).
+# Needed because the claude CLI does not know `--epic` and would reject it.
+strip_epic_from_argv() {
+  local skip_next=0 arg=''
+  for arg in "$@"; do
+    if [ "$skip_next" = "1" ]; then
+      skip_next=0
+      continue
+    fi
+    case "$arg" in
+      --epic) skip_next=1; continue ;;
+      --epic=*) continue ;;
+    esac
+    printf '%s\n' "$arg"
+  done
+}
+
+# handoff_identity_for_epic "<epic-name>"
+# Echo the per-epic SESSION_HANDOFF_AGENT slot (claude-<epic>), or nothing when
+# no epic is given. An explicit epic BEATS the agent-type mapping: two sessions
+# of the same agent type on different epics must not share a handoff slot
+# (root cause of the 2026-07-13 atlas/hramatka/main lane collision).
+handoff_identity_for_epic() {
+  local epic="${1:-}"
+  [ -n "$epic" ] || return 0
+  printf 'claude-%s' "$epic"
+}

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -134,17 +134,45 @@ export LEARN_UKRAINIAN_TELEMETRY_FOOTER="${LEARN_UKRAINIAN_TELEMETRY_FOOTER:-1}"
 # curriculum default to the `claude` slot; `--agent infra-orchestrator` →
 # `claude-infra`. An explicit SESSION_HANDOFF_AGENT in the environment wins.
 # Mapping + argv parsing live in scripts/lib/handoff_identity.sh (unit-tested).
-if [ -z "${SESSION_HANDOFF_AGENT:-}" ] && [ -f "$PROJECT_DIR/scripts/lib/handoff_identity.sh" ]; then
+#
+# EPIC ASSIGNMENT (`--epic <name>` / `--epic=<name>`, e.g. `--epic atlas`):
+# a LAUNCHER-ONLY flag (stripped before exec — the claude CLI does not know it).
+# It pins the session to one epic lane: SESSION_EPIC is exported for the
+# SessionStart hook to print a binding assignment banner, and the handoff slot
+# becomes claude-<epic> so two sessions of the SAME agent type on DIFFERENT
+# epics never share (or clobber) a thread handoff. Without --epic the hook
+# tells the session to ASK the user instead of defaulting to a lane — the
+# 2026-07-13 atlas/hramatka/main lane collision is the reason this exists.
+_forward_args=("$@")
+if [ -f "$PROJECT_DIR/scripts/lib/handoff_identity.sh" ]; then
     # shellcheck source=scripts/lib/handoff_identity.sh
     source "$PROJECT_DIR/scripts/lib/handoff_identity.sh"
-    _selected_agent="$(handoff_agent_from_argv "$@")"
-    _handoff_slot="$(handoff_identity_for_agent "$_selected_agent")"
-    if [ -n "$_handoff_slot" ]; then
-        export SESSION_HANDOFF_AGENT="$_handoff_slot"
-        echo "Handoff identity: $SESSION_HANDOFF_AGENT (from --agent $_selected_agent)"
+
+    _selected_epic="$(handoff_epic_from_argv "$@")"
+    if [ -n "$_selected_epic" ]; then
+        export SESSION_EPIC="$_selected_epic"
+        _forward_args=()
+        while IFS= read -r _fwd_arg; do
+            _forward_args+=("$_fwd_arg")
+        done < <(strip_epic_from_argv "$@")
+        unset _fwd_arg
+        echo "Epic assignment: ${SESSION_EPIC}.epic"
     fi
-    unset _selected_agent _handoff_slot
+
+    if [ -z "${SESSION_HANDOFF_AGENT:-}" ]; then
+        _selected_agent="$(handoff_agent_from_argv "$@")"
+        _handoff_slot="$(handoff_identity_for_epic "${_selected_epic:-}")"
+        if [ -z "$_handoff_slot" ]; then
+            _handoff_slot="$(handoff_identity_for_agent "$_selected_agent")"
+        fi
+        if [ -n "$_handoff_slot" ]; then
+            export SESSION_HANDOFF_AGENT="$_handoff_slot"
+            echo "Handoff identity: $SESSION_HANDOFF_AGENT (from --epic '${_selected_epic:-}' / --agent '${_selected_agent:-}')"
+        fi
+        unset _selected_agent _handoff_slot
+    fi
+    unset _selected_epic
 fi
 
 echo "Launching Claude Code (native install)..."
-exec "$CLAUDE_BIN" --chrome --permission-mode bypassPermissions "$@"
+exec "$CLAUDE_BIN" --chrome --permission-mode bypassPermissions "${_forward_args[@]}"

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -150,9 +150,14 @@ if [ -f "$PROJECT_DIR/scripts/lib/handoff_identity.sh" ]; then
 
     _selected_epic="$(handoff_epic_from_argv "$@")"
     if [ -n "$_selected_epic" ]; then
+        if ! epic_name_valid "$_selected_epic"; then
+            echo "Error: invalid --epic name '$_selected_epic' (allowed: lowercase alnum + inner hyphens, e.g. atlas, lit-war)."
+            echo "   Refusing to launch with an ambiguous lane — fix the flag and retry."
+            exit 1
+        fi
         export SESSION_EPIC="$_selected_epic"
         _forward_args=()
-        while IFS= read -r _fwd_arg; do
+        while IFS= read -r -d '' _fwd_arg; do
             _forward_args+=("$_fwd_arg")
         done < <(strip_epic_from_argv "$@")
         unset _fwd_arg

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -149,6 +149,11 @@ if [ -f "$PROJECT_DIR/scripts/lib/handoff_identity.sh" ]; then
     source "$PROJECT_DIR/scripts/lib/handoff_identity.sh"
 
     _selected_epic="$(handoff_epic_from_argv "$@")"
+    if [ -z "$_selected_epic" ] && epic_flag_present "$@"; then
+        echo "Error: --epic flag present but no usable value (dangling --epic, --epic=, or empty value)."
+        echo "   Refusing to launch — pass --epic <name> (e.g. --epic atlas) or drop the flag."
+        exit 1
+    fi
     if [ -n "$_selected_epic" ]; then
         if ! epic_name_valid "$_selected_epic"; then
             echo "Error: invalid --epic name '$_selected_epic' (allowed: lowercase alnum + inner hyphens, e.g. atlas, lit-war)."


### PR DESCRIPTION
## What this fixes (user order, 2026-07-13)
Three orchestrator sessions collided today: the launch command `./start-claude.sh --agent curriculum-orchestrator` carries only the agent TYPE, so the atlas and hramatka sessions were indistinguishable at start — one self-claimed "main orchestrator" (the agent-def default) and worked harness-lane issues, and both curriculum sessions pointed at the same `.agent/claude-thread-handoff.md` slot.

## Mechanism
`./start-claude.sh --agent curriculum-orchestrator --epic atlas`
- `--epic` is launcher-only (stripped before `exec claude` — the CLI doesn't know it). Accepts `atlas` or `atlas.epic`.
- Exports `SESSION_EPIC` → SessionStart hook prints a **binding ASSIGNED EPIC banner** pointing at `.claude/<epic>-epic/CLAUDE-DRIVER-HANDOFF.md`.
- Handoff slot becomes `claude-<epic>` → same-type sessions on different epics can never share/clobber a thread handoff.
- **No `--epic`** → the hook forbids the old main-orchestrator default: resolve from first message → `.agent/lane-assignments.md` → ASK the user.
- Agent def cold-start updated to match (the "Standalone session = main orchestrator" line is gone).

## Verification (my runs, raw)
- `bash scripts/audit/test_handoff_identity.sh` → ok (13 new fixtures incl. the collision invariant: same agent type + different epics → different slots).
- `bash scripts/audit/test_session_setup_hook.sh` → ok (no regression).
- Hook simulated both ways: with `SESSION_EPIC=atlas` prints the binding banner + driver-handoff pointer; without prints the resolve-or-ask protocol.
- `bash -n` clean on all three shell files.

Deploy note: after merge, `scripts/deploy_prompts.sh` refreshes the untracked `.claude/` copies (hook + agent def).

🤖 Generated with [Claude Code](https://claude.com/claude-code)