### PR TITLE
fix(review): distinguish learner performance from supplied audio

### DIFF
--- a/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
+++ b/agents_extensions/shared/skills/post-build-review/config/track-policy.v1.yaml
@@ -1,7 +1,7 @@
 review_protocol_version: 2.0.1
 deterministic_contract_version: 1.2.0
 semantic_prompt_version: 2.0.0
-track_policy_version: 1.2.0
+track_policy_version: 1.2.1
 
 defaults:
   semantic_requirements:
@@ -21,7 +21,7 @@ defaults:
     evidence_requirements:
       - id: audio-dependent-task
         modality: audio
-        regex: '(?:слух\w*|чує\w*|почут\w*|прослух\w*|аудіо\w*|часов\w*\s+позначк\w*)'
+        regex: '(?:прослух(?:ай(?:те)?|овуванн\w*|ати|овуй\w*|овуват\w*)|слухай(?:те)?|аудіо\w*|часов\w*\s+позначк\w*|(?:ви|де|що)\s+чуєте\b|виразно\s+почут\w*\s+(?:слов|звук|нот|фраз|акорд)\w*)'
       - id: video-dependent-task
         modality: video
         regex: '(?:дивіться|переглян\w*|відео\w*|екранн\w*\s+момент\w*)'

--- a/curriculum/l2-uk-en/plans/folk/narodna-kultura-yak-systema.yaml
+++ b/curriculum/l2-uk-en/plans/folk/narodna-kultura-yak-systema.yaml
@@ -4,7 +4,7 @@ sequence: 1
 slug: narodna-kultura-yak-systema
 title: "Народна культура як система"
 subtitle: "Oral tradition as the foundation of written Ukrainian literature"
-version: 4
+version: 5
 status: locked
 phase: base-first
 cefr_min: C1
@@ -21,7 +21,7 @@ pedagogy:
   notes:
     - "Begin from a short primary text excerpt, then move to genre/system map."
     - "Keep Christian-heritage-first framing where the tradition is historically Christian; seasonal imagery is read as poetics in genre context."
-    - "Do not publish module until hosted readings are cleaned or created with public source_url frontmatter."
+    - "Publish only with cleaned hosted readings that expose public source_url frontmatter."
 content_outline:
   - section: "Постановка проблеми"
     words: 550
@@ -116,7 +116,7 @@ readings:
     source: "Народна творчість. УкрЛіб."
     source_url: "https://www.ukrlib.com.ua/narod/printout.php?id=6&bookid=1"
     license: public_domain
-    hosting: needs-clean-hosted-reading
+    hosting: hosted
     reading_slug: "shchedrivka-oi-syvaia-ta-i-zozulechka"
   - title: "Ой весна, весна, ти красна"
     title_en: "Oh Spring, Beautiful Spring"
@@ -126,7 +126,7 @@ readings:
     source: "Народна творчість. УкрЛіб."
     source_url: "https://www.ukrlib.com.ua/narod/printout.php?id=0&bookid=0"
     license: public_domain
-    hosting: needs-clean-hosted-reading
+    hosting: hosted
     reading_slug: "vesnianka-oi-vesna-vesna-ty-krasna"
   - title: "Втеча трьох братів з города Азова, з турецької неволі"
     title_en: "The Escape of Three Brothers from Azov"
@@ -136,7 +136,7 @@ readings:
     source: "Народна творчість. УкрЛіб."
     source_url: "https://www.ukrlib.com.ua/narod/printout.php?id=11&bookid=1"
     license: public_domain
-    hosting: needs-clean-hosted-reading
+    hosting: hosted
     reading_slug: "duma-vtecha-trokh-brativ-z-azova"
   - title: "Пісня про Байду"
     title_en: "The Song about Baida"
@@ -160,6 +160,9 @@ connects_to:
   - folk-010-dumy-nevilnytski-lytsarski
   - folk-014-istorychni-pisni
 changelog:
+  - version: 5
+    date: "2026-07-14"
+    note: "Post-build review: align reading hosting metadata with the four published canonical reading pages."
   - version: 4
     date: "2026-07-14"
     note: "Post-build repair: replace five bare sequence links with canonical FOLK module IDs."

--- a/tests/audit/test_post_build_review.py
+++ b/tests/audit/test_post_build_review.py
@@ -690,6 +690,23 @@ def test_maiboroda_regression_inventories_audio_dependent_tasks() -> None:
     assert any("module.md" in item["location"] for item in audio)
 
 
