### PR TITLE
fix(harness): collect stability replays and derive cost plans (#5118)

### DIFF
--- a/scripts/audit/layerb_collect_emissions.py
+++ b/scripts/audit/layerb_collect_emissions.py
@@ -39,7 +39,7 @@ from scripts.audit.layerb_label_common import atomic_write_json
 from scripts.audit.llm_reviewer_dispatch import tool_events_from_dispatch_meta
 
 EMISSIONS_VERSION = "qg-layer-b-qualification-emissions.v1"
-CACHE_VERSION = "qg-layer-b-qualification-collector-cache.v2"
+CACHE_VERSION = "qg-layer-b-qualification-collector-cache.v3"
 COLLECTOR_VERSION = "qg-layer-b-qualification-collector.v1"
 
 
@@ -75,6 +75,7 @@ class ModuleEnvelope:
     corpus: str
     artifact_sha256: str
     cases: tuple[PreparedCase, ...]
+    attempt: int = 0
 
 
 def _canonical_json(value: Any) -> str:
@@ -359,6 +360,7 @@ def _planned_modules(
     *,
     eligibility: str,
     effective_route: layerb_qualify.EffectiveRoute,
+    attempt: int = 0,
 ) -> list[ModuleEnvelope]:
     grouped: dict[tuple[str, str], list[PreparedCase]] = defaultdict(list)
     for prepared in prepared_cases:
@@ -373,12 +375,41 @@ def _planned_modules(
         grouped[(prepared.corpus, prepared.artifact_sha256)].append(prepared)
     return [
         ModuleEnvelope(
-            corpus=corpus, artifact_sha256=artifact_sha, cases=tuple(sorted(cases, key=lambda item: item.case_id))
+            corpus=corpus,
+            artifact_sha256=artifact_sha,
+            cases=tuple(sorted(cases, key=lambda item: item.case_id)),
+            attempt=attempt,
         )
         for (corpus, artifact_sha), cases in sorted(
             grouped.items(), key=lambda item: (0 if item[0][0] == "probe" else 1, item[0][1])
         )
     ]
+
+
+def _stability_modules(
+    prepared_cases: Sequence[PreparedCase],
+    *,
+    main_cases: Sequence[Mapping[str, Any]],
+    probe_cases: Sequence[Mapping[str, Any]],
+    eligibility: str,
+    effective_route: layerb_qualify.EffectiveRoute,
+) -> tuple[list[str], list[ModuleEnvelope]]:
+    """Plan exactly the fixed scorer-selected replay subset as attempt one."""
+
+    selected = layerb_qualify.stability_case_ids(main_cases, probe_cases)
+    selected_ids = set(selected)
+    prepared_by_id = {prepared.case_id: prepared for prepared in prepared_cases}
+    if len(prepared_by_id) != len(prepared_cases):
+        raise CollectionError("qualification labels contain duplicate case_id values")
+    missing = sorted(selected_ids - set(prepared_by_id))
+    if missing:
+        raise CollectionError(f"stability selection is absent from prepared labels: {', '.join(missing[:8])}")
+    return selected, _planned_modules(
+        [prepared_by_id[case_id] for case_id in selected],
+        eligibility=eligibility,
+        effective_route=effective_route,
+        attempt=1,
+    )
 
 
 def _module_request(module: ModuleEnvelope) -> tuple[dict[str, Any], dict[str, str]]:
@@ -569,6 +600,7 @@ def _emission(
     prepared: PreparedCase,
     *,
     call_id: str,
+    attempt: int = 0,
     observed: Mapping[str, float],
     response: Mapping[str, Any],
     status: str,
@@ -585,6 +617,7 @@ def _emission(
         # call_id remains the immutable artifact-envelope identity.
         "module_id": _required_str(prepared.case, "fixture_id", prepared.case_id),
         "call_id": call_id,
+        "attempt": attempt,
         "observed": dict(observed),
         "windows": windows,
         "response": dict(response),
@@ -598,17 +631,69 @@ def _emission(
     return result
 
 
-def _cache_path(cache_dir: Path, request: Mapping[str, Any], route: Mapping[str, Any]) -> Path:
+def _cache_path(cache_dir: Path, request: Mapping[str, Any], route: Mapping[str, Any], *, attempt: int) -> Path:
     key = _sha256_json(
         {
             "version": CACHE_VERSION,
             "request": request,
             "route": route,
+            "attempt": attempt,
             "prompt_version": layerb_shadow.PROMPT_VERSION,
             "output_version": layerb_shadow.JUDGE_OUTPUT_VERSION,
         }
     )
     return cache_dir / f"{key}.json"
+
+
+def _module_id(module: ModuleEnvelope) -> str:
+    module_ids = {_required_str(prepared.case, "fixture_id", prepared.case_id) for prepared in module.cases}
+    if len(module_ids) != 1:
+        raise CollectionError(
+            f"artifact {module.artifact_sha256} spans multiple fixture_id values: {', '.join(sorted(module_ids))}"
+        )
+    return next(iter(module_ids))
+
+
+def _call_id(module: ModuleEnvelope) -> str:
+    base = f"artifact-{module.artifact_sha256}"
+    return base if module.attempt == 0 else f"{base}-attempt-{module.attempt}"
+
+
+def _module_call_plan(
+    modules: Sequence[ModuleEnvelope],
+    module_requests: Sequence[tuple[Mapping[str, Any], Mapping[str, str]]],
+    request_routes: Sequence[layerb_shadow.JudgeRoute],
+) -> dict[str, dict[str, Any]]:
+    """Derive every per-fixture envelope from the collector's concrete batch plan."""
+
+    plans: dict[str, dict[str, Any]] = {}
+    for module, (request, _serialized_hashes), route in zip(modules, module_requests, request_routes, strict=True):
+        module_id = _module_id(module)
+        max_output_tokens = request.get("max_output_tokens")
+        if not isinstance(max_output_tokens, int) or isinstance(max_output_tokens, bool) or max_output_tokens < 1:
+            raise CollectionError(f"{module_id}: request has no positive max_output_tokens")
+        plan = plans.setdefault(
+            module_id,
+            {
+                "expected_call_ids": [],
+                "expected_call_count": 0,
+                "expected_prompt_tokens": 0,
+                "expected_completion_tokens": 0,
+                "expected_cost_usd": 0.0,
+            },
+        )
+        call_id = _call_id(module)
+        if call_id in plan["expected_call_ids"]:
+            raise CollectionError(f"{module_id}: duplicate planned call identity {call_id}")
+        plan["expected_call_ids"].append(call_id)
+        plan["expected_call_count"] += 1
+        plan["expected_prompt_tokens"] += route.max_input_tokens
+        plan["expected_completion_tokens"] += max_output_tokens
+        plan["expected_cost_usd"] += route.worst_case_usd
+    return {
+        module_id: {**plan, "expected_call_ids": sorted(plan["expected_call_ids"])}
+        for module_id, plan in sorted(plans.items())
+    }
 
 
 def _route_metadata(
@@ -736,11 +821,19 @@ def _write_collector_outputs(
     emissions: Mapping[str, Any],
     route: Mapping[str, Any],
     manifest: Sequence[Mapping[str, Any]],
+    module_call_plan: Mapping[str, Mapping[str, Any]],
 ) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     atomic_write_json(output_dir / "emissions.json", {"version": EMISSIONS_VERSION, "emissions": dict(emissions)})
     atomic_write_json(output_dir / "route.json", dict(route))
-    atomic_write_json(output_dir / "raw-call-manifest.json", list(manifest))
+    atomic_write_json(
+        output_dir / "raw-call-manifest.json",
+        {
+            "version": "qg-layer-b-qualification-collector-manifest.v2",
+            "calls": list(manifest),
+            "module_call_plan": dict(module_call_plan),
+        },
+    )
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -800,10 +893,26 @@ def main(argv: Sequence[str] | None = None) -> int:
         }
         artifacts = _artifact_sources(source_hashes, (args.main_labels, args.probe_labels)) if source_hashes else {}
         prepared = [_prepared_case(corpus, case, artifacts) for corpus, case in all_cases]
-        modules = _planned_modules(prepared, eligibility=args.eligibility, effective_route=effective_route)
+        primary_modules = _planned_modules(prepared, eligibility=args.eligibility, effective_route=effective_route)
+        stability_ids, stability_replay_modules = _stability_modules(
+            prepared,
+            main_cases=main_cases,
+            probe_cases=probe_cases,
+            eligibility=args.eligibility,
+            effective_route=effective_route,
+        )
+        # Preserve probe-first authorization for both samples.  A stability
+        # replay of a probe therefore cannot follow any main judge request.
+        modules = [
+            *[module for module in primary_modules if module.corpus == "probe"],
+            *[module for module in stability_replay_modules if module.corpus == "probe"],
+            *[module for module in primary_modules if module.corpus == "main"],
+            *[module for module in stability_replay_modules if module.corpus == "main"],
+        ]
         module_requests = [_module_request(module) for module in modules]
         request_routes = [_request_route(judge_route, request) for request, _hashes in module_requests]
         _preflight_caps(args=args, request_routes=request_routes, seat_key=seat_key, seat_caps=seat_caps)
+        module_call_plan = _module_call_plan(modules, module_requests, request_routes)
         candidate_windows = sum(len(item.windows) for item in prepared)
         serializer_hash_checks = sum(len(item.windows) for item in prepared)
         probe_classes = sorted(
@@ -820,8 +929,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             "probe_cases": len(probe_cases),
             "candidate_windows": candidate_windows,
             "module_calls": len(modules),
+            "primary_module_calls": len(primary_modules),
+            "stability_module_calls": len(stability_replay_modules),
             "probe_module_calls": sum(module.corpus == "probe" for module in modules),
             "main_module_calls": sum(module.corpus == "main" for module in modules),
+            "stability_case_ids": stability_ids,
             "serializer_hash_checks": serializer_hash_checks,
             "worst_case_usd": sum(route.worst_case_usd for route in request_routes),
             "seat_key": seat_key,
@@ -846,7 +958,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         output_dir = args.output_dir
         cache_dir = output_dir / "cache"
         cache_dir.mkdir(parents=True, exist_ok=True)
-        emissions: dict[str, Any] = {}
+        emissions: dict[str, list[dict[str, Any]]] = {}
         manifest: list[dict[str, Any]] = []
         ledger = layerb_shadow.BudgetLedger(args.max_usd, seat_caps, args.max_judge_calls)
         judge = layerb_shadow.SubprocessJudge(shlex.split(args.judge_command), args.judge_timeout_seconds)
@@ -854,9 +966,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             modules, module_requests, request_routes, strict=True
         ):
             request_hash = _sha256_json(request)
-            cache_path = _cache_path(cache_dir, request, effective_route.to_dict())
+            cache_path = _cache_path(cache_dir, request, effective_route.to_dict(), attempt=module.attempt)
             cached = _read_json(cache_path) if args.resume and cache_path.is_file() else None
-            call_id = f"artifact-{module.artifact_sha256}"
+            call_id = _call_id(module)
+            module_id = _module_id(module)
             call: layerb_shadow.JudgeCall | None = None
             response: Mapping[str, Any] | None = None
             status = "completed"
@@ -925,17 +1038,26 @@ def main(argv: Sequence[str] | None = None) -> int:
                 module_emissions[prepared_case.case_id] = _emission(
                     prepared_case,
                     call_id=call_id,
+                    attempt=module.attempt,
                     observed=observed,
                     response=case_response or _failure_response(prepared_case),
                     status=status,
                     validation_substituted=substitutions_by_case.get(prepared_case.case_id, ()),
                     evidence_pattern_hits=evidence_pattern_hits_by_case.get(prepared_case.case_id, ()),
                 )
-            emissions.update(module_emissions)
+            for case_id, emission in module_emissions.items():
+                attempts = emissions.setdefault(case_id, [])
+                if len(attempts) != module.attempt:
+                    raise CollectionError(
+                        f"{case_id}: cannot record attempt {module.attempt} after {len(attempts)} prior attempts"
+                    )
+                attempts.append(emission)
             manifest.append(
                 {
                     "artifact_sha256": module.artifact_sha256,
+                    "module_id": module_id,
                     "call_id": call_id,
+                    "attempt": module.attempt,
                     "corpus": module.corpus,
                     "case_ids": sorted(module_emissions),
                     "request_sha256": request_hash,
@@ -947,6 +1069,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     },
                     "serialized_window_sha256": serialized_window_hashes,
                     "input_token_upper_bound": module_route.max_input_tokens,
+                    "expected_module_envelope": module_call_plan[module_id],
                     "cost": dict(observed),
                     "seat": {"key": seat_key, "metadata": seat_metadata},
                     "status": status,
@@ -955,7 +1078,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "timestamp": _utc_now(),
                 }
             )
-            _write_collector_outputs(output_dir, emissions, route_payload, manifest)
+            _write_collector_outputs(output_dir, emissions, route_payload, manifest, module_call_plan)
             if module.corpus == "probe":
                 for prepared_case in module.cases:
                     probe_error = _probe_error(prepared_case, module_emissions[prepared_case.case_id], effective_route)

--- a/scripts/audit/layerb_qualify.py
+++ b/scripts/audit/layerb_qualify.py
@@ -650,6 +650,79 @@ def stability_case_ids(main_cases: Sequence[Mapping[str, Any]], probe_cases: Seq
     return selected
 
 
+def collection_call_plan_from_manifest(value: Any) -> dict[str, dict[str, Any]]:
+    """Read the collector-owned batch plan without inferring it from emissions."""
+
+    records = value.get("calls") if isinstance(value, Mapping) else value
+    declared_plans = value.get("module_call_plan") if isinstance(value, Mapping) else None
+    if not isinstance(records, list):
+        raise QualificationError("collector manifest requires a calls list")
+
+    def normalize(module_id: str, envelope: Mapping[str, Any], context: str) -> dict[str, Any]:
+        expected_ids = envelope.get("expected_call_ids")
+        expected_count = envelope.get("expected_call_count")
+        expected_prompt = envelope.get("expected_prompt_tokens")
+        expected_completion = envelope.get("expected_completion_tokens")
+        expected_cost = envelope.get("expected_cost_usd")
+        if (
+            not isinstance(expected_ids, list)
+            or not expected_ids
+            or any(not isinstance(item, str) or not item for item in expected_ids)
+            or len(set(expected_ids)) != len(expected_ids)
+            or not isinstance(expected_count, int)
+            or isinstance(expected_count, bool)
+            or expected_count != len(expected_ids)
+            or not isinstance(expected_prompt, int)
+            or isinstance(expected_prompt, bool)
+            or expected_prompt < 1
+            or not isinstance(expected_completion, int)
+            or isinstance(expected_completion, bool)
+            or expected_completion < 1
+            or not isinstance(expected_cost, (int, float))
+            or isinstance(expected_cost, bool)
+            or expected_cost < 0
+        ):
+            raise QualificationError(f"collector manifest {context} has an invalid expected module envelope")
+        return {
+            "expected_call_ids": tuple(sorted(expected_ids)),
+            "expected_call_count": expected_count,
+            "expected_prompt_tokens": expected_prompt,
+            "expected_completion_tokens": expected_completion,
+            "expected_cost_usd": float(expected_cost),
+        }
+
+    plans: dict[str, dict[str, Any]] = {}
+    if declared_plans is not None:
+        if not isinstance(declared_plans, Mapping) or not declared_plans:
+            raise QualificationError("collector manifest has no module_call_plan")
+        for module_id, envelope in declared_plans.items():
+            if not isinstance(module_id, str) or not module_id or not isinstance(envelope, Mapping):
+                raise QualificationError("collector manifest has malformed module_call_plan")
+            plans[module_id] = normalize(module_id, envelope, f"module plan {module_id}")
+    elif not records:
+        raise QualificationError("collector manifest requires a non-empty calls list")
+    for index, record in enumerate(records):
+        if not isinstance(record, Mapping):
+            raise QualificationError(f"collector manifest call {index} is not an object")
+        module_id, call_id, envelope = (
+            record.get("module_id"),
+            record.get("call_id"),
+            record.get("expected_module_envelope"),
+        )
+        if not isinstance(module_id, str) or not module_id or not isinstance(call_id, str) or not call_id:
+            raise QualificationError(f"collector manifest call {index} is missing module_id or call_id")
+        if not isinstance(envelope, Mapping):
+            raise QualificationError(f"collector manifest call {index} has no expected_module_envelope")
+        normalized = normalize(module_id, envelope, f"call {index}")
+        if call_id not in normalized["expected_call_ids"]:
+            raise QualificationError(f"collector manifest call {index} is not included in its expected module envelope")
+        existing = plans.get(module_id)
+        if existing is not None and existing != normalized:
+            raise QualificationError(f"collector manifest has conflicting expected envelopes for {module_id}")
+        plans[module_id] = normalized
+    return plans
+
+
 class QualificationRunner:
     """Score recorded emissions in probe-first order without invoking a judge."""
 
@@ -658,11 +731,13 @@ class QualificationRunner:
         *,
         route: EffectiveRoute,
         layer_a_probe_results: Sequence[Mapping[str, Any]],
+        collection_call_plan: Mapping[str, Mapping[str, Any]] | None = None,
         max_judge_calls: int | None = None,
         human_audit_complete: bool = False,
     ) -> None:
         self.route = route
         self.layer_a_probe_results = tuple(layer_a_probe_results)
+        self.collection_call_plan = dict(collection_call_plan or {})
         self.max_judge_calls = max_judge_calls
         self.human_audit_complete = human_audit_complete
 
@@ -834,45 +909,100 @@ class QualificationRunner:
     def _emission_for(emissions: Mapping[str, Any], case_id: str, attempt: int = 0) -> Mapping[str, Any] | None:
         value = emissions.get(case_id)
         if isinstance(value, list):
-            return value[attempt] if attempt < len(value) and isinstance(value[attempt], Mapping) else None
+            emission = value[attempt] if attempt < len(value) and isinstance(value[attempt], Mapping) else None
+            if emission is None:
+                return None
+            recorded_attempt = emission.get("attempt")
+            if recorded_attempt is not None and recorded_attempt != attempt:
+                return None
+            return emission
         return value if attempt == 0 and isinstance(value, Mapping) else None
 
-    def _cost_metrics(self, records: Sequence[Mapping[str, Any]]) -> tuple[dict[str, Any], list[str]]:
+    def _cost_metrics(
+        self, records: Sequence[Mapping[str, Any]], emissions: Mapping[str, Any]
+    ) -> tuple[dict[str, Any], list[str]]:
         calls: dict[str, dict[str, Any]] = {}
         errors: list[str] = []
         for record in records:
-            emission = record.get("emission")
-            if not isinstance(emission, Mapping) or record.get("actual_aggregate_relation", "").startswith("LAYER_A_"):
+            if record.get("actual_aggregate_relation", "").startswith("LAYER_A_"):
                 continue
-            module_id, call_id, observed = emission.get("module_id"), emission.get("call_id"), emission.get("observed")
-            if not isinstance(module_id, str) or not isinstance(call_id, str) or not isinstance(observed, Mapping):
-                errors.append("COST_OBSERVATION_MISSING")
-                continue
-            numeric = ("prompt_tokens", "completion_tokens", "cost_usd")
-            if any(not isinstance(observed.get(field), (int, float)) for field in numeric):
-                errors.append("COST_OBSERVATION_MALFORMED")
-                continue
-            entry = {"module_id": module_id, "call_id": call_id, **{field: float(observed[field]) for field in numeric}}
-            existing = calls.get(call_id)
-            if existing is not None and existing != entry:
-                errors.append("RAW_CALL_IDENTITY_FAILURE")
-            else:
-                calls[call_id] = entry
+            value = emissions.get(record["case_id"])
+            attempts: Iterable[Any] = value if isinstance(value, list) else (value,)
+            for emission in attempts:
+                if not isinstance(emission, Mapping):
+                    errors.append("COST_OBSERVATION_MISSING")
+                    continue
+                module_id, call_id, observed = (
+                    emission.get("module_id"),
+                    emission.get("call_id"),
+                    emission.get("observed"),
+                )
+                if not isinstance(module_id, str) or not isinstance(call_id, str) or not isinstance(observed, Mapping):
+                    errors.append("COST_OBSERVATION_MISSING")
+                    continue
+                numeric = ("prompt_tokens", "completion_tokens", "cost_usd")
+                if any(
+                    not isinstance(observed.get(field), (int, float)) or isinstance(observed.get(field), bool)
+                    for field in numeric
+                ):
+                    errors.append("COST_OBSERVATION_MALFORMED")
+                    continue
+                entry = {
+                    "module_id": module_id,
+                    "call_id": call_id,
+                    **{field: float(observed[field]) for field in numeric},
+                }
+                existing = calls.get(call_id)
+                if existing is not None and existing != entry:
+                    errors.append("RAW_CALL_IDENTITY_FAILURE")
+                else:
+                    calls[call_id] = entry
         per_module: dict[str, list[dict[str, Any]]] = defaultdict(list)
         for call in calls.values():
             per_module[call["module_id"]].append(call)
         modules: list[dict[str, Any]] = []
-        for module_id, module_calls in sorted(per_module.items()):
+        for module_id in sorted(set(per_module) | set(self.collection_call_plan)):
+            module_calls = per_module.get(module_id, [])
             prompt = sum(call["prompt_tokens"] for call in module_calls)
             completion = sum(call["completion_tokens"] for call in module_calls)
             cost = sum(call["cost_usd"] for call in module_calls)
+            plan = self.collection_call_plan.get(module_id)
+            if plan is None:
+                errors.append("COLLECTION_CALL_PLAN_MISSING")
+                plan = {}
+            expected_call_ids = plan.get("expected_call_ids")
+            expected_call_count = plan.get("expected_call_count")
+            expected_prompt = plan.get("expected_prompt_tokens")
+            expected_completion = plan.get("expected_completion_tokens")
+            expected_cost = plan.get("expected_cost_usd")
+            plan_complete = (
+                isinstance(expected_call_ids, tuple)
+                and isinstance(expected_call_count, int)
+                and isinstance(expected_prompt, int)
+                and isinstance(expected_completion, int)
+                and isinstance(expected_cost, float)
+            )
+            if not plan_complete:
+                errors.append("COLLECTION_CALL_PLAN_MALFORMED")
+                expected_call_ids, expected_call_count = (), 0
+                expected_prompt, expected_completion, expected_cost = 0, 0, 0.0
             module = {
                 "module_id": module_id,
                 "call_count": len(module_calls),
                 "prompt_tokens": prompt,
                 "completion_tokens": completion,
                 "cost_usd": cost,
-                "within_envelope": len(module_calls) <= 1 and prompt <= 10_000 and completion <= 800 and cost <= 0.25,
+                "expected_call_count": expected_call_count,
+                "expected_prompt_tokens": expected_prompt,
+                "expected_completion_tokens": expected_completion,
+                "expected_cost_usd": expected_cost,
+                "within_envelope": (
+                    len(module_calls) == expected_call_count
+                    and {call["call_id"] for call in module_calls} == set(expected_call_ids)
+                    and prompt <= expected_prompt
+                    and completion <= expected_completion
+                    and cost <= expected_cost + 1e-12
+                ),
             }
             modules.append(module)
             if not module["within_envelope"]:
@@ -933,10 +1063,12 @@ class QualificationRunner:
             raise QualificationError("both label sidecars require a cases list")
         main_cases = [case if isinstance(case, Mapping) else {} for case in main_cases_value]
         probe_cases = [case if isinstance(case, Mapping) else {} for case in probe_cases_value]
-        expected_cap = len(main_cases) + len(probe_cases)
+        expected_cap = sum(int(plan["expected_call_count"]) for plan in self.collection_call_plan.values())
+        if not self.collection_call_plan:
+            raise QualificationAbort("qualification scoring requires a collector-derived module call plan")
         if self.max_judge_calls is not None and self.max_judge_calls != expected_cap:
             raise QualificationAbort(
-                f"--max-judge-calls must equal {expected_cap} (535 + probes for the frozen run), got {self.max_judge_calls}"
+                f"--max-judge-calls must equal {expected_cap} collector-planned calls, got {self.max_judge_calls}"
             )
         layer_a = self._layer_a_gate()
         records: list[dict[str, Any]] = []
@@ -969,9 +1101,9 @@ class QualificationRunner:
             for record in records
             if record["emission"] is not None
         ]
-        cost, cost_errors = self._cost_metrics(records)
-        if cost["call_count"] > expected_cap:
-            cost_errors.append("MAX_JUDGE_CALLS_EXCEEDED")
+        cost, cost_errors = self._cost_metrics(records, emissions)
+        if cost["call_count"] != expected_cap:
+            cost_errors.append("COLLECTION_CALL_PLAN_TOTAL_MISMATCH")
         integrity_failures = Counter(
             failure for record in records for failure in [*record["integrity_failures"], *cost_errors]
         )
@@ -1290,11 +1422,23 @@ def _emissions_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
     raise QualificationError("emissions must be an object keyed by case_id or a list of emission objects")
 
 
+def _read_json_value(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise QualificationError(f"invalid JSON at {path}: {exc}") from exc
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Hermetic QG Layer-B judge qualification scorer")
     parser.add_argument("--main-labels", type=Path)
     parser.add_argument("--probe-labels", type=Path)
     parser.add_argument("--emissions", type=Path, help="Recorded emissions; never a judge command")
+    parser.add_argument(
+        "--collector-manifest",
+        type=Path,
+        help="Collector raw-call manifest carrying the concrete per-module batch plan.",
+    )
     parser.add_argument("--route", type=Path, help="Exact effective-route JSON")
     parser.add_argument("--layer-a-probes", type=Path, help="Six deterministic serializer probe results")
     parser.add_argument("--output-dir", type=Path, required=True)
@@ -1324,6 +1468,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             "--main-labels": args.main_labels,
             "--probe-labels": args.probe_labels,
             "--emissions": args.emissions,
+            "--collector-manifest": args.collector_manifest,
             "--route": args.route,
             "--layer-a-probes": args.layer_a_probes,
         }
@@ -1337,6 +1482,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         runner = QualificationRunner(
             route=EffectiveRoute.from_mapping(_read_json(args.route)),
             layer_a_probe_results=[probe for probe in probe_results if isinstance(probe, Mapping)],
+            collection_call_plan=collection_call_plan_from_manifest(_read_json_value(args.collector_manifest)),
             max_judge_calls=args.max_judge_calls,
             human_audit_complete=args.human_audit_complete,
         )

--- a/tests/test_layerb_collect_emissions.py
+++ b/tests/test_layerb_collect_emissions.py
@@ -129,6 +129,60 @@ def _shared_artifact_cases(directory: Path) -> list[dict[str, Any]]:
     ]
 
 
+def _many_shared_artifact_cases(directory: Path, count: int) -> list[dict[str, Any]]:
+    """Build a stability-sized main corpus that remains one artifact batch."""
+
+    raw = "Олена Теліга народилася 1906 року."
+    event = {
+        "tool": "query_wikipedia",
+        "input": {"query": "stability-module"},
+        "output": raw,
+        "status": "completed",
+        "document_id": "synthetic-stability-module",
+    }
+    fact_checks = [
+        {
+            "fact_check_id": f"stability-fact-{index}",
+            "claim": raw,
+            "verdict": "CONFIRMED",
+            "grounding": {"tool": "query_wikipedia", "query": "stability-module", "evidence_excerpt": raw},
+        }
+        for index in range(count)
+    ]
+    artifact = {
+        "schema_version": "qg_bakeoff_run.v1",
+        "fixture": {"slug": "stability-module"},
+        "payload": {"fact_checks": fact_checks},
+        "dispatch": {"tool_events": [event]},
+    }
+    candidate = layerb_candidates.materialize_candidates(fact_checks[0]["grounding"], [event]).candidates[0].to_dict()
+    candidate["expected_source_relation"] = "ENTAILS"
+    candidate["expected_support_spans"] = [{"start": 0, "end": len(raw), "role": "SUPPORTS"}]
+    path = directory / "stability-shared.json"
+    _write_json(path, artifact)
+    artifact_sha256 = hashlib.sha256(path.read_bytes()).hexdigest()
+    return [
+        {
+            "case_id": f"openrouter-deepseek-deepseek-v4-pro__stability.json#fact_checks[{index}]::stability-{index}",
+            "artifact_sha256": artifact_sha256,
+            "fixture_id": "stability-module",
+            "fact_check_id": fact_check["fact_check_id"],
+            "fact_check_index": index,
+            "claim": raw,
+            "evidence_excerpt": raw,
+            "expected_reviewer_verdict": "CONFIRMED",
+            "expected_layer_a_decision": "ANCHOR",
+            "anchor_scan_complete": True,
+            "candidate_set_complete": True,
+            "candidates_by_event_output_id": {candidate["event_output_id"]: [candidate]},
+            "expected_aggregate_relation": "ENTAILS",
+            "expected_fact_check_decision": "ACCEPT",
+            "failure_class": "ALTERED_CLAIM_VALUE",
+        }
+        for index, fact_check in enumerate(fact_checks)
+    ]
+
+
 def _datasets(tmp_path: Path, *, include_gemma: bool = False) -> tuple[Path, Path, dict[str, Any], dict[str, Any]]:
     main_case = _case_artifact(
         tmp_path,
@@ -426,7 +480,7 @@ def test_happy_path_emission_shape_matches_scorer_response_contract(tmp_path: Pa
 
     emission = json.loads((output_dir / "emissions.json").read_text(encoding="utf-8"))["emissions"][
         main_case["case_id"]
-    ]
+    ][0]
     candidates = layerb_qualify._candidate_rows(main_case)
     windows, _hashes, window_errors = layerb_qualify._validate_windows(candidates, emission)
     relations, response_errors = layerb_qualify._response_relations(main_case, candidates, emission, windows)
@@ -462,6 +516,8 @@ def test_collector_emissions_round_trip_through_scorer_without_judge_or_delimite
                 str(probe_path),
                 "--emissions",
                 str(output_dir / "emissions.json"),
+                "--collector-manifest",
+                str(output_dir / "raw-call-manifest.json"),
                 "--route",
                 str(output_dir / "route.json"),
                 "--layer-a-probes",
@@ -495,6 +551,77 @@ def test_one_module_envelope_covers_multiple_cases_with_one_judge_call(tmp_path:
     emissions = json.loads((output_dir / "emissions.json").read_text(encoding="utf-8"))["emissions"]
     assert set(emissions) == {shared_cases[0]["case_id"], shared_cases[1]["case_id"], probe_case["case_id"]}
     assert _counter_lines(counter) == 2
+
+
+def test_stability_replay_plan_collects_exact_subset_as_attempt_one(tmp_path: Path, monkeypatch, capsys) -> None:
+    main_path, probe_path, _main_case, probe_case = _datasets(tmp_path)
+    main_cases = _many_shared_artifact_cases(tmp_path, layerb_qualify.STABILITY_CASES)
+    _write_json(main_path, {"schema_version": "qg-layer-b-labels.v2", "cases": main_cases})
+    counter = tmp_path / "calls.log"
+    monkeypatch.setenv("LAYERB_STUB_COUNTER", str(counter))
+
+    assert (
+        layerb_collect_emissions.main(_collector_args(main_path, probe_path, tmp_path / "dry", calls=4, dry_run=True))
+        == 0
+    )
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["module_calls"] == 4
+    assert summary["primary_module_calls"] == 2
+    assert summary["stability_module_calls"] == 2
+    assert len(summary["stability_case_ids"]) == layerb_qualify.STABILITY_CASES
+    assert _counter_lines(counter) == 0
+
+    output_dir = tmp_path / "collector"
+    assert layerb_collect_emissions.main(_collector_args(main_path, probe_path, output_dir, calls=3)) == 2
+    assert _counter_lines(counter) == 0
+    assert layerb_collect_emissions.main(_collector_args(main_path, probe_path, output_dir, calls=4)) == 0
+    assert _counter_lines(counter) == 4
+
+    emissions = json.loads((output_dir / "emissions.json").read_text(encoding="utf-8"))["emissions"]
+    selected = set(layerb_qualify.stability_case_ids(main_cases, [probe_case]))
+    assert selected == set(summary["stability_case_ids"])
+    for case in [probe_case, *main_cases]:
+        attempts = emissions[case["case_id"]]
+        assert [entry["attempt"] for entry in attempts] == list(range(len(attempts)))
+        assert len(attempts) == (2 if case["case_id"] in selected else 1)
+
+    manifest = json.loads((output_dir / "raw-call-manifest.json").read_text(encoding="utf-8"))
+    assert manifest["version"] == "qg-layer-b-qualification-collector-manifest.v2"
+    assert len(manifest["calls"]) == 4
+    assert {entry["attempt"] for entry in manifest["calls"]} == {0, 1}
+    assert all(entry["expected_module_envelope"]["expected_call_count"] == 2 for entry in manifest["calls"])
+    assert all(plan["expected_call_count"] == 2 for plan in manifest["module_call_plan"].values())
+
+    calls_before_score = _counter_lines(counter)
+    score_dir = tmp_path / "score"
+    assert (
+        layerb_qualify.main(
+            [
+                "--main-labels",
+                str(main_path),
+                "--probe-labels",
+                str(probe_path),
+                "--emissions",
+                str(output_dir / "emissions.json"),
+                "--collector-manifest",
+                str(output_dir / "raw-call-manifest.json"),
+                "--route",
+                str(output_dir / "route.json"),
+                "--layer-a-probes",
+                str(_layer_a_probes(tmp_path / "layer-a-probes.json")),
+                "--output-dir",
+                str(score_dir),
+                "--max-judge-calls",
+                "4",
+            ]
+        )
+        == 0
+    )
+    report = json.loads((score_dir / "qualification-report.json").read_text(encoding="utf-8"))
+    assert report["thresholds"]["semantic_stability"]["status"] == "PASS"
+    assert report["thresholds"]["cost_envelope"]["status"] == "PASS"
+    assert report["thresholds"]["cost_envelope"]["call_count"] == 4
+    assert _counter_lines(counter) == calls_before_score
 
 
 @pytest.mark.parametrize(
@@ -578,8 +705,49 @@ def test_bridge_failure_emits_audited_probe_row_without_running_main(tmp_path: P
     assert layerb_collect_emissions.main(_collector_args(main_path, probe_path, output_dir, calls=2)) == 2
 
     emissions = json.loads((output_dir / "emissions.json").read_text(encoding="utf-8"))["emissions"]
-    assert emissions[probe_case["case_id"]]["status"] == "failure"
+    assert emissions[probe_case["case_id"]][0]["status"] == "failure"
     assert main_case["case_id"] not in emissions
+    assert _counter_lines(counter) == 1
+
+
+def test_probe_abort_preserves_full_call_plan_for_hermetic_scoring(tmp_path: Path, monkeypatch) -> None:
+    main_path, probe_path, _main_case, _probe_case = _datasets(tmp_path)
+    counter = tmp_path / "calls.log"
+    monkeypatch.setenv("LAYERB_STUB_COUNTER", str(counter))
+    monkeypatch.setenv("LAYERB_STUB_EXIT", "7")
+    output_dir = tmp_path / "collector"
+
+    assert layerb_collect_emissions.main(_collector_args(main_path, probe_path, output_dir, calls=2)) == 2
+    manifest = json.loads((output_dir / "raw-call-manifest.json").read_text(encoding="utf-8"))
+    assert len(manifest["calls"]) == 1
+    assert sum(plan["expected_call_count"] for plan in manifest["module_call_plan"].values()) == 2
+
+    score_dir = tmp_path / "score"
+    assert (
+        layerb_qualify.main(
+            [
+                "--main-labels",
+                str(main_path),
+                "--probe-labels",
+                str(probe_path),
+                "--emissions",
+                str(output_dir / "emissions.json"),
+                "--collector-manifest",
+                str(output_dir / "raw-call-manifest.json"),
+                "--route",
+                str(output_dir / "route.json"),
+                "--layer-a-probes",
+                str(_layer_a_probes(tmp_path / "layer-a-probes.json")),
+                "--output-dir",
+                str(score_dir),
+                "--max-judge-calls",
+                "2",
+            ]
+        )
+        == 2
+    )
+    report = json.loads((score_dir / "qualification-report.json").read_text(encoding="utf-8"))
+    assert report["aborted_reason"].startswith("PROBE_FAILURE:")
     assert _counter_lines(counter) == 1
 
 

--- a/tests/test_layerb_qualify.py
+++ b/tests/test_layerb_qualify.py
@@ -141,11 +141,47 @@ def _emission(
 
 
 def _run(
-    main_cases: list[dict[str, Any]], probe_cases: list[dict[str, Any]], emissions: dict[str, Any], **kwargs: Any
+    main_cases: list[dict[str, Any]],
+    probe_cases: list[dict[str, Any]],
+    emissions: dict[str, Any],
+    collection_call_plan: dict[str, dict[str, Any]] | None = None,
+    **kwargs: Any,
 ) -> dict[str, Any]:
-    return layerb_qualify.QualificationRunner(route=ROUTE, layer_a_probe_results=_probes(), **kwargs).run(
-        main_labels={"cases": main_cases}, probe_labels={"cases": probe_cases}, emissions=emissions
-    )
+    plans: dict[str, dict[str, Any]] = {}
+    for value in emissions.values():
+        attempts = value if isinstance(value, list) else [value]
+        for emission in attempts:
+            if not isinstance(emission, dict):
+                continue
+            module_id, call_id = emission.get("module_id"), emission.get("call_id")
+            if not isinstance(module_id, str) or not isinstance(call_id, str):
+                continue
+            plan = plans.setdefault(
+                module_id,
+                {
+                    "expected_call_ids": [],
+                    "expected_call_count": 0,
+                    "expected_prompt_tokens": 0,
+                    "expected_completion_tokens": 0,
+                    "expected_cost_usd": 0.0,
+                },
+            )
+            if call_id not in plan["expected_call_ids"]:
+                plan["expected_call_ids"].append(call_id)
+                plan["expected_call_count"] += 1
+                plan["expected_prompt_tokens"] += 10_000
+                plan["expected_completion_tokens"] += 800
+                plan["expected_cost_usd"] += 0.25
+    normalized_plans = {
+        module_id: {**plan, "expected_call_ids": tuple(sorted(plan["expected_call_ids"]))}
+        for module_id, plan in plans.items()
+    }
+    return layerb_qualify.QualificationRunner(
+        route=ROUTE,
+        layer_a_probe_results=_probes(),
+        collection_call_plan=collection_call_plan or normalized_plans,
+        **kwargs,
+    ).run(main_labels={"cases": main_cases}, probe_labels={"cases": probe_cases}, emissions=emissions)
 
 
 def test_per_candidate_scoring_reuses_production_aggregation_and_contradiction_can_accept() -> None:
@@ -431,6 +467,7 @@ def test_decisive_span_requires_role_matched_critical_coverage() -> None:
     assert candidate_score["agreement"] is False
     assert report["thresholds"]["relation_agreement"]["status"] == "FAIL"
     assert "SPAN_GOLD_OVERLAP_FAILURE" in report["thresholds"]["integrity"]["failures"]
+    assert report["thresholds"]["integrity"]["failures"]["SPAN_GOLD_OVERLAP_FAILURE"] == 1
 
 
 def test_invalid_or_hash_mismatched_rows_fail_without_leaving_a_denominator() -> None:
@@ -479,8 +516,17 @@ def test_call_cap_must_exactly_cover_main_plus_probe_rows() -> None:
     raw = "one"
     main = _case("main", raw)
     probe = _case("probe", raw)
+    plan = {
+        "module-1": {
+            "expected_call_ids": ("main-call", "probe-call"),
+            "expected_call_count": 2,
+            "expected_prompt_tokens": 20_000,
+            "expected_completion_tokens": 1_600,
+            "expected_cost_usd": 0.5,
+        }
+    }
     with pytest.raises(layerb_qualify.QualificationAbort, match="must equal 2"):
-        _run([main], [probe], {}, max_judge_calls=1)
+        _run([main], [probe], {}, collection_call_plan=plan, max_judge_calls=1)
 
 
 def test_six_layer_a_fail_closed_probes_are_serialized_by_production_delimiter() -> None:
@@ -522,6 +568,58 @@ def test_cost_envelopes_use_module_call_grouping_and_p95() -> None:
     assert any(not module["within_envelope"] for module in cost["modules"])
 
 
+def test_cost_envelope_uses_collector_plan_and_includes_stability_attempts() -> None:
+    raw = "planned cost source"
+    case = _case("planned-cost", raw)
+    primary = _emission(
+        case,
+        {"candidate-1": raw},
+        call_id="planned-primary",
+        observed={"prompt_tokens": 9_000.0, "completion_tokens": 300.0, "cost_usd": 0.10},
+    )
+    replay = _emission(
+        case,
+        {"candidate-1": raw},
+        call_id="planned-replay",
+        observed={"prompt_tokens": 9_500.0, "completion_tokens": 350.0, "cost_usd": 0.11},
+    )
+    primary["attempt"] = 0
+    replay["attempt"] = 1
+    envelope = {
+        "expected_call_ids": ["planned-primary", "planned-replay"],
+        "expected_call_count": 2,
+        "expected_prompt_tokens": 20_000,
+        "expected_completion_tokens": 1_600,
+        "expected_cost_usd": 0.50,
+    }
+    manifest = [
+        {"module_id": "module-1", "call_id": call_id, "expected_module_envelope": envelope}
+        for call_id in envelope["expected_call_ids"]
+    ]
+
+    report = _run(
+        [case],
+        [],
+        {case["case_id"]: [primary, replay]},
+        collection_call_plan=layerb_qualify.collection_call_plan_from_manifest(manifest),
+    )
+
+    cost = report["thresholds"]["cost_envelope"]
+    assert cost["status"] == "PASS"
+    assert cost["call_count"] == 2
+    module = cost["modules"][0]
+    assert module["module_id"] == "module-1"
+    assert module["call_count"] == 2
+    assert module["prompt_tokens"] == 18_500.0
+    assert module["completion_tokens"] == 650.0
+    assert module["cost_usd"] == pytest.approx(0.21)
+    assert module["expected_call_count"] == 2
+    assert module["expected_prompt_tokens"] == 20_000
+    assert module["expected_completion_tokens"] == 1_600
+    assert module["expected_cost_usd"] == 0.5
+    assert module["within_envelope"] is True
+
+
 def test_fixed_stability_subset_replay_rejects_any_relation_disagreement() -> None:
     raw = "stable source"
     probe = _case("stability-probe", raw, failure_class="PROMPT_INJECTION")
@@ -541,7 +639,7 @@ def test_fixed_stability_subset_replay_rejects_any_relation_disagreement() -> No
             {"candidate-1": raw},
             relations={"candidate-1": "CONTRADICTS"} if case is not probe else None,
             module_id=f"module-{index}",
-            call_id=f"call-{index}",
+            call_id=f"call-{index}-attempt-1",
         )
         emissions[case["case_id"]] = [first, second]
 


### PR DESCRIPTION
## Summary

Fixes the qualification-run machinery gaps from #5118.

- Replays exactly `stability_case_ids(..., seed=4913)` as attempt 1, keeps probe attempts ahead of any main request, and writes ordered per-attempt emissions. Replay cache keys and call IDs include the attempt, so a resumed primary response cannot satisfy the duplicate.
- Derives the exact cap and dry-run arithmetic from the complete primary-plus-replay module plan. The collector records that plan at the top level of `raw-call-manifest.json`, including expected call IDs, count, conservative prompt/completion bounds, and worst-case cost per fixture module.
- Requires the scorer to consume that collector manifest. Cost accounting covers every attempt and fails closed if observed call IDs/counts or aggregate prompt/completion/cost fall outside the collector-derived plan. A probe abort retains the full plan and scores as an abort under the original cap.
- Verified `SPAN_GOLD_OVERLAP_FAILURE` is emitted once per affected scored case into integrity; the same bad span correctly makes that candidate disagree for `relation_agreement`, rather than adding a second integrity failure.

## Verification (#M-4)

Working directory: `/Users/krisztiankoos/projects/learn-ukrainian/.worktrees/dispatch/codex/5118-qual-machinery`

```text
$ .venv/bin/python -m pytest -q tests/test_layerb_*.py
============================= 153 passed in 6.34s ==============================

$ .venv/bin/ruff check scripts/audit/layerb_collect_emissions.py scripts/audit/layerb_qualify.py tests/test_layerb_collect_emissions.py tests/test_layerb_qualify.py
All checks passed!
```

Real frozen-label dry run (535 main + 23 probes; `/usr/bin/true` was metadata-only and was not invoked):

```json
{"judge_calls_made": 0, "main_module_calls": 129, "module_calls": 131, "primary_module_calls": 112, "probe_module_calls": 2, "stability_module_calls": 19, "status": "dry-run"}
```

The exact cap is fail-closed: `--max-judge-calls 130` returns `--max-judge-calls must equal 131, got 130`.

## Review / merge

No auto-merge has been enabled. This ready PR needs the required independent non-GPT review before its responsible reviewer can arm auto-merge.

Refs #5118