### PR TITLE
fix(lexicon): carry over antonym SUM-20/ВТС annotations when offline (Refs #5121)

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -80,6 +80,7 @@ from scripts.lexicon.lemma_normalization import strip_acute_stress
 from scripts.lexicon.load_relation_candidates import load_approved_synonym_verdicts
 from scripts.lexicon.manifest_fingerprint import DEFAULT_FINGERPRINT, write_fingerprint
 from scripts.lexicon.manifest_io import (
+    GATE_ANNOTATIONS_CARRIED,
     GATE_REJECTED,
     GATE_SKIPPED_OFFLINE,
 )
@@ -5360,6 +5361,88 @@ def _resolve_gated_section(
     return resolved, (GATE_SKIPPED_OFFLINE if resolved else None)
 
 
+# #5121 — antonym pointer ANNOTATIONS (the СУМ-20/ВТС "протилежне → X" source segments
+# plus their source_urls) come from the per-lemma slovnyk cache slugs below. Item
+# MEMBERSHIP is Вікісловник + local-db and offline-safe, so its gate always runs; the
+# annotation augmentation is NOT — an offline run with a cold cache recomputes the same
+# items without their published annotation pointers. This is the #5077 preserve contract
+# applied one level down, at annotation granularity, with membership left untouched.
+_SLOVNYK_ANTONYM_ANNOTATION_SLUGS = ("newsum", "vts")
+
+
+def _annotation_segment_item(segment: str) -> str | None:
+    """Canonical item a rendered pointer-annotation ``source`` segment points at.
+
+    Pointer segments render as ``"<dict>: <pattern> → <item>[ (reciprocal)][ [gate: …]]"``
+    (see :func:`_relation_source_label`). The base Вікісловник label carries no ``→`` and
+    is not a pointer annotation, so it returns ``None`` — only per-item pointer segments
+    are carry-over candidates.
+    """
+    marker = " → "
+    idx = segment.rfind(marker)
+    if idx == -1:
+        return None
+    tail = segment[idx + len(marker) :]
+    for cut in (" (reciprocal)", " [gate:"):
+        pos = tail.find(cut)
+        if pos != -1:
+            tail = tail[:pos]
+    # Key it exactly as _section_item_keys keys the rendered items so both sides of the
+    # membership match normalize identically (base word, stress-stripped, casefolded).
+    return _section_item_key(tail.strip())
+
+
+def _carry_over_pointer_annotations(
+    new_section: dict[str, Any] | None,
+    baseline_section: dict[str, Any] | None,
+    *,
+    gate_ran: bool,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Carry a baseline section's pointer annotations forward when the annotation
+    source could not be consulted this run (#5121).
+
+    Item MEMBERSHIP is untouched — ``new_section`` already holds the offline-safe items
+    computed from local sources. Only the secondary annotation layer is restored, and only
+    per-item: a baseline pointer segment is carried iff its item survives in ``new_section``
+    (match by canonical term), so an item absent from the baseline gains no phantom
+    annotation. Returns ``(section, provenance_or_None)``; provenance is ``None`` whenever
+    nothing was carried, keeping a normal run's diff minimal.
+    """
+    if gate_ran or not new_section or not isinstance(baseline_section, dict):
+        return new_section, None
+    new_keys = _section_item_keys(new_section)
+    existing_segments = {
+        seg.strip()
+        for seg in str(new_section.get("source") or "").split(" + ")
+        if seg.strip()
+    }
+    carried_segments: list[str] = []
+    for raw in str(baseline_section.get("source") or "").split(" + "):
+        seg = raw.strip()
+        if not seg or seg in existing_segments or seg in carried_segments:
+            continue
+        item_key = _annotation_segment_item(seg)
+        if item_key is None or item_key not in new_keys:
+            continue  # base label, or a pointer at a non-member item — no phantom carry
+        carried_segments.append(seg)
+    if not carried_segments:
+        return new_section, None
+    resolved = dict(new_section)
+    base_source = str(resolved.get("source") or "").strip()
+    resolved["source"] = " + ".join(part for part in (base_source, *carried_segments) if part)
+    # source_urls are per-(dictionary, lemma), shared across a source's items, not per-item;
+    # membership is protected so every carried item's source survives — carry the baseline
+    # annotation URLs the fresh recompute lacks (its own Вікісловник URL already dedups out).
+    urls = [str(url) for url in resolved.get("source_urls", []) if str(url).strip()]
+    for raw_url in baseline_section.get("source_urls") or []:
+        url = str(raw_url).strip()
+        if url and url not in urls:
+            urls.append(url)
+    if urls:
+        resolved["source_urls"] = list(dict.fromkeys(urls))
+    return resolved, GATE_ANNOTATIONS_CARRIED
+
+
 def _ordered_sections(
     sections: dict[str, object], baseline: dict[str, Any]
 ) -> dict[str, object]:
@@ -5499,9 +5582,24 @@ def enrich_entry(
         )
     )
     antonyms = _merge_antonym_relations(antonyms, antonym_relations)
-    # Antonyms are Вікісловник + lexicographer-pointer driven (local db); the gate
-    # always runs, so authoritative local retractions apply even offline (finding 2).
+    # #5121: item membership is Вікісловник + local-db (offline-safe, gate always runs),
+    # but the СУМ-20/ВТС pointer ANNOTATIONS ride the per-lemma slovnyk cache. When that
+    # cache could not be consulted (offline + no newsum/vts slug), carry the published
+    # pointer annotations forward per-item rather than silently dropping them; online or
+    # cache-present the fresh recompute wins and nothing is carried.
+    antonym_annotation_gate_ran = _slovnyk_gate_ran(
+        slovnyk_cache, _SLOVNYK_ANTONYM_ANNOTATION_SLUGS
+    )
+    antonyms, antonym_annotation_outcome = _carry_over_pointer_annotations(
+        antonyms, baseline_sections.get("antonyms"), gate_ran=antonym_annotation_gate_ran
+    )
+    # Antonyms are Вікісловник + lexicographer-pointer driven (local db); the membership
+    # gate always runs, so authoritative local retractions apply even offline (finding 2).
     _apply_section("antonyms", antonyms, gate_ran=True)
+    if antonym_annotation_outcome and "antonyms" in sections:
+        # Distinct key so the annotation carry-over sits ALONGSIDE the membership outcome
+        # and stays invisible to the item-count shrink gate (which reads real section names).
+        gate_provenance["antonyms_annotations"] = antonym_annotation_outcome
     homonym_relations = (
         pointer_homonym_relations
         if pointer_homonym_relations is not None

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -5285,15 +5285,19 @@ def _section_item_key(item: object) -> str | None:
 
     Synonym/antonym chips are strings, optionally ``"word (qualifier)"``; homonym,
     paronym and idiom items are dicts. The qualifier is stripped so a purely cosmetic
-    re-tag (``дорога (діал.)`` -> ``дорога``) is not counted as a lost item.
+    re-tag (``дорога (діал.)`` -> ``дорога``) is not counted as a lost item. The bare
+    term is then run through the same canonicalization as synonym terms
+    (``_strip_stress`` then ``_lookup_key`` apostrophe folding + whitespace collapse +
+    strip + casefold) so a difference only in stress marks (``мали́й``/``малий``) or
+    apostrophe style (``бабу’ся``/``бабу'ся``) never splits one member into two keys.
     """
     if isinstance(item, str):
-        return _base_word(item).strip().casefold() or None
+        return _lookup_key(_strip_stress(_base_word(item))) or None
     if isinstance(item, dict):
         for field in ("word", "target", "lemma", "phrase", "text", "definition"):
             value = item.get(field)
             if isinstance(value, str) and value.strip():
-                return _base_word(value).strip().casefold() or None
+                return _lookup_key(_strip_stress(_base_word(value))) or None
     return None
 
 

--- a/scripts/lexicon/manifest_io.py
+++ b/scripts/lexicon/manifest_io.py
@@ -47,6 +47,12 @@ FORCE_HYDRATE_ENV = "ATLAS_MANIFEST_FORCE_HYDRATE"
 GATE_CONFIRMED = "confirmed"  # gate ran; kept or added items (default — not recorded)
 GATE_REJECTED = "rejected"  # gate ran and dropped item(s): a quality win (allowed to shrink)
 GATE_SKIPPED_OFFLINE = "skipped-offline"  # gate could not run; existing section preserved
+GATE_ANNOTATIONS_CARRIED = "annotations-carried-offline"  # #5121: item membership recomputed
+# from local sources, but a section's SECONDARY annotation source (e.g. СУМ-20/ВТС antonym
+# pointers via the per-lemma slovnyk cache) was not consultable, so its published annotation
+# pointers were carried forward per-item. Recorded on a distinct ``<section>_annotations`` key
+# so it sits alongside — never clobbers — the membership outcome and is invisible to the
+# item-count shrink gate (which only consults real section names).
 
 
 def _sha256(data: bytes) -> str:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "3290f1c115d62a8d3ad0c2c5333d3e0eebfeb2ef17a4330e748c78fcf7b7cbc5",
+  "fingerprint": "bf972df68cd46602d5891bd95da35eab7e624e7f53de06ef157e2bfa73258d1e",
   "inputs": {
     "lexicon_code": [
       {
@@ -52,7 +52,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "d93fe5ae565eddc685cfd89d0ab04a8b36580b6eecffd3086101bad97fa89a36"
+        "sha256": "80cfd4fc0858940e56c0ee850f9eb3a1c2368aa73cb61fba0dbd68dd447d785a"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "bf972df68cd46602d5891bd95da35eab7e624e7f53de06ef157e2bfa73258d1e",
+  "fingerprint": "b40f569524811bd28b53b22006be968bc9967825b5319d4fffcdebe96cb87928",
   "inputs": {
     "lexicon_code": [
       {
@@ -52,7 +52,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "80cfd4fc0858940e56c0ee850f9eb3a1c2368aa73cb61fba0dbd68dd447d785a"
+        "sha256": "042635510b49afc7b68be3d10ecdc8420a82a8d803cb9a32100cebecfab7518f"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -3651,7 +3651,11 @@ def test_vts_definition_card_resolves_cross_reference_live_shape(monkeypatch) ->
 # cache reset) a gate that CANNOT run must PRESERVE the previously-confirmed section
 # rather than silently overwrite it with an empty recomputation. Only a gate that RAN
 # may retract items (e.g. WordNet auto-translation junk). See scripts/lexicon/README.md.
-from scripts.lexicon.manifest_io import GATE_REJECTED, GATE_SKIPPED_OFFLINE
+from scripts.lexicon.manifest_io import (
+    GATE_ANNOTATIONS_CARRIED,
+    GATE_REJECTED,
+    GATE_SKIPPED_OFFLINE,
+)
 
 
 def _stub_section_producers(monkeypatch) -> None:
@@ -3908,3 +3912,124 @@ def test_offline_gate_did_not_run_records_skipped_even_without_loss(monkeypatch)
     )
     assert entry["sections"]["synonyms"]["items"] == ["джерело", "живець"]  # took new (no loss)
     assert entry["gate_provenance"]["synonyms"] == GATE_SKIPPED_OFFLINE  # still recorded
+
+
+# --- #5121 antonym pointer-annotation carry-over ---------------------------------------
+
+
+def _run_antonym_annotation_gate(monkeypatch, *, offline, cache, new_antonyms, baseline):
+    """Drive enrich_entry with a controllable local-compute antonym section over a
+    published baseline, exercising the #5121 annotation carry-over in isolation."""
+    entry = _run_enrich_entry(
+        monkeypatch,
+        {"lemma": "великий", "pos": "adj", "sections": {"antonyms": baseline}},
+        offline=offline,
+        cache=cache,
+    )
+    monkeypatch.setattr(enrich_manifest_module, "_antonyms_wiktionary", lambda *a, **k: new_antonyms)
+    monkeypatch.setattr(enrich_manifest_module, "_merge_antonym_relations", lambda ex, rel: new_antonyms)
+    _drive_enrich_entry(entry)
+    return entry
+
+
+def test_offline_cold_cache_carries_antonym_annotations_from_baseline(monkeypatch) -> None:
+    # #5121 (a): offline + cold cache. The СУМ-20/ВТС pointer annotation source could not
+    # be consulted (no newsum/vts slug), so item MEMBERSHIP is exactly what local sources
+    # computed, but the published annotation pointers are carried forward per-item instead
+    # of silently degrading to the bare Вікісловник label.
+    new_antonyms = {
+        "items": ["малий"],  # local (Вікісловник) compute — no annotation offline
+        "source": "Вікісловник: explicit antonym list",
+        "source_urls": ["https://example.invalid/wiktionary/velykyi"],
+    }
+    baseline = {
+        "items": ["малий"],
+        "source": "Вікісловник: explicit antonym list + СУМ-20: протилежне → малий",
+        "source_urls": [
+            "https://example.invalid/wiktionary/velykyi",
+            "https://example.invalid/sum20/velykyi",
+        ],
+    }
+    entry = _run_antonym_annotation_gate(
+        monkeypatch,
+        offline=True,
+        cache={"lookups": {}},  # no newsum/vts -> annotation source not consultable
+        new_antonyms=new_antonyms,
+        baseline=baseline,
+    )
+    section = entry["sections"]["antonyms"]
+    assert section["items"] == ["малий"]  # membership identical to local compute
+    assert section["source"] == (
+        "Вікісловник: explicit antonym list + СУМ-20: протилежне → малий"
+    )
+    assert section["source_urls"] == [
+        "https://example.invalid/wiktionary/velykyi",
+        "https://example.invalid/sum20/velykyi",
+    ]
+    assert entry["gate_provenance"]["antonyms_annotations"] == GATE_ANNOTATIONS_CARRIED
+    assert "antonyms" not in entry["gate_provenance"]  # membership gate: confirmed, unrecorded
+
+
+def test_cache_present_fresh_antonym_annotations_win_no_carry(monkeypatch) -> None:
+    # #5121 (b): the annotation source WAS consultable (newsum cached), so the fresh
+    # recompute is authoritative — a stale baseline annotation is NOT merged back in and
+    # no carry-over provenance is recorded.
+    new_antonyms = {
+        "items": ["малий"],
+        "source": "Вікісловник: explicit antonym list + СУМ-20: протилежне → малий",
+        "source_urls": [
+            "https://example.invalid/wiktionary/velykyi",
+            "https://example.invalid/sum20/velykyi",
+        ],
+    }
+    baseline = {
+        "items": ["малий"],
+        "source": "Вікісловник: explicit antonym list + ВТС: прот. → малий",  # stale
+        "source_urls": [
+            "https://example.invalid/wiktionary/velykyi",
+            "https://example.invalid/vts/velykyi",  # stale — must NOT be carried
+        ],
+    }
+    entry = _run_antonym_annotation_gate(
+        monkeypatch,
+        offline=True,
+        cache={"lookups": {"newsum": {"text": "x"}}},  # annotation gate ran
+        new_antonyms=new_antonyms,
+        baseline=baseline,
+    )
+    assert entry["sections"]["antonyms"] == new_antonyms  # fresh wins, verbatim
+    assert "https://example.invalid/vts/velykyi" not in entry["sections"]["antonyms"]["source_urls"]
+    assert "antonyms_annotations" not in entry.get("gate_provenance", {})
+
+
+def test_offline_carry_over_skips_items_absent_from_baseline(monkeypatch) -> None:
+    # #5121 (c): a local item that never existed in the baseline gains NO phantom
+    # annotation — only items matched by canonical term inherit their baseline pointers.
+    new_antonyms = {
+        "items": ["малий", "крихітний"],  # крихітний is fresh local membership
+        "source": "Вікісловник: explicit antonym list",
+        "source_urls": ["https://example.invalid/wiktionary/velykyi"],
+    }
+    baseline = {
+        "items": ["малий"],  # крихітний absent from baseline
+        "source": "Вікісловник: explicit antonym list + СУМ-20: протилежне → малий",
+        "source_urls": [
+            "https://example.invalid/wiktionary/velykyi",
+            "https://example.invalid/sum20/velykyi",
+        ],
+    }
+    entry = _run_antonym_annotation_gate(
+        monkeypatch,
+        offline=True,
+        cache={"lookups": {}},
+        new_antonyms=new_antonyms,
+        baseline=baseline,
+    )
+    section = entry["sections"]["antonyms"]
+    assert section["items"] == ["малий", "крихітний"]  # membership untouched
+    # only малий's pointer is carried; крихітний gets no phantom annotation segment
+    assert section["source"] == (
+        "Вікісловник: explicit antonym list + СУМ-20: протилежне → малий"
+    )
+    assert "крихітний" not in section["source"]
+    assert entry["gate_provenance"]["antonyms_annotations"] == GATE_ANNOTATIONS_CARRIED

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -4033,3 +4033,72 @@ def test_offline_carry_over_skips_items_absent_from_baseline(monkeypatch) -> Non
     )
     assert "крихітний" not in section["source"]
     assert entry["gate_provenance"]["antonyms_annotations"] == GATE_ANNOTATIONS_CARRIED
+
+
+def test_offline_carry_over_matches_across_apostrophe_style(monkeypatch) -> None:
+    # #5121 (d) / #5128 finding 1: a baseline pointer segment whose term uses a curly
+    # apostrophe (бабу’ся) must still carry onto a present member stored with a straight
+    # apostrophe (бабу'ся). Both sides normalize through the shared canonical key, so
+    # apostrophe style never splits one member into two keys and silently drops the pointer.
+    new_antonyms = {
+        "items": ["бабу'ся"],  # straight-apostrophe stored form (local membership)
+        "source": "Вікісловник: explicit antonym list",
+        "source_urls": ["https://example.invalid/wiktionary/didus"],
+    }
+    baseline = {
+        "items": ["бабу’ся"],  # curly-apostrophe baseline form
+        "source": "Вікісловник: explicit antonym list + СУМ-20: протилежне → бабу’ся",
+        "source_urls": [
+            "https://example.invalid/wiktionary/didus",
+            "https://example.invalid/sum20/didus",
+        ],
+    }
+    entry = _run_antonym_annotation_gate(
+        monkeypatch,
+        offline=True,
+        cache={"lookups": {}},  # annotation source not consultable -> carry path
+        new_antonyms=new_antonyms,
+        baseline=baseline,
+    )
+    section = entry["sections"]["antonyms"]
+    assert section["items"] == ["бабу'ся"]  # membership untouched
+    assert section["source"] == (
+        "Вікісловник: explicit antonym list + СУМ-20: протилежне → бабу’ся"
+    )
+    assert section["source_urls"] == [
+        "https://example.invalid/wiktionary/didus",
+        "https://example.invalid/sum20/didus",
+    ]
+    assert entry["gate_provenance"]["antonyms_annotations"] == GATE_ANNOTATIONS_CARRIED
+
+
+def test_offline_carry_over_matches_across_stress_marks(monkeypatch) -> None:
+    # #5121 (e) / #5128 finding 1: a baseline pointer segment whose term carries a stress
+    # mark (мали́й) must still carry onto the present bare member (малий). Stress-stripping
+    # in the shared canonical key keeps both on the same key.
+    new_antonyms = {
+        "items": ["малий"],  # bare stored form (local membership)
+        "source": "Вікісловник: explicit antonym list",
+        "source_urls": ["https://example.invalid/wiktionary/velykyi"],
+    }
+    baseline = {
+        "items": ["малий"],
+        "source": "Вікісловник: explicit antonym list + СУМ-20: протилежне → мали́й",
+        "source_urls": [
+            "https://example.invalid/wiktionary/velykyi",
+            "https://example.invalid/sum20/velykyi",
+        ],
+    }
+    entry = _run_antonym_annotation_gate(
+        monkeypatch,
+        offline=True,
+        cache={"lookups": {}},
+        new_antonyms=new_antonyms,
+        baseline=baseline,
+    )
+    section = entry["sections"]["antonyms"]
+    assert section["items"] == ["малий"]
+    assert section["source"] == (
+        "Вікісловник: explicit antonym list + СУМ-20: протилежне → мали́й"
+    )
+    assert entry["gate_provenance"]["antonyms_annotations"] == GATE_ANNOTATIONS_CARRIED


### PR DESCRIPTION
## What

Offline antonym recompute keeps its item membership (Вікісловник + local-db, offline-safe — the membership gate always runs) but its **secondary** annotation source — the СУМ-20/ВТС pointer segments and `source_urls` read from the per-lemma slovnyk cache — is not consultable with a cold cache. Previously-published annotation pointers silently degraded to the bare Вікісловник label (item counts unchanged, so the shrink gate stayed blind).

## Fix

Mirrors the #5077 preserve-vs-retract contract **one level down**, at annotation granularity:

- New `_slovnyk_gate_ran(cache, ("newsum", "vts"))` decides whether the annotation source was consultable this run (online → always; offline → only if the cache holds newsum/vts).
- When it did **not** run, `_carry_over_pointer_annotations` carries the baseline entry's pointer annotations forward **per-item** (match by canonical term). Item **membership is untouched** — exactly what local sources computed. A new item absent from the baseline gains **no phantom annotation**.
- Recorded on a distinct `gate_provenance["antonyms_annotations"] = "annotations-carried-offline"` key so it sits *alongside* the membership outcome and stays invisible to the item-count shrink gate (which only reads real section names). Online / cache-present → fresh recompute wins, nothing carried, zero diff.

## Tests

- offline cold cache → items identical to local compute, annotations carried from baseline
- online / cache-present → fresh annotations win, stale baseline not merged
- item absent from baseline → no phantom annotations

`.venv/bin/pytest tests/test_lexicon_enrich_manifest.py` → **144 passed**; verify/io/fingerprint suites → **182 passed** combined; `ruff check` clean; fingerprint sidecar regenerated.

Refs #5121, #5077, PR #5114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)