+def test_folk_productive_performance_is_not_supplied_audio_evidence() -> None:
+    target = pbr.resolve_target("folk/narodna-kultura-yak-systema")
+    policy = pbr.resolve_track_policy("folk", pbr.load_track_policy())
+    texts = pbr._learner_surface_texts(target)
+
+    assert "show_record_button: true" in next(
+        text for path, text in texts.items() if path.endswith("activities.yaml")
+    )
+
+    requirements = pbr.inventory_evidence_requirements(
+        texts,
+        policy["mechanical_checks"]["evidence_requirements"],
+    )
+
+    assert requirements == []
+
+
 def test_audio_evidence_requires_matching_reviewer_capability() -> None:
     semantic = {
         "verdict": "PASS",
@@ -887,7 +904,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
     catalog = yaml.safe_load(REGRESSIONS.read_text(encoding="utf-8"))
     rows = catalog["regressions"]
     assert catalog["catalog_version"] == "2.0.1"
-    assert len(rows) == 24
+    assert len(rows) == 25
     assert len({row["bug_id"] for row in rows}) == len(rows)
     assert {row["responsible_layer"] for row in rows} == {
         "deterministic_code",
@@ -902,6 +919,7 @@ def test_regression_catalog_covers_every_discovered_layer() -> None:
         "1.0.1",
         "1.1.0",
         "1.2.0",
+        "1.2.1",
         "2.0.0",
         "2.0.1",
     }

--- a/tests/fixtures/post_build_review/bio-oleksandr-bilash.result.v2.json
+++ b/tests/fixtures/post_build_review/bio-oleksandr-bilash.result.v2.json
@@ -21,213 +21,45 @@
     },
     "evidence_requirements": [
       {
-        "evidence": "слухання",
-        "id": "audio-dependent-task-1",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:5",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слух",
-        "id": "audio-dependent-task-2",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:11",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слуховий",
-        "id": "audio-dependent-task-3",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:13",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слуху",
-        "id": "audio-dependent-task-4",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:15",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слуху",
-        "id": "audio-dependent-task-5",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:17",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слухом",
-        "id": "audio-dependent-task-6",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:21",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слух",
-        "id": "audio-dependent-task-7",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:23",
-        "modality": "audio"
-      },
-      {
-        "evidence": "чує",
-        "id": "audio-dependent-task-8",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:33",
-        "modality": "audio"
-      },
-      {
         "evidence": "слухайте",
-        "id": "audio-dependent-task-9",
+        "id": "audio-dependent-task-1",
         "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:41",
         "modality": "audio"
       },
       {
-        "evidence": "Слухач",
-        "id": "audio-dependent-task-10",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:43",
-        "modality": "audio"
-      },
-      {
-        "evidence": "почуте",
-        "id": "audio-dependent-task-11",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:47",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слухача",
-        "id": "audio-dependent-task-12",
+        "evidence": "часові позначки",
+        "id": "audio-dependent-task-2",
         "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:51",
         "modality": "audio"
       },
       {
-        "evidence": "слухаєте",
-        "id": "audio-dependent-task-13",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:55",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слухання",
-        "id": "audio-dependent-task-14",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:57",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слухацької",
-        "id": "audio-dependent-task-15",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:59",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слухачів",
-        "id": "audio-dependent-task-16",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:73",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слухання",
-        "id": "audio-dependent-task-17",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:77",
-        "modality": "audio"
-      },
-      {
-        "evidence": "почуття",
-        "id": "audio-dependent-task-18",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:79",
-        "modality": "audio"
-      },
-      {
         "evidence": "Часова позначка",
-        "id": "audio-dependent-task-19",
+        "id": "audio-dependent-task-3",
         "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:87",
         "modality": "audio"
       },
       {
-        "evidence": "почути",
-        "id": "audio-dependent-task-20",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:91",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слухацьких",
-        "id": "audio-dependent-task-21",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:93",
-        "modality": "audio"
-      },
-      {
         "evidence": "часовими позначками",
-        "id": "audio-dependent-task-22",
+        "id": "audio-dependent-task-4",
         "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:95",
         "modality": "audio"
       },
       {
-        "evidence": "слухач",
-        "id": "audio-dependent-task-23",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:97",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слухацьке",
-        "id": "audio-dependent-task-24",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/module.md:100",
-        "modality": "audio"
-      },
-      {
         "evidence": "часову позначку",
-        "id": "audio-dependent-task-25",
+        "id": "audio-dependent-task-5",
         "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/activities.yaml:19",
         "modality": "audio"
       },
       {
-        "evidence": "чує",
-        "id": "audio-dependent-task-26",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/activities.yaml:20",
-        "modality": "audio"
-      },
-      {
-        "evidence": "почуте",
-        "id": "audio-dependent-task-27",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/activities.yaml:30",
-        "modality": "audio"
-      },
-      {
         "evidence": "часовими позначками",
-        "id": "audio-dependent-task-28",
+        "id": "audio-dependent-task-6",
         "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/activities.yaml:43",
         "modality": "audio"
       },
       {
         "evidence": "часові позначки",
-        "id": "audio-dependent-task-29",
+        "id": "audio-dependent-task-7",
         "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/activities.yaml:49",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слух",
-        "id": "audio-dependent-task-30",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/activities.yaml:58",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слухання",
-        "id": "audio-dependent-task-31",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/activities.yaml:59",
-        "modality": "audio"
-      },
-      {
-        "evidence": "чує",
-        "id": "audio-dependent-task-32",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/activities.yaml:87",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слухачів",
-        "id": "audio-dependent-task-33",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/activities.yaml:114",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слухачів",
-        "id": "audio-dependent-task-34",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/activities.yaml:123",
-        "modality": "audio"
-      },
-      {
-        "evidence": "слухацьке",
-        "id": "audio-dependent-task-35",
-        "location": "curriculum/l2-uk-en/bio/oleksandr-bilash/vocabulary.yaml:41",
         "modality": "audio"
       }
     ],
