### PR TITLE
feat(orchestration): wire automatic thread rollover startup

### DIFF
--- a/agents_extensions/shared/agents/curriculum-orchestrator.md
+++ b/agents_extensions/shared/agents/curriculum-orchestrator.md
@@ -35,11 +35,9 @@ initialPrompt: |
      - `curl -s --max-time 2 'http://localhost:8765/api/session/current?agent=orchestrator'` only if session hash changed
      - `curl -s --max-time 2 http://localhost:8765/api/orient`
      - `curl -s --max-time 2 'http://localhost:8765/api/comms/inbox?agent=claude'`
-  3. **Load the session from `.agent/claude-thread-handoff.md` FIRST** — the gitignored local
-   driver handoff is the freshest session state (done/in-flight/queue/hygiene; driver handoffs
-   are out of git per user policy 2026-06-23). Then read `docs/session-state/current.orchestrator.md`
-   for the durable cross-agent handoff; `current.md` is only the router. If the thread handoff is
-   missing or stale (older than current.orchestrator.md), say so and use the durable one.
+  3. **Use automatic SessionStart first.** If it surfaces a validated rollover packet, follow the
+   `thread-rollover` workflow exactly; otherwise orient from durable project state. Do not scan flat
+   `.agent/*-thread-handoff.md` files or parse lease JSON yourself.
   4. Check `docs/decisions/pending/`; pending decisions block only their declared Scope.
   5. Then begin work. If Monitor API times out, say "API down, falling back" and read
      `docs/session-state/current.md` router -> matching `current.<agent>.md` -> `memory/MEMORY.md` -> `CLAUDE.md`.
@@ -48,12 +46,9 @@ initialPrompt: |
      on the queue or merge-train. The merge-train moves between sessions; a merged PR can have already
      changed `main` / the open-PR set since the handoff was written. Acting on a stale picture is the
      #01 re-collision class (2026-06-14). Read open PRs first, then drive.
-  7. Mint the context canary from facts just gathered in steps 2-6 (origin/main SHA, open-PR
-     numbers, corpus/queue counts — 8-10 anchors):
-     `.venv/bin/python scripts/context_canary.py mint --facts '<json {id,q,a} list>' --out .agent/canary-<stamp>.json`
-     Score FROM MEMORY (no scrolling back) at ≥50% of the active model's window and again before
-     any handoff: `context_canary.py score --probe <file> --answers <my-answers.json>`. Rot
-     evidence is PER-MODEL — on a model not yet canaried, this is mandatory (user go 2026-07-07).
+  7. For a rollover, use `$thread-rollover` semantic records only: goals, decisions/rationales,
+     negative constraints/prohibitions, and next actions from durable sources. Never turn Git, GitHub,
+     or Monitor facts into continuity anchors; SessionStart provides the exact commands.
 
   Lane identity comes from the EPIC ASSIGNMENT banner the SessionStart hook prints
   (from the launcher's `--epic` flag) — that binding beats everything below. Without a
@@ -151,9 +146,8 @@ review, orchestration, precise dispatch briefs.
   driver's machine, e.g. `.claude/bio-epic/CLAUDE-DRIVER-HANDOFF.md` (user policy 2026-06-23 — driver
   handoffs are out of git/PRs). You (main) do NOT read it; track drivers report to you via TRACK-UPDATE
   pings + their PR descriptions.
-- Main orchestrator source of truth: session layer = `.agent/claude-thread-handoff.md`
-  (gitignored LOCAL driver handoff — load first, write at session end); durable cross-agent
-  layer = `docs/session-state/current.md` router plus `docs/session-state/current.orchestrator.md`.
+- Main orchestrator rollover source of truth is the validated `.agent/thread-rollovers/<agent>/<lineage-id>/`
+  packet surfaced by automatic SessionStart; durable cross-agent state remains the documented router/brief layer.
 - Track pings use:
   `TRACK-UPDATE track=<track> pr=<number|none> state=<blocked|ready|in-flight>
   owner=<agent> needs=<main-review|merge|codex-help|decision|none>

--- a/agents_extensions/shared/agents/infra-orchestrator.md
+++ b/agents_extensions/shared/agents/infra-orchestrator.md
@@ -35,22 +35,17 @@ initialPrompt: |
      `gh pr list --search 'author:@me' --state open` (and `gh pr list --state open`). The merge-train moves
      between sessions; a merged PR can have changed `main` / the open-PR set since the handoff was written.
      Acting on a stale picture is the #1 re-collision class. Read open PRs first, then drive.
-  3. Read YOUR lane handoff: `.agent/claude-infra-thread-handoff.md` (gitignored, machine-local — the live
-     infra/code queue, START HERE) + the committed pointer `docs/session-state/current.claude-infra.md`.
+  3. Use the validated packet surfaced by automatic SessionStart when one exists; otherwise continue with
+     durable orientation. Do not scan flat `.agent/*-thread-handoff.md` paths or parse rollover leases yourself.
   4. Orient via Monitor API, not files: `http://localhost:8765/api/state/manifest`,
      `/api/orient`, `/api/delegate/active`, `/api/worktrees`, `/api/comms/inbox?agent=claude-infra`.
      If the API times out, say "API down, falling back" and read the handoff + `memory/MEMORY.md` + `CLAUDE.md`.
-  5. ⚠️ IDENTITY GUARDRAIL — your handoff slot is `claude-infra`. If SessionStart pointed you at
-     `.agent/claude-thread-handoff.md` (the FOLK lane's `claude` slot) instead of
-     `.agent/claude-infra-thread-handoff.md`, you were mis-launched as agent `claude`. STOP, do NOT adopt the
-     folk/seminar queue, tell the user in one line, and relaunch with
-     `./start-claude.sh --agent infra-orchestrator` (the launcher exports `SESSION_HANDOFF_AGENT=claude-infra`
-     so cold-start routes to your own slot).
+  5. ⚠️ IDENTITY GUARDRAIL — use the `thread-rollover` skill and SessionStart engine output. A packet bound
+     to another thread is a stop condition; never adopt it or inspect a different agent's packet.
   6. Check `docs/decisions/pending/`; pending decisions block only their declared Scope.
-  7. Mint the context canary from facts just gathered (origin/main SHA, open-PR numbers, queue
-     counts — 8-10 anchors): `.venv/bin/python scripts/context_canary.py mint --facts '<json {id,q,a} list>'
-     --out .agent/canary-<stamp>.json`. Score FROM MEMORY at ≥50% of the active model's window and
-     before any handoff. Rot evidence is PER-MODEL — on a model not yet canaried, mandatory (user go 2026-07-07).
+  7. For a rollover, use `$thread-rollover` semantic records only: goals, decisions/rationales,
+     negative constraints/prohibitions, and next actions from durable sources. Never turn Git, GitHub,
+     or Monitor facts into continuity anchors; SessionStart provides the exact commands.
 
   Standalone session = you drive the infra/code queue without asking when the next action is obvious.
   Folk/seminar content (agent `claude`) and per-track content (Codex = B1) are other lanes — awareness-only

--- a/agents_extensions/shared/hooks/post-compact.sh
+++ b/agents_extensions/shared/hooks/post-compact.sh
@@ -27,19 +27,27 @@ IN-PROGRESS MODULES:
 $MODULE_LIST"
 fi
 
-# 2. Current open GH issues (top 5)
-if command -v gh >/dev/null 2>&1; then
-  ISSUES=$(gh issue list --state open --limit 5 --json number,title 2>/dev/null | jq -r '.[] | "  #\(.number): \(.title)"' 2>/dev/null)
-  if [ -n "$ISSUES" ]; then
-    CONTEXT="$CONTEXT
-OPEN ISSUES (top 5):
-$ISSUES"
+# 2. Local rollover health only. PostCompact must never prepare, resume, prove,
+# confirm, clean up, query GitHub, or manufacture handoff anchors.
+HANDOFF_AGENT="${SESSION_HANDOFF_AGENT:-}"
+if [ -z "$HANDOFF_AGENT" ]; then
+  if [[ "${0:-}" == *"/.codex/"* ]] || [ -n "${CODEX_THREAD_ID:-}${CODEX_SESSION_ID:-}" ]; then
+    HANDOFF_AGENT="codex"
+  else
+    HANDOFF_AGENT="claude"
   fi
 fi
+CANONICAL_ROOT="${CODEX_CANONICAL_REPO_ROOT:-$PROJECT_DIR}"
+ROLLOVER_PYTHON="${THREAD_ROLLOVER_PYTHON:-$PROJECT_DIR/.venv/bin/python}"
+ROLLOVER_SCRIPT="${THREAD_ROLLOVER_SCRIPT:-$PROJECT_DIR/scripts/orchestration/thread_handoff.py}"
+ROLLOVER_HEALTH=$("$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
+  --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" 2>&1) || true
 
 # 3. Key reminders
 CONTEXT="$CONTEXT
 KEY REMINDERS:
+  - Thread rollover health (read-only): $ROLLOVER_HEALTH
+  - If a live packet is shown, read its handoff path; SessionStart provides the lifecycle commands.
   - Word targets are MINIMUMS (check config.py)
   - Edit agents_extensions/shared/, not .claude/ directly
   - .venv/bin/python only

--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -300,12 +300,7 @@ if command -v git >/dev/null 2>&1 && [ -d "$PROJECT_DIR/.git" ]; then
   fi
 fi
 
-# 13. Session handoff — prefer gitignored local thread rollover packets.
-# Do not read/dump docs/session-state/current.md by default. That router is
-# git-tracked and has repeatedly dirtied the shared main checkout. Rollover
-# state belongs in .agent/<agent>-thread-handoff.md, produced by
-# scripts/orchestration/thread_handoff.py prepare.
-HANDOFF_FILE="$PROJECT_DIR/docs/session-state/current.md"
+# 13. Session handoff — engine-first, legacy-compatible fallback.
 if [ -n "${SESSION_HANDOFF_AGENT:-}" ]; then
     HANDOFF_AGENT="$SESSION_HANDOFF_AGENT"
 elif [[ "${0:-}" == *"/.codex/"* ]]; then
@@ -317,7 +312,11 @@ elif [ -n "${CODEX_THREAD_ID:-}${CODEX_SESSION_ID:-}" ]; then
 else
     HANDOFF_AGENT="claude"
 fi
-LOCAL_THREAD_HANDOFF="$PROJECT_DIR/.agent/${HANDOFF_AGENT}-thread-handoff.md"
+
+CANONICAL_ROOT="${CODEX_CANONICAL_REPO_ROOT:-$PROJECT_DIR}"
+CURRENT_THREAD_ID="${CODEX_THREAD_ID:-${CODEX_SESSION_ID:-}}"
+ROLLOVER_PYTHON="${THREAD_ROLLOVER_PYTHON:-$PROJECT_DIR/.venv/bin/python}"
+ROLLOVER_SCRIPT="${THREAD_ROLLOVER_SCRIPT:-$PROJECT_DIR/scripts/orchestration/thread_handoff.py}"
 HANDOFF_CONTEXT=""
 HANDOFF_WARNINGS=""
 
@@ -336,13 +335,12 @@ EOF
 
 build_local_handoff_pointer() {
   local handoff_path="$1"
-  local bootstrap_path=".agent/${HANDOFF_AGENT}-thread-bootstrap.md"
   cat <<EOF
 PREVIOUS-SESSION HANDOFF — read the local thread rollover packet first.
 
 Agent: $HANDOFF_AGENT
 Thread handoff: $handoff_path
-Bootstrap prompt: $bootstrap_path
+Bootstrap prompt: .agent/${HANDOFF_AGENT}-thread-bootstrap.md
 Read with: Read tool. These files are gitignored local state and must not be committed.
 Cold-start protocol: docs/best-practices/codex-thread-handoff.md
 
@@ -370,52 +368,88 @@ Do not dump or rewrite docs/session-state/current.md. For thread rollover, run:
 EOF
 }
 
-if [ -f "$LOCAL_THREAD_HANDOFF" ]; then
-  HANDOFF_CONTEXT=$(build_local_handoff_pointer ".agent/${HANDOFF_AGENT}-thread-handoff.md")
-elif [ "${SESSION_HANDOFF_ALLOW_GIT_ROUTER:-0}" = "1" ] && [ -f "$HANDOFF_FILE" ]; then
-  AGENT_HANDOFF=$(sed -n "s/^[[:space:]]*-[[:space:]]*${HANDOFF_AGENT}:[[:space:]]*//p" "$HANDOFF_FILE" 2>/dev/null | head -1 | sed 's/[[:space:]]*$//')
-  if [ -n "$AGENT_HANDOFF" ]; then
-    if [ -f "$PROJECT_DIR/$AGENT_HANDOFF" ]; then
-      HANDOFF_CONTEXT=$(build_handoff_pointer "$AGENT_HANDOFF")
-    else
-      HANDOFF_WARNINGS="WARN: Agent-Handoff for $HANDOFF_AGENT pointed to $AGENT_HANDOFF but file missing on disk."
-    fi
+if ! DETECT_OUTPUT=$("$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
+  --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \
+  --current-thread-id "$CURRENT_THREAD_ID" --format json 2>&1); then
+  HANDOFF_CONTEXT="ERROR: thread_handoff.py detect failed. Stop.
+Output:
+$DETECT_OUTPUT"
+elif ! DETECT_STATUS=$(printf '%s' "$DETECT_OUTPUT" | "$ROLLOVER_PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read()).get("status", ""), end="")'); then
+  HANDOFF_CONTEXT="ERROR: thread_handoff.py detect output could not be parsed. Stop.
+Output:
+$DETECT_OUTPUT"
+elif [ "$DETECT_STATUS" = "pending_start" ] || [ "$DETECT_STATUS" = "resumed" ]; then
+  if ! HANDOFF_CONTEXT=$("$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
+    --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \
+    --current-thread-id "$CURRENT_THREAD_ID" --format session-start 2>&1); then
+    HANDOFF_CONTEXT="ERROR: thread_handoff.py detect failed. Stop.
+Output:
+$HANDOFF_CONTEXT"
   fi
+elif [ "$DETECT_STATUS" = "none" ]; then
+  # Legacy compatibility remains if no v2 live packet is active.
+  HANDOFF_FILE="$PROJECT_DIR/docs/session-state/current.md"
 
-  MARKER_BRIEF=$(grep -m1 '^Latest-Brief:' "$HANDOFF_FILE" 2>/dev/null | sed 's/^Latest-Brief:[[:space:]]*//; s/[[:space:]]*$//')
+  if [ -f "$PROJECT_DIR/.agent/${HANDOFF_AGENT}-thread-handoff.md" ]; then
+    HANDOFF_CONTEXT=$(build_local_handoff_pointer ".agent/${HANDOFF_AGENT}-thread-handoff.md")
+  elif [ "${SESSION_HANDOFF_ALLOW_GIT_ROUTER:-0}" = "1" ] && [ -f "$HANDOFF_FILE" ]; then
+    AGENT_HANDOFF=$(sed -n "s/^[[:space:]]*-[[:space:]]*${HANDOFF_AGENT}:[[:space:]]*//p" "$HANDOFF_FILE" 2>/dev/null | head -1 | sed 's/[[:space:]]*$//')
 
-  if [ -z "$HANDOFF_CONTEXT" ] && [ -n "$MARKER_BRIEF" ]; then
-    if [ -f "$PROJECT_DIR/$MARKER_BRIEF" ]; then
-      HANDOFF_CONTEXT=$(build_handoff_pointer "$MARKER_BRIEF")
-    else
-      HANDOFF_WARNINGS="WARN: Latest-Brief pointed to $MARKER_BRIEF but file missing on disk."
-    fi
-  fi
-
-  if [ -z "$HANDOFF_CONTEXT" ]; then
-    TABLE_BRIEF=$(sed -n 's/.*\*\*Brief (read first):\*\* `\([^`]*\)`.*/\1/p' "$HANDOFF_FILE" 2>/dev/null | head -1)
-
-    if [ -n "$TABLE_BRIEF" ]; then
-      if [ -f "$PROJECT_DIR/$TABLE_BRIEF" ]; then
-        if [ -z "$MARKER_BRIEF" ]; then
-          HANDOFF_WARNINGS="${HANDOFF_WARNINGS:+$HANDOFF_WARNINGS
-}WARN: Latest-Brief marker missing in current.md — fell back to table regex. Add the marker to fix."
-        fi
-        HANDOFF_CONTEXT="${HANDOFF_WARNINGS:+$HANDOFF_WARNINGS
-
-}$(build_handoff_pointer "$TABLE_BRIEF")"
+    if [ -n "$AGENT_HANDOFF" ]; then
+      if [ -f "$PROJECT_DIR/$AGENT_HANDOFF" ]; then
+        HANDOFF_CONTEXT=$(build_handoff_pointer "$AGENT_HANDOFF")
       else
