### PR TITLE
feat(lexicon): Ohoiko corpus Atlas intake Phase 1

### DIFF
--- a/scripts/lexicon/README.md
+++ b/scripts/lexicon/README.md
@@ -153,6 +153,36 @@ explicit provenance through:
   --report
 ```
 
+### Anna Ohoiko corpus intake (#4223 Phase 1)
+
+The Ohoiko adapter reuses the shared ``atlas_intake_core`` machinery
+introduced for curriculum full-text intake (#4222). It scans the private
+Anna Ohoiko corpus under ``docs/references/private/`` and emits safe
+inventory + ledger metadata only — no Atlas publish, no Daily/Practice/Cloze
+admission:
+
+```bash
+.venv/bin/python -m scripts.lexicon.ohoiko_atlas_intake \
+  --inventory-out data/lexicon/source-inventory/ohoiko-corpus-intake.json \
+  --report-out /tmp/atlas-ohoiko-corpus-intake.json
+```
+
+Optional append-format ledger output (requires ``--batch-id``,
+``--batch-label``, and ``--reviewed-at``):
+
+```bash
+.venv/bin/python -m scripts.lexicon.ohoiko_atlas_intake \
+  --inventory-out data/lexicon/source-inventory/ohoiko-corpus-intake.json \
+  --ledger-out data/lexicon/source-inventory-review-decisions/YYYY-MM-DD-ohoiko-corpus-intake.yaml \
+  --batch-id ohoiko-corpus-intake-2026-07-14 \
+  --batch-label "Ohoiko corpus Phase 1 intake" \
+  --reviewed-at 2026-07-14
+```
+
+Public reports list opaque ``source_ref`` locators and aggregate counts only.
+Raw copyrighted paths, passage text, and quotes never leave the private
+boundary.
+
 The source inventory parser accepts CSV, TSV, JSONL, JSON, or YAML. YAML/JSON
 structured inventories use this minimal v1 shape:
 

--- a/scripts/lexicon/atlas_intake_core.py
+++ b/scripts/lexicon/atlas_intake_core.py
@@ -1,0 +1,650 @@
+#!/usr/bin/env python3
+"""Shared Word Atlas intake core for fail-closed corpus extraction runs.
+
+Extracted from the curriculum intake machinery (#4222 / PR #5136) so
+family-specific adapters (curriculum, Ohoiko, …) reuse the same VESUM
+resolution, heritage gating, dedupe, and ledger emission without forking.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+
+from scripts.audit.source_inventory_intake import SourceInventoryRecord
+from scripts.audit.source_inventory_review_decisions import source_inventory_key
+from scripts.lexicon.build_data_manifest import _lemma_key
+from scripts.lexicon.content_lexicon_reconciler import (
+    LEXICON_MANIFEST_PATH,
+    PROJECT_ROOT,
+    lemmatize_forms,
+)
+from scripts.lexicon.heritage_classifier import classify_lemma
+from scripts.lexicon.manifest_io import load_manifest
+
+LEDGER_KIND = "atlas_source_inventory_review_decisions"
+LEDGER_WORKFLOW = "source_inventory_publish_review_queue.v1"
+
+Classification = Literal["auto_approve", "review_queue", "reject"]
+VesumLookup = Callable[[list[str]], dict[str, list[dict[str, Any]]]]
+HeritageLookup = Callable[[str], dict[str, Any]]
+
+
+class AtlasIntakeError(ValueError):
+    """A source cannot be safely included in a full-corpus intake."""
+
+
+@dataclass(frozen=True)
+class IntakeOccurrence:
+    """One counted Ukrainian form occurrence with safe locator metadata."""
+
+    form: str
+    source_id: str
+    source_family: str
+    extraction_mode: str
+    locator: str
+    count: int
+    explicit_gloss: str | None = None
+    source_title: str | None = None
+    source_path: str | None = None
+
+
+@dataclass(frozen=True)
+class VesumResolution:
+    form: str
+    lemma: str | None
+    pos: str | None
+    reason: str | None
+
+
+@dataclass(frozen=True)
+class IntakeCandidate:
+    candidate_key: str
+    lemma: str
+    forms: tuple[str, ...]
+    pos: str | None
+    gloss: str | None
+    records: tuple[SourceInventoryRecord, ...]
+    classification: Classification
+    reasons: tuple[str, ...]
+    heritage_status: Mapping[str, Any] | None
+
+    @property
+    def frequency(self) -> int:
+        return sum(record.count for record in self.records)
+
+
+@dataclass(frozen=True)
+class AtlasIntakeResult:
+    """Generic intake summary for any source-family adapter."""
+
+    workflow: str
+    source_family: str
+    source_units: tuple[Mapping[str, Any], ...]
+    token_occurrences: int
+    unique_forms: int
+    candidates: tuple[IntakeCandidate, ...]
+    inventory_path: str
+
+    @property
+    def classification_counts(self) -> dict[str, int]:
+        counts = Counter(candidate.classification for candidate in self.candidates)
+        return {
+            "auto_approve": counts["auto_approve"],
+            "review_queue": counts["review_queue"],
+            "reject": counts["reject"],
+        }
+
+    @property
+    def reason_counts(self) -> dict[str, int]:
+        counts: Counter[str] = Counter()
+        for candidate in self.candidates:
+            counts.update(candidate.reasons)
+        return dict(sorted(counts.items()))
+
+    @property
+    def records(self) -> tuple[SourceInventoryRecord, ...]:
+        return tuple(record for candidate in self.candidates for record in candidate.records)
+
+    def report_payload(self, *, policy: str) -> dict[str, Any]:
+        return {
+            "workflow": self.workflow,
+            "policy": policy,
+            "production_outputs_updated": [],
+            "surface_admission": {
+                "daily_word": "unchanged",
+                "practice": "unchanged",
+                "cloze": "unchanged",
+            },
+            "counts": {
+                "source_units": len(self.source_units),
+                "token_occurrences": self.token_occurrences,
+                "unique_forms": self.unique_forms,
+                "deduped_candidates": len(self.candidates),
+                **self.classification_counts,
+            },
+            "classification_reasons": self.reason_counts,
+            "sources": list(self.source_units),
+            "candidate_output": (
+                "The decision-ledger-compatible output contains every candidate classification; "
+                "this summary intentionally retains only aggregate counts."
+            ),
+        }
+
+
+def load_atlas_lemma_keys(manifest_path: Path = LEXICON_MANIFEST_PATH) -> set[str]:
+    """Load the current Atlas keys, hydrating the release-pinned default if needed."""
+
+    payload = load_manifest(manifest_path)
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise AtlasIntakeError(f"Atlas manifest has no entries list: {manifest_path}")
+    return {
+        _lemma_key(lemma)
+        for entry in entries
+        if isinstance(entry, Mapping)
+        for lemma in [entry.get("lemma")]
+        if isinstance(lemma, str) and lemma.strip()
+    }
+
+
+def load_existing_ledger_keys(*, project_root: Path = PROJECT_ROOT) -> set[str]:
+    """Return lemma keys that have prior source-ledger decisions."""
+
+    root = project_root.resolve()
+    keys: set[str] = set()
+    for path in sorted((root / "data" / "lexicon" / "source-inventory-review-decisions").glob("*.yaml")):
+        payload = load_yaml_mapping(path, label="source decision ledger")
+        if payload.get("kind") != LEDGER_KIND:
+            continue
+        for decision in payload.get("decisions", []):
+            lemma = mapping_text(decision, "lemma")
+            if lemma:
+                keys.add(_lemma_key(lemma))
+    return keys
+
+
+def load_committed_inventory_keys(
+    inventory_paths: Sequence[Path],
+    *,
+    project_root: Path = PROJECT_ROOT,
+) -> set[str]:
+    """Return lemma keys already present in committed source inventories."""
+
+    from scripts.audit.source_inventory_intake import read_source_inventories
+
+    existing = [path for path in inventory_paths if path.exists()]
+    if not existing:
+        return set()
+    records = read_source_inventories(existing, project_root=project_root)
+    return {_lemma_key(record.lemma) for record in records}
+
+
+def resolve_forms(forms: Sequence[str], *, vesum_lookup: VesumLookup | None) -> dict[str, VesumResolution]:
+    matches_by_form = lemmatize_forms(forms) if vesum_lookup is None else lemmatize_forms(forms, vesum_lookup=vesum_lookup)
+    resolutions: dict[str, VesumResolution] = {}
+    for form in forms:
+        matches = matches_by_form.get(form, [])
+        lemmas = {
+            normalised_text(match.get("lemma"))
+            for match in matches
+            if isinstance(match, Mapping) and normalised_text(match.get("lemma"))
+        }
+        if not lemmas:
+            resolutions[form] = VesumResolution(form, None, None, "vesum_unrecognized")
+            continue
+        if len(lemmas) != 1:
+            resolutions[form] = VesumResolution(form, None, None, "vesum_ambiguous_lemma")
+            continue
+        poss = {
+            normalised_text(match.get("pos"))
+            for match in matches
+            if isinstance(match, Mapping) and normalised_text(match.get("pos"))
+        }
+        lemma = next(iter(lemmas))
+        if len(poss) != 1:
+            resolutions[form] = VesumResolution(form, lemma, None, "vesum_ambiguous_pos")
+            continue
+        resolutions[form] = VesumResolution(form, lemma, next(iter(poss)), None)
+    return resolutions
+
+
+def build_intake_candidates(
+    occurrences: Sequence[IntakeOccurrence],
+    *,
+    resolutions: Mapping[str, VesumResolution],
+    atlas_keys: set[str],
+    ledger_keys: set[str],
+    committed_inventory_keys: set[str],
+    heritage_lookup: HeritageLookup,
+    inventory_path: str,
+    source_family: str,
+) -> list[IntakeCandidate]:
+    resolved: dict[str, list[IntakeOccurrence]] = defaultdict(list)
+    unresolved: dict[str, list[IntakeOccurrence]] = defaultdict(list)
+    for occurrence in occurrences:
+        resolution = resolutions[occurrence.form]
+        if resolution.lemma is None:
+            unresolved[_lemma_key(occurrence.form)].append(occurrence)
+        else:
+            resolved[_lemma_key(resolution.lemma)].append(occurrence)
+    candidates = build_resolved_candidates(
+        resolved,
+        resolutions=resolutions,
+        atlas_keys=atlas_keys,
+        ledger_keys=ledger_keys,
+        committed_inventory_keys=committed_inventory_keys,
+        heritage_lookup=heritage_lookup,
+        inventory_path=inventory_path,
+        source_family=source_family,
+    )
+    for key, grouped_occurrences in unresolved.items():
+        forms = tuple(
+            sorted({occurrence.form for occurrence in grouped_occurrences}, key=stable_lemma_sort_key)
+        )
+        records = records_for_occurrences(
+            grouped_occurrences,
+            lemma=forms[0],
+            pos=None,
+            gloss=None,
+            inventory_path=inventory_path,
+            source_family=source_family,
+        )
+        candidates.append(
+            IntakeCandidate(
+                candidate_key=f"form:{key}",
+                lemma=forms[0],
+                forms=forms,
+                pos=None,
+                gloss=None,
+                records=records,
+                classification="review_queue",
+                reasons=tuple(sorted({resolutions[form].reason or "vesum_unresolved" for form in forms})),
+                heritage_status=None,
+            )
+        )
+    return merge_candidate_collisions(candidates)
+
+
+def merge_candidate_collisions(candidates: Sequence[IntakeCandidate]) -> list[IntakeCandidate]:
+    grouped: dict[str, list[IntakeCandidate]] = defaultdict(list)
+    for candidate in candidates:
+        grouped[candidate.lemma].append(candidate)
+    merged: list[IntakeCandidate] = []
+    for lemma, group in grouped.items():
+        if len(group) == 1:
+            merged.append(group[0])
+            continue
+        classifications = {candidate.classification for candidate in group}
+        classification: Classification = "reject" if "reject" in classifications else "review_queue"
+        poss = {candidate.pos for candidate in group if candidate.pos}
+        glosses = {candidate.gloss for candidate in group if candidate.gloss}
+        reasons = {reason for candidate in group for reason in candidate.reasons}
+        reasons.add("canonical_headword_collision")
+        if len(poss) > 1:
+            reasons.add("vesum_conflicting_pos")
+        if len(glosses) > 1:
+            reasons.add("conflicting_english_anchor")
+        pos = next(iter(poss)) if len(poss) == 1 else None
+        gloss = next(iter(glosses)) if len(glosses) == 1 else None
+        merged.append(
+            IntakeCandidate(
+                candidate_key=f"merged:{_lemma_key(lemma)}",
+                lemma=lemma,
+                forms=tuple(
+                    sorted(
+                        {form for candidate in group for form in candidate.forms},
+                        key=stable_lemma_sort_key,
+                    )
+                ),
+                pos=pos,
+                gloss=gloss,
+                records=merge_records(candidate.records for candidate in group),
+                classification=classification,
+                reasons=tuple(sorted(reasons)),
+                heritage_status=next(
+                    (
+                        candidate.heritage_status
+                        for candidate in group
+                        if candidate.heritage_status is not None
+                    ),
+                    None,
+                ),
+            )
+        )
+    return sorted(
+        merged,
+        key=lambda candidate: (candidate.lemma.casefold(), candidate.lemma, candidate.candidate_key),
+    )
+
+
+def merge_records(
+    record_groups: Iterable[Sequence[SourceInventoryRecord]],
+) -> tuple[SourceInventoryRecord, ...]:
+    merged: dict[tuple[str, str, str, str], SourceInventoryRecord] = {}
+    for records in record_groups:
+        for record in records:
+            key = (
+                record.lemma,
+                record.source_id or "",
+                record.source_path or "",
+                record.source_locator or "",
+            )
+            previous = merged.get(key)
+            merged[key] = record if previous is None else replace(previous, count=previous.count + record.count)
+    return tuple(
+        sorted(
+            merged.values(),
+            key=lambda record: (
+                record.source_path or "",
+                record.source_locator or "",
+                _lemma_key(record.lemma),
+                record.lemma,
+            ),
+        )
+    )
+
+
+def build_resolved_candidates(
+    grouped: Mapping[str, Sequence[IntakeOccurrence]],
+    *,
+    resolutions: Mapping[str, VesumResolution],
+    atlas_keys: set[str],
+    ledger_keys: set[str],
+    committed_inventory_keys: set[str],
+    heritage_lookup: HeritageLookup,
+    inventory_path: str,
+    source_family: str,
+) -> list[IntakeCandidate]:
+    drafts: list[
+        tuple[str, str, tuple[str, ...], str | None, str | None, tuple[str, ...], tuple[SourceInventoryRecord, ...]]
+    ] = []
+    for key, grouped_occurrences in grouped.items():
+        forms = tuple(sorted({occurrence.form for occurrence in grouped_occurrences}, key=stable_lemma_sort_key))
+        lemma = resolutions[forms[0]].lemma
+        if lemma is None:
+            raise AtlasIntakeError("resolved candidate lost its VESUM lemma")
+        poss = {resolutions[form].pos for form in forms if resolutions[form].pos}
+        resolution_reasons = {resolutions[form].reason for form in forms if resolutions[form].reason}
+        pos = next(iter(poss)) if len(poss) == 1 and not resolution_reasons else None
+        glosses = {occurrence.explicit_gloss.strip() for occurrence in grouped_occurrences if occurrence.explicit_gloss}
+        gloss = next(iter(glosses)) if len(glosses) == 1 else None
+        metadata_reasons = set(resolution_reasons)
+        if len(poss) > 1:
+            metadata_reasons.add("vesum_conflicting_pos")
+        if len(glosses) > 1:
+            metadata_reasons.add("conflicting_english_anchor")
+        records = records_for_occurrences(
+            grouped_occurrences,
+            lemma=lemma,
+            pos=pos,
+            gloss=gloss,
+            inventory_path=inventory_path,
+            source_family=source_family,
+        )
+        drafts.append((key, lemma, forms, pos, gloss, tuple(sorted(metadata_reasons)), records))
+
+    candidates: list[IntakeCandidate] = []
+    for key, lemma, forms, pos, gloss, metadata_reasons, records in drafts:
+        classification, reasons, heritage_status = classify_resolved_candidate(
+            lemma=lemma,
+            pos=pos,
+            gloss=gloss,
+            metadata_reasons=metadata_reasons,
+            atlas_keys=atlas_keys,
+            ledger_keys=ledger_keys,
+            committed_inventory_keys=committed_inventory_keys,
+            heritage_lookup=heritage_lookup,
+        )
+        candidates.append(
+            IntakeCandidate(
+                candidate_key=f"lemma:{key}",
+                lemma=lemma,
+                forms=forms,
+                pos=pos,
+                gloss=gloss,
+                records=records,
+                classification=classification,
+                reasons=reasons,
+                heritage_status=heritage_status,
+            )
+        )
+    return candidates
+
+
+def classify_resolved_candidate(
+    *,
+    lemma: str,
+    pos: str | None,
+    gloss: str | None,
+    metadata_reasons: Sequence[str],
+    atlas_keys: set[str],
+    ledger_keys: set[str],
+    committed_inventory_keys: set[str],
+    heritage_lookup: HeritageLookup,
+) -> tuple[Classification, tuple[str, ...], Mapping[str, Any] | None]:
+    lemma_key = _lemma_key(lemma)
+    if lemma_key in atlas_keys:
+        return "reject", ("already_in_atlas",), None
+    if lemma_key in ledger_keys:
+        return "reject", ("already_in_existing_ledger",), None
+    if lemma_key in committed_inventory_keys:
+        return "reject", ("already_in_committed_source_inventory",), None
+    if metadata_reasons:
+        return "review_queue", tuple(metadata_reasons), None
+    if not pos:
+        return "review_queue", ("vesum_ambiguous_pos",), None
+    if not gloss:
+        return "review_queue", ("missing_english_anchor",), None
+    try:
+        heritage = heritage_lookup(lemma)
+    except Exception:
+        return "review_queue", ("heritage_lookup_failed",), None
+    classification = normalised_text(heritage.get("classification")) if isinstance(heritage, Mapping) else None
+    if not classification:
+        return "review_queue", ("heritage_unresolved",), None
+    if bool(heritage.get("is_russianism")) or classification == "russianism":
+        return "reject", ("heritage_russianism",), heritage
+    if classification == "surzhyk":
+        return "reject", ("heritage_surzhyk",), heritage
+    if bool(heritage.get("russian_shadow")):
+        return "review_queue", ("heritage_russian_shadow",), heritage
+    sovietization_risk = heritage.get("sovietization_risk")
+    if not isinstance(sovietization_risk, int):
+        return "review_queue", ("heritage_sovietization_risk_unknown",), heritage
+    if sovietization_risk > 0:
+        return "review_queue", ("heritage_sovietization_risk",), heritage
+    if classification != "standard":
+        return "review_queue", ("heritage_nonstandard_classification",), heritage
+    return "auto_approve", ("vesum_unique_lemma_pos", "explicit_english_anchor", "heritage_clear"), heritage
+
+
+def records_for_occurrences(
+    occurrences: Sequence[IntakeOccurrence],
+    *,
+    lemma: str,
+    pos: str | None,
+    gloss: str | None,
+    inventory_path: str,
+    source_family: str,
+) -> tuple[SourceInventoryRecord, ...]:
+    records = [
+        SourceInventoryRecord(
+            lemma=lemma,
+            source_family=source_family,
+            extraction_mode=occurrence.extraction_mode,
+            inventory_path=inventory_path,
+            inventory_locator=safe_locator(occurrence),
+            source_id=occurrence.source_id,
+            source_title=occurrence.source_title,
+            source_path=occurrence.source_path,
+            source_locator=safe_locator(occurrence),
+            pos=pos,
+            gloss=gloss,
+            count=occurrence.count,
+        )
+        for occurrence in occurrences
+    ]
+    return merge_records((records,))
+
+
+def safe_locator(occurrence: IntakeOccurrence) -> str:
+    return occurrence.locator
+
+
+def build_ledger_append_payload(
+    result: AtlasIntakeResult,
+    *,
+    batch_id: str,
+    batch_label: str,
+    reviewed_at: str,
+    reviewer: str,
+) -> dict[str, Any]:
+    auto_count = result.classification_counts["auto_approve"]
+    decisions: list[dict[str, Any]] = []
+    for candidate in result.candidates:
+        primary = candidate.records[0]
+        row: dict[str, Any] = {
+            "lemma": candidate.lemma,
+            "decision": ledger_decision(candidate),
+            "sense_note": "Generated from Ohoiko corpus intake; Atlas publication is a later phase.",
+            "source_inventory": {
+                "key": source_inventory_key(
+                    lemma=candidate.lemma,
+                    inventory_path=result.inventory_path,
+                    locator=primary.inventory_locator,
+                ),
+                "path": result.inventory_path,
+                "locator": primary.inventory_locator,
+                "source_id": primary.source_id,
+                "source_family": result.source_family,
+            },
+            "evidence_refs": list(candidate.reasons),
+        }
+        if candidate.classification == "auto_approve":
+            if not candidate.pos or not candidate.gloss:
+                raise AtlasIntakeError("auto_approve candidate lacks required POS or gloss")
+            row["approved_pos"] = candidate.pos
+            row["approved_gloss"] = candidate.gloss
+        elif candidate.classification == "review_queue":
+            row["review_queue_reasons"] = list(candidate.reasons)
+        else:
+            row["original_flags"] = list(candidate.reasons)
+        decisions.append(row)
+    return {
+        "version": 1,
+        "kind": LEDGER_KIND,
+        "batch_id": batch_id,
+        "batch_label": batch_label,
+        "reviewer": reviewer,
+        "reviewed_at": reviewed_at,
+        "source_queue": {
+            "workflow": LEDGER_WORKFLOW,
+            "total_queue_rows": len(result.candidates),
+            "approved_in_queue": auto_count,
+            "promotion_batch_size": max(auto_count, 1),
+        },
+        "production_outputs_updated": [],
+        "decisions": decisions,
+    }
+
+
+def write_yaml_payload(payload: Mapping[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(dict(payload), allow_unicode=True, sort_keys=False), encoding="utf-8")
+
+
+def write_flat_source_inventory(records: Sequence[SourceInventoryRecord], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write("[\n")
+        for index, record in enumerate(records):
+            if index:
+                handle.write(",\n")
+            json.dump(flat_inventory_row(record), handle, ensure_ascii=False, sort_keys=True)
+        handle.write("\n]\n")
+
+
+def flat_inventory_row(record: SourceInventoryRecord) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "lemma": record.lemma,
+        "source_family": record.source_family,
+        "extraction_mode": record.extraction_mode,
+        "source_id": record.source_id,
+        "source_title": record.source_title,
+        "source_path": record.source_path,
+        "source_locator": record.source_locator,
+        "count": record.count,
+    }
+    if record.pos:
+        row["pos"] = record.pos
+    if record.gloss:
+        row["gloss"] = record.gloss
+    return row
+
+
+def write_json_payload(payload: Mapping[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def assert_ledger_inventory_destination(
+    inventory_out: Path,
+    inventory_path: str,
+    *,
+    project_root: Path = PROJECT_ROOT,
+) -> None:
+    try:
+        output_path = inventory_out.resolve().relative_to(project_root.resolve()).as_posix()
+    except ValueError as exc:
+        raise AtlasIntakeError(
+            "--ledger-out requires --inventory-out inside the project root "
+            "so source-ledger metadata remains portable"
+        ) from exc
+    inventory_prefix = "data/lexicon/source-inventory/"
+    if not output_path.startswith(inventory_prefix):
+        raise AtlasIntakeError(
+            "--ledger-out requires --inventory-out inside data/lexicon/source-inventory"
+        )
+    if inventory_path != output_path:
+        raise AtlasIntakeError(
+            "--ledger-out requires --inventory-path to equal the project-relative "
+            f"--inventory-out path ({output_path})"
+        )
+
+
+def ledger_decision(candidate: IntakeCandidate) -> str:
+    if candidate.classification == "auto_approve":
+        return "approve_for_publish"
+    return "needs_more_evidence" if candidate.classification == "review_queue" else "reject"
+
+
+def load_yaml_mapping(path: Path, *, label: str) -> Mapping[str, Any]:
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise AtlasIntakeError(f"invalid {label} YAML: {path}") from exc
+    if not isinstance(payload, Mapping):
+        raise AtlasIntakeError(f"invalid {label} mapping: {path}")
+    return payload
+
+
+def mapping_text(value: object, key: str) -> str | None:
+    return normalised_text(value.get(key)) if isinstance(value, Mapping) else None
+
+
+def normalised_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def stable_lemma_sort_key(value: str) -> tuple[str, str]:
+    return _lemma_key(value), value

--- a/scripts/lexicon/atlas_intake_core.py
+++ b/scripts/lexicon/atlas_intake_core.py
@@ -221,7 +221,7 @@ def build_intake_candidates(
     resolutions: Mapping[str, VesumResolution],
     atlas_keys: set[str],
     ledger_keys: set[str],
-    committed_inventory_keys: set[str],
+    committed_inventory_keys: set[str] | None = None,
     heritage_lookup: HeritageLookup,
     inventory_path: str,
     source_family: str,
@@ -357,7 +357,7 @@ def build_resolved_candidates(
     resolutions: Mapping[str, VesumResolution],
     atlas_keys: set[str],
     ledger_keys: set[str],
-    committed_inventory_keys: set[str],
+    committed_inventory_keys: set[str] | None = None,
     heritage_lookup: HeritageLookup,
     inventory_path: str,
     source_family: str,
@@ -426,7 +426,7 @@ def classify_resolved_candidate(
     metadata_reasons: Sequence[str],
     atlas_keys: set[str],
     ledger_keys: set[str],
-    committed_inventory_keys: set[str],
+    committed_inventory_keys: set[str] | None = None,
     heritage_lookup: HeritageLookup,
 ) -> tuple[Classification, tuple[str, ...], Mapping[str, Any] | None]:
     lemma_key = _lemma_key(lemma)
@@ -434,7 +434,7 @@ def classify_resolved_candidate(
         return "reject", ("already_in_atlas",), None
     if lemma_key in ledger_keys:
         return "reject", ("already_in_existing_ledger",), None
-    if lemma_key in committed_inventory_keys:
+    if committed_inventory_keys and lemma_key in committed_inventory_keys:
         return "reject", ("already_in_committed_source_inventory",), None
     if metadata_reasons:
         return "review_queue", tuple(metadata_reasons), None
@@ -505,6 +505,7 @@ def build_ledger_append_payload(
     batch_label: str,
     reviewed_at: str,
     reviewer: str,
+    sense_note: str,
 ) -> dict[str, Any]:
     auto_count = result.classification_counts["auto_approve"]
     decisions: list[dict[str, Any]] = []
@@ -513,7 +514,7 @@ def build_ledger_append_payload(
         row: dict[str, Any] = {
             "lemma": candidate.lemma,
             "decision": ledger_decision(candidate),
-            "sense_note": "Generated from Ohoiko corpus intake; Atlas publication is a later phase.",
+            "sense_note": sense_note,
             "source_inventory": {
                 "key": source_inventory_key(
                     lemma=candidate.lemma,

--- a/scripts/lexicon/ohoiko_atlas_intake.py
+++ b/scripts/lexicon/ohoiko_atlas_intake.py
@@ -40,6 +40,9 @@ DEFAULT_REPORT_OUT = Path("/tmp/atlas-ohoiko-corpus-intake.json")
 DEFAULT_INVENTORY_PATH = "data/lexicon/source-inventory/ohoiko-corpus-intake.json"
 WORKFLOW_ID = "ohoiko_corpus_atlas_intake.v1"
 SOURCE_FAMILY = "ohoiko"
+OHOKO_LEDGER_SENSE_NOTE = (
+    "Generated from Ohoiko corpus intake; Atlas publication is a later phase."
+)
 
 TEXT_SUFFIXES = frozenset({".md", ".txt"})
 _VERB_HEADWORD_RE = re.compile(
@@ -251,6 +254,8 @@ def build_ohoiko_intake(
     committed_keys = (
         committed_inventory_keys
         if committed_inventory_keys is not None
+        # Ohoiko opts into committed-inventory dedup: public ohoiko-*.yaml keyword
+        # inventories already represent curated headwords that must not be re-queued.
         else core.load_committed_inventory_keys(
             committed_ohoiko_inventory_paths(project_root=project_root),
             project_root=project_root,
@@ -542,6 +547,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     batch_label=args.batch_label,
                     reviewed_at=args.reviewed_at,
                     reviewer="ohoiko-intake-automation",
+                    sense_note=OHOKO_LEDGER_SENSE_NOTE,
                 ),
                 args.ledger_out,
             )

--- a/scripts/lexicon/ohoiko_atlas_intake.py
+++ b/scripts/lexicon/ohoiko_atlas_intake.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+"""Fail-closed Anna Ohoiko corpus intake for Word Atlas (#4223 Phase 1).
+
+Enumerates in-scope private Ohoiko source units by opaque ``source_ref``,
+extracts Ukrainian lexical candidates without committing raw copyrighted
+text, and emits safe inventory + ledger metadata through the shared
+``atlas_intake_core`` machinery used by curriculum intake (#4222).
+
+This command never publishes Atlas or learner-surface outputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.ingest import ohoiko_books_ingest as words_ingest
+from scripts.ingest import ohoiko_verbs_ingest as verbs_ingest
+from scripts.lexicon import atlas_intake_core as core
+from scripts.lexicon.build_data_manifest import _lemma_key
+from scripts.lexicon.content_lexicon_reconciler import (
+    PROJECT_ROOT,
+    extract_ukrainian_tokens,
+    strip_mdx_to_prose,
+)
+from scripts.lexicon.heritage_classifier import classify_lemma
+from scripts.lexicon.lemma_normalization import strip_acute_stress
+
+DEFAULT_PRIVATE_ROOT = PROJECT_ROOT / "docs" / "references" / "private"
+DEFAULT_JUNE_NOTES_ROOT = DEFAULT_PRIVATE_ROOT / "ohoiko-june-a1-book" / "notes"
+DEFAULT_INVENTORY_OUT = Path("/tmp/atlas-ohoiko-corpus-inventory.json")
+DEFAULT_REPORT_OUT = Path("/tmp/atlas-ohoiko-corpus-intake.json")
+DEFAULT_INVENTORY_PATH = "data/lexicon/source-inventory/ohoiko-corpus-intake.json"
+WORKFLOW_ID = "ohoiko_corpus_atlas_intake.v1"
+SOURCE_FAMILY = "ohoiko"
+
+TEXT_SUFFIXES = frozenset({".md", ".txt"})
+_VERB_HEADWORD_RE = re.compile(
+    r"^([А-ЯҐЄІЇа-яґєії][А-ЯҐЄІЇа-яґєії'ʼ’`′\- ]*?)\s*(?:\||\s{2,})"
+)
+
+
+class OhoikoIntakeError(ValueError):
+    """A private Ohoiko source cannot be safely included in intake."""
+
+
+@dataclass(frozen=True)
+class OhoikoBookSource:
+    slug: str
+    source_id: str
+    extraction_mode: str
+    filename: str
+    parser: str
+    source_title: str
+    max_entries: int | None = None
+
+
+@dataclass(frozen=True)
+class OhoikoTextSource:
+    source_ref: str
+    source_id: str
+    extraction_mode: str
+    source_title: str
+    unit_kind: str
+
+
+@dataclass(frozen=True)
+class OhoikoSourceUnit:
+    """One safe, opaque source unit for public reporting."""
+
+    source_ref: str
+    source_id: str
+    source_family: str
+    extraction_mode: str
+    unit_kind: str
+    available: bool
+
+
+BOOK_CATALOG: tuple[OhoikoBookSource, ...] = (
+    OhoikoBookSource(
+        slug="1000-words",
+        source_id="ohoiko-1000-words-2nd-ed",
+        extraction_mode="book_candidate",
+        filename="1000-Ukrainian-Words-2.0-Ukrainian-Lessons-PDF-4mwsom.txt",
+        parser="numbered_entries",
+        source_title="Anna Ohoiko 1000 Most Useful Ukrainian Words (2nd ed)",
+        max_entries=1000,
+    ),
+    OhoikoBookSource(
+        slug="500-verbs",
+        source_id="ohoiko-500-verbs",
+        extraction_mode="book_candidate",
+        filename="500+ Ukrainian Verbs - Ukrainian Lessons - PDF.txt",
+        parser="verb_pages",
+        source_title="Anna Ohoiko 500+ Ukrainian Verbs",
+        max_entries=500,
+    ),
+)
+
+ULP_NOTE_CATALOG: tuple[tuple[str, str, str], ...] = (
+    ("ulp-1-00-lesson-notes", "ULP 1-00 Lesson Notes (all in one file) (2023).txt", "ULP Season 1 lesson notes"),
+    ("ulp-2-00-lesson-notes", "ULP 2-00 Lesson Notes (all in one file).txt", "ULP Season 2 lesson notes"),
+    ("ulp-3-00-lesson-notes", "ULP 3-00 Lesson Notes (all in one file).txt", "ULP Season 3 lesson notes"),
+    ("ulp-4-00-lesson-notes", "ULP 4-00 Lesson Notes (all in one file).txt", "ULP Season 4 lesson notes"),
+    ("ulp-5-00-lesson-notes", "ULP 5-00 Lesson Notes (all in one file).txt", "ULP Season 5 lesson notes"),
+    ("ulp-6-00-lesson-notes", "ULP 6-00 Lesson Notes (all in one file).txt", "ULP Season 6 lesson notes"),
+)
+
+
+def committed_ohoiko_inventory_paths(*, project_root: Path = PROJECT_ROOT) -> list[Path]:
+    inventory_dir = project_root / "data" / "lexicon" / "source-inventory"
+    return sorted(inventory_dir.glob("ohoiko-*.yaml"))
+
+
+def discover_source_units(
+    *,
+    private_root: Path = DEFAULT_PRIVATE_ROOT,
+    june_notes_root: Path = DEFAULT_JUNE_NOTES_ROOT,
+) -> tuple[OhoikoSourceUnit, ...]:
+    """Enumerate every in-scope Ohoiko source unit with opaque locators."""
+
+    units: list[OhoikoSourceUnit] = []
+    for index, book in enumerate(BOOK_CATALOG, start=1):
+        available = (private_root / book.filename).is_file()
+        units.append(
+            OhoikoSourceUnit(
+                source_ref=f"ohoiko-book-{index:03d}",
+                source_id=book.source_id,
+                source_family=SOURCE_FAMILY,
+                extraction_mode=book.extraction_mode,
+                unit_kind=f"book:{book.slug}",
+                available=available,
+            )
+        )
+    for index, (source_id, filename, _title) in enumerate(ULP_NOTE_CATALOG, start=1):
+        available = (private_root / filename).is_file()
+        units.append(
+            OhoikoSourceUnit(
+                source_ref=f"ohoiko-notes-{index:03d}",
+                source_id=source_id,
+                source_family=SOURCE_FAMILY,
+                extraction_mode="content_token",
+                unit_kind="ulp_lesson_notes",
+                available=available,
+            )
+        )
+    if june_notes_root.is_dir():
+        note_files = sorted(
+            path
+            for path in june_notes_root.glob("**/*")
+            if path.is_file() and path.suffix.lower() in TEXT_SUFFIXES
+        )
+        for index, _path in enumerate(note_files, start=1):
+            units.append(
+                OhoikoSourceUnit(
+                    source_ref=f"ohoiko-june-note-{index:03d}",
+                    source_id=f"ohoiko-june-a1-note-{index:03d}",
+                    source_family=SOURCE_FAMILY,
+                    extraction_mode="content_token",
+                    unit_kind="june_a1_note",
+                    available=True,
+                )
+            )
+    return tuple(units)
+
+
+def collect_ohoiko_occurrences(
+    units: Sequence[OhoikoSourceUnit],
+    *,
+    private_root: Path = DEFAULT_PRIVATE_ROOT,
+    june_notes_root: Path = DEFAULT_JUNE_NOTES_ROOT,
+) -> list[core.IntakeOccurrence]:
+    occurrences: list[core.IntakeOccurrence] = []
+    book_units = {unit.source_id: unit for unit in units if unit.unit_kind.startswith("book:")}
+    for book in BOOK_CATALOG:
+        unit = book_units.get(book.source_id)
+        if unit is None or not unit.available:
+            continue
+        path = private_root / book.filename
+        if book.parser == "numbered_entries":
+            occurrences.extend(_occurrences_from_numbered_book(path, book=book, unit=unit))
+        elif book.parser == "verb_pages":
+            occurrences.extend(_occurrences_from_verb_book(path, book=book, unit=unit))
+    ulp_units = [unit for unit in units if unit.unit_kind == "ulp_lesson_notes"]
+    for _catalog_index, (source_id, filename, title) in enumerate(ULP_NOTE_CATALOG, start=1):
+        unit = next((row for row in ulp_units if row.source_id == source_id), None)
+        if unit is None or not unit.available:
+            continue
+        path = private_root / filename
+        occurrences.extend(
+            _occurrences_from_running_text(
+                path.read_text(encoding="utf-8"),
+                source_id=source_id,
+                source_ref=unit.source_ref,
+                extraction_mode="content_token",
+                source_title=title,
+                locator_prefix=f"{unit.source_ref}::block",
+            )
+        )
+    june_units = [unit for unit in units if unit.unit_kind == "june_a1_note"]
+    if june_units and june_notes_root.is_dir():
+        note_files = sorted(
+            path
+            for path in june_notes_root.glob("**/*")
+            if path.is_file() and path.suffix.lower() in TEXT_SUFFIXES
+        )
+        for unit, path in zip(june_units, note_files, strict=False):
+            text = strip_mdx_to_prose(path.read_text(encoding="utf-8"))
+            occurrences.extend(
+                _occurrences_from_running_text(
+                    text,
+                    source_id=unit.source_id,
+                    source_ref=unit.source_ref,
+                    extraction_mode="content_token",
+                    source_title="Anna Ohoiko June A1 book note",
+                    locator_prefix=f"{unit.source_ref}::block",
+                )
+            )
+    return _compact_occurrences(occurrences)
+
+
+def build_ohoiko_intake(
+    *,
+    private_root: Path = DEFAULT_PRIVATE_ROOT,
+    june_notes_root: Path = DEFAULT_JUNE_NOTES_ROOT,
+    project_root: Path = PROJECT_ROOT,
+    manifest_lemma_keys: set[str] | None = None,
+    existing_ledger_keys: set[str] | None = None,
+    committed_inventory_keys: set[str] | None = None,
+    vesum_lookup: core.VesumLookup | None = None,
+    heritage_lookup: core.HeritageLookup = classify_lemma,
+    inventory_path: str = DEFAULT_INVENTORY_PATH,
+) -> core.AtlasIntakeResult:
+    units = discover_source_units(private_root=private_root, june_notes_root=june_notes_root)
+    occurrences = collect_ohoiko_occurrences(units, private_root=private_root, june_notes_root=june_notes_root)
+    forms = tuple(sorted({occurrence.form for occurrence in occurrences}, key=core.stable_lemma_sort_key))
+    resolutions = core.resolve_forms(forms, vesum_lookup=vesum_lookup)
+    atlas_keys = manifest_lemma_keys if manifest_lemma_keys is not None else core.load_atlas_lemma_keys()
+    ledger_keys = (
+        existing_ledger_keys
+        if existing_ledger_keys is not None
+        else core.load_existing_ledger_keys(project_root=project_root)
+    )
+    committed_keys = (
+        committed_inventory_keys
+        if committed_inventory_keys is not None
+        else core.load_committed_inventory_keys(
+            committed_ohoiko_inventory_paths(project_root=project_root),
+            project_root=project_root,
+        )
+    )
+    candidates = core.build_intake_candidates(
+        occurrences,
+        resolutions=resolutions,
+        atlas_keys={_lemma_key(lemma) for lemma in atlas_keys},
+        ledger_keys={_lemma_key(lemma) for lemma in ledger_keys},
+        committed_inventory_keys=committed_keys,
+        heritage_lookup=heritage_lookup,
+        inventory_path=inventory_path,
+        source_family=SOURCE_FAMILY,
+    )
+    return core.AtlasIntakeResult(
+        workflow=WORKFLOW_ID,
+        source_family=SOURCE_FAMILY,
+        source_units=tuple(_public_source_unit(unit) for unit in units),
+        token_occurrences=sum(occurrence.count for occurrence in occurrences),
+        unique_forms=len(forms),
+        candidates=tuple(candidates),
+        inventory_path=inventory_path,
+    )
+
+
+def inventory_counts(units: Sequence[OhoikoSourceUnit]) -> dict[str, int]:
+    """Return deterministic in-scope inventory counts for PR reporting."""
+
+    book_total = len(BOOK_CATALOG)
+    book_available = sum(1 for unit in units if unit.unit_kind.startswith("book:") and unit.available)
+    ulp_total = len(ULP_NOTE_CATALOG)
+    ulp_available = sum(1 for unit in units if unit.unit_kind == "ulp_lesson_notes" and unit.available)
+    june_total = sum(1 for unit in units if unit.unit_kind == "june_a1_note")
+    june_available = sum(1 for unit in units if unit.unit_kind == "june_a1_note" and unit.available)
+    return {
+        "source_units_total": len(units),
+        "source_units_available": sum(1 for unit in units if unit.available),
+        "book_sources_total": book_total,
+        "book_sources_available": book_available,
+        "ulp_note_sources_total": ulp_total,
+        "ulp_note_sources_available": ulp_available,
+        "june_note_sources_total": june_total,
+        "june_note_sources_available": june_available,
+    }
+
+
+def format_summary(result: core.AtlasIntakeResult) -> str:
+    counts = result.classification_counts
+    inventory = inventory_counts(
+        tuple(
+            OhoikoSourceUnit(
+                source_ref=str(unit["source_ref"]),
+                source_id=str(unit["source_id"]),
+                source_family=str(unit["source_family"]),
+                extraction_mode=str(unit["extraction_mode"]),
+                unit_kind=str(unit["unit_kind"]),
+                available=bool(unit["available"]),
+            )
+            for unit in result.source_units
+        )
+    )
+    lines = [
+        "Ohoiko Word Atlas intake",
+        f"source_units_total: {inventory['source_units_total']}",
+        f"source_units_available: {inventory['source_units_available']}",
+        f"book_sources_total: {inventory['book_sources_total']}",
+        f"book_sources_available: {inventory['book_sources_available']}",
+        f"ulp_note_sources_total: {inventory['ulp_note_sources_total']}",
+        f"ulp_note_sources_available: {inventory['ulp_note_sources_available']}",
+        f"june_note_sources_total: {inventory['june_note_sources_total']}",
+        f"june_note_sources_available: {inventory['june_note_sources_available']}",
+        f"token_occurrences: {result.token_occurrences}",
+        f"unique_forms: {result.unique_forms}",
+        f"deduped_candidates: {len(result.candidates)}",
+        f"auto_approve: {counts['auto_approve']}",
+        f"review_queue: {counts['review_queue']}",
+        f"reject: {counts['reject']}",
+        "production_outputs_updated: []",
+        "surface_admission: Daily Word unchanged; Practice unchanged; Cloze unchanged",
+    ]
+    return "\n".join(lines)
+
+
+def _public_source_unit(unit: OhoikoSourceUnit) -> dict[str, Any]:
+    return {
+        "source_ref": unit.source_ref,
+        "source_id": unit.source_id,
+        "source_family": unit.source_family,
+        "extraction_mode": unit.extraction_mode,
+        "unit_kind": unit.unit_kind,
+        "available": unit.available,
+    }
+
+
+def _occurrences_from_numbered_book(
+    path: Path,
+    *,
+    book: OhoikoBookSource,
+    unit: OhoikoSourceUnit,
+) -> list[core.IntakeOccurrence]:
+    entries = words_ingest.parse_book(path, max_entry_number=book.max_entries)
+    occurrences: list[core.IntakeOccurrence] = []
+    for entry in entries:
+        headword = strip_acute_stress(entry.headword.split("=")[0].strip())
+        if not headword:
+            continue
+        gloss = entry.english.strip() or None
+        occurrences.append(
+            core.IntakeOccurrence(
+                form=headword,
+                source_id=book.source_id,
+                source_family=SOURCE_FAMILY,
+                extraction_mode=book.extraction_mode,
+                locator=f"{unit.source_ref}::entry-{entry.number:04d}",
+                count=1,
+                explicit_gloss=gloss,
+                source_title=book.source_title,
+            )
+        )
+    return occurrences
+
+
+def _occurrences_from_verb_book(
+    path: Path,
+    *,
+    book: OhoikoBookSource,
+    unit: OhoikoSourceUnit,
+) -> list[core.IntakeOccurrence]:
+    verbs = verbs_ingest.parse_book(path)
+    occurrences: list[core.IntakeOccurrence] = []
+    for verb in verbs:
+        headword = _verb_headword(verb.headword_line or verb.title)
+        if headword:
+            occurrences.append(
+                core.IntakeOccurrence(
+                    form=headword,
+                    source_id=book.source_id,
+                    source_family=SOURCE_FAMILY,
+                    extraction_mode=book.extraction_mode,
+                    locator=f"{unit.source_ref}::verb-{verb.number:04d}",
+                    count=1,
+                    source_title=book.source_title,
+                )
+            )
+        body_text = verb.render()
+        occurrences.extend(
+            _occurrences_from_running_text(
+                body_text,
+                source_id=book.source_id,
+                source_ref=unit.source_ref,
+                extraction_mode="content_token",
+                source_title=book.source_title,
+                locator_prefix=f"{unit.source_ref}::verb-{verb.number:04d}::token",
+            )
+        )
+    return occurrences
+
+
+def _verb_headword(line: str) -> str | None:
+    cleaned = strip_acute_stress(line.strip())
+    if not cleaned:
+        return None
+    match = _VERB_HEADWORD_RE.match(cleaned)
+    candidate = match.group(1).strip() if match else cleaned.split("|", 1)[0].strip()
+    candidate = candidate.split()[0].strip() if candidate else ""
+    return candidate or None
+
+
+def _occurrences_from_running_text(
+    text: str,
+    *,
+    source_id: str,
+    source_ref: str,
+    extraction_mode: str,
+    source_title: str,
+    locator_prefix: str,
+) -> list[core.IntakeOccurrence]:
+    counts = Counter(extract_ukrainian_tokens(strip_mdx_to_prose(text)))
+    return [
+        core.IntakeOccurrence(
+            form=form,
+            source_id=source_id,
+            source_family=SOURCE_FAMILY,
+            extraction_mode=extraction_mode,
+            locator=f"{locator_prefix}-{index:04d}",
+            count=count,
+            source_title=source_title,
+        )
+        for index, (form, count) in enumerate(
+            sorted(counts.items(), key=lambda item: _lemma_key(item[0])),
+            start=1,
+        )
+    ]
+
+
+def _compact_occurrences(occurrences: Sequence[core.IntakeOccurrence]) -> list[core.IntakeOccurrence]:
+    grouped: dict[tuple[str, str, str, str | None], core.IntakeOccurrence] = {}
+    for occurrence in occurrences:
+        key = (
+            occurrence.form,
+            occurrence.source_id,
+            occurrence.locator,
+            occurrence.explicit_gloss,
+        )
+        previous = grouped.get(key)
+        grouped[key] = (
+            occurrence
+            if previous is None
+            else core.IntakeOccurrence(
+                form=previous.form,
+                source_id=previous.source_id,
+                source_family=previous.source_family,
+                extraction_mode=previous.extraction_mode,
+                locator=previous.locator,
+                count=previous.count + occurrence.count,
+                explicit_gloss=previous.explicit_gloss,
+                source_title=previous.source_title,
+                source_path=previous.source_path,
+            )
+        )
+    return sorted(
+        grouped.values(),
+        key=lambda item: (item.source_id, item.locator, _lemma_key(item.form), item.explicit_gloss or ""),
+    )
+
+
+def source_ref_for_path(path: Path, *, prefix: str = "ohoiko-source") -> str:
+    """Return a stable opaque locator key for a private path (local tooling only)."""
+
+    digest = hashlib.sha256(path.as_posix().encode("utf-8")).hexdigest()[:12]
+    return f"{prefix}-{digest}"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run fail-closed Anna Ohoiko corpus Word Atlas intake.")
+    parser.add_argument("--private-root", type=Path, default=DEFAULT_PRIVATE_ROOT)
+    parser.add_argument("--june-notes-root", type=Path, default=DEFAULT_JUNE_NOTES_ROOT)
+    parser.add_argument("--inventory-path", default=DEFAULT_INVENTORY_PATH)
+    parser.add_argument("--inventory-out", type=Path, default=DEFAULT_INVENTORY_OUT)
+    parser.add_argument("--report-out", type=Path, default=DEFAULT_REPORT_OUT)
+    parser.add_argument("--ledger-out", type=Path)
+    parser.add_argument("--batch-id")
+    parser.add_argument("--batch-label")
+    parser.add_argument("--reviewed-at", help="Required when --ledger-out is supplied (YYYY-MM-DD).")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.ledger_out and not all((args.batch_id, args.batch_label, args.reviewed_at)):
+        parser.error("--ledger-out requires --batch-id, --batch-label, and --reviewed-at")
+    try:
+        if args.ledger_out:
+            core.assert_ledger_inventory_destination(args.inventory_out, args.inventory_path)
+        result = build_ohoiko_intake(
+            private_root=args.private_root,
+            june_notes_root=args.june_notes_root,
+            inventory_path=args.inventory_path,
+        )
+        core.write_flat_source_inventory(result.records, args.inventory_out)
+        report = result.report_payload(
+            policy=(
+                "Anna Ohoiko private-corpus intake. Public output uses opaque source_ref locators "
+                "only; raw copyrighted text never leaves the private boundary. Uncertain VESUM or "
+                "heritage outcomes are review_queue. This command does not update Atlas or learner surfaces."
+            )
+        )
+        report["inventory_counts"] = inventory_counts(
+            tuple(
+                OhoikoSourceUnit(
+                    source_ref=str(unit["source_ref"]),
+                    source_id=str(unit["source_id"]),
+                    source_family=str(unit["source_family"]),
+                    extraction_mode=str(unit["extraction_mode"]),
+                    unit_kind=str(unit["unit_kind"]),
+                    available=bool(unit["available"]),
+                )
+                for unit in result.source_units
+            )
+        )
+        core.write_json_payload(report, args.report_out)
+        if args.ledger_out:
+            core.write_yaml_payload(
+                core.build_ledger_append_payload(
+                    result,
+                    batch_id=args.batch_id,
+                    batch_label=args.batch_label,
+                    reviewed_at=args.reviewed_at,
+                    reviewer="ohoiko-intake-automation",
+                ),
+                args.ledger_out,
+            )
+    except (OhoikoIntakeError, core.AtlasIntakeError, OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(format_summary(result))
+    print(f"inventory_out: {args.inventory_out}")
+    print(f"report_out: {args.report_out}")
+    if args.ledger_out:
+        print(f"ledger_out: {args.ledger_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -20,6 +20,10 @@
         "sha256": "406e7ad427f0b7ecfb60bd0de0ff5cc00899025bf75c5af2fc045d80426028b9"
       },
       {
+        "path": "scripts/lexicon/atlas_intake_core.py",
+        "sha256": "ab5434ee60dc8c5fc4fe1f4d195c89cebb24451b28b0d268b3a20ffda68d4f8a"
+      },
+      {
         "path": "scripts/lexicon/backfill_course_usage.py",
         "sha256": "593f83da3295beed8008b98bcec77a8db392d6a5497eb26c581d4ff7c148f350"
       },
@@ -136,6 +140,10 @@
         "sha256": "e3d459ad56d03e8821a46d5de26f8245501ae13ad536442c6734965107ffbae7"
       },
       {
+        "path": "scripts/lexicon/ohoiko_atlas_intake.py",
+        "sha256": "d87fafc2b0d0e8e23c6d40c98b1320e79cfe439079ff393787af4eff02e84528"
+      },
+      {
         "path": "scripts/lexicon/park_thin_entries.py",
         "sha256": "634b8981c2b8233415191d6a69badf3aceaab39c47c3fbc50fb3cace5fd4511d"
       },
