### PR TITLE
fix(lexicon): emit browse artifacts in generate_search_index --db mode

### DIFF
--- a/scripts/audit/generate_search_index.py
+++ b/scripts/audit/generate_search_index.py
@@ -349,6 +349,143 @@ def _site_build_entry_model_gates(conn: sqlite3.Connection) -> None:
         )
 
 
+def _primary_source_for_slug(conn: sqlite3.Connection, slug: str) -> str | None:
+    families = [
+        row[0]
+        for row in conn.execute(
+            "SELECT source_family FROM article_provenance WHERE slug = ? ORDER BY rowid",
+            (slug,),
+        )
+        if row[0]
+    ]
+    if _SURZHYK_SOURCE in families:
+        return _SURZHYK_SOURCE
+    return families[0] if families else None
+
+
+def _heritage_status_for_slug(
+    conn: sqlite3.Connection,
+    slug: str,
+    *,
+    heritage_classification: str | None,
+) -> Mapping[str, Any]:
+    row = conn.execute(
+        "SELECT payload_json FROM enrichment WHERE slug = ? AND section = 'heritage_status'",
+        (slug,),
+    ).fetchone()
+    if row is not None:
+        payload = json.loads(row[0])
+        if isinstance(payload, dict):
+            if heritage_classification and not payload.get("classification"):
+                return {**payload, "classification": heritage_classification}
+            return payload
+    if heritage_classification:
+        return {"classification": heritage_classification}
+    return {}
+
+
+def browse_rows_from_db_articles(
+    articles: list[dict[str, Any]],
+    db_path: Path,
+) -> list[dict[str, Any]]:
+    """Attach browse ``cls`` codes to DB article rows using stored heritage/provenance."""
+
+    conn = sqlite3.connect(db_path)
+    try:
+        heritage_by_slug = {
+            slug: heritage_classification
+            for slug, heritage_classification in conn.execute(
+                "SELECT slug, heritage_classification FROM articles"
+            )
+        }
+        browse_rows: list[dict[str, Any]] = []
+        for row in articles:
+            slug = str(row["s"])
+            pseudo_entry = {
+                "primary_source": _primary_source_for_slug(conn, slug),
+                "heritage_status": _heritage_status_for_slug(
+                    conn,
+                    slug,
+                    heritage_classification=_clean_text(heritage_by_slug.get(slug)),
+                ),
+            }
+            browse_row = dict(row)
+            cls = classification_code(pseudo_entry)
+            if cls:
+                browse_row["cls"] = cls
+            browse_rows.append(browse_row)
+        return browse_rows
+    finally:
+        conn.close()
+
+
+def guard_browse_staleness(
+    browse_meta_out: Path,
+    reviewed_article_count: int,
+    *,
+    will_refresh_browse: bool,
+) -> None:
+    """Fail loudly when search would advance but browse artifacts would stay pinned."""
+
+    if will_refresh_browse or not browse_meta_out.is_file():
+        return
+    try:
+        existing = json.loads(browse_meta_out.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return
+    existing_total = existing.get("total")
+    if isinstance(existing_total, int) and existing_total < reviewed_article_count:
+        raise SystemExit(
+            "browse-meta stale: "
+            f"{existing_total} browse records pinned while DB has "
+            f"{reviewed_article_count} reviewed articles; refusing to refresh search "
+            "index without also refreshing browse artifacts"
+        )
+
+
+def verify_browse_artifacts_written(
+    meta_out: Path,
+    browse_dir: Path,
+    expected_total: int,
+) -> None:
+    """Fail loudly when browse outputs were not written or do not match the build."""
+
+    if not meta_out.is_file():
+        raise SystemExit(f"browse-meta not written: {meta_out}")
+    meta = json.loads(meta_out.read_text(encoding="utf-8"))
+    actual_total = meta.get("total")
+    if actual_total != expected_total:
+        raise SystemExit(
+            "browse-meta total mismatch after write: "
+            f"expected {expected_total}, got {actual_total!r}"
+        )
+    letter_counts = meta.get("letterCounts")
+    if not isinstance(letter_counts, dict):
+        raise SystemExit("browse-meta missing letterCounts after write")
+    shard_total = sum(int(letter_counts.get(letter, 0)) for letter in UKRAINIAN_ALPHABET)
+    if shard_total != expected_total:
+        raise SystemExit(
+            "browse-meta letterCounts sum mismatch after write: "
+            f"expected {expected_total}, got {shard_total}"
+        )
+    for letter in UKRAINIAN_ALPHABET:
+        count = int(letter_counts.get(letter, 0))
+        shard_path = browse_dir / f"{letter}.json"
+        if count == 0:
+            if shard_path.exists():
+                raise SystemExit(
+                    f"browse shard {shard_path} must not exist when letterCounts[{letter!r}] is 0"
+                )
+            continue
+        if not shard_path.is_file():
+            raise SystemExit(f"browse shard missing for letter {letter!r}: {shard_path}")
+        shard_rows = json.loads(shard_path.read_text(encoding="utf-8"))
+        if len(shard_rows) != count:
+            raise SystemExit(
+                f"browse shard {letter!r} count mismatch: meta={count}, file={len(shard_rows)}"
+            )
+
+
 def build_atlas_db_search_artifacts(
     db_path: Path,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, int]]:
