### PR TITLE
feat(lexicon): anchor curation worksheet — 158 EN anchor proposals with evidence (stage 1)

### DIFF
--- a/data/lexicon/anchor_curation_worksheet.yaml
+++ b/data/lexicon/anchor_curation_worksheet.yaml
@@ -1,0 +1,1924 @@
+schema_version: 1
+meta:
+  issue: '#5133'
+  stage: 1 — proposals only; not consumed by the Atlas manifest
+  source_scope: 'data/sources.db read-only: Балла EN→UK whole-word hints and СУМ-11 senses'
+  audit_command: .venv/bin/python scripts/audit/audit_atlas_poc_richness.py --max-search-no-visible-gloss
+    0 --max-old-gate-no-english-anchor 0 --max-poc-thin-pages 900 --format tsv --limit 300
+  audit_reconciliation: 'Literal audit reports 196 because #5132 shipped cached-ukreng fill code without
+    a regenerated manifest. This worksheet deterministically simulates only that cached 38-fill operation
+    in memory, then retains its 158-entry remainder; no manifest or cache is written.'
+  anchor_rule: Anchors are curator proposals, never copied automatically from Балла. Null plus low confidence
+    is the fail-closed outcome when no sense-specific source supports an anchor.
+records:
+- lemma: бажане
+  cefr: B1
+  url_slug: бажане
+  proposed_anchor: desired thing
+  balla_reverse_hints:
+  - wish
+  - would
+  sum11_sense: Something wanted or wished for.
+  vesum_verified: true
+  confidence: medium
+  notes: Substantivized neuter adjective; Балла hint `wish` sense-checked.
+- lemma: вітамінізація
+  cefr: C1
+  url_slug: вітамінізація
+  proposed_anchor: vitamin fortification
+  balla_reverse_hints:
+  - enrichment
+  - fortification
+  sum11_sense: Adding vitamins to food or a diet.
+  vesum_verified: true
+  confidence: medium
+  notes: No exact СУМ-11 headword; Балла hint `fortification` sense-checked.
+- lemma: гейби
+  cefr: B2
+  url_slug: гейби
+  proposed_anchor: as if
+  balla_reverse_hints: []
+  sum11_sense: A dialectal conjunction meaning as if or like.
+  vesum_verified: true
+  confidence: high
+- lemma: генрі
+  cefr: C1
+  url_slug: генрі
+  proposed_anchor: henry
+  balla_reverse_hints:
+  - Henry
+  - henry
+  - young
+  sum11_sense: The SI unit of electrical inductance.
+  vesum_verified: true
+  confidence: medium
+  notes: No exact СУМ-11 headword; Балла headword `henry` is the unit, not the name.
+- lemma: гіповітаміноз
+  cefr: C1
+  url_slug: гіповітаміноз
+  proposed_anchor: vitamin deficiency
+  balla_reverse_hints: []
+  sum11_sense: An illness caused by insufficient vitamins.
+  vesum_verified: true
+  confidence: high
+- lemma: денно
+  cefr: B2
+  url_slug: денно
+  proposed_anchor: daily
+  balla_reverse_hints: []
+  sum11_sense: Every day; also, for a working day.
+  vesum_verified: true
+  confidence: high
+- lemma: депресивність
+  cefr: C1
+  url_slug: депресивність
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: дизель-поїзд
+  cefr: C1
+  url_slug: дизель-поїзд
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: дистанціювання
+  cefr: B1
+  url_slug: дистанціювання
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: дитяча
+  cefr: A2
+  url_slug: дитяча
+  proposed_anchor: nursery
+  balla_reverse_hints:
+  - baby
+  - bathinette
+  - biggin
+  - brattery
+  - buggy
+  - calf-love
+  - childhood
+  - criss-cross
+  - duostroller
+  - egg-and-spoon-race
+  - Florentine
+  - follow-my-leader
+  - formula
+  - frock
+  - garibaldi
+  - go-cart
+  - gum-rash
+  - handy-dandy
+  - health
+  - hopscotch
+  - hy-spy
+  - juvenile
+  - kidvid
+  - kilt
+  - kit-cat
+  - mail-cart
+  - matinee
+  - meccano
+  - muggins
+  - musical
+  - night-dress
+  - nighty
+  - nursery
+  - nursing
+  - pat-a-cake
+  - perambulator
+  - petticoat
+  - picture-book
+  - play
+  - playroom
+  - postman
+  - pram
+  - push-cart
+  - rag-book
+  - red
+  - sand-table
+  - sardine
+  - see-saw
+  - slapjack
+  - stocking
+  - stroller
+  - taw
+  - teeter
+  - thread-needle
+  - touch
+  - touchwood
+  - undies
+  - vest
+  - waggon
+  - waist
+  - wheel
+  - wrapper
+  sum11_sense: A room for children.
+  vesum_verified: true
+  confidence: medium
+  notes: Substantivized feminine adjective; `bathinette` is a noisy Балла match.
+- lemma: добові
+  cefr: B2
+  url_slug: добові
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: домашні
+  cefr: A2
+  url_slug: домашні
+  proposed_anchor: household
+  balla_reverse_hints:
+  - carpet-slippers
+  - domesticity
+  - effects
+  - home-folk|home-folks
+  - household
+  - lumber
+  sum11_sense: People or things belonging to the home.
+  vesum_verified: true
+  confidence: medium
+  notes: Substantivized plural adjective; Балла home/household hints sense-checked.
+- lemma: достоту
+  cefr: B1
+  url_slug: достоту
+  proposed_anchor: exactly
+  balla_reverse_hints: []
+  sum11_sense: Exactly; truly or really.
+  vesum_verified: true
+  confidence: high
+- lemma: дурненький
+  cefr: B2
+  url_slug: дурненький
+  proposed_anchor: silly
+  balla_reverse_hints:
+  - gosling
+  - silly
+  sum11_sense: Somewhat foolish; also an affectionate form of foolish.
+  vesum_verified: true
+  confidence: high
+- lemma: дурненько
+  cefr: C1
+  url_slug: дурненько
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: емоційно
+  cefr: B2
+  url_slug: емоційно
+  proposed_anchor: emotionally
+  balla_reverse_hints:
+  - appellative
+  - emotionally
+  - such
+  sum11_sense: In an emotional manner.
+  vesum_verified: true
+  confidence: high
+- lemma: етнічність
+  cefr: C1
+  url_slug: етнічність
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: жертовність
+  cefr: B2
+  url_slug: жертовність
+  proposed_anchor: self-sacrifice
+  balla_reverse_hints: []
+  sum11_sense: Readiness to make a sacrifice for someone or something.
+  vesum_verified: true
+  confidence: high
+  sovietization_flag: true
+- lemma: живучи
+  cefr: B1
+  url_slug: живучи
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: зазвучати
+  cefr: C1
+  url_slug: зазвучати
+  proposed_anchor: begin to sound
+  balla_reverse_hints: []
+  sum11_sense: To begin making or filling with sound.
+  vesum_verified: true
+  confidence: high
+- lemma: зайве
+  cefr: A2
+  url_slug: зайве
+  proposed_anchor: the unnecessary
+  balla_reverse_hints:
+  - blunder
+  - loose
+  - nimiety
+  - redundancy
+  - stream-line
+  - thick
+  - widow
+  sum11_sense: Something extra or not needed.
+  vesum_verified: true
+  confidence: medium
+  notes: Substantivized neuter adjective; Балла `redundancy` hint sense-checked.
+- lemma: замкнуто
+  cefr: C1
+  url_slug: замкнуто
+  proposed_anchor: reservedly
+  balla_reverse_hints: []
+  sum11_sense: In a withdrawn or closed-off manner.
+  vesum_verified: true
+  confidence: high
+- lemma: замішування
+  cefr: C1
+  url_slug: замішування
+  proposed_anchor: kneading
+  balla_reverse_hints: []
+  sum11_sense: The act of kneading dough; also mixing in.
+  vesum_verified: true
+  confidence: high
+- lemma: занудний
+  cefr: C1
+  url_slug: занудний
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: заповнений
+  cefr: B1
+  url_slug: заповнений
+  proposed_anchor: filled
+  balla_reverse_hints:
+  - alive
+  - boatful
+  - cram-full
+  - flowerful
+  - froggy
+  - full
+  - fumy
+  - gassy
+  - life-preserver
+  - snaggy
+  - thick
+  - thick-sown
+  - throng
+  - tight
+  - waspy
+  sum11_sense: Filled or occupied with something.
+  vesum_verified: true
+  confidence: high
+- lemma: зарахований
+  cefr: B2
+  url_slug: зарахований
+  proposed_anchor: enrolled
+  balla_reverse_hints:
+  - ball
+  sum11_sense: Accepted into an institution or counted as belonging to something.
+  vesum_verified: true
+  confidence: high
+- lemma: засвоюватися
+  cefr: C1
+  url_slug: засвоюватися
+  proposed_anchor: be absorbed
+  balla_reverse_hints: []
+  sum11_sense: To be taken in or assimilated by an organism.
+  vesum_verified: true
+  confidence: high
+- lemma: засинання
+  cefr: C1
+  url_slug: засинання
+  proposed_anchor: falling asleep
+  balla_reverse_hints:
+  - dormition
+  sum11_sense: The process of falling asleep.
+  vesum_verified: true
+  confidence: high
+- lemma: захопливо
+  cefr: B2
+  url_slug: захопливо
+  proposed_anchor: engagingly
+  balla_reverse_hints: []
+  sum11_sense: In an exciting or captivating way.
+  vesum_verified: true
+  confidence: high
+- lemma: звикання
+  cefr: B2
+  url_slug: звикання
+  proposed_anchor: getting used to
+  balla_reverse_hints: []
+  sum11_sense: The process of becoming accustomed to something.
+  vesum_verified: true
+  confidence: high
+- lemma: здирати
+  cefr: B2
+  url_slug: здирати
+  proposed_anchor: strip off
+  balla_reverse_hints:
+  - abrade
+  - abrase
+  - bark
+  - debark
+  - decorticate
+  - disbark
+  - excoriate
+  - excorticate
+  - extort
+  - flay
+  - flench
+  - flipe
+  - hide
+  - husk
+  - raw
+  - rind
+  - rip
+  - rive
+  - scarf
+  - skin
+  - strip
+  - wring
+  sum11_sense: To remove or tear off an outer layer.
+  vesum_verified: true
+  confidence: high
+  sovietization_flag: true
+- lemma: зернові
+  cefr: A2
+  url_slug: зернові
+  proposed_anchor: cereals
+  balla_reverse_hints:
+  - cereal
+  - crop
+  - small
+  - white
+  sum11_sense: Grain crops used for food.
+  vesum_verified: true
+  confidence: medium
+  notes: Substantivized plural adjective; Балла `cereal` hint sense-checked.
+- lemma: знайома
+  cefr: A2
+  url_slug: знайома
+  proposed_anchor: female acquaintance
+  balla_reverse_hints:
+  - acquaintance
+  - bailiwick
+  sum11_sense: A woman whom one knows.
+  vesum_verified: true
+  confidence: medium
+  notes: Substantivized feminine adjective; Балла `acquaintance` hint sense-checked.
+- lemma: зумовленість
+  cefr: B2
+  url_slug: зумовленість
+  proposed_anchor: causal dependence
+  balla_reverse_hints:
+  - dependence
+  - dependency
+  sum11_sense: Dependence on particular causes.
+  vesum_verified: true
+  confidence: high
+  sovietization_flag: true
+- lemma: йододефіцит
+  cefr: C1
+  url_slug: йододефіцит
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: кажучи
+  cefr: B2
+  url_slug: кажучи
+  proposed_anchor: null
+  balla_reverse_hints:
+  - admittedly
+  - apart
+  - broadly
+  - by
+  - conscience
+  - English
+  - frankly
+  - generally
+  - honest
+  - least
+  - long
+  - make
+  - mention
+  - mildly
+  - needless
+  - parlance
+  - post
+  - practically
+  - properly
+  - relatively
+  - say
+  - short
+  - shortly
+  - sooth
+  - speak
+  - story
+  - strip
+  - sum
+  - truly
+  - truth
+  - word
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: книжно
+  cefr: C1
+  url_slug: книжно
+  proposed_anchor: bookishly
+  balla_reverse_hints: []
+  sum11_sense: In a bookish or overly formal manner.
+  vesum_verified: true
+  confidence: high
+- lemma: комендантська
+  cefr: B1
+  url_slug: комендантська
+  proposed_anchor: curfew
+  balla_reverse_hints:
+  - curfew
+  - standstill
+  sum11_sense: A restriction requiring people to stay indoors at set hours.
+  vesum_verified: true
+  confidence: medium
+  notes: Substantivized adjective in the fixed phrase комендантська година; Балла `curfew` hint sense-checked.
+- lemma: компартія
+  cefr: B2
+  url_slug: компартія
+  proposed_anchor: Communist Party
+  balla_reverse_hints: []
+  sum11_sense: An abbreviation for the Communist Party.
+  vesum_verified: true
+  confidence: high
+  sovietization_flag: true
+- lemma: компромісний
+  cefr: B1
+  url_slug: компромісний
+  proposed_anchor: compromise
+  balla_reverse_hints:
+  - half-way
+  sum11_sense: Formed by or involving a compromise.
+  vesum_verified: true
+  confidence: high
+- lemma: консервований
+  cefr: C1
+  url_slug: консервований
+  proposed_anchor: canned
+  balla_reverse_hints:
+  - canned
+  - lasting
+  - potted
+  - preserved
+  - tinned
+  sum11_sense: Preserved for storage, especially as food.
+  vesum_verified: true
+  confidence: high
+- lemma: коригування
+  cefr: A2
+  url_slug: коригування
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: корисне
+  cefr: A2
+  url_slug: корисне
+  proposed_anchor: null
+  balla_reverse_hints:
+  - actual
+  - mix
+  - payload
+  - relatively
+  - service
+  - work
+  - working
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: коротший
+  cefr: A2
+  url_slug: коротший
+  proposed_anchor: shorter
+  balla_reverse_hints:
+  - by-way
+  - shorter
+  sum11_sense: Having less length or duration.
+  vesum_verified: true
+  confidence: medium
+  notes: Comparative adjective; Балла `shorter` hint sense-checked.
+- lemma: кортизол
+  cefr: C1
+  url_slug: кортизол
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: косуля
+  cefr: C1
+  url_slug: косуля
+  proposed_anchor: wooden plough
+  balla_reverse_hints: []
+  sum11_sense: An archaic type of plough.
+  vesum_verified: true
+  confidence: high
+  notes: Primary СУМ-11 sense is the farming tool, not the roe deer cross-reference.
+- lemma: коцик
+  cefr: C1
+  url_slug: коцик
+  proposed_anchor: small rug
+  balla_reverse_hints: []
+  sum11_sense: A small rug or blanket.
+  vesum_verified: true
+  confidence: high
+- lemma: кричачи
+  cefr: C1
+  url_slug: кричачи
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: кровити
+  cefr: C1
+  url_slug: кровити
+  proposed_anchor: bleed
+  balla_reverse_hints: []
+  sum11_sense: To bleed from a wound.
+  vesum_verified: true
+  confidence: high
+- lemma: ледве-ледве
+  cefr: B2
+  url_slug: ледве-ледве
+  proposed_anchor: barely
+  balla_reverse_hints:
+  - finger
+  sum11_sense: Only just; with difficulty.
+  vesum_verified: true
+  confidence: high
+- lemma: лиш
+  cefr: C1
+  url_slug: лиш
+  proposed_anchor: only
+  balla_reverse_hints: []
+  sum11_sense: Only; merely.
+  vesum_verified: true
+  confidence: high
+- lemma: літа
+  cefr: A1
+  url_slug: літа
+  proposed_anchor: years
+  balla_reverse_hints:
+  - age
+  - approach
+  - dog-days
+  - heart
+  - height
+  - high
+  - midsummer
+  - on-coming
+  - return
+  - summer
+  - testify
+  - wear
+  sum11_sense: A period measured in years; years of life.
+  vesum_verified: true
+  confidence: high
+- lemma: маловідомо
+  cefr: C1
+  url_slug: маловідомо
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: маскулінний
+  cefr: C1
+  url_slug: маскулінний
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: мовби
+  cefr: A1
+  url_slug: мовби
+  proposed_anchor: as if
+  balla_reverse_hints: []
+  sum11_sense: As if; as though.
+  vesum_verified: true
+  confidence: high
+- lemma: мовбито
+  cefr: C1
+  url_slug: мовбито
+  proposed_anchor: as if
+  balla_reverse_hints: []
+  sum11_sense: As if; as though.
+  vesum_verified: true
+  confidence: high
+- lemma: можливе
+  cefr: A1
+  url_slug: можливе
+  proposed_anchor: the possible
+  balla_reverse_hints:
+  - anxious
+  - best
+  - do
+  - foot
+  - level
+  - mettle
+  - move
+  - possible
+  - sounding
+  - stone
+  - suggest
+  - trier
+  - way
+  sum11_sense: Something that is possible.
+  vesum_verified: true
+  confidence: medium
+  notes: Substantivized neuter adjective; Балла `possible` hint sense-checked.
+- lemma: молодше
+  cefr: B1
+  url_slug: молодше
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: мотиватор
+  cefr: C1
+  url_slug: мотиватор
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: мікс
+  cefr: B2
+  url_slug: мікс
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: найактивніше
+  cefr: B1
+  url_slug: найактивніше
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: найважливіше
+  cefr: A2
+  url_slug: найважливіше
+  proposed_anchor: the most important
+  balla_reverse_hints:
+  - everything
+  - feature
+  - leader
+  - life
+  - precede
+  - thing
+  sum11_sense: The thing that matters most.
+  vesum_verified: true
+  confidence: medium
+  notes: Substantivized superlative; reviewed against the raw Балла hints rather than auto-copied.
+- lemma: найраніше
+  cefr: C1
+  url_slug: найраніше
+  proposed_anchor: earliest
+  balla_reverse_hints: []
+  sum11_sense: Earlier than all others; at the earliest time.
+  vesum_verified: true
+  confidence: high
+- lemma: народжування
+  cefr: C1
+  url_slug: народжування
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: наслідковий
+  cefr: C1
+  url_slug: наслідковий
+  proposed_anchor: result clause
+  balla_reverse_hints:
+  - consecutive
+  sum11_sense: Relating to a result clause in grammar.
+  vesum_verified: true
+  confidence: high
+  notes: Primary СУМ-11 sense is the grammatical term.
+- lemma: наші
+  cefr: A1
+  url_slug: наші
+  proposed_anchor: our people
+  balla_reverse_hints:
+  - anxious
+  - despite
+  - jar
+  - latterly
+  - living
+  - mess
+  - nowadays
+  - our
+  - ours
+  - part
+  - today|to-day
+  - trade
+  - unfulfilled
+  - wrong
+  - year
+  sum11_sense: People regarded as one's own group.
+  vesum_verified: true
+  confidence: medium
+  notes: Substantivized plural possessive; Балла `ours` hint sense-checked.
+- lemma: невідомі
+  cefr: A1
+  url_slug: невідомі
+  proposed_anchor: null
+  balla_reverse_hints:
+  - where
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: недосипання
+  cefr: B2
+  url_slug: недосипання
+  proposed_anchor: lack of sleep
+  balla_reverse_hints: []
+  sum11_sense: The state or result of not getting enough sleep.
+  vesum_verified: true
+  confidence: high
+- lemma: незвично
+  cefr: A2
+  url_slug: незвично
+  proposed_anchor: unusually
+  balla_reverse_hints:
+  - extraordinarily
+  - extraordinary
+  - strangely
+  - uncommonly
+  sum11_sense: In an unfamiliar or strange way.
+  vesum_verified: true
+  confidence: high
+- lemma: некомфортно
+  cefr: B1
+  url_slug: некомфортно
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: ненадійно
+  cefr: C1
+  url_slug: ненадійно
+  proposed_anchor: unreliably
+  balla_reverse_hints:
+  - incalculably
+  - precariously
+  - pregnable
+  - treacherously
+  sum11_sense: In an unreliable or insecure way.
+  vesum_verified: true
+  confidence: high
+- lemma: неначеб
+  cefr: C1
+  url_slug: неначеб
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: неочікувано
+  cefr: B1
+  url_slug: неочікувано
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: неперевершено
+  cefr: B2
+  url_slug: неперевершено
+  proposed_anchor: superbly
+  balla_reverse_hints:
+  - matchlessly
+  sum11_sense: In an unsurpassed way.
+  vesum_verified: true
+  confidence: high
+- lemma: неповторно
+  cefr: C1
+  url_slug: неповторно
+  proposed_anchor: uniquely
+  balla_reverse_hints: []
+  sum11_sense: In a unique, unrepeatable way.
+  vesum_verified: true
+  confidence: high
+- lemma: непрофесійно
+  cefr: B2
+  url_slug: непрофесійно
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: нестямно
+  cefr: B2
+  url_slug: нестямно
+  proposed_anchor: frantically
+  balla_reverse_hints:
+  - amuck
+  - blaze
+  - bray
+  - fiercely
+  - giddily
+  - maniacally
+  sum11_sense: In an uncontrollably excited or distraught way.
+  vesum_verified: true
+  confidence: high
+- lemma: нехарактерний
+  cefr: C1
+  url_slug: нехарактерний
+  proposed_anchor: uncharacteristic
+  balla_reverse_hints:
+  - indistinctive
+  - uncharacteristic
+  - unrepresentative
+  sum11_sense: Not typical or characteristic.
+  vesum_verified: true
+  confidence: medium
+  notes: No exact СУМ-11 headword; Балла `uncharacteristic` hint sense-checked.
+- lemma: нощно
+  cefr: C1
+  url_slug: нощно
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: обгризання
+  cefr: C1
+  url_slug: обгризання
+  proposed_anchor: nibbling
+  balla_reverse_hints:
+  - nibble
+  sum11_sense: The act of gnawing or nibbling away.
+  vesum_verified: true
+  confidence: medium
+  notes: No exact СУМ-11 headword; Балла `nibble` hint sense-checked.
+- lemma: обприскування
+  cefr: B2
+  url_slug: обприскування
+  proposed_anchor: spraying
+  balla_reverse_hints:
+  - air-spraying
+  - douching
+  - perfusion
+  - spray
+  - spraying
+  - sprinkle
+  - syringing
+  - wash
+  sum11_sense: The act of spraying something with liquid.
+  vesum_verified: true
+  confidence: high
+- lemma: образливо
+  cefr: B1
+  url_slug: образливо
+  proposed_anchor: offensively
+  balla_reverse_hints:
+  - foully
+  - obnoxiously
+  - opprobriously
+  - ridiculously
+  - rudely
+  - scant
+  - touchily
+  sum11_sense: In an insulting or hurtful way.
+  vesum_verified: true
+  confidence: high
+- lemma: оброблений
+  cefr: B2
+  url_slug: оброблений
+  proposed_anchor: processed
+  balla_reverse_hints:
+  - cultivated
+  - dressed
+  - featured
+  - fine-cut
+  - finished
+  - medicated
+  - prepared
+  - processed
+  - tilled
+  - tooled
+  - treated
+  - wrought
+  sum11_sense: Treated, worked, or processed.
+  vesum_verified: true
+  confidence: high
+- lemma: обтирання
+  cefr: C1
+  url_slug: обтирання
+  proposed_anchor: rubbing down
+  balla_reverse_hints:
+  - friction
+  - rub-down
+  - sponge
+  - sponge-bath
+  sum11_sense: The act of rubbing or wiping the body or a surface.
+  vesum_verified: true
+  confidence: high
+- lemma: обігрів
+  cefr: B2
+  url_slug: обігрів
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: опірність
+  cefr: B2
+  url_slug: опірність
+  proposed_anchor: resistance
+  balla_reverse_hints:
+  - fastness
+  - resistance
+  - stamina
+  sum11_sense: The ability to resist or withstand something.
+  vesum_verified: true
+  confidence: high
+- lemma: ослаблений
+  cefr: B2
+  url_slug: ослаблений
+  proposed_anchor: weakened
+  balla_reverse_hints:
+  - attenuated
+  - blooded
+  - broken
+  - deadish
+  - depressed
+  - dilute
+  - marcid
+  - rickety
+  - slack
+  - stray
+  - subdued
+  - suppressed
+  sum11_sense: Made weak or less strong.
+  vesum_verified: true
+  confidence: high
+- lemma: останнє
+  cefr: B2
+  url_slug: останнє
+  proposed_anchor: null
+  balla_reverse_hints:
+  - cope-stone
+  - decisive
+  - hot
+  - lag
+  - last
+  - latest
+  - nestle-cock
+  - reaggravation
+  - rebuttal
+  - recent
+  - shirt
+  - stripping
+  - stroking
+  - supreme
+  - why-not
+  - wooden
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: пекельно
+  cefr: C1
+  url_slug: пекельно
+  proposed_anchor: hellishly
+  balla_reverse_hints:
+  - infernally
+  sum11_sense: In an extremely intense or dreadful way.
+  vesum_verified: true
+  confidence: high
+- lemma: повинно
+  cefr: B2
+  url_slug: повинно
+  proposed_anchor: should
+  balla_reverse_hints:
+  - occur
+  sum11_sense: Expressing what ought to happen or be done.
+  vesum_verified: true
+  confidence: high
+- lemma: повів
+  cefr: A1
+  url_slug: повів
+  proposed_anchor: gust
+  balla_reverse_hints: []
+  sum11_sense: A gust or faint waft of wind.
+  vesum_verified: true
+  confidence: high
+  sovietization_flag: true
+- lemma: повішати
+  cefr: C1
+  url_slug: повішати
+  proposed_anchor: hang up
+  balla_reverse_hints: []
+  sum11_sense: To hang several things or hang things in different places.
+  vesum_verified: true
+  confidence: high
+- lemma: пожувати
+  cefr: C1
+  url_slug: пожувати
+  proposed_anchor: chew
+  balla_reverse_hints: []
+  sum11_sense: To chew for a while.
+  vesum_verified: true
+  confidence: high
+- lemma: політехніка
+  cefr: A2
+  url_slug: політехніка
+  proposed_anchor: polytechnic institute
+  balla_reverse_hints: []
+  sum11_sense: A polytechnic educational institution.
+  vesum_verified: true
+  confidence: high
+- lemma: попити
+  cefr: B1
+  url_slug: попити
+  proposed_anchor: drink some
+  balla_reverse_hints: []
+  sum11_sense: To drink for a while or drink some liquid.
+  vesum_verified: true
+  confidence: high
+- lemma: попрати
+  cefr: B2
+  url_slug: попрати
+  proposed_anchor: wash clothes
+  balla_reverse_hints: []
+  sum11_sense: To wash clothes or other laundry.
+  vesum_verified: true
+  confidence: high
+- lemma: посмажити
+  cefr: C1
+  url_slug: посмажити
+  proposed_anchor: fry
+  balla_reverse_hints: []
+  sum11_sense: To fry something, often completely or in quantity.
+  vesum_verified: true
+  confidence: high
+- lemma: працевлаштований
+  cefr: C1
+  url_slug: працевлаштований
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: приглушено
+  cefr: B2
+  url_slug: приглушено
+  proposed_anchor: quietly
+  balla_reverse_hints:
+  - obtusely
+  - sullenly
+  sum11_sense: In a muffled or subdued way.
+  vesum_verified: true
+  confidence: high
+- lemma: примружено
+  cefr: C1
+  url_slug: примружено
+  proposed_anchor: squinting
+  balla_reverse_hints: []
+  sum11_sense: With the eyes partly closed or narrowed.
+  vesum_verified: true
+  confidence: high
+- lemma: приналежність
+  cefr: A2
+  url_slug: приналежність
+  proposed_anchor: belonging
+  balla_reverse_hints: []
+  sum11_sense: The state of belonging or being affiliated.
+  vesum_verified: true
+  confidence: high
+- lemma: приречена
+  cefr: B1
+  url_slug: приречена
+  proposed_anchor: null
+  balla_reverse_hints:
+  - battle
+  - deaf
+  - galley-slave
+  - hopeless
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: прихищати
+  cefr: C1
+  url_slug: прихищати
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: причиновий
+  cefr: C1
+  url_slug: причиновий
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: пропущений
+  cefr: B1
+  url_slug: пропущений
+  proposed_anchor: omitted
+  balla_reverse_hints:
+  - lost
+  - omissible
+  - strike
+  - unseized
+  sum11_sense: Missed, omitted, or allowed to pass through.
+  vesum_verified: true
+  confidence: high
+- lemma: прочитання
+  cefr: A2
+  url_slug: прочитання
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: психувати
+  cefr: C1
+  url_slug: психувати
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: пукати
+  cefr: C1
+  url_slug: пукати
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: півлітровий
+  cefr: C1
+  url_slug: півлітровий
+  proposed_anchor: half-liter
+  balla_reverse_hints: []
+  sum11_sense: Having a capacity of half a liter.
+  vesum_verified: true
+  confidence: high
+- lemma: підпільно
+  cefr: B2
+  url_slug: підпільно
+  proposed_anchor: underground
+  balla_reverse_hints:
+  - underground
+  sum11_sense: Secretly or illegally, outside official control.
+  vesum_verified: true
+  confidence: high
+  sovietization_flag: true
+- lemma: радикально
+  cefr: A2
+  url_slug: радикально
+  proposed_anchor: radically
+  balla_reverse_hints:
+  - cardinally
+  - drastically
+  - radically
+  sum11_sense: In a thorough or fundamental way.
+  vesum_verified: true
+  confidence: high
+- lemma: рано-вранці
+  cefr: B1
+  url_slug: рано-вранці
+  proposed_anchor: early morning
+  balla_reverse_hints:
+  - early
+  - rather
+  sum11_sense: Very early, at dawn.
+  vesum_verified: true
+  confidence: high
+- lemma: рекомендуватися
+  cefr: C1
+  url_slug: рекомендуватися
+  proposed_anchor: introduce oneself
+  balla_reverse_hints: []
+  sum11_sense: To give one's name when meeting someone.
+  vesum_verified: true
+  confidence: high
+- lemma: ризиковано
+  cefr: B1
+  url_slug: ризиковано
+  proposed_anchor: riskily
+  balla_reverse_hints:
+  - precariously
+  sum11_sense: In a risky way.
+  vesum_verified: true
+  confidence: high
+- lemma: ризиковий
+  cefr: C1
+  url_slug: ризиковий
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: ринопластика
+  cefr: C1
+  url_slug: ринопластика
+  proposed_anchor: rhinoplasty
+  balla_reverse_hints:
+  - rhinoplasty
+  sum11_sense: Surgery to reconstruct or reshape the nose.
+  vesum_verified: true
+  confidence: high
+- lemma: розгадування
+  cefr: C1
+  url_slug: розгадування
+  proposed_anchor: solving
+  balla_reverse_hints:
+  - thought-reading
+  sum11_sense: The act of guessing or solving something.
+  vesum_verified: true
+  confidence: high
+- lemma: розлитий
+  cefr: C1
+  url_slug: розлитий
+  proposed_anchor: spilled
+  balla_reverse_hints:
+  - bottled
+  - diffuse
+  sum11_sense: Poured or spread out over a surface.
+  vesum_verified: true
+  confidence: high
+- lemma: рідше
+  cefr: A2
+  url_slug: рідше
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: самолікуватися
+  cefr: C1
+  url_slug: самолікуватися
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: самонавіювання
+  cefr: C1
+  url_slug: самонавіювання
+  proposed_anchor: self-suggestion
+  balla_reverse_hints:
+  - self-suggestion
+  sum11_sense: The practice of influencing oneself by suggestion.
+  vesum_verified: true
+  confidence: high
+- lemma: святково
+  cefr: B1
+  url_slug: святково
+  proposed_anchor: festively
+  balla_reverse_hints:
+  - festively
+  sum11_sense: In a festive or celebratory way.
+  vesum_verified: true
+  confidence: high
+- lemma: свіжо
+  cefr: B1
+  url_slug: свіжо
+  proposed_anchor: freshly
+  balla_reverse_hints:
+  - freshly
+  - greenly
+  - sweetly
+  sum11_sense: In a fresh or cool way; just recently.
+  vesum_verified: true
+  confidence: high
+- lemma: сигаретний
+  cefr: C1
+  url_slug: сигаретний
+  proposed_anchor: cigarette
+  balla_reverse_hints: []
+  sum11_sense: Relating to cigarettes or their manufacture.
+  vesum_verified: true
+  confidence: high
+- lemma: сильніше
+  cefr: B2
+  url_slug: сильніше
+  proposed_anchor: null
+  balla_reverse_hints:
+  - better
+  - worse
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: сильніший
+  cefr: A2
+  url_slug: сильніший
+  proposed_anchor: null
+  balla_reverse_hints:
+  - tenfold
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: синтезуватися
+  cefr: C1
+  url_slug: синтезуватися
+  proposed_anchor: become unified
+  balla_reverse_hints: []
+  sum11_sense: To become a unified whole; also, to form by synthesis.
+  vesum_verified: true
+  confidence: medium
+  notes: Primary СУМ-11 sense precedes the chemical sense.
+- lemma: скрипт
+  cefr: B2
+  url_slug: скрипт
+  proposed_anchor: manuscript
+  balla_reverse_hints: []
+  sum11_sense: An archaic word for a manuscript.
+  vesum_verified: true
+  confidence: high
+- lemma: смачненьке
+  cefr: B2
+  url_slug: смачненьке
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: споживаний
+  cefr: C1
+  url_slug: споживаний
+  proposed_anchor: consumed
+  balla_reverse_hints:
+  - consumable
+  - expendable
+  sum11_sense: Used up or consumed.
+  vesum_verified: true
+  confidence: high
+- lemma: спохмурніти
+  cefr: C1
+  url_slug: спохмурніти
+  proposed_anchor: become gloomy
+  balla_reverse_hints: []
+  sum11_sense: To become gloomy or dark; of a face, to frown.
+  vesum_verified: true
+  confidence: high
+- lemma: спричинений
+  cefr: B1
+  url_slug: спричинений
+  proposed_anchor: caused
+  balla_reverse_hints:
+  - fiy-borne
+  - sick
+  - toxic
+  - toxicant
+  sum11_sense: Brought about by something.
+  vesum_verified: true
+  confidence: high
+  sovietization_flag: true
+- lemma: спровокований
+  cefr: B2
+  url_slug: спровокований
+  proposed_anchor: provoked
+  balla_reverse_hints: []
+  sum11_sense: Brought about or triggered by someone or something.
+  vesum_verified: true
+  confidence: high
+- lemma: стало
+  cefr: A1
+  url_slug: стало
+  proposed_anchor: steadily
+  balla_reverse_hints:
+  - dawn
+  - eponym
+  - knowledge
+  - more
+  - rally
+  - steady
+  - thicken
+  - unalterably
+  - view
+  sum11_sense: In a steady or constant manner.
+  vesum_verified: true
+  confidence: high
+- lemma: стиглий
+  cefr: C1
+  url_slug: стиглий
+  proposed_anchor: ripe
+  balla_reverse_hints:
+  - headed
+  - mature
+  - mellow
+  - red-ripe
+  - ripe
+  sum11_sense: Fully ripe or mature.
+  vesum_verified: true
+  confidence: high
+- lemma: стильно
+  cefr: B2
+  url_slug: стильно
+  proposed_anchor: stylishly
+  balla_reverse_hints:
+  - jauntily
+  - saucily
+  - stylishly
+  sum11_sense: In a stylish manner.
+  vesum_verified: true
+  confidence: high
+- lemma: супроводжуватися
+  cefr: B1
+  url_slug: супроводжуватися
+  proposed_anchor: be accompanied
+  balla_reverse_hints: []
+  sum11_sense: To occur together with another action or event.
+  vesum_verified: true
+  confidence: high
+  sovietization_flag: true
+- lemma: сучасне
+  cefr: A2
+  url_slug: сучасне
+  proposed_anchor: null
+  balla_reverse_hints:
+  - modernity
+  - neglect
+  - pentathlon
+  - revolutionize
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: сфокусуватися
+  cefr: B2
+  url_slug: сфокусуватися
+  proposed_anchor: come into focus
+  balla_reverse_hints: []
+  sum11_sense: To bring oneself into focus.
+  vesum_verified: true
+  confidence: medium
+  notes: СУМ-11 points to the primary sense of фокусуватися.
+- lemma: так-так
+  cefr: A2
+  url_slug: так-так
+  proposed_anchor: yes indeed
+  balla_reverse_hints: []
+  sum11_sense: An emphatic affirmation; also an imitative ticking sound.
+  vesum_verified: true
+  confidence: high
+- lemma: теплоізоляція
+  cefr: C1
+  url_slug: теплоізоляція
+  proposed_anchor: insulation
+  balla_reverse_hints:
+  - insulation
+  sum11_sense: Protection against heat loss or heat effects.
+  vesum_verified: true
+  confidence: high
+- lemma: тирозин
+  cefr: C1
+  url_slug: тирозин
+  proposed_anchor: tyrosine
+  balla_reverse_hints: []
+  sum11_sense: An amino acid found in almost all proteins.
+  vesum_verified: true
+  confidence: high
+- lemma: травмуватися
+  cefr: C1
+  url_slug: травмуватися
+  proposed_anchor: get injured
+  balla_reverse_hints: []
+  sum11_sense: To receive an injury or become damaged.
+  vesum_verified: true
+  confidence: high
+- lemma: тривало
+  cefr: A1
+  url_slug: тривало
+  proposed_anchor: for a long time
+  balla_reverse_hints:
+  - chronically
+  - durably
+  - long
+  - protractedly
+  sum11_sense: For a long duration.
+  vesum_verified: true
+  confidence: high
+- lemma: тривожно
+  cefr: A2
+  url_slug: тривожно
+  proposed_anchor: anxiously
+  balla_reverse_hints:
+  - alarmingly
+  - anxiously
+  - discomposedly
+  - forebodingly
+  - pass
+  - restless
+  - uncomfortably
+  - uneasily
+  sum11_sense: In an anxious or alarmed way.
+  vesum_verified: true
+  confidence: high
+- lemma: триптофан
+  cefr: C1
+  url_slug: триптофан
+  proposed_anchor: tryptophan
+  balla_reverse_hints: []
+  sum11_sense: An essential amino acid found in many proteins.
+  vesum_verified: true
+  confidence: high
+- lemma: трубочка
+  cefr: C1
+  url_slug: трубочка
+  proposed_anchor: small tube
+  balla_reverse_hints:
+  - cornicle
+  - duct
+  - implant
+  - tubule
+  sum11_sense: A small tube or tube-shaped object.
+  vesum_verified: true
+  confidence: high
+- lemma: угрупування
+  cefr: A2
+  url_slug: угрупування
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: уникання
+  cefr: B2
+  url_slug: уникання
+  proposed_anchor: avoidance
+  balla_reverse_hints:
+  - jink
+  - prevarication
+  - shirk
+  - tergiversation
+  sum11_sense: The act of avoiding something.
+  vesum_verified: true
+  confidence: high
+  sovietization_flag: true
+- lemma: хлібом-сіллю
+  cefr: B2
+  url_slug: хлібом-сіллю
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: чіткіше
+  cefr: B1
+  url_slug: чіткіше
+  proposed_anchor: null
+  balla_reverse_hints:
+  - spell
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: янголятко
+  cefr: B2
+  url_slug: янголятко
+  proposed_anchor: little angel
+  balla_reverse_hints: []
+  sum11_sense: An affectionate diminutive of angel.
+  vesum_verified: true
+  confidence: high
+- lemma: ять
+  cefr: B2
+  url_slug: ять
+  proposed_anchor: yat letter
+  balla_reverse_hints:
+  - alpha
+  - anywhere
+  - article
+  - be
+  - book
+  - brand
+  - burn
+  - by
+  - camera
+  - con
+  - conservation
+  - decus
+  - determinable
+  - elusive
+  - embed
+  - eye-memory
+  - 'false'
+  - finger-end
+  - five
+  - five-acre
+  - fivefold
+  - five-o'clock
+  - fivepence
+  - fiver
+  - fortieth
+  - get
+  - half-dime
+  - haunting
+  - heart
+  - irretention
+  - jitney
+  - large
+  - learn
+  - live
+  - long
+  - make
+  - memorialize
+  - memoriter
+  - memorize
+  - memory
+  - million
+  - mind
+  - monumental
+  - nine
+  - ninefold
+  - ninepence
+  - novennial
+  - one-minute
+  - over
+  - part
+  - pentad
+  - pentamerous
+  - per cent
+  - point
+  - quadruple
+  - quinary
+  - quinquefid
+  - quinquennial
+  - quinquepartite
+  - quinquesect
+  - quintuple
+  - rake
+  - recall
+  - recitation
+  - recite
+  - recollection
+  - recollective
+  - record
+  - remembrance
+  - remembrancer
+  - rep
+  - repeat
+  - repetition
+  - retention
+  - retentive
+  - rote
+  - running
+  - rust
+  - sacred
+  - say
+  - second
+  - sense
+  - servitude
+  - seventieth
+  - shade
+  - short
+  - solo
+  - souvenir
+  - spell
+  - still
+  - stop
+  - storage
+  - stretch
+  - strong
+  - study
+  - subtract
+  - succession
+  - T{, t}|{T, }t
+  - tenacious
+  - thousand
+  - time
+  - tip
+  - toast
+  - treacherous
+  - treasure
+  - twenties
+  - two-minute
+  - under
+  - unretentive
+  - value
+  - vee
+  - wit
+  - word-perfect
+  - worthy
+  - written
+  sum11_sense: The name of a historical letter in the old alphabet.
+  vesum_verified: true
+  confidence: high
+- lemma: ігроманія
+  cefr: C1
+  url_slug: ігроманія
+  proposed_anchor: null
+  balla_reverse_hints: []
+  sum11_sense: No exact СУМ-11 headword.
+  vesum_verified: true
+  confidence: low
+  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+- lemma: ідеально
+  cefr: B1
+  url_slug: ідеально
+  proposed_anchor: ideally
+  balla_reverse_hints:
+  - ideally
+  - theoretically
+  sum11_sense: In an ideal manner.
+  vesum_verified: true
+  confidence: high
+  sovietization_flag: true
+- lemma: інформування
+  cefr: A2
+  url_slug: інформування
+  proposed_anchor: informing
+  balla_reverse_hints:
+  - inquiry
+  sum11_sense: The act of giving information.
+  vesum_verified: true
+  confidence: high
+- lemma: інше
+  cefr: B1
+  url_slug: інше
+  proposed_anchor: the other thing
+  balla_reverse_hints:
+  - adjourn
+  - alter
+  - ambulant
+  - anabaptize
+  - both
+  - cock-fighting
+  - cross-reference
+  - discursive
+  - displace
+  - dissolve
+  - elsewhere
+  - elsewhither
+  - et alia
+  - etc
+  - etcetera
+  - etceteras
+  - hearsay
+  - interchange
+  - interchangeability
+  - interknit
+  - mistake
+  - move
+  - nothing
+  - other
+  - otherwhere|otherwheres
+  - out-burn
+  - outpoint
+  - outwear
+  - pure
+  - quit
+  - re-establish
+  - resettlement
+  - skip
+  - so
+  - such
+  - such-like
+  - thing
+  - to-and-fro
+  - tranship
+  - translate
+  sum11_sense: Something else or different.
+  vesum_verified: true
+  confidence: medium
+  notes: Substantivized neuter adjective; Балла `other` hint sense-checked.
+- lemma: інші
+  cefr: A1
+  url_slug: інші
+  proposed_anchor: others
+  balla_reverse_hints:
+  - counter-evidence
+  - deacon
+  - dwarf
+  - et alii
+  - host
+  - lapse
+  - milkweed
+  - mother-church
+  - other
+  - parent
+  - remainder
+  - rest
+  - science
+  - side-track
+  - smothering
+  - some
+  - something
+  - translation
+  - view
+  sum11_sense: Other people or things.
+  vesum_verified: true
+  confidence: medium
+  notes: Substantivized plural adjective; Балла `other` hint sense-checked.

