### PR TITLE
test(orchestration): prove fresh thread restart lifecycle

### DIFF
--- a/agents_extensions/shared/hooks/session-setup.sh
+++ b/agents_extensions/shared/hooks/session-setup.sh
@@ -313,7 +313,17 @@ else
     HANDOFF_AGENT="claude"
 fi
 
-CANONICAL_ROOT="${CODEX_CANONICAL_REPO_ROOT:-$PROJECT_DIR}"
+if [ -n "${CODEX_CANONICAL_REPO_ROOT:-}" ]; then
+  CANONICAL_ROOT="$CODEX_CANONICAL_REPO_ROOT"
+else
+  GIT_COMMON_DIR=$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+  if [ -n "$GIT_COMMON_DIR" ] && [ "$(basename "$GIT_COMMON_DIR")" = ".git" ]; then
+    CANONICAL_ROOT=$(dirname "$GIT_COMMON_DIR")
+  else
+    # Non-Git fixtures and partially initialized checkouts remain isolated.
+    CANONICAL_ROOT="$PROJECT_DIR"
+  fi
+fi
 CURRENT_THREAD_ID="${CODEX_THREAD_ID:-${CODEX_SESSION_ID:-}}"
 ROLLOVER_PYTHON="${THREAD_ROLLOVER_PYTHON:-$PROJECT_DIR/.venv/bin/python}"
 ROLLOVER_SCRIPT="${THREAD_ROLLOVER_SCRIPT:-$PROJECT_DIR/scripts/orchestration/thread_handoff.py}"

--- a/docs/best-practices/codex-thread-handoff.md
+++ b/docs/best-practices/codex-thread-handoff.md
@@ -230,6 +230,8 @@ evidence="/tmp/rollover-smoke-$(date +%Y%m%dT%H%M%S)"
 mkdir -p "$evidence"
 cd "$canonical"
 npm run agents:deploy | tee "$evidence/canonical-deploy.txt"
+test -z "$(git status --porcelain)"
+source_head=$(git rev-parse HEAD)
 .venv/bin/python scripts/orchestration/thread_handoff.py prepare \
   --agent codex \
   --active-thread-id <predecessor-task-id> \
@@ -259,6 +261,8 @@ test -f "$fresh/.codex/hooks.json"
 test -x "$fresh/.codex/hooks/session-setup.sh"
 test "$(readlink "$fresh/.agent/thread-rollovers")" = \
   "$canonical/.agent/thread-rollovers"
+test "$(git -C "$fresh" rev-parse HEAD)" = "$source_head"
+test -z "$(git -C "$fresh" status --porcelain)"
 ```
 
 For this smoke, do not pre-export `CODEX_CANONICAL_REPO_ROOT`. The reopened
@@ -310,6 +314,8 @@ challenge=$(jq -r .replacement.canary_challenge "$lease")
   --challenge "$challenge" \
   --proof-file "$canonical/$proof_rel" \
   | tee "$evidence/canary.json"
+test "$(git rev-parse HEAD)" = "$source_head"
+test -z "$(git status --porcelain)"
 .venv/bin/python scripts/orchestration/thread_handoff.py confirm-started \
   --agent codex \
   --lineage-id "$lineage_id" \
@@ -326,7 +332,9 @@ fresh task id differs from the predecessor, and `confirm.json` says
 `"old_automation_ready_to_delete": true`. Keep all captured evidence under
 `/tmp/rollover-smoke-*`; the packet itself stays under gitignored
 `.agent/thread-rollovers/`. Delete or pause the predecessor automation only
-after all four checks pass.
+after all four checks pass. `prepare`, `resume`, and `confirm-started` fail
+closed if their invoking checkout is dirty, is at a different HEAD, or if a
+live pending/resumed lease lacks the source-checkout binding.
 
 ## Worker Run Inbox
 

--- a/docs/best-practices/codex-thread-handoff.md
+++ b/docs/best-practices/codex-thread-handoff.md
@@ -212,6 +212,122 @@ Dry-run without writing files:
 .venv/bin/python scripts/orchestration/thread_handoff.py prepare --agent codex --dry-run
 ```
 
+## Fresh Codex App Task/Restart Smoke
+
+The repository E2E suite exercises the process, hook, and real-worktree seams,
+but it cannot create a Codex app task. Run this smoke from the app before
+calling a restart change accepted. A fresh replacement is a new task identity;
+do not fork, continue, or run `codex exec resume` on provider conversation
+history.
+
+Before opening the fresh project task, deploy the canonical checkout and
+prepare the packet:
+
+```bash
+set -euo pipefail
+canonical=$(git rev-parse --show-toplevel)
+evidence="/tmp/rollover-smoke-$(date +%Y%m%dT%H%M%S)"
+mkdir -p "$evidence"
+cd "$canonical"
+npm run agents:deploy | tee "$evidence/canonical-deploy.txt"
+.venv/bin/python scripts/orchestration/thread_handoff.py prepare \
+  --agent codex \
+  --active-thread-id <predecessor-task-id> \
+  --active-automation-id <predecessor-automation-id> \
+  | tee "$evidence/prepare.json"
+lineage_id=$(jq -r .lineage_id "$evidence/prepare.json")
+rollover_id=$(jq -r .rollover_id "$evidence/prepare.json")
+lease_rel=$(jq -r .state_file "$evidence/prepare.json")
+lease="$canonical/$lease_rel"
+```
+
+Create one genuinely fresh Codex app project task and record its new task id
+and app-created worktree path. If the app supports a worktree setup command,
+configure the bootstrap helper below to run before the task first opens. If it
+does not, the first SessionStart is not acceptance evidence: run the helper,
+close the new task, and reopen/restart that same fresh task so the deployed
+SessionStart hook actually runs.
+
+```bash
+fresh=<absolute-app-worktree-path>
+replacement_task_id=<fresh-task-id>
+bash "$fresh/scripts/lib/thread_rollover_link.sh" "$canonical" "$fresh" \
+  | tee "$evidence/fresh-bootstrap.txt"
+git -C "$canonical" worktree list | tee "$evidence/worktrees.txt"
+readlink "$fresh/.agent/thread-rollovers" | tee "$evidence/rollover-link.txt"
+test -f "$fresh/.codex/hooks.json"
+test -x "$fresh/.codex/hooks/session-setup.sh"
+test "$(readlink "$fresh/.agent/thread-rollovers")" = \
+  "$canonical/.agent/thread-rollovers"
+```
+
+For this smoke, do not pre-export `CODEX_CANONICAL_REPO_ROOT`. The reopened
+task's automatic SessionStart output must name the prepared `lineage_id` and
+`rollover_id` and show `PENDING THREAD ROLLOVER DETECTED`. Then, from the fresh
+worktree, claim only that packet:
+
+```bash
+cd "$fresh"
+.venv/bin/python scripts/orchestration/thread_handoff.py resume \
+  --agent codex \
+  --lineage-id "$lineage_id" \
+  --rollover-id "$rollover_id" \
+  --replacement-thread-id "$replacement_task_id" \
+  | tee "$evidence/resume.json"
+```
+
+Read the packet and durable role handoff named by SessionStart. Write the ten
+truthful semantic anchors to the lease's reserved snapshot path. Answer the
+generated questions from restored context; do not read the answer-bearing
+probe to manufacture recall answers.
+
+```bash
+snapshot_rel=$(jq -r .replacement.semantic_snapshot_path "$lease")
+probe_rel=$(jq -r .replacement.strict_probe_path "$lease")
+questions_rel=$(jq -r .replacement.strict_questions_path "$lease")
+answers_rel=$(jq -r .replacement.strict_answers_path "$lease")
+verdict_rel=$(jq -r .replacement.strict_verdict_path "$lease")
+proof_rel=$(jq -r .replacement.canary_proof_path "$lease")
+challenge=$(jq -r .replacement.canary_challenge "$lease")
+
+# The fresh task writes "$canonical/$snapshot_rel" from the restored packet.
+.venv/bin/python scripts/context_canary.py mint \
+  --snapshot "$canonical/$snapshot_rel" --out "$canonical/$probe_rel"
+.venv/bin/python scripts/context_canary.py questions \
+  --probe "$canonical/$probe_rel" --out "$canonical/$questions_rel"
+# The fresh task now writes {"<question-id>": "<recalled-answer>"} to
+# "$canonical/$answers_rel" without opening the probe.
+.venv/bin/python scripts/context_canary.py score \
+  --probe "$canonical/$probe_rel" \
+  --answers "$canonical/$answers_rel" \
+  --expected-lineage-id "$lineage_id" \
+  --expected-rollover-id "$rollover_id" \
+  --verdict "$canonical/$verdict_rel" \
+  | tee "$evidence/strict-score.txt"
+.venv/bin/python scripts/orchestration/thread_handoff_canary.py \
+  --rollover-id "$rollover_id" \
+  --replacement-thread-id "$replacement_task_id" \
+  --challenge "$challenge" \
+  --proof-file "$canonical/$proof_rel" \
+  | tee "$evidence/canary.json"
+.venv/bin/python scripts/orchestration/thread_handoff.py confirm-started \
+  --agent codex \
+  --lineage-id "$lineage_id" \
+  --rollover-id "$rollover_id" \
+  --new-thread-id "$replacement_task_id" \
+  --canary-proof "$canonical/$proof_rel" \
+  --strict-probe "$canonical/$probe_rel" \
+  --strict-verdict "$canonical/$verdict_rel" \
+  | tee "$evidence/confirm.json"
+```
+
+The smoke passes only when the score says `10/10`, the canary says `PASS`, the
+fresh task id differs from the predecessor, and `confirm.json` says
+`"old_automation_ready_to_delete": true`. Keep all captured evidence under
+`/tmp/rollover-smoke-*`; the packet itself stays under gitignored
+`.agent/thread-rollovers/`. Delete or pause the predecessor automation only
+after all four checks pass.
+
 ## Worker Run Inbox
 
 Use `scripts/orchestration/orchestrator_control.py` when worker dispatch state

