### PR TITLE
fix(lexicon): fill learner English anchors from cached ukreng (#4515 part a)

### DIFF
--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -4886,15 +4886,20 @@ _SLOVNYK_UKRENG_PREFIX_LABELS = {
     "військ",
     "геогр",
     "геол",
+    "г",
     "гірн",
     "грам",
     "діал",
+    "див",
+    "док",
     "ек",
     "ел",
     "жарт",
+    "збірн",
     "зоол",
     "інформ",
     "іст",
+    "комп",
     "кул",
     "лінгв",
     "мат",
@@ -4904,25 +4909,78 @@ _SLOVNYK_UKRENG_PREFIX_LABELS = {
     "мн",
     "мор",
     "муз",
+    "недок",
+    "невідм",
     "перен",
     "побут",
     "поет",
     "політ",
+    "прийм",
+    "род",
     "розм",
+    "с",
+    "спец",
     "спорт",
     "тех",
+    "текст",
     "тж",
+    "тк",
     "фіз",
+    "фізіол",
     "філол",
     "філос",
     "хім",
     "церк",
+    "відм",
+    "в",
+    "спол",
+    "лит",
 }
 
 
-def _ukreng_prefix_is_label(prefix: str) -> bool:
-    words = re.findall(r"[А-Яа-яЄєІіЇїҐґ]+", prefix.casefold())
-    return all(word in _SLOVNYK_UKRENG_PREFIX_LABELS for word in words)
+def _ukreng_strip_aspect_prefix(body: str) -> str:
+    """Remove leading imperfective/perfective aspect pair(s) from ukreng body text."""
+    return re.sub(
+        r"^недок\.\s+.+?,\s+док\.\s+(?:\S+(?:,\s+\S+)*)?\s*",
+        "",
+        body,
+        count=1,
+        flags=re.IGNORECASE,
+    )
+
+
+def _ukreng_prefix_lemma_tokens(lemma: str) -> set[str]:
+    return {_strip_stress(variant).casefold() for variant in _split_lemma_variants(lemma) if variant}
+
+
+def _ukreng_prefix_is_label(prefix: str, *, lemma: str = "") -> bool:
+    """Return True when Cyrillic text before the English gloss is label-only."""
+    cleaned = re.sub(r"\([^)]*\)", " ", prefix)
+    if "див." in cleaned.casefold():
+        cleaned = re.sub(r"^.*?див\.\s*", " ", cleaned, count=1, flags=re.IGNORECASE)
+        cleaned = re.sub(r"^[^—–-]+(?:[—–-]\s*)?", " ", cleaned, count=1)
+    cleaned = re.sub(r"^в\s+спол\.\s+\S+(?:\s+як\s*)?", " ", cleaned, flags=re.IGNORECASE)
+    words = re.findall(r"[А-Яа-яЄєІіЇїҐґ]+|\d+", cleaned.casefold())
+    skip = _ukreng_prefix_lemma_tokens(lemma)
+    words = [word for word in words if word not in skip]
+    if not words:
+        return True
+    return all(word in _SLOVNYK_UKRENG_PREFIX_LABELS or word.isdigit() for word in words)
+
+
+def _slovnyk_ukreng_body_chunks(body: str) -> list[str]:
+    """Split ukreng body text into sense-sized chunks in deterministic order."""
+    chunks: list[str] = []
+    aspect_stripped = _ukreng_strip_aspect_prefix(body)
+    for part in re.split(r";|\n", aspect_stripped):
+        part = part.strip()
+        if not part:
+            continue
+        for sense in re.split(r"(?<=\))\s*(?=\d+\))", part):
+            sense = sense.strip()
+            if sense:
+                chunks.append(sense)
+    return chunks
 
 
 def _clean_ukreng_gloss(candidate: str) -> str | None:
@@ -4945,17 +5003,18 @@ def _slovnyk_ukreng_glosses(row: dict[str, Any], lemma: str, *, limit: int = 6) 
     body = _SOURCE_TAIL_RE.sub("", _entry_text_without_headword(text, lemma, str(row.get("word") or "")))
     out: list[str] = []
     seen: set[str] = set()
-    for chunk in re.split(r";|\n", body):
+    for chunk in _slovnyk_ukreng_body_chunks(body):
         chunk = re.sub(r"^\s*\d+\)?\.?\s*", "", chunk.strip())
         if not chunk:
             continue
         first_latin = _LATIN_RE.search(chunk)
-        if not first_latin or not _ukreng_prefix_is_label(chunk[: first_latin.start()]):
+        if not first_latin or not _ukreng_prefix_is_label(chunk[: first_latin.start()], lemma=lemma):
             continue
         english_part = chunk[first_latin.start() :]
         first_cyrillic = re.search(r"[А-Яа-яЄєІіЇїҐґ]", english_part)
         if first_cyrillic:
             english_part = english_part[: first_cyrillic.start()]
+        english_part = re.sub(r"\([^)]*\)", " ", english_part)
         english_part = re.split(r"\s+—", english_part, maxsplit=1)[0]
         for candidate in re.split(r",|/|\bor\b", english_part, flags=re.IGNORECASE):
             gloss = _clean_ukreng_gloss(candidate)
@@ -5004,6 +5063,62 @@ def _slovnyk_ukreng_translation(lemma: str, cache: dict[str, Any] | None) -> dic
     if source_url:
         block["source_url"] = source_url
     return block
+
+
+def _entry_has_learner_english_anchor(entry: dict[str, Any]) -> bool:
+    gloss = entry.get("gloss")
+    if isinstance(gloss, str) and gloss.strip():
+        return True
+    enrichment = entry.get("enrichment")
+    if not isinstance(enrichment, dict):
+        return False
+    translation = enrichment.get("translation")
+    if isinstance(translation, dict):
+        terms = translation.get("en")
+        if isinstance(terms, list) and any(isinstance(term, str) and term.strip() for term in terms):
+            return True
+    meaning = enrichment.get("meaning")
+    if isinstance(meaning, dict) and meaning.get("source") == KAIKKI_SOURCE:
+        definitions = meaning.get("definitions")
+        if isinstance(definitions, list) and any(isinstance(item, str) and item.strip() for item in definitions):
+            return True
+    return False
+
+
+def _fill_learner_english_anchor_from_slovnyk_cache(
+    entry: dict[str, Any],
+    lemma: str,
+    slovnyk_cache: dict[str, Any] | None,
+) -> bool:
+    """Fill a missing learner English anchor from a cached slovnyk ukreng row (#4515).
+
+    Offline-safe (#5114): only rows with cached ``text`` are consulted; never
+    live-fetch or invent a gloss.
+    """
+    if _entry_has_learner_english_anchor(entry):
+        return False
+    row = _cache_lookup(slovnyk_cache, _SLOVNYK_UKRENG_SLUG)
+    if not row:
+        return False
+    glosses = _slovnyk_ukreng_glosses(row, lemma)
+    if not glosses:
+        return False
+    translation: dict[str, object] = {
+        "en": glosses,
+        "source": _SLOVNYK_UKRENG_SOURCE,
+    }
+    source_url = str(row.get("source_url") or "").strip()
+    if source_url:
+        translation["source_url"] = source_url
+    enrichment = entry.get("enrichment")
+    if not isinstance(enrichment, dict):
+        enrichment = {}
+        entry["enrichment"] = enrichment
+    enrichment["translation"] = translation
+    sources = set(enrichment.get("sources") or [])
+    sources.add(_SLOVNYK_UKRENG_SOURCE)
+    enrichment["sources"] = sorted(sources)
+    return True
 
 
 def _translation(
@@ -5722,13 +5837,15 @@ def enrich_entry(
     else:
         entry.pop("enrichment", None)
 
+    filled_anchor = _fill_learner_english_anchor_from_slovnyk_cache(entry, lemma, slovnyk_cache)
+
     wiki_ref = _wiki_reference(lemma, block.get("literary_attestation"))
     if wiki_ref:
         entry["wiki_reference"] = wiki_ref
     else:
         entry.pop("wiki_reference", None)
 
-    return bool(block or sections or pronunciation or wiki_ref)
+    return bool(block or sections or pronunciation or wiki_ref or filled_anchor)
 
 
 def enrich() -> tuple[int, int]:

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,6 +1,5 @@
 {
-  "schema_version": 1,
-  "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
+  "fingerprint": "78da57a36df4668bd7fdfc40a59358fe7f87212c959f4c54a0facfa9bfe59bd0",
   "inputs": {
     "lexicon_code": [
       {
@@ -53,7 +52,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "042635510b49afc7b68be3d10ecdc8420a82a8d803cb9a32100cebecfab7518f"
+        "sha256": "c7598fb57ce24c46359a3de84b8459c85f3a9ed3f803200a5584299a9e06cdfc"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -133,11 +132,11 @@
       },
       {
         "path": "scripts/lexicon/publish_manifest.py",
-        "sha256": "f22cb1acc7d7d1fb23ac082301fbcf0c3de0e8e178f1eddfc74d072bf73aa6a6"
+        "sha256": "d1614c11e5099113ad2b4ec5104f07f86b16e64c7a5a8e46a40d0d9317562513"
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",
-        "sha256": "9270110568552cffdf82bfb907cb624afc38da121c4d3aa3e2af3fc95bb3a162"
+        "sha256": "28c72082c388ae5b301acc006eeed4e585c9fbbda48b805d1ff543d31862745d"
       },
       {
         "path": "scripts/lexicon/relation_pairs.py",
@@ -161,7 +160,8 @@
       }
     ]
   },
-  "fingerprint": "fc98f3dc7992876d33fbdd187930a806fe7ddde7b501deae4fcb7cea43608d03",
+  "schema_version": 1,
+  "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
     "lexicon_code_files": 39
   }

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "78da57a36df4668bd7fdfc40a59358fe7f87212c959f4c54a0facfa9bfe59bd0",
+  "fingerprint": "b87bba5c9d95daab04404d2a90074baadda710e4f9e8bb83badb94f76a838e54",
   "inputs": {
     "lexicon_code": [
       {
@@ -52,7 +52,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "c7598fb57ce24c46359a3de84b8459c85f3a9ed3f803200a5584299a9e06cdfc"
+        "sha256": "116d65bea38faaa2a984ebecc4623dc3cbcfa36960f328b50840c46cd127843a"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -132,11 +132,11 @@
       },
       {
         "path": "scripts/lexicon/publish_manifest.py",
-        "sha256": "d1614c11e5099113ad2b4ec5104f07f86b16e64c7a5a8e46a40d0d9317562513"
+        "sha256": "f22cb1acc7d7d1fb23ac082301fbcf0c3de0e8e178f1eddfc74d072bf73aa6a6"
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",
-        "sha256": "28c72082c388ae5b301acc006eeed4e585c9fbbda48b805d1ff543d31862745d"
+        "sha256": "9270110568552cffdf82bfb907cb624afc38da121c4d3aa3e2af3fc95bb3a162"
       },
       {
         "path": "scripts/lexicon/relation_pairs.py",

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -30,8 +30,10 @@ from scripts.lexicon.enrich_manifest import (
     _definition_pointer_relations_by_headword,
     _definition_synonym_targets,
     _dmklinger_key,
+    _entry_has_learner_english_anchor,
     _etymology,
     _etymology_lookup_variants,
+    _fill_learner_english_anchor_from_slovnyk_cache,
     _homonym_relations,
     _homonym_relations_by_headword,
     _idioms,
@@ -2340,10 +2342,49 @@ def test_translation_parses_slovnyk_ukreng_plural_label(monkeypatch) -> None:
     }
 
     assert _translation(conn, "бризки", {}, slovnyk_cache=cache) == {
-        "en": ["splashes", "spray"],
+        "en": ["splashes", "spray", "sparks", "fine drops of rain"],
         "source": _SLOVNYK_UKRENG_SOURCE,
         "source_url": "https://slovnyk.me/dict/ukreng/бризки",
     }
+
+
+def test_fill_learner_english_anchor_from_cached_ukreng() -> None:
+    cache = {
+        "lookups": {
+            "ukreng": {
+                "dictionary_slug": "ukreng",
+                "text": "перезавантаження комп. rebooting Джерело: Українсько-англійський словник на Slovnyk.me",
+                "source_url": "https://slovnyk.me/dict/ukreng/перезавантаження",
+            }
+        }
+    }
+    entry: dict[str, object] = {
+        "lemma": "перезавантаження",
+        "enrichment": {"cefr": {"level": "C1", "source": "estimated (GRAC frequency)"}},
+    }
+
+    assert _fill_learner_english_anchor_from_slovnyk_cache(entry, "перезавантаження", cache) is True
+    assert _entry_has_learner_english_anchor(entry)
+    enrichment = entry["enrichment"]
+    assert isinstance(enrichment, dict)
+    translation = enrichment["translation"]
+    assert isinstance(translation, dict)
+    assert translation["en"] == ["rebooting"]
+    assert translation["source"] == _SLOVNYK_UKRENG_SOURCE
+
+
+def test_fill_learner_english_anchor_leaves_entry_without_cached_ukreng() -> None:
+    entry: dict[str, object] = {
+        "lemma": "бажане",
+        "enrichment": {"cefr": {"level": "B1", "source": "estimated (GRAC frequency)"}},
+    }
+    cache = {"lookups": {"ukreng": None}}
+
+    assert _fill_learner_english_anchor_from_slovnyk_cache(entry, "бажане", cache) is False
+    assert not _entry_has_learner_english_anchor(entry)
+    enrichment = entry["enrichment"]
+    assert isinstance(enrichment, dict)
+    assert "translation" not in enrichment
 
 
 def test_translation_prefers_kaikki_over_curated_learner_gloss(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- Wire `_fill_learner_english_anchor_from_slovnyk_cache()` into `enrich_entry()` so grow-published entries missing a learner-facing gloss get `enrichment.translation.en` from **already-cached** slovnyk ukreng rows (offline-safe: `_cache_lookup` with text only; no live fetch; no invented glosses).
- Extend `_slovnyk_ukreng_glosses()` parsing for common ukreng cache shapes (aspect pairs, numbered senses, extra domain labels, parenthetical stripping).
- Unit tests for anchor fill (cached ukreng → anchor populated; null ukreng row → untouched).
- Refresh `lexicon-manifest.fingerprint.json` for the enrich code change.

## Audit (#M-4)

**Before** (baseline manifest `/tmp/lexicon-manifest-pre-4515-gloss-fill.json`, `--local`):

```
search_no_visible_gloss: 196
old_gate_no_english_anchor: 196
```

**After** (local fill run, `--local`):

```
search_no_visible_gloss: 158
old_gate_no_english_anchor: 158
```

**Filled:** 38 entries gained `enrichment.translation` from cached ukreng glosses.

## Fail-closed remainder (158)

Not filled (by design — no usable cached ukreng gloss):

| Reason | Count |
| --- | ---: |
| Cached ukreng slug present but row is `null` (lemma absent from ukreng dict offline) | 151 |
| Cached ukreng text present but parser yields no clean gloss | 7 |

Unparsed-text lemmas: `замкнуто`, `здирати`, `коригування`, `косуля`, `літа`, `мовби`, `стиглий`.

Re-publish / part (b) CI gate placement intentionally **not** in scope.

## Verification

- `verify_manifest.py --manifest site/src/data/lexicon-manifest.json --baseline /tmp/lexicon-manifest-pre-4515-gloss-fill.json --sample 0` → **CLEAN** (shrink gate passed; add-only)
- `pytest tests/test_lexicon_enrich_manifest.py` (143 passed incl. new anchor-fill tests)
- `ruff check scripts/lexicon/enrich_manifest.py tests/test_lexicon_enrich_manifest.py`

Refs #4515

Made with [Cursor](https://cursor.com)