@@ -606,6 +743,14 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.db is not None:
         rows, aliases, counts = build_atlas_db_search_artifacts(args.db)
+        reviewed_count = counts["reviewed_entries"]
+        guard_browse_staleness(
+            args.browse_meta_out,
+            reviewed_count,
+            will_refresh_browse=True,
+        )
+        browse_rows = browse_rows_from_db_articles(rows, args.db)
+        meta, browse_shards, flagged_rows = build_browse_outputs(browse_rows)
         search_shards, search_shard_rows = build_search_shards(rows)
         write_index(rows, args.out)
         write_aliases(aliases, args.aliases_out)
@@ -615,12 +760,22 @@ def main(argv: list[str] | None = None) -> int:
             args.search_shards_out,
             args.search_shard_dir,
         )
+        write_browse_outputs(
+            meta,
+            browse_shards,
+            flagged_rows,
+            args.browse_meta_out,
+            args.browse_flagged_out,
+            args.browse_dir,
+        )
+        verify_browse_artifacts_written(args.browse_meta_out, args.browse_dir, meta["total"])
         print(
             "atlas search artifacts: "
             f"reviewed_articles={counts['reviewed_entries']} "
             f"public_alias_records={counts['public_alias_records']} "
             f"emitted_aliases={counts['emitted_aliases']} "
-            f"alias_deduplication={counts['deduplicated_aliases']}"
+            f"alias_deduplication={counts['deduplicated_aliases']} "
+            f"browse_records={meta['total']}"
         )
         return 0
 

--- a/tests/test_generate_search_index.py
+++ b/tests/test_generate_search_index.py
@@ -16,6 +16,7 @@ from scripts.audit.generate_search_index import (
     build_browse_outputs,
     build_index,
     classification_code,
+    guard_browse_staleness,
     main,
 )
 
@@ -398,3 +399,81 @@ def test_legacy_run_refuses_to_overwrite_article_index(tmp_path, monkeypatch) ->
         ]
     )
     assert rc == 0
+
+
+def test_db_mode_writes_browse_artifacts(tmp_path: Path) -> None:
+    db = atlas_db_fixture(tmp_path)
+    search_out = tmp_path / "search.json"
+    aliases_out = tmp_path / "aliases.json"
+    search_shards_out = tmp_path / "search-shards.json"
+    meta_out = tmp_path / "browse-meta.json"
+    flagged_out = tmp_path / "browse-flagged.json"
+    browse_dir = tmp_path / "browse"
+
+    assert (
+        main(
+            [
+                "--db",
+                str(db),
+                "--out",
+                str(search_out),
+                "--aliases-out",
+                str(aliases_out),
+                "--search-shards-out",
+                str(search_shards_out),
+                "--browse-meta-out",
+                str(meta_out),
+                "--browse-flagged-out",
+                str(flagged_out),
+                "--browse-dir",
+                str(browse_dir),
+            ]
+        )
+        == 0
+    )
+
+    _, _, counts = build_atlas_db_search_artifacts(db)
+    meta = json.loads(meta_out.read_text(encoding="utf-8"))
+    flagged = json.loads(flagged_out.read_text(encoding="utf-8"))
+    search_rows = json.loads(search_out.read_text(encoding="utf-8"))
+
+    assert counts["reviewed_entries"] == 2
+    assert len(search_rows) == 2
+    assert meta["schema"] == "atlas-browse-meta"
+    assert meta["total"] == 2
+    assert meta["letterCounts"]["А"] == 1
+    assert meta["letterCounts"]["І"] == 1
+    assert flagged == []
+    assert json.loads((browse_dir / "А.json").read_text(encoding="utf-8")) == [
+        {
+            "l": "автобус",
+            "s": "автобус",
+            "g": "bus",
+            "c": None,
+            "hay": "автобус bus avtobus",
+        },
+    ]
+    assert json.loads((browse_dir / "І.json").read_text(encoding="utf-8")) == [
+        {
+            "l": "Іван",
+            "s": "іван",
+            "g": "Ivan",
+            "c": None,
+            "hay": "іван ivan ivan",
+        },
+    ]
+
+
+def test_browse_staleness_guard_fires_when_browse_would_stay_pinned(tmp_path: Path) -> None:
+    stale_meta = tmp_path / "browse-meta.json"
+    stale_meta.write_text(json.dumps({"total": 1}), encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="browse-meta stale"):
+        guard_browse_staleness(stale_meta, reviewed_article_count=5, will_refresh_browse=False)
+
+
+def test_browse_staleness_guard_allows_refresh_when_browse_will_be_rewritten(tmp_path: Path) -> None:
+    stale_meta = tmp_path / "browse-meta.json"
+    stale_meta.write_text(json.dumps({"total": 1}), encoding="utf-8")
+
+    guard_browse_staleness(stale_meta, reviewed_article_count=5, will_refresh_browse=True)