-        HANDOFF_WARNINGS="${HANDOFF_WARNINGS:+$HANDOFF_WARNINGS
-}WARN: Latest-Brief pointed to $TABLE_BRIEF but file missing on disk."
+        HANDOFF_WARNINGS="WARN: Agent-Handoff for $HANDOFF_AGENT pointed to $AGENT_HANDOFF but file missing on disk."
       fi
     fi
+
+    MARKER_BRIEF=$(grep -m1 '^Latest-Brief:' "$HANDOFF_FILE" 2>/dev/null | sed 's/^Latest-Brief:[[:space:]]*//; s/[[:space:]]*$//')
+
+    if [ -z "$HANDOFF_CONTEXT" ] && [ -n "$MARKER_BRIEF" ]; then
+      if [ -f "$PROJECT_DIR/$MARKER_BRIEF" ]; then
+        HANDOFF_CONTEXT=$(build_handoff_pointer "$MARKER_BRIEF")
+      else
+        HANDOFF_WARNINGS="WARN: Latest-Brief pointed to $MARKER_BRIEF but file missing on disk."
+      fi
+    fi
+
+    if [ -z "$HANDOFF_CONTEXT" ]; then
+      TABLE_BRIEF=$(sed -n 's/.*\*\*Brief (read first):\*\* `\([^`]*\)`.*/\1/p' "$HANDOFF_FILE" 2>/dev/null | head -1)
+
+      if [ -n "$TABLE_BRIEF" ]; then
+        if [ -f "$PROJECT_DIR/$TABLE_BRIEF" ]; then
+          if [ -z "$MARKER_BRIEF" ]; then
+            HANDOFF_WARNINGS="${HANDOFF_WARNINGS:+$HANDOFF_WARNINGS
+}WARN: Latest-Brief marker missing in current.md — fell back to table regex. Add the marker to fix."
+          fi
+          HANDOFF_CONTEXT="${HANDOFF_WARNINGS:+$HANDOFF_WARNINGS
+
+}$(build_handoff_pointer "$TABLE_BRIEF")"
+        else
+          HANDOFF_WARNINGS="${HANDOFF_WARNINGS:+$HANDOFF_WARNINGS
+}WARN: Latest-Brief pointed to $TABLE_BRIEF but file missing on disk."
+        fi
+      fi
+    fi
+
+    if [ -z "$HANDOFF_CONTEXT" ]; then
+      HANDOFF_WARNINGS="${HANDOFF_WARNINGS:+$HANDOFF_WARNINGS
+}WARN: Could not locate latest brief in current.md under legacy router opt-in. Not dumping git-tracked router contents."
+      HANDOFF_CONTEXT=$(build_handoff_fallback "$HANDOFF_WARNINGS")
+    fi
   fi
 
   if [ -z "$HANDOFF_CONTEXT" ]; then
-    HANDOFF_WARNINGS="${HANDOFF_WARNINGS:+$HANDOFF_WARNINGS
-}WARN: Could not locate latest brief in current.md under legacy router opt-in. Not dumping git-tracked router contents."
-    HANDOFF_CONTEXT=$(build_handoff_fallback "$HANDOFF_WARNINGS")
+    if ! HANDOFF_CONTEXT=$("$ROLLOVER_PYTHON" "$ROLLOVER_SCRIPT" \
+      --repo-root "$CANONICAL_ROOT" detect --agent "$HANDOFF_AGENT" \
+      --current-thread-id "$CURRENT_THREAD_ID" --format session-start 2>&1); then
+      HANDOFF_CONTEXT="ERROR: thread_handoff.py detect failed. Stop.
+Output:
+$HANDOFF_CONTEXT"
+    fi
   fi
+else
+  HANDOFF_CONTEXT="ERROR: Unexpected detect status: $DETECT_STATUS"
 fi
 
 # Epic assignment banner — the FIRST thing the session reads. SESSION_EPIC is

--- a/agents_extensions/shared/rules/workflow.md
+++ b/agents_extensions/shared/rules/workflow.md
@@ -95,13 +95,14 @@ only as the offline fallback above.
 After a write that needs to be immediately visible (just-committed
 change, just-filed issue), pass `?fresh=true` to `/api/orient`.
 
-**Canary mint (orchestrator sessions, user go 2026-07-07):** after orientation,
-freeze 8-10 anchors from the facts just gathered (origin/main SHA, open-PR numbers,
-queue/corpus counts): `.venv/bin/python scripts/context_canary.py mint --facts
-'<json {id,q,a} list>' --out .agent/canary-<stamp>.json`. Score FROM MEMORY (no
-scrolling back) at ≥50% of the active model's window and before any handoff. Rot
-evidence is PER-MODEL (Claude lane rotates: Opus 4.8 verified, Fable 5 improvised
-10/10 @ ~500K, Sonnet 5 pending) — on a not-yet-canaried model this is mandatory.
+**Canary mint (production v2):** use this only inside a prepared rollover packet.
+The reserved snapshot has exactly 3 goals, 3 decision/rationale records, 2 negative
+constraint/prohibition records, and 2 next actions from durable allowed `source_ref`
+records. Never relabel Git, GitHub, or Monitor metadata as semantic anchors, fabricate,
+or pad. The replacement must run the exact reserved-path commands emitted by
+`thread_handoff.py detect --agent codex --format session-start`, including
+`context_canary.py mint --snapshot`, `questions`, and strict `score --verdict` before
+the separate challenge proof and `confirm-started` can unlock cleanup.
 
 ## Merge policy — ready PRs must not sit (user directive 2026-07-07, #4703)
 
@@ -139,13 +140,23 @@ in-stream PRs from sitting, so this net is a rare safety valve, not the primary 
 
 ## Two-tier handoffs (epic #1865 item #1, shipped 2026-05-11)
 
-Thread rollover handoffs are separate from durable session records. When a
-thread approaches context threshold, run
-`.venv/bin/python scripts/orchestration/thread_handoff.py prepare --agent <name>`
-and continue from `.agent/<name>-thread-bootstrap.md` plus
-`.agent/<name>-thread-handoff.md`. Those files are gitignored local state.
+Thread rollover handoffs are managed by the `thread-rollover` skill. When a
+thread approaches context threshold, use the `thread-rollover` skill to prepare
+a handoff packet using `scripts/orchestration/thread_handoff.py prepare --agent codex --active-thread-id <id>`.
+This creates an isolated `handoff.md` inside `.agent/thread-rollovers/codex/<lineage-id>/`.
 Do **not** write `docs/session-state/current.md` or any other git-tracked
 handoff file just to survive compaction.
+
+SessionStart automatically runs the read-only engine detector. If it reports a
+packet, follow its exact ordered commands; it never chooses a lease by filesystem
+order and never auto-runs resume, proof, confirmation, or cleanup. A no-packet
+cold start uses a complete legacy orientation-health probe only after tool-backed
+orientation:
+
+```bash
+printf '%s\n' '[{"id":"goal","q":"What is the active durable goal?","a":"<truthful durable answer>"},{"id":"decision","q":"What durable decision constrains this task?","a":"<truthful durable answer>"},{"id":"constraint","q":"What prohibition still applies?","a":"<truthful durable answer>"},{"id":"next-action","q":"What is the next durable action?","a":"<truthful durable answer>"},{"id":"owner","q":"Who owns the active task?","a":"<truthful durable answer>"},{"id":"scope","q":"What is explicitly out of scope?","a":"<truthful durable answer>"},{"id":"evidence","q":"Which durable artifact was read?","a":"<truthful durable answer>"},{"id":"risk","q":"What unresolved risk remains?","a":"<truthful durable answer>"},{"id":"validation","q":"What validation is required?","a":"<truthful durable answer>"},{"id":"next-boundary","q":"What condition ends this session?","a":"<truthful durable answer>"}]' > .agent/orientation-health-facts.json
+.venv/bin/python scripts/context_canary.py mint --facts .agent/orientation-health-facts.json --out .agent/orientation-health-probe.json
+```
 
 Every new durable session handoff ships as **MD brief only** (user decision 2026-07-07 —
 the HTML halves were not being read):