@@ -472,8 +304,8 @@
       "source": "semantic"
     }
   ],
-  "prompt_sha256": "f48057421a91997fd9408d3d2ddf1467c5cf611f551b4ff7f61251eca87ba7cb",
-  "reproducibility_key": "5800e00c8c203dd3d2c75fbb15a4f7948d4452584c61c53d5555fcbbbafec919",
+  "prompt_sha256": "b22e0640dfdf2e632e72d6e8b26fcf2c0faaeffe80e320b5b050d2eba9006061",
+  "reproducibility_key": "88c3397306788288d77f1358544c9741f38b82ade90017099886513a9743f708",
   "review_protocol_version": "2.0.1",
   "reviewer": {
     "agent": "fixture",
@@ -553,5 +385,5 @@
     "slug": "oleksandr-bilash",
     "track": "bio"
   },
-  "track_policy_version": "1.2.0"
+  "track_policy_version": "1.2.1"
 }

--- a/tests/fixtures/post_build_review/regressions.v1.yaml
+++ b/tests/fixtures/post_build_review/regressions.v1.yaml
@@ -137,3 +137,9 @@ regressions:
     version_field: review_protocol_version
     input: Two reviews prepare and finalize concurrently for different module targets.
     expected: Each invocation receives a distinct run directory whose packet, exact semantic response, and result cannot cross targets.
+  - bug_id: folk-productive-performance-misclassified-as-supplied-audio
+    responsible_layer: track_policy
+    fixed_in_version: 1.2.1
+    version_field: track_policy_version
+    input: Descriptive prose about listeners plus a learner-created vocal performance with show_record_button metadata.
+    expected: No supplied-audio requirement; productive-task metadata never proves media access, while explicit listening and timestamp tasks remain inventoried.


### PR DESCRIPTION
## Summary

- narrow the FOLK post-build audio-dependency detector so ordinary Ukrainian prose and learner-created recording tasks do not fabricate supplied-audio requirements
- add a repository-backed regression proving `show_record_button: true` is productive metadata, not media-access evidence
- regenerate the canonical BIO golden under track policy 1.2.1 and record the regression in the catalog
- update FOLK-001 plan hosting metadata after directly verifying all four published canonical reading pages

## Root cause and protocol evidence

The prior detector matched broad stems such as `слух*`, `чує*`, and `почут*`. That misclassified ordinary words such as `слухачів`, `чується`, and `почуттів`, and it treated a learner-created vocal recording as supplied audio.

Malformed semantic output was not repaired or normalized: the response that declared 32 claims but contained 35 was preserved and finalized as schema-v2 `INCOMPLETE` with an explicit `semantic-response-integrity` finding. A separate exact raw reviewer response then passed strict parsing.

Final isolated review:
- schema: `post-build-review.result.v2`
- disposition: `PASS`
- protocol/policy: `2.0.1` / `1.2.1`
- deterministic evidence requirements: none
- semantic coverage: 35/35 supported; 7 directly inspected text evidence entries; 0 findings
- raw response SHA-256: `7a0a11126566c369c0f77c2c7b8fad99ed558d2726ed526edcdb86c7e4dc8074`
- reproducibility key: `9efbc7bc7bca431937c495c94aa0cb938a11d7b5d92dec535a0ca6b90f6a5b03`

## Independent review gate

Claude Sonnet independently reviewed live HEAD `15c4a7956d` through task `review-5105-cross-family-final`: **APPROVE — no unresolved material findings**. It rechecked the five-file diff and load-bearing protocol claims read-only rather than relying on this report.

## Verification

- `.venv/bin/python -m pytest tests/audit/test_post_build_review.py -q` — 50 passed
- `.venv/bin/python -m pytest tests/test_deploy_script_idempotency.py -q` — 14 passed
- `.venv/bin/ruff check tests/audit/test_post_build_review.py` — passed
- `.venv/bin/python scripts/lint/lint_agent_skills.py` — passed
- canonical skill quick validation — passed
- `bash scripts/check_rules_deployment.sh` — passed
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` — passed
- `git diff --check origin/main...HEAD` — passed
- complete isolated `post_build_review.py validate` — passed

Fixes #5105
