### PR TITLE
fix(review): isolate post-build review runs

### DIFF
--- a/agents_extensions/shared/skills/post-build-review/SKILL.md
+++ b/agents_extensions/shared/skills/post-build-review/SKILL.md
@@ -16,7 +16,15 @@ artifacts. Report findings; do not fix the module during this invocation.
    every evidence modality it can directly inspect: `text`, `audio`, `video`,
    `image`, or `interactive`. Do not declare a capability merely because page
    metadata is readable.
-3. Run deterministic preparation:
+3. Allocate one invocation-scoped run directory. Copy the emitted paths exactly
+   and use them only for this review. Never reuse another review's run directory
+   or fall back to global `/tmp/post-build-review-*.json` names:
+
+   ```bash
+   .venv/bin/python scripts/audit/post_build_review.py allocate <track/slug>
+   ```
+
+4. Run deterministic preparation with the emitted `packet` path:
 
    ```bash
    .venv/bin/python scripts/audit/post_build_review.py prepare \
@@ -26,33 +34,34 @@ artifacts. Report findings; do not fix the module during this invocation.
      --reviewer-model <model> \
      --reviewer-effort <effort> \
      --reviewer-capability text \
-     --output /tmp/post-build-review-packet.json
+     --output <packet_path>
    ```
 
-4. Read `/tmp/post-build-review-packet.json`. Follow its `semantic_prompt`
+5. Read `<packet_path>`. Follow its `semantic_prompt`
    exactly. Read every path in `target.files`; use the project source tools for
    Ukrainian, factual, attribution, and quotation claims. Never guess a
    Ukrainian fact. If required tools or evidence are unavailable, return
    `INCOMPLETE`.
-5. Preserve the reviewer's exact response bytes at
-   `/tmp/post-build-review-semantic-response.json`. Do not extract, repair,
+6. Preserve the reviewer's exact response bytes at the emitted
+   `<semantic_response_path>`. Do not extract, repair,
    normalize, merge, or reconcile malformed output. A malformed response ends
    this review as `INCOMPLETE`; any retry is a distinct review with a new
-   packet/result and cannot replace the failed artifact. Use `apply_patch`, not
-   a shell heredoc, when the current agent is the reviewer.
-6. Finalize and validate:
+   packet/result and cannot replace the failed artifact. Allocate a new run
+   directory before every retry. Use `apply_patch`, not a shell heredoc, when
+   the current agent is the reviewer.
+7. Finalize and validate using paths from the same allocated run directory:
 
    ```bash
    .venv/bin/python scripts/audit/post_build_review.py finalize \
-     --packet /tmp/post-build-review-packet.json \
-     --semantic-response /tmp/post-build-review-semantic-response.json \
-     --output /tmp/post-build-review-result.json
+     --packet <packet_path> \
+     --semantic-response <semantic_response_path> \
+     --output <result_path>
    ```
 
-7. Read the result back, report the combined disposition and material findings,
-   and cite `/tmp/post-build-review-result.json`. A non-zero finalize exit means
+8. Read the result back, report the combined disposition and material findings,
+   and cite `<result_path>`. A non-zero finalize exit means
    `BLOCK`, `REVISE`, or `INCOMPLETE`; it is a review outcome, not a tool crash.
-8. Verify `git status --short` is unchanged from before the invocation.
+9. Verify `git status --short` is unchanged from before the invocation.
 
 ## Canonical resources
 

--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,4 +1,4 @@
-review_protocol_version: 2.0.0
+review_protocol_version: 2.0.1
 deterministic_contract_version: 1.2.0
 semantic_prompt_version: 2.0.0
 track_policy_version: 1.2.0

--- a/docs/runbooks/post-build-review.md
+++ b/docs/runbooks/post-build-review.md
@@ -15,8 +15,8 @@ Use $post-build-review for bio/oleksandr-bilash.
 
 The skill runs deterministic preparation, selects the core or seminar semantic
 family from versioned track policy, requires a source-backed semantic result,
-and combines both layers into `/tmp/post-build-review-result.json`. It must not
-write curriculum audit/status/review files or telemetry.
+and combines both layers inside an invocation-unique directory allocated under
+`/tmp`. It must not write curriculum audit/status/review files or telemetry.
 
 ## Responsibility boundaries
 
@@ -25,7 +25,7 @@ write curriculum audit/status/review files or telemetry.
 | Deterministic facts and aggregation | `scripts/audit/post_build_review.py` plus existing audit code |
 | Mechanically verifiable track rules | `post-build-review/config/track-policy.v1.yaml` |
 | Semantic judgment | `post-build-review/prompts/*.md` |