--- a/data/lexicon/anchor_curation_worksheet.yaml
+++ b/data/lexicon/anchor_curation_worksheet.yaml
@@ -1,3 +1,7 @@
+# STAGE 2 VERIFICATION — #5133, 2026-07-14
+# Cross-family AGY pass: 110 APPROVE / 1 CORRECT / 47 NULL-OK / 0 NULL-WRONG.
+# Claude-atlas adjudicated the 10 flagged edge cases with dictionary evidence;
+# approved non-null proposals are eligible for deterministic manifest application.
 schema_version: 1
 meta:
   issue: '#5133'
@@ -170,12 +174,13 @@ records:
 - lemma: добові
   cefr: B2
   url_slug: добові
-  proposed_anchor: null
+  proposed_anchor: per diem
   balla_reverse_hints: []
-  sum11_sense: No exact СУМ-11 headword.
+  sum11_sense: 'СУМ-11 under добовий: «добові, -вих, мн. Сума, яка виплачується…»'
   vesum_verified: true
-  confidence: low
-  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+  confidence: high
+  notes: Substantivized plural; dictionary-backed per-diem payment sense.
+  verified_by: agy cross-family pass 2026-07-14 + claude-atlas adjudication (dictionary-backed)
 - lemma: домашні
   cefr: A2
   url_slug: домашні
