### PR TITLE
fix(lexicon): explicit preserve-vs-retract gate semantics for offline enrich (#5077)

### DIFF
--- a/scripts/lexicon/README.md
+++ b/scripts/lexicon/README.md
@@ -52,24 +52,38 @@ authorized. See `docs/bug-autopsies/atlas-manifest-source-split.md` for the
 
 ### Offline enrich is non-destructive (preserve-vs-retract, #5077)
 
-`enrich_manifest.py` recomputes gated sections (synonyms/antonyms/homonyms/idioms)
-from scratch each run. Some gates need a live lookup (the Ukrajinet WordNet gate
-wants СУМ-20/slovnyk confirmation; the per-lemma slovnyk cache is reset when its
-`schema_version` bumps). With `LEXICON_SLOVNYK_OFFLINE=1` — or after a cache reset,
-or a transient error — a gate that **cannot run** used to return empty and silently
-overwrite the previously-confirmed published section (809 sections stripped + 1,748
-shrunk on the 2026-07-13 go-live). Enrich now distinguishes three per-section
-outcomes and records the notable ones in an entry's `gate_provenance` map:
+`enrich_manifest.py` recomputes gated sections (synonyms/antonyms/homonyms/paronyms/
+idioms) from scratch each run. The **synonyms** and **idioms** sections need a live
+slovnyk lookup (synonyms from the slovnyk synonym dictionaries; idioms from the
+Фразеологічний page). With `LEXICON_SLOVNYK_OFFLINE=1` — or after the per-lemma cache
+is reset when its `schema_version` bumps, or a transient error — a gate that **cannot
+run** used to return empty and silently overwrite the previously-confirmed published
+section (809 sections stripped + 1,748 shrunk on the 2026-07-13 go-live). Enrich now
+distinguishes three per-section outcomes and records the notable ones in an entry's
+`gate_provenance` map:
 
 - **ran-and-confirmed** — gate ran, kept/added items (default; not recorded).
 - **ran-and-rejected** — gate ran and dropped items (a quality win, e.g. WordNet
   auto-translation junk `ключ→джерело/живець`); recorded as `rejected`.
-- **did-not-run** — gate could not consult its source; the existing section is
-  preserved byte-for-byte; recorded as `skipped-offline`.
+- **did-not-run** — gate could not consult its source; a confirmed item that would be
+  dropped is preserved byte-for-byte, and the non-consultation is always recorded as
+  `skipped-offline` (even when nothing was lost), so the audit trail distinguishes a
+  freshly-gated section from one carried over unconsulted.
 
-Because an offline gate that did not run **preserves** rather than recomputes, an
-offline run cannot add brand-new items to a preserved section — run online (the full
-recipe above, on a data-enabled checkout) to pick up new slovnyk-sourced chips.
+"Did the gate run" is decided **per relevant slug set**, not `bool(lookups)`: the
+synonyms gate ran only when a synonym slug was consulted, the idioms gate only when
+the phraseology slug was. A partial cache that holds only unrelated slugs (e.g. the
+davydov warning slug) does not count as the synonym gate having run. **Homonyms,
+antonyms and paronyms are local** (VESUM/СУМ numbering, Вікісловник, approved corpus
+relation pairs, ZNO paronym pairs) — their source is always available, so their gate
+always runs and offline runs let their authoritative local data update.
+
+`gate_provenance` is a **current-run snapshot**: it replaces any prior map wholesale
+so each field reflects this run's status (the signal the shrink gate reads); it is not
+a history log. Because an offline gate that did not run **preserves** rather than
+recomputes, an offline run cannot add brand-new items to a preserved slovnyk section —
+run online (the full recipe above, on a data-enabled checkout) to pick up new
+slovnyk-sourced chips.
 
 `verify_manifest.py --baseline <hydrated>` adds a **shrink gate**: any per-section
 item-count regression vs the hydrated baseline fails the promote unless the entry's

--- a/scripts/lexicon/README.md
+++ b/scripts/lexicon/README.md
@@ -37,17 +37,45 @@ manifest, so do not set `ATLAS_MANIFEST_FORCE_HYDRATE=1` for this workflow.
 ```bash
 .venv/bin/python -c \
   "from scripts.lexicon.manifest_io import load_manifest; print(len(load_manifest()['entries']))"
+cp site/src/data/lexicon-manifest.json /tmp/atlas-hydrated-baseline.json   # #5077 shrink-gate baseline
 .venv/bin/python scripts/lexicon/enrich_manifest.py
 .venv/bin/python -m scripts.audit.generate_search_index --db data/atlas.db
 .venv/bin/python scripts/lexicon/export_open_dataset.py
 .venv/bin/python -m scripts.audit.generate_daily_pool
-.venv/bin/python scripts/lexicon/verify_manifest.py
+.venv/bin/python scripts/lexicon/verify_manifest.py --baseline /tmp/atlas-hydrated-baseline.json
 .venv/bin/python -m scripts.lexicon.publish_manifest
 ```
 
 The last command publishes a Release asset and must run only when publishing is
 authorized. See `docs/bug-autopsies/atlas-manifest-source-split.md` for the
 2026-07-13 evidence behind this split.
+
+### Offline enrich is non-destructive (preserve-vs-retract, #5077)
+
+`enrich_manifest.py` recomputes gated sections (synonyms/antonyms/homonyms/idioms)
+from scratch each run. Some gates need a live lookup (the Ukrajinet WordNet gate
+wants СУМ-20/slovnyk confirmation; the per-lemma slovnyk cache is reset when its
+`schema_version` bumps). With `LEXICON_SLOVNYK_OFFLINE=1` — or after a cache reset,
+or a transient error — a gate that **cannot run** used to return empty and silently
+overwrite the previously-confirmed published section (809 sections stripped + 1,748
+shrunk on the 2026-07-13 go-live). Enrich now distinguishes three per-section
+outcomes and records the notable ones in an entry's `gate_provenance` map:
+
+- **ran-and-confirmed** — gate ran, kept/added items (default; not recorded).
+- **ran-and-rejected** — gate ran and dropped items (a quality win, e.g. WordNet
+  auto-translation junk `ключ→джерело/живець`); recorded as `rejected`.
+- **did-not-run** — gate could not consult its source; the existing section is
+  preserved byte-for-byte; recorded as `skipped-offline`.
+
+Because an offline gate that did not run **preserves** rather than recomputes, an
+offline run cannot add brand-new items to a preserved section — run online (the full
+recipe above, on a data-enabled checkout) to pick up new slovnyk-sourced chips.
+
+`verify_manifest.py --baseline <hydrated>` adds a **shrink gate**: any per-section
+item-count regression vs the hydrated baseline fails the promote unless the entry's
+`gate_provenance` marks it `rejected` (gate ran) or the `(lemma, section)` pair is on
+`scripts/lexicon/shrink_allowlist.yaml`. This is the second line of defence the old
+NONEMPTY→EMPTY hazard scan lacked — it also catches partial shrinks.
 
 ## Module Release Recipe
 

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -79,6 +79,10 @@ from scripts.lexicon.heritage_classifier import classify_lemma, compute_warning_
 from scripts.lexicon.lemma_normalization import strip_acute_stress
 from scripts.lexicon.load_relation_candidates import load_approved_synonym_verdicts
 from scripts.lexicon.manifest_fingerprint import DEFAULT_FINGERPRINT, write_fingerprint
+from scripts.lexicon.manifest_io import (
+    GATE_REJECTED,
+    GATE_SKIPPED_OFFLINE,
+)
 from scripts.verification.vesum import verify_lemma, verify_word
 from scripts.wiki.slovnyk_me import primary_synonym_sense_text
 
@@ -5265,6 +5269,91 @@ def _single_word_etymology_coverage(manifest: dict) -> tuple[int, int]:
     return covered, len(entries)
 
 
+# --- #5077 preserve-vs-retract section semantics ---------------------------------
+# enrich_entry recomputes gated sections from scratch each run. Offline (or after a
+# schema-version cache reset, or a transient lookup error) a gate that CANNOT run
+# returns empty and silently overwrites the previously-confirmed published section
+# (809 stripped + 1,748 shrunk on the 2026-07-13 8,552 go-live). The contract below
+# distinguishes THREE outcomes per section so a gate that did not run preserves the
+# existing content while a gate that ran keeps its authoritative retractions.
+
+
+def _section_item_key(item: object) -> str | None:
+    """Canonical identity for one rendered section item (string chip or relation dict).
+
+    Synonym/antonym chips are strings, optionally ``"word (qualifier)"``; homonym,
+    paronym and idiom items are dicts. The qualifier is stripped so a purely cosmetic
+    re-tag (``дорога (діал.)`` -> ``дорога``) is not counted as a lost item.
+    """
+    if isinstance(item, str):
+        return _base_word(item).strip().casefold() or None
+    if isinstance(item, dict):
+        for field in ("word", "target", "lemma", "phrase", "text", "definition"):
+            value = item.get(field)
+            if isinstance(value, str) and value.strip():
+                return _base_word(value).strip().casefold() or None
+    return None
+
+
+def _section_item_keys(section: object) -> set[str]:
+    if not isinstance(section, dict):
+        return set()
+    keys: set[str] = set()
+    for item in section.get("items") or []:
+        key = _section_item_key(item)
+        if key:
+            keys.add(key)
+    return keys
+
+
+def _section_loses_items(existing: object, new: object) -> bool:
+    """True iff a confirmed item present in ``existing`` is absent from ``new``."""
+    return bool(_section_item_keys(existing) - _section_item_keys(new))
+
+
+def _slovnyk_gate_ran(cache: dict[str, Any] | None) -> bool:
+    """Whether the slovnyk.me gate could consult its data source this run (#5077).
+
+    Online the live source is always consulted. Offline the gate only ran if the
+    per-lemma cache already holds lookups; an empty ``lookups`` map means a
+    schema-reset / never-fetched lemma the offline gate could NOT consult — its
+    sections must be preserved, not recomputed to empty.
+    """
+    if not _phase1_offline_mode():
+        return True
+    if not isinstance(cache, dict):
+        return False
+    lookups = cache.get("lookups")
+    return isinstance(lookups, dict) and bool(lookups)
+
+
+def _resolve_gated_section(
+    new_section: dict[str, Any] | None,
+    existing_section: dict[str, Any] | None,
+    *,
+    gate_ran: bool,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Apply the #5077 preserve-vs-retract contract to one gated section.
+
+    Three explicitly-distinguished outcomes:
+      * gate ran, no confirmed item lost   -> ran-and-confirmed: take the new section
+        (additions welcome); no provenance marker (default, keeps the diff minimal).
+      * gate ran, confirmed item(s) dropped -> ran-and-rejected: the retraction is
+        authoritative (e.g. WordNet auto-translation junk ключ->джерело/живець); take
+        the new section (may be ``None`` when everything was retracted); mark ``rejected``.
+      * gate did NOT run and would drop confirmed item(s) -> did-not-run: PRESERVE the
+        existing section unchanged; mark ``skipped-offline``.
+
+    Returns ``(section_or_None, provenance_or_None)``.
+    """
+    loses = _section_loses_items(existing_section, new_section)
+    if gate_ran:
+        return new_section, (GATE_REJECTED if loses else None)
+    if loses:
+        return existing_section, GATE_SKIPPED_OFFLINE
+    return new_section, None
+
+
 def enrich_entry(
     entry,
     conn,
@@ -5325,7 +5414,24 @@ def enrich_entry(
         entry["pronunciation"] = pronunciation
     else:
         entry.pop("pronunciation", None)
+    # #5077: the hydrated/published sections are the preserve baseline. Capture them
+    # BEFORE recomputing so a gate that did not run can restore its confirmed content
+    # instead of silently overwriting it with an offline-empty recomputation.
+    existing_sections = entry.get("sections")
+    baseline_sections = existing_sections if isinstance(existing_sections, dict) else {}
+    slovnyk_gate_ran = _slovnyk_gate_ran(slovnyk_cache)
     sections: dict[str, object] = {}
+    gate_provenance: dict[str, str] = {}
+
+    def _apply_section(name: str, new_section: dict[str, Any] | None, *, gate_ran: bool) -> None:
+        resolved, outcome = _resolve_gated_section(
+            new_section, baseline_sections.get(name), gate_ran=gate_ran
+        )
+        if resolved:
+            sections[name] = resolved
+        if outcome:
+            gate_provenance[name] = outcome
+
     synonyms = _synonyms_slovnyk(base, slovnyk_cache, entry_pos=entry_pos)
     if not synonyms and fallback_base:
         synonyms = _synonyms_slovnyk(fallback_base, entry_pos=entry_pos)
@@ -5342,8 +5448,7 @@ def enrich_entry(
         )
     )
     synonyms = _merge_synonym_relations(synonyms, pointer_relations)
-    if synonyms:
-        sections["synonyms"] = synonyms
+    _apply_section("synonyms", synonyms, gate_ran=slovnyk_gate_ran)
     antonyms = _antonyms_wiktionary(conn, base, entry_pos=entry_pos)
     if not antonyms and fallback_base:
         antonyms = _antonyms_wiktionary(conn, fallback_base, entry_pos=entry_pos)
@@ -5360,8 +5465,7 @@ def enrich_entry(
         )
     )
     antonyms = _merge_antonym_relations(antonyms, antonym_relations)
-    if antonyms:
-        sections["antonyms"] = antonyms
+    _apply_section("antonyms", antonyms, gate_ran=slovnyk_gate_ran)
     homonym_relations = (
         pointer_homonym_relations
         if pointer_homonym_relations is not None
@@ -5372,23 +5476,26 @@ def enrich_entry(
         )
     )
     homonyms = _merge_homonym_relations(None, homonym_relations)
-    if homonyms:
-        sections["homonyms"] = homonyms
+    _apply_section("homonyms", homonyms, gate_ran=slovnyk_gate_ran)
     paronym_relations = (
         pointer_paronym_relations
         if pointer_paronym_relations is not None
         else _paronym_relations(conn, lemma)
     )
     paronyms = _merge_paronym_relations(None, paronym_relations)
-    if paronyms:
-        sections["paronyms"] = paronyms
+    # Paronyms come from local ZNO/cache pairs only (no slovnyk.me), so their gate runs
+    # fully offline — retractions here are always authoritative.
+    _apply_section("paronyms", paronyms, gate_ran=True)
     idioms = _idioms(conn, lemma, slovnyk_cache)
-    if idioms:
-        sections["idioms"] = idioms
+    _apply_section("idioms", idioms, gate_ran=slovnyk_gate_ran)
     if sections:
         entry["sections"] = sections
     else:
         entry.pop("sections", None)
+    if gate_provenance:
+        entry["gate_provenance"] = gate_provenance
+    else:
+        entry.pop("gate_provenance", None)
     block: dict[str, object] = {}
     stressed_lemma = _stress_display_form(lemma)
     if stressed_lemma:

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -48,7 +48,7 @@ import sqlite3
 import sys
 import time
 import unicodedata
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from functools import lru_cache
 from html.parser import HTMLParser
 from pathlib import Path
@@ -166,6 +166,7 @@ _SLOVNYK_DICT_LABELS: dict[str, str] = {
 }
 _SLOVNYK_LOOKUP_SLUGS = tuple(_SLOVNYK_DICT_LABELS)
 _SLOVNYK_SYNONYM_SLUGS = ("synonyms_karavansky", "synonyms")
+_SLOVNYK_IDIOM_SLUGS = ("phraseology",)
 _SLOVNYK_WARNING_SLUGS = ("davydov", "voloschak", "foreign_shtepa")
 _SLOVNYK_UKRENG_SLUG = "ukreng"
 _SLOVNYK_UKRENG_LABEL = "Українсько-англійський словник"
@@ -5311,20 +5312,24 @@ def _section_loses_items(existing: object, new: object) -> bool:
     return bool(_section_item_keys(existing) - _section_item_keys(new))
 
 
-def _slovnyk_gate_ran(cache: dict[str, Any] | None) -> bool:
-    """Whether the slovnyk.me gate could consult its data source this run (#5077).
+def _slovnyk_gate_ran(cache: dict[str, Any] | None, slugs: Sequence[str]) -> bool:
+    """Whether the slovnyk.me gate for a section depending on ``slugs`` could
+    consult its data source this run (#5077).
 
-    Online the live source is always consulted. Offline the gate only ran if the
-    per-lemma cache already holds lookups; an empty ``lookups`` map means a
-    schema-reset / never-fetched lemma the offline gate could NOT consult — its
-    sections must be preserved, not recomputed to empty.
+    Online the live source is always fetched, so the gate ran. Offline it ran only
+    if the per-lemma cache already holds at least one of the section's OWN slugs —
+    a lemma whose cache is missing every relevant slug (schema reset, never fetched)
+    is one the offline gate could NOT consult, so its section must be preserved.
+
+    Per-slug is load-bearing (#5077 review finding 1): a generic ``bool(lookups)``
+    treats a partial cache holding only unrelated slugs (e.g. the davydov warning
+    slug) as "the synonym gate ran" and lets it retract a section its source was
+    never consulted for. The gate ran for a section only when the section's own
+    source is present.
     """
     if not _phase1_offline_mode():
         return True
-    if not isinstance(cache, dict):
-        return False
-    lookups = cache.get("lookups")
-    return isinstance(lookups, dict) and bool(lookups)
+    return any(_cache_has_lookup(cache, slug) for slug in slugs)
 
 
 def _resolve_gated_section(
@@ -5341,17 +5346,40 @@ def _resolve_gated_section(
       * gate ran, confirmed item(s) dropped -> ran-and-rejected: the retraction is
         authoritative (e.g. WordNet auto-translation junk ключ->джерело/живець); take
         the new section (may be ``None`` when everything was retracted); mark ``rejected``.
-      * gate did NOT run and would drop confirmed item(s) -> did-not-run: PRESERVE the
-        existing section unchanged; mark ``skipped-offline``.
+      * gate did NOT run -> did-not-run: never retract a confirmed item (PRESERVE the
+        existing section when the recomputation would drop one), and ALWAYS mark
+        ``skipped-offline`` so the audit trail records the non-consultation, not only
+        the losses (#5077 review finding 4).
 
     Returns ``(section_or_None, provenance_or_None)``.
     """
     loses = _section_loses_items(existing_section, new_section)
     if gate_ran:
         return new_section, (GATE_REJECTED if loses else None)
-    if loses:
-        return existing_section, GATE_SKIPPED_OFFLINE
-    return new_section, None
+    resolved = existing_section if loses else (new_section or existing_section)
+    return resolved, (GATE_SKIPPED_OFFLINE if resolved else None)
+
+
+def _ordered_sections(
+    sections: dict[str, object], baseline: dict[str, Any]
+) -> dict[str, object]:
+    """Emit sections in the baseline manifest's key order so a pure-preserve run
+    serializes byte-identical to its baseline (#5077 review finding 3).
+
+    The recompute rebuilds ``sections`` in a fixed apply order (synonyms, antonyms,
+    homonyms, paronyms, idioms). When the entry already had published sections in a
+    different order, that reorder alone produced spurious byte diffs on runs that
+    changed nothing. Keys present in the baseline keep the baseline's order; keys new
+    to this entry follow in canonical apply order.
+    """
+    ordered: dict[str, object] = {}
+    for name in baseline:
+        if name in sections:
+            ordered[name] = sections[name]
+    for name, value in sections.items():
+        if name not in ordered:
+            ordered[name] = value
+    return ordered
 
 
 def enrich_entry(
@@ -5419,7 +5447,13 @@ def enrich_entry(
     # instead of silently overwriting it with an offline-empty recomputation.
     existing_sections = entry.get("sections")
     baseline_sections = existing_sections if isinstance(existing_sections, dict) else {}
-    slovnyk_gate_ran = _slovnyk_gate_ran(slovnyk_cache)
+    # "Did the gate run" is decided per RELEVANT slug set (#5077 review finding 1):
+    # synonyms depend on the slovnyk synonym dictionaries, idioms on the phraseology
+    # dictionary. Homonyms/antonyms/paronyms are db/pointer-driven local sections with
+    # no slovnyk dependency, so their gate always runs (finding 2) — an offline run
+    # must let their authoritative local data update, not freeze a stale section.
+    synonyms_gate_ran = _slovnyk_gate_ran(slovnyk_cache, _SLOVNYK_SYNONYM_SLUGS)
+    idioms_gate_ran = _slovnyk_gate_ran(slovnyk_cache, _SLOVNYK_IDIOM_SLUGS)
     sections: dict[str, object] = {}
     gate_provenance: dict[str, str] = {}
 
@@ -5448,7 +5482,7 @@ def enrich_entry(
         )
     )
     synonyms = _merge_synonym_relations(synonyms, pointer_relations)
-    _apply_section("synonyms", synonyms, gate_ran=slovnyk_gate_ran)
+    _apply_section("synonyms", synonyms, gate_ran=synonyms_gate_ran)
     antonyms = _antonyms_wiktionary(conn, base, entry_pos=entry_pos)
     if not antonyms and fallback_base:
         antonyms = _antonyms_wiktionary(conn, fallback_base, entry_pos=entry_pos)
@@ -5465,7 +5499,9 @@ def enrich_entry(
         )
     )
     antonyms = _merge_antonym_relations(antonyms, antonym_relations)
-    _apply_section("antonyms", antonyms, gate_ran=slovnyk_gate_ran)
+    # Antonyms are Вікісловник + lexicographer-pointer driven (local db); the gate
+    # always runs, so authoritative local retractions apply even offline (finding 2).
+    _apply_section("antonyms", antonyms, gate_ran=True)
     homonym_relations = (
         pointer_homonym_relations
         if pointer_homonym_relations is not None
@@ -5476,7 +5512,9 @@ def enrich_entry(
         )
     )
     homonyms = _merge_homonym_relations(None, homonym_relations)
-    _apply_section("homonyms", homonyms, gate_ran=slovnyk_gate_ran)
+    # Homonyms come from СУМ numbering + approved corpus relation pairs (local db); the
+    # gate always runs, so an offline run updates from local data (finding 2).
+    _apply_section("homonyms", homonyms, gate_ran=True)
     paronym_relations = (
         pointer_paronym_relations
         if pointer_paronym_relations is not None
@@ -5487,11 +5525,17 @@ def enrich_entry(
     # fully offline — retractions here are always authoritative.
     _apply_section("paronyms", paronyms, gate_ran=True)
     idioms = _idioms(conn, lemma, slovnyk_cache)
-    _apply_section("idioms", idioms, gate_ran=slovnyk_gate_ran)
+    _apply_section("idioms", idioms, gate_ran=idioms_gate_ran)
     if sections:
-        entry["sections"] = sections
+        entry["sections"] = _ordered_sections(sections, baseline_sections)
     else:
         entry.pop("sections", None)
+    # gate_provenance is a CURRENT-RUN snapshot: it replaces any prior map wholesale so
+    # each field reflects this run's consultation status (rejected / skipped-offline),
+    # which is exactly the signal the verify_manifest shrink gate reads. It is not a
+    # history log — a section confirmed this run drops its stale prior marker by design
+    # (#5077 review finding 4; replacement chosen over a `previous` key for the smaller
+    # diff and because the shrink gate only ever consults the current status).
     if gate_provenance:
         entry["gate_provenance"] = gate_provenance
     else:

--- a/scripts/lexicon/manifest_io.py
+++ b/scripts/lexicon/manifest_io.py
@@ -38,6 +38,16 @@ REQUIRED_POINTER_KEYS = (
 DOWNLOAD_ATTEMPTS = 3
 FORCE_HYDRATE_ENV = "ATLAS_MANIFEST_FORCE_HYDRATE"
 
+# Per-section gate-provenance outcomes for the #5077 preserve-vs-retract contract.
+# Recorded in an entry's ``gate_provenance`` map so offline preserves and gate-ran
+# retractions are auditable at release time. Shared here (a stdlib-only module both
+# enrich_manifest and verify_manifest already import) so neither has to depend on the
+# other. ``confirmed`` is the default outcome and is intentionally never recorded, so
+# a normal full run leaves the manifest diff minimal.
+GATE_CONFIRMED = "confirmed"  # gate ran; kept or added items (default — not recorded)
+GATE_REJECTED = "rejected"  # gate ran and dropped item(s): a quality win (allowed to shrink)
+GATE_SKIPPED_OFFLINE = "skipped-offline"  # gate could not run; existing section preserved
+
 
 def _sha256(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()

--- a/scripts/lexicon/shrink_allowlist.yaml
+++ b/scripts/lexicon/shrink_allowlist.yaml
@@ -1,0 +1,26 @@
+# Atlas manifest shrink-gate allowlist (#5077).
+#
+# The shrink gate in verify_manifest.py fails a per-section item-count regression
+# vs the hydrated baseline, because an offline gate that could not run once stripped
+# 809 sections and shrank 1,748 more on the 2026-07-13 go-live.
+#
+# INTENDED retractions belong here. A retraction is normally auto-justified when the
+# enricher records `gate_provenance: {<section>: rejected}` on the entry (the stricter
+# gate ran online and dropped WordNet auto-translation junk). This file covers the
+# residual cases where that provenance is absent — e.g. a manually-curated manifest
+# edit — so the gate stays quiet for known-good removals without a provenance marker.
+#
+# The three canonical WordNet auto-translation retractions from #5077 / #1657 are
+# listed for documentation; online re-enrich tags them `rejected` automatically.
+version: 1
+kind: atlas_shrink_allowlist
+retractions:
+  - lemma: ключ
+    section: synonyms
+    reason: WordNet auto-translated джерело/живець are a wrong sense of ключ (#1657).
+  - lemma: адвокат
+    section: synonyms
+    reason: WordNet auto-translated прихильник/радник are a wrong sense of адвокат (#1657).
+  - lemma: аеродром
+    section: synonyms
+    reason: WordNet auto-translated поле is a wrong sense of аеродром (#1657).

--- a/scripts/lexicon/verify_manifest.py
+++ b/scripts/lexicon/verify_manifest.py
@@ -41,11 +41,15 @@ DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
 DEFAULT_VESUM = ROOT / "data" / "vesum.db"
 DEFAULT_SOURCES_DB = ROOT / "data" / "sources.db"
 DEFAULT_CURRICULUM = ROOT / "curriculum" / "l2-uk-en" / "curriculum.yaml"
+# Curated (lemma, section) retractions the shrink gate permits even without a
+# gate-ran provenance marker (e.g. a manually-edited manifest). Co-located with this
+# script so it is always present in worktrees (unlike gitignored data/).
+DEFAULT_SHRINK_ALLOWLIST = ROOT / "scripts" / "lexicon" / "shrink_allowlist.yaml"
 
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from scripts.lexicon.manifest_io import load_manifest
+from scripts.lexicon.manifest_io import GATE_REJECTED, load_manifest
 
 # DEFINITIVELY cross-domain auto-translation junk that must never be a synonym.
 # Keep MINIMAL (see module docstring) — only tokens with zero defensible sense
@@ -118,6 +122,81 @@ def hazards(manifest: dict, entries: list[dict]) -> dict[str, list]:
     }
 
 
+def _section_item_count(section: object) -> int:
+    """Number of rendered items in a section (0 for a missing/malformed section)."""
+    if not isinstance(section, dict):
+        return 0
+    items = section.get("items")
+    return len(items) if isinstance(items, list) else 0
+
+
+def _load_shrink_allowlist(path: Path | None) -> set[tuple[str, str]]:
+    """Load curated ``(lemma, section)`` retractions permitted to shrink (#5077).
+
+    Shape (YAML)::
+
+        version: 1
+        kind: atlas_shrink_allowlist
+        retractions:
+          - lemma: ключ
+            section: synonyms
+            reason: WordNet auto-translation junk (джерело/живець wrong sense)
+    """
+    if not path or not path.exists():
+        return set()
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    allow: set[tuple[str, str]] = set()
+    for row in data.get("retractions") or []:
+        if isinstance(row, dict) and row.get("lemma") and row.get("section"):
+            allow.add((str(row["lemma"]), str(row["section"])))
+    return allow
+
+
+def shrink_regressions(
+    entries: list[dict],
+    baseline_entries: list[dict],
+    *,
+    allowlist: set[tuple[str, str]],
+) -> list[tuple[str, str, int, int]]:
+    """Per-section item-count regressions vs the hydrated baseline (#5077).
+
+    The NONEMPTY->EMPTY hazard scan catches only fully-stripped sections; it misses
+    partial shrinks (1,748 on the 2026-07-13 go-live). A section that lost items — or
+    vanished — relative to the baseline is a hazard UNLESS its retraction is justified:
+
+      * the entry's ``gate_provenance`` records the gate ran and retracted (``rejected``
+        — a quality win, e.g. WordNet auto-translation junk), or
+      * the ``(lemma, section)`` pair is on the explicit curated allowlist.
+
+    An unexplained regression is the offline gate-did-not-run strip/shrink bug and
+    fails verification. Returns ``(lemma, section, baseline_count, current_count)``.
+    """
+    base_by_lemma = {str(e.get("lemma")): e for e in baseline_entries if e.get("lemma")}
+    regressions: list[tuple[str, str, int, int]] = []
+    for entry in entries:
+        lemma = str(entry.get("lemma") or "")
+        base = base_by_lemma.get(lemma)
+        if not base:
+            continue
+        base_sections = base.get("sections")
+        if not isinstance(base_sections, dict):
+            continue
+        provenance = entry.get("gate_provenance") or {}
+        cur_sections = entry.get("sections") if isinstance(entry.get("sections"), dict) else {}
+        for name, base_sec in base_sections.items():
+            base_n = _section_item_count(base_sec)
+            if base_n == 0:
+                continue
+            if _section_item_count(cur_sections.get(name)) >= base_n:
+                continue
+            if provenance.get(name) == GATE_REJECTED:
+                continue  # gate ran and retracted — quality win (#5077 design pt 4)
+            if (lemma, name) in allowlist:
+                continue  # curated intended retraction
+            regressions.append((lemma, name, base_n, _section_item_count(cur_sections.get(name))))
+    return regressions
+
+
 def conformance(
     manifest: dict,
     *,
@@ -168,16 +247,18 @@ def run(
     curriculum_path: Path = DEFAULT_CURRICULUM,
     vesum_path: Path = DEFAULT_VESUM,
     sources_path: Path = DEFAULT_SOURCES_DB,
+    shrink_allowlist_path: Path | None = None,
 ) -> int:
     manifest = load_manifest(manifest_path)
     entries = manifest.get("entries", [])
     cov = coverage(entries)
 
     print(f"=== COVERAGE ({manifest_path.name}) ===")
-    base_cov = None
+    base_entries: list[dict] | None = None
     if baseline_path and baseline_path.exists():
         base = json.loads(baseline_path.read_text(encoding="utf-8"))
-        base_cov = coverage(base.get("entries", []))
+        base_entries = base.get("entries", [])
+    base_cov = coverage(base_entries) if base_entries is not None else None
     for k, v in cov.items():
         delta = f"  (was {base_cov[k]})" if base_cov and base_cov.get(k) != v else ""
         print(f"  {k:18} {v}{delta}")
@@ -187,6 +268,20 @@ def run(
     for name, hits in haz.items():
         status = "CLEAN" if not hits else f"{len(hits)} — {hits[:8]}"
         print(f"  {name:18} {status}")
+
+    # #5077 shrink gate: needs the hydrated baseline to compare per-section item counts.
+    shrink: list[tuple[str, str, int, int]] = []
+    if base_entries is not None:
+        allowlist = _load_shrink_allowlist(shrink_allowlist_path)
+        shrink = shrink_regressions(entries, base_entries, allowlist=allowlist)
+        print("\n=== SHRINK GATE (per-section item count vs baseline, #5077) ===")
+        if not shrink:
+            print("  CLEAN — no unexplained section shrink")
+        else:
+            for lemma, name, base_n, cur_n in shrink[:20]:
+                print(f"  {lemma:16} {name:12} {base_n} -> {cur_n}")
+            if len(shrink) > 20:
+                print(f"  ... and {len(shrink) - 20} more")
 
     if sample > 0:
         print(f"\n=== SAMPLE (every {max(1, len(entries) // sample)}th entry — eyeball for sense) ===")
@@ -219,13 +314,16 @@ def run(
 
     has_hazard = any(haz.values())
     has_conformance_fail = bool(conf)
-    failed = has_hazard or has_conformance_fail
+    has_shrink = bool(shrink)
+    failed = has_hazard or has_conformance_fail or has_shrink
     if failed:
         reasons = []
         if has_hazard:
             reasons.append("structural hazard")
         if has_conformance_fail:
             reasons.append(f"{len(conf)} conformance violation(s)")
+        if has_shrink:
+            reasons.append(f"{len(shrink)} unexplained section shrink(s)")
         verdict = f"{' + '.join(reasons)} — do NOT commit"
     else:
         verdict = "clean (eyeball the sample before commit)"
@@ -236,7 +334,12 @@ def run(
 def main() -> int:
     p = argparse.ArgumentParser(description="Verify the Atlas lexicon manifest before promote (#M-11).")
     p.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST, help="Manifest JSON to verify.")
-    p.add_argument("--baseline", type=Path, default=None, help="Optional prior manifest for coverage deltas.")
+    p.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help="Prior (hydrated) manifest for coverage deltas AND the #5077 shrink gate.",
+    )
     p.add_argument("--sample", type=int, default=12, help="How many spread-sampled entries to print (0 = none).")
     p.add_argument(
         "--skip-conformance",
@@ -251,6 +354,12 @@ def main() -> int:
         default=DEFAULT_SOURCES_DB,
         help="sources.db for the Грінченко/ЕСУМ heritage fallback on VESUM-gap lemmas (#3211).",
     )
+    p.add_argument(
+        "--shrink-allowlist",
+        type=Path,
+        default=DEFAULT_SHRINK_ALLOWLIST,
+        help="Curated (lemma, section) retractions the #5077 shrink gate permits.",
+    )
     args = p.parse_args()
     return run(
         args.manifest,
@@ -260,6 +369,7 @@ def main() -> int:
         curriculum_path=args.curriculum,
         vesum_path=args.vesum,
         sources_path=args.sources,
+        shrink_allowlist_path=args.shrink_allowlist,
     )
 
 

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "bed2f6523f035bfb1910cef8e6fde21087f5f6aca15acbe5bd94c8aef20bd5f7",
+  "fingerprint": "3290f1c115d62a8d3ad0c2c5333d3e0eebfeb2ef17a4330e748c78fcf7b7cbc5",
   "inputs": {
     "lexicon_code": [
       {
@@ -52,7 +52,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "7f7cd03522b4ccda26b43da841ec67b4141a04398c417f0fdc363ca2ab76f9ac"
+        "sha256": "d93fe5ae565eddc685cfd89d0ab04a8b36580b6eecffd3086101bad97fa89a36"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -152,7 +152,7 @@
       },
       {
         "path": "scripts/lexicon/verify_manifest.py",
-        "sha256": "e128d60f2c72ca44fdc550fb99436adc27481d59b9877f22480f67a988ae3059"
+        "sha256": "47df54386fda97fb7b372e8e68f89afb3ac5bd647c5a292a7380f14c5ae1f4b0"
       },
       {
         "path": "scripts/lexicon/verify_synonym_pairs.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -3785,3 +3785,126 @@ def test_offline_with_cached_lookups_counts_as_gate_ran(monkeypatch) -> None:
     )
     assert "synonyms" not in entry.get("sections", {})
     assert entry["gate_provenance"]["synonyms"] == GATE_REJECTED
+
+
+def test_offline_partial_cache_without_synonym_slugs_preserves(monkeypatch) -> None:
+    # #5077 review finding 1: a cache holding only NON-synonym slugs (the davydov /
+    # voloschak warning slugs) must NOT read as "the synonym gate ran". The old
+    # bool(lookups) signal retracted a section whose source was never consulted; the
+    # per-slug signal now preserves it byte-for-byte and marks skipped-offline.
+    existing = {"items": ["джерело", "живець"], "source": "s"}
+    baseline = json.loads(json.dumps(existing, ensure_ascii=False))
+    entry = _run_synonyms_gate(
+        monkeypatch,
+        offline=True,
+        cache={"lookups": {"davydov": {"text": "x"}, "voloschak": {"text": "y"}}},
+        new_synonyms=None,  # synonym slugs absent -> recompute yields nothing
+        existing_synonyms=existing,
+    )
+    assert entry["sections"]["synonyms"] == baseline
+    assert json.dumps(entry["sections"]["synonyms"], ensure_ascii=False) == json.dumps(
+        baseline, ensure_ascii=False
+    )
+    assert entry["gate_provenance"]["synonyms"] == GATE_SKIPPED_OFFLINE
+
+
+def _run_enrich_entry(monkeypatch, entry, *, offline, cache):
+    """Drive enrich_entry with every producer neutralized except the ones a caller
+    overrides afterward — the #5077 gate harness for direct-entry assertions."""
+    _stub_section_producers(monkeypatch)
+    monkeypatch.setattr(enrich_manifest_module, "_phase1_offline_mode", lambda: offline)
+    monkeypatch.setattr(enrich_manifest_module, "_slovnyk_cache", lambda lemma: cache)
+    monkeypatch.setattr(enrich_manifest_module, "_synonyms_slovnyk", lambda *a, **k: None)
+    monkeypatch.setattr(enrich_manifest_module, "_merge_synonym_relations", lambda syn, rel: syn)
+    return entry
+
+
+def _drive_enrich_entry(entry) -> None:
+    enrich_manifest_module.enrich_entry(
+        entry,
+        sqlite3.connect(":memory:"),
+        {},
+        has_sum11_flags=False,
+        pointer_synonym_relations=[],
+        pointer_antonym_relations=[],
+        pointer_homonym_relations=[],
+        pointer_paronym_relations=[],
+    )
+
+
+def test_preexisting_provenance_replaced_by_current_run(monkeypatch) -> None:
+    # #5077 review finding 4: gate_provenance is a current-run snapshot. A prior
+    # 'rejected' from an online run is replaced by this offline run's 'skipped-offline'
+    # (not merged, not kept as history) — the shrink gate reads only the current status.
+    entry = _run_enrich_entry(
+        monkeypatch,
+        {
+            "lemma": "ключ",
+            "pos": "noun",
+            "sections": {"synonyms": {"items": ["джерело"], "source": "s"}},
+            "gate_provenance": {"synonyms": GATE_REJECTED},
+        },
+        offline=True,
+        cache={"lookups": {}},  # gate did not run
+    )
+    _drive_enrich_entry(entry)
+    assert entry["sections"]["synonyms"]["items"] == ["джерело"]  # preserved
+    assert entry["gate_provenance"]["synonyms"] == GATE_SKIPPED_OFFLINE  # replaced, not merged
+
+
+def test_offline_empty_cache_updates_local_sections(monkeypatch) -> None:
+    # #5077 review finding 2: homonyms/antonyms are local db/pointer sections. Offline
+    # with an EMPTY slovnyk cache they still update from local data and are never frozen
+    # as skipped-offline — only synonyms/idioms are slovnyk-gated.
+    entry = _run_enrich_entry(
+        monkeypatch,
+        {"lemma": "ключ", "pos": "noun", "sections": {"antonyms": {"items": [], "source": "old"}}},
+        offline=True,
+        cache={"lookups": {}},
+    )
+    new_antonyms = {"items": ["день"], "source": "Вікісловник"}
+    new_homonyms = {"items": [{"word": "ключ", "gloss": "spring"}], "source": "СУМ"}
+    monkeypatch.setattr(enrich_manifest_module, "_antonyms_wiktionary", lambda *a, **k: new_antonyms)
+    monkeypatch.setattr(enrich_manifest_module, "_merge_antonym_relations", lambda ex, rel: new_antonyms)
+    monkeypatch.setattr(enrich_manifest_module, "_merge_homonym_relations", lambda ex, rel: new_homonyms)
+    _drive_enrich_entry(entry)
+    assert entry["sections"]["antonyms"] == new_antonyms  # updated from local, not preserved
+    assert entry["sections"]["homonyms"] == new_homonyms  # added from local
+    # Local gates ran (additions) -> no skipped-offline provenance for them.
+    assert "gate_provenance" not in entry
+
+
+def test_pure_preserve_run_serializes_sections_byte_identical(monkeypatch) -> None:
+    # #5077 review finding 3: a run that preserves every section must serialize the
+    # sections map byte-identical to the baseline — including its ORIGINAL key order,
+    # not the recompute's fixed apply order (synonyms, antonyms, ..., idioms).
+    baseline_sections = {
+        "idioms": {"items": [{"phrase": "p", "definition": "d"}], "source": "s"},
+        "synonyms": {"items": ["джерело"], "source": "s"},
+    }
+    baseline_bytes = json.dumps(baseline_sections, ensure_ascii=False)
+    entry = _run_enrich_entry(
+        monkeypatch,
+        {"lemma": "ключ", "pos": "noun", "sections": json.loads(baseline_bytes)},
+        offline=True,
+        cache={"lookups": {}},  # gate did not run -> synonyms + idioms both preserved
+    )
+    _drive_enrich_entry(entry)
+    assert list(entry["sections"]) == ["idioms", "synonyms"]  # baseline order, not apply order
+    assert json.dumps(entry["sections"], ensure_ascii=False) == baseline_bytes
+
+
+def test_offline_gate_did_not_run_records_skipped_even_without_loss(monkeypatch) -> None:
+    # #5077 review finding 4: skipped-offline is recorded WHENEVER the gate did not run,
+    # not only when items would be lost. Mirrors a mixed section (e.g. idioms) whose local
+    # source grows the section offline while its slovnyk source stayed unconsulted.
+    existing = {"items": ["джерело"], "source": "s"}
+    entry = _run_synonyms_gate(
+        monkeypatch,
+        offline=True,
+        cache={"lookups": {}},  # gate did not run
+        new_synonyms={"items": ["джерело", "живець"], "source": "s"},  # grew, no confirmed loss
+        existing_synonyms=existing,
+    )
+    assert entry["sections"]["synonyms"]["items"] == ["джерело", "живець"]  # took new (no loss)
+    assert entry["gate_provenance"]["synonyms"] == GATE_SKIPPED_OFFLINE  # still recorded

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -3644,3 +3644,144 @@ def test_vts_definition_card_resolves_cross_reference_live_shape(monkeypatch) ->
     assert card["definitions"][0].startswith("(докон. до заховувати / див. заховувати) ")
     assert card["definitions"][0].endswith("Класти що-небудь у невідоме місце.")
     assert card["cross_reference"]["target"] == "заховувати"
+
+
+# --- #5077 preserve-vs-retract section gate semantics ------------------------------
+# enrich_entry recomputes gated sections each run. Offline (or after a schema-version
+# cache reset) a gate that CANNOT run must PRESERVE the previously-confirmed section
+# rather than silently overwrite it with an empty recomputation. Only a gate that RAN
+# may retract items (e.g. WordNet auto-translation junk). See scripts/lexicon/README.md.
+from scripts.lexicon.manifest_io import GATE_REJECTED, GATE_SKIPPED_OFFLINE
+
+
+def _stub_section_producers(monkeypatch) -> None:
+    """Neutralize every enrich_entry producer except the synonyms gate so the
+    preserve-vs-retract contract can be exercised in isolation."""
+
+    def none(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(enrich_manifest_module, "_definition_cards", lambda *a, **k: [])
+    monkeypatch.setattr(
+        enrich_manifest_module,
+        "classify_lemma",
+        lambda lemma: {
+            "classification": "standard",
+            "is_russianism": False,
+            "russian_shadow": False,
+            "calque_warning": None,
+            "attestations": [],
+        },
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_warning_slovnyk", none)
+    monkeypatch.setattr(enrich_manifest_module, "_curated_calque", none)
+    monkeypatch.setattr(enrich_manifest_module, "_reverse_calques", none)
+    monkeypatch.setattr(enrich_manifest_module, "_kaikki_pronunciation", none)
+    monkeypatch.setattr(enrich_manifest_module, "_antonyms_wiktionary", none)
+    monkeypatch.setattr(enrich_manifest_module, "_merge_antonym_relations", lambda existing, rel: None)
+    monkeypatch.setattr(enrich_manifest_module, "_merge_homonym_relations", lambda existing, rel: None)
+    monkeypatch.setattr(enrich_manifest_module, "_merge_paronym_relations", lambda existing, rel: None)
+    monkeypatch.setattr(enrich_manifest_module, "_idioms", none)
+    monkeypatch.setattr(enrich_manifest_module, "_stress_display_form", lambda *a, **k: "")
+    monkeypatch.setattr(enrich_manifest_module, "_kaikki_stress", none)
+    monkeypatch.setattr(enrich_manifest_module, "_cefr", none)
+    monkeypatch.setattr(enrich_manifest_module, "_morphology", none)
+    monkeypatch.setattr(enrich_manifest_module, "_meaning", none)
+    monkeypatch.setattr(enrich_manifest_module, "_etymology", none)
+    monkeypatch.setattr(enrich_manifest_module, "_literary_attestation", none)
+    monkeypatch.setattr(enrich_manifest_module, "_translation", none)
+    monkeypatch.setattr(enrich_manifest_module, "_wiki_reference", none)
+    monkeypatch.setattr(enrich_manifest_module, "_base_lookup_for_entry", lambda lemma, pos: None)
+
+
+def _run_synonyms_gate(monkeypatch, *, offline, cache, new_synonyms, existing_synonyms):
+    _stub_section_producers(monkeypatch)
+    monkeypatch.setattr(enrich_manifest_module, "_phase1_offline_mode", lambda: offline)
+    monkeypatch.setattr(enrich_manifest_module, "_slovnyk_cache", lambda lemma: cache)
+    monkeypatch.setattr(enrich_manifest_module, "_synonyms_slovnyk", lambda *a, **k: new_synonyms)
+    monkeypatch.setattr(enrich_manifest_module, "_merge_synonym_relations", lambda syn, rel: syn)
+
+    entry = {"lemma": "ключ", "pos": "noun", "sections": {"synonyms": existing_synonyms}}
+    enrich_manifest_module.enrich_entry(
+        entry,
+        sqlite3.connect(":memory:"),
+        {},
+        has_sum11_flags=False,
+        pointer_synonym_relations=[],
+        pointer_antonym_relations=[],
+        pointer_homonym_relations=[],
+        pointer_paronym_relations=[],
+    )
+    return entry
+
+
+def test_offline_gate_did_not_run_preserves_section_byte_identical(monkeypatch) -> None:
+    existing = {"items": ["джерело", "живець"], "source": "slovnyk.me: Словник синонімів"}
+    baseline = json.loads(json.dumps(existing, ensure_ascii=False))  # pristine reference
+    entry = _run_synonyms_gate(
+        monkeypatch,
+        offline=True,
+        cache={"lookups": {}},  # schema-reset / never-fetched offline -> gate did not run
+        new_synonyms=None,  # offline recompute yields nothing
+        existing_synonyms=existing,
+    )
+    assert entry["sections"]["synonyms"] == baseline
+    # byte-identical serialization is the #5077 "must PRESERVE" contract
+    assert json.dumps(entry["sections"]["synonyms"], ensure_ascii=False) == json.dumps(
+        baseline, ensure_ascii=False
+    )
+    assert entry["gate_provenance"]["synonyms"] == GATE_SKIPPED_OFFLINE
+
+
+def test_online_gate_ran_and_rejected_retracts_with_provenance(monkeypatch) -> None:
+    existing = {"items": ["джерело", "живець"], "source": "slovnyk.me: WordNet"}
+    entry = _run_synonyms_gate(
+        monkeypatch,
+        offline=False,  # online -> gate ran
+        cache={"lookups": {"synonyms": {"text": "x"}}},
+        new_synonyms=None,  # ran and rejected everything (auto-translation junk)
+        existing_synonyms=existing,
+    )
+    assert "synonyms" not in entry.get("sections", {})
+    assert entry["gate_provenance"]["synonyms"] == GATE_REJECTED
+
+
+def test_online_gate_partial_retraction_keeps_survivors_marks_rejected(monkeypatch) -> None:
+    existing = {"items": ["замок", "джерело", "живець"], "source": "s"}
+    entry = _run_synonyms_gate(
+        monkeypatch,
+        offline=False,
+        cache={"lookups": {"synonyms": {"text": "x"}}},
+        new_synonyms={"items": ["замок"], "source": "s"},  # dropped 2 junk senses
+        existing_synonyms=existing,
+    )
+    assert entry["sections"]["synonyms"]["items"] == ["замок"]
+    assert entry["gate_provenance"]["synonyms"] == GATE_REJECTED
+
+
+def test_online_gate_confirmed_addition_records_no_provenance(monkeypatch) -> None:
+    existing = {"items": ["замок"], "source": "s"}
+    entry = _run_synonyms_gate(
+        monkeypatch,
+        offline=False,
+        cache={"lookups": {"synonyms": {"text": "x"}}},
+        new_synonyms={"items": ["замок", "шифр"], "source": "s"},
+        existing_synonyms=existing,
+    )
+    assert entry["sections"]["synonyms"]["items"] == ["замок", "шифр"]
+    assert "gate_provenance" not in entry  # minimal diff — confirmed outcome is default
+
+
+def test_offline_with_cached_lookups_counts_as_gate_ran(monkeypatch) -> None:
+    # Offline is NOT the signal — a populated cache means the gate consulted its data,
+    # so an offline run over cached lemmas still applies authoritative retractions.
+    existing = {"items": ["джерело", "живець"], "source": "s"}
+    entry = _run_synonyms_gate(
+        monkeypatch,
+        offline=True,
+        cache={"lookups": {"synonyms": {"text": "x"}}},  # cache present -> gate ran
+        new_synonyms=None,
+        existing_synonyms=existing,
+    )
+    assert "synonyms" not in entry.get("sections", {})
+    assert entry["gate_provenance"]["synonyms"] == GATE_REJECTED

--- a/tests/test_verify_manifest.py
+++ b/tests/test_verify_manifest.py
@@ -195,6 +195,26 @@ def test_shrink_gate_allows_gate_ran_rejection_via_provenance(tmp_path, capsys):
     assert "no unexplained section shrink" in out
 
 
+def test_shrink_gate_flags_skipped_offline_shrink_as_unexplained(tmp_path, capsys):
+    # #5077 review finding 8: skipped-offline provenance means the gate did NOT run,
+    # so it must NOT exempt a shrink the way 'rejected' (gate ran + retracted) does.
+    # A section that shrank under skipped-offline is the exact offline-strip hazard and
+    # stays flagged as unexplained.
+    base, cur = _ключ_manifests(
+        tmp_path,
+        cur_entry={
+            "lemma": "ключ",
+            "sections": {"synonyms": {"items": ["замок"], "source": "s"}},
+            "gate_provenance": {"synonyms": "skipped-offline"},
+        },
+    )
+    rc = verify_manifest.run(cur, sample=0, baseline_path=base)
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert "unexplained section shrink" in out
+    assert "ключ" in out
+
+
 def test_shrink_gate_ignores_growth_and_equal(tmp_path, capsys):
     base, cur = _ключ_manifests(
         tmp_path,

--- a/tests/test_verify_manifest.py
+++ b/tests/test_verify_manifest.py
@@ -119,3 +119,102 @@ def test_conformance_clean_entry_passes(tmp_path, capsys):
     assert rc == 0
     assert "CLEAN — 0 violations" in out
     assert "lemma_in_vesum skipped" in out
+
+
+# --- #5077 shrink gate ------------------------------------------------------
+# The NONEMPTY->EMPTY hazard catches fully-stripped sections but MISSES partial
+# shrinks (1,748 on the 2026-07-13 go-live). The shrink gate flags per-section
+# item-count regressions vs the hydrated baseline, exempting retractions justified
+# by gate-ran provenance or the curated allowlist.
+
+
+def _write_named(path: Path, entries: list[dict]) -> Path:
+    path.write_text(json.dumps({"entries": entries}, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def _ключ_manifests(tmp_path: Path, *, cur_entry: dict) -> tuple[Path, Path]:
+    base = _write_named(
+        tmp_path / "base.json",
+        [{"lemma": "ключ", "sections": {"synonyms": {"items": ["джерело", "живець", "замок"], "source": "s"}}}],
+    )
+    cur = _write_named(tmp_path / "cur.json", [cur_entry])
+    return base, cur
+
+
+def test_shrink_gate_catches_unexplained_regression(tmp_path, capsys):
+    base, cur = _ключ_manifests(
+        tmp_path,
+        cur_entry={"lemma": "ключ", "sections": {"synonyms": {"items": ["замок"], "source": "s"}}},
+    )
+    rc = verify_manifest.run(cur, sample=0, baseline_path=base)
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert "SHRINK GATE" in out
+    assert "unexplained section shrink" in out
+    assert "ключ" in out
+
+
+def test_shrink_gate_flags_vanished_section(tmp_path, capsys):
+    base, cur = _ключ_manifests(tmp_path, cur_entry={"lemma": "ключ"})  # synonyms gone entirely
+    rc = verify_manifest.run(cur, sample=0, baseline_path=base)
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert "3 -> 0" in out
+
+
+def test_shrink_gate_allows_allowlisted_retraction(tmp_path, capsys):
+    base, cur = _ключ_manifests(
+        tmp_path,
+        cur_entry={"lemma": "ключ", "sections": {"synonyms": {"items": ["замок"], "source": "s"}}},
+    )
+    allowlist = tmp_path / "allow.yaml"
+    allowlist.write_text(
+        "version: 1\nkind: atlas_shrink_allowlist\n"
+        "retractions:\n  - lemma: ключ\n    section: synonyms\n    reason: WordNet junk\n",
+        encoding="utf-8",
+    )
+    rc = verify_manifest.run(cur, sample=0, baseline_path=base, shrink_allowlist_path=allowlist)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "no unexplained section shrink" in out
+
+
+def test_shrink_gate_allows_gate_ran_rejection_via_provenance(tmp_path, capsys):
+    base, cur = _ключ_manifests(
+        tmp_path,
+        cur_entry={
+            "lemma": "ключ",
+            "sections": {"synonyms": {"items": ["замок"], "source": "s"}},
+            "gate_provenance": {"synonyms": "rejected"},
+        },
+    )
+    rc = verify_manifest.run(cur, sample=0, baseline_path=base)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "no unexplained section shrink" in out
+
+
+def test_shrink_gate_ignores_growth_and_equal(tmp_path, capsys):
+    base, cur = _ключ_manifests(
+        tmp_path,
+        cur_entry={
+            "lemma": "ключ",
+            "sections": {"synonyms": {"items": ["джерело", "живець", "замок", "шифр"], "source": "s"}},
+        },
+    )
+    rc = verify_manifest.run(cur, sample=0, baseline_path=base)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "no unexplained section shrink" in out
+
+
+def test_shrink_gate_off_without_baseline(tmp_path, capsys):
+    cur = _write_named(
+        tmp_path / "cur.json",
+        [{"lemma": "ключ", "sections": {"synonyms": {"items": ["замок"], "source": "s"}}}],
+    )
+    rc = verify_manifest.run(cur, sample=0, baseline_path=None)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "SHRINK GATE" not in out  # no baseline -> gate cannot run, stays silent


### PR DESCRIPTION
## Problem (tool-verified)

`LEXICON_SLOVNYK_OFFLINE=1` enrich on the hydrated 8,552 release stripped **809 sections to empty** and **shrank 1,748** vs the published asset. Root cause traced in `enrich_manifest.py::enrich_entry`: it recomputes gated sections from scratch each run and unconditionally does `entry["sections"] = sections`. A gate that **cannot run** (offline; per-lemma slovnyk cache reset on a `schema_version` bump then never refetched; transient error) returns empty and silently overwrites the previously-confirmed published section. `verify_manifest`'s NONEMPTY→EMPTY hazard caught only the empties, not the partial shrinks.

## Design — three-outcome contract at the gate layer (root cause, not per-callsite)

`enrich_entry` now captures the hydrated/published sections as an explicit **preserve baseline** (threaded through the function, no hidden global) and resolves each gated section via `_resolve_gated_section`:

| Outcome | Condition | Action | `gate_provenance` |
|---|---|---|---|
| ran-and-confirmed | gate ran, no confirmed item lost | take new (additions welcome) | *(none — default, minimal diff)* |
| ran-and-rejected | gate ran, dropped item(s) | take new (quality win) | `rejected` |
| did-not-run | gate could not consult its source **and** would drop confirmed item(s) | **preserve existing byte-for-byte** | `skipped-offline` |

**"Did the slovnyk gate run" is honest, not offline-blind** (`_slovnyk_gate_ran`): online always ran; offline ran **iff** the per-lemma cache already holds lookups — an empty `lookups` map is exactly the schema-reset/never-fetched lemma the offline gate cannot consult. So an offline run over already-cached lemmas still applies authoritative retractions; only genuinely-unconsulted lemmas are preserved. Paronyms are local ZNO/cache only → their gate always runs (`gate_ran=True`).

**Design point 4 honored:** when the stricter gate *can* run, its retractions (WordNet auto-translation junk `ключ→джерело/живець`, `адвокат→прихильник/радник`, `аеродром→поле`) are `gate_ran=True` → taken as authoritative and marked `rejected`, never blocked.

## verify_manifest shrink gate

`verify_manifest.py --baseline <hydrated>` adds a **per-section item-count shrink gate**. A regression fails the promote **unless** justified by:
- the entry's `gate_provenance[section] == rejected` (the gate ran — a quality win), **or**
- the `(lemma, section)` pair on the curated `scripts/lexicon/shrink_allowlist.yaml` (explicit intended-retraction mechanism).

This is the second line of defence the empty-section hazard lacked — it also catches partial shrinks.

## Verification evidence (tool-backed, #M-4)

**Affected + wider suites — 159 in the commit gate, all green:**
```
tests/test_lexicon_enrich_manifest.py ... tests/test_verify_manifest.py ... tests/test_manifest_io.py
============================= 159 passed in 1.24s ==============================
```
Wider sweep (conformance, publish, perf, reenrich, grow_*, fill_local, wiki, manifest_api, fingerprint, calque): all green (`96 passed, 1 skipped`; `29 passed`; `62 passed`).

**New tests (design step 4):**
- `test_offline_gate_did_not_run_preserves_section_byte_identical` — (a) preserve byte-identical + `skipped-offline`.
- `test_online_gate_ran_and_rejected_retracts_with_provenance` / `..._partial_retraction_keeps_survivors_marks_rejected` — (b) retraction allowed + `rejected`.
- `test_offline_with_cached_lookups_counts_as_gate_ran` — cache, not offline, is the signal.
- `test_online_gate_confirmed_addition_records_no_provenance` — minimal-diff default.
- `test_shrink_gate_catches_unexplained_regression` / `_flags_vanished_section` / `_allows_allowlisted_retraction` / `_allows_gate_ran_rejection_via_provenance` / `_ignores_growth_and_equal` / `_off_without_baseline` — (c) shrink gate + both exemption paths.

**Real CLI (not just `run()`):**
```
# unexplained shrink (стіл, not allowlisted, no provenance)
=== SHRINK GATE (per-section item count vs baseline, #5077) ===
  стіл             synonyms     3 -> 1
=== VERDICT: 1 unexplained section shrink(s) — do NOT commit ===
exit code = 2
# allowlisted lemma (ключ, on shrink_allowlist.yaml) → CLEAN, rc=0
```

**Ruff:** `All checks passed!` on all changed files.

## Notes / decisions that deviate or need a reviewer eye

1. **Preserve is whole-section, not an item-level union.** The issue's design point 1 says a gate that did not run must *preserve the existing section*; the item-level merge is named only as the **one-time recovery**. I implemented the literal contract: on a did-not-run loss the baseline section is kept unchanged (byte-identical), and offline additions from still-available sources are **deferred to the next online run** (auditable via `gate_provenance: skipped-offline`). This is the conservative, non-destructive choice; flagging it explicitly in case a reviewer prefers the union for offline relation-only republishes.
2. **`gate_provenance` is a new top-level entry key**, recorded only for `rejected`/`skipped-offline` (never `confirmed`) to keep full-run diffs minimal. No lexicon-entry JSON schema constrains entry keys; conformance/hazard gates ignore it.
3. **`site/src/data/lexicon-manifest.fingerprint.json` is included** — it is the required `check_manifest_freshness` companion to the two changed code files (`manifest_io.py` is excluded from the fingerprint glob, so only the enrich/verify hashes moved). Freshness gate re-run: `rc=0`.
4. Shared `GATE_*` constants live in `manifest_io.py` (stdlib-only) so enrich and verify share them without either importing the other's heavy deps.

Refs #5077