--- a/agents_extensions/shared/skills/thread-rollover/SKILL.md
+++ b/agents_extensions/shared/skills/thread-rollover/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: thread-rollover
+description: Prepare, resume, validate, and confirm a durable Codex thread rollover with the repository's strict continuity packet. Use when a Codex task approaches context exhaustion, SessionStart reports a pending or resumed rollover, or a replacement task must prove continuity before predecessor cleanup.
+---
+
+# Thread Rollover
+
+Use `--agent codex` for every Codex orchestrator command. Never fork, continue,
+copy provider history, or select an ambiguous task. Use the Codex app to create a
+fresh task titled `Rollover <lineage-id> <rollover-id>` after `prepare` prints both IDs.
+
+## Health
+
+Run this read-only command at a session boundary. It returns `status: none`, one
+validated `pending_start`/`resumed` packet, or exit 2 with explicit corruption,
+identity, path, or ambiguity evidence.
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py detect --agent codex
+```
+
+For a known packet, inspect health without changing it.
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py check --agent codex --lineage-id <lineage-id>
+```
+
+## Rollover
+
+Prepare only from the active Codex thread; this reserves every packet path and
+keeps cleanup false.
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py prepare --agent codex --active-thread-id "$CODEX_THREAD_ID"
+```
+
+Read the resulting `handoff_file`, then create the fresh Codex app task with the
+unique title above. Do not use a fork, copied provider history, or an ambiguous
+existing task.
+
+## Resume and confirm
+
+In the fresh task, use the exact paths returned by `detect` or `resume`. First
+bind the replacement thread, then read the handoff and write a truthful durable
+semantic snapshot at the reserved `semantic_snapshot_path`. Its records must be
+exactly 3 goals, 3 decisions/rationales, 2 negative constraints/prohibitions, and
+2 next actions with real allowed `source_ref` values; never use Git, GitHub, or
+Monitor facts and never pad anchors.
+
+```bash
+.venv/bin/python scripts/orchestration/thread_handoff.py resume --agent codex --lineage-id <lineage-id> --rollover-id <rollover-id> --replacement-thread-id "$CODEX_THREAD_ID"
+.venv/bin/python scripts/context_canary.py mint --snapshot <semantic_snapshot_path> --out <strict_probe_path>
+.venv/bin/python scripts/context_canary.py questions --probe <strict_probe_path> --out <strict_questions_path>
+.venv/bin/python scripts/context_canary.py score --probe <strict_probe_path> --answers <strict_answers_path> --expected-lineage-id <lineage-id> --expected-rollover-id <rollover-id> --verdict <strict_verdict_path>
+.venv/bin/python scripts/orchestration/thread_handoff_canary.py --rollover-id <rollover-id> --replacement-thread-id "$CODEX_THREAD_ID" --challenge <canary_challenge> --proof-file <canary_proof_path>
+.venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent codex --lineage-id <lineage-id> --rollover-id <rollover-id> --new-thread-id "$CODEX_THREAD_ID" --canary-proof <canary_proof_path> --strict-probe <strict_probe_path> --strict-verdict <strict_verdict_path>
+```
+
+Create `strict_answers_path` only from the questions-only view after restoring
+context. `confirm-started` unlocks cleanup only when the separate challenge proof
+and strict verdict both bind to the exact reserved packet paths and pass 10/10.

--- a/agents_extensions/shared/skills/thread-rollover/agents/openai.yaml
+++ b/agents_extensions/shared/skills/thread-rollover/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Thread Rollover"
+  short_description: "Safely resume and prove thread continuity"
+  default_prompt: "Use $thread-rollover to prepare or safely resume this Codex thread rollover."

--- a/scripts/audit/test_handoff_identity.sh
+++ b/scripts/audit/test_handoff_identity.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck source=scripts/lib/handoff_identity.sh
 source "$REPO_ROOT/scripts/lib/handoff_identity.sh"
+# shellcheck source=scripts/lib/thread_rollover_link.sh
+source "$REPO_ROOT/scripts/lib/thread_rollover_link.sh"
 
 fail() {
   printf 'FAIL: %s\n' "$1" >&2
@@ -97,6 +99,28 @@ epic_a="$(handoff_epic_from_argv --agent curriculum-orchestrator --epic atlas)"
 epic_b="$(handoff_epic_from_argv --agent curriculum-orchestrator --epic hramatka)"
 if [[ "$(handoff_identity_for_epic "$epic_a")" == "$(handoff_identity_for_epic "$epic_b")" ]]; then
   fail "same-agent different-epic launches must not share a handoff slot"
+fi
+
+# --- Codex launcher rollover bridge: narrow, canonical, and fail-loud ---
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+canonical="$tmp_root/canonical"
+worktree="$tmp_root/worktree"
+mkdir -p "$canonical" "$worktree"
+ensure_thread_rollover_link "$canonical" "$worktree"
+[[ -d "$canonical/.agent/thread-rollovers" ]] || fail "first launch creates canonical rollover directory"
+[[ -L "$worktree/.agent/thread-rollovers" ]] || fail "first launch creates narrow rollover symlink"
+eq "$(readlink "$worktree/.agent/thread-rollovers")" "$canonical/.agent/thread-rollovers" "rollover symlink target"
+ensure_thread_rollover_link "$canonical" "$worktree"
+rm "$worktree/.agent/thread-rollovers"
+mkdir "$worktree/.agent/thread-rollovers"
+if ensure_thread_rollover_link "$canonical" "$worktree"; then
+  fail "real rollover directory collision must fail"
+fi
+rm -rf "$worktree/.agent/thread-rollovers"
+ln -s "$tmp_root/wrong" "$worktree/.agent/thread-rollovers"
+if ensure_thread_rollover_link "$canonical" "$worktree"; then
+  fail "wrong or broken rollover symlink must fail"
 fi
 
 printf 'ok - handoff identity fixtures passed\n'

--- a/scripts/audit/test_session_setup_hook.sh
+++ b/scripts/audit/test_session_setup_hook.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HOOK="$REPO_ROOT/agents_extensions/shared/hooks/session-setup.sh"
+POST_COMPACT_HOOK="$REPO_ROOT/agents_extensions/shared/hooks/post-compact.sh"
 TMP_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
@@ -17,6 +18,7 @@ assert_contains() {
   local label="$3"
 
   if [[ "$haystack" != *"$needle"* ]]; then
+    echo "OUTPUT WAS: $haystack"
     fail "$label: expected output to contain: $needle"
   fi
 }
@@ -27,6 +29,7 @@ assert_not_contains() {
   local label="$3"
 
   if [[ "$haystack" == *"$needle"* ]]; then
+    echo "OUTPUT WAS: $haystack"
     fail "$label: expected output not to contain: $needle"
   fi
 }
@@ -41,7 +44,7 @@ setup_fixture() {
   local root="$1"
 
   rm -rf "$root"
-  mkdir -p "$root/docs/session-state" "$root/.venv/bin" "$root/.mcp/servers/message-broker" "$TMP_ROOT/home"
+  mkdir -p "$root/docs/session-state" "$root/.venv/bin" "$root/.mcp/servers/message-broker" "$TMP_ROOT/home" "$root/.git"
   # Dispatching stub: most tests just need a python-version banner, but the
   # strict-adoption-gate fixtures (below) need a controllable
   # `check_research_registry.py --strict-adoption` response without a real
@@ -56,25 +59,78 @@ printf "Python 3.12.8\n"
 PYEOF
   printf 'fixture db\n' > "$root/.mcp/servers/message-broker/messages.db"
   chmod +x "$root/.venv/bin/python"
+  mkdir -p "$root/scripts/orchestration"
+  touch "$root/scripts/orchestration/thread_handoff.py"
 }
 
 run_hook() {
   local root="$1"
   local allow_git_router="${2:-0}"
   local handoff_agent="${3:-claude}"
+  local current_thread_id="${4:-}"
 
-  HOME="$TMP_ROOT/home" \
+  HOME="$TMP_ROOT/home" XDG_CONFIG_HOME="$TMP_ROOT/xdg-config" XDG_CACHE_HOME="$TMP_ROOT/xdg-cache" XDG_DATA_HOME="$TMP_ROOT/xdg-data" XDG_STATE_HOME="$TMP_ROOT/xdg-state" GH_CONFIG_DIR="$TMP_ROOT/gh" PATH="/usr/bin:/bin" \
     CLAUDE_PROJECT_DIR="$root" \
     CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS=32000 \
+    CODEX_THREAD_ID="$current_thread_id" \
+    CODEX_CANONICAL_REPO_ROOT="$root" \
+    THREAD_ROLLOVER_PYTHON="$REPO_ROOT/.venv/bin/python" \
+    THREAD_ROLLOVER_SCRIPT="$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
     SESSION_HANDOFF_AGENT="$handoff_agent" \
     SESSION_HANDOFF_ALLOW_GIT_ROUTER="$allow_git_router" \
     "$HOOK"
 }
 
+prepare_fixture() {
+  local root="$1"
+  local agent="$2"
+  local thread_id="$3"
+
+  HOME="$TMP_ROOT/home" XDG_CONFIG_HOME="$TMP_ROOT/xdg-config" XDG_CACHE_HOME="$TMP_ROOT/xdg-cache" XDG_DATA_HOME="$TMP_ROOT/xdg-data" XDG_STATE_HOME="$TMP_ROOT/xdg-state" GH_CONFIG_DIR="$TMP_ROOT/gh" \
+    CODEX_CANONICAL_REPO_ROOT="$root" PATH="/usr/bin:/bin" \
+    "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+    --repo-root "$root" --monitor-base-url http://127.0.0.1:1 prepare --agent "$agent" --active-thread-id "$thread_id" >/dev/null
+}
+
+find_rollover_lease() {
+  local root="$1"
+  local agent="$2"
+
+  find "$root/.agent/thread-rollovers/$agent" -name lease.json -print -quit
+}
+
+resume_fixture() {
+  local root="$1"
+  local agent="$2"
+  local state_file="$3"
+  local replacement_thread_id="$4"
+  local rollover_id
+
+  rollover_id=$("$REPO_ROOT/.venv/bin/python" -c \
+    'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["replacement"]["rollover_id"])' \
+    "$state_file")
+
+  HOME="$TMP_ROOT/home" XDG_CONFIG_HOME="$TMP_ROOT/xdg-config" XDG_CACHE_HOME="$TMP_ROOT/xdg-cache" XDG_DATA_HOME="$TMP_ROOT/xdg-data" XDG_STATE_HOME="$TMP_ROOT/xdg-state" GH_CONFIG_DIR="$TMP_ROOT/gh" PATH="/usr/bin:/bin" \
+    "$REPO_ROOT/.venv/bin/python" "$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+    --repo-root "$root" --monitor-base-url http://127.0.0.1:1 resume --agent "$agent" \
+    --state-file "$state_file" --rollover-id "$rollover_id" \
+    --replacement-thread-id "$replacement_thread_id" >/dev/null
+}
+
+run_post_compact() {
+  local root="$1"
+  HOME="$TMP_ROOT/home" XDG_CONFIG_HOME="$TMP_ROOT/xdg-config" XDG_CACHE_HOME="$TMP_ROOT/xdg-cache" XDG_DATA_HOME="$TMP_ROOT/xdg-data" XDG_STATE_HOME="$TMP_ROOT/xdg-state" GH_CONFIG_DIR="$TMP_ROOT/gh" \
+    CLAUDE_PROJECT_DIR="$root" SESSION_HANDOFF_AGENT="codex" CODEX_CANONICAL_REPO_ROOT="$root" \
+    THREAD_ROLLOVER_PYTHON="$REPO_ROOT/.venv/bin/python" \
+    THREAD_ROLLOVER_SCRIPT="$REPO_ROOT/scripts/orchestration/thread_handoff.py" \
+    "$POST_COMPACT_HOOK"
+}
+
 fixture_root="$TMP_ROOT/project"
 fallback_warn_count=0
+marker_bytes="0"
 
-# 1. Local gitignored thread handoff wins by default.
+# 1. Local gitignored thread handoff wins when no v2 packet is live.
 setup_fixture "$fixture_root"
 mkdir -p "$fixture_root/.agent" "$fixture_root/docs/session-state"
 printf '# local handoff\n' > "$fixture_root/.agent/claude-thread-handoff.md"
@@ -89,7 +145,7 @@ assert_contains "$output" "Bootstrap prompt: .agent/claude-thread-bootstrap.md" 
 assert_not_contains "$output" "CURRENT BODY SHOULD NOT APPEAR" "local handoff"
 assert_not_contains "$output" "WARN:" "local handoff"
 
-# 2. current.md is ignored by default when no local thread handoff exists.
+# 2. current.md is ignored by default when no local handoff exists.
 setup_fixture "$fixture_root"
 cat > "$fixture_root/docs/session-state/current.md" <<'EOF'
 # Current
@@ -100,7 +156,7 @@ output="$(run_hook "$fixture_root")"
 assert_not_contains "$output" "DEFAULT ROUTER BODY SHOULD NOT APPEAR" "router ignored by default"
 assert_not_contains "$output" "WARN: Could not locate latest brief in current.md" "router ignored by default"
 
-# 3. Legacy marker path hits only when explicitly enabled.
+# 3. Marker path is used when legacy router is explicitly enabled.
 setup_fixture "$fixture_root"
 mkdir -p "$fixture_root/foo"
 printf 'brief body\n' > "$fixture_root/foo/bar-brief.md"
@@ -118,7 +174,7 @@ assert_not_contains "$output" "HEAD BODY SHOULD NOT APPEAR" "marker hit"
 assert_not_contains "$output" "WARN:" "marker hit"
 marker_bytes="$(printf '%s' "$output" | wc -c | tr -d ' ')"
 
-# 4. Agent-Handoff mapping wins over the compatibility Latest-Brief marker when legacy router is enabled.
+# 4. Agent-Handoff mapping wins over Latest-Brief.
 setup_fixture "$fixture_root"
 mkdir -p "$fixture_root/docs/session-state"
 printf 'orchestrator body\n' > "$fixture_root/docs/session-state/codex-orchestrator-handoff.md"
@@ -137,7 +193,7 @@ assert_contains "$output" "Brief: docs/session-state/current.claude.md" "agent h
 assert_not_contains "$output" "Brief: docs/session-state/codex-orchestrator-handoff.md" "agent handoff"
 assert_not_contains "$output" "WARN:" "agent handoff"
 
-# 5. Table regex fallback when legacy router is enabled.
+# 5. Table regex fallback with missing marker.
 setup_fixture "$fixture_root"
 mkdir -p "$fixture_root/foo"
 printf 'brief body\n' > "$fixture_root/foo/bar-brief.md"
@@ -156,7 +212,7 @@ assert_contains "$output" "WARN: Latest-Brief marker missing in current.md" "tab
 assert_not_contains "$output" "TABLE FALLBACK BODY SHOULD NOT APPEAR" "table fallback"
 fallback_warn_count=$((fallback_warn_count + $(count_warns "$output")))
 
-# 6. Brief missing when legacy router is enabled.
+# 6. Missing-brief warning retains no-router fallback guidance.
 setup_fixture "$fixture_root"
 cat > "$fixture_root/docs/session-state/current.md" <<'EOF'
 # Current
@@ -171,7 +227,7 @@ assert_contains "$output" "legacy git router opt-in could not locate a compact h
 assert_not_contains "$output" "MISSING MARKER FALLBACK BODY" "missing brief"
 fallback_warn_count=$((fallback_warn_count + $(count_warns "$output")))
 
-# 7. No handoff table at all when legacy router is enabled.
+# 7. No table in legacy mode falls back to deterministic guidance.
 setup_fixture "$fixture_root"
 cat > "$fixture_root/docs/session-state/current.md" <<'EOF'
 # Current
@@ -184,22 +240,18 @@ assert_contains "$output" "thread_handoff.py prepare --agent claude" "no table"
 assert_not_contains "$output" "NO TABLE FALLBACK BODY" "no table"
 fallback_warn_count=$((fallback_warn_count + $(count_warns "$output")))
 
-# 8. SESSION_HANDOFF_AGENT routes each lane to its OWN thread handoff slot.
-#    Regression guard for the infra/folk cold-start collision: with both handoff files
-#    present, agent=claude-infra must select the infra slot, never the folk `claude` slot.
+# 8. SESSION_HANDOFF_AGENT isolates local packet lanes.
 setup_fixture "$fixture_root"
 mkdir -p "$fixture_root/.agent"
 printf '# infra handoff\n' > "$fixture_root/.agent/claude-infra-thread-handoff.md"
 printf '# folk handoff\n' > "$fixture_root/.agent/claude-thread-handoff.md"
 output="$(run_hook "$fixture_root" 0 claude-infra)"
 assert_contains "$output" "Thread handoff: .agent/claude-infra-thread-handoff.md" "infra lane isolation"
-assert_contains "$output" "Bootstrap prompt: .agent/claude-infra-thread-bootstrap.md" "infra lane isolation"
 assert_not_contains "$output" "Thread handoff: .agent/claude-thread-handoff.md" "infra lane isolation"
 assert_not_contains "$output" "WARN:" "infra lane isolation"
 
-# 9. Research-registry strict-adoption gate (ADR-011 P4, PR #4998 review): a
-#    fresh stream-audit cache plus a failing gate must surface an ISSUES entry.
-#    Proves the gate is wired into a real cold-start path, not a dead CLI.
+# 9. Research-registry strict-adoption gate (ADR-011 P4, PR #4998 review):
+#    a fresh stream-audit cache plus a failing gate must surface an ISSUES entry.
 setup_fixture "$fixture_root"
 mkdir -p "$fixture_root/scripts/audit" "$fixture_root/scripts/orchestration" "$fixture_root/docs/references" "$fixture_root/batch_state"
 printf '# stub\n' > "$fixture_root/scripts/audit/check_research_registry.py"
@@ -214,8 +266,7 @@ unset STRICT_GATE_FAKE_JSON STRICT_GATE_FAKE_EXIT
 assert_contains "$output" "Research registry strict-adoption gate FAILED" "strict gate wired"
 assert_contains "$output" "demo-record: consumer issue 999 did not resolve" "strict gate wired"
 
-# 10. A passing strict-adoption gate must NOT add an ISSUES entry (non-blocking,
-#     silent on success).
+# 10. A passing strict-adoption gate must remain silent on success.
 setup_fixture "$fixture_root"
 mkdir -p "$fixture_root/scripts/audit" "$fixture_root/scripts/orchestration" "$fixture_root/docs/references" "$fixture_root/batch_state"
 printf '# stub\n' > "$fixture_root/scripts/audit/check_research_registry.py"
@@ -227,8 +278,68 @@ export STRICT_GATE_FAKE_JSON='{"ok": true, "errors": [], "drift": [], "cache": "
 export STRICT_GATE_FAKE_EXIT=0
 output="$(run_hook "$fixture_root")"
 unset STRICT_GATE_FAKE_JSON STRICT_GATE_FAKE_EXIT
-assert_not_contains "$output" "strict-adoption gate FAILED" "strict gate passing"
+assert_not_contains "$output" "Research registry strict-adoption gate FAILED" "strict gate passing"
 assert_not_contains "$output" "WARN:" "strict gate passing"
+
+# 11. Engine-generated pending packet is authoritative.
+setup_fixture "$fixture_root"
+prepare_fixture "$fixture_root" claude old-thread
+output="$(run_hook "$fixture_root")"
+assert_contains "$output" "PENDING THREAD ROLLOVER DETECTED" "pending packet"
+assert_contains "$output" "--agent claude" "pending packet"
+assert_not_contains "$output" "COLD START: NO LIVE THREAD ROLLOVER" "pending packet"
+
+# 12. No live packet + no legacy artifacts emits cold-start engine guidance.
+setup_fixture "$fixture_root"
+output="$(run_hook "$fixture_root")"
+assert_contains "$output" "COLD START: NO LIVE THREAD ROLLOVER" "engine cold start"
+assert_contains "$output" "Create exactly ten truthful legacy orientation facts" "engine cold start"
+
+# 13. Engine lane isolation across local .agent paths.
+setup_fixture "$fixture_root"
+prepare_fixture "$fixture_root" claude old-claude
+prepare_fixture "$fixture_root" claude-infra old-infra
+output_claude="$(run_hook "$fixture_root" 0 claude)"
+assert_contains "$output_claude" "--agent claude " "engine lane isolation"
+output_infra="$(run_hook "$fixture_root" 0 claude-infra)"
+assert_contains "$output_infra" "--agent claude-infra" "engine lane isolation"
+
+# 14. Malformed and ambiguous v2 packets stop and do not fall back.
+setup_fixture "$fixture_root"
+prepare_fixture "$fixture_root" claude old-a
+state_file="$(find_rollover_lease "$fixture_root" claude)"
+cat > "$state_file" <<'EOF'
+{ "schema_version": 2, "thread": "broken"
+EOF
+output="$(run_hook "$fixture_root" 0 claude)"
+assert_contains "$output" "ERROR: thread_handoff.py detect failed. Stop." "malformed packet"
+
+setup_fixture "$fixture_root"
+prepare_fixture "$fixture_root" codex old-a
+prepare_fixture "$fixture_root" codex old-b
+output="$(run_hook "$fixture_root" 0 codex)"
+assert_contains "$output" "Multiple live pending rollovers found for agent codex" "ambiguous packet"
+
+# 15. Resumed packet for current thread allowed; mismatch blocks.
+setup_fixture "$fixture_root"
+prepare_fixture "$fixture_root" codex old-thread
+state_file="$(find_rollover_lease "$fixture_root" codex)"
+resume_fixture "$fixture_root" codex "$state_file" old-thread
+output="$(run_hook "$fixture_root" 0 codex old-thread)"
+assert_contains "$output" "RESUMED THREAD ROLLOVER DETECTED" "resumed same thread"
+assert_not_contains "$output" "PENDING THREAD ROLLOVER DETECTED" "resumed same thread"
+
+output="$(run_hook "$fixture_root" 0 codex other-thread)"
+assert_contains "$output" "live rollover is already bound to a different replacement thread" "resumed bound other thread"
+assert_contains "$output" "old-thread" "resumed bound other thread"
+
+# 16. PostCompact remains read-only and surfaces packet health only.
+setup_fixture "$fixture_root"
+prepare_fixture "$fixture_root" codex old-thread
+output="$(run_post_compact "$fixture_root")"
+assert_contains "$output" "Thread rollover health (read-only)" "post compact health"
+assert_contains "$output" '\"status\": \"pending_start\"' "post compact packet"
+assert_not_contains "$output" "confirm-started" "post compact no confirmation"
 
 printf 'marker_hit_stdout_bytes=%s\n' "$marker_bytes"
 printf 'fallback_warn_count=%s\n' "$fallback_warn_count"

--- a/scripts/context_canary.py
+++ b/scripts/context_canary.py
@@ -124,6 +124,30 @@ CATEGORY_KIND_ALLOW: dict[str, tuple[str, ...]] = {
     # next actions from queue or handoff
     "next-action": ("queue", "handoff"),
 }
+PRODUCTION_PROBE_KEYS = frozenset(
+    {
+        "version",
+        "schema",
+        "source",
+        "lineage_id",
+        "rollover_id",
+        "seed",
+        "generated_at",
+        "anchor_counts",
+        "strict_production",
+        "policy",
+        "anchors",
+    }
+)
+PRODUCTION_ANCHOR_FIELDS = ("id", "q", "a", "category", "match_mode", "source_ref")
+PRODUCTION_ANCHOR_KEYS = frozenset(PRODUCTION_ANCHOR_FIELDS)
+PRODUCTION_ANCHOR_COUNTS = {
+    "goal": 3,
+    "decision/rationale": 3,
+    "negative-constraint/prohibition": 2,
+    "next-action": 2,
+}
+PRODUCTION_POLICY = "strict-10/10-only-from-durable-continuity-artifacts"
 
 
 def _parse_and_validate_source_ref(source_ref: object, category: str) -> bool:
@@ -208,6 +232,105 @@ def _validate_identity(val: object, kind: str) -> bool:
         return False
     # Reject consecutive path syntax
     return not ("--" in val or "//" in val or "\\\\" in val or ".." in val or val.endswith("-"))
+
+
+def validate_production_probe(
+    probe: object,
+    *,
+    expected_lineage_id: object | None = None,
+    expected_rollover_id: object | None = None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Validate the closed production-v2 probe contract without performing I/O.
+
+    Both the score command and rollover confirmation consume this validator so a
+    self-consistent hand-written verdict cannot bless a partial probe that the
+    score command would have rejected.
+    """
+    if not isinstance(probe, dict):
+        return None, "production probe must be a JSON object"
+    if set(probe.keys()) != PRODUCTION_PROBE_KEYS:
+        return (
+            None,
+            "production probe must have exactly these top-level keys with no missing/extra: "
+            "version,schema,source,lineage_id,rollover_id,seed,generated_at,anchor_counts,"
+            "strict_production,policy,anchors",
+        )
+    if probe.get("version") != "2":
+        return None, 'production probe version must be "2"'
+    if probe.get("schema") != "production-handoff-v2":
+        return None, "production probe schema must be production-handoff-v2"
+    if probe.get("source") != "snapshot":
+        return None, "production probe source must be snapshot"
+    if probe.get("strict_production") is not True:
+        return None, "production probe strict_production must be true"
+    if probe.get("policy") != PRODUCTION_POLICY:
+        return None, "production probe policy must be exact"
+    seed = probe.get("seed")
+    if not isinstance(seed, int) or isinstance(seed, bool):
+        return None, "production probe seed must be an integer"
+    if not _validate_utc_timestamp(probe.get("generated_at")):
+        return None, "production probe generated_at must be a real UTC timestamp"
+    anchor_counts = probe.get("anchor_counts")
+    if (
+        not isinstance(anchor_counts, dict)
+        or set(anchor_counts) != set(PRODUCTION_ANCHOR_COUNTS)
+        or any(type(count) is not int for count in anchor_counts.values())
+        or anchor_counts != PRODUCTION_ANCHOR_COUNTS
+    ):
+        return None, "production probe anchor_counts must be exact 3/3/2/2"
+
+    anchors = probe["anchors"]
+    if not isinstance(anchors, list) or len(anchors) != 10:
+        return None, "production probe must have exactly 10 anchors"
+    seen: set[str] = set()
+    category_counts = dict.fromkeys(PRODUCTION_ANCHOR_COUNTS, 0)
+    for anchor in anchors:
+        if not isinstance(anchor, dict) or set(anchor.keys()) != PRODUCTION_ANCHOR_KEYS:
+            return (
+                None,
+                "each production anchor must have exactly keys {id,q,a,category,match_mode,source_ref} "
+                "(no missing/extra)",
+            )
+        for field in PRODUCTION_ANCHOR_FIELDS:
+            value = anchor.get(field)
+            if value is None or (isinstance(value, str) and not value.strip()) or _has_unknowns(value):
+                return None, f"production anchor missing/empty/UNKNOWN field: {field}"
+        anchor_id = anchor["id"]
+        if not isinstance(anchor_id, str) or not anchor_id.strip() or anchor_id in seen:
+            return None, "v2 anchors require unique non-empty string ids (exact match; do not normalize IDs)"
+        seen.add(anchor_id)
+        category = anchor["category"]
+        if not isinstance(category, str) or category not in category_counts:
+            return None, f"invalid category {category} for v2 production"
+        category_counts[category] += 1
+        match_mode = anchor["match_mode"]
+        if not isinstance(match_mode, str) or match_mode not in ("exact", "normalized"):
+            return None, f"invalid match_mode '{match_mode}' (supported: exact, normalized)"
+        for field in ("q", "a"):
+            if not isinstance(anchor[field], str):
+                return None, f"production anchor missing/empty/UNKNOWN field: {field}"
+        if not _parse_and_validate_source_ref(anchor["source_ref"], category):
+            return (
+                None,
+                "v2 source_ref must follow kind:repo-relative-path#record-fragment with allowed kinds/roots for its "
+                "category; reject git:,github:,monitor:,abs,../,arbitrary,wrong-pair,UNKNOWN",
+            )
+    if category_counts != PRODUCTION_ANCHOR_COUNTS:
+        return None, "v2 probe must have exactly 3 goals, 3 decisions/rationales, 2 neg constraints, 2 next actions"
+
+    lineage_id = probe.get("lineage_id")
+    rollover_id = probe.get("rollover_id")
+    if not _validate_identity(lineage_id, "lineage"):
+        return None, "v2 probe requires well-formed lineage_id (exact identity)"
+    if not _validate_identity(rollover_id, "rollover"):
+        return None, "v2 probe requires well-formed rollover_id (exact identity)"
+    if not _validate_identity(expected_lineage_id, "lineage"):
+        return None, "production score requires --expected-lineage-id (well-formed identity)"
+    if not _validate_identity(expected_rollover_id, "rollover"):
+        return None, "production score requires --expected-rollover-id (well-formed identity)"
+    if expected_lineage_id != lineage_id or expected_rollover_id != rollover_id:
+        return None, "--expected-lineage-id and --expected-rollover-id must exactly match probe identity"
+    return probe, None
 
 
 def _is_exact_legacy_anchors_only(probe: object) -> bool:
@@ -526,136 +649,21 @@ def cmd_score(args: argparse.Namespace) -> int:
                 )
         return 0 if verdict == "PASS" else 2
     else:
-        # Strict v2 production path: exact metadata, exact anchor keys, source_ref grammar+cat, identity, expected match.
         # Any production marker or extra top key routes here and fails if not complete/valid.
-        required_keys = {
-            "version",
-            "schema",
-            "source",
-            "lineage_id",
-            "rollover_id",
-            "seed",
-            "generated_at",
-            "anchor_counts",
-            "strict_production",
-            "policy",
-            "anchors",
-        }
-        if set(probe.keys()) != required_keys:
-            print(
-                "error: production probe must have exactly these top-level keys with no missing/extra: version,schema,source,lineage_id,rollover_id,seed,generated_at,anchor_counts,strict_production,policy,anchors",
-                file=sys.stderr,
-            )
+        validated_probe, validation_error = validate_production_probe(
+            probe,
+            expected_lineage_id=getattr(args, "expected_lineage_id", None),
+            expected_rollover_id=getattr(args, "expected_rollover_id", None),
+        )
+        if validation_error:
+            print(f"error: {validation_error}", file=sys.stderr)
             return 2
-        if probe.get("version") != "2":
-            print('error: production probe version must be "2"', file=sys.stderr)
-            return 2
-        if probe.get("schema") != "production-handoff-v2":
-            print("error: production probe schema must be production-handoff-v2", file=sys.stderr)
-            return 2
-        if probe.get("source") != "snapshot":
-            print("error: production probe source must be snapshot", file=sys.stderr)
-            return 2
-        if probe.get("strict_production") is not True:
-            print("error: production probe strict_production must be true", file=sys.stderr)
-            return 2
-        if probe.get("policy") != "strict-10/10-only-from-durable-continuity-artifacts":
-            print("error: production probe policy must be exact", file=sys.stderr)
-            return 2
-        seed = probe.get("seed")
-        if not isinstance(seed, int):
-            print("error: production probe seed must be an integer", file=sys.stderr)
-            return 2
-        if not _validate_utc_timestamp(probe.get("generated_at")):
-            print("error: production probe generated_at must be a real UTC timestamp", file=sys.stderr)
-            return 2
-        expected_counts = {"goal": 3, "decision/rationale": 3, "negative-constraint/prohibition": 2, "next-action": 2}
-        if probe.get("anchor_counts") != expected_counts:
-            print("error: production probe anchor_counts must be exact 3/3/2/2", file=sys.stderr)
-            return 2
-
-        # anchors: exact keys + values validated recursively + source_ref closed
+        assert validated_probe is not None
+        probe = validated_probe
         anchors = probe["anchors"]
-        if not isinstance(anchors, list) or len(anchors) != 10:
-            print("error: production probe must have exactly 10 anchors", file=sys.stderr)
-            return 2
-        anchor_keys = {"id", "q", "a", "category", "match_mode", "source_ref"}
-        seen: set[str] = set()
-        cat_c: dict[str, int] = {
-            "goal": 0,
-            "decision/rationale": 0,
-            "negative-constraint/prohibition": 0,
-            "next-action": 0,
-        }
-        for a in anchors:
-            if not isinstance(a, dict) or set(a.keys()) != anchor_keys:
-                print(
-                    "error: each production anchor must have exactly keys {id,q,a,category,match_mode,source_ref} (no missing/extra)",
-                    file=sys.stderr,
-                )
-                return 2
-            for req in ("id", "q", "a", "category", "match_mode", "source_ref"):
-                val = a.get(req)
-                if val is None or (isinstance(val, str) and not val.strip()) or _has_unknowns(val):
-                    print(f"error: production anchor missing/empty/UNKNOWN field: {req}", file=sys.stderr)
-                    return 2
-            aid = a["id"]
-            if not isinstance(aid, str) or not aid.strip() or aid in seen:
-                print(
-                    "error: v2 anchors require unique non-empty string ids (exact match; do not normalize IDs)",
-                    file=sys.stderr,
-                )
-                return 2
-            seen.add(aid)
-            cat = a["category"]
-            if cat not in cat_c:
-                print(f"error: invalid category {cat} for v2 production", file=sys.stderr)
-                return 2
-            cat_c[cat] += 1
-            mm = a["match_mode"]
-            if mm not in ("exact", "normalized"):
-                print(f"error: invalid match_mode '{mm}' (supported: exact, normalized)", file=sys.stderr)
-                return 2
-            sr = a["source_ref"]
-            if not _parse_and_validate_source_ref(sr, cat):
-                print(
-                    "error: v2 source_ref must follow kind:repo-relative-path#record-fragment with allowed kinds/roots for its category; reject git:,github:,monitor:,abs,../,arbitrary,wrong-pair,UNKNOWN",
-                    file=sys.stderr,
-                )
-                return 2
-        if cat_c != expected_counts:
-            print(
-                "error: v2 probe must have exactly 3 goals, 3 decisions/rationales, 2 neg constraints, 2 next actions",
-                file=sys.stderr,
-            )
-            return 2
-
-        # Require explicit lineage_id + rollover_id (no unknown). Use centralized validator, exact raw.
-        lid = probe.get("lineage_id")
-        rid = probe.get("rollover_id")
-        if not _validate_identity(lid, "lineage"):
-            print("error: v2 probe requires well-formed lineage_id (exact identity)", file=sys.stderr)
-            return 2
-        if not _validate_identity(rid, "rollover"):
-            print("error: v2 probe requires well-formed rollover_id (exact identity)", file=sys.stderr)
-            return 2
-
-        # Production score REQUIRES caller-supplied expected ids and exact match before any scoring.
-        # Validate with same centralized closed validator (exact raw) BEFORE the == comparison.
-        exp_lid = getattr(args, "expected_lineage_id", None)
-        exp_rid = getattr(args, "expected_rollover_id", None)
-        if not _validate_identity(exp_lid, "lineage"):
-            print("error: production score requires --expected-lineage-id (well-formed identity)", file=sys.stderr)
-            return 2
-        if not _validate_identity(exp_rid, "rollover"):
-            print("error: production score requires --expected-rollover-id (well-formed identity)", file=sys.stderr)
-            return 2
-        if exp_lid != lid or exp_rid != rid:
-            print(
-                "error: --expected-lineage-id and --expected-rollover-id must exactly match probe identity",
-                file=sys.stderr,
-            )
-            return 2
+        lid = probe["lineage_id"]
+        rid = probe["rollover_id"]
+        seed = probe["seed"]
 
         # Strict 10/10 scoring. IDs matched exactly. match_mode only for text.
         correct = 0

--- a/scripts/context_canary.py
+++ b/scripts/context_canary.py
@@ -721,6 +721,46 @@ def cmd_score(args: argparse.Namespace) -> int:
         return 0 if is_pass else 2
 
 
+def cmd_questions(args: argparse.Namespace) -> int:
+    """Write the recall-only view of a strict production probe.
+
+    This deliberately excludes ground-truth answers so a replacement thread can
+    perform a memory recall without first reading the answer-bearing probe.
+    """
+    try:
+        probe = json.loads(Path(args.probe).read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        print(f"error: cannot read production probe: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(probe, dict) or probe.get("schema") != "production-handoff-v2":
+        print("error: questions requires a production-handoff-v2 probe", file=sys.stderr)
+        return 2
+    anchors = probe.get("anchors")
+    if not isinstance(anchors, list) or len(anchors) != 10:
+        print("error: questions requires exactly 10 production anchors", file=sys.stderr)
+        return 2
+    questions: list[dict[str, str]] = []
+    for anchor in anchors:
+        if (
+            not isinstance(anchor, dict)
+            or not isinstance(anchor.get("id"), str)
+            or not isinstance(anchor.get("q"), str)
+        ):
+            print("error: production probe has malformed question anchors", file=sys.stderr)
+            return 2
+        questions.append({"id": anchor["id"], "q": anchor["q"]})
+    payload = {
+        "version": "2",
+        "schema": "production-handoff-v2-questions",
+        "lineage_id": probe.get("lineage_id"),
+        "rollover_id": probe.get("rollover_id"),
+        "questions": questions,
+    }
+    Path(args.out).write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"questions written -> {args.out}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -741,6 +781,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     mint.add_argument("--out", required=True, help="Probe output path")
     mint.set_defaults(func=cmd_mint)
+
+    questions = sub.add_parser(
+        "questions",
+        help="Write an answer-free questions-only view of a strict production probe.",
+    )
+    questions.add_argument("--probe", required=True)
+    questions.add_argument("--out", required=True)
+    questions.set_defaults(func=cmd_questions)
 
     score = sub.add_parser(
         "score",

--- a/scripts/lib/thread_rollover_link.sh
+++ b/scripts/lib/thread_rollover_link.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Canonical thread-rollover state is shared deliberately across linked worktrees.
+
+ensure_thread_rollover_link() {
+  local canonical_root="$1"
+  local worktree_root="$2"
+  local source="$canonical_root/.agent/thread-rollovers"
+  local target="$worktree_root/.agent/thread-rollovers"
+
+  mkdir -p "$source" "$worktree_root/.agent"
+  if [ -L "$target" ]; then
+    if [ "$(readlink "$target")" != "$source" ]; then
+      printf 'Error: rollover symlink at %s points somewhere other than %s.\n' "$target" "$source" >&2
+      return 1
+    fi
+    return 0
+  fi
+  if [ -e "$target" ]; then
+    printf 'Error: real or broken rollover path at %s blocks canonical state sharing.\n' "$target" >&2
+    return 1
+  fi
+  ln -s "$source" "$target"
+}

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -17,6 +17,7 @@ import os
 import re
 import sqlite3
 import subprocess
+import sys
 import urllib.error
 import urllib.request
 import uuid
@@ -28,10 +29,13 @@ from pathlib import Path
 from typing import Any
 
 try:
+    from scripts import context_canary
     from scripts.orchestration import thread_handoff_canary
 except ModuleNotFoundError as exc:
     if __package__ or exc.name != "scripts":
         raise
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import context_canary
     import thread_handoff_canary
 
 SCHEMA_VERSION = 2
@@ -40,6 +44,7 @@ DEFAULT_AGENT = "orchestrator"
 DEFAULT_ROUTER_AGENTS = ("orchestrator", "codex", "claude", "gemini")
 AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9-]*$")
 LINEAGE_ID_RE = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+ROLLOVER_ID_RE = re.compile(r"^rollover-[a-z0-9]+(?:-[a-z0-9]+)*$")
 DEFAULT_ROUTER_PATH = Path("docs/session-state/current.md")
 ORCHESTRATOR_HANDOFF_PATH = Path("docs/session-state/codex-orchestrator-handoff.md")
 DEFAULT_STALE_HOURS = 12
@@ -121,6 +126,15 @@ def normalize_lineage_id(value: str) -> str:
     return lineage_id
 
 
+def normalize_rollover_id(value: str) -> str:
+    rollover_id = value.strip().lower()
+    if rollover_id != value or not ROLLOVER_ID_RE.fullmatch(rollover_id):
+        raise ValueError(
+            "rollover ids must match rollover-[a-z0-9]+(-[a-z0-9]+)* so runtime paths cannot escape the repo"
+        )
+    return rollover_id
+
+
 def argparse_lineage_id(value: str) -> str:
     try:
         return normalize_lineage_id(value)
@@ -148,6 +162,22 @@ def default_bootstrap_path(agent: str, lineage_id: str, generation: int, rollove
 
 def default_thread_handoff_path(agent: str, lineage_id: str, generation: int, rollover_id: str) -> Path:
     return runtime_dir(agent, lineage_id, generation, rollover_id) / "handoff.md"
+
+
+def replacement_packet_paths(agent: str, lineage_id: str, generation: int, rollover_id: str) -> dict[str, str]:
+    """Return the complete, immutable set of paths reserved by one rollover."""
+    packet_dir = runtime_dir(agent, lineage_id, generation, rollover_id)
+    return {
+        "runtime_path": packet_dir.as_posix(),
+        "bootstrap_prompt_path": (packet_dir / "bootstrap.md").as_posix(),
+        "handoff_path": (packet_dir / "handoff.md").as_posix(),
+        "semantic_snapshot_path": (packet_dir / "semantic-snapshot.json").as_posix(),
+        "strict_probe_path": (packet_dir / "strict-probe.json").as_posix(),
+        "strict_questions_path": (packet_dir / "strict-questions.json").as_posix(),
+        "strict_answers_path": (packet_dir / "strict-answers.json").as_posix(),
+        "strict_verdict_path": (packet_dir / "strict-verdict.json").as_posix(),
+        "canary_proof_path": (packet_dir / "canary-pass.json").as_posix(),
+    }
 
 
 def default_handoff_path(agent: str) -> Path:
@@ -209,11 +239,13 @@ def resolve_state_path(
     repo_root: Path,
     state_root: Path,
     supplied_state_file: Path | None,
-    default_path: Path,
+    default_path: Path | None,
 ) -> Path:
     """Resolve an explicit fixture path or a canonical default runtime path."""
     if supplied_state_file is not None:
         return repo_local_path(repo_root, supplied_state_file)
+    if default_path is None:
+        raise ValueError("--lineage-id is required when --state-file is not supplied")
     return repo_local_path(state_root, default_path)
 
 
@@ -572,19 +604,16 @@ def prepare_state(
 
     generation = int((prepared["active"] or {}).get("generation", 0)) + 1
     rollover_id = new_rollover_id()
-    packet_dir = runtime_dir(agent, lineage_id, generation, rollover_id)
+    packet_paths = replacement_packet_paths(agent, lineage_id, generation, rollover_id)
     replacement = {
         "rollover_id": rollover_id,
         "lineage_id": lineage_id,
         "generation": generation,
-        "runtime_path": packet_dir.as_posix(),
         "status": "pending_start",
         "prepared_at": isoformat_z(now),
         "thread_id": None,
-        "bootstrap_prompt_path": (packet_dir / "bootstrap.md").as_posix(),
-        "handoff_path": (packet_dir / "handoff.md").as_posix(),
-        "canary_proof_path": (packet_dir / "canary-pass.json").as_posix(),
         "canary_challenge": new_canary_challenge(),
+        **packet_paths,
     }
     prepared["replacement"] = replacement
     prepared["rollover_id"] = rollover_id
@@ -601,6 +630,138 @@ def prepare_state(
     return prepared
 
 
+def validate_live_lease(
+    state: dict[str, Any], *, agent: str, state_path: Path
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Validate a detectable v2 lease without accepting partial or relocated state."""
+    if state.get("state_error"):
+        return None, str(state["state_error"])
+    if state.get("schema_version") != SCHEMA_VERSION:
+        return None, f"schema_version must be {SCHEMA_VERSION}"
+    if state.get("agent") != agent:
+        return None, f"lease agent {state.get('agent')!r} does not match requested agent {agent!r}"
+    lineage_id = state.get("lineage_id")
+    if (
+        not isinstance(lineage_id, str)
+        or not lineage_id.startswith("lineage-")
+        or not LINEAGE_ID_RE.fullmatch(lineage_id)
+    ):
+        return None, "lease lineage_id is malformed"
+    if state_path.parent.name != lineage_id:
+        return None, "lease lineage_id does not match its canonical directory"
+    active = state.get("active")
+    if (
+        not isinstance(active, dict)
+        or active.get("lineage_id") != lineage_id
+        or not isinstance(active.get("thread_id"), str)
+        or not active["thread_id"].strip()
+    ):
+        return None, "lease active identity is malformed or mismatched"
+    replacement = state.get("replacement")
+    if not isinstance(replacement, dict):
+        return None, "lease replacement is missing or malformed"
+    if replacement.get("lineage_id") != lineage_id:
+        return None, "replacement lineage_id does not match lease lineage_id"
+    rollover_id = replacement.get("rollover_id")
+    if not isinstance(rollover_id, str):
+        return None, "replacement rollover_id is missing"
+    try:
+        normalize_rollover_id(rollover_id)
+    except ValueError as exc:
+        return None, str(exc)
+    generation = replacement.get("generation")
+    if not isinstance(generation, int) or generation < 1:
+        return None, "replacement generation is malformed"
+    if state.get("rollover_id") != rollover_id:
+        return None, "lease rollover_id does not match replacement rollover_id"
+    if replacement.get("status") not in {"pending_start", "resumed", "started"}:
+        return None, "replacement status is malformed"
+    if replacement.get("status") == "resumed" and (
+        not isinstance(replacement.get("resumed_thread_id"), str) or not replacement["resumed_thread_id"].strip()
+    ):
+        return None, "resumed replacement has no valid replacement thread identity"
+    if replacement.get("status") in {"pending_start", "resumed"}:
+        expected_paths = replacement_packet_paths(agent, lineage_id, generation, rollover_id)
+        for key, expected in expected_paths.items():
+            if replacement.get(key) != expected:
+                return None, f"replacement {key} is missing, forged, or not the reserved packet path"
+        challenge = replacement.get("canary_challenge")
+        if not isinstance(challenge, str) or not re.fullmatch(r"[0-9a-f]{64}", challenge):
+            return None, "replacement canary_challenge is malformed"
+    return replacement, None
+
+
+def _canonical_json_sha256(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def validate_strict_verdict(
+    *,
+    replacement: dict[str, Any],
+    state_root: Path,
+    strict_probe: Path,
+    strict_verdict: Path,
+) -> dict[str, Any]:
+    """Require the reserved strict v2 10/10 evidence before cleanup can unlock."""
+    expected_probe = repo_local_path(state_root, Path(replacement["strict_probe_path"]))
+    expected_verdict = repo_local_path(state_root, Path(replacement["strict_verdict_path"]))
+    if strict_probe != expected_probe or strict_verdict != expected_verdict:
+        raise ValueError("strict probe and verdict must use the paths reserved by this rollover")
+    try:
+        probe = json.loads(strict_probe.read_text(encoding="utf-8"))
+        verdict = json.loads(strict_verdict.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"strict production evidence is unreadable: {type(exc).__name__}: {exc}") from exc
+    if not isinstance(probe, dict) or not isinstance(verdict, dict):
+        raise ValueError("strict production evidence must be JSON objects")
+    if probe.get("schema") != "production-handoff-v2" or probe.get("strict_production") is not True:
+        raise ValueError("strict probe is not a production-handoff-v2 probe")
+    if probe.get("lineage_id") != replacement["lineage_id"] or probe.get("rollover_id") != replacement["rollover_id"]:
+        raise ValueError("strict probe identity does not match the pending rollover")
+    anchors = probe.get("anchors")
+    if not isinstance(anchors, list) or len(anchors) != 10:
+        raise ValueError("strict probe must contain exactly 10 anchors")
+    anchor_ids = [anchor.get("id") for anchor in anchors if isinstance(anchor, dict)]
+    if len(anchor_ids) != 10 or len(set(anchor_ids)) != 10:
+        raise ValueError("strict probe anchors are malformed")
+    required_verdict_keys = {
+        "version",
+        "schema",
+        "lineage_id",
+        "rollover_id",
+        "probe_sha256",
+        "seed",
+        "k",
+        "correct",
+        "score",
+        "verdict",
+        "model",
+        "per_anchor",
+    }
+    if set(verdict) != required_verdict_keys:
+        raise ValueError("strict verdict has missing or forged fields")
+    if (
+        verdict.get("version") != "2"
+        or verdict.get("schema") != "production-handoff-v2"
+        or verdict.get("lineage_id") != replacement["lineage_id"]
+        or verdict.get("rollover_id") != replacement["rollover_id"]
+        or verdict.get("probe_sha256") != _canonical_json_sha256(probe)
+        or verdict.get("k") != 10
+        or verdict.get("correct") != 10
+        or verdict.get("score") != 1.0
+        or verdict.get("verdict") != "PASS"
+    ):
+        raise ValueError("strict verdict is not the required PASS 10/10 for this reserved probe")
+    rows = verdict.get("per_anchor")
+    if not isinstance(rows, list) or len(rows) != 10:
+        raise ValueError("strict verdict does not attest every anchor")
+    row_ids = [row.get("id") for row in rows if isinstance(row, dict) and row.get("match") is True]
+    if set(row_ids) != set(anchor_ids) or len(row_ids) != 10:
+        raise ValueError("strict verdict does not report a matching PASS for every anchor")
+    return verdict
+
+
 def confirm_started(
     state: dict[str, Any],
     *,
@@ -609,6 +770,9 @@ def confirm_started(
     confirmed_by: str,
     now: datetime,
     canary_proof: Path,
+    strict_probe: Path,
+    strict_verdict: Path,
+    state_root: Path,
 ) -> dict[str, Any]:
     if not new_thread_id.strip():
         raise ValueError("--new-thread-id is required")
@@ -629,12 +793,19 @@ def confirm_started(
     )
     if proof_error:
         raise ValueError(f"script-proven canary PASS is required: {proof_error}")
+    strict_evidence = validate_strict_verdict(
+        replacement=replacement,
+        state_root=state_root,
+        strict_probe=strict_probe,
+        strict_verdict=strict_verdict,
+    )
     replacement["status"] = "started"
     replacement["thread_id"] = new_thread_id.strip()
     replacement["confirmed_at"] = isoformat_z(now)
     if new_automation_id:
         replacement["automation_id"] = new_automation_id
     replacement["canary_proof"] = proof
+    replacement["strict_verdict"] = strict_evidence
     confirmed["replacement"] = replacement
 
     cleanup = dict(confirmed.get("cleanup") or {})
@@ -801,8 +972,18 @@ def render_bootstrap_prompt(
     rollover_id = replacement.get("rollover_id") or "unknown"
     canary_challenge = replacement.get("canary_challenge") or "unknown"
     canary_proof_path = Path(replacement.get("canary_proof_path") or "unknown")
+    semantic_snapshot_path = Path(replacement.get("semantic_snapshot_path") or "unknown")
+    strict_probe_path = Path(replacement.get("strict_probe_path") or "unknown")
+    strict_questions_path = Path(replacement.get("strict_questions_path") or "unknown")
+    strict_answers_path = Path(replacement.get("strict_answers_path") or "unknown")
+    strict_verdict_path = Path(replacement.get("strict_verdict_path") or "unknown")
     if state_root is not None:
         canary_proof_path = repo_local_path(state_root, canary_proof_path)
+        semantic_snapshot_path = repo_local_path(state_root, semantic_snapshot_path)
+        strict_probe_path = repo_local_path(state_root, strict_probe_path)
+        strict_questions_path = repo_local_path(state_root, strict_questions_path)
+        strict_answers_path = repo_local_path(state_root, strict_answers_path)
+        strict_verdict_path = repo_local_path(state_root, strict_verdict_path)
     context_percent = (state.get("last_handoff") or {}).get("context_percent")
     agent_label = "Codex orchestrator" if agent == "orchestrator" else agent
 
@@ -846,11 +1027,14 @@ def render_bootstrap_prompt(
                 ".venv/bin/python scripts/orchestration/orchestrator_control.py inbox --recent 20 --include-results",
                 "```",
                 "",
