### PR TITLE
feat(audit): postings deduplication, corpus scoping, and metadata persistence

### DIFF
--- a/scripts/audit/verbatim_overlap_gate.py
+++ b/scripts/audit/verbatim_overlap_gate.py
@@ -66,6 +66,61 @@ OPTIONAL_CORPORA: list[tuple[str, str, str, str]] = [
     ("wikipedia", "title", "text", "wikipedia"),
 ]
 
+ALL_POSSIBLE_CORPORA: dict[str, tuple[str, str, str, str]] = {
+    "textbooks": ("textbooks", "chunk_id", "text", "textbooks"),
+    "literary": ("literary_texts", "chunk_id", "text", "literary"),
+    "external": ("external_articles", "chunk_id", "text", "external"),
+    "ukrainian_wiki": ("ukrainian_wiki", "passage_id", "text", "ukrainian_wiki"),
+    "wikipedia": ("wikipedia", "title", "text", "wikipedia"),
+}
+
+
+def get_default_index_db_path(
+    sources_db: Path | str,
+    k: int,
+    corpora: list[tuple[str, str, str, str]] | None = None,
+) -> Path:
+    sources_db = Path(sources_db)
+    parent_dir = Path(".") if str(sources_db) == ":memory:" else sources_db.parent
+
+    default_corpora = FULL_CORPORA + SELF_CORPORA
+    is_default = False
+    if corpora is None:
+        is_default = True
+    else:
+        default_labels = {c[3] for c in default_corpora}
+        current_labels = {c[3] for c in corpora}
+        if default_labels == current_labels:
+            is_default = True
+
+    if is_default:
+        return parent_dir / f"verbatim_shingle_k{k}.db"
+    else:
+        labels = sorted([c[3] for c in corpora])
+        slug = "-".join(labels)
+        return parent_dir / f"verbatim_shingle_k{k}_{slug}.db"
+
+
+def parse_corpora_labels(raw_labels: list[str] | None) -> list[tuple[str, str, str, str]] | None:
+    if raw_labels is None:
+        return None
+    labels = []
+    for rl in raw_labels:
+        for lbl in rl.split(","):
+            lbl = lbl.strip()
+            if lbl:
+                labels.append(lbl)
+
+    valid_labels = sorted(list(ALL_POSSIBLE_CORPORA.keys()))
+    invalid = [l for l in labels if l not in ALL_POSSIBLE_CORPORA]
+    if invalid:
+        raise argparse.ArgumentTypeError(
+            f"Invalid corpus label(s): {', '.join(invalid)}. Valid labels are: {', '.join(valid_labels)}"
+        )
+
+    unique_labels = list(dict.fromkeys(labels))
+    return [ALL_POSSIBLE_CORPORA[lbl] for lbl in unique_labels]
+
 
 def normalize_text(text: str) -> str:
     """Ukrainian-aware normalization for shingling (must be identical on both sides).
@@ -145,6 +200,7 @@ def _find_offsets(haystack: str, needle: str) -> tuple[int, int]:
 @dataclass
 class ExtractedSpan:
     """One extracted UA content span with audit provenance."""
+
     text: str
     norm: str
     tokens: list[str]
@@ -391,7 +447,9 @@ def extract_from_activities_yaml(yaml_path: Path) -> list[ExtractedSpan]:
     return unique
 
 
-def extract_module_content(level_or_path: str | Path, slug: str | None = None) -> tuple[list[ExtractedSpan], dict[str, Any]]:
+def extract_module_content(
+    level_or_path: str | Path, slug: str | None = None
+) -> tuple[list[ExtractedSpan], dict[str, Any]]:
     """High level extractor for a module.
 
     Accepts either a path to module.md / module dir, or level+slug.
@@ -458,6 +516,7 @@ def module_tokens_from_spans(spans: list[ExtractedSpan]) -> list[str]:
 
 # ----------------------------- Index + metrics -----------------------------
 
+
 @dataclass
 class VerbatimReport:
     module: str
@@ -472,6 +531,9 @@ class VerbatimReport:
     df_excluded_count: int = 0
     verified_quote_excludes: list[dict] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
+    corpus_hash: str = ""
+    indexed_corpora: list[str] = field(default_factory=list)
+    scope_note: str | None = None
 
 
 class ShingleIndex:
@@ -514,11 +576,24 @@ class ShingleIndex:
         self.conn.execute("INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)", (key, value))
         self.conn.commit()
 
-    def corpus_hash_matches(self, fp: str) -> bool:
+    def corpus_hash_matches(self, fp: str, corpora: list[tuple[str, str, str, str]]) -> bool:
         stored = self.get_meta("corpus_hash")
         k_stored = self.get_meta("k")
         spec = self.get_meta("extraction_spec")
-        return stored == fp and k_stored == str(self.k) and spec == EXTRACTION_SPEC_VERSION
+        stored_corpora_json = self.get_meta("indexed_corpora")
+
+        requested_labels = [c[3] for c in corpora]
+        try:
+            stored_corpora = json.loads(stored_corpora_json) if stored_corpora_json else []
+        except Exception:
+            stored_corpora = []
+
+        return (
+            stored == fp
+            and k_stored == str(self.k)
+            and spec == EXTRACTION_SPEC_VERSION
+            and stored_corpora == requested_labels
+        )
 
     def close(self) -> None:
         self.conn.close()
@@ -535,7 +610,7 @@ class ShingleIndex:
 
         # Compute fingerprint (content sensitive but cheap)
         fp = self._compute_fingerprint(sources_conn, corpora)