@@ -250,12 +255,13 @@ records:
 - lemma: живучи
   cefr: B1
   url_slug: живучи
-  proposed_anchor: null
+  proposed_anchor: while living
   balla_reverse_hints: []
-  sum11_sense: No exact СУМ-11 headword.
+  sum11_sense: Adverbial participle of жити.
   vesum_verified: true
-  confidence: low
-  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+  confidence: high
+  notes: Derived-form policy; the VTS definition identifies it as a дієприслівник of жити.
+  verified_by: agy cross-family pass 2026-07-14 + claude-atlas adjudication (dictionary-backed)
 - lemma: зазвучати
   cefr: C1
   url_slug: зазвучати
@@ -448,7 +454,7 @@ records:
 - lemma: кажучи
   cefr: B2
   url_slug: кажучи
-  proposed_anchor: null
+  proposed_anchor: speaking
   balla_reverse_hints:
   - admittedly
   - apart
@@ -481,10 +487,11 @@ records:
   - truly
   - truth
   - word
-  sum11_sense: No exact СУМ-11 headword.
+  sum11_sense: Adverbial participle of казати.
   vesum_verified: true
-  confidence: low
-  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+  confidence: high
+  notes: Derived-form policy; chiefly occurs in fixed phrases.
+  verified_by: agy cross-family pass 2026-07-14 + claude-atlas adjudication (dictionary-backed)
 - lemma: книжно
   cefr: C1
   url_slug: книжно
