### PR TITLE
feat(orchestration): implement worktree GC cleanup mechanism and API automation Refs #4956

### DIFF
--- a/scripts/api/main.py
+++ b/scripts/api/main.py
@@ -15,6 +15,7 @@ import logging
 import os
 import socket
 import subprocess
+import threading
 from collections.abc import Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
@@ -33,6 +34,8 @@ try:
     from path_safety import safe_join  # scripts/ on sys.path (test sys.path-hack)
 except ImportError:
     from ..path_safety import safe_join  # scripts.api package import (production)
+
+from scripts.orchestration.reap_worktrees import primary_checkout_root, reap_worktrees
 
 from . import delegate_router as delegate_api
 from . import runtime_router as runtime_api
@@ -394,7 +397,72 @@ async def _collect_pipeline_orient_data() -> dict:
     return {"summary": await state_api.state_summary()}
 
 
+_gc_sweep_lock = threading.Lock()
+_gc_sweep_thread: threading.Thread | None = None
+_last_gc_sweep_summary: dict[str, Any] | None = None
+
+
+def _maybe_run_worktree_gc_sweep() -> None:
+    # Check kill switch first
+    kill_switch = os.environ.get("LEARN_UK_WORKTREE_GC", "1")
+    if kill_switch in ("0", "false", "no", "False", "NO"):
+        return
+
+    # Check cache TTL (default 60 minutes)
+    try:
+        interval_min = float(os.environ.get("LEARN_UK_WORKTREE_GC_INTERVAL_MIN", "60"))
+    except ValueError:
+        interval_min = 60.0
+    interval_s = interval_min * 60.0
+
+    if cache_get("worktree_gc_sweep", ttl=interval_s) is not None:
+        return
+
+    # Set cache to prevent concurrent triggering
+    cache_set("worktree_gc_sweep", True)
+
+    global _gc_sweep_thread
+    with _gc_sweep_lock:
+        if _gc_sweep_thread is not None and _gc_sweep_thread.is_alive():
+            return
+        _gc_sweep_thread = threading.Thread(
+            target=_run_worktree_gc_sweep, daemon=True
+        )
+        _gc_sweep_thread.start()
+
+
+def _run_worktree_gc_sweep() -> None:
+    global _last_gc_sweep_summary
+    try:
+        repo_root = primary_checkout_root(PROJECT_ROOT)
+
+        results = reap_worktrees(
+            repo_root=repo_root,
+            apply=True,
+            prune_merged_branches=True,
+            safe_only=True,
+        )
+
+        removed = sum(1 for r in results if r.action in ("removed", "preserved_then_removed"))
+        skipped = sum(1 for r in results if r.action == "skipped")
+        errors = sum(1 for r in results if r.action == "error")
+
+        _last_gc_sweep_summary = {
+            "time": _isoformat_z(datetime.now(UTC)),
+            "removed": removed,
+            "skipped": skipped,
+            "errors": errors,
+        }
+        logger.info(
+            "worktree GC sweep: removed=%d, skipped=%d, errors=%d",
+            removed, skipped, errors
+        )
+    except Exception as exc:
+        logger.exception("worktree GC sweep failed: %s", exc)
+
+
 def _collect_runtime_orient_data() -> dict:
+    _maybe_run_worktree_gc_sweep()
     agents = runtime_api.list_runtime_agents()
     headroom = {}
     for agent_info in agents:
@@ -407,11 +475,15 @@ def _collect_runtime_orient_data() -> dict:
         except Exception:
             ok = False
         headroom[str(name)] = ok
