### PR TITLE
fix(lexicon): gate Atlas richness at publish time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,10 +257,9 @@ jobs:
       # Learner-facing static Atlas gate (#3930). ADVISORY since #4515: all
       # three caps (gloss, anchor, thin pages) audit the LIVE release asset,
       # not this PR's diff — regressions can only enter at publish time, where
-      # scripts/lexicon/publish_manifest.py enforces the thin-page cap
-      # (DEFAULT_MAX_POC_THIN_PAGES in audit_atlas_poc_richness.py) as a hard
-      # ManifestPublishError; anchor/gloss caps are held at 0 by the same
-      # publish flow. Blocking here failed unrelated PRs after the fact
+      # scripts/lexicon/publish_manifest.py compares all three metrics against
+      # the canonical published Release asset and raises ManifestPublishError
+      # only for a regression. Blocking here failed unrelated PRs after the fact
       # (#4514/#4512, 2026-07-06). Kept for visibility only.
       - name: Gate Atlas POC richness and learner anchors (#3930, advisory since #4515)
         continue-on-error: true

--- a/docs/bug-autopsies/2026-06-26-atlas-hydrate-clobber.md
+++ b/docs/bug-autopsies/2026-06-26-atlas-hydrate-clobber.md
@@ -77,9 +77,10 @@ paid (bundle output-neutral code changes into a PR that regenerates the manifest
 
    ```python
    from scripts.lexicon import publish_manifest as pm
-   gz = pm.gzip_manifest()                        # re-gzip the freshly regenerated manifest
-   payload = pm.build_pointer_payload(...)         # new gz_sha256/json_sha256/fingerprint
-   pm.write_pointer(pointer_path, payload)         # NO gh release upload
+   # Do not call gzip_manifest/build_pointer_payload/write_pointer directly:
+   # every canonical pointer write must first pass the shared richness gate.
+   # Use publish_manifest (or reenrich_thin_manifest_entries.py --write), which
+   # records the gate decision and then packages the pointer.
    ```
 
    Now `local manifest sha == pointer.json_sha256` → hydrate is a **no-op** → the build renders the

--- a/scripts/audit/audit_atlas_poc_richness.py
+++ b/scripts/audit/audit_atlas_poc_richness.py
@@ -21,10 +21,9 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
 
-# #4515: the BINDING thin-page cap. Enforced hard at publish time
-# (scripts/lexicon/publish_manifest.py) — the per-PR CI step reports the same
-# number advisorily. Raising this value is threshold-lowering and needs an
-# operator decision; the aligned fix is enriching thin pages before publish.
+# #4515: the advisory per-PR CI threshold. The publish path compares the
+# candidate against the canonical live Release asset instead, so improving a
+# pre-existing debt count remains publishable without raising this threshold.
 DEFAULT_MAX_POC_THIN_PAGES = 900
 
 SCRIPT_DIR = Path(__file__).resolve().parent

--- a/scripts/lexicon/README.md
+++ b/scripts/lexicon/README.md
@@ -67,6 +67,19 @@ reason:
 The pointer written by a real publish records the baseline/candidate counts,
 regressions, and any override reason.
 
+The first canonical asset must use the explicit bootstrap path; it remains
+fail-closed by default. Bootstrap succeeds only when no canonical release asset
+exists, still rejects broken form stubs, and records `bootstrap: true` in the
+pointer's `richness_gate` record:
+
+```bash
+.venv/bin/python -m scripts.lexicon.publish_manifest --bootstrap-no-baseline
+```
+
+Both `publish_manifest` and `reenrich_thin_manifest_entries.py --write` use the
+same gate before gzip or pointer writes. The pointer builder and writer reject
+payloads without its complete recorded decision.
+
 ### Offline enrich is non-destructive (preserve-vs-retract, #5077)
 
 `enrich_manifest.py` recomputes gated sections (synonyms/antonyms/homonyms/paronyms/

--- a/scripts/lexicon/README.md
+++ b/scripts/lexicon/README.md
@@ -50,6 +50,23 @@ The last command publishes a Release asset and must run only when publishing is
 authorized. See `docs/bug-autopsies/atlas-manifest-source-split.md` for the
 2026-07-13 evidence behind this split.
 
+Before packaging or uploading, `publish_manifest` downloads the canonical live
+Release asset and compares the three Atlas POC richness counts against the
+candidate: `poc_thin_pages`, `search_no_visible_gloss`, and
+`old_gate_no_english_anchor`. A count may remain above the advisory CI limit if
+it improves (for example, gloss-less search rows `158→120`); a regression
+blocks publish.
+An operator may publish an approved exception only with a non-empty recorded
+reason:
+
+```bash
+.venv/bin/python -m scripts.lexicon.publish_manifest \
+  --allow-richness-regression "<operator decision and reason>"
+```
+
+The pointer written by a real publish records the baseline/candidate counts,
+regressions, and any override reason.
+
 ### Offline enrich is non-destructive (preserve-vs-retract, #5077)
 
 `enrich_manifest.py` recomputes gated sections (synonyms/antonyms/homonyms/paronyms/

--- a/scripts/lexicon/publish_manifest.py
+++ b/scripts/lexicon/publish_manifest.py
@@ -42,6 +42,11 @@ REQUIRED_POINTER_KEYS = (
     "gz_bytes",
     "json_bytes",
 )
+RICHNESS_REGRESSION_KEYS = (
+    "poc_thin_pages",
+    "search_no_visible_gloss",
+    "old_gate_no_english_anchor",
+)
 
 
 class ManifestPublishError(RuntimeError):
@@ -235,6 +240,26 @@ def _download_release_asset(
     return result.stdout
 
 
+def download_published_manifest(
+    *,
+    release_tag: str = DEFAULT_RELEASE_TAG,
+    repo: str = DEFAULT_REPO,
+) -> dict[str, Any]:
+    """Return the canonical live Atlas manifest used as the publish baseline."""
+    try:
+        manifest_bytes = gzip.decompress(
+            _download_release_asset(ASSET_NAME, release_tag=release_tag, repo=repo)
+        )
+        manifest = json.loads(manifest_bytes.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ManifestPublishError(
+            "could not read the canonical published Atlas manifest for the richness baseline"
+        ) from exc
+    if not isinstance(manifest, dict):
+        raise ManifestPublishError("canonical published Atlas manifest must contain a JSON object")
+    return manifest
+
+
 def verify_existing_release_asset(
     asset_name: str,
     *,
@@ -280,27 +305,25 @@ def upload_manifest_assets(
 def assert_manifest_richness_publishable(
     manifest_path: Path,
     *,
-    max_poc_thin_pages: int | None = None,
+    baseline_manifest: dict[str, Any],
+    allow_richness_regression_reason: str | None = None,
 ) -> dict[str, Any]:
-    """#4515: thin-page regressions can only ENTER at publish time — so the
-    binding cap lives here, not in per-PR CI (which audits the live asset and
-    therefore fails unrelated PRs after the fact; that step is now advisory).
+    """Block publish-time richness regressions relative to the live asset.
 
-    Raises :class:`ManifestPublishError` with an actionable message when the
-    manifest about to be published carries more thin POC pages than the cap.
-    Runs on dry-run too (preflight should fail the same way the real publish
-    would). There is deliberately NO CLI override — enrich, don't bypass.
+    Per-PR CI deliberately audits the live asset only as an advisory signal.
+    This mutation chokepoint compares the manifest about to be published with
+    the canonical live Release asset, including on dry runs.
     """
-    from scripts.audit.audit_atlas_poc_richness import (
-        DEFAULT_MAX_POC_THIN_PAGES,
-        audit_manifest,
-    )
+    from scripts.audit.audit_atlas_poc_richness import audit_manifest
 
-    cap = DEFAULT_MAX_POC_THIN_PAGES if max_poc_thin_pages is None else max_poc_thin_pages
+    reason = allow_richness_regression_reason.strip() if allow_richness_regression_reason else None
+    if allow_richness_regression_reason is not None and not reason:
+        raise ManifestPublishError("--allow-richness-regression requires a non-empty reason")
+
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    summary = audit_manifest(manifest)
-    thin = int(summary["poc_thin_pages"])
-    broken_stubs = int(summary.get("form_stub_broken", 0))
+    candidate_summary = audit_manifest(manifest)
+    baseline_summary = audit_manifest(baseline_manifest)
+    broken_stubs = int(candidate_summary.get("form_stub_broken", 0))
     if broken_stubs > 0:
         raise ManifestPublishError(
             f"publish blocked (#4220): manifest at {manifest_path} has {broken_stubs} "
@@ -310,16 +333,31 @@ def assert_manifest_richness_publishable(
             f"--limit 2000, bucket form_stub_broken) before publishing. There is no "
             f"publish-time override by design."
         )
-    if thin > cap:
-        raise ManifestPublishError(
-            f"publish blocked (#4515): manifest at {manifest_path} has {thin} thin "
-            f"POC pages (> cap {cap}). Enrich the thin entries before publishing "
-            f"(entry list: scripts/audit/audit_atlas_poc_richness.py --format tsv; "
-            f"machine-readable: --format json --limit 2000; fill via enrich_entry / "
-            f"the fill recipe), then re-run. The cap has no publish-time override "
-            f"by design."
+    regressions = {
+        key: {
+            "baseline": int(baseline_summary[key]),
+            "candidate": int(candidate_summary[key]),
+        }
+        for key in RICHNESS_REGRESSION_KEYS
+        if int(candidate_summary[key]) > int(baseline_summary[key])
+    }
+    record = {
+        "baseline": {key: int(baseline_summary[key]) for key in RICHNESS_REGRESSION_KEYS},
+        "candidate": {key: int(candidate_summary[key]) for key in RICHNESS_REGRESSION_KEYS},
+        "regressions": regressions,
+        "override_reason": reason,
+    }
+    if regressions and reason is None:
+        details = ", ".join(
+            f"{key} {values['baseline']}→{values['candidate']}"
+            for key, values in regressions.items()
         )
-    return summary
+        raise ManifestPublishError(
+            f"publish blocked (#4515): Atlas POC richness regressed versus the canonical "
+            f"published manifest ({details}). Enrich the affected entries before publishing "
+            "or use --allow-richness-regression with an operator decision reason."
+        )
+    return record
 
 
 def publish_manifest(
@@ -331,8 +369,14 @@ def publish_manifest(
     release_tag: str = DEFAULT_RELEASE_TAG,
     repo: str = DEFAULT_REPO,
     dry_run: bool = False,
+    allow_richness_regression_reason: str | None = None,
 ) -> dict[str, Any]:
-    assert_manifest_richness_publishable(manifest_path)
+    baseline_manifest = download_published_manifest(release_tag=release_tag, repo=repo)
+    richness_record = assert_manifest_richness_publishable(
+        manifest_path,
+        baseline_manifest=baseline_manifest,
+        allow_richness_regression_reason=allow_richness_regression_reason,
+    )
     gzip_manifest(manifest_path, gzip_path)
     pointer = build_pointer_payload(
         manifest_path=manifest_path,
@@ -341,6 +385,7 @@ def publish_manifest(
         release_tag=release_tag,
         repo=repo,
     )
+    pointer["richness_gate"] = richness_record
 
     if dry_run:
         return pointer
@@ -359,6 +404,11 @@ def main() -> int:
     parser.add_argument("--release-tag", default=DEFAULT_RELEASE_TAG)
     parser.add_argument("--repo", default=DEFAULT_REPO)
     parser.add_argument("--dry-run", action="store_true", help="Build metadata without uploading or writing pointer")
+    parser.add_argument(
+        "--allow-richness-regression",
+        metavar="REASON",
+        help="Publish despite a richness regression, recording this required operator decision reason.",
+    )
     args = parser.parse_args()
 
     pointer = publish_manifest(
@@ -369,6 +419,7 @@ def main() -> int:
         release_tag=args.release_tag,
         repo=args.repo,
         dry_run=args.dry_run,
+        allow_richness_regression_reason=args.allow_richness_regression,
     )
     print(
         "Atlas manifest pointer "

--- a/scripts/lexicon/publish_manifest.py
+++ b/scripts/lexicon/publish_manifest.py
@@ -144,7 +144,10 @@ def build_pointer_payload(
     fingerprint_path: Path = DEFAULT_FINGERPRINT,
     release_tag: str = DEFAULT_RELEASE_TAG,
     repo: str = DEFAULT_REPO,
+    richness_gate: dict[str, Any],
 ) -> dict[str, Any]:
+    """Build a pointer only after the shared release-richness gate has run."""
+    validate_richness_gate_record(richness_gate)
     manifest_bytes = manifest_path.read_bytes()
     gzip_bytes = gzip_path.read_bytes()
     manifest = json.loads(manifest_bytes.decode("utf-8"))
@@ -171,6 +174,7 @@ def build_pointer_payload(
         "json_sha256": json_sha256,
         "gz_bytes": len(gzip_bytes),
         "json_bytes": len(manifest_bytes),
+        "richness_gate": richness_gate,
         "note": "Pins GitHub Release asset manifest for #3659; hydrate it build time instead committing raw JSON.",
     }
     validate_pointer_freshness(pointer, fingerprint, manifest=manifest)
@@ -178,6 +182,11 @@ def build_pointer_payload(
 
 
 def write_pointer(pointer_path: Path, payload: dict[str, Any]) -> None:
+    """Persist only a pointer built with a recorded richness-gate decision."""
+    gate_record = payload.get("richness_gate")
+    if not isinstance(gate_record, dict):
+        raise ManifestPublishError("Atlas manifest pointer requires a richness_gate record")
+    validate_richness_gate_record(gate_record)
     pointer_path.parent.mkdir(parents=True, exist_ok=True)
     temp_path = pointer_path.with_suffix(f"{pointer_path.suffix}.tmp")
     temp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
@@ -240,6 +249,19 @@ def _download_release_asset(
     return result.stdout
 
 
+def _stderr_excerpt(error: subprocess.CalledProcessError, *, limit: int = 400) -> str:
+    """Return bounded command stderr without inspecting the process environment."""
+    stderr = error.stderr
+    if isinstance(stderr, bytes):
+        text = stderr.decode("utf-8", errors="replace")
+    elif isinstance(stderr, str):
+        text = stderr
+    else:
+        text = ""
+    normalized = " ".join(text.split())
+    return normalized[:limit]
+
+
 def download_published_manifest(
     *,
     release_tag: str = DEFAULT_RELEASE_TAG,
@@ -251,9 +273,11 @@ def download_published_manifest(
             _download_release_asset(ASSET_NAME, release_tag=release_tag, repo=repo)
         )
         manifest = json.loads(manifest_bytes.decode("utf-8"))
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (subprocess.CalledProcessError, OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        excerpt = _stderr_excerpt(exc) if isinstance(exc, subprocess.CalledProcessError) else ""
+        detail = f" (gh stderr: {excerpt})" if excerpt else ""
         raise ManifestPublishError(
-            "could not read the canonical published Atlas manifest for the richness baseline"
+            "could not read the canonical published Atlas manifest for the richness baseline" + detail
         ) from exc
     if not isinstance(manifest, dict):
         raise ManifestPublishError("canonical published Atlas manifest must contain a JSON object")
@@ -360,6 +384,102 @@ def assert_manifest_richness_publishable(
     return record
 
 
+def assert_manifest_richness_bootstrap_publishable(manifest_path: Path) -> dict[str, Any]:
+    """Validate a first publish that deliberately has no canonical baseline yet."""
+    from scripts.audit.audit_atlas_poc_richness import audit_manifest
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    candidate_summary = audit_manifest(manifest)
+    broken_stubs = int(candidate_summary.get("form_stub_broken", 0))
+    if broken_stubs > 0:
+        raise ManifestPublishError(
+            f"publish blocked (#4220): manifest at {manifest_path} has {broken_stubs} "
+            "broken form_of stub page(s). Each stub must point at an existing manifest "
+            "entry and expose a gloss or form_of lemma label. Repair the broken stubs "
+            "(samples: scripts/audit/audit_atlas_poc_richness.py --format json "
+            "--limit 2000, bucket form_stub_broken) before publishing. There is no "
+            "publish-time override by design."
+        )
+    return {
+        "bootstrap": True,
+        "baseline": None,
+        "candidate": {key: int(candidate_summary[key]) for key in RICHNESS_REGRESSION_KEYS},
+        "regressions": {},
+        "override_reason": None,
+    }
+
+
+def canonical_published_manifest_exists(
+    *,
+    release_tag: str = DEFAULT_RELEASE_TAG,
+    repo: str = DEFAULT_REPO,
+) -> bool:
+    """Return whether the canonical baseline asset exists on the configured release."""
+    try:
+        return ASSET_NAME in _release_asset_names(release_tag=release_tag, repo=repo)
+    except subprocess.CalledProcessError as exc:
+        excerpt = _stderr_excerpt(exc)
+        raise ManifestPublishError(
+            "could not determine whether the canonical published Atlas manifest exists"
+            + (f" (gh stderr: {excerpt})" if excerpt else "")
+        ) from exc
+
+
+def evaluate_manifest_pointer_write_gate(
+    manifest_path: Path,
+    *,
+    release_tag: str = DEFAULT_RELEASE_TAG,
+    repo: str = DEFAULT_REPO,
+    allow_richness_regression_reason: str | None = None,
+    bootstrap_no_baseline: bool = False,
+) -> dict[str, Any]:
+    """Run the one required richness decision before any Atlas pointer packaging."""
+    if bootstrap_no_baseline:
+        if allow_richness_regression_reason is not None:
+            raise ManifestPublishError(
+                "--bootstrap-no-baseline cannot be combined with --allow-richness-regression"
+            )
+        if canonical_published_manifest_exists(release_tag=release_tag, repo=repo):
+            raise ManifestPublishError(
+                "--bootstrap-no-baseline is only valid when the canonical published Atlas manifest "
+                "does not exist"
+            )
+        return assert_manifest_richness_bootstrap_publishable(manifest_path)
+
+    baseline_manifest = download_published_manifest(release_tag=release_tag, repo=repo)
+    record = assert_manifest_richness_publishable(
+        manifest_path,
+        baseline_manifest=baseline_manifest,
+        allow_richness_regression_reason=allow_richness_regression_reason,
+    )
+    record["bootstrap"] = False
+    return record
+
+
+def validate_richness_gate_record(record: dict[str, Any]) -> None:
+    """Reject pointer payloads that did not carry a complete gate decision."""
+    bootstrap = record.get("bootstrap")
+    if not isinstance(bootstrap, bool):
+        raise ManifestPublishError("Atlas manifest richness_gate must record boolean bootstrap")
+
+    candidate = record.get("candidate")
+    if not isinstance(candidate, dict) or any(key not in candidate for key in RICHNESS_REGRESSION_KEYS):
+        raise ManifestPublishError("Atlas manifest richness_gate must record all candidate richness metrics")
+
+    baseline = record.get("baseline")
+    if bootstrap:
+        if baseline is not None:
+            raise ManifestPublishError("bootstrap richness_gate must not contain a baseline")
+    elif not isinstance(baseline, dict) or any(key not in baseline for key in RICHNESS_REGRESSION_KEYS):
+        raise ManifestPublishError("Atlas manifest richness_gate must record all baseline richness metrics")
+
+    regressions = record.get("regressions")
+    if not isinstance(regressions, dict):
+        raise ManifestPublishError("Atlas manifest richness_gate must record regressions")
+    if "override_reason" not in record:
+        raise ManifestPublishError("Atlas manifest richness_gate must record override_reason")
+
+
 def publish_manifest(
     *,
     manifest_path: Path = DEFAULT_MANIFEST,
@@ -370,12 +490,14 @@ def publish_manifest(
     repo: str = DEFAULT_REPO,
     dry_run: bool = False,
     allow_richness_regression_reason: str | None = None,
+    bootstrap_no_baseline: bool = False,
 ) -> dict[str, Any]:
-    baseline_manifest = download_published_manifest(release_tag=release_tag, repo=repo)
-    richness_record = assert_manifest_richness_publishable(
+    richness_record = evaluate_manifest_pointer_write_gate(
         manifest_path,
-        baseline_manifest=baseline_manifest,
+        release_tag=release_tag,
+        repo=repo,
         allow_richness_regression_reason=allow_richness_regression_reason,
+        bootstrap_no_baseline=bootstrap_no_baseline,
     )
     gzip_manifest(manifest_path, gzip_path)
     pointer = build_pointer_payload(
@@ -384,8 +506,8 @@ def publish_manifest(
         fingerprint_path=fingerprint_path,
         release_tag=release_tag,
         repo=repo,
+        richness_gate=richness_record,
     )
-    pointer["richness_gate"] = richness_record
 
     if dry_run:
         return pointer
@@ -409,6 +531,14 @@ def main() -> int:
         metavar="REASON",
         help="Publish despite a richness regression, recording this required operator decision reason.",
     )
+    parser.add_argument(
+        "--bootstrap-no-baseline",
+        action="store_true",
+        help=(
+            "Allow the first publish only when the canonical release asset does not exist; "
+            "records bootstrap=true in the pointer."
+        ),
+    )
     args = parser.parse_args()
 
     pointer = publish_manifest(
@@ -420,6 +550,7 @@ def main() -> int:
         repo=args.repo,
         dry_run=args.dry_run,
         allow_richness_regression_reason=args.allow_richness_regression,
+        bootstrap_no_baseline=args.bootstrap_no_baseline,
     )
     print(
         "Atlas manifest pointer "

--- a/scripts/lexicon/reenrich_thin_manifest_entries.py
+++ b/scripts/lexicon/reenrich_thin_manifest_entries.py
@@ -26,6 +26,7 @@ from scripts.lexicon.publish_manifest import (
     DEFAULT_GZIP,
     DEFAULT_POINTER,
     build_pointer_payload,
+    evaluate_manifest_pointer_write_gate,
     gzip_manifest,
     write_pointer,
 )
@@ -58,11 +59,25 @@ def _refresh_manifest_fingerprint(manifest: dict[str, Any]) -> None:
     }
 
 
-def _write_default_release_pointer(manifest_path: Path) -> dict[str, Any] | None:
+def _write_default_release_pointer(
+    manifest_path: Path,
+    *,
+    bootstrap_no_baseline: bool = False,
+    allow_richness_regression_reason: str | None = None,
+) -> dict[str, Any] | None:
     if manifest_path.resolve() != DEFAULT_MANIFEST.resolve():
         return None
+    richness_gate = evaluate_manifest_pointer_write_gate(
+        manifest_path,
+        bootstrap_no_baseline=bootstrap_no_baseline,
+        allow_richness_regression_reason=allow_richness_regression_reason,
+    )
     gzip_manifest(manifest_path, DEFAULT_GZIP)
-    pointer = build_pointer_payload(manifest_path=manifest_path, gzip_path=DEFAULT_GZIP)
+    pointer = build_pointer_payload(
+        manifest_path=manifest_path,
+        gzip_path=DEFAULT_GZIP,
+        richness_gate=richness_gate,
+    )
     write_pointer(DEFAULT_POINTER, pointer)
     return pointer
 
@@ -310,6 +325,16 @@ def main() -> int:
     )
     parser.add_argument("--refresh-wiki", action="store_true")
     parser.add_argument("--write", action="store_true")
+    parser.add_argument(
+        "--allow-richness-regression",
+        metavar="REASON",
+        help="Record an operator decision to permit a richness regression while writing the pointer.",
+    )
+    parser.add_argument(
+        "--bootstrap-no-baseline",
+        action="store_true",
+        help="Write only an initial pointer when no canonical release asset exists; records bootstrap=true.",
+    )
     args = parser.parse_args()
 
     manifest_path = args.manifest if args.manifest.is_absolute() else ROOT / args.manifest
@@ -334,7 +359,11 @@ def main() -> int:
     if args.write:
         _refresh_manifest_fingerprint(manifest)
         _write_manifest(manifest_path, manifest)
-        pointer = _write_default_release_pointer(manifest_path)
+        pointer = _write_default_release_pointer(
+            manifest_path,
+            bootstrap_no_baseline=args.bootstrap_no_baseline,
+            allow_richness_regression_reason=args.allow_richness_regression,
+        )
         if pointer:
             print(
                 "Updated local atlas-manifest pointer "

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,6 @@
 {
-  "fingerprint": "b40f569524811bd28b53b22006be968bc9967825b5319d4fffcdebe96cb87928",
+  "schema_version": 1,
+  "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "inputs": {
     "lexicon_code": [
       {
@@ -132,11 +133,11 @@
       },
       {
         "path": "scripts/lexicon/publish_manifest.py",
-        "sha256": "d1614c11e5099113ad2b4ec5104f07f86b16e64c7a5a8e46a40d0d9317562513"
+        "sha256": "f22cb1acc7d7d1fb23ac082301fbcf0c3de0e8e178f1eddfc74d072bf73aa6a6"
       },
       {
         "path": "scripts/lexicon/reenrich_thin_manifest_entries.py",
-        "sha256": "28c72082c388ae5b301acc006eeed4e585c9fbbda48b805d1ff543d31862745d"
+        "sha256": "9270110568552cffdf82bfb907cb624afc38da121c4d3aa3e2af3fc95bb3a162"
       },
       {
         "path": "scripts/lexicon/relation_pairs.py",
@@ -160,8 +161,7 @@
       }
     ]
   },
-  "schema_version": 1,
-  "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
+  "fingerprint": "fc98f3dc7992876d33fbdd187930a806fe7ddde7b501deae4fcb7cea43608d03",
   "stats": {
     "lexicon_code_files": 39
   }

--- a/tests/test_publish_manifest.py
+++ b/tests/test_publish_manifest.py
@@ -88,6 +88,10 @@ def test_publish_manifest_uploads_versioned_and_canonical_assets(
         raise AssertionError(f"unexpected command: {args}")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        "scripts.lexicon.publish_manifest.download_published_manifest",
+        lambda **kwargs: {"entries": []},
+    )
 
     pointer = publish_manifest(
         manifest_path=manifest_path,
@@ -138,6 +142,10 @@ def test_publish_manifest_skips_existing_verified_versioned_asset(
         raise AssertionError(f"unexpected command: {args}")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        "scripts.lexicon.publish_manifest.download_published_manifest",
+        lambda **kwargs: {"entries": []},
+    )
 
     publish_manifest(
         manifest_path=manifest_path,
@@ -170,24 +178,62 @@ def test_pointer_freshness_guard_fails_on_stale_pointer_fixture() -> None:
         validate_pointer_freshness(pointer, fingerprint)
 
 
-def test_richness_gate_blocks_publish_above_cap(tmp_path: Path, monkeypatch) -> None:
-    """#4515: the binding thin-page cap lives at publish time. A manifest whose
-    audit exceeds the cap must raise ManifestPublishError before any gzip/
-    upload/pointer work happens — on dry-run too (preflight parity)."""
+def test_download_published_manifest_decodes_canonical_release_asset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from scripts.lexicon.publish_manifest import download_published_manifest
+
+    release_manifest = {"version": "live", "entries": []}
+    calls: list[tuple[str, str, str]] = []
+
+    def fake_download(asset_name: str, *, release_tag: str, repo: str) -> bytes:
+        calls.append((asset_name, release_tag, repo))
+        return gzip.compress(json.dumps(release_manifest).encode("utf-8"))
+
+    monkeypatch.setattr("scripts.lexicon.publish_manifest._download_release_asset", fake_download)
+
+    assert download_published_manifest(release_tag="live-tag", repo="learn-ukrainian/example") == release_manifest
+    assert calls == [(ASSET_NAME, "live-tag", "learn-ukrainian/example")]
+
+
+def _richness_summary(*, thin: int, gloss: int, anchor: int, broken_stubs: int = 0) -> dict:
+    return {
+        "poc_thin_pages": thin,
+        "search_no_visible_gloss": gloss,
+        "old_gate_no_english_anchor": anchor,
+        "form_stub_broken": broken_stubs,
+    }
+
+
+def _install_richness_audit(monkeypatch: pytest.MonkeyPatch) -> None:
+    import scripts.audit.audit_atlas_poc_richness as richness
+
+    monkeypatch.setattr(richness, "audit_manifest", lambda manifest: manifest["richness_summary"])
+
+
+def test_richness_regression_blocks_before_packaging(tmp_path: Path, monkeypatch) -> None:
+    """#4515: the publish chokepoint compares candidate and live baseline before gzip/upload."""
     import scripts.audit.audit_atlas_poc_richness as richness
     from scripts.lexicon.publish_manifest import assert_manifest_richness_publishable
 
     manifest_path = tmp_path / "lexicon-manifest.json"
-    _write_json(manifest_path, {"version": "0.1", "entries": []})
+    baseline = {"richness_summary": _richness_summary(thin=158, gloss=8, anchor=4)}
+    _write_json(
+        manifest_path,
+        {"richness_summary": _richness_summary(thin=159, gloss=8, anchor=4)},
+    )
 
-    monkeypatch.setattr(richness, "audit_manifest", lambda m: {"poc_thin_pages": 901})
+    monkeypatch.setattr(richness, "audit_manifest", lambda manifest: manifest["richness_summary"])
 
-    with pytest.raises(ManifestPublishError, match=r"publish blocked \(#4515\).*901"):
-        assert_manifest_richness_publishable(manifest_path, max_poc_thin_pages=900)
+    with pytest.raises(ManifestPublishError, match=r"poc_thin_pages 158→159"):
+        assert_manifest_richness_publishable(manifest_path, baseline_manifest=baseline)
 
-    # Wired into publish_manifest itself (cap from DEFAULT_MAX_POC_THIN_PAGES=900),
-    # and dry_run does NOT bypass it.
+    # Wired into publish_manifest itself, and dry_run does NOT bypass it.
     gzip_calls: list[Path] = []
+    monkeypatch.setattr(
+        "scripts.lexicon.publish_manifest.download_published_manifest",
+        lambda **kwargs: baseline,
+    )
     monkeypatch.setattr(
         "scripts.lexicon.publish_manifest.gzip_manifest",
         lambda mp, gp: gzip_calls.append(mp),
@@ -204,30 +250,104 @@ def test_richness_gate_blocks_publish_above_cap(tmp_path: Path, monkeypatch) -> 
     assert gzip_calls == [], "gate must fire before any packaging work"
 
 
-def test_richness_gate_passes_at_cap_and_reports_summary(tmp_path: Path, monkeypatch) -> None:
-    import scripts.audit.audit_atlas_poc_richness as richness
+def test_richness_improvement_passes_despite_nonzero_debt(tmp_path: Path, monkeypatch) -> None:
     from scripts.lexicon.publish_manifest import assert_manifest_richness_publishable
 
     manifest_path = tmp_path / "lexicon-manifest.json"
-    _write_json(manifest_path, {"version": "0.1", "entries": []})
+    baseline = {"richness_summary": _richness_summary(thin=800, gloss=158, anchor=4)}
+    _write_json(
+        manifest_path,
+        {"richness_summary": _richness_summary(thin=700, gloss=120, anchor=1)},
+    )
+    _install_richness_audit(monkeypatch)
 
-    monkeypatch.setattr(richness, "audit_manifest", lambda m: {"poc_thin_pages": 900, "form_stub_broken": 0})
-    summary = assert_manifest_richness_publishable(manifest_path, max_poc_thin_pages=900)
-    assert summary["poc_thin_pages"] == 900
+    record = assert_manifest_richness_publishable(manifest_path, baseline_manifest=baseline)
+    assert record["candidate"]["search_no_visible_gloss"] == 120
+    assert record["regressions"] == {}
+
+
+def test_richness_equal_counts_pass(tmp_path: Path, monkeypatch) -> None:
+    from scripts.lexicon.publish_manifest import assert_manifest_richness_publishable
+
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    baseline = {"richness_summary": _richness_summary(thin=158, gloss=8, anchor=4)}
+    _write_json(
+        manifest_path,
+        {"richness_summary": _richness_summary(thin=158, gloss=8, anchor=4)},
+    )
+    _install_richness_audit(monkeypatch)
+
+    record = assert_manifest_richness_publishable(manifest_path, baseline_manifest=baseline)
+    assert record["regressions"] == {}
+
+
+def test_richness_override_requires_nonempty_reason(tmp_path: Path, monkeypatch) -> None:
+    from scripts.lexicon.publish_manifest import assert_manifest_richness_publishable
+
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    _write_json(
+        manifest_path,
+        {"richness_summary": _richness_summary(thin=159, gloss=8, anchor=4)},
+    )
+    _install_richness_audit(monkeypatch)
+
+    with pytest.raises(ManifestPublishError, match="requires a non-empty reason"):
+        assert_manifest_richness_publishable(
+            manifest_path,
+            baseline_manifest={"richness_summary": _richness_summary(thin=158, gloss=8, anchor=4)},
+            allow_richness_regression_reason="  ",
+        )
+
+
+def test_richness_override_records_reason_in_publish_pointer(tmp_path: Path, monkeypatch) -> None:
+    fingerprint = {"schema_version": 1, "fingerprint": "abc123"}
+    baseline = {"richness_summary": _richness_summary(thin=158, gloss=8, anchor=4)}
+    manifest = {
+        "version": "0.1",
+        "generated_at": "2026-06-23T00:00:00+00:00",
+        "manifest_fingerprint": fingerprint,
+        "entries": [],
+        "richness_summary": _richness_summary(thin=159, gloss=8, anchor=4),
+    }
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    fingerprint_path = tmp_path / "lexicon-manifest.fingerprint.json"
+    _write_json(manifest_path, manifest)
+    _write_json(fingerprint_path, fingerprint)
+    _install_richness_audit(monkeypatch)
+    monkeypatch.setattr(
+        "scripts.lexicon.publish_manifest.download_published_manifest",
+        lambda **kwargs: baseline,
+    )
+
+    pointer = publish_manifest(
+        manifest_path=manifest_path,
+        gzip_path=tmp_path / "lexicon-manifest.json.gz",
+        pointer_path=tmp_path / "lexicon-manifest.pointer.json",
+        fingerprint_path=fingerprint_path,
+        repo="learn-ukrainian/example",
+        dry_run=True,
+        allow_richness_regression_reason="operator approved source migration",
+    )
+
+    assert pointer["richness_gate"]["override_reason"] == "operator approved source migration"
+    assert pointer["richness_gate"]["regressions"]["poc_thin_pages"] == {
+        "baseline": 158,
+        "candidate": 159,
+    }
 
 
 def test_richness_gate_blocks_publish_on_broken_form_stubs(tmp_path: Path, monkeypatch) -> None:
-    import scripts.audit.audit_atlas_poc_richness as richness
     from scripts.lexicon.publish_manifest import assert_manifest_richness_publishable
 
     manifest_path = tmp_path / "lexicon-manifest.json"
-    _write_json(manifest_path, {"version": "0.1", "entries": []})
-
-    monkeypatch.setattr(
-        richness,
-        "audit_manifest",
-        lambda m: {"poc_thin_pages": 0, "form_stub_broken": 2},
+    _write_json(
+        manifest_path,
+        {"richness_summary": _richness_summary(thin=0, gloss=0, anchor=0, broken_stubs=2)},
     )
+    _install_richness_audit(monkeypatch)
 
     with pytest.raises(ManifestPublishError, match=r"publish blocked \(#4220\).*2"):
-        assert_manifest_richness_publishable(manifest_path, max_poc_thin_pages=900)
+        assert_manifest_richness_publishable(
+            manifest_path,
+            baseline_manifest={"richness_summary": _richness_summary(thin=0, gloss=0, anchor=0)},
+        )

--- a/tests/test_publish_manifest.py
+++ b/tests/test_publish_manifest.py
@@ -25,6 +25,21 @@ def _write_json(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def _richness_gate_record(*, bootstrap: bool = False) -> dict:
+    counts = {
+        "poc_thin_pages": 0,
+        "search_no_visible_gloss": 0,
+        "old_gate_no_english_anchor": 0,
+    }
+    return {
+        "bootstrap": bootstrap,
+        "baseline": None if bootstrap else counts.copy(),
+        "candidate": counts,
+        "regressions": {},
+        "override_reason": None,
+    }
+
+
 def test_build_pointer_payload_records_manifest_version_and_fingerprint(tmp_path: Path) -> None:
     fingerprint = {"schema_version": 1, "fingerprint": "abc123"}
     manifest = {
@@ -45,6 +60,7 @@ def test_build_pointer_payload_records_manifest_version_and_fingerprint(tmp_path
         gzip_path=gzip_path,
         fingerprint_path=fingerprint_path,
         repo="learn-ukrainian/example",
+        richness_gate=_richness_gate_record(),
     )
 
     manifest_bytes = manifest_path.read_bytes()
@@ -56,6 +72,7 @@ def test_build_pointer_payload_records_manifest_version_and_fingerprint(tmp_path
     assert payload["fingerprint_schema_version"] == 1
     assert payload["json_sha256"] == _sha256(manifest_bytes)
     assert payload["gz_sha256"] == _sha256(gzip_path.read_bytes())
+    assert payload["richness_gate"] == _richness_gate_record()
 
 
 def test_publish_manifest_uploads_versioned_and_canonical_assets(
@@ -194,6 +211,41 @@ def test_download_published_manifest_decodes_canonical_release_asset(
 
     assert download_published_manifest(release_tag="live-tag", repo="learn-ukrainian/example") == release_manifest
     assert calls == [(ASSET_NAME, "live-tag", "learn-ukrainian/example")]
+
+
+def test_baseline_fetch_failure_aborts_before_gzip_with_manifest_publish_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    _write_json(manifest_path, {"version": "0.1", "entries": []})
+    gzip_calls: list[Path] = []
+    failure = subprocess.CalledProcessError(
+        1,
+        ["gh", "release", "download"],
+        stderr=b"release API unavailable; retry later",
+    )
+
+    def fail_download(*args: object, **kwargs: object) -> bytes:
+        raise failure
+
+    monkeypatch.setattr("scripts.lexicon.publish_manifest._download_release_asset", fail_download)
+    monkeypatch.setattr(
+        "scripts.lexicon.publish_manifest.gzip_manifest",
+        lambda manifest, gzip_path: gzip_calls.append(manifest),
+    )
+
+    with pytest.raises(ManifestPublishError, match="release API unavailable"):
+        publish_manifest(
+            manifest_path=manifest_path,
+            gzip_path=tmp_path / "lexicon-manifest.json.gz",
+            pointer_path=tmp_path / "lexicon-manifest.pointer.json",
+            fingerprint_path=tmp_path / "lexicon-manifest.fingerprint.json",
+            repo="learn-ukrainian/example",
+            dry_run=True,
+        )
+
+    assert gzip_calls == []
 
 
 def _richness_summary(*, thin: int, gloss: int, anchor: int, broken_stubs: int = 0) -> dict:
@@ -350,4 +402,64 @@ def test_richness_gate_blocks_publish_on_broken_form_stubs(tmp_path: Path, monke
         assert_manifest_richness_publishable(
             manifest_path,
             baseline_manifest={"richness_summary": _richness_summary(thin=0, gloss=0, anchor=0)},
+        )
+
+
+def test_bootstrap_publish_requires_no_canonical_baseline(tmp_path: Path, monkeypatch) -> None:
+    fingerprint = {"schema_version": 1, "fingerprint": "abc123"}
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    fingerprint_path = tmp_path / "lexicon-manifest.fingerprint.json"
+    _write_json(
+        manifest_path,
+        {
+            "version": "0.1",
+            "manifest_fingerprint": fingerprint,
+            "richness_summary": _richness_summary(thin=1, gloss=2, anchor=3),
+        },
+    )
+    _write_json(fingerprint_path, fingerprint)
+    _install_richness_audit(monkeypatch)
+    monkeypatch.setattr(
+        "scripts.lexicon.publish_manifest.canonical_published_manifest_exists",
+        lambda **kwargs: False,
+    )
+
+    pointer = publish_manifest(
+        manifest_path=manifest_path,
+        gzip_path=tmp_path / "lexicon-manifest.json.gz",
+        pointer_path=tmp_path / "lexicon-manifest.pointer.json",
+        fingerprint_path=fingerprint_path,
+        repo="learn-ukrainian/example",
+        dry_run=True,
+        bootstrap_no_baseline=True,
+    )
+
+    assert pointer["richness_gate"]["bootstrap"] is True
+    assert pointer["richness_gate"]["baseline"] is None
+
+    monkeypatch.setattr(
+        "scripts.lexicon.publish_manifest.canonical_published_manifest_exists",
+        lambda **kwargs: True,
+    )
+    with pytest.raises(ManifestPublishError, match="only valid when the canonical published Atlas manifest"):
+        publish_manifest(
+            manifest_path=manifest_path,
+            gzip_path=tmp_path / "refused.json.gz",
+            pointer_path=tmp_path / "refused.pointer.json",
+            fingerprint_path=fingerprint_path,
+            repo="learn-ukrainian/example",
+            dry_run=True,
+            bootstrap_no_baseline=True,
+        )
+
+    with pytest.raises(ManifestPublishError, match="cannot be combined"):
+        publish_manifest(
+            manifest_path=manifest_path,
+            gzip_path=tmp_path / "conflict.json.gz",
+            pointer_path=tmp_path / "conflict.pointer.json",
+            fingerprint_path=fingerprint_path,
+            repo="learn-ukrainian/example",
+            dry_run=True,
+            bootstrap_no_baseline=True,
+            allow_richness_regression_reason="not applicable",
         )

--- a/tests/test_reenrich_thin_manifest_entries.py
+++ b/tests/test_reenrich_thin_manifest_entries.py
@@ -1,6 +1,10 @@
 import sqlite3
 
+import pytest
+
 from scripts.lexicon import enrich_manifest
+from scripts.lexicon import reenrich_thin_manifest_entries as reenrich
+from scripts.lexicon.publish_manifest import ManifestPublishError
 from scripts.lexicon.reenrich_thin_manifest_entries import (
     _preserve_existing_metadata,
     _reenrich_translation_only,
@@ -156,3 +160,41 @@ def test_cached_slovnyk_only_does_not_live_fetch_missing_ukreng(monkeypatch) -> 
         _reenrich_translation_only(conn, entry, {}, cached_slovnyk_only=True)
 
     assert "translation" not in entry["enrichment"]
+
+
+def test_reenrich_pointer_write_blocks_richness_regression_before_gzip(
+    tmp_path, monkeypatch
+) -> None:
+    manifest_path = tmp_path / "lexicon-manifest.json"
+    manifest_path.write_text(
+        '{"richness_summary": {"poc_thin_pages": 2, "search_no_visible_gloss": 0, '
+        '"old_gate_no_english_anchor": 0, "form_stub_broken": 0}}\n',
+        encoding="utf-8",
+    )
+    baseline = {
+        "richness_summary": {
+            "poc_thin_pages": 1,
+            "search_no_visible_gloss": 0,
+            "old_gate_no_english_anchor": 0,
+            "form_stub_broken": 0,
+        }
+    }
+    gzip_calls = []
+
+    monkeypatch.setattr(reenrich, "DEFAULT_MANIFEST", manifest_path)
+    monkeypatch.setattr(
+        "scripts.lexicon.publish_manifest.download_published_manifest",
+        lambda **kwargs: baseline,
+    )
+    monkeypatch.setattr(
+        reenrich, "gzip_manifest", lambda manifest, gzip_path: gzip_calls.append(manifest)
+    )
+    monkeypatch.setattr(
+        "scripts.audit.audit_atlas_poc_richness.audit_manifest",
+        lambda manifest: manifest["richness_summary"],
+    )
+
+    with pytest.raises(ManifestPublishError, match=r"publish blocked \(#4515\)"):
+        reenrich._write_default_release_pointer(manifest_path)
+
+    assert gzip_calls == []


### PR DESCRIPTION
## Summary
- compare the candidate Atlas manifest with the canonical live Release asset before packaging or upload
- block only regressions in thin pages, visible-gloss gaps, or English-anchor gaps; record an explicit override reason in the pointer
- retain the per-PR CI audit as advisory with its existing thresholds

## Verification
- `.venv/bin/pytest tests/test_publish_manifest.py` (11 passed)
- `.venv/bin/ruff check scripts/lexicon/publish_manifest.py scripts/audit/audit_atlas_poc_richness.py tests/test_publish_manifest.py` (passed)
- `.venv/bin/python scripts/audit/lint_agent_trailer.py` (passed)

## Review
- Independent Gemini/AGY review returned `NO FINDINGS`; the direct Gemini CLI reported unavailable, so a Pool-review substitution was initiated as the configured fallback.

Refs #4515 part (b)