-        if self.corpus_hash_matches(fp):
+        if self.corpus_hash_matches(fp, corpora):
             if progress:
                 print("Index up-to-date for corpus hash; skipping rebuild.")
             return fp
@@ -564,10 +639,12 @@ class ShingleIndex:
                     shingle_to_chunks[sh].add((corpus_label, cid))
                 total_shingles += len(shs)
                 # insert postings (char_offset 0 is sufficient; LCS recovers exact)
+                # deduplicate postings to unique (shingle_key, corpus, chunk_id) before insert
                 if shs:
+                    unique_shs = list(dict.fromkeys(shs))
                     self.conn.executemany(
                         "INSERT INTO postings (shingle_key, corpus, chunk_id, char_offset) VALUES (?, ?, ?, 0)",
-                        [(sh, corpus_label, cid) for sh in shs],
+                        [(sh, corpus_label, cid) for sh in unique_shs],
                     )
             if progress:
                 print(f"  indexed {len(rows)} from {corpus_label} ({table})")
@@ -581,6 +658,7 @@ class ShingleIndex:
         self.set_meta("k", str(self.k))
         self.set_meta("extraction_spec", EXTRACTION_SPEC_VERSION)
         self.set_meta("total_shingles", str(total_shingles))
+        self.set_meta("indexed_corpora", json.dumps([c[3] for c in corpora]))
         self.conn.commit()
 
         if progress:
@@ -659,9 +737,31 @@ def compute_metrics(
     verify_quote_fn: Callable[[str, str], float] | None = None,
 ) -> VerbatimReport:
     """Core deterministic computation. Returns full report (no side effects)."""
+    indexed_corpora_meta = index.get_meta("indexed_corpora")
+    if indexed_corpora_meta is None:
+        raise ValueError("Missing indexed_corpora in index metadata")
+    try:
+        indexed_corpora = json.loads(indexed_corpora_meta)
+    except Exception:
+        indexed_corpora = []
+
+    corpus_hash = index.get_meta("corpus_hash", "")
+
+    # Check if scope is non-default
+    default_corpora = FULL_CORPORA + SELF_CORPORA
+    default_labels = {c[3] for c in default_corpora}
+    scope_note = None
+    if set(indexed_corpora) != default_labels:
+        scope_note = (
+            "WARNING: DF counts and the verify_quote allowlist are computed over the scoped corpus only. "
+            "Ratios are NOT comparable to full-index runs and MUST NOT set enforcement thresholds without a full-index delta check."
+        )
+
     if verify_quote_fn is None:
+
         def _no_verify(author: str, txt: str) -> float:
             return 0.0
+
         verify_quote_fn = _no_verify
 
     total = len(module_tokens)
@@ -675,6 +775,9 @@ def compute_metrics(
             max_contiguous_run=0,
             max_contiguous_run_df_filtered=0,
             overlap_ratio=0.0,
+            corpus_hash=corpus_hash,
+            indexed_corpora=indexed_corpora,
+            scope_note=scope_note,
         )
 
     mod_shingles = make_shingles(module_tokens, index.k)