### PR DESCRIPTION
## Summary

- **Root cause:** `generate_search_index.py` `--db` branch wrote search index, aliases, and shards then `return 0` before `build_browse_outputs` / `write_browse_outputs`, so `npm run hydrate` → `atlas:build-search` never refreshed browse artifacts (#4941 / #4936 blast radius).
- **Fix:** `--db` mode now derives browse rows from DB article heritage/provenance, writes `lexicon-browse-meta.json`, `lexicon-browse-flagged.json`, and `site/public/lexicon/browse/*.json`, then verifies on-disk totals match the build via `verify_browse_artifacts_written`. `guard_browse_staleness(..., will_refresh_browse=False)` fails loudly if a regression ever refreshes search without browse.
- **Tests:** `test_db_mode_writes_browse_artifacts` (fixture db) + staleness guard tests.

## Deterministic verification (#M-4)

**pytest** (13 passed):
```
tests/test_generate_search_index.py .............                        [100%]
============================== 13 passed in 1.04s ==============================
```

**ruff:**
```
All checks passed!
```

**CLI `--db` run** (fixture db — `data/atlas.db` absent in sparse worktree):
```
atlas search artifacts: reviewed_articles=2 public_alias_records=3 emitted_aliases=3 alias_deduplication=0 browse_records=2
exit 0
{"schema":"atlas-browse-meta","schemaVersion":1,"total":2,"letterCounts":{"А":1,...,"І":1,...}
shards ['І.json', 'А.json']
```

## Richness audit diagnostic (196 search entries, report only)

Ran `.venv/bin/python scripts/audit/audit_atlas_poc_richness.py --max-search-no-visible-gloss 0 --max-old-gate-no-english-anchor 0 --max-poc-thin-pages 900`. Result: **196 search entries with no visible English gloss/anchor** — identical counts for both `search_no_visible_gloss` and `old_gate_no_english_anchor`. This is a **separate manifest content gap**, not browse-artifact staleness: the audit walks `site/src/data/lexicon-manifest.json` entries via `search_has_visible_gloss()` / `has_learner_english_anchor()`, flagging old-gate-enriched lemma articles that lack both a top-level `gloss` and `enrichment.translation.en`. Top sources: `content_lexicon_grow` (300), `built_vocabulary` (370), `source_inventory_grow` (50). Samples (`бажане`, `відмикати`, `вітамінізація`) show `gloss=False english=False` with 2–6 rich sections present — enrichment exists but no learner-facing English anchor for typeahead. Unrelated to #4941’s silent browse-meta pin (which left browse totals behind DB article counts without updating shard files).

## Test plan

- [x] `.venv/bin/pytest tests/test_generate_search_index.py -q`
- [x] `.venv/bin/ruff check scripts/audit/generate_search_index.py tests/test_generate_search_index.py`
- [x] CLI `--db` fixture run writes browse-meta + letter shards
- [ ] Independent cross-family review (not self-merge)

Refs #4941

Made with [Cursor](https://cursor.com)