-                "Bind this new thread to this exact rollover, then create its script-proven canary PASS proof:",
+                "Bind this new thread and complete the strict semantic recall before proof and confirmation:",
                 "```bash",
                 f".venv/bin/python scripts/orchestration/thread_handoff.py resume --agent {agent} --lineage-id {replacement.get('lineage_id', 'unknown')} --rollover-id {rollover_id} --replacement-thread-id <replacement-thread-id>",
+                f".venv/bin/python scripts/context_canary.py mint --snapshot {semantic_snapshot_path.as_posix()} --out {strict_probe_path.as_posix()}",
+                f".venv/bin/python scripts/context_canary.py questions --probe {strict_probe_path.as_posix()} --out {strict_questions_path.as_posix()}",
+                f".venv/bin/python scripts/context_canary.py score --probe {strict_probe_path.as_posix()} --answers {strict_answers_path.as_posix()} --expected-lineage-id {replacement.get('lineage_id', 'unknown')} --expected-rollover-id {rollover_id} --verdict {strict_verdict_path.as_posix()}",
                 f".venv/bin/python scripts/orchestration/thread_handoff_canary.py --rollover-id {rollover_id} --replacement-thread-id <replacement-thread-id> --challenge {canary_challenge} --proof-file {canary_proof_path.as_posix()}",