@@ -705,7 +808,7 @@ def compute_metrics(
             # pick first (now stable due to ORDER BY in postings) for legacy LCS
             c, cid = posts[0]
             candidate_sources.append((c, cid, sh))
-            for (c2, cid2) in posts:
+            for c2, cid2 in posts:
                 source_positions[(c2, cid2)].update(modposs)
             # verify using real source author (not empty) + shingle text for attribution
             # require matched source author for a real attribution
@@ -715,7 +818,9 @@ def compute_metrics(
                     tbl = "textbooks" if c2 == "textbooks" else ("literary_texts" if c2 == "literary" else None)
                     idc = "chunk_id"
                     if tbl:
-                        row = sources_conn.execute(f"SELECT author FROM {tbl} WHERE {idc} = ? LIMIT 1", (cid2,)).fetchone()
+                        row = sources_conn.execute(
+                            f"SELECT author FROM {tbl} WHERE {idc} = ? LIMIT 1", (cid2,)
+                        ).fetchone()
                         author = str(row[0] or "") if row else ""
                 except Exception:
                     author = ""
@@ -725,16 +830,17 @@ def compute_metrics(
                     for p in modposs:
                         for t in range(p, min(p + index.k, total)):
                             verified_token_positions.add(t)
-                    verified_excludes.append({
-                        "text": sh,
-                        "author": author,
-                        "corpus": c2,
-                        "chunk_id": cid2,
-                        "conf": conf,
-                        "excluded_from_ratio": True,
-                    })
+                    verified_excludes.append(
+                        {
+                            "text": sh,
+                            "author": author,
+                            "corpus": c2,
+                            "chunk_id": cid2,
+                            "conf": conf,
+                            "excluded_from_ratio": True,
+                        }
+                    )
                     # do not break: allow all matching shingles of the quote to be recorded/excluded
-
 
     # raw max run: per source chunk (bug7), high-DF retained via source_positions
     max_raw = 0
@@ -761,7 +867,7 @@ def compute_metrics(
 
     # overlap tokens for ratio: ONLY shingles that actually matched postings (bug1), minus DF, minus verified (bug2)
     covered: set[int] = set()
-    for sh in (hit_shingles - df_excluded):
+    for sh in hit_shingles - df_excluded:
         for p in sh_to_pos[sh]:
             for t in range(p, min(p + index.k, total)):
                 if t not in verified_token_positions:
@@ -817,6 +923,9 @@ def compute_metrics(
         df_excluded_count=len(df_excluded),
         verified_quote_excludes=verified_excludes,
         notes=[f"DF allowlist N={df_n} (ratio only)", "LCS used for true max run"],
+        corpus_hash=corpus_hash,
+        indexed_corpora=indexed_corpora,
+        scope_note=scope_note,
     )
     return report
 
@@ -844,6 +953,7 @@ def _chained_run_len(tokens: list[str], hit_start_positions: set[int], k: int) -
 
 # ----------------------------- CLI + sweep ---------------------------------
 
+
 def open_sources(db_path: Path | str) -> sqlite3.Connection:
     conn = sqlite3.connect(str(db_path), check_same_thread=False)
     conn.row_factory = sqlite3.Row
@@ -852,6 +962,7 @@ def open_sources(db_path: Path | str) -> sqlite3.Connection:
 
 def make_default_verify_fn(sources_db: Path | str) -> Callable[[str, str], float]:
     """Best-effort verify_quote using direct SQL + difflib (no rapidfuzz dep)."""
+
     def _fn(author: str, text: str) -> float:
         if not text or len(text) < 6:
             return 0.0
@@ -875,6 +986,7 @@ def make_default_verify_fn(sources_db: Path | str) -> Callable[[str, str], float
             return best
         except Exception:
             return 0.0
+
     return _fn
 
 
@@ -885,6 +997,7 @@ def analyze_module(
     k: int = K_DEFAULT,
     df_n: int = DF_N_DEFAULT,
     verify_fn: Callable[[str, str], float] | None = None,
+    corpora: list[tuple[str, str, str, str]] | None = None,
 ) -> VerbatimReport:
     """End-to-end for one module (used by CLI and tests)."""
     spans, _meta = extract_module_content(module_path)
@@ -893,12 +1006,10 @@ def analyze_module(
 
     sources_conn = open_sources(sources_db)
     if index_db is None:
-        # derive stable index location (next to sources or in /tmp for tests)
-        idx_name = f"verbatim_shingle_k{k}_{Path(sources_db).stem}.db"
-        index_db = Path(sources_db).parent / idx_name
+        index_db = get_default_index_db_path(sources_db, k, corpora)
     idx = ShingleIndex(index_db, k=k)
 
-    fp = idx.build(sources_conn, progress=False)
+    fp = idx.build(sources_conn, corpora=corpora, progress=False)
     # ensure matches
     _ = fp
 
@@ -923,8 +1034,9 @@ def cmd_analyze(args: argparse.Namespace) -> int:
         index_db=args.index_db,
         k=args.k,
         df_n=args.df_n,
+        corpora=args.corpora_resolved,
     )
-    print(json.dumps({
+    out = {
         "module": rpt.module,
         "k": rpt.k,
         "df_n": rpt.df_n,
@@ -937,15 +1049,20 @@ def cmd_analyze(args: argparse.Namespace) -> int:
         "verified_quote_excludes": rpt.verified_quote_excludes,
         "notes": rpt.notes,
         "extraction_spec": rpt.extraction_spec,
-    }, ensure_ascii=False, indent=2))
+        "corpus_hash": rpt.corpus_hash,
+        "indexed_corpora": rpt.indexed_corpora,
+    }
+    if rpt.scope_note is not None:
+        out["scope_note"] = rpt.scope_note
+    print(json.dumps(out, ensure_ascii=False, indent=2))
     return 0
 
 
 def cmd_build_index(args: argparse.Namespace) -> int:
     sources_conn = open_sources(args.sources_db)
-    idx_path = args.index_db or (Path(args.sources_db).parent / f"verbatim_shingle_k{args.k}.db")
+    idx_path = args.index_db or get_default_index_db_path(args.sources_db, args.k, args.corpora_resolved)
     idx = ShingleIndex(idx_path, k=args.k)
-    fp = idx.build(sources_conn, progress=True)
+    fp = idx.build(sources_conn, corpora=args.corpora_resolved, progress=True)
     print(f"OK corpus_hash={fp} index={idx_path}")
     sources_conn.close()
     idx.close()
@@ -963,9 +1080,9 @@ def cmd_baseline_sweep(args: argparse.Namespace) -> int:
     modules = sorted(modules)[: args.limit or 9999]
 
     sources_conn = open_sources(args.sources_db)
-    idx_path = args.index_db or (Path(args.sources_db).parent / f"verbatim_shingle_k{args.k}.db")
+    idx_path = args.index_db or get_default_index_db_path(args.sources_db, args.k, args.corpora_resolved)
     idx = ShingleIndex(idx_path, k=args.k)
-    _ = idx.build(sources_conn, progress=args.verbose)
+    _ = idx.build(sources_conn, corpora=args.corpora_resolved, progress=args.verbose)
 
     results = []
     for md in modules:
@@ -973,16 +1090,43 @@ def cmd_baseline_sweep(args: argparse.Namespace) -> int:
         toks = module_tokens_from_spans(spans)
         rpt = compute_metrics(toks, idx, sources_conn, df_n=args.df_n)
         rpt.module = f"{md.parent.parent.name}/{md.parent.name}"
-        results.append({
-            "module": rpt.module,
-            "tokens": rpt.total_prose_tokens,
-            "max_run": rpt.max_contiguous_run,
-            "ratio": rpt.overlap_ratio,
-        })
+        results.append(
+            {
+                "module": rpt.module,
+                "tokens": rpt.total_prose_tokens,
+                "max_run": rpt.max_contiguous_run,
+                "ratio": rpt.overlap_ratio,
+            }
+        )
         if args.verbose:
             print(rpt.module, rpt.max_contiguous_run, rpt.overlap_ratio)
 
-    print(json.dumps({"count": len(results), "results": results[:50]}, indent=2, ensure_ascii=False))
+    corpus_hash = idx.get_meta("corpus_hash", "")
+    indexed_corpora_json = idx.get_meta("indexed_corpora")
+    if indexed_corpora_json is None:
+        raise ValueError("Missing indexed_corpora in index metadata")
+    try:
+        indexed_corpora = json.loads(indexed_corpora_json)
+    except Exception:
+        indexed_corpora = []
+
+    out = {
+        "count": len(results),
+        "results": results[:50],
+        "corpus_hash": corpus_hash,
+        "indexed_corpora": indexed_corpora,
+        "extraction_spec": EXTRACTION_SPEC_VERSION,
+    }
+
+    default_corpora = FULL_CORPORA + SELF_CORPORA
+    default_labels = {c[3] for c in default_corpora}
+    if set(indexed_corpora) != default_labels:
+        out["scope_note"] = (
+            "WARNING: DF counts and the verify_quote allowlist are computed over the scoped corpus only. "
+            "Ratios are NOT comparable to full-index runs and MUST NOT set enforcement thresholds without a full-index delta check."
+        )
+
+    print(json.dumps(out, indent=2, ensure_ascii=False))
     sources_conn.close()
     idx.close()
     return 0
@@ -994,6 +1138,12 @@ def build_argparser() -> argparse.ArgumentParser:
     p.add_argument("--index-db", default=None, help="Explicit index sqlite path")
     p.add_argument("--k", type=int, default=K_DEFAULT, help="Shingle size (words)")
     p.add_argument("--df-n", type=int, default=DF_N_DEFAULT, help="DF threshold for ratio allowlist")
+    p.add_argument(
+        "--corpus",
+        action="append",
+        default=None,
+        help="Corpus to index/analyze (repeatable or comma-separated list of: textbooks, literary, external, ukrainian_wiki, wikipedia)",
+    )
 
     sub = p.add_subparsers(dest="cmd", required=True)
 
@@ -1015,6 +1165,12 @@ def build_argparser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_argparser()
     args = parser.parse_args(argv)
+
+    try:
+        args.corpora_resolved = parse_corpora_labels(args.corpus)
+    except argparse.ArgumentTypeError as e:
+        parser.error(str(e))
+
     return args.func(args)
 
 

--- a/tests/test_verbatim_overlap_gate.py
+++ b/tests/test_verbatim_overlap_gate.py
@@ -171,8 +171,15 @@ def test_hermetic_verbatim_copy_flagged(tmp_path: Path):
 
     # Simulate module that copied a long contiguous chunk
     copy = "Біля вокзалу я раптом зустріла однокласника. Він усміхнувся і запропонував піти разом."
-    spans = [ExtractedSpan(text=copy, norm=normalize_text(copy), tokens=tokenize(normalize_text(copy)),
-                           source="test.md:10-20", kind="test")]
+    spans = [
+        ExtractedSpan(
+            text=copy,
+            norm=normalize_text(copy),
+            tokens=tokenize(normalize_text(copy)),
+            source="test.md:10-20",
+            kind="test",
+        )
+    ]
     mod_tokens = module_tokens_from_spans(spans)
 
     idx = ShingleIndex(tmp_path / "idx.db", k=4)  # smaller k for toy
@@ -194,8 +201,9 @@ def test_paraphrase_is_clean(tmp_path: Path):
     _seed_corpus(conn, [{"table": "literary_texts", "chunk_id": "lit-42", "text": corpus_text, "author": "Тест"}])
 
     para = "Ми неквапно крокували вузьким провулком і раптом почули звуки. Двері зненацька розчахнулися."
-    spans = [ExtractedSpan(text=para, norm=normalize_text(para), tokens=tokenize(normalize_text(para)),
-                           source="p", kind="p")]
+    spans = [
+        ExtractedSpan(text=para, norm=normalize_text(para), tokens=tokenize(normalize_text(para)), source="p", kind="p")
+    ]
     mod_tokens = module_tokens_from_spans(spans)
 
     idx = ShingleIndex(tmp_path / "idx2.db", k=5)
@@ -212,10 +220,23 @@ def test_paraphrase_is_clean(tmp_path: Path):
 def test_attributed_quote_allowlisted_in_ratio(tmp_path: Path):
     conn, _dbp = _tiny_sources_db()
     qtext = "І сниться мені, що я лечу."
-    _seed_corpus(conn, [{"table": "literary_texts", "chunk_id": "shev-1", "text": "І сниться мені, що я лечу крізь ніч.", "author": "Шевченко"}])
+    _seed_corpus(
+        conn,
+        [
+            {
+                "table": "literary_texts",
+                "chunk_id": "shev-1",
+                "text": "І сниться мені, що я лечу крізь ніч.",
+                "author": "Шевченко",
+            }
+        ],
+    )
 
-    spans = [ExtractedSpan(text=qtext, norm=normalize_text(qtext), tokens=tokenize(normalize_text(qtext)),
-                           source="q", kind="quote")]
+    spans = [
+        ExtractedSpan(
+            text=qtext, norm=normalize_text(qtext), tokens=tokenize(normalize_text(qtext)), source="q", kind="quote"
+        )
+    ]
     mod_tokens = module_tokens_from_spans(spans)
 
     idx = ShingleIndex(tmp_path / "idxq.db", k=3)
@@ -249,8 +270,15 @@ def test_df_gaming_long_run_still_flagged_by_max_contiguous(tmp_path: Path):
     _seed_corpus(conn, [{"table": "textbooks", "chunk_id": "long-1", "text": long_run}])
 
     # Module copies the long run
-    spans = [ExtractedSpan(text=long_run, norm=normalize_text(long_run), tokens=tokenize(normalize_text(long_run)),
-                           source="m", kind="m")]
+    spans = [
+        ExtractedSpan(
+            text=long_run,
+            norm=normalize_text(long_run),
+            tokens=tokenize(normalize_text(long_run)),
+            source="m",
+            kind="m",
+        )
+    ]
     mod_tokens = module_tokens_from_spans(spans)
 
     idx = ShingleIndex(tmp_path / "idxdf.db", k=4)
@@ -270,8 +298,15 @@ def test_copied_activity_is_flagged(tmp_path: Path):
     _seed_corpus(conn, [{"table": "textbooks", "chunk_id": "actbook-7", "text": act_text + " і слухати музику."}])
 
     # Simulate extracted activity item
-    spans = [ExtractedSpan(text=act_text, norm=normalize_text(act_text), tokens=tokenize(normalize_text(act_text)),
-                           source="activities.yaml#act-1", kind="activity")]
+    spans = [
+        ExtractedSpan(
+            text=act_text,
+            norm=normalize_text(act_text),
+            tokens=tokenize(normalize_text(act_text)),
+            source="activities.yaml#act-1",
+            kind="activity",
+        )
+    ]
     mod_tokens = module_tokens_from_spans(spans)
 
     idx = ShingleIndex(tmp_path / "idxact.db", k=4)
@@ -285,10 +320,13 @@ def test_copied_activity_is_flagged(tmp_path: Path):
 
 def test_index_build_is_deterministic(tmp_path: Path):
     conn, _dbp = _tiny_sources_db()
-    _seed_corpus(conn, [
-        {"table": "literary_texts", "chunk_id": "d1", "text": "Сонце сідає за обрій. Птахи замовкають."},
-        {"table": "literary_texts", "chunk_id": "d2", "text": "Вітер гуляє в полі. Дерева шумлять."},
-    ])
+    _seed_corpus(
+        conn,
+        [
+            {"table": "literary_texts", "chunk_id": "d1", "text": "Сонце сідає за обрій. Птахи замовкають."},
+            {"table": "literary_texts", "chunk_id": "d2", "text": "Вітер гуляє в полі. Дерева шумлять."},
+        ],
+    )
     idx1 = ShingleIndex(tmp_path / "d1.db", k=3)
     fp1 = idx1.build(conn)
     p1 = idx1.conn.execute("SELECT COUNT(*) FROM postings").fetchone()[0]
@@ -307,7 +345,9 @@ def test_index_build_is_deterministic(tmp_path: Path):
 def test_full_extract_module_and_analyze_hermetic(tmp_path: Path):
     conn, _dbp = _tiny_sources_db()
     # Seed a chunk that will verbatim match something in real A1 (but we use synthetic for isolation)
-    _seed_corpus(conn, [{"table": "textbooks", "chunk_id": "toy-1", "text": "Ходімо в кіно в суботу. Добре. О котрій?"}])
+    _seed_corpus(
+        conn, [{"table": "textbooks", "chunk_id": "toy-1", "text": "Ходімо в кіно в суботу. Добре. О котрій?"}]
+    )
 
     # Use real A1 module extraction (it must not crash and must surface UA)
     spans, meta = extract_module_content(A1_FREE_TIME)
@@ -333,7 +373,9 @@ def test_chained_run_and_lcs_recovery(tmp_path: Path):
 
     # module has almost exact but with one high-DF break
     mod = "один два три чотири п'ять шість сім вісім дев'ять десять"
-    spans = [ExtractedSpan(text=mod, norm=normalize_text(mod), tokens=tokenize(normalize_text(mod)), source="s", kind="s")]
+    spans = [
+        ExtractedSpan(text=mod, norm=normalize_text(mod), tokens=tokenize(normalize_text(mod)), source="s", kind="s")
+    ]
     toks = module_tokens_from_spans(spans)
 
     idx = ShingleIndex(tmp_path / "lcs.db", k=3)
@@ -424,7 +466,9 @@ def test_L698_overlap_ratio_zero_when_no_matches(tmp_path: Path):
     _seed_corpus(conn, [{"table": "textbooks", "chunk_id": "u1", "text": "Сонце світить."}])
     # module prose with no overlap at all (unique tokens)
     uniq = "Каламар плаває в океані глибоко під водою шукаючи скарби."
-    spans = [ExtractedSpan(text=uniq, norm=normalize_text(uniq), tokens=tokenize(normalize_text(uniq)), source="t", kind="t")]
+    spans = [
+        ExtractedSpan(text=uniq, norm=normalize_text(uniq), tokens=tokenize(normalize_text(uniq)), source="t", kind="t")
+    ]
     toks = module_tokens_from_spans(spans)
     idx = ShingleIndex(tmp_path / "zero.db", k=4)
     idx.build(conn)
@@ -445,7 +489,9 @@ def test_L741_verify_quote_excludes_from_ratio_truthfully(tmp_path: Path):
     conn, _ = _tiny_sources_db()
     q = "І сниться мені що я лечу крізь ніч."
     _seed_corpus(conn, [{"table": "literary_texts", "chunk_id": "sh1", "text": q + " ще слова.", "author": "Шевченко"}])
-    spans = [ExtractedSpan(text=q, norm=normalize_text(q), tokens=tokenize(normalize_text(q)), source="mod:1", kind="quote")]
+    spans = [
+        ExtractedSpan(text=q, norm=normalize_text(q), tokens=tokenize(normalize_text(q)), source="mod:1", kind="quote")
+    ]
     toks = module_tokens_from_spans(spans)
     idx = ShingleIndex(tmp_path / "ver.db", k=3)
     idx.build(conn)
@@ -485,7 +531,9 @@ def test_L686_max_contiguous_run_per_chunk_not_summed(tmp_path: Path):
         {"table": "textbooks", "chunk_id": "cD", "text": "p3 p4 p5 fillerD"},
     ]
     _seed_corpus(conn, chunks)
-    spans = [ExtractedSpan(text=mod, norm=normalize_text(mod), tokens=tokenize(normalize_text(mod)), source="m", kind="m")]
+    spans = [
+        ExtractedSpan(text=mod, norm=normalize_text(mod), tokens=tokenize(normalize_text(mod)), source="m", kind="m")
+    ]
     toks = module_tokens_from_spans(spans)
     idx = ShingleIndex(tmp_path / "run.db", k=3)
     idx.build(conn)
@@ -566,6 +614,7 @@ def test_L307_extract_activities_prompt_and_options_text():
     Golden: the prompt text e.g. '___ ти?' MUST appear in extracted spans.
     """
     from pathlib import Path
+
     yaml_p = Path("curriculum/l2-uk-en/a1/questions/activities.yaml")
     spans = extract_from_activities_yaml(yaml_p)
     texts = [s.text for s in spans]
@@ -579,3 +628,184 @@ def test_L307_extract_activities_prompt_and_options_text():
     mod_spans, _meta = extract_module_content("curriculum/l2-uk-en/a1/questions")
     mod_texts = " ".join(s.text for s in mod_spans)
     assert "___ ти?" in mod_texts or any("___ ти?" in s.norm for s in mod_spans)
+
+
+def test_postings_deduplication_metrics_identical(tmp_path: Path):
+    import json
+
+    from scripts.audit.verbatim_overlap_gate import make_shingles
+
+    conn, _ = _tiny_sources_db()
+    # A chunk with highly repeated shingles
+    repeated_txt = "котик грається м'ячиком котик грається м'ячиком котик грається м'ячиком"
+    _seed_corpus(conn, [{"table": "textbooks", "chunk_id": "rep-1", "text": repeated_txt}])
+
+    # 1. Build index with our updated deduplicated code
+    idx_dedup = ShingleIndex(tmp_path / "dedup.db", k=3)
+    idx_dedup.build(conn)
+
+    # 2. Build a duplicate-postings index manually to simulate the old behavior
+    idx_dup = ShingleIndex(tmp_path / "dup.db", k=3)
+    # We populate it manually without deduplication
+    idx_dup.conn.executescript("DELETE FROM postings; DELETE FROM shingle_df; DELETE FROM meta;")
+    # Get the shingles
+    toks = tokenize(normalize_text(repeated_txt))
+    shs = make_shingles(toks, 3)
+    # Insert multiple postings for the same shingle from the same chunk
+    idx_dup.conn.executemany(
+        "INSERT INTO postings (shingle_key, corpus, chunk_id, char_offset) VALUES (?, 'textbooks', 'rep-1', 0)",
+        [(sh,) for sh in shs],
+    )
+    # Build df manually
+    shingle_to_chunks = {}
+    for sh in shs:
+        if sh not in shingle_to_chunks:
+            shingle_to_chunks[sh] = 1  # df is 1 chunk
+    df_rows = [(sh, 1) for sh in shingle_to_chunks]
+    idx_dup.conn.executemany("INSERT OR REPLACE INTO shingle_df (shingle_key, df) VALUES (?, ?)", df_rows)
+    idx_dup.set_meta("corpus_hash", "some-hash")
+    idx_dup.set_meta("k", "3")
+    idx_dup.set_meta("extraction_spec", EXTRACTION_SPEC_VERSION)
+    idx_dup.set_meta("indexed_corpora", json.dumps(["textbooks"]))
+    idx_dup.conn.commit()
+
+    # Now compute metrics for a query/module using both indices
+    module_query = "котик грається м'ячиком котик"
+    mod_toks = tokenize(normalize_text(module_query))
+
+    rpt_dedup = compute_metrics(mod_toks, idx_dedup, conn, df_n=5)
+    rpt_dup = compute_metrics(mod_toks, idx_dup, conn, df_n=5)
+
+    assert rpt_dedup.overlap_ratio == rpt_dup.overlap_ratio
+    assert rpt_dedup.max_contiguous_run == rpt_dup.max_contiguous_run
+    assert rpt_dedup.max_contiguous_run_df_filtered == rpt_dup.max_contiguous_run_df_filtered
+
+    conn.close()
+    idx_dedup.close()
+    idx_dup.close()
+
+
+def test_cli_corpus_scoping_options():
+    import argparse
+
+    from scripts.audit.verbatim_overlap_gate import parse_corpora_labels
+
+    # Test valid parsing: textbooks,literary comma-separated
+    res1 = parse_corpora_labels(["textbooks,literary"])
+    assert len(res1) == 2
+    assert res1[0][3] == "textbooks"
+    assert res1[1][3] == "literary"
+
+    # Test repeatable options
+    res2 = parse_corpora_labels(["textbooks", "external"])
+    assert len(res2) == 2
+    assert res2[0][3] == "textbooks"
+    assert res2[1][3] == "external"
+
+    # Test combination of both
+    res3 = parse_corpora_labels(["textbooks,literary", "external"])
+    assert len(res3) == 3
+    assert res3[0][3] == "textbooks"
+    assert res3[1][3] == "literary"
+    assert res3[2][3] == "external"
+
+    # Test unknown corpus raises argparse.ArgumentTypeError
+    import pytest
+
+    with pytest.raises(argparse.ArgumentTypeError) as excinfo:
+        parse_corpora_labels(["textbooks,invalid_corpus"])
+    assert "Invalid corpus label(s): invalid_corpus" in str(excinfo.value)
+
+
+def test_index_db_filename_scoping(tmp_path: Path):
+    from scripts.audit.verbatim_overlap_gate import get_default_index_db_path
+
+    sources_db = tmp_path / "sources.db"
+
+    # Default (no corpora, or FULL_CORPORA + SELF_CORPORA)
+    path_def1 = get_default_index_db_path(sources_db, k=8)
+    assert path_def1.name == "verbatim_shingle_k8.db"
+
+    # Scoped non-default
+    from scripts.audit.verbatim_overlap_gate import ALL_POSSIBLE_CORPORA
+
+    scoped = [ALL_POSSIBLE_CORPORA["textbooks"], ALL_POSSIBLE_CORPORA["literary"]]
+    path_scoped = get_default_index_db_path(sources_db, k=8, corpora=scoped)
+    # alphabet sorted: literary, textbooks
+    assert path_scoped.name == "verbatim_shingle_k8_literary-textbooks.db"
+
+
+def test_missing_indexed_corpora_raises_hard_error(tmp_path: Path):
+    import pytest
+
+    conn, _ = _tiny_sources_db()
+    _seed_corpus(conn, [{"table": "textbooks", "chunk_id": "t-1", "text": "це просто тест"}])
+
+    idx = ShingleIndex(tmp_path / "idx_missing.db", k=3)
+    idx.build(conn)
+
+    # Manually delete indexed_corpora from meta table
+    idx.conn.execute("DELETE FROM meta WHERE key = 'indexed_corpora'")
+    idx.conn.commit()
+
+    # Try to compute metrics
+    mod_toks = tokenize(normalize_text("це просто тест"))
+    with pytest.raises(ValueError) as excinfo:
+        compute_metrics(mod_toks, idx, conn, df_n=5)
+    assert "Missing indexed_corpora in index metadata" in str(excinfo.value)
+
+    conn.close()
+    idx.close()
+
+
+def test_cross_scope_df_exclusion_warning(tmp_path: Path):
+    from scripts.audit.verbatim_overlap_gate import ALL_POSSIBLE_CORPORA, FULL_CORPORA, SELF_CORPORA
+
+    conn, _ = _tiny_sources_db()
+
+    # We want a phrase to appear in textbooks (2 times) and literary_texts (4 times)
+    # Total DF in full index = 6
+    # Total DF in textbooks index = 2
+    # If df_n = 5:
+    # Full index: DF (6) >= 5, so phrase is excluded from ratio.
+    # Textbooks index: DF (2) < 5, so phrase is NOT excluded from ratio.
+
+    phrase = "сонце світить над лісом весело"
+    # Seed 2 textbook chunks with the phrase
+    for i in range(2):
+        _seed_corpus(conn, [{"table": "textbooks", "chunk_id": f"tb-{i}", "text": phrase + f" {i}"}])
+    # Seed 4 literary chunks with the phrase
+    for i in range(4):
+        _seed_corpus(conn, [{"table": "literary_texts", "chunk_id": f"lit-{i}", "text": phrase + f" {i}"}])
+
+    # Module query
+    mod_toks = tokenize(normalize_text(phrase))
+
+    # --- 1. FULL INDEX ---
+    idx_full = ShingleIndex(tmp_path / "full.db", k=3)
+    idx_full.build(conn, corpora=FULL_CORPORA + SELF_CORPORA)
+
+    rpt_full = compute_metrics(mod_toks, idx_full, conn, df_n=5)
+    # The shingles are excluded because DF=6 >= 5. Ratio should be 0.0
+    assert rpt_full.overlap_ratio == 0.0
+    # No scope note since it is default/full
+    assert rpt_full.scope_note is None
+    assert set(rpt_full.indexed_corpora) == {"textbooks", "literary", "external", "ukrainian_wiki"}
+
+    # --- 2. SCOPED INDEX ---
+    idx_scoped = ShingleIndex(tmp_path / "scoped.db", k=3)
+    # index textbooks only
+    idx_scoped.build(conn, corpora=[ALL_POSSIBLE_CORPORA["textbooks"]])
+
+    rpt_scoped = compute_metrics(mod_toks, idx_scoped, conn, df_n=5)
+    # The shingles are NOT excluded because DF=2 < 5. Ratio should be > 0.0
+    assert rpt_scoped.overlap_ratio > 0.0
+    # Warning and labeling should appear
+    assert rpt_scoped.scope_note is not None
+    assert "WARNING" in rpt_scoped.scope_note
+    assert "DF counts" in rpt_scoped.scope_note
+    assert rpt_scoped.indexed_corpora == ["textbooks"]
+
+    conn.close()
+    idx_full.close()
+    idx_scoped.close()


### PR DESCRIPTION
Implement corpus scoping, postings deduplication at insertion, and database filename/metadata persistence.

Refs #4964

### Changes
1. **Postings Deduplication at Insert**: Deduplicate postings to unique `(shingle_key, corpus, chunk_id)` inside `ShingleIndex.build()` using `dict.fromkeys(shs)`.
2. **Corpus Scoping**: Add repeatable/comma-separated `--corpus` CLI parameter to `analyze`, `build-index`, and `baseline-sweep`. Validate against valid labels: textbooks, literary, external, ukrainian_wiki, wikipedia.
3. **Database Filename Scoping**: Generate index DB file names consistently using the sorted corpora slug `verbatim_shingle_k{k}_<slug>.db`, using `verbatim_shingle_k{k}.db` for the default full-index scope.
4. **Metadata & JSON Persistence**: Save `indexed_corpora` (ordered JSON list of labels) in index meta. Output `indexed_corpora`, `corpus_hash`, `extraction_spec`, and (if scoped) `scope_note` warning in JSON outputs.
5. **Scoped-DF Warning**: Emit explicit warning about scoped DF counts and ratio comparability when the scoped index is used.

### Verification Evidence

#### Pytest Run
```
tests/test_verbatim_overlap_gate.py::test_normalize_and_tokenize_deterministic_and_ua_aware PASSED [  2%]
tests/test_verbatim_overlap_gate.py::test_golden_extraction_a1_free_time_has_dialogue_ua PASSED [  5%]
tests/test_verbatim_overlap_gate.py::test_golden_extraction_b1_has_substantial_ua_prose PASSED [  8%]
tests/test_verbatim_overlap_gate.py::test_extraction_spec_version_is_stable PASSED [ 11%]
tests/test_verbatim_overlap_gate.py::test_hermetic_verbatim_copy_flagged PASSED [ 14%]
tests/test_verbatim_overlap_gate.py::test_paraphrase_is_clean PASSED     [ 17%]
tests/test_verbatim_overlap_gate.py::test_attributed_quote_allowlisted_in_ratio PASSED [ 20%]
tests/test_verbatim_overlap_gate.py::test_df_gaming_long_run_still_flagged_by_max_contiguous PASSED [ 22%]
tests/test_verbatim_overlap_gate.py::test_copied_activity_is_flagged PASSED [ 25%]
tests/test_verbatim_overlap_gate.py::test_index_build_is_deterministic PASSED [ 28%]
tests/test_verbatim_overlap_gate.py::test_full_extract_module_and_analyze_hermetic PASSED [ 31%]
tests/test_verbatim_overlap_gate.py::test_chained_run_and_lcs_recovery PASSED [ 34%]
tests/test_verbatim_overlap_gate.py::test_L544_postings_and_reports_deterministic_across_insert_order PASSED [ 37%]
tests/test_verbatim_overlap_gate.py::test_L584_fingerprint_content_based_on_text_change PASSED [ 40%]
tests/test_verbatim_overlap_gate.py::test_L698_overlap_ratio_zero_when_no_matches PASSED [ 42%]
tests/test_verbatim_overlap_gate.py::test_L741_verify_quote_excludes_from_ratio_truthfully PASSED [ 45%]
tests/test_verbatim_overlap_gate.py::test_L686_max_contiguous_run_per_chunk_not_summed PASSED [ 48%]
tests/test_verbatim_overlap_gate.py::test_multiline_html_comment_not_leaked_into_extraction PASSED [ 51%]
tests/test_verbatim_overlap_gate.py::test_normalize_L79_strips_only_stress_preserves_uk_letters PASSED [ 54%]
tests/test_verbatim_overlap_gate.py::test_L307_extract_activities_prompt_and_options_text PASSED [ 57%]
tests/test_verbatim_overlap_gate.py::test_postings_deduplication_metrics_identical PASSED [ 60%]
tests/test_verbatim_overlap_gate.py::test_cli_corpus_scoping_options PASSED [ 62%]
tests/test_verbatim_overlap_gate.py::test_index_db_filename_scoping PASSED [ 65%]
tests/test_verbatim_overlap_gate.py::test_missing_indexed_corpora_raises_hard_error PASSED [ 68%]
tests/test_verbatim_overlap_gate.py::test_cross_scope_df_exclusion_warning PASSED [ 71%]
tests/test_vesum_yaml_verbatim_primary_exemption.py::test_yaml_primary_spans_are_stripped_but_scoped_terms_remain PASSED [ 74%]
tests/test_vesum_yaml_verbatim_primary_exemption.py::test_module_primary_cross_reference_does_not_need_corpus PASSED [ 77%]
tests/test_vesum_yaml_verbatim_primary_exemption.py::test_bare_dialect_citations_from_verified_primary_are_exempted PASSED [ 80%]
tests/test_vesum_yaml_verbatim_primary_exemption.py::test_italic_emphasis_does_not_bypass_vesum_check PASSED [ 82%]
tests/test_vesum_yaml_verbatim_primary_exemption.py::test_bare_citations_not_in_verified_primary_still_checked PASSED [ 85%]
tests/test_vesum_yaml_verbatim_primary_exemption.py::test_core_level_bare_primary_citation_is_not_exempted PASSED [ 88%]
tests/test_vesum_yaml_verbatim_primary_exemption.py::test_vocabulary_usage_primary_span_is_stripped PASSED [ 91%]
tests/test_vesum_yaml_verbatim_primary_exemption.py::test_core_level_yaml_primary_text_is_not_exempted PASSED [ 94%]
tests/test_vesum_yaml_verbatim_primary_exemption.py::test_literary_corpus_exemption_does_not_cross_activity_field_boundary PASSED [ 97%]
tests/test_vesum_yaml_verbatim_primary_exemption.py::test_modern_activity_nonword_still_fails_vesum PASSED [100%]

============================== 35 passed in 0.57s ==============================
```

#### Ruff Check & Format
```
All checks passed!
2 files already formatted
```