--- a/scripts/audit/test_deploy_extensions.sh
+++ b/scripts/audit/test_deploy_extensions.sh
@@ -74,7 +74,7 @@ out="$(deploy_agent_extensions "$WORK_DIR/empty" agents:deploy)" \
 contains "$out" "not found" "missing package.json warns instead of failing"
 
 # --- launchers actually use the helper (regression guard on the wiring) ---
-for launcher in start-claude.sh start-codex.sh; do
+for launcher in start-claude.sh; do
   grep -q 'deploy_extensions.sh' "$REPO_ROOT/$launcher" \
     || fail "$launcher no longer sources deploy_extensions.sh"
   grep -q 'deploy_agent_extensions' "$REPO_ROOT/$launcher" \
@@ -85,5 +85,10 @@ for launcher in start-claude.sh start-codex.sh; do
     fail "$launcher reintroduced a fail-silent npm deploy"
   fi
 done
+
+grep -q 'thread_rollover_link.sh' "$REPO_ROOT/start-codex.sh" \
+  || fail "start-codex.sh no longer sources the Codex checkout bootstrap"
+grep -q 'bootstrap_codex_checkout' "$REPO_ROOT/start-codex.sh" \
+  || fail "start-codex.sh no longer bootstraps the target checkout"
 
 echo "ok - deploy extensions fixtures passed"

--- a/scripts/audit/test_session_setup_hook.sh
+++ b/scripts/audit/test_session_setup_hook.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_COMMON_DIR GIT_DIR GIT_INDEX_FILE
+unset GIT_OBJECT_DIRECTORY GIT_PREFIX GIT_WORK_TREE
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 HOOK="$REPO_ROOT/agents_extensions/shared/hooks/session-setup.sh"
 POST_COMPACT_HOOK="$REPO_ROOT/agents_extensions/shared/hooks/post-compact.sh"