-    return {
+
+    res = {
         "agents": [agent["name"] for agent in agents if agent.get("name")],
         "recent_outcomes": runtime_api.runtime_recent_outcomes_today(),
         "headroom": headroom,
     }
+    if _last_gc_sweep_summary is not None:
+        res["worktree_gc"] = _last_gc_sweep_summary
+    return res
 
 
 def _collect_delegate_orient_data() -> dict:

--- a/scripts/orchestration/reap_worktrees.py
+++ b/scripts/orchestration/reap_worktrees.py
@@ -287,6 +287,22 @@ def _worktree_age_hours(path: Path, now: float | None = None) -> float | None:
     return ((now or time.time()) - mtime) / 3600
 
 
+def _active_task_ids() -> set[str] | None:
+    try:
+        import urllib.request
+        with urllib.request.urlopen("http://127.0.0.1:8765/api/delegate/active", timeout=3) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+            tasks = data.get("tasks", [])
+            return {str(t.get("task_id")) for t in tasks if t.get("task_id")}
+    except Exception:
+        return None
+
+
+def _is_ancestor_of_origin_main(path: Path) -> bool:
+    proc = _run(["git", "merge-base", "--is-ancestor", "HEAD", "origin/main"], cwd=path)
+    return proc.returncode == 0
+
+
 def _qualifying_reason(
     *,
     repo_root: Path,
@@ -294,21 +310,79 @@ def _qualifying_reason(
     pr_state: PullRequestState | None,
     build_age_hours: float,
     now: float | None,
+    active_ids: set[str] | None = None,
+    safe_only: bool = False,
 ) -> str | None:
-    if pr_state is not None:
-        pr_label = f"PR #{pr_state.number}" if pr_state.number is not None else "PR"
-        if pr_state.state == "MERGED":
-            return f"{pr_label} MERGED"
-        if pr_state.state == "CLOSED":
-            return f"{pr_label} CLOSED"
+    if info.branch is not None:
+        if pr_state is not None:
+            pr_label = f"PR #{pr_state.number}" if pr_state.number is not None else "PR"
+            if pr_state.state == "MERGED":
+                return f"{pr_label} MERGED"
+            if pr_state.state == "CLOSED":
+                return f"{pr_label} CLOSED"
 
-    if info.branch and info.branch.startswith("build/"):
-        age_hours = _worktree_age_hours(info.path, now=now)
-        if age_hours is not None and age_hours > build_age_hours:
-            return f"build branch age {age_hours:.1f}h > {build_age_hours:g}h"
+        if not safe_only:
+            if info.branch.startswith("build/"):
+                age_hours = _worktree_age_hours(info.path, now=now)
+                if age_hours is not None and age_hours > build_age_hours:
+                    return f"build branch age {age_hours:.1f}h > {build_age_hours:g}h"
 
-    if _origin_matches_head(info.path, info.branch):
-        return f"HEAD matches origin/{info.branch}"
+            if _origin_matches_head(info.path, info.branch):
+                return f"HEAD matches origin/{info.branch}"
+
+    # Class B: detached-HEAD worktrees under .worktrees/
+    is_under_wt = is_under_worktrees(repo_root, info.path)
+    clean = _worktree_clean(info.path)
+    dispatch_root = (repo_root / ".worktrees" / "dispatch").resolve()
+    is_dispatch_candidate = False
+    task_id = None
+    try:
+        rel_path = info.path.resolve().relative_to(dispatch_root)
+        if len(rel_path.parts) == 2:
+            task_id = rel_path.parts[1]
+            is_dispatch_candidate = True
+    except ValueError:
+        pass
+
+    if is_under_wt and info.detached and clean is True and _is_ancestor_of_origin_main(info.path):
+        has_matching_task = False
+        task_settled = False
+        if is_dispatch_candidate:
+            task_file = repo_root / "batch_state" / "tasks" / f"{task_id}.json"
+            if task_file.exists():
+                has_matching_task = True
+                try:
+                    task_data = json.loads(task_file.read_text(encoding="utf-8"))
+                    task_status = task_data.get("status")
+                    if task_status in ("done", "failed") and active_ids is not None and task_id not in active_ids:
+                        task_settled = True
+                except Exception:
+                    pass
+
+        if has_matching_task:
+            if task_settled:
+                return f"detached HEAD ancestor of origin/main; settled dispatch task-id={task_id}"
+        else:
+            age_hours = _worktree_age_hours(info.path, now=now)
+            if age_hours is not None and age_hours > 24.0:
+                return f"detached HEAD ancestor of origin/main; age {age_hours:.1f}h > 24h"
+
+    # Class A: settled-dispatch, no PR
+    if is_dispatch_candidate and clean is True:
+        task_file = repo_root / "batch_state" / "tasks" / f"{task_id}.json"
+        if task_file.exists():
+            try:
+                task_data = json.loads(task_file.read_text(encoding="utf-8"))
+                task_status = task_data.get("status")
+                if task_status in ("done", "failed") and active_ids is not None and task_id not in active_ids:
+                    if info.branch:
+                        prs, pr_error = _query_pr_states(repo_root, info.branch)
+                        if pr_error is None and not any(pr.state == "OPEN" for pr in prs):
+                            return f"settled dispatch task-id={task_id} status={task_status}"
+                    else:
+                        return f"settled dispatch task-id={task_id} status={task_status}"
+            except Exception:
+                pass
 
     return None
 
@@ -343,10 +417,11 @@ def _remove_worktree(repo_root: Path, info: WorktreeInfo) -> str | None:
     return None
 
 
-def _prune_branch(repo_root: Path, branch: str | None) -> str | None:
+def _prune_branch(repo_root: Path, branch: str | None, force: bool = False) -> str | None:
     if not branch:
         return None
-    proc = _run(["git", "branch", "-d", branch], cwd=repo_root)
+    flag = "-D" if force else "-d"
+    proc = _run(["git", "branch", flag, branch], cwd=repo_root)
     if proc.returncode != 0:
         return _format_failure(proc)
     return None
@@ -420,7 +495,7 @@ def _reap_qualified_worktree(
 
     branch_prune_error = None
     if prune_merged_branches and pr_state is not None and pr_state.state == "MERGED":
-        branch_prune_error = _prune_branch(repo_root, info.branch)
+        branch_prune_error = _prune_branch(repo_root, info.branch, force=True)
 
     if branch_prune_error is not None:
         return ReapResult(
@@ -458,11 +533,13 @@ def reap_worktrees(
     prune_merged_branches: bool = False,
     target_paths: list[Path] | None = None,
     now: float | None = None,
+    safe_only: bool = False,
 ) -> list[ReapResult]:
     """Evaluate and optionally reap eligible worktrees."""
     repo_root = repo_root.resolve()
     targets = _target_filter(target_paths)
     results: list[ReapResult] = []
+    active_ids = _active_task_ids()
 
     for info in list_git_worktrees(repo_root):
         if targets is not None and info.path.resolve() not in targets:
@@ -478,35 +555,34 @@ def reap_worktrees(
                 )
             )
             continue
-        if info.branch is None:
-            results.append(
-                ReapResult(
-                    path=str(info.path),
-                    branch=None,
-                    action="skipped",
-                    reason="detached or missing branch",
-                    dirty=None,
-                )
-            )
-            continue
 
         dirty_state = _worktree_clean(info.path)
         dirty = None if dirty_state is None else not dirty_state
-        pr_states, pr_error = _query_pr_states(repo_root, info.branch)
-        pr_state = _best_pr(pr_states)
+
+        pr_state = None
+        pr_error = None
+        if info.branch is not None:
+            pr_states, pr_error = _query_pr_states(repo_root, info.branch)
+            pr_state = _best_pr(pr_states)
+
         reason = _qualifying_reason(
             repo_root=repo_root,
             info=info,
             pr_state=pr_state,
             build_age_hours=build_age_hours,
             now=now,
+            active_ids=active_ids,
+            safe_only=safe_only,
         )
         if reason is None:
-            reason = (
-                f"no reap condition matched; {pr_error}"
-                if pr_error
-                else "no reap condition matched"
-            )
+            if info.branch is None:
+                reason = "detached or missing branch"
+            else:
+                reason = (
+                    f"no reap condition matched; {pr_error}"
+                    if pr_error
+                    else "no reap condition matched"
+                )
             results.append(
                 ReapResult(
                     path=str(info.path),
@@ -668,6 +744,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="After removing a MERGED PR worktree, run safe 'git branch -d <branch>'.",
     )
     parser.add_argument(
+        "--safe-only",
+        action="store_true",
+        help="Restrict reaping to provably-safe classes (merged PRs + settled dispatches + detached-HEAD ancestors).",
+    )
+    parser.add_argument(
         "--worktree",
         action="append",
         type=Path,
@@ -693,6 +774,7 @@ def main(argv: list[str] | None = None) -> int:
         preserve_then_reap=bool(args.preserve_then_reap),
         prune_merged_branches=bool(args.prune_merged_branches),
         target_paths=args.worktree,
+        safe_only=bool(args.safe_only),
     )
     if args.json:
         print(json.dumps([_result_payload(result) for result in results], indent=2))

--- a/tests/api/test_worktree_gc_sweep.py
+++ b/tests/api/test_worktree_gc_sweep.py
@@ -1,0 +1,135 @@
+"""Hermetic tests for the worktree GC sweep loop in the Monitor API server."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import scripts.api.main as api_main
+import scripts.api.state_helpers as state_helpers
+from scripts.orchestration.reap_worktrees import ReapResult
+
+client = TestClient(api_main.app, raise_server_exceptions=False)
+
+
+def _patch_orient_sources(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Patch non-runtime sources to keep orient fast and hermetic
+    monkeypatch.setattr(api_main, "_collect_git_orient_data", lambda: {"branch": "main"})
+    monkeypatch.setattr(api_main, "_collect_issues_orient_data", lambda: {"issues": []})
+
+    async def fake_pipeline():
+        return {"summary": {}}
+
+    monkeypatch.setattr(api_main, "_collect_pipeline_orient_data", fake_pipeline)
+    monkeypatch.setattr(api_main, "_collect_delegate_orient_data", lambda: {})
+    monkeypatch.setattr(api_main, "_collect_wiki_orient_data", lambda: {"by_track": {}})
+    monkeypatch.setattr(
+        api_main,
+        "_collect_governance_orient_data",
+        lambda: {
+            "decisions_total": 0,
+            "decisions_stale": 0,
+            "decisions_approaching_expiry": 0,
+            "adrs_total": 0,
+            "adrs_warnings": 0,
+            "adrs_errors": 0,
+        },
+    )
+    monkeypatch.setattr(api_main, "_collect_health_orient_data", lambda: {"api": True})
+    monkeypatch.setattr(api_main, "_collect_session_hints_orient_data", lambda: [])
+
+    # Patch runtime API dependencies
+    monkeypatch.setattr(api_main.runtime_api, "list_runtime_agents", lambda: [])
+    monkeypatch.setattr(api_main.runtime_api, "runtime_recent_outcomes_today", lambda: [])
+
+
+@pytest.fixture(autouse=True)
+def setup_teardown(monkeypatch: pytest.MonkeyPatch):
+    # Reset global GC variables
+    api_main._last_gc_sweep_summary = None
+    api_main._gc_sweep_thread = None
+    state_helpers.cache_invalidate("worktree_gc_sweep")
+
+    # Force ONLY the GC sweep thread to run synchronously in tests
+    original_start = threading.Thread.start
+    def fake_start(self):
+        target = getattr(self, "_target", None)
+        if target and getattr(target, "__name__", None) == "_run_worktree_gc_sweep":
+            self._target(*self._args, **self._kwargs)
+        else:
+            original_start(self)
+    monkeypatch.setattr(threading.Thread, "start", fake_start)
+
+    yield
+
+
+def test_gc_sweep_disabled_by_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEARN_UK_WORKTREE_GC", "0")
+    _patch_orient_sources(monkeypatch)
+
+    response = client.get("/api/orient?fresh=true")
+    assert response.status_code == 200
+    data = response.json()
+    assert "worktree_gc" not in data.get("runtime", {})
+    assert api_main._last_gc_sweep_summary is None
+
+
+def test_gc_sweep_runs_and_exposes_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEARN_UK_WORKTREE_GC", "1")
+    _patch_orient_sources(monkeypatch)
+
+    # Mock reap_worktrees to return a controlled set of results
+    fake_results = [
+        ReapResult(path="/wt/1", branch="b1", action="removed", reason="merged", dirty=False),
+        ReapResult(path="/wt/2", branch="b2", action="removed", reason="merged", dirty=False),
+        ReapResult(path="/wt/3", branch="b3", action="skipped", reason="dirty", dirty=True),
+        ReapResult(path="/wt/4", branch="b4", action="error", reason="fail", dirty=False, error="err"),
+    ]
+
+    monkeypatch.setattr(api_main, "reap_worktrees", lambda **kwargs: fake_results)
+    monkeypatch.setattr(api_main, "primary_checkout_root", lambda path: Path("/dummy"))
+
+    response = client.get("/api/orient?fresh=true")
+    assert response.status_code == 200
+    data = response.json()
+    runtime = data["runtime"]
+    assert "worktree_gc" in runtime
+    summary = runtime["worktree_gc"]
+    assert summary["removed"] == 2
+    assert summary["skipped"] == 1
+    assert summary["errors"] == 1
+    assert "time" in summary
+
+
+def test_gc_sweep_respects_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LEARN_UK_WORKTREE_GC", "1")
+    monkeypatch.setenv("LEARN_UK_WORKTREE_GC_INTERVAL_MIN", "60")
+    _patch_orient_sources(monkeypatch)
+
+    # First call returns 1 removed
+    monkeypatch.setattr(
+        api_main,
+        "reap_worktrees",
+        lambda **kwargs: [ReapResult(path="/wt/1", branch="b1", action="removed", reason="m", dirty=False)]
+    )
+    monkeypatch.setattr(api_main, "primary_checkout_root", lambda path: Path("/dummy"))
+
+    response = client.get("/api/orient?fresh=true")
+    assert response.json()["runtime"]["worktree_gc"]["removed"] == 1
+
+    # Update return value to 5 removed, but sweep shouldn't run again due to TTL cache
+    monkeypatch.setattr(
+        api_main,
+        "reap_worktrees",
+        lambda **kwargs: [ReapResult(path=f"/wt/{i}", branch=f"b{i}", action="removed", reason="m", dirty=False) for i in range(5)]
+    )
+    response2 = client.get("/api/orient")
+    assert response2.json()["runtime"]["worktree_gc"]["removed"] == 1
+
+    # Invalidate sweep cache, now it should run and update
+    state_helpers.cache_invalidate("worktree_gc_sweep")
+    response3 = client.get("/api/orient?fresh=true")
+    assert response3.json()["runtime"]["worktree_gc"]["removed"] == 5

--- a/tests/orchestration/test_reap_worktrees.py
+++ b/tests/orchestration/test_reap_worktrees.py
@@ -18,7 +18,7 @@ def git_env() -> dict[str, str]:
     return {
         key: value
         for key, value in os.environ.items()
-        if not key.startswith("GIT_") and not key.startswith("PRE_COMMIT")
+        if not key.startswith("GIT_") and not key.startswith("PRE_COMMIT") and key != "AGENT_NO_MERGE"
     }
 
 
@@ -262,3 +262,194 @@ def test_dry_run_makes_zero_filesystem_change(
     assert worktree.exists()
     assert git(worktree, "status", "--porcelain") == ""
     assert_main_checkout_unchanged(repo)
+
+
+def test_class_a_settled_dispatch_removed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    task_id = "5102-raisa-review-repair"
+    worktree_path = repo / ".worktrees" / "dispatch" / "codex" / task_id
+    add_worktree(repo, "codex/5102-raisa", path=worktree_path)
+
+    # Create task JSON
+    tasks_dir = repo / "batch_state" / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps({"status": "done"}), encoding="utf-8"
+    )
+
+    # Mock active set and PR state
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+    patch_gh(monkeypatch, {"codex/5102-raisa": []})
+
+    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    result = result_for(results, worktree_path)
+    assert result.action == "removed"
+    assert "settled dispatch" in result.reason
+    assert "task-id=5102-raisa-review-repair" in result.reason
+    assert not worktree_path.exists()
+
+
+def test_class_a_fail_safe_skips(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    task_id = "5102-raisa-fail"
+    worktree_path = repo / ".worktrees" / "dispatch" / "codex" / task_id
+    add_worktree(repo, "codex/5102-raisa-fail", path=worktree_path)
+
+    tasks_dir = repo / "batch_state" / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    task_file = tasks_dir / f"{task_id}.json"
+    task_file.write_text(json.dumps({"status": "done"}), encoding="utf-8")
+
+    # Case 1: active task
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: {task_id})
+    patch_gh(monkeypatch, {"codex/5102-raisa-fail": []})
+    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    assert result_for(results, worktree_path).action == "skipped"
+
+    # Case 2: API down
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: None)
+    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    assert result_for(results, worktree_path).action == "skipped"
+
+    # Case 3: missing task file
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+    task_file.unlink()
+    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    assert result_for(results, worktree_path).action == "skipped"
+
+    # Re-create task file for remaining cases
+    task_file.write_text(json.dumps({"status": "running"}), encoding="utf-8")
+
+    # Case 4: task status is not done/failed
+    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    assert result_for(results, worktree_path).action == "skipped"
+
+    # Set status back to done
+    task_file.write_text(json.dumps({"status": "done"}), encoding="utf-8")
+
+    # Case 5: dirty tree
+    (worktree_path / "dirty.txt").write_text("uncommitted change", encoding="utf-8")
+    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    assert result_for(results, worktree_path).action == "skipped"
+
+    # Clean up dirty file
+    (worktree_path / "dirty.txt").unlink()
+
+    # Case 6: branch has open PR
+    patch_gh(monkeypatch, {"codex/5102-raisa-fail": [{"number": 42, "state": "OPEN"}]})
+    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    assert result_for(results, worktree_path).action == "skipped"
+
+
+def test_class_b_detached_head_removed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    # Add a detached HEAD worktree
+    worktree_path = repo / ".worktrees" / "detached-wt"
+    git(repo, "worktree", "add", "--detach", str(worktree_path), "main")
+
+    # Set age > 24h
+    now = time.time()
+    old = now - 25 * 3600
+    os.utime(worktree_path, (old, old))
+
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+
+    # Check it is removed because age > 24h and no matching task
+    results = rw.reap_worktrees(repo_root=repo, apply=True, now=now)
+    result = result_for(results, worktree_path)
+    assert result.action == "removed"
+    assert "detached HEAD ancestor of origin/main" in result.reason
+    assert "age 25.0h > 24h" in result.reason
+    assert not worktree_path.exists()
+
+
+def test_class_b_settled_task_removed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    # Add detached HEAD under dispatch
+    task_id = "detached-task"
+    worktree_path = repo / ".worktrees" / "dispatch" / "codex" / task_id
+    git(repo, "worktree", "add", "--detach", str(worktree_path), "main")
+
+    # Create task JSON
+    tasks_dir = repo / "batch_state" / "tasks"
+    tasks_dir.mkdir(parents=True, exist_ok=True)
+    (tasks_dir / f"{task_id}.json").write_text(
+        json.dumps({"status": "done"}), encoding="utf-8"
+    )
+
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+
+    # Check it is removed even if age is fresh (e.g. 0h) because task is settled
+    results = rw.reap_worktrees(repo_root=repo, apply=True)
+    result = result_for(results, worktree_path)
+    assert result.action == "removed"
+    assert "detached HEAD ancestor of origin/main; settled dispatch task-id=detached-task" in result.reason
+    assert not worktree_path.exists()
+
+
+def test_class_b_fail_safe_skips(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree_path = repo / ".worktrees" / "detached-wt-fail"
+    git(repo, "worktree", "add", "--detach", str(worktree_path), "main")
+
+    # Case 1: HEAD is not ancestor of origin/main
+    # Create a new commit in the worktree so HEAD is ahead of main (origin/main)
+    git(worktree_path, "commit", "--allow-empty", "-m", "new commit")
+
+    now = time.time()
+    old = now - 25 * 3600
+    os.utime(worktree_path, (old, old))
+    monkeypatch.setattr(rw, "_active_task_ids", lambda: set())
+
+    results = rw.reap_worktrees(repo_root=repo, apply=True, now=now)
+    assert result_for(results, worktree_path).action == "skipped"
+
+
+def test_squash_merge_branch_force_delete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = init_repo(tmp_path)
+    worktree_path = add_worktree(repo, "codex/squash-merged")
+
+    # Commit a change so that the local branch has a commit not in main.
+    (worktree_path / "change.txt").write_text("change\n", encoding="utf-8")
+    git(worktree_path, "add", "change.txt")
+    git(worktree_path, "commit", "-m", "feat: change")
+
+    patch_gh(monkeypatch, {"codex/squash-merged": [{"number": 101, "state": "MERGED"}]})
+
+    # Run reap with prune_merged_branches=True.
+    results = rw.reap_worktrees(
+        repo_root=repo,
+        apply=True,
+        prune_merged_branches=True,
+    )
+
+    result = result_for(results, worktree_path)
+    assert result.action == "removed"
+    assert not worktree_path.exists()
+
+    # Check that the branch was indeed deleted
+    proc = subprocess.run(
+        ["git", "branch", "--list", "codex/squash-merged"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    assert "codex/squash-merged" not in proc.stdout


### PR DESCRIPTION
This PR implements the fail-safe worktree GC cleanup mechanism and hooks it into the FastAPI server's background sweeps.

### Details:
1. Implements two new reap classes (settled-dispatch and detached-HEAD) with extensive safety checks.
2. Fixes squash-merge branch pruning to force deletion only for verified `MERGED` PRs on GitHub.
3. Automatically triggers periodic background sweeps inside `/api/orient` using `threading.Thread(..., daemon=True)` and TTL cache-guarding.
4. Exposes the last-sweep summary under `runtime -> worktree_gc`.
5. Unit tests for both core reaper logic and API server sweep loops.