### PR TITLE
feat(runtime): task-scoped tmp lease

### DIFF
--- a/scripts/agent_runtime/env_sanitize.py
+++ b/scripts/agent_runtime/env_sanitize.py
@@ -50,6 +50,15 @@ _SAFE_NAME_PREFIXES = (
     "LU_",
 )
 
+# These are process-control paths, not credentials. A task id such as
+# ``task-4956`` contains the substring ``sk-`` and otherwise looks like an
+# OpenAI key to the generic value redactor, so keep the tmp lease controls
+# before the value-pattern filter. Their names remain narrowly allowlisted.
+_SAFE_VALUE_NAME_ALLOWLIST = {
+    "TMPDIR",
+    "LU_RUNTIME_TMP_ROOT",
+}
+
 _PROVIDER_SECRET_ALLOWLIST = {
     "gemini": {
         "GEMINI_API_KEY",
@@ -108,6 +117,10 @@ def _normalized_provider(provider: str) -> str:
 def _is_safe_name(name: str) -> bool:
     upper = name.upper()
     return upper in _SAFE_NAME_ALLOWLIST or upper.startswith(_SAFE_NAME_PREFIXES)
+
+
+def _is_safe_value_name(name: str) -> bool:
+    return name.upper() in _SAFE_VALUE_NAME_ALLOWLIST
 
 
 def _is_provider_secret(name: str, provider: str) -> bool:
@@ -189,6 +202,9 @@ def build_agent_env(
             env[name] = value
             continue
 
+        if _is_safe_value_name(name):
+            env[name] = value
+            continue
         if _looks_sensitive_value(value):
             continue
         if _is_provider_safe_name(name, provider):

--- a/scripts/agent_runtime/env_sanitize.py
+++ b/scripts/agent_runtime/env_sanitize.py
@@ -56,6 +56,7 @@ _SAFE_NAME_PREFIXES = (
 # before the value-pattern filter. Their names remain narrowly allowlisted.
 _SAFE_VALUE_NAME_ALLOWLIST = {
     "TMPDIR",
+    "LU_RUNTIME_TMP_BASE_ROOT",
     "LU_RUNTIME_TMP_ROOT",
 }
 

--- a/scripts/ai_agent_bridge/_dispatch_wrappers.py
+++ b/scripts/ai_agent_bridge/_dispatch_wrappers.py
@@ -19,6 +19,9 @@ MANDATORY_COMMIT_PUSH_PR_CHECKLIST = """## MANDATORY checklist — do NOT skip t
 3. `git push -u origin <branch-name>`
 4. `gh pr create --title "..." --body "..."` — return the URL in your final response
 5. Worktree at `.worktrees/dispatch/codex/<task-id>/`. NEVER branch in the main checkout.
+6. Put transient artifacts in `$LU_RUNTIME_TMP_ROOT` or the task worktree; never leave
+   evidence copies or model caches in bare `/tmp`. Explicitly clean any named temporary
+   path outside those locations before finishing.
 
 If you finish writing code but skip steps 2-4, the work is lost. Don't make that mistake.
 """

--- a/scripts/ai_agent_bridge/_dispatch_wrappers.py
+++ b/scripts/ai_agent_bridge/_dispatch_wrappers.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -72,7 +76,22 @@ def _run_text_command(cmd: list[str]) -> str:
     return proc.stdout
 
 
-def _write_dispatch_fix_auto_brief(task_id: str) -> Path:
+@contextmanager
+def _prompt_directory() -> Iterator[Path]:
+    """Yield a task lease or a self-cleaning directory for prompt files."""
+    runtime_tmp_root = os.environ.get("LU_RUNTIME_TMP_ROOT")
+    if runtime_tmp_root:
+        lease_root = Path(runtime_tmp_root)
+        if not lease_root.is_dir():
+            raise RuntimeError(f"runtime tmp lease is not a directory: {lease_root}")
+        yield lease_root
+        return
+
+    with tempfile.TemporaryDirectory(prefix="learn-ukrainian-bridge-") as directory:
+        yield Path(directory)
+
+
+def _write_dispatch_fix_auto_brief(task_id: str, prompt_directory: Path) -> Path:
     issue = _run_json_command(["gh", "issue", "view", task_id, "--json", "title,body"])
     title = str(issue.get("title") or "").strip()
     body = str(issue.get("body") or "").strip()
@@ -82,21 +101,25 @@ def _write_dispatch_fix_auto_brief(task_id: str) -> Path:
         f"{body}\n\n"
         f"{MANDATORY_COMMIT_PUSH_PR_CHECKLIST}"
     )
-    brief_path = Path("/tmp") / f"dispatch-fix-{_safe_path_component(task_id)}.md"
+    brief_path = prompt_directory / f"dispatch-fix-{_safe_path_component(task_id)}.md"
     brief_path.write_text(prompt, encoding="utf-8")
     return brief_path
 
 
-def _dispatch_fix_prompt_file(task_id: str, brief_file: str | None) -> Path:
+def _dispatch_fix_prompt_file(
+    task_id: str,
+    brief_file: str | None,
+    prompt_directory: Path,
+) -> Path:
     if brief_file:
         path = Path(brief_file).expanduser()
         prompt = path.read_text(encoding="utf-8")
         if MANDATORY_COMMIT_PUSH_PR_CHECKLIST not in prompt:
             prompt = f"{prompt.rstrip()}\n\n{MANDATORY_COMMIT_PUSH_PR_CHECKLIST}"
-        brief_path = Path("/tmp") / f"dispatch-fix-{_safe_path_component(task_id)}.md"
+        brief_path = prompt_directory / f"dispatch-fix-{_safe_path_component(task_id)}.md"
         brief_path.write_text(prompt, encoding="utf-8")
         return brief_path
-    return _write_dispatch_fix_auto_brief(task_id)
+    return _write_dispatch_fix_auto_brief(task_id, prompt_directory)
 
 
 def build_dispatch_fix_command(task_id: str, prompt_file: Path) -> list[str]:
@@ -140,7 +163,7 @@ def _serialize_files(files: Any) -> str:
     return "\n".join(lines)
 
 
-def _write_review_deep_pr_prompt(pr_number: str) -> Path:
+def _write_review_deep_pr_prompt(pr_number: str, prompt_directory: Path) -> Path:
     pr = _run_json_command(["gh", "pr", "view", pr_number, "--json", "title,body,files"])
     diff = _run_text_command(["gh", "pr", "diff", pr_number])
     title = str(pr.get("title") or "").strip()
@@ -153,7 +176,7 @@ def _write_review_deep_pr_prompt(pr_number: str) -> Path:
         f"### Files\n\n{files}\n\n"
         f"### Diff\n\n```diff\n{diff}\n```\n"
     )
-    prompt_path = Path("/tmp") / f"review-deep-pr-{_safe_path_component(pr_number)}.md"
+    prompt_path = prompt_directory / f"review-deep-pr-{_safe_path_component(pr_number)}.md"
     prompt_path.write_text(prompt, encoding="utf-8")
     return prompt_path
 
@@ -171,7 +194,7 @@ def _read_review_path(target: Path) -> str:
     return "\n\n".join(chunks)
 
 
-def _write_review_deep_path_prompt(target: str) -> Path:
+def _write_review_deep_path_prompt(target: str, prompt_directory: Path) -> Path:
     path = Path(target).expanduser()
     if not path.exists():
         raise SystemExit(f"review-deep target is not a PR number or existing path: {target}")
@@ -182,7 +205,7 @@ def _write_review_deep_path_prompt(target: str) -> Path:
         f"## Path target\n\n{resolved}\n\n"
         f"## Contents\n\n{content}\n"
     )
-    prompt_path = Path("/tmp") / f"review-deep-path-{_safe_path_component(target)}.md"
+    prompt_path = prompt_directory / f"review-deep-path-{_safe_path_component(target)}.md"
     prompt_path.write_text(prompt, encoding="utf-8")
     return prompt_path
 
@@ -192,10 +215,10 @@ def _review_task_id(target: str) -> str:
     return f"review-{_safe_path_component(target)}-{timestamp}"
 
 
-def _review_prompt_file(target: str) -> Path:
+def _review_prompt_file(target: str, prompt_directory: Path) -> Path:
     if _is_pr_number(target):
-        return _write_review_deep_pr_prompt(target.lstrip("#"))
-    return _write_review_deep_path_prompt(target)
+        return _write_review_deep_pr_prompt(target.lstrip("#"), prompt_directory)
+    return _write_review_deep_path_prompt(target, prompt_directory)
 
 
 def build_review_deep_command(target: str, prompt_file: Path, effort: str) -> list[str]:
@@ -250,12 +273,18 @@ def _run_dispatch(command: list[str], dry_run: bool, prompt_file: Path) -> int:
 
 
 def handle_dispatch_fix(args: Any) -> int:
-    prompt_file = _dispatch_fix_prompt_file(args.task_id, args.brief_file)
-    command = build_dispatch_fix_command(args.task_id, prompt_file)
-    return _run_dispatch(command, args.dry_run, prompt_file)
+    with _prompt_directory() as prompt_directory:
+        prompt_file = _dispatch_fix_prompt_file(
+            args.task_id,
+            args.brief_file,
+            prompt_directory,
+        )
+        command = build_dispatch_fix_command(args.task_id, prompt_file)
+        return _run_dispatch(command, args.dry_run, prompt_file)
 
 
 def handle_review_deep(args: Any) -> int:
-    prompt_file = _review_prompt_file(args.target)
-    command = build_review_deep_command(args.target, prompt_file, args.effort)
-    return _run_dispatch(command, args.dry_run, prompt_file)
+    with _prompt_directory() as prompt_directory:
+        prompt_file = _review_prompt_file(args.target, prompt_directory)
+        command = build_review_deep_command(args.target, prompt_file, args.effort)
+        return _run_dispatch(command, args.dry_run, prompt_file)

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -3701,11 +3701,11 @@ def _ensure_codex_writer_home(
     skips MCP config, and ``-c`` overrides can't add a fresh server
     entry — verified via ``ab ask-codex`` 2026-05-22 + smoke tests.
 
-    The scoped home is materialized at
-    ``$CODEX_HOME_USER/.../codex-v7-writer/`` (project temp dir under
-    the OS temp root) and updated idempotently each call so changes
-    to the canonical config get picked up. Auth is symlinked rather
-    than copied so token refreshes propagate.
+    During a delegate task the scoped home is nested in that task's
+    ``$LU_RUNTIME_TMP_ROOT`` lease. Outside a task it keeps the legacy
+    shared ``$TMPDIR/codex-v7-writer-{uid}`` fallback. Both forms update
+    idempotently each call so changes to the canonical config get picked
+    up. Auth is symlinked rather than copied so token refreshes propagate.
 
     Returns the absolute path to the scoped home.
 
@@ -3722,11 +3722,31 @@ def _ensure_codex_writer_home(
     real_home = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
     real_auth = real_home / "auth.json"
 
-    # Scoped home under tempdir — survives across invocations within a
-    # single user session but doesn't pollute the repo tree. Per-user
-    # uid stays away from cross-user clobbering when multiple shells
-    # share /tmp.
-    scoped_home = Path(tempfile.gettempdir()) / f"codex-v7-writer-{os.getuid()}"
+    # The dispatch runtime sets both values for spawned agents. Require them
+    # to agree before treating LU_RUNTIME_TMP_ROOT as task context so a stale
+    # or externally supplied environment variable cannot redirect CODEX_HOME.
+    runtime_tmp_root = os.environ.get("LU_RUNTIME_TMP_ROOT")
+    scoped_home: Path
+    if runtime_tmp_root:
+        candidate = Path(runtime_tmp_root)
+        try:
+            resolved_candidate = candidate.resolve(strict=True)
+            candidate_is_lease = (
+                not candidate.is_symlink()
+                and candidate.is_dir()
+                and resolved_candidate == Path(tempfile.gettempdir()).resolve(strict=True)
+                and resolved_candidate.parent.name == "learn-ukrainian"
+            )
+        except OSError:
+            candidate_is_lease = False
+        if candidate_is_lease:
+            scoped_home = resolved_candidate / f"codex-v7-writer-{os.getuid()}"
+        else:
+            scoped_home = Path(tempfile.gettempdir()) / f"codex-v7-writer-{os.getuid()}"
+    else:
+        # Legacy no-task behavior: one shared, per-user tmp home. This is
+        # deliberately preserved for direct pipeline runs outside delegate.
+        scoped_home = Path(tempfile.gettempdir()) / f"codex-v7-writer-{os.getuid()}"
     scoped_home.mkdir(parents=True, exist_ok=True)
 
     config_path = scoped_home / "config.toml"

--- a/scripts/build/linear_pipeline.py
+++ b/scripts/build/linear_pipeline.py
@@ -3722,19 +3722,24 @@ def _ensure_codex_writer_home(
     real_home = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
     real_auth = real_home / "auth.json"
 
-    # The dispatch runtime sets both values for spawned agents. Require them
-    # to agree before treating LU_RUNTIME_TMP_ROOT as task context so a stale
+    # The dispatch runtime records the temp root that contained the lease
+    # before it sets TMPDIR to the lease itself. Require both locations to
+    # agree before treating LU_RUNTIME_TMP_ROOT as task context so a stale
     # or externally supplied environment variable cannot redirect CODEX_HOME.
     runtime_tmp_root = os.environ.get("LU_RUNTIME_TMP_ROOT")
+    runtime_tmp_base_root = os.environ.get("LU_RUNTIME_TMP_BASE_ROOT")
     scoped_home: Path
     if runtime_tmp_root:
         candidate = Path(runtime_tmp_root)
         try:
             resolved_candidate = candidate.resolve(strict=True)
+            resolved_base_root = Path(
+                runtime_tmp_base_root or tempfile.gettempdir(),
+            ).resolve(strict=True)
             candidate_is_lease = (
                 not candidate.is_symlink()
                 and candidate.is_dir()
-                and resolved_candidate == Path(tempfile.gettempdir()).resolve(strict=True)
+                and resolved_candidate.parent.parent == resolved_base_root
                 and resolved_candidate.parent.name == "learn-ukrainian"
             )
         except OSError:

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -92,9 +92,12 @@ import logging
 import os
 import re
 import shlex
+import shutil
 import signal
+import stat
 import subprocess
 import sys
+import tempfile
 import time
 import urllib.error
 import urllib.parse
@@ -341,6 +344,138 @@ def _normalize_task_id(agent: str, task_id: str) -> str:
         if task_id.startswith(prefix):
             return task_id[len(prefix) :]
     return task_id
+
+
+def _runtime_tmp_lease_name(task_id: str) -> str:
+    """Return one safe path component for a task's runtime tmp lease."""
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", task_id).strip("./-") or "task"
+
+
+def _create_runtime_tmp_lease(task_id: str) -> tuple[Path, Path]:
+    """Create and return a task lease plus its resolved namespace root.
+
+    The lease is intentionally deterministic per task ID: a task can restart
+    after its previous worker has finished and re-create the same root, while
+    Stage 2 will eventually handle roots left by crashed processes.
+    """
+    namespace_root = Path(tempfile.gettempdir()) / "learn-ukrainian"
+    try:
+        namespace_root.mkdir(parents=True, exist_ok=True)
+        namespace_stat = namespace_root.lstat()
+    except OSError as exc:
+        raise RuntimeError(
+            f"could not create runtime tmp namespace {namespace_root}: {exc}",
+        ) from exc
+    if stat.S_ISLNK(namespace_stat.st_mode):
+        raise RuntimeError(
+            f"runtime tmp namespace must not be a symlink: {namespace_root}",
+        )
+
+    lease_root = namespace_root / _runtime_tmp_lease_name(task_id)
+    try:
+        lease_root.mkdir(exist_ok=True)
+        lease_stat = lease_root.lstat()
+        resolved_namespace = namespace_root.resolve(strict=True)
+        resolved_lease = lease_root.resolve(strict=True)
+    except OSError as exc:
+        raise RuntimeError(
+            f"could not create runtime tmp lease {lease_root}: {exc}",
+        ) from exc
+    if stat.S_ISLNK(lease_stat.st_mode):
+        raise RuntimeError(
+            f"runtime tmp lease must not be a symlink: {lease_root}",
+        )
+    if not stat.S_ISDIR(lease_stat.st_mode) or resolved_lease.parent != resolved_namespace:
+        raise RuntimeError(
+            f"runtime tmp lease is not a direct child of its namespace: {lease_root}",
+        )
+    return resolved_lease, resolved_namespace
+
+
+def _runtime_tmp_lease_bytes(lease_root: Path) -> int:
+    """Count lease payload bytes without traversing directory symlinks."""
+    total = 0
+    seen_regular_files: set[tuple[int, int]] = set()
+    for directory, dirnames, filenames in os.walk(lease_root, followlinks=False):
+        for name in [*dirnames, *filenames]:
+            path = Path(directory) / name
+            try:
+                entry = path.lstat()
+            except FileNotFoundError:
+                continue
+            if stat.S_ISREG(entry.st_mode):
+                inode = (entry.st_dev, entry.st_ino)
+                if inode in seen_regular_files:
+                    continue
+                seen_regular_files.add(inode)
+                total += entry.st_size
+            elif stat.S_ISLNK(entry.st_mode):
+                # Account for the link's own small directory entry, never its
+                # target. ``os.walk(..., followlinks=False)`` will not descend.
+                total += entry.st_size
+    return total
+
+
+def _reap_runtime_tmp_lease(
+    lease_root: Path | str | None,
+    namespace_root: Path | str | None,
+) -> dict[str, int | str | None]:
+    """Best-effort, fd-relative deletion of one task-scoped runtime lease.
+
+    This is intentionally stricter than a generic ``rm -rf``. It only removes
+    a non-symlink direct child of the dispatcher-created namespace and uses
+    ``shutil.rmtree``'s fd-based implementation so a symlink swap cannot turn
+    cleanup into a deletion outside the lease. Any failure is state telemetry,
+    never a worker failure.
+    """
+    result: dict[str, int | str | None] = {
+        "tmp_bytes_freed": 0,
+        "tmp_reap_error": None,
+    }
+    try:
+        if lease_root is None or namespace_root is None:
+            raise ValueError("runtime tmp lease metadata is missing")
+        lease = Path(lease_root)
+        namespace = Path(namespace_root)
+        namespace_stat = namespace.lstat()
+        lease_stat = lease.lstat()
+        if stat.S_ISLNK(namespace_stat.st_mode):
+            raise ValueError("runtime tmp namespace is a symlink")
+        if stat.S_ISLNK(lease_stat.st_mode):
+            raise ValueError("runtime tmp lease is a symlink")
+        if not stat.S_ISDIR(namespace_stat.st_mode):
+            raise ValueError("runtime tmp namespace is not a directory")
+        if not stat.S_ISDIR(lease_stat.st_mode):
+            raise ValueError("runtime tmp lease is not a directory")
+
+        resolved_namespace = namespace.resolve(strict=True)
+        resolved_lease = lease.resolve(strict=True)
+        if resolved_lease.parent != resolved_namespace:
+            raise ValueError(
+                "resolved runtime tmp lease is not under $TMPDIR/learn-ukrainian",
+            )
+        if resolved_namespace.name != "learn-ukrainian":
+            raise ValueError("runtime tmp namespace has the wrong name")
+        if not getattr(shutil.rmtree, "avoids_symlink_attacks", False):
+            raise RuntimeError("platform rmtree lacks symlink-attack protection")
+
+        bytes_freed = _runtime_tmp_lease_bytes(lease)
+        open_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+        if hasattr(os, "O_NOFOLLOW"):
+            open_flags |= os.O_NOFOLLOW
+        namespace_fd = os.open(namespace, open_flags)
+        try:
+            # Passing a basename plus dir_fd keeps the deletion anchored to
+            # the verified namespace even if an ancestor changes afterwards.
+            shutil.rmtree(lease.name, dir_fd=namespace_fd)
+        finally:
+            os.close(namespace_fd)
+        result["tmp_bytes_freed"] = bytes_freed
+    except Exception as exc:
+        result["tmp_reap_error"] = (
+            f"{type(exc).__name__}: {exc}"
+        )[:500]
+    return result
 
 
 def _derive_worktree_branch(agent: str, task_id: str) -> str:
@@ -1577,6 +1712,8 @@ def _emit_terminal_dispatch_event(
                 "cost_usd": cost.cost_usd,
                 "billing_model": cost.billing_model,
                 "cost_provenance": cost.provenance,
+                "tmp_bytes_freed": final_state.get("tmp_bytes_freed"),
+                "tmp_reap_error": final_state.get("tmp_reap_error"),
             },
         )
     except Exception as exc:  # pragma: no cover - degraded mode only
@@ -1601,6 +1738,8 @@ def _run_worker(
     initial_response_timeout: int = DEFAULT_INITIAL_RESPONSE_TIMEOUT_S,
     keep_worktree: bool = False,
     provider: str | None = None,
+    runtime_tmp_root: str | None = None,
+    runtime_tmp_namespace_root: str | None = None,
 ) -> int:
     """Worker main loop. Invokes the runtime, updates the state file.
 
@@ -1657,6 +1796,7 @@ def _run_worker(
     timed_out = False
     result = None
     substitution: dict[str, Any] | None = None
+    runtime_tmp_reap: dict[str, int | str | None] | None = None
 
     cancelled = False
     try:
@@ -1724,6 +1864,12 @@ def _run_worker(
         # "crashed" forever.
         stderr_excerpt = f"worker unexpected: {type(exc).__name__}: {exc}"[:500]
         returncode_reason = "unexpected worker exception before a terminal subprocess returncode was available"
+    finally:
+        if runtime_tmp_root is not None or runtime_tmp_namespace_root is not None:
+            runtime_tmp_reap = _reap_runtime_tmp_lease(
+                runtime_tmp_root,
+                runtime_tmp_namespace_root,
+            )
 
     duration_s = time.monotonic() - start
 
@@ -1834,6 +1980,16 @@ def _run_worker(
             "needs_finalize": needs_finalize,
             "keep_worktree": keep_worktree,
             "worktree_reap": worktree_reap,
+            "tmp_bytes_freed": (
+                runtime_tmp_reap["tmp_bytes_freed"]
+                if runtime_tmp_reap is not None
+                else final_state.get("tmp_bytes_freed")
+            ),
+            "tmp_reap_error": (
+                runtime_tmp_reap["tmp_reap_error"]
+                if runtime_tmp_reap is not None
+                else final_state.get("tmp_reap_error")
+            ),
             "auto_finalize": (
                 {
                     "ok": auto_finalize.ok,
@@ -1989,34 +2145,92 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     else:
         dispatch_agent = args.agent
 
-    if getattr(args, "dry_run", False) and not requested_branch:
-        print(task_id)
-        return 0
-
-    if getattr(args, "dry_run", False) and requested_branch:
-        resolved_raw = (
-            str(_auto_worktree_path(dispatch_agent, task_id))
-            if worktree_arg == "auto"
-            else worktree_arg
-        )
-        assert resolved_raw is not None  # --branch above supplies the auto sentinel.
-        try:
-            worktree_path, worktree_branch, worktree_telemetry = _ensure_worktree(
-                agent=dispatch_agent,
-                task_id=task_id,
-                raw_path=resolved_raw,
-                base=getattr(args, "base", None) or "main",
-                branch=requested_branch,
-                dry_run=True,
+    if getattr(args, "dry_run", False):
+        dry_run_worktree: Path | None = None
+        dry_run_branch: str | None = None
+        dry_run_worktree_telemetry: dict[str, Any] = {}
+        if requested_branch:
+            resolved_raw = (
+                str(_auto_worktree_path(dispatch_agent, task_id))
+                if worktree_arg == "auto"
+                else worktree_arg
             )
-        except (ValueError, RuntimeError) as exc:
-            print(f"❌ failed to validate branch reuse for {task_id!r}: {exc}", file=sys.stderr)
+            assert resolved_raw is not None  # --branch above supplies the auto sentinel.
+            try:
+                (
+                    dry_run_worktree,
+                    dry_run_branch,
+                    dry_run_worktree_telemetry,
+                ) = _ensure_worktree(
+                    agent=dispatch_agent,
+                    task_id=task_id,
+                    raw_path=resolved_raw,
+                    base=getattr(args, "base", None) or "main",
+                    branch=requested_branch,
+                    dry_run=True,
+                )
+            except (ValueError, RuntimeError) as exc:
+                print(f"❌ failed to validate branch reuse for {task_id!r}: {exc}", file=sys.stderr)
+                return 1
+
+        try:
+            runtime_tmp_root, runtime_tmp_namespace_root = _create_runtime_tmp_lease(task_id)
+        except RuntimeError as exc:
+            print(f"❌ failed to create runtime tmp lease for {task_id!r}: {exc}", file=sys.stderr)
             return 1
-        print(
-            f"🌲 branch reuse validated: branch={worktree_branch} "
-            f"path={worktree_path} base_sha={worktree_telemetry.get('base_sha') or '?'} [reused]",
-            file=sys.stderr,
+
+        start_telemetry = resolve_dispatch_start_telemetry(
+            agent_name=dispatch_agent,
+            requested_model=args.model,
+            requested_effort=getattr(args, "effort", None),
         )
+        dry_run_state = {
+            "task_id": task_id,
+            "agent": dispatch_agent,
+            "model": start_telemetry.model,
+            "effort": start_telemetry.effort,
+            "cli_version": start_telemetry.cli_version,
+            "mode": args.mode,
+            "cwd": str(dry_run_worktree or (Path(args.cwd) if args.cwd else _REPO_ROOT)),
+            "worktree_path": str(dry_run_worktree) if dry_run_worktree else None,
+            "worktree_branch": dry_run_branch,
+            "worktree_base_sha": dry_run_worktree_telemetry.get("base_sha"),
+            "runtime_tmp_root": str(runtime_tmp_root),
+            "tmp_bytes_freed": None,
+            "tmp_reap_error": None,
+            "pid": None,
+            "status": "dry_run",
+            "started_at": datetime.now(UTC).isoformat(),
+            "finished_at": None,
+            "duration_s": None,
+            "prompt_chars": len(prompt),
+            "response_chars": None,
+            "result_file": None,
+            "stderr_excerpt": None,
+            "returncode": None,
+            "returncode_reason": None,
+            "substitution": None,
+        }
+        dry_run_reap = _reap_runtime_tmp_lease(
+            runtime_tmp_root,
+            runtime_tmp_namespace_root,
+        )
+        dry_run_state.update(
+            {
+                "finished_at": datetime.now(UTC).isoformat(),
+                "duration_s": 0.0,
+                "tmp_bytes_freed": dry_run_reap["tmp_bytes_freed"],
+                "tmp_reap_error": dry_run_reap["tmp_reap_error"],
+            }
+        )
+        _write_state_atomic(state_path, dry_run_state)
+        if requested_branch:
+            print(
+                f"🌲 branch reuse validated: branch={dry_run_branch} "
+                f"path={dry_run_worktree} "
+                f"base_sha={dry_run_worktree_telemetry.get('base_sha') or '?'} [reused]",
+                file=sys.stderr,
+            )
         print(task_id)
         return 0
 
@@ -2059,6 +2273,14 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
             print(f"❌ failed to prepare worktree for {task_id!r}: {exc}", file=sys.stderr)
             return 1
 
+    try:
+        runtime_tmp_root, runtime_tmp_namespace_root = _create_runtime_tmp_lease(task_id)
+    except RuntimeError as exc:
+        stdout_fd.close()
+        stderr_fd.close()
+        print(f"❌ failed to create runtime tmp lease for {task_id!r}: {exc}", file=sys.stderr)
+        return 1
+
     cwd = str(worktree_path or (Path(args.cwd) if args.cwd else _REPO_ROOT))
     prompt = _augment_prompt_with_worktree(prompt, worktree_path)
 
@@ -2097,6 +2319,9 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         "worktree_rebased": bool(worktree_telemetry.get("rebased")),
         "worktree_reused": bool(worktree_telemetry.get("reused")),
         "worktree_layout": worktree_layout,
+        "runtime_tmp_root": str(runtime_tmp_root),
+        "tmp_bytes_freed": None,
+        "tmp_reap_error": None,
         "keep_worktree": keep_worktree,
         "hard_timeout": args.hard_timeout,
         "silence_timeout": silence_timeout,
@@ -2163,6 +2388,10 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
         str(silence_timeout),
         "--initial-response-timeout",
         str(initial_response_timeout),
+        "--runtime-tmp-root",
+        str(runtime_tmp_root),
+        "--runtime-tmp-namespace-root",
+        str(runtime_tmp_namespace_root),
     ]
     if keep_worktree:
         cmd.append("--keep-worktree")
@@ -2185,6 +2414,8 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     worker_env = os.environ.copy()
     _inject_gh_token_for_agent(worker_env, dispatch_agent)
     worker_env["AGENT_NO_TELEMETRY_FOOTER"] = "1"
+    worker_env["TMPDIR"] = str(runtime_tmp_root)
+    worker_env["LU_RUNTIME_TMP_ROOT"] = str(runtime_tmp_root)
     if getattr(args, "allow_merge", False):
         worker_env.pop("AGENT_NO_MERGE", None)
         worker_env["AGENT_ALLOW_MERGE"] = "1"
@@ -2219,6 +2450,12 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
                     "returncode": None,
                     "returncode_reason": "worker process was not started",
                 }
+            )
+            failed_state.update(
+                _reap_runtime_tmp_lease(
+                    runtime_tmp_root,
+                    runtime_tmp_namespace_root,
+                )
             )
             _write_state_atomic(state_path, failed_state)
             print(
@@ -2513,7 +2750,9 @@ def cmd_status_or_fail(args: argparse.Namespace) -> int:
 # Wait command — poll until terminal state or timeout
 # ---------------------------------------------------------------------------
 
-_TERMINAL_STATUSES = frozenset({"done", "failed", "timeout", "rate_limited", "crashed", "cancelled"})
+_TERMINAL_STATUSES = frozenset(
+    {"done", "failed", "timeout", "rate_limited", "crashed", "cancelled", "dry_run"},
+)
 
 
 def cmd_wait(args: argparse.Namespace) -> int:
@@ -2702,6 +2941,8 @@ def cmd_worker(args: argparse.Namespace) -> int:
             DEFAULT_INITIAL_RESPONSE_TIMEOUT_S,
         ),
         keep_worktree=bool(getattr(args, "keep_worktree", False)),
+        runtime_tmp_root=getattr(args, "runtime_tmp_root", None),
+        runtime_tmp_namespace_root=getattr(args, "runtime_tmp_namespace_root", None),
     )
 
 
@@ -3023,6 +3264,7 @@ def build_parser() -> argparse.ArgumentParser:
             "crashed",
             "cancelled",
             "needs_finalize",
+            "dry_run",
         ],
         help="Optional status filter, e.g. running or failed.",
     )
@@ -3050,6 +3292,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     wk.add_argument("--keep-worktree", action="store_true")
     wk.add_argument("--max-budget-usd", type=float, default=None)
+    wk.add_argument("--runtime-tmp-root", default=None)
+    wk.add_argument("--runtime-tmp-namespace-root", default=None)
     wk.set_defaults(func=cmd_worker)
 
     return p

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -450,6 +450,20 @@ def _reap_runtime_tmp_lease(
 
         resolved_namespace = namespace.resolve(strict=True)
         resolved_lease = lease.resolve(strict=True)
+        resolved_tmp_root = Path(tempfile.gettempdir()).resolve(strict=True)
+        if resolved_tmp_root == resolved_lease:
+            # The worker deliberately points TMPDIR at its lease. In that one
+            # process context, use the pre-override root recorded by the
+            # dispatcher; parent cleanup still validates against its live
+            # tempfile root, so a stale inherited base cannot bless a child.
+            runtime_tmp_base_root = os.environ.get("LU_RUNTIME_TMP_BASE_ROOT")
+            if not runtime_tmp_base_root:
+                raise ValueError("runtime tmp worker is missing its base root")
+            resolved_tmp_root = Path(runtime_tmp_base_root).resolve(strict=True)
+        if resolved_namespace.parent != resolved_tmp_root:
+            raise ValueError(
+                "resolved runtime tmp namespace is not directly under $TMPDIR",
+            )
         if resolved_lease.parent != resolved_namespace:
             raise ValueError(
                 "resolved runtime tmp lease is not under $TMPDIR/learn-ukrainian",
@@ -2416,6 +2430,7 @@ def cmd_dispatch(args: argparse.Namespace) -> int:
     worker_env["AGENT_NO_TELEMETRY_FOOTER"] = "1"
     worker_env["TMPDIR"] = str(runtime_tmp_root)
     worker_env["LU_RUNTIME_TMP_ROOT"] = str(runtime_tmp_root)
+    worker_env["LU_RUNTIME_TMP_BASE_ROOT"] = str(runtime_tmp_namespace_root.parent)
     if getattr(args, "allow_merge", False):
         worker_env.pop("AGENT_NO_MERGE", None)
         worker_env["AGENT_ALLOW_MERGE"] = "1"

--- a/tests/test_ab_dispatch_wrappers.py
+++ b/tests/test_ab_dispatch_wrappers.py
@@ -32,9 +32,13 @@ def test_dispatch_fix_with_explicit_brief_file_appends_checklist_and_dispatches(
     brief = tmp_path / "brief.md"
     brief.write_text("# Fix this\n\nExisting acceptance criteria.\n", encoding="utf-8")
     calls = []
+    captured_prompt: dict[str, str | Path] = {}
 
     def fake_run(command, **kwargs):
         calls.append((command, kwargs))
+        prompt_path = Path(_option(command, "--prompt-file"))
+        captured_prompt["path"] = prompt_path
+        captured_prompt["text"] = prompt_path.read_text(encoding="utf-8")
         return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr(wrappers.subprocess, "run", fake_run)
@@ -52,13 +56,16 @@ def test_dispatch_fix_with_explicit_brief_file_appends_checklist_and_dispatches(
     assert _option(command, "--base") == "origin/main"
     assert _option(command, "--task-id") == "1741"
     assert _option(command, "--effort") == "high"
-    prompt = Path(_option(command, "--prompt-file")).read_text(encoding="utf-8")
-    assert "Existing acceptance criteria." in prompt
-    assert wrappers.MANDATORY_COMMIT_PUSH_PR_CHECKLIST in prompt
+    assert "Existing acceptance criteria." in str(captured_prompt["text"])
+    assert wrappers.MANDATORY_COMMIT_PUSH_PR_CHECKLIST in str(captured_prompt["text"])
+    assert not Path(captured_prompt["path"]).exists()
 
 
 def test_dispatch_fix_with_auto_brief_uses_issue_body_and_dry_run_state(monkeypatch, tmp_path):
     state_dir = _patch_state_dir(monkeypatch, tmp_path)
+    lease_root = tmp_path / "learn-ukrainian" / "task-1701"
+    lease_root.mkdir(parents=True)
+    monkeypatch.setenv("LU_RUNTIME_TMP_ROOT", str(lease_root))
 
     def fake_run(command, **kwargs):
         assert command == ["gh", "issue", "view", "1701", "--json", "title,body"]
@@ -80,7 +87,9 @@ def test_dispatch_fix_with_auto_brief_uses_issue_body_and_dry_run_state(monkeypa
     assert state["model"] is None
     assert state["effort"] == "high"
     assert _option(command, "--task-id") == "1701"
-    prompt = Path(state["prompt_file"]).read_text(encoding="utf-8")
+    prompt_path = Path(state["prompt_file"])
+    assert prompt_path.parent == lease_root
+    prompt = prompt_path.read_text(encoding="utf-8")
     assert "Security issue" in prompt
     assert "Acceptance criteria from issue." in prompt
     assert wrappers.MANDATORY_COMMIT_PUSH_PR_CHECKLIST in prompt
@@ -88,6 +97,9 @@ def test_dispatch_fix_with_auto_brief_uses_issue_body_and_dry_run_state(monkeypa
 
 def test_review_deep_for_pr_target_generates_prompt_and_dry_run_state(monkeypatch, tmp_path):
     state_dir = _patch_state_dir(monkeypatch, tmp_path)
+    lease_root = tmp_path / "learn-ukrainian" / "task-review"
+    lease_root.mkdir(parents=True)
+    monkeypatch.setenv("LU_RUNTIME_TMP_ROOT", str(lease_root))
 
     def fake_run(command, **kwargs):
         if command == ["gh", "pr", "view", "1740", "--json", "title,body,files"]:
@@ -119,7 +131,9 @@ def test_review_deep_for_pr_target_generates_prompt_and_dry_run_state(monkeypatc
     assert _option(command, "--model") == "claude-opus-4-8"
     assert _option(command, "--effort") == "xhigh"
     assert _option(command, "--task-id").startswith("review-1740-")
-    prompt = Path(state["prompt_file"]).read_text(encoding="utf-8")
+    prompt_path = Path(state["prompt_file"])
+    assert prompt_path.parent == lease_root
+    prompt = prompt_path.read_text(encoding="utf-8")
     assert wrappers.REVIEW_DEEP_INSTRUCTIONS in prompt
     assert "Review this behavior." in prompt
     assert "diff --git" in prompt
@@ -129,9 +143,13 @@ def test_review_deep_for_path_target_generates_prompt_and_dispatches(monkeypatch
     target = tmp_path / "target.py"
     target.write_text("def broken():\n    return missing_name\n", encoding="utf-8")
     calls = []
+    captured_prompt: dict[str, str | Path] = {}
 
     def fake_run(command, **kwargs):
         calls.append((command, kwargs))
+        prompt_path = Path(_option(command, "--prompt-file"))
+        captured_prompt["path"] = prompt_path
+        captured_prompt["text"] = prompt_path.read_text(encoding="utf-8")
         return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr(wrappers.subprocess, "run", fake_run)
@@ -147,6 +165,6 @@ def test_review_deep_for_path_target_generates_prompt_and_dispatches(monkeypatch
     assert _option(command, "--model") == "claude-opus-4-8"
     assert _option(command, "--effort") == "high"
     assert _option(command, "--task-id").startswith("review-")
-    prompt = Path(_option(command, "--prompt-file")).read_text(encoding="utf-8")
-    assert wrappers.REVIEW_DEEP_INSTRUCTIONS in prompt
-    assert "def broken()" in prompt
+    assert wrappers.REVIEW_DEEP_INSTRUCTIONS in str(captured_prompt["text"])
+    assert "def broken()" in str(captured_prompt["text"])
+    assert not Path(captured_prompt["path"]).exists()

--- a/tests/test_agent_runtime_env_sanitize.py
+++ b/tests/test_agent_runtime_env_sanitize.py
@@ -160,6 +160,7 @@ def test_build_agent_env_preserves_safe_allowlist_and_applies_overrides_first():
             "LC_ALL": "C",
             "AB_REPO_ROOT": "/repo",
             "LU_BYPASS_RATE_LIMIT": "1",
+            "LU_RUNTIME_TMP_ROOT": "/tmp/learn-ukrainian/task-4956",
             "UNRELATED": "drop-me",
         },
         clear=True,
@@ -181,6 +182,7 @@ def test_build_agent_env_preserves_safe_allowlist_and_applies_overrides_first():
     assert env["LC_ALL"] == "C"
     assert env["AB_REPO_ROOT"] == "/repo"
     assert env["LU_BYPASS_RATE_LIMIT"] == "1"
+    assert env["LU_RUNTIME_TMP_ROOT"] == "/tmp/learn-ukrainian/task-4956"
     assert env["GEMINI_AUTH_MODE"] == "subscription"
     assert "AB_BAD_OVERRIDE" not in env
     assert "GITHUB_TOKEN" not in env
@@ -291,6 +293,46 @@ def test_runner_smoke_spawns_each_provider_with_only_its_own_key(tmp_path):
 
             assert outcome.parse.ok is True
             assert json.loads(outcome.stdout_text) == expected_env
+
+
+def test_runner_passes_runtime_tmp_lease_to_agent_subprocess(tmp_path):
+    lease_root = tmp_path / "learn-ukrainian" / "runtime-tmp-env"
+    lease_root.mkdir(parents=True)
+    script = (
+        "import json, os; "
+        "print(json.dumps({key: os.environ.get(key) for key in "
+        "('TMPDIR', 'LU_RUNTIME_TMP_ROOT')}, sort_keys=True))"
+    )
+    parent_env = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": str(tmp_path),
+        "TMPDIR": str(lease_root),
+        "LU_RUNTIME_TMP_ROOT": str(lease_root),
+    }
+
+    with patch.dict("os.environ", parent_env, clear=True), patch(
+        "agent_runtime.runner._POLL_INTERVAL_S", 0.01,
+    ):
+        outcome = _execute_invocation_plan(
+            agent_name="codex",
+            adapter=_SmokeAdapter(),
+            plan=_SmokePlan(cmd=[_TEST_PYTHON, "-c", script], cwd=tmp_path),
+            prompt="tmp lease env smoke",
+            mode="read-only",
+            cwd=tmp_path,
+            model="smoke-model",
+            task_id="runtime-tmp-env-smoke",
+            session_id=None,
+            entrypoint="runtime-test",
+            hard_timeout=10,
+            stall_timeout=10,
+        )
+
+    assert outcome.parse.ok is True
+    assert json.loads(outcome.stdout_text) == {
+        "LU_RUNTIME_TMP_ROOT": str(lease_root),
+        "TMPDIR": str(lease_root),
+    }
 
 
 def test_runner_codex_subprocess_gets_gh_token_for_gh_auth_status(tmp_path):

--- a/tests/test_agent_runtime_env_sanitize.py
+++ b/tests/test_agent_runtime_env_sanitize.py
@@ -160,6 +160,7 @@ def test_build_agent_env_preserves_safe_allowlist_and_applies_overrides_first():
             "LC_ALL": "C",
             "AB_REPO_ROOT": "/repo",
             "LU_BYPASS_RATE_LIMIT": "1",
+            "LU_RUNTIME_TMP_BASE_ROOT": "/tmp",
             "LU_RUNTIME_TMP_ROOT": "/tmp/learn-ukrainian/task-4956",
             "UNRELATED": "drop-me",
         },
@@ -182,6 +183,7 @@ def test_build_agent_env_preserves_safe_allowlist_and_applies_overrides_first():
     assert env["LC_ALL"] == "C"
     assert env["AB_REPO_ROOT"] == "/repo"
     assert env["LU_BYPASS_RATE_LIMIT"] == "1"
+    assert env["LU_RUNTIME_TMP_BASE_ROOT"] == "/tmp"
     assert env["LU_RUNTIME_TMP_ROOT"] == "/tmp/learn-ukrainian/task-4956"
     assert env["GEMINI_AUTH_MODE"] == "subscription"
     assert "AB_BAD_OVERRIDE" not in env

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -79,6 +79,86 @@ def test_state_path_sanitizes_slashes(tmp_tasks_dir):
     assert p.name == "issue_1184_subtask.json"
 
 
+def test_create_runtime_tmp_lease_sanitizes_task_id(tmp_path, monkeypatch):
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    lease_root, namespace_root = delegate._create_runtime_tmp_lease(
+        "codex/4956 tmp/../lease",
+    )
+
+    assert namespace_root == tmp_path / "learn-ukrainian"
+    assert lease_root == namespace_root / "codex-4956-tmp-..-lease"
+    assert lease_root.is_dir()
+
+
+def test_runtime_tmp_reap_refuses_root_outside_namespace(tmp_path):
+    namespace_root = tmp_path / "learn-ukrainian"
+    namespace_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    payload = outside / "keep.txt"
+    payload.write_text("keep", encoding="utf-8")
+
+    result = delegate._reap_runtime_tmp_lease(outside, namespace_root)
+
+    assert result["tmp_bytes_freed"] == 0
+    assert "not under $TMPDIR/learn-ukrainian" in str(result["tmp_reap_error"])
+    assert payload.read_text(encoding="utf-8") == "keep"
+
+
+def test_runtime_tmp_reap_refuses_a_symlinked_lease_root(tmp_path):
+    namespace_root = tmp_path / "learn-ukrainian"
+    namespace_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    payload = outside / "keep.txt"
+    payload.write_text("keep", encoding="utf-8")
+    lease_root = namespace_root / "task"
+    lease_root.symlink_to(outside, target_is_directory=True)
+
+    result = delegate._reap_runtime_tmp_lease(lease_root, namespace_root)
+
+    assert result["tmp_bytes_freed"] == 0
+    assert "lease is a symlink" in str(result["tmp_reap_error"])
+    assert payload.read_text(encoding="utf-8") == "keep"
+
+
+def test_runtime_tmp_reap_unlinks_child_symlinks_without_following_them(tmp_path):
+    namespace_root = tmp_path / "learn-ukrainian"
+    lease_root = namespace_root / "task"
+    lease_root.mkdir(parents=True)
+    (lease_root / "payload.bin").write_bytes(b"lease")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    payload = outside / "keep.txt"
+    payload.write_text("keep", encoding="utf-8")
+    (lease_root / "outside-link").symlink_to(outside, target_is_directory=True)
+
+    result = delegate._reap_runtime_tmp_lease(lease_root, namespace_root)
+
+    assert result == {"tmp_bytes_freed": 5 + len(str(outside)), "tmp_reap_error": None}
+    assert not lease_root.exists()
+    assert payload.read_text(encoding="utf-8") == "keep"
+
+
+def test_runtime_tmp_reap_records_cleanup_errors(tmp_path, monkeypatch):
+    namespace_root = tmp_path / "learn-ukrainian"
+    lease_root = namespace_root / "task"
+    lease_root.mkdir(parents=True)
+
+    def fail_rmtree(*_args, **_kwargs):
+        raise OSError("permission denied")
+
+    fail_rmtree.avoids_symlink_attacks = True
+    monkeypatch.setattr(delegate.shutil, "rmtree", fail_rmtree)
+
+    result = delegate._reap_runtime_tmp_lease(lease_root, namespace_root)
+
+    assert result["tmp_bytes_freed"] == 0
+    assert "permission denied" in str(result["tmp_reap_error"])
+    assert lease_root.exists()
+
+
 def test_write_state_atomic_no_partial_reads(tmp_tasks_dir):
     """Atomic write should never leave a partial file visible."""
     path = tmp_tasks_dir / "atomic-test.json"
@@ -957,6 +1037,11 @@ def test_run_worker_emits_one_terminal_dispatch_event_with_cost_fields(
     monkeypatch.setenv("LU_RUN_ID", "run-dispatch")
     monkeypatch.setenv("LU_SESSION_ID", "session-dispatch")
 
+    runtime_tmp_namespace = tmp_path / "learn-ukrainian"
+    runtime_tmp_root = runtime_tmp_namespace / "worker-dispatch-event"
+    runtime_tmp_root.mkdir(parents=True)
+    (runtime_tmp_root / "payload.bin").write_bytes(b"lease")
+
     state_path = delegate._state_path("worker-dispatch-event")
     delegate._write_state_atomic(state_path, {
         "task_id": "worker-dispatch-event",
@@ -966,6 +1051,9 @@ def test_run_worker_emits_one_terminal_dispatch_event_with_cost_fields(
         "prompt_chars": 2,
         "worktree_branch": "deepseek/worker-dispatch-event",
         "worktree_path": str(tmp_path),
+        "runtime_tmp_root": str(runtime_tmp_root),
+        "tmp_bytes_freed": None,
+        "tmp_reap_error": None,
     })
 
     mock_result = type(
@@ -1001,6 +1089,8 @@ def test_run_worker_emits_one_terminal_dispatch_event_with_cost_fields(
             model=None,
             hard_timeout=60,
             effort=None,
+            runtime_tmp_root=str(runtime_tmp_root),
+            runtime_tmp_namespace_root=str(runtime_tmp_namespace),
         )
 
     assert rc == 0
@@ -1024,9 +1114,14 @@ def test_run_worker_emits_one_terminal_dispatch_event_with_cost_fields(
     state = delegate._read_state(state_path)
     assert state is not None
     assert state["substitution"]["actual_provider"] == "openrouter"
+    assert state["tmp_bytes_freed"] == 5
+    assert state["tmp_reap_error"] is None
+    assert not runtime_tmp_root.exists()
     assert event["cost_usd"] == pytest.approx(0.00002)
     assert event["billing_model"] == "per_token"
     assert event["cost_provenance"] == "priced"
+    assert event["tmp_bytes_freed"] == 5
+    assert event["tmp_reap_error"] is None
 
 
 def test_run_worker_marks_needs_finalize_for_dirty_danger_worktree(
@@ -1799,6 +1894,93 @@ def test_dispatch_defaults_worker_env_to_no_merge(tmp_tasks_dir, monkeypatch):
     env = recorded["env"]
     assert env["AGENT_NO_MERGE"] == "1"
     assert "AGENT_ALLOW_MERGE" not in env
+
+
+def test_dispatch_records_runtime_tmp_lease_and_injects_worker_env(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    recorded: dict[str, object] = {}
+
+    class _FakeStdin:
+        def write(self, _data):
+            pass
+
+        def close(self):
+            pass
+
+    class _FakeProc:
+        pid = 24681
+        stdin = _FakeStdin()
+
+    def fake_popen(cmd, **kwargs):
+        recorded["cmd"] = cmd
+        recorded["env"] = kwargs["env"]
+        return _FakeProc()
+
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
+    monkeypatch.setattr(delegate.subprocess, "Popen", fake_popen)
+    args = delegate.build_parser().parse_args(
+        [
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "codex/4956 tmp",
+            "--prompt",
+            "test",
+        ],
+    )
+
+    assert delegate.cmd_dispatch(args) == 0
+
+    state = delegate._read_state(delegate._state_path("codex/4956 tmp"))
+    assert state is not None
+    lease_root = tmp_path / "learn-ukrainian" / "codex-4956-tmp"
+    assert state["runtime_tmp_root"] == str(lease_root)
+    assert state["tmp_bytes_freed"] is None
+    assert state["tmp_reap_error"] is None
+    assert lease_root.is_dir()
+
+    env = recorded["env"]
+    assert isinstance(env, dict)
+    assert env["TMPDIR"] == str(lease_root)
+    assert env["LU_RUNTIME_TMP_ROOT"] == str(lease_root)
+    cmd = recorded["cmd"]
+    assert isinstance(cmd, list)
+    assert cmd[cmd.index("--runtime-tmp-root") + 1] == str(lease_root)
+
+
+def test_dispatch_dry_run_records_and_reaps_runtime_tmp_lease(
+    tmp_tasks_dir,
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
+    args = delegate.build_parser().parse_args(
+        [
+            "dispatch",
+            "--agent",
+            "codex",
+            "--task-id",
+            "dry/run tmp",
+            "--prompt",
+            "test",
+            "--dry-run",
+        ],
+    )
+
+    assert delegate.cmd_dispatch(args) == 0
+
+    state = delegate._read_state(delegate._state_path("dry/run tmp"))
+    assert state is not None
+    lease_root = tmp_path / "learn-ukrainian" / "dry-run-tmp"
+    assert state["status"] == "dry_run"
+    assert state["runtime_tmp_root"] == str(lease_root)
+    assert state["tmp_bytes_freed"] == 0
+    assert state["tmp_reap_error"] is None
+    assert not lease_root.exists()
 
 
 def test_dispatch_allow_merge_opt_in_updates_worker_env(tmp_tasks_dir, monkeypatch):

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -91,7 +91,8 @@ def test_create_runtime_tmp_lease_sanitizes_task_id(tmp_path, monkeypatch):
     assert lease_root.is_dir()
 
 
-def test_runtime_tmp_reap_refuses_root_outside_namespace(tmp_path):
+def test_runtime_tmp_reap_refuses_root_outside_namespace(tmp_path, monkeypatch):
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
     namespace_root = tmp_path / "learn-ukrainian"
     namespace_root.mkdir()
     outside = tmp_path / "outside"
@@ -106,7 +107,60 @@ def test_runtime_tmp_reap_refuses_root_outside_namespace(tmp_path):
     assert payload.read_text(encoding="utf-8") == "keep"
 
 
-def test_runtime_tmp_reap_refuses_a_symlinked_lease_root(tmp_path):
+def test_runtime_tmp_reap_refuses_namespace_outside_tempdir(tmp_path, monkeypatch):
+    os_tmp_root = tmp_path / "os-tmp"
+    os_tmp_root.mkdir()
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(os_tmp_root))
+    namespace_root = tmp_path / "repository" / "learn-ukrainian"
+    lease_root = namespace_root / "scripts"
+    lease_root.mkdir(parents=True)
+    payload = lease_root / "keep.txt"
+    payload.write_text("keep", encoding="utf-8")
+
+    result = delegate._reap_runtime_tmp_lease(lease_root, namespace_root)
+
+    assert result["tmp_bytes_freed"] == 0
+    assert "not directly under $TMPDIR" in str(result["tmp_reap_error"])
+    assert payload.read_text(encoding="utf-8") == "keep"
+
+
+def test_runtime_tmp_reap_refuses_wrong_namespace_name(tmp_path, monkeypatch):
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
+    namespace_root = tmp_path / "wrong-namespace"
+    lease_root = namespace_root / "task"
+    lease_root.mkdir(parents=True)
+    payload = lease_root / "keep.txt"
+    payload.write_text("keep", encoding="utf-8")
+
+    result = delegate._reap_runtime_tmp_lease(lease_root, namespace_root)
+
+    assert result["tmp_bytes_freed"] == 0
+    assert "namespace has the wrong name" in str(result["tmp_reap_error"])
+    assert payload.read_text(encoding="utf-8") == "keep"
+
+
+def test_runtime_tmp_reap_refuses_missing_symlink_protection(tmp_path, monkeypatch):
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
+    namespace_root = tmp_path / "learn-ukrainian"
+    lease_root = namespace_root / "task"
+    lease_root.mkdir(parents=True)
+    payload = lease_root / "keep.txt"
+    payload.write_text("keep", encoding="utf-8")
+
+    def unprotected_rmtree(*_args, **_kwargs):
+        raise AssertionError("rmtree must not run without symlink protection")
+
+    monkeypatch.setattr(delegate.shutil, "rmtree", unprotected_rmtree)
+
+    result = delegate._reap_runtime_tmp_lease(lease_root, namespace_root)
+
+    assert result["tmp_bytes_freed"] == 0
+    assert "lacks symlink-attack protection" in str(result["tmp_reap_error"])
+    assert payload.read_text(encoding="utf-8") == "keep"
+
+
+def test_runtime_tmp_reap_refuses_a_symlinked_lease_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
     namespace_root = tmp_path / "learn-ukrainian"
     namespace_root.mkdir()
     outside = tmp_path / "outside"
@@ -123,7 +177,8 @@ def test_runtime_tmp_reap_refuses_a_symlinked_lease_root(tmp_path):
     assert payload.read_text(encoding="utf-8") == "keep"
 
 
-def test_runtime_tmp_reap_unlinks_child_symlinks_without_following_them(tmp_path):
+def test_runtime_tmp_reap_unlinks_child_symlinks_without_following_them(tmp_path, monkeypatch):
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
     namespace_root = tmp_path / "learn-ukrainian"
     lease_root = namespace_root / "task"
     lease_root.mkdir(parents=True)
@@ -142,6 +197,7 @@ def test_runtime_tmp_reap_unlinks_child_symlinks_without_following_them(tmp_path
 
 
 def test_runtime_tmp_reap_records_cleanup_errors(tmp_path, monkeypatch):
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(tmp_path))
     namespace_root = tmp_path / "learn-ukrainian"
     lease_root = namespace_root / "task"
     lease_root.mkdir(parents=True)
@@ -1041,6 +1097,8 @@ def test_run_worker_emits_one_terminal_dispatch_event_with_cost_fields(
     runtime_tmp_root = runtime_tmp_namespace / "worker-dispatch-event"
     runtime_tmp_root.mkdir(parents=True)
     (runtime_tmp_root / "payload.bin").write_bytes(b"lease")
+    monkeypatch.setattr(delegate.tempfile, "gettempdir", lambda: str(runtime_tmp_root))
+    monkeypatch.setenv("LU_RUNTIME_TMP_BASE_ROOT", str(tmp_path))
 
     state_path = delegate._state_path("worker-dispatch-event")
     delegate._write_state_atomic(state_path, {
@@ -1947,6 +2005,7 @@ def test_dispatch_records_runtime_tmp_lease_and_injects_worker_env(
     assert isinstance(env, dict)
     assert env["TMPDIR"] == str(lease_root)
     assert env["LU_RUNTIME_TMP_ROOT"] == str(lease_root)
+    assert env["LU_RUNTIME_TMP_BASE_ROOT"] == str(tmp_path)
     cmd = recorded["cmd"]
     assert isinstance(cmd, list)
     assert cmd[cmd.index("--runtime-tmp-root") + 1] == str(lease_root)

--- a/tests/test_mcp_init_observability.py
+++ b/tests/test_mcp_init_observability.py
@@ -328,10 +328,14 @@ def test_runtime_tool_config_codex_tools_nests_home_in_runtime_tmp_lease(
     (fake_home / "auth.json").write_text("{}", encoding="utf-8")
     monkeypatch.setenv("CODEX_HOME", str(fake_home))
 
-    lease_root = tmp_path / "learn-ukrainian" / "task-4956"
+    tmp_root = tmp_path / "os-tmp"
+    tmp_root.mkdir()
+    lease_root = tmp_root / "learn-ukrainian" / "task-4956"
     lease_root.mkdir(parents=True)
     monkeypatch.setattr(linear_pipeline.tempfile, "gettempdir", lambda: str(lease_root))
+    monkeypatch.setenv("TMPDIR", str(lease_root))
     monkeypatch.setenv("LU_RUNTIME_TMP_ROOT", str(lease_root))
+    monkeypatch.setenv("LU_RUNTIME_TMP_BASE_ROOT", str(tmp_root))
 
     config = linear_pipeline._runtime_tool_config(
         "codex-tools",

--- a/tests/test_mcp_init_observability.py
+++ b/tests/test_mcp_init_observability.py
@@ -316,6 +316,49 @@ def test_runtime_tool_config_codex_tools_scoped_codex_home(
     assert Path(auth_link.resolve()) == (fake_home / "auth.json").resolve()
 
 
+def test_runtime_tool_config_codex_tools_nests_home_in_runtime_tmp_lease(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _valid_sources_config(tmp_path / ".mcp.json")
+    monkeypatch.setattr(tool_config_mod, "_DEFAULT_MCP_CONFIG_PATH", config_path)
+
+    fake_home = tmp_path / "fake-codex-home"
+    fake_home.mkdir()
+    (fake_home / "auth.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(fake_home))
+
+    lease_root = tmp_path / "learn-ukrainian" / "task-4956"
+    lease_root.mkdir(parents=True)
+    monkeypatch.setattr(linear_pipeline.tempfile, "gettempdir", lambda: str(lease_root))
+    monkeypatch.setenv("LU_RUNTIME_TMP_ROOT", str(lease_root))
+
+    config = linear_pipeline._runtime_tool_config(
+        "codex-tools",
+        workspace_dir=linear_pipeline.PROJECT_ROOT,
+    )
+
+    assert config["codex_home_override"] == str(
+        lease_root / f"codex-v7-writer-{os.getuid()}",
+    )
+
+
+def test_ensure_codex_writer_home_keeps_shared_no_task_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_home = tmp_path / "fake-codex-home"
+    fake_home.mkdir()
+    (fake_home / "auth.json").write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("CODEX_HOME", str(fake_home))
+    monkeypatch.delenv("LU_RUNTIME_TMP_ROOT", raising=False)
+    monkeypatch.setattr(linear_pipeline.tempfile, "gettempdir", lambda: str(tmp_path))
+
+    scoped_home = linear_pipeline._ensure_codex_writer_home()
+
+    assert scoped_home == str(tmp_path / f"codex-v7-writer-{os.getuid()}")
+
+
 def test_runtime_tool_config_codex_tools_scoped_home_emits_event(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- Creates a sanitized, task-scoped runtime lease under `$TMPDIR/learn-ukrainian/` and persists `runtime_tmp_root` in delegate state.
- Propagates `TMPDIR` and `LU_RUNTIME_TMP_ROOT` through sanitized agent environments; the Codex V7 writer home now nests inside a valid task lease.
- Reaps each lease in the worker finally path with fd-relative, symlink-safe removal and records `tmp_bytes_freed` / `tmp_reap_error` in state and terminal telemetry.
- Adds the dispatch-brief temporary-artifact contract. No Stage 2 sweeper or Stage 3 rotation/cache work is included.

## Why

Six 1.2 GB shadow databases were left in bare `/tmp`, causing 7.2 GB of avoidable disk pressure. This Stage 1 enforcement root confines runtime-created temporary data to one task-owned lease and reaps it at task completion. Refs #4956.

## Validation

`.venv/bin/python -m pytest -q tests/test_delegate.py tests/test_delegate_check_budget.py tests/test_agent_runtime_env_sanitize.py tests/test_mcp_init_observability.py tests/test_ab_dispatch_wrappers.py`

```text
174 passed in 8.01s
```

`.venv/bin/ruff check ...` and `git diff --check origin/main...HEAD`

```text
All checks passed!
```

Real dry-run proof persisted:

```text
runtime_tmp_root: /private/var/folders/.../T/learn-ukrainian/4956-tmp-lease-stage1-proof
tmp_bytes_freed: 0
tmp_reap_error: null
status: dry_run
```

## Independent review

Hermes / DeepSeek V4 Flash reviewed `origin/main...HEAD` read-only through dispatched task `review-5143-runtime-tmp-lease`: **APPROVE**, no blocking findings. Its own task lease was reaped successfully (`tmp_bytes_freed: 600696`, `tmp_reap_error: null`). Auto-merge is intentionally not enabled.