### PR TITLE
fix(atlas): replace anglicism and ambiguous wording in runtime status labels

### DIFF
--- a/site/src/lexicon/AtlasRuntimeStatus.astro
+++ b/site/src/lexicon/AtlasRuntimeStatus.astro
@@ -76,10 +76,10 @@ const statusUrl = "/api/lexicon/status.json";
     setRuntimeText(root, "publicAtlas", formatCount(status.entryModel.total_reviewed_entries));
     
     const aliasCount = status.entryModel.alias_records ?? 0;
-    const aliasLabel = pluralizeUk(aliasCount, ["форма пошуку", "форми пошуку", "форм пошуку"]);
+    const aliasLabel = pluralizeUk(aliasCount, ["пошукова словоформа", "пошукові словоформи", "пошукових словоформ"]);
     
     const shardCount = status.publicAtlas.searchShards ?? 0;
-    const shardLabel = pluralizeUk(shardCount, ["пошук-шард", "пошук-шарди", "пошук-шардів"]);
+    const shardLabel = pluralizeUk(shardCount, ["сегмент пошуку", "сегменти пошуку", "сегментів пошуку"]);
 
     setRuntimeDetail(
       root,


### PR DESCRIPTION
Fixes #5130. Wording updates to search shards and search wordforms.