### PR TITLE
feat(practice): report per-CEFR mode coverage in static asset checker

### DIFF
--- a/scripts/audit/check_static_practice_assets.py
+++ b/scripts/audit/check_static_practice_assets.py
@@ -75,6 +75,7 @@ MODE_BODY_KEYS = {
 }
 DRILL_MODES = ("stress", "classify", "paradigm", "synonym", "heritage", "paronym")
 MODE_SHARD_KINDS = ("cloze", *DRILL_MODES)
+COVERAGE_MODES = MODE_SHARD_KINDS
 
 
 def _read_json(path: Path, errors: list[str]) -> Any:
@@ -528,7 +529,52 @@ def _check_level(
         **{kind: len(rows) for kind, rows in mode_items.items() if isinstance(rows, list)},
         "deck_versions": sorted(versions),
         "lexeme_ids": frozenset(lexeme_by_id),
+        "mode_coverage": dict(mode_coverage),
     }
+
+
+def _build_coverage(
+    practice: dict[str, dict[str, Any]],
+    levels: tuple[str, ...],
+) -> dict[str, Any]:
+    level_rows: dict[str, dict[str, dict[str, Any]]] = {}
+    for level in levels:
+        mode_coverage = practice.get(level, {}).get("mode_coverage", {})
+        if not isinstance(mode_coverage, dict):
+            mode_coverage = {}
+        cells: dict[str, dict[str, Any]] = {}
+        for mode in COVERAGE_MODES:
+            ratio = float(mode_coverage.get(mode, 0.0))
+            threshold = THIN_WARN_THRESHOLDS.get(mode)
+            cells[mode] = {
+                "ratio": ratio,
+                "pct": round(ratio * 100, 1),
+                "thin": threshold is not None and ratio < threshold,
+            }
+        level_rows[level] = cells
+    return {
+        "modes": list(COVERAGE_MODES),
+        "levels": level_rows,
+    }
+
+
+def _format_coverage_table(coverage: dict[str, Any]) -> str:
+    modes: list[str] = coverage["modes"]
+    level_rows: dict[str, dict[str, dict[str, Any]]] = coverage["levels"]
+    header = " " * 6 + "".join(f"{mode:>9}" for mode in modes)
+    lines = ["Practice mode coverage (% of lexemes):", header]
+    for level, row in level_rows.items():
+        cells = []
+        for mode in modes:
+            cell = row[mode]
+            label = f"{cell['pct']:5.1f}%"
+            if cell["thin"]:
+                label += "*"
+            cells.append(f"{label:>9}")
+        lines.append(f"  {level}  " + "".join(cells))
+    if any(cell["thin"] for row in level_rows.values() for cell in row.values()):
+        lines.append("* below thin-deck warning threshold")
+    return "\n".join(lines)
 
 
 def check_assets(
@@ -577,12 +623,17 @@ def check_assets(
     if total_cloze and not reviewed:
         errors.append(f"{reviewed_sources}: cloze shards are nonempty but reviewed allowlist is empty")
 
+    coverage = _build_coverage(practice, levels)
+    for level_row in practice.values():
+        level_row.pop("mode_coverage", None)
+
     return {
         "ok": not errors,
         "errors": errors,
         "warnings": warnings,
         "daily": daily,
         "practice": practice,
+        "coverage": coverage,
         "reviewed_sources": len(reviewed),
         "total_cloze": total_cloze,
         "deck_versions": sorted(deck_versions),
@@ -611,6 +662,7 @@ def _print_summary(summary: dict[str, Any]) -> None:
             f"  {level}: index={row['index']} lexemes={row['lexemes']} "
             f"cloze={row['cloze']} {mode_counts}"
         )
+    print(_format_coverage_table(summary["coverage"]))
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_check_static_practice_assets.py
+++ b/tests/test_check_static_practice_assets.py
@@ -587,3 +587,70 @@ def test_thin_deck_warnings(tmp_path: Path) -> None:
     assert summary["ok"] is True
     assert any("A1 synonym coverage 0.0000 is below thin-deck threshold 0.05" in warning for warning in summary["warnings"])
     assert any("A1 paronym coverage 0.0000 is below thin-deck threshold 0.01" in warning for warning in summary["warnings"])
+
+
+def test_check_assets_summary_includes_coverage_structure(tmp_path: Path) -> None:
+    daily_pool, practice_dir, reviewed_sources = _fixture_paths(tmp_path)
+    _write_level(practice_dir, level="A2")
+    index_path = practice_dir / "practice-index.A2.json"
+    index_payload = json.loads(index_path.read_text(encoding="utf-8"))
+    index_payload["counts"]["modeCoverage"]["cloze"] = 0.5
+    index_payload["counts"]["modeCoverage"]["synonym"] = 0.08
+    _write_json(index_path, index_payload)
+
+    summary = check_assets(
+        daily_pool=daily_pool,
+        practice_dir=practice_dir,
+        reviewed_sources=reviewed_sources,
+        levels=("A1", "A2"),
+        min_daily_pool_size=2,
+        min_practice_lexemes_per_level=1,
+    )
+
+    coverage = summary["coverage"]
+    assert coverage["modes"] == [
+        "cloze",
+        "stress",
+        "classify",
+        "paradigm",
+        "synonym",
+        "heritage",
+        "paronym",
+    ]
+    assert coverage["levels"]["A1"]["cloze"] == {"ratio": 0.0, "pct": 0.0, "thin": True}
+    assert coverage["levels"]["A1"]["synonym"] == {"ratio": 0.0, "pct": 0.0, "thin": True}
+    assert coverage["levels"]["A1"]["heritage"] == {"ratio": 0.0, "pct": 0.0, "thin": True}
+    assert coverage["levels"]["A2"]["cloze"] == {"ratio": 0.5, "pct": 50.0, "thin": False}
+    assert coverage["levels"]["A2"]["synonym"] == {"ratio": 0.08, "pct": 8.0, "thin": False}
+
+
+def test_cli_prints_coverage_table(tmp_path: Path) -> None:
+    daily_pool, practice_dir, reviewed_sources = _fixture_paths(tmp_path)
+
+    result = subprocess.run(
+        [
+            ".venv/bin/python",
+            "scripts/audit/check_static_practice_assets.py",
+            "--daily-pool",
+            str(daily_pool),
+            "--practice-dir",
+            str(practice_dir),
+            "--reviewed-sources",
+            str(reviewed_sources),
+            "--levels",
+            "A1",
+            "--min-daily-pool-size",
+            "2",
+            "--min-practice-lexemes-per-level",
+            "1",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Practice mode coverage (% of lexemes):" in result.stdout
+    assert "cloze" in result.stdout and "synonym" in result.stdout
+    assert "0.0%*" in result.stdout
+    assert "* below thin-deck warning threshold" in result.stdout


### PR DESCRIPTION
## Summary

- Extend `scripts/audit/check_static_practice_assets.py` to emit a human-readable **practice mode coverage** table (rows = CEFR levels, columns = modes, cells = `%` from `counts.modeCoverage`) with `*` on thin-threshold cells.
- Add structured `coverage` key to `--format json` output for machine consumption.
- Exit-code semantics unchanged: coverage is informational; existing thin-deck warnings stay non-blocking on stderr.

Refs #4383 — closes the final acceptance checkbox (coverage % per CEFR reported).

## CI hook

Runs in `.github/workflows/ci.yml` step **"Check static Word Day / practice assets (#3935)"**:
`python scripts/audit/check_static_practice_assets.py`

## Verification

### pytest

```
$ .venv/bin/pytest tests/test_check_static_practice_assets.py -q
============================= test session starts ==============================
platform darwin -- Python 3.12.8, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/cursor/fix-4383-coverage-report
configfile: pyproject.toml
plugins: cov-7.1.0, anyio-4.14.1, xdist-3.8.0
collected 15 items

tests/test_check_static_practice_assets.py ...............               [100%]

============================== 15 passed in 0.54s ==============================
```

### ruff

```
$ .venv/bin/ruff check scripts/audit/check_static_practice_assets.py
All checks passed!
```

## Test plan

- [x] `test_check_assets_summary_includes_coverage_structure` — JSON `coverage` levels/modes/ratios/thin flags
- [x] `test_cli_prints_coverage_table` — stdout table with `*` markers
- [x] Existing thin-deck warning tests still pass (15/15)


Made with [Cursor](https://cursor.com)