-| Orchestration order | `post-build-review/SKILL.md` |
+| Orchestration order and run isolation | `post-build-review/SKILL.md` plus `post_build_review.py allocate` |
 | Output shape | `post-build-review/schema/review-result.v2.schema.json` |
 | Operator maintenance | This runbook |
 
@@ -83,6 +83,12 @@ For every review defect:
 9. Commit with an `X-Agent` trailer and merge through one scoped PR. Close the
    linked stream issue with command/output evidence and clean the worktree.
 
+Each invocation starts with `post_build_review.py allocate <track/slug>` and
+keeps its packet, exact semantic response, and result in the returned directory.
+Fixed global `/tmp/post-build-review-*.json` names are forbidden because
+concurrent reviewers can replace one another's evidence between `prepare` and
+`finalize`.
+
 For semantic-response defects, preserve the exact reviewer output. Never copy
 selected fields into a new JSON object, strip a Markdown wrapper, choose one of
 multiple objects, adjust counts, or reconcile retries. Finalize the raw response
@@ -120,8 +126,7 @@ Then forward-test the exact short prompt in a fresh agent. Validate the emitted
 result with:
 
 ```bash
-.venv/bin/python scripts/audit/post_build_review.py validate \
-  /tmp/post-build-review-result.json
+.venv/bin/python scripts/audit/post_build_review.py validate <result_path>
 ```
 
 Compare `reproducibility_key`, version fields, prompt hash, source hashes,

--- a/scripts/audit/post_build_review.py
+++ b/scripts/audit/post_build_review.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import re
 import subprocess
+import tempfile
 from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
 from pathlib import Path
@@ -1298,6 +1299,27 @@ def ensure_output_outside_repo(path: Path, *, repo_root: Path = PROJECT_ROOT) ->
     raise ReviewProtocolError("Review outputs must be written outside the repository")
 
 
+def allocate_run_paths(
+    target_value: str,
+    *,
+    temp_root: Path | None = None,
+    repo_root: Path = PROJECT_ROOT,
+) -> dict[str, str]:
+    """Reserve one invocation-scoped directory for every review artifact."""
+    target = resolve_target(target_value, repo_root=repo_root)
+    root = (temp_root or Path(tempfile.gettempdir())).resolve()
+    ensure_output_outside_repo(root / "post-build-review-placeholder", repo_root=repo_root)
+    root.mkdir(parents=True, exist_ok=True)
+    prefix = f"post-build-review-{target['track']}-{target['slug']}-"
+    run_dir = Path(tempfile.mkdtemp(prefix=prefix, dir=root)).resolve()
+    return {
+        "run_dir": str(run_dir),
+        "packet": str(run_dir / "packet.json"),
+        "semantic_response": str(run_dir / "semantic-response.json"),
+        "result": str(run_dir / "result.json"),
+    }
+
+
 def _write_or_print(value: object, output: Path | None, *, repo_root: Path) -> None:
     text = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
     if output is None:
@@ -1311,6 +1333,13 @@ def _write_or_print(value: object, output: Path | None, *, repo_root: Path) -> N
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run the canonical read-only post-build review protocol.")
     subparsers = parser.add_subparsers(dest="command", required=True)
+    allocate = subparsers.add_parser(
+        "allocate",
+        help="Reserve invocation-scoped paths for packet, semantic response, and result.",
+    )
+    allocate.add_argument("target", help="track/slug, e.g. bio/oleksandr-bilash")
+    allocate.add_argument("--temp-root", type=Path)
+
     prepare = subparsers.add_parser("prepare", help="Run deterministic stages and assemble the semantic prompt.")
     prepare.add_argument("target", help="track/slug, e.g. bio/oleksandr-bilash")
     prepare.add_argument("--reviewer-agent", required=True)