-                f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --lineage-id {replacement.get('lineage_id', 'unknown')} --rollover-id {rollover_id} --new-thread-id <replacement-thread-id> --canary-proof {canary_proof_path.as_posix()}",
+                f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --lineage-id {replacement.get('lineage_id', 'unknown')} --rollover-id {rollover_id} --new-thread-id <replacement-thread-id> --canary-proof {canary_proof_path.as_posix()} --strict-probe {strict_probe_path.as_posix()} --strict-verdict {strict_verdict_path.as_posix()}",
                 "```",
                 "",
                 "Only after that command reports old_automation_ready_to_delete=true may the old heartbeat automation be deleted or paused.",
@@ -886,8 +1070,18 @@ def render_current_markdown(
     prompt_path = replacement.get("bootstrap_prompt_path") or "unknown"
     thread_handoff_text = replacement.get("handoff_path") or "unknown"
     canary_proof_path = Path(replacement.get("canary_proof_path") or "unknown")
+    strict_probe_path = Path(replacement.get("strict_probe_path") or "unknown")
+    strict_questions_path = Path(replacement.get("strict_questions_path") or "unknown")
+    strict_answers_path = Path(replacement.get("strict_answers_path") or "unknown")
+    strict_verdict_path = Path(replacement.get("strict_verdict_path") or "unknown")
+    semantic_snapshot_path = Path(replacement.get("semantic_snapshot_path") or "unknown")
     if state_root is not None:
         canary_proof_path = repo_local_path(state_root, canary_proof_path)
+        strict_probe_path = repo_local_path(state_root, strict_probe_path)
+        strict_questions_path = repo_local_path(state_root, strict_questions_path)
+        strict_answers_path = repo_local_path(state_root, strict_answers_path)
+        strict_verdict_path = repo_local_path(state_root, strict_verdict_path)
+        semantic_snapshot_path = repo_local_path(state_root, semantic_snapshot_path)
     role_handoff = (role_handoff_path or default_handoff_path(agent)).as_posix()
     title_agent = "Orchestrator" if agent == "orchestrator" else agent.title()
 
@@ -981,8 +1175,11 @@ def render_current_markdown(
         "",
         "```bash",
         f".venv/bin/python scripts/orchestration/thread_handoff.py resume --agent {agent} --lineage-id {replacement.get('lineage_id', '<lineage-id>')} --rollover-id {replacement.get('rollover_id', '<rollover-id>')} --replacement-thread-id <replacement-thread-id>",
+        f".venv/bin/python scripts/context_canary.py mint --snapshot {semantic_snapshot_path.as_posix()} --out {strict_probe_path.as_posix()}",
+        f".venv/bin/python scripts/context_canary.py questions --probe {strict_probe_path.as_posix()} --out {strict_questions_path.as_posix()}",
+        f".venv/bin/python scripts/context_canary.py score --probe {strict_probe_path.as_posix()} --answers {strict_answers_path.as_posix()} --expected-lineage-id {replacement.get('lineage_id', '<lineage-id>')} --expected-rollover-id {replacement.get('rollover_id', '<rollover-id>')} --verdict {strict_verdict_path.as_posix()}",
         f".venv/bin/python scripts/orchestration/thread_handoff_canary.py --rollover-id {replacement.get('rollover_id', '<rollover-id>')} --replacement-thread-id <replacement-thread-id> --challenge {replacement.get('canary_challenge', '<canary-challenge>')} --proof-file {canary_proof_path.as_posix()}",
-        f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --lineage-id {replacement.get('lineage_id', '<lineage-id>')} --rollover-id {replacement.get('rollover_id', '<rollover-id>')} --new-thread-id <replacement-thread-id> --canary-proof {canary_proof_path.as_posix()}",
+        f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started --agent {agent} --lineage-id {replacement.get('lineage_id', '<lineage-id>')} --rollover-id {replacement.get('rollover_id', '<rollover-id>')} --new-thread-id <replacement-thread-id> --canary-proof {canary_proof_path.as_posix()} --strict-probe {strict_probe_path.as_posix()} --strict-verdict {strict_verdict_path.as_posix()}",
         "```",
         "",
         "Do not delete the old heartbeat automation before this confirmation.",
@@ -1131,7 +1328,7 @@ def cmd_prepare(args: argparse.Namespace) -> int:
             repo_root=repo_root,
             state_root=state_root,
             supplied_state_file=args.state_file,
-            default_path=default_state_path(agent, lineage_id),
+            default_path=default_state_path(agent, lineage_id) if lineage_id else None,
         )
         router_path = repo_local_path(repo_root, router_file)
     except ValueError as exc:
@@ -1250,6 +1447,12 @@ def cmd_prepare(args: argparse.Namespace) -> int:
             "current_file": router_path.as_posix(),
             "would_write_router": bool(args.write_current),
             "old_automation_ready_to_delete": False,
+            "semantic_snapshot_file": replacement["semantic_snapshot_path"],
+            "strict_probe_file": replacement["strict_probe_path"],
+            "strict_questions_file": replacement["strict_questions_path"],
+            "strict_answers_file": replacement["strict_answers_path"],
+            "strict_verdict_file": replacement["strict_verdict_path"],
+            "canary_proof_file": replacement["canary_proof_path"],
             "bootstrap_prompt": prompt,
         }
         print(json.dumps(output, indent=2))