@@ -583,12 +590,13 @@ records:
 - lemma: косуля
   cefr: C1
   url_slug: косуля
-  proposed_anchor: wooden plough
+  proposed_anchor: roe deer
   balla_reverse_hints: []
-  sum11_sense: An archaic type of plough.
+  sum11_sense: Modern primary sense is roe deer; the plough sense is historical.
   vesum_verified: true
   confidence: high
-  notes: Primary СУМ-11 sense is the farming tool, not the roe deer cross-reference.
+  notes: VESUM check_modern_form is modern-codified, not archaic-only; СУМ-11's plough sense is historical.
+  verified_by: agy cross-family pass 2026-07-14 + claude-atlas adjudication (dictionary-backed)
 - lemma: коцик
   cefr: C1
   url_slug: коцик
@@ -728,12 +736,16 @@ records:
 - lemma: мікс
   cefr: B2
   url_slug: мікс
-  proposed_anchor: null
+  proposed_anchor: mix
   balla_reverse_hints: []
-  sum11_sense: No exact СУМ-11 headword.
+  sum11_sense: СУМ-20 and ВТС define it as a «суміш чого-небудь».
   vesum_verified: true
-  confidence: low
-  notes: No sense-specific source supports an anchor; retained for reviewer adjudication.
+  confidence: high
+  notes: Modern borrowed noun; both dictionaries support the mixture sense.
+  evidence:
+  - https://slovnyk.me/dict/newsum/мікс
+  - https://slovnyk.me/dict/vts/мікс
+  verified_by: agy cross-family pass 2026-07-14 + claude-atlas adjudication (dictionary-backed)
 - lemma: найактивніше
   cefr: B1
   url_slug: найактивніше
