### PR TITLE
fix(site): preserve numeric timecodes in MDX

### DIFF
--- a/site/plugins/remark-admonitions.mjs
+++ b/site/plugins/remark-admonitions.mjs
@@ -10,6 +10,23 @@ const DEFAULT_TITLES = {
   danger: 'Небезпека',
   warning: 'Застереження',
 };
+const TIMECODE_TEXT_DIRECTIVE_RE = /^\d+$/;
+
+function isNumericTextDirective(node) {
+  return node?.type === 'textDirective' && TIMECODE_TEXT_DIRECTIVE_RE.test(node.name || '');
+}
+
+function hasNoChildren(node) {
+  return !Array.isArray(node.children) || node.children.length === 0;
+}
+
+function hasNoAttributes(node) {
+  return !node.attributes || Object.keys(node.attributes).length === 0;
+}
+
+function isPlainNumericTimecodeSuffix(node) {
+  return isNumericTextDirective(node) && hasNoChildren(node) && hasNoAttributes(node);
+}
 
 function visit(node, callback) {
   if (!node || typeof node !== 'object') return;
@@ -43,6 +60,21 @@ function splitLabel(children) {
   };
 }
 
+function normalizeNumericTextDirectives(tree) {
+  visit(tree, (node) => {
+    if (!isPlainNumericTimecodeSuffix(node)) return;
+
+    // Convert accidental numeric directives like ":57" back into literal text.
+    // Keep real admonition/other non-numeric directives intact.
+    const value = `:${node.name}`;
+    node.type = 'text';
+    node.value = value;
+    delete node.name;
+    delete node.children;
+    delete node.attributes;
+  });
+}
+
 function titleNode(name, label) {
   const hasLabel = label && nodeText(label).trim().length > 0;
 
@@ -61,6 +93,8 @@ function titleNode(name, label) {
 
 export default function remarkAdmonitions() {
   return function transformAdmonitions(tree) {
+    normalizeNumericTextDirectives(tree);
+
     visit(tree, (node) => {
       if (node.type !== 'containerDirective' || !ADMONITION_TYPES.has(node.name)) return;
 

--- a/site/tests/unit/remark-admonitions.test.ts
+++ b/site/tests/unit/remark-admonitions.test.ts
@@ -19,6 +19,33 @@ async function renderMarkdown(source: string): Promise<string> {
   return String(file);
 }
 
+async function parseMarkdown(source: string) {
+  const processor = unified().use(remarkParse).use(remarkDirective).use(remarkAdmonitions);
+  const tree = processor.parse(source);
+  return processor.run(tree);
+}
+
+interface DirectiveNode {
+  type?: string;
+  name?: string;
+  children?: unknown[];
+  attributes?: Record<string, string | null> | null;
+}
+
+function collectTextDirectives(node: unknown, acc: DirectiveNode[] = []): DirectiveNode[] {
+  if (!node || typeof node !== 'object') return acc;
+
+  const candidate = node as DirectiveNode;
+  if (candidate.type === 'textDirective') acc.push(candidate);
+
+  const children = candidate.children;
+  if (Array.isArray(children)) {
+    for (const child of children) collectTextDirectives(child, acc);
+  }
+
+  return acc;
+}
+
 describe('remark admonitions', () => {
   it('renders a labelled info directive as an aside with title and markdown body', async () => {
     const html = await renderMarkdown(':::info[Title]\nBody with **bold**.\n:::\n');
@@ -36,5 +63,48 @@ describe('remark admonitions', () => {
     expect(html).toContain('<p class="admonition-title">Порада</p>');
     expect(html).toContain('<p>Keep going.</p>');
     expect(html).not.toContain('::::tip');
+  });
+
+  it('keeps mm:ss and h:mm:ss timecodes as literal text', async () => {
+    const html = await renderMarkdown('від 28:57 до 32:47, а «Два кольори» — від 1:03:15 до 1:07:29');
+
+    expect(html).toContain('28:57');
+    expect(html).toContain('32:47');
+    expect(html).toContain('1:03:15');
+    expect(html).toContain('1:07:29');
+
+    expect(html).not.toContain('<div></div>');
+    expect(html).not.toContain('</p><p>');
+    expect(html).toContain('<p>від 28:57 до 32:47, а «Два кольори» — від 1:03:15 до 1:07:29</p>');
+  });
+
+  it('keeps numeric directive-like suffixes literal after formatted text', async () => {
+    const html = await renderMarkdown('**1**:03');
+
+    expect(html).toContain('<p><strong>1</strong>:03</p>');
+    expect(html).not.toContain('<div></div>');
+  });
+
+  it('keeps standalone numeric directive-like text literal', async () => {
+    const html = await renderMarkdown('word :57');
+
+    expect(html).toContain('<p>word :57</p>');
+    expect(html).not.toContain('<div></div>');
+  });
+
+  it('preserves explicit numeric text directive labels and attributes', async () => {
+    const labeled = await parseMarkdown('x 2:123[label]');
+    const labeledDirectives = collectTextDirectives(labeled);
+    const labeledDirective = labeledDirectives.find((node) => node.name === '123');
+
+    expect(labeledDirective).toBeDefined();
+    expect((labeledDirective?.children ?? []).length).toBeGreaterThan(0);
+
+    const attributed = await parseMarkdown('x 2:123{key=value}');
+    const attributedDirective = collectTextDirectives(attributed).find((node) => node.name === '123');
+
+    expect(attributedDirective).toBeDefined();
+    expect(attributedDirective?.attributes).toBeDefined();
+    expect(Object.keys(attributedDirective?.attributes ?? {}).length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

- normalize empty numeric `textDirective` nodes back to literal text before the admonition transform
- preserve intentional numeric directives that carry labels or attributes
- cover the exact Oleksandr Bilash `mm:ss` and `h:mm:ss` regression plus formatted and standalone edge cases

## Root cause and impact

`remark-directive` interpreted numeric timecode suffixes such as `:57` and `:15` as directives. The downstream MDX transform rendered those empty directives as `<div></div>`, splitting the visible sentence on the Bilash page. The normalization keeps the timecodes as inline text without broadening or weakening real directive handling.

## Verification

- `npx vitest run tests/unit/remark-admonitions.test.ts tests/unit/build-renders.test.ts` — 11 passed
- `.venv/bin/python -m pytest tests/test_dispatch.py -q` — 27 passed (repository pre-push gate)
- `npx astro build` — 8,973 pages built
- production HTML contains `від 28:57 до 32:47, а «Два кольори» — від 1:03:15 до 1:07:29` and has no matching empty-div/paragraph-split artifacts
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- `git diff --check` — passed

## Review gate

- local cross-model review findings were adjudicated and resolved before commit
- independent Grok release review validated the AST behavior, source positions, edge cases, production build, and scope; its sole finding was to remove two build-generated search-index files, which were restored before commit
- DeepSeek was attempted first but timed out during startup; Grok was used as the documented cross-family fallback