@@ -1277,6 +1480,12 @@ def cmd_prepare(args: argparse.Namespace) -> int:
         "current_file": rel(router_path, repo_root) if wrote_router else None,
         "replacement_status": prepared_state["replacement"]["status"],
         "old_automation_ready_to_delete": prepared_state["cleanup"]["old_automation_ready_to_delete"],
+        "semantic_snapshot_file": replacement["semantic_snapshot_path"],
+        "strict_probe_file": replacement["strict_probe_path"],
+        "strict_questions_file": replacement["strict_questions_path"],
+        "strict_answers_file": replacement["strict_answers_path"],
+        "strict_verdict_file": replacement["strict_verdict_path"],
+        "canary_proof_file": replacement["canary_proof_path"],
     }
     print(json.dumps(output, indent=2))
     return 0
@@ -1300,7 +1509,7 @@ def cmd_confirm_started(args: argparse.Namespace) -> int:
             repo_root=repo_root,
             state_root=state_root,
             supplied_state_file=args.state_file,
-            default_path=default_state_path(agent, lineage_id),
+            default_path=default_state_path(agent, lineage_id) if lineage_id else None,
         )
     except ValueError as exc:
         print(json.dumps({"error": str(exc), "agent": agent}, indent=2))
@@ -1320,6 +1529,8 @@ def cmd_confirm_started(args: argparse.Namespace) -> int:
     expected_proof = repo_local_path(state_root, Path(state["replacement"]["canary_proof_path"]))
     try:
         supplied_proof = repo_local_path(state_root, args.canary_proof)
+        supplied_strict_probe = repo_local_path(state_root, args.strict_probe)
+        supplied_strict_verdict = repo_local_path(state_root, args.strict_verdict)
     except ValueError as exc:
         print(json.dumps({"error": str(exc), "agent": agent}, indent=2))
         return 2
@@ -1334,6 +1545,9 @@ def cmd_confirm_started(args: argparse.Namespace) -> int:
             confirmed_by=args.confirmed_by,
             now=utc_now(),
             canary_proof=supplied_proof,
+            strict_probe=supplied_strict_probe,
+            strict_verdict=supplied_strict_verdict,
+            state_root=state_root,
         )
     except ValueError as exc:
         print(json.dumps({"error": str(exc)}, indent=2))
@@ -1373,7 +1587,7 @@ def cmd_resume(args: argparse.Namespace) -> int:
             repo_root=repo_root,
             state_root=state_root,
             supplied_state_file=args.state_file,
-            default_path=default_state_path(agent, args.lineage_id),
+            default_path=default_state_path(agent, args.lineage_id) if args.lineage_id else None,
         )
     except ValueError as exc:
         print(json.dumps({"error": str(exc), "agent": agent}, indent=2))
@@ -1403,6 +1617,11 @@ def cmd_resume(args: argparse.Namespace) -> int:
                 "rollover_id": replacement["rollover_id"],
                 "replacement_thread_id": replacement["resumed_thread_id"],
                 "canary_proof_file": replacement["canary_proof_path"],
+                "semantic_snapshot_file": replacement["semantic_snapshot_path"],
+                "strict_probe_file": replacement["strict_probe_path"],
+                "strict_questions_file": replacement["strict_questions_path"],
+                "strict_answers_file": replacement["strict_answers_path"],
+                "strict_verdict_file": replacement["strict_verdict_path"],
                 "status": replacement["status"],
             },
             indent=2,
@@ -1428,7 +1647,7 @@ def cmd_check(args: argparse.Namespace) -> int:
             repo_root=repo_root,
             state_root=state_root,
             supplied_state_file=args.state_file,
-            default_path=default_state_path(agent, args.lineage_id),
+            default_path=default_state_path(agent, args.lineage_id) if args.lineage_id else None,
         )
     except ValueError as exc:
         print(json.dumps({"error": str(exc), "agent": agent}, indent=2))
@@ -1451,6 +1670,151 @@ def cmd_audit(args: argparse.Namespace) -> int:
     audit = inspect_codex_home(codex_home)
     audit["monitor"] = gather_monitor_state(args.monitor_base_url) if args.include_monitor else "skipped"
     print(json.dumps(audit, indent=2))
