### PR TITLE
feat(curriculum): enforce evidence-led module size policy

### DIFF
--- a/agents_extensions/shared/agents/curriculum-writer.md
+++ b/agents_extensions/shared/agents/curriculum-writer.md
@@ -15,6 +15,8 @@ You are a Ukrainian curriculum content writer for one module per invocation. You
 - Follow the plan, learner state, contract YAML, and writer prompt exactly.
 - Treat word targets as floors, but obey the rendered Module Size Policy when deciding whether expansion is allowed.
 - Never invent depth, examples, reception history, controversy, or interpretation to satisfy a word count. If the prompt's size policy says expansion requires plan/policy review or a research dossier, complete the verifiable coverage and surface the requested mismatch marker instead of padding.
+- Satisfy objectives and evidence coverage, not a token target. Do not repeat framing, conclusions, transitions, or definitions to reach the floor.
+- When grounded material is exhausted, emit the requested `SIZE_POLICY_MISMATCH` marker and stop for plan review; never auto-pad the module.
 - Put IPA notation in `phonetic_rules` when phonetics are requested.
 - Do not add English meta-narration about how the lesson works.
 

--- a/agents_extensions/shared/rules/non-negotiable-rules.md
+++ b/agents_extensions/shared/rules/non-negotiable-rules.md
@@ -9,7 +9,7 @@ All rules are hard requirements. Partial compliance = failure.
 | When... | Do this |
 |---|---|
 | Building content | Check `config.py` target_words FIRST — never hardcode from memory |
-| Module under word target | Expand content to meet target. Never lower the target |
+| Module under word target | Add only source-backed necessary pedagogy; if grounded material is exhausted, emit `SIZE_POLICY_MISMATCH` and route to plan review. Never lower the target or auto-pad |
 | Audit gate shows ❌ | Fix it. ALL gates must be GREEN or the module fails |
 | Fixing a module | Reviewer provides `<fixes>` — apply deterministically (rule 4) |
 | Reviewing content | Cite SPECIFIC examples from the text, or the review is invalid (rule 6) |
@@ -26,7 +26,9 @@ All rules are hard requirements. Partial compliance = failure.
 
 <critical>
 
-Expand content to meet targets. Never lower targets to match content.
+Meet reviewed targets with source-backed necessary pedagogy. Never lower targets
+to match content, repeat exposition to reach them, or auto-pad. If grounded
+material is exhausted, emit `SIZE_POLICY_MISMATCH` and route to plan review.
 
 **Always read config.py** before generating content_outline or word budgets: `.venv/bin/python -c "import sys; sys.path.insert(0,'scripts'); from audit.config import LEVEL_CONFIG; print(LEVEL_CONFIG['{LEVEL}']['target_words'])"`
 
@@ -64,7 +66,9 @@ Section targets are guidance, not hard limits.
 
 **Flexible:** Redistribute words between sections freely. One section 20% over is fine if no section is >10% under.
 
-**Priority:** Total word count first → fix sections >10% under → don't worry about over-target sections.
+**Priority:** Objectives and evidence coverage first → repair genuine section
+gaps with sourced pedagogy → route plan-policy mismatch instead of filling a
+section quota with repeated prose.
 
 ---
 

--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,7 +1,7 @@
 review_protocol_version: 1.0.1
-deterministic_contract_version: 1.0.1
-semantic_prompt_version: 1.0.0
-track_policy_version: 1.0.0
+deterministic_contract_version: 1.1.0
+semantic_prompt_version: 1.1.0
+track_policy_version: 1.1.0
 
 families:
   core:
@@ -10,7 +10,14 @@ families:
       claim_coverage: not_applicable
       verify_ukrainian_with_project_sources: true
       review_plan_pedagogy_activities: true
-    size_policy_blocking_statuses: [invalid_size_policy, plan_review_needed]
+    size_policy_signal_severities:
+      missing_plan_word_target: high
+      invalid_size_policy: high
+      plan_review_needed: high
+      below_plan_floor: high
+      repetitive_authored_prose: medium
+      over_advisory_ceiling: info
+      exceptional_justification_required: info
     mechanical_checks:
       connects_to_sequence:
         severity: high
@@ -31,7 +38,15 @@ families:
       verify_ukrainian_with_project_sources: true
       verify_every_factual_claim: true
       decolonization_review: required
-    size_policy_blocking_statuses: [invalid_size_policy, plan_review_needed, missing_research_dossier]
+    size_policy_signal_severities:
+      missing_plan_word_target: high
+      invalid_size_policy: high
+      missing_dossier: high
+      plan_review_needed: high
+      below_plan_floor: high
+      repetitive_authored_prose: medium
+      over_advisory_ceiling: info
+      exceptional_justification_required: info
     mechanical_checks:
       connects_to_sequence:
         severity: high

--- a/agents_extensions/shared/skills/post-build-review/contracts/evidence-derived-size-policy-contract.md
+++ b/agents_extensions/shared/skills/post-build-review/contracts/evidence-derived-size-policy-contract.md
@@ -1,6 +1,6 @@
 # Evidence-derived size-policy contract
 
-Size-policy contract version: `1.0.0`
+Size-policy contract version: `1.1.0`
 
 Consume the existing structured record from
 `scripts/audit/module_size_policy_audit.py` and the implementation in
@@ -9,16 +9,33 @@ prompts, track policy, or this contract.
 
 - `word_target` and a valid reviewed `size_policy.floor_words` are deterministic
   floors, not targets to pad toward with unsupported material.
+- Enforce floors against authored instructional/expository words. Report
+  learner-visible words, quoted primary-source words, excluded markup/directive/
+  URL tokens, and the legacy raw whitespace-token count separately. Heading
+  text is learner-visible; it is authored outside primary-reading blocks and
+  quoted inside them. Markdown markers are not words.
 - The recommended range and advisory ceiling express evidence/pedagogical
   pressure. Crossing the ceiling triggers semantic inspection; it is not an
   automatic fail.
 - Source-backed density and necessary pedagogy are acceptable. Repeated framing,
   generic exposition, uncited interpretation, and inflated transitions are
   padding evidence.
+- Detect repetition only in authored prose paragraphs of at least 40 lexical
+  words. Exclude primary-reading blocks, blockquotes, fenced examples, list/
+  table activity boilerplate, activity sections, and short recaps. Normalize
+  Unicode/case, build five-word shingle sets, and report a pair when it shares
+  at least eight shingles and either Jaccard similarity is at least `0.55` or
+  shorter-paragraph containment is at least `0.82` with length ratio at least
+  `0.70`. Every finding records both line ranges, headings, scores, and shared
+  text; source order and fixed score rounding make serialization deterministic.
 - If grounded material runs out before the floor, surface a plan-policy mismatch
-  instead of inventing depth.
+  instead of inventing depth. `SIZE_POLICY_MISMATCH` never waives the floor; it
+  stops automatic expansion and routes the plan to versioned plan review.
 - Invalid reviewed policy or missing required dossier evidence blocks automatic
   expansion.
+- Sparse dossier classification is not proof of padding, but unsupported sparse
+  material cannot trigger automatic expansion. Exceeding an advisory ceiling is
+  review information, never an automatic failure.
 
 Oleksandr Bilash is the first exemplar only. Its current range, ceiling,
 headings, evidence density, and conclusion belong to its plan/result fixture,

--- a/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/common-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Common semantic post-build review prompt
 
-Semantic prompt version: `1.0.0`
+Semantic prompt version: `1.1.0`
 
 Review the resolved built module, not an imagined template. Deterministic facts
 and mechanically verifiable track rules are already in the resolved context;
@@ -23,6 +23,12 @@ that code cannot decide.
 - Inspect pedagogy, plan adherence, coherence, learner register, cognitive
   load, naturalness, engagement, and source-backed density. Do not turn a word
   count or Bilash-specific structure into a universal rule.
+- Inspect deterministic paragraph-repetition locations and the marginal
+  pedagogical value of authored prose throughout the full size band, not only
+  above the advisory ceiling. Repeated framing, conclusions, transitions, or
+  definitions require revision even when total length is nominally in range.
+- Treat long source-dense material and necessary pedagogy as acceptable.
+  Advisory-ceiling excess alone is never a semantic failure.
 
 ## Severity and verdict
 

--- a/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/core-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Core semantic post-build review prompt
 
-Semantic prompt version: `1.0.0`
+Semantic prompt version: `1.1.0`
 
 Apply this only to A1-C2 core tracks, after the common prompt.
 
@@ -16,6 +16,9 @@ Apply this only to A1-C2 core tracks, after the common prompt.
   material, and activities use only knowledge available to the learner.
 - Compare plan objectives and required vocabulary with prose and activities,
   but do not invent hard counts or headings not supplied by current policy.
+- Judge whether explanation and practice satisfy objectives at the resolved
+  learner state rather than merely consuming a token budget. Flag duplicated
+  explanations or definitions that add no new example, contrast, or practice.
 - Set `claim_coverage.status` to `not_applicable` unless the module makes
   factual claims that require explicit verification; then use `complete` or
   `incomplete` and report the counts.

--- a/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
+++ b/agents_extensions/shared/skills/post-build-review/prompts/seminar-semantic-review-prompt.md
@@ -1,6 +1,6 @@
 # Seminar semantic post-build review prompt
 
-Semantic prompt version: `1.0.0`
+Semantic prompt version: `1.1.0`
 
 Apply this only to FOLK, HIST, BIO, ISTORIO, LIT and subtracks, OES, or RUTH,
 after the common prompt.
@@ -32,5 +32,8 @@ named source/person/event should be findable.
   edition/source identity, dating, genre, and anachronism risks.
 - For FOLK, enforce decolonized framing and distinguish documented practice
   from occult belief claims or demonizing ethnographic language.
+- Distinguish source-backed exposition and necessary primary readings from
+  authored padding. Quoted refrains are not repetition; repeated authorial
+  framing, conclusions, transitions, or definitions without new evidence are.
 - Set `claim_coverage.status` to `complete` only when every extracted claim was
   checked with attributable evidence.

--- a/scripts/audit/module_size_policy_audit.py
+++ b/scripts/audit/module_size_policy_audit.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Measure dossier-led module size policy signals without enforcing gates.
+"""Measure evidence-led module size and deterministic anti-bloat signals.
 
-This command is deliberately advisory. It reports how a plan's current
-``word_target`` relates to the available research/evidence packet so #4801 can
-be calibrated before any prompt, config, or audit gate starts changing behavior.
+Plan floors remain binding. Advisory ceilings describe review pressure, while
+Markdown-aware authored/quoted counts and paragraph repetition evidence make
+the policy useful across core and seminar tracks without treating raw markup as
+instructional prose.
 """
 
 from __future__ import annotations
@@ -12,8 +13,10 @@ import argparse
 import json
 import re
 import sys
+import unicodedata
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
+from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +26,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 CURRICULUM_ROOT = PROJECT_ROOT / "curriculum" / "l2-uk-en"
 RESEARCH_ROOT = PROJECT_ROOT / "docs" / "research"
 
