### PR TITLE
feat(practice): paronym UI integration and static checker warnings

### DIFF
--- a/scripts/audit/check_static_practice_assets.py
+++ b/scripts/audit/check_static_practice_assets.py
@@ -23,6 +23,7 @@ if str(AUDIT_DIR) not in sys.path:
     sys.path.insert(0, str(AUDIT_DIR))
 
 from generate_practice_deck import (
+    THIN_WARN_THRESHOLDS,
     validate_classify_item,
     validate_classify_session_cap,
     validate_heritage_item,
@@ -310,6 +311,7 @@ def _check_level(
     min_lexemes: int,
     reviewed: set[tuple[str, str]],
     errors: list[str],
+    warnings: list[str],
     *,
     lower_lexeme_ids: set[str] | None = None,
 ) -> dict[str, Any]:
@@ -511,6 +513,14 @@ def _check_level(
                 f"{mode_coverage.get(kind)!r} != {expected_mode_coverage!r}"
             )
 
+    if isinstance(mode_coverage, dict):
+        for mode, threshold in THIN_WARN_THRESHOLDS.items():
+            cov = mode_coverage.get(mode, 0.0)
+            if cov < threshold:
+                warnings.append(
+                    f"{level} {mode} coverage {cov:.4f} is below thin-deck threshold {threshold:.2f}"
+                )
+
     return {
         "index": len(index_items),
         "lexemes": len(lexemes),
@@ -534,6 +544,7 @@ def check_assets(
         ensure_practice_deck_hydrated(practice_dir)
 
     errors: list[str] = []
+    warnings: list[str] = []
     daily = _check_daily_pool(daily_pool, min_daily_pool_size, errors)
     reviewed = _reviewed_source_keys(reviewed_sources, errors)
     practice: dict[str, dict[str, Any]] = {}
@@ -547,6 +558,7 @@ def check_assets(
             min_practice_lexemes_per_level,
             reviewed,
             errors,
+            warnings,
             lower_lexeme_ids=seen_lexeme_ids,
         )
         seen_lexeme_ids |= set(row.pop("lexeme_ids", None) or ())
@@ -568,6 +580,7 @@ def check_assets(
     return {
         "ok": not errors,
         "errors": errors,
+        "warnings": warnings,
         "daily": daily,
         "practice": practice,
         "reviewed_sources": len(reviewed),
@@ -624,6 +637,10 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(summary, ensure_ascii=False, indent=2))
     else:
         _print_summary(summary)
+        if summary["warnings"]:
+            print("Static practice asset warnings:", file=sys.stderr)
+            for warning in summary["warnings"]:
+                print(f"- {warning}", file=sys.stderr)
         if summary["errors"]:
             print("Static practice asset gate failed:")
             for error in summary["errors"]:

--- a/site/src/components/LexiconPractice.tsx
+++ b/site/src/components/LexiconPractice.tsx
@@ -40,6 +40,8 @@ import {
   type PracticeDeckData,
   type PracticeHeritageItem,
   type PracticeHeritageShard,
+  type PracticeParonymItem,
+  type PracticeParonymShard,
   type PracticeIndexItem,
   type PracticeIndexShard,
   type PracticeLexeme,
@@ -94,6 +96,12 @@ interface HeritageFeedback {
   textUk: string;
   textEn?: string;
   citations?: string[];
+}
+
+interface ParonymFeedback {
+  kind: 'correct' | 'wrong';
+  textUk: string;
+  textEn?: string;
 }
 
 interface ClozeFeedback {
@@ -243,6 +251,7 @@ type VisiblePracticeModeFilter = Extract<
   | 'classify'
   | 'paradigm'
   | 'synonym'
+  | 'paronym'
   | 'heritage'
 >;
 
@@ -256,6 +265,7 @@ const MODE_LABELS: Record<VisiblePracticeModeFilter, string> = {
   classify: 'Classify',
   paradigm: 'Paradigm',
   synonym: 'Synonym',
+  paronym: 'Пароніми',
   heritage: 'Спадщина',
 };
 
@@ -269,6 +279,7 @@ const MODE_CARD_ORDER: VisiblePracticeModeFilter[] = [
   'classify',
   'paradigm',
   'synonym',
+  'paronym',
   'heritage',
 ];
 
@@ -364,6 +375,15 @@ const MODE_META: Record<
     step: 'Лексика',
     stepEn: 'Vocabulary',
     accent: 'orange',
+  },
+  paronym: {
+    title: 'Пароніми',
+    en: 'Paronyms',
+    description: 'Розрізняйте близькі за звуковим складом, але різні за значенням слова.',
+    descriptionEn: 'Distinguish words that sound similar but have different meanings.',
+    step: 'Лексика',
+    stepEn: 'Vocabulary',
+    accent: 'purple',
   },
   heritage: {
     title: 'Спадщина',
@@ -565,6 +585,17 @@ function ModeIcon({ mode }: { mode: VisiblePracticeModeFilter }) {
     );
   }
 
+  if (mode === 'paronym') {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M9 3H5a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h4" />
+        <path d="M15 21h4a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-4" />
+        <path d="M9 10h6" />
+        <path d="M9 14h6" />
+      </svg>
+    );
+  }
+
   if (mode === 'heritage') {
     return (
       <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
@@ -602,6 +633,7 @@ function hasLoadedDrillShards(deck: PracticeDeckData | null): boolean {
         (deck.classify?.length ?? 0) > 0 ||
         (deck.paradigm?.length ?? 0) > 0 ||
         (deck.synonym?.length ?? 0) > 0 ||
+        (deck.paronym?.length ?? 0) > 0 ||
         (deck.heritage?.length ?? 0) > 0),
   );
 }
@@ -906,7 +938,7 @@ function slotPromptParts(prompt: string): [string, string] {
 }
 
 function shouldLoadCloze(mode: PracticeModeFilter): boolean {
-  return ['mixed', 'cloze', 'stress', 'classify', 'paradigm', 'synonym', 'heritage'].includes(mode);
+  return ['mixed', 'cloze', 'stress', 'classify', 'paradigm', 'synonym', 'paronym', 'heritage'].includes(mode);
 }
 
 function sessionScopeIndexForMode(
@@ -924,9 +956,15 @@ function shouldShowFocusModeCard(
   deck: PracticeDeckData | null,
   indexForStats: PracticeIndexItem[],
 ): boolean {
-  if (practiceMode !== 'heritage') return true;
-  if (deck) return (deck.heritage?.length ?? 0) > 0;
-  return indexForStats.some((item) => item.modes.includes('heritage'));
+  if (practiceMode === 'heritage') {
+    if (deck) return (deck.heritage?.length ?? 0) > 0;
+    return indexForStats.some((item) => item.modes.includes('heritage'));
+  }
+  if (practiceMode === 'paronym') {
+    if (deck) return (deck.paronym?.length ?? 0) > 0;
+    return indexForStats.some((item) => item.modes.includes('paronym'));
+  }
+  return true;
 }
 
 /** Learner level persisted in the shared `lu-learner-level` key (also used by Words of the Day). */
@@ -1074,6 +1112,7 @@ function LexiconPracticeIsland({
   const [clozeFeedback, setClozeFeedback] = useState<ClozeFeedback | null>(null);
   const [clozeAttemptRecorded, setClozeAttemptRecorded] = useState(false);
   const [heritageFeedback, setHeritageFeedback] = useState<HeritageFeedback | null>(null);
+  const [paronymFeedback, setParonymFeedback] = useState<ParonymFeedback | null>(null);
   const [dueIndex, setDueIndex] = useState<PracticeIndexItem[] | null>(null);
   const [publishedLevels] = useState<Set<CefrLevel>>(
     () => new Set(PUBLISHED_PRACTICE_LEVELS as unknown as CefrLevel[]),
@@ -1109,6 +1148,7 @@ function LexiconPracticeIsland({
     setClozeFeedback(null);
     setClozeAttemptRecorded(false);
     setHeritageFeedback(null);
+    setParonymFeedback(null);
     setPendingOutcome(null);
     pendingOutcomeRef.current = null;
     matchedSelectedRatingRef.current = null;
@@ -1491,6 +1531,7 @@ function LexiconPracticeIsland({
           `${shardBaseUrl}/practice-classify.${targetLevel}.json`,
           `${shardBaseUrl}/practice-paradigm.${targetLevel}.json`,
           `${shardBaseUrl}/practice-synonym.${targetLevel}.json`,
+          `${shardBaseUrl}/practice-paronym.${targetLevel}.json`,
           `${shardBaseUrl}/practice-heritage.${targetLevel}.json`,
         ];
         const drillResults = await Promise.all(
@@ -1498,7 +1539,7 @@ function LexiconPracticeIsland({
             getShardJson<any>(u, shardJsonCacheRef.current).catch(() => ({})),
           ),
         );
-        const [clozeR, stressR, classifyR, paradigmR, synonymR, heritageR] = drillResults;
+        const [clozeR, stressR, classifyR, paradigmR, synonymR, paronymR, heritageR] = drillResults;
         nextDeck = {
           ...nextDeck!,
           cloze: [...(nextDeck!.cloze ?? []), ...((clozeR as { cloze?: PracticeClozeItem[] }).cloze ?? [])],
@@ -1506,6 +1547,7 @@ function LexiconPracticeIsland({
           classify: [...(nextDeck!.classify ?? []), ...((classifyR as { classify?: any[] }).classify ?? [])],
           paradigm: [...(nextDeck!.paradigm ?? []), ...((paradigmR as { paradigm?: any[] }).paradigm ?? [])],
           synonym: [...(nextDeck!.synonym ?? []), ...((synonymR as { synonym?: any[] }).synonym ?? [])],
+          paronym: [...(nextDeck!.paronym ?? []), ...((paronymR as { paronym?: any[] }).paronym ?? [])],
           heritage: [...(nextDeck!.heritage ?? []), ...((heritageR as { heritage?: any[] }).heritage ?? [])],
         };
         nextClozeLoaded = true;
@@ -1526,6 +1568,7 @@ function LexiconPracticeIsland({
                   `${shardBaseUrl}/practice-classify.${lv}.json`,
                   `${shardBaseUrl}/practice-paradigm.${lv}.json`,
                   `${shardBaseUrl}/practice-synonym.${lv}.json`,
+                  `${shardBaseUrl}/practice-paronym.${lv}.json`,
                   `${shardBaseUrl}/practice-heritage.${lv}.json`,
                 ];
                 const rs = await Promise.all(
@@ -1537,7 +1580,8 @@ function LexiconPracticeIsland({
                   classify: (rs[2] as { classify?: any[] }).classify ?? [],
                   paradigm: (rs[3] as { paradigm?: any[] }).paradigm ?? [],
                   synonym: (rs[4] as { synonym?: any[] }).synonym ?? [],
-                  heritage: (rs[5] as { heritage?: any[] }).heritage ?? [],
+                  paronym: (rs[5] as { paronym?: any[] }).paronym ?? [],
+                  heritage: (rs[6] as { heritage?: any[] }).heritage ?? [],
                 };
               }),
             );
@@ -1551,6 +1595,7 @@ function LexiconPracticeIsland({
                 classify: [...(prev.classify ?? []), ...lowerDrillBatches.flatMap((b) => b.classify)],
                 paradigm: [...(prev.paradigm ?? []), ...lowerDrillBatches.flatMap((b) => b.paradigm)],
                 synonym: [...(prev.synonym ?? []), ...lowerDrillBatches.flatMap((b) => b.synonym)],
+                paronym: [...(prev.paronym ?? []), ...lowerDrillBatches.flatMap((b) => b.paronym)],
                 heritage: [...(prev.heritage ?? []), ...lowerDrillBatches.flatMap((b) => b.heritage)],
               };
             });
@@ -1996,8 +2041,12 @@ function LexiconPracticeIsland({
     const nextHeritageFeedback = selection.heritage
       ? heritageFeedbackFor(selection.heritage, option)
       : null;
+    const nextParonymFeedback = selection.paronym
+      ? paronymFeedbackFor(selection.paronym, option)
+      : null;
     setAnswerLocked(true);
     setHeritageFeedback(nextHeritageFeedback);
+    setParonymFeedback(nextParonymFeedback);
     setFeedback({
       uk: option.correct ? `${selection.lemma.lemma}: Правильно` : `${selection.lemma.lemma}: Ще раз`,
       en: option.correct ? `${selection.lemma.lemma}: Correct` : `${selection.lemma.lemma}: Again`,
@@ -2604,6 +2653,7 @@ function LexiconPracticeIsland({
                     clozeInput={clozeInput}
                     clozeFeedback={clozeFeedback}
                     heritageFeedback={heritageFeedback}
+                    paronymFeedback={paronymFeedback}
                     onClozeInput={setClozeInput}
                     onFlashcardRating={(rating) => rateAndComplete(selection, rating)}
                     onChoice={handleChoice}
@@ -2656,6 +2706,15 @@ function LexiconPracticeIsland({
                     </span>
                   ) : null}
                 </p>
+              ) : mode === 'paronym' && (deck.paronym?.length ?? 0) === 0 ? (
+                <p className="lexicon-practice-muted" data-testid="practice-paronym-empty">
+                  <span lang="uk">Вправи з паронімами для цього рівня ще готуються.</span>
+                  {showEnglishSubtitles ? (
+                    <span className="btn-sub" lang="en" style={{ display: 'block', fontSize: '0.85em', marginTop: '4px' }}>
+                      / Paronym exercises for this level are still being prepared.
+                    </span>
+                  ) : null}
+                </p>
               ) : (
                 <p className="lexicon-practice-muted">
                   <span lang="uk">Усі картки на зараз повторено.</span>
@@ -2695,6 +2754,7 @@ function PracticeItem({
   clozeInput,
   clozeFeedback,
   heritageFeedback,
+  paronymFeedback,
   onClozeInput,
   onFlashcardRating,
   onChoice,
@@ -2711,6 +2771,7 @@ function PracticeItem({
   clozeInput: string;
   clozeFeedback: ClozeFeedback | null;
   heritageFeedback: HeritageFeedback | null;
+  paronymFeedback: ParonymFeedback | null;
   onClozeInput(value: string): void;
   onFlashcardRating(rating: PracticeRating): void;
   onChoice(option: ChoiceOption): void;
@@ -2758,6 +2819,18 @@ function PracticeItem({
       <PracticeHeritage
         item={selection.heritage}
         feedback={heritageFeedback}
+        answerLocked={answerLocked}
+        onChoice={onChoice}
+        showEnglishSubtitles={showEnglishSubtitles}
+      />
+    );
+  }
+
+  if (selection.mode === 'paronym' && selection.paronym) {
+    return (
+      <PracticeParonym
+        item={selection.paronym}
+        feedback={paronymFeedback}
         answerLocked={answerLocked}
         onChoice={onChoice}
         showEnglishSubtitles={showEnglishSubtitles}
@@ -2886,6 +2959,105 @@ function PracticeItem({
           </li>
         ))}
       </ul>
+    </div>
+  );
+}
+
+function paronymOptions(item: PracticeParonymItem): ChoiceOption[] {
+  return item.options.map((option) => ({
+    label: option.label,
+    correct: option.label === item.answer,
+  }));
+}
+
+function paronymFeedbackFor(item: PracticeParonymItem, option: ChoiceOption): ParonymFeedback {
+  if (option.correct) {
+    return {
+      kind: 'correct',
+      textUk: `Правильно! ${item.distinction_gloss_uk}`,
+      textEn: 'Correct!',
+    };
+  }
+  return {
+    kind: 'wrong',
+    textUk: `Неправильно. ${item.distinction_gloss_uk}`,
+    textEn: 'Incorrect.',
+  };
+}
+
+function PracticeParonym({
+  item,
+  feedback,
+  answerLocked,
+  onChoice,
+  showEnglishSubtitles,
+}: {
+  item: PracticeParonymItem;
+  feedback: ParonymFeedback | null;
+  answerLocked: boolean;
+  onChoice(option: ChoiceOption): void;
+  showEnglishSubtitles: boolean;
+}) {
+  const [before, after] = slotPromptParts(item.prompt);
+  const options = paronymOptions(item);
+  const slotText = feedback?.kind === 'correct' ? item.answer : '___';
+  return (
+    <div className="lexicon-paronym" data-testid="practice-paronym">
+      <p className="paronym-task">
+        <span lang="uk">Оберіть правильний паронім.</span>
+        {showEnglishSubtitles ? (
+          <span className="btn-sub" lang="en">/ Choose the correct paronym.</span>
+        ) : null}
+      </p>
+      <p className="paronym-sentence">
+        <span>{before}</span>
+        <span className={feedback?.kind === 'correct' ? 'paronym-slot filled' : 'paronym-slot'}>
+          {slotText}
+        </span>
+        <span>{after}</span>
+      </p>
+      <ul className="lexicon-option-list mc-options">
+        {options.map((option, index) => (
+          <li key={`${option.label}-${index}`}>
+            <button
+              className={`mc-opt${answerLocked && option.correct ? ' correct' : ''}`}
+              type="button"
+              disabled={answerLocked}
+              onClick={() => onChoice(option)}
+            >
+              <span>{option.label}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+      {feedback ? (
+        <div
+          className={`paronym-feedback ${feedback.kind}`}
+          role={feedback.kind === 'wrong' ? 'alert' : 'status'}
+          aria-live="polite"
+          data-testid="practice-paronym-feedback"
+        >
+          <p>
+            <span lang="uk">{feedback.textUk}</span>
+            {showEnglishSubtitles && feedback.textEn ? (
+              <span className="btn-sub" lang="en">/ {feedback.textEn}</span>
+            ) : null}
+          </p>
+          <div style={{ marginTop: '0.4rem' }}>
+            <a
+              href={`/lexicon/${item.lemmaId}/`}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ fontSize: '0.85rem', textDecoration: 'underline', color: 'inherit', fontWeight: 'bold' }}
+            >
+              <span lang="uk">Відкрити в Атласі →</span>
+              {showEnglishSubtitles ? (
+                <span className="btn-sub" lang="en">/ Open in Atlas →</span>
+              ) : null}
+            </a>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/site/src/lib/lexicon/srs.ts
+++ b/site/src/lib/lexicon/srs.ts
@@ -230,6 +230,26 @@ export interface PracticeHeritageItem {
   authenticSense?: string;
 }
 
+export interface PracticeParonymOption {
+  label: string;
+}
+
+export interface PracticeParonymItem {
+  paronymId: string;
+  lemmaId: string;
+  srsKey: string;
+  lemma: string;
+  confusable: string;
+  distinction_gloss_uk: string;
+  frameIndex: number;
+  cefr: string;
+  prompt: string;
+  answer: string;
+  options: PracticeParonymOption[];
+  origin?: string;
+  citations?: string[];
+}
+
 export interface PracticeShardMeta {
   schema: string;
   schemaVersion: number;
@@ -277,6 +297,10 @@ export interface PracticeHeritageShard extends PracticeShardMeta {
   heritage: PracticeHeritageItem[];
 }
 
+export interface PracticeParonymShard extends PracticeShardMeta {
+  paronym: PracticeParonymItem[];
+}
+
 export interface PracticeDeckData {
   deckVersion: string;
   level: string;
@@ -287,6 +311,7 @@ export interface PracticeDeckData {
   classify?: PracticeClassifyItem[];
   paradigm?: PracticeParadigmItem[];
   synonym?: PracticeSynonymItem[];
+  paronym?: PracticeParonymItem[];
   heritage?: PracticeHeritageItem[];
   fixtureNote?: string;
 }
@@ -405,6 +430,7 @@ export interface PracticeSelection {
   classifySetId?: string;
   paradigm?: PracticeParadigmItem;
   synonym?: PracticeSynonymItem;
+  paronym?: PracticeParonymItem;
   heritage?: PracticeHeritageItem;
   recallDirection: RecallDirection;
   choicePolarity: ChoicePolarity;
@@ -1235,6 +1261,7 @@ interface DeckMaps {
   classify: Map<string, PracticeClassifyItem>;
   paradigm: Map<string, PracticeParadigmItem[]>;
   synonym: Map<string, PracticeSynonymItem[]>;
+  paronym: Map<string, PracticeParonymItem[]>;
   heritage: Map<string, PracticeHeritageItem[]>;
 }
 
@@ -1260,6 +1287,7 @@ function deckMaps(deck: PracticeDeckData): DeckMaps {
     classify: new Map((deck.classify ?? []).map((item) => [item.lemmaId, item])),
     paradigm: groupByLemma(deck.paradigm),
     synonym: groupByLemma(deck.synonym),
+    paronym: groupByLemma(deck.paronym),
     heritage: groupByLemma(deck.heritage),
   };
   deckMapsCache.set(deck, maps);
@@ -1595,6 +1623,19 @@ function buildStaticCandidates(deck: PracticeDeckData, modeFilter: PracticeModeF
         continue;
       }
       if (mode === 'paronym') {
+        const items = maps.paronym.get(indexItem.lemmaId) ?? [];
+        for (const paronym of items) {
+          candidates.push(
+            cachedSelection({
+              itemId: makeItemId(indexItem.lemmaId, mode, paronym.paronymId),
+              lemma,
+              indexItem,
+              mode,
+              cardKey: paronym.srsKey,
+              paronym,
+            }),
+          );
+        }
         continue;
       }
       const key = cardKey(indexItem.lemmaId, mode);
@@ -1811,6 +1852,7 @@ export function combinePracticeShards(
     classify?: PracticeClassifyShard;
     paradigm?: PracticeParadigmShard;
     synonym?: PracticeSynonymShard;
+    paronym?: PracticeParonymShard;
     heritage?: PracticeHeritageShard;
   } = {},
 ): PracticeDeckData {
@@ -1824,6 +1866,7 @@ export function combinePracticeShards(
     classify: modeShards.classify?.classify ?? [],
     paradigm: modeShards.paradigm?.paradigm ?? [],
     synonym: modeShards.synonym?.synonym ?? [],
+    paronym: modeShards.paronym?.paronym ?? [],
     heritage: modeShards.heritage?.heritage ?? [],
     fixtureNote: indexShard.fixtureNote,
   };
@@ -1845,6 +1888,7 @@ export function extendWithLowerDecks(base: PracticeDeckData, lowers: PracticeDec
     classify: [...(base.classify ?? []), ...lowers.flatMap((d) => d.classify ?? [])],
     paradigm: [...(base.paradigm ?? []), ...lowers.flatMap((d) => d.paradigm ?? [])],
     synonym: [...(base.synonym ?? []), ...lowers.flatMap((d) => d.synonym ?? [])],
+    paronym: [...(base.paronym ?? []), ...lowers.flatMap((d) => d.paronym ?? [])],
     heritage: [...(base.heritage ?? []), ...lowers.flatMap((d) => d.heritage ?? [])],
     fixtureNote: base.fixtureNote ?? lowers.find((d) => d.fixtureNote)?.fixtureNote,
   };

--- a/site/src/pages/words-of-the-day/practice.astro
+++ b/site/src/pages/words-of-the-day/practice.astro
@@ -209,7 +209,8 @@ const frontmatter = {
   }
 
   :global(.lexicon-choice),
-  :global(.lexicon-cloze) {
+  :global(.lexicon-cloze),
+  :global(.lexicon-paronym) {
     display: grid;
     gap: 1rem;
   }
@@ -725,7 +726,8 @@ const frontmatter = {
 
   :global(.lexicon-choice),
   :global(.lexicon-cloze),
-  :global(.lexicon-heritage) {
+  :global(.lexicon-heritage),
+  :global(.lexicon-paronym) {
     display: grid;
     gap: 1rem;
   }
@@ -804,6 +806,66 @@ const frontmatter = {
     color: var(--lu-text-muted);
     font-size: 0.86rem;
     font-weight: 700;
+  }
+
+  :global(.paronym-task) {
+    margin: 0 0 -0.1rem;
+    color: var(--lu-purple);
+    font-size: 0.92rem;
+    font-weight: 900;
+  }
+
+  :global(.paronym-sentence) {
+    margin: 0;
+    padding: 1.4rem 1.5rem;
+    border: 1px solid var(--lu-border);
+    border-left: 4px solid var(--lu-purple);
+    border-radius: 14px;
+    background: var(--lu-surface-raised);
+    box-shadow: var(--lu-shadow);
+    color: var(--lu-text);
+    font-size: 1.45rem;
+    font-weight: 700;
+    line-height: 1.6;
+  }
+
+  :global(.paronym-slot) {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 96px;
+    padding: 0 10px;
+    margin: 0 4px;
+    border-bottom: 3px solid var(--lu-purple);
+    color: var(--lu-purple);
+    font-weight: 900;
+  }
+
+  :global(.paronym-slot.filled) {
+    border-bottom-color: var(--lu-green);
+    color: var(--lu-state-correct-fg);
+  }
+
+  :global(.paronym-feedback) {
+    margin: 0;
+    padding: 0.85rem 0.95rem;
+    border-radius: 8px;
+    font-weight: 800;
+    line-height: 1.45;
+  }
+
+  :global(.paronym-feedback p) {
+    margin: 0;
+  }
+
+  :global(.paronym-feedback.correct) {
+    background: var(--lu-state-correct-bg);
+    color: var(--lu-state-correct-fg);
+  }
+
+  :global(.paronym-feedback.wrong) {
+    background: var(--lu-state-wrong-bg);
+    color: var(--lu-state-wrong-fg);
   }
 
   :global(.mc-q) {

--- a/site/tests/unit/LexiconPractice.test.tsx
+++ b/site/tests/unit/LexiconPractice.test.tsx
@@ -11,6 +11,7 @@ import {
   saveState,
   type PracticeDeckData,
   type PracticeHeritageItem,
+  type PracticeParonymItem,
   type PracticeLexeme,
   type PracticeMode,
   type PracticeRating,
@@ -39,7 +40,7 @@ function mockShardFetch(counts: Partial<Record<CefrLevel, number>>) {
     const url = String(input);
     requested.push(url);
     const match = url.match(
-      /practice-(index|lexemes|cloze|stress|classify|paradigm|synonym|heritage)\.([ABC][12])\.json/,
+      /practice-(index|lexemes|cloze|stress|classify|paradigm|synonym|paronym|heritage)\.([ABC][12])\.json/,
     );
     if (!match) return notFoundResponse();
     const kind = match[1] as
@@ -50,6 +51,7 @@ function mockShardFetch(counts: Partial<Record<CefrLevel, number>>) {
       | 'classify'
       | 'paradigm'
       | 'synonym'
+      | 'paronym'
       | 'heritage';
     const level = match[2] as CefrLevel;
     const n = counts[level];
@@ -98,7 +100,7 @@ function mockProgressiveFetch(counts: Partial<Record<CefrLevel, number>>) {
     const url = String(input);
     requested.push(url);
     const match = url.match(
-      /practice-(index|lexemes|cloze|stress|classify|paradigm|synonym|heritage)\.([ABC][12])\.json/,
+      /practice-(index|lexemes|cloze|stress|classify|paradigm|synonym|paronym|heritage)\.([ABC][12])\.json/,
     );
     if (!match) return notFoundResponse();
     const kind = match[1] as any;
@@ -850,6 +852,145 @@ describe('LexiconPractice', () => {
     const link = screen.getByRole('link', { name: /Відкрити в Атласі/ });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute('href', '/lexicon/dim/');
+  });
+
+  function paronymPracticeItem(): PracticeParonymItem {
+    return {
+      paronymId: 'par-test-fixture',
+      lemmaId: 'bihate',
+      srsKey: cardKey('bihate', 'paronym'),
+      lemma: 'бігати',
+      confusable: 'біжить',
+      distinction_gloss_uk: 'бігати регулярно, бігти конкретно зараз',
+      frameIndex: 1,
+      cefr: 'A1',
+      prompt: 'Вранці він ___ у парку.',
+      answer: 'бігає',
+      options: [
+        { label: 'бігає' },
+        { label: 'біжить' },
+      ],
+    };
+  }
+
+  function paronymDeck({ includeItems = true } = {}): PracticeDeckData {
+    const entry = lexeme(
+      'bihate',
+      'бігати',
+      'to run',
+      {
+        nominative: 'бігати',
+        accusative: 'бігати',
+        locative: 'бігати',
+      },
+      { cefr: 'A1' },
+    );
+    return {
+      deckVersion: 'test-paronym',
+      level: 'A1',
+      lexemes: [entry],
+      index: [
+        {
+          lemmaId: entry.lemmaId,
+          lemma: entry.lemma,
+          cefr: 'A1',
+          modes: ['paronym'],
+          hasCloze: false,
+          clozeIds: [],
+          newOrder: 0,
+        },
+      ],
+      cloze: [],
+      stress: [],
+      classify: [],
+      paradigm: [],
+      synonym: [],
+      paronym: includeItems ? [paronymPracticeItem()] : [],
+    };
+  }
+
+  test('paronym renders in mixed sessions and paronym focus mode', async () => {
+    const user = userEvent.setup();
+    const mixedRender = render(
+      <LexiconPractice
+        initialDeck={paronymDeck()}
+        autoStart
+        initialMode="mixed"
+        advanceDelayMs={10_000}
+      />,
+    );
+
+    expect(screen.getByTestId('practice-paronym')).toBeInTheDocument();
+    expect(screen.getByText('Оберіть правильний паронім.')).toBeInTheDocument();
+    expect(screen.getByText(/Вранці він/)).toBeInTheDocument();
+
+    mixedRender.unmount();
+    const { container } = render(<LexiconPractice initialDeck={paronymDeck()} advanceDelayMs={10_000} />);
+    expect(screen.getByText('Пароніми')).toBeInTheDocument();
+
+    await user.click(container.querySelector<HTMLButtonElement>('[data-mode="paronym"]')!);
+
+    expect(await screen.findByTestId('practice-paronym')).toBeInTheDocument();
+  });
+
+  test('paronym wrong choice scores again and shows explanation', async () => {
+    const user = userEvent.setup();
+    render(
+      <LexiconPractice
+        initialDeck={paronymDeck()}
+        autoStart
+        initialMode="paronym"
+        advanceDelayMs={10_000}
+      />,
+    );
+
+    await user.click(
+      within(screen.getByTestId('practice-paronym')).getByRole('button', { name: /біжить/ }),
+    );
+
+    const feedback = screen.getByTestId('practice-paronym-feedback');
+    expect(feedback).toHaveTextContent('Неправильно. бігати регулярно, бігти конкретно зараз');
+    await waitFor(() => {
+      expect(storedState().reviews[0]).toMatchObject({
+        lemmaId: 'bihate',
+        mode: 'paronym',
+        rating: 'again',
+        cardKey: cardKey('bihate', 'paronym'),
+      });
+    });
+  });
+
+  test('paronym correct answer scores good', async () => {
+    const user = userEvent.setup();
+    render(
+      <LexiconPractice
+        initialDeck={paronymDeck()}
+        autoStart
+        initialMode="paronym"
+        advanceDelayMs={10_000}
+      />,
+    );
+
+    await user.click(
+      within(screen.getByTestId('practice-paronym')).getByRole('button', { name: /бігає/ }),
+    );
+
+    expect(screen.getByTestId('practice-paronym-feedback')).toHaveTextContent('Правильно! бігати регулярно, бігти конкретно зараз');
+    await waitFor(() => {
+      expect(storedState().reviews[0]).toMatchObject({
+        lemmaId: 'bihate',
+        mode: 'paronym',
+        rating: 'good',
+        cardKey: cardKey('bihate', 'paronym'),
+      });
+    });
+  });
+
+  test('hides paronym mode card when the loaded deck has no paronym items', () => {
+    render(<LexiconPractice initialDeck={paronymDeck({ includeItems: false })} />);
+
+    expect(screen.queryByText('Пароніми')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Пароніми/ })).not.toBeInTheDocument();
   });
 
   test('focus deep-link: a bare Atlas lemma resolves to its item with no double session start', async () => {

--- a/tests/test_check_static_practice_assets.py
+++ b/tests/test_check_static_practice_assets.py
@@ -572,3 +572,18 @@ def test_non_heritage_modes_stay_strictly_same_level(tmp_path: Path) -> None:
 
     assert summary["ok"] is False
     assert any("lemmaId 'dim' missing from A2 lexeme shard" in error for error in summary["errors"])
+
+
+def test_thin_deck_warnings(tmp_path: Path) -> None:
+    daily_pool, practice_dir, reviewed_sources = _fixture_paths(tmp_path)
+    summary = check_assets(
+        daily_pool=daily_pool,
+        practice_dir=practice_dir,
+        reviewed_sources=reviewed_sources,
+        levels=("A1",),
+        min_daily_pool_size=2,
+        min_practice_lexemes_per_level=1,
+    )
+    assert summary["ok"] is True
+    assert any("A1 synonym coverage 0.0000 is below thin-deck threshold 0.05" in warning for warning in summary["warnings"])
+    assert any("A1 paronym coverage 0.0000 is below thin-deck threshold 0.01" in warning for warning in summary["warnings"])


### PR DESCRIPTION
This PR surfaces the paronym mode in the practice UI, sets up its SRS/loading logic, adds UI styling, and enhances the static practice asset audit script with non-blocking thin-deck warnings.

Refs #4383

## Deliverables

### Deliverable A: Practice Zone - Paronym UI Integration
1. **SRS Types & Candidates:** `PracticeParonymOption`, `PracticeParonymItem`, and `PracticeParonymShard` added to `site/src/lib/lexicon/srs.ts`. Paronym candidates grouped by lemma and selected in `buildStaticCandidates`.
2. **UI Filters & Configuration:** Mode `'paronym'` registered in `VisiblePracticeModeFilter`, `MODE_LABELS`, `MODE_CARD_ORDER`, and `MODE_META` in `site/src/components/LexiconPractice.tsx`.
3. **Drill Shard Loading:** Dynamic loading in `shouldLoadCloze` and `hasLoadedDrillShards` in `LexiconPractice.tsx` configured to fetch `practice-paronym.${level}.json` shards.
4. **Paronym Practice Card:** Implemented `<PracticeParonym>` component rendering a cloze-style task with custom options, mistake feedback highlighting Ukrainian-first distinction glosses, and an Atlas deep link.
5. **Aesthetics & Styling:** Added purple-themed (`var(--lu-purple)`) styling classes (`.lexicon-paronym`, `.paronym-task`, `.paronym-sentence`, `.paronym-slot`, and `.paronym-feedback`) to `site/src/pages/words-of-the-day/practice.astro`.

### Deliverable B: Static Practice Asset Audit - Thin-deck Warnings
1. **Importing Thresholds:** Shared `THIN_WARN_THRESHOLDS` from `generate_practice_deck.py` to keep the single source of truth.
2. **Warning Emission:** Updated `check_static_practice_assets.py` to audit and print non-blocking warnings to `sys.stderr` when a level's mode falls below the thresholds, while keeping the exit status at `0` for warnings.

## Verification Evidence

### 1. Vitest Unit Tests
Run of `npx vitest run LexiconPractice.test.tsx` successfully passed 54 tests:
```
 ✓ tests/unit/LexiconPractice.test.tsx (54 tests) 6760ms
     ✓ paronym renders in mixed sessions and paronym focus mode 14ms
     ✓ paronym wrong choice scores again and shows explanation 4ms
     ✓ paronym correct answer scores good 4ms
     ✓ hides paronym mode card when the loaded deck has no paronym items 19ms
```

Full suite run completed successfully with `603 passed` (see tool output from task-152):
```
 Test Files  37 passed (37)
      Tests  603 passed (603)
   Start at  02:07:47
   Duration  110.33s
```

### 2. TypeScript Compilation Check
`tsc --noEmit` checks in `site/` passed cleanly on all components, interfaces, and test files:
`tsc` task ran successfully with exit status 0 on the files modified (the only warnings were unrelated pre-existing issues in packages).

### 3. Python Audit Tests
Ruff check and pytest runs for `check_static_practice_assets.py` passed successfully:
```
tests/test_check_static_practice_assets.py::test_thin_deck_warnings PASSED [100%]
============================== 13 passed in 0.23s ==============================
```
Pre-commit hook verified ruff formatting:
```
pre-commit: ruff check...
All checks passed!
```

X-Agent: agy (dispatch fix-4383-paronym-ui)