+    return 0
+
+
+def render_session_start_context(candidate: dict[str, Any] | None, *, agent: str, current_thread_id: str) -> str:
+    """Render the only SessionStart handoff text; shell hooks never parse leases."""
+    if candidate is None:
+        facts_path = ".agent/orientation-health-facts.json"
+        return "\n".join(
+            [
+                "COLD START: NO LIVE THREAD ROLLOVER",
+                "No pending or resumed packet exists for this agent.",
+                "Orient from durable project state with tool-backed reads before ordinary work.",
+                "Create exactly ten truthful legacy orientation facts, then run:",
+                f".venv/bin/python scripts/context_canary.py mint --facts {facts_path} --out .agent/orientation-health-probe.json",
+                "Do not invent a lineage_id or rollover_id; prepare creates both only when this thread later rolls over.",
+                "Keep the primary checkout read-only and use a dispatch worktree for implementation.",
+            ]
+        )
+    thread_id = current_thread_id or "<current-codex-thread-id>"
+    lineage_id = candidate["lineage_id"]
+    rollover_id = candidate["rollover_id"]
+    base = [
+        f"--agent {agent}",
+        f"--lineage-id {lineage_id}",
+        f"--rollover-id {rollover_id}",
+    ]
+    proof = candidate["canary_proof_path"]
+    snapshot = candidate["semantic_snapshot_path"]
+    probe = candidate["strict_probe_path"]
+    questions = candidate["strict_questions_path"]
+    answers = candidate["strict_answers_path"]
+    verdict = candidate["strict_verdict_path"]
+    common = " ".join(base)
+    if candidate["status"] == "resumed":
+        title = "RESUMED THREAD ROLLOVER DETECTED"
+        first = "This same Codex thread already holds the packet; do not resume it again."
+    else:
+        title = "PENDING THREAD ROLLOVER DETECTED"
+        first = "Claim this packet before ordinary work:"
+    lines = [title, first]
+    if candidate["status"] == "pending_start":
+        lines.append(
+            f".venv/bin/python scripts/orchestration/thread_handoff.py resume {common} --replacement-thread-id {thread_id}"
+        )
+    lines.extend(
+        [
+            f"Read the packet: {candidate['handoff_path']}",
+            f"Write the validated durable semantic snapshot to its reserved path: {snapshot}",
+            f".venv/bin/python scripts/context_canary.py mint --snapshot {snapshot} --out {probe}",
+            f".venv/bin/python scripts/context_canary.py questions --probe {probe} --out {questions}",
+            f'Answer only the IDs/questions in {questions} from restored context; write {{"id": "answer"}} JSON to {answers}.',
+            f".venv/bin/python scripts/context_canary.py score --probe {probe} --answers {answers} --expected-lineage-id {lineage_id} --expected-rollover-id {rollover_id} --verdict {verdict}",
+            f".venv/bin/python scripts/orchestration/thread_handoff_canary.py --rollover-id {rollover_id} --replacement-thread-id {thread_id} --challenge {candidate['canary_challenge']} --proof-file {proof}",
+            f".venv/bin/python scripts/orchestration/thread_handoff.py confirm-started {common} --new-thread-id {thread_id} --canary-proof {proof} --strict-probe {probe} --strict-verdict {verdict}",
+            "Do not auto-run any mutation above. Cleanup remains locked unless both exact proofs pass.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def cmd_detect(args: argparse.Namespace) -> int:
+    try:
+        _, state_root = resolve_roots(args.repo_root)
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}, indent=2))
+        return 2
+    agent = normalize_agent_name(args.agent)
+
+    agent_dir = state_root / ".agent" / "thread-rollovers" / agent
+    if not agent_dir.exists():
+        output: dict[str, Any] = {"agent": agent, "status": "none"}
+        print(
+            render_session_start_context(None, agent=agent, current_thread_id=args.current_thread_id)
+            if args.format == "session-start"
+            else json.dumps(output, indent=2)
+        )
+        return 0
+
+    live_leases: list[tuple[Path, dict[str, Any], dict[str, Any]]] = []
+
+    for path in sorted(agent_dir.glob("*/lease.json")):
+        state = load_state(path)
+        replacement, error = validate_live_lease(state, agent=agent, state_path=path)
+        if error:
+            print(json.dumps({"error": f"invalid rollover lease {rel(path, state_root)}: {error}"}, indent=2))
+            return 2
+        if replacement is not None and replacement["status"] in {"pending_start", "resumed"}:
+            live_leases.append((path, state, replacement))
+
+    if not live_leases:
+        output = {"agent": agent, "status": "none"}
+        print(
+            render_session_start_context(None, agent=agent, current_thread_id=args.current_thread_id)
+            if args.format == "session-start"
+            else json.dumps(output, indent=2)
+        )
+        return 0
+
+    if len(live_leases) > 1:
+        print(
+            json.dumps({"error": f"Multiple live pending rollovers found for agent {agent} in {agent_dir}"}, indent=2)
+        )
+        return 2
+
+    path, state, replacement = live_leases[0]
+    if (
+        replacement["status"] == "resumed"
+        and args.current_thread_id
+        and replacement.get("resumed_thread_id") != args.current_thread_id
+    ):
+        print(
+            json.dumps(
+                {
+                    "error": "live rollover is already bound to a different replacement thread",
+                    "resumed_thread_id": replacement.get("resumed_thread_id"),
+                },
+                indent=2,
+            )
+        )
+        return 2
+
+    output = {
+        "agent": agent,
+        "lineage_id": state.get("lineage_id"),
+        "rollover_id": replacement.get("rollover_id"),
+        "status": replacement.get("status"),
+        "state_file": rel(path, state_root),
+        "state": "live",
+        "runtime_path": replacement.get("runtime_path"),
+        "handoff_path": replacement.get("handoff_path"),
+        "bootstrap_prompt_path": replacement.get("bootstrap_prompt_path"),
+        "canary_challenge": replacement.get("canary_challenge"),
+        "canary_proof_path": replacement.get("canary_proof_path"),
+        "resumed_thread_id": replacement.get("resumed_thread_id"),
+        "strict_probe_path": replacement.get("strict_probe_path"),
+        "semantic_snapshot_path": replacement.get("semantic_snapshot_path"),
+        "strict_questions_path": replacement.get("strict_questions_path"),
+        "strict_answers_path": replacement.get("strict_answers_path"),
+        "strict_verdict_path": replacement.get("strict_verdict_path"),
+    }
+    print(
+        render_session_start_context(output, agent=agent, current_thread_id=args.current_thread_id)
+        if args.format == "session-start"
+        else json.dumps(output, indent=2)
+    )
     return 0
 
 
@@ -1503,6 +1867,8 @@ def build_parser() -> argparse.ArgumentParser:
     confirm.add_argument("--new-thread-id", required=True)
     confirm.add_argument("--new-automation-id")
     confirm.add_argument("--canary-proof", type=Path, required=True)
+    confirm.add_argument("--strict-probe", type=Path, required=True)
+    confirm.add_argument("--strict-verdict", type=Path, required=True)
     confirm.add_argument("--confirmed-by", default=os.environ.get("USER", "operator"))
     confirm.set_defaults(func=cmd_confirm_started)
 
@@ -1530,6 +1896,12 @@ def build_parser() -> argparse.ArgumentParser:
     audit.add_argument("--codex-home", default=os.environ.get("CODEX_HOME", str(Path.home() / ".codex")))
     audit.add_argument("--include-monitor", action="store_true")
     audit.set_defaults(func=cmd_audit)
+
+    detect = subparsers.add_parser("detect", help="Detect a single pending/resumed thread rollover.")
+    detect.add_argument("--agent", type=argparse_agent_name, default=DEFAULT_AGENT)
+    detect.add_argument("--current-thread-id", default="")
+    detect.add_argument("--format", choices=("json", "session-start"), default="json")
+    detect.set_defaults(func=cmd_detect)
     return parser
 
 

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -715,16 +715,16 @@ def validate_strict_verdict(
         raise ValueError(f"strict production evidence is unreadable: {type(exc).__name__}: {exc}") from exc
     if not isinstance(probe, dict) or not isinstance(verdict, dict):
         raise ValueError("strict production evidence must be JSON objects")
-    if probe.get("schema") != "production-handoff-v2" or probe.get("strict_production") is not True:
-        raise ValueError("strict probe is not a production-handoff-v2 probe")
-    if probe.get("lineage_id") != replacement["lineage_id"] or probe.get("rollover_id") != replacement["rollover_id"]:
-        raise ValueError("strict probe identity does not match the pending rollover")
-    anchors = probe.get("anchors")
-    if not isinstance(anchors, list) or len(anchors) != 10:
-        raise ValueError("strict probe must contain exactly 10 anchors")
-    anchor_ids = [anchor.get("id") for anchor in anchors if isinstance(anchor, dict)]
-    if len(anchor_ids) != 10 or len(set(anchor_ids)) != 10:
-        raise ValueError("strict probe anchors are malformed")
+    validated_probe, probe_error = context_canary.validate_production_probe(
+        probe,
+        expected_lineage_id=replacement["lineage_id"],
+        expected_rollover_id=replacement["rollover_id"],
+    )
+    if probe_error:
+        raise ValueError(f"strict probe failed production validation: {probe_error}")
+    assert validated_probe is not None
+    probe = validated_probe
+    anchor_ids = [anchor["id"] for anchor in probe["anchors"]]
     required_verdict_keys = {
         "version",
         "schema",
@@ -747,6 +747,7 @@ def validate_strict_verdict(
         or verdict.get("lineage_id") != replacement["lineage_id"]
         or verdict.get("rollover_id") != replacement["rollover_id"]
         or verdict.get("probe_sha256") != _canonical_json_sha256(probe)
+        or verdict.get("seed") != probe["seed"]
         or verdict.get("k") != 10
         or verdict.get("correct") != 10
         or verdict.get("score") != 1.0

--- a/start-codex.sh
+++ b/start-codex.sh
@@ -7,6 +7,9 @@
 
 set -e
 
+# shellcheck source=scripts/lib/thread_rollover_link.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/lib/thread_rollover_link.sh"
+
 # Ensure common local bin paths are available
 export PATH="$HOME/.local/bin:/opt/homebrew/bin:$PATH"
 hash -r 2>/dev/null || true
@@ -146,6 +149,10 @@ if [ "$CODEX_TARGET" = "worktree" ]; then
         echo "Symlinked data/ into worktree"
     fi
 
+    # Bridge only the canonical rollover directory, never the whole .agent tree.
+    ensure_thread_rollover_link "$PROJECT_DIR" "$WORKTREE_DIR"
+    echo "Verified .agent/thread-rollovers canonical bridge"
+
     TARGET_DIR="$WORKTREE_DIR"
 fi
 
@@ -187,4 +194,5 @@ echo ""
 
 echo "Launching Codex in $CODEX_TARGET checkout..."
 export CODEX_SESSION=1
+export CODEX_CANONICAL_REPO_ROOT="$PROJECT_DIR"
 codex "${CODEX_FLAGS[@]}" -C "$TARGET_DIR" "${CODEX_ARGS[@]}"

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -1254,3 +1254,63 @@ def test_confirmation_rejects_nine_of_ten_and_wrong_reserved_paths(tmp_path: Pat
     assert json.loads(state_path.read_text(encoding="utf-8"))["cleanup"]["old_automation_ready_to_delete"] is False
     assert th.main([*command[:-2], "--strict-probe", "wrong.json", "--strict-verdict", str(strict_verdict)]) == 2
     assert json.loads(state_path.read_text(encoding="utf-8"))["cleanup"]["old_automation_ready_to_delete"] is False
+
+
+@pytest.mark.parametrize("forgery", ["minimal", "top_level", "category", "source_ref"])
+def test_confirmation_revalidates_probe_before_handwritten_pass_can_unlock_cleanup(tmp_path: Path, forgery: str):
+    """The Fable bypass cannot turn a resumed lease into a started lease."""
+    state = prepared()
+    resumed, proof_path = resumed_with_proof(tmp_path, state)
+    strict_probe, strict_verdict = strict_artifacts(tmp_path, resumed)
+
+    if forgery == "minimal":
+        probe = {
+            "schema": "production-handoff-v2",
+            "strict_production": True,
+            "lineage_id": resumed["lineage_id"],
+            "rollover_id": resumed["replacement"]["rollover_id"],
+            "anchors": [{"id": f"forged-{index}"} for index in range(10)],
+        }
+    else:
+        probe = json.loads(strict_probe.read_text(encoding="utf-8"))
+        if forgery == "top_level":
+            probe.pop("source")
+        elif forgery == "category":
+            probe["anchors"][0]["category"] = "decision/rationale"
+        else:
+            probe["anchors"][0]["source_ref"] = "git:HEAD"
+    th.write_json_atomic(strict_probe, probe)
+
+    forged_verdict = {
+        "version": "2",
+        "schema": "production-handoff-v2",
+        "lineage_id": resumed["lineage_id"],
+        "rollover_id": resumed["replacement"]["rollover_id"],
+        "probe_sha256": th._canonical_json_sha256(probe),
+        "seed": probe.get("seed", 0),
+        "k": 10,
+        "correct": 10,
+        "score": 1.0,
+        "verdict": "PASS",
+        "model": "handwritten",
+        "per_anchor": [{"id": anchor["id"], "match": True} for anchor in probe["anchors"]],
+    }
+    th.write_json_atomic(strict_verdict, forged_verdict)
+    before_confirmation = json.loads(json.dumps(resumed))
+
+    with pytest.raises(ValueError, match="strict probe failed production validation"):
+        th.confirm_started(
+            resumed,
+            new_thread_id="new-thread",
+            new_automation_id=None,
+            confirmed_by="tester",
+            now=datetime(2026, 5, 30, 8, 3, tzinfo=UTC),
+            canary_proof=proof_path,
+            strict_probe=strict_probe,
+            strict_verdict=strict_verdict,
+            state_root=tmp_path,
+        )
+
+    assert resumed == before_confirmation
+    assert resumed["replacement"]["status"] == "resumed"
+    assert resumed["cleanup"]["old_automation_ready_to_delete"] is False

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -90,6 +90,66 @@ def resumed_with_proof(tmp_path: Path, state: dict, thread_id: str = "new-thread
     return resumed, proof_path
 
 
+def strict_artifacts(tmp_path: Path, state: dict) -> tuple[Path, Path]:
+    """Create script-scored strict evidence at this lease's reserved paths."""
+    replacement = state["replacement"]
+    snapshot = tmp_path / replacement["semantic_snapshot_path"]
+    probe = tmp_path / replacement["strict_probe_path"]
+    answers = tmp_path / replacement["strict_answers_path"]
+    verdict = tmp_path / replacement["strict_verdict_path"]
+    source = "handoff:.agent/thread-rollovers/evidence.json"
+    payload = {
+        "generated_at": "2026-07-13T12:00:00Z",
+        "lineage_id": state["lineage_id"],
+        "rollover_id": replacement["rollover_id"],
+        "seed": 7,
+        "goals": [{"id": f"goal-{i}", "statement": f"goal {i}", "source_ref": f"{source}#goal-{i}"} for i in range(3)],
+        "decision_records": [
+            {
+                "id": f"decision-{i}",
+                "decision": f"decision {i}",
+                "source_ref": f"decision:docs/decisions/evidence.md#decision-{i}",
+            }
+            for i in range(3)
+        ],
+        "constraint_records": [
+            {"id": f"constraint-{i}", "prohibition": f"prohibition {i}", "source_ref": f"{source}#constraint-{i}"}
+            for i in range(2)
+        ],
+        "next_actions": [
+            {
+                "id": f"action-{i}",
+                "action": f"action {i}",
+                "source_ref": f"queue:batch_state/orchestrator-runs/evidence.json#action-{i}",
+            }
+            for i in range(2)
+        ],
+    }
+    th.write_json_atomic(snapshot, payload)
+    assert th.context_canary.main(["mint", "--snapshot", str(snapshot), "--out", str(probe)]) == 0
+    minted = json.loads(probe.read_text(encoding="utf-8"))
+    th.write_json_atomic(answers, {anchor["id"]: anchor["a"] for anchor in minted["anchors"]})
+    assert (
+        th.context_canary.main(
+            [
+                "score",
+                "--probe",
+                str(probe),
+                "--answers",
+                str(answers),
+                "--expected-lineage-id",
+                state["lineage_id"],
+                "--expected-rollover-id",
+                replacement["rollover_id"],
+                "--verdict",
+                str(verdict),
+            ]
+        )
+        == 0
+    )
+    return probe, verdict
+
+
 def test_direct_script_help_from_repository_root():
     repo_root = Path(__file__).resolve().parents[2]
     env = os.environ.copy()
@@ -121,6 +181,7 @@ def test_prepare_state_requires_confirmation_before_cleanup(tmp_path: Path):
     assert state["cleanup"]["old_automation_ready_to_delete"] is False
 
     resumed, proof_path = resumed_with_proof(tmp_path, state)
+    strict_probe, strict_verdict = strict_artifacts(tmp_path, resumed)
     confirmed = th.confirm_started(
         resumed,
         new_thread_id="new-thread",
@@ -128,6 +189,9 @@ def test_prepare_state_requires_confirmation_before_cleanup(tmp_path: Path):
         confirmed_by="tester",
         now=now + timedelta(minutes=2),
         canary_proof=proof_path,
+        strict_probe=strict_probe,
+        strict_verdict=strict_verdict,
+        state_root=tmp_path,
     )
     assert confirmed["replacement"]["status"] == "started"
     assert confirmed["replacement"]["thread_id"] == "new-thread"
@@ -143,6 +207,9 @@ def test_confirm_started_rejects_missing_pending_replacement():
             confirmed_by="tester",
             now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC),
             canary_proof=Path("missing-proof.json"),
+            strict_probe=Path("missing-probe.json"),
+            strict_verdict=Path("missing-verdict.json"),
+            state_root=Path("."),
         )
 
 
@@ -385,6 +452,7 @@ def test_confirm_started_is_scoped_to_selected_agent(tmp_path: Path, capsys):
         replacement_thread_id="new-claude",
         now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
     )
+    strict_probe, strict_verdict = strict_artifacts(tmp_path, resumed)
     proof_path = tmp_path / resumed["replacement"]["canary_proof_path"]
     canary.write_json_atomic(
         proof_path,
@@ -396,6 +464,7 @@ def test_confirm_started_is_scoped_to_selected_agent(tmp_path: Path, capsys):
         ),
     )
     th.write_json_atomic(claude_path, resumed)
+    capsys.readouterr()
 
     rc = th.main(
         [
@@ -412,6 +481,10 @@ def test_confirm_started_is_scoped_to_selected_agent(tmp_path: Path, capsys):
             "new-claude",
             "--canary-proof",
             str(proof_path),
+            "--strict-probe",
+            str(strict_probe),
+            "--strict-verdict",
+            str(strict_verdict),
         ]
     )
     payload = json.loads(capsys.readouterr().out)
@@ -442,6 +515,10 @@ def test_confirm_started_missing_agent_prepare_is_safe(tmp_path: Path, capsys):
             "new-gemini",
             "--canary-proof",
             ".agent/missing-proof.json",
+            "--strict-probe",
+            ".agent/missing-probe.json",
+            "--strict-verdict",
+            ".agent/missing-verdict.json",
         ]
     )
     payload = json.loads(capsys.readouterr().out)