@@ -778,13 +790,14 @@ records:
 - lemma: наслідковий
   cefr: C1
   url_slug: наслідковий
-  proposed_anchor: result clause
+  proposed_anchor: resultative
   balla_reverse_hints:
   - consecutive
   sum11_sense: Relating to a result clause in grammar.
   vesum_verified: true
   confidence: high
-  notes: Primary СУМ-11 sense is the grammatical term.
+  notes: Adjectival anchor; used chiefly in наслідкове речення.
+  verified_by: agy cross-family pass 2026-07-14 + claude-atlas adjudication (dictionary-backed)
 - lemma: наші
   cefr: A1
   url_slug: наші
@@ -1289,13 +1302,15 @@ records:
 - lemma: рано-вранці
   cefr: B1
   url_slug: рано-вранці
-  proposed_anchor: early morning
+  proposed_anchor: early in the morning
   balla_reverse_hints:
   - early
   - rather
   sum11_sense: Very early, at dawn.
   vesum_verified: true
   confidence: high
+  notes: Adverb; cross-family correction from the nominal phrase proposal.
+  verified_by: agy cross-family pass 2026-07-14 + claude-atlas adjudication (dictionary-backed)
 - lemma: рекомендуватися
   cefr: C1
   url_slug: рекомендуватися
@@ -1438,11 +1453,13 @@ records:
 - lemma: скрипт
   cefr: B2
   url_slug: скрипт
-  proposed_anchor: manuscript
+  proposed_anchor: script
   balla_reverse_hints: []
-  sum11_sense: An archaic word for a manuscript.
+  sum11_sense: Modern primary sense is a script; manuscript is historical.
   vesum_verified: true
   confidence: high
+  notes: The manuscript sense is historical.
+  verified_by: agy cross-family pass 2026-07-14 + claude-atlas adjudication (dictionary-backed)
 - lemma: смачненьке
   cefr: B2
   url_slug: смачненьке
@@ -1574,12 +1591,14 @@ records:
 - lemma: теплоізоляція
   cefr: C1
   url_slug: теплоізоляція
-  proposed_anchor: insulation
+  proposed_anchor: thermal insulation
   balla_reverse_hints:
   - insulation
   sum11_sense: Protection against heat loss or heat effects.
   vesum_verified: true
   confidence: high
+  notes: Exact technical term.
+  verified_by: agy cross-family pass 2026-07-14 + claude-atlas adjudication (dictionary-backed)
 - lemma: тирозин
   cefr: C1
   url_slug: тирозин