+CORE_TRACKS = {"a1", "a2", "b1", "b2", "c1", "c2"}
 SEMINAR_TRACKS = {
     "bio",
     "folk",
@@ -33,6 +37,7 @@ SEMINAR_TRACKS = {
     "lit-crimea",
     "lit-doc",
     "lit-drama",
+    "lit-essay",
     "lit-fantastika",
     "lit-hist-fic",
     "lit-humor",
@@ -41,7 +46,7 @@ SEMINAR_TRACKS = {
     "oes",
     "ruth",
 }
-CORE_RESEARCH_TRACKS = {"c1", "c2"}
+CORE_RESEARCH_TRACKS = CORE_TRACKS
 
 MODULE_SIZE_BANDS: dict[str, tuple[int, int | None]] = {
     "sparse": (3800, 5000),
@@ -52,8 +57,45 @@ MODULE_SIZE_BANDS: dict[str, tuple[int, int | None]] = {
 
 _URL_RE = re.compile(r"https?://[^\s)>\"]+")
 _MD_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+_MD_INLINE_LINK_RE = re.compile(
+    r"!?\[([^\]]*)\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)"
+)
 _HEADING_RE = re.compile(r"^\s{0,3}#{1,6}\s+", re.MULTILINE)
 _WORD_RE = re.compile(r"\S+")
+_LEXICAL_WORD_RE = re.compile(r"[^\W_]+(?:[’'ʼ:-][^\W_]+)*", re.UNICODE)
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+_HTML_TAG_RE = re.compile(r"</?[A-Za-z][^>]*>")
+_COMPONENT_EXPRESSION_RE = re.compile(r"\{(?:[^{}]|\{[^{}]*\})*\}")
+_DIRECTIVE_OPEN_RE = re.compile(r"^\s*:{3,}\s*([a-z][a-z0-9-]*)\b", re.IGNORECASE)
+_DIRECTIVE_CLOSE_RE = re.compile(r"^\s*:{3,}\s*$")
+_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+_HEADING_LINE_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.*)$")
+_LIST_LINE_RE = re.compile(r"^\s*(?:[-+*]|\d+[.)])\s+")
+_ACTIVITY_HEADING_RE = re.compile(
+    r"^(?:activities|activity|exercises|exercise|workbook|"
+    r"вправи|вправа|завдання|самоперевірка|робочий зошит)$",
+    re.IGNORECASE,
+)
+_SIZE_POLICY_MISMATCH_RE = re.compile(r"\bSIZE_POLICY_MISMATCH\b")
+_LEGACY_PRIMARY_OPEN_RE = re.compile(
+    r"^<!--\s*PRIMARY-READING\s*-->$", re.IGNORECASE
+)
+_LEGACY_PRIMARY_CLOSE_RE = re.compile(
+    r"^<!--\s*/PRIMARY-READING\s*-->$", re.IGNORECASE
+)
+_LEGACY_PRIMARY_OPEN_SENTINEL = "\x00PRIMARY_OPEN\x00"
+_LEGACY_PRIMARY_CLOSE_SENTINEL = "\x00PRIMARY_CLOSE\x00"
+_LEGACY_PRIMARY_SENTINEL_RE = re.compile(
+    f"({_LEGACY_PRIMARY_OPEN_SENTINEL}|{_LEGACY_PRIMARY_CLOSE_SENTINEL})"
+)
+_YAML_PAYLOAD_DIRECTIVES = {"myth-box", "high-culture-bridge"}
+
+REPETITION_SHINGLE_WORDS = 5
+REPETITION_MIN_PARAGRAPH_WORDS = 40
+REPETITION_MIN_SHARED_SHINGLES = 8
+REPETITION_JACCARD_THRESHOLD = 0.55
+REPETITION_CONTAINMENT_THRESHOLD = 0.82
+REPETITION_MIN_LENGTH_RATIO = 0.70
 _CHUNK_ID_RE = re.compile(
     r"\b(?:[0-9a-f]{8}_c\d{4}|[a-z0-9-]+_s\d{4}|wikipedia:[^\s`]+:chunk_\d+)\b",
     re.IGNORECASE,
@@ -97,6 +139,47 @@ class DensityMetrics:
 
 
 @dataclass(frozen=True)
+class MarkdownWordMetrics:
+    """Structured module counts; ``raw_whitespace_tokens`` is compatibility-only."""
+
+    learner_visible_words: int
+    authored_instructional_words: int
+    quoted_primary_source_words: int
+    excluded_markup_directive_url_tokens: int
+    raw_whitespace_tokens: int
+
+
+@dataclass(frozen=True)
+class AuthoredParagraph:
+    start_line: int
+    end_line: int
+    heading: str | None
+    normalized_words: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RepetitionMatch:
+    first_start_line: int
+    first_end_line: int
+    second_start_line: int
+    second_end_line: int
+    first_heading: str | None
+    second_heading: str | None
+    match_type: str
+    jaccard_similarity: float
+    shorter_paragraph_containment: float
+    shared_shingle_count: int
+    shared_text: str
+
+
+@dataclass(frozen=True)
+class RepetitionEvidence:
+    algorithm: str
+    eligible_paragraphs: int
+    matches: tuple[RepetitionMatch, ...]
+
+
+@dataclass(frozen=True)
 class SizePolicyRecord:
     track: str
     slug: str
@@ -115,6 +198,11 @@ class SizePolicyRecord:
     status: str
     notes: list[str]
     metrics: DensityMetrics | None
+    content_metrics: MarkdownWordMetrics | None = None
+    repetition: RepetitionEvidence | None = None
+    size_policy_mismatch: bool = False
+    legacy_raw_whitespace_words: int | None = None
+    decision_signals: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -138,8 +226,335 @@ def display_path(path: Path | None) -> str | None:
         return str(path)
 
 
+def _blank_preserving_newlines(value: str) -> str:
+    return "".join("\n" if char == "\n" else " " for char in value)
+
+
+def _strip_nonvisible_regions(text: str) -> tuple[str, int]:
+    excluded = 0
+
+    def replace_comment(match: re.Match[str]) -> str:
+        nonlocal excluded
+        value = match.group(0)
+        token_count = len(_WORD_RE.findall(value))
+        if _LEGACY_PRIMARY_OPEN_RE.fullmatch(value.strip()):
+            excluded += token_count
+            return _LEGACY_PRIMARY_OPEN_SENTINEL.ljust(len(value), " ")
+        if _LEGACY_PRIMARY_CLOSE_RE.fullmatch(value.strip()):
+            excluded += token_count
+            return _LEGACY_PRIMARY_CLOSE_SENTINEL.ljust(len(value), " ")
+        excluded += token_count
+        return _blank_preserving_newlines(value)
+
+    text = _HTML_COMMENT_RE.sub(replace_comment, text)
+    lines = text.splitlines(keepends=True)
+    if lines and lines[0].strip() == "---":
+        for index in range(1, len(lines)):
+            if lines[index].strip() != "---":
+                continue
+            for frontmatter_index in range(index + 1):
+                excluded += len(_WORD_RE.findall(lines[frontmatter_index]))
+                lines[frontmatter_index] = _blank_preserving_newlines(
+                    lines[frontmatter_index]
+                )
+            break
+    return "".join(lines), excluded
+
+
+def _clean_visible_line(line: str) -> tuple[str, int]:
+    """Return learner-visible text and a deterministic excluded-token count."""
+    excluded = 0
+
+    def replace_link(match: re.Match[str]) -> str:
+        nonlocal excluded
+        excluded += 1
+        return match.group(1)
+
+    line = _MD_INLINE_LINK_RE.sub(replace_link, line)
+    urls = list(_URL_RE.finditer(line))
+    excluded += len(urls)
+    line = _URL_RE.sub(" ", line)
+
+    tags = list(_HTML_TAG_RE.finditer(line))
+    excluded += sum(len(_WORD_RE.findall(match.group(0))) for match in tags)
+    line = _HTML_TAG_RE.sub(" ", line)
+
+    expressions = list(_COMPONENT_EXPRESSION_RE.finditer(line))
+    excluded += sum(len(_WORD_RE.findall(match.group(0))) for match in expressions)
+    line = _COMPONENT_EXPRESSION_RE.sub(" ", line)
+
+    line = re.sub(r"^\s*>\s?", "", line)
+    line = _LIST_LINE_RE.sub("", line)
+    return line.strip(), excluded
+
+
+def _normalized_words(text: str) -> tuple[str, ...]:
+    words: list[str] = []
+    for match in _LEXICAL_WORD_RE.finditer(text):
+        value = match.group(0)
+        if any(char.isalpha() for char in value):
+            words.append(value.casefold())
+    return tuple(words)
+
+
+def _shingles(words: tuple[str, ...]) -> set[tuple[str, ...]]:
+    if len(words) < REPETITION_SHINGLE_WORDS:
+        return set()
+    return {
+        words[index : index + REPETITION_SHINGLE_WORDS]
+        for index in range(len(words) - REPETITION_SHINGLE_WORDS + 1)
+    }
+
+
+def _shared_text(first: tuple[str, ...], second: tuple[str, ...]) -> str:
+    block = SequenceMatcher(None, first, second, autojunk=False).find_longest_match()
+    if block.size == 0:
+        return ""
+    value = " ".join(first[block.a : block.a + block.size])
+    return value if len(value) <= 240 else value[:237].rstrip() + "..."
+
+
+def detect_authored_repetition(
+    paragraphs: list[AuthoredParagraph],
+) -> RepetitionEvidence:
+    """Find exact/near duplicates using deterministic five-word shingle overlap.
+
+    Paragraphs shorter than 40 lexical words are excluded as deliberate recaps.
+    A pair is actionable when it has at least eight shared shingles and either
+    Jaccard overlap is at least 0.55 or shorter-paragraph containment is at
+    least 0.82 with a length ratio of at least 0.70.
+    """
+    matches: list[RepetitionMatch] = []
+    shingle_sets = [_shingles(paragraph.normalized_words) for paragraph in paragraphs]
+    for first_index, first in enumerate(paragraphs):
+        first_shingles = shingle_sets[first_index]
+        for second_index in range(first_index + 1, len(paragraphs)):
+            second = paragraphs[second_index]
+            second_shingles = shingle_sets[second_index]
+            shared = first_shingles & second_shingles
+            if len(shared) < REPETITION_MIN_SHARED_SHINGLES:
+                continue
+            union = first_shingles | second_shingles
+            jaccard = len(shared) / len(union) if union else 0.0
+            shorter = min(len(first_shingles), len(second_shingles))
+            containment = len(shared) / shorter if shorter else 0.0
+            length_ratio = min(
+                len(first.normalized_words), len(second.normalized_words)
+            ) / max(len(first.normalized_words), len(second.normalized_words))
+            exact = first.normalized_words == second.normalized_words
+            near = jaccard >= REPETITION_JACCARD_THRESHOLD or (
+                containment >= REPETITION_CONTAINMENT_THRESHOLD
+                and length_ratio >= REPETITION_MIN_LENGTH_RATIO
+            )
+            if not exact and not near:
+                continue
+            matches.append(
+                RepetitionMatch(
+                    first_start_line=first.start_line,
+                    first_end_line=first.end_line,
+                    second_start_line=second.start_line,
+                    second_end_line=second.end_line,
+                    first_heading=first.heading,
+                    second_heading=second.heading,
+                    match_type="exact" if exact else "near_duplicate",
+                    jaccard_similarity=round(jaccard, 6),
+                    shorter_paragraph_containment=round(containment, 6),
+                    shared_shingle_count=len(shared),
+                    shared_text=_shared_text(
+                        first.normalized_words, second.normalized_words
+                    ),
+                )
+            )
+    return RepetitionEvidence(
+        algorithm=(
+            "paragraph_5_word_shingles_v1:jaccard>=0.55_or_"
+            "containment>=0.82,length_ratio>=0.70,min_shared=8,min_words=40"
+        ),
+        eligible_paragraphs=len(paragraphs),
+        matches=tuple(matches),
+    )
+
+
+def markdown_module_evidence(
+    text: str,
+) -> tuple[MarkdownWordMetrics, RepetitionEvidence, bool]:
+    """Extract Markdown-aware counts, repetition evidence, and mismatch marker."""
+    text = unicodedata.normalize("NFC", text)
+    raw_whitespace_tokens = len(_WORD_RE.findall(text))
+    has_mismatch_marker = bool(_SIZE_POLICY_MISMATCH_RE.search(text))
+    visible_text, excluded = _strip_nonvisible_regions(text)
+    directive_stack: list[str] = []
+    current_heading: str | None = None
+    activity_section = False
+    in_fence = False
+    in_legacy_primary = False
+    authored_words = 0
+    primary_words = 0
+    paragraphs: list[AuthoredParagraph] = []
+    paragraph_lines: list[str] = []
+    paragraph_start = 0
+    paragraph_end = 0
+    paragraph_heading: str | None = None
+
+    def flush_paragraph() -> None:
+        nonlocal paragraph_lines, paragraph_start, paragraph_end, paragraph_heading
+        if paragraph_lines:
+            words = _normalized_words(" ".join(paragraph_lines))
+            if len(words) >= REPETITION_MIN_PARAGRAPH_WORDS:
+                paragraphs.append(
+                    AuthoredParagraph(
+                        start_line=paragraph_start,
+                        end_line=paragraph_end,
+                        heading=paragraph_heading,
+                        normalized_words=words,
+                    )
+                )
+        paragraph_lines = []
+        paragraph_start = 0
+        paragraph_end = 0
+        paragraph_heading = None
+
+    def record_content(
+        raw_line: str,
+        content_line: str,
+        line_number: int,
+        *,
+        in_primary: bool,
+    ) -> None:
+        nonlocal authored_words, excluded, paragraph_end, paragraph_heading
+        nonlocal paragraph_start, primary_words
+        in_yaml_payload = any(
+            directive in _YAML_PAYLOAD_DIRECTIVES for directive in directive_stack
+        )
+        if in_yaml_payload:
+            content_line = re.sub(
+                r"^\s*(?:-\s*)?[A-Za-z_][A-Za-z0-9_-]*:\s*",
+                "",
+                content_line,
+            )
+        cleaned, line_excluded = _clean_visible_line(content_line)
+        excluded += line_excluded
+        words = _normalized_words(cleaned)
+        if in_primary:
+            flush_paragraph()
+            primary_words += len(words)
+            return
+
+        authored_words += len(words)
+        non_prose = (
+            in_fence
+            or raw_line.lstrip().startswith(">")
+            or bool(_LIST_LINE_RE.match(raw_line))
+            or raw_line.lstrip().startswith("|")
+            or activity_section
+            or in_yaml_payload
+        )
+        if non_prose:
+            flush_paragraph()
+            return
+        if cleaned:
+            if not paragraph_lines:
+                paragraph_start = line_number
+                paragraph_heading = current_heading
+            paragraph_lines.append(cleaned)
+            paragraph_end = line_number
+
+    for line_number, raw_line in enumerate(visible_text.splitlines(), 1):
+        stripped = raw_line.strip()
+        if (
+            _LEGACY_PRIMARY_OPEN_SENTINEL in raw_line
+            or _LEGACY_PRIMARY_CLOSE_SENTINEL in raw_line
+        ):
+            for segment in _LEGACY_PRIMARY_SENTINEL_RE.split(raw_line):
+                if segment == _LEGACY_PRIMARY_OPEN_SENTINEL:
+                    flush_paragraph()
+                    in_legacy_primary = True
+                elif segment == _LEGACY_PRIMARY_CLOSE_SENTINEL:
+                    flush_paragraph()
+                    in_legacy_primary = False
+                elif segment:
+                    record_content(
+                        raw_line,
+                        segment,
+                        line_number,
+                        in_primary=in_legacy_primary
+                        or "primary-reading" in directive_stack,
+                    )
+            continue
+        directive_open = _DIRECTIVE_OPEN_RE.match(raw_line)
+        if directive_open:
+            flush_paragraph()
+            directive_kind = directive_open.group(1).casefold()
+            directive_stack.append(directive_kind)
+            title_match = re.search(r"\[([^\]]+)\]", raw_line)
+            title_words = (
+                _normalized_words(title_match.group(1))
+                if title_match is not None and directive_kind != "primary-reading"
+                else ()
+            )
+            authored_words += len(title_words)
+            excluded += max(1, len(_WORD_RE.findall(raw_line)) - len(title_words))
+            continue
+        if _DIRECTIVE_CLOSE_RE.match(raw_line):
+            flush_paragraph()
+            if directive_stack:
+                directive_stack.pop()
+            excluded += len(_WORD_RE.findall(raw_line))
+            continue
+        if _FENCE_RE.match(raw_line):
+            flush_paragraph()
+            in_fence = not in_fence
+            excluded += len(_WORD_RE.findall(raw_line))
+            continue
+        if not stripped:
+            flush_paragraph()
+            continue
+
+        heading_match = _HEADING_LINE_RE.match(raw_line)
+        if heading_match:
+            flush_paragraph()
+            cleaned, line_excluded = _clean_visible_line(heading_match.group(2))
+            excluded += line_excluded + 1
+            words = _normalized_words(cleaned)
+            if in_legacy_primary or "primary-reading" in directive_stack:
+                primary_words += len(words)
+            else:
+                authored_words += len(words)
+                current_heading = cleaned or None
+                activity_section = bool(
+                    current_heading
+                    and _ACTIVITY_HEADING_RE.fullmatch(current_heading)
+                )
+            continue
+
+        record_content(
+            raw_line,
+            raw_line,
+            line_number,
+            in_primary=in_legacy_primary or "primary-reading" in directive_stack,
+        )
+
+    flush_paragraph()
+    metrics = MarkdownWordMetrics(
+        learner_visible_words=authored_words + primary_words,
+        authored_instructional_words=authored_words,
+        quoted_primary_source_words=primary_words,
+        excluded_markup_directive_url_tokens=excluded,
+        raw_whitespace_tokens=raw_whitespace_tokens,
+    )
+    return metrics, detect_authored_repetition(paragraphs), has_mismatch_marker
+
+
+def module_content_evidence(
+    path: Path,
+) -> tuple[MarkdownWordMetrics, RepetitionEvidence, bool]:
+    return markdown_module_evidence(path.read_text(encoding="utf-8"))
+
+
 def word_count(path: Path) -> int:
-    return len(_WORD_RE.findall(path.read_text(encoding="utf-8")))
+    """Return canonical authored instructional words for floor enforcement."""
+    metrics, _, _ = module_content_evidence(path)
+    return metrics.authored_instructional_words
 
 
 def read_yaml(path: Path) -> dict[str, Any]:
@@ -233,7 +648,7 @@ def classify_dossier(track: str, metrics: DensityMetrics) -> str:
 
 
 def classify_core_evidence(plan: dict[str, Any]) -> str:
-    """Classify C1-C2 modules by plan/evidence pressure, not dossier size."""
+    """Classify A1-C2 modules by plan/evidence pressure, not dossier size."""
     target = _as_int(plan.get("word_target"))
     outline_words = _sum_outline_words(plan.get("content_outline"))
     refs = plan.get("references")
@@ -383,6 +798,9 @@ def build_explicit_size_policy_record(
     actual_words: int | None,
     metrics: DensityMetrics | None,
     override: SizePolicyOverride,
+    content_metrics: MarkdownWordMetrics | None = None,
+    repetition: RepetitionEvidence | None = None,
+    size_policy_mismatch: bool = False,
 ) -> SizePolicyRecord:
     """Build the effective record for a valid, reviewed plan override."""
     notes = [
@@ -394,17 +812,36 @@ def build_explicit_size_policy_record(
             "required."
         ),
     ]
-    status = "explicit_override"
-    if actual_words is not None:
-        if actual_words < override.floor_words:
-            status = "below_plan_floor"
-            notes.append("Built module is below the current plan floor.")
-        elif actual_words > override.ceiling_words:
-            status = "exceptional_justification_required"
-            notes.append(
-                "Built module exceeds the explicit advisory ceiling and requires "
-                "exceptional justification."
-            )
+    signals: list[str] = []
+    if size_policy_mismatch:
+        signals.append("plan_review_needed")
+        notes.append(
+            "SIZE_POLICY_MISMATCH declares exhausted grounded material; stop automatic expansion and route to plan review."
+        )
+    if actual_words is not None and actual_words < override.floor_words:
+        signals.append("below_plan_floor")
+        notes.append("Built module is below the current plan floor.")
+    elif actual_words is not None and actual_words > override.ceiling_words:
+        signals.append("over_advisory_ceiling")
+        notes.append(
+            "Built module exceeds the explicit advisory ceiling; review sourced pedagogy without failing on length alone."
+        )
+    if repetition is not None and repetition.matches:
+        signals.append("repetitive_authored_prose")
+        notes.append(
+            f"Detected {len(repetition.matches)} actionable exact/near-duplicate authored paragraph pair(s)."
+        )
+
+    if "plan_review_needed" in signals:
+        status = "plan_review_needed"
+    elif "below_plan_floor" in signals:
+        status = "below_plan_floor"
+    elif "repetitive_authored_prose" in signals:
+        status = "repetitive_authored_prose"
+    elif "over_advisory_ceiling" in signals:
+        status = "over_advisory_ceiling"
+    else:
+        status = "explicit_override"
 
     return SizePolicyRecord(
         track=track,
@@ -424,6 +861,13 @@ def build_explicit_size_policy_record(
         status=status,
         notes=notes,
         metrics=metrics,
+        content_metrics=content_metrics,
+        repetition=repetition,
+        size_policy_mismatch=size_policy_mismatch,
+        legacy_raw_whitespace_words=(
+            content_metrics.raw_whitespace_tokens if content_metrics else None
+        ),
+        decision_signals=tuple(signals),
     )
 
 
@@ -435,7 +879,14 @@ def _plan_paths_for_track(track: str) -> list[Path]:
 
 
 def _module_path(track: str, slug: str) -> Path:
-    return CURRICULUM_ROOT / track / slug / "module.md"
+    track_dir = CURRICULUM_ROOT / track
+    nested = track_dir / slug / "module.md"
+    candidates = [
+        nested,
+        track_dir / f"{slug}.md",
+        *sorted(track_dir.glob(f"[0-9]*-{slug}.md")),
+    ]
+    return next((candidate for candidate in candidates if candidate.exists()), nested)
 
 
 def _dossier_from_plan(plan: dict[str, Any]) -> Path | None:
@@ -480,15 +931,28 @@ def _status_and_notes(
     band_max: int | None,
     advisory_ceiling: int | None,
     dossier_path: Path | None,
-) -> tuple[str, list[str]]:
+    repetition: RepetitionEvidence | None = None,
+    size_policy_mismatch: bool = False,
+) -> tuple[str, list[str], tuple[str, ...]]:
     notes: list[str] = []
-    status = "advisory_ok"
+    signals: list[str] = []
 
     if plan_floor is None:
-        return "missing_plan_word_target", ["Plan has no numeric word_target."]
+        return (
+            "missing_plan_word_target",
+            ["Plan has no numeric word_target."],
+            ("missing_plan_word_target",),
+        )
+
+    if size_policy_mismatch:
+        signals.append("plan_review_needed")
+        notes.append(
+            "SIZE_POLICY_MISMATCH declares exhausted grounded material; stop automatic expansion and route to plan review."
+        )
 
     if track.lower() in SEMINAR_TRACKS and dossier_path is None:
-        return "missing_dossier", ["Seminar module has no discoverable research dossier."]
+        signals.append("missing_dossier")
+        notes.append("Seminar module has no discoverable research dossier.")
 
     if band == "sparse":
         notes.append(
@@ -496,36 +960,51 @@ def _status_and_notes(
         )
     if band.startswith("core_"):
         notes.append(
-            "Core C1-C2 uses a pedagogy/evidence-packet basis; do not apply seminar dossier ceilings mechanically."
+            "Core A1-C2 uses a pedagogy/evidence-packet basis; do not apply seminar dossier ceilings mechanically."
         )
 
     if band_max is not None and plan_floor > band_max:
-        status = "plan_review_needed"
+        if "plan_review_needed" not in signals:
+            signals.append("plan_review_needed")
         notes.append(
             "Plan floor exceeds the dossier/evidence advisory ceiling; review the plan before asking writers to expand."
         )
 
     if actual_words is not None:
         if actual_words < plan_floor:
-            if status == "plan_review_needed":
+            signals.append("below_plan_floor")
+            if "plan_review_needed" in signals:
                 notes.append(
                     "Built module is below the current plan floor, but the plan floor already exceeds the advisory ceiling; review the plan before expanding."
                 )
             else:
-                status = "below_plan_floor"
                 notes.append("Built module is below the current plan floor.")
         elif advisory_ceiling is not None and actual_words > advisory_ceiling:
-            if status != "plan_review_needed":
-                status = "over_advisory_ceiling"
+            signals.append("over_advisory_ceiling")
             notes.append(
                 "Built module exceeds the advisory ceiling; expansion should be justified by sourced pedagogy."
             )
         if actual_words >= MODULE_SIZE_BANDS["exceptional"][0]:
-            if status != "plan_review_needed":
-                status = "exceptional_justification_required"
+            signals.append("exceptional_justification_required")
             notes.append("Modules at 8000+ words require explicit justification.")
 
-    return status, notes
+    if repetition is not None and repetition.matches:
+        signals.append("repetitive_authored_prose")
+        notes.append(
+            f"Detected {len(repetition.matches)} actionable exact/near-duplicate authored paragraph pair(s)."
+        )
+
+    priority = (
+        "missing_plan_word_target",
+        "missing_dossier",
+        "plan_review_needed",
+        "below_plan_floor",
+        "repetitive_authored_prose",
+        "exceptional_justification_required",
+        "over_advisory_ceiling",
+    )
+    status = next((signal for signal in priority if signal in signals), "advisory_ok")
+    return status, notes, tuple(dict.fromkeys(signals))
 
 
 def build_record(track: str, plan_path: Path) -> SizePolicyRecord:
@@ -534,7 +1013,16 @@ def build_record(track: str, plan_path: Path) -> SizePolicyRecord:
     plan_floor = _as_int(plan.get("word_target"))
     plan_outline_words = _sum_outline_words(plan.get("content_outline"))
     module_path = _module_path(track, slug)
-    actual_words = word_count(module_path) if module_path.exists() else None
+    content_metrics: MarkdownWordMetrics | None = None
+    repetition: RepetitionEvidence | None = None
+    size_policy_mismatch = False
+    if module_path.exists():
+        content_metrics, repetition, size_policy_mismatch = module_content_evidence(
+            module_path
+        )
+    actual_words = (
+        content_metrics.authored_instructional_words if content_metrics else None
+    )
     dossier_path = _dossier_path(track, slug, plan)
 
     metrics = dossier_metrics(dossier_path) if dossier_path else None
@@ -554,6 +1042,9 @@ def build_record(track: str, plan_path: Path) -> SizePolicyRecord:
             actual_words=actual_words,
             metrics=metrics,
             override=override,
+            content_metrics=content_metrics,
+            repetition=repetition,
+            size_policy_mismatch=size_policy_mismatch,
         )
 
     if metrics is not None:
@@ -572,7 +1063,7 @@ def build_record(track: str, plan_path: Path) -> SizePolicyRecord:
     if plan_floor is not None:
         advisory_ceiling = max(plan_floor, band_max) if band_max is not None else None
 
-    status, notes = _status_and_notes(
+    status, notes, decision_signals = _status_and_notes(
         track=track,
         plan_floor=plan_floor,
         actual_words=actual_words,
@@ -580,9 +1071,12 @@ def build_record(track: str, plan_path: Path) -> SizePolicyRecord:
         band_max=band_max,
         advisory_ceiling=advisory_ceiling,
         dossier_path=dossier_path,
+        repetition=repetition,
+        size_policy_mismatch=size_policy_mismatch,
     )
     if override_errors:
         status = "invalid_size_policy"
+        decision_signals = ("invalid_size_policy", *decision_signals)
         notes.extend(
             [
                 "Explicit size_policy is invalid and cannot replace generic density-band limits.",
@@ -608,6 +1102,13 @@ def build_record(track: str, plan_path: Path) -> SizePolicyRecord:
         status=status,
         notes=notes,
         metrics=metrics,
+        content_metrics=content_metrics,
+        repetition=repetition,
+        size_policy_mismatch=size_policy_mismatch,
+        legacy_raw_whitespace_words=(
+            content_metrics.raw_whitespace_tokens if content_metrics else None
+        ),
+        decision_signals=tuple(dict.fromkeys(decision_signals)),
     )
 
 
@@ -639,10 +1140,7 @@ def _parse_slug_filter(values: list[str] | None) -> set[str] | None:
 
 
 def _record_to_dict(record: SizePolicyRecord) -> dict[str, Any]:
-    data = asdict(record)
-    if record.metrics is not None:
-        data["metrics"] = asdict(record.metrics)
-    return data
+    return asdict(record)
 
 
 def build_records(
@@ -681,10 +1179,11 @@ def print_summary(records: list[SizePolicyRecord]) -> None:
         "basis",
         "band",
         "plan",
-        "actual",
+        "authored",
+        "visible",
+        "raw",
         "ceiling",
-        "dossier",
-        "refs",
+        "repeat",
         "status",
     ]
     rows: list[list[str]] = []
@@ -698,12 +1197,21 @@ def print_summary(records: list[SizePolicyRecord]) -> None:
                 str(record.plan_floor if record.plan_floor is not None else "-"),
                 str(record.actual_words if record.actual_words is not None else "-"),
                 str(
+                    record.content_metrics.learner_visible_words
+                    if record.content_metrics
+                    else "-"
+                ),
+                str(
+                    record.legacy_raw_whitespace_words
+                    if record.legacy_raw_whitespace_words is not None
+                    else "-"
+                ),
+                str(
                     record.advisory_ceiling
                     if record.advisory_ceiling is not None
                     else "-"
                 ),
-                str(record.metrics.words if record.metrics else "-"),
-                str(record.metrics.source_refs if record.metrics else "-"),
+                str(len(record.repetition.matches) if record.repetition else "-"),
                 record.status,
             ]
         )

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -353,19 +353,51 @@ def _check_size_policy_status(
     track_policy: Mapping[str, Any],
     size_record: Mapping[str, Any] | None,
 ) -> list[dict[str, Any]]:
-    blocking_size_statuses = {str(value) for value in track_policy.get("size_policy_blocking_statuses") or []}
-    if size_record is None or str(size_record.get("status")) not in blocking_size_statuses:
+    if size_record is None:
         return []
-    return [
-        _policy_finding(
-            "size-policy-blocking-status",
-            "size_policy",
-            "high",
-            "Evidence-derived size policy is not ready for module approval.",
-            evidence=f"status={size_record.get('status')}; notes={size_record.get('notes')}",
-            location=str(target["files"]["plan"]),
+    severities = track_policy.get("size_policy_signal_severities")
+    if not isinstance(severities, Mapping):
+        return []
+    raw_signals = size_record.get("decision_signals") or [size_record.get("status")]
+    signals = [str(signal) for signal in raw_signals if str(signal) in severities]
+    messages = {
+        "missing_plan_word_target": "Plan has no enforceable word floor.",
+        "invalid_size_policy": "Explicit size-policy override is invalid.",
+        "missing_dossier": "Required seminar research dossier is missing.",
+        "plan_review_needed": "Grounded material and the reviewed plan floor require plan review; automatic expansion is forbidden.",
+        "below_plan_floor": "Authored instructional prose is below the reviewed plan floor.",
+        "repetitive_authored_prose": "Deterministic paragraph evidence found repetitive authored exposition requiring revision.",
+        "over_advisory_ceiling": "Module exceeds the advisory ceiling; inspect source density and marginal pedagogical value without failing on length alone.",
+        "exceptional_justification_required": "Exceptional length requires explicit source-backed pedagogical justification.",
+    }
+    findings: list[dict[str, Any]] = []
+    content_path = str(target["files"].get("content") or target["files"]["plan"])
+    for signal in dict.fromkeys(signals):
+        location = (
+            str(target["files"]["plan"])
+            if signal in {
+                "missing_plan_word_target",
+                "invalid_size_policy",
+                "missing_dossier",
+                "plan_review_needed",
+            }
+            else content_path
         )
-    ]
+        findings.append(
+            _policy_finding(
+                f"size-policy-{signal}",
+                "size_policy",
+                str(severities[signal]),
+                messages.get(signal, "Evidence-derived size policy requires review."),
+                evidence=(
+                    f"signal={signal}; status={size_record.get('status')}; "
+                    f"notes={size_record.get('notes')}; "
+                    f"repetition={size_record.get('repetition')}"
+                ),
+                location=location,
+            )
+        )
+    return findings
 
 
 def _check_connects_to(

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -48,6 +48,7 @@ CLAUDE_WRITER_AGENT_TARGET = PROJECT_ROOT / ".claude" / "agents" / "curriculum-w
 
 from scripts.audit.content_surface_gates import scan_module_surface, scan_surface_text
 from scripts.audit.failure_classes import FailureClass, FailureRecord
+from scripts.audit.module_size_policy_audit import markdown_module_evidence
 from scripts.audit.wiki_completeness_gate import SEMINAR_LEVELS
 from scripts.build.citation_matcher import (
     CitationKey,
@@ -10292,13 +10293,10 @@ def _word_count(text: str) -> int:
     return len(_WORD_RE.findall(text))
 
 
-# Word-target tolerance: 8% lower band. User direction 2026-05-23
-# (handoff docs/session-state/2026-05-23-architectural-reset-strip-v7-llm-demote.md
-# decision row B): word targets stay as MINIMUMS for the writer prompt
-# guidance, but the gate tolerates ±8% below target to avoid 0.25%-short
-# rejections like deepseek-pro 1197/1200. Empirically the 8% band still
-# rejects gemini-tools 1031/1200 (14% short).
-_WORD_COUNT_TOLERANCE_BELOW = 0.08
+# Reviewed plan word targets are exact minimums. A short draft is revised with
+# grounded material or routed to plan review through SIZE_POLICY_MISMATCH; the
+# gate never lowers the floor by a percentage tolerance.
+_WORD_COUNT_TOLERANCE_BELOW = 0.0
 _PRIMARY_READING_BLOCK_RE = re.compile(
     r"(?:<!--\s*PRIMARY-READING\s*-->.*?<!--\s*/PRIMARY-READING\s*-->|^:::primary-reading(?:\s*\{[^\n]*\})?\s*\n.*?\n:::\s*$)",
     re.IGNORECASE | re.DOTALL | re.MULTILINE,
@@ -10310,7 +10308,7 @@ def _strip_primary_reading_blocks(text: str) -> str:
 
 
 def _word_count_gate(text: str, target: int) -> dict[str, Any]:
-    count = _word_count(_strip_comments(_strip_primary_reading_blocks(text)))
+    count = markdown_module_evidence(text)[0].authored_instructional_words
     min_with_tolerance = int(target * (1 - _WORD_COUNT_TOLERANCE_BELOW))
     return {
         "passed": count >= min_with_tolerance,
@@ -10325,7 +10323,7 @@ _WRITER_DRAFT_SECTION_FLOOR_RATIO = 0.85
 
 
 def _writer_draft_countable_words(text: str) -> int:
-    return _word_count(_strip_comments(_strip_primary_reading_blocks(text)))
+    return markdown_module_evidence(text)[0].authored_instructional_words
 
 
 def _writer_draft_section_length_report(
@@ -10384,6 +10382,7 @@ def writer_draft_length_report(
         plan,
         plan_path=plan_path,
         actual_words=count,
+        module_text=module_text,
     )
     section_reports = _writer_draft_section_length_report(
         plan,
@@ -10438,13 +10437,14 @@ def render_writer_draft_length_expansion_prompt(
         plan,
         plan_path=plan_path,
         actual_words=int(length_report.get("count") or 0),
+        module_text=module_text,
     )
     return "\n".join(
         [
             "# Writer Draft Length Pre-check",
             "",
             "The deterministic first-draft length pre-check failed before the full Python QG loop.",
-            "Gate-counted words exclude markdown comments and `:::primary-reading` blocks.",
+            "Gate-counted authored words exclude Markdown comments, directive/component syntax, URLs, and `:::primary-reading` source text.",
             "",
             "## Size policy",
             render_writer_size_policy(size_policy),
@@ -10506,6 +10506,7 @@ def run_writer_draft_length_precheck(
         plan,
         plan_path=plan_path,
         actual_words=int(before["count"]),
+        module_text=before_text,
     )
     if not size_policy_allows_auto_expansion(size_policy):
         _emit(

--- a/scripts/build/module_size_policy.py
+++ b/scripts/build/module_size_policy.py
@@ -33,6 +33,7 @@ def build_size_policy_for_plan(
     *,
     plan_path: Path | None = None,
     actual_words: int | None = None,
+    module_text: str | None = None,
 ) -> audit.SizePolicyRecord:
     """Resolve the effective advisory size policy for an already-loaded plan."""
     track = str(plan.get("level") or "").strip().lower()
@@ -40,8 +41,19 @@ def build_size_policy_for_plan(
     plan_floor = audit._as_int(plan.get("word_target"))
     plan_outline_words = audit._sum_outline_words(plan.get("content_outline"))
     module_path = audit._module_path(track, slug) if track and slug else None
-    if actual_words is None and module_path is not None and module_path.exists():
-        actual_words = audit.word_count(module_path)
+    content_metrics: audit.MarkdownWordMetrics | None = None
+    repetition: audit.RepetitionEvidence | None = None
+    size_policy_mismatch = False
+    if module_text is not None:
+        content_metrics, repetition, size_policy_mismatch = (
+            audit.markdown_module_evidence(module_text)
+        )
+    elif module_path is not None and module_path.exists():
+        content_metrics, repetition, size_policy_mismatch = audit.module_content_evidence(
+            module_path
+        )
+    if content_metrics is not None:
+        actual_words = content_metrics.authored_instructional_words
 
     policy_uses_dossier_metrics = "size_policy" in plan or (
         track in audit.SEMINAR_TRACKS or track in audit.CORE_RESEARCH_TRACKS
@@ -70,6 +82,9 @@ def build_size_policy_for_plan(
             actual_words=actual_words,
             metrics=metrics,
             override=override,
+            content_metrics=content_metrics,
+            repetition=repetition,
+            size_policy_mismatch=size_policy_mismatch,
         )
 
     if track not in audit.SEMINAR_TRACKS and track not in audit.CORE_RESEARCH_TRACKS:
@@ -103,6 +118,13 @@ def build_size_policy_for_plan(
             status=status,
             notes=notes,
             metrics=metrics,
+            content_metrics=content_metrics,
+            repetition=repetition,
+            size_policy_mismatch=size_policy_mismatch,
+            legacy_raw_whitespace_words=(
+                content_metrics.raw_whitespace_tokens if content_metrics else None
+            ),
+            decision_signals=(status,) if status != PLAN_FLOOR_ONLY else (),
         )
 
     if metrics is not None:
@@ -119,7 +141,7 @@ def build_size_policy_for_plan(
     advisory_ceiling = None
     if plan_floor is not None:
         advisory_ceiling = max(plan_floor, band_max) if band_max is not None else None
-    status, notes = audit._status_and_notes(
+    status, notes, decision_signals = audit._status_and_notes(
         track=track,
         plan_floor=plan_floor,
         actual_words=actual_words,
@@ -127,9 +149,12 @@ def build_size_policy_for_plan(
         band_max=band_max,
         advisory_ceiling=advisory_ceiling,
         dossier_path=dossier_path,
+        repetition=repetition,
+        size_policy_mismatch=size_policy_mismatch,
     )
     if override_errors:
         status = INVALID_SIZE_POLICY
+        decision_signals = (INVALID_SIZE_POLICY, *decision_signals)
         notes.extend(
             [
                 "Explicit size_policy is invalid and cannot replace generic density-band limits.",
@@ -155,12 +180,31 @@ def build_size_policy_for_plan(
         status=status,
         notes=notes,
         metrics=metrics,
+        content_metrics=content_metrics,
+        repetition=repetition,
+        size_policy_mismatch=size_policy_mismatch,
+        legacy_raw_whitespace_words=(
+            content_metrics.raw_whitespace_tokens if content_metrics else None
+        ),
+        decision_signals=tuple(dict.fromkeys(decision_signals)),
     )
 
 
 def size_policy_allows_auto_expansion(record: audit.SizePolicyRecord) -> bool:
     """Return whether build code may auto-request expansion for short drafts."""
-    return record.status not in {PLAN_REVIEW_NEEDED, MISSING_DOSSIER, INVALID_SIZE_POLICY}
+    blocking_signals = {
+        PLAN_REVIEW_NEEDED,
+        MISSING_DOSSIER,
+        INVALID_SIZE_POLICY,
+        "missing_plan_word_target",
+        "repetitive_authored_prose",
+    }
+    if set(record.decision_signals).intersection(blocking_signals):
+        return False
+    return not (
+        record.density_band == "sparse"
+        and record.basis != "explicit_plan_size_policy"
+    )
 
 
 def size_policy_padding_diagnostic(record: audit.SizePolicyRecord) -> dict[str, Any]:
@@ -169,13 +213,25 @@ def size_policy_padding_diagnostic(record: audit.SizePolicyRecord) -> dict[str, 
         "status": "not_evaluated",
         "review_action": "no_count_available",
         "over_advisory_ceiling_words": 0,
+        "repetition_status": "clear",
+        "repetition_match_count": 0,
     }
+    if record.repetition is not None and record.repetition.matches:
+        diagnostic["repetition_status"] = "revision_needed"
+        diagnostic["repetition_match_count"] = len(record.repetition.matches)
     if record.actual_words is None:
         return diagnostic
 
     if record.actual_words < (record.plan_floor or 0):
         diagnostic["status"] = "below_plan_floor"
         diagnostic["review_action"] = "do_not_pad; check whether plan floor exceeds sourced evidence"
+        return diagnostic
+
+    if diagnostic["repetition_match_count"]:
+        diagnostic["status"] = "repetitive_authored_prose"
+        diagnostic["review_action"] = (
+            "revise exact/near-duplicate authored paragraphs; do not add more prose"
+        )
         return diagnostic
 
     if record.advisory_ceiling is None:
@@ -207,6 +263,10 @@ def size_policy_summary(record: audit.SizePolicyRecord) -> dict[str, Any]:
         data["expansion_permission"] = "blocked_until_research_dossier"
     elif record.status == INVALID_SIZE_POLICY:
         data["expansion_permission"] = "blocked_until_size_policy_is_valid"
+    elif "repetitive_authored_prose" in record.decision_signals:
+        data["expansion_permission"] = "revision_required_before_expansion"
+    elif record.density_band == "sparse" and record.basis != "explicit_plan_size_policy":
+        data["expansion_permission"] = "blocked_until_source_saturation_or_plan_review"
     elif record.status == PLAN_FLOOR_ONLY:
         data["expansion_permission"] = "plan_floor_only"
     else:
@@ -235,9 +295,10 @@ def render_writer_size_policy(record: audit.SizePolicyRecord) -> str:
             f"- Advisory ceiling words: {ceiling}",
             f"- Expansion permission: {summary['expansion_permission']}",
             f"- Status: {record.status}",
-            "- Rule: meet the plan floor with complete coverage, but expand only when the added material is source-backed and pedagogically useful.",
+            "- Rule: satisfy objectives and evidence coverage, not a token target; the reviewed plan floor still binds.",
+            "- Rule: expand only when added material is source-backed and pedagogically necessary.",
             "- Rule: if grounded material runs out before the floor, emit `<!-- SIZE_POLICY_MISMATCH: plan floor exceeds sourced evidence -->` instead of inventing depth.",
-            "- Rule: do not add repeated framing, generic exposition, uncited interpretation, or filler to chase old fixed multipliers.",
+            "- Rule: do not repeat framing, conclusions, transitions, definitions, generic exposition, or uncited interpretation to reach the floor.",
             "Notes:",
             note_lines,
         ]
@@ -253,11 +314,14 @@ def render_reviewer_size_policy(record: audit.SizePolicyRecord) -> str:
         [
             base,
             "- Reviewer rule: do not fail or pass a module on word count alone; deterministic gates handled the floor.",
-            "- Reviewer rule: if the padding diagnostic is `over_advisory_ceiling`, inspect whether the extra length is source-backed density, necessary pedagogy, or filler/padding.",
+            "- Reviewer rule: inspect deterministic repetition evidence and marginal pedagogical value throughout the full size band, not only above the advisory ceiling.",
+            "- Reviewer rule: if the module is over the advisory ceiling, decide whether the extra length is source-backed density, necessary pedagogy, or filler/padding; length alone is not a failure.",
             "- Reviewer rule: source-backed density is acceptable evidence; repeated framing, generic exposition, uncited interpretation, and inflated transitions are padding evidence.",
             "Padding diagnostic:",
             f"- Status: {padding['status']}",
             f"- Over advisory ceiling words: {padding['over_advisory_ceiling_words']}",
+            f"- Repetition status: {padding['repetition_status']}",
+            f"- Repetition matches: {padding['repetition_match_count']}",
             f"- Review action: {padding['review_action']}",
         ]
     )

--- a/scripts/build/phases/linear-review-dim.md
+++ b/scripts/build/phases/linear-review-dim.md
@@ -495,7 +495,7 @@ deterministic paragraph matches and marginal pedagogical value throughout the
 full size band, not only above the advisory ceiling. Source-backed density and
 necessary pedagogy remain acceptable even when long. Repeated framing,
 conclusions, transitions, definitions, generic exposition, or uncited
-interpretation are defects when they affect `{DIM}`.
+interpretation are filler/padding defects when they affect `{DIM}`.
 
 ## Immersion Rule
 

--- a/scripts/build/phases/linear-review-dim.md
+++ b/scripts/build/phases/linear-review-dim.md
@@ -490,11 +490,12 @@ them to know what to fix on retry.
 
 {SIZE_POLICY}
 
-Use this as review context, not as a mechanical word-count gate. If the module
-is over the advisory ceiling, decide whether the extra length is source-backed
-density and necessary pedagogy, or filler/padding. Source-backed density is not
-a defect; repeated framing, generic exposition, uncited interpretation, and
-inflated transitions are defects when they affect `{DIM}`.
+Use this as review context, not as a mechanical word-count gate. Inspect the
+deterministic paragraph matches and marginal pedagogical value throughout the
+full size band, not only above the advisory ceiling. Source-backed density and
+necessary pedagogy remain acceptable even when long. Repeated framing,
+conclusions, transitions, definitions, generic exposition, or uncited
+interpretation are defects when they affect `{DIM}`.
 
 ## Immersion Rule
 

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -213,7 +213,7 @@ Non-plan vocabulary must pass `query_cefr_level`, frequency, or ULP coverage for
 
 {SIZE_POLICY}
 
-Satisfy the objectives and evidence coverage, not a token target. The policy never lowers the plan floor. Do not repeat framing, conclusions, transitions, or definitions to reach it. If grounded material is exhausted or the policy blocks expansion, emit the required `SIZE_POLICY_MISMATCH` marker and stop for plan review instead of padding.
+Satisfy the objectives and evidence coverage, not a token target; retire the old 150% multiplier thinking. The policy never lowers the plan floor. Expansion must be source-backed and pedagogically useful; do not repeat framing, conclusions, transitions, or definitions to reach the floor. If grounded material is exhausted or the policy blocks expansion, emit the required `SIZE_POLICY_MISMATCH` marker and stop for plan review instead of padding.
 
 ## Section Word Budgets — policy-aware first-draft requirements
 

--- a/scripts/build/phases/linear-write.md
+++ b/scripts/build/phases/linear-write.md
@@ -207,17 +207,17 @@ Non-plan vocabulary must pass `query_cefr_level`, frequency, or ULP coverage for
 - Slug: {MODULE_SLUG}
 - Topic: {TOPIC_TITLE}
 - Phase: {PHASE}
-- Word **minimum**: {WORD_TARGET} — this is a FLOOR. The gate hard-rejects below 92% of this number. Plan section budgets around **~1.20× the minimum** because the strict gate tokenization excludes markdown comments, JSX tag/attribute syntax, punctuation tokens, numbers, and page refs; self-counted `wc -w` usually runs 15-16% high.
+- Authored-word **minimum**: {WORD_TARGET} — this is an exact reviewed FLOOR. The Markdown-aware gate counts learner-facing authored instructional/expository words, including heading text, while reporting primary-source quotations separately and excluding comments, directive/component syntax, and URLs.
 
 ## Module Size Policy — dossier/evidence-led expansion control (#4801)
 
 {SIZE_POLICY}
 
-This policy does not lower the plan floor on its own. It controls expansion permission: never invent depth to satisfy a fixed word count, and never treat old 150% multiplier thinking as a target. If the policy reports `plan_policy_review_required` or `blocked_until_research_dossier`, complete the verifiable coverage and emit the required `SIZE_POLICY_MISMATCH` marker instead of padding.
+Satisfy the objectives and evidence coverage, not a token target. The policy never lowers the plan floor. Do not repeat framing, conclusions, transitions, or definitions to reach it. If grounded material is exhausted or the policy blocks expansion, emit the required `SIZE_POLICY_MISMATCH` marker and stop for plan review instead of padding.
 
 ## Section Word Budgets — policy-aware first-draft requirements
 
-The first draft must meet or exceed `{WORD_TARGET}` and must hit every section `words:` budget below when the size policy permits source-backed expansion. If the first draft is short, the pipeline may request targeted expansion before Python QG continues; that expansion is allowed only with substantive, cited exposition, examples, close-reading, source comparison, and cultural/grammar analysis. `:::primary-reading` quoted text is excluded from counted words; surrounding explanation must carry the budget.
+The first draft must meet or exceed `{WORD_TARGET}` when the evidence can responsibly support the reviewed plan. Section `words:` values guide coverage; they are not quotas to fill with repeated prose. Targeted expansion is allowed only with substantive, cited exposition, examples, close-reading, source comparison, and necessary cultural/grammar analysis. `:::primary-reading` quoted text is reported separately; surrounding authored explanation carries the floor.
 
 {SECTION_WORD_BUDGETS}
 

--- a/tests/audit/test_module_size_policy_audit.py
+++ b/tests/audit/test_module_size_policy_audit.py
@@ -48,6 +48,106 @@ def _write_module(root: Path, track: str, slug: str, words: int) -> Path:
     return path
 
 
+def _write_module_text(root: Path, track: str, slug: str, text: str) -> Path:
+    path = root / "curriculum" / "l2-uk-en" / track / slug / "module.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_markdown_counts_visible_authored_words_without_markup_inflation() -> None:
+    text = """---
+title: Hidden metadata tokens
+---
+# Visible Heading
+
+<!-- hidden comment and INJECT_ACTIVITY marker words -->
+Authored **lesson** [label](https://example.org/hidden-target) https://example.org/bare
+
+:::note[Visible note title]
+Visible note body.
+:::
+
+<Component prop="ignored words" />
+"""
+
+    metrics, repetition, mismatch = audit.markdown_module_evidence(text)
+
+    assert metrics.authored_instructional_words == 11
+    assert metrics.learner_visible_words == 11
+    assert metrics.quoted_primary_source_words == 0
+    assert metrics.excluded_markup_directive_url_tokens > 0
+    assert metrics.raw_whitespace_tokens > metrics.authored_instructional_words
+    assert repetition.eligible_paragraphs == 0
+    assert repetition.matches == ()
+    assert mismatch is False
+
+
+def test_primary_source_words_are_visible_but_excluded_from_authored_repetition() -> None:
+    refrain = " ".join(f"приспів{index}" for index in range(45))
+    text = f"""# Навчальна тема
+
+Пояснення учням.
+
+:::primary-reading
+# Джерельний заголовок
+{refrain}
+:::
+
+:::primary-reading
+{refrain}
+:::
+"""
+
+    metrics, repetition, _ = audit.markdown_module_evidence(text)
+
+    assert metrics.authored_instructional_words == 4
+    assert metrics.quoted_primary_source_words == 92
+    assert metrics.learner_visible_words == 96
+    assert repetition.eligible_paragraphs == 0
+    assert repetition.matches == ()
+
+
+def test_near_duplicate_authored_paragraphs_emit_stable_line_evidence() -> None:
+    first = [f"термін{index}" for index in range(50)]
+    second = [*first[:45], *(f"заміна{index}" for index in range(5))]
+    text = (
+        "# Перша частина\n\n"
+        + " ".join(first)
+        + "\n\n<!-- PRIMARY-READING -->\n"
+        + " ".join(f"приспів{index}" for index in range(45))
+        + "\n<!-- /PRIMARY-READING -->\n\n# Друга частина\n\n"
+        + " ".join(second)
+        + "\n"
+    )
+
+    _, repetition, _ = audit.markdown_module_evidence(text)
+
+    assert repetition.eligible_paragraphs == 2
+    assert len(repetition.matches) == 1
+    match = repetition.matches[0]
+    assert match.match_type == "near_duplicate"
+    assert (match.first_start_line, match.second_start_line) == (3, 11)
+    assert (match.first_heading, match.second_heading) == (
+        "Перша частина",
+        "Друга частина",
+    )
+    assert match.jaccard_similarity >= audit.REPETITION_JACCARD_THRESHOLD
+    assert match.shared_shingle_count >= audit.REPETITION_MIN_SHARED_SHINGLES
+    assert match.shared_text.startswith("термін0 термін1")
+
+
+def test_short_intentional_recap_is_not_actionable_repetition() -> None:
+    recap = "Коротко повторімо головну думку модуля для самоперевірки учня."
+
+    _, repetition, _ = audit.markdown_module_evidence(
+        f"# Підсумок\n\n{recap}\n\n## Ще раз\n\n{recap}\n"
+    )
+
+    assert repetition.eligible_paragraphs == 0
+    assert repetition.matches == ()
+
+
 def test_sparse_bio_dossier_reports_plan_review_without_lowering_floor(
     tmp_path: Path,
     monkeypatch,
@@ -299,7 +399,133 @@ def test_core_c1_c2_uses_evidence_packet_basis_when_no_dossier_exists(
     assert row["density_band"] == "core_research_extended"
     assert row["advisory_ceiling"] == 6500
     assert row["status"] == "advisory_ok"
-    assert "Core C1-C2 uses a pedagogy/evidence-packet basis" in " ".join(row["notes"])
+    assert "Core A1-C2 uses a pedagogy/evidence-packet basis" in " ".join(row["notes"])
+
+
+def test_filler_heavy_module_above_floor_still_requires_repetition_revision(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _patch_roots(monkeypatch, tmp_path)
+    _write_plan(
+        tmp_path,
+        "a1",
+        "padded-core",
+        {
+            "word_target": 80,
+            "content_outline": [{"section": "Огляд", "words": 80}],
+        },
+    )
+    paragraph = " ".join(f"пояснення{index}" for index in range(45))
+    _write_module_text(
+        tmp_path,
+        "a1",
+        "padded-core",
+        f"# Огляд\n\n{paragraph}\n\n## Повтор\n\n{paragraph}\n",
+    )
+
+    row = audit.build_report(tracks=["a1"], built_only=True)[0]
+
+    assert row["actual_words"] > row["plan_floor"]
+    assert row["status"] == "repetitive_authored_prose"
+    assert row["decision_signals"] == ("repetitive_authored_prose",)
+    assert len(row["repetition"]["matches"]) == 1
+
+
+def test_source_dense_module_above_ceiling_is_advisory_not_size_rejection(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _patch_roots(monkeypatch, tmp_path)
+    _write_plan(
+        tmp_path,
+        "folk",
+        "long-source-dense",
+        {
+            "word_target": 5000,
+            "content_outline": [{"section": "Корпус", "words": 5000}],
+        },
+    )
+    _write_dossier(
+        tmp_path,
+        "folk",
+        "long-source-dense",
+        5600,
+        evidence=(
+            " ".join(["архів", "цитата", "верифікація", "корпус"] * 3)
+            + " "
+            + " ".join(["дискусія", "міф", "деколонізація"] * 2)
+            + " "
+            + " ".join(["варіант", "обряд", "виконавство", "регіон"] * 2)
+            + "\n"
+            + "\n".join(f"https://example.org/source-{index}" for index in range(10))
+        ),
+    )
+    _write_module(tmp_path, "folk", "long-source-dense", 8100)
+
+    row = audit.build_report(tracks=["folk"], built_only=True)[0]
+
+    assert row["actual_words"] > row["advisory_ceiling"]
+    assert row["decision_signals"] == (
+        "over_advisory_ceiling",
+        "exceptional_justification_required",
+    )
+    assert row["status"] == "exceptional_justification_required"
+    assert row["repetition"]["matches"] == ()
+
+
+def test_mismatch_marker_and_exact_floor_violation_are_both_preserved(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _patch_roots(monkeypatch, tmp_path)
+    _write_plan(
+        tmp_path,
+        "a1",
+        "exhausted-evidence",
+        {
+            "word_target": 100,
+            "content_outline": [{"section": "Огляд", "words": 100}],
+        },
+    )
+    _write_module_text(
+        tmp_path,
+        "a1",
+        "exhausted-evidence",
+        "<!-- SIZE_POLICY_MISMATCH: plan floor exceeds sourced evidence -->\n"
+        "# Огляд\n\n"
+        + " ".join(["слово"] * 50),
+    )
+
+    row = audit.build_report(tracks=["a1"], built_only=True)[0]
+
+    assert row["actual_words"] == 51
+    assert row["size_policy_mismatch"] is True
+    assert row["status"] == "plan_review_needed"
+    assert row["decision_signals"] == ("plan_review_needed", "below_plan_floor")
+
+
+def test_all_core_and_seminar_tracks_have_one_size_policy_route() -> None:
+    policy = yaml.safe_load(
+        (
+            audit.PROJECT_ROOT
+            / "agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml"
+        ).read_text(encoding="utf-8")
+    )
+    core = {
+        track
+        for track, config in policy["tracks"].items()
+        if config["family"] == "core"
+    }
+    seminar = {
+        track
+        for track, config in policy["tracks"].items()
+        if config["family"] == "seminar"
+    }
+
+    assert core == audit.CORE_TRACKS
+    assert seminar == audit.SEMINAR_TRACKS
+    assert set(policy["tracks"]) == audit.CORE_TRACKS | audit.SEMINAR_TRACKS
 
 
 def test_cli_json_output_is_stable_and_read_only(
@@ -327,6 +553,10 @@ def test_cli_json_output_is_stable_and_read_only(
     assert output[0]["module_path"] == "curriculum/l2-uk-en/bio/built-person/module.md"
     assert not (tmp_path / "curriculum" / "l2-uk-en" / "bio" / "built-person" / "status").exists()
     assert not (tmp_path / "data" / "telemetry").exists()
+
+    first = json.dumps(audit.build_report(tracks=["bio"], built_only=True), sort_keys=True)
+    second = json.dumps(audit.build_report(tracks=["bio"], built_only=True), sort_keys=True)
+    assert first == second
 
 
 def test_summary_prints_zero_counts(capsys) -> None:

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -113,6 +113,20 @@ def test_track_resolution_covers_every_versioned_track() -> None:
         pbr.resolve_track_policy("unknown", policy)
 
 
+def test_every_track_inherits_the_family_size_signal_policy() -> None:
+    policy = pbr.load_track_policy()
+
+    for track, config in policy["tracks"].items():
+        resolved = pbr.resolve_track_policy(track, policy)
+        expected = policy["families"][config["family"]][
+            "size_policy_signal_severities"
+        ]
+        assert resolved["size_policy_signal_severities"] == expected
+
+    assert set(policy["tracks"]) >= {"a1", "a2", "b1", "b2", "c1", "c2"}
+    assert "lit-essay" in policy["tracks"]
+
+
 def test_venv_python_resolution_preserves_symlink_entrypoint(tmp_path: Path) -> None:
     """The command path must stay inside .venv so Python loads pyvenv.cfg."""
     runtime_python = tmp_path / "runtime-python"
@@ -278,6 +292,91 @@ def test_bilash_size_policy_is_exemplar_only(bilash_packet: dict) -> None:
     policy_text = (SKILL / "config" / "track-policy.v1.yaml").read_text(encoding="utf-8")
     assert "2200" not in policy_text
     assert "4000" not in policy_text
+
+
+@pytest.mark.parametrize(
+    ("signal", "expected_severity", "expected_disposition"),
+    [
+        ("below_plan_floor", "high", "BLOCK"),
+        ("repetitive_authored_prose", "medium", "REVISE"),
+        ("over_advisory_ceiling", "info", "PASS"),
+    ],
+)
+def test_size_policy_signals_drive_fail_closed_post_build_disposition(
+    signal: str,
+    expected_severity: str,
+    expected_disposition: str,
+) -> None:
+    policy = pbr.load_track_policy()
+    track_policy = pbr.resolve_track_policy("bio", policy)
+    target = {
+        "files": {
+            "plan": "curriculum/l2-uk-en/plans/bio/subject.yaml",
+            "content": "curriculum/l2-uk-en/bio/subject/module.md",
+        }
+    }
+    findings = pbr._check_size_policy_status(
+        target,
+        track_policy,
+        {
+            "status": signal,
+            "decision_signals": [signal],
+            "notes": ["synthetic regression evidence"],
+            "repetition": {
+                "matches": [{"first_start_line": 10, "second_start_line": 40}]
+                if signal == "repetitive_authored_prose"
+                else []
+            },
+        },
+    )
+    deterministic = {
+        "track_audit": {"status": "complete"},
+        "size_policy": {"status": "complete"},
+        "policy_findings": findings,
+        "skip_assessments": [],
+    }
+    deterministic["aggregate"] = pbr.aggregate_deterministic(deterministic)
+    semantic = {
+        "verdict": "PASS",
+        "claim_coverage": {
+            "status": "complete",
+            "claims_total": 1,
+            "claims_verified": 1,
+        },
+    }
+
+    assert [finding["severity"] for finding in findings] == [expected_severity]
+    assert (
+        pbr.combine_disposition(deterministic, semantic, findings)["status"]
+        == expected_disposition
+    )
+
+
+def test_multiple_size_policy_signals_are_not_hidden_by_status_priority() -> None:
+    track_policy = pbr.resolve_track_policy("a1", pbr.load_track_policy())
+    target = {
+        "files": {
+            "plan": "curriculum/l2-uk-en/plans/a1/subject.yaml",
+            "content": "curriculum/l2-uk-en/a1/subject/module.md",
+        }
+    }
+
+    findings = pbr._check_size_policy_status(
+        target,
+        track_policy,
+        {
+            "status": "plan_review_needed",
+            "decision_signals": ["plan_review_needed", "below_plan_floor"],
+            "notes": ["SIZE_POLICY_MISMATCH"],
+            "repetition": None,
+        },
+    )
+
+    assert [finding["id"] for finding in findings] == [
+        "size-policy-plan_review_needed",
+        "size-policy-below_plan_floor",
+    ]
+    assert {finding["severity"] for finding in findings} == {"high"}
 
 
 def test_semantic_pass_cannot_override_mechanical_high(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -461,8 +560,8 @@ def test_skill_forbids_mutating_legacy_paths() -> None:
 def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
-    assert catalog["catalog_version"] == "1.0.2"
-    assert len(rows) == 12
+    assert catalog["catalog_version"] == "1.1.0"
+    assert len(rows) == 16
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",
@@ -472,7 +571,11 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
         "schema",
         "orchestration",
     }
-    assert {row["fixed_in_version"] for row in rows} == {"1.0.0", "1.0.1"}
+    assert {row["fixed_in_version"] for row in rows} == {
+        "1.0.0",
+        "1.0.1",
+        "1.1.0",
+    }
     null_result = next(row for row in rows if row["bug_id"] == "deterministic-stage-null-result-crash")
     assert null_result["responsible_layer"] == "orchestration"
     assert null_result["fixed_in_version"] == "1.0.1"

--- a/tests/fixtures/post_build_review/bio-oleksandr-bilash.result.v1.json
+++ b/tests/fixtures/post_build_review/bio-oleksandr-bilash.result.v1.json
@@ -33,7 +33,7 @@
           "json"
         ],
         "config_path": "agents_extensions/shared/skills/post-build-review/contracts/evidence-derived-size-policy-contract.md",
-        "config_version": "1.0.1",
+        "config_version": "1.1.0",
         "cwd": ".",
         "executed_argv": [
           ".venv/bin/python",
@@ -48,17 +48,26 @@
         ],
         "exit_code": 0,
         "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-        "stdout_sha256": "fe74233e41557022ec77c64d37de861f5c5e291b9811fa3d453d686337a5b4f6"
+        "stdout_sha256": "33218425f5749b60947938a6cedb3673fcfdce61da3d38a7adda51a5f651eeea"
       },
       "result": {
-        "actual_words": 2497,
+        "actual_words": 2401,
         "advisory_ceiling": 4000,
         "band_max": 2800,
         "band_min": 2200,
         "basis": "explicit_plan_size_policy",
+        "content_metrics": {
+          "authored_instructional_words": 2401,
+          "excluded_markup_directive_url_tokens": 25,
+          "learner_visible_words": 2401,
+          "quoted_primary_source_words": 0,
+          "raw_whitespace_tokens": 2497
+        },
+        "decision_signals": [],
         "density_band": "reviewed_plan_override",
         "dossier_path": "docs/research/bio/oleksandr-bilash.md",
         "effective_min": 2200,
+        "legacy_raw_whitespace_words": 2497,
         "metrics": {
           "contested_markers": 6,
           "headings": 12,
@@ -77,6 +86,12 @@
         "plan_floor": 2200,
         "plan_outline_words": 2200,
         "plan_path": "curriculum/l2-uk-en/plans/bio/oleksandr-bilash.yaml",
+        "repetition": {
+          "algorithm": "paragraph_5_word_shingles_v1:jaccard>=0.55_or_containment>=0.82,length_ratio>=0.70,min_shared=8,min_words=40",
+          "eligible_paragraphs": 32,
+          "matches": []
+        },
+        "size_policy_mismatch": false,
         "slug": "oleksandr-bilash",
         "status": "explicit_override",
         "track": "bio"
@@ -194,10 +209,10 @@
       "status": "complete"
     }
   },
-  "deterministic_contract_version": "1.0.1",
+  "deterministic_contract_version": "1.1.0",
   "findings": [],
-  "prompt_sha256": "eb163248e6c61c1d7cab9407636d5ba88b109bc49c281637946abb5cfb27ffda",
-  "reproducibility_key": "8efb250d4fed5ab45a30e06442a8eb780d76ad8e4f2c4593d93c59531bbf693c",
+  "prompt_sha256": "85254a48351797a3d42207bf3b203df64750e3962296c21b201eecb641fd4897",
+  "reproducibility_key": "536f49e6f9869d1fe0f553b11cd41b100894f2194894c7e895a2424b1012328e",
   "review_protocol_version": "1.0.1",
   "reviewer": {
     "agent": "agy",
@@ -217,7 +232,7 @@
     "summary": "Exhaustive BIO review verified 275 atomic factual, attribution, quotation, language, activity, plan-adherence, decolonization, rights, and media claim instances across all five resolved target files. All previous findings, including crosslinks, rights placeholders, reassigned Suspilne URLs, unbound recordings, broadcast claims, and nonstandard language, have been definitively resolved. The module effectively executes the seminar prompt with accurate claims, clear attribution, precise source framing, and rigorous, plan-adherent activities.",
     "verdict": "PASS"
   },
-  "semantic_prompt_version": "1.0.0",
+  "semantic_prompt_version": "1.1.0",
   "source_hashes": {
     "activities": "20fcad8f33a05631aa5c917e1a89915d456e5407af12e370a4abd141c2bec095",
     "content": "65d5da02915983a4b54a67d0d3bf2682ecaa33451d21013b5b4782c2b1cb02b8",
@@ -238,5 +253,5 @@
     "slug": "oleksandr-bilash",
     "track": "bio"
   },
-  "track_policy_version": "1.0.0"
+  "track_policy_version": "1.1.0"
 }

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -1,4 +1,4 @@
-catalog_version: 1.0.2
+catalog_version: 1.1.0
 regressions:
   - bug_id: bilash-evening-school-location-role
     responsible_layer: semantic_prompt
@@ -65,3 +65,27 @@ regressions:
     version_field: deterministic_contract_version
     input: Repository .venv/bin/python is a symlink to a host interpreter.
     expected: Execute through the .venv entrypoint path so pyvenv.cfg and project dependencies remain active.
+  - bug_id: markdown-syntax-inflated-module-floor
+    responsible_layer: deterministic_code
+    fixed_in_version: 1.1.0
+    version_field: deterministic_contract_version
+    input: Markdown comments, frontmatter, URLs, link targets, component syntax, and injection markers around a short lesson.
+    expected: Only learner-visible authored instructional words satisfy the exact plan floor; quoted primary-source words remain separate.
+  - bug_id: repeated-authored-prose-passed-inside-band
+    responsible_layer: track_policy
+    fixed_in_version: 1.1.0
+    version_field: track_policy_version
+    input: Two exact or near-duplicate authored paragraphs of at least 40 words inside the nominal size band.
+    expected: Structured repetition evidence produces a medium finding and combined disposition REVISE.
+  - bug_id: below-floor-status-was-not-post-build-blocking
+    responsible_layer: track_policy
+    fixed_in_version: 1.1.0
+    version_field: track_policy_version
+    input: Authored instructional prose is one word below the reviewed plan floor.
+    expected: Exact floor violation produces a high mechanical finding and combined disposition BLOCK.
+  - bug_id: size-policy-mismatch-was-auto-expanded
+    responsible_layer: orchestration
+    fixed_in_version: 1.1.0
+    version_field: deterministic_contract_version
+    input: Draft contains SIZE_POLICY_MISMATCH because grounded evidence is exhausted below the plan floor.
+    expected: Writer precheck preserves plan-review and below-floor signals and never invokes automatic expansion.

--- a/tests/test_pr_b_band_widening.py
+++ b/tests/test_pr_b_band_widening.py
@@ -1,4 +1,4 @@
-"""Tests for PR-B band widening: word_count tolerance + callout_min (2026-05-23)."""
+"""Tests for exact authored-word floors plus the retained callout minimum."""
 
 import pytest
 
@@ -24,21 +24,20 @@ def test_word_count_above_target_passes() -> None:
     assert report["passed"] is True
 
 
-def test_word_count_within_8pct_tolerance_passes() -> None:
-    """Regression: deepseek-pro 1197 vs A1 target 1200 (0.25% short) now passes."""
+def test_word_count_below_exact_floor_fails() -> None:
+    """A reviewed plan floor is exact; even a small shortfall remains blocked."""
     text = "word " * 1197
     report = _word_count_gate(text, 1200)
-    assert report["passed"] is True
+    assert report["passed"] is False
     assert report["count"] == 1197
-    assert report["min_with_tolerance"] == 1104  # int(1200 * 0.92)
+    assert report["min_with_tolerance"] == 1200
 
 
-def test_word_count_at_band_edge_passes() -> None:
-    """count == min_with_tolerance (target * 0.92) passes."""
-    text = "word " * 1104  # int(1200 * 0.92)
+def test_retired_tolerance_band_no_longer_passes() -> None:
+    text = "word " * 1104
     report = _word_count_gate(text, 1200)
-    assert report["passed"] is True
-    assert report["min_with_tolerance"] == 1104
+    assert report["passed"] is False
+    assert report["min_with_tolerance"] == 1200
 
 
 def test_word_count_just_below_band_fails() -> None:
@@ -57,11 +56,10 @@ def test_word_count_14pct_below_target_fails() -> None:
     assert report["count"] == 1031
 
 
-def test_word_count_reports_tolerance_metadata() -> None:
-    """The gate report includes min_with_tolerance + tolerance_below_pct."""
+def test_word_count_reports_exact_floor_metadata() -> None:
     report = _word_count_gate("word " * 1200, 1200)
-    assert report["min_with_tolerance"] == 1104
-    assert report["tolerance_below_pct"] == 8.0
+    assert report["min_with_tolerance"] == 1200
+    assert report["tolerance_below_pct"] == 0.0
     assert report["target"] == 1200
 
 

--- a/tests/test_writer_size_policy.py
+++ b/tests/test_writer_size_policy.py
@@ -17,6 +17,10 @@ from scripts.build.module_size_policy import (
 from scripts.build.phases.implementation_map import seed_implementation_map
 
 PROMPT_FIXTURES: tuple[tuple[str, str], ...] = (
+    ("a1", "sounds-letters-and-hello"),
+    ("a2", "a2-bridge"),
+    ("b1", "adjectives-comparative"),
+    ("b2", "academic-writing"),
     ("bio", "andrii-malyshko"),
     ("folk", "kolomyiky"),
     ("c1", "abstract-writing"),
@@ -82,9 +86,9 @@ def test_claude_and_codex_writer_prompts_include_size_policy(
 
     assert "## Module Size Policy — dossier/evidence-led expansion control (#4801)" in prompt
     assert "- Expansion permission:" in prompt
-    assert "never invent depth to satisfy a fixed word count" in prompt
+    assert "satisfy objectives and evidence coverage, not a token target" in prompt.lower()
     assert "SIZE_POLICY_MISMATCH" in prompt
-    assert "old 150% multiplier thinking as a target" in prompt
+    assert "do not repeat framing, conclusions, transitions, or definitions" in prompt.lower()
 
 
 def test_size_policy_blocks_auto_expansion_when_plan_floor_exceeds_sparse_ceiling(
@@ -107,6 +111,36 @@ def test_size_policy_blocks_auto_expansion_when_plan_floor_exceeds_sparse_ceilin
     assert size_policy_allows_auto_expansion(record) is False
     block = render_writer_size_policy(record)
     assert "Expansion permission: plan_policy_review_required" in block
+
+
+def test_sparse_dossier_blocks_auto_expansion_even_when_floor_is_in_band(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_size_policy_roots(monkeypatch, tmp_path)
+    plan = {
+        "level": "BIO",
+        "slug": "thin-in-band-person",
+        "word_target": 4500,
+        "content_outline": [{"section": "Огляд", "words": 4500}],
+        "references": [
+            {
+                "type": "dossier",
+                "path": "docs/research/bio/thin-in-band-person.md",
+            }
+        ],
+    }
+    _write_dossier(tmp_path, "bio", "thin-in-band-person", 900)
+
+    record = build_size_policy_for_plan(plan, actual_words=4000)
+
+    assert record.density_band == "sparse"
+    assert record.status == "below_plan_floor"
+    assert size_policy_allows_auto_expansion(record) is False
+    assert (
+        "Expansion permission: blocked_until_source_saturation_or_plan_review"
+        in render_writer_size_policy(record)
+    )
 
 
 def test_reviewed_size_policy_override_allows_expansion_below_generic_track_floor(
@@ -192,6 +226,7 @@ def test_size_policy_reports_advisory_padding_diagnostic(
     assert "source-backed density from filler/padding" in diagnostic["review_action"]
     reviewer_block = render_reviewer_size_policy(record)
     assert "do not fail or pass a module on word count alone" in reviewer_block
+    assert "throughout the full size band" in reviewer_block
     assert "source-backed density" in reviewer_block
 
 
@@ -287,3 +322,47 @@ def test_writer_length_precheck_returns_policy_mismatch_without_invoking_writer(
             "size_policy_status": "plan_review_needed",
         }
     ]
+
+
+def test_writer_precheck_honors_embedded_mismatch_marker_without_invocation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_size_policy_roots(monkeypatch, tmp_path)
+    plan = {
+        "level": "A1",
+        "sequence": 1,
+        "slug": "exhausted-core",
+        "word_target": 100,
+        "content_outline": [{"section": "Огляд", "words": 100}],
+    }
+    module_dir = tmp_path / "module"
+    module_dir.mkdir()
+    (module_dir / "module.md").write_text(
+        "<!-- SIZE_POLICY_MISMATCH: plan floor exceeds sourced evidence -->\n"
+        "# Огляд\n\n"
+        + " ".join(["слово"] * 50),
+        encoding="utf-8",
+    )
+    plan_path = tmp_path / "plan.yaml"
+    plan_path.write_text(yaml.safe_dump(plan, allow_unicode=True), encoding="utf-8")
+
+    def fail_if_invoked(*_args, **_kwargs):
+        raise AssertionError("writer must not auto-expand a mismatch-marked draft")
+
+    result = linear_pipeline.run_writer_draft_length_precheck(
+        plan=plan,
+        module_dir=module_dir,
+        plan_path=plan_path,
+        writer="claude-tools",
+        invoker=fail_if_invoked,
+    )
+
+    assert result["applied"] is False
+    assert result["patch_status"] == "policy_mismatch"
+    assert result["policy_mismatch"] is True
+    assert result["size_policy"]["size_policy_mismatch"] is True
+    assert result["size_policy"]["decision_signals"] == (
+        "plan_review_needed",
+        "below_plan_floor",
+    )


### PR DESCRIPTION
Closes #4801
Part of #3120

## Summary

- replace raw `\S+` module counts with deterministic Markdown-aware learner-visible, authored, quoted-primary, excluded-syntax, and legacy raw metrics
- enforce reviewed plan floors against authored instructional words across A1-C2 and every seminar track
- add deterministic paragraph repetition evidence with stable line ranges, headings, scores, and shared text
- stop automatic expansion for `SIZE_POLICY_MISMATCH`, invalid policy, missing seminar dossier, repeated prose, and unsupported sparse evidence
- keep advisory-ceiling excess informational so source-dense long modules are not rejected merely for length
- integrate signal severities and evidence into canonical post-build review; bump deterministic, semantic, track-policy, and size-contract versions to 1.1.0
- update writer/reviewer policy language, regression catalog, and reproducible Bilash golden fixture

## Root cause and decision rules

The old audit used raw whitespace tokens, so Markdown syntax, URLs, directives, and primary readings could satisfy a plan floor. It also reduced the record to one status and only asked reviewers to inspect padding above the ceiling.

The new policy keeps plan floors exact and fail-closed. Below-floor and plan-policy mismatches are high mechanical findings; authored repetition is medium and requires revision even inside the band; over-ceiling and exceptional-length signals are informational and require source-density/pedagogy review rather than automatic rejection.

Repetition uses NFC/case-folded authored paragraphs of at least 40 lexical words, five-word shingles, at least eight shared shingles, and either Jaccard >= 0.55 or shorter-paragraph containment >= 0.82 with length ratio >= 0.70. Primary readings, quoted refrains, blockquotes, fenced examples, activity/list/table boilerplate, and short recaps are excluded.

## Calibration

Read-only comparison against the preserved pre-change baseline under `/tmp`:

- 356 built modules across A1, A2, B1, B2, BIO, and FOLK
- raw whitespace tokens: 1,197,558
- learner-visible words: 1,093,436
- authored instructional words: 1,086,870
- quoted primary-source words: 6,566
- 198 legacy status transitions because raw Markdown had previously satisfied floors
- 0 real-module repetition findings at the calibrated threshold; synthetic exact/near-duplicate fixtures remain actionable
- no curriculum modules, plans, generated audit/status/review files, or calibration artifacts changed

Migration risk is explicit: existing modules newly exposed below the authored floor now fail closed for repair or versioned plan review; this PR does not lower targets or auto-pad them.

## Validation

- `.venv/bin/python -m pytest tests/audit/test_module_size_policy_audit.py tests/test_writer_size_policy.py tests/test_pr_b_band_widening.py tests/audit/test_post_build_review.py -q` — **91 passed**
- commit hook rerun — **91 passed**
- `.venv/bin/ruff check ...` — **All checks passed**
- Python compile — passed
- JSON/YAML parse and post-build-review schema validation — passed
- `scripts/deploy_prompts.sh` — prompt/skill lint passed; mirrors deployed
- `git diff --check` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- mandatory pre-submit guard — 19 files; protected configs and generated artifacts absent

## Independent review

Gemini 3.1 Pro High performed the cross-family adversarial review. It found two primary-reading evidence bugs (legacy-marker line offsets and headings routed to authored words); both were fixed with regression coverage. Final re-review disposition: `NO_MATERIAL_FINDINGS`.