@@ -605,6 +682,7 @@ def test_resume_is_deterministic_and_refuses_a_different_thread():
 def test_confirm_requires_matching_script_proven_canary_pass(tmp_path: Path):
     state = prepared()
     resumed, proof_path = resumed_with_proof(tmp_path, state)
+    strict_probe, strict_verdict = strict_artifacts(tmp_path, resumed)
     confirmed = th.confirm_started(
         resumed,
         new_thread_id="new-thread",
@@ -612,6 +690,9 @@ def test_confirm_requires_matching_script_proven_canary_pass(tmp_path: Path):
         confirmed_by="tester",
         now=datetime(2026, 5, 30, 8, 3, tzinfo=UTC),
         canary_proof=proof_path,
+        strict_probe=strict_probe,
+        strict_verdict=strict_verdict,
+        state_root=tmp_path,
     )
     assert confirmed["replacement"]["status"] == "started"
     assert confirmed["cleanup"]["old_automation_ready_to_delete"] is True
@@ -634,6 +715,9 @@ def test_confirm_requires_matching_script_proven_canary_pass(tmp_path: Path):
             confirmed_by="tester",
             now=datetime(2026, 5, 30, 8, 3, tzinfo=UTC),
             canary_proof=wrong_proof,
+            strict_probe=strict_probe,
+            strict_verdict=strict_verdict,
+            state_root=tmp_path,
         )
 
 
@@ -674,8 +758,8 @@ def test_cli_requires_exact_rollover_and_reserved_canary_proof(tmp_path: Path, c
                 "--repo-root",
                 str(tmp_path),
                 "resume",
-                "--lineage-id",
-                prepared_payload["lineage_id"],
+                "--state-file",
+                prepared_payload["state_file"],
                 "--rollover-id",
                 prepared_payload["rollover_id"],
                 "--replacement-thread-id",
@@ -702,6 +786,8 @@ def test_cli_requires_exact_rollover_and_reserved_canary_proof(tmp_path: Path, c
         == 0
     )
     capsys.readouterr()
+    strict_probe, strict_verdict = strict_artifacts(tmp_path, state)
+    capsys.readouterr()
 
     assert (
         th.main(
@@ -717,6 +803,10 @@ def test_cli_requires_exact_rollover_and_reserved_canary_proof(tmp_path: Path, c
                 "new-thread",
                 "--canary-proof",
                 state["replacement"]["canary_proof_path"],
+                "--strict-probe",
+                str(strict_probe.relative_to(tmp_path)),
+                "--strict-verdict",
+                str(strict_verdict.relative_to(tmp_path)),
             ]
         )
         == 0
@@ -886,14 +976,17 @@ def test_confirmation_refuses_unresumed_and_identity_mismatched_rollovers(tmp_pa
             confirmed_by="tester",
             now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
             canary_proof=proof_path,
+            strict_probe=tmp_path / "strict-probe.json",
+            strict_verdict=tmp_path / "strict-verdict.json",
+            state_root=tmp_path,
         )
-
     resumed = th.resume_state(
         state,
         rollover_id=replacement["rollover_id"],
         replacement_thread_id="bound-thread",
         now=datetime(2026, 5, 30, 8, 1, tzinfo=UTC),
     )
+    strict_probe, strict_verdict = strict_artifacts(tmp_path, resumed)
     with pytest.raises(ValueError, match="does not match the thread"):
         th.confirm_started(
             resumed,
@@ -902,4 +995,262 @@ def test_confirmation_refuses_unresumed_and_identity_mismatched_rollovers(tmp_pa
             confirmed_by="tester",
             now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
             canary_proof=proof_path,
+            strict_probe=strict_probe,
+            strict_verdict=strict_verdict,
+            state_root=tmp_path,
         )
+
+
+def test_detect_is_structured_fail_closed_and_reports_reserved_packet_paths(tmp_path: Path, capsys, monkeypatch):
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "codex"]) == 0
+    assert json.loads(capsys.readouterr().out) == {"agent": "codex", "status": "none"}
+
+    assert th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", "old"]) == 0
+    prepared_payload = json.loads(capsys.readouterr().out)
+    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "codex"]) == 0
+    detected = json.loads(capsys.readouterr().out)
+    assert detected["lineage_id"] == prepared_payload["lineage_id"]
+    assert detected["rollover_id"] == prepared_payload["rollover_id"]
+    for key in (
+        "state_file",
+        "runtime_path",
+        "handoff_path",
+        "bootstrap_prompt_path",
+        "canary_challenge",
+        "canary_proof_path",
+        "semantic_snapshot_path",
+        "strict_probe_path",
+        "strict_questions_path",
+        "strict_answers_path",
+        "strict_verdict_path",
+    ):
+        assert detected[key]
+
+    state_path = tmp_path / detected["state_file"]
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["replacement"]["strict_probe_path"] = "forged.json"
+    th.write_json_atomic(state_path, state)
+    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "codex"]) == 2
+    assert "reserved packet path" in json.loads(capsys.readouterr().out)["error"]
+
+
+def test_detect_ignores_completed_started_rollovers_for_status_none(tmp_path: Path, capsys, monkeypatch):
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    assert (
+        th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", "old-thread"]) == 0
+    )
+    capsys.readouterr()
+
+    state_file = next((tmp_path / ".agent/thread-rollovers/codex").glob("*/lease.json"))
+    state = json.loads(state_file.read_text(encoding="utf-8"))
+    state["replacement"]["status"] = "started"
+    for key in (
+        "runtime_path",
+        "handoff_path",
+        "bootstrap_prompt_path",
+        "canary_challenge",
+        "canary_proof_path",
+        "semantic_snapshot_path",
+        "strict_probe_path",
+        "strict_questions_path",
+        "strict_answers_path",
+        "strict_verdict_path",
+    ):
+        state["replacement"].pop(key, None)
+    th.write_json_atomic(state_file, state)
+
+    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "codex"]) == 0
+    assert json.loads(capsys.readouterr().out) == {"agent": "codex", "status": "none"}
+
+
+@pytest.mark.parametrize("mutation", ["schema", "agent", "lineage", "rollover", "ambiguous"])
+def test_detect_rejects_bad_or_ambiguous_engine_leases(tmp_path: Path, capsys, monkeypatch, mutation: str):
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    for thread_id in ("old-a", "old-b") if mutation == "ambiguous" else ("old-a",):
+        assert (
+            th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", thread_id]) == 0
+        )
+        capsys.readouterr()
+    if mutation != "ambiguous":
+        state_path = next((tmp_path / ".agent/thread-rollovers/codex").glob("*/lease.json"))
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        if mutation == "schema":
+            state["schema_version"] = 9
+        elif mutation == "agent":
+            state["agent"] = "claude"
+        elif mutation == "lineage":
+            state["replacement"]["lineage_id"] = "lineage-other"
+        else:
+            state["replacement"]["rollover_id"] = "rollover-!!!"
+        th.write_json_atomic(state_path, state)
+    assert th.main(["--repo-root", str(tmp_path), "detect", "--agent", "codex"]) == 2
+
+
+def test_lifecycle_requires_strict_ten_of_ten_before_cleanup(tmp_path: Path, capsys, monkeypatch):
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    assert (
+        th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", "old-thread"]) == 0
+    )
+    packet = json.loads(capsys.readouterr().out)
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "detect",
+                "--agent",
+                "codex",
+                "--format",
+                "session-start",
+                "--current-thread-id",
+                "new-thread",
+            ]
+        )
+        == 0
+    )
+    startup = capsys.readouterr().out
+    assert "PENDING THREAD ROLLOVER DETECTED" in startup and "context_canary.py questions" in startup
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "resume",
+                "--agent",
+                "codex",
+                "--lineage-id",
+                packet["lineage_id"],
+                "--rollover-id",
+                packet["rollover_id"],
+                "--replacement-thread-id",
+                "new-thread",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    state_path = tmp_path / packet["state_file"]
+    resumed = json.loads(state_path.read_text(encoding="utf-8"))
+    strict_probe, strict_verdict = strict_artifacts(tmp_path, resumed)
+    questions = tmp_path / resumed["replacement"]["strict_questions_path"]
+    assert th.context_canary.main(["questions", "--probe", str(strict_probe), "--out", str(questions)]) == 0
+    assert all("a" not in item for item in json.loads(questions.read_text(encoding="utf-8"))["questions"])
+    proof = tmp_path / resumed["replacement"]["canary_proof_path"]
+    assert (
+        canary.main(
+            [
+                "--rollover-id",
+                packet["rollover_id"],
+                "--replacement-thread-id",
+                "new-thread",
+                "--challenge",
+                resumed["replacement"]["canary_challenge"],
+                "--proof-file",
+                str(proof),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "confirm-started",
+                "--agent",
+                "codex",
+                "--lineage-id",
+                packet["lineage_id"],
+                "--rollover-id",
+                packet["rollover_id"],
+                "--new-thread-id",
+                "new-thread",
+                "--canary-proof",
+                str(proof),
+                "--strict-probe",
+                str(strict_probe),
+                "--strict-verdict",
+                str(strict_verdict),
+            ]
+        )
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out)["old_automation_ready_to_delete"] is True
+
+
+def test_confirmation_rejects_nine_of_ten_and_wrong_reserved_paths(tmp_path: Path, capsys, monkeypatch):
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    assert (
+        th.main(["--repo-root", str(tmp_path), "prepare", "--agent", "codex", "--active-thread-id", "old-thread"]) == 0
+    )
+    packet = json.loads(capsys.readouterr().out)
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "resume",
+                "--agent",
+                "codex",
+                "--lineage-id",
+                packet["lineage_id"],
+                "--rollover-id",
+                packet["rollover_id"],
+                "--replacement-thread-id",
+                "new-thread",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    state_path = tmp_path / packet["state_file"]
+    resumed = json.loads(state_path.read_text(encoding="utf-8"))
+    strict_probe, strict_verdict = strict_artifacts(tmp_path, resumed)
+    verdict = json.loads(strict_verdict.read_text(encoding="utf-8"))
+    verdict["correct"] = 9
+    verdict["score"] = 0.9
+    verdict["verdict"] = "FAIL-HANDOFF"
+    verdict["per_anchor"][-1]["match"] = False
+    th.write_json_atomic(strict_verdict, verdict)
+    proof = tmp_path / resumed["replacement"]["canary_proof_path"]
+    assert (
+        canary.main(
+            [
+                "--rollover-id",
+                packet["rollover_id"],
+                "--replacement-thread-id",
+                "new-thread",
+                "--challenge",
+                resumed["replacement"]["canary_challenge"],
+                "--proof-file",
+                str(proof),
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    command = [
+        "--repo-root",
+        str(tmp_path),
+        "confirm-started",
+        "--agent",
+        "codex",
+        "--lineage-id",
+        packet["lineage_id"],
+        "--rollover-id",
+        packet["rollover_id"],
+        "--new-thread-id",
+        "new-thread",
+        "--canary-proof",
+        str(proof),
+        "--strict-probe",
+        str(strict_probe),
+        "--strict-verdict",
+        str(strict_verdict),
+    ]
+    assert th.main(command) == 2
+    assert json.loads(state_path.read_text(encoding="utf-8"))["cleanup"]["old_automation_ready_to_delete"] is False
+    assert th.main([*command[:-2], "--strict-probe", "wrong.json", "--strict-verdict", str(strict_verdict)]) == 2
+    assert json.loads(state_path.read_text(encoding="utf-8"))["cleanup"]["old_automation_ready_to_delete"] is False

--- a/tests/test_session_setup_hook.py
+++ b/tests/test_session_setup_hook.py
@@ -33,7 +33,7 @@ def test_session_setup_hook_handoff_fixtures() -> None:
     assert result.returncode == 0, (
         f"hook fixtures failed (rc={result.returncode})\n"
         f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
-        )
+    )
     assert "ok - session setup hook handoff fixtures passed" in result.stdout
 
 
@@ -95,9 +95,16 @@ def test_session_setup_drift_fp_regression(tmp_path: Path) -> None:
     hook_path = _REPO_ROOT / "agents_extensions" / "shared" / "hooks" / "session-setup.sh"
 
     # Environment variables
+    isolated_home = tmp_path / "home"
     env = {
         "CLAUDE_PROJECT_DIR": str(project_dir),
         "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS": "32000",
+        "HOME": str(isolated_home),
+        "XDG_CONFIG_HOME": str(tmp_path / "xdg-config"),
+        "XDG_CACHE_HOME": str(tmp_path / "xdg-cache"),
+        "XDG_DATA_HOME": str(tmp_path / "xdg-data"),
+        "XDG_STATE_HOME": str(tmp_path / "xdg-state"),
+        "GH_CONFIG_DIR": str(tmp_path / "gh-config"),
         "PATH": f"{venv_bin}:{os.environ.get('PATH', '')}",
     }
 


### PR DESCRIPTION
Fixes #5058
Parent epic: #5054
Stream epic: #4707

## Summary

- add the canonical `thread-rollover` skill and wire Codex orchestrator startup to engine-owned rollover detection
- keep SessionStart fail-closed and legacy-compatible only when no live v2 lease exists
- keep PostCompact local and read-only
- preserve canonical rollover state across detached launcher worktrees
- require reserved challenge proof plus a closed strict-production 10/10 probe/verdict before cleanup unlocks
- update orchestrator definitions and workflow guidance

## Scope

15 directly related files; no generated audit/status/review/telemetry artifacts and no protected config changes.

## Verification

- `99 passed` across the focused six-file Python suite
- `bash scripts/audit/test_handoff_identity.sh`
- `bash scripts/audit/test_session_setup_hook.sh`
- Ruff check and format check
- shell syntax checks
- canonical skill validation
- `git diff --check`
- agent trailer lint for both commits
- forbidden-path and `sys.executable`/skip scans

## Independent review

Fable (`claude-fable-5`, read-only cross-family gate) reviewed exact head `dfdd1032c18d1a77e2cf03a8ecaece1770b22d54`. The first review found and reproduced a forged-probe cleanup bypass. The follow-up commit extracted one closed production-probe validator shared by scoring and confirmation, added four regression cases, and bound verdict seed/SHA/IDs. Fable then replayed the original attack and a mutation battery; all failed closed, the positive pipeline passed, and the final disposition was **PASS**.