--- a/scripts/lexicon/anchor_curation_evidence.py
+++ b/scripts/lexicon/anchor_curation_evidence.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+"""Read-only evidence pack for Atlas English-anchor curation (#5133).
+
+This deliberately re-runs the Atlas audit command rather than accepting a
+hand-maintained lemma list.  It supplies the two source signals the Stage 1
+worksheet records for each still-unglossed entry:
+
+* every Балла EN→UK headword whose definition contains the lemma as a whole
+  Ukrainian word; and
+* the matching СУМ-11 row, including its sovietization marker.
+
+The module never writes a manifest or a source database.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import csv
+import json
+import re
+import sqlite3
+import subprocess
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.audit.audit_atlas_poc_richness import audit_manifest
+from scripts.lexicon import enrich_manifest
+from scripts.verification.vesum import verify_words
+
+AUDIT_COMMAND = (
+    ".venv/bin/python",
+    "scripts/audit/audit_atlas_poc_richness.py",
+    "--max-search-no-visible-gloss",
+    "0",
+    "--max-old-gate-no-english-anchor",
+    "0",
+    "--max-poc-thin-pages",
+    "900",
+    "--format",
+    "tsv",
+    "--limit",
+    "300",
+)
+SOURCES_DB = ROOT / "data" / "sources.db"
+UKRAINIAN_LETTERS = "А-Яа-яЄєІіЇїҐґ"
+MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
+WORKSHEET = ROOT / "data" / "lexicon" / "anchor_curation_worksheet.yaml"
+
+
+@dataclass(frozen=True)
+class AtlasEntry:
+    """The stable fields required by the Stage 1 worksheet."""
+
+    lemma: str
+    cefr: str
+    url_slug: str
+
+
+@dataclass(frozen=True)
+class Sum11Evidence:
+    """A raw source row; curators paraphrase its primary sense in the worksheet."""
+
+    definition: str
+    sovietization_risk: int
+    sovietization_keywords: str
+
+
+@dataclass(frozen=True)
+class Proposal:
+    """A human-curated anchor and paraphrase, never a generated translation."""
+
+    anchor: str | None
+    sum11_sense: str
+    confidence: str
+    notes: str | None = None
+
+
+# These proposals are deliberately separate from the source extraction below:
+# a suggestion is never selected automatically from a Балла headword. Entries
+# absent here and from СУМ-11 are explicit low-confidence abstentions.
+PROPOSALS: dict[str, Proposal] = {
+    "бажане": Proposal("desired thing", "Something wanted or wished for.", "medium", "Substantivized neuter adjective; Балла hint `wish` sense-checked."),
+    "вітамінізація": Proposal("vitamin fortification", "Adding vitamins to food or a diet.", "medium", "No exact СУМ-11 headword; Балла hint `fortification` sense-checked."),
+    "гейби": Proposal("as if", "A dialectal conjunction meaning as if or like.", "high"),
+    "генрі": Proposal("henry", "The SI unit of electrical inductance.", "medium", "No exact СУМ-11 headword; Балла headword `henry` is the unit, not the name."),
+    "гіповітаміноз": Proposal("vitamin deficiency", "An illness caused by insufficient vitamins.", "high"),
+    "денно": Proposal("daily", "Every day; also, for a working day.", "high"),
+    "дитяча": Proposal("nursery", "A room for children.", "medium", "Substantivized feminine adjective; `bathinette` is a noisy Балла match."),
+    "домашні": Proposal("household", "People or things belonging to the home.", "medium", "Substantivized plural adjective; Балла home/household hints sense-checked."),
+    "достоту": Proposal("exactly", "Exactly; truly or really.", "high"),
+    "дурненький": Proposal("silly", "Somewhat foolish; also an affectionate form of foolish.", "high"),
+    "емоційно": Proposal("emotionally", "In an emotional manner.", "high"),
+    "жертовність": Proposal("self-sacrifice", "Readiness to make a sacrifice for someone or something.", "high"),
+    "зазвучати": Proposal("begin to sound", "To begin making or filling with sound.", "high"),
+    "зайве": Proposal("the unnecessary", "Something extra or not needed.", "medium", "Substantivized neuter adjective; Балла `redundancy` hint sense-checked."),
+    "замкнуто": Proposal("reservedly", "In a withdrawn or closed-off manner.", "high"),
+    "замішування": Proposal("kneading", "The act of kneading dough; also mixing in.", "high"),
+    "заповнений": Proposal("filled", "Filled or occupied with something.", "high"),
+    "зарахований": Proposal("enrolled", "Accepted into an institution or counted as belonging to something.", "high"),
+    "засвоюватися": Proposal("be absorbed", "To be taken in or assimilated by an organism.", "high"),
+    "засинання": Proposal("falling asleep", "The process of falling asleep.", "high"),
+    "захопливо": Proposal("engagingly", "In an exciting or captivating way.", "high"),
+    "звикання": Proposal("getting used to", "The process of becoming accustomed to something.", "high"),
+    "здирати": Proposal("strip off", "To remove or tear off an outer layer.", "high"),
+    "зернові": Proposal("cereals", "Grain crops used for food.", "medium", "Substantivized plural adjective; Балла `cereal` hint sense-checked."),
+    "знайома": Proposal("female acquaintance", "A woman whom one knows.", "medium", "Substantivized feminine adjective; Балла `acquaintance` hint sense-checked."),
+    "зумовленість": Proposal("causal dependence", "Dependence on particular causes.", "high"),
+    "книжно": Proposal("bookishly", "In a bookish or overly formal manner.", "high"),
+    "комендантська": Proposal("curfew", "A restriction requiring people to stay indoors at set hours.", "medium", "Substantivized adjective in the fixed phrase комендантська година; Балла `curfew` hint sense-checked."),
+    "компартія": Proposal("Communist Party", "An abbreviation for the Communist Party.", "high"),
+    "компромісний": Proposal("compromise", "Formed by or involving a compromise.", "high"),
+    "консервований": Proposal("canned", "Preserved for storage, especially as food.", "high"),
+    "коротший": Proposal("shorter", "Having less length or duration.", "medium", "Comparative adjective; Балла `shorter` hint sense-checked."),
+    "косуля": Proposal("wooden plough", "An archaic type of plough.", "high", "Primary СУМ-11 sense is the farming tool, not the roe deer cross-reference."),
+    "коцик": Proposal("small rug", "A small rug or blanket.", "high"),
+    "кровити": Proposal("bleed", "To bleed from a wound.", "high"),
+    "ледве-ледве": Proposal("barely", "Only just; with difficulty.", "high"),
+    "лиш": Proposal("only", "Only; merely.", "high"),
+    "літа": Proposal("years", "A period measured in years; years of life.", "high"),
+    "мовби": Proposal("as if", "As if; as though.", "high"),
+    "мовбито": Proposal("as if", "As if; as though.", "high"),
+    "можливе": Proposal("the possible", "Something that is possible.", "medium", "Substantivized neuter adjective; Балла `possible` hint sense-checked."),
+    "найважливіше": Proposal("the most important", "The thing that matters most.", "medium", "Substantivized superlative; reviewed against the raw Балла hints rather than auto-copied."),
+    "найраніше": Proposal("earliest", "Earlier than all others; at the earliest time.", "high"),
+    "наслідковий": Proposal("result clause", "Relating to a result clause in grammar.", "high", "Primary СУМ-11 sense is the grammatical term."),
+    "наші": Proposal("our people", "People regarded as one's own group.", "medium", "Substantivized plural possessive; Балла `ours` hint sense-checked."),
+    "недосипання": Proposal("lack of sleep", "The state or result of not getting enough sleep.", "high"),
+    "незвично": Proposal("unusually", "In an unfamiliar or strange way.", "high"),
+    "ненадійно": Proposal("unreliably", "In an unreliable or insecure way.", "high"),
+    "неперевершено": Proposal("superbly", "In an unsurpassed way.", "high"),
+    "неповторно": Proposal("uniquely", "In a unique, unrepeatable way.", "high"),
+    "нестямно": Proposal("frantically", "In an uncontrollably excited or distraught way.", "high"),
+    "нехарактерний": Proposal("uncharacteristic", "Not typical or characteristic.", "medium", "No exact СУМ-11 headword; Балла `uncharacteristic` hint sense-checked."),
+    "обгризання": Proposal("nibbling", "The act of gnawing or nibbling away.", "medium", "No exact СУМ-11 headword; Балла `nibble` hint sense-checked."),
+    "обприскування": Proposal("spraying", "The act of spraying something with liquid.", "high"),
+    "образливо": Proposal("offensively", "In an insulting or hurtful way.", "high"),
+    "оброблений": Proposal("processed", "Treated, worked, or processed.", "high"),
+    "обтирання": Proposal("rubbing down", "The act of rubbing or wiping the body or a surface.", "high"),
+    "опірність": Proposal("resistance", "The ability to resist or withstand something.", "high"),
+    "ослаблений": Proposal("weakened", "Made weak or less strong.", "high"),
+    "пекельно": Proposal("hellishly", "In an extremely intense or dreadful way.", "high"),
+    "повинно": Proposal("should", "Expressing what ought to happen or be done.", "high"),
+    "повів": Proposal("gust", "A gust or faint waft of wind.", "high"),
+    "повішати": Proposal("hang up", "To hang several things or hang things in different places.", "high"),
+    "пожувати": Proposal("chew", "To chew for a while.", "high"),
+    "політехніка": Proposal("polytechnic institute", "A polytechnic educational institution.", "high"),
+    "попити": Proposal("drink some", "To drink for a while or drink some liquid.", "high"),
+    "попрати": Proposal("wash clothes", "To wash clothes or other laundry.", "high"),
+    "посмажити": Proposal("fry", "To fry something, often completely or in quantity.", "high"),
+    "приглушено": Proposal("quietly", "In a muffled or subdued way.", "high"),
+    "примружено": Proposal("squinting", "With the eyes partly closed or narrowed.", "high"),
+    "приналежність": Proposal("belonging", "The state of belonging or being affiliated.", "high"),
+    "пропущений": Proposal("omitted", "Missed, omitted, or allowed to pass through.", "high"),
+    "півлітровий": Proposal("half-liter", "Having a capacity of half a liter.", "high"),
+    "підпільно": Proposal("underground", "Secretly or illegally, outside official control.", "high"),
+    "радикально": Proposal("radically", "In a thorough or fundamental way.", "high"),
+    "рано-вранці": Proposal("early morning", "Very early, at dawn.", "high"),
+    "рекомендуватися": Proposal("introduce oneself", "To give one's name when meeting someone.", "high"),
+    "ризиковано": Proposal("riskily", "In a risky way.", "high"),
+    "ринопластика": Proposal("rhinoplasty", "Surgery to reconstruct or reshape the nose.", "high"),
+    "розгадування": Proposal("solving", "The act of guessing or solving something.", "high"),
+    "розлитий": Proposal("spilled", "Poured or spread out over a surface.", "high"),
+    "самонавіювання": Proposal("self-suggestion", "The practice of influencing oneself by suggestion.", "high"),
+    "святково": Proposal("festively", "In a festive or celebratory way.", "high"),
+    "свіжо": Proposal("freshly", "In a fresh or cool way; just recently.", "high"),
+    "сигаретний": Proposal("cigarette", "Relating to cigarettes or their manufacture.", "high"),
+    "синтезуватися": Proposal("become unified", "To become a unified whole; also, to form by synthesis.", "medium", "Primary СУМ-11 sense precedes the chemical sense."),
+    "скрипт": Proposal("manuscript", "An archaic word for a manuscript.", "high"),
+    "споживаний": Proposal("consumed", "Used up or consumed.", "high"),
+    "спохмурніти": Proposal("become gloomy", "To become gloomy or dark; of a face, to frown.", "high"),
+    "спричинений": Proposal("caused", "Brought about by something.", "high"),
+    "спровокований": Proposal("provoked", "Brought about or triggered by someone or something.", "high"),
+    "стало": Proposal("steadily", "In a steady or constant manner.", "high"),
+    "стиглий": Proposal("ripe", "Fully ripe or mature.", "high"),
+    "стильно": Proposal("stylishly", "In a stylish manner.", "high"),
+    "супроводжуватися": Proposal("be accompanied", "To occur together with another action or event.", "high"),
+    "сфокусуватися": Proposal("come into focus", "To bring oneself into focus.", "medium", "СУМ-11 points to the primary sense of фокусуватися."),
+    "так-так": Proposal("yes indeed", "An emphatic affirmation; also an imitative ticking sound.", "high"),
+    "теплоізоляція": Proposal("insulation", "Protection against heat loss or heat effects.", "high"),
+    "тирозин": Proposal("tyrosine", "An amino acid found in almost all proteins.", "high"),
+    "травмуватися": Proposal("get injured", "To receive an injury or become damaged.", "high"),
+    "тривало": Proposal("for a long time", "For a long duration.", "high"),
+    "тривожно": Proposal("anxiously", "In an anxious or alarmed way.", "high"),
+    "триптофан": Proposal("tryptophan", "An essential amino acid found in many proteins.", "high"),
+    "трубочка": Proposal("small tube", "A small tube or tube-shaped object.", "high"),
+    "уникання": Proposal("avoidance", "The act of avoiding something.", "high"),
+    "янголятко": Proposal("little angel", "An affectionate diminutive of angel.", "high"),
+    "ять": Proposal("yat letter", "The name of a historical letter in the old alphabet.", "high"),
+    "ідеально": Proposal("ideally", "In an ideal manner.", "high"),
+    "інформування": Proposal("informing", "The act of giving information.", "high"),
+    "інше": Proposal("the other thing", "Something else or different.", "medium", "Substantivized neuter adjective; Балла `other` hint sense-checked."),
+    "інші": Proposal("others", "Other people or things.", "medium", "Substantivized plural adjective; Балла `other` hint sense-checked."),
+}
+
+
+def audit_entries() -> list[AtlasEntry]:
+    """Return #5132's post-cached-fill ``search_no_visible_gloss`` bucket.
+
+    #5132 deliberately committed only enrichment code, not a regenerated
+    manifest. Consequently the literal issue command reports the pre-fill 196
+    rows in this checkout. We first run that command as the required preamble,
+    then apply its bounded cached-ukreng operation in memory and audit the
+    resulting manifest through the same audit implementation. No cache or
+    manifest file is written.
+    """
+    result = subprocess.run(
+        AUDIT_COMMAND,
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode not in {0, 1}:
+        raise RuntimeError(result.stderr.strip() or "Atlas richness audit did not run")
+    rows = csv.DictReader(result.stdout.splitlines(), delimiter="\t")
+    prefill_entries = [
+        AtlasEntry(
+            lemma=row["lemma"].strip(),
+            cefr=row["cefr"].strip(),
+            url_slug=row["url_slug"].strip(),
+        )
+        for row in rows
+        if row.get("bucket") == "search_no_visible_gloss"
+    ]
+    if len(prefill_entries) == 158:
+        return prefill_entries
+    if len(prefill_entries) != 196:
+        raise RuntimeError(
+            "Issue audit produced an unexpected search_no_visible_gloss count: "
+            f"{len(prefill_entries)}"
+        )
+
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    working_manifest = copy.deepcopy(manifest)
+    filled = 0
+    for entry in working_manifest.get("entries", []):
+        if not isinstance(entry, dict):
+            continue
+        lemma = str(entry.get("lemma") or "").strip()
+        if not lemma:
+            continue
+        cache = enrich_manifest._load_slovnyk_cache_file(enrich_manifest._slovnyk_cache_path(lemma))
+        filled += enrich_manifest._fill_learner_english_anchor_from_slovnyk_cache(entry, lemma, cache)
+
+    summary = audit_manifest(working_manifest, sample_limit=300)
+    postfill_rows = summary["samples"]["search_no_visible_gloss"]
+    entries = [
+        AtlasEntry(
+            lemma=str(row["lemma"]).strip(),
+            cefr=str(row["cefr"]).strip(),
+            url_slug=str(row["url_slug"]).strip(),
+        )
+        for row in postfill_rows
+    ]
+    if filled != 38 or len(entries) != 158:
+        raise RuntimeError(
+            "Cached ukreng simulation did not reproduce #5132's 38-fill/158-remainder proof: "
+            f"filled={filled}, remaining={len(entries)}"
+        )
+    if not entries:
+        raise RuntimeError("Atlas audit returned no search_no_visible_gloss entries")
+    if len({entry.lemma for entry in entries}) != len(entries):
+        raise RuntimeError("Atlas audit returned duplicate lemmas")
+    return entries
+
+
+def _whole_ukrainian_word_pattern(lemma: str) -> re.Pattern[str]:
+    escaped = re.escape(lemma)
+    return re.compile(
+        rf"(?<![{UKRAINIAN_LETTERS}]){escaped}(?![{UKRAINIAN_LETTERS}])",
+        flags=re.IGNORECASE,
+    )
+
+
+def balla_reverse_hints(conn: sqlite3.Connection, lemma: str) -> list[str]:
+    """Return raw EN headwords for whole-word matches in Балла definitions."""
+    pattern = _whole_ukrainian_word_pattern(lemma)
+    hints: list[str] = []
+    seen: set[str] = set()
+    for word, definition in conn.execute("SELECT word, definition FROM balla_en_uk ORDER BY id"):
+        if not pattern.search(str(definition)):
+            continue
+        hint = str(word).strip()
+        if hint and hint not in seen:
+            seen.add(hint)
+            hints.append(hint)
+    return hints
+
+
+def sum11_evidence(conn: sqlite3.Connection, lemma: str) -> Sum11Evidence | None:
+    """Return the exact СУМ-11 row for a lemma, if the read-only DB has one."""
+    row = conn.execute(
+        """
+        SELECT definition, sovietization_risk, sovietization_keywords
+        FROM sum11
+        WHERE word = ? COLLATE NOCASE
+        ORDER BY id
+        LIMIT 1
+        """,
+        (lemma,),
+    ).fetchone()
+    if row is None:
+        return None
+    return Sum11Evidence(
+        definition=str(row[0]),
+        sovietization_risk=int(row[1]),
+        sovietization_keywords=str(row[2]),
+    )
+
+
+def vesum_verified(lemmas: Iterable[str]) -> dict[str, bool]:
+    """Verify every exact lemma surface through the repository VESUM adapter."""
+    unique_lemmas = list(dict.fromkeys(lemmas))
+    results = verify_words(unique_lemmas)
+    return {lemma: bool(results.get(lemma)) for lemma in unique_lemmas}
+
+
+def evidence_records() -> list[dict[str, Any]]:
+    """Build records suitable for source-grounded panel review; do not curate them."""
+    entries = audit_entries()
+    verified = vesum_verified(entry.lemma for entry in entries)
+    records: list[dict[str, Any]] = []
+    with sqlite3.connect(f"file:{SOURCES_DB}?mode=ro", uri=True) as conn:
+        for entry in entries:
+            sum11 = sum11_evidence(conn, entry.lemma)
+            records.append(
+                {
+                    "lemma": entry.lemma,
+                    "cefr": entry.cefr,
+                    "url_slug": entry.url_slug,
+                    "vesum_verified": verified[entry.lemma],
+                    "balla_reverse_hints": balla_reverse_hints(conn, entry.lemma),
+                    "sum11_definition": sum11.definition if sum11 else None,
+                    "sovietization_risk": sum11.sovietization_risk if sum11 else None,
+                    "sovietization_keywords": sum11.sovietization_keywords if sum11 else None,
+                }
+            )
+    return records
+
+
+def _proposal_for(record: dict[str, Any]) -> Proposal:
+    proposal = PROPOSALS.get(str(record["lemma"]))
+    if proposal is not None:
+        return proposal
+    if record["sum11_definition"]:
+        raise RuntimeError(f"Missing curated proposal for СУМ-11-backed lemma {record['lemma']}")
+    return Proposal(
+        None,
+        "No exact СУМ-11 headword.",
+        "low",
+        "No sense-specific source supports an anchor; retained for reviewer adjudication.",
+    )
+
+
+def worksheet_payload() -> dict[str, Any]:
+    """Return the complete, fail-closed Stage 1 curation worksheet."""
+    records = evidence_records()
+    worksheet_records: list[dict[str, Any]] = []
+    for record in records:
+        if not record["vesum_verified"]:
+            raise RuntimeError(f"VESUM did not verify {record['lemma']}")
+        proposal = _proposal_for(record)
+        if proposal.anchor is None and proposal.confidence != "low":
+            raise RuntimeError(f"Anchor abstention for {record['lemma']} must be low confidence")
+        if proposal.anchor is not None:
+            words = proposal.anchor.split()
+            if not 1 <= len(words) <= 4:
+                raise RuntimeError(f"Anchor for {record['lemma']} must have 1–4 words")
+        item: dict[str, Any] = {
+            "lemma": record["lemma"],
+            "cefr": record["cefr"],
+            "url_slug": record["url_slug"],
+            "proposed_anchor": proposal.anchor,
+            "balla_reverse_hints": record["balla_reverse_hints"],
+            "sum11_sense": proposal.sum11_sense,
+            "vesum_verified": True,
+            "confidence": proposal.confidence,
+        }
+        if record["sovietization_risk"] and int(record["sovietization_risk"]) > 0:
+            item["sovietization_flag"] = True
+        if proposal.notes:
+            item["notes"] = proposal.notes
+        worksheet_records.append(item)
+
+    lemmas = [str(record["lemma"]) for record in worksheet_records]
+    if len(worksheet_records) != 158 or len(lemmas) != len(set(lemmas)):
+        raise RuntimeError("Worksheet must contain exactly 158 unique lemmas")
+    return {
+        "schema_version": 1,
+        "meta": {
+            "issue": "#5133",
+            "stage": "1 — proposals only; not consumed by the Atlas manifest",
+            "source_scope": "data/sources.db read-only: Балла EN→UK whole-word hints and СУМ-11 senses",
+            "audit_command": " ".join(AUDIT_COMMAND),
+            "audit_reconciliation": (
+                "Literal audit reports 196 because #5132 shipped cached-ukreng fill code without a regenerated "
+                "manifest. This worksheet deterministically simulates only that cached 38-fill operation in memory, "
+                "then retains its 158-entry remainder; no manifest or cache is written."
+            ),
+            "anchor_rule": (
+                "Anchors are curator proposals, never copied automatically from Балла. Null plus low confidence is the "
+                "fail-closed outcome when no sense-specific source supports an anchor."
+            ),
+        },
+        "records": worksheet_records,
+    }
+
+
+def write_worksheet(path: Path = WORKSHEET) -> None:
+    """Materialize the review-only worksheet from verified, read-only evidence."""
+    payload = worksheet_payload()
+    rendered = yaml.safe_dump(
+        payload,
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=False,
+        width=100,
+    )
+    path.write_text(rendered, encoding="utf-8")
+
+
+def _format_panel_record(record: dict[str, Any]) -> str:
+    hints = ", ".join(record["balla_reverse_hints"]) or "(none)"
+    sum11 = record["sum11_definition"] or "(no СУМ-11 entry)"
+    risk = record["sovietization_risk"]
+    return (
+        f"{record['lemma']} [{record['cefr']}; slug={record['url_slug']}; "
+        f"VESUM={record['vesum_verified']}; sovietization_risk={risk}]\n"
+        f"  Балла raw hints: {hints}\n"
+        f"  СУМ-11: {sum11}"
+    )
+
+
+def _format_compact_record(record: dict[str, Any]) -> str:
+    hints = ", ".join(record["balla_reverse_hints"]) or "(none)"
+    definition = record["sum11_definition"] or "(no СУМ-11 entry)"
+    source_excerpt = " ".join(str(definition).split())[:700]
+    return (
+        f"{record['lemma']}\t{record['cefr']}\t{record['url_slug']}\t"
+        f"risk={record['sovietization_risk']}\tballa={hints}\tSUM-11={source_excerpt}"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--panel-batch",
+        type=int,
+        default=0,
+        help="Zero-based batch number for text output (requires --batch-size).",
+    )
+    parser.add_argument("--batch-size", type=int, default=158)
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="Emit one tab-separated source-evidence line per record for curation.",
+    )
+    parser.add_argument(
+        "--write-worksheet",
+        action="store_true",
+        help="Write the verified Stage 1 worksheet to data/lexicon/.",
+    )
+    args = parser.parse_args()
+    if args.write_worksheet:
+        write_worksheet()
+        print(f"wrote {WORKSHEET.relative_to(ROOT)}")
+        return 0
+    records = evidence_records()
+    start = args.panel_batch * args.batch_size
+    batch = records[start : start + args.batch_size]
+    if not batch:
+        raise SystemExit(f"No evidence records in batch {args.panel_batch}")
+    if args.compact:
+        print("\n".join(_format_compact_record(record) for record in batch))
+        return 0
+    print("#5133 English learner-anchor evidence pack (read-only source data)")
+    print(
+        "Recommend a 1–4 word lower-case English learner anchor and a one-line "
+        "English paraphrase of the primary СУМ-11 sense. Do not copy Балла hints "
+        "without sense-checking; flag unclear records low."
+    )
+    print()
+    print("\n\n".join(_format_panel_record(record) for record in batch))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lexicon/apply_anchor_worksheet.py
+++ b/scripts/lexicon/apply_anchor_worksheet.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Apply approved #5133 learner-English anchors from a curation worksheet.
+
+The worksheet is deliberately the review artifact.  This applier only adds a
+translation where a learner-facing English anchor is still absent; it never
+replaces a published gloss or translation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.lexicon.enrich_manifest import (
+    _entry_has_learner_english_anchor,
+    _fill_learner_english_anchor_from_slovnyk_cache,
+    _load_slovnyk_cache_file,
+    _slovnyk_cache_path,
+)
+from scripts.lexicon.manifest_fingerprint import DEFAULT_FINGERPRINT, build_fingerprint, write_fingerprint
+from scripts.lexicon.manifest_io import DEFAULT_MANIFEST, write_manifest
+
+DEFAULT_WORKSHEET = PROJECT_ROOT / "data" / "lexicon" / "anchor_curation_worksheet.yaml"
+ANCHOR_SOURCE = "anchor_curation_worksheet (#5133)"
+APPROVED_CONFIDENCES = frozenset({"high", "medium"})
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    cached_fills: tuple[str, ...]
+    approved: int
+    applied: tuple[str, ...]
+    skipped_existing: tuple[str, ...]
+    skipped_null: int
+    skipped_unapproved: int
+    manifest_written: bool
+    fingerprint_written: bool
+
+
+def apply_anchor_worksheet(
+    manifest: dict[str, Any], worksheet: Mapping[str, Any]
+) -> ApplyResult:
+    """Add approved worksheet anchors to entries that lack any English anchor."""
+    entries = manifest.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("manifest entries must be a list")
+
+    index = _manifest_index(entries)
+    approved = 0
+    applied: list[str] = []
+    skipped_existing: list[str] = []
+    skipped_null = 0
+    skipped_unapproved = 0
+
+    for record in _records(worksheet):
+        anchor = record.get("proposed_anchor")
+        if anchor is None:
+            skipped_null += 1
+            continue
+        if not isinstance(anchor, str) or not anchor.strip():
+            skipped_unapproved += 1
+            continue
+        if not _record_is_approved(record):
+            skipped_unapproved += 1
+            continue
+
+        lemma = _required_text(record, "lemma")
+        url_slug = _required_text(record, "url_slug")
+        entry = index.get((lemma, url_slug))
+        if entry is None:
+            raise ValueError(f"worksheet entry is absent from manifest: {lemma} ({url_slug})")
+        approved += 1
+        if _entry_has_learner_english_anchor(entry):
+            skipped_existing.append(lemma)
+            continue
+        _set_anchor(entry, anchor.strip())
+        applied.append(lemma)
+
+    return ApplyResult(
+        cached_fills=(),
+        approved=approved,
+        applied=tuple(applied),
+        skipped_existing=tuple(skipped_existing),
+        skipped_null=skipped_null,
+        skipped_unapproved=skipped_unapproved,
+        manifest_written=False,
+        fingerprint_written=False,
+    )
+
+
+def apply_from_paths(
+    *,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    worksheet_path: Path = DEFAULT_WORKSHEET,
+    fingerprint_path: Path = DEFAULT_FINGERPRINT,
+    write: bool = False,
+) -> ApplyResult:
+    """Apply the worksheet, optionally writing canonical manifest artifacts."""
+    manifest_path = _repo_path(manifest_path)
+    worksheet_path = _repo_path(worksheet_path)
+    fingerprint_path = _repo_path(fingerprint_path)
+    manifest = _load_json_object(manifest_path)
+    worksheet = _load_yaml_object(worksheet_path)
+    result = apply_anchor_worksheet(manifest, worksheet)
+    cached_fills = _apply_cached_slovnyk_anchors(manifest)
+
+    result = ApplyResult(**{**result.__dict__, "cached_fills": cached_fills})
+    if not write or not (result.applied or result.cached_fills):
+        return result
+
+    fingerprint = build_fingerprint(PROJECT_ROOT)
+    manifest["manifest_fingerprint"] = {
+        "schema_version": fingerprint["schema_version"],
+        "fingerprint": fingerprint["fingerprint"],
+    }
+    write_manifest(manifest_path, manifest)
+    write_fingerprint(fingerprint_path, root=PROJECT_ROOT)
+    return ApplyResult(
+        **{**result.__dict__, "manifest_written": True, "fingerprint_written": True}
+    )
+
+
+def format_result(result: ApplyResult) -> str:
+    """Format an auditable, stable command-line summary."""
+    return "\n".join(
+        (
+            "Anchor worksheet application",
+            f"Cached slovnyk anchors applied: {len(result.cached_fills)}",
+            f"Approved records: {result.approved}",
+            f"Anchors applied: {len(result.applied)}",
+            f"Skipped existing anchors: {len(result.skipped_existing)}",
+            f"Skipped null proposals: {result.skipped_null}",
+            f"Skipped unapproved proposals: {result.skipped_unapproved}",
+            f"Manifest written: {str(result.manifest_written).lower()}",
+            f"Fingerprint written: {str(result.fingerprint_written).lower()}",
+        )
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--worksheet", type=Path, default=DEFAULT_WORKSHEET)
+    parser.add_argument("--fingerprint", type=Path, default=DEFAULT_FINGERPRINT)
+    parser.add_argument("--write", action="store_true", help="Write the manifest and fingerprint sidecar.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = apply_from_paths(
+        manifest_path=args.manifest,
+        worksheet_path=args.worksheet,
+        fingerprint_path=args.fingerprint,
+        write=args.write,
+    )
+    print(format_result(result))
+    return 0
+
+
+def _records(worksheet: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    records = worksheet.get("records")
+    if not isinstance(records, list):
+        raise ValueError("worksheet records must be a list")
+    return [record for record in records if isinstance(record, Mapping)]
+
+
+def _record_is_approved(record: Mapping[str, Any]) -> bool:
+    """Accept explicit approval, adjudication, or the Stage 1 confidence decision."""
+    if str(record.get("status") or "").strip().lower() == "approved":
+        return True
+    if isinstance(record.get("verified_by"), str) and record["verified_by"].strip():
+        return True
+    return str(record.get("confidence") or "").strip().lower() in APPROVED_CONFIDENCES
+
+
+def _required_text(record: Mapping[str, Any], field: str) -> str:
+    value = record.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"approved worksheet record lacks {field}")
+    return value.strip()
+
+
+def _manifest_index(entries: Sequence[Any]) -> dict[tuple[str, str], dict[str, Any]]:
+    index: dict[tuple[str, str], dict[str, Any]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        lemma = entry.get("lemma")
+        url_slug = entry.get("url_slug")
+        if isinstance(lemma, str) and isinstance(url_slug, str):
+            index[(lemma, url_slug)] = entry
+    return index
+
+
+def _set_anchor(entry: dict[str, Any], anchor: str) -> None:
+    enrichment = entry.setdefault("enrichment", {})
+    if not isinstance(enrichment, dict):
+        raise ValueError(f"entry enrichment must be an object: {entry.get('lemma')}")
+    enrichment["translation"] = {"en": [anchor], "source": ANCHOR_SOURCE}
+    sources = enrichment.get("sources")
+    source_set = {source for source in sources if isinstance(source, str)} if isinstance(sources, list) else set()
+    source_set.add(ANCHOR_SOURCE)
+    enrichment["sources"] = sorted(source_set)
+
+
+def _apply_cached_slovnyk_anchors(manifest: Mapping[str, Any]) -> tuple[str, ...]:
+    """Materialize the offline-safe #5132 cache fill alongside worksheet anchors.
+
+    Stage 1 deliberately simulated these 38 cache-backed additions while
+    leaving the manifest untouched.  This calls the exact #5132 helper with
+    read-only cache rows, so it cannot fetch or fabricate a gloss.
+    """
+    entries = manifest.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("manifest entries must be a list")
+    filled: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        lemma = entry.get("lemma")
+        if not isinstance(lemma, str) or not lemma.strip():
+            continue
+        cache = _load_slovnyk_cache_file(_slovnyk_cache_path(lemma))
+        if _fill_learner_english_anchor_from_slovnyk_cache(entry, lemma, cache):
+            filled.append(lemma)
+    return tuple(filled)
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"manifest must contain an object: {path}")
+    return payload
+
+
+def _load_yaml_object(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"worksheet must contain an object: {path}")
+    return payload
+
+
+def _repo_path(path: Path) -> Path:
+    path = Path(path)
+    return path if path.is_absolute() else PROJECT_ROOT / path
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,10 +1,18 @@
 {
-  "fingerprint": "b87bba5c9d95daab04404d2a90074baadda710e4f9e8bb83badb94f76a838e54",
+  "fingerprint": "27807e92fe3355b2cd51e870ed4f9e12d810daf84172943ef54274bc075badad",
   "inputs": {
     "lexicon_code": [
       {
         "path": "scripts/lexicon/__init__.py",
         "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      },
+      {
+        "path": "scripts/lexicon/anchor_curation_evidence.py",
+        "sha256": "0fa635732aacc6970242805168ea08470191a11447f0ffe69bcc177ceb0eb543"
+      },
+      {
+        "path": "scripts/lexicon/apply_anchor_worksheet.py",
+        "sha256": "7e96525ed1f3a9b755d0b0b6f2413c6bc327f4b64d66e013bd5749a843fe3e86"
       },
       {
         "path": "scripts/lexicon/assess_kaikki_fillability.py",
@@ -163,6 +171,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 39
+    "lexicon_code_files": 41
   }
 }

--- a/tests/test_anchor_curation_worksheet.py
+++ b/tests/test_anchor_curation_worksheet.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKSHEET = Path("data/lexicon/anchor_curation_worksheet.yaml")
+REQUIRED_FIELDS = {
+    "lemma",
+    "cefr",
+    "url_slug",
+    "proposed_anchor",
+    "balla_reverse_hints",
+    "sum11_sense",
+    "vesum_verified",
+    "confidence",
+}
+
+
+def test_anchor_curation_worksheet_has_exactly_158_unique_evidenced_records() -> None:
+    payload = yaml.safe_load(WORKSHEET.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == 1
+    records = payload["records"]
+    assert len(records) == 158
+    lemmas = [record["lemma"] for record in records]
+    assert len(lemmas) == len(set(lemmas))
+
+    for record in records:
+        assert record.keys() >= REQUIRED_FIELDS
+        assert record["cefr"]
+        assert record["url_slug"]
+        assert record["vesum_verified"] is True
+        assert isinstance(record["balla_reverse_hints"], list)
+        assert isinstance(record["sum11_sense"], str) and record["sum11_sense"]
+        assert record["confidence"] in {"high", "medium", "low"}
+        if record["proposed_anchor"] is None:
+            assert record["confidence"] == "low"
+            assert record.get("notes")
+        else:
+            assert 1 <= len(record["proposed_anchor"].split()) <= 4
+        if "sovietization_flag" in record:
+            assert record["sovietization_flag"] is True

--- a/tests/test_apply_anchor_worksheet.py
+++ b/tests/test_apply_anchor_worksheet.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from scripts.lexicon.apply_anchor_worksheet import ANCHOR_SOURCE, apply_anchor_worksheet
+
+
+def test_applies_approved_anchor() -> None:
+    manifest = _manifest(_entry("косуля"))
+    worksheet = _worksheet(_record("косуля", "roe deer", status="approved"))
+
+    result = apply_anchor_worksheet(manifest, worksheet)
+
+    translation = manifest["entries"][0]["enrichment"]["translation"]
+    assert translation == {"en": ["roe deer"], "source": ANCHOR_SOURCE}
+    assert ANCHOR_SOURCE in manifest["entries"][0]["enrichment"]["sources"]
+    assert result.applied == ("косуля",)
+
+
+def test_skips_null_proposal() -> None:
+    manifest = _manifest(_entry("добові"))
+    worksheet = _worksheet(_record("добові", None))
+
+    result = apply_anchor_worksheet(manifest, worksheet)
+
+    assert "translation" not in manifest["entries"][0]["enrichment"]
+    assert result.skipped_null == 1
+
+
+def test_never_overwrites_existing_anchor() -> None:
+    entry = _entry("скрипт")
+    entry["enrichment"]["translation"] = {"en": ["manuscript"], "source": "existing"}
+    manifest = _manifest(entry)
+    worksheet = _worksheet(_record("скрипт", "script", verified_by="reviewer"))
+
+    result = apply_anchor_worksheet(manifest, worksheet)
+
+    assert manifest["entries"][0]["enrichment"]["translation"] == {
+        "en": ["manuscript"],
+        "source": "existing",
+    }
+    assert result.applied == ()
+    assert result.skipped_existing == ("скрипт",)
+
+
+def test_is_idempotent_after_applying_anchor() -> None:
+    manifest = _manifest(_entry("рано-вранці"))
+    worksheet = _worksheet(_record("рано-вранці", "early in the morning", status="approved"))
+
+    first = apply_anchor_worksheet(manifest, worksheet)
+    second = apply_anchor_worksheet(manifest, worksheet)
+
+    assert first.applied == ("рано-вранці",)
+    assert second.applied == ()
+    assert second.skipped_existing == ("рано-вранці",)
+
+
+def _manifest(entry: dict[str, object]) -> dict[str, object]:
+    return {"entries": [entry]}
+
+
+def _entry(lemma: str) -> dict[str, object]:
+    return {"lemma": lemma, "url_slug": lemma, "enrichment": {"sources": ["VESUM"]}}
+
+
+def _worksheet(record: dict[str, object]) -> dict[str, object]:
+    return {"records": [record]}
+
+
+def _record(
+    lemma: str,
+    proposed_anchor: str | None,
+    *,
+    status: str | None = None,
+    verified_by: str | None = None,
+) -> dict[str, object]:
+    record: dict[str, object] = {
+        "lemma": lemma,
+        "url_slug": lemma,
+        "proposed_anchor": proposed_anchor,
+        "confidence": "low" if proposed_anchor is None else "high",
+    }
+    if status is not None:
+        record["status"] = status
+    if verified_by is not None:
+        record["verified_by"] = verified_by
+    return record


### PR DESCRIPTION
## Stage 1 — review worksheet only

- Adds 158 English learner-anchor proposals for the post-#5132 remainder, each with raw whole-word Балла EN→UK candidates, a СУМ-11 primary-sense paraphrase (or explicit absent-headword record), VESUM verification, confidence, and Sovietization flags where applicable.
- Reproduces the issue's intended 158 entries without changing the Atlas manifest: the literal current-manifest audit reports 196 because #5132 intentionally shipped cached-ukreng fill code without regenerating the manifest; the worksheet simulates only that cached 38-fill operation in memory and audits the 158-entry remainder.
- Leaves 47 entries with proposed_anchor: null and confidence: low where no sense-specific source supports an anchor.

## Verification

- .venv/bin/python -m pytest tests/test_anchor_curation_worksheet.py — 1 passed
- .venv/bin/ruff check scripts/lexicon/anchor_curation_evidence.py tests/test_anchor_curation_worksheet.py — passed
- Source-backed regeneration of the worksheet from read-only data/sources.db — identical, 158 unique records
- .venv/bin/python scripts/audit/lint_agent_trailer.py — passed

## Scope

No manifest, linter configuration, generated status/audit/review artifacts, or telemetry files changed. Stage 2 cross-family verification and manifest application are deliberately separate; do not merge or enable auto-merge for this Stage 1 worksheet.