@@ -1338,6 +1367,13 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    if args.command == "allocate":
+        _write_or_print(
+            allocate_run_paths(args.target, temp_root=args.temp_root),
+            None,
+            repo_root=PROJECT_ROOT,
+        )
+        return 0
     if args.command == "prepare":
         reviewer = {
             "agent": args.reviewer_agent,

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import json
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -815,6 +816,43 @@ def test_repository_output_paths_are_rejected(tmp_path: Path) -> None:
     pbr.ensure_output_outside_repo(tmp_path / "review.json")
 
 
+def test_concurrent_review_runs_allocate_isolated_artifact_paths(tmp_path: Path) -> None:
+    command = [
+        str(ROOT / ".venv" / "bin" / "python"),
+        str(ROOT / "scripts" / "audit" / "post_build_review.py"),
+        "allocate",
+        "bio/oleksandr-bilash",
+        "--temp-root",
+        str(tmp_path),
+    ]
+
+    def allocate() -> dict[str, str]:
+        completed = subprocess.run(
+            command,
+            cwd=ROOT,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+        return json.loads(completed.stdout)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        first, second = list(executor.map(lambda _: allocate(), range(2)))
+
+    assert first["run_dir"] != second["run_dir"]
+    for paths in (first, second):
+        run_dir = Path(paths["run_dir"])
+        assert run_dir.is_dir()
+        assert Path(paths["packet"]) == run_dir / "packet.json"
+        assert Path(paths["semantic_response"]) == run_dir / "semantic-response.json"
+        assert Path(paths["result"]) == run_dir / "result.json"
+
+    Path(first["packet"]).write_text('{"target":"first"}\n', encoding="utf-8")
+    Path(second["packet"]).write_text('{"target":"second"}\n', encoding="utf-8")
+    assert json.loads(Path(first["packet"]).read_text(encoding="utf-8"))["target"] == "first"
+    assert json.loads(Path(second["packet"]).read_text(encoding="utf-8"))["target"] == "second"
+
+
 def test_tampered_packet_paths_cannot_escape_repository() -> None:
     target = {"files": {"plan": "../../etc/passwd"}}
     with pytest.raises(pbr.ReviewProtocolError, match="escapes the checkout"):
@@ -840,14 +878,16 @@ def test_skill_forbids_mutating_legacy_paths() -> None:
     assert "Preserve the reviewer's exact response bytes" in text
     assert "--semantic-response" in text
     assert "--semantic-result" not in text
+    assert "post_build_review.py allocate <track/slug>" in text
+    assert "--output <packet_path>" in text
     assert "curriculum/l2-uk-en/{track}/audit" not in text
 
 
 def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
-    assert catalog["catalog_version"] == "2.0.0"
-    assert len(rows) == 23
+    assert catalog["catalog_version"] == "2.0.1"
+    assert len(rows) == 24
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",
@@ -863,6 +903,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
         "1.1.0",
         "1.2.0",
         "2.0.0",
+        "2.0.1",
     }
     null_result = next(row for row in rows if row["bug_id"] == "deterministic-stage-null-result-crash")
     assert null_result["responsible_layer"] == "orchestration"

--- a/tests/fixtures/post_build_review/bio-oleksandr-bilash.result.v2.json
+++ b/tests/fixtures/post_build_review/bio-oleksandr-bilash.result.v2.json
@@ -473,8 +473,8 @@
     }
   ],
   "prompt_sha256": "f48057421a91997fd9408d3d2ddf1467c5cf611f551b4ff7f61251eca87ba7cb",
-  "reproducibility_key": "0a891f4a4bd499bc7476c428f7564ed746fbc751b6a08dcd29dabccd77222d35",
-  "review_protocol_version": "2.0.0",
+  "reproducibility_key": "5800e00c8c203dd3d2c75fbb15a4f7948d4452584c61c53d5555fcbbbafec919",
+  "review_protocol_version": "2.0.1",
   "reviewer": {
     "agent": "fixture",
     "capabilities": [

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -1,4 +1,4 @@
-catalog_version: 2.0.0
+catalog_version: 2.0.1
 regressions:
   - bug_id: bilash-evening-school-location-role
     responsible_layer: semantic_prompt
@@ -131,3 +131,9 @@ regressions:
     version_field: semantic_prompt_version
     input: Catalog metadata plus exact auditory timestamps, breaths, contour, stress, accompaniment, and cadence.
     expected: Metadata supports catalog facts only; absent audio-capable verification the result is INCOMPLETE.
+  - bug_id: concurrent-review-global-tmp-collision
+    responsible_layer: orchestration
+    fixed_in_version: 2.0.1
+    version_field: review_protocol_version
+    input: Two reviews prepare and finalize concurrently for different module targets.
+    expected: Each invocation receives a distinct run directory whose packet, exact semantic response, and result cannot cross targets.


### PR DESCRIPTION
## Summary

- allocate a unique absolute temporary directory for every post-build review invocation
- require packet, exact semantic response, and final result to remain inside one isolated run directory
- preserve fail-closed malformed-output behavior and forbid fixed global temporary names
- add a concurrent allocation regression and bump the review protocol to 2.0.1

## Verification

- `.venv/bin/python -m pytest tests/audit/test_post_build_review.py -q` — 49 passed
- `.venv/bin/ruff check scripts/audit/post_build_review.py tests/audit/test_post_build_review.py`
- `.venv/bin/python -m py_compile scripts/audit/post_build_review.py`
- `npm run agents:deploy` — idempotent, no deployment drift
- `bash scripts/check_rules_deployment.sh`
- prompt and skill lint — passed
- `git diff --check`

## Independent review

AGY Gemini 3.1 Pro (High), task `review-5103-implementation-r3`: PASS. The reviewer confirmed temporary-path isolation, repository-boundary enforcement, fail-closed exact-response handling, schema-v2 compatibility, and concurrent write separation.

Fixes #5103