@@ -44,7 +47,7 @@ setup_fixture() {
   local root="$1"
 
   rm -rf "$root"
-  mkdir -p "$root/docs/session-state" "$root/.venv/bin" "$root/.mcp/servers/message-broker" "$TMP_ROOT/home" "$root/.git"
+  mkdir -p "$root/docs/session-state" "$root/.venv/bin" "$root/.mcp/servers/message-broker" "$TMP_ROOT/home"
   # Dispatching stub: most tests just need a python-version banner, but the
   # strict-adoption-gate fixtures (below) need a controllable
   # `check_research_registry.py --strict-adoption` response without a real
@@ -61,6 +64,13 @@ PYEOF
   chmod +x "$root/.venv/bin/python"
   mkdir -p "$root/scripts/orchestration"
   touch "$root/scripts/orchestration/thread_handoff.py"
+  git -C "$root" init -q
+  git -C "$root" config user.email "session-setup@example.invalid"
+  git -C "$root" config user.name "Session Setup Fixture"
+  printf 'fixture\n' > "$root/.git-fixture"
+  git -C "$root" add .git-fixture
+  git -C "$root" -c commit.gpgsign=false commit -q -m "fixture"
+  printf '*\n' > "$root/.git/info/exclude"
 }
 
 run_hook() {

--- a/scripts/lib/thread_rollover_link.sh
+++ b/scripts/lib/thread_rollover_link.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
-# Canonical thread-rollover state is shared deliberately across linked worktrees.
+# Bootstrap Codex checkouts without copying provider history or the .agent tree.
 
 ensure_thread_rollover_link() {
   local canonical_root="$1"
   local worktree_root="$2"
   local source="$canonical_root/.agent/thread-rollovers"
   local target="$worktree_root/.agent/thread-rollovers"
+
+  if [ "$canonical_root" = "$worktree_root" ]; then
+    mkdir -p "$source"
+    return 0
+  fi
 
   mkdir -p "$source" "$worktree_root/.agent"
   if [ -L "$target" ]; then
@@ -21,3 +26,65 @@ ensure_thread_rollover_link() {
   fi
   ln -s "$source" "$target"
 }
+
+ensure_codex_venv_link() {
+  local canonical_root="$1"
+  local worktree_root="$2"
+  local source="$canonical_root/.venv"
+  local target="$worktree_root/.venv"
+
+  if [ "$canonical_root" = "$worktree_root" ]; then
+    return 0
+  fi
+  if [ -L "$target" ]; then
+    if [ "$(readlink "$target")" != "$source" ]; then
+      printf 'Error: virtualenv symlink at %s points somewhere other than %s.\n' "$target" "$source" >&2
+      return 1
+    fi
+    return 0
+  fi
+  if [ -e "$target" ]; then
+    return 0
+  fi
+  if [ ! -d "$source" ]; then
+    printf 'Error: canonical virtualenv not found at %s.\n' "$source" >&2
+    return 1
+  fi
+  ln -s "$source" "$target"
+}
+
+bootstrap_codex_checkout() {
+  local canonical_root="$1"
+  local worktree_root="$2"
+  local deploy_failure_policy="${3:-fail}"
+  local deploy_helper="$worktree_root/scripts/lib/deploy_extensions.sh"
+
+  ensure_codex_venv_link "$canonical_root" "$worktree_root" || return 1
+  ensure_thread_rollover_link "$canonical_root" "$worktree_root" || return 1
+
+  if [ ! -f "$deploy_helper" ]; then
+    printf 'Error: Codex deploy helper not found at %s.\n' "$deploy_helper" >&2
+    return 1
+  fi
+  # shellcheck disable=SC1090
+  source "$deploy_helper"
+  local deploy_exit=0
+  deploy_agent_extensions "$worktree_root" agents:deploy || deploy_exit=$?
+  if [ "$deploy_exit" -eq 0 ]; then
+    return 0
+  fi
+
+  if [ "$deploy_failure_policy" = "continue" ]; then
+    echo "Continuing launch despite deploy failure (see banner above)."
+    return 0
+  fi
+  return "$deploy_exit"
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  if [ "$#" -ne 2 ]; then
+    echo "Usage: bash scripts/lib/thread_rollover_link.sh <canonical-repo-root> <checkout-root>" >&2
+    exit 2
+  fi
+  bootstrap_codex_checkout "$1" "$2"
+fi

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -423,8 +423,7 @@ def source_checkout_binding(git_state: Mapping[str, Any]) -> dict[str, Any]:
         raise ValueError("source checkout status could not be determined")
     if modified_files:
         paths = ", ".join(
-            str(item.get("path") or "unknown") if isinstance(item, dict) else "unknown"
-            for item in modified_files[:5]
+            str(item.get("path") or "unknown") if isinstance(item, dict) else "unknown" for item in modified_files[:5]
         )
         raise ValueError(f"source checkout must be clean before prepare; dirty paths: {paths}")
     return {"full_head": full_head, "clean": True}
@@ -444,9 +443,7 @@ def source_checkout_binding_error(replacement: Mapping[str, Any]) -> str | None:
     return None
 
 
-def checkout_continuity_error(
-    replacement: Mapping[str, Any], current_git_state: Mapping[str, Any]
-) -> str | None:
+def checkout_continuity_error(replacement: Mapping[str, Any], current_git_state: Mapping[str, Any]) -> str | None:
     binding_error = source_checkout_binding_error(replacement)
     if binding_error:
         return binding_error
@@ -461,8 +458,7 @@ def checkout_continuity_error(
         return "invoking checkout status could not be determined"
     if modified_files:
         paths = ", ".join(
-            str(item.get("path") or "unknown") if isinstance(item, dict) else "unknown"
-            for item in modified_files[:5]
+            str(item.get("path") or "unknown") if isinstance(item, dict) else "unknown" for item in modified_files[:5]
         )
         return f"invoking checkout must be clean; dirty paths: {paths}"
     return None

--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -353,10 +353,21 @@ def parse_status(raw: str) -> list[dict[str, str]]:
     for line in raw.splitlines():
         if not line:
             continue
+        if len(line) > 2 and line[2] == " ":
+            status = line[:2].strip() or line[:2]
+            path = line[3:]
+        elif len(line) > 1 and line[1] == " ":
+            # run_command strips the porcelain line's leading worktree-status
+            # column when the index is clean (for example `` M file``).
+            status = line[0]
+            path = line[2:]
+        else:
+            status = line[:2].strip() or line[:2]
+            path = line[3:] if len(line) > 3 else ""
         files.append(
             {
-                "status": line[:2].strip() or line[:2],
-                "path": line[3:] if len(line) > 3 else "",
+                "status": status,
+                "path": path,
             }
         )
     return files
@@ -395,6 +406,72 @@ def gather_git_state(repo_root: Path) -> dict[str, Any]:
         "last_commits": parse_git_log(git_output(repo_root, "log", "-5", "--pretty=format:%h%x09%s")),
         "modified_files": parse_status(git_output(repo_root, "status", "--short")),
     }
+
+
+def source_checkout_binding(git_state: Mapping[str, Any]) -> dict[str, Any]:
+    """Bind a rollover to one clean source revision.
+
+    ``git status --short`` includes tracked and untracked files but excludes
+    ignored runtime state, which is exactly the continuity boundary required
+    for local rollover packets.
+    """
+    full_head = git_state.get("full_head")
+    modified_files = git_state.get("modified_files")
+    if not isinstance(full_head, str) or not full_head.strip():
+        raise ValueError("source checkout HEAD could not be determined")
+    if not isinstance(modified_files, list):
+        raise ValueError("source checkout status could not be determined")
+    if modified_files:
+        paths = ", ".join(
+            str(item.get("path") or "unknown") if isinstance(item, dict) else "unknown"
+            for item in modified_files[:5]
+        )
+        raise ValueError(f"source checkout must be clean before prepare; dirty paths: {paths}")
+    return {"full_head": full_head, "clean": True}
+
+
+def source_checkout_binding_error(replacement: Mapping[str, Any]) -> str | None:
+    binding = replacement.get("source_checkout")
+    if not isinstance(binding, dict):
+        return "live rollover is missing its source checkout binding"
+    if set(binding) != {"full_head", "clean"}:
+        return "live rollover source checkout binding is malformed"
+    if binding.get("clean") is not True:
+        return "live rollover source checkout binding is not clean"
+    full_head = binding.get("full_head")
+    if not isinstance(full_head, str) or not full_head.strip():
+        return "live rollover source checkout HEAD is malformed"
+    return None
+
+
+def checkout_continuity_error(
+    replacement: Mapping[str, Any], current_git_state: Mapping[str, Any]
+) -> str | None:
+    binding_error = source_checkout_binding_error(replacement)
+    if binding_error:
+        return binding_error
+    current_head = current_git_state.get("full_head")
+    if not isinstance(current_head, str) or not current_head.strip():
+        return "invoking checkout HEAD could not be determined"
+    expected_head = replacement["source_checkout"]["full_head"]
+    if current_head != expected_head:
+        return f"invoking checkout HEAD {current_head} does not match prepared HEAD {expected_head}"
+    modified_files = current_git_state.get("modified_files")
+    if not isinstance(modified_files, list):
+        return "invoking checkout status could not be determined"
+    if modified_files:
+        paths = ", ".join(
+            str(item.get("path") or "unknown") if isinstance(item, dict) else "unknown"
+            for item in modified_files[:5]
+        )
+        return f"invoking checkout must be clean; dirty paths: {paths}"
+    return None
+
+
+def require_checkout_continuity(replacement: Mapping[str, Any], repo_root: Path) -> None:
+    error = checkout_continuity_error(replacement, gather_git_state(repo_root))
+    if error:
+        raise ValueError(f"checkout continuity failed: {error}")
 
 
 def gather_monitor_state(base_url: str) -> dict[str, Any]:
@@ -681,6 +758,9 @@ def validate_live_lease(
     ):
         return None, "resumed replacement has no valid replacement thread identity"
     if replacement.get("status") in {"pending_start", "resumed"}:
+        binding_error = source_checkout_binding_error(replacement)
+        if binding_error:
+            return None, binding_error
         expected_paths = replacement_packet_paths(agent, lineage_id, generation, rollover_id)
         for key, expected in expected_paths.items():
             if replacement.get(key) != expected:
@@ -1009,6 +1089,7 @@ def render_bootstrap_prompt(
                 "",
                 "Rules:",
                 "- Continue from the durable packet exactly; do not fork, continue, or resume provider conversation history.",
+                f"- Keep the invoking checkout clean at prepared HEAD {replacement.get('source_checkout', {}).get('full_head', 'unknown')} through resume and confirmation.",
                 "- Keep the main checkout read-only; thread rollover state belongs in gitignored .agent/ files.",
                 "- Use dispatch worktrees for implementation work: .worktrees/dispatch/<agent>/<task>/.",
                 "- Do not edit generated status/audit/review artifacts, linter configs, or .python-version.",
@@ -1104,6 +1185,7 @@ def render_current_markdown(
         f"- Replacement runtime path: `{replacement.get('runtime_path', 'unknown')}`",
         f"- Replacement status: `{replacement.get('status', 'unknown')}`",
         f"- Replacement thread id: `{replacement.get('thread_id') or 'not-confirmed'}`",
+        f"- Source checkout HEAD: `{replacement.get('source_checkout', {}).get('full_head', 'unknown')}`",
         f"- Old automation ready to delete: `{cleanup.get('old_automation_ready_to_delete', False)}`",
         f"- Bootstrap prompt: `{prompt_path}`",
         f"- Durable role handoff: `{role_handoff}`",
@@ -1409,6 +1491,23 @@ def cmd_prepare(args: argparse.Namespace) -> int:
     bootstrap_path = repo_local_path(state_root, Path(replacement["bootstrap_prompt_path"]))
     handoff_path = repo_local_path(state_root, Path(replacement["handoff_path"]))
     snapshot = gather_snapshot(repo_root, args.monitor_base_url)
+    # Recompute after the slower Monitor/GitHub reads so the lease binds the
+    # checkout as close as possible to the atomic packet write below.
+    snapshot["git"] = gather_git_state(repo_root)
+    try:
+        replacement["source_checkout"] = source_checkout_binding(snapshot["git"])
+    except ValueError as exc:
+        print(
+            json.dumps(
+                {
+                    "error": f"checkout continuity failed: {exc}",
+                    "state_file": rel(state_path, state_root),
+                    "old_automation_ready_to_delete": False,
+                },
+                indent=2,
+            )
+        )
+        return 2
     prompt = render_bootstrap_prompt(
         snapshot,
         prepared_state,
@@ -1527,6 +1626,11 @@ def cmd_confirm_started(args: argparse.Namespace) -> int:
     if args.rollover_id != replacement.get("rollover_id"):
         print(json.dumps({"error": "--rollover-id does not match the isolated pending rollover"}, indent=2))
         return 2
+    try:
+        require_checkout_continuity(replacement, repo_root)
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc)}, indent=2))
+        return 2
     expected_proof = repo_local_path(state_root, Path(state["replacement"]["canary_proof_path"]))
     try:
         supplied_proof = repo_local_path(state_root, args.canary_proof)
@@ -1597,6 +1701,11 @@ def cmd_resume(args: argparse.Namespace) -> int:
     state_error = state_error_payload(state, state_path, state_root)
     if state_error:
         print(json.dumps(state_error, indent=2))
+        return 2
+    try:
+        require_checkout_continuity(state.get("replacement") or {}, repo_root)
+    except ValueError as exc:
+        print(json.dumps({"error": str(exc), "state_file": rel(state_path, state_root)}, indent=2))
         return 2
     try:
         resumed = resume_state(

--- a/start-codex.sh
+++ b/start-codex.sh
@@ -130,12 +130,6 @@ if [ "$CODEX_TARGET" = "worktree" ]; then
         echo "Worktree updated to latest."
     fi
 
-    # Symlink .venv into the worktree so Codex has the same Python env
-    if [ ! -e "$WORKTREE_DIR/.venv" ]; then
-        ln -s "$PROJECT_DIR/.venv" "$WORKTREE_DIR/.venv"
-        echo "Symlinked .venv into worktree"
-    fi
-
     # Symlink node_modules so npm/vitest work
     if [ -d "$PROJECT_DIR/site/node_modules" ] && [ ! -e "$WORKTREE_DIR/site/node_modules" ]; then
         mkdir -p "$WORKTREE_DIR/site"
@@ -149,22 +143,15 @@ if [ "$CODEX_TARGET" = "worktree" ]; then
         echo "Symlinked data/ into worktree"
     fi
 
-    # Bridge only the canonical rollover directory, never the whole .agent tree.
-    ensure_thread_rollover_link "$PROJECT_DIR" "$WORKTREE_DIR"
-    echo "Verified .agent/thread-rollovers canonical bridge"
-
     TARGET_DIR="$WORKTREE_DIR"
 fi
 
-# Deploy shared agent extensions into ignored runtime dirs for the checkout
-# Codex will actually use. This keeps .codex/.agents generated while
-# agents_extensions/ remains the tracked source of truth. Fail-honest: a
-# failing deploy prints a loud banner + the real output instead of the old
-# silent `|| true` that claimed success over stale deploy targets.
-# shellcheck source=scripts/lib/deploy_extensions.sh
-source "$PROJECT_DIR/scripts/lib/deploy_extensions.sh"
-deploy_agent_extensions "$TARGET_DIR" agents:deploy \
-    || echo "Continuing launch despite deploy failure (see banner above)."
+# Bootstrap the checkout Codex will actually use. The helper shares only the
+# canonical virtualenv and gitignored rollover directory, then deploys the
+# generated hook/config targets. It is also the supported seam for app-created
+# fresh worktrees, which do not inherit ignored .codex files.
+bootstrap_codex_checkout "$PROJECT_DIR" "$TARGET_DIR" continue
+echo "Verified Codex runtime bootstrap in $TARGET_DIR"
 
 echo ""
 echo "LEARN UKRAINIAN - Ukrainian Language Learning"

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -26,9 +26,7 @@ def sample_snapshot(tmp_path: Path) -> dict:
                 {"sha": "abc123def0", "subject": "docs(session): handoff"},
                 {"sha": "1111111111", "subject": "feat(api): monitor"},
             ],
-            "modified_files": [
-                {"status": "M", "path": "docs/session-state/current.md"},
-            ],
+            "modified_files": [],
         },
         "monitor": {
             "base_url": "http://127.0.0.1:8765",
@@ -57,8 +55,14 @@ def sample_snapshot(tmp_path: Path) -> dict:
     }
 
 
+@pytest.fixture(autouse=True)
+def clean_invoking_checkout(monkeypatch):
+    """Unit CLI fixtures run outside Git; model the clean bound checkout."""
+    monkeypatch.setattr(th, "gather_git_state", lambda root: sample_snapshot(root)["git"])
+
+
 def prepared(*, agent: str = "orchestrator", thread_id: str = "old-thread") -> dict:
-    return th.prepare_state(
+    state = th.prepare_state(
         {"schema_version": th.SCHEMA_VERSION},
         agent=agent,
         now=datetime(2026, 5, 30, 8, 0, tzinfo=UTC),
@@ -67,6 +71,11 @@ def prepared(*, agent: str = "orchestrator", thread_id: str = "old-thread") -> d
         context_percent=86.0,
         force_new_replacement=False,
     )
+    state["replacement"]["source_checkout"] = {
+        "full_head": sample_snapshot(Path("."))["git"]["full_head"],
+        "clean": True,
+    }
+    return state
 
 
 def resumed_with_proof(tmp_path: Path, state: dict, thread_id: str = "new-thread") -> tuple[dict, Path]:
@@ -228,6 +237,7 @@ def test_render_bootstrap_prompt_contains_guardrails(tmp_path: Path):
     assert "git worktree list" in prompt
     assert "confirm-started --agent orchestrator --lineage-id" in prompt
     assert "Only after that command reports old_automation_ready_to_delete=true" in prompt
+    assert "Keep the invoking checkout clean at prepared HEAD abc123def0456789" in prompt
     assert "Context estimate: 86.0% (ROLL OVER NOW; threshold 82.0%)." in prompt
     assert "orchestrator_control.py inbox --recent 20 --include-results" in prompt
 
@@ -248,6 +258,7 @@ def test_render_current_markdown_includes_required_handoff_sections(tmp_path: Pa
     assert "confirm-started --agent orchestrator --lineage-id" in rendered
     assert "orchestrator_control.py inbox --recent 20 --include-results" in rendered
     assert "Durable role handoff: `docs/session-state/codex-orchestrator-handoff.md`" in rendered
+    assert "Source checkout HEAD: `abc123def0456789`" in rendered
 
 
 def test_render_bootstrap_prompt_for_codex_uses_orchestrator_pointer(tmp_path: Path):
@@ -310,6 +321,130 @@ def test_default_agent_paths_are_agent_specific():
     assert th.default_handoff_path("claude") == Path("docs/session-state/current.claude.md")
 
 
+def test_checkout_continuity_requires_clean_source_binding_and_same_clean_head():
+    clean = sample_snapshot(Path("."))["git"]
+    assert th.parse_status("M tracked.txt\n?? untracked.txt") == [
+        {"status": "M", "path": "tracked.txt"},
+        {"status": "??", "path": "untracked.txt"},
+    ]
+    binding = th.source_checkout_binding(clean)
+    replacement = {"source_checkout": binding}
+
+    assert th.checkout_continuity_error(replacement, clean) is None
+    assert "missing its source checkout binding" in th.checkout_continuity_error({}, clean)
+
+    wrong_head = {**clean, "full_head": "different-head"}
+    assert "does not match prepared HEAD" in th.checkout_continuity_error(replacement, wrong_head)
+
+    dirty = {**clean, "modified_files": [{"status": "M", "path": "tracked.txt"}]}
+    assert "invoking checkout must be clean" in th.checkout_continuity_error(replacement, dirty)
+    with pytest.raises(ValueError, match="source checkout must be clean before prepare"):
+        th.source_checkout_binding(dirty)
+
+
+def test_live_lease_requires_binding_but_started_history_remains_compatible():
+    state = prepared(agent="codex")
+    state["replacement"].pop("source_checkout")
+    state_path = th.default_state_path("codex", state["lineage_id"])
+
+    replacement, error = th.validate_live_lease(state, agent="codex", state_path=state_path)
+    assert replacement is None
+    assert "missing its source checkout binding" in error
+
+    state["replacement"]["status"] = "started"
+    state["replacement"]["thread_id"] = "historical-thread"
+    replacement, error = th.validate_live_lease(state, agent="codex", state_path=state_path)
+    assert error is None
+    assert replacement is not None
+    assert replacement["status"] == "started"
+
+
+def test_prepare_rejects_dirty_source_checkout_without_writing_packet(tmp_path: Path, capsys, monkeypatch):
+    dirty_snapshot = sample_snapshot(tmp_path)
+    dirty_snapshot["git"]["modified_files"] = [{"status": "??", "path": "untracked.txt"}]
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: dirty_snapshot)
+    monkeypatch.setattr(th, "gather_git_state", lambda root: dirty_snapshot["git"])
+
+    assert th.main(["--repo-root", str(tmp_path), "prepare", "--active-thread-id", "old-thread"]) == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert "source checkout must be clean before prepare" in payload["error"]
+    assert payload["old_automation_ready_to_delete"] is False
+    assert not (tmp_path / ".agent/thread-rollovers").exists()
+
+
+def test_resume_and_confirm_independently_recheck_checkout_continuity(tmp_path: Path, capsys, monkeypatch):
+    clean = sample_snapshot(tmp_path)["git"]
+    monkeypatch.setattr(th, "gather_snapshot", lambda root, url: sample_snapshot(root))
+    assert th.main(["--repo-root", str(tmp_path), "prepare", "--active-thread-id", "old-thread"]) == 0
+    packet = json.loads(capsys.readouterr().out)
+    state_path = tmp_path / packet["state_file"]
+
+    monkeypatch.setattr(th, "gather_git_state", lambda root: {**clean, "full_head": "wrong-head"})
+    resume_command = [
+        "--repo-root",
+        str(tmp_path),
+        "resume",
+        "--lineage-id",
+        packet["lineage_id"],
+        "--rollover-id",
+        packet["rollover_id"],
+        "--replacement-thread-id",
+        "new-thread",
+    ]
+    assert th.main(resume_command) == 2
+    assert "does not match prepared HEAD" in json.loads(capsys.readouterr().out)["error"]
+    assert json.loads(state_path.read_text(encoding="utf-8"))["replacement"]["status"] == "pending_start"
+
+    monkeypatch.setattr(th, "gather_git_state", lambda root: clean)
+    assert th.main(resume_command) == 0
+    capsys.readouterr()
+    resumed = json.loads(state_path.read_text(encoding="utf-8"))
+    strict_probe, strict_verdict = strict_artifacts(tmp_path, resumed)
+    capsys.readouterr()
+    proof = tmp_path / resumed["replacement"]["canary_proof_path"]
+    canary.write_json_atomic(
+        proof,
+        canary.build_pass_proof(
+            rollover_id=packet["rollover_id"],
+            replacement_thread_id="new-thread",
+            challenge=resumed["replacement"]["canary_challenge"],
+            now=datetime(2026, 5, 30, 8, 2, tzinfo=UTC),
+        ),
+    )
+
+    monkeypatch.setattr(
+        th,
+        "gather_git_state",
+        lambda root: {**clean, "modified_files": [{"status": "M", "path": "tracked.txt"}]},
+    )
+    assert (
+        th.main(
+            [
+                "--repo-root",
+                str(tmp_path),
+                "confirm-started",
+                "--lineage-id",
+                packet["lineage_id"],
+                "--rollover-id",
+                packet["rollover_id"],
+                "--new-thread-id",
+                "new-thread",
+                "--canary-proof",
+                str(proof),
+                "--strict-probe",
+                str(strict_probe),
+                "--strict-verdict",
+                str(strict_verdict),
+            ]
+        )
+        == 2
+    )
+    assert "invoking checkout must be clean" in json.loads(capsys.readouterr().out)["error"]
+    final_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert final_state["replacement"]["status"] == "resumed"
+    assert final_state["cleanup"]["old_automation_ready_to_delete"] is False
+
+
 def test_prepare_orchestrator_writes_only_local_thread_handoff_by_default(
     tmp_path: Path,
     capsys,
@@ -342,6 +477,8 @@ def test_prepare_orchestrator_writes_only_local_thread_handoff_by_default(
     assert payload["router_file"] is None
     assert not (tmp_path / "docs/session-state/current.md").exists()
     assert "## Thread Lease" in (tmp_path / payload["handoff_file"]).read_text(encoding="utf-8")
+    lease = json.loads((tmp_path / payload["state_file"]).read_text(encoding="utf-8"))
+    assert lease["replacement"]["source_checkout"] == {"full_head": "abc123def0456789", "clean": True}
 
 
 def test_prepare_rejects_write_current_without_explicit_router_unlock(

--- a/tests/orchestration/test_thread_restart_e2e.py
+++ b/tests/orchestration/test_thread_restart_e2e.py
@@ -68,21 +68,29 @@ def init_repo(tmp_path: Path, *, bootstrap_sources: bool = False) -> tuple[Path,
     git(primary, "config", "user.name", "Thread Restart E2E")
     (primary / ".gitignore").write_text(".agent/\n.codex/\n.claude/\n.agents/\n.gemini/\n.venv\n", encoding="utf-8")
     (primary / "tracked.txt").write_text("canonical\n", encoding="utf-8")
+    sources = [
+        "scripts/__init__.py",
+        "scripts/context_canary.py",
+        "scripts/orchestration/thread_handoff.py",
+        "scripts/orchestration/thread_handoff_canary.py",
+    ]
     if bootstrap_sources:
-        sources = (
-            "scripts/lib/thread_rollover_link.sh",
-            "scripts/lib/deploy_extensions.sh",
-            "agents_extensions/codex/hooks.json",
-            "agents_extensions/shared/hooks/session-setup.sh",
+        sources.extend(
+            [
+                "scripts/lib/thread_rollover_link.sh",
+                "scripts/lib/deploy_extensions.sh",
+                "agents_extensions/codex/hooks.json",
+                "agents_extensions/shared/hooks/session-setup.sh",
+            ]
         )
-        for relative in sources:
-            target = primary / relative
-            target.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(REPO_ROOT / relative, target)
         (primary / "package.json").write_text(
             '{"scripts":{"agents:deploy":"scripts/deploy_prompts.sh"}}\n',
             encoding="utf-8",
         )
+    for relative in sources:
+        target = primary / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(REPO_ROOT / relative, target)
     git(primary, "add", ".")
     git(primary, "commit", "-m", "test fixture")
     (primary / ".venv").symlink_to(REPO_ROOT / ".venv", target_is_directory=True)
@@ -96,6 +104,16 @@ def handoff_command(primary: Path, *args: str) -> list[str | Path]:
         HANDOFF,
         "--repo-root",
         primary,
+        "--monitor-base-url",
+        "http://127.0.0.1:1",
+        *args,
+    ]
+
+
+def checkout_handoff_command(checkout: Path, *args: str) -> list[str | Path]:
+    return [
+        checkout / ".venv/bin/python",
+        checkout / "scripts/orchestration/thread_handoff.py",
         "--monitor-base-url",
         "http://127.0.0.1:1",
         *args,
@@ -302,6 +320,11 @@ def test_packet_only_lifecycle_answers_exactly_ten_questions_and_unlocks_cleanup
     primary, _ = init_repo(tmp_path)
     packet = prepare(primary)
     assert_cleanup_locked(primary, packet)
+    lease = load_lease(primary, packet)
+    assert lease["replacement"]["source_checkout"] == {
+        "full_head": git(primary, "rev-parse", "HEAD").stdout.strip(),
+        "clean": True,
+    }
     runtime = primary / packet["runtime_path"]
     bootstrap = (runtime / "bootstrap.md").read_text(encoding="utf-8")
     assert "do not fork, continue, or resume provider conversation history" in bootstrap
@@ -468,21 +491,72 @@ def test_parallel_lineages_have_distinct_paths_and_reject_cross_claims(tmp_path:
 
 def test_monitor_outage_and_dirty_replacement_never_unlock_cleanup(tmp_path: Path) -> None:
     primary, replacement = init_repo(tmp_path)
-    packet = prepare(primary)
+    (replacement / ".venv").symlink_to(primary / ".venv", target_is_directory=True)
+    prepared = run(
+        checkout_handoff_command(
+            primary,
+            "prepare",
+            "--agent",
+            "codex",
+            "--active-thread-id",
+            "old-thread",
+            "--active-automation-id",
+            "automation-old-thread",
+        ),
+        cwd=primary,
+        check=True,
+    )
+    packet = json.loads(prepared.stdout)
+    resumed = run(
+        checkout_handoff_command(
+            replacement,
+            "resume",
+            "--agent",
+            "codex",
+            "--lineage-id",
+            packet["lineage_id"],
+            "--rollover-id",
+            packet["rollover_id"],
+            "--replacement-thread-id",
+            "fresh-thread",
+        ),
+        cwd=replacement,
+        check=True,
+    )
+    assert json.loads(resumed.stdout)["status"] == "resumed"
+    probe, verdict, _ = strict_evidence(primary, packet)
+    proof = canary_proof(primary, packet)
+
     (replacement / "tracked.txt").write_text("dirty replacement\n", encoding="utf-8")
     assert git(replacement, "status", "--short").stdout.startswith(" M tracked.txt")
     assert_cleanup_locked(primary, packet)
-    missing_proofs = run(
-        confirm_command(
-            primary,
-            packet,
-            proof=primary / "missing-proof.json",
-            probe=primary / "missing-probe.json",
-            verdict=primary / "missing-verdict.json",
+    rejected = run(
+        checkout_handoff_command(
+            replacement,
+            "confirm-started",
+            "--agent",
+            "codex",
+            "--lineage-id",
+            packet["lineage_id"],
+            "--rollover-id",
+            packet["rollover_id"],
+            "--new-thread-id",
+            "fresh-thread",
+            "--canary-proof",
+            str(proof),
+            "--strict-probe",
+            str(probe),
+            "--strict-verdict",
+            str(verdict),
         ),
         cwd=replacement,
     )
-    assert missing_proofs.returncode == 2
+    assert rejected.returncode == 2
+    error = json.loads(rejected.stdout)["error"]
+    assert "checkout continuity failed: invoking checkout must be clean" in error
+    assert "tracked.txt" in error
+    lease = load_lease(primary, packet)
+    assert lease["replacement"]["status"] == "resumed"
     assert_cleanup_locked(primary, packet)
 
 

--- a/tests/orchestration/test_thread_restart_e2e.py
+++ b/tests/orchestration/test_thread_restart_e2e.py
@@ -66,7 +66,10 @@ def init_repo(tmp_path: Path, *, bootstrap_sources: bool = False) -> tuple[Path,
     git(primary, "init", "-b", "main")
     git(primary, "config", "user.email", "e2e@example.invalid")
     git(primary, "config", "user.name", "Thread Restart E2E")
-    (primary / ".gitignore").write_text(".agent/\n.codex/\n.claude/\n.agents/\n.gemini/\n.venv\n", encoding="utf-8")
+    (primary / ".gitignore").write_text(
+        ".agent/\n.codex/\n.claude/\n.agents/\n.gemini/\n.venv\n__pycache__/\n",
+        encoding="utf-8",
+    )
     (primary / "tracked.txt").write_text("canonical\n", encoding="utf-8")
     sources = [
         "scripts/__init__.py",

--- a/tests/orchestration/test_thread_restart_e2e.py
+++ b/tests/orchestration/test_thread_restart_e2e.py
@@ -1,0 +1,548 @@
+"""End-to-end acceptance for packet-only Codex thread replacement.
+
+These tests deliberately cross subprocess, Git-worktree, shell-helper, hook,
+and strict-canary seams. Unit-level state-machine cases remain in
+``test_thread_handoff.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPO_PYTHON = REPO_ROOT / ".venv/bin/python"
+HANDOFF = REPO_ROOT / "scripts/orchestration/thread_handoff.py"
+HANDOFF_CANARY = REPO_ROOT / "scripts/orchestration/thread_handoff_canary.py"
+CONTEXT_CANARY = REPO_ROOT / "scripts/context_canary.py"
+
+
+def run(
+    args: list[str | Path],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    command_env = (os.environ if env is None else env).copy()
+    for key in tuple(command_env):
+        if key.startswith("GIT_"):
+            command_env.pop(key)
+    completed = subprocess.run(
+        [str(arg) for arg in args],
+        cwd=cwd,
+        env=command_env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    if check and completed.returncode != 0:
+        raise AssertionError(
+            f"command failed ({completed.returncode}): {' '.join(map(str, args))}\n"
+            f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+        )
+    return completed
+
+
+def git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return run(["git", *args], cwd=cwd, check=check)
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def init_repo(tmp_path: Path, *, bootstrap_sources: bool = False) -> tuple[Path, Path]:
+    primary = tmp_path / "canonical"
+    replacement = tmp_path / "replacement"
+    primary.mkdir(parents=True)
+    git(primary, "init", "-b", "main")
+    git(primary, "config", "user.email", "e2e@example.invalid")
+    git(primary, "config", "user.name", "Thread Restart E2E")
+    (primary / ".gitignore").write_text(".agent/\n.codex/\n.claude/\n.agents/\n.gemini/\n.venv\n", encoding="utf-8")
+    (primary / "tracked.txt").write_text("canonical\n", encoding="utf-8")
+    if bootstrap_sources:
+        sources = (
+            "scripts/lib/thread_rollover_link.sh",
+            "scripts/lib/deploy_extensions.sh",
+            "agents_extensions/codex/hooks.json",
+            "agents_extensions/shared/hooks/session-setup.sh",
+        )
+        for relative in sources:
+            target = primary / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(REPO_ROOT / relative, target)
+        (primary / "package.json").write_text(
+            '{"scripts":{"agents:deploy":"scripts/deploy_prompts.sh"}}\n',
+            encoding="utf-8",
+        )
+    git(primary, "add", ".")
+    git(primary, "commit", "-m", "test fixture")
+    (primary / ".venv").symlink_to(REPO_ROOT / ".venv", target_is_directory=True)
+    git(primary, "worktree", "add", "-b", "replacement", str(replacement), "HEAD")
+    return primary, replacement
+
+
+def handoff_command(primary: Path, *args: str) -> list[str | Path]:
+    return [
+        REPO_PYTHON,
+        HANDOFF,
+        "--repo-root",
+        primary,
+        "--monitor-base-url",
+        "http://127.0.0.1:1",
+        *args,
+    ]
+
+
+def prepare(primary: Path, *, active_thread_id: str = "old-thread") -> dict:
+    completed = run(
+        handoff_command(
+            primary,
+            "prepare",
+            "--agent",
+            "codex",
+            "--active-thread-id",
+            active_thread_id,
+            "--active-automation-id",
+            f"automation-{active_thread_id}",
+        ),
+        cwd=primary,
+        check=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def load_lease(primary: Path, packet: dict) -> dict:
+    return json.loads((primary / packet["state_file"]).read_text(encoding="utf-8"))
+
+
+def assert_cleanup_locked(primary: Path, packet: dict) -> None:
+    assert load_lease(primary, packet)["cleanup"]["old_automation_ready_to_delete"] is False
+
+
+def resume(primary: Path, packet: dict, replacement_thread_id: str = "fresh-thread") -> dict:
+    completed = run(
+        handoff_command(
+            primary,
+            "resume",
+            "--agent",
+            "codex",
+            "--lineage-id",
+            packet["lineage_id"],
+            "--rollover-id",
+            packet["rollover_id"],
+            "--replacement-thread-id",
+            replacement_thread_id,
+        ),
+        cwd=primary,
+        check=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def semantic_snapshot(lease: dict) -> dict:
+    replacement = lease["replacement"]
+    handoff_ref = replacement["handoff_path"]
+    return {
+        "generated_at": "2026-07-13T12:00:00Z",
+        "lineage_id": lease["lineage_id"],
+        "rollover_id": replacement["rollover_id"],
+        "seed": 5057,
+        "goals": [
+            {
+                "id": f"goal-{index}",
+                "statement": f"continue durable goal {index}",
+                "source_ref": f"handoff:{handoff_ref}#goal-{index}",
+            }
+            for index in range(3)
+        ],
+        "decision_records": [
+            {
+                "id": f"decision-{index}",
+                "decision": f"keep packet decision {index}",
+                "source_ref": f"decision:docs/decisions/thread-restart.md#decision-{index}",
+            }
+            for index in range(3)
+        ],
+        "constraint_records": [
+            {
+                "id": f"constraint-{index}",
+                "prohibition": f"never transfer provider history {index}",
+                "source_ref": f"handoff:{handoff_ref}#constraint-{index}",
+            }
+            for index in range(2)
+        ],
+        "next_actions": [
+            {
+                "id": f"action-{index}",
+                "action": f"execute durable action {index}",
+                "source_ref": f"queue:batch_state/orchestrator-runs/epic-5054-thread-continuity.json#action-{index}",
+            }
+            for index in range(2)
+        ],
+    }
+
+
+def strict_evidence(primary: Path, packet: dict, *, wrong_answer: bool = False) -> tuple[Path, Path, Path]:
+    lease = load_lease(primary, packet)
+    replacement = lease["replacement"]
+    snapshot_path = primary / replacement["semantic_snapshot_path"]
+    probe_path = primary / replacement["strict_probe_path"]
+    questions_path = primary / replacement["strict_questions_path"]
+    answers_path = primary / replacement["strict_answers_path"]
+    verdict_path = primary / replacement["strict_verdict_path"]
+    snapshot = semantic_snapshot(lease)
+    write_json(snapshot_path, snapshot)
+    minted = run(
+        [REPO_PYTHON, CONTEXT_CANARY, "mint", "--snapshot", snapshot_path, "--out", probe_path],
+        cwd=primary,
+        check=True,
+    )
+    assert "minted 10 anchors" in minted.stdout
+    run(
+        [REPO_PYTHON, CONTEXT_CANARY, "questions", "--probe", probe_path, "--out", questions_path],
+        cwd=primary,
+        check=True,
+    )
+    probe = json.loads(probe_path.read_text(encoding="utf-8"))
+    questions = json.loads(questions_path.read_text(encoding="utf-8"))["questions"]
+    assert len(questions) == 10
+    assert all(set(question) == {"id", "q"} for question in questions)
+    assert {question["id"] for question in questions} == {anchor["id"] for anchor in probe["anchors"]}
+    snapshot_text = snapshot_path.read_text(encoding="utf-8")
+    assert all(str(anchor["a"]) in snapshot_text for anchor in probe["anchors"])
+    answers = {anchor["id"]: anchor["a"] for anchor in probe["anchors"]}
+    if wrong_answer:
+        answers[probe["anchors"][-1]["id"]] = "wrong answer"
+    write_json(answers_path, answers)
+    scored = run(
+        [
+            REPO_PYTHON,
+            CONTEXT_CANARY,
+            "score",
+            "--probe",
+            probe_path,
+            "--answers",
+            answers_path,
+            "--expected-lineage-id",
+            packet["lineage_id"],
+            "--expected-rollover-id",
+            packet["rollover_id"],
+            "--verdict",
+            verdict_path,
+        ],
+        cwd=primary,
+    )
+    expected_score = "SCORE 9/10" if wrong_answer else "SCORE 10/10"
+    assert expected_score in scored.stdout
+    assert scored.returncode == (2 if wrong_answer else 0)
+    return probe_path, verdict_path, questions_path
+
+
+def canary_proof(primary: Path, packet: dict, *, challenge: str | None = None) -> Path:
+    lease = load_lease(primary, packet)
+    replacement = lease["replacement"]
+    proof_path = primary / replacement["canary_proof_path"]
+    run(
+        [
+            REPO_PYTHON,
+            HANDOFF_CANARY,
+            "--rollover-id",
+            packet["rollover_id"],
+            "--replacement-thread-id",
+            "fresh-thread",
+            "--challenge",
+            challenge or replacement["canary_challenge"],
+            "--proof-file",
+            proof_path,
+        ],
+        cwd=primary,
+        check=True,
+    )
+    return proof_path
+
+
+def confirm_command(
+    primary: Path,
+    packet: dict,
+    *,
+    proof: Path,
+    probe: Path,
+    verdict: Path,
+) -> list[str | Path]:
+    return handoff_command(
+        primary,
+        "confirm-started",
+        "--agent",
+        "codex",
+        "--lineage-id",
+        packet["lineage_id"],
+        "--rollover-id",
+        packet["rollover_id"],
+        "--new-thread-id",
+        "fresh-thread",
+        "--canary-proof",
+        str(proof),
+        "--strict-probe",
+        str(probe),
+        "--strict-verdict",
+        str(verdict),
+    )
+
+
+def test_packet_only_lifecycle_answers_exactly_ten_questions_and_unlocks_cleanup(tmp_path: Path) -> None:
+    primary, _ = init_repo(tmp_path)
+    packet = prepare(primary)
+    assert_cleanup_locked(primary, packet)
+    runtime = primary / packet["runtime_path"]
+    bootstrap = (runtime / "bootstrap.md").read_text(encoding="utf-8")
+    assert "do not fork, continue, or resume provider conversation history" in bootstrap
+    assert "thread_handoff.py resume" in bootstrap
+    assert "thread_handoff_canary.py" in bootstrap
+    assert "thread_handoff.py confirm-started" in bootstrap
+    assert "codex exec resume" not in bootstrap
+    assert not list(primary.glob(".agent/**/*state_5.sqlite"))
+    assert not list(primary.glob(".agent/**/*.jsonl"))
+
+    resumed = resume(primary, packet)
+    assert resumed["replacement_thread_id"] == "fresh-thread"
+    assert resumed["replacement_thread_id"] != "old-thread"
+    validated = run(
+        handoff_command(
+            primary,
+            "check",
+            "--agent",
+            "codex",
+            "--lineage-id",
+            packet["lineage_id"],
+        ),
+        cwd=primary,
+        check=True,
+    )
+    assert json.loads(validated.stdout)["warnings"] == []
+    probe, verdict, questions = strict_evidence(primary, packet)
+    assert len(json.loads(questions.read_text(encoding="utf-8"))["questions"]) == 10
+    proof = canary_proof(primary, packet)
+    confirmed = run(
+        confirm_command(primary, packet, proof=proof, probe=probe, verdict=verdict),
+        cwd=primary,
+        check=True,
+    )
+    result = json.loads(confirmed.stdout)
+    assert result["replacement_status"] == "started"
+    assert result["old_automation_ready_to_delete"] is True
+    assert load_lease(primary, packet)["cleanup"]["old_automation_ready_to_delete"] is True
+    assert git(primary, "status", "--short", "--untracked-files=all").stdout == ""
+
+
+@pytest.mark.parametrize("case", ["second-prepare", "wrong-rollover", "missing-thread-id", "stale", "corrupt"])
+def test_pre_confirmation_failures_leave_cleanup_locked(tmp_path: Path, case: str) -> None:
+    primary, _ = init_repo(tmp_path)
+    packet = prepare(primary)
+    state_path = primary / packet["state_file"]
+
+    if case == "second-prepare":
+        failed = run(
+            handoff_command(
+                primary,
+                "prepare",
+                "--agent",
+                "codex",
+                "--active-thread-id",
+                "old-thread",
+            ),
+            cwd=primary,
+        )
+    elif case == "wrong-rollover":
+        failed = run(
+            handoff_command(
+                primary,
+                "resume",
+                "--agent",
+                "codex",
+                "--lineage-id",
+                packet["lineage_id"],
+                "--rollover-id",
+                "rollover-wrong",
+                "--replacement-thread-id",
+                "fresh-thread",
+            ),
+            cwd=primary,
+        )
+    elif case == "missing-thread-id":
+        failed = run(
+            handoff_command(
+                primary,
+                "resume",
+                "--agent",
+                "codex",
+                "--lineage-id",
+                packet["lineage_id"],
+                "--rollover-id",
+                packet["rollover_id"],
+            ),
+            cwd=primary,
+        )
+    elif case == "stale":
+        lease = load_lease(primary, packet)
+        lease["replacement"]["prepared_at"] = "2000-01-01T00:00:00Z"
+        write_json(state_path, lease)
+        failed = run(
+            handoff_command(
+                primary,
+                "check",
+                "--agent",
+                "codex",
+                "--lineage-id",
+                packet["lineage_id"],
+                "--stale-hours",
+                "1",
+            ),
+            cwd=primary,
+        )
+    else:
+        state_path.write_text('{"schema_version": 2, "broken"', encoding="utf-8")
+        failed = run(
+            handoff_command(primary, "detect", "--agent", "codex"),
+            cwd=primary,
+        )
+
+    assert failed.returncode != 0
+    if case == "corrupt":
+        assert '"old_automation_ready_to_delete": true' not in state_path.read_text(encoding="utf-8")
+    else:
+        assert_cleanup_locked(primary, packet)
+
+
+@pytest.mark.parametrize("case", ["nine-of-ten", "failed-canary"])
+def test_failed_replacement_proofs_leave_cleanup_locked(tmp_path: Path, case: str) -> None:
+    primary, _ = init_repo(tmp_path)
+    packet = prepare(primary)
+    resume(primary, packet)
+    probe, verdict, _ = strict_evidence(primary, packet, wrong_answer=case == "nine-of-ten")
+    proof = canary_proof(primary, packet, challenge="0" * 64 if case == "failed-canary" else None)
+    failed = run(
+        confirm_command(primary, packet, proof=proof, probe=probe, verdict=verdict),
+        cwd=primary,
+    )
+    assert failed.returncode == 2
+    assert_cleanup_locked(primary, packet)
+
+
+def test_parallel_lineages_have_distinct_paths_and_reject_cross_claims(tmp_path: Path) -> None:
+    primary, _ = init_repo(tmp_path)
+    first = prepare(primary, active_thread_id="old-a")
+    second = prepare(primary, active_thread_id="old-b")
+    assert first["lineage_id"] != second["lineage_id"]
+    assert first["rollover_id"] != second["rollover_id"]
+    assert first["state_file"] != second["state_file"]
+    assert first["runtime_path"] != second["runtime_path"]
+
+    crossed = run(
+        handoff_command(
+            primary,
+            "resume",
+            "--agent",
+            "codex",
+            "--lineage-id",
+            first["lineage_id"],
+            "--rollover-id",
+            second["rollover_id"],
+            "--replacement-thread-id",
+            "cross-claim",
+        ),
+        cwd=primary,
+    )
+    assert crossed.returncode == 2
+    assert_cleanup_locked(primary, first)
+    assert_cleanup_locked(primary, second)
+
+
+def test_monitor_outage_and_dirty_replacement_never_unlock_cleanup(tmp_path: Path) -> None:
+    primary, replacement = init_repo(tmp_path)
+    packet = prepare(primary)
+    (replacement / "tracked.txt").write_text("dirty replacement\n", encoding="utf-8")
+    assert git(replacement, "status", "--short").stdout.startswith(" M tracked.txt")
+    assert_cleanup_locked(primary, packet)
+    missing_proofs = run(
+        confirm_command(
+            primary,
+            packet,
+            proof=primary / "missing-proof.json",
+            probe=primary / "missing-probe.json",
+            verdict=primary / "missing-verdict.json",
+        ),
+        cwd=replacement,
+    )
+    assert missing_proofs.returncode == 2
+    assert_cleanup_locked(primary, packet)
+
+
+def test_app_style_worktree_bootstrap_deploys_hook_and_discovers_canonical_packet(tmp_path: Path) -> None:
+    primary, replacement = init_repo(tmp_path, bootstrap_sources=True)
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_npm = fake_bin / "npm"
+    fake_npm.write_text(
+        "#!/bin/bash\n"
+        "set -e\n"
+        "mkdir -p .codex/hooks\n"
+        "cp agents_extensions/codex/hooks.json .codex/hooks.json\n"
+        "cp agents_extensions/shared/hooks/session-setup.sh .codex/hooks/session-setup.sh\n",
+        encoding="utf-8",
+    )
+    fake_npm.chmod(0o755)
+    fake_gh = fake_bin / "gh"
+    fake_gh.write_text("#!/bin/bash\nexit 1\n", encoding="utf-8")
+    fake_gh.chmod(0o755)
+    jq = shutil.which("jq")
+    assert jq is not None
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{Path(jq).parent}:/usr/bin:/bin"
+
+    for _ in range(2):
+        bootstrapped = run(
+            ["bash", replacement / "scripts/lib/thread_rollover_link.sh", primary, replacement],
+            cwd=replacement,
+            env=env,
+        )
+        assert bootstrapped.returncode == 0, bootstrapped.stderr
+    assert (replacement / ".venv").is_symlink()
+    rollover_link = replacement / ".agent/thread-rollovers"
+    assert rollover_link.is_symlink()
+    assert rollover_link.resolve() == (primary / ".agent/thread-rollovers").resolve()
+    assert (replacement / ".codex/hooks.json").is_file()
+    deployed_hook = replacement / ".codex/hooks/session-setup.sh"
+    assert deployed_hook.is_file()
+
+    packet = prepare(primary)
+    hook_env = env.copy()
+    hook_env.update(
+        {
+            "HOME": str(tmp_path / "home"),
+            "PYENV_ROOT": str(tmp_path / "pyenv"),
+            "CLAUDE_PROJECT_DIR": str(replacement),
+            "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS": "32000",
+            "SESSION_HANDOFF_AGENT": "codex",
+            "CODEX_THREAD_ID": "fresh-app-thread",
+            "THREAD_ROLLOVER_PYTHON": str(REPO_PYTHON),
+            "THREAD_ROLLOVER_SCRIPT": str(HANDOFF),
+        }
+    )
+    hook_env.pop("CODEX_CANONICAL_REPO_ROOT", None)
+    started = run(["bash", deployed_hook], cwd=replacement, env=hook_env)
+    assert started.returncode == 0, started.stderr
+    assert "PENDING THREAD ROLLOVER DETECTED" in started.stdout
+    assert packet["lineage_id"] in started.stdout
+    assert packet["rollover_id"] in started.stdout
+    assert "--replacement-thread-id fresh-app-thread" in started.stdout
+    assert_cleanup_locked(primary, packet)
+    assert git(replacement, "status", "--short", "--untracked-files=all").stdout == ""


### PR DESCRIPTION
Refs #5057
Parent epic: #5054
Stream epic: #4707

Issue #5057 will be closed manually only after the post-merge real Codex app fresh-task restart smoke passes. This PR intentionally does not use an auto-close keyword.

## Summary

- add an idempotent fresh-checkout bootstrap that links only the canonical virtualenv and `.agent/thread-rollovers`, then deploys ignored Codex hooks/config
- derive canonical SessionStart rollover state from Git's common directory when `CODEX_CANONICAL_REPO_ROOT` is absent
- bind prepared rollovers to one clean source HEAD and independently reject missing binding, wrong HEAD, or dirtiness at both resume and confirmation
- add real-worktree/process E2E coverage for packet-only 10/10 lifecycle, failure locking, parallel lineage isolation, app-style hook discovery, dirty-checkout rejection, and monitor outage
- document the exact post-merge Codex app smoke without claiming it has already run

## Scope

Nine directly related files. No generated status/audit/review/telemetry artifacts, protected configs, dependency changes, or linter-config changes.

## Verification

- focused regression gate: **272 passed**
- stock-Python E2E with `PYTHONDONTWRITEBYTECODE` unset: **11 passed**
- SessionStart, handoff-identity, deploy-extension, and deploy-idempotency fixtures: passed
- Ruff check and format check: passed
- shell syntax, Python compilation, `git diff --check`, forbidden-path scans, and four-commit X-Agent trailer audit: passed
- full repository pytest collection was not a valid local gate because optional `lxml`, `ruamel`, and `FlagEmbedding` packages are absent; no scoped test failed

## Independent cross-family review

Claude Fable (`claude-fable-5`, xhigh, read-only) reviewed exact head `3fe710ed28`, reproduced one material fixture-hygiene blocker, and returned **BLOCK**. The fixture now ignores `__pycache__/`. Fable re-reviewed exact head `071ab3bbb9`, reran the stock-Python E2E (**11 passed**), verified the complete nine-file scope and all trailers, and returned **PASS**. Review tasks: `finalreview-5057-fable`, `rereview-5057-fable`.

## Post-merge gate

After merge, the orchestrator will create a clean fresh Codex app predecessor task and a genuinely fresh replacement task, deploy the bootstrap helper before the replacement's restart turn, verify automatic SessionStart packet discovery without a canonical-root export, execute resume → ten-question 10/10 score → challenge canary → confirm, record source/replacement task IDs and titles, and require `old_automation_ready_to_delete=true` before closing #5057 and #5054.