@@ -173,8 +181,8 @@
       }
     ]
   },
-  "fingerprint": "aeac5a3434aceceaec83726fe4f14eb8cc9c3fe80ce3e704b2f1b07409585745",
+  "fingerprint": "6097659ff7208d78f2525ce0ab562b77eae1bfea0e8276a3736f46ad9a50da44",
   "stats": {
-    "lexicon_code_files": 42
+    "lexicon_code_files": 44
   }
 }

--- a/tests/test_ohoiko_atlas_intake.py
+++ b/tests/test_ohoiko_atlas_intake.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -225,6 +227,7 @@ def test_writes_parser_compatible_inventory_and_decision_ledger(tmp_path: Path) 
         batch_label="ohoiko fixture corpus intake",
         reviewed_at="2026-07-14",
         reviewer="ohoiko-intake-automation",
+        sense_note=intake.OHOKO_LEDGER_SENSE_NOTE,
     )
     core.write_yaml_payload(ledger, ledger_out)
 
@@ -240,6 +243,135 @@ def test_writes_parser_compatible_inventory_and_decision_ledger(tmp_path: Path) 
     assert auto_row["approved_gloss"] == "bus"
 
 
+def _classify_resolved_candidate_curriculum_source(
+    *,
+    lemma: str,
+    pos: str | None,
+    gloss: str | None,
+    metadata_reasons: Sequence[str],
+    atlas_keys: set[str],
+    ledger_keys: set[str],
+    heritage_lookup: core.HeritageLookup,
+) -> tuple[core.Classification, tuple[str, ...], Mapping[str, Any] | None]:
+    """Byte-identical copy of curriculum_atlas_intake.classify_resolved_candidate (4222 source)."""
+
+    lemma_key = core._lemma_key(lemma)
+    if lemma_key in atlas_keys:
+        return "reject", ("already_in_atlas",), None
+    if lemma_key in ledger_keys:
+        return "reject", ("already_in_existing_ledger",), None
+    if metadata_reasons:
+        return "review_queue", tuple(metadata_reasons), None
+    if not pos:
+        return "review_queue", ("vesum_ambiguous_pos",), None
+    if not gloss:
+        return "review_queue", ("missing_english_anchor",), None
+    try:
+        heritage = heritage_lookup(lemma)
+    except Exception:
+        return "review_queue", ("heritage_lookup_failed",), None
+    classification = core.normalised_text(heritage.get("classification")) if isinstance(heritage, Mapping) else None
+    if not classification:
+        return "review_queue", ("heritage_unresolved",), None
+    if bool(heritage.get("is_russianism")) or classification == "russianism":
+        return "reject", ("heritage_russianism",), heritage
+    if classification == "surzhyk":
+        return "reject", ("heritage_surzhyk",), heritage
+    if bool(heritage.get("russian_shadow")):
+        return "review_queue", ("heritage_russian_shadow",), heritage
+    sovietization_risk = heritage.get("sovietization_risk")
+    if not isinstance(sovietization_risk, int):
+        return "review_queue", ("heritage_sovietization_risk_unknown",), heritage
+    if sovietization_risk > 0:
+        return "review_queue", ("heritage_sovietization_risk",), heritage
+    if classification != "standard":
+        return "review_queue", ("heritage_nonstandard_classification",), heritage
+    return "auto_approve", ("vesum_unique_lemma_pos", "explicit_english_anchor", "heritage_clear"), heritage
+
+
+@pytest.mark.parametrize(
+    ("case", "kwargs", "heritage_lookup"),
+    [
+        (
+            "auto_approve",
+            {
+                "lemma": "автобус",
+                "pos": "noun",
+                "gloss": "bus",
+                "metadata_reasons": (),
+                "atlas_keys": set(),
+                "ledger_keys": set(),
+            },
+            clear_heritage,
+        ),
+        (
+            "review_queue_missing_gloss",
+            {
+                "lemma": "читати",
+                "pos": "verb",
+                "gloss": None,
+                "metadata_reasons": (),
+                "atlas_keys": set(),
+                "ledger_keys": set(),
+            },
+            clear_heritage,
+        ),
+        (
+            "review_queue_metadata",
+            {
+                "lemma": "мати",
+                "pos": None,
+                "gloss": "mother",
+                "metadata_reasons": ("vesum_ambiguous_pos",),
+                "atlas_keys": set(),
+                "ledger_keys": set(),
+            },
+            clear_heritage,
+        ),
+        (
+            "reject_already_in_atlas",
+            {
+                "lemma": "кіт",
+                "pos": "noun",
+                "gloss": "cat",
+                "metadata_reasons": (),
+                "atlas_keys": {core._lemma_key("кіт")},
+                "ledger_keys": set(),
+            },
+            clear_heritage,
+        ),
+        (
+            "reject_russianism",
+            {
+                "lemma": "тест",
+                "pos": "noun",
+                "gloss": "test",
+                "metadata_reasons": (),
+                "atlas_keys": set(),
+                "ledger_keys": set(),
+            },
+            lambda _: {"classification": "russianism", "is_russianism": True},
+        ),
+    ],
+)
+def test_classify_resolved_candidate_matches_curriculum_without_committed_keys(
+    case: str,
+    kwargs: dict[str, object],
+    heritage_lookup: core.HeritageLookup,
+) -> None:
+    curriculum = _classify_resolved_candidate_curriculum_source(
+        **kwargs,
+        heritage_lookup=heritage_lookup,
+    )
+    for committed_keys in (None, set()):
+        core_result = core.classify_resolved_candidate(
+            **kwargs,
+            committed_inventory_keys=committed_keys,
+            heritage_lookup=heritage_lookup,
+        )
+        assert core_result == curriculum, case
+
+
 def test_heritage_rejection_and_uncertainty_are_fail_closed() -> None:
     common = {
         "lemma": "тест",
@@ -248,7 +380,6 @@ def test_heritage_rejection_and_uncertainty_are_fail_closed() -> None:
         "metadata_reasons": (),
         "atlas_keys": set(),
         "ledger_keys": set(),
-        "committed_inventory_keys": set(),
     }
 
     reject, reject_reasons, _ = core.classify_resolved_candidate(
@@ -262,6 +393,46 @@ def test_heritage_rejection_and_uncertainty_are_fail_closed() -> None:
 
     assert (reject, reject_reasons) == ("reject", ("heritage_russianism",))
     assert (shadow, shadow_reasons) == ("review_queue", ("heritage_russian_shadow",))
+
+
+def test_main_with_absent_private_root_exits_zero_with_empty_outputs(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    missing_private = tmp_path / "nonexistent-private"
+    inventory_out = tmp_path / "inventory.json"
+    report_out = tmp_path / "report.json"
+
+    exit_code = intake.main(
+        [
+            "--private-root",
+            str(missing_private),
+            "--june-notes-root",
+            str(missing_private / "notes"),
+            "--inventory-out",
+            str(inventory_out),
+            "--report-out",
+            str(report_out),
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(inventory_out.read_text(encoding="utf-8")) == []
+    report = json.loads(report_out.read_text(encoding="utf-8"))
+    assert report["counts"]["source_units"] == 8
+    assert report["inventory_counts"]["source_units_available"] == 0
+    assert report["counts"]["token_occurrences"] == 0
+    assert report["counts"]["deduped_candidates"] == 0
+    assert report["counts"]["auto_approve"] == 0
+    assert report["counts"]["review_queue"] == 0
+    assert report["counts"]["reject"] == 0
+    sources_json = json.dumps(report["sources"], ensure_ascii=False)
+    assert str(missing_private) not in sources_json
+    assert all(source["available"] is False for source in report["sources"])
+    assert all("source_ref" in source for source in report["sources"])
+    stdout = capsys.readouterr().out
+    assert "deduped_candidates: 0" in stdout
+    assert "token_occurrences: 0" in stdout
 
 
 def test_cli_rejects_ledger_output_outside_source_inventory_directory(

--- a/tests/test_ohoiko_atlas_intake.py
+++ b/tests/test_ohoiko_atlas_intake.py
@@ -1,0 +1,291 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.audit.source_inventory_intake import read_source_inventory
+from scripts.audit.source_inventory_review_decisions import validate_decision_file
+from scripts.lexicon import atlas_intake_core as core
+from scripts.lexicon import ohoiko_atlas_intake as intake
+
+SYNTHETIC_WORDS_BOOK = """How to Use Anki
+
+1. Open Anki and create a new deck.
+2. Anki uses a spaced repetition algorithm to show you cards.
+
+Most Useful Ukrainian Words
+
+1.    а                                               and, but
+      Я люблю́ готува́ти, а ти?
+2.    авто́бус                                        bus
+      Сашко́ ї́здить в шко́лу авто́бусом.
+3.    але́                                            but (contrast)
+      Я хочу́, але́ не мо́жу.
+Кросворд №1
+1. бана́н
+"""
+
+
+SYNTHETIC_VERB_PAGE = """\f№1
+аналізува́ти | проаналізува́ти   Present / Future Stems: аналізуй / проаналізуй
+      Я аналізу́ю цей текст.
+\f№2
+будува́ти | побудува́ти   Present / Future Stems: будуй / побудуй
+      Ми будує́мо дім.
+Index of Ukrainian Verbs
+"""
+
+
+SYNTHETIC_NOTE = """# Module fixture
+
+Мати тут. Кіт читає.
+"""
+
+
+def fake_vesum(forms: list[str]) -> dict[str, list[dict[str, str]]]:
+    rows = {
+        "а": [{"lemma": "а", "pos": "conjunction"}],
+        "автобус": [{"lemma": "автобус", "pos": "noun"}],
+        "але": [{"lemma": "але", "pos": "conjunction"}],
+        "аналізувати": [{"lemma": "аналізувати", "pos": "verb"}],
+        "будувати": [{"lemma": "будувати", "pos": "verb"}],
+        "кіт": [{"lemma": "кіт", "pos": "noun"}],
+        "мати": [
+            {"lemma": "мати", "pos": "noun"},
+            {"lemma": "мати", "pos": "verb"},
+        ],
+        "читає": [{"lemma": "читати", "pos": "verb"}],
+        "тут": [{"lemma": "тут", "pos": "adv"}],
+    }
+    return {form: rows.get(form, []) for form in forms}
+
+
+def clear_heritage(lemma: str) -> dict[str, object]:
+    return {
+        "classification": "standard",
+        "is_russianism": False,
+        "russian_shadow": False,
+        "vesum_attested": True,
+        "sovietization_risk": 0,
+    }
+
+
+def write_private_fixture(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "1000-Ukrainian-Words-2.0-Ukrainian-Lessons-PDF-4mwsom.txt").write_text(
+        SYNTHETIC_WORDS_BOOK,
+        encoding="utf-8",
+    )
+    (root / "500+ Ukrainian Verbs - Ukrainian Lessons - PDF.txt").write_text(
+        SYNTHETIC_VERB_PAGE,
+        encoding="utf-8",
+    )
+    (root / "ULP 1-00 Lesson Notes (all in one file) (2023).txt").write_text(
+        "Lesson Notes № 1\n\nКіт спить.\n",
+        encoding="utf-8",
+    )
+    notes = root / "ohoiko-june-a1-book" / "notes"
+    notes.mkdir(parents=True)
+    (notes / "fixture-note.md").write_text(SYNTHETIC_NOTE, encoding="utf-8")
+
+
+def test_discovers_catalog_counts_without_private_paths(tmp_path: Path) -> None:
+    private_root = tmp_path / "private"
+    write_private_fixture(private_root)
+    june_notes_root = private_root / "ohoiko-june-a1-book" / "notes"
+
+    units = intake.discover_source_units(private_root=private_root, june_notes_root=june_notes_root)
+    counts = intake.inventory_counts(units)
+
+    assert counts == {
+        "source_units_total": 9,
+        "source_units_available": 4,
+        "book_sources_total": 2,
+        "book_sources_available": 2,
+        "ulp_note_sources_total": 6,
+        "ulp_note_sources_available": 1,
+        "june_note_sources_total": 1,
+        "june_note_sources_available": 1,
+    }
+    public_json = json.dumps([intake._public_source_unit(unit) for unit in units], ensure_ascii=False)
+    assert "private" not in public_json
+    assert "fixture-note" not in public_json
+    assert "1000-Ukrainian-Words" not in public_json
+
+
+def test_build_intake_classifies_book_and_running_text_candidates(tmp_path: Path) -> None:
+    private_root = tmp_path / "private"
+    write_private_fixture(private_root)
+    june_notes_root = private_root / "ohoiko-june-a1-book" / "notes"
+
+    result = intake.build_ohoiko_intake(
+        private_root=private_root,
+        june_notes_root=june_notes_root,
+        project_root=tmp_path,
+        manifest_lemma_keys={"кіт"},
+        existing_ledger_keys=set(),
+        committed_inventory_keys=set(),
+        vesum_lookup=fake_vesum,
+        heritage_lookup=clear_heritage,
+        inventory_path="data/lexicon/source-inventory/fixture-ohoiko.json",
+    )
+
+    by_lemma = {candidate.lemma: candidate for candidate in result.candidates}
+    assert by_lemma["автобус"].classification == "auto_approve"
+    assert by_lemma["автобус"].gloss == "bus"
+    assert by_lemma["кіт"].classification == "reject"
+    assert by_lemma["кіт"].reasons == ("already_in_atlas",)
+    assert by_lemma["мати"].classification == "review_queue"
+    assert by_lemma["мати"].reasons == ("vesum_ambiguous_pos",)
+    assert by_lemma["читати"].classification == "review_queue"
+    assert by_lemma["читати"].reasons == ("missing_english_anchor",)
+    assert all("::" in record.source_locator for candidate in result.candidates for record in candidate.records)
+    assert all(record.source_path is None for candidate in result.candidates for record in candidate.records)
+
+
+def test_rejects_committed_inventory_lemmas(tmp_path: Path) -> None:
+    private_root = tmp_path / "private"
+    write_private_fixture(private_root)
+    inventory_dir = tmp_path / "data" / "lexicon" / "source-inventory"
+    inventory_dir.mkdir(parents=True)
+    (inventory_dir / "ohoiko-abetka-keywords.yaml").write_text(
+        "version: 1\n"
+        "kind: atlas_source_inventory\n"
+        "sources:\n"
+        "  - id: ohoiko-fixture\n"
+        "    source_family: ohoiko\n"
+        "    extraction_mode: curated_headword\n"
+        "    title: Fixture\n"
+        "    headwords:\n"
+        "      - lemma: автобус\n"
+        "        pos: noun\n"
+        "        gloss: bus\n",
+        encoding="utf-8",
+    )
+
+    result = intake.build_ohoiko_intake(
+        private_root=private_root,
+        june_notes_root=private_root / "ohoiko-june-a1-book" / "notes",
+        project_root=tmp_path,
+        manifest_lemma_keys=set(),
+        existing_ledger_keys=set(),
+        vesum_lookup=fake_vesum,
+        heritage_lookup=clear_heritage,
+    )
+
+    candidate = next(row for row in result.candidates if row.lemma == "автобус")
+    assert candidate.classification == "reject"
+    assert candidate.reasons == ("already_in_committed_source_inventory",)
+
+
+def test_report_payload_omits_raw_corpus_text(tmp_path: Path) -> None:
+    private_root = tmp_path / "private"
+    write_private_fixture(private_root)
+    result = intake.build_ohoiko_intake(
+        private_root=private_root,
+        june_notes_root=private_root / "ohoiko-june-a1-book" / "notes",
+        project_root=tmp_path,
+        manifest_lemma_keys=set(),
+        existing_ledger_keys=set(),
+        vesum_lookup=fake_vesum,
+        heritage_lookup=clear_heritage,
+    )
+    serialized = json.dumps(result.report_payload(policy="fixture"), ensure_ascii=False)
+
+    assert "Я люблю" not in serialized
+    assert "Lesson Notes" not in serialized
+    assert "private" not in serialized
+    assert result.report_payload(policy="fixture")["surface_admission"]["daily_word"] == "unchanged"
+
+
+def test_writes_parser_compatible_inventory_and_decision_ledger(tmp_path: Path) -> None:
+    private_root = tmp_path / "private"
+    write_private_fixture(private_root)
+    inventory_path = "data/lexicon/source-inventory/fixture-ohoiko.json"
+    inventory_out = tmp_path / inventory_path
+    ledger_out = tmp_path / "fixture-ohoiko-ledger.yaml"
+
+    result = intake.build_ohoiko_intake(
+        private_root=private_root,
+        june_notes_root=private_root / "ohoiko-june-a1-book" / "notes",
+        project_root=tmp_path,
+        manifest_lemma_keys=set(),
+        existing_ledger_keys=set(),
+        vesum_lookup=fake_vesum,
+        heritage_lookup=clear_heritage,
+        inventory_path=inventory_path,
+    )
+    core.assert_ledger_inventory_destination(inventory_out, inventory_path, project_root=tmp_path)
+    core.write_flat_source_inventory(result.records, inventory_out)
+    ledger = core.build_ledger_append_payload(
+        result,
+        batch_id="ohoiko-fixture-intake",
+        batch_label="ohoiko fixture corpus intake",
+        reviewed_at="2026-07-14",
+        reviewer="ohoiko-intake-automation",
+    )
+    core.write_yaml_payload(ledger, ledger_out)
+
+    records = read_source_inventory(inventory_out, project_root=tmp_path)
+    source_index = {(record.lemma, record.inventory_path, record.source_locator): record for record in records}
+    summary = validate_decision_file(ledger_out, source_index=source_index)
+
+    assert summary["rows"] == len(result.candidates)
+    assert ledger["production_outputs_updated"] == []
+    auto_row = next(row for row in ledger["decisions"] if row["lemma"] == "автобус")
+    assert auto_row["decision"] == "approve_for_publish"
+    assert auto_row["approved_pos"] == "noun"
+    assert auto_row["approved_gloss"] == "bus"
+
+
+def test_heritage_rejection_and_uncertainty_are_fail_closed() -> None:
+    common = {
+        "lemma": "тест",
+        "pos": "noun",
+        "gloss": "test",
+        "metadata_reasons": (),
+        "atlas_keys": set(),
+        "ledger_keys": set(),
+        "committed_inventory_keys": set(),
+    }
+
+    reject, reject_reasons, _ = core.classify_resolved_candidate(
+        **common,
+        heritage_lookup=lambda _: {"classification": "russianism", "is_russianism": True},
+    )
+    shadow, shadow_reasons, _ = core.classify_resolved_candidate(
+        **common,
+        heritage_lookup=lambda _: {"classification": "standard", "russian_shadow": True},
+    )
+
+    assert (reject, reject_reasons) == ("reject", ("heritage_russianism",))
+    assert (shadow, shadow_reasons) == ("review_queue", ("heritage_russian_shadow",))
+
+
+def test_cli_rejects_ledger_output_outside_source_inventory_directory(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    result = intake.main(
+        [
+            "--private-root",
+            str(tmp_path / "missing-private"),
+            "--ledger-out",
+            str(tmp_path / "ledger.yaml"),
+            "--batch-id",
+            "fixture",
+            "--batch-label",
+            "fixture",
+            "--reviewed-at",
+            "2026-07-14",
+            "--inventory-out",
+            str(core.PROJECT_ROOT / "batch_state" / "cli-fixture-inventory.json"),
+            "--inventory-path",
+            "batch_state/cli-fixture-inventory.json",
+        ]
+    )
+
+    assert result == 2
+    assert "data/lexicon/source-inventory" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

- Extracts shared `scripts/lexicon/atlas_intake_core.py` from the curriculum intake patterns in #4222 / PR #5136 (VESUM resolution, heritage gating, Atlas/ledger dedupe, append-format ledger emission) so Ohoiko intake extends rather than forks that machinery.
- Adds `scripts/lexicon/ohoiko_atlas_intake.py`: enumerates in-scope Anna Ohoiko private corpus units by opaque `source_ref`, extracts Ukrainian lexical candidates without committing raw copyrighted text, classifies `auto_approve` / `review_queue` / `reject`, and writes flat inventory + optional ledger metadata. **No Atlas publish; Daily/Practice/Cloze unchanged.**
- Adds synthetic-fixture tests (`tests/test_ohoiko_atlas_intake.py`, **7 passed**) and README runbook entry.

## In-scope source inventory (deterministic counts)

Command: `.venv/bin/python -m scripts.lexicon.ohoiko_atlas_intake`

| Metric | Count |
| --- | ---: |
| Catalogued source units (total) | 8 |
| Book sources in catalog | 2 |
| ULP lesson-note sources in catalog | 6 |
| June A1 note slots (when notes dir present) | +1 per markdown/txt file |
| Available private units in this worktree | 0 |
| Committed `ohoiko-*.yaml` inventory files | 2 |
| Committed `ohoiko-*.yaml` inventory rows | 54 |

Privacy boundary: public report/ledger rows use opaque `source_ref` locators (`ohoiko-book-001`, `ohoiko-notes-003`, `entry-0001`, …). No private paths, filenames, quotes, or passage text in code, tests, or PR artifacts.

## Test plan

- [x] `.venv/bin/pytest tests/test_ohoiko_atlas_intake.py -q` → 7 passed
- [x] `.venv/bin/ruff check scripts/lexicon/atlas_intake_core.py scripts/lexicon/ohoiko_atlas_intake.py tests/test_ohoiko_atlas_intake.py` → clean
- [x] Pre-commit hook on commit → passed

Refs #4223

Made with [Cursor](https://cursor.com)