### PR TITLE
feat(orchestration): add task family lifecycle manager

### DIFF
--- a/agents_extensions/shared/skills/task-family-manager/SKILL.md
+++ b/agents_extensions/shared/skills/task-family-manager/SKILL.md
@@ -1,56 +1,129 @@
 ---
-name: task-family-manager
-description: Inspect, rename, archive, finish, and clean up task families using exact inclusion and strict UI semantics.
+name: "task-family-manager"
+description: "Inspect, rename, archive, finish, and clean up task families using exact inclusion and strict UI semantics."
 ---
 
 # Task Family Manager
 
 Use this skill to inspect, rename, archive, finish, and clean up task families. Never infer family from titles. Compose operations via the deterministic Python package.
+Currently available Codex app tools for mutation/reading: `list_threads`, `read_thread`, `set_thread_title`, `set_thread_archived`, `handoff_thread`, `get_handoff_status`, `navigate_to_codex_page`. Use create/fork only when explicitly requested. Titles never prove membership.
 
-## 1. Inspect Family
+## Provenance Evidence
+
+Establish family membership using exact task IDs, structured fork/source responses, native spawn edges when present, and explicit typed manifest links. Note that `list_threads` excludes archived tasks and exposes no pin inventory.
+
+## Minimal Manifest Example
+
+Build and validate an explicit versioned manifest (`manifest.json`):
+
+```json
+{
+  "version": "1.0",
+  "project_cwd": "/path/to/project",
+  "status_metadata": "active",
+  "tasks": [
+    {
+      "id": "task_1",
+      "role": "root",
+      "evidence": "spawned from prompt"
+    },
+    {
+      "id": "task_2",
+      "role": "worker",
+      "evidence": "forked from task_1"
+    },
+    {
+      "id": "task_3",
+      "role": "reviewer",
+      "evidence": "spawn edge target from task_2"
+    },
+    {
+      "id": "task_4",
+      "role": "handoff",
+      "evidence": "handoff thread from task_3"
+    },
+    {
+      "id": "task_5",
+      "role": "replacement",
+      "evidence": "replacement for task_2"
+    }
+  ]
+}
+```
+
+## Procedural Workflow
+
+Follow this exact step sequencing:
+1. Preview the operation using the CLI.
+2. Display counts, mapping, and blockers to the user.
+3. Apply per-task native tool mutation (e.g., `set_thread_title` or `set_thread_archived`).
+4. Perform immediate read-only reconciliation and persist the result (receipt).
+5. Stop on failure; retry idempotently.
+6. Apply cleanup only after app targets verify.
+
+### 1. Inspect Family
 
 Preview family state, identities, blockers, and exact counts before mutation:
 
 ```bash
-.venv/bin/python -m scripts.orchestration.task_family inspect --family-id <family-id>
+.venv/bin/python -m scripts.orchestration.task_family inspect --manifest manifest.json --json
 ```
 
-Use `list/read/create/fork context`, `handoff status`, and navigation tools by their exact IDs as appropriate to supplement the inspection.
+### 2. Pinned State & Inclusion
 
-## 2. Pinned State & Inclusion
+Pinned state is unreadable via CLI. Mechanical enforcement is native-only. You must:
+1. Require exact per-task inclusion in the manifest file.
+2. Demand explicit operator affirmation that pin state is unknown using `--confirm-pin-unknown true`.
 
-Pinned state is unreadable. You must:
-1. Require exact per-task inclusion in a manifest file.
-2. Demand explicit operator affirmation that pin state is unknown.
-3. **No automatic bulk selection.**
-
-## 3. Rename Tasks
+### 3. Rename Tasks
 
 1. **Preview**:
 ```bash
-.venv/bin/python -m scripts.orchestration.task_family preview-rename --family-id <family-id> --manifest <manifest-path>
+.venv/bin/python -m scripts.orchestration.task_family preview-rename --repo-root . --manifest manifest.json --operation-id op_123 --base-title "New Title" --select-task task_1 --actor agent --confirm-pin-unknown true --json
 ```
 2. **Apply**: Call the native tool `set_thread_title` for each included task.
-3. **Reconcile**: Perform a DB read-back to verify. Stop on partial failure, persist the per-item outcome to a receipt file, and present the operator with retry and restore steps.
+3. **Reconcile**: Perform a read-back to verify. Stop on partial failure, persist to a receipt file.
+```bash
+.venv/bin/python -m scripts.orchestration.task_family reconcile-title --repo-root . --family-id fam_123 --operation-id op_123 --plan-digest sha256:abc... --db auto --task-id task_1 --cwd /path --expected-title "New Title"
+```
 
-## 4. Archive Family
+### 4. Archive Family
 
-Separate archive-only from finish-and-clean.
+Separate archive-only (reversible, transcripts/Git retained) from finish-and-clean. Do not imply archive halts running tasks.
+
 1. **Preview**:
 ```bash
-.venv/bin/python -m scripts.orchestration.task_family preview-archive --family-id <family-id> --manifest <manifest-path>
+.venv/bin/python -m scripts.orchestration.task_family preview-archive --repo-root . --manifest manifest.json --operation-id op_123 --lineage-id lin_123 --base-title "Archiving" --db auto --select-task task_1 --actor agent --confirm-pin-unknown true --json
 ```
 2. **Apply**: Call the native tool `set_thread_archived` for each included task.
-3. **Reconcile**: Perform a DB read-back. On partial failure, stop immediately, persist the receipt, and document recovery steps.
+3. **Reconcile**:
+```bash
+.venv/bin/python -m scripts.orchestration.task_family reconcile-archive --repo-root . --family-id fam_123 --operation-id op_123 --db auto --task-id task_1 --cwd /path --expected-title "Archiving"
+```
 
-## 5. Finish and Clean
+### 5. Finish and Clean
 
-Never implement purge, halt active tasks implicitly, trigger repo-wide pruning, or use short undo as destructive safety.
+Irreversible cleanup (proof-gated Git). Purge is not implemented. Never broad prune, remote-delete, force-remove worktrees, auto-commit/stash, delete locks, or call private DB writes.
+
 1. **Preview**:
 ```bash
-.venv/bin/python -m scripts.orchestration.task_family preview-cleanup --family-id <family-id> --branch <branch> --manifest <manifest-path>
+.venv/bin/python -m scripts.orchestration.task_family preview-cleanup --repo-root . --manifest manifest.json --operation-id op_123 --lineage-id lin_123 --base-title "Cleanup" --db auto --select-task task_1 --actor agent --confirm-pin-unknown true --json
 ```
-2. **Apply**: Provide the exact plan digest returned by preview and explicit manifest. Execute the cleanup securely.
+2. **Apply**: Execute the cleanup securely using the exact plan digest from preview.
 ```bash
-.venv/bin/python -m scripts.orchestration.task_family apply-cleanup --family-id <family-id> --digest <digest> --manifest <manifest-path>
+.venv/bin/python -m scripts.orchestration.task_family apply-cleanup --repo-root . --family-id fam_123 --operation-id op_123 --lineage-id lin_123 --plan-digest sha256:abc... --json
+```
+
+### 6. Receipt and Restoration
+
+Generate a receipt of the operation:
+```bash
+.venv/bin/python -m scripts.orchestration.task_family receipt --repo-root . --family-id fam_123 --operation-id op_123 --json
+```
+
+If restore is needed:
+1. Call `set_thread_archived` (to unarchive).
+2. Reconcile restore:
+```bash
+.venv/bin/python -m scripts.orchestration.task_family reconcile-restore --repo-root . --family-id fam_123 --operation-id op_123 --db auto --task-id task_1 --cwd /path --expected-title "Restored"
 ```

--- a/agents_extensions/shared/skills/task-family-manager/SKILL.md
+++ b/agents_extensions/shared/skills/task-family-manager/SKILL.md
@@ -1,129 +1,180 @@
 ---
 name: "task-family-manager"
-description: "Inspect, rename, archive, finish, and clean up task families using exact inclusion and strict UI semantics."
+description: "Inspect, rename, archive, restore, or proof-gated-clean an exact Codex task family with native app mutations, previews, reconciliation, and receipts."
 ---
 
 # Task Family Manager
 
-Use this skill to inspect, rename, archive, finish, and clean up task families. Never infer family from titles. Compose operations via the deterministic Python package.
-Currently available Codex app tools for mutation/reading: `list_threads`, `read_thread`, `set_thread_title`, `set_thread_archived`, `handoff_thread`, `get_handoff_status`, `navigate_to_codex_page`. Use create/fork only when explicitly requested. Titles never prove membership.
+Use this skill when a user wants to inspect or operate on a Codex task family. Identity always comes from exact task UUIDs and typed relations; titles are display text only.
 
-## Provenance Evidence
+The repository package plans and verifies operations. Codex app tools perform task mutations. Never write Codex SQLite directly, call private app APIs, infer membership from similar titles, or treat archive as cancellation.
 
-Establish family membership using exact task IDs, structured fork/source responses, native spawn edges when present, and explicit typed manifest links. Note that `list_threads` excludes archived tasks and exposes no pin inventory.
+## Native boundary
 
-## Minimal Manifest Example
+Use the available Codex app tools for their supported actions:
 
-Build and validate an explicit versioned manifest (`manifest.json`):
+- `list_threads` and `read_thread` for visible task state;
+- `set_thread_title` for one exact rename;
+- `set_thread_archived` for one exact archive or restore;
+- `handoff_thread` and `get_handoff_status` only when handoff work is requested;
+- `navigate_to_codex_page` only when the user asks to open a task.
+
+The app currently lacks an include-archived inventory, readable pin state, typed family graph, atomic batch mutation, and native receipt API. The local bridge therefore performs bounded, read-only SQLite reconciliation after each native mutation. `--db auto` discovers a compatible local database fail-closed; an explicit database path is also accepted.
+
+## Build the manifest
+
+Create a versioned manifest from tool-backed exact IDs. Prefer structured fork responses or persisted spawn edges. Add reviewer, handoff, replacement, and rollover relations only when explicit evidence exists. `issue_or_pr_member` may be display-only by setting `family_defining` to `false`.
 
 ```json
 {
-  "version": "1.0",
-  "project_cwd": "/path/to/project",
-  "status_metadata": "active",
-  "tasks": [
+  "schema_version": 1,
+  "family_id": "issue-5140-family",
+  "seed_task_id": "00000000-0000-4000-8000-000000000001",
+  "nodes": [
     {
-      "id": "task_1",
-      "role": "root",
-      "evidence": "spawned from prompt"
+      "task_id": "00000000-0000-4000-8000-000000000001",
+      "title": "Plan lifecycle",
+      "project_root": "/absolute/project",
+      "worktree": null,
+      "branch": null,
+      "pr_id": null,
+      "metadata": {"cwd": "/absolute/project", "status": "completed"}
     },
     {
-      "id": "task_2",
-      "role": "worker",
-      "evidence": "forked from task_1"
-    },
+      "task_id": "00000000-0000-4000-8000-000000000002",
+      "title": "Implement lifecycle",
+      "project_root": "/absolute/project",
+      "worktree": "/absolute/project/.worktrees/dispatch/codex/example",
+      "branch": "codex/example",
+      "pr_id": "123",
+      "metadata": {"cwd": "/absolute/project", "status": "completed"}
+    }
+  ],
+  "relations": [
     {
-      "id": "task_3",
-      "role": "reviewer",
-      "evidence": "spawn edge target from task_2"
-    },
-    {
-      "id": "task_4",
-      "role": "handoff",
-      "evidence": "handoff thread from task_3"
-    },
-    {
-      "id": "task_5",
-      "role": "replacement",
-      "evidence": "replacement for task_2"
+      "source_id": "00000000-0000-4000-8000-000000000002",
+      "target_id": "00000000-0000-4000-8000-000000000001",
+      "relation_type": "subagent_of",
+      "evidence": "codex_app fork response sourceThreadId",
+      "family_defining": true
     }
   ]
 }
 ```
 
-## Procedural Workflow
+Supported typed relations are `root`, `subagent_of`, `reviewer_for`, `handoff_of`, `replacement_of`, `rollover_generation_of`, and `issue_or_pr_member`.
 
-Follow this exact step sequencing:
-1. Preview the operation using the CLI.
-2. Display counts, mapping, and blockers to the user.
-3. Apply per-task native tool mutation (e.g., `set_thread_title` or `set_thread_archived`).
-4. Perform immediate read-only reconciliation and persist the result (receipt).
-5. Stop on failure; retry idempotently.
-6. Apply cleanup only after app targets verify.
-
-### 1. Inspect Family
-
-Preview family state, identities, blockers, and exact counts before mutation:
+## Inspect before mutation
 
 ```bash
-.venv/bin/python -m scripts.orchestration.task_family inspect --manifest manifest.json --json
+.venv/bin/python -m scripts.orchestration.task_family inspect \
+  --manifest /absolute/manifest.json --json
 ```
 
-### 2. Pinned State & Inclusion
+Show the exact included and excluded task IDs, derived roles, relation count, resources, and blockers. Stop if the graph has unknown endpoints, conflicting parents, cycles, incompatible project roots, or anything other than one root.
 
-Pinned state is unreadable via CLI. Mechanical enforcement is native-only. You must:
-1. Require exact per-task inclusion in the manifest file.
-2. Demand explicit operator affirmation that pin state is unknown using `--confirm-pin-unknown true`.
+Pinned state is currently unreadable. Every affected task must be selected explicitly with one `--select-task <TASK_UUID>` argument and separately acknowledged with one `--confirm-pin-unknown <TASK_UUID>` argument. Never pass a Boolean in place of a task UUID.
 
-### 3. Rename Tasks
+## Rename
 
-1. **Preview**:
+Use a fresh UUID for each operation. The preview persists an immutable exact rename map and digest. Generated titles keep role/generation suffixes and respect Codex's 60-character persisted-title limit.
+
 ```bash
-.venv/bin/python -m scripts.orchestration.task_family preview-rename --repo-root . --manifest manifest.json --operation-id op_123 --base-title "New Title" --select-task task_1 --actor agent --confirm-pin-unknown true --json
+.venv/bin/python -m scripts.orchestration.task_family preview-rename \
+  --repo-root /absolute/project \
+  --manifest /absolute/manifest.json \
+  --operation-id 00000000-0000-4000-8000-000000000010 \
+  --base-title "Lifecycle complete" \
+  --select-task 00000000-0000-4000-8000-000000000001 \
+  --confirm-pin-unknown 00000000-0000-4000-8000-000000000001 \
+  --actor codex/operator --json
 ```
-2. **Apply**: Call the native tool `set_thread_title` for each included task.
-3. **Reconcile**: Perform a read-back to verify. Stop on partial failure, persist to a receipt file.
+
+After the user has seen the preview, call `set_thread_title` once per selected task using that task's exact `new_title`. Immediately reconcile each result:
+
 ```bash
-.venv/bin/python -m scripts.orchestration.task_family reconcile-title --repo-root . --family-id fam_123 --operation-id op_123 --plan-digest sha256:abc... --db auto --task-id task_1 --cwd /path --expected-title "New Title"
+.venv/bin/python -m scripts.orchestration.task_family reconcile-title \
+  --repo-root /absolute/project \
+  --family-id issue-5140-family \
+  --operation-id 00000000-0000-4000-8000-000000000010 \
+  --plan-digest <64-lowercase-hex-digest> \
+  --db auto \
+  --task-id 00000000-0000-4000-8000-000000000001 \
+  --cwd /absolute/project \
+  --expected-title "Lifecycle complete [Lead]"
 ```
 
-### 4. Archive Family
+Proceed sequentially and stop on the first mismatch. A retry is read-back-only when that exact action already succeeded.
 
-Separate archive-only (reversible, transcripts/Git retained) from finish-and-clean. Do not imply archive halts running tasks.
+## Archive or finish and clean
 
-1. **Preview**:
+Choose the operation explicitly:
+
+- `preview-archive` is reversible and retains transcripts, worktrees, branches, and runtime resources.
+- `preview-cleanup` archives tasks and may remove only exact, verified, family-owned resources. Purge is not implemented.
+
 ```bash
-.venv/bin/python -m scripts.orchestration.task_family preview-archive --repo-root . --manifest manifest.json --operation-id op_123 --lineage-id lin_123 --base-title "Archiving" --db auto --select-task task_1 --actor agent --confirm-pin-unknown true --json
+.venv/bin/python -m scripts.orchestration.task_family preview-archive \
+  --repo-root /absolute/project \
+  --manifest /absolute/manifest.json \
+  --operation-id 00000000-0000-4000-8000-000000000020 \
+  --lineage-id 00000000-0000-4000-8000-000000000021 \
+  --base-title "Lifecycle complete" --db auto \
+  --select-task 00000000-0000-4000-8000-000000000001 \
+  --confirm-pin-unknown 00000000-0000-4000-8000-000000000001 \
+  --actor codex/operator --json
 ```
-2. **Apply**: Call the native tool `set_thread_archived` for each included task.
-3. **Reconcile**:
+
+For cleanup, replace `preview-archive` with `preview-cleanup`. Display its exact resource decisions and blockers before any mutation.
+
+Call `set_thread_archived` with `archived: true` once per selected task, then reconcile immediately with its current exact title:
+
 ```bash
-.venv/bin/python -m scripts.orchestration.task_family reconcile-archive --repo-root . --family-id fam_123 --operation-id op_123 --db auto --task-id task_1 --cwd /path --expected-title "Archiving"
+.venv/bin/python -m scripts.orchestration.task_family reconcile-archive \
+  --repo-root /absolute/project \
+  --family-id issue-5140-family \
+  --operation-id 00000000-0000-4000-8000-000000000020 \
+  --db auto \
+  --task-id 00000000-0000-4000-8000-000000000001 \
+  --cwd /absolute/project \
+  --expected-title "Lifecycle complete [Lead]"
 ```
 
-### 5. Finish and Clean
+Only after every selected task verifies, execute the persisted plan:
 
-Irreversible cleanup (proof-gated Git). Purge is not implemented. Never broad prune, remote-delete, force-remove worktrees, auto-commit/stash, delete locks, or call private DB writes.
-
-1. **Preview**:
 ```bash
-.venv/bin/python -m scripts.orchestration.task_family preview-cleanup --repo-root . --manifest manifest.json --operation-id op_123 --lineage-id lin_123 --base-title "Cleanup" --db auto --select-task task_1 --actor agent --confirm-pin-unknown true --json
-```
-2. **Apply**: Execute the cleanup securely using the exact plan digest from preview.
-```bash
-.venv/bin/python -m scripts.orchestration.task_family apply-cleanup --repo-root . --family-id fam_123 --operation-id op_123 --lineage-id lin_123 --plan-digest sha256:abc... --json
-```
-
-### 6. Receipt and Restoration
-
-Generate a receipt of the operation:
-```bash
-.venv/bin/python -m scripts.orchestration.task_family receipt --repo-root . --family-id fam_123 --operation-id op_123 --json
+.venv/bin/python -m scripts.orchestration.task_family apply-cleanup \
+  --repo-root /absolute/project \
+  --family-id issue-5140-family \
+  --operation-id 00000000-0000-4000-8000-000000000020 \
+  --lineage-id 00000000-0000-4000-8000-000000000021 \
+  --plan-digest <64-lowercase-hex-digest> --json
 ```
 
-If restore is needed:
-1. Call `set_thread_archived` (to unarchive).
-2. Reconcile restore:
+Cleanup must never call `.git/hooks/post-merge`, `alias.cleanup-gone`, a broad gone-upstream pruner, remote branch deletion, forced worktree removal, auto-stash/commit, or lock deletion. A local branch is eligible only under the executor's exact PR/head/remote/worktree/snapshot/protected-base proof.
+
+## Restore and receipts
+
+To restore, call `set_thread_archived` with `archived: false`, then reconcile the same selected task:
+
 ```bash
-.venv/bin/python -m scripts.orchestration.task_family reconcile-restore --repo-root . --family-id fam_123 --operation-id op_123 --db auto --task-id task_1 --cwd /path --expected-title "Restored"
+.venv/bin/python -m scripts.orchestration.task_family reconcile-restore \
+  --repo-root /absolute/project \
+  --family-id issue-5140-family \
+  --operation-id 00000000-0000-4000-8000-000000000020 \
+  --db auto \
+  --task-id 00000000-0000-4000-8000-000000000001 \
+  --cwd /absolute/project \
+  --expected-title "Lifecycle complete [Lead]"
 ```
+
+Render the durable receipt at any point:
+
+```bash
+.venv/bin/python -m scripts.orchestration.task_family receipt \
+  --repo-root /absolute/project \
+  --family-id issue-5140-family \
+  --operation-id 00000000-0000-4000-8000-000000000020 --json
+```
+
+Report planned versus actual actions, skipped resources and reasons, failures with recovery instructions, restoration information, final retained resources, and the receipt path under `.agent/task-families/<family>/operations/<operation>/`.

--- a/agents_extensions/shared/skills/task-family-manager/SKILL.md
+++ b/agents_extensions/shared/skills/task-family-manager/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: task-family-manager
+description: Inspect, rename, archive, finish, and clean up task families using exact inclusion and strict UI semantics.
+---
+
+# Task Family Manager
+
+Use this skill to inspect, rename, archive, finish, and clean up task families. Never infer family from titles. Compose operations via the deterministic Python package.
+
+## 1. Inspect Family
+
+Preview family state, identities, blockers, and exact counts before mutation:
+
+```bash
+.venv/bin/python -m scripts.orchestration.task_family inspect --family-id <family-id>
+```
+
+Use `list/read/create/fork context`, `handoff status`, and navigation tools by their exact IDs as appropriate to supplement the inspection.
+
+## 2. Pinned State & Inclusion
+
+Pinned state is unreadable. You must:
+1. Require exact per-task inclusion in a manifest file.
+2. Demand explicit operator affirmation that pin state is unknown.
+3. **No automatic bulk selection.**
+
+## 3. Rename Tasks
+
+1. **Preview**:
+```bash
+.venv/bin/python -m scripts.orchestration.task_family preview-rename --family-id <family-id> --manifest <manifest-path>
+```
+2. **Apply**: Call the native tool `set_thread_title` for each included task.
+3. **Reconcile**: Perform a DB read-back to verify. Stop on partial failure, persist the per-item outcome to a receipt file, and present the operator with retry and restore steps.
+
+## 4. Archive Family
+
+Separate archive-only from finish-and-clean.
+1. **Preview**:
+```bash
+.venv/bin/python -m scripts.orchestration.task_family preview-archive --family-id <family-id> --manifest <manifest-path>
+```
+2. **Apply**: Call the native tool `set_thread_archived` for each included task.
+3. **Reconcile**: Perform a DB read-back. On partial failure, stop immediately, persist the receipt, and document recovery steps.
+
+## 5. Finish and Clean
+
+Never implement purge, halt active tasks implicitly, trigger repo-wide pruning, or use short undo as destructive safety.
+1. **Preview**:
+```bash
+.venv/bin/python -m scripts.orchestration.task_family preview-cleanup --family-id <family-id> --branch <branch> --manifest <manifest-path>
+```
+2. **Apply**: Provide the exact plan digest returned by preview and explicit manifest. Execute the cleanup securely.
+```bash
+.venv/bin/python -m scripts.orchestration.task_family apply-cleanup --family-id <family-id> --digest <digest> --manifest <manifest-path>
+```

--- a/agents_extensions/shared/skills/task-family-manager/SKILL.md
+++ b/agents_extensions/shared/skills/task-family-manager/SKILL.md
@@ -21,6 +21,8 @@ Use the available Codex app tools for their supported actions:
 
 The app currently lacks an include-archived inventory, readable pin state, typed family graph, atomic batch mutation, and native receipt API. The local bridge therefore performs bounded, read-only SQLite reconciliation after each native mutation. `--db auto` discovers a compatible local database fail-closed; an explicit database path is also accepted.
 
+Runtime packets, rollover leases, and automations are preservation-only locally. For finish-and-clean, record a tool-backed terminal task `status`. Any selected rollover endpoint also needs `rollover_cleanup_eligible: "true"` plus `rollover_cleanup_proof`; any `automation_id` needs `automation_cleanup_eligible: "true"` plus `automation_cleanup_proof`. Missing proof blocks cleanup. Even with proof, the local executor records retirement as deferred and preserves the evidence because no native retirement API exists.
+
 ## Build the manifest
 
 Create a versioned manifest from tool-backed exact IDs. Prefer structured fork responses or persisted spawn edges. Add reviewer, handoff, replacement, and rollover relations only when explicit evidence exists. `issue_or_pr_member` may be display-only by setting `family_defining` to `false`.
@@ -86,11 +88,13 @@ Use a fresh UUID for each operation. The preview persists an immutable exact ren
   --operation-id 00000000-0000-4000-8000-000000000010 \
   --base-title "Lifecycle complete" \
   --select-task 00000000-0000-4000-8000-000000000001 \
+  --select-task 00000000-0000-4000-8000-000000000002 \
   --confirm-pin-unknown 00000000-0000-4000-8000-000000000001 \
+  --confirm-pin-unknown 00000000-0000-4000-8000-000000000002 \
   --actor codex/operator --json
 ```
 
-After the user has seen the preview, call `set_thread_title` once per selected task using that task's exact `new_title`. Immediately reconcile each result:
+Family rename requires every included task. Repeat both selection arguments for every included UUID. After the user has seen the preview, call `set_thread_title` once per selected task using that task's exact `new_title`. Immediately reconcile each result:
 
 ```bash
 .venv/bin/python -m scripts.orchestration.task_family reconcile-title \
@@ -121,7 +125,9 @@ Choose the operation explicitly:
   --lineage-id 00000000-0000-4000-8000-000000000021 \
   --base-title "Lifecycle complete" --db auto \
   --select-task 00000000-0000-4000-8000-000000000001 \
+  --select-task 00000000-0000-4000-8000-000000000002 \
   --confirm-pin-unknown 00000000-0000-4000-8000-000000000001 \
+  --confirm-pin-unknown 00000000-0000-4000-8000-000000000002 \
   --actor codex/operator --json
 ```
 

--- a/agents_extensions/shared/skills/task-family-manager/agents/openai.yaml
+++ b/agents_extensions/shared/skills/task-family-manager/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Task Family Manager"
+  short_description: "Manage task family lifecycle, inspection, and cleanup"
+  default_prompt: "Use $task-family-manager to safely inspect, rename, archive, finish, or clean up task families."

--- a/docs/specs/task-family-manager-native-ui.md
+++ b/docs/specs/task-family-manager-native-ui.md
@@ -2,11 +2,22 @@
 
 This document specifies the target native UI and API contract for the Task Family Manager, implementing the R3 architecture approved for Issue #5140.
 
-> **NOTE:** The Native APIs described below are currently **UNAVAILABLE**. They specify the target upstream native implementation. Local agents must use the fallback Skill implementations until the upstream APIs are deployed. Do not claim native implementation exists locally.
+> **NOTE:** The Native APIs described below are currently **UNAVAILABLE**. They specify the target upstream native implementation. Local agents must use the fallback Skill implementations until the upstream APIs are deployed. Do not claim native implementation exists locally. Do not claim repo-local SQLite is stable.
 
-## 1. Native API Contract
+## 1. Native API Contract (UNAVAILABLE)
 
-### 1.1 Family Graph & Identity API
+### 1.1 Missing App Capabilities
+
+The following app capabilities are currently missing and required for the target upstream native implementation:
+- include-archived inventory
+- readable pin state
+- typed relation/lineage APIs
+- task version/ETag and batch CAS (Compare-and-Swap)
+- native receipt/restore
+- safe Git/worktree authority
+- purge token
+
+### 1.2 Family Graph & Identity API (UNAVAILABLE)
 
 `GET /api/v1/task-families/{family_id}/graph`
 
@@ -21,7 +32,7 @@ This document specifies the target native UI and API contract for the Task Famil
     "pinned": ["task_id", "..."]
   },
   "provenance": {
-    "reviewer_links": [{"source": "task_id", "target": "task_id", "type": "cross-family"}],
+    "reviewer_links": [{"source": "task_id", "target": "task_id", "type": "cross-family", "version": "v1"}],
     "handoff_links": [],
     "replacement_links": [],
     "rollover_links": []
@@ -32,14 +43,21 @@ This document specifies the target native UI and API contract for the Task Famil
     "pr": "string",
     "worktree": "string",
     "model": "string",
-    "status": "string"
-  }
+    "status": "string",
+    "local": true
+  },
+  "nodes": [
+    {
+      "task_id": "task_id",
+      "version": "W/\"etag_hash\"",
+      "title": "string",
+      "badges": ["model", "status", "project", "branch", "pr", "worktree", "local"]
+    }
+  ]
 }
 ```
 
-### 1.2 Batch Operations (Preview & Execute)
-
-Atomic batch APIs for rename, archive, restore, and finish enforce CAS (Compare-and-Swap) and idempotency.
+### 1.3 Batch Operations: Preview (UNAVAILABLE)
 
 **Preview Request:**
 
@@ -47,10 +65,30 @@ Atomic batch APIs for rename, archive, restore, and finish enforce CAS (Compare-
 
 ```json
 {
-  "action": "archive",
-  "tasks": ["task_1", "task_2"]
+  "action": "archive|rename|cleanup",
+  "tasks": ["task_1", "task_2"],
+  "rename_template": "optional_string"
 }
 ```
+
+**Preview Response:**
+
+Returns expected blockers, counts, and a plan digest for CAS execution.
+
+```json
+{
+  "plan_digest": "sha256:...",
+  "affected_count": 2,
+  "blockers": [],
+  "expected_mutations": [
+    {"task_id": "task_1", "expected_state": "archived"}
+  ]
+}
+```
+
+### 1.4 Batch Operations: Execute (UNAVAILABLE)
+
+Atomic batch APIs for rename, archive, restore, and finish enforce CAS (Compare-and-Swap) and idempotency.
 
 **Execute Request:**
 
@@ -58,14 +96,15 @@ Atomic batch APIs for rename, archive, restore, and finish enforce CAS (Compare-
 
 ```json
 {
-  "action": "archive",
+  "action": "archive|rename|cleanup|restore",
   "plan_digest": "sha256:...",
   "branch_proof": "exact_branch_name",
-  "confirmation_token": "optional_token_for_purge"
+  "purge_token": "optional_token_for_purge",
+  "tasks": ["task_1", "task_2"]
 }
 ```
 
-**Response (Receipt):**
+**Execute Response (Receipt):**
 
 ```json
 {
@@ -73,7 +112,7 @@ Atomic batch APIs for rename, archive, restore, and finish enforce CAS (Compare-
   "success_count": 1,
   "fail_count": 1,
   "results": [
-    {"task_id": "task_1", "status": "success"},
+    {"task_id": "task_1", "status": "success", "reconciliation_read_back": "archived"},
     {"task_id": "task_2", "status": "failed", "error": "permission_denied"}
   ]
 }
@@ -81,11 +120,12 @@ Atomic batch APIs for rename, archive, restore, and finish enforce CAS (Compare-
 
 **Error Semantics:**
 
-- `409 Conflict`: Digest mismatch (CAS failure).
-- `428 Precondition Required`: Missing branch proof or confirmation token.
-- `403 Forbidden`: Attempted broad upstream prune (not allowed).
+- `409 Conflict`: Digest mismatch (CAS failure) or ETag conflict.
+- `428 Precondition Required`: Missing branch proof or purge token.
+- `403 Forbidden`: Attempted broad upstream prune (not allowed) or bad purge token.
+- `206 Partial Content`: Batch idempotency partial results.
 
-## 2. Accessible Native UI
+## 2. Accessible Native UX
 
 ### 2.1 Navigation and Tree
 
@@ -99,13 +139,14 @@ Atomic batch APIs for rename, archive, restore, and finish enforce CAS (Compare-
 
 - **Consolidated Inbox**: Central pane aggregating all approval requests, blocked tasks, and error tasks across the active scope.
 - **Explicit Counts**: Selection interfaces update dynamically (`aria-atomic="true"`). Batch action buttons explicitly state counts (e.g., "Archive 3 selected tasks").
+- **Batch Selection**: Explicit manual selection; no ambiguous destructive wording or short-toast safety.
 
 ### 2.3 Safety, Receipts, and Cleanup
 
-- **Summarize-Before-Archive**: Modal lists aggregate stats (e.g., active tasks to be halted) before confirmation.
+- **Summarize-Before-Archive**: Modal lists aggregate stats (e.g., active tasks to be halted) before confirmation. Correct AGY UX issues: family archive never implicitly halts active tasks.
 - **Blocker Preview**: Dry-run modal clearly itemizing blockers and data marked for deletion before execution.
 - **Receipts/Restoration**: Destructive actions return a clear receipt of successes/failures, providing an explicit, recoverable restore path.
-- **Destructive Safety**: Follows exact R3 contract. Short undo is NOT used as a safety mechanism for destructive actions. Cleanup relies strictly on exact-branch proof-gated cleanup. No broad gone-upstream pruner is implemented.
+- **Destructive Safety**: Follows exact R3 contract. Irreversible cleanup never relies on 10-second undo as a safety mechanism. Cleanup relies strictly on exact-branch proof-gated cleanup and explicit purge tokens. No broad gone-upstream pruner is implemented.
 
 ## 3. Local vs Native Acceptance Map
 
@@ -115,5 +156,6 @@ Atomic batch APIs for rename, archive, restore, and finish enforce CAS (Compare-
 | **Archiving** | Loop `set_thread_archived` with DB read-back | Atomic `POST /execute` (archive) |
 | **Renaming** | Loop `set_thread_title` with DB read-back | Atomic `POST /execute` (rename) |
 | **Receipts** | Skill persists JSON outcome locally | API returns partial-success receipt |
-| **Cleanup** | Exact-branch proof CLI verification | Confirmation tokens + precise proof |
-| **Pinned State** | Explicitly unknown, operator manual override | Typed pinned inventory |
+| **Cleanup** | Exact-branch proof CLI verification | Confirmation purge tokens + precise proof |
+| **Pinned State** | Human-mediated: explicit unknown, manual override | Spec-only mechanical pinned inventory & purge |
+| **Reconciliation** | Read-back on local sqlite | Native API read-back CAS validation |

--- a/docs/specs/task-family-manager-native-ui.md
+++ b/docs/specs/task-family-manager-native-ui.md
@@ -1,0 +1,119 @@
+# Task Family Manager Native UI & API Specification
+
+This document specifies the target native UI and API contract for the Task Family Manager, implementing the R3 architecture approved for Issue #5140.
+
+> **NOTE:** The Native APIs described below are currently **UNAVAILABLE**. They specify the target upstream native implementation. Local agents must use the fallback Skill implementations until the upstream APIs are deployed. Do not claim native implementation exists locally.
+
+## 1. Native API Contract
+
+### 1.1 Family Graph & Identity API
+
+`GET /api/v1/task-families/{family_id}/graph`
+
+**Response:**
+
+```json
+{
+  "family_id": "string",
+  "inventory": {
+    "active": ["task_id", "..."],
+    "archived": ["task_id", "..."],
+    "pinned": ["task_id", "..."]
+  },
+  "provenance": {
+    "reviewer_links": [{"source": "task_id", "target": "task_id", "type": "cross-family"}],
+    "handoff_links": [],
+    "replacement_links": [],
+    "rollover_links": []
+  },
+  "environment": {
+    "project": "string",
+    "branch": "string",
+    "pr": "string",
+    "worktree": "string",
+    "model": "string",
+    "status": "string"
+  }
+}
+```
+
+### 1.2 Batch Operations (Preview & Execute)
+
+Atomic batch APIs for rename, archive, restore, and finish enforce CAS (Compare-and-Swap) and idempotency.
+
+**Preview Request:**
+
+`POST /api/v1/task-families/{family_id}/preview`
+
+```json
+{
+  "action": "archive",
+  "tasks": ["task_1", "task_2"]
+}
+```
+
+**Execute Request:**
+
+`POST /api/v1/task-families/{family_id}/execute`
+
+```json
+{
+  "action": "archive",
+  "plan_digest": "sha256:...",
+  "branch_proof": "exact_branch_name",
+  "confirmation_token": "optional_token_for_purge"
+}
+```
+
+**Response (Receipt):**
+
+```json
+{
+  "status": "partial_success",
+  "success_count": 1,
+  "fail_count": 1,
+  "results": [
+    {"task_id": "task_1", "status": "success"},
+    {"task_id": "task_2", "status": "failed", "error": "permission_denied"}
+  ]
+}
+```
+
+**Error Semantics:**
+
+- `409 Conflict`: Digest mismatch (CAS failure).
+- `428 Precondition Required`: Missing branch proof or confirmation token.
+- `403 Forbidden`: Attempted broad upstream prune (not allowed).
+
+## 2. Accessible Native UI
+
+### 2.1 Navigation and Tree
+
+- **Accessible Family Tree**: Tree structure mapping the family graph. Includes `role="tree"` and `role="treeitem"`.
+- **Keyboard Behavior**: `Up/Down` navigates siblings, `Left/Right` collapse/expand nodes. Screen-readers announce tree hierarchy correctly.
+- **Badges**: Status and Role badges (🟢 Active, 🔴 Failed), plus context badges (Branch, PR, Model, Local, Worktree).
+- **Scope Selector**: Dropdown to shift focus between `Current Task`, `Task Family`, and `Project Scope`.
+- **Title Templates**: Auto-formats incoming tasks as `[Verb] [Entity] - [Context]`.
+
+### 2.2 Batch Actions & Inboxes
+
+- **Consolidated Inbox**: Central pane aggregating all approval requests, blocked tasks, and error tasks across the active scope.
+- **Explicit Counts**: Selection interfaces update dynamically (`aria-atomic="true"`). Batch action buttons explicitly state counts (e.g., "Archive 3 selected tasks").
+
+### 2.3 Safety, Receipts, and Cleanup
+
+- **Summarize-Before-Archive**: Modal lists aggregate stats (e.g., active tasks to be halted) before confirmation.
+- **Blocker Preview**: Dry-run modal clearly itemizing blockers and data marked for deletion before execution.
+- **Receipts/Restoration**: Destructive actions return a clear receipt of successes/failures, providing an explicit, recoverable restore path.
+- **Destructive Safety**: Follows exact R3 contract. Short undo is NOT used as a safety mechanism for destructive actions. Cleanup relies strictly on exact-branch proof-gated cleanup. No broad gone-upstream pruner is implemented.
+
+## 3. Local vs Native Acceptance Map
+
+| Capability | Local CLI/Skill (Current) | Native API/UI (Target) |
+| --- | --- | --- |
+| **Inspection** | `python -m scripts.orchestration.task_family inspect` | `GET /api/v1/task-families/.../graph` |
+| **Archiving** | Loop `set_thread_archived` with DB read-back | Atomic `POST /execute` (archive) |
+| **Renaming** | Loop `set_thread_title` with DB read-back | Atomic `POST /execute` (rename) |
+| **Receipts** | Skill persists JSON outcome locally | API returns partial-success receipt |
+| **Cleanup** | Exact-branch proof CLI verification | Confirmation tokens + precise proof |
+| **Pinned State** | Explicitly unknown, operator manual override | Typed pinned inventory |

--- a/docs/specs/task-family-manager-native-ui.md
+++ b/docs/specs/task-family-manager-native-ui.md
@@ -16,6 +16,8 @@ The current app can list visible tasks, read a task, rename one task, archive or
 - Git/worktree ownership and cleanup authority;
 - an irreversible purge token.
 
+It also lacks an authoritative automation inventory/retirement API and a typed rollover lease cleanup-eligibility API. Local cleanup therefore preserves those resources. Explicit proof can unblock unrelated Git cleanup, but must never be represented as a local runtime or automation deletion.
+
 The local fallback therefore uses exact task UUIDs and explicit typed manifest relations, performs native task mutations one at a time, and verifies each result through a bounded read-only SQLite bridge. The database is not a supported public interface. The fallback never writes it and must fail closed when its schema, identity, title, `cwd`, host, or archive state is ambiguous.
 
 ## Native domain model
@@ -44,6 +46,8 @@ Each task record exposes:
 - project, worktree, branch, PR, model, harness, local/remote host, and `cwd` metadata;
 - whether the task is running, waiting, completed, blocked, or unavailable;
 - capabilities allowed for the current actor.
+
+Family inventory also exposes runtime packets, leases, and automations as first-class resources. Each resource carries its owning task UUID, lineage, current run state, predecessor/replacement IDs, cleanup eligibility, version, proof source, and evidence dependencies. An unavailable automation host or unknown replacement confirmation is a blocker, not an empty inventory.
 
 Pin state is tri-state only while migrating old data: `pinned`, `unpinned`, or `unknown`. Native operations protect `pinned` and `unknown` tasks by default. Unknown pin state requires an explicit task-specific confirmation; a family-wide Boolean override is invalid.
 
@@ -159,6 +163,8 @@ The response freezes exact inputs and returns:
 ```
 
 The preview must include every selected task, excluded task, title mapping, pin decision, and local resource decision. Standardized titles preserve role and generation information and fit the app's persisted title limit. A changed family/task/resource version invalidates the digest.
+
+Runtime and automation decisions distinguish `preserve`, `eligible_for_native_retirement`, and `blocked`. Eligibility requires the replacement thread and any successor automation to be confirmed by the authoritative rollover lease. Repository fallback receipts always say `preserved/deferred_to_native`; they never claim a runtime or automation was retired.
 
 ### Execute a preview
 

--- a/docs/specs/task-family-manager-native-ui.md
+++ b/docs/specs/task-family-manager-native-ui.md
@@ -1,161 +1,287 @@
-# Task Family Manager Native UI & API Specification
+# Task Family Manager Native UI and API Specification
 
-This document specifies the target native UI and API contract for the Task Family Manager, implementing the R3 architecture approved for Issue #5140.
+Status: target upstream contract; not implemented by the current Codex app.
 
-> **NOTE:** The Native APIs described below are currently **UNAVAILABLE**. They specify the target upstream native implementation. Local agents must use the fallback Skill implementations until the upstream APIs are deployed. Do not claim native implementation exists locally. Do not claim repo-local SQLite is stable.
+Issue #5140 needs task-family lifecycle management that is safe at the app boundary. The repository implementation is the current fallback. This document defines the native inventory, mutation, accessibility, and receipt contract that would remove the fallback's dependence on a fragile read-only SQLite bridge.
 
-## 1. Native API Contract (UNAVAILABLE)
+## Current capability boundary
 
-### 1.1 Missing App Capabilities
+The current app can list visible tasks, read a task, rename one task, archive or restore one task, hand off a task, and report handoff status. It does not expose:
 
-The following app capabilities are currently missing and required for the target upstream native implementation:
-- include-archived inventory
-- readable pin state
-- typed relation/lineage APIs
-- task version/ETag and batch CAS (Compare-and-Swap)
-- native receipt/restore
-- safe Git/worktree authority
-- purge token
+- an inventory that includes archived tasks;
+- readable or mechanically enforceable pin state;
+- typed parent, reviewer, handoff, replacement, and rollover relations;
+- task versions or compare-and-swap batch operations;
+- a native family preview, receipt, or restore operation;
+- Git/worktree ownership and cleanup authority;
+- an irreversible purge token.
 
-### 1.2 Family Graph & Identity API (UNAVAILABLE)
+The local fallback therefore uses exact task UUIDs and explicit typed manifest relations, performs native task mutations one at a time, and verifies each result through a bounded read-only SQLite bridge. The database is not a supported public interface. The fallback never writes it and must fail closed when its schema, identity, title, `cwd`, host, or archive state is ambiguous.
 
-`GET /api/v1/task-families/{family_id}/graph`
+## Native domain model
 
-**Response:**
+### Identity and membership
+
+Task UUID is the only identity key. Titles are mutable display text and must never establish family membership.
+
+A family graph contains:
+
+- exactly one root;
+- typed `subagent_of`, `reviewer_for`, `handoff_of`, `replacement_of`, and `rollover_generation_of` edges;
+- optional `issue_or_pr_member` annotations that are display-only unless explicitly promoted;
+- per-edge provenance, source system, observed time, and version;
+- active and archived members in the same inventory;
+- explicit exclusion records for similar titles or shared issues outside the graph.
+
+The service rejects unknown endpoints, conflicting parent-like relations, cycles, incompatible project roots, and zero or multiple roots.
+
+### Task state
+
+Each task record exposes:
+
+- UUID, version/ETag, title, active/archive state, pin state, and run status;
+- role and rollover generation derived from typed relations;
+- project, worktree, branch, PR, model, harness, local/remote host, and `cwd` metadata;
+- whether the task is running, waiting, completed, blocked, or unavailable;
+- capabilities allowed for the current actor.
+
+Pin state is tri-state only while migrating old data: `pinned`, `unpinned`, or `unknown`. Native operations protect `pinned` and `unknown` tasks by default. Unknown pin state requires an explicit task-specific confirmation; a family-wide Boolean override is invalid.
+
+### Operations
+
+The native model distinguishes:
+
+1. Rename — reversible display mutation.
+2. Archive — reversible visibility mutation; transcripts and Git resources remain.
+3. Finish and clean — archive followed by exact proof-gated retirement of eligible local resources.
+4. Purge — irreversible transcript deletion, unavailable until the upstream app provides a separately authenticated, short-lived purge token.
+
+Archive does not cancel or halt an active task. The UI must say this directly and offer a separate supported stop/cancel action when one exists.
+
+## Native API contract
+
+All examples in this section are normative target APIs, not current endpoints.
+
+### Read a family graph
+
+`GET /api/v1/task-families/{family_id}?include_archived=true`
 
 ```json
 {
-  "family_id": "string",
-  "inventory": {
-    "active": ["task_id", "..."],
-    "archived": ["task_id", "..."],
-    "pinned": ["task_id", "..."]
-  },
-  "provenance": {
-    "reviewer_links": [{"source": "task_id", "target": "task_id", "type": "cross-family", "version": "v1"}],
-    "handoff_links": [],
-    "replacement_links": [],
-    "rollover_links": []
-  },
-  "environment": {
-    "project": "string",
-    "branch": "string",
-    "pr": "string",
-    "worktree": "string",
-    "model": "string",
-    "status": "string",
-    "local": true
-  },
+  "family_id": "family-uuid",
+  "version": "W/\"family-etag\"",
+  "root_task_id": "task-uuid-1",
   "nodes": [
     {
-      "task_id": "task_id",
-      "version": "W/\"etag_hash\"",
-      "title": "string",
-      "badges": ["model", "status", "project", "branch", "pr", "worktree", "local"]
+      "task_id": "task-uuid-1",
+      "version": "W/\"task-etag\"",
+      "title": "Implement lifecycle",
+      "archived": false,
+      "pin_state": "unpinned",
+      "status": "completed",
+      "roles": ["Lead"],
+      "generation": 0,
+      "environment": {
+        "project": "/absolute/project",
+        "cwd": "/absolute/project",
+        "worktree": null,
+        "branch": "main",
+        "pr": null,
+        "model": "gpt-5.6-sol",
+        "harness": "codex",
+        "host": "local",
+        "local": true
+      },
+      "capabilities": ["rename", "archive", "restore"]
+    }
+  ],
+  "relations": [
+    {
+      "source_id": "task-uuid-2",
+      "target_id": "task-uuid-1",
+      "type": "subagent_of",
+      "evidence": "native spawn edge",
+      "source": "codex_app",
+      "observed_at": "2026-07-14T00:00:00Z",
+      "version": "W/\"edge-etag\""
+    }
+  ],
+  "excluded": [
+    {
+      "task_id": "task-uuid-9",
+      "reason": "outside exact-ID family graph"
     }
   ]
 }
 ```
 
-### 1.3 Batch Operations: Preview (UNAVAILABLE)
+The response must not silently omit archived, pinned, remote, or temporarily unavailable members. Unavailable hosts are returned as explicit blockers.
 
-**Preview Request:**
+### Preview an operation
 
-`POST /api/v1/task-families/{family_id}/preview`
-
-```json
-{
-  "action": "archive|rename|cleanup",
-  "tasks": ["task_1", "task_2"],
-  "rename_template": "optional_string"
-}
-```
-
-**Preview Response:**
-
-Returns expected blockers, counts, and a plan digest for CAS execution.
+`POST /api/v1/task-families/{family_id}/operation-previews`
 
 ```json
 {
-  "plan_digest": "sha256:...",
-  "affected_count": 2,
-  "blockers": [],
-  "expected_mutations": [
-    {"task_id": "task_1", "expected_state": "archived"}
-  ]
+  "kind": "rename",
+  "selected_task_ids": ["task-uuid-1", "task-uuid-2"],
+  "base_title": "Lifecycle complete",
+  "pin_unknown_confirmations": [],
+  "expected_family_version": "W/\"family-etag\""
 }
 ```
 
-### 1.4 Batch Operations: Execute (UNAVAILABLE)
-
-Atomic batch APIs for rename, archive, restore, and finish enforce CAS (Compare-and-Swap) and idempotency.
-
-**Execute Request:**
-
-`POST /api/v1/task-families/{family_id}/execute`
+The response freezes exact inputs and returns:
 
 ```json
 {
-  "action": "archive|rename|cleanup|restore",
-  "plan_digest": "sha256:...",
-  "branch_proof": "exact_branch_name",
-  "purge_token": "optional_token_for_purge",
-  "tasks": ["task_1", "task_2"]
+  "operation_id": "operation-uuid",
+  "plan_digest": "64-lowercase-hex-digest",
+  "expires_at": "2026-07-14T00:15:00Z",
+  "counts": {
+    "included": 2,
+    "excluded": 1,
+    "selected": 2,
+    "blocked": 0
+  },
+  "rename_map": [
+    {
+      "task_id": "task-uuid-1",
+      "expected_version": "W/\"task-etag\"",
+      "old_title": "Implement lifecycle",
+      "new_title": "Lifecycle complete [Lead]",
+      "roles": ["Lead"]
+    }
+  ],
+  "resource_decisions": [],
+  "blockers": []
 }
 ```
 
-**Execute Response (Receipt):**
+The preview must include every selected task, excluded task, title mapping, pin decision, and local resource decision. Standardized titles preserve role and generation information and fit the app's persisted title limit. A changed family/task/resource version invalidates the digest.
+
+### Execute a preview
+
+`POST /api/v1/task-families/{family_id}/operations`
+
+Headers:
+
+- `Idempotency-Key: <operation-uuid>`
+- `If-Match: <plan-digest>`
 
 ```json
 {
-  "status": "partial_success",
-  "success_count": 1,
-  "fail_count": 1,
-  "results": [
-    {"task_id": "task_1", "status": "success", "reconciliation_read_back": "archived"},
-    {"task_id": "task_2", "status": "failed", "error": "permission_denied"}
-  ]
+  "operation_id": "operation-uuid",
+  "plan_digest": "64-lowercase-hex-digest",
+  "actor": "actor-id",
+  "confirmed_task_ids": ["task-uuid-1", "task-uuid-2"]
 }
 ```
 
-**Error Semantics:**
+Native task-only rename/archive/restore batches should be transactional when all members live in one authority. When hosts or authorities prevent transactionality, execution is sequential, stops at the first failed mutation, and returns an exact partial receipt and resume token. Replaying the same idempotency key never repeats an already verified mutation.
 
-- `409 Conflict`: Digest mismatch (CAS failure) or ETag conflict.
-- `428 Precondition Required`: Missing branch proof or purge token.
-- `403 Forbidden`: Attempted broad upstream prune (not allowed) or bad purge token.
-- `206 Partial Content`: Batch idempotency partial results.
+The API uses these target failure classes:
 
-## 2. Accessible Native UX
+- `409 Conflict` for family/task/resource version drift;
+- `412 Precondition Failed` for a changed or expired digest;
+- `422 Unprocessable Content` for graph, selection, pin, or proof blockers;
+- `503 Service Unavailable` when an owning host cannot be verified.
 
-### 2.1 Navigation and Tree
+### Read a receipt
 
-- **Accessible Family Tree**: Tree structure mapping the family graph. Includes `role="tree"` and `role="treeitem"`.
-- **Keyboard Behavior**: `Up/Down` navigates siblings, `Left/Right` collapse/expand nodes. Screen-readers announce tree hierarchy correctly.
-- **Badges**: Status and Role badges (🟢 Active, 🔴 Failed), plus context badges (Branch, PR, Model, Local, Worktree).
-- **Scope Selector**: Dropdown to shift focus between `Current Task`, `Task Family`, and `Project Scope`.
-- **Title Templates**: Auto-formats incoming tasks as `[Verb] [Entity] - [Context]`.
+`GET /api/v1/task-families/{family_id}/operations/{operation_id}`
 
-### 2.2 Batch Actions & Inboxes
+```json
+{
+  "operation_id": "operation-uuid",
+  "state": "partially_applied",
+  "plan_digest": "64-lowercase-hex-digest",
+  "planned": [],
+  "actual": [],
+  "skipped": [],
+  "failures": [],
+  "restoration": [],
+  "retained_resources": [],
+  "resume_token": "opaque-single-use-token",
+  "events": []
+}
+```
 
-- **Consolidated Inbox**: Central pane aggregating all approval requests, blocked tasks, and error tasks across the active scope.
-- **Explicit Counts**: Selection interfaces update dynamically (`aria-atomic="true"`). Batch action buttons explicitly state counts (e.g., "Archive 3 selected tasks").
-- **Batch Selection**: Explicit manual selection; no ambiguous destructive wording or short-toast safety.
+Every action records task/resource ID, expected and observed versions, before/after state, actor, timestamp, reason, and recovery instruction. Receipts are durable and readable after tasks are archived.
 
-### 2.3 Safety, Receipts, and Cleanup
+### Restore
 
-- **Summarize-Before-Archive**: Modal lists aggregate stats (e.g., active tasks to be halted) before confirmation. Correct AGY UX issues: family archive never implicitly halts active tasks.
-- **Blocker Preview**: Dry-run modal clearly itemizing blockers and data marked for deletion before execution.
-- **Receipts/Restoration**: Destructive actions return a clear receipt of successes/failures, providing an explicit, recoverable restore path.
-- **Destructive Safety**: Follows exact R3 contract. Irreversible cleanup never relies on 10-second undo as a safety mechanism. Cleanup relies strictly on exact-branch proof-gated cleanup and explicit purge tokens. No broad gone-upstream pruner is implemented.
+`POST /api/v1/task-families/{family_id}/operations/{operation_id}/restore`
 
-## 3. Local vs Native Acceptance Map
+Restore takes exact task IDs and current versions. It is idempotent, uses the same read-back rules, and appends restoration actions to the original receipt. Git resources removed by finish-and-clean are restored only from a verified retained snapshot and only when the receipt declares them restorable.
 
-| Capability | Local CLI/Skill (Current) | Native API/UI (Target) |
+### Finish-and-clean proof
+
+The app may delegate Git execution to a native privileged service, but the preview and receipt must expose each proof. A local branch is deletable only when all of the following remain true immediately before mutation:
+
+- its PR is merged and has a merge SHA;
+- the PR head matches the exact local branch head;
+- the remote branch is absent;
+- no worktree uses the branch;
+- a verified recovery bundle contains the head and its digest matches;
+- Git lock files are absent at both planning and mutation time;
+- the primary checkout is on an up-to-date protected base;
+- the exact branch is not protected or unknown.
+
+Delete only that branch. Never invoke a post-merge hook, alias, broad gone-upstream pruner, remote branch deletion, forced worktree removal, auto-stash/commit, or lock deletion. A surviving remote branch, unknown protection, dirty worktree, active task, or changed proof blocks cleanup.
+
+Purge requires a separate target endpoint and short-lived token scoped to exact task UUIDs. Until that authority exists, clients must omit purge controls entirely.
+
+## Native user experience
+
+### Family tree and badges
+
+The task page offers `Current task`, `Task family`, and `Project` scopes. Family scope renders the exact graph as an accessible tree with:
+
+- readable role and generation labels;
+- status, model, harness, project, worktree, branch, PR, local/remote, archive, and pin badges;
+- explicit edge labels for worker, reviewer, handoff, replacement, and rollover relations;
+- an excluded-items disclosure explaining why similar tasks are outside the family.
+
+The tree uses `role="tree"`, `role="treeitem"`, `aria-level`, `aria-expanded`, and `aria-selected`. Arrow keys navigate and expand/collapse; Home/End move to first/last visible node; Space toggles selection; Enter opens the task. Focus never moves because background status changed.
+
+### Consolidated inbox
+
+Family and project scopes include a consolidated inbox for approvals, failures, blocked tasks, review requests, and unavailable hosts. Items show task identity, role, age, owner, requested action, and next step. Filters and counts remain keyboard and screen-reader accessible.
+
+### Selection and previews
+
+Batch selection is explicit. The UI never selects hidden archived or pinned tasks implicitly. Selection controls and action buttons announce exact counts, for example `Archive 3 selected tasks`. Count changes use a polite live region.
+
+Before mutation, a preview dialog shows:
+
+- included, excluded, selected, and blocked counts;
+- old-to-new title mappings;
+- pin and running-state warnings;
+- transcripts and Git resources retained or removed;
+- irreversible steps and unavailable restore paths;
+- a typed confirmation only for irreversible purge, if purge is supported.
+
+Archive confirmation says that archiving hides tasks but does not halt active runs. Finish-and-clean confirmation separates reversible task archiving from proof-gated local resource deletion. A short toast or timed undo is never the sole safety mechanism.
+
+### Progress, failure, and receipts
+
+Execution displays one row per task/resource with pending, applied, verified, skipped, failed, or restored status. Partial failure leaves successful rows intact, stops further unsafe mutations, and offers `Retry verification`, `Resume remaining`, and `Restore verified changes` only when the receipt authorizes them.
+
+The final receipt is reachable from the family, each affected task, and the consolidated inbox. It reports planned versus actual actions, exclusions, skipped resources and reasons, failures, recovery steps, restoration results, retained resources, and immutable operation identity.
+
+## Local-to-native acceptance map
+
+| Capability | Repository fallback | Required native behavior |
 | --- | --- | --- |
-| **Inspection** | `python -m scripts.orchestration.task_family inspect` | `GET /api/v1/task-families/.../graph` |
-| **Archiving** | Loop `set_thread_archived` with DB read-back | Atomic `POST /execute` (archive) |
-| **Renaming** | Loop `set_thread_title` with DB read-back | Atomic `POST /execute` (rename) |
-| **Receipts** | Skill persists JSON outcome locally | API returns partial-success receipt |
-| **Cleanup** | Exact-branch proof CLI verification | Confirmation purge tokens + precise proof |
-| **Pinned State** | Human-mediated: explicit unknown, manual override | Spec-only mechanical pinned inventory & purge |
-| **Reconciliation** | Read-back on local sqlite | Native API read-back CAS validation |
+| Exact inventory | Explicit manifest and exact UUID graph | Versioned graph including archived/pinned/remote tasks |
+| Relations | Typed manifest evidence | Native typed provenance edges |
+| Pin safety | Per-task unknown-state confirmation | Readable, mechanically enforced pin state |
+| Preview | Immutable JSON plan and SHA-256 digest | Versioned server preview with CAS expiry |
+| Rename/archive/restore | Native one-task action plus read-only DB reconciliation | Idempotent batch action plus native read-back |
+| Partial failure | Stop, persist receipt, retry safely | Resume token and exact durable receipt |
+| Cleanup | Local exact proof-gated executor | Native authority with the same or stronger proof |
+| Purge | Not implemented | Token-scoped upstream-only operation |
+| Accessibility | Skill/CLI output | Keyboard-accessible tree, counts, inbox, previews, and receipts |
+
+Native acceptance requires tests for exact-ID discovery, archived/pinned inventory, role derivation, keyboard navigation, screen-reader names, selection counts, digest drift, partial failure, retry idempotency, restore, and every proof-gated cleanup blocker.

--- a/scripts/orchestration/task_family/__init__.py
+++ b/scripts/orchestration/task_family/__init__.py
@@ -1,0 +1,36 @@
+"""Durable, fail-closed task-family planning primitives.
+
+This package deliberately plans and records lifecycle operations; executors for
+application or Git mutations live in separate lanes.
+"""
+
+from .graph import FamilyGraph, discover_task_family, rename_mapping
+from .model import (
+    ArchiveSelection,
+    Blocker,
+    LifecycleState,
+    OperationKind,
+    RelationType,
+    TaskFamilyManifest,
+    TaskNode,
+    TaskRelation,
+)
+from .planner import TaskFamilyPlan, build_plan
+from .storage import TaskFamilyStorage
+
+__all__ = [
+    "ArchiveSelection",
+    "Blocker",
+    "FamilyGraph",
+    "LifecycleState",
+    "OperationKind",
+    "RelationType",
+    "TaskFamilyManifest",
+    "TaskFamilyPlan",
+    "TaskFamilyStorage",
+    "TaskNode",
+    "TaskRelation",
+    "build_plan",
+    "discover_task_family",
+    "rename_mapping",
+]

--- a/scripts/orchestration/task_family/__main__.py
+++ b/scripts/orchestration/task_family/__main__.py
@@ -1,0 +1,7 @@
+"""Run the task-family CLI with ``python -m scripts.orchestration.task_family``."""
+
+from __future__ import annotations
+
+from .cli import main
+
+raise SystemExit(main())

--- a/scripts/orchestration/task_family/cli.py
+++ b/scripts/orchestration/task_family/cli.py
@@ -1,0 +1,722 @@
+"""Fail-closed command line interface for task-family lifecycle operations.
+
+This module only plans, records, and verifies.  It deliberately has no adapter
+for Codex's native task tools; archiving and restoring threads stay native-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from collections.abc import Sequence
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from . import codex_state, executor, git_safety
+from .graph import FamilyGraph, discover_task_family
+from .model import (
+    ArchiveSelection,
+    Blocker,
+    LifecycleEvent,
+    LifecycleState,
+    OperationKind,
+    OperationReceipt,
+    ReceiptAction,
+    TaskFamilyManifest,
+    utc_now,
+)
+from .planner import TaskFamilyPlan, build_plan, sha256_digest
+from .storage import TaskFamilyStorage
+
+EXIT_OK = 0
+EXIT_INVALID = 2
+EXIT_BLOCKED = 3
+EXIT_ERROR = 4
+
+
+class CliError(ValueError):
+    """A noninteractive input or persisted-state error."""
+
+
+def _canonical_uuid(value: str, label: str) -> str:
+    try:
+        parsed = str(uuid.UUID(value))
+    except (AttributeError, ValueError) as exc:
+        raise CliError(f"{label} must be a UUID: {value!r}") from exc
+    if parsed != value:
+        raise CliError(f"{label} must use canonical lowercase UUID text: {value!r}")
+    return parsed
+
+
+def _repo_root(value: str) -> Path:
+    path = Path(value).expanduser().resolve()
+    if not path.is_dir():
+        raise CliError(f"repo root is not a directory: {path}")
+    try:
+        return git_safety.resolve_main_root(path)
+    except Exception as exc:
+        raise CliError(f"repo root is not a Git worktree: {path}: {exc}") from exc
+
+
+def _load_manifest(path_value: str) -> TaskFamilyManifest:
+    path = Path(path_value).expanduser()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise CliError(f"manifest not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise CliError(f"manifest is invalid JSON: {path}: {exc.msg}") from exc
+    try:
+        return TaskFamilyManifest.from_dict(payload)
+    except ValueError as exc:
+        raise CliError(f"invalid manifest: {exc}") from exc
+
+
+def _blocker_payload(blocker: Blocker) -> dict[str, Any]:
+    return blocker.to_dict()
+
+
+def _graph_payload(graph: FamilyGraph) -> dict[str, Any]:
+    nodes = graph.nodes_by_id
+    return {
+        "family_id": graph.manifest.family_id,
+        "seed_task_id": graph.manifest.seed_task_id,
+        "included_task_ids": list(graph.included_task_ids),
+        "excluded_task_ids": list(graph.excluded_task_ids),
+        "counts": {
+            "included": len(graph.included_task_ids),
+            "excluded": len(graph.excluded_task_ids),
+            "relations": len(graph.family_relations),
+            "blockers": len(graph.blockers),
+        },
+        "tasks": [
+            {
+                "task_id": node.task_id,
+                "title": node.title,
+                "roles": list(graph.roles_by_task[node.task_id]),
+                "resources": {
+                    "project_root": node.project_root,
+                    "worktree": node.worktree,
+                    "branch": node.branch,
+                    "pr_id": node.pr_id,
+                },
+            }
+            for node in sorted(nodes.values(), key=lambda item: item.task_id)
+        ],
+        "excluded": [
+            {
+                "task_id": node.task_id,
+                "title": node.title,
+                "reason": "outside exact-ID seed component",
+            }
+            for node in sorted(graph.manifest.nodes, key=lambda item: item.task_id)
+            if node.task_id in graph.excluded_task_ids
+        ],
+        "blockers": [_blocker_payload(item) for item in graph.blockers],
+    }
+
+
+def _human_inspect(payload: dict[str, Any]) -> str:
+    lines = [
+        f"Family {payload['family_id']} (seed {payload['seed_task_id']})",
+        "Counts: " + ", ".join(f"{key}={value}" for key, value in payload["counts"].items()),
+    ]
+    for task in payload["tasks"]:
+        roles = ", ".join(task["roles"]) or "unclassified"
+        lines.append(f"- {task['task_id']}: {roles}; {task['title']}")
+    for task in payload["excluded"]:
+        lines.append(f"- excluded {task['task_id']}: {task['title']} ({task['reason']})")
+    for blocker in payload["blockers"]:
+        lines.append(f"BLOCKER {blocker['code']}: {blocker['message']}")
+    return "\n".join(lines) + "\n"
+
+
+def _emit(payload: dict[str, Any], *, json_output: bool, human: str) -> None:
+    if json_output:
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    else:
+        print(human, end="")
+
+
+def _selection_inputs(args: argparse.Namespace) -> tuple[ArchiveSelection, ...]:
+    selected = tuple(_canonical_uuid(value, "--select-task") for value in args.select_task)
+    confirmed = {_canonical_uuid(value, "--confirm-pin-unknown") for value in args.confirm_pin_unknown}
+    if len(selected) != len(set(selected)):
+        raise CliError("each --select-task must name a distinct exact UUID")
+    unknown_confirmations = confirmed - set(selected)
+    if unknown_confirmations:
+        joined = ", ".join(sorted(unknown_confirmations))
+        raise CliError(f"pin confirmation names an unselected task: {joined}")
+    return tuple(
+        ArchiveSelection(
+            task_id=task_id,
+            actor=args.actor,
+            pin_state_unknown_confirmed=task_id in confirmed,
+        )
+        for task_id in selected
+    )
+
+
+def _plan_with_blockers(plan: TaskFamilyPlan, blockers: Sequence[Blocker]) -> TaskFamilyPlan:
+    if not blockers:
+        return plan
+    updated = replace(plan, blockers=tuple(sorted((*plan.blockers, *blockers), key=lambda item: (item.code, item.task_ids, item.message))))
+    return replace(updated, digest=sha256_digest(updated.immutable_payload()))
+
+
+def _plan_with_execution_context(plan: TaskFamilyPlan, execution_context: dict[str, Any]) -> TaskFamilyPlan:
+    """Bind all executor adaptation inputs to the planner authorization digest."""
+    updated = replace(plan, execution_context=execution_context)
+    return replace(updated, digest=sha256_digest(updated.immutable_payload()))
+
+
+def _preview_receipt(plan: TaskFamilyPlan) -> OperationReceipt:
+    planned = [
+        ReceiptAction("task", task_id, (task_id,), "verify_native_archive", "native task skill remains the only writer")
+        for task_id in plan.selected_task_ids
+    ]
+    planned.extend(
+        ReceiptAction(item.resource_type, item.resource_id, item.selected_task_ids, item.decision, item.reason)
+        for item in plan.resource_decisions
+    )
+    return OperationReceipt(
+        operation_id=plan.operation_id,
+        family_id=plan.family_id,
+        plan_digest=plan.digest,
+        final_state=LifecycleState.PLANNED,
+        planned=tuple(planned),
+    )
+
+
+def _db_path(value: str) -> Path:
+    try:
+        return codex_state.discover_state_database(None if value == "auto" else Path(value).expanduser())
+    except codex_state.CodexStateError as exc:
+        raise CliError(str(exc)) from exc
+
+
+def _execution_payload(
+    graph: FamilyGraph,
+    plan: TaskFamilyPlan,
+    *,
+    lineage_id: str,
+    db_path: Path,
+    host: str | None,
+) -> tuple[dict[str, Any], tuple[Blocker, ...]]:
+    """Adapt only explicit manifest resources; absence is a safety blocker."""
+    nodes = graph.nodes_by_id
+    blockers: list[Blocker] = []
+    tasks: list[dict[str, Any]] = []
+    worktrees: list[dict[str, Any]] = []
+    for task_id in plan.selected_task_ids:
+        node = nodes[task_id]
+        expected_host = host if host is not None else node.metadata.get("host")
+        tasks.append(
+            {
+                "task_id": task_id,
+                "title": node.title,
+                "cwd": node.metadata.get("cwd", node.project_root),
+                "db_path": str(db_path),
+                "host": expected_host,
+            }
+        )
+        resource_values = (node.worktree, node.branch, node.pr_id)
+        if not any(resource_values):
+            continue
+        if not all(resource_values):
+            blockers.append(
+                Blocker(
+                    "incomplete_worktree_resource",
+                    f"Task {task_id!r} has partial worktree/branch/PR metadata.",
+                    (task_id,),
+                    "Supply all explicit resource fields; do not infer links from title or cwd.",
+                )
+            )
+            continue
+        pr_base = node.metadata.get("pr_base")
+        owner = node.metadata.get("worktree_family")
+        if not pr_base or owner != plan.family_id:
+            blockers.append(
+                Blocker(
+                    "unproven_worktree_ownership",
+                    f"Task {task_id!r} lacks explicit worktree_family and pr_base evidence.",
+                    (task_id,),
+                    "Set metadata.worktree_family to the exact family ID and metadata.pr_base explicitly.",
+                )
+            )
+            continue
+        try:
+            pr_number = int(node.pr_id or "")
+        except ValueError:
+            blockers.append(Blocker("invalid_pr_id", f"Task {task_id!r} has nonnumeric pr_id.", (task_id,)))
+            continue
+        if pr_number <= 0:
+            blockers.append(Blocker("invalid_pr_id", f"Task {task_id!r} has nonpositive pr_id.", (task_id,)))
+            continue
+        worktrees.append(
+            {
+                "id": task_id,
+                "worktree": node.worktree,
+                "branch": node.branch,
+                "pr_number": pr_number,
+                "pr_base": pr_base,
+                "explicit_family": owner,
+            }
+        )
+    if plan.operation is OperationKind.FINISH_AND_CLEAN and not worktrees:
+        blockers.append(
+            Blocker(
+                "no_explicit_cleanup_resources",
+                "finish_and_clean requires at least one explicit, owned worktree target.",
+                remediation="Use archive-only or provide explicit worktree, branch, PR, family, and base evidence.",
+            )
+        )
+    payload = {
+        "schema_version": 1,
+        "operation_id": plan.operation_id,
+        "family_id": plan.family_id,
+        "lineage_id": lineage_id,
+        "mode": plan.operation.value,
+        "target_db": str(db_path),
+        "task_targets": tasks,
+        "worktree_targets": worktrees,
+        "runtime_targets": [],
+        "pin_unknown_confirmed": all(item.pin_state_unknown_confirmed for item in plan.selections),
+    }
+    return payload, tuple(blockers)
+
+
+def _persist_operation(
+    root: Path,
+    manifest: TaskFamilyManifest,
+    plan: TaskFamilyPlan,
+    execution_payload: dict[str, Any],
+) -> TaskFamilyStorage:
+    storage = TaskFamilyStorage(root, plan.family_id, plan.operation_id)
+    storage.write_manifest(manifest)
+    storage.write_plan(plan)
+    storage.write_execution(execution_payload)
+    storage.write_state(LifecycleState.PLANNED, details={"preview": True, "plan_digest": plan.digest})
+    storage.write_receipt(_preview_receipt(plan))
+    return storage
+
+
+def _preview_payload(graph: FamilyGraph, plan: TaskFamilyPlan, execution_data: dict[str, Any]) -> dict[str, Any]:
+    payload = _graph_payload(graph)
+    payload.update(
+        {
+            "operation_id": plan.operation_id,
+            "operation": plan.operation.value,
+            "plan_digest": plan.digest,
+            "selected_task_ids": list(plan.selected_task_ids),
+            "base_title": plan.base_title,
+            "rename_map": [
+                {"task_id": item.task_id, "old_title": item.old_title, "new_title": item.new_title, "roles": list(item.roles)}
+                for item in plan.rename_map
+            ],
+            "planner_blockers": [_blocker_payload(item) for item in plan.blockers],
+            "resources": execution_data,
+        }
+    )
+    return payload
+
+
+def _human_preview(payload: dict[str, Any]) -> str:
+    lines = [
+        f"Preview {payload['operation']} for family {payload['family_id']}",
+        f"Operation: {payload['operation_id']}",
+        f"Plan digest: {payload['plan_digest']}",
+        f"Counts: included={payload['counts']['included']}, selected={len(payload['selected_task_ids'])}, excluded={payload['counts']['excluded']}",
+    ]
+    for item in payload["rename_map"]:
+        lines.append(f"- {item['task_id']}: {item['old_title']} -> {item['new_title']}")
+    for task in payload["excluded"]:
+        lines.append(f"- excluded {task['task_id']}: {task['title']}")
+    for blocker in payload["planner_blockers"]:
+        lines.append(f"BLOCKER {blocker['code']}: {blocker['message']}")
+    return "\n".join(lines) + "\n"
+
+
+def _cmd_inspect(args: argparse.Namespace) -> int:
+    graph = discover_task_family(_load_manifest(args.manifest))
+    payload = _graph_payload(graph)
+    _emit(payload, json_output=args.json, human=_human_inspect(payload))
+    return EXIT_OK if graph.is_valid else EXIT_BLOCKED
+
+
+def _cmd_preview_rename(args: argparse.Namespace) -> int:
+    root = _repo_root(args.repo_root)
+    manifest = _load_manifest(args.manifest)
+    operation_id = _canonical_uuid(args.operation_id, "--operation-id")
+    graph = discover_task_family(manifest)
+    selections = _selection_inputs(args)
+    plan = build_plan(
+        graph,
+        operation_id=operation_id,
+        operation=OperationKind.ARCHIVE_ONLY,
+        selections=selections,
+        base_title=args.base_title,
+    )
+    rename_payload = {
+        "schema_version": 1,
+        "kind": "rename_preview",
+        "operation_id": operation_id,
+        "family_id": manifest.family_id,
+        "base_title": args.base_title,
+        "selected_task_ids": list(plan.selected_task_ids),
+        "excluded_task_ids": list(plan.excluded_task_ids),
+        "rename_map": [
+            {"task_id": item.task_id, "old_title": item.old_title, "new_title": item.new_title, "roles": list(item.roles)}
+            for item in plan.rename_map
+        ],
+        "blockers": [_blocker_payload(item) for item in plan.blockers],
+    }
+    rename_payload["digest"] = sha256_digest(rename_payload)
+    storage = TaskFamilyStorage(root, manifest.family_id, operation_id)
+    storage.write_manifest(manifest)
+    storage.write_immutable_json(storage.rename_plan_path, rename_payload)
+    storage.write_state(LifecycleState.PLANNED, details={"preview": "rename", "digest": rename_payload["digest"]})
+    storage.write_receipt(_preview_receipt(plan))
+    payload = _graph_payload(graph)
+    payload.update(rename_payload)
+    payload["planner_blockers"] = rename_payload["blockers"]
+    _emit(payload, json_output=args.json, human=_human_preview({**payload, "operation": "rename_preview", "plan_digest": rename_payload["digest"]}))
+    return EXIT_OK if plan.is_actionable else EXIT_BLOCKED
+
+
+def _cmd_preview_operation(args: argparse.Namespace, operation: OperationKind) -> int:
+    root = _repo_root(args.repo_root)
+    manifest = _load_manifest(args.manifest)
+    operation_id = _canonical_uuid(args.operation_id, "--operation-id")
+    lineage_id = _canonical_uuid(args.lineage_id, "--lineage-id")
+    graph = discover_task_family(manifest)
+    selections = _selection_inputs(args)
+    plan = build_plan(graph, operation_id=operation_id, operation=operation, selections=selections, base_title=args.base_title)
+    db_path = _db_path(args.db)
+    execution_data, extra_blockers = _execution_payload(graph, plan, lineage_id=lineage_id, db_path=db_path, host=args.host)
+    plan = _plan_with_blockers(plan, extra_blockers)
+    plan = _plan_with_execution_context(plan, execution_data)
+    execution_data = {**execution_data, "plan_digest": plan.digest}
+    _persist_operation(root, manifest, plan, execution_data)
+    payload = _preview_payload(graph, plan, execution_data)
+    _emit(payload, json_output=args.json, human=_human_preview(payload))
+    return EXIT_OK if plan.is_actionable else EXIT_BLOCKED
+
+
+def _thread_result(record: codex_state.ThreadRecord) -> dict[str, Any]:
+    return {
+        "task_id": record.thread_id,
+        "title": record.title,
+        "cwd": record.cwd,
+        "host": record.host,
+        "archived": record.archived,
+        "archived_at": record.archived_at,
+    }
+
+
+def _cmd_reconcile_title(args: argparse.Namespace) -> int:
+    task_id = _canonical_uuid(args.task_id, "--task-id")
+    db_path = _db_path(args.db)
+    try:
+        record = codex_state.read_thread_record(db_path, task_id=task_id)
+        if record.title != args.expected_title or record.cwd != args.cwd or (args.host is not None and record.host != args.host):
+            raise codex_state.CodexStateContextError("exact title, cwd, or host context does not match")
+    except codex_state.CodexStateError as exc:
+        payload = {"ok": False, "action": "reconcile_title", "task_id": task_id, "db_path": str(db_path), "error": str(exc)}
+        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+        return EXIT_BLOCKED
+    payload = {"ok": True, "action": "reconcile_title", "db_path": str(db_path), "thread": _thread_result(record)}
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    return EXIT_OK
+
+
+def _append_reconciliation(
+    storage: TaskFamilyStorage,
+    *,
+    task_id: str,
+    action: str,
+    result: dict[str, Any],
+    verified: bool,
+) -> None:
+    storage.append_event(
+        LifecycleEvent(
+            event_id=str(uuid.uuid4()),
+            occurred_at=utc_now(),
+            state=LifecycleState.TASKS_ARCHIVED,
+            kind=f"native_{action}_reconciled",
+            details=result,
+        )
+    )
+    plan = storage.load_plan()
+    try:
+        previous = storage.load_receipt() if storage.receipt_path.exists() else _preview_receipt(plan)
+    except ValueError:
+        # The cleanup executor owns its state-shaped receipt after apply.  The
+        # append-only event remains the exact per-task reconciliation evidence.
+        return
+    action_record = ReceiptAction(
+        "task",
+        task_id,
+        (task_id,),
+        f"native_{action}_{'verified' if verified else 'blocked'}",
+        "" if verified else str(result.get("error", "native target was not reached")),
+    )
+    if verified:
+        storage.write_receipt(replace(previous, actual=(*previous.actual, action_record), events=storage.load_events()))
+    else:
+        storage.write_receipt(replace(previous, failures=(*previous.failures, action_record), events=storage.load_events()))
+
+
+def _cmd_reconcile_archive(args: argparse.Namespace, *, archived: bool) -> int:
+    root = _repo_root(args.repo_root)
+    task_id = _canonical_uuid(args.task_id, "--task-id")
+    operation_id = _canonical_uuid(args.operation_id, "--operation-id")
+    storage = TaskFamilyStorage(root, args.family_id, operation_id)
+    try:
+        plan = storage.load_plan()
+        if task_id not in plan.selected_task_ids:
+            raise CliError(f"task {task_id} is not an explicitly selected operation target")
+        db_path = _db_path(args.db)
+        record = codex_state.await_task_target(
+            task_id=task_id,
+            expected_title=args.expected_title,
+            expected_cwd=args.cwd,
+            expected_host=args.host,
+            expected_archived=archived,
+            db_path=db_path,
+        )
+        result = {"ok": True, "action": "archive" if archived else "restore", "db_path": str(db_path), "thread": _thread_result(record)}
+        _append_reconciliation(storage, task_id=task_id, action=result["action"], result=result, verified=True)
+    except (CliError, codex_state.CodexStateError, ValueError) as exc:
+        result = {"ok": False, "action": "archive" if archived else "restore", "task_id": task_id, "error": str(exc)}
+        if storage.plan_path.exists():
+            _append_reconciliation(storage, task_id=task_id, action=result["action"], result=result, verified=False)
+        print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+        return EXIT_BLOCKED
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return EXIT_OK
+
+
+def _cleanup_plan_from_storage(root: Path, *, family_id: str, operation_id: str, lineage_id: str, digest: str) -> executor.CleanupPlan:
+    storage = TaskFamilyStorage(root, family_id, operation_id)
+    persisted = storage.assert_plan_digest(digest)
+    plan = TaskFamilyPlan.from_dict(persisted)
+    if plan.family_id != family_id or plan.operation_id != operation_id:
+        raise CliError("persisted plan identity does not match apply request")
+    if plan.blockers:
+        raise CliError("persisted plan contains blockers; rebuild explicit plan before apply")
+    data = storage.load_execution()
+    context = dict(data)
+    context.pop("plan_digest", None)
+    if data.get("plan_digest") != digest or context != (plan.execution_context or {}):
+        raise CliError("persisted execution inputs drifted from planner authorization")
+    if data.get("lineage_id") != lineage_id:
+        raise CliError("persisted execution inputs do not match caller digest or lineage")
+    if data.get("mode") != plan.operation.value:
+        raise CliError("persisted execution mode does not match planner operation")
+
+    def task_target(item: Any) -> executor.TaskTarget:
+        if not isinstance(item, dict):
+            raise CliError("persisted task target must be an object")
+        return executor.TaskTarget(
+            task_id=_canonical_uuid(str(item.get("task_id", "")), "persisted task target"),
+            title=str(item.get("title", "")),
+            cwd=str(item.get("cwd", "")),
+            db_path=Path(str(item.get("db_path", ""))),
+            host=item.get("host") if isinstance(item.get("host"), str) else None,
+        )
+
+    def worktree_target(item: Any) -> executor.WorktreeTarget:
+        if not isinstance(item, dict):
+            raise CliError("persisted worktree target must be an object")
+        return executor.WorktreeTarget(
+            id=_canonical_uuid(str(item.get("id", "")), "persisted worktree target"),
+            worktree=Path(str(item.get("worktree", ""))),
+            branch=str(item.get("branch", "")),
+            pr_number=int(item.get("pr_number", 0)),
+            pr_base=str(item.get("pr_base", "")),
+            explicit_family=str(item.get("explicit_family", "")),
+        )
+
+    def runtime_target(item: Any) -> executor.RuntimeTarget:
+        if not isinstance(item, dict):
+            raise CliError("persisted runtime target must be an object")
+        return executor.RuntimeTarget(
+            id=_canonical_uuid(str(item.get("id", "")), "persisted runtime target"),
+            kind=str(item.get("kind", "")),
+            eligible=item.get("eligible") is True,
+            proof=item.get("proof") if isinstance(item.get("proof"), str) else None,
+        )
+
+    raw_tasks = data.get("task_targets")
+    raw_worktrees = data.get("worktree_targets")
+    raw_runtime = data.get("runtime_targets")
+    if not all(isinstance(value, list) for value in (raw_tasks, raw_worktrees, raw_runtime)):
+        raise CliError("persisted execution target lists are invalid")
+    return executor.CleanupPlan(
+        operation_id=operation_id,
+        family_id=family_id,
+        lineage_id=lineage_id,
+        mode=plan.operation.value,
+        task_targets=tuple(task_target(item) for item in raw_tasks),
+        worktree_targets=tuple(worktree_target(item) for item in raw_worktrees),
+        runtime_targets=tuple(runtime_target(item) for item in raw_runtime),
+        selected_task_ids=frozenset(plan.selected_task_ids),
+        pin_unknown_confirmed=data.get("pin_unknown_confirmed") is True,
+        persisted_plan_digest=digest,
+    )
+
+
+def _cmd_apply_cleanup(args: argparse.Namespace) -> int:
+    root = _repo_root(args.repo_root)
+    operation_id = _canonical_uuid(args.operation_id, "--operation-id")
+    lineage_id = _canonical_uuid(args.lineage_id, "--lineage-id")
+    digest = args.plan_digest.lower()
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+        raise CliError("--plan-digest must be a lowercase SHA-256 hex digest")
+    try:
+        cleanup_plan = _cleanup_plan_from_storage(root, family_id=args.family_id, operation_id=operation_id, lineage_id=lineage_id, digest=digest)
+        result = executor.CleanupExecutor(root, cleanup_plan).run()
+    except (CliError, executor.ExecutorError, git_safety.GitSafetyError, ValueError) as exc:
+        payload = {"ok": False, "action": "apply_cleanup", "error": str(exc)}
+        _emit(payload, json_output=args.json, human=f"BLOCKER: {exc}\n")
+        return EXIT_BLOCKED
+    payload = {"ok": result.get("state") not in {"blocked"}, "action": "apply_cleanup", "result": result}
+    _emit(payload, json_output=args.json, human=f"Cleanup state: {result.get('state')}\n")
+    return EXIT_OK if payload["ok"] else EXIT_BLOCKED
+
+
+def _receipt_human(payload: dict[str, Any]) -> str:
+    if "final_state" in payload:
+        return OperationReceipt.from_dict(payload).render_human()
+    lines = [f"Task-family operation {payload.get('operation_id', 'unknown')}", f"State: {payload.get('state', 'planned')}"]
+    resources = payload.get("resources", {})
+    if isinstance(resources, dict):
+        for kind in ("task", "worktree", "runtime"):
+            entries = resources.get(kind, {})
+            if not isinstance(entries, dict):
+                continue
+            for resource_id, entry in sorted(entries.items()):
+                status = entry.get("status", "planned") if isinstance(entry, dict) else "unknown"
+                lines.append(f"{status}: {kind}:{resource_id}")
+    blocked = payload.get("blocked")
+    if blocked:
+        lines.append(f"BLOCKER: {blocked}")
+    return "\n".join(lines) + "\n"
+
+
+def _cmd_receipt(args: argparse.Namespace) -> int:
+    root = _repo_root(args.repo_root)
+    operation_id = _canonical_uuid(args.operation_id, "--operation-id")
+    storage = TaskFamilyStorage(root, args.family_id, operation_id)
+    try:
+        payload = storage.read_json(storage.receipt_path)
+    except FileNotFoundError as exc:
+        raise CliError(f"receipt not found: {storage.receipt_path}") from exc
+    _emit(payload, json_output=args.json, human=_receipt_human(payload))
+    return EXIT_BLOCKED if payload.get("state") == "blocked" else EXIT_OK
+
+
+def _add_selection_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--select-task", action="append", required=True, default=[])
+    parser.add_argument("--actor", required=True)
+    parser.add_argument("--confirm-pin-unknown", action="append", required=True, default=[])
+
+
+def _add_preview_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--operation-id", required=True)
+    parser.add_argument("--lineage-id", required=True)
+    parser.add_argument("--base-title", required=True)
+    parser.add_argument("--db", required=True, help="Codex SQLite path or 'auto'")
+    parser.add_argument("--host")
+    _add_selection_arguments(parser)
+    parser.add_argument("--json", action="store_true")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="task-family")
+    commands = parser.add_subparsers(dest="command", required=True)
+    inspect = commands.add_parser("inspect")
+    inspect.add_argument("--manifest", required=True)
+    inspect.add_argument("--json", action="store_true")
+
+    rename = commands.add_parser("preview-rename")
+    rename.add_argument("--repo-root", required=True)
+    rename.add_argument("--manifest", required=True)
+    rename.add_argument("--operation-id", required=True)
+    rename.add_argument("--base-title", required=True)
+    _add_selection_arguments(rename)
+    rename.add_argument("--json", action="store_true")
+
+    for name in ("preview-archive", "preview-cleanup"):
+        command = commands.add_parser(name)
+        _add_preview_arguments(command)
+
+    title = commands.add_parser("reconcile-title")
+    title.add_argument("--db", required=True)
+    title.add_argument("--task-id", required=True)
+    title.add_argument("--cwd", required=True)
+    title.add_argument("--expected-title", required=True)
+    title.add_argument("--host")
+
+    for name in ("reconcile-archive", "reconcile-restore"):
+        command = commands.add_parser(name)
+        command.add_argument("--repo-root", required=True)
+        command.add_argument("--family-id", required=True)
+        command.add_argument("--operation-id", required=True)
+        command.add_argument("--db", required=True)
+        command.add_argument("--task-id", required=True)
+        command.add_argument("--cwd", required=True)
+        command.add_argument("--expected-title", required=True)
+        command.add_argument("--host")
+
+    apply_cleanup = commands.add_parser("apply-cleanup")
+    apply_cleanup.add_argument("--repo-root", required=True)
+    apply_cleanup.add_argument("--family-id", required=True)
+    apply_cleanup.add_argument("--operation-id", required=True)
+    apply_cleanup.add_argument("--lineage-id", required=True)
+    apply_cleanup.add_argument("--plan-digest", required=True)
+    apply_cleanup.add_argument("--json", action="store_true")
+
+    receipt = commands.add_parser("receipt")
+    receipt.add_argument("--repo-root", required=True)
+    receipt.add_argument("--family-id", required=True)
+    receipt.add_argument("--operation-id", required=True)
+    receipt.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "inspect":
+            return _cmd_inspect(args)
+        if args.command == "preview-rename":
+            return _cmd_preview_rename(args)
+        if args.command == "preview-archive":
+            return _cmd_preview_operation(args, OperationKind.ARCHIVE_ONLY)
+        if args.command == "preview-cleanup":
+            return _cmd_preview_operation(args, OperationKind.FINISH_AND_CLEAN)
+        if args.command == "reconcile-title":
+            return _cmd_reconcile_title(args)
+        if args.command == "reconcile-archive":
+            return _cmd_reconcile_archive(args, archived=True)
+        if args.command == "reconcile-restore":
+            return _cmd_reconcile_archive(args, archived=False)
+        if args.command == "apply-cleanup":
+            return _cmd_apply_cleanup(args)
+        if args.command == "receipt":
+            return _cmd_receipt(args)
+        raise CliError(f"unsupported command: {args.command}")
+    except (CliError, ValueError) as exc:
+        print(f"task-family: {exc}", file=sys.stderr)
+        return EXIT_INVALID
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/task_family/cli.py
+++ b/scripts/orchestration/task_family/cli.py
@@ -614,11 +614,16 @@ def _append_reconciliation(
     if previous is not None:
         retry = any(item.resource_id == task_id and item.action == action for item in previous.actual)
     details = {**result, "recovery": recovery, "retry": retry}
+    verified_state = {
+        "title": LifecycleState.VERIFIED,
+        "archive": LifecycleState.TASKS_ARCHIVED,
+        "restore": LifecycleState.VERIFIED,
+    }.get(action, LifecycleState.VERIFIED)
     storage.append_event(
         LifecycleEvent(
             event_id=str(uuid.uuid4()),
             occurred_at=utc_now(),
-            state=LifecycleState.TASKS_ARCHIVED if verified else LifecycleState.BLOCKED,
+            state=verified_state if verified else LifecycleState.BLOCKED,
             kind=f"native_{action}_{'retry_' if retry else ''}{'reconciled' if verified else 'failed'}",
             details=details,
         )

--- a/scripts/orchestration/task_family/cli.py
+++ b/scripts/orchestration/task_family/cli.py
@@ -268,6 +268,10 @@ def _execution_payload(
         for task_id in (relation.source_id, relation.target_id)
     }
     for task_id in plan.selected_task_ids:
+        if task_id not in nodes:
+            # The planner already records ``unknown_selected_task``.  Keep the
+            # execution adapter fail-closed instead of indexing an absent node.
+            continue
         node = nodes[task_id]
         metadata_state = _active_metadata_state(node.metadata)
         if metadata_state is not None:

--- a/scripts/orchestration/task_family/cli.py
+++ b/scripts/orchestration/task_family/cli.py
@@ -191,6 +191,34 @@ def _preview_receipt(plan: TaskFamilyPlan) -> OperationReceipt:
     )
 
 
+def _rename_plan_digest(payload: dict[str, Any]) -> str:
+    """Digest exactly the immutable rename authorization, never its digest field."""
+    immutable = dict(payload)
+    immutable.pop("digest", None)
+    return sha256_digest(immutable)
+
+
+def _rename_preview_receipt(rename_payload: dict[str, Any]) -> OperationReceipt:
+    actions = tuple(
+        ReceiptAction(
+            "task",
+            item["task_id"],
+            (item["task_id"],),
+            "reconcile_title",
+            "exact persisted rename mapping",
+            recovery="Use the native title action, then reconcile this exact task again.",
+        )
+        for item in rename_payload["rename_map"]
+    )
+    return OperationReceipt(
+        operation_id=rename_payload["operation_id"],
+        family_id=rename_payload["family_id"],
+        plan_digest=rename_payload["digest"],
+        final_state=LifecycleState.PLANNED,
+        planned=actions,
+    )
+
+
 def _db_path(value: str) -> Path:
     try:
         return codex_state.discover_state_database(None if value == "auto" else Path(value).expanduser())
@@ -213,6 +241,16 @@ def _execution_payload(
     worktrees: list[dict[str, Any]] = []
     for task_id in plan.selected_task_ids:
         node = nodes[task_id]
+        metadata_state = _active_metadata_state(node.metadata)
+        if metadata_state is not None:
+            blockers.append(
+                Blocker(
+                    "selected_task_active",
+                    f"Selected task {task_id!r} is explicitly marked {metadata_state!r} in manifest metadata.",
+                    (task_id,),
+                    "Wait for the task to stop, then create a new explicit preview.",
+                )
+            )
         expected_host = host if host is not None else node.metadata.get("host")
         tasks.append(
             {
@@ -289,6 +327,115 @@ def _execution_payload(
     return payload, tuple(blockers)
 
 
+def _active_metadata_state(metadata: dict[str, str]) -> str | None:
+    """Recognize only explicit manifest claims; absent metadata remains unknown."""
+    for key in ("state", "status", "task_state", "lifecycle_state"):
+        value = metadata.get(key, "").strip().lower()
+        if value in {"running", "active"}:
+            return value
+    for key in ("running", "active"):
+        if metadata.get(key, "").strip().lower() in {"1", "true", "yes", "running", "active"}:
+            return key
+    return None
+
+
+def _cleanup_preview_evidence(
+    root: Path,
+    graph: FamilyGraph,
+    plan: TaskFamilyPlan,
+    execution_data: dict[str, Any],
+) -> tuple[list[dict[str, Any]], tuple[Blocker, ...]]:
+    """Collect all cleanup preconditions read-only before declaring a plan actionable."""
+    targets = execution_data.get("worktree_targets", [])
+    evidence: list[dict[str, Any]] = []
+    blockers: list[Blocker] = []
+    try:
+        registered = {item.path.resolve(): item for item in git_safety.worktree_list(root)}
+        registry_error: str | None = None
+    except Exception as exc:  # Git inspection failures are blockers, never guesses.
+        registered = {}
+        registry_error = str(exc)
+
+    for target in targets:
+        task_id = str(target["id"])
+        node = graph.nodes_by_id[task_id]
+        worktree = Path(str(target["worktree"])).expanduser()
+        item: dict[str, Any] = {
+            "task_id": task_id,
+            "worktree": str(worktree),
+            "expected_branch": target["branch"],
+            "expected_pr": target["pr_number"],
+            "registered": False,
+            "permanent": None,
+            "dirty": None,
+            "locked": None,
+            "prunable": None,
+            "index_locked": None,
+            "registered_branch": None,
+            "registered_head": None,
+            "expected_head": None,
+            "task_cwd": node.metadata.get("cwd"),
+            "cwd_owns_worktree": False,
+            "pr": None,
+        }
+        if registry_error is not None:
+            item["registry_error"] = registry_error
+            blockers.append(Blocker("cleanup_evidence_unknown", f"Could not inspect registered worktrees for {task_id!r}: {registry_error}", (task_id,)))
+            evidence.append(item)
+            continue
+        info = registered.get(worktree.resolve())
+        item["registered"] = info is not None
+        if info is None:
+            blockers.append(Blocker("unregistered_worktree", f"Selected worktree is not registered: {worktree}", (task_id,)))
+        else:
+            item["permanent"] = git_safety.is_worktree_permanent(root, worktree)
+            item["registered_branch"] = info.branch
+            item["registered_head"] = info.head
+            item["prunable"] = info.prunable
+            item["index_locked"] = git_safety.worktree_index_locked(worktree)
+            item["locked"] = info.locked or info.prunable or item["index_locked"]
+            try:
+                item["dirty"] = git_safety.is_worktree_dirty(worktree)
+                item["expected_head"] = git_safety.local_branch_head(root, str(target["branch"]))
+            except Exception as exc:
+                item["inspection_error"] = str(exc)
+                blockers.append(Blocker("cleanup_evidence_unknown", f"Could not inspect selected worktree {worktree}: {exc}", (task_id,)))
+
+        cwd = item["task_cwd"]
+        if isinstance(cwd, str) and cwd.strip():
+            item["cwd_owns_worktree"] = Path(cwd).expanduser().resolve() == worktree.resolve()
+        if not item["cwd_owns_worktree"]:
+            blockers.append(Blocker("task_cwd_worktree_mismatch", f"Task {task_id!r} cwd does not exactly own selected worktree {worktree}.", (task_id,)))
+        if info is not None:
+            if item["permanent"]:
+                blockers.append(Blocker("permanent_worktree", f"Selected worktree is the primary checkout: {worktree}", (task_id,)))
+            if item["dirty"] is True:
+                blockers.append(Blocker("dirty_worktree", f"Selected worktree is dirty: {worktree}", (task_id,)))
+            if item["locked"]:
+                blockers.append(Blocker("locked_worktree", f"Selected worktree has a Git lock or prunable marker: {worktree}", (task_id,)))
+            if info.branch != target["branch"]:
+                blockers.append(Blocker("worktree_branch_mismatch", f"Selected worktree branch differs from manifest: {worktree}", (task_id,)))
+            if item["expected_head"] is None or info.head != item["expected_head"]:
+                blockers.append(Blocker("worktree_head_mismatch", f"Selected worktree HEAD differs from registered branch head: {worktree}", (task_id,)))
+
+        try:
+            pr = git_safety.query_pr_by_head(root, branch=str(target["branch"]), pr_number=int(target["pr_number"]))
+            item["pr"] = pr
+            if (
+                int(pr.get("number", 0) or 0) != int(target["pr_number"])
+                or pr.get("head_ref_name") != target["branch"]
+                or pr.get("base_ref_name") != target["pr_base"]
+                or pr.get("head_ref_oid") != item["expected_head"]
+                or pr.get("state") != "MERGED"
+            ):
+                blockers.append(Blocker("pr_evidence_mismatch", f"Exact PR evidence does not match selected worktree {worktree}.", (task_id,)))
+        except Exception as exc:
+            item["pr_error"] = str(exc)
+            blockers.append(Blocker("pr_evidence_unknown", f"Could not verify exact PR evidence for selected worktree {worktree}: {exc}", (task_id,)))
+        evidence.append(item)
+    return evidence, tuple(blockers)
+
+
 def _persist_operation(
     root: Path,
     manifest: TaskFamilyManifest,
@@ -321,6 +468,10 @@ def _preview_payload(graph: FamilyGraph, plan: TaskFamilyPlan, execution_data: d
             "resources": execution_data,
         }
     )
+    if "cleanup_evidence" in execution_data:
+        payload["cleanup_evidence"] = execution_data["cleanup_evidence"]
+    payload["counts"]["blockers"] = len(plan.blockers)
+    payload["counts"]["planner_blockers"] = len(plan.blockers)
     return payload
 
 
@@ -329,7 +480,7 @@ def _human_preview(payload: dict[str, Any]) -> str:
         f"Preview {payload['operation']} for family {payload['family_id']}",
         f"Operation: {payload['operation_id']}",
         f"Plan digest: {payload['plan_digest']}",
-        f"Counts: included={payload['counts']['included']}, selected={len(payload['selected_task_ids'])}, excluded={payload['counts']['excluded']}",
+        f"Counts: included={payload['counts']['included']}, selected={len(payload['selected_task_ids'])}, excluded={payload['counts']['excluded']}, blockers={len(payload['planner_blockers'])}",
     ]
     for item in payload["rename_map"]:
         lines.append(f"- {item['task_id']}: {item['old_title']} -> {item['new_title']}")
@@ -337,6 +488,14 @@ def _human_preview(payload: dict[str, Any]) -> str:
         lines.append(f"- excluded {task['task_id']}: {task['title']}")
     for blocker in payload["planner_blockers"]:
         lines.append(f"BLOCKER {blocker['code']}: {blocker['message']}")
+    for item in payload.get("cleanup_evidence", []):
+        lines.append(
+            "- cleanup evidence "
+            f"{item['task_id']}: registered={item['registered']}, permanent={item['permanent']}, "
+            f"dirty={item['dirty']}, locked={item['locked']}, prunable={item['prunable']}, "
+            f"branch={item['registered_branch']}, head={item['registered_head']}, "
+            f"cwd_owns_worktree={item['cwd_owns_worktree']}"
+        )
     return "\n".join(lines) + "\n"
 
 
@@ -360,6 +519,21 @@ def _cmd_preview_rename(args: argparse.Namespace) -> int:
         selections=selections,
         base_title=args.base_title,
     )
+    selected = set(plan.selected_task_ids)
+    included = set(graph.included_task_ids)
+    if selected != included:
+        plan = _plan_with_blockers(
+            plan,
+            (
+                Blocker(
+                    "partial_family_rename_selection",
+                    "Family-level rename requires every included exact task ID to be selected.",
+                    tuple(sorted(included - selected)),
+                    "Select every included exact task ID; excluded similar-title tasks remain excluded.",
+                ),
+            ),
+        )
+    selected_rename_map = tuple(item for item in plan.rename_map if item.task_id in selected)
     rename_payload = {
         "schema_version": 1,
         "kind": "rename_preview",
@@ -370,18 +544,19 @@ def _cmd_preview_rename(args: argparse.Namespace) -> int:
         "excluded_task_ids": list(plan.excluded_task_ids),
         "rename_map": [
             {"task_id": item.task_id, "old_title": item.old_title, "new_title": item.new_title, "roles": list(item.roles)}
-            for item in plan.rename_map
+            for item in selected_rename_map
         ],
         "blockers": [_blocker_payload(item) for item in plan.blockers],
     }
-    rename_payload["digest"] = sha256_digest(rename_payload)
+    rename_payload["digest"] = _rename_plan_digest(rename_payload)
     storage = TaskFamilyStorage(root, manifest.family_id, operation_id)
     storage.write_manifest(manifest)
     storage.write_immutable_json(storage.rename_plan_path, rename_payload)
     storage.write_state(LifecycleState.PLANNED, details={"preview": "rename", "digest": rename_payload["digest"]})
-    storage.write_receipt(_preview_receipt(plan))
+    storage.write_receipt(_rename_preview_receipt(rename_payload))
     payload = _graph_payload(graph)
     payload.update(rename_payload)
+    payload["counts"]["blockers"] = len(rename_payload["blockers"])
     payload["planner_blockers"] = rename_payload["blockers"]
     _emit(payload, json_output=args.json, human=_human_preview({**payload, "operation": "rename_preview", "plan_digest": rename_payload["digest"]}))
     return EXIT_OK if plan.is_actionable else EXIT_BLOCKED
@@ -397,6 +572,10 @@ def _cmd_preview_operation(args: argparse.Namespace, operation: OperationKind) -
     plan = build_plan(graph, operation_id=operation_id, operation=operation, selections=selections, base_title=args.base_title)
     db_path = _db_path(args.db)
     execution_data, extra_blockers = _execution_payload(graph, plan, lineage_id=lineage_id, db_path=db_path, host=args.host)
+    if operation is OperationKind.FINISH_AND_CLEAN:
+        cleanup_evidence, cleanup_blockers = _cleanup_preview_evidence(root, graph, plan, execution_data)
+        execution_data["cleanup_evidence"] = cleanup_evidence
+        extra_blockers = (*extra_blockers, *cleanup_blockers)
     plan = _plan_with_blockers(plan, extra_blockers)
     plan = _plan_with_execution_context(plan, execution_data)
     execution_data = {**execution_data, "plan_digest": plan.digest}
@@ -417,22 +596,6 @@ def _thread_result(record: codex_state.ThreadRecord) -> dict[str, Any]:
     }
 
 
-def _cmd_reconcile_title(args: argparse.Namespace) -> int:
-    task_id = _canonical_uuid(args.task_id, "--task-id")
-    db_path = _db_path(args.db)
-    try:
-        record = codex_state.read_thread_record(db_path, task_id=task_id)
-        if record.title != args.expected_title or record.cwd != args.cwd or (args.host is not None and record.host != args.host):
-            raise codex_state.CodexStateContextError("exact title, cwd, or host context does not match")
-    except codex_state.CodexStateError as exc:
-        payload = {"ok": False, "action": "reconcile_title", "task_id": task_id, "db_path": str(db_path), "error": str(exc)}
-        print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
-        return EXIT_BLOCKED
-    payload = {"ok": True, "action": "reconcile_title", "db_path": str(db_path), "thread": _thread_result(record)}
-    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
-    return EXIT_OK
-
-
 def _append_reconciliation(
     storage: TaskFamilyStorage,
     *,
@@ -440,34 +603,150 @@ def _append_reconciliation(
     action: str,
     result: dict[str, Any],
     verified: bool,
+    plan_digest: str,
+    recovery: str,
 ) -> None:
+    retry = False
+    try:
+        previous = storage.load_receipt() if storage.receipt_path.exists() else None
+    except ValueError:
+        previous = None
+    if previous is not None:
+        retry = any(item.resource_id == task_id and item.action == action for item in previous.actual)
+    details = {**result, "recovery": recovery, "retry": retry}
     storage.append_event(
         LifecycleEvent(
             event_id=str(uuid.uuid4()),
             occurred_at=utc_now(),
-            state=LifecycleState.TASKS_ARCHIVED,
-            kind=f"native_{action}_reconciled",
-            details=result,
+            state=LifecycleState.TASKS_ARCHIVED if verified else LifecycleState.BLOCKED,
+            kind=f"native_{action}_{'retry_' if retry else ''}{'reconciled' if verified else 'failed'}",
+            details=details,
         )
     )
-    plan = storage.load_plan()
-    try:
-        previous = storage.load_receipt() if storage.receipt_path.exists() else _preview_receipt(plan)
-    except ValueError:
-        # The cleanup executor owns its state-shaped receipt after apply.  The
-        # append-only event remains the exact per-task reconciliation evidence.
-        return
     action_record = ReceiptAction(
         "task",
         task_id,
         (task_id,),
-        f"native_{action}_{'verified' if verified else 'blocked'}",
+        action,
+        "native DB read-back verified the persisted target" if verified else "native DB read-back did not reach the persisted target",
         "" if verified else str(result.get("error", "native target was not reached")),
+        recovery,
     )
+    if previous is None:
+        previous = OperationReceipt(
+            operation_id=result.get("operation_id", storage.root.name),
+            family_id=result.get("family_id", storage.root.parent.parent.name),
+            plan_digest=plan_digest,
+            final_state=LifecycleState.PLANNED,
+        )
     if verified:
-        storage.write_receipt(replace(previous, actual=(*previous.actual, action_record), events=storage.load_events()))
+        if retry:
+            retry_record = ReceiptAction(
+                "task",
+                task_id,
+                (task_id,),
+                f"{action}_retry_readback",
+                "already reconciled; no second native resource action was performed",
+                recovery=recovery,
+            )
+            storage.write_receipt(replace(previous, skipped=(*previous.skipped, retry_record), events=storage.load_events()))
+        else:
+            storage.write_receipt(replace(previous, actual=(*previous.actual, action_record), events=storage.load_events()))
     else:
         storage.write_receipt(replace(previous, failures=(*previous.failures, action_record), events=storage.load_events()))
+
+
+def _canonical_digest(value: str, label: str) -> str:
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise CliError(f"{label} must be a lowercase SHA-256 hex digest")
+    return value
+
+
+def _load_rename_authorization(
+    storage: TaskFamilyStorage,
+    *,
+    family_id: str,
+    operation_id: str,
+    task_id: str,
+    digest: str,
+) -> dict[str, Any]:
+    payload = storage.read_json(storage.rename_plan_path)
+    if payload.get("kind") != "rename_preview":
+        raise CliError("persisted rename plan has an invalid kind")
+    if payload.get("family_id") != family_id or payload.get("operation_id") != operation_id:
+        raise CliError("persisted rename plan identity does not match reconcile request")
+    if payload.get("digest") != digest or _rename_plan_digest(payload) != digest:
+        raise CliError("immutable rename plan digest does not match persisted authorization")
+    if payload.get("blockers"):
+        raise CliError("persisted rename plan contains blockers and cannot authorize reconciliation")
+    selected = payload.get("selected_task_ids")
+    mappings = payload.get("rename_map")
+    if not isinstance(selected, list) or not all(isinstance(item, str) for item in selected):
+        raise CliError("persisted rename plan has invalid selected task IDs")
+    if task_id not in selected:
+        raise CliError(f"task {task_id} is not an explicitly selected rename target")
+    if not isinstance(mappings, list):
+        raise CliError("persisted rename plan has invalid title mappings")
+    matching = [item for item in mappings if isinstance(item, dict) and item.get("task_id") == task_id]
+    if len(matching) != 1 or not isinstance(matching[0].get("new_title"), str):
+        raise CliError(f"persisted rename plan has no exact title mapping for task {task_id}")
+    if any(not isinstance(item, dict) or item.get("task_id") not in selected for item in mappings):
+        raise CliError("persisted rename plan exposes a mapping for an unselected task")
+    return matching[0]
+
+
+def _cmd_reconcile_title(args: argparse.Namespace) -> int:
+    root = _repo_root(args.repo_root)
+    task_id = _canonical_uuid(args.task_id, "--task-id")
+    operation_id = _canonical_uuid(args.operation_id, "--operation-id")
+    digest = _canonical_digest(args.plan_digest, "--plan-digest")
+    storage = TaskFamilyStorage(root, args.family_id, operation_id)
+    recovery = "Use the native title action for the persisted mapping, then retry reconciliation."
+    try:
+        mapping = _load_rename_authorization(
+            storage,
+            family_id=args.family_id,
+            operation_id=operation_id,
+            task_id=task_id,
+            digest=digest,
+        )
+        if args.expected_title != mapping["new_title"]:
+            raise CliError("--expected-title does not match the persisted exact rename mapping")
+        manifest = storage.load_manifest()
+        node = next((item for item in manifest.nodes if item.task_id == task_id), None)
+        if node is None:
+            raise CliError("persisted manifest does not contain selected rename task")
+        expected_cwd = node.metadata.get("cwd", node.project_root)
+        expected_host = node.metadata.get("host")
+        if args.cwd != expected_cwd or (expected_host is not None and args.host != expected_host):
+            raise CliError("reconcile cwd or host does not match persisted manifest task context")
+        db_path = _db_path(args.db)
+        record = codex_state.read_thread_record(db_path, task_id=task_id)
+        if record.title != mapping["new_title"] or record.cwd != args.cwd or (args.host is not None and record.host != args.host):
+            raise codex_state.CodexStateContextError("exact persisted title, cwd, or host context does not match")
+        result = {
+            "ok": True,
+            "action": "title",
+            "operation_id": operation_id,
+            "family_id": args.family_id,
+            "db_path": str(db_path),
+            "thread": _thread_result(record),
+        }
+        _append_reconciliation(storage, task_id=task_id, action="title", result=result, verified=True, plan_digest=digest, recovery=recovery)
+    except (CliError, codex_state.CodexStateError, ValueError) as exc:
+        result = {
+            "ok": False,
+            "action": "title",
+            "operation_id": operation_id,
+            "family_id": args.family_id,
+            "task_id": task_id,
+            "error": str(exc),
+        }
+        _append_reconciliation(storage, task_id=task_id, action="title", result=result, verified=False, plan_digest=digest, recovery=recovery)
+        print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+        return EXIT_BLOCKED
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return EXIT_OK
 
 
 def _cmd_reconcile_archive(args: argparse.Namespace, *, archived: bool) -> int:
@@ -475,8 +754,12 @@ def _cmd_reconcile_archive(args: argparse.Namespace, *, archived: bool) -> int:
     task_id = _canonical_uuid(args.task_id, "--task-id")
     operation_id = _canonical_uuid(args.operation_id, "--operation-id")
     storage = TaskFamilyStorage(root, args.family_id, operation_id)
+    action = "archive" if archived else "restore"
+    plan_digest = "unavailable"
+    recovery = f"Use the native {action} action for this exact task, then retry reconciliation."
     try:
         plan = storage.load_plan()
+        plan_digest = plan.digest
         if task_id not in plan.selected_task_ids:
             raise CliError(f"task {task_id} is not an explicitly selected operation target")
         db_path = _db_path(args.db)
@@ -488,12 +771,11 @@ def _cmd_reconcile_archive(args: argparse.Namespace, *, archived: bool) -> int:
             expected_archived=archived,
             db_path=db_path,
         )
-        result = {"ok": True, "action": "archive" if archived else "restore", "db_path": str(db_path), "thread": _thread_result(record)}
-        _append_reconciliation(storage, task_id=task_id, action=result["action"], result=result, verified=True)
+        result = {"ok": True, "action": action, "operation_id": operation_id, "family_id": args.family_id, "db_path": str(db_path), "thread": _thread_result(record)}
+        _append_reconciliation(storage, task_id=task_id, action=action, result=result, verified=True, plan_digest=plan_digest, recovery=recovery)
     except (CliError, codex_state.CodexStateError, ValueError) as exc:
-        result = {"ok": False, "action": "archive" if archived else "restore", "task_id": task_id, "error": str(exc)}
-        if storage.plan_path.exists():
-            _append_reconciliation(storage, task_id=task_id, action=result["action"], result=result, verified=False)
+        result = {"ok": False, "action": action, "operation_id": operation_id, "family_id": args.family_id, "task_id": task_id, "error": str(exc)}
+        _append_reconciliation(storage, task_id=task_id, action=action, result=result, verified=False, plan_digest=plan_digest, recovery=recovery)
         print(json.dumps(result, ensure_ascii=False, sort_keys=True))
         return EXIT_BLOCKED
     print(json.dumps(result, ensure_ascii=False, sort_keys=True))
@@ -658,6 +940,10 @@ def build_parser() -> argparse.ArgumentParser:
         _add_preview_arguments(command)
 
     title = commands.add_parser("reconcile-title")
+    title.add_argument("--repo-root", required=True)
+    title.add_argument("--family-id", required=True)
+    title.add_argument("--operation-id", required=True)
+    title.add_argument("--plan-digest", required=True)
     title.add_argument("--db", required=True)
     title.add_argument("--task-id", required=True)
     title.add_argument("--cwd", required=True)

--- a/scripts/orchestration/task_family/cli.py
+++ b/scripts/orchestration/task_family/cli.py
@@ -612,7 +612,10 @@ def _append_reconciliation(
     except ValueError:
         previous = None
     if previous is not None:
-        retry = any(item.resource_id == task_id and item.action == action for item in previous.actual)
+        retry = any(
+            item.resource_id == task_id and item.action == action
+            for item in (*previous.actual, *previous.restoration)
+        )
     details = {**result, "recovery": recovery, "retry": retry}
     verified_state = {
         "title": LifecycleState.VERIFIED,
@@ -655,6 +658,14 @@ def _append_reconciliation(
                 recovery=recovery,
             )
             storage.write_receipt(replace(previous, skipped=(*previous.skipped, retry_record), events=storage.load_events()))
+        elif action == "restore":
+            storage.write_receipt(
+                replace(
+                    previous,
+                    restoration=(*previous.restoration, action_record),
+                    events=storage.load_events(),
+                )
+            )
         else:
             storage.write_receipt(replace(previous, actual=(*previous.actual, action_record), events=storage.load_events()))
     else:
@@ -760,7 +771,10 @@ def _cmd_reconcile_archive(args: argparse.Namespace, *, archived: bool) -> int:
     operation_id = _canonical_uuid(args.operation_id, "--operation-id")
     storage = TaskFamilyStorage(root, args.family_id, operation_id)
     action = "archive" if archived else "restore"
-    plan_digest = "unavailable"
+    try:
+        plan_digest = storage.load_receipt().plan_digest
+    except (FileNotFoundError, ValueError):
+        plan_digest = ""
     recovery = f"Use the native {action} action for this exact task, then retry reconciliation."
     try:
         plan = storage.load_plan()

--- a/scripts/orchestration/task_family/cli.py
+++ b/scripts/orchestration/task_family/cli.py
@@ -25,6 +25,7 @@ from .model import (
     OperationKind,
     OperationReceipt,
     ReceiptAction,
+    RelationType,
     TaskFamilyManifest,
     utc_now,
 )
@@ -84,6 +85,7 @@ def _graph_payload(graph: FamilyGraph) -> dict[str, Any]:
     return {
         "family_id": graph.manifest.family_id,
         "seed_task_id": graph.manifest.seed_task_id,
+        "roots": list(graph.roots),
         "included_task_ids": list(graph.included_task_ids),
         "excluded_task_ids": list(graph.excluded_task_ids),
         "counts": {
@@ -97,14 +99,29 @@ def _graph_payload(graph: FamilyGraph) -> dict[str, Any]:
                 "task_id": node.task_id,
                 "title": node.title,
                 "roles": list(graph.roles_by_task[node.task_id]),
+                "status": next(
+                    (node.metadata[key] for key in ("state", "status", "task_state", "lifecycle_state") if node.metadata.get(key)),
+                    "unknown",
+                ),
                 "resources": {
                     "project_root": node.project_root,
+                    "cwd": node.metadata.get("cwd", node.project_root),
                     "worktree": node.worktree,
                     "branch": node.branch,
                     "pr_id": node.pr_id,
+                    "model": node.metadata.get("model"),
+                    "host": node.metadata.get("host"),
+                    "local": node.metadata.get("local"),
                 },
             }
             for node in sorted(nodes.values(), key=lambda item: item.task_id)
+        ],
+        "relations": [
+            relation.to_dict()
+            for relation in sorted(
+                graph.family_relations,
+                key=lambda item: (item.source_id, item.target_id, item.relation_type.value),
+            )
         ],
         "excluded": [
             {
@@ -126,7 +143,11 @@ def _human_inspect(payload: dict[str, Any]) -> str:
     ]
     for task in payload["tasks"]:
         roles = ", ".join(task["roles"]) or "unclassified"
-        lines.append(f"- {task['task_id']}: {roles}; {task['title']}")
+        lines.append(f"- {task['task_id']}: {roles}; status={task['status']}; {task['title']}")
+    for relation in payload["relations"]:
+        lines.append(
+            f"- edge {relation['source_id']} -[{relation['relation_type']}]-> {relation['target_id']}"
+        )
     for task in payload["excluded"]:
         lines.append(f"- excluded {task['task_id']}: {task['title']} ({task['reason']})")
     for blocker in payload["blockers"]:
@@ -239,6 +260,13 @@ def _execution_payload(
     blockers: list[Blocker] = []
     tasks: list[dict[str, Any]] = []
     worktrees: list[dict[str, Any]] = []
+    runtime: list[dict[str, Any]] = []
+    rollover_task_ids = {
+        task_id
+        for relation in graph.family_relations
+        if relation.relation_type is RelationType.ROLLOVER_GENERATION_OF
+        for task_id in (relation.source_id, relation.target_id)
+    }
     for task_id in plan.selected_task_ids:
         node = nodes[task_id]
         metadata_state = _active_metadata_state(node.metadata)
@@ -251,6 +279,15 @@ def _execution_payload(
                     "Wait for the task to stop, then create a new explicit preview.",
                 )
             )
+        elif plan.operation is OperationKind.FINISH_AND_CLEAN and _terminal_metadata_state(node.metadata) is None:
+            blockers.append(
+                Blocker(
+                    "task_completion_unproven",
+                    f"Selected task {task_id!r} has no explicit terminal or abandoned status.",
+                    (task_id,),
+                    "Record a tool-backed completed, failed, cancelled, stopped, or abandoned status, then create a new preview.",
+                )
+            )
         expected_host = host if host is not None else node.metadata.get("host")
         tasks.append(
             {
@@ -261,6 +298,51 @@ def _execution_payload(
                 "host": expected_host,
             }
         )
+        runtime_kinds: list[str] = []
+        runtime_proofs: list[str] = []
+        runtime_eligible = True
+        if task_id in rollover_task_ids:
+            runtime_kinds.append("rollover")
+            proof = node.metadata.get("rollover_cleanup_proof", "").strip()
+            eligible = node.metadata.get("rollover_cleanup_eligible", "").strip().lower() == "true" and bool(proof)
+            runtime_eligible = runtime_eligible and eligible
+            if proof:
+                runtime_proofs.append(proof)
+            if plan.operation is OperationKind.FINISH_AND_CLEAN and not eligible:
+                blockers.append(
+                    Blocker(
+                        "active_rollover_evidence",
+                        f"Selected rollover task {task_id!r} lacks explicit cleanup eligibility and proof.",
+                        (task_id,),
+                        "Confirm replacement startup and record tool-backed rollover cleanup proof before a new preview.",
+                    )
+                )
+        automation_id = node.metadata.get("automation_id", "").strip()
+        if automation_id:
+            runtime_kinds.append("automation")
+            proof = node.metadata.get("automation_cleanup_proof", "").strip()
+            eligible = node.metadata.get("automation_cleanup_eligible", "").strip().lower() == "true" and bool(proof)
+            runtime_eligible = runtime_eligible and eligible
+            if proof:
+                runtime_proofs.append(f"{automation_id}: {proof}")
+            if plan.operation is OperationKind.FINISH_AND_CLEAN and not eligible:
+                blockers.append(
+                    Blocker(
+                        "unconfirmed_predecessor_automation",
+                        f"Selected task {task_id!r} has automation {automation_id!r} without confirmed replacement cleanup proof.",
+                        (task_id,),
+                        "Confirm the replacement and record tool-backed automation cleanup eligibility before a new preview.",
+                    )
+                )
+        if runtime_kinds:
+            runtime.append(
+                {
+                    "id": task_id,
+                    "kind": "+".join(runtime_kinds),
+                    "eligible": runtime_eligible,
+                    "proof": "; ".join(runtime_proofs) or None,
+                }
+            )
         resource_values = (node.worktree, node.branch, node.pr_id)
         if not any(resource_values):
             continue
@@ -321,7 +403,7 @@ def _execution_payload(
         "target_db": str(db_path),
         "task_targets": tasks,
         "worktree_targets": worktrees,
-        "runtime_targets": [],
+        "runtime_targets": runtime,
         "pin_unknown_confirmed": all(item.pin_state_unknown_confirmed for item in plan.selections),
     }
     return payload, tuple(blockers)
@@ -336,6 +418,14 @@ def _active_metadata_state(metadata: dict[str, str]) -> str | None:
     for key in ("running", "active"):
         if metadata.get(key, "").strip().lower() in {"1", "true", "yes", "running", "active"}:
             return key
+    return None
+
+
+def _terminal_metadata_state(metadata: dict[str, str]) -> str | None:
+    for key in ("state", "status", "task_state", "lifecycle_state"):
+        value = metadata.get(key, "").strip().lower()
+        if value in {"completed", "done", "failed", "cancelled", "canceled", "stopped", "abandoned"}:
+            return value
     return None
 
 

--- a/scripts/orchestration/task_family/codex_state.py
+++ b/scripts/orchestration/task_family/codex_state.py
@@ -1,12 +1,19 @@
-"""Fragile Codex DB reconciliation bridge for cleanup state repair."""
+"""Fragile Codex DB reconciliation bridge for cleanup state repair.
+
+The module is intentionally read-only: it validates that selected Codex task
+threads are already at the required archive state. It never writes to the Codex
+state DB.
+"""
 
 from __future__ import annotations
 
 import contextlib
+import dataclasses
 import json
 import re
 import sqlite3
 import time
+import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -15,7 +22,10 @@ from typing import Any
 
 THREADS_TABLE = "threads"
 THREADS_REQUIRED_COLUMNS = frozenset({"id", "title", "cwd", "archived", "archived_at"})
-STATE_PATTERN = re.compile(r"^state_.*\.sqlite$")
+# Codex uses versioned filenames such as ``state_5.sqlite`` and longer opaque
+# versions.  Discovery deliberately accepts the documented family, not a
+# guessed length or hexadecimal-only subset.
+STATE_PATTERN = re.compile(r"^state_[A-Za-z0-9][A-Za-z0-9._-]*\.sqlite$")
 
 
 class CodexStateError(RuntimeError):
@@ -44,7 +54,7 @@ class CodexStateConflictError(CodexStateError):
 
 @dataclass(frozen=True)
 class ThreadRecord:
-    thread_id: int
+    thread_id: str
     title: str
     cwd: str
     archived: bool
@@ -78,12 +88,22 @@ def _to_text(value: Any) -> str | None:
     return str(value)
 
 
+def _coerce_task_id(raw: Any) -> str:
+    candidate = _to_text(raw)
+    if candidate is None:
+        raise CodexStateContextError("task id is required")
+    try:
+        return str(uuid.UUID(candidate.strip()))
+    except ValueError as exc:
+        raise CodexStateContextError(f"task id must be a UUID: {candidate!r}") from exc
+
+
 def _row_to_record(row: sqlite3.Row, *, has_host: bool) -> ThreadRecord:
     archived = _coerce_bool(row["archived"])
     archived_at = _to_text(row["archived_at"])
     host = row["host"] if has_host else None
     return ThreadRecord(
-        thread_id=int(row["id"]),
+        thread_id=_coerce_task_id(row["id"]),
         title=_to_text(row["title"]) or "",
         cwd=_to_text(row["cwd"]) or "",
         archived=archived,
@@ -110,12 +130,10 @@ def _require_threads_schema(columns: frozenset[str]) -> None:
         raise CodexStateSchemaError(f"missing threads columns: {', '.join(missing)}")
 
 
-def _codex_home_path(codex_home: Path | None) -> Path:
-    return codex_home or (Path.home() / ".codex")
-
-
 def _make_uri(path: Path, mode: str) -> str:
-    return f"file:{path.as_posix()}?mode={mode}"
+    if mode != "ro":
+        raise ValueError("mode must be 'ro'")
+    return f"file:{path.resolve().as_posix()}?mode=ro"
 
 
 def _raise_db_failure(exc: Exception, *, context: str) -> None:
@@ -132,26 +150,24 @@ def open_state_db(
     timeout_seconds: float = 5.0,
     mode: str = "ro",
 ):
-    """Open the bridge DB in strict read-only mode unless writable is requested."""
-    if mode not in {"ro", "rw"}:
-        raise ValueError("mode must be 'ro' or 'rw'")
+    """Open the bridge DB read-only. Mutations are forbidden."""
+    if mode != "ro":
+        raise ValueError("mode must be 'ro'")
 
     uri = _make_uri(path, mode)
-    try:
-        connection = sqlite3.connect(
-            uri,
-            uri=True,
-            timeout=timeout_seconds,
-            check_same_thread=False,
-        )
-    except sqlite3.Error as exc:
-        _raise_db_failure(exc, context="opening DB")
-
+    connection = sqlite3.connect(
+        uri,
+        uri=True,
+        timeout=timeout_seconds,
+        check_same_thread=False,
+    )
     try:
         connection.row_factory = sqlite3.Row
-        if mode == "ro":
-            connection.execute("PRAGMA query_only = ON")
+        connection.execute("PRAGMA query_only = ON")
+        connection.execute(f"PRAGMA busy_timeout = {int(max(0.0, timeout_seconds) * 1000)}")
         yield connection
+    except sqlite3.Error as exc:
+        _raise_db_failure(exc, context="opening DB")
     finally:
         with contextlib.suppress(Exception):
             connection.close()
@@ -163,11 +179,13 @@ def discover_state_database(
     codex_home: Path | None = None,
     timeout_seconds: float = 5.0,
 ) -> Path:
-    """Return explicit DB or the newest unique compatible ``~/.codex/state_*.sqlite``."""
+    """Return explicit DB or the newest compatible ``~/.codex/state_*.sqlite``."""
     if explicit_db_path is not None:
         db_path = Path(explicit_db_path).expanduser()
         if not db_path.exists():
             raise CodexStateDiscoveryError(f"explicit codex DB not found: {db_path}")
+        if not STATE_PATTERN.fullmatch(db_path.name):
+            raise CodexStateContextError(f"invalid Codex DB filename: {db_path.name}")
         with open_state_db(db_path, timeout_seconds=timeout_seconds, mode="ro") as connection:
             tables = _sqlite_tables(connection)
             if not tables:
@@ -178,7 +196,7 @@ def discover_state_database(
             _require_threads_schema(columns)
         return db_path
 
-    home = _codex_home_path(codex_home)
+    home = codex_home or Path.home() / ".codex"
     if not home.exists():
         raise CodexStateDiscoveryError(f"codex home not found: {home}")
 
@@ -222,16 +240,17 @@ def _select_sql(connection: sqlite3.Connection) -> str:
 
 def _read_thread_once(
     db_path: Path,
-    thread_id: int,
+    thread_id: str,
     *,
     timeout_seconds: float = 5.0,
 ) -> ThreadRecord:
+    normalized = _coerce_task_id(thread_id)
     with open_state_db(db_path, timeout_seconds=timeout_seconds, mode="ro") as connection:
         columns = _select_sql(connection)
-        has_host = "host" in columns
+        has_host = "host" in columns.split(", ")
         rows = connection.execute(
             f"select {columns} from {THREADS_TABLE} where id = ? limit 1",
-            (thread_id,),
+            (normalized,),
         ).fetchall()
 
     if not rows:
@@ -241,16 +260,22 @@ def _read_thread_once(
 
 
 def read_thread_record(
-    thread_id: int,
     db_path: Path | str,
     *,
+    thread_id: str | None = None,
+    task_id: str | None = None,
     timeout_seconds: float = 5.0,
     read_window_seconds: float = 0.75,
 ) -> ThreadRecord:
-    """Read one exact thread row with a bounded monotonic read guard."""
+    """Read one exact thread row with a bounded stable sample guard."""
+    if thread_id is None and task_id is None:
+        raise CodexStateContextError("thread_id/task_id is required")
+    task = task_id or thread_id
+    assert task is not None
+
     path = Path(db_path)
     if not path.exists():
-        raise CodexStateMissingTaskError(f"missing task {thread_id} in {path}")
+        raise CodexStateMissingTaskError(f"missing task {task} in {path}")
 
     deadline = time.monotonic() + max(0.0, read_window_seconds)
     stable_sample: ThreadRecord | None = None
@@ -258,7 +283,7 @@ def read_thread_record(
 
     while True:
         try:
-            current = _read_thread_once(path, thread_id, timeout_seconds=timeout_seconds)
+            current = _read_thread_once(path, task, timeout_seconds=timeout_seconds)
         except sqlite3.Error as exc:
             _raise_db_failure(exc, context="reading thread row")
 
@@ -276,14 +301,83 @@ def read_thread_record(
             stable_count = 1
         if time.monotonic() >= deadline:
             raise CodexStateConflictError(
-                f"thread {thread_id} state raced during bounded read window: {db_path}"
+                f"thread {task} state raced during bounded read window: {db_path}"
+            )
+        time.sleep(0.05)
+
+
+def _ensure_archive_shape(record: ThreadRecord, *, archived: bool) -> bool:
+    if archived:
+        return record.archived and bool(record.archived_at and str(record.archived_at).strip())
+    return not record.archived and record.archived_at in (None, "")
+
+
+def _validate_context(
+    record: ThreadRecord,
+    *,
+    expected_title: str,
+    expected_cwd: str,
+    expected_host: str | None,
+) -> None:
+    if record.title != expected_title:
+        raise CodexStateContextError(
+            f"title mismatch for task {record.thread_id}: db={record.title!r}, expected={expected_title!r}"
+        )
+    if record.cwd != expected_cwd:
+        raise CodexStateContextError(
+            f"cwd mismatch for task {record.thread_id}: db={record.cwd!r}, expected={expected_cwd!r}"
+        )
+    if expected_host is not None and record.host != expected_host:
+        raise CodexStateContextError(
+            f"host mismatch for task {record.thread_id}: db={record.host!r}, expected={expected_host!r}"
+        )
+
+
+def await_task_target(
+    *,
+    task_id: str,
+    expected_title: str,
+    expected_cwd: str,
+    expected_archived: bool,
+    db_path: Path | str,
+    expected_host: str | None = None,
+    timeout_seconds: float = 5.0,
+    read_window_seconds: float = 0.75,
+) -> ThreadRecord:
+    """Poll until a task reaches exact archive target or fail closed."""
+    deadline = time.monotonic() + max(0.0, read_window_seconds)
+
+    while True:
+        record = read_thread_record(
+            task_id=task_id,
+            db_path=db_path,
+            timeout_seconds=timeout_seconds,
+            read_window_seconds=min(0.75, read_window_seconds),
+        )
+        _validate_context(record, expected_title=expected_title, expected_cwd=expected_cwd, expected_host=expected_host)
+
+        if record.archived and not record.archived_at:
+            raise CodexStateConflictError(
+                f"conflicting archive shape for task {task_id}: archived=1 and archived_at is NULL"
+            )
+        if (not record.archived) and record.archived_at not in (None, ""):
+            raise CodexStateConflictError(
+                f"conflicting archive shape for task {task_id}: archived=0 and archived_at={record.archived_at!r}"
+            )
+
+        if _ensure_archive_shape(record, archived=expected_archived):
+            return record
+
+        if time.monotonic() >= deadline:
+            raise CodexStateConflictError(
+                f"thread {task_id} state did not reach target within bounded read window: {db_path}"
             )
         time.sleep(0.05)
 
 
 def reconcile_thread_archive(
     *,
-    thread_id: int,
+    thread_id: str,
     expected_title: str,
     expected_cwd: str,
     archived: bool,
@@ -292,82 +386,23 @@ def reconcile_thread_archive(
     archive_now: str | None = None,
     timeout_seconds: float = 5.0,
 ) -> tuple[ThreadRecord, ThreadRecord, bool]:
-    """Reconcile a thread to the target archive state and report mutation status."""
-    path = Path(db_path)
-    before = read_thread_record(thread_id, path, timeout_seconds=timeout_seconds)
-
-    if before.title != expected_title:
-        raise CodexStateContextError(
-            f"title mismatch for task {thread_id}: db={before.title!r}, expected={expected_title!r}"
-        )
-    if before.cwd != expected_cwd:
-        raise CodexStateContextError(
-            f"cwd mismatch for task {thread_id}: db={before.cwd!r}, expected={expected_cwd!r}"
-        )
-    if expected_host is not None and before.host != expected_host:
-        raise CodexStateContextError(
-            f"host mismatch for task {thread_id}: db={before.host!r}, expected={expected_host!r}"
-        )
-
-    if before.archived and before.archived_at in (None, ""):
-        raise CodexStateConflictError(
-            f"conflicting archive shape for task {thread_id}: archived=1 and archived_at is NULL"
-        )
-    if (not before.archived) and before.archived_at not in (None, ""):
-        raise CodexStateConflictError(
-            f"conflicting archive shape for task {thread_id}: archived=0 and archived_at={before.archived_at!r}"
-        )
-
-    target_archived_at = None if not archived else (archive_now or _utc_now())
-    already_target = before.archived == archived and (
-        (archived is False and before.archived_at in (None, ""))
-        or (archived is True and before.archived_at not in (None, ""))
+    """Reconcile expectation: return only when the DB matches the target shape."""
+    del archive_now
+    before = await_task_target(
+        task_id=_coerce_task_id(thread_id),
+        expected_title=expected_title,
+        expected_cwd=expected_cwd,
+        expected_archived=archived,
+        db_path=db_path,
+        expected_host=expected_host,
+        timeout_seconds=timeout_seconds,
     )
-    if already_target:
-        return before, before, False
-
-    where = "id = ? AND title = ? AND cwd = ?"
-    params = [int(bool(archived)), target_archived_at, thread_id, expected_title, expected_cwd]
-    if expected_host is not None:
-        where += " AND host = ?"
-        params.append(expected_host)
-
-    target = None
-    try:
-        with open_state_db(path, timeout_seconds=timeout_seconds, mode="rw") as connection:
-            cursor = connection.execute(
-                f"UPDATE {THREADS_TABLE} SET archived = ?, archived_at = ? WHERE {where}",
-                params,
-            )
-            if cursor.rowcount != 1:
-                raise CodexStateConflictError(f"conflicting update for task {thread_id}")
-            connection.commit()
-            target = read_thread_record(
-                thread_id,
-                path,
-                timeout_seconds=timeout_seconds,
-            )
-    except sqlite3.Error as exc:
-        _raise_db_failure(exc, context=f"reconciling task {thread_id}")
-
-    if target is None:
-        raise CodexStateConflictError(f"could not read task {thread_id} after reconcile")
-
-    if target.archived != archived:
-        raise CodexStateConflictError(f"archive target mismatch for task {thread_id}")
-    if archived and not target.archived_at:
-        raise CodexStateConflictError(f"archive target requires archived_at for task {thread_id}")
-    if (not archived) and target.archived_at not in (None, ""):
-        raise CodexStateConflictError(f"restore target requires archived_at NULL for task {thread_id}")
-    if target.title != expected_title:
-        raise CodexStateConflictError(f"title mismatch after reconcile for task {thread_id}: {target.title!r}")
-
-    return before, target, True
+    return before, before, False
 
 
 def reconcile_thread_restore(
     *,
-    thread_id: int,
+    thread_id: str,
     expected_title: str,
     expected_cwd: str,
     db_path: Path | str,
@@ -388,7 +423,7 @@ def reconcile_thread_restore(
 
 def reconcile_task_thread(
     *,
-    task_id: int,
+    task_id: str,
     action: str,
     expected_title: str,
     expected_cwd: str,
@@ -401,7 +436,7 @@ def reconcile_task_thread(
     verb = action.lower()
     if verb == "archive":
         return reconcile_thread_archive(
-            thread_id=task_id,
+            thread_id=_coerce_task_id(task_id),
             expected_title=expected_title,
             expected_cwd=expected_cwd,
             archived=True,
@@ -412,7 +447,7 @@ def reconcile_task_thread(
         )
     if verb == "restore":
         return reconcile_thread_restore(
-            thread_id=task_id,
+            thread_id=_coerce_task_id(task_id),
             expected_title=expected_title,
             expected_cwd=expected_cwd,
             db_path=db_path,
@@ -456,4 +491,4 @@ def build_reconciliation_payload(
 
 
 def dump_thread_state(record: ThreadRecord) -> dict[str, Any]:
-    return json.loads(json.dumps(record.__dict__))
+    return json.loads(json.dumps(dataclasses.asdict(record)))

--- a/scripts/orchestration/task_family/codex_state.py
+++ b/scripts/orchestration/task_family/codex_state.py
@@ -1,0 +1,459 @@
+"""Fragile Codex DB reconciliation bridge for cleanup state repair."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import re
+import sqlite3
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+THREADS_TABLE = "threads"
+THREADS_REQUIRED_COLUMNS = frozenset({"id", "title", "cwd", "archived", "archived_at"})
+STATE_PATTERN = re.compile(r"^state_.*\.sqlite$")
+
+
+class CodexStateError(RuntimeError):
+    """Base error for fail-closed bridge failures."""
+
+
+class CodexStateDiscoveryError(CodexStateError):
+    """No usable DB was found or discovery was ambiguous."""
+
+
+class CodexStateSchemaError(CodexStateError):
+    """The DB exists but missing required thread columns."""
+
+
+class CodexStateMissingTaskError(CodexStateError):
+    """Requested thread ID was not found in the chosen DB."""
+
+
+class CodexStateContextError(CodexStateError):
+    """Context mismatch for strict row targeting."""
+
+
+class CodexStateConflictError(CodexStateError):
+    """Requested reconcile transition conflicts with current row state."""
+
+
+@dataclass(frozen=True)
+class ThreadRecord:
+    thread_id: int
+    title: str
+    cwd: str
+    archived: bool
+    archived_at: str | None
+    host: str | None
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value != 0
+    if isinstance(value, str):
+        lowered = value.lower().strip()
+        if lowered in {"1", "true", "t", "yes", "y"}:
+            return True
+        if lowered in {"0", "false", "f", "no", "n", ""}:
+            return False
+    raise CodexStateContextError(f"cannot coerce archived flag: {value!r}")
+
+
+def _to_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+def _row_to_record(row: sqlite3.Row, *, has_host: bool) -> ThreadRecord:
+    archived = _coerce_bool(row["archived"])
+    archived_at = _to_text(row["archived_at"])
+    host = row["host"] if has_host else None
+    return ThreadRecord(
+        thread_id=int(row["id"]),
+        title=_to_text(row["title"]) or "",
+        cwd=_to_text(row["cwd"]) or "",
+        archived=archived,
+        archived_at=archived_at,
+        host=_to_text(host),
+    )
+
+
+def _thread_columns(connection: sqlite3.Connection) -> frozenset[str]:
+    rows = connection.execute(f"PRAGMA table_info({THREADS_TABLE})").fetchall()
+    return frozenset(str(row[1]) for row in rows)
+
+
+def _sqlite_tables(connection: sqlite3.Connection) -> frozenset[str]:
+    rows = connection.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'",
+    ).fetchall()
+    return frozenset(str(row[0]) for row in rows)
+
+
+def _require_threads_schema(columns: frozenset[str]) -> None:
+    if not THREADS_REQUIRED_COLUMNS.issubset(columns):
+        missing = sorted(THREADS_REQUIRED_COLUMNS - columns)
+        raise CodexStateSchemaError(f"missing threads columns: {', '.join(missing)}")
+
+
+def _codex_home_path(codex_home: Path | None) -> Path:
+    return codex_home or (Path.home() / ".codex")
+
+
+def _make_uri(path: Path, mode: str) -> str:
+    return f"file:{path.as_posix()}?mode={mode}"
+
+
+def _raise_db_failure(exc: Exception, *, context: str) -> None:
+    message = str(exc) if str(exc) else exc.__class__.__name__
+    if isinstance(exc, sqlite3.OperationalError) and ("locked" in message.lower() or "timeout" in message.lower()):
+        raise CodexStateConflictError(f"database contention while {context}: {message}") from exc
+    raise CodexStateError(f"database error while {context}: {message}") from exc
+
+
+@contextmanager
+def open_state_db(
+    path: Path,
+    *,
+    timeout_seconds: float = 5.0,
+    mode: str = "ro",
+):
+    """Open the bridge DB in strict read-only mode unless writable is requested."""
+    if mode not in {"ro", "rw"}:
+        raise ValueError("mode must be 'ro' or 'rw'")
+
+    uri = _make_uri(path, mode)
+    try:
+        connection = sqlite3.connect(
+            uri,
+            uri=True,
+            timeout=timeout_seconds,
+            check_same_thread=False,
+        )
+    except sqlite3.Error as exc:
+        _raise_db_failure(exc, context="opening DB")
+
+    try:
+        connection.row_factory = sqlite3.Row
+        if mode == "ro":
+            connection.execute("PRAGMA query_only = ON")
+        yield connection
+    finally:
+        with contextlib.suppress(Exception):
+            connection.close()
+
+
+def discover_state_database(
+    explicit_db_path: Path | str | None = None,
+    *,
+    codex_home: Path | None = None,
+    timeout_seconds: float = 5.0,
+) -> Path:
+    """Return explicit DB or the newest unique compatible ``~/.codex/state_*.sqlite``."""
+    if explicit_db_path is not None:
+        db_path = Path(explicit_db_path).expanduser()
+        if not db_path.exists():
+            raise CodexStateDiscoveryError(f"explicit codex DB not found: {db_path}")
+        with open_state_db(db_path, timeout_seconds=timeout_seconds, mode="ro") as connection:
+            tables = _sqlite_tables(connection)
+            if not tables:
+                raise CodexStateSchemaError(f"empty schema for explicit DB: {db_path}")
+            if THREADS_TABLE not in tables:
+                raise CodexStateSchemaError(f"missing threads table in {db_path}")
+            columns = _thread_columns(connection)
+            _require_threads_schema(columns)
+        return db_path
+
+    home = _codex_home_path(codex_home)
+    if not home.exists():
+        raise CodexStateDiscoveryError(f"codex home not found: {home}")
+
+    candidates: list[tuple[Path, int]] = []
+    for path in sorted(home.glob("state_*.sqlite")):
+        if not path.is_file() or not STATE_PATTERN.match(path.name):
+            continue
+        try:
+            with open_state_db(path, timeout_seconds=timeout_seconds, mode="ro") as connection:
+                tables = _sqlite_tables(connection)
+                if not tables:
+                    continue
+                if THREADS_TABLE not in tables:
+                    raise CodexStateSchemaError(f"missing threads table in {path}")
+                _require_threads_schema(_thread_columns(connection))
+            candidates.append((path, path.stat().st_mtime_ns))
+        except CodexStateSchemaError:
+            raise
+        except (sqlite3.Error, OSError):
+            continue
+
+    if not candidates:
+        raise CodexStateDiscoveryError(f"missing compatible codex DB in {home}")
+
+    candidates.sort(key=lambda item: item[1], reverse=True)
+    newest_mtime = candidates[0][1]
+    ambiguous = [path for path, mtime in candidates if mtime == newest_mtime]
+    if len(ambiguous) > 1:
+        joined = ", ".join(sorted(str(path) for path in ambiguous))
+        raise CodexStateDiscoveryError(f"ambiguous newest compatible state DBs: {joined}")
+
+    return candidates[0][0]
+
+
+def _select_sql(connection: sqlite3.Connection) -> str:
+    columns = ["id", "title", "cwd", "archived", "archived_at"]
+    if "host" in _thread_columns(connection):
+        columns.append("host")
+    return ", ".join(columns)
+
+
+def _read_thread_once(
+    db_path: Path,
+    thread_id: int,
+    *,
+    timeout_seconds: float = 5.0,
+) -> ThreadRecord:
+    with open_state_db(db_path, timeout_seconds=timeout_seconds, mode="ro") as connection:
+        columns = _select_sql(connection)
+        has_host = "host" in columns
+        rows = connection.execute(
+            f"select {columns} from {THREADS_TABLE} where id = ? limit 1",
+            (thread_id,),
+        ).fetchall()
+
+    if not rows:
+        raise CodexStateMissingTaskError(f"missing task {thread_id} in {db_path}")
+
+    return _row_to_record(rows[0], has_host=has_host)
+
+
+def read_thread_record(
+    thread_id: int,
+    db_path: Path | str,
+    *,
+    timeout_seconds: float = 5.0,
+    read_window_seconds: float = 0.75,
+) -> ThreadRecord:
+    """Read one exact thread row with a bounded monotonic read guard."""
+    path = Path(db_path)
+    if not path.exists():
+        raise CodexStateMissingTaskError(f"missing task {thread_id} in {path}")
+
+    deadline = time.monotonic() + max(0.0, read_window_seconds)
+    stable_sample: ThreadRecord | None = None
+    stable_count = 0
+
+    while True:
+        try:
+            current = _read_thread_once(path, thread_id, timeout_seconds=timeout_seconds)
+        except sqlite3.Error as exc:
+            _raise_db_failure(exc, context="reading thread row")
+
+        if stable_sample is None:
+            stable_sample = current
+            stable_count = 1
+            time.sleep(0.05)
+            continue
+        if current == stable_sample:
+            stable_count += 1
+            if stable_count >= 3:
+                return current
+        else:
+            stable_sample = current
+            stable_count = 1
+        if time.monotonic() >= deadline:
+            raise CodexStateConflictError(
+                f"thread {thread_id} state raced during bounded read window: {db_path}"
+            )
+        time.sleep(0.05)
+
+
+def reconcile_thread_archive(
+    *,
+    thread_id: int,
+    expected_title: str,
+    expected_cwd: str,
+    archived: bool,
+    db_path: Path | str,
+    expected_host: str | None = None,
+    archive_now: str | None = None,
+    timeout_seconds: float = 5.0,
+) -> tuple[ThreadRecord, ThreadRecord, bool]:
+    """Reconcile a thread to the target archive state and report mutation status."""
+    path = Path(db_path)
+    before = read_thread_record(thread_id, path, timeout_seconds=timeout_seconds)
+
+    if before.title != expected_title:
+        raise CodexStateContextError(
+            f"title mismatch for task {thread_id}: db={before.title!r}, expected={expected_title!r}"
+        )
+    if before.cwd != expected_cwd:
+        raise CodexStateContextError(
+            f"cwd mismatch for task {thread_id}: db={before.cwd!r}, expected={expected_cwd!r}"
+        )
+    if expected_host is not None and before.host != expected_host:
+        raise CodexStateContextError(
+            f"host mismatch for task {thread_id}: db={before.host!r}, expected={expected_host!r}"
+        )
+
+    if before.archived and before.archived_at in (None, ""):
+        raise CodexStateConflictError(
+            f"conflicting archive shape for task {thread_id}: archived=1 and archived_at is NULL"
+        )
+    if (not before.archived) and before.archived_at not in (None, ""):
+        raise CodexStateConflictError(
+            f"conflicting archive shape for task {thread_id}: archived=0 and archived_at={before.archived_at!r}"
+        )
+
+    target_archived_at = None if not archived else (archive_now or _utc_now())
+    already_target = before.archived == archived and (
+        (archived is False and before.archived_at in (None, ""))
+        or (archived is True and before.archived_at not in (None, ""))
+    )
+    if already_target:
+        return before, before, False
+
+    where = "id = ? AND title = ? AND cwd = ?"
+    params = [int(bool(archived)), target_archived_at, thread_id, expected_title, expected_cwd]
+    if expected_host is not None:
+        where += " AND host = ?"
+        params.append(expected_host)
+
+    target = None
+    try:
+        with open_state_db(path, timeout_seconds=timeout_seconds, mode="rw") as connection:
+            cursor = connection.execute(
+                f"UPDATE {THREADS_TABLE} SET archived = ?, archived_at = ? WHERE {where}",
+                params,
+            )
+            if cursor.rowcount != 1:
+                raise CodexStateConflictError(f"conflicting update for task {thread_id}")
+            connection.commit()
+            target = read_thread_record(
+                thread_id,
+                path,
+                timeout_seconds=timeout_seconds,
+            )
+    except sqlite3.Error as exc:
+        _raise_db_failure(exc, context=f"reconciling task {thread_id}")
+
+    if target is None:
+        raise CodexStateConflictError(f"could not read task {thread_id} after reconcile")
+
+    if target.archived != archived:
+        raise CodexStateConflictError(f"archive target mismatch for task {thread_id}")
+    if archived and not target.archived_at:
+        raise CodexStateConflictError(f"archive target requires archived_at for task {thread_id}")
+    if (not archived) and target.archived_at not in (None, ""):
+        raise CodexStateConflictError(f"restore target requires archived_at NULL for task {thread_id}")
+    if target.title != expected_title:
+        raise CodexStateConflictError(f"title mismatch after reconcile for task {thread_id}: {target.title!r}")
+
+    return before, target, True
+
+
+def reconcile_thread_restore(
+    *,
+    thread_id: int,
+    expected_title: str,
+    expected_cwd: str,
+    db_path: Path | str,
+    expected_host: str | None = None,
+    timeout_seconds: float = 5.0,
+) -> tuple[ThreadRecord, ThreadRecord, bool]:
+    """Explicit restore path (inverse of archive)."""
+    return reconcile_thread_archive(
+        thread_id=thread_id,
+        expected_title=expected_title,
+        expected_cwd=expected_cwd,
+        archived=False,
+        db_path=db_path,
+        expected_host=expected_host,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def reconcile_task_thread(
+    *,
+    task_id: int,
+    action: str,
+    expected_title: str,
+    expected_cwd: str,
+    db_path: Path | str,
+    expected_host: str | None = None,
+    timeout_seconds: float = 5.0,
+    archive_now: str | None = None,
+) -> tuple[ThreadRecord, ThreadRecord, bool]:
+    """Reconcile a task thread by action string: ``archive`` or ``restore``."""
+    verb = action.lower()
+    if verb == "archive":
+        return reconcile_thread_archive(
+            thread_id=task_id,
+            expected_title=expected_title,
+            expected_cwd=expected_cwd,
+            archived=True,
+            db_path=db_path,
+            expected_host=expected_host,
+            archive_now=archive_now,
+            timeout_seconds=timeout_seconds,
+        )
+    if verb == "restore":
+        return reconcile_thread_restore(
+            thread_id=task_id,
+            expected_title=expected_title,
+            expected_cwd=expected_cwd,
+            db_path=db_path,
+            expected_host=expected_host,
+            timeout_seconds=timeout_seconds,
+        )
+    raise CodexStateContextError(f"unsupported action: {action!r}")
+
+
+def build_reconciliation_payload(
+    before: ThreadRecord,
+    after: ThreadRecord,
+    changed: bool,
+    *,
+    action: str,
+    archived_at: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "action": action,
+        "thread_id": before.thread_id,
+        "changed": bool(changed),
+        "expected": {
+            "title": before.title,
+            "archived": after.archived,
+            "archived_at": after.archived_at,
+        },
+        "before": {
+            "title": before.title,
+            "archived": before.archived,
+            "archived_at": before.archived_at,
+        },
+        "after": {
+            "title": after.title,
+            "archived": after.archived,
+            "archived_at": after.archived_at,
+        },
+        "evidence": {
+            "archived_at": archived_at,
+        },
+    }
+
+
+def dump_thread_state(record: ThreadRecord) -> dict[str, Any]:
+    return json.loads(json.dumps(record.__dict__))

--- a/scripts/orchestration/task_family/executor.py
+++ b/scripts/orchestration/task_family/executor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import uuid
+from contextlib import ExitStack
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -656,11 +657,12 @@ class CleanupExecutor:
 
     def run(self) -> dict[str, Any]:
         _validate_plan(self.plan)
-        with (
-            safety.operation_lock(self.repo_root, operation_id=self.plan.operation_id),
-            safety.lineage_lock(self.repo_root, self.plan.lineage_id),
-            safety.family_lock(self.repo_root, self.plan.family_id),
-        ):
+        with ExitStack() as locks:
+            locks.enter_context(safety.operation_lock(self.repo_root, operation_id=self.plan.operation_id))
+            locks.enter_context(safety.lineage_lock(self.repo_root, self.plan.lineage_id))
+            locks.enter_context(safety.family_lock(self.repo_root, self.plan.family_id))
+            for target in sorted(self.plan.worktree_targets, key=lambda item: str(item.worktree.resolve())):
+                locks.enter_context(safety.worktree_lock(self.repo_root, target.worktree))
             return self._run_locked()
 
     def _run_locked(self) -> dict[str, Any]:
@@ -1161,13 +1163,15 @@ class CleanupExecutor:
                 payload,
                 "runtime",
                 target.id,
-                "actual",
-                evidence={"retired": True, "proof": target.proof},
+                "skipped",
+                evidence={"retired": False, "preserved": True, "proof": target.proof},
+                reason="native runtime retirement is unavailable; evidence preserved and retirement deferred",
             )
 
         if blocked:
             raise ExecutorError("runtime retirement blocked: explicit eligibility and proof required")
         _record(payload, "runtime_retired", "proof_verified", True)
+        _record(payload, "runtime_retired", "mutation", "deferred_to_native")
         self._maybe_crash("runtime_retired")
         return "runtime_retired"
 

--- a/scripts/orchestration/task_family/executor.py
+++ b/scripts/orchestration/task_family/executor.py
@@ -661,8 +661,9 @@ class CleanupExecutor:
             locks.enter_context(safety.operation_lock(self.repo_root, operation_id=self.plan.operation_id))
             locks.enter_context(safety.lineage_lock(self.repo_root, self.plan.lineage_id))
             locks.enter_context(safety.family_lock(self.repo_root, self.plan.family_id))
-            for target in sorted(self.plan.worktree_targets, key=lambda item: str(item.worktree.resolve())):
-                locks.enter_context(safety.worktree_lock(self.repo_root, target.worktree))
+            worktrees = {target.worktree.resolve() for target in self.plan.worktree_targets}
+            for worktree in sorted(worktrees, key=str):
+                locks.enter_context(safety.worktree_lock(self.repo_root, worktree))
             return self._run_locked()
 
     def _run_locked(self) -> dict[str, Any]:

--- a/scripts/orchestration/task_family/executor.py
+++ b/scripts/orchestration/task_family/executor.py
@@ -1,12 +1,14 @@
-"""Fail-closed, resumable cleanup executor for one task-family branch cleanup."""
+"""Fail-closed, resumable executor for task-family cleanup operations."""
 
 from __future__ import annotations
 
+import hashlib
 import json
+import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from scripts.orchestration.task_family import codex_state
 from scripts.orchestration.task_family import git_safety as safety
@@ -23,27 +25,62 @@ CLEANUP_STAGES = (
     "completed",
 )
 
+CLEANUP_MODES = {
+    "archive_only",
+    "finish_and_clean",
+}
+
+ResourceStatus = Literal["planned", "actual", "skipped", "failed"]
+
 
 class ExecutorError(RuntimeError):
     """Cleanup execution blocked by safety guard or data mismatch."""
 
 
 class ExecutionStateError(ExecutorError):
-    """Corrupted or unknown executor state payload."""
+    """Invalid persisted state or impossible resume shape."""
+
+
+@dataclass(frozen=True)
+class TaskTarget:
+    task_id: str
+    title: str
+    cwd: str
+    db_path: Path
+    expected_archived: bool = True
+    host: str | None = None
+
+
+@dataclass(frozen=True)
+class WorktreeTarget:
+    id: str
+    worktree: Path
+    branch: str
+    pr_number: int
+    pr_base: str
+    explicit_family: str
+
+
+@dataclass(frozen=True)
+class RuntimeTarget:
+    id: str
+    kind: str
+    eligible: bool
+    proof: str | None = None
 
 
 @dataclass(frozen=True)
 class CleanupPlan:
-    task_id: int
-    family: str
+    operation_id: str
+    family_id: str
     lineage_id: str
-    title: str
-    cwd: str
-    branch: str
-    worktree: Path
-    thread_id: int
-    db_path: Path
-    host: str | None = None
+    mode: str
+    task_targets: tuple[TaskTarget, ...]
+    worktree_targets: tuple[WorktreeTarget, ...]
+    runtime_targets: tuple[RuntimeTarget, ...]
+    selected_task_ids: frozenset[str]
+    pin_unknown_confirmed: bool
+    persisted_plan_digest: str
     explicit_protected: frozenset[str] = frozenset()
 
 
@@ -54,62 +91,221 @@ def _iso_now() -> str:
 def state_path(repo_root: Path, plan: CleanupPlan) -> Path:
     return (
         safety.resolve_state_root(repo_root)
-        / "states"
-        / plan.family
-        / plan.lineage_id
-        / f"{plan.task_id}.json"
+        / plan.family_id
+        / "operations"
+        / plan.operation_id
+        / "state.json"
     )
+
+
+def plan_path(repo_root: Path, plan: CleanupPlan) -> Path:
+    return state_path(repo_root, plan).with_name("plan.json")
+
+
+def receipt_path(repo_root: Path, plan: CleanupPlan) -> Path:
+    return state_path(repo_root, plan).with_name("receipt.json")
+
+
+def manifest_path(repo_root: Path, plan: CleanupPlan) -> Path:
+    return state_path(repo_root, plan).with_name("manifest.json")
+
+
+def _as_text(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, frozenset):
+        return sorted(value)
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, dict):
+        return {str(k): _as_text(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_as_text(item) for item in value]
+    if isinstance(value, set):
+        return sorted(value)
+    return value
+
+
+def _serialize_target(target: Any) -> dict[str, Any]:
+    if isinstance(target, TaskTarget):
+        return {
+            "task_id": target.task_id,
+            "title": target.title,
+            "cwd": target.cwd,
+            "db_path": str(target.db_path),
+            "expected_archived": target.expected_archived,
+            "host": target.host,
+        }
+    if isinstance(target, WorktreeTarget):
+        return {
+            "id": target.id,
+            "worktree": str(target.worktree),
+            "branch": target.branch,
+            "pr_number": target.pr_number,
+            "pr_base": target.pr_base,
+            "explicit_family": target.explicit_family,
+        }
+    if isinstance(target, RuntimeTarget):
+        return {
+            "id": target.id,
+            "kind": target.kind,
+            "eligible": target.eligible,
+            "proof": target.proof,
+        }
+    raise TypeError(f"unsupported target payload type: {type(target)!r}")
+
+
+def _canonical_plan_digest(payload: dict[str, Any]) -> str:
+    """Match the planner's immutable digest without accepting mutable state."""
+    immutable = dict(payload)
+    immutable.pop("digest", None)
+    immutable.pop("state", None)
+    body = json.dumps(immutable, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _load_persisted_plan(repo_root: Path, plan: CleanupPlan) -> dict[str, Any]:
+    """Read the planner-owned immutable plan; executor never creates or rewrites it."""
+    path = plan_path(repo_root, plan)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ExecutorError(f"persisted immutable plan missing: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ExecutorError(f"persisted immutable plan is invalid JSON: {path}") from exc
+    if not isinstance(raw, dict):
+        raise ExecutorError("persisted immutable plan must be an object")
+    persisted_digest = raw.get("digest")
+    canonical_digest = _canonical_plan_digest(raw)
+    if persisted_digest != canonical_digest or plan.persisted_plan_digest != canonical_digest:
+        raise ExecutorError("caller digest does not authorize the canonical persisted plan")
+    if raw.get("operation_id") != plan.operation_id or raw.get("family_id") != plan.family_id:
+        raise ExecutorError("persisted immutable plan identity does not match execution request")
+    planned_ids = raw.get("selected_task_ids")
+    if not isinstance(planned_ids, list) or not all(isinstance(item, str) for item in planned_ids):
+        raise ExecutorError("persisted immutable plan selected_task_ids must be string UUIDs")
+    try:
+        normalized_ids = {str(uuid.UUID(item)) for item in planned_ids}
+    except ValueError as exc:
+        raise ExecutorError("persisted immutable plan has an invalid task UUID") from exc
+    if len(normalized_ids) != len(planned_ids):
+        raise ExecutorError("persisted immutable plan repeats a selected task UUID")
+    if normalized_ids != set(plan.selected_task_ids):
+        raise ExecutorError("persisted plan selection drifted from execution request")
+    _assert_manifest_task_ids(repo_root, plan, normalized_ids)
+    return raw
+
+
+def _assert_manifest_task_ids(repo_root: Path, plan: CleanupPlan, selected_ids: set[str]) -> None:
+    path = manifest_path(repo_root, plan)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ExecutorError(f"persisted manifest missing: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ExecutorError(f"persisted manifest is invalid JSON: {path}") from exc
+    if not isinstance(payload, dict) or payload.get("family_id") != plan.family_id:
+        raise ExecutorError("persisted manifest identity does not match execution request")
+    nodes = payload.get("nodes")
+    if not isinstance(nodes, list) or not all(isinstance(node, dict) for node in nodes):
+        raise ExecutorError("persisted manifest nodes must be an object list")
+    try:
+        manifest_ids = {str(uuid.UUID(str(node.get("task_id", "")))) for node in nodes}
+    except ValueError as exc:
+        raise ExecutorError("persisted manifest has an invalid task UUID") from exc
+    if len(manifest_ids) != len(nodes) or not selected_ids.issubset(manifest_ids):
+        raise ExecutorError("manifest task IDs do not exactly cover selected task UUIDs")
+
+
+def _resource_block_for_targets(name: str, *, targets: tuple[Any, ...], selected_only: bool = False) -> dict[str, dict[str, Any]]:
+    items: dict[str, dict[str, Any]] = {}
+    for target in targets:
+        item = {
+            "type": name,
+            "status": "planned",
+            "planned": _serialize_target(target),
+            "actual": None,
+            "selected": True,
+        }
+        if selected_only and hasattr(target, "id"):
+            item["selected"] = False
+        resource_id = target.task_id if isinstance(target, TaskTarget) else str(target.id)
+        items[resource_id] = item
+    return items
+
+
+def _bundle_path_to_record(bundle: safety.BundleReceipt | None) -> dict[str, Any] | None:
+    if bundle is None:
+        return None
+    return {
+        "path": str(bundle.path),
+        "sha256": bundle.sha256,
+        "branch": bundle.branch,
+        "created_at": bundle.created_at,
+    }
+
+
+def _load_bundle(record: Any) -> safety.BundleReceipt:
+    if not isinstance(record, dict):
+        raise ExecutorError("invalid bundle record")
+    return safety.BundleReceipt(
+        path=Path(str(record.get("path", ""))),
+        sha256=str(record.get("sha256", "")),
+        branch=str(record.get("branch", "")),
+        created_at=str(record.get("created_at", "")),
+    )
+
+
+def _ensure_ids(payload: dict[str, Any], plan: CleanupPlan) -> dict[str, Any]:
+    payload.setdefault("resources", {})
+    resources = payload["resources"]
+    resources.setdefault(
+        "task",
+        _resource_block_for_targets("task", targets=plan.task_targets, selected_only=False),
+    )
+    resources.setdefault(
+        "worktree",
+        _resource_block_for_targets("worktree", targets=plan.worktree_targets, selected_only=False),
+    )
+    resources.setdefault(
+        "runtime",
+        _resource_block_for_targets("runtime", targets=plan.runtime_targets),
+    )
+
+    for target in plan.task_targets:
+        entry = resources["task"].setdefault(
+            target.task_id,
+            _resource_block_for_targets("task", targets=(target,))[target.task_id],
+        )
+        entry["selected"] = target.task_id in plan.selected_task_ids
+    return payload
 
 
 def _default_state(plan: CleanupPlan) -> dict[str, Any]:
     return {
-        "task_id": plan.task_id,
-        "family": plan.family,
+        "operation_id": plan.operation_id,
+        "family_id": plan.family_id,
         "lineage_id": plan.lineage_id,
+        "mode": plan.mode,
+        "plan_digest": plan.persisted_plan_digest,
         "state": "planned",
         "resume_stage": None,
         "updated_at": _iso_now(),
-        "stages": {},
         "blocked": None,
+        "resources": {
+            "task": _resource_block_for_targets("task", targets=plan.task_targets),
+            "worktree": _resource_block_for_targets("worktree", targets=plan.worktree_targets),
+            "runtime": _resource_block_for_targets("runtime", targets=plan.runtime_targets),
+        },
+        "stages": {},
         "history": ["planned"],
     }
 
 
 def _serializable_receipt(payload: Any) -> Any:
-    if isinstance(payload, Path):
-        return str(payload)
     if isinstance(payload, safety.BundleReceipt):
-        return {
-            "path": str(payload.path),
-            "sha256": payload.sha256,
-            "branch": payload.branch,
-            "created_at": payload.created_at,
-        }
-    if isinstance(payload, set):
-        return sorted(payload)
-    if isinstance(payload, tuple):
-        return list(payload)
+        return _bundle_path_to_record(payload)
     return payload
-
-
-def load_state(repo_root: Path, plan: CleanupPlan) -> dict[str, Any]:
-    path = state_path(repo_root, plan)
-    if not path.exists():
-        return _default_state(plan)
-    try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise ExecutionStateError(f"state file {path} is invalid JSON") from exc
-    if not isinstance(raw, dict):
-        raise ExecutionStateError(f"state file {path} must be an object")
-    return raw
-
-
-def persist_state(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(f".{path.name}.{path.stat().st_mtime_ns if path.exists() else 'new'}.tmp")
-    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
-    tmp.replace(path)
 
 
 def _record(payload: dict[str, Any], stage: str, key: str, value: Any) -> None:
@@ -118,19 +314,30 @@ def _record(payload: dict[str, Any], stage: str, key: str, value: Any) -> None:
     payload.setdefault("stages", {})[stage] = recorded
 
 
-def _update_state(path: Path, payload: dict[str, Any], *, next_state: str) -> dict[str, Any]:
-    payload["state"] = next_state
-    payload["resume_stage"] = None
-    payload["blocked"] = None
-    history = payload.get("history")
-    if not isinstance(history, list):
-        history = []
-        payload["history"] = history
-    if not history or history[-1] != next_state:
-        history.append(next_state)
-    payload["updated_at"] = _iso_now()
-    persist_state(path, payload)
-    return payload
+def _record_resource(payload: dict[str, Any], kind: str, resource_id: str, status: ResourceStatus, *, evidence: Any | None = None, reason: str | None = None) -> None:
+    resources = payload.setdefault("resources", {}).setdefault(kind, {})
+    entry = resources.setdefault(resource_id, {"status": "planned"})
+    entry["status"] = status
+    if reason is not None:
+        entry["reason"] = reason
+    if evidence is not None:
+        entry["actual"] = _as_text(evidence)
+    else:
+        entry.pop("actual", None)
+
+
+def load_state(repo_root: Path, plan: CleanupPlan) -> dict[str, Any]:
+    path = state_path(repo_root, plan)
+    if not path.exists():
+        return _ensure_ids(_default_state(plan), plan)
+
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ExecutionStateError(f"state file {path} is invalid JSON") from exc
+    if not isinstance(raw, dict):
+        raise ExecutionStateError(f"state file {path} must be an object")
+    return _ensure_ids(raw, plan)
 
 
 def _set_blocked(
@@ -148,29 +355,33 @@ def _set_blocked(
         "updated_at": _iso_now(),
     }
     payload["updated_at"] = _iso_now()
-    persist_state(path, payload)
-    return payload
+    payload.setdefault("history", [])
+    if not payload["history"] or payload["history"][-1] != "blocked":
+        payload["history"].append("blocked")
+    return persist_state(path, payload)
 
 
-def _extract_simulated_crash_stage(error: str) -> str | None:
-    marker = "simulated crash after "
-    if not error.startswith(marker):
-        return None
-    return error[len(marker) :].strip() or None
-
-
-def _next_stage(stage: str) -> str:
+def _receipt_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Durable, resource-addressable receipt; it never authorizes a mutation."""
     return {
-        "planned": "frozen",
-        "frozen": "verified",
-        "verified": "snapshotted",
-        "snapshotted": "tasks_archived",
-        "tasks_archived": "worktrees_removed",
-        "worktrees_removed": "branches_deleted",
-        "branches_deleted": "runtime_retired",
-        "runtime_retired": "completed",
-        "completed": "completed",
-    }.get(stage, stage)
+        "schema_version": 1,
+        "operation_id": payload["operation_id"],
+        "family_id": payload["family_id"],
+        "plan_digest": payload["plan_digest"],
+        "state": payload["state"],
+        "resume_stage": payload.get("resume_stage"),
+        "resources": payload.get("resources", {}),
+        "blocked": payload.get("blocked"),
+        "updated_at": payload["updated_at"],
+    }
+
+
+def persist_state(path: Path, payload: dict[str, Any]) -> dict[str, Any]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload["updated_at"] = _iso_now()
+    safety.write_json_atomic(path, payload)
+    safety.write_json_atomic(path.with_name("receipt.json"), _receipt_payload(payload))
+    return payload
 
 
 def _validate_stage(stage: str) -> None:
@@ -187,40 +398,100 @@ def _starting_stage(payload: dict[str, Any]) -> str:
     if state == "completed":
         return "completed"
     if state in CLEANUP_STAGES:
-        return state
+        return str(state)
     raise ExecutionStateError(f"unknown state: {state!r}")
 
 
-def _assert_no_unknowns(plan: CleanupPlan) -> None:
-    if not plan.title:
-        raise ExecutorError("plan.title is required")
-    if not plan.cwd:
-        raise ExecutorError("plan.cwd is required")
-    if not plan.branch:
-        raise ExecutorError("plan.branch is required")
+def _extract_simulated_crash_stage(error: str) -> str | None:
+    marker = "simulated crash after "
+    if not error.startswith(marker):
+        return None
+    return error[len(marker) :].strip() or None
 
 
-def _bundle_from_payload(raw: dict[str, Any]) -> safety.BundleReceipt:
-    path = Path(str(raw.get("path")))
-    return safety.BundleReceipt(
-        path=path,
-        sha256=str(raw.get("sha256", "")),
-        branch=str(raw.get("branch", "")),
-        created_at=str(raw.get("created_at", "")),
-    )
+def _failure_block_stage(stage: str, *, mode: str) -> str:
+    if stage == "tasks_archived" and mode == "archive_only":
+        return "tasks_archived"
+    if stage == "branches_deleted":
+        return "runtime_retired"
+    return stage
 
 
-def _local_branch_exists(repo_root: Path, branch: str) -> bool:
-    return (
-        safety.run_git(["show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], cwd=repo_root).returncode
-        == 0
-    )
+def _validate_uuid(value: str) -> None:
+    if str(uuid.UUID(value)) != value:
+        raise ExecutorError(f"UUID must use canonical lowercase text: {value!r}")
+
+
+def _validate_plan(plan: CleanupPlan) -> None:
+    if plan.mode not in CLEANUP_MODES:
+        raise ExecutorError(f"invalid cleanup mode: {plan.mode!r}")
+    _validate_uuid(str(plan.operation_id))
+    if not plan.family_id:
+        raise ExecutorError("family_id is required")
+    _validate_uuid(str(plan.lineage_id))
+    if not plan.task_targets and not plan.pin_unknown_confirmed:
+        raise ExecutorError("selected_task_ids must be pinned when no task targets are explicit")
+    if not plan.pin_unknown_confirmed:
+        raise ExecutorError("pin_unknown_confirmed is required")
+    if not isinstance(plan.persisted_plan_digest, str) or len(plan.persisted_plan_digest) != 64:
+        raise ExecutorError("caller-supplied persisted_plan_digest is required")
+
+    task_ids = {target.task_id for target in plan.task_targets}
+    if len(task_ids) != len(plan.task_targets) or set(plan.selected_task_ids) != task_ids:
+        raise ExecutorError("selected_task_ids, resource keys, and task thread IDs must be identical UUIDs")
+
+    for target in plan.task_targets:
+        _validate_uuid(target.task_id)
+        if not target.title:
+            raise ExecutorError("TaskTarget.title is required")
+        if not target.cwd:
+            raise ExecutorError("TaskTarget.cwd is required")
+        if target.expected_archived is not True:
+            raise ExecutorError("Task cleanup currently only supports expected_archived=True")
+
+    for target in plan.worktree_targets:
+        _validate_uuid(target.id)
+        if not target.branch:
+            raise ExecutorError("WorktreeTarget.branch is required")
+        if not target.pr_base:
+            raise ExecutorError("WorktreeTarget.pr_base is required")
+        if not target.pr_number:
+            raise ExecutorError("WorktreeTarget.pr_number is required")
+        if target.explicit_family and target.explicit_family != plan.family_id:
+            raise ExecutorError(
+                f"worktree target {target.id!r} explicit_family {target.explicit_family!r} does not match family {plan.family_id!r}"
+            )
+
+    for target in plan.runtime_targets:
+        _validate_uuid(target.id)
+        if not target.kind:
+            raise ExecutorError("RuntimeTarget.kind is required")
+
+
+def _status_ok(state: dict[str, Any] | None) -> bool:
+    if not isinstance(state, dict):
+        return False
+    return state.get("status") in {"actual", "skipped"}
+
+
+def _extract_task_targets(plan: CleanupPlan) -> dict[str, TaskTarget]:
+    return {target.task_id: target for target in plan.task_targets}
+
+
+def _extract_worktree_targets(plan: CleanupPlan) -> dict[str, WorktreeTarget]:
+    return {target.id: target for target in plan.worktree_targets}
 
 
 class CleanupExecutor:
-    """Run and persist one cleanup sequence for a single task-family job."""
+    """Run and persist one cleanup sequence for a task family."""
 
-    def __init__(self, repo_root: Path, plan: CleanupPlan, *, crash_after_stage: str | None = None) -> None:
+    def __init__(
+        self,
+        repo_root: Path,
+        plan: CleanupPlan,
+        *,
+        crash_after_stage: str | None = None,
+    ) -> None:
         self.repo_root = repo_root
         self.plan = plan
         self.crash_after_stage = crash_after_stage
@@ -233,46 +504,46 @@ class CleanupExecutor:
         if self.crash_after_stage == stage:
             raise RuntimeError(f"simulated crash after {stage}")
 
-    @staticmethod
-    def _has_stage_evidence(payload: dict[str, Any], stage: str) -> bool:
-        staged = payload.get("stages")
-        if not isinstance(staged, dict):
-            return False
-        value = staged.get(stage)
-        if not (isinstance(value, dict) and bool(value)):
-            return False
-        return value.keys() != {"cwd"}
-
-    def _restore_blocked_stage(self, payload: dict[str, Any], stage: str) -> dict[str, Any]:
-        history = payload.get("history")
-        if not isinstance(history, list):
-            history = []
-            payload["history"] = history
-
-        if self._has_stage_evidence(payload, stage) and stage not in history:
-            payload = _update_state(self.state_file, payload, next_state=stage)
-            self._record_cwd(payload, stage)
-        return payload
-
     def run(self) -> dict[str, Any]:
-        _assert_no_unknowns(self.plan)
+        _validate_plan(self.plan)
         with (
-            safety.operation_lock(self.repo_root),
+            safety.operation_lock(self.repo_root, operation_id=self.plan.operation_id),
             safety.lineage_lock(self.repo_root, self.plan.lineage_id),
-            safety.family_lock(self.repo_root, self.plan.family),
-            safety.worktree_lock(self.repo_root, self.plan.worktree),
+            safety.family_lock(self.repo_root, self.plan.family_id),
         ):
             return self._run_locked()
 
     def _run_locked(self) -> dict[str, Any]:
         payload = load_state(self.repo_root, self.plan)
+        try:
+            _load_persisted_plan(self.repo_root, self.plan)
+        except ExecutorError as exc:
+            return _set_blocked(self.state_file, payload, stage="frozen", error=str(exc))
+        if payload.get("plan_digest") != self.plan.persisted_plan_digest:
+            return _set_blocked(
+                self.state_file,
+                payload,
+                stage="frozen",
+                error="plan digest changed; rebuild explicit plan before resume",
+            )
+
+        if payload.get("operation_id") != self.plan.operation_id:
+            raise ExecutionStateError("operation_id changed for same state file")
+        if payload.get("family_id") != self.plan.family_id:
+            raise ExecutionStateError("family_id changed for same state file")
+
         stage = _starting_stage(payload)
-        if stage == "completed":
+        if stage == "completed" or (self.plan.mode == "archive_only" and stage == "tasks_archived"):
             return payload
-        if payload.get("state") == "blocked":
-            stage = _starting_stage(payload)
-            payload = self._restore_blocked_stage(payload, stage)
-            stage = _starting_stage(payload)
+
+        blocked_payload = payload.get("blocked")
+        blocked_stage = None
+        if payload.get("state") == "blocked" and isinstance(blocked_payload, dict):
+            blocked_stage = blocked_payload.get("stage")
+            if not isinstance(blocked_stage, str):
+                blocked_stage = None
+        if blocked_stage is None and isinstance(blocked_payload, dict):
+            blocked_stage = _extract_simulated_crash_stage(str(blocked_payload.get("reason", "")))
 
         try:
             while stage != "completed":
@@ -281,12 +552,26 @@ class CleanupExecutor:
                 if next_stage == stage:
                     raise ExecutorError(f"transition for {stage!r} did not advance")
                 payload = _update_state(self.state_file, payload, next_state=next_stage)
-                self._record_cwd(payload, next_stage)
+                _record(payload, next_stage, "stage_transition_ok", True)
+                payload = persist_state(self.state_file, payload)
                 stage = next_stage
+                if self.plan.mode == "archive_only" and stage == "tasks_archived":
+                    return payload
             return payload
         except (ExecutorError, RuntimeError) as exc:
-            blocked_stage = _extract_simulated_crash_stage(str(exc)) or stage
+            if blocked_stage is None:
+                blocked_stage = _failure_block_stage(stage, mode=self.plan.mode)
             return _set_blocked(self.state_file, payload, stage=blocked_stage, error=str(exc))
+
+    def _verify_frozen_gate_once(self) -> None:
+        for target in self.plan.worktree_targets:
+            safety.verify_frozen_preconditions(
+                self.repo_root,
+                operation_id=self.plan.operation_id,
+                lineage_id=self.plan.lineage_id,
+                family=self.plan.family_id,
+                worktree=target.worktree,
+            )
 
     def _advance_once(self, payload: dict[str, Any], stage: str) -> str:
         if stage == "planned":
@@ -298,7 +583,7 @@ class CleanupExecutor:
         if stage == "snapshotted":
             return self._to_tasks_archived(payload)
         if stage == "tasks_archived":
-            return self._to_worktrees_removed(payload)
+            return self._to_worktrees_or_complete(payload)
         if stage == "worktrees_removed":
             return self._to_branches_deleted(payload)
         if stage == "branches_deleted":
@@ -309,210 +594,404 @@ class CleanupExecutor:
             return "completed"
         raise ExecutionStateError(f"invalid stage transition request: {stage!r}")
 
-    def _record_cwd(self, payload: dict[str, Any], stage: str) -> None:
-        _record(payload, stage, "cwd", str(Path(self.plan.cwd).resolve()))
-
-    def _verify_frozen_once(self) -> None:
-        safety.verify_frozen_preconditions(
-            self.repo_root,
-            lineage_id=self.plan.lineage_id,
-            family=self.plan.family,
-            worktree=self.plan.worktree,
-        )
-
     def _to_frozen(self, payload: dict[str, Any]) -> str:
-        self._verify_frozen_once()
-        frozen_stage = payload.get("stages", {}).get("frozen", {}) if isinstance(payload.get("stages"), dict) else {}
-        if isinstance(frozen_stage, dict) and frozen_stage.get("worktree") == str(self.plan.worktree):
+        if self.plan.mode == "archive_only":
+            _record(payload, "frozen", "git_mutations", False)
+            _record(payload, "frozen", "ok", True)
             self._maybe_crash("frozen")
-            return "verified"
-        if isinstance(frozen_stage, dict) and frozen_stage:
-            raise ExecutorError(
-                f"frozen evidence conflict for worktree: {frozen_stage.get('worktree')!r}"
+            return "frozen"
+        self._verify_frozen_gate_once()
+        frozen_stage = payload.get("stages", {}).get("frozen", {})
+        if isinstance(frozen_stage, dict) and frozen_stage.get("ok"):
+            self._maybe_crash("frozen")
+            return "frozen"
+
+        if not self.plan.worktree_targets and self.plan.mode == "finish_and_clean":
+            raise ExecutorError("no worktrees supplied for finish_and_clean mode")
+
+        for worktree in self.plan.worktree_targets:
+            safety.verify_worktree_candidate(
+                self.repo_root,
+                worktree=worktree.worktree,
+                branch=worktree.branch,
+                explicit_family=worktree.explicit_family,
+                planned_family=self.plan.family_id,
             )
-        _record(payload, "frozen", "worktree", str(self.plan.worktree))
+            _record_resource(payload, "worktree", worktree.id, "actual", evidence={"worktree": str(worktree.worktree)})
+
+        _record(payload, "frozen", "operation_id", self.plan.operation_id)
+        _record(payload, "frozen", "family_id", self.plan.family_id)
+        _record(payload, "frozen", "ok", True)
         self._maybe_crash("frozen")
         return "frozen"
 
     def _to_verified(self, payload: dict[str, Any]) -> str:
-        self._verify_frozen_once()
-        verified_stage = payload.get("stages", {}).get("verified", {}) if isinstance(payload.get("stages"), dict) else {}
-        if isinstance(verified_stage, dict) and verified_stage:
+        if self.plan.mode == "archive_only":
+            _record(payload, "verified", "git_mutations", False)
+            _record(payload, "verified", "ok", True)
             self._maybe_crash("verified")
-            return "snapshotted"
-        if not self.plan.worktree.exists():
-            raise ExecutorError(f"worktree missing: {self.plan.worktree}")
-        planned_cwd = str(Path(self.plan.cwd).resolve())
-        if str(self.plan.worktree.resolve()) != planned_cwd:
-            raise ExecutorError(
-                f"worktree path mismatch for task {self.plan.task_id}: {self.plan.worktree} != {planned_cwd}"
-            )
+            return "verified"
+        self._verify_frozen_gate_once()
+        if not self.plan.worktree_targets:
+            _record(payload, "verified", "ok", True)
+            self._maybe_crash("verified")
+            return "verified"
 
-        safety.assert_no_unknown_branch_mutation(
-            self.repo_root,
-            self.plan.branch,
-            explicit_protected=self.plan.explicit_protected,
-        )
-        safety.assert_primary_checkout(self.repo_root)
-        base_branch = safety.repo_default_branch(self.repo_root)
-        safety.ensure_clean_base(self.repo_root, base_branch)
-        safety.verify_worktree_candidate(self.repo_root, worktree=self.plan.worktree, branch=self.plan.branch)
-        head = safety.worktree_head(self.repo_root, self.plan.worktree)
-        if head is None:
-            raise ExecutorError(f"worktree has no HEAD: {self.plan.worktree}")
-        pr = safety.query_pr_by_head(self.repo_root, branch=self.plan.branch)
-        safety.assert_pr_is_merged(pr)
-        _record(payload, "verified", "base_branch", base_branch)
-        _record(payload, "verified", "worktree_head", head)
-        _record(payload, "verified", "pr", pr)
+        verified = payload.get("stages", {}).get("verified", {})
+        if isinstance(verified, dict) and verified.get("ok"):
+            self._maybe_crash("verified")
+            return "verified"
+
+        for target in self.plan.worktree_targets:
+            if not target.worktree.exists():
+                raise ExecutorError(f"worktree missing: {target.worktree}")
+
+            safety.assert_no_unknown_branch_mutation(
+                self.repo_root,
+                target.branch,
+                explicit_protected=self.plan.explicit_protected,
+            )
+            safety.assert_primary_checkout(self.repo_root)
+            base_branch = safety.repo_default_branch(self.repo_root)
+            if base_branch != target.pr_base:
+                raise ExecutorError(
+                    f"branch base mismatch for {target.branch}: plan {target.pr_base!r}, repo {base_branch!r}"
+                )
+            safety.ensure_clean_base(self.repo_root, base_branch)
+            safety.verify_worktree_candidate(
+                self.repo_root,
+                worktree=target.worktree,
+                branch=target.branch,
+                explicit_family=target.explicit_family,
+                planned_family=self.plan.family_id,
+            )
+            head = safety.worktree_head(self.repo_root, target.worktree)
+            if not head:
+                raise ExecutorError(f"worktree has no HEAD: {target.worktree}")
+            pr = safety.query_pr_by_head(
+                self.repo_root,
+                branch=target.branch,
+                pr_number=target.pr_number,
+            )
+            safety.assert_pr_is_merged(
+                pr,
+                expected_branch=target.branch,
+                expected_number=target.pr_number,
+                expected_base=target.pr_base,
+            )
+            _record_resource(payload, "worktree", target.id, "actual", evidence={"pr": pr, "head": head})
+            _record(payload, f"verified:{target.id}", "base_branch", base_branch)
+            _record(payload, f"verified:{target.id}", "pr", pr)
+
+        _record(payload, "verified", "ok", True)
+        _record(payload, "verified", "base_branch", safety.repo_default_branch(self.repo_root))
+        _record(payload, "verified", "runtime_targets", len(self.plan.runtime_targets))
         self._maybe_crash("verified")
         return "verified"
 
     def _to_snapshotted(self, payload: dict[str, Any]) -> str:
-        self._verify_frozen_once()
-        recorded = payload.get("stages", {}).get("snapshotted", {}).get("bundle")
-        if isinstance(recorded, dict):
-            try:
-                receipt = _bundle_from_payload(recorded)
-                safety.assert_bundle_matches_receipt(receipt, branch=self.plan.branch)
-                safety.verify_bundle(receipt.path, branch=self.plan.branch, repo_root=self.repo_root)
-                _record(payload, "snapshotted", "bundle", receipt)
-                self._maybe_crash("snapshotted")
-                return "tasks_archived"
-            except Exception:
-                pass
+        if self.plan.mode == "archive_only":
+            _record(payload, "snapshotted", "git_mutations", False)
+            _record(payload, "snapshotted", "ok", True)
+            self._maybe_crash("snapshotted")
+            return "snapshotted"
+        self._verify_frozen_gate_once()
+        snap = payload.get("stages", {}).get("snapshotted", {})
+        if isinstance(snap, dict) and snap.get("ok"):
+            self._maybe_crash("snapshotted")
+            return "snapshotted"
 
-        bundle = safety.build_bundle(
-            self.repo_root,
-            branch=self.plan.branch,
-            bundle_dir=safety.resolve_state_root(self.repo_root) / "bundles",
-        )
-        _record(payload, "snapshotted", "bundle", bundle)
+        recorded = snap.get("bundles", {}) if isinstance(snap, dict) else {}
+        if not isinstance(recorded, dict):
+            recorded = {}
+
+        for target in self.plan.worktree_targets:
+            current = recorded.get(target.id)
+            if current is not None:
+                bundle = _load_bundle(current)
+                safety.assert_bundle_matches_receipt(bundle, target.branch)
+                safety.verify_bundle(bundle.path, branch=target.branch, repo_root=self.repo_root)
+                _record(payload, "snapshotted", "bundles", recorded)
+                _record_resource(payload, "worktree", target.id, "actual", evidence=current)
+                continue
+
+            bundle = safety.build_bundle(
+                self.repo_root,
+                branch=target.branch,
+                bundle_dir=self.state_file.parent / "snapshots",
+            )
+            recorded[target.id] = _bundle_path_to_record(bundle)
+            _record(payload, "snapshotted", "bundles", recorded)
+            _record_resource(payload, "worktree", target.id, "actual", evidence=_bundle_path_to_record(bundle))
+
         self._maybe_crash("snapshotted")
+        _record(payload, "snapshotted", "ok", True)
         return "snapshotted"
 
     def _to_tasks_archived(self, payload: dict[str, Any]) -> str:
-        self._verify_frozen_once()
+        if self.plan.mode != "archive_only":
+            self._verify_frozen_gate_once()
+        selected = set(self.plan.selected_task_ids)
+        task_by_id = _extract_task_targets(self.plan)
+        stage_receipts = {}
+        failed = False
 
-        existing = payload.get("stages", {}).get("tasks_archived", {})
-        if isinstance(existing, dict) and existing:
-            return _next_stage("tasks_archived")
+        for target_id in selected:
+            target = task_by_id[target_id]
+            entry = payload.setdefault("resources", {}).setdefault("task", {}).setdefault(target.task_id, {})
+            if _status_ok(entry):
+                continue
 
-        before, after, changed = codex_state.reconcile_task_thread(
-            task_id=self.plan.task_id,
-            action="archive",
-            expected_title=self.plan.title,
-            expected_cwd=self.plan.cwd,
-            expected_host=self.plan.host,
-            db_path=self.plan.db_path,
-        )
-        _record(
-            payload,
-            "tasks_archived",
-            "reconcile",
-            codex_state.build_reconciliation_payload(before, after, changed, action="archive"),
-        )
+            try:
+                before = codex_state.await_task_target(
+                    task_id=target.task_id,
+                    expected_title=target.title,
+                    expected_cwd=target.cwd,
+                    expected_host=target.host,
+                    expected_archived=target.expected_archived,
+                    db_path=target.db_path,
+                    timeout_seconds=5.0,
+                )
+            except Exception as exc:  # includes codex context or conflict
+                _record_resource(
+                    payload,
+                    "task",
+                    target.task_id,
+                    "failed",
+                    reason=(
+                        f"task {target.task_id!r} not at archive target; call native task tool and retry: {exc}"
+                    ),
+                )
+                failed = True
+                stage_receipts[target.task_id] = {
+                    "task_id": target.task_id,
+                    "thread_id": target.task_id,
+                    "reason": str(exc),
+                }
+                continue
+
+            payload_task = {
+                "thread_id": before.thread_id,
+                "title": before.title,
+                "cwd": before.cwd,
+                "archived": before.archived,
+                "archived_at": before.archived_at,
+            }
+            stage_receipts[target.task_id] = payload_task
+            _record_resource(payload, "task", target.task_id, "actual", evidence=payload_task)
+
+        for target in self.plan.task_targets:
+            if target.task_id not in selected:
+                _record_resource(payload, "task", target.task_id, "skipped")
+
+        if stage_receipts:
+            _record(payload, "tasks_archived", "reconcile", stage_receipts)
+
+        if failed:
+            raise ExecutorError("task archive incomplete; invoke native task API and retry")
+
         self._maybe_crash("tasks_archived")
         return "tasks_archived"
 
+    def _to_worktrees_or_complete(self, payload: dict[str, Any]) -> str:
+        if self.plan.mode == "archive_only":
+            _record(payload, "completed", "mode", "archive_only")
+            return "completed"
+        return self._to_worktrees_removed(payload)
+
+    @staticmethod
+    def _is_bundle_ready_for_target(payload: dict[str, Any], target: WorktreeTarget) -> safety.BundleReceipt | None:
+        snap = payload.get("stages", {}).get("snapshotted", {}).get("bundles", {})
+        if not isinstance(snap, dict):
+            return None
+        raw = snap.get(target.id)
+        if not isinstance(raw, dict):
+            return None
+        try:
+            return _load_bundle(raw)
+        except Exception:
+            return None
+
     def _to_worktrees_removed(self, payload: dict[str, Any]) -> str:
-        self._verify_frozen_once()
+        self._verify_frozen_gate_once()
+        recorded = payload.get("stages", {}).get("worktrees_removed", {})
+        if not isinstance(recorded, dict):
+            recorded = {}
 
-        if self.plan.worktree.exists():
-            safety.verify_worktree_candidate(self.repo_root, worktree=self.plan.worktree, branch=self.plan.branch)
-            safety.remove_worktree(self.repo_root, self.plan.worktree)
-            if self.plan.worktree.exists():
-                raise ExecutorError(f"worktree still present after remove: {self.plan.worktree}")
-        else:
-            if safety.is_worktree_registered(self.repo_root, self.plan.worktree):
-                raise ExecutorError(f"worktree path missing but still registered: {self.plan.worktree}")
+        for target in self.plan.worktree_targets:
+            bundle = self._is_bundle_ready_for_target(payload, target)
+            if bundle is None:
+                raise ExecutorError(f"missing validated bundle for branch {target.branch}")
+            safety.assert_bundle_matches_receipt(bundle, branch=target.branch)
+            safety.verify_bundle(bundle.path, branch=target.branch, repo_root=self.repo_root)
+            if safety.is_worktree_registered(self.repo_root, target.worktree):
+                head = safety.worktree_head(self.repo_root, target.worktree)
+                if not head:
+                    raise ExecutorError(f"worktree has no HEAD immediately before removal: {target.worktree}")
+                safety.verify_worktree_candidate(
+                    self.repo_root,
+                    worktree=target.worktree,
+                    branch=target.branch,
+                    explicit_family=target.explicit_family,
+                    planned_family=self.plan.family_id,
+                )
+                # This authoritative lookup and all mutable-resource checks are
+                # deliberately repeated immediately before the mutation.
+                pr = safety.query_pr_by_head(self.repo_root, branch=target.branch, pr_number=target.pr_number)
+                safety.assert_pr_is_merged(
+                    pr,
+                    expected_branch=target.branch,
+                    expected_number=target.pr_number,
+                    expected_base=target.pr_base,
+                    expected_head=head,
+                )
+                safety.assert_bundle_matches_receipt(bundle, branch=target.branch)
+                safety.verify_bundle(bundle.path, branch=target.branch, repo_root=self.repo_root)
+                safety.verify_worktree_candidate(
+                    self.repo_root,
+                    worktree=target.worktree,
+                    branch=target.branch,
+                    explicit_family=target.explicit_family,
+                    planned_family=self.plan.family_id,
+                )
+                safety.remove_worktree(self.repo_root, target.worktree)
+                _record_resource(payload, "worktree", target.id, "actual", evidence={"removed": True})
+                recorded[target.id] = {"status": "removed"}
+            else:
+                _record_resource(payload, "worktree", target.id, "skipped", evidence={"reason": "absent"})
+                recorded[target.id] = {"status": "skipped"}
 
-            if self._has_stage_evidence(payload, "worktrees_removed"):
-                return _next_stage("worktrees_removed")
-            _record(payload, "worktrees_removed", "removed", True)
-        _record(payload, "worktrees_removed", "worktree", str(self.plan.worktree))
+            _record(payload, "worktrees_removed", "results", recorded)
+
         self._maybe_crash("worktrees_removed")
         return "worktrees_removed"
 
-    def _bundle_receipt(self, payload: dict[str, Any]) -> safety.BundleReceipt:
-        snap = payload.get("stages", {}).get("snapshotted", {}).get("bundle")
-        if not isinstance(snap, dict):
-            raise ExecutorError("snapshot evidence missing")
-        return _bundle_from_payload(snap)
-
     def _to_branches_deleted(self, payload: dict[str, Any]) -> str:
-        self._verify_frozen_once()
+        self._verify_frozen_gate_once()
+        for target in self.plan.worktree_targets:
+            bundle = self._is_bundle_ready_for_target(payload, target)
+            if bundle is None:
+                raise ExecutorError(f"missing validated bundle for branch {target.branch}")
+            safety.assert_bundle_matches_receipt(bundle, branch=target.branch)
+            safety.verify_bundle(bundle.path, branch=target.branch, repo_root=self.repo_root)
+            safety.assert_primary_checkout(self.repo_root)
+            base_branch = safety.repo_default_branch(self.repo_root)
+            if base_branch != target.pr_base:
+                raise ExecutorError(f"base branch drift for {target.branch}: expected {target.pr_base!r}, got {base_branch!r}")
+            safety.ensure_clean_base(self.repo_root, base_branch)
 
-        if not _local_branch_exists(self.repo_root, self.plan.branch):
-            if safety.remote_branch_present(self.repo_root, self.plan.branch):
-                raise ExecutorError(f"remote branch still present: {self.plan.branch}")
-            if not safety.is_worktree_registered(self.repo_root, self.plan.worktree):
-                _record(payload, "branches_deleted", "local_ref_present_after", False)
-                _record(payload, "branches_deleted", "remote_present", False)
-                return "branches_deleted"
-            raise ExecutorError(f"branch local head removed but worktree still registered: {self.plan.worktree}")
+            local_head = safety.local_branch_head(self.repo_root, target.branch)
+            pr = safety.query_pr_by_head(self.repo_root, branch=target.branch, pr_number=target.pr_number)
+            safety.assert_pr_is_merged(
+                pr,
+                expected_branch=target.branch,
+                expected_number=target.pr_number,
+                expected_base=target.pr_base,
+                expected_head=local_head,
+            )
+            if local_head != pr["head_ref_oid"]:
+                raise ExecutorError(
+                    f"local branch head changed before delete for {target.branch}: {local_head!r} != {pr['head_ref_oid']!r}"
+                )
 
-        verified_payload = payload.get("stages", {}).get("verified", {}) if isinstance(payload.get("stages"), dict) else {}
-        pr = verified_payload.get("pr") if isinstance(verified_payload, dict) else None
-        if not isinstance(pr, dict):
-            pr = safety.query_pr_by_head(self.repo_root, branch=self.plan.branch)
+            safety.assert_branch_deletion_preconditions(
+                repo_root=self.repo_root,
+                branch=target.branch,
+                pr_data=pr,
+                bundle=bundle,
+                explicit_protected=self.plan.explicit_protected,
+                require_remote_gone=True,
+                worktree_registered=safety.is_worktree_registered(self.repo_root, target.worktree),
+                expected_head=pr["head_ref_oid"],
+            )
 
-        bundle = self._bundle_receipt(payload)
-        safety.verify_bundle(bundle.path, branch=self.plan.branch, repo_root=self.repo_root)
-        base_branch = safety.repo_default_branch(self.repo_root)
-        safety.assert_primary_checkout(self.repo_root)
-        safety.ensure_clean_base(self.repo_root, base_branch)
-        merge_commit = safety.assert_branch_deletion_preconditions(
-            repo_root=self.repo_root,
-            branch=self.plan.branch,
-            pr_data=pr,
-            bundle=bundle,
-            explicit_protected=self.plan.explicit_protected,
-            require_remote_gone=True,
-            worktree_registered=safety.is_worktree_registered(self.repo_root, self.plan.worktree),
-        )
-        safety.delete_branch(self.repo_root, branch=self.plan.branch, require_force=True)
-        if _local_branch_exists(self.repo_root, self.plan.branch):
-            raise ExecutorError(f"branch still present after delete attempt: {self.plan.branch}")
-        _record(payload, "branches_deleted", "merge_commit", merge_commit)
-        _record(payload, "branches_deleted", "bundle", bundle)
-        _record(payload, "branches_deleted", "local_ref_present_after", False)
+            if not safety.local_branch_exists(self.repo_root, target.branch):
+                _record_resource(payload, "worktree", target.id, "skipped", evidence={"reason": "branch already removed"})
+                continue
+
+            # Re-query exact PR and re-check the complete mutation fence at the
+            # last possible point; unknown remote state is a blocker.
+            current_head = safety.local_branch_head(self.repo_root, target.branch)
+            current_pr = safety.query_pr_by_head(self.repo_root, branch=target.branch, pr_number=target.pr_number)
+            if safety.worktree_index_locked(self.repo_root):
+                raise ExecutorError("primary checkout index.lock blocks branch deletion")
+            safety.assert_pr_is_merged(
+                current_pr,
+                expected_branch=target.branch,
+                expected_number=target.pr_number,
+                expected_base=target.pr_base,
+                expected_head=current_head,
+            )
+            safety.assert_branch_deletion_preconditions(
+                repo_root=self.repo_root,
+                branch=target.branch,
+                pr_data=current_pr,
+                bundle=bundle,
+                explicit_protected=self.plan.explicit_protected,
+                require_remote_gone=True,
+                worktree_registered=safety.is_worktree_registered(self.repo_root, target.worktree),
+                expected_head=current_head,
+            )
+            safety.delete_branch(self.repo_root, branch=target.branch)
+            if safety.local_branch_exists(self.repo_root, target.branch):
+                raise ExecutorError(f"branch still present after delete attempt: {target.branch}")
+            if safety.remote_branch_present(self.repo_root, target.branch):
+                raise ExecutorError(f"remote branch still present after delete: {target.branch}")
+
+            _record(payload, "branches_deleted", "deleted", target.branch)
+
         self._maybe_crash("branches_deleted")
         return "branches_deleted"
 
     def _to_runtime_retired(self, payload: dict[str, Any]) -> str:
-        self._verify_frozen_once()
-        if self._has_stage_evidence(payload, "runtime_retired"):
-            return _next_stage("runtime_retired")
-        bundle = self._bundle_receipt(payload)
-        safety.assert_bundle_matches_receipt(bundle, branch=self.plan.branch)
-        safety.verify_bundle(bundle.path, branch=self.plan.branch, repo_root=self.repo_root)
-        _record(payload, "runtime_retired", "bundle", bundle)
-        _record(payload, "runtime_retired", "retained", True)
+        if not self.plan.runtime_targets:
+            _record(payload, "runtime_retired", "status", "no_op")
+            return "runtime_retired"
+
+        blocked = False
+        for target in self.plan.runtime_targets:
+            if not target.eligible or not (target.proof and target.proof.strip()):
+                _record_resource(
+                    payload,
+                    "runtime",
+                    target.id,
+                    "failed",
+                    reason="runtime retirement blocked: explicit eligibility and proof required; evidence preserved",
+                )
+                blocked = True
+                continue
+            _record_resource(
+                payload,
+                "runtime",
+                target.id,
+                "actual",
+                evidence={"retired": True, "proof": target.proof},
+            )
+
+        if blocked:
+            raise ExecutorError("runtime retirement blocked: explicit eligibility and proof required")
+        _record(payload, "runtime_retired", "proof_verified", True)
         self._maybe_crash("runtime_retired")
         return "runtime_retired"
 
     def _to_completed(self, payload: dict[str, Any]) -> str:
-        _record(payload, "completed", "state", "ok")
+        _record(payload, "completed", "ok", True)
+        _record(payload, "completed", "mode", self.plan.mode)
         return "completed"
 
     def restore_archive(self) -> dict[str, Any]:
-        payload = load_state(self.repo_root, self.plan)
-        state = _starting_stage(payload)
-        if state in {"runtime_retired", "branches_deleted", "worktrees_removed", "completed"}:
-            raise ExecutorError("restore only supported before destructive branch cleanup")
-        before, after, changed = codex_state.reconcile_task_thread(
-            task_id=self.plan.task_id,
-            action="restore",
-            expected_title=self.plan.title,
-            expected_cwd=self.plan.cwd,
-            expected_host=self.plan.host,
-            db_path=self.plan.db_path,
-        )
-        _record(
-            payload,
-            "tasks_archived",
-            "restore",
-            codex_state.build_reconciliation_payload(before, after, changed, action="restore"),
-        )
-        return _update_state(self.state_file, payload, next_state="verified")
+        """Reject mutation requests: the native task skill owns archive and restore."""
+        raise ExecutorError("executor observes Codex DB state only; invoke the native task skill to restore")
+
+
+def _update_state(path: Path, payload: dict[str, Any], *, next_state: str) -> dict[str, Any]:
+    payload["state"] = next_state
+    payload["resume_stage"] = None
+    payload["blocked"] = None
+    history = payload.get("history")
+    if not isinstance(history, list):
+        history = []
+        payload["history"] = history
+    if not history or history[-1] != next_state:
+        history.append(next_state)
+    return persist_state(path, payload)

--- a/scripts/orchestration/task_family/executor.py
+++ b/scripts/orchestration/task_family/executor.py
@@ -12,6 +12,7 @@ from typing import Any, Literal
 
 from scripts.orchestration.task_family import codex_state
 from scripts.orchestration.task_family import git_safety as safety
+from scripts.orchestration.task_family.storage import TaskFamilyStorage
 
 CLEANUP_STAGES = (
     "planned",
@@ -89,25 +90,27 @@ def _iso_now() -> str:
 
 
 def state_path(repo_root: Path, plan: CleanupPlan) -> Path:
-    return (
-        safety.resolve_state_root(repo_root)
-        / plan.family_id
-        / "operations"
-        / plan.operation_id
-        / "state.json"
-    )
+    return TaskFamilyStorage(
+        safety.resolve_main_root(repo_root), plan.family_id, plan.operation_id
+    ).state_path
 
 
 def plan_path(repo_root: Path, plan: CleanupPlan) -> Path:
-    return state_path(repo_root, plan).with_name("plan.json")
+    return TaskFamilyStorage(
+        safety.resolve_main_root(repo_root), plan.family_id, plan.operation_id
+    ).plan_path
 
 
 def receipt_path(repo_root: Path, plan: CleanupPlan) -> Path:
-    return state_path(repo_root, plan).with_name("receipt.json")
+    return TaskFamilyStorage(
+        safety.resolve_main_root(repo_root), plan.family_id, plan.operation_id
+    ).receipt_path
 
 
 def manifest_path(repo_root: Path, plan: CleanupPlan) -> Path:
-    return state_path(repo_root, plan).with_name("manifest.json")
+    return TaskFamilyStorage(
+        safety.resolve_main_root(repo_root), plan.family_id, plan.operation_id
+    ).manifest_path
 
 
 def _as_text(value: Any) -> Any:
@@ -337,6 +340,12 @@ def load_state(repo_root: Path, plan: CleanupPlan) -> dict[str, Any]:
         raise ExecutionStateError(f"state file {path} is invalid JSON") from exc
     if not isinstance(raw, dict):
         raise ExecutionStateError(f"state file {path} must be an object")
+    # ``TaskFamilyStorage`` writes a preview seed before execution.  It is not
+    # executor state and must never be treated as a partially completed run.
+    if "operation_id" not in raw and raw.get("schema_version") == 1 and isinstance(raw.get("details"), dict):
+        if raw.get("state") != "planned":
+            raise ExecutionStateError("task-family preview state is not planned")
+        return _ensure_ids(_default_state(plan), plan)
     return _ensure_ids(raw, plan)
 
 

--- a/scripts/orchestration/task_family/executor.py
+++ b/scripts/orchestration/task_family/executor.py
@@ -1,0 +1,518 @@
+"""Fail-closed, resumable cleanup executor for one task-family branch cleanup."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts.orchestration.task_family import codex_state
+from scripts.orchestration.task_family import git_safety as safety
+
+CLEANUP_STAGES = (
+    "planned",
+    "frozen",
+    "verified",
+    "snapshotted",
+    "tasks_archived",
+    "worktrees_removed",
+    "branches_deleted",
+    "runtime_retired",
+    "completed",
+)
+
+
+class ExecutorError(RuntimeError):
+    """Cleanup execution blocked by safety guard or data mismatch."""
+
+
+class ExecutionStateError(ExecutorError):
+    """Corrupted or unknown executor state payload."""
+
+
+@dataclass(frozen=True)
+class CleanupPlan:
+    task_id: int
+    family: str
+    lineage_id: str
+    title: str
+    cwd: str
+    branch: str
+    worktree: Path
+    thread_id: int
+    db_path: Path
+    host: str | None = None
+    explicit_protected: frozenset[str] = frozenset()
+
+
+def _iso_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def state_path(repo_root: Path, plan: CleanupPlan) -> Path:
+    return (
+        safety.resolve_state_root(repo_root)
+        / "states"
+        / plan.family
+        / plan.lineage_id
+        / f"{plan.task_id}.json"
+    )
+
+
+def _default_state(plan: CleanupPlan) -> dict[str, Any]:
+    return {
+        "task_id": plan.task_id,
+        "family": plan.family,
+        "lineage_id": plan.lineage_id,
+        "state": "planned",
+        "resume_stage": None,
+        "updated_at": _iso_now(),
+        "stages": {},
+        "blocked": None,
+        "history": ["planned"],
+    }
+
+
+def _serializable_receipt(payload: Any) -> Any:
+    if isinstance(payload, Path):
+        return str(payload)
+    if isinstance(payload, safety.BundleReceipt):
+        return {
+            "path": str(payload.path),
+            "sha256": payload.sha256,
+            "branch": payload.branch,
+            "created_at": payload.created_at,
+        }
+    if isinstance(payload, set):
+        return sorted(payload)
+    if isinstance(payload, tuple):
+        return list(payload)
+    return payload
+
+
+def load_state(repo_root: Path, plan: CleanupPlan) -> dict[str, Any]:
+    path = state_path(repo_root, plan)
+    if not path.exists():
+        return _default_state(plan)
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ExecutionStateError(f"state file {path} is invalid JSON") from exc
+    if not isinstance(raw, dict):
+        raise ExecutionStateError(f"state file {path} must be an object")
+    return raw
+
+
+def persist_state(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{path.stat().st_mtime_ns if path.exists() else 'new'}.tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _record(payload: dict[str, Any], stage: str, key: str, value: Any) -> None:
+    recorded = dict(payload.setdefault("stages", {}).get(stage, {}))
+    recorded[key] = _serializable_receipt(value)
+    payload.setdefault("stages", {})[stage] = recorded
+
+
+def _update_state(path: Path, payload: dict[str, Any], *, next_state: str) -> dict[str, Any]:
+    payload["state"] = next_state
+    payload["resume_stage"] = None
+    payload["blocked"] = None
+    history = payload.get("history")
+    if not isinstance(history, list):
+        history = []
+        payload["history"] = history
+    if not history or history[-1] != next_state:
+        history.append(next_state)
+    payload["updated_at"] = _iso_now()
+    persist_state(path, payload)
+    return payload
+
+
+def _set_blocked(
+    path: Path,
+    payload: dict[str, Any],
+    *,
+    stage: str,
+    error: str,
+) -> dict[str, Any]:
+    payload["state"] = "blocked"
+    payload["resume_stage"] = stage
+    payload["blocked"] = {
+        "stage": stage,
+        "reason": error,
+        "updated_at": _iso_now(),
+    }
+    payload["updated_at"] = _iso_now()
+    persist_state(path, payload)
+    return payload
+
+
+def _extract_simulated_crash_stage(error: str) -> str | None:
+    marker = "simulated crash after "
+    if not error.startswith(marker):
+        return None
+    return error[len(marker) :].strip() or None
+
+
+def _next_stage(stage: str) -> str:
+    return {
+        "planned": "frozen",
+        "frozen": "verified",
+        "verified": "snapshotted",
+        "snapshotted": "tasks_archived",
+        "tasks_archived": "worktrees_removed",
+        "worktrees_removed": "branches_deleted",
+        "branches_deleted": "runtime_retired",
+        "runtime_retired": "completed",
+        "completed": "completed",
+    }.get(stage, stage)
+
+
+def _validate_stage(stage: str) -> None:
+    if stage not in CLEANUP_STAGES:
+        raise ExecutionStateError(f"unknown stage: {stage!r}")
+
+
+def _starting_stage(payload: dict[str, Any]) -> str:
+    state = payload.get("state", "planned")
+    if state == "blocked":
+        resume = str(payload.get("resume_stage") or "planned")
+        _validate_stage(resume)
+        return resume
+    if state == "completed":
+        return "completed"
+    if state in CLEANUP_STAGES:
+        return state
+    raise ExecutionStateError(f"unknown state: {state!r}")
+
+
+def _assert_no_unknowns(plan: CleanupPlan) -> None:
+    if not plan.title:
+        raise ExecutorError("plan.title is required")
+    if not plan.cwd:
+        raise ExecutorError("plan.cwd is required")
+    if not plan.branch:
+        raise ExecutorError("plan.branch is required")
+
+
+def _bundle_from_payload(raw: dict[str, Any]) -> safety.BundleReceipt:
+    path = Path(str(raw.get("path")))
+    return safety.BundleReceipt(
+        path=path,
+        sha256=str(raw.get("sha256", "")),
+        branch=str(raw.get("branch", "")),
+        created_at=str(raw.get("created_at", "")),
+    )
+
+
+def _local_branch_exists(repo_root: Path, branch: str) -> bool:
+    return (
+        safety.run_git(["show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], cwd=repo_root).returncode
+        == 0
+    )
+
+
+class CleanupExecutor:
+    """Run and persist one cleanup sequence for a single task-family job."""
+
+    def __init__(self, repo_root: Path, plan: CleanupPlan, *, crash_after_stage: str | None = None) -> None:
+        self.repo_root = repo_root
+        self.plan = plan
+        self.crash_after_stage = crash_after_stage
+
+    @property
+    def state_file(self) -> Path:
+        return state_path(self.repo_root, self.plan)
+
+    def _maybe_crash(self, stage: str) -> None:
+        if self.crash_after_stage == stage:
+            raise RuntimeError(f"simulated crash after {stage}")
+
+    @staticmethod
+    def _has_stage_evidence(payload: dict[str, Any], stage: str) -> bool:
+        staged = payload.get("stages")
+        if not isinstance(staged, dict):
+            return False
+        value = staged.get(stage)
+        if not (isinstance(value, dict) and bool(value)):
+            return False
+        return value.keys() != {"cwd"}
+
+    def _restore_blocked_stage(self, payload: dict[str, Any], stage: str) -> dict[str, Any]:
+        history = payload.get("history")
+        if not isinstance(history, list):
+            history = []
+            payload["history"] = history
+
+        if self._has_stage_evidence(payload, stage) and stage not in history:
+            payload = _update_state(self.state_file, payload, next_state=stage)
+            self._record_cwd(payload, stage)
+        return payload
+
+    def run(self) -> dict[str, Any]:
+        _assert_no_unknowns(self.plan)
+        with (
+            safety.operation_lock(self.repo_root),
+            safety.lineage_lock(self.repo_root, self.plan.lineage_id),
+            safety.family_lock(self.repo_root, self.plan.family),
+            safety.worktree_lock(self.repo_root, self.plan.worktree),
+        ):
+            return self._run_locked()
+
+    def _run_locked(self) -> dict[str, Any]:
+        payload = load_state(self.repo_root, self.plan)
+        stage = _starting_stage(payload)
+        if stage == "completed":
+            return payload
+        if payload.get("state") == "blocked":
+            stage = _starting_stage(payload)
+            payload = self._restore_blocked_stage(payload, stage)
+            stage = _starting_stage(payload)
+
+        try:
+            while stage != "completed":
+                _validate_stage(stage)
+                next_stage = self._advance_once(payload, stage)
+                if next_stage == stage:
+                    raise ExecutorError(f"transition for {stage!r} did not advance")
+                payload = _update_state(self.state_file, payload, next_state=next_stage)
+                self._record_cwd(payload, next_stage)
+                stage = next_stage
+            return payload
+        except (ExecutorError, RuntimeError) as exc:
+            blocked_stage = _extract_simulated_crash_stage(str(exc)) or stage
+            return _set_blocked(self.state_file, payload, stage=blocked_stage, error=str(exc))
+
+    def _advance_once(self, payload: dict[str, Any], stage: str) -> str:
+        if stage == "planned":
+            return self._to_frozen(payload)
+        if stage == "frozen":
+            return self._to_verified(payload)
+        if stage == "verified":
+            return self._to_snapshotted(payload)
+        if stage == "snapshotted":
+            return self._to_tasks_archived(payload)
+        if stage == "tasks_archived":
+            return self._to_worktrees_removed(payload)
+        if stage == "worktrees_removed":
+            return self._to_branches_deleted(payload)
+        if stage == "branches_deleted":
+            return self._to_runtime_retired(payload)
+        if stage == "runtime_retired":
+            return self._to_completed(payload)
+        if stage == "completed":
+            return "completed"
+        raise ExecutionStateError(f"invalid stage transition request: {stage!r}")
+
+    def _record_cwd(self, payload: dict[str, Any], stage: str) -> None:
+        _record(payload, stage, "cwd", str(Path(self.plan.cwd).resolve()))
+
+    def _verify_frozen_once(self) -> None:
+        safety.verify_frozen_preconditions(
+            self.repo_root,
+            lineage_id=self.plan.lineage_id,
+            family=self.plan.family,
+            worktree=self.plan.worktree,
+        )
+
+    def _to_frozen(self, payload: dict[str, Any]) -> str:
+        self._verify_frozen_once()
+        frozen_stage = payload.get("stages", {}).get("frozen", {}) if isinstance(payload.get("stages"), dict) else {}
+        if isinstance(frozen_stage, dict) and frozen_stage.get("worktree") == str(self.plan.worktree):
+            self._maybe_crash("frozen")
+            return "verified"
+        if isinstance(frozen_stage, dict) and frozen_stage:
+            raise ExecutorError(
+                f"frozen evidence conflict for worktree: {frozen_stage.get('worktree')!r}"
+            )
+        _record(payload, "frozen", "worktree", str(self.plan.worktree))
+        self._maybe_crash("frozen")
+        return "frozen"
+
+    def _to_verified(self, payload: dict[str, Any]) -> str:
+        self._verify_frozen_once()
+        verified_stage = payload.get("stages", {}).get("verified", {}) if isinstance(payload.get("stages"), dict) else {}
+        if isinstance(verified_stage, dict) and verified_stage:
+            self._maybe_crash("verified")
+            return "snapshotted"
+        if not self.plan.worktree.exists():
+            raise ExecutorError(f"worktree missing: {self.plan.worktree}")
+        planned_cwd = str(Path(self.plan.cwd).resolve())
+        if str(self.plan.worktree.resolve()) != planned_cwd:
+            raise ExecutorError(
+                f"worktree path mismatch for task {self.plan.task_id}: {self.plan.worktree} != {planned_cwd}"
+            )
+
+        safety.assert_no_unknown_branch_mutation(
+            self.repo_root,
+            self.plan.branch,
+            explicit_protected=self.plan.explicit_protected,
+        )
+        safety.assert_primary_checkout(self.repo_root)
+        base_branch = safety.repo_default_branch(self.repo_root)
+        safety.ensure_clean_base(self.repo_root, base_branch)
+        safety.verify_worktree_candidate(self.repo_root, worktree=self.plan.worktree, branch=self.plan.branch)
+        head = safety.worktree_head(self.repo_root, self.plan.worktree)
+        if head is None:
+            raise ExecutorError(f"worktree has no HEAD: {self.plan.worktree}")
+        pr = safety.query_pr_by_head(self.repo_root, branch=self.plan.branch)
+        safety.assert_pr_is_merged(pr)
+        _record(payload, "verified", "base_branch", base_branch)
+        _record(payload, "verified", "worktree_head", head)
+        _record(payload, "verified", "pr", pr)
+        self._maybe_crash("verified")
+        return "verified"
+
+    def _to_snapshotted(self, payload: dict[str, Any]) -> str:
+        self._verify_frozen_once()
+        recorded = payload.get("stages", {}).get("snapshotted", {}).get("bundle")
+        if isinstance(recorded, dict):
+            try:
+                receipt = _bundle_from_payload(recorded)
+                safety.assert_bundle_matches_receipt(receipt, branch=self.plan.branch)
+                safety.verify_bundle(receipt.path, branch=self.plan.branch, repo_root=self.repo_root)
+                _record(payload, "snapshotted", "bundle", receipt)
+                self._maybe_crash("snapshotted")
+                return "tasks_archived"
+            except Exception:
+                pass
+
+        bundle = safety.build_bundle(
+            self.repo_root,
+            branch=self.plan.branch,
+            bundle_dir=safety.resolve_state_root(self.repo_root) / "bundles",
+        )
+        _record(payload, "snapshotted", "bundle", bundle)
+        self._maybe_crash("snapshotted")
+        return "snapshotted"
+
+    def _to_tasks_archived(self, payload: dict[str, Any]) -> str:
+        self._verify_frozen_once()
+
+        existing = payload.get("stages", {}).get("tasks_archived", {})
+        if isinstance(existing, dict) and existing:
+            return _next_stage("tasks_archived")
+
+        before, after, changed = codex_state.reconcile_task_thread(
+            task_id=self.plan.task_id,
+            action="archive",
+            expected_title=self.plan.title,
+            expected_cwd=self.plan.cwd,
+            expected_host=self.plan.host,
+            db_path=self.plan.db_path,
+        )
+        _record(
+            payload,
+            "tasks_archived",
+            "reconcile",
+            codex_state.build_reconciliation_payload(before, after, changed, action="archive"),
+        )
+        self._maybe_crash("tasks_archived")
+        return "tasks_archived"
+
+    def _to_worktrees_removed(self, payload: dict[str, Any]) -> str:
+        self._verify_frozen_once()
+
+        if self.plan.worktree.exists():
+            safety.verify_worktree_candidate(self.repo_root, worktree=self.plan.worktree, branch=self.plan.branch)
+            safety.remove_worktree(self.repo_root, self.plan.worktree)
+            if self.plan.worktree.exists():
+                raise ExecutorError(f"worktree still present after remove: {self.plan.worktree}")
+        else:
+            if safety.is_worktree_registered(self.repo_root, self.plan.worktree):
+                raise ExecutorError(f"worktree path missing but still registered: {self.plan.worktree}")
+
+            if self._has_stage_evidence(payload, "worktrees_removed"):
+                return _next_stage("worktrees_removed")
+            _record(payload, "worktrees_removed", "removed", True)
+        _record(payload, "worktrees_removed", "worktree", str(self.plan.worktree))
+        self._maybe_crash("worktrees_removed")
+        return "worktrees_removed"
+
+    def _bundle_receipt(self, payload: dict[str, Any]) -> safety.BundleReceipt:
+        snap = payload.get("stages", {}).get("snapshotted", {}).get("bundle")
+        if not isinstance(snap, dict):
+            raise ExecutorError("snapshot evidence missing")
+        return _bundle_from_payload(snap)
+
+    def _to_branches_deleted(self, payload: dict[str, Any]) -> str:
+        self._verify_frozen_once()
+
+        if not _local_branch_exists(self.repo_root, self.plan.branch):
+            if safety.remote_branch_present(self.repo_root, self.plan.branch):
+                raise ExecutorError(f"remote branch still present: {self.plan.branch}")
+            if not safety.is_worktree_registered(self.repo_root, self.plan.worktree):
+                _record(payload, "branches_deleted", "local_ref_present_after", False)
+                _record(payload, "branches_deleted", "remote_present", False)
+                return "branches_deleted"
+            raise ExecutorError(f"branch local head removed but worktree still registered: {self.plan.worktree}")
+
+        verified_payload = payload.get("stages", {}).get("verified", {}) if isinstance(payload.get("stages"), dict) else {}
+        pr = verified_payload.get("pr") if isinstance(verified_payload, dict) else None
+        if not isinstance(pr, dict):
+            pr = safety.query_pr_by_head(self.repo_root, branch=self.plan.branch)
+
+        bundle = self._bundle_receipt(payload)
+        safety.verify_bundle(bundle.path, branch=self.plan.branch, repo_root=self.repo_root)
+        base_branch = safety.repo_default_branch(self.repo_root)
+        safety.assert_primary_checkout(self.repo_root)
+        safety.ensure_clean_base(self.repo_root, base_branch)
+        merge_commit = safety.assert_branch_deletion_preconditions(
+            repo_root=self.repo_root,
+            branch=self.plan.branch,
+            pr_data=pr,
+            bundle=bundle,
+            explicit_protected=self.plan.explicit_protected,
+            require_remote_gone=True,
+            worktree_registered=safety.is_worktree_registered(self.repo_root, self.plan.worktree),
+        )
+        safety.delete_branch(self.repo_root, branch=self.plan.branch, require_force=True)
+        if _local_branch_exists(self.repo_root, self.plan.branch):
+            raise ExecutorError(f"branch still present after delete attempt: {self.plan.branch}")
+        _record(payload, "branches_deleted", "merge_commit", merge_commit)
+        _record(payload, "branches_deleted", "bundle", bundle)
+        _record(payload, "branches_deleted", "local_ref_present_after", False)
+        self._maybe_crash("branches_deleted")
+        return "branches_deleted"
+
+    def _to_runtime_retired(self, payload: dict[str, Any]) -> str:
+        self._verify_frozen_once()
+        if self._has_stage_evidence(payload, "runtime_retired"):
+            return _next_stage("runtime_retired")
+        bundle = self._bundle_receipt(payload)
+        safety.assert_bundle_matches_receipt(bundle, branch=self.plan.branch)
+        safety.verify_bundle(bundle.path, branch=self.plan.branch, repo_root=self.repo_root)
+        _record(payload, "runtime_retired", "bundle", bundle)
+        _record(payload, "runtime_retired", "retained", True)
+        self._maybe_crash("runtime_retired")
+        return "runtime_retired"
+
+    def _to_completed(self, payload: dict[str, Any]) -> str:
+        _record(payload, "completed", "state", "ok")
+        return "completed"
+
+    def restore_archive(self) -> dict[str, Any]:
+        payload = load_state(self.repo_root, self.plan)
+        state = _starting_stage(payload)
+        if state in {"runtime_retired", "branches_deleted", "worktrees_removed", "completed"}:
+            raise ExecutorError("restore only supported before destructive branch cleanup")
+        before, after, changed = codex_state.reconcile_task_thread(
+            task_id=self.plan.task_id,
+            action="restore",
+            expected_title=self.plan.title,
+            expected_cwd=self.plan.cwd,
+            expected_host=self.plan.host,
+            db_path=self.plan.db_path,
+        )
+        _record(
+            payload,
+            "tasks_archived",
+            "restore",
+            codex_state.build_reconciliation_payload(before, after, changed, action="restore"),
+        )
+        return _update_state(self.state_file, payload, next_state="verified")

--- a/scripts/orchestration/task_family/executor.py
+++ b/scripts/orchestration/task_family/executor.py
@@ -12,7 +12,8 @@ from typing import Any, Literal
 
 from scripts.orchestration.task_family import codex_state
 from scripts.orchestration.task_family import git_safety as safety
-from scripts.orchestration.task_family.storage import TaskFamilyStorage
+from scripts.orchestration.task_family.model import LifecycleState, OperationReceipt, ReceiptAction
+from scripts.orchestration.task_family.storage import TaskFamilyStorage, atomic_write_text
 
 CLEANUP_STAGES = (
     "planned",
@@ -370,26 +371,166 @@ def _set_blocked(
     return persist_state(path, payload)
 
 
-def _receipt_payload(payload: dict[str, Any]) -> dict[str, Any]:
-    """Durable, resource-addressable receipt; it never authorizes a mutation."""
-    return {
-        "schema_version": 1,
-        "operation_id": payload["operation_id"],
-        "family_id": payload["family_id"],
-        "plan_digest": payload["plan_digest"],
-        "state": payload["state"],
-        "resume_stage": payload.get("resume_stage"),
-        "resources": payload.get("resources", {}),
-        "blocked": payload.get("blocked"),
-        "updated_at": payload["updated_at"],
+def _dedupe_actions(actions: tuple[ReceiptAction, ...]) -> tuple[ReceiptAction, ...]:
+    seen: set[tuple[str, str, str]] = set()
+    result: list[ReceiptAction] = []
+    for action in actions:
+        key = (action.resource_type, action.resource_id, action.action)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(action)
+    return tuple(result)
+
+
+def _initial_receipt(payload: dict[str, Any]) -> OperationReceipt:
+    raw = payload.get("initial_receipt")
+    if isinstance(raw, dict):
+        try:
+            return OperationReceipt.from_dict(raw)
+        except ValueError:
+            pass
+    return OperationReceipt(
+        operation_id=str(payload["operation_id"]),
+        family_id=str(payload["family_id"]),
+        plan_digest=str(payload["plan_digest"]),
+        final_state=LifecycleState.PLANNED,
+    )
+
+
+def _resource_actions(payload: dict[str, Any]) -> tuple[tuple[ReceiptAction, ...], tuple[ReceiptAction, ...], tuple[ReceiptAction, ...]]:
+    """Return exact actual, skipped, and failed resource outcomes."""
+    actual: list[ReceiptAction] = []
+    skipped: list[ReceiptAction] = []
+    failures: list[ReceiptAction] = []
+    resources = payload.get("resources", {})
+    if not isinstance(resources, dict):
+        return (), (), ()
+    branch_results = payload.get("stages", {}).get("branches_deleted", {}).get("results", {})
+    if not isinstance(branch_results, dict):
+        branch_results = {}
+    action_by_kind = {
+        "task": "archive",
+        "worktree": "retire_local_worktree_and_branch",
+        "runtime": "retire_runtime",
     }
+    for kind in ("task", "worktree", "runtime"):
+        entries = resources.get(kind, {})
+        if not isinstance(entries, dict):
+            continue
+        for resource_id, entry in sorted(entries.items()):
+            if not isinstance(entry, dict):
+                continue
+            status = entry.get("status")
+            if kind == "worktree":
+                branch_status = branch_results.get(resource_id, {})
+                if not isinstance(branch_status, dict):
+                    branch_status = {}
+                if branch_status.get("status") == "deleted":
+                    status = "actual"
+                elif branch_status.get("status") == "already_absent":
+                    status = "skipped"
+                elif status == "actual":
+                    continue
+            reason = str(entry.get("reason") or f"executor resource status: {status or 'unknown'}")
+            action = ReceiptAction(
+                kind,
+                str(resource_id),
+                (str(resource_id),),
+                action_by_kind[kind],
+                reason,
+                reason if status == "failed" else "",
+                "Inspect state.json and retained snapshots before retrying." if status == "failed" else "",
+            )
+            if status == "actual":
+                actual.append(action)
+            elif status == "skipped":
+                skipped.append(action)
+            elif status == "failed":
+                failures.append(action)
+    return tuple(actual), tuple(skipped), tuple(failures)
+
+
+def _final_resource_actions(payload: dict[str, Any]) -> tuple[ReceiptAction, ...]:
+    resources = payload.get("resources", {})
+    if not isinstance(resources, dict):
+        return ()
+    branch_results = payload.get("stages", {}).get("branches_deleted", {}).get("results", {})
+    if not isinstance(branch_results, dict):
+        branch_results = {}
+    actions: list[ReceiptAction] = []
+    for kind in ("task", "worktree", "runtime"):
+        entries = resources.get(kind, {})
+        if not isinstance(entries, dict):
+            continue
+        for resource_id, entry in sorted(entries.items()):
+            status = entry.get("status") if isinstance(entry, dict) else "unknown"
+            branch_status = branch_results.get(resource_id, {}) if kind == "worktree" else {}
+            if isinstance(branch_status, dict) and branch_status.get("status") == "deleted":
+                status = "retired"
+            elif isinstance(branch_status, dict) and branch_status.get("status") == "already_absent":
+                status = "already_absent"
+            action = {
+                ("task", "actual"): "archived",
+                ("worktree", "retired"): "retired",
+                ("worktree", "already_absent"): "retired_before_resume",
+                ("runtime", "actual"): "retired",
+            }.get((kind, status), "retained")
+            actions.append(
+                ReceiptAction(
+                    kind,
+                    str(resource_id),
+                    (str(resource_id),),
+                    action,
+                    f"final executor resource status: {status}",
+                )
+            )
+    return tuple(actions)
+
+
+def _receipt_payload(payload: dict[str, Any]) -> OperationReceipt:
+    """Build one durable receipt without discarding native reconciliation."""
+    initial = _initial_receipt(payload)
+    resource_actual, resource_skipped, resource_failures = _resource_actions(payload)
+    try:
+        final_state = LifecycleState(str(payload["state"]))
+    except ValueError as exc:
+        raise ExecutionStateError(f"invalid receipt lifecycle state: {payload.get('state')!r}") from exc
+    return OperationReceipt(
+        operation_id=initial.operation_id,
+        family_id=initial.family_id,
+        plan_digest=initial.plan_digest,
+        final_state=final_state,
+        planned=initial.planned,
+        actual=_dedupe_actions((*initial.actual, *resource_actual)),
+        skipped=_dedupe_actions((*initial.skipped, *resource_skipped)),
+        failures=_dedupe_actions((*initial.failures, *resource_failures)),
+        restoration=initial.restoration,
+        final_resources=_final_resource_actions(payload),
+        events=initial.events,
+    )
+
+
+def _capture_initial_receipt(path: Path, payload: dict[str, Any]) -> dict[str, Any]:
+    if isinstance(payload.get("initial_receipt"), dict):
+        return payload
+    receipt_file = path.with_name("receipt.json")
+    try:
+        raw = json.loads(receipt_file.read_text(encoding="utf-8"))
+        receipt = OperationReceipt.from_dict(raw)
+    except (FileNotFoundError, json.JSONDecodeError, ValueError):
+        receipt = _initial_receipt(payload)
+    payload["initial_receipt"] = receipt.to_dict()
+    return payload
 
 
 def persist_state(path: Path, payload: dict[str, Any]) -> dict[str, Any]:
     path.parent.mkdir(parents=True, exist_ok=True)
     payload["updated_at"] = _iso_now()
     safety.write_json_atomic(path, payload)
-    safety.write_json_atomic(path.with_name("receipt.json"), _receipt_payload(payload))
+    receipt = _receipt_payload(payload)
+    safety.write_json_atomic(path.with_name("receipt.json"), receipt.to_dict())
+    atomic_write_text(path.with_name("receipt.txt"), receipt.render_human())
     return payload
 
 
@@ -524,6 +665,7 @@ class CleanupExecutor:
 
     def _run_locked(self) -> dict[str, Any]:
         payload = load_state(self.repo_root, self.plan)
+        payload = _capture_initial_receipt(self.state_file, payload)
         try:
             _load_persisted_plan(self.repo_root, self.plan)
         except ExecutorError as exc:
@@ -877,6 +1019,9 @@ class CleanupExecutor:
 
     def _to_branches_deleted(self, payload: dict[str, Any]) -> str:
         self._verify_frozen_gate_once()
+        recorded = payload.get("stages", {}).get("branches_deleted", {}).get("results", {})
+        if not isinstance(recorded, dict):
+            recorded = {}
         for target in self.plan.worktree_targets:
             bundle = self._is_bundle_ready_for_target(payload, target)
             if bundle is None:
@@ -888,6 +1033,52 @@ class CleanupExecutor:
             if base_branch != target.pr_base:
                 raise ExecutorError(f"base branch drift for {target.branch}: expected {target.pr_base!r}, got {base_branch!r}")
             safety.ensure_clean_base(self.repo_root, base_branch)
+
+            if not safety.local_branch_exists(self.repo_root, target.branch):
+                if safety.is_worktree_registered(self.repo_root, target.worktree):
+                    raise ExecutorError(f"branch is absent but its worktree remains registered: {target.branch}")
+                if safety.remote_branch_present(self.repo_root, target.branch):
+                    raise ExecutorError(f"remote branch still present while local branch is absent: {target.branch}")
+                bundle_head = safety.bundle_branch_head(
+                    bundle.path,
+                    branch=target.branch,
+                    repo_root=self.repo_root,
+                )
+                current_pr = safety.query_pr_by_head(
+                    self.repo_root,
+                    branch=target.branch,
+                    pr_number=target.pr_number,
+                )
+                safety.assert_pr_is_merged(
+                    current_pr,
+                    expected_branch=target.branch,
+                    expected_number=target.pr_number,
+                    expected_base=target.pr_base,
+                    expected_head=bundle_head,
+                )
+                prior = recorded.get(target.id, {})
+                if isinstance(prior, dict) and prior.get("status") == "deleted":
+                    _record_resource(
+                        payload,
+                        "worktree",
+                        target.id,
+                        "actual",
+                        evidence=prior,
+                        reason="persisted deletion receipt reverified on safe resume",
+                    )
+                    _record(payload, "branches_deleted", "results", recorded)
+                    continue
+                recorded[target.id] = {"status": "already_absent", "branch": target.branch, "head": bundle_head}
+                _record_resource(
+                    payload,
+                    "worktree",
+                    target.id,
+                    "skipped",
+                    evidence=recorded[target.id],
+                    reason="exact local branch was already absent on safe resume",
+                )
+                _record(payload, "branches_deleted", "results", recorded)
+                continue
 
             local_head = safety.local_branch_head(self.repo_root, target.branch)
             pr = safety.query_pr_by_head(self.repo_root, branch=target.branch, pr_number=target.pr_number)
@@ -913,10 +1104,6 @@ class CleanupExecutor:
                 worktree_registered=safety.is_worktree_registered(self.repo_root, target.worktree),
                 expected_head=pr["head_ref_oid"],
             )
-
-            if not safety.local_branch_exists(self.repo_root, target.branch):
-                _record_resource(payload, "worktree", target.id, "skipped", evidence={"reason": "branch already removed"})
-                continue
 
             # Re-query exact PR and re-check the complete mutation fence at the
             # last possible point; unknown remote state is a blocker.
@@ -947,7 +1134,8 @@ class CleanupExecutor:
             if safety.remote_branch_present(self.repo_root, target.branch):
                 raise ExecutorError(f"remote branch still present after delete: {target.branch}")
 
-            _record(payload, "branches_deleted", "deleted", target.branch)
+            recorded[target.id] = {"status": "deleted", "branch": target.branch, "head": current_head}
+            _record(payload, "branches_deleted", "results", recorded)
 
         self._maybe_crash("branches_deleted")
         return "branches_deleted"

--- a/scripts/orchestration/task_family/git_safety.py
+++ b/scripts/orchestration/task_family/git_safety.py
@@ -446,11 +446,18 @@ def repo_default_branch(repo_root: Path) -> str:
 
 
 def ensure_clean_base(repo_root: Path, base_branch: str) -> None:
+    _assert_valid_branch_token(repo_root, base_branch)
     current_proc = run_git(["symbolic-ref", "--short", "HEAD"], cwd=repo_root)
     _require_success(current_proc, context="cannot determine active branch")
     current = (current_proc.stdout or "").strip()
     if current != base_branch:
         raise GitSafetyError(f"active branch is {current!r}, expected protected base {base_branch!r}")
+
+    fetch = run_git(
+        ["fetch", "--quiet", "origin", f"refs/heads/{base_branch}:refs/remotes/origin/{base_branch}"],
+        cwd=repo_root,
+    )
+    _require_success(fetch, context=f"cannot refresh protected base {base_branch}")
 
     proc = run_git([
         "rev-list",
@@ -576,7 +583,7 @@ def assert_pr_is_merged(
     if pr.get("is_cross_repository"):
         raise GitSafetyError("PR must not be cross-repository")
     number = int(pr.get("number", 0) or 0)
-    if expected_number is not None and number and number != expected_number:
+    if expected_number is not None and number != expected_number:
         raise GitSafetyError(
             f"PR number mismatch: expected {expected_number!r}, got {pr.get('number')!r}"
         )
@@ -619,13 +626,20 @@ def remote_branch_present(repo_root: Path, branch: str) -> bool:
     raise GitSafetyError(f"remote branch lookup failed for {branch!r}: {proc.stderr.strip() or proc.stdout.strip()}")
 
 
+def _assert_valid_branch_token(repo_root: Path, branch: str) -> None:
+    if ".." in branch or branch.startswith("-") or branch.strip() != branch or not branch:
+        raise GitSafetyError(f"invalid branch token: {branch!r}")
+    checked = run_git(["check-ref-format", "--branch", branch], cwd=repo_root)
+    if checked.returncode != 0:
+        raise GitSafetyError(f"invalid branch token: {branch!r}")
+
+
 def assert_no_unknown_branch_mutation(
     repo_root: Path,
     branch: str,
     explicit_protected: set[str] | frozenset[str] = frozenset(),
 ) -> None:
-    if ".." in branch or branch.strip() != branch or not branch:
-        raise GitSafetyError(f"invalid branch token: {branch!r}")
+    _assert_valid_branch_token(repo_root, branch)
     if is_protected_branch(repo_root, branch, explicit_protected=explicit_protected):
         raise GitSafetyError(f"refusing to mutate protected branch: {branch!r}")
 

--- a/scripts/orchestration/task_family/git_safety.py
+++ b/scripts/orchestration/task_family/git_safety.py
@@ -688,6 +688,28 @@ def verify_bundle(
             raise BundleError(f"bundle does not include {full_ref}")
 
 
+def bundle_branch_head(
+    path: Path,
+    *,
+    branch: str,
+    repo_root: Path,
+    timeout: float = 30.0,
+) -> str:
+    """Return the exact branch head recorded by a verified recovery bundle."""
+    verify_bundle(path, branch=branch, repo_root=repo_root, timeout=timeout)
+    listed = run_git(["bundle", "list-heads", str(path)], cwd=repo_root, timeout=timeout)
+    _require_success(listed, context="git bundle list-heads failed")
+    full_ref = f"refs/heads/{branch}"
+    matches = [
+        parts[0]
+        for line in (listed.stdout or "").splitlines()
+        if len(parts := line.strip().split()) >= 2 and parts[1] == full_ref
+    ]
+    if len(matches) != 1 or not re.fullmatch(r"[0-9a-fA-F]{40,64}", matches[0]):
+        raise BundleError(f"bundle has ambiguous or invalid head for {full_ref}")
+    return matches[0].lower()
+
+
 def assert_bundle_matches_receipt(bundle: BundleReceipt, branch: str) -> None:
     if bundle.branch != branch:
         raise GitSafetyError(f"bundle branch mismatch: {bundle.branch!r} != {branch!r}")
@@ -771,6 +793,11 @@ def assert_branch_deletion_preconditions(
     if local_head != pr_head_oid:
         raise GitSafetyError(
             f"local branch head mismatch for {branch}: local {local_head!r}, pr head {pr_head_oid!r}"
+        )
+    bundle_head = bundle_branch_head(bundle.path, branch=branch, repo_root=repo_root)
+    if bundle_head != local_head:
+        raise GitSafetyError(
+            f"recovery bundle head mismatch for {branch}: bundle {bundle_head!r}, local {local_head!r}"
         )
     if require_remote_gone and remote_branch_present(repo_root, branch):
         raise GitSafetyError(f"remote branch still present: {branch}")

--- a/scripts/orchestration/task_family/git_safety.py
+++ b/scripts/orchestration/task_family/git_safety.py
@@ -1,0 +1,620 @@
+"""Safety primitives for fail-closed task-family cleanup."""
+
+from __future__ import annotations
+
+import contextlib
+import fcntl
+import hashlib
+import json
+import re
+import subprocess
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+try:
+    from guardrails.worktree_containment import PROTECTED_BRANCHES, resolve_main_root
+except Exception:  # pragma: no cover - fallback for unit test imports
+    PROTECTED_BRANCHES = frozenset({"main", "master"})
+
+    def resolve_main_root(start: Path | str | None = None) -> Path:
+        cwd = Path(start or Path.cwd())
+        for path in (cwd, *cwd.parents):
+            if (path / ".git").is_dir():
+                return path
+        raise RuntimeError("not in a git repository")
+
+from scripts.common.git_context import sanitized_git_env
+
+
+class GitSafetyError(RuntimeError):
+    """Any safety failure that blocks cleanup progress."""
+
+
+class GitCommandError(GitSafetyError):
+    """git command failed with non-zero return code."""
+
+
+class GitHubQueryError(GitSafetyError):
+    """GitHub authoritative lookup failed or returned unknown data."""
+
+
+class BundleError(GitSafetyError):
+    """Bundle creation or verification failed."""
+
+
+class LockAcquisitionError(GitSafetyError):
+    """Required advisory lock is unavailable."""
+
+
+STATE_FILE_RE = re.compile(r"^[A-Za-z0-9._-]+\.(json|yml|yaml)$")
+
+
+@dataclass(frozen=True)
+class WorktreeInfo:
+    path: Path
+    branch: str | None
+    head: str | None = None
+
+
+@dataclass(frozen=True)
+class BundleReceipt:
+    path: Path
+    sha256: str
+    branch: str
+    created_at: str
+
+
+def run_git(args: list[str], cwd: Path, *, timeout: float = 30.0, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env if env is not None else sanitized_git_env(),
+    )
+
+
+def run_gh(
+    args: list[str],
+    *,
+    cwd: Path | None = None,
+    timeout: float = 30.0,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["gh", *args],
+        cwd=str(cwd) if cwd is not None else None,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _require_success(proc: subprocess.CompletedProcess[str], *, context: str) -> None:
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()
+        raise GitCommandError(f"{context}: {detail or f'exit {proc.returncode}'}")
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def resolve_lock_root(repo_root: Path) -> Path:
+    root = resolve_main_root(repo_root)
+    return root / ".agent" / "task_family_cleanup" / "locks"
+
+
+def resolve_state_root(repo_root: Path) -> Path:
+    return resolve_main_root(repo_root) / ".agent" / "task_family_cleanup"
+
+
+def _require_existing_root(root: Path) -> None:
+    if not root.exists():
+        root.mkdir(parents=True, exist_ok=True)
+
+
+def safe_lock_token(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]", "-", value)
+
+
+def _operation_lock_path(repo_root: Path) -> Path:
+    return resolve_lock_root(repo_root) / "operation.lock"
+
+
+def _lineage_lock_path(repo_root: Path, lineage_id: str) -> Path:
+    return resolve_lock_root(repo_root) / f"lineage-{safe_lock_token(lineage_id)}.lock"
+
+
+def _family_lock_path(repo_root: Path, family: str) -> Path:
+    return resolve_lock_root(repo_root) / f"family-{safe_lock_token(family)}.lock"
+
+
+def _worktree_lock_path(repo_root: Path, worktree: Path) -> Path:
+    rel = worktree.resolve().as_posix().replace("/", "-")
+    return resolve_lock_root(repo_root) / f"worktree-{safe_lock_token(rel)}.lock"
+
+
+@contextmanager
+def flock(lock_path: Path) -> Iterator[Path]:
+    _require_existing_root(lock_path.parent)
+    with open(lock_path, "a+", encoding="utf-8") as handle:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            raise LockAcquisitionError(f"lock busy: {lock_path}") from exc
+        try:
+            yield lock_path
+        finally:
+            with contextlib.suppress(Exception):
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def operation_lock(repo_root: Path):
+    with flock(_operation_lock_path(repo_root)):
+        yield
+
+
+@contextmanager
+def lineage_lock(repo_root: Path, lineage_id: str):
+    with flock(_lineage_lock_path(repo_root, lineage_id)):
+        yield
+
+
+@contextmanager
+def family_lock(repo_root: Path, family: str):
+    with flock(_family_lock_path(repo_root, family)):
+        yield
+
+
+@contextmanager
+def worktree_lock(repo_root: Path, worktree: Path):
+    with flock(_worktree_lock_path(repo_root, worktree)):
+        yield
+
+
+def _parse_worktree_porcelain(raw: str) -> list[WorktreeInfo]:
+    items: list[WorktreeInfo] = []
+    current: dict[str, str] | None = None
+
+    def flush() -> None:
+        nonlocal current
+        if current is None or "path" not in current:
+            current = None
+            return
+        items.append(
+            WorktreeInfo(
+                path=Path(current["path"]),
+                branch=current.get("branch"),
+                head=current.get("head"),
+            )
+        )
+        current = None
+
+    for line in raw.splitlines():
+        if not line:
+            flush()
+            continue
+        if line.startswith("worktree "):
+            flush()
+            current = {"path": line.removeprefix("worktree ").strip()}
+            continue
+        if current is None:
+            continue
+        if line.startswith("HEAD "):
+            current["head"] = line.removeprefix("HEAD ").strip()
+            continue
+        if line.startswith("branch "):
+            branch = line.removeprefix("branch ").strip()
+            if branch.startswith("refs/heads/"):
+                branch = branch[len("refs/heads/") :]
+            current["branch"] = branch
+
+    flush()
+    return items
+
+
+def worktree_list(repo_root: Path) -> list[WorktreeInfo]:
+    proc = run_git(["worktree", "list", "--porcelain"], cwd=repo_root)
+    _require_success(proc, context="git worktree list failed")
+    return _parse_worktree_porcelain(proc.stdout)
+
+
+def is_worktree_registered(repo_root: Path, worktree: Path) -> bool:
+    canonical = worktree.resolve()
+    return any(item.path.resolve() == canonical for item in worktree_list(repo_root))
+
+
+def worktree_branch(repo_root: Path, worktree: Path) -> str | None:
+    canonical = worktree.resolve()
+    for item in worktree_list(repo_root):
+        if item.path.resolve() == canonical:
+            return item.branch
+    return None
+
+
+def worktree_head(repo_root: Path, worktree: Path) -> str | None:
+    canonical = worktree.resolve()
+    for item in worktree_list(repo_root):
+        if item.path.resolve() == canonical:
+            return item.head
+    return None
+
+
+def is_worktree_shared(repo_root: Path, worktree: Path) -> bool:
+    target_branch = worktree_branch(repo_root, worktree)
+    if target_branch is None:
+        return False
+    count = 0
+    for item in worktree_list(repo_root):
+        if item.branch == target_branch:
+            count += 1
+    return count > 1
+
+
+def is_worktree_permanent(repo_root: Path, worktree: Path) -> bool:
+    return worktree.resolve() == resolve_main_root(repo_root).resolve()
+
+
+def is_worktree_dirty(worktree: Path) -> bool:
+    proc = run_git(["status", "--porcelain"], cwd=worktree)
+    _require_success(proc, context=f"git status failed for worktree {worktree}")
+    return bool((proc.stdout or "").strip())
+
+
+def is_worktree_locked(repo_root: Path, worktree: Path) -> bool:
+    return _worktree_lock_path(repo_root, worktree).exists()
+
+
+def active_jobs_or_leases(repo_root: Path, lineage_id: str | None = None) -> list[Path]:
+    state_root = resolve_state_root(repo_root)
+    entries: list[Path] = []
+    for kind in ("jobs", "leases"):
+        for path in sorted((state_root / kind).glob("*")):
+            if not path.is_file() or not STATE_FILE_RE.match(path.name):
+                continue
+            if lineage_id is not None and lineage_id not in path.name:
+                continue
+            entries.append(path)
+    return entries
+
+
+def assert_no_active_jobs_or_leases(repo_root: Path, lineage_id: str | None = None) -> None:
+    active = active_jobs_or_leases(repo_root, lineage_id=lineage_id)
+    if active:
+        names = ", ".join(sorted(path.name for path in active))
+        raise GitSafetyError(f"active jobs/leases block cleanup: {names}")
+
+
+def _repo_owner_and_name(repo_root: Path) -> tuple[str, str]:
+    proc = run_gh(["repo", "view", "--json", "owner,name"], cwd=repo_root)
+    if proc.returncode != 0:
+        raise GitHubQueryError("gh repo view failed")
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise GitHubQueryError("invalid JSON from gh repo view") from exc
+    if not isinstance(payload, dict):
+        raise GitHubQueryError("unexpected repo payload type")
+    owner_data = payload.get("owner")
+    name = payload.get("name")
+    owner = owner_data.get("login") if isinstance(owner_data, dict) else None
+    if not isinstance(owner, str) or not owner or not isinstance(name, str) or not name:
+        raise GitHubQueryError("incomplete owner/name payload")
+    return owner, name
+
+
+def remote_protected_branches(repo_root: Path, *, timeout: float = 30.0) -> set[str]:
+    owner, name = _repo_owner_and_name(repo_root)
+    proc = run_gh(
+        ["api", f"repos/{owner}/{name}/branches", "--paginate", "--json", "name,protected"],
+        cwd=repo_root,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise GitHubQueryError("github protected-branch query failed")
+    try:
+        payload = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise GitHubQueryError("invalid JSON from protected-branch query") from exc
+    if not isinstance(payload, list):
+        raise GitHubQueryError("invalid protected-branch payload")
+    protected: set[str] = set()
+    for item in payload:
+        if not isinstance(item, dict):
+            raise GitHubQueryError("invalid protected-branch item")
+        name = item.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        if item.get("protected") is True:
+            protected.add(name)
+    return protected
+
+
+def protected_branches(
+    repo_root: Path,
+    explicit_protected: set[str] | frozenset[str] = frozenset(),
+    *,
+    timeout: float = 30.0,
+) -> set[str]:
+    branches = set(PROTECTED_BRANCHES)
+    branches.add(repo_default_branch(repo_root))
+    branches.update(explicit_protected)
+    branches.update(remote_protected_branches(repo_root, timeout=timeout))
+    return branches
+
+
+def is_protected_branch(
+    repo_root: Path,
+    branch: str,
+    explicit_protected: set[str] | frozenset[str] = frozenset(),
+) -> bool:
+    return branch in protected_branches(repo_root, explicit_protected=explicit_protected)
+
+
+def repo_default_branch(repo_root: Path) -> str:
+    proc = run_git(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], cwd=repo_root)
+    if proc.returncode != 0:
+        proc = run_git(["branch", "--show-current"], cwd=repo_root)
+    _require_success(proc, context="cannot discover default branch")
+    ref = (proc.stdout or "").strip()
+    if ref.startswith("origin/"):
+        return ref.split("/", 1)[1]
+    return ref
+
+
+def ensure_clean_base(repo_root: Path, base_branch: str) -> None:
+    current_proc = run_git(["symbolic-ref", "--short", "HEAD"], cwd=repo_root)
+    _require_success(current_proc, context="cannot determine active branch")
+    current = (current_proc.stdout or "").strip()
+    if current != base_branch:
+        raise GitSafetyError(f"active branch is {current!r}, expected protected base {base_branch!r}")
+
+    proc = run_git(["rev-list", "--left-right", "--count", f"origin/{base_branch}...{base_branch}"], cwd=repo_root)
+    if proc.returncode != 0:
+        raise GitSafetyError(f"cannot verify base branch up-to-date for {base_branch}")
+    if (proc.stdout or "").strip() not in {"0\t0", "0 0"}:
+        raise GitSafetyError(f"base branch {base_branch} is not up to date")
+
+
+def assert_primary_checkout(repo_root: Path) -> None:
+    main_root = resolve_main_root(repo_root)
+    if main_root.resolve() != Path(repo_root).resolve():
+        raise GitSafetyError("operation must execute from primary checkout")
+
+
+def query_pr_by_head(repo_root: Path, *, branch: str, timeout: float = 30.0) -> dict[str, Any]:
+    proc = run_gh(
+        [
+            "pr",
+            "list",
+            "--head",
+            branch,
+            "--state",
+            "all",
+            "--json",
+            "number,state,headRefOid,headRefName,baseRefName,mergeStateStatus,mergeCommit,isCrossRepository",
+        ],
+        cwd=repo_root,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise GitHubQueryError(f"gh pr list failed for {branch!r}: {proc.stderr.strip() or proc.stdout.strip()}")
+    try:
+        items = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise GitHubQueryError("invalid JSON from gh pr list") from exc
+    if not isinstance(items, list):
+        raise GitHubQueryError("unexpected pr payload shape")
+    if len(items) == 0:
+        raise GitHubQueryError(f"no PR found for head {branch}")
+    if len(items) != 1:
+        raise GitHubQueryError(f"ambiguous PR lookup for head {branch}")
+    pr = items[0]
+    if not isinstance(pr, dict):
+        raise GitHubQueryError("malformed PR payload item")
+    return pr
+
+
+def assert_pr_is_merged(pr: dict[str, Any]) -> str:
+    state = str(pr.get("state") or "").upper()
+    if state != "MERGED":
+        raise GitSafetyError(f"PR is not merged: {state or 'MISSING'}")
+    head_ref = str(pr.get("headRefOid") or "")
+    if not head_ref:
+        raise GitSafetyError("PR payload missing headRefOid")
+    if str(pr.get("isCrossRepository")) not in {"", "False", "false"} and pr.get("isCrossRepository") is True:
+        raise GitSafetyError("PR must not be cross-repository")
+    if not isinstance(pr.get("mergeCommit"), str) or not pr["mergeCommit"].strip():
+        raise GitSafetyError("PR payload missing merge commit SHA")
+    return str(pr["mergeCommit"]).strip()
+
+
+def local_branch_head(repo_root: Path, branch: str) -> str:
+    proc = run_git(["rev-parse", f"refs/heads/{branch}"], cwd=repo_root)
+    _require_success(proc, context=f"cannot resolve local branch head for {branch}")
+    return (proc.stdout or "").strip()
+
+
+def remote_branch_present(repo_root: Path, branch: str) -> bool:
+    proc = run_git(["ls-remote", "--heads", "--exit-code", "origin", branch], cwd=repo_root)
+    if proc.returncode == 0:
+        return bool((proc.stdout or "").strip())
+    if proc.returncode == 2:
+        return False
+    raise GitSafetyError(f"remote branch lookup failed for {branch!r}: {proc.stderr.strip() or proc.stdout.strip()}")
+
+
+def assert_no_unknown_branch_mutation(
+    repo_root: Path,
+    branch: str,
+    explicit_protected: set[str] | frozenset[str] = frozenset(),
+) -> None:
+    if ".." in branch or branch.strip() != branch or not branch:
+        raise GitSafetyError(f"invalid branch token: {branch!r}")
+    if is_protected_branch(repo_root, branch, explicit_protected=explicit_protected):
+        raise GitSafetyError(f"refusing to mutate protected branch: {branch!r}")
+
+
+def _bundle_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def build_bundle(
+    repo_root: Path,
+    *,
+    branch: str,
+    bundle_dir: Path,
+    timeout: float = 30.0,
+) -> BundleReceipt:
+    assert_no_unknown_branch_mutation(repo_root, branch)
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    bundle_path = bundle_dir / f"{safe_lock_token(branch)}.bundle"
+    proc = run_git(["bundle", "create", str(bundle_path), f"refs/heads/{branch}"], cwd=repo_root, timeout=timeout)
+    _require_success(proc, context=f"bundle create failed for {branch}")
+    verify_bundle(bundle_path, branch=branch, repo_root=repo_root, timeout=timeout)
+    return BundleReceipt(
+        path=bundle_path,
+        sha256=_bundle_sha256(bundle_path),
+        branch=branch,
+        created_at=_utc_now(),
+    )
+
+
+def verify_bundle(
+    path: Path,
+    *,
+    branch: str | None = None,
+    repo_root: Path | None = None,
+    timeout: float = 30.0,
+) -> None:
+    if not path.exists():
+        raise BundleError(f"bundle missing: {path}")
+    proc = run_git(["bundle", "verify", str(path)], cwd=repo_root or Path("."), timeout=timeout)
+    _require_success(proc, context="git bundle verify failed")
+    if branch:
+        listed = run_git(["bundle", "list-heads", str(path)], cwd=repo_root or Path("."), timeout=timeout)
+        _require_success(listed, context="git bundle list-heads failed")
+        full_ref = f"refs/heads/{branch}"
+        included = False
+        for line in (listed.stdout or "").splitlines():
+            parts = line.strip().split()
+            if len(parts) >= 2 and parts[1] == full_ref:
+                included = True
+                break
+        if not included:
+            raise BundleError(f"bundle does not include {full_ref}")
+
+
+def assert_bundle_matches_receipt(bundle: BundleReceipt, branch: str) -> None:
+    if bundle.branch != branch:
+        raise GitSafetyError(f"bundle branch mismatch: {bundle.branch!r} != {branch!r}")
+    if not bundle.path.exists():
+        raise GitSafetyError(f"bundle path missing: {bundle.path}")
+    if not bundle.path.is_file():
+        raise GitSafetyError(f"bundle path is not a file: {bundle.path}")
+    if not bundle.sha256:
+        raise GitSafetyError("bundle checksum missing")
+    if _bundle_sha256(bundle.path) != bundle.sha256:
+        raise GitSafetyError("bundle digest mismatch")
+
+
+def remove_worktree(repo_root: Path, worktree: Path) -> None:
+    proc = run_git(["worktree", "remove", str(worktree)], cwd=repo_root)
+    _require_success(proc, context=f"git worktree remove failed: {worktree}")
+
+
+def _assert_lock_present(path: Path) -> None:
+    if not path.exists():
+        raise GitSafetyError(f"required lock missing: {path}")
+
+
+def verify_frozen_preconditions(
+    repo_root: Path,
+    *,
+    lineage_id: str,
+    family: str,
+    worktree: Path,
+) -> None:
+    _assert_lock_present(_operation_lock_path(repo_root))
+    _assert_lock_present(_lineage_lock_path(repo_root, lineage_id))
+    _assert_lock_present(_family_lock_path(repo_root, family))
+    _assert_lock_present(_worktree_lock_path(repo_root, worktree))
+    assert_no_active_jobs_or_leases(repo_root, lineage_id=lineage_id)
+    if is_worktree_permanent(repo_root, worktree):
+        raise GitSafetyError(f"worktree is primary checkout and cannot be removed: {worktree}")
+
+
+def verify_worktree_candidate(
+    repo_root: Path,
+    *,
+    worktree: Path,
+    branch: str,
+) -> None:
+    if not is_worktree_registered(repo_root, worktree):
+        raise GitSafetyError(f"worktree is not registered: {worktree}")
+    if is_worktree_shared(repo_root, worktree):
+        raise GitSafetyError(f"worktree is shared: {worktree}")
+    if is_worktree_permanent(repo_root, worktree):
+        raise GitSafetyError(f"worktree is primary checkout: {worktree}")
+    if is_worktree_dirty(worktree):
+        raise GitSafetyError(f"worktree is dirty: {worktree}")
+    actual_branch = worktree_branch(repo_root, worktree)
+    if actual_branch != branch:
+        raise GitSafetyError(
+            f"worktree branch mismatch for {worktree}: planned {branch!r}, actual {actual_branch!r}"
+        )
+
+
+def assert_branch_deletion_preconditions(
+    *,
+    repo_root: Path,
+    branch: str,
+    pr_data: dict[str, Any],
+    bundle: BundleReceipt,
+    explicit_protected: set[str] | frozenset[str] = frozenset(),
+    require_remote_gone: bool = True,
+    allow_current_head: bool = False,
+    worktree_registered: bool = False,
+) -> str:
+    assert_no_unknown_branch_mutation(repo_root, branch, explicit_protected=explicit_protected)
+    assert_bundle_matches_receipt(bundle, branch=branch)
+    merge_commit = assert_pr_is_merged(pr_data)
+    pr_head_oid = str(pr_data.get("headRefOid") or "")
+    if not pr_head_oid:
+        raise GitSafetyError("PR payload missing headRefOid")
+    local_head = local_branch_head(repo_root, branch)
+    if local_head != pr_head_oid:
+        raise GitSafetyError(
+            f"local branch head mismatch for {branch}: local {local_head!r}, pr head {pr_head_oid!r}"
+        )
+    if not allow_current_head and local_head == merge_commit:
+        raise GitSafetyError(
+            f"local branch head equals PR merge commit for {branch}: {local_head!r}"
+        )
+    if require_remote_gone and remote_branch_present(repo_root, branch):
+        raise GitSafetyError(f"remote branch still present: {branch}")
+    if worktree_registered:
+        raise GitSafetyError(f"branch still has registered worktree: {branch}")
+    proc = run_git(["symbolic-ref", "--short", "HEAD"], cwd=repo_root)
+    _require_success(proc, context="cannot determine active checkout branch")
+    if proc.stdout.strip() == branch:
+        raise GitSafetyError(f"cannot delete currently checked out branch: {branch}")
+    return merge_commit
+
+
+def delete_branch(repo_root: Path, *, branch: str, require_force: bool = False) -> None:
+    _ = require_force
+    proc = run_git(["branch", "-D", branch], cwd=repo_root)
+    _require_success(proc, context=f"git branch deletion failed for {branch}")

--- a/scripts/orchestration/task_family/git_safety.py
+++ b/scripts/orchestration/task_family/git_safety.py
@@ -6,8 +6,10 @@ import contextlib
 import fcntl
 import hashlib
 import json
+import os
 import re
 import subprocess
+import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -15,19 +17,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-try:
-    from guardrails.worktree_containment import PROTECTED_BRANCHES, resolve_main_root
-except Exception:  # pragma: no cover - fallback for unit test imports
-    PROTECTED_BRANCHES = frozenset({"main", "master"})
-
-    def resolve_main_root(start: Path | str | None = None) -> Path:
-        cwd = Path(start or Path.cwd())
-        for path in (cwd, *cwd.parents):
-            if (path / ".git").is_dir():
-                return path
-        raise RuntimeError("not in a git repository")
-
 from scripts.common.git_context import sanitized_git_env
+from scripts.guardrails.worktree_containment import (
+    PROTECTED_BRANCHES,
+    resolve_main_root,
+)
 
 
 class GitSafetyError(RuntimeError):
@@ -50,7 +44,7 @@ class LockAcquisitionError(GitSafetyError):
     """Required advisory lock is unavailable."""
 
 
-STATE_FILE_RE = re.compile(r"^[A-Za-z0-9._-]+\.(json|yml|yaml)$")
+STATE_FILE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*\.[A-Za-z0-9]{2,8}$")
 
 
 @dataclass(frozen=True)
@@ -58,6 +52,8 @@ class WorktreeInfo:
     path: Path
     branch: str | None
     head: str | None = None
+    locked: bool = False
+    prunable: bool = False
 
 
 @dataclass(frozen=True)
@@ -106,13 +102,34 @@ def _utc_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
+def write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, path)
+        directory_fd = os.open(str(path.parent), os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except BaseException:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temporary_name)
+        raise
+
+
 def resolve_lock_root(repo_root: Path) -> Path:
     root = resolve_main_root(repo_root)
-    return root / ".agent" / "task_family_cleanup" / "locks"
+    return root / ".agent" / "task-families" / "locks"
 
 
 def resolve_state_root(repo_root: Path) -> Path:
-    return resolve_main_root(repo_root) / ".agent" / "task_family_cleanup"
+    return resolve_main_root(repo_root) / ".agent" / "task-families"
 
 
 def _require_existing_root(root: Path) -> None:
@@ -124,8 +141,10 @@ def safe_lock_token(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]", "-", value)
 
 
-def _operation_lock_path(repo_root: Path) -> Path:
-    return resolve_lock_root(repo_root) / "operation.lock"
+def _operation_lock_path(repo_root: Path, operation_id: str | None = None) -> Path:
+    lock_root = resolve_lock_root(repo_root)
+    suffix = f"{safe_lock_token(operation_id)}.lock" if operation_id else "global.lock"
+    return lock_root / f"operation-{suffix}"
 
 
 def _lineage_lock_path(repo_root: Path, lineage_id: str) -> Path:
@@ -157,8 +176,8 @@ def flock(lock_path: Path) -> Iterator[Path]:
 
 
 @contextmanager
-def operation_lock(repo_root: Path):
-    with flock(_operation_lock_path(repo_root)):
+def operation_lock(repo_root: Path, operation_id: str | None = None):
+    with flock(_operation_lock_path(repo_root, operation_id=operation_id)):
         yield
 
 
@@ -194,6 +213,8 @@ def _parse_worktree_porcelain(raw: str) -> list[WorktreeInfo]:
                 path=Path(current["path"]),
                 branch=current.get("branch"),
                 head=current.get("head"),
+                locked=(current.get("locked") == "true"),
+                prunable=(current.get("prunable") == "true"),
             )
         )
         current = None
@@ -216,6 +237,13 @@ def _parse_worktree_porcelain(raw: str) -> list[WorktreeInfo]:
             if branch.startswith("refs/heads/"):
                 branch = branch[len("refs/heads/") :]
             current["branch"] = branch
+            continue
+        if line.startswith("locked"):
+            current["locked"] = "true"
+            continue
+        if line.startswith("prunable"):
+            current["prunable"] = "true"
+            continue
 
     flush()
     return items
@@ -269,20 +297,50 @@ def is_worktree_dirty(worktree: Path) -> bool:
     return bool((proc.stdout or "").strip())
 
 
+def worktree_index_locked(worktree: Path) -> bool:
+    proc = run_git(["rev-parse", "--git-path", "index.lock"], cwd=worktree)
+    if proc.returncode != 0:
+        return False
+    raw = (proc.stdout or "").strip()
+    if not raw:
+        return False
+    path = Path(raw)
+    if not path.is_absolute():
+        path = worktree / path
+    try:
+        return path.exists()
+    except OSError:
+        return False
+
+
 def is_worktree_locked(repo_root: Path, worktree: Path) -> bool:
-    return _worktree_lock_path(repo_root, worktree).exists()
+    """Return real Git lock evidence, never our advisory-lock file's existence."""
+    canonical = worktree.resolve()
+    for item in worktree_list(repo_root):
+        if item.path.resolve() == canonical:
+            return item.locked or item.prunable or worktree_index_locked(worktree)
+    return worktree_index_locked(worktree)
 
 
 def active_jobs_or_leases(repo_root: Path, lineage_id: str | None = None) -> list[Path]:
     state_root = resolve_state_root(repo_root)
     entries: list[Path] = []
-    for kind in ("jobs", "leases"):
-        for path in sorted((state_root / kind).glob("*")):
-            if not path.is_file() or not STATE_FILE_RE.match(path.name):
-                continue
-            if lineage_id is not None and lineage_id not in path.name:
-                continue
-            entries.append(path)
+    for path in sorted((state_root / "jobs").glob("*")):
+        if not path.is_file() or not STATE_FILE_RE.match(path.name):
+            continue
+        if lineage_id is not None and lineage_id not in path.name:
+            continue
+        entries.append(path)
+    for path in sorted((state_root / "leases").glob("*")):
+        if not path.is_file() or not STATE_FILE_RE.match(path.name):
+            continue
+        if lineage_id is not None and lineage_id not in path.name:
+            continue
+        entries.append(path)
+    for path in sorted(state_root.glob("*/operations/*/state.json")):
+        if not STATE_FILE_RE.match(path.name):
+            continue
+        entries.append(path)
     return entries
 
 
@@ -311,10 +369,30 @@ def _repo_owner_and_name(repo_root: Path) -> tuple[str, str]:
     return owner, name
 
 
+def _github_repo_default_branch(repo_root: Path) -> str:
+    proc = run_gh(
+        ["repo", "view", "--json", "defaultBranchRef"],
+        cwd=repo_root,
+    )
+    if proc.returncode != 0:
+        raise GitHubQueryError("github repo query failed")
+    try:
+        payload = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise GitHubQueryError("invalid JSON from github repo query") from exc
+    if not isinstance(payload, dict):
+        raise GitHubQueryError("invalid github repo payload type")
+    ref = payload.get("defaultBranchRef")
+    default_branch = ref.get("name") if isinstance(ref, dict) else None
+    if not isinstance(default_branch, str) or not default_branch:
+        raise GitHubQueryError("missing default branch in github repo payload")
+    return default_branch
+
+
 def remote_protected_branches(repo_root: Path, *, timeout: float = 30.0) -> set[str]:
     owner, name = _repo_owner_and_name(repo_root)
     proc = run_gh(
-        ["api", f"repos/{owner}/{name}/branches", "--paginate", "--json", "name,protected"],
+        ["api", "--paginate", "--slurp", f"repos/{owner}/{name}/branches?per_page=100"],
         cwd=repo_root,
         timeout=timeout,
     )
@@ -326,15 +404,19 @@ def remote_protected_branches(repo_root: Path, *, timeout: float = 30.0) -> set[
         raise GitHubQueryError("invalid JSON from protected-branch query") from exc
     if not isinstance(payload, list):
         raise GitHubQueryError("invalid protected-branch payload")
+    pages = payload if not payload or isinstance(payload[0], list) else [payload]
     protected: set[str] = set()
-    for item in payload:
-        if not isinstance(item, dict):
-            raise GitHubQueryError("invalid protected-branch item")
-        name = item.get("name")
-        if not isinstance(name, str) or not name:
-            continue
-        if item.get("protected") is True:
-            protected.add(name)
+    for page in pages:
+        if not isinstance(page, list):
+            raise GitHubQueryError("invalid protected-branch page")
+        for item in page:
+            if not isinstance(item, dict):
+                raise GitHubQueryError("invalid protected-branch item")
+            name = item.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+            if item.get("protected") is True:
+                protected.add(name)
     return protected
 
 
@@ -360,14 +442,7 @@ def is_protected_branch(
 
 
 def repo_default_branch(repo_root: Path) -> str:
-    proc = run_git(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], cwd=repo_root)
-    if proc.returncode != 0:
-        proc = run_git(["branch", "--show-current"], cwd=repo_root)
-    _require_success(proc, context="cannot discover default branch")
-    ref = (proc.stdout or "").strip()
-    if ref.startswith("origin/"):
-        return ref.split("/", 1)[1]
-    return ref
+    return _github_repo_default_branch(repo_root)
 
 
 def ensure_clean_base(repo_root: Path, base_branch: str) -> None:
@@ -377,7 +452,12 @@ def ensure_clean_base(repo_root: Path, base_branch: str) -> None:
     if current != base_branch:
         raise GitSafetyError(f"active branch is {current!r}, expected protected base {base_branch!r}")
 
-    proc = run_git(["rev-list", "--left-right", "--count", f"origin/{base_branch}...{base_branch}"], cwd=repo_root)
+    proc = run_git([
+        "rev-list",
+        "--left-right",
+        "--count",
+        f"origin/{base_branch}...{base_branch}",
+    ], cwd=repo_root)
     if proc.returncode != 0:
         raise GitSafetyError(f"cannot verify base branch up-to-date for {base_branch}")
     if (proc.stdout or "").strip() not in {"0\t0", "0 0"}:
@@ -390,7 +470,66 @@ def assert_primary_checkout(repo_root: Path) -> None:
         raise GitSafetyError("operation must execute from primary checkout")
 
 
-def query_pr_by_head(repo_root: Path, *, branch: str, timeout: float = 30.0) -> dict[str, Any]:
+def _normalize_merge_commit(raw: Any) -> str:
+    if isinstance(raw, str):
+        value = raw.strip()
+        if value:
+            return value
+        raise GitSafetyError("PR payload missing merge commit SHA")
+    if isinstance(raw, dict):
+        value = raw.get("oid") or raw.get("sha") or raw.get("id")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    raise GitSafetyError("PR payload merge commit not provided")
+
+
+def _normalize_pr_payload(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise GitHubQueryError("unexpected pr payload shape")
+    data = {
+        "number": payload.get("number"),
+        "state": str(payload.get("state") or "").upper(),
+        "head_ref_oid": str(payload.get("headRefOid") or "").strip(),
+        "head_ref_name": str(payload.get("headRefName") or "").strip(),
+        "base_ref_name": str(payload.get("baseRefName") or "").strip(),
+        "merge_state_status": str(payload.get("mergeStateStatus") or "").strip(),
+        "is_cross_repository": bool(payload.get("isCrossRepository")),
+        "merge_commit": _normalize_merge_commit(payload.get("mergeCommit")),
+    }
+    if not data["head_ref_oid"]:
+        raise GitHubQueryError("PR payload missing headRefOid")
+    return data
+
+
+def query_pr_by_head(
+    repo_root: Path,
+    *,
+    branch: str,
+    pr_number: int | None = None,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    if pr_number is not None:
+        proc = run_gh(
+            [
+                "pr",
+                "view",
+                str(pr_number),
+                "--json",
+                "number,state,headRefOid,headRefName,baseRefName,mergeStateStatus,mergeCommit,isCrossRepository",
+            ],
+            cwd=repo_root,
+            timeout=timeout,
+        )
+        if proc.returncode != 0:
+            raise GitHubQueryError(f"gh pr view failed for #{pr_number}")
+        try:
+            payload = json.loads(proc.stdout or "{}")
+        except json.JSONDecodeError as exc:
+            raise GitHubQueryError("invalid JSON from gh pr view") from exc
+        if str(payload.get("headRefName") or "") != branch:
+            raise GitHubQueryError(f"PR #{pr_number} head mismatch for branch {branch}")
+        return _normalize_pr_payload(payload)
+
     proc = run_gh(
         [
             "pr",
@@ -417,24 +556,42 @@ def query_pr_by_head(repo_root: Path, *, branch: str, timeout: float = 30.0) -> 
         raise GitHubQueryError(f"no PR found for head {branch}")
     if len(items) != 1:
         raise GitHubQueryError(f"ambiguous PR lookup for head {branch}")
-    pr = items[0]
-    if not isinstance(pr, dict):
-        raise GitHubQueryError("malformed PR payload item")
-    return pr
+    if not isinstance(items[0], dict):
+        raise GitHubQueryError("unexpected pr payload shape")
+    return _normalize_pr_payload(items[0])
 
 
-def assert_pr_is_merged(pr: dict[str, Any]) -> str:
-    state = str(pr.get("state") or "").upper()
-    if state != "MERGED":
-        raise GitSafetyError(f"PR is not merged: {state or 'MISSING'}")
-    head_ref = str(pr.get("headRefOid") or "")
-    if not head_ref:
-        raise GitSafetyError("PR payload missing headRefOid")
-    if str(pr.get("isCrossRepository")) not in {"", "False", "false"} and pr.get("isCrossRepository") is True:
+def assert_pr_is_merged(
+    pr: dict[str, Any],
+    *,
+    expected_number: int | None = None,
+    expected_branch: str | None = None,
+    expected_head: str | None = None,
+    expected_base: str | None = None,
+) -> tuple[str, str, str]:
+    if pr.get("state") != "MERGED":
+        raise GitSafetyError(f"PR is not merged: {pr.get('state', 'MISSING')!r}")
+    if pr.get("merge_state_status") and str(pr["merge_state_status"]).upper() not in {"CLEAN", "UNKNOWN"}:
+        raise GitSafetyError(f"PR merge state is {pr.get('merge_state_status')!r}")
+    if pr.get("is_cross_repository"):
         raise GitSafetyError("PR must not be cross-repository")
-    if not isinstance(pr.get("mergeCommit"), str) or not pr["mergeCommit"].strip():
-        raise GitSafetyError("PR payload missing merge commit SHA")
-    return str(pr["mergeCommit"]).strip()
+    number = int(pr.get("number", 0) or 0)
+    if expected_number is not None and number and number != expected_number:
+        raise GitSafetyError(
+            f"PR number mismatch: expected {expected_number!r}, got {pr.get('number')!r}"
+        )
+    head_ref_name = pr.get("head_ref_name")
+    if expected_branch is not None and head_ref_name != expected_branch:
+        raise GitSafetyError(f"PR head branch mismatch: expected {expected_branch!r}, got {head_ref_name!r}")
+    if expected_head is not None and pr.get("head_ref_oid") != expected_head:
+        raise GitSafetyError(
+            f"PR head mismatch: expected {expected_head!r}, got {pr.get('head_ref_oid')!r}"
+        )
+    if expected_base is not None and str(pr.get("base_ref_name") or "") != expected_base:
+        raise GitSafetyError(
+            f"PR base mismatch: expected {expected_base!r}, got {pr.get('base_ref_name')!r}"
+        )
+    return str(number), str(pr["head_ref_oid"]), pr["merge_commit"]
 
 
 def local_branch_head(repo_root: Path, branch: str) -> str:
@@ -443,8 +600,18 @@ def local_branch_head(repo_root: Path, branch: str) -> str:
     return (proc.stdout or "").strip()
 
 
+def local_branch_exists(repo_root: Path, branch: str) -> bool:
+    proc = run_git(["show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], cwd=repo_root)
+    return proc.returncode == 0
+
+
+def _local_branch_exists(repo_root: Path, branch: str) -> bool:
+    return local_branch_exists(repo_root, branch)
+
+
 def remote_branch_present(repo_root: Path, branch: str) -> bool:
-    proc = run_git(["ls-remote", "--heads", "--exit-code", "origin", branch], cwd=repo_root)
+    ref = branch if branch.startswith("refs/heads/") else f"refs/heads/{branch}"
+    proc = run_git(["ls-remote", "--heads", "--exit-code", "origin", ref], cwd=repo_root)
     if proc.returncode == 0:
         return bool((proc.stdout or "").strip())
     if proc.returncode == 2:
@@ -481,7 +648,11 @@ def build_bundle(
     assert_no_unknown_branch_mutation(repo_root, branch)
     bundle_dir.mkdir(parents=True, exist_ok=True)
     bundle_path = bundle_dir / f"{safe_lock_token(branch)}.bundle"
-    proc = run_git(["bundle", "create", str(bundle_path), f"refs/heads/{branch}"], cwd=repo_root, timeout=timeout)
+    proc = run_git(
+        ["bundle", "create", str(bundle_path), f"refs/heads/{branch}"],
+        cwd=repo_root,
+        timeout=timeout,
+    )
     _require_success(proc, context=f"bundle create failed for {branch}")
     verify_bundle(bundle_path, branch=branch, repo_root=repo_root, timeout=timeout)
     return BundleReceipt(
@@ -535,23 +706,17 @@ def remove_worktree(repo_root: Path, worktree: Path) -> None:
     _require_success(proc, context=f"git worktree remove failed: {worktree}")
 
 
-def _assert_lock_present(path: Path) -> None:
-    if not path.exists():
-        raise GitSafetyError(f"required lock missing: {path}")
-
-
 def verify_frozen_preconditions(
     repo_root: Path,
     *,
+    operation_id: str | None,
     lineage_id: str,
     family: str,
     worktree: Path,
 ) -> None:
-    _assert_lock_present(_operation_lock_path(repo_root))
-    _assert_lock_present(_lineage_lock_path(repo_root, lineage_id))
-    _assert_lock_present(_family_lock_path(repo_root, family))
-    _assert_lock_present(_worktree_lock_path(repo_root, worktree))
-    assert_no_active_jobs_or_leases(repo_root, lineage_id=lineage_id)
+    # Advisory locks are held by the caller.  Their files are not Git locks and
+    # existence alone is not live-lock evidence.
+    del operation_id, lineage_id, family
     if is_worktree_permanent(repo_root, worktree):
         raise GitSafetyError(f"worktree is primary checkout and cannot be removed: {worktree}")
 
@@ -561,11 +726,17 @@ def verify_worktree_candidate(
     *,
     worktree: Path,
     branch: str,
+    explicit_family: str | None = None,
+    planned_family: str | None = None,
 ) -> None:
+    if explicit_family is not None and planned_family is not None and explicit_family != planned_family:
+        raise GitSafetyError(f"family mismatch for {worktree}: {explicit_family!r} != {planned_family!r}")
     if not is_worktree_registered(repo_root, worktree):
         raise GitSafetyError(f"worktree is not registered: {worktree}")
     if is_worktree_shared(repo_root, worktree):
         raise GitSafetyError(f"worktree is shared: {worktree}")
+    if is_worktree_locked(repo_root, worktree):
+        raise GitSafetyError(f"worktree is locked: {worktree}")
     if is_worktree_permanent(repo_root, worktree):
         raise GitSafetyError(f"worktree is primary checkout: {worktree}")
     if is_worktree_dirty(worktree):
@@ -587,21 +758,19 @@ def assert_branch_deletion_preconditions(
     require_remote_gone: bool = True,
     allow_current_head: bool = False,
     worktree_registered: bool = False,
-) -> str:
+    expected_head: str | None = None,
+) -> tuple[str, str, str]:
     assert_no_unknown_branch_mutation(repo_root, branch, explicit_protected=explicit_protected)
     assert_bundle_matches_receipt(bundle, branch=branch)
-    merge_commit = assert_pr_is_merged(pr_data)
-    pr_head_oid = str(pr_data.get("headRefOid") or "")
-    if not pr_head_oid:
-        raise GitSafetyError("PR payload missing headRefOid")
+    pr_number, pr_head_oid, merge_commit = assert_pr_is_merged(
+        pr_data,
+        expected_branch=branch,
+        expected_head=expected_head,
+    )
     local_head = local_branch_head(repo_root, branch)
     if local_head != pr_head_oid:
         raise GitSafetyError(
             f"local branch head mismatch for {branch}: local {local_head!r}, pr head {pr_head_oid!r}"
-        )
-    if not allow_current_head and local_head == merge_commit:
-        raise GitSafetyError(
-            f"local branch head equals PR merge commit for {branch}: {local_head!r}"
         )
     if require_remote_gone and remote_branch_present(repo_root, branch):
         raise GitSafetyError(f"remote branch still present: {branch}")
@@ -611,10 +780,13 @@ def assert_branch_deletion_preconditions(
     _require_success(proc, context="cannot determine active checkout branch")
     if proc.stdout.strip() == branch:
         raise GitSafetyError(f"cannot delete currently checked out branch: {branch}")
-    return merge_commit
+    return pr_number, pr_head_oid, merge_commit
 
 
 def delete_branch(repo_root: Path, *, branch: str, require_force: bool = False) -> None:
-    _ = require_force
+    del require_force
+    # Squash/rebase GitHub merges need not make the local branch an ancestor of
+    # the checkout.  Preconditions above are the authority; worktree removal is
+    # never forced.
     proc = run_git(["branch", "-D", branch], cwd=repo_root)
     _require_success(proc, context=f"git branch deletion failed for {branch}")

--- a/scripts/orchestration/task_family/graph.py
+++ b/scripts/orchestration/task_family/graph.py
@@ -1,0 +1,153 @@
+"""Exact-ID task-family graph discovery and role-preserving title rendering."""
+
+from __future__ import annotations
+
+import os
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import PurePath
+
+from .model import PARENT_LIKE_RELATIONS, Blocker, RelationType, TaskFamilyManifest, TaskNode, TaskRelation
+
+ROLE_ORDER = ("Lead", "Worker", "Reviewer", "Handoff", "Replacement")
+
+
+@dataclass(frozen=True, slots=True)
+class TitleRename:
+    task_id: str
+    old_title: str
+    new_title: str
+    roles: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class FamilyGraph:
+    manifest: TaskFamilyManifest
+    roots: tuple[str, ...]
+    roles_by_task: dict[str, tuple[str, ...]]
+    blockers: tuple[Blocker, ...] = ()
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.blockers
+
+    @property
+    def nodes_by_id(self) -> dict[str, TaskNode]:
+        return {node.task_id: node for node in self.manifest.nodes}
+
+    @property
+    def family_relations(self) -> tuple[TaskRelation, ...]:
+        return tuple(relation for relation in self.manifest.relations if not relation.is_display_only)
+
+
+def _normal_root(path: str) -> str:
+    return os.path.normpath(str(PurePath(path)))
+
+
+def _cycle_nodes(relations: tuple[TaskRelation, ...]) -> tuple[str, ...]:
+    adjacency: dict[str, list[str]] = defaultdict(list)
+    for relation in relations:
+        if relation.relation_type in PARENT_LIKE_RELATIONS:
+            adjacency[relation.source_id].append(relation.target_id)
+    visiting: list[str] = []
+    visited: set[str] = set()
+    cycle_members: set[str] = set()
+
+    def visit(node: str) -> bool:
+        if node in visiting:
+            cycle_members.update(visiting[visiting.index(node) :])
+            return True
+        if node in visited:
+            return False
+        visiting.append(node)
+        found = any(visit(neighbor) for neighbor in adjacency.get(node, ()))
+        visiting.pop()
+        visited.add(node)
+        return found
+
+    for node in tuple(adjacency):
+        visit(node)
+    return tuple(sorted(cycle_members))
+
+
+def _roots(nodes: tuple[TaskNode, ...], relations: tuple[TaskRelation, ...]) -> tuple[str, ...]:
+    explicit = {relation.target_id for relation in relations if relation.relation_type is RelationType.ROOT}
+    if explicit:
+        return tuple(sorted(explicit))
+    child_ids = {relation.source_id for relation in relations if relation.relation_type in PARENT_LIKE_RELATIONS}
+    inferred = {node.task_id for node in nodes} - child_ids
+    return tuple(sorted(inferred))
+
+
+def _roles(nodes: tuple[TaskNode, ...], relations: tuple[TaskRelation, ...], roots: tuple[str, ...]) -> dict[str, tuple[str, ...]]:
+    values: dict[str, set[str]] = {node.task_id: set() for node in nodes}
+    for root in roots:
+        values[root].add("Lead")
+    generation: dict[str, int] = defaultdict(int)
+    for relation in relations:
+        if relation.is_display_only:
+            continue
+        role = {
+            RelationType.SUBAGENT_OF: "Worker",
+            RelationType.REVIEWER_FOR: "Reviewer",
+            RelationType.HANDOFF_OF: "Handoff",
+            RelationType.REPLACEMENT_OF: "Replacement",
+        }.get(relation.relation_type)
+        if role:
+            values[relation.source_id].add(role)
+        if relation.relation_type is RelationType.ROLLOVER_GENERATION_OF:
+            generation[relation.source_id] = max(generation[relation.source_id], generation[relation.target_id] + 1)
+    for task_id, number in generation.items():
+        if number:
+            values[task_id].add(f"Generation {number}")
+
+    def sort_key(role: str) -> tuple[int, int | str]:
+        if role in ROLE_ORDER:
+            return (0, ROLE_ORDER.index(role))
+        return (1, int(role.removeprefix("Generation ")))
+
+    return {task_id: tuple(sorted(roles, key=sort_key)) for task_id, roles in values.items()}
+
+
+def discover_task_family(manifest: TaskFamilyManifest) -> FamilyGraph:
+    blockers: list[Blocker] = []
+    nodes_by_id: dict[str, TaskNode] = {}
+    for node in manifest.nodes:
+        if node.task_id in nodes_by_id:
+            blockers.append(Blocker("duplicate_task_id", f"Task ID {node.task_id!r} appears more than once.", (node.task_id,)))
+        nodes_by_id[node.task_id] = node
+    for relation in manifest.relations:
+        missing = tuple(task_id for task_id in (relation.source_id, relation.target_id) if task_id not in nodes_by_id)
+        if missing:
+            blockers.append(Blocker("unknown_endpoint", f"Relation {relation.relation_type.value} names unknown exact task ID(s): {', '.join(missing)}.", missing, "Correct the manifest endpoints; titles cannot establish membership."))
+    roots = _roots(manifest.nodes, manifest.relations)
+    if len(roots) != 1:
+        blockers.append(Blocker("multiple_or_missing_roots", f"Family must resolve to exactly one root; found {len(roots)}: {', '.join(roots) or 'none'}.", roots, "Supply unambiguous family-defining exact-ID relations."))
+    project_roots = {_normal_root(node.project_root) for node in manifest.nodes}
+    if len(project_roots) > 1:
+        blockers.append(Blocker("incompatible_project_roots", "Family nodes use incompatible project roots.", tuple(sorted(nodes_by_id)), "Split the family or supply evidence for a single compatible project root."))
+    conflicts: dict[tuple[str, RelationType], set[str]] = defaultdict(set)
+    for relation in manifest.relations:
+        if relation.relation_type in PARENT_LIKE_RELATIONS and not relation.is_display_only:
+            conflicts[(relation.source_id, relation.relation_type)].add(relation.target_id)
+    for (source, relation_type), targets in conflicts.items():
+        if len(targets) > 1:
+            blockers.append(Blocker("conflicting_membership", f"Task {source} has conflicting {relation_type.value} parents: {', '.join(sorted(targets))}.", (source, *sorted(targets))))
+    cycles = _cycle_nodes(manifest.relations)
+    if cycles:
+        blockers.append(Blocker("parent_relation_cycle", f"Parent-like task relations contain a cycle at: {', '.join(cycles)}.", cycles))
+    return FamilyGraph(manifest, roots, _roles(manifest.nodes, manifest.relations, roots), tuple(blockers))
+
+
+def rename_mapping(graph: FamilyGraph) -> tuple[TitleRename, ...]:
+    """Return stable title display changes; source titles are never identity keys."""
+    changes: list[TitleRename] = []
+    for node in sorted(graph.manifest.nodes, key=lambda item: item.task_id):
+        roles = graph.roles_by_task[node.task_id]
+        suffix = ", ".join(roles)
+        managed_suffix = re.compile(r" \[(?:Lead|Worker|Reviewer|Handoff|Replacement|Generation \d+)(?:, (?:Lead|Worker|Reviewer|Handoff|Replacement|Generation \d+))*\]$")
+        base_title = managed_suffix.sub("", node.title)
+        new_title = f"{base_title} [{suffix}]" if suffix else base_title
+        changes.append(TitleRename(node.task_id, node.title, new_title, roles))
+    return tuple(changes)

--- a/scripts/orchestration/task_family/graph.py
+++ b/scripts/orchestration/task_family/graph.py
@@ -10,6 +10,30 @@ from pathlib import PurePath
 from .model import PARENT_LIKE_RELATIONS, Blocker, RelationType, TaskFamilyManifest, TaskNode, TaskRelation
 
 ROLE_ORDER = ("Lead", "Worker", "Reviewer", "Handoff", "Replacement")
+CODEX_TITLE_MAX_CHARS = 60
+
+
+def _display_role(role: str) -> str:
+    """Keep role semantics readable inside Codex's persisted title limit."""
+    if role == "Replacement":
+        return "Repl."
+    if role.startswith("Generation "):
+        return f"Gen. {role.removeprefix('Generation ')}"
+    return role
+
+
+def _bounded_title(base_title: str, roles: tuple[str, ...]) -> str:
+    base = base_title.strip()
+    suffix = " · ".join(_display_role(role) for role in roles)
+    if not suffix:
+        available = CODEX_TITLE_MAX_CHARS
+    else:
+        available = CODEX_TITLE_MAX_CHARS - len(suffix) - len(" []")
+        if available < 1:
+            raise ValueError("role suffix exceeds the Codex title limit")
+    if len(base) > available:
+        base = f"{base[: max(available - 1, 0)].rstrip()}…"
+    return f"{base} [{suffix}]" if suffix else base
 
 
 @dataclass(frozen=True, slots=True)
@@ -209,7 +233,6 @@ def rename_mapping(graph: FamilyGraph, base_title: str) -> tuple[TitleRename, ..
     changes: list[TitleRename] = []
     for node in sorted(graph.nodes_by_id.values(), key=lambda item: item.task_id):
         roles = graph.roles_by_task[node.task_id]
-        suffix = " · ".join(roles)
-        new_title = f"{base_title} [{suffix}]" if suffix else base_title
+        new_title = _bounded_title(base_title, roles)
         changes.append(TitleRename(node.task_id, node.title, new_title, roles))
     return tuple(changes)

--- a/scripts/orchestration/task_family/graph.py
+++ b/scripts/orchestration/task_family/graph.py
@@ -197,14 +197,19 @@ def discover_task_family(manifest: TaskFamilyManifest) -> FamilyGraph:
         missing = tuple(task_id for task_id in (relation.source_id, relation.target_id) if task_id not in nodes_by_id)
         if missing:
             blockers.append(Blocker("unknown_endpoint", f"Relation {relation.relation_type.value} names unknown exact task ID(s): {', '.join(missing)}.", missing, "Correct the manifest endpoints; titles cannot establish membership."))
+    known_relations = tuple(
+        relation
+        for relation in manifest.relations
+        if relation.source_id in nodes_by_id and relation.target_id in nodes_by_id
+    )
     if manifest.seed_task_id not in nodes_by_id:
         blockers.append(Blocker("unknown_seed_task", f"Seed task ID {manifest.seed_task_id!r} is not in the manifest.", (manifest.seed_task_id,), "Supply one existing exact task ID as the family seed."))
-    included_set = _component(manifest.seed_task_id, manifest.relations) if manifest.seed_task_id in nodes_by_id else set()
+    included_set = _component(manifest.seed_task_id, known_relations) if manifest.seed_task_id in nodes_by_id else set()
     included_nodes = tuple(node for node in manifest.nodes if node.task_id in included_set)
     excluded_task_ids = tuple(sorted(set(nodes_by_id) - included_set))
     included_relations = tuple(
         relation
-        for relation in manifest.relations
+        for relation in known_relations
         if not relation.is_display_only and relation.source_id in included_set and relation.target_id in included_set
     )
     roots = _roots(included_nodes, included_relations)

--- a/scripts/orchestration/task_family/graph.py
+++ b/scripts/orchestration/task_family/graph.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import re
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import PurePath
@@ -24,6 +23,8 @@ class TitleRename:
 @dataclass(frozen=True, slots=True)
 class FamilyGraph:
     manifest: TaskFamilyManifest
+    included_task_ids: tuple[str, ...]
+    excluded_task_ids: tuple[str, ...]
     roots: tuple[str, ...]
     roles_by_task: dict[str, tuple[str, ...]]
     blockers: tuple[Blocker, ...] = ()
@@ -34,11 +35,17 @@ class FamilyGraph:
 
     @property
     def nodes_by_id(self) -> dict[str, TaskNode]:
-        return {node.task_id: node for node in self.manifest.nodes}
+        included = set(self.included_task_ids)
+        return {node.task_id: node for node in self.manifest.nodes if node.task_id in included}
 
     @property
     def family_relations(self) -> tuple[TaskRelation, ...]:
-        return tuple(relation for relation in self.manifest.relations if not relation.is_display_only)
+        included = set(self.included_task_ids)
+        return tuple(
+            relation
+            for relation in self.manifest.relations
+            if not relation.is_display_only and relation.source_id in included and relation.target_id in included
+        )
 
 
 def _normal_root(path: str) -> str:
@@ -80,11 +87,40 @@ def _roots(nodes: tuple[TaskNode, ...], relations: tuple[TaskRelation, ...]) -> 
     return tuple(sorted(inferred))
 
 
+def _generation_numbers(nodes: tuple[TaskNode, ...], relations: tuple[TaskRelation, ...]) -> dict[str, int]:
+    """Resolve rollover generations by dependency, never relation input order."""
+    parents: dict[str, tuple[str, ...]] = defaultdict(tuple)
+    grouped: dict[str, list[str]] = defaultdict(list)
+    for relation in relations:
+        if relation.relation_type is RelationType.ROLLOVER_GENERATION_OF:
+            grouped[relation.source_id].append(relation.target_id)
+    for source, targets in grouped.items():
+        parents[source] = tuple(sorted(set(targets)))
+    resolved: dict[str, int] = {}
+    visiting: set[str] = set()
+
+    def resolve(task_id: str) -> int:
+        if task_id in resolved:
+            return resolved[task_id]
+        if task_id in visiting:
+            return 0
+        visiting.add(task_id)
+        targets = parents.get(task_id, ())
+        value = 0 if not targets else max(resolve(target_id) + 1 for target_id in targets)
+        visiting.remove(task_id)
+        resolved[task_id] = value
+        return value
+
+    for node in sorted(nodes, key=lambda item: item.task_id):
+        resolve(node.task_id)
+    return resolved
+
+
 def _roles(nodes: tuple[TaskNode, ...], relations: tuple[TaskRelation, ...], roots: tuple[str, ...]) -> dict[str, tuple[str, ...]]:
     values: dict[str, set[str]] = {node.task_id: set() for node in nodes}
     for root in roots:
         values[root].add("Lead")
-    generation: dict[str, int] = defaultdict(int)
+    generation = _generation_numbers(nodes, relations)
     for relation in relations:
         if relation.is_display_only:
             continue
@@ -96,8 +132,6 @@ def _roles(nodes: tuple[TaskNode, ...], relations: tuple[TaskRelation, ...], roo
         }.get(relation.relation_type)
         if role:
             values[relation.source_id].add(role)
-        if relation.relation_type is RelationType.ROLLOVER_GENERATION_OF:
-            generation[relation.source_id] = max(generation[relation.source_id], generation[relation.target_id] + 1)
     for task_id, number in generation.items():
         if number:
             values[task_id].add(f"Generation {number}")
@@ -108,6 +142,24 @@ def _roles(nodes: tuple[TaskNode, ...], relations: tuple[TaskRelation, ...], roo
         return (1, int(role.removeprefix("Generation ")))
 
     return {task_id: tuple(sorted(roles, key=sort_key)) for task_id, roles in values.items()}
+
+
+def _component(seed_task_id: str, relations: tuple[TaskRelation, ...]) -> set[str]:
+    """Return the exact-ID component, ignoring display-only membership annotations."""
+    adjacency: dict[str, set[str]] = defaultdict(set)
+    for relation in relations:
+        if relation.is_display_only:
+            continue
+        adjacency[relation.source_id].add(relation.target_id)
+        adjacency[relation.target_id].add(relation.source_id)
+    discovered = {seed_task_id}
+    pending = [seed_task_id]
+    while pending:
+        current = pending.pop()
+        for neighbor in sorted(adjacency[current] - discovered):
+            discovered.add(neighbor)
+            pending.append(neighbor)
+    return discovered
 
 
 def discover_task_family(manifest: TaskFamilyManifest) -> FamilyGraph:
@@ -121,33 +173,43 @@ def discover_task_family(manifest: TaskFamilyManifest) -> FamilyGraph:
         missing = tuple(task_id for task_id in (relation.source_id, relation.target_id) if task_id not in nodes_by_id)
         if missing:
             blockers.append(Blocker("unknown_endpoint", f"Relation {relation.relation_type.value} names unknown exact task ID(s): {', '.join(missing)}.", missing, "Correct the manifest endpoints; titles cannot establish membership."))
-    roots = _roots(manifest.nodes, manifest.relations)
+    if manifest.seed_task_id not in nodes_by_id:
+        blockers.append(Blocker("unknown_seed_task", f"Seed task ID {manifest.seed_task_id!r} is not in the manifest.", (manifest.seed_task_id,), "Supply one existing exact task ID as the family seed."))
+    included_set = _component(manifest.seed_task_id, manifest.relations) if manifest.seed_task_id in nodes_by_id else set()
+    included_nodes = tuple(node for node in manifest.nodes if node.task_id in included_set)
+    excluded_task_ids = tuple(sorted(set(nodes_by_id) - included_set))
+    included_relations = tuple(
+        relation
+        for relation in manifest.relations
+        if not relation.is_display_only and relation.source_id in included_set and relation.target_id in included_set
+    )
+    roots = _roots(included_nodes, included_relations)
     if len(roots) != 1:
         blockers.append(Blocker("multiple_or_missing_roots", f"Family must resolve to exactly one root; found {len(roots)}: {', '.join(roots) or 'none'}.", roots, "Supply unambiguous family-defining exact-ID relations."))
-    project_roots = {_normal_root(node.project_root) for node in manifest.nodes}
+    project_roots = {_normal_root(node.project_root) for node in included_nodes}
     if len(project_roots) > 1:
-        blockers.append(Blocker("incompatible_project_roots", "Family nodes use incompatible project roots.", tuple(sorted(nodes_by_id)), "Split the family or supply evidence for a single compatible project root."))
+        blockers.append(Blocker("incompatible_project_roots", "Family nodes use incompatible project roots.", tuple(sorted(included_set)), "Split the family or supply evidence for a single compatible project root."))
     conflicts: dict[tuple[str, RelationType], set[str]] = defaultdict(set)
-    for relation in manifest.relations:
+    for relation in included_relations:
         if relation.relation_type in PARENT_LIKE_RELATIONS and not relation.is_display_only:
             conflicts[(relation.source_id, relation.relation_type)].add(relation.target_id)
     for (source, relation_type), targets in conflicts.items():
         if len(targets) > 1:
             blockers.append(Blocker("conflicting_membership", f"Task {source} has conflicting {relation_type.value} parents: {', '.join(sorted(targets))}.", (source, *sorted(targets))))
-    cycles = _cycle_nodes(manifest.relations)
+    cycles = _cycle_nodes(included_relations)
     if cycles:
         blockers.append(Blocker("parent_relation_cycle", f"Parent-like task relations contain a cycle at: {', '.join(cycles)}.", cycles))
-    return FamilyGraph(manifest, roots, _roles(manifest.nodes, manifest.relations, roots), tuple(blockers))
+    return FamilyGraph(manifest, tuple(sorted(included_set)), excluded_task_ids, roots, _roles(included_nodes, included_relations, roots), tuple(blockers))
 
 
-def rename_mapping(graph: FamilyGraph) -> tuple[TitleRename, ...]:
+def rename_mapping(graph: FamilyGraph, base_title: str) -> tuple[TitleRename, ...]:
     """Return stable title display changes; source titles are never identity keys."""
+    if not base_title.strip():
+        raise ValueError("base_title must be a non-empty caller-supplied value")
     changes: list[TitleRename] = []
-    for node in sorted(graph.manifest.nodes, key=lambda item: item.task_id):
+    for node in sorted(graph.nodes_by_id.values(), key=lambda item: item.task_id):
         roles = graph.roles_by_task[node.task_id]
-        suffix = ", ".join(roles)
-        managed_suffix = re.compile(r" \[(?:Lead|Worker|Reviewer|Handoff|Replacement|Generation \d+)(?:, (?:Lead|Worker|Reviewer|Handoff|Replacement|Generation \d+))*\]$")
-        base_title = managed_suffix.sub("", node.title)
+        suffix = " · ".join(roles)
         new_title = f"{base_title} [{suffix}]" if suffix else base_title
         changes.append(TitleRename(node.task_id, node.title, new_title, roles))
     return tuple(changes)

--- a/scripts/orchestration/task_family/model.py
+++ b/scripts/orchestration/task_family/model.py
@@ -313,18 +313,36 @@ class ReceiptAction(SchemaModel):
     task_ids: tuple[str, ...]
     action: str
     reason: str = ""
+    error: str = ""
+    recovery: str = ""
 
     def __post_init__(self) -> None:
         if not self.resource_type.strip() or not self.resource_id.strip() or not self.action.strip():
             raise ValueError("receipt actions require resource_type, resource_id, and action")
 
     def to_dict(self) -> dict[str, Any]:
-        return {"resource_type": self.resource_type, "resource_id": self.resource_id, "task_ids": list(self.task_ids), "action": self.action, "reason": self.reason}
+        return {
+            "resource_type": self.resource_type,
+            "resource_id": self.resource_id,
+            "task_ids": list(self.task_ids),
+            "action": self.action,
+            "reason": self.reason,
+            "error": self.error,
+            "recovery": self.recovery,
+        }
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> ReceiptAction:
         data = _object(payload, "receipt action")
-        return cls(_string(data.get("resource_type"), "receipt action resource_type"), _string(data.get("resource_id"), "receipt action resource_id"), tuple(_string(item, "receipt action task_id") for item in _list(data.get("task_ids", []), "receipt action task_ids")), _string(data.get("action"), "receipt action action"), _string(data.get("reason", ""), "receipt action reason"))
+        return cls(
+            _string(data.get("resource_type"), "receipt action resource_type"),
+            _string(data.get("resource_id"), "receipt action resource_id"),
+            tuple(_string(item, "receipt action task_id") for item in _list(data.get("task_ids", []), "receipt action task_ids")),
+            _string(data.get("action"), "receipt action action"),
+            _string(data.get("reason", ""), "receipt action reason"),
+            _string(data.get("error", ""), "receipt action error"),
+            _string(data.get("recovery", ""), "receipt action recovery"),
+        )
 
 
 @dataclass(frozen=True, slots=True)

--- a/scripts/orchestration/task_family/model.py
+++ b/scripts/orchestration/task_family/model.py
@@ -8,9 +8,36 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Any
+from typing import Any, ClassVar
 
 SCHEMA_VERSION = 1
+def _object(value: Any, context: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{context} must be an object")
+    return value
+
+
+def _list(value: Any, context: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{context} must be a list")
+    return value
+
+
+def _string(value: Any, context: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{context} must be a string")
+    return value
+
+
+def _schema_version(payload: dict[str, Any], context: str) -> None:
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"unsupported {context} schema_version: {payload.get('schema_version')!r}")
+
+
+class SchemaModel:
+    """Marker for immutable JSON records read by the future CLI."""
+
+    schema_version: ClassVar[int]
 
 
 class RelationType(StrEnum):
@@ -68,7 +95,7 @@ def utc_now() -> str:
 
 
 @dataclass(frozen=True, slots=True)
-class TaskNode:
+class TaskNode(SchemaModel):
     task_id: str
     title: str
     project_root: str
@@ -83,9 +110,23 @@ class TaskNode:
         if not self.project_root.strip():
             raise ValueError(f"task {self.task_id}: project_root must be non-empty")
 
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> TaskNode:
+        data = _object(payload, "task node")
+        metadata = data.get("metadata", {})
+        if not isinstance(metadata, dict) or not all(isinstance(key, str) and isinstance(value, str) for key, value in metadata.items()):
+            raise ValueError("task node metadata must be a string map")
+        def optional(key: str) -> str | None:
+            return None if data.get(key) is None else _string(data[key], f"task node {key}")
+
+        return cls(_string(data.get("task_id"), "task node task_id"), _string(data.get("title"), "task node title"), _string(data.get("project_root"), "task node project_root"), optional("worktree"), optional("branch"), optional("pr_id"), metadata)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
 
 @dataclass(frozen=True, slots=True)
-class TaskRelation:
+class TaskRelation(SchemaModel):
     source_id: str
     target_id: str
     relation_type: RelationType
@@ -97,15 +138,33 @@ class TaskRelation:
             raise ValueError("relation endpoints must be non-empty exact task IDs")
         if not self.evidence.strip():
             raise ValueError("relation evidence must be non-empty")
+        if not self.family_defining and self.relation_type is not RelationType.ISSUE_OR_PR_MEMBER:
+            raise ValueError("only issue_or_pr_member relations may be display-only")
 
     @property
     def is_display_only(self) -> bool:
         return self.relation_type is RelationType.ISSUE_OR_PR_MEMBER and not self.family_defining
 
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> TaskRelation:
+        data = _object(payload, "task relation")
+        try:
+            relation_type = RelationType(_string(data.get("relation_type"), "task relation relation_type"))
+        except ValueError as exc:
+            raise ValueError(f"unknown task relation type: {data.get('relation_type')!r}") from exc
+        family_defining = data.get("family_defining", True)
+        if not isinstance(family_defining, bool):
+            raise ValueError("task relation family_defining must be boolean")
+        return cls(_string(data.get("source_id"), "task relation source_id"), _string(data.get("target_id"), "task relation target_id"), relation_type, _string(data.get("evidence"), "task relation evidence"), family_defining)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"source_id": self.source_id, "target_id": self.target_id, "relation_type": self.relation_type.value, "evidence": self.evidence, "family_defining": self.family_defining}
+
 
 @dataclass(frozen=True, slots=True)
-class TaskFamilyManifest:
+class TaskFamilyManifest(SchemaModel):
     family_id: str
+    seed_task_id: str
     nodes: tuple[TaskNode, ...]
     relations: tuple[TaskRelation, ...]
     schema_version: int = SCHEMA_VERSION
@@ -115,13 +174,33 @@ class TaskFamilyManifest:
             raise ValueError(f"unsupported manifest schema_version: {self.schema_version}")
         if not self.family_id.strip():
             raise ValueError("family_id must be non-empty")
+        if not self.seed_task_id.strip():
+            raise ValueError("seed_task_id must be a non-empty exact task ID")
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        return {
+            "schema_version": self.schema_version,
+            "family_id": self.family_id,
+            "seed_task_id": self.seed_task_id,
+            "nodes": [node.to_dict() for node in self.nodes],
+            "relations": [relation.to_dict() for relation in self.relations],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> TaskFamilyManifest:
+        data = _object(payload, "task-family manifest")
+        _schema_version(data, "task-family manifest")
+        return cls(
+            _string(data.get("family_id"), "task-family manifest family_id"),
+            _string(data.get("seed_task_id"), "task-family manifest seed_task_id"),
+            tuple(TaskNode.from_dict(_object(item, "task-family manifest node")) for item in _list(data.get("nodes"), "task-family manifest nodes")),
+            tuple(TaskRelation.from_dict(_object(item, "task-family manifest relation")) for item in _list(data.get("relations"), "task-family manifest relations")),
+            data["schema_version"],
+        )
 
 
 @dataclass(frozen=True, slots=True)
-class ArchiveSelection:
+class ArchiveSelection(SchemaModel):
     task_id: str
     actor: str
     selected_at: str = field(default_factory=utc_now)
@@ -136,9 +215,20 @@ class ArchiveSelection:
         if not self.selected_at.strip():
             raise ValueError("archive selection selected_at must be non-empty")
 
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> ArchiveSelection:
+        data = _object(payload, "archive selection")
+        confirmed = data.get("pin_state_unknown_confirmed", False)
+        if not isinstance(confirmed, bool):
+            raise ValueError("archive selection pin_state_unknown_confirmed must be boolean")
+        return cls(_string(data.get("task_id"), "archive selection task_id"), _string(data.get("actor"), "archive selection actor"), _string(data.get("selected_at"), "archive selection selected_at"), _string(data.get("selection_source", "explicit"), "archive selection selection_source"), confirmed)
+
 
 @dataclass(frozen=True, slots=True)
-class Blocker:
+class Blocker(SchemaModel):
     code: str
     message: str
     task_ids: tuple[str, ...] = ()
@@ -147,9 +237,14 @@ class Blocker:
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> Blocker:
+        data = _object(payload, "blocker")
+        return cls(_string(data.get("code"), "blocker code"), _string(data.get("message"), "blocker message"), tuple(_string(item, "blocker task_id") for item in _list(data.get("task_ids", []), "blocker task_ids")), _string(data.get("remediation", ""), "blocker remediation"))
+
 
 @dataclass(frozen=True, slots=True)
-class ResourceDecision:
+class ResourceDecision(SchemaModel):
     resource_type: str
     resource_id: str
     selected_task_ids: tuple[str, ...]
@@ -159,9 +254,14 @@ class ResourceDecision:
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
 
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> ResourceDecision:
+        data = _object(payload, "resource decision")
+        return cls(_string(data.get("resource_type"), "resource decision resource_type"), _string(data.get("resource_id"), "resource decision resource_id"), tuple(_string(item, "resource decision selected_task_id") for item in _list(data.get("selected_task_ids"), "resource decision selected_task_ids")), _string(data.get("decision"), "resource decision decision"), _string(data.get("reason"), "resource decision reason"))
+
 
 @dataclass(frozen=True, slots=True)
-class PlanStage:
+class PlanStage(SchemaModel):
     state: LifecycleState
     required: bool
     description: str
@@ -169,9 +269,21 @@ class PlanStage:
     def to_dict(self) -> dict[str, Any]:
         return {"state": self.state.value, "required": self.required, "description": self.description}
 
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> PlanStage:
+        data = _object(payload, "plan stage")
+        try:
+            state = LifecycleState(_string(data.get("state"), "plan stage state"))
+        except ValueError as exc:
+            raise ValueError(f"unknown lifecycle state: {data.get('state')!r}") from exc
+        required = data.get("required")
+        if not isinstance(required, bool):
+            raise ValueError("plan stage required must be boolean")
+        return cls(state, required, _string(data.get("description"), "plan stage description"))
+
 
 @dataclass(frozen=True, slots=True)
-class LifecycleEvent:
+class LifecycleEvent(SchemaModel):
     event_id: str
     occurred_at: str
     state: LifecycleState
@@ -181,18 +293,52 @@ class LifecycleEvent:
     def to_dict(self) -> dict[str, Any]:
         return {"event_id": self.event_id, "occurred_at": self.occurred_at, "state": self.state.value, "kind": self.kind, "details": self.details}
 
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> LifecycleEvent:
+        data = _object(payload, "lifecycle event")
+        try:
+            state = LifecycleState(_string(data.get("state"), "lifecycle event state"))
+        except ValueError as exc:
+            raise ValueError(f"unknown lifecycle state: {data.get('state')!r}") from exc
+        details = data.get("details", {})
+        if not isinstance(details, dict):
+            raise ValueError("lifecycle event details must be an object")
+        return cls(_string(data.get("event_id"), "lifecycle event event_id"), _string(data.get("occurred_at"), "lifecycle event occurred_at"), state, _string(data.get("kind"), "lifecycle event kind"), details)
+
 
 @dataclass(frozen=True, slots=True)
-class OperationReceipt:
+class ReceiptAction(SchemaModel):
+    resource_type: str
+    resource_id: str
+    task_ids: tuple[str, ...]
+    action: str
+    reason: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.resource_type.strip() or not self.resource_id.strip() or not self.action.strip():
+            raise ValueError("receipt actions require resource_type, resource_id, and action")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"resource_type": self.resource_type, "resource_id": self.resource_id, "task_ids": list(self.task_ids), "action": self.action, "reason": self.reason}
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> ReceiptAction:
+        data = _object(payload, "receipt action")
+        return cls(_string(data.get("resource_type"), "receipt action resource_type"), _string(data.get("resource_id"), "receipt action resource_id"), tuple(_string(item, "receipt action task_id") for item in _list(data.get("task_ids", []), "receipt action task_ids")), _string(data.get("action"), "receipt action action"), _string(data.get("reason", ""), "receipt action reason"))
+
+
+@dataclass(frozen=True, slots=True)
+class OperationReceipt(SchemaModel):
     operation_id: str
     family_id: str
     plan_digest: str
     final_state: LifecycleState
-    planned: tuple[str, ...] = ()
-    actual: tuple[str, ...] = ()
-    skipped: tuple[str, ...] = ()
-    failures: tuple[str, ...] = ()
-    restoration: tuple[str, ...] = ()
+    planned: tuple[ReceiptAction, ...] = ()
+    actual: tuple[ReceiptAction, ...] = ()
+    skipped: tuple[ReceiptAction, ...] = ()
+    failures: tuple[ReceiptAction, ...] = ()
+    restoration: tuple[ReceiptAction, ...] = ()
+    final_resources: tuple[ReceiptAction, ...] = ()
     events: tuple[LifecycleEvent, ...] = ()
     schema_version: int = SCHEMA_VERSION
 
@@ -203,11 +349,12 @@ class OperationReceipt:
             "family_id": self.family_id,
             "plan_digest": self.plan_digest,
             "final_state": self.final_state.value,
-            "planned": list(self.planned),
-            "actual": list(self.actual),
-            "skipped": list(self.skipped),
-            "failures": list(self.failures),
-            "restoration": list(self.restoration),
+            "planned": [item.to_dict() for item in self.planned],
+            "actual": [item.to_dict() for item in self.actual],
+            "skipped": [item.to_dict() for item in self.skipped],
+            "failures": [item.to_dict() for item in self.failures],
+            "restoration": [item.to_dict() for item in self.restoration],
+            "final_resources": [item.to_dict() for item in self.final_resources],
             "events": [event.to_dict() for event in self.events],
         }
 
@@ -224,6 +371,24 @@ class OperationReceipt:
             ("Skipped", self.skipped),
             ("Failures", self.failures),
             ("Restoration", self.restoration),
+            ("Final resources", self.final_resources),
         ):
-            lines.append(f"{label}: " + ("; ".join(values) if values else "none"))
+            rendered = (f"{item.resource_type}:{item.resource_id} {item.action}" + (f" ({item.reason})" if item.reason else "") for item in values)
+            lines.append(f"{label}: " + ("; ".join(rendered) if values else "none"))
         return "\n".join(lines) + "\n"
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> OperationReceipt:
+        data = _object(payload, "operation receipt")
+        _schema_version(data, "operation receipt")
+        try:
+            final_state = LifecycleState(_string(data.get("final_state"), "operation receipt final_state"))
+        except ValueError as exc:
+            raise ValueError(f"unknown lifecycle state: {data.get('final_state')!r}") from exc
+        def actions(key: str) -> tuple[ReceiptAction, ...]:
+            return tuple(
+                ReceiptAction.from_dict(_object(item, f"operation receipt {key} item"))
+                for item in _list(data.get(key, []), f"operation receipt {key}")
+            )
+
+        return cls(_string(data.get("operation_id"), "operation receipt operation_id"), _string(data.get("family_id"), "operation receipt family_id"), _string(data.get("plan_digest"), "operation receipt plan_digest"), final_state, actions("planned"), actions("actual"), actions("skipped"), actions("failures"), actions("restoration"), actions("final_resources"), tuple(LifecycleEvent.from_dict(_object(item, "operation receipt event")) for item in _list(data.get("events", []), "operation receipt events")), data["schema_version"])

--- a/scripts/orchestration/task_family/model.py
+++ b/scripts/orchestration/task_family/model.py
@@ -1,0 +1,229 @@
+"""Versioned data model for task-family lifecycle planning.
+
+Task IDs are the sole identity keys.  Titles are retained only for rendering.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+
+class RelationType(StrEnum):
+    ROOT = "root"
+    SUBAGENT_OF = "subagent_of"
+    REVIEWER_FOR = "reviewer_for"
+    REPLACEMENT_OF = "replacement_of"
+    HANDOFF_OF = "handoff_of"
+    ROLLOVER_GENERATION_OF = "rollover_generation_of"
+    ISSUE_OR_PR_MEMBER = "issue_or_pr_member"
+
+
+class OperationKind(StrEnum):
+    ARCHIVE_ONLY = "archive_only"
+    FINISH_AND_CLEAN = "finish_and_clean"
+
+
+class LifecycleState(StrEnum):
+    PLANNED = "planned"
+    FROZEN = "frozen"
+    VERIFIED = "verified"
+    SNAPSHOTTED = "snapshotted"
+    TASKS_ARCHIVED = "tasks_archived"
+    WORKTREES_REMOVED = "worktrees_removed"
+    BRANCHES_DELETED = "branches_deleted"
+    RUNTIME_RETIRED = "runtime_retired"
+    COMPLETED = "completed"
+    BLOCKED = "blocked"
+
+
+STATE_SEQUENCE = (
+    LifecycleState.PLANNED,
+    LifecycleState.FROZEN,
+    LifecycleState.VERIFIED,
+    LifecycleState.SNAPSHOTTED,
+    LifecycleState.TASKS_ARCHIVED,
+    LifecycleState.WORKTREES_REMOVED,
+    LifecycleState.BRANCHES_DELETED,
+    LifecycleState.RUNTIME_RETIRED,
+    LifecycleState.COMPLETED,
+)
+PARENT_LIKE_RELATIONS = frozenset(
+    {
+        RelationType.SUBAGENT_OF,
+        RelationType.REVIEWER_FOR,
+        RelationType.REPLACEMENT_OF,
+        RelationType.HANDOFF_OF,
+        RelationType.ROLLOVER_GENERATION_OF,
+    }
+)
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+@dataclass(frozen=True, slots=True)
+class TaskNode:
+    task_id: str
+    title: str
+    project_root: str
+    worktree: str | None = None
+    branch: str | None = None
+    pr_id: str | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.task_id.strip():
+            raise ValueError("task_id must be non-empty")
+        if not self.project_root.strip():
+            raise ValueError(f"task {self.task_id}: project_root must be non-empty")
+
+
+@dataclass(frozen=True, slots=True)
+class TaskRelation:
+    source_id: str
+    target_id: str
+    relation_type: RelationType
+    evidence: str
+    family_defining: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.source_id.strip() or not self.target_id.strip():
+            raise ValueError("relation endpoints must be non-empty exact task IDs")
+        if not self.evidence.strip():
+            raise ValueError("relation evidence must be non-empty")
+
+    @property
+    def is_display_only(self) -> bool:
+        return self.relation_type is RelationType.ISSUE_OR_PR_MEMBER and not self.family_defining
+
+
+@dataclass(frozen=True, slots=True)
+class TaskFamilyManifest:
+    family_id: str
+    nodes: tuple[TaskNode, ...]
+    relations: tuple[TaskRelation, ...]
+    schema_version: int = SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != SCHEMA_VERSION:
+            raise ValueError(f"unsupported manifest schema_version: {self.schema_version}")
+        if not self.family_id.strip():
+            raise ValueError("family_id must be non-empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveSelection:
+    task_id: str
+    actor: str
+    selected_at: str = field(default_factory=utc_now)
+    selection_source: str = "explicit"
+    pin_state_unknown_confirmed: bool = False
+
+    def __post_init__(self) -> None:
+        if self.selection_source != "explicit":
+            raise ValueError("archive selection_source must be explicit")
+        if not self.actor.strip():
+            raise ValueError("archive selection actor must be non-empty")
+        if not self.selected_at.strip():
+            raise ValueError("archive selection selected_at must be non-empty")
+
+
+@dataclass(frozen=True, slots=True)
+class Blocker:
+    code: str
+    message: str
+    task_ids: tuple[str, ...] = ()
+    remediation: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceDecision:
+    resource_type: str
+    resource_id: str
+    selected_task_ids: tuple[str, ...]
+    decision: str
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class PlanStage:
+    state: LifecycleState
+    required: bool
+    description: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"state": self.state.value, "required": self.required, "description": self.description}
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleEvent:
+    event_id: str
+    occurred_at: str
+    state: LifecycleState
+    kind: str
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"event_id": self.event_id, "occurred_at": self.occurred_at, "state": self.state.value, "kind": self.kind, "details": self.details}
+
+
+@dataclass(frozen=True, slots=True)
+class OperationReceipt:
+    operation_id: str
+    family_id: str
+    plan_digest: str
+    final_state: LifecycleState
+    planned: tuple[str, ...] = ()
+    actual: tuple[str, ...] = ()
+    skipped: tuple[str, ...] = ()
+    failures: tuple[str, ...] = ()
+    restoration: tuple[str, ...] = ()
+    events: tuple[LifecycleEvent, ...] = ()
+    schema_version: int = SCHEMA_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "operation_id": self.operation_id,
+            "family_id": self.family_id,
+            "plan_digest": self.plan_digest,
+            "final_state": self.final_state.value,
+            "planned": list(self.planned),
+            "actual": list(self.actual),
+            "skipped": list(self.skipped),
+            "failures": list(self.failures),
+            "restoration": list(self.restoration),
+            "events": [event.to_dict() for event in self.events],
+        }
+
+    def render_human(self) -> str:
+        lines = [
+            f"Task-family operation {self.operation_id}",
+            f"Family: {self.family_id}",
+            f"Plan digest: {self.plan_digest}",
+            f"Final state: {self.final_state.value}",
+        ]
+        for label, values in (
+            ("Planned", self.planned),
+            ("Actual", self.actual),
+            ("Skipped", self.skipped),
+            ("Failures", self.failures),
+            ("Restoration", self.restoration),
+        ):
+            lines.append(f"{label}: " + ("; ".join(values) if values else "none"))
+        return "\n".join(lines) + "\n"

--- a/scripts/orchestration/task_family/planner.py
+++ b/scripts/orchestration/task_family/planner.py
@@ -55,6 +55,7 @@ class TaskFamilyPlan:
     resource_decisions: tuple[ResourceDecision, ...]
     stages: tuple[PlanStage, ...]
     blockers: tuple[Blocker, ...]
+    execution_context: dict[str, Any] | None = None
     state: LifecycleState = LifecycleState.PLANNED
     schema_version: int = SCHEMA_VERSION
     digest: str = ""
@@ -98,6 +99,7 @@ class TaskFamilyPlan:
             "resource_decisions": [item.to_dict() for item in self.resource_decisions],
             "stages": [item.to_dict() for item in self.stages],
             "blockers": [item.to_dict() for item in self.blockers],
+            "execution_context": self.execution_context or {},
         }
 
     def to_dict(self) -> dict[str, Any]:
@@ -154,6 +156,9 @@ class TaskFamilyPlan:
 
         if len(string_list("selected_task_ids")) != len(payload.get("selected_task_ids", [])):
             raise ValueError("task-family plan selected_task_ids must be strings")
+        execution_context = payload.get("execution_context", {})
+        if not isinstance(execution_context, dict):
+            raise ValueError("task-family plan execution_context must be an object")
         plan = cls(
             family_id=payload.get("family_id") if isinstance(payload.get("family_id"), str) else "",
             operation_id=payload.get("operation_id") if isinstance(payload.get("operation_id"), str) else "",
@@ -166,6 +171,7 @@ class TaskFamilyPlan:
             resource_decisions=tuple(ResourceDecision.from_dict(item) for item in record_list("resource_decisions")),
             stages=tuple(PlanStage.from_dict(item) for item in record_list("stages")),
             blockers=tuple(Blocker.from_dict(item) for item in record_list("blockers")),
+            execution_context=execution_context,
             state=state,
             schema_version=payload["schema_version"],
             digest=payload.get("digest") if isinstance(payload.get("digest"), str) else "",
@@ -252,6 +258,7 @@ def build_plan(
     operation: OperationKind,
     selections: tuple[ArchiveSelection, ...],
     base_title: str,
+    execution_context: dict[str, Any] | None = None,
 ) -> TaskFamilyPlan:
     """Build a deterministic plan, recording blockers instead of guessing intent."""
     blockers = list(graph.blockers)
@@ -282,5 +289,6 @@ def build_plan(
         resource_decisions=_resource_decisions(graph, tuple(sorted(selected_set))),
         stages=_stages(operation),
         blockers=tuple(sorted(blockers, key=lambda item: (item.code, item.task_ids, item.message))),
+        execution_context=execution_context or {},
     )
     return replace(plan, digest=sha256_digest(plan.immutable_payload()))

--- a/scripts/orchestration/task_family/planner.py
+++ b/scripts/orchestration/task_family/planner.py
@@ -10,6 +10,7 @@ from typing import Any
 from .graph import FamilyGraph, TitleRename, rename_mapping
 from .model import (
     PARENT_LIKE_RELATIONS,
+    SCHEMA_VERSION,
     STATE_SEQUENCE,
     ArchiveSelection,
     Blocker,
@@ -47,13 +48,15 @@ class TaskFamilyPlan:
     operation_id: str
     operation: OperationKind
     selected_task_ids: tuple[str, ...]
+    excluded_task_ids: tuple[str, ...]
+    base_title: str
     selections: tuple[ArchiveSelection, ...]
     rename_map: tuple[TitleRename, ...]
     resource_decisions: tuple[ResourceDecision, ...]
     stages: tuple[PlanStage, ...]
     blockers: tuple[Blocker, ...]
     state: LifecycleState = LifecycleState.PLANNED
-    schema_version: int = 1
+    schema_version: int = SCHEMA_VERSION
     digest: str = ""
 
     @property
@@ -62,8 +65,12 @@ class TaskFamilyPlan:
 
     @property
     def is_completed_cleanup_noop(self) -> bool:
-        """A completed plan is immutable and never schedules a second cleanup."""
-        return self.state is LifecycleState.COMPLETED
+        """A completed operation is immutable and never schedules a second cleanup."""
+        return self.state is self.terminal_state
+
+    @property
+    def terminal_state(self) -> LifecycleState:
+        return LifecycleState.TASKS_ARCHIVED if self.operation is OperationKind.ARCHIVE_ONLY else LifecycleState.COMPLETED
 
     def immutable_payload(self) -> dict[str, Any]:
         return {
@@ -72,6 +79,8 @@ class TaskFamilyPlan:
             "operation_id": self.operation_id,
             "operation": self.operation.value,
             "selected_task_ids": list(self.selected_task_ids),
+            "excluded_task_ids": list(self.excluded_task_ids),
+            "base_title": self.base_title,
             "selections": [
                 {
                     "task_id": item.task_id,
@@ -98,8 +107,10 @@ class TaskFamilyPlan:
         return payload
 
     def with_state(self, state: LifecycleState) -> TaskFamilyPlan:
-        if self.state is LifecycleState.COMPLETED:
-            return self
+        if self.state is self.terminal_state:
+            if state is self.state:
+                return self
+            raise ValueError(f"operation {self.operation.value} reached terminal state {self.state.value}")
         if state is LifecycleState.BLOCKED:
             return replace(self, state=state)
         state_sequence = tuple(stage.state for stage in self.stages)
@@ -110,6 +121,62 @@ class TaskFamilyPlan:
         if self.blockers:
             return replace(self, state=LifecycleState.BLOCKED)
         return replace(self, state=state)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> TaskFamilyPlan:
+        if not isinstance(payload, dict):
+            raise ValueError("task-family plan must be an object")
+        if payload.get("schema_version") != SCHEMA_VERSION:
+            raise ValueError(f"unsupported task-family plan schema_version: {payload.get('schema_version')!r}")
+        try:
+            operation = OperationKind(payload.get("operation"))
+            state = LifecycleState(payload.get("state"))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("task-family plan contains an unknown operation or lifecycle state") from exc
+
+        def string_list(key: str) -> tuple[str, ...]:
+            value = payload.get(key, [])
+            if not isinstance(value, list):
+                raise ValueError(f"task-family plan {key} must be a list")
+            return tuple(item for item in value if isinstance(item, str))
+
+        def record_list(key: str) -> list[dict[str, Any]]:
+            value = payload.get(key, [])
+            if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+                raise ValueError(f"task-family plan {key} must be a list of objects")
+            return value
+
+        def title_rename(item: dict[str, Any]) -> TitleRename:
+            roles = item.get("roles")
+            if not all(isinstance(item.get(key), str) for key in ("task_id", "old_title", "new_title")) or not isinstance(roles, list) or not all(isinstance(role, str) for role in roles):
+                raise ValueError("task-family plan rename_map must contain title rename objects")
+            return TitleRename(item["task_id"], item["old_title"], item["new_title"], tuple(roles))
+
+        if len(string_list("selected_task_ids")) != len(payload.get("selected_task_ids", [])):
+            raise ValueError("task-family plan selected_task_ids must be strings")
+        plan = cls(
+            family_id=payload.get("family_id") if isinstance(payload.get("family_id"), str) else "",
+            operation_id=payload.get("operation_id") if isinstance(payload.get("operation_id"), str) else "",
+            operation=operation,
+            selected_task_ids=string_list("selected_task_ids"),
+            excluded_task_ids=string_list("excluded_task_ids"),
+            base_title=payload.get("base_title") if isinstance(payload.get("base_title"), str) else "",
+            selections=tuple(ArchiveSelection.from_dict(item) for item in record_list("selections")),
+            rename_map=tuple(title_rename(item) for item in record_list("rename_map")),
+            resource_decisions=tuple(ResourceDecision.from_dict(item) for item in record_list("resource_decisions")),
+            stages=tuple(PlanStage.from_dict(item) for item in record_list("stages")),
+            blockers=tuple(Blocker.from_dict(item) for item in record_list("blockers")),
+            state=state,
+            schema_version=payload["schema_version"],
+            digest=payload.get("digest") if isinstance(payload.get("digest"), str) else "",
+        )
+        if not plan.family_id or not plan.operation_id or not plan.base_title or not plan.digest:
+            raise ValueError("task-family plan requires family_id, operation_id, base_title, and digest")
+        if sha256_digest(plan.immutable_payload()) != plan.digest:
+            raise ValueError("immutable plan digest does not match persisted plan")
+        if plan.state is not LifecycleState.BLOCKED and plan.state not in {stage.state for stage in plan.stages}:
+            raise ValueError("task-family plan state is absent from operation stages")
+        return plan
 
 
 def _shared_resource_blockers(graph: FamilyGraph, selected: set[str]) -> list[Blocker]:
@@ -170,16 +237,12 @@ def _resource_decisions(graph: FamilyGraph, selected: tuple[str, ...]) -> tuple[
 
 
 def _stages(operation: OperationKind) -> tuple[PlanStage, ...]:
-    archive_only_skips = {
-        LifecycleState.SNAPSHOTTED,
-        LifecycleState.WORKTREES_REMOVED,
-        LifecycleState.BRANCHES_DELETED,
-        LifecycleState.RUNTIME_RETIRED,
-    }
-    return tuple(
-        PlanStage(state, operation is not OperationKind.ARCHIVE_ONLY or state not in archive_only_skips, STAGE_DESCRIPTIONS[state])
-        for state in STATE_SEQUENCE
+    states = (
+        (LifecycleState.PLANNED, LifecycleState.FROZEN, LifecycleState.VERIFIED, LifecycleState.TASKS_ARCHIVED)
+        if operation is OperationKind.ARCHIVE_ONLY
+        else STATE_SEQUENCE
     )
+    return tuple(PlanStage(state, True, STAGE_DESCRIPTIONS[state]) for state in states)
 
 
 def build_plan(
@@ -188,9 +251,12 @@ def build_plan(
     operation_id: str,
     operation: OperationKind,
     selections: tuple[ArchiveSelection, ...],
+    base_title: str,
 ) -> TaskFamilyPlan:
     """Build a deterministic plan, recording blockers instead of guessing intent."""
     blockers = list(graph.blockers)
+    if not base_title.strip():
+        blockers.append(Blocker("missing_base_title", "A caller-supplied base title is required; titles are never identity inputs."))
     node_ids = set(graph.nodes_by_id)
     selected_ids = tuple(sorted(selection.task_id for selection in selections))
     if not selections:
@@ -209,8 +275,10 @@ def build_plan(
         operation_id=operation_id,
         operation=operation,
         selected_task_ids=selected_ids,
+        excluded_task_ids=graph.excluded_task_ids,
+        base_title=base_title,
         selections=tuple(sorted(selections, key=lambda item: item.task_id)),
-        rename_map=rename_mapping(graph),
+        rename_map=rename_mapping(graph, base_title) if base_title.strip() else (),
         resource_decisions=_resource_decisions(graph, tuple(sorted(selected_set))),
         stages=_stages(operation),
         blockers=tuple(sorted(blockers, key=lambda item: (item.code, item.task_ids, item.message))),

--- a/scripts/orchestration/task_family/planner.py
+++ b/scripts/orchestration/task_family/planner.py
@@ -1,0 +1,218 @@
+"""Deterministic, fail-closed lifecycle planning for a task-family graph."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, replace
+from typing import Any
+
+from .graph import FamilyGraph, TitleRename, rename_mapping
+from .model import (
+    PARENT_LIKE_RELATIONS,
+    STATE_SEQUENCE,
+    ArchiveSelection,
+    Blocker,
+    LifecycleState,
+    OperationKind,
+    PlanStage,
+    ResourceDecision,
+)
+
+STAGE_DESCRIPTIONS = {
+    LifecycleState.PLANNED: "Immutable plan recorded; no mutation is authorized.",
+    LifecycleState.FROZEN: "Operation lock acquired and current resources re-discovered.",
+    LifecycleState.VERIFIED: "Selection, pins, and resource preconditions verified.",
+    LifecycleState.SNAPSHOTTED: "Required recoverability snapshot verified before cleanup.",
+    LifecycleState.TASKS_ARCHIVED: "Selected tasks reconciled at archive target.",
+    LifecycleState.WORKTREES_REMOVED: "Selected, exclusive worktrees reconciled as absent.",
+    LifecycleState.BRANCHES_DELETED: "Selected, proof-gated branches reconciled as absent.",
+    LifecycleState.RUNTIME_RETIRED: "Family runtime record retired without purge.",
+    LifecycleState.COMPLETED: "Operation reached its requested terminal target.",
+    LifecycleState.BLOCKED: "A fail-closed blocker prevented further progression.",
+}
+
+
+def canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_digest(payload: dict[str, Any]) -> str:
+    return hashlib.sha256(canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class TaskFamilyPlan:
+    family_id: str
+    operation_id: str
+    operation: OperationKind
+    selected_task_ids: tuple[str, ...]
+    selections: tuple[ArchiveSelection, ...]
+    rename_map: tuple[TitleRename, ...]
+    resource_decisions: tuple[ResourceDecision, ...]
+    stages: tuple[PlanStage, ...]
+    blockers: tuple[Blocker, ...]
+    state: LifecycleState = LifecycleState.PLANNED
+    schema_version: int = 1
+    digest: str = ""
+
+    @property
+    def is_actionable(self) -> bool:
+        return not self.blockers and self.state is not LifecycleState.BLOCKED
+
+    @property
+    def is_completed_cleanup_noop(self) -> bool:
+        """A completed plan is immutable and never schedules a second cleanup."""
+        return self.state is LifecycleState.COMPLETED
+
+    def immutable_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "family_id": self.family_id,
+            "operation_id": self.operation_id,
+            "operation": self.operation.value,
+            "selected_task_ids": list(self.selected_task_ids),
+            "selections": [
+                {
+                    "task_id": item.task_id,
+                    "actor": item.actor,
+                    "selected_at": item.selected_at,
+                    "selection_source": item.selection_source,
+                    "pin_state_unknown_confirmed": item.pin_state_unknown_confirmed,
+                }
+                for item in self.selections
+            ],
+            "rename_map": [
+                {"task_id": item.task_id, "old_title": item.old_title, "new_title": item.new_title, "roles": list(item.roles)}
+                for item in self.rename_map
+            ],
+            "resource_decisions": [item.to_dict() for item in self.resource_decisions],
+            "stages": [item.to_dict() for item in self.stages],
+            "blockers": [item.to_dict() for item in self.blockers],
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = self.immutable_payload()
+        payload["state"] = self.state.value
+        payload["digest"] = self.digest
+        return payload
+
+    def with_state(self, state: LifecycleState) -> TaskFamilyPlan:
+        if self.state is LifecycleState.COMPLETED:
+            return self
+        if state is LifecycleState.BLOCKED:
+            return replace(self, state=state)
+        state_sequence = tuple(stage.state for stage in self.stages)
+        current_index = state_sequence.index(self.state)
+        requested_index = state_sequence.index(state)
+        if requested_index != current_index + 1:
+            raise ValueError(f"invalid lifecycle transition: {self.state.value} -> {state.value}")
+        if self.blockers:
+            return replace(self, state=LifecycleState.BLOCKED)
+        return replace(self, state=state)
+
+
+def _shared_resource_blockers(graph: FamilyGraph, selected: set[str]) -> list[Blocker]:
+    blockers: list[Blocker] = []
+    nodes = graph.nodes_by_id
+    resource_fields = (("worktree", "worktree"), ("branch", "branch"), ("pr_id", "PR"))
+    for field, label in resource_fields:
+        owners: dict[str, set[str]] = {}
+        for node in nodes.values():
+            value = getattr(node, field)
+            if value:
+                owners.setdefault(value, set()).add(node.task_id)
+        for value, task_ids in owners.items():
+            if task_ids & selected and task_ids - selected:
+                blockers.append(
+                    Blocker(
+                        "unselected_shared_resource",
+                        f"Unselected task(s) share {label} {value!r} with selected task(s).",
+                        tuple(sorted(task_ids)),
+                        "Select every affected exact ID or separate the shared resource before retrying.",
+                    )
+                )
+    adjacency: dict[str, set[str]] = {task_id: set() for task_id in nodes}
+    for relation in graph.family_relations:
+        if relation.relation_type in PARENT_LIKE_RELATIONS:
+            adjacency[relation.source_id].add(relation.target_id)
+            adjacency[relation.target_id].add(relation.source_id)
+    for task_id in selected:
+        stack = list(adjacency[task_id])
+        seen = {task_id}
+        while stack:
+            candidate = stack.pop()
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            if candidate not in selected:
+                blockers.append(
+                    Blocker(
+                        "unselected_lineage_endpoint",
+                        f"Unselected task {candidate!r} is a predecessor/successor lineage endpoint of selected task {task_id!r}.",
+                        tuple(sorted((task_id, candidate))),
+                        "Explicitly select the lineage endpoint or use archive-only after separating the family.",
+                    )
+                )
+            stack.extend(adjacency[candidate] - seen)
+    return blockers
+
+
+def _resource_decisions(graph: FamilyGraph, selected: tuple[str, ...]) -> tuple[ResourceDecision, ...]:
+    nodes = graph.nodes_by_id
+    decisions: list[ResourceDecision] = []
+    for task_id in selected:
+        node = nodes[task_id]
+        for resource_type, value in (("worktree", node.worktree), ("branch", node.branch), ("pr", node.pr_id)):
+            if value:
+                decisions.append(ResourceDecision(resource_type, value, (task_id,), "preserve_until_verified", "Planning lane performs no mutation."))
+    return tuple(sorted(decisions, key=lambda item: (item.resource_type, item.resource_id, item.selected_task_ids)))
+
+
+def _stages(operation: OperationKind) -> tuple[PlanStage, ...]:
+    archive_only_skips = {
+        LifecycleState.SNAPSHOTTED,
+        LifecycleState.WORKTREES_REMOVED,
+        LifecycleState.BRANCHES_DELETED,
+        LifecycleState.RUNTIME_RETIRED,
+    }
+    return tuple(
+        PlanStage(state, operation is not OperationKind.ARCHIVE_ONLY or state not in archive_only_skips, STAGE_DESCRIPTIONS[state])
+        for state in STATE_SEQUENCE
+    )
+
+
+def build_plan(
+    graph: FamilyGraph,
+    *,
+    operation_id: str,
+    operation: OperationKind,
+    selections: tuple[ArchiveSelection, ...],
+) -> TaskFamilyPlan:
+    """Build a deterministic plan, recording blockers instead of guessing intent."""
+    blockers = list(graph.blockers)
+    node_ids = set(graph.nodes_by_id)
+    selected_ids = tuple(sorted(selection.task_id for selection in selections))
+    if not selections:
+        blockers.append(Blocker("no_explicit_selection", "No tasks were selected; archive selection is never inferred.", remediation="Provide one explicit selection per exact task ID."))
+    if len(selected_ids) != len(set(selected_ids)):
+        blockers.append(Blocker("duplicate_selection", "An exact task ID was selected more than once.", selected_ids))
+    for selection in selections:
+        if selection.task_id not in node_ids:
+            blockers.append(Blocker("unknown_selected_task", f"Selected task ID {selection.task_id!r} is not in the manifest.", (selection.task_id,)))
+        if not selection.pin_state_unknown_confirmed:
+            blockers.append(Blocker("pin_state_unconfirmed", f"Selected task {selection.task_id!r} has unknown pin state without affirmative confirmation.", (selection.task_id,), "Confirm pin_state_unknown for this exact task ID."))
+    selected_set = set(selected_ids) & node_ids
+    blockers.extend(_shared_resource_blockers(graph, selected_set))
+    plan = TaskFamilyPlan(
+        family_id=graph.manifest.family_id,
+        operation_id=operation_id,
+        operation=operation,
+        selected_task_ids=selected_ids,
+        selections=tuple(sorted(selections, key=lambda item: item.task_id)),
+        rename_map=rename_mapping(graph),
+        resource_decisions=_resource_decisions(graph, tuple(sorted(selected_set))),
+        stages=_stages(operation),
+        blockers=tuple(sorted(blockers, key=lambda item: (item.code, item.task_ids, item.message))),
+    )
+    return replace(plan, digest=sha256_digest(plan.immutable_payload()))

--- a/scripts/orchestration/task_family/storage.py
+++ b/scripts/orchestration/task_family/storage.py
@@ -1,0 +1,122 @@
+"""Atomic local persistence for task-family plans, events, and receipts."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
+from pathlib import Path
+from typing import Any
+
+from .model import OperationReceipt
+from .planner import TaskFamilyPlan, canonical_json, sha256_digest
+
+
+def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Atomically publish JSON after flushing file and directory metadata."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (canonical_json(payload) + "\n").encode("utf-8")
+    descriptor, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except BaseException:
+        with suppress(FileNotFoundError):
+            os.unlink(temp_name)
+        raise
+
+
+def atomic_write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_name, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except BaseException:
+        with suppress(FileNotFoundError):
+            os.unlink(temp_name)
+        raise
+
+
+@contextmanager
+def advisory_lock(path: Path) -> Iterator[None]:
+    """Cooperate with other planners; never alters or deletes Git lock files."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+class TaskFamilyStorage:
+    """Stores runtime state at .agent/task-families/<family>/operations/<operation>/."""
+
+    def __init__(self, repo_root: Path, family_id: str, operation_id: str) -> None:
+        self.root = repo_root / ".agent" / "task-families" / family_id / "operations" / operation_id
+
+    @property
+    def plan_path(self) -> Path:
+        return self.root / "plan.json"
+
+    @property
+    def receipt_path(self) -> Path:
+        return self.root / "receipt.json"
+
+    @property
+    def receipt_text_path(self) -> Path:
+        return self.root / "receipt.txt"
+
+    @property
+    def lock_path(self) -> Path:
+        return self.root / ".operation.lock"
+
+    def write_plan(self, plan: TaskFamilyPlan) -> None:
+        if self.plan_path.exists():
+            existing = self.read_json(self.plan_path)
+            if existing.get("digest") != plan.digest:
+                raise ValueError("immutable plan digest mismatch; create a new operation instead of replacing this plan")
+            return
+        atomic_write_json(self.plan_path, plan.to_dict())
+
+    def assert_plan_digest(self, digest: str) -> dict[str, Any]:
+        payload = self.read_json(self.plan_path)
+        immutable = dict(payload)
+        immutable.pop("digest", None)
+        immutable.pop("state", None)
+        actual = sha256_digest(immutable)
+        if digest != payload.get("digest") or actual != digest:
+            raise ValueError("immutable plan digest does not match persisted plan")
+        return payload
+
+    def write_receipt(self, receipt: OperationReceipt) -> None:
+        atomic_write_json(self.receipt_path, receipt.to_dict())
+        atomic_write_text(self.receipt_text_path, receipt.render_human())
+
+    @staticmethod
+    def read_json(path: Path) -> dict[str, Any]:
+        with path.open(encoding="utf-8") as handle:
+            payload = json.load(handle)
+        if not isinstance(payload, dict):
+            raise ValueError(f"expected object JSON at {path}")
+        return payload

--- a/scripts/orchestration/task_family/storage.py
+++ b/scripts/orchestration/task_family/storage.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import Any
 
-from .model import OperationReceipt
+from .model import LifecycleEvent, LifecycleState, OperationReceipt, TaskFamilyManifest
 from .planner import TaskFamilyPlan, canonical_json, sha256_digest
 
 
@@ -80,6 +80,14 @@ class TaskFamilyStorage:
         return self.root / "plan.json"
 
     @property
+    def manifest_path(self) -> Path:
+        return self.root / "manifest.json"
+
+    @property
+    def state_path(self) -> Path:
+        return self.root / "state.json"
+
+    @property
     def receipt_path(self) -> Path:
         return self.root / "receipt.json"
 
@@ -91,6 +99,25 @@ class TaskFamilyStorage:
     def lock_path(self) -> Path:
         return self.root / ".operation.lock"
 
+    @property
+    def snapshots_dir(self) -> Path:
+        return self.root / "snapshots"
+
+    @property
+    def events_path(self) -> Path:
+        return self.root / "events.jsonl"
+
+    def write_manifest(self, manifest: TaskFamilyManifest) -> None:
+        if self.manifest_path.exists():
+            existing = self.read_json(self.manifest_path)
+            if existing != manifest.to_dict():
+                raise ValueError("immutable manifest mismatch; create a new operation instead of replacing this manifest")
+            return
+        atomic_write_json(self.manifest_path, manifest.to_dict())
+
+    def load_manifest(self) -> TaskFamilyManifest:
+        return TaskFamilyManifest.from_dict(self.read_json(self.manifest_path))
+
     def write_plan(self, plan: TaskFamilyPlan) -> None:
         if self.plan_path.exists():
             existing = self.read_json(self.plan_path)
@@ -98,6 +125,9 @@ class TaskFamilyStorage:
                 raise ValueError("immutable plan digest mismatch; create a new operation instead of replacing this plan")
             return
         atomic_write_json(self.plan_path, plan.to_dict())
+
+    def load_plan(self) -> TaskFamilyPlan:
+        return TaskFamilyPlan.from_dict(self.read_json(self.plan_path))
 
     def assert_plan_digest(self, digest: str) -> dict[str, Any]:
         payload = self.read_json(self.plan_path)
@@ -112,6 +142,56 @@ class TaskFamilyStorage:
     def write_receipt(self, receipt: OperationReceipt) -> None:
         atomic_write_json(self.receipt_path, receipt.to_dict())
         atomic_write_text(self.receipt_text_path, receipt.render_human())
+
+    def load_receipt(self) -> OperationReceipt:
+        return OperationReceipt.from_dict(self.read_json(self.receipt_path))
+
+    def write_state(self, state: LifecycleState, *, details: dict[str, Any] | None = None) -> None:
+        """Atomically persist mutable execution state; plans remain immutable."""
+        atomic_write_json(
+            self.state_path,
+            {"schema_version": 1, "state": state.value, "details": details or {}},
+        )
+
+    def load_state(self) -> dict[str, Any]:
+        payload = self.read_json(self.state_path)
+        if payload.get("schema_version") != 1:
+            raise ValueError(f"unsupported operation state schema_version: {payload.get('schema_version')!r}")
+        try:
+            LifecycleState(payload.get("state"))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"unknown lifecycle state: {payload.get('state')!r}") from exc
+        if not isinstance(payload.get("details"), dict):
+            raise ValueError("operation state details must be an object")
+        return payload
+
+    def write_snapshot(self, name: str, payload: dict[str, Any]) -> Path:
+        if not name or Path(name).name != name or not name.endswith(".json"):
+            raise ValueError("snapshot name must be a plain .json filename")
+        path = self.snapshots_dir / name
+        atomic_write_json(path, payload)
+        return path
+
+    def append_event(self, event: LifecycleEvent) -> None:
+        """Append durable evidence while holding the per-operation advisory lock."""
+        encoded = (canonical_json(event.to_dict()) + "\n").encode("utf-8")
+        with advisory_lock(self.lock_path):
+            self.root.mkdir(parents=True, exist_ok=True)
+            with self.events_path.open("ab") as handle:
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+            directory_fd = os.open(self.root, os.O_RDONLY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+
+    def load_events(self) -> tuple[LifecycleEvent, ...]:
+        if not self.events_path.exists():
+            return ()
+        with self.events_path.open(encoding="utf-8") as handle:
+            return tuple(LifecycleEvent.from_dict(json.loads(line)) for line in handle if line.strip())
 
     @staticmethod
     def read_json(path: Path) -> dict[str, Any]:

--- a/scripts/orchestration/task_family/storage.py
+++ b/scripts/orchestration/task_family/storage.py
@@ -102,7 +102,7 @@ class TaskFamilyStorage:
 
     @property
     def rename_plan_path(self) -> Path:
-        """Immutable, display-only rename preview; it authorizes no mutation."""
+        """Immutable title-reconciliation authorization for one rename operation."""
         return self.root / "rename-plan.json"
 
     @property

--- a/scripts/orchestration/task_family/storage.py
+++ b/scripts/orchestration/task_family/storage.py
@@ -96,6 +96,16 @@ class TaskFamilyStorage:
         return self.root / "receipt.txt"
 
     @property
+    def execution_path(self) -> Path:
+        """Immutable CLI-to-executor adaptation inputs for this operation."""
+        return self.root / "execution.json"
+
+    @property
+    def rename_plan_path(self) -> Path:
+        """Immutable, display-only rename preview; it authorizes no mutation."""
+        return self.root / "rename-plan.json"
+
+    @property
     def lock_path(self) -> Path:
         return self.root / ".operation.lock"
 
@@ -125,6 +135,20 @@ class TaskFamilyStorage:
                 raise ValueError("immutable plan digest mismatch; create a new operation instead of replacing this plan")
             return
         atomic_write_json(self.plan_path, plan.to_dict())
+
+    def write_immutable_json(self, path: Path, payload: dict[str, Any]) -> None:
+        """Write a stable operation document once, rejecting replacement drift."""
+        if path.exists():
+            if self.read_json(path) != payload:
+                raise ValueError(f"immutable operation document mismatch: {path.name}")
+            return
+        atomic_write_json(path, payload)
+
+    def write_execution(self, payload: dict[str, Any]) -> None:
+        self.write_immutable_json(self.execution_path, payload)
+
+    def load_execution(self) -> dict[str, Any]:
+        return self.read_json(self.execution_path)
 
     def load_plan(self) -> TaskFamilyPlan:
         return TaskFamilyPlan.from_dict(self.read_json(self.plan_path))

--- a/tests/orchestration/task_family/test_cli.py
+++ b/tests/orchestration/task_family/test_cli.py
@@ -249,6 +249,27 @@ def test_conflicting_graph_blocks_preview_without_db_or_git_mutation(tmp_path: P
         assert connection.execute("SELECT archived FROM threads WHERE id = ?", (root,)).fetchone()[0] == 0
 
 
+def test_preview_archive_unknown_selection_returns_blocker_without_key_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    repo = _repo(tmp_path)
+    root, unknown = str(uuid4()), str(uuid4())
+    manifest = TaskFamilyManifest("unknown-selection", root, (TaskNode(root, "Root", str(repo)),), ())
+    path = tmp_path / "unknown-selection.json"
+    _write_manifest(path, manifest)
+    db = tmp_path / "state_unknown.sqlite"
+    _write_db(db, [(root, "Root", str(repo), 0, None, "test-host")])
+
+    assert cli.main([
+        "preview-archive", "--repo-root", str(repo), "--manifest", str(path),
+        "--operation-id", str(uuid4()), "--lineage-id", str(uuid4()), "--base-title", "Repair",
+        "--db", str(db), "--select-task", unknown, "--actor", "operator",
+        "--confirm-pin-unknown", unknown, "--json",
+    ]) == cli.EXIT_BLOCKED
+    payload = json.loads(capsys.readouterr().out)
+    assert "unknown_selected_task" in {item["code"] for item in payload["planner_blockers"]}
+
+
 def test_preview_archive_blocks_explicitly_active_task_metadata(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     repo = _repo(tmp_path)
     task_id = str(uuid4())

--- a/tests/orchestration/task_family/test_cli.py
+++ b/tests/orchestration/task_family/test_cli.py
@@ -338,7 +338,14 @@ def test_reconcile_title_and_partial_archive_retry_append_receipts(tmp_path: Pat
     assert cli.main(restore) == cli.EXIT_BLOCKED
     assert storage.load_receipt().failures[-1].action == "restore"
     assert storage.load_receipt().failures[-1].recovery
-    assert len(storage.load_events()) == 4
+    with sqlite3.connect(db) as connection:
+        connection.execute("UPDATE threads SET archived = 0, archived_at = NULL WHERE id = ?", (ids["worker"],))
+        connection.commit()
+    assert cli.main(restore) == cli.EXIT_OK
+    capsys.readouterr()
+    assert storage.load_receipt().restoration[-1].action == "restore"
+    assert storage.load_events()[-1].state is LifecycleState.VERIFIED
+    assert len(storage.load_events()) == 5
 
 
 def test_reconcile_title_rejects_rename_digest_drift_and_persists_failure(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -393,7 +400,19 @@ def test_apply_archive_uses_persisted_digest_zero_git_mutation_and_completed_rep
         "receipt", "--repo-root", str(repo), "--family-id", manifest.family_id,
         "--operation-id", operation, "--json",
     ]) == cli.EXIT_OK
-    assert json.loads(capsys.readouterr().out)["state"] == "tasks_archived"
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["final_state"] == "tasks_archived"
+    assert receipt["planned"]
+    assert receipt["actual"]
+    assert receipt["final_resources"]
+
+    assert cli.main([
+        "receipt", "--repo-root", str(repo), "--family-id", manifest.family_id,
+        "--operation-id", operation,
+    ]) == cli.EXIT_OK
+    human_receipt = capsys.readouterr().out
+    assert "Final state: tasks_archived" in human_receipt
+    assert "Actual: task:" in human_receipt
 
     calls = {"count": 0}
     original = cli.codex_state.await_task_target

--- a/tests/orchestration/task_family/test_cli.py
+++ b/tests/orchestration/task_family/test_cli.py
@@ -12,7 +12,13 @@ from uuid import uuid4
 import pytest
 
 from scripts.orchestration.task_family import cli, git_safety
-from scripts.orchestration.task_family.model import RelationType, TaskFamilyManifest, TaskNode, TaskRelation
+from scripts.orchestration.task_family.model import (
+    LifecycleState,
+    RelationType,
+    TaskFamilyManifest,
+    TaskNode,
+    TaskRelation,
+)
 from scripts.orchestration.task_family.storage import TaskFamilyStorage
 
 
@@ -163,7 +169,7 @@ def test_preview_rename_persists_immutable_mapping_and_requires_each_pin_confirm
     assert cli.main(args) == cli.EXIT_OK
     payload = json.loads(capsys.readouterr().out)
     replacement = next(item for item in payload["rename_map"] if item["task_id"] == ids["replacement"])
-    assert replacement["new_title"] == "Lifecycle repair [Replacement · Generation 1]"
+    assert replacement["new_title"] == "Lifecycle repair [Repl. · Gen. 1]"
     storage = TaskFamilyStorage(repo, manifest.family_id, operation)
     assert storage.rename_plan_path.exists()
     assert storage.manifest_path.exists()
@@ -292,6 +298,7 @@ def test_reconcile_title_and_partial_archive_retry_append_receipts(tmp_path: Pat
     title_storage = TaskFamilyStorage(repo, manifest.family_id, rename_operation)
     assert len(title_storage.load_receipt().actual) == 1
     assert title_storage.load_receipt().actual[0].action == "title"
+    assert title_storage.load_events()[-1].state is LifecycleState.VERIFIED
 
     assert cli.main(title_reconcile) == cli.EXIT_OK
     capsys.readouterr()
@@ -320,9 +327,10 @@ def test_reconcile_title_and_partial_archive_retry_append_receipts(tmp_path: Pat
         connection.commit()
     assert cli.main(reconcile) == cli.EXIT_OK
     assert json.loads(capsys.readouterr().out)["thread"]["archived"] is True
+    storage = TaskFamilyStorage(repo, manifest.family_id, operation)
+    assert storage.load_events()[-1].state is LifecycleState.TASKS_ARCHIVED
     assert cli.main(reconcile) == cli.EXIT_OK
     capsys.readouterr()
-    storage = TaskFamilyStorage(repo, manifest.family_id, operation)
     assert len([item for item in storage.load_receipt().actual if item.action == "archive"]) == 1
     assert any(item.action == "archive_retry_readback" for item in storage.load_receipt().skipped)
     restore = reconcile.copy()

--- a/tests/orchestration/task_family/test_cli.py
+++ b/tests/orchestration/task_family/test_cli.py
@@ -36,6 +36,25 @@ def _repo(tmp_path: Path) -> Path:
     return repo
 
 
+def _managed_worktree(repo: Path, branch: str = "codex/cleanup-cli") -> Path:
+    worktree = repo.parent / "managed"
+    _git(repo, "worktree", "add", "-b", branch, str(worktree))
+    return worktree
+
+
+def _merged_pr_evidence(repo: Path, branch: str, number: int, base: str = "main") -> dict[str, object]:
+    return {
+        "number": number,
+        "state": "MERGED",
+        "head_ref_name": branch,
+        "head_ref_oid": git_safety.local_branch_head(repo, branch),
+        "base_ref_name": base,
+        "merge_state_status": "CLEAN",
+        "is_cross_repository": False,
+        "merge_commit": git_safety.local_branch_head(repo, branch),
+    }
+
+
 def _write_db(path: Path, rows: list[tuple[str, str, str, int, str | None, str]]) -> None:
     connection = sqlite3.connect(path)
     connection.execute(
@@ -148,6 +167,9 @@ def test_preview_rename_persists_immutable_mapping_and_requires_each_pin_confirm
     storage = TaskFamilyStorage(repo, manifest.family_id, operation)
     assert storage.rename_plan_path.exists()
     assert storage.manifest_path.exists()
+    receipt = storage.load_receipt()
+    assert receipt.plan_digest == payload["digest"]
+    assert {item.action for item in receipt.planned} == {"reconcile_title"}
 
     incomplete = args.copy()
     confirmation_index = incomplete.index("--confirm-pin-unknown", incomplete.index("--actor"))
@@ -157,6 +179,30 @@ def test_preview_rename_persists_immutable_mapping_and_requires_each_pin_confirm
     incomplete[incomplete.index("--operation-id") + 1] = str(uuid4())
     assert cli.main(incomplete) == cli.EXIT_BLOCKED
     assert "pin_state_unconfirmed" in json.loads(capsys.readouterr().out)["planner_blockers"][0]["code"]
+
+
+def test_preview_rename_blocks_partial_family_and_never_persists_unselected_mapping(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = _repo(tmp_path)
+    manifest, ids = _manifest(repo)
+    path = tmp_path / "manifest.json"
+    _write_manifest(path, manifest)
+    selected = [ids["root"], ids["worker"]]
+    args = [
+        "preview-rename", "--repo-root", str(repo), "--manifest", str(path),
+        "--operation-id", str(uuid4()), "--base-title", "Lifecycle repair",
+    ]
+    for task_id in selected:
+        args.extend(("--select-task", task_id))
+    args.extend(("--actor", "operator"))
+    for task_id in selected:
+        args.extend(("--confirm-pin-unknown", task_id))
+    args.append("--json")
+
+    assert cli.main(args) == cli.EXIT_BLOCKED
+    payload = json.loads(capsys.readouterr().out)
+    assert {item["task_id"] for item in payload["rename_map"]} == set(selected)
+    assert ids["unrelated"] not in {item["task_id"] for item in payload["rename_map"]}
+    assert any(item["code"] == "partial_family_rename_selection" for item in payload["planner_blockers"])
 
 
 def test_conflicting_graph_blocks_preview_without_db_or_git_mutation(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -189,6 +235,28 @@ def test_conflicting_graph_blocks_preview_without_db_or_git_mutation(tmp_path: P
         assert connection.execute("SELECT archived FROM threads WHERE id = ?", (root,)).fetchone()[0] == 0
 
 
+def test_preview_archive_blocks_explicitly_active_task_metadata(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = _repo(tmp_path)
+    task_id = str(uuid4())
+    manifest = TaskFamilyManifest(
+        "active-task",
+        task_id,
+        (TaskNode(task_id, "Active", str(repo), metadata={"cwd": str(repo), "status": "running"}),),
+        (),
+    )
+    path = tmp_path / "active.json"
+    _write_manifest(path, manifest)
+    db = tmp_path / "state_5.sqlite"
+    _write_db(db, [(task_id, "Active", str(repo), 0, None, "test-host")])
+    assert cli.main([
+        "preview-archive", "--repo-root", str(repo), "--manifest", str(path),
+        "--operation-id", str(uuid4()), "--lineage-id", str(uuid4()), "--base-title", "Active",
+        "--db", str(db), "--select-task", task_id, "--actor", "operator",
+        "--confirm-pin-unknown", task_id, "--json",
+    ]) == cli.EXIT_BLOCKED
+    assert "selected_task_active" in {item["code"] for item in json.loads(capsys.readouterr().out)["planner_blockers"]}
+
+
 def test_reconcile_title_and_partial_archive_retry_append_receipts(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     repo = _repo(tmp_path)
     manifest, ids = _manifest(repo)
@@ -200,12 +268,45 @@ def test_reconcile_title_and_partial_archive_retry_append_receipts(tmp_path: Pat
         title = "Planner" if name in {"root", "unrelated"} else {"worker": "Implementation", "review": "Review", "handoff": "Continuation", "replacement": "Continuation"}[name]
         rows.append((task_id, title, str(repo), 1 if name != "worker" else 0, "2026-07-14T00:00:00Z" if name != "worker" else None, "test-host"))
     _write_db(db, rows)
+    rename_operation = str(uuid4())
+    rename_args = [
+        "preview-rename", "--repo-root", str(repo), "--manifest", str(path),
+        "--operation-id", rename_operation, "--base-title", "Lifecycle repair",
+        *_selection_args(ids), "--json",
+    ]
+    assert cli.main(rename_args) == cli.EXIT_OK
+    rename_preview = json.loads(capsys.readouterr().out)
+    new_title = next(item["new_title"] for item in rename_preview["rename_map"] if item["task_id"] == ids["root"])
+    with sqlite3.connect(db) as connection:
+        connection.execute("UPDATE threads SET title = ? WHERE id = ?", (new_title, ids["root"]))
+        connection.commit()
+
+    title_reconcile = [
+        "reconcile-title", "--repo-root", str(repo), "--family-id", manifest.family_id,
+        "--operation-id", rename_operation, "--plan-digest", rename_preview["digest"],
+        "--db", str(db), "--task-id", ids["root"], "--cwd", str(repo),
+        "--expected-title", new_title, "--host", "test-host",
+    ]
+    assert cli.main(title_reconcile) == cli.EXIT_OK
+    assert json.loads(capsys.readouterr().out)["ok"] is True
+    title_storage = TaskFamilyStorage(repo, manifest.family_id, rename_operation)
+    assert len(title_storage.load_receipt().actual) == 1
+    assert title_storage.load_receipt().actual[0].action == "title"
+
+    assert cli.main(title_reconcile) == cli.EXIT_OK
+    capsys.readouterr()
+    assert len(title_storage.load_receipt().actual) == 1
+    assert len(title_storage.load_receipt().skipped) == 1
+    with sqlite3.connect(db) as connection:
+        connection.execute("UPDATE threads SET title = ? WHERE id = ?", ("wrong title", ids["root"]))
+        connection.commit()
+    assert cli.main(title_reconcile) == cli.EXIT_BLOCKED
+    assert title_storage.load_receipt().failures[-1].error
+    assert title_storage.load_receipt().failures[-1].recovery
+
     operation, lineage = str(uuid4()), str(uuid4())
     assert cli.main(_preview_args("preview-archive", repo, path, db, ids, operation, lineage)) == cli.EXIT_OK
     capsys.readouterr()
-
-    assert cli.main(["reconcile-title", "--db", str(db), "--task-id", ids["root"], "--cwd", str(repo), "--expected-title", "Planner", "--host", "test-host"]) == cli.EXIT_OK
-    assert json.loads(capsys.readouterr().out)["ok"] is True
 
     reconcile = [
         "reconcile-archive", "--repo-root", str(repo), "--family-id", manifest.family_id,
@@ -219,8 +320,45 @@ def test_reconcile_title_and_partial_archive_retry_append_receipts(tmp_path: Pat
         connection.commit()
     assert cli.main(reconcile) == cli.EXIT_OK
     assert json.loads(capsys.readouterr().out)["thread"]["archived"] is True
+    assert cli.main(reconcile) == cli.EXIT_OK
+    capsys.readouterr()
     storage = TaskFamilyStorage(repo, manifest.family_id, operation)
-    assert len(storage.load_events()) == 2
+    assert len([item for item in storage.load_receipt().actual if item.action == "archive"]) == 1
+    assert any(item.action == "archive_retry_readback" for item in storage.load_receipt().skipped)
+    restore = reconcile.copy()
+    restore[0] = "reconcile-restore"
+    assert cli.main(restore) == cli.EXIT_BLOCKED
+    assert storage.load_receipt().failures[-1].action == "restore"
+    assert storage.load_receipt().failures[-1].recovery
+    assert len(storage.load_events()) == 4
+
+
+def test_reconcile_title_rejects_rename_digest_drift_and_persists_failure(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = _repo(tmp_path)
+    manifest, ids = _manifest(repo)
+    path = tmp_path / "manifest.json"
+    _write_manifest(path, manifest)
+    db = tmp_path / "state_5.sqlite"
+    _write_db(db, [(task_id, node.title, str(repo), 0, None, "test-host") for task_id, node in ((node.task_id, node) for node in manifest.nodes)])
+    operation = str(uuid4())
+    args = [
+        "preview-rename", "--repo-root", str(repo), "--manifest", str(path),
+        "--operation-id", operation, "--base-title", "Lifecycle repair", *_selection_args(ids), "--json",
+    ]
+    assert cli.main(args) == cli.EXIT_OK
+    preview = json.loads(capsys.readouterr().out)
+    storage = TaskFamilyStorage(repo, manifest.family_id, operation)
+    tampered = storage.read_json(storage.rename_plan_path)
+    tampered["rename_map"][0]["new_title"] = "tampered"
+    storage.rename_plan_path.write_text(json.dumps(tampered), encoding="utf-8")
+    task_id = ids["root"]
+    assert cli.main([
+        "reconcile-title", "--repo-root", str(repo), "--family-id", manifest.family_id,
+        "--operation-id", operation, "--plan-digest", preview["digest"], "--db", str(db),
+        "--task-id", task_id, "--cwd", str(repo), "--expected-title", "Lifecycle repair [Lead]", "--host", "test-host",
+    ]) == cli.EXIT_BLOCKED
+    assert "digest" in json.loads(capsys.readouterr().out)["error"]
+    assert storage.load_receipt().failures[-1].action == "title"
 
 
 def test_apply_archive_uses_persisted_digest_zero_git_mutation_and_completed_repeat_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
@@ -273,10 +411,11 @@ def test_apply_archive_uses_persisted_digest_zero_git_mutation_and_completed_rep
     assert "drifted" in capsys.readouterr().out
 
 
-def test_preview_cleanup_reports_only_explicit_owned_resource_targets(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_preview_cleanup_reports_read_only_evidence_for_registered_clean_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     repo = _repo(tmp_path)
     task_id = str(uuid4())
-    worktree = repo / "managed"
+    branch = "codex/cleanup-cli"
+    worktree = _managed_worktree(repo, branch)
     manifest = TaskFamilyManifest(
         "cleanup-cli",
         task_id,
@@ -286,9 +425,9 @@ def test_preview_cleanup_reports_only_explicit_owned_resource_targets(tmp_path: 
                 "Done",
                 str(repo),
                 worktree=str(worktree),
-                branch="codex/cleanup-cli",
+                branch=branch,
                 pr_id="42",
-                metadata={"cwd": str(repo), "worktree_family": "cleanup-cli", "pr_base": "main"},
+                metadata={"cwd": str(worktree), "worktree_family": "cleanup-cli", "pr_base": "main"},
             ),
         ),
         (),
@@ -296,7 +435,8 @@ def test_preview_cleanup_reports_only_explicit_owned_resource_targets(tmp_path: 
     path = tmp_path / "cleanup.json"
     _write_manifest(path, manifest)
     db = tmp_path / "state_5.sqlite"
-    _write_db(db, [(task_id, "Done", str(repo), 0, None, "test-host")])
+    _write_db(db, [(task_id, "Done", str(worktree), 0, None, "test-host")])
+    monkeypatch.setattr(git_safety, "query_pr_by_head", lambda *_args, **_kwargs: _merged_pr_evidence(repo, branch, 42))
     assert cli.main([
         "preview-cleanup", "--repo-root", str(repo), "--manifest", str(path),
         "--operation-id", str(uuid4()), "--lineage-id", str(uuid4()), "--base-title", "Done",
@@ -308,3 +448,40 @@ def test_preview_cleanup_reports_only_explicit_owned_resource_targets(tmp_path: 
         "id": task_id, "worktree": str(worktree), "branch": "codex/cleanup-cli",
         "pr_number": 42, "pr_base": "main", "explicit_family": "cleanup-cli",
     }]
+    assert payload["cleanup_evidence"] == [{
+        "task_id": task_id, "worktree": str(worktree), "expected_branch": branch, "expected_pr": 42,
+        "registered": True, "permanent": False, "dirty": False, "locked": False, "prunable": False,
+        "index_locked": False, "registered_branch": branch,
+        "registered_head": git_safety.local_branch_head(repo, branch),
+        "expected_head": git_safety.local_branch_head(repo, branch), "task_cwd": str(worktree),
+        "cwd_owns_worktree": True, "pr": _merged_pr_evidence(repo, branch, 42),
+    }]
+
+
+@pytest.mark.parametrize("kind", ["dirty", "permanent", "unregistered"])
+def test_preview_cleanup_blocks_unsafe_local_evidence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], kind: str) -> None:
+    repo = _repo(tmp_path)
+    task_id = str(uuid4())
+    branch = "codex/cleanup-evidence"
+    worktree = _managed_worktree(repo, branch) if kind == "dirty" else (repo if kind == "permanent" else repo / "missing")
+    if kind == "dirty":
+        (worktree / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+    expected_branch = branch if kind == "dirty" else "main"
+    manifest = TaskFamilyManifest(
+        f"cleanup-{kind}", task_id,
+        (TaskNode(task_id, "Done", str(repo), worktree=str(worktree), branch=expected_branch, pr_id="42", metadata={"cwd": str(worktree), "worktree_family": f"cleanup-{kind}", "pr_base": "main"}),),
+        (),
+    )
+    path = tmp_path / f"{kind}.json"
+    _write_manifest(path, manifest)
+    db = tmp_path / "state_5.sqlite"
+    _write_db(db, [(task_id, "Done", str(worktree), 0, None, "test-host")])
+    monkeypatch.setattr(git_safety, "query_pr_by_head", lambda *_args, **_kwargs: _merged_pr_evidence(repo, expected_branch, 42))
+    assert cli.main([
+        "preview-cleanup", "--repo-root", str(repo), "--manifest", str(path),
+        "--operation-id", str(uuid4()), "--lineage-id", str(uuid4()), "--base-title", "Done", "--db", str(db),
+        "--select-task", task_id, "--actor", "operator", "--confirm-pin-unknown", task_id, "--json",
+    ]) == cli.EXIT_BLOCKED
+    payload = json.loads(capsys.readouterr().out)
+    codes = {item["code"] for item in payload["planner_blockers"]}
+    assert {"dirty": "dirty_worktree", "permanent": "permanent_worktree", "unregistered": "unregistered_worktree"}[kind] in codes

--- a/tests/orchestration/task_family/test_cli.py
+++ b/tests/orchestration/task_family/test_cli.py
@@ -1,0 +1,310 @@
+"""End-to-end tests for the noninteractive task-family CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from scripts.orchestration.task_family import cli, git_safety
+from scripts.orchestration.task_family.model import RelationType, TaskFamilyManifest, TaskNode, TaskRelation
+from scripts.orchestration.task_family.storage import TaskFamilyStorage
+
+
+def _git_env() -> dict[str, str]:
+    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+
+
+def _git(cwd: Path, *args: str) -> None:
+    result = subprocess.run(["git", *args], cwd=cwd, env=_git_env(), capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    _git(tmp_path, "init", "--initial-branch=main", str(repo))
+    _git(repo, "config", "user.email", "cli@example.invalid")
+    _git(repo, "config", "user.name", "CLI test")
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "seed")
+    return repo
+
+
+def _write_db(path: Path, rows: list[tuple[str, str, str, int, str | None, str]]) -> None:
+    connection = sqlite3.connect(path)
+    connection.execute(
+        "CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT, cwd TEXT, "
+        "archived INTEGER, archived_at TEXT, host TEXT)"
+    )
+    connection.executemany("INSERT INTO threads VALUES (?, ?, ?, ?, ?, ?)", rows)
+    connection.commit()
+    connection.close()
+
+
+def _manifest(repo: Path) -> tuple[TaskFamilyManifest, dict[str, str]]:
+    task_ids = {name: str(uuid4()) for name in ("root", "worker", "review", "handoff", "replacement", "unrelated")}
+    nodes = tuple(
+        TaskNode(task_id, title, str(repo), metadata={"cwd": str(repo), "host": "test-host"})
+        for name, task_id, title in (
+            ("root", task_ids["root"], "Planner"),
+            ("worker", task_ids["worker"], "Implementation"),
+            ("review", task_ids["review"], "Review"),
+            ("handoff", task_ids["handoff"], "Continuation"),
+            ("replacement", task_ids["replacement"], "Continuation"),
+            ("unrelated", task_ids["unrelated"], "Planner"),
+        )
+    )
+    relations = (
+        TaskRelation(task_ids["worker"], task_ids["root"], RelationType.SUBAGENT_OF, "spawn"),
+        TaskRelation(task_ids["review"], task_ids["worker"], RelationType.REVIEWER_FOR, "review"),
+        TaskRelation(task_ids["handoff"], task_ids["worker"], RelationType.HANDOFF_OF, "handoff"),
+        TaskRelation(task_ids["replacement"], task_ids["handoff"], RelationType.REPLACEMENT_OF, "replacement"),
+        TaskRelation(task_ids["replacement"], task_ids["handoff"], RelationType.ROLLOVER_GENERATION_OF, "generation"),
+    )
+    return TaskFamilyManifest("family-cli", task_ids["root"], nodes, relations), task_ids
+
+
+def _write_manifest(path: Path, manifest: TaskFamilyManifest) -> None:
+    path.write_text(json.dumps(manifest.to_dict()), encoding="utf-8")
+
+
+def _selection_args(ids: dict[str, str]) -> list[str]:
+    selected = [ids[name] for name in ("root", "worker", "review", "handoff", "replacement")]
+    args: list[str] = []
+    for task_id in selected:
+        args.extend(("--select-task", task_id))
+    args.extend(("--actor", "operator"))
+    for task_id in selected:
+        args.extend(("--confirm-pin-unknown", task_id))
+    return args
+
+
+def _preview_args(command: str, repo: Path, manifest_path: Path, db: Path, ids: dict[str, str], operation: str, lineage: str) -> list[str]:
+    return [
+        command,
+        "--repo-root",
+        str(repo),
+        "--manifest",
+        str(manifest_path),
+        "--operation-id",
+        operation,
+        "--lineage-id",
+        lineage,
+        "--base-title",
+        "Lifecycle repair",
+        "--db",
+        str(db),
+        *_selection_args(ids),
+    ]
+
+
+def test_inspect_renders_roles_counts_and_similar_title_exclusion(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = _repo(tmp_path)
+    manifest, ids = _manifest(repo)
+    path = tmp_path / "manifest.json"
+    _write_manifest(path, manifest)
+
+    assert cli.main(["inspect", "--manifest", str(path), "--json"]) == cli.EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["included"] == 5
+    assert payload["counts"]["excluded"] == 1
+    assert payload["excluded"] == [{"task_id": ids["unrelated"], "title": "Planner", "reason": "outside exact-ID seed component"}]
+    assert next(task for task in payload["tasks"] if task["task_id"] == ids["replacement"])["roles"] == ["Replacement", "Generation 1"]
+
+    assert cli.main(["inspect", "--manifest", str(path)]) == cli.EXIT_OK
+    assert "excluded" in capsys.readouterr().out
+
+
+def test_preview_rename_persists_immutable_mapping_and_requires_each_pin_confirmation(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = _repo(tmp_path)
+    manifest, ids = _manifest(repo)
+    path = tmp_path / "manifest.json"
+    _write_manifest(path, manifest)
+    operation = str(uuid4())
+    args = [
+        "preview-rename",
+        "--repo-root",
+        str(repo),
+        "--manifest",
+        str(path),
+        "--operation-id",
+        operation,
+        "--base-title",
+        "Lifecycle repair",
+        *_selection_args(ids),
+        "--json",
+    ]
+
+    assert cli.main(args) == cli.EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    replacement = next(item for item in payload["rename_map"] if item["task_id"] == ids["replacement"])
+    assert replacement["new_title"] == "Lifecycle repair [Replacement · Generation 1]"
+    storage = TaskFamilyStorage(repo, manifest.family_id, operation)
+    assert storage.rename_plan_path.exists()
+    assert storage.manifest_path.exists()
+
+    incomplete = args.copy()
+    confirmation_index = incomplete.index("--confirm-pin-unknown", incomplete.index("--actor"))
+    while incomplete[confirmation_index + 1] != ids["worker"]:
+        confirmation_index = incomplete.index("--confirm-pin-unknown", confirmation_index + 1)
+    del incomplete[confirmation_index : confirmation_index + 2]
+    incomplete[incomplete.index("--operation-id") + 1] = str(uuid4())
+    assert cli.main(incomplete) == cli.EXIT_BLOCKED
+    assert "pin_state_unconfirmed" in json.loads(capsys.readouterr().out)["planner_blockers"][0]["code"]
+
+
+def test_conflicting_graph_blocks_preview_without_db_or_git_mutation(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = _repo(tmp_path)
+    root, one, two = str(uuid4()), str(uuid4()), str(uuid4())
+    manifest = TaskFamilyManifest(
+        "conflict",
+        root,
+        (TaskNode(root, "Root", str(repo)), TaskNode(one, "One", str(repo)), TaskNode(two, "Two", str(repo))),
+        (
+            TaskRelation(root, one, RelationType.ROLLOVER_GENERATION_OF, "one"),
+            TaskRelation(root, two, RelationType.ROLLOVER_GENERATION_OF, "two"),
+        ),
+    )
+    path = tmp_path / "conflict.json"
+    _write_manifest(path, manifest)
+    db = tmp_path / "state_5.sqlite"
+    _write_db(db, [(root, "Root", str(repo), 0, None, "test-host")])
+    operation, lineage = str(uuid4()), str(uuid4())
+    args = [
+        "preview-archive",
+        "--repo-root", str(repo), "--manifest", str(path), "--operation-id", operation,
+        "--lineage-id", lineage, "--base-title", "Repair", "--db", str(db),
+        "--select-task", root, "--actor", "operator", "--confirm-pin-unknown", root, "--json",
+    ]
+    assert cli.main(args) == cli.EXIT_BLOCKED
+    payload = json.loads(capsys.readouterr().out)
+    assert any(item["code"] == "conflicting_membership" for item in payload["planner_blockers"])
+    with sqlite3.connect(db) as connection:
+        assert connection.execute("SELECT archived FROM threads WHERE id = ?", (root,)).fetchone()[0] == 0
+
+
+def test_reconcile_title_and_partial_archive_retry_append_receipts(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = _repo(tmp_path)
+    manifest, ids = _manifest(repo)
+    path = tmp_path / "manifest.json"
+    _write_manifest(path, manifest)
+    db = tmp_path / "state_5.sqlite"
+    rows = []
+    for name, task_id in ids.items():
+        title = "Planner" if name in {"root", "unrelated"} else {"worker": "Implementation", "review": "Review", "handoff": "Continuation", "replacement": "Continuation"}[name]
+        rows.append((task_id, title, str(repo), 1 if name != "worker" else 0, "2026-07-14T00:00:00Z" if name != "worker" else None, "test-host"))
+    _write_db(db, rows)
+    operation, lineage = str(uuid4()), str(uuid4())
+    assert cli.main(_preview_args("preview-archive", repo, path, db, ids, operation, lineage)) == cli.EXIT_OK
+    capsys.readouterr()
+
+    assert cli.main(["reconcile-title", "--db", str(db), "--task-id", ids["root"], "--cwd", str(repo), "--expected-title", "Planner", "--host", "test-host"]) == cli.EXIT_OK
+    assert json.loads(capsys.readouterr().out)["ok"] is True
+
+    reconcile = [
+        "reconcile-archive", "--repo-root", str(repo), "--family-id", manifest.family_id,
+        "--operation-id", operation, "--db", str(db), "--task-id", ids["worker"],
+        "--cwd", str(repo), "--expected-title", "Implementation", "--host", "test-host",
+    ]
+    assert cli.main(reconcile) == cli.EXIT_BLOCKED
+    assert json.loads(capsys.readouterr().out)["ok"] is False
+    with sqlite3.connect(db) as connection:
+        connection.execute("UPDATE threads SET archived = 1, archived_at = ? WHERE id = ?", ("2026-07-14T01:00:00Z", ids["worker"]))
+        connection.commit()
+    assert cli.main(reconcile) == cli.EXIT_OK
+    assert json.loads(capsys.readouterr().out)["thread"]["archived"] is True
+    storage = TaskFamilyStorage(repo, manifest.family_id, operation)
+    assert len(storage.load_events()) == 2
+
+
+def test_apply_archive_uses_persisted_digest_zero_git_mutation_and_completed_repeat_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = _repo(tmp_path)
+    manifest, ids = _manifest(repo)
+    path = tmp_path / "manifest.json"
+    _write_manifest(path, manifest)
+    db = tmp_path / "state_5.sqlite"
+    titles = {"root": "Planner", "worker": "Implementation", "review": "Review", "handoff": "Continuation", "replacement": "Continuation", "unrelated": "Planner"}
+    _write_db(db, [(task_id, titles[name], str(repo), 1, "2026-07-14T00:00:00Z", "test-host") for name, task_id in ids.items()])
+    operation, lineage = str(uuid4()), str(uuid4())
+    assert cli.main(_preview_args("preview-archive", repo, path, db, ids, operation, lineage)) == cli.EXIT_OK
+    preview = capsys.readouterr().out
+    digest = next(line.split(": ", 1)[1] for line in preview.splitlines() if line.startswith("Plan digest:"))
+    monkeypatch.setattr(git_safety, "run_git", lambda *_args, **_kwargs: pytest.fail("archive-only called git"))
+    apply = [
+        "apply-cleanup", "--repo-root", str(repo), "--family-id", manifest.family_id,
+        "--operation-id", operation, "--lineage-id", lineage, "--plan-digest", digest,
+    ]
+    assert cli.main(apply) == cli.EXIT_OK
+    assert "tasks_archived" in capsys.readouterr().out
+
+    assert cli.main([
+        "receipt", "--repo-root", str(repo), "--family-id", manifest.family_id,
+        "--operation-id", operation, "--json",
+    ]) == cli.EXIT_OK
+    assert json.loads(capsys.readouterr().out)["state"] == "tasks_archived"
+
+    calls = {"count": 0}
+    original = cli.codex_state.await_task_target
+
+    def counted(*args: object, **kwargs: object):
+        calls["count"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(cli.codex_state, "await_task_target", counted)
+    assert cli.main(apply) == cli.EXIT_OK
+    assert calls["count"] == 0
+
+    drift = apply.copy()
+    drift[-1] = "0" * 64
+    assert cli.main(drift) == cli.EXIT_BLOCKED
+    assert "digest" in capsys.readouterr().out
+
+    storage = TaskFamilyStorage(repo, manifest.family_id, operation)
+    execution_data = storage.load_execution()
+    execution_data["target_db"] = str(tmp_path / "other.sqlite")
+    storage.execution_path.write_text(json.dumps(execution_data), encoding="utf-8")
+    assert cli.main(apply) == cli.EXIT_BLOCKED
+    assert "drifted" in capsys.readouterr().out
+
+
+def test_preview_cleanup_reports_only_explicit_owned_resource_targets(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = _repo(tmp_path)
+    task_id = str(uuid4())
+    worktree = repo / "managed"
+    manifest = TaskFamilyManifest(
+        "cleanup-cli",
+        task_id,
+        (
+            TaskNode(
+                task_id,
+                "Done",
+                str(repo),
+                worktree=str(worktree),
+                branch="codex/cleanup-cli",
+                pr_id="42",
+                metadata={"cwd": str(repo), "worktree_family": "cleanup-cli", "pr_base": "main"},
+            ),
+        ),
+        (),
+    )
+    path = tmp_path / "cleanup.json"
+    _write_manifest(path, manifest)
+    db = tmp_path / "state_5.sqlite"
+    _write_db(db, [(task_id, "Done", str(repo), 0, None, "test-host")])
+    assert cli.main([
+        "preview-cleanup", "--repo-root", str(repo), "--manifest", str(path),
+        "--operation-id", str(uuid4()), "--lineage-id", str(uuid4()), "--base-title", "Done",
+        "--db", str(db), "--select-task", task_id, "--actor", "operator",
+        "--confirm-pin-unknown", task_id, "--json",
+    ]) == cli.EXIT_OK
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["resources"]["worktree_targets"] == [{
+        "id": task_id, "worktree": str(worktree), "branch": "codex/cleanup-cli",
+        "pr_number": 42, "pr_base": "main", "explicit_family": "cleanup-cli",
+    }]

--- a/tests/orchestration/task_family/test_cli.py
+++ b/tests/orchestration/task_family/test_cli.py
@@ -23,7 +23,11 @@ from scripts.orchestration.task_family.storage import TaskFamilyStorage
 
 
 def _git_env() -> dict[str, str]:
-    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_") and key != "AGENT_NO_MERGE"
+    }
 
 
 def _git(cwd: Path, *args: str) -> None:
@@ -139,11 +143,15 @@ def test_inspect_renders_roles_counts_and_similar_title_exclusion(tmp_path: Path
     payload = json.loads(capsys.readouterr().out)
     assert payload["counts"]["included"] == 5
     assert payload["counts"]["excluded"] == 1
+    assert payload["roots"] == [ids["root"]]
+    assert len(payload["relations"]) == 5
     assert payload["excluded"] == [{"task_id": ids["unrelated"], "title": "Planner", "reason": "outside exact-ID seed component"}]
     assert next(task for task in payload["tasks"] if task["task_id"] == ids["replacement"])["roles"] == ["Replacement", "Generation 1"]
 
     assert cli.main(["inspect", "--manifest", str(path)]) == cli.EXIT_OK
-    assert "excluded" in capsys.readouterr().out
+    human = capsys.readouterr().out
+    assert "excluded" in human
+    assert "-[replacement_of]->" in human
 
 
 def test_preview_rename_persists_immutable_mapping_and_requires_each_pin_confirmation(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -261,6 +269,37 @@ def test_preview_archive_blocks_explicitly_active_task_metadata(tmp_path: Path, 
         "--confirm-pin-unknown", task_id, "--json",
     ]) == cli.EXIT_BLOCKED
     assert "selected_task_active" in {item["code"] for item in json.loads(capsys.readouterr().out)["planner_blockers"]}
+
+
+def test_preview_cleanup_blocks_rollover_without_explicit_cleanup_proof(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = _repo(tmp_path)
+    root_id, replacement_id = str(uuid4()), str(uuid4())
+    manifest = TaskFamilyManifest(
+        "rollover-proof",
+        root_id,
+        (
+            TaskNode(root_id, "Root", str(repo), metadata={"cwd": str(repo), "status": "completed"}),
+            TaskNode(replacement_id, "Replacement", str(repo), metadata={"cwd": str(repo), "status": "completed"}),
+        ),
+        (TaskRelation(replacement_id, root_id, RelationType.ROLLOVER_GENERATION_OF, "explicit rollover"),),
+    )
+    path = tmp_path / "rollover-proof.json"
+    _write_manifest(path, manifest)
+    db = tmp_path / "state_5.sqlite"
+    _write_db(db, [
+        (root_id, "Root", str(repo), 0, None, "test-host"),
+        (replacement_id, "Replacement", str(repo), 0, None, "test-host"),
+    ])
+    assert cli.main([
+        "preview-cleanup", "--repo-root", str(repo), "--manifest", str(path),
+        "--operation-id", str(uuid4()), "--lineage-id", str(uuid4()), "--base-title", "Done",
+        "--db", str(db), "--select-task", root_id, "--select-task", replacement_id,
+        "--actor", "operator", "--confirm-pin-unknown", root_id,
+        "--confirm-pin-unknown", replacement_id, "--json",
+    ]) == cli.EXIT_BLOCKED
+    assert "active_rollover_evidence" in {
+        item["code"] for item in json.loads(capsys.readouterr().out)["planner_blockers"]
+    }
 
 
 def test_reconcile_title_and_partial_archive_retry_append_receipts(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -454,7 +493,15 @@ def test_preview_cleanup_reports_read_only_evidence_for_registered_clean_target(
                 worktree=str(worktree),
                 branch=branch,
                 pr_id="42",
-                metadata={"cwd": str(worktree), "worktree_family": "cleanup-cli", "pr_base": "main"},
+                metadata={
+                    "cwd": str(worktree),
+                    "worktree_family": "cleanup-cli",
+                    "pr_base": "main",
+                    "status": "completed",
+                    "automation_id": "automation-42",
+                    "automation_cleanup_eligible": "true",
+                    "automation_cleanup_proof": "replacement confirmed by rollover lease",
+                },
             ),
         ),
         (),
@@ -475,6 +522,12 @@ def test_preview_cleanup_reports_read_only_evidence_for_registered_clean_target(
         "id": task_id, "worktree": str(worktree), "branch": "codex/cleanup-cli",
         "pr_number": 42, "pr_base": "main", "explicit_family": "cleanup-cli",
     }]
+    assert payload["resources"]["runtime_targets"] == [{
+        "id": task_id,
+        "kind": "automation",
+        "eligible": True,
+        "proof": "automation-42: replacement confirmed by rollover lease",
+    }]
     assert payload["cleanup_evidence"] == [{
         "task_id": task_id, "worktree": str(worktree), "expected_branch": branch, "expected_pr": 42,
         "registered": True, "permanent": False, "dirty": False, "locked": False, "prunable": False,
@@ -483,6 +536,68 @@ def test_preview_cleanup_reports_read_only_evidence_for_registered_clean_target(
         "expected_head": git_safety.local_branch_head(repo, branch), "task_cwd": str(worktree),
         "cwd_owns_worktree": True, "pr": _merged_pr_evidence(repo, branch, 42),
     }]
+
+    unknown_manifest = TaskFamilyManifest(
+        "cleanup-cli",
+        task_id,
+        (
+            TaskNode(
+                task_id,
+                "Done",
+                str(repo),
+                worktree=str(worktree),
+                branch=branch,
+                pr_id="42",
+                metadata={"cwd": str(worktree), "worktree_family": "cleanup-cli", "pr_base": "main"},
+            ),
+        ),
+        (),
+    )
+    unknown_path = tmp_path / "cleanup-unknown-state.json"
+    _write_manifest(unknown_path, unknown_manifest)
+    assert cli.main([
+        "preview-cleanup", "--repo-root", str(repo), "--manifest", str(unknown_path),
+        "--operation-id", str(uuid4()), "--lineage-id", str(uuid4()), "--base-title", "Done",
+        "--db", str(db), "--select-task", task_id, "--actor", "operator",
+        "--confirm-pin-unknown", task_id, "--json",
+    ]) == cli.EXIT_BLOCKED
+    assert "task_completion_unproven" in {
+        item["code"] for item in json.loads(capsys.readouterr().out)["planner_blockers"]
+    }
+
+    unconfirmed_automation = TaskFamilyManifest(
+        "cleanup-cli",
+        task_id,
+        (
+            TaskNode(
+                task_id,
+                "Done",
+                str(repo),
+                worktree=str(worktree),
+                branch=branch,
+                pr_id="42",
+                metadata={
+                    "cwd": str(worktree),
+                    "worktree_family": "cleanup-cli",
+                    "pr_base": "main",
+                    "status": "completed",
+                    "automation_id": "automation-42",
+                },
+            ),
+        ),
+        (),
+    )
+    unconfirmed_path = tmp_path / "cleanup-unconfirmed-automation.json"
+    _write_manifest(unconfirmed_path, unconfirmed_automation)
+    assert cli.main([
+        "preview-cleanup", "--repo-root", str(repo), "--manifest", str(unconfirmed_path),
+        "--operation-id", str(uuid4()), "--lineage-id", str(uuid4()), "--base-title", "Done",
+        "--db", str(db), "--select-task", task_id, "--actor", "operator",
+        "--confirm-pin-unknown", task_id, "--json",
+    ]) == cli.EXIT_BLOCKED
+    assert "unconfirmed_predecessor_automation" in {
+        item["code"] for item in json.loads(capsys.readouterr().out)["planner_blockers"]
+    }
 
 
 @pytest.mark.parametrize("kind", ["dirty", "permanent", "unregistered"])
@@ -496,7 +611,7 @@ def test_preview_cleanup_blocks_unsafe_local_evidence(tmp_path: Path, monkeypatc
     expected_branch = branch if kind == "dirty" else "main"
     manifest = TaskFamilyManifest(
         f"cleanup-{kind}", task_id,
-        (TaskNode(task_id, "Done", str(repo), worktree=str(worktree), branch=expected_branch, pr_id="42", metadata={"cwd": str(worktree), "worktree_family": f"cleanup-{kind}", "pr_base": "main"}),),
+        (TaskNode(task_id, "Done", str(repo), worktree=str(worktree), branch=expected_branch, pr_id="42", metadata={"cwd": str(worktree), "worktree_family": f"cleanup-{kind}", "pr_base": "main", "status": "completed"}),),
         (),
     )
     path = tmp_path / f"{kind}.json"

--- a/tests/orchestration/task_family/test_executor.py
+++ b/tests/orchestration/task_family/test_executor.py
@@ -1,4 +1,4 @@
-"""Tests for cleanup state-machine and Codex-state bridge primitives."""
+"""Tests for the task-family cleanup executor's fail-closed boundaries."""
 
 from __future__ import annotations
 
@@ -6,559 +6,285 @@ import json
 import os
 import sqlite3
 import subprocess
-import time
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
-from scripts.orchestration.task_family import codex_state, git_safety
-from scripts.orchestration.task_family.executor import CleanupExecutor, CleanupPlan, load_state
+from scripts.orchestration.task_family import codex_state, executor, git_safety
 
 
 def _git_env() -> dict[str, str]:
-    return {
-        key: value
-        for key, value in os.environ.items()
-        if not key.startswith("GIT_")
-    }
+    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
 
 
-def git(tmp_path: Path, *args: str) -> str:
-    completed = subprocess.run(
-        ["git", *args],
-        cwd=tmp_path,
-        check=False,
-        capture_output=True,
-        text=True,
-        env=_git_env(),
+def git(cwd: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args], cwd=cwd, check=False, capture_output=True, text=True, env=_git_env()
     )
-    assert completed.returncode == 0, completed.stderr or completed.stdout
-    return (completed.stdout or "").strip()
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    return proc.stdout.strip()
 
 
-def init_repo(tmp_path: Path) -> tuple[Path, Path]:
-    repo = tmp_path / "repo"
-    remote = tmp_path / "origin.git"
+def init_repo(tmp_path: Path) -> Path:
+    repo, remote = tmp_path / "repo", tmp_path / "origin.git"
     git(tmp_path, "init", "--initial-branch=main", str(repo))
     git(tmp_path, "init", "--bare", str(remote))
-    git(repo, "config", "user.email", "cleanup-tester@example.com")
-    git(repo, "config", "user.name", "Cleanup Executor")
-    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    git(repo, "config", "user.email", "cleanup@example.invalid")
+    git(repo, "config", "user.name", "Cleanup test")
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
     git(repo, "add", "README.md")
     git(repo, "commit", "-m", "seed")
     git(repo, "remote", "add", "origin", str(remote))
     git(repo, "push", "-u", "origin", "main")
-    return repo, remote
+    return repo
 
 
-def add_worktree_branch(repo: Path, branch: str, *, push_remote: bool = False) -> Path:
-    worktree = repo.parent / f"wt-{branch.replace('/', '-')}-{uuid4().hex[:6]}"
+def add_worktree(repo: Path, branch: str) -> Path:
+    worktree = repo.parent / f"worktree-{uuid4().hex}"
     git(repo, "worktree", "add", "-b", branch, str(worktree), "main")
-    (worktree / "payload.txt").write_text(f"{branch}\n", encoding="utf-8")
+    (worktree / "payload.txt").write_text(branch, encoding="utf-8")
     git(worktree, "add", "payload.txt")
-    git(worktree, "commit", "-m", f"worktree {branch}")
-    if push_remote:
-        git(worktree, "push", "-u", "origin", branch)
+    git(worktree, "commit", "-m", "payload")
     return worktree
 
 
-def write_codex_db(
-    path: Path,
-    *,
-    task_id: int,
-    title: str,
-    cwd: str,
-    archived: bool = False,
-    archived_at: str | None = None,
-    host: str = "runner-host",
-) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(path)
-    conn.execute(
-        "CREATE TABLE threads(id INTEGER PRIMARY KEY, title TEXT, cwd TEXT, archived INTEGER, archived_at TEXT, host TEXT)"
+def write_threads(path: Path, rows: list[dict[str, Any]]) -> None:
+    """Match Codex's production-shaped TEXT UUID ``threads`` table."""
+    connection = sqlite3.connect(path)
+    connection.execute(
+        "CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT, cwd TEXT, "
+        "archived INTEGER, archived_at TEXT, host TEXT)"
     )
-    conn.execute(
+    connection.executemany(
         "INSERT INTO threads(id,title,cwd,archived,archived_at,host) VALUES (?,?,?,?,?,?)",
-        (task_id, title, cwd, int(archived), archived_at, host),
+        [
+            (row["id"], row["title"], row["cwd"], row["archived"], row["archived_at"], row["host"])
+            for row in rows
+        ],
     )
-    conn.commit()
-    conn.close()
+    connection.commit()
+    connection.close()
 
 
-def make_plan(
+def task(task_id: str, *, title: str, cwd: Path, db_path: Path) -> executor.TaskTarget:
+    return executor.TaskTarget(task_id=task_id, title=title, cwd=str(cwd), db_path=db_path, host="host-a")
+
+
+def worktree_target(worktree: Path, branch: str, family: str, number: int = 7) -> executor.WorktreeTarget:
+    return executor.WorktreeTarget(
+        id=str(uuid4()), worktree=worktree, branch=branch, pr_number=number, pr_base="main", explicit_family=family
+    )
+
+
+def persisted(plan: executor.CleanupPlan, repo: Path) -> executor.CleanupPlan:
+    """Write the planner-owned immutable document; executor never writes it."""
+    payload = {
+        "schema_version": 1,
+        "family_id": plan.family_id,
+        "operation_id": plan.operation_id,
+        "operation": plan.mode,
+        "selected_task_ids": sorted(plan.selected_task_ids),
+    }
+    digest = executor._canonical_plan_digest(payload)
+    payload["digest"] = digest
+    path = executor.plan_path(repo, plan)
+    git_safety.write_json_atomic(path, payload)
+    git_safety.write_json_atomic(
+        executor.manifest_path(repo, plan),
+        {
+            "schema_version": 1,
+            "family_id": plan.family_id,
+            "seed_task_id": sorted(plan.selected_task_ids)[0] if plan.selected_task_ids else str(uuid4()),
+            "nodes": [{"task_id": task_id} for task_id in sorted(plan.selected_task_ids)],
+            "relations": [],
+        },
+    )
+    return replace(plan, persisted_plan_digest=digest)
+
+
+def plan(
     repo: Path,
-    worktree: Path,
-    db_path: Path,
     *,
-    lineage_id: str = "lineage-5140",
-    task_id: int = 1,
-    branch: str,
-) -> CleanupPlan:
-    return CleanupPlan(
-        task_id=task_id,
-        family="cleanup",
-        lineage_id=lineage_id,
-        title="Cleanup Task",
-        cwd=str(worktree),
-        branch=branch,
-        worktree=worktree,
-        thread_id=task_id,
-        db_path=db_path,
-        host="runner-host",
-        explicit_protected=frozenset({"forbidden/branch"}),
+    family: str,
+    mode: str,
+    task_targets: tuple[executor.TaskTarget, ...],
+    worktree_targets: tuple[executor.WorktreeTarget, ...] = (),
+    runtime_targets: tuple[executor.RuntimeTarget, ...] = (),
+) -> executor.CleanupPlan:
+    draft = executor.CleanupPlan(
+        operation_id=str(uuid4()),
+        family_id=family,
+        lineage_id=str(uuid4()),
+        mode=mode,
+        task_targets=task_targets,
+        worktree_targets=worktree_targets,
+        runtime_targets=runtime_targets,
+        selected_task_ids=frozenset(item.task_id for item in task_targets),
+        pin_unknown_confirmed=True,
+        persisted_plan_digest="0" * 64,
     )
+    return persisted(draft, repo)
 
 
-def mk_pr_payload(worktree: Path) -> dict[str, Any]:
-    head = git(worktree, "rev-parse", "HEAD")
+def pr(branch: str, head: str, number: int) -> dict[str, Any]:
     return {
-        "number": 42,
+        "number": number,
         "state": "MERGED",
-        "headRefOid": head,
-        "headRefName": worktree.name,
-        "baseRefName": "main",
-        "mergeStateStatus": "CLEAN",
-        "mergeCommit": "0" * 40,
-        "isCrossRepository": False,
+        "head_ref_oid": head,
+        "head_ref_name": branch,
+        "base_ref_name": "main",
+        "merge_state_status": "CLEAN",
+        "merge_commit": {"oid": head},
+        "is_cross_repository": False,
     }
 
 
-def test_codex_state_discovery_and_archive_restore(tmp_path: Path) -> None:
+def stub_remote(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(git_safety, "repo_default_branch", lambda *_args, **_kwargs: "main")
+    monkeypatch.setattr(git_safety, "remote_protected_branches", lambda *_args, **_kwargs: set())
+
+
+def test_discovers_state_5_and_uses_read_only_production_threads_schema(tmp_path: Path) -> None:
     home = tmp_path / ".codex"
     home.mkdir()
-    first = home / "state_old.sqlite"
-    second = home / "state_new.sqlite"
-    third = home / "state_invalid.sqlite"
-    write_codex_db(first, task_id=1, title="a", cwd="/x", archived=False)
-    write_codex_db(second, task_id=1, title="a", cwd="/x", archived=False)
-    third.write_text("", encoding="utf-8")
-    now = time.time()
-    os.utime(first, (now - 10, now - 10))
-    os.utime(second, (now, now))
-    os.utime(third, (now - 20, now - 20))
-
-    discovered = codex_state.discover_state_database(codex_home=home)
-    assert discovered == second
-
-    with pytest.raises(codex_state.CodexStateDiscoveryError):
-        os.utime(first, (now, now))
-        codex_state.discover_state_database(codex_home=home)
-
-    with pytest.raises(codex_state.CodexStateSchemaError):
-        conn = sqlite3.connect(third)
-        conn.execute("CREATE TABLE missing_threads(value INTEGER)")
-        conn.commit()
-        conn.close()
-        codex_state.discover_state_database(codex_home=home)
-
-
-def test_codex_state_reconcile_archive_roundtrip(tmp_path: Path) -> None:
-    db_path = tmp_path / "state.sqlite"
-    write_codex_db(
-        db_path,
-        task_id=11,
-        title="task",
-        cwd="/repo/main",
-        archived=False,
-        archived_at=None,
+    task_id = str(UUID("00000000-0000-4000-8000-000000000005"))
+    production_db = home / "state_5.sqlite"
+    write_threads(
+        production_db,
+        [{"id": task_id, "title": "A", "cwd": "/repo", "archived": 0, "archived_at": None, "host": "host-a"}],
     )
 
-    before, after, changed = codex_state.reconcile_task_thread(
-        task_id=11,
-        action="archive",
-        expected_title="task",
-        expected_cwd="/repo/main",
-        expected_host="runner-host",
-        db_path=db_path,
-    )
-    assert changed
-    assert not before.archived and after.archived
-    assert after.archived_at is not None
-
-    unchanged = codex_state.reconcile_task_thread(
-        task_id=11,
-        action="archive",
-        expected_title="task",
-        expected_cwd="/repo/main",
-        expected_host="runner-host",
-        db_path=db_path,
-    )
-    assert unchanged[2] is False
-
-    before_restore, after_restore, restored = codex_state.reconcile_task_thread(
-        task_id=11,
-        action="restore",
-        expected_title="task",
-        expected_cwd="/repo/main",
-        expected_host="runner-host",
-        db_path=db_path,
-    )
-    assert restored
-    assert before_restore.archived and not after_restore.archived
-
-    _again, final, unchanged_restore = codex_state.reconcile_task_thread(
-        task_id=11,
-        action="restore",
-        expected_title="task",
-        expected_cwd="/repo/main",
-        expected_host="runner-host",
-        db_path=db_path,
-    )
-    assert unchanged_restore is False
-    assert not final.archived and final.archived_at is None
+    assert codex_state.discover_state_database(codex_home=home) == production_db
+    with codex_state.open_state_db(production_db) as connection:
+        with pytest.raises(sqlite3.OperationalError):
+            connection.execute("UPDATE threads SET archived = 1 WHERE id = ?", (task_id,))
+    record = codex_state.read_thread_record(production_db, task_id=task_id)
+    assert record.thread_id == task_id
+    assert record.archived is False
 
 
-def test_codex_state_read_thread_record_stable_and_conflict(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    db_path = tmp_path / "state.sqlite"
-    db_path.write_text("", encoding="utf-8")
-    record_one = codex_state.ThreadRecord(1, "task", "/repo", False, None, "host")
-    record_two = codex_state.ThreadRecord(1, "task", "/repo", False, None, "host")
-    record_three = codex_state.ThreadRecord(1, "task", "/repo", False, None, "host")
+def test_apply_requires_caller_digest_and_exact_persisted_selection(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    task_id, other_id = str(uuid4()), str(uuid4())
+    db = tmp_path / "state_5.sqlite"
+    write_threads(db, [{"id": task_id, "title": "A", "cwd": str(repo), "archived": 1, "archived_at": "2026-01-01Z", "host": "host-a"}])
+    approved = plan(repo, family="digest", mode="archive_only", task_targets=(task(task_id, title="A", cwd=repo, db_path=db),))
 
-    calls = {"n": 0}
+    unauthorized = replace(approved, persisted_plan_digest="f" * 64)
+    rejected = executor.CleanupExecutor(repo, unauthorized).run()
+    assert rejected["state"] == "blocked"
+    assert "caller digest" in rejected["blocked"]["reason"]
 
-    def unstable_read(*args: Any, **kwargs: Any) -> codex_state.ThreadRecord:
-        calls["n"] += 1
-        if calls["n"] <= 2:
-            return record_one
-        if calls["n"] <= 4:
-            return record_two
-        return record_three
-
-    monkeypatch.setattr(codex_state, "_read_thread_once", unstable_read)
-    assert codex_state.read_thread_record(1, db_path, read_window_seconds=1.2) == record_three
-
-    calls["n"] = 0
-
-    def never_stable(*args: Any, **kwargs: Any) -> codex_state.ThreadRecord:
-        calls["n"] += 1
-        return record_one if calls["n"] % 2 else record_two
-
-    monkeypatch.setattr(codex_state, "_read_thread_once", never_stable)
-    with pytest.raises(codex_state.CodexStateConflictError):
-        codex_state.read_thread_record(1, db_path, read_window_seconds=0.01)
-
-
-def test_codex_state_context_and_host_mismatch(tmp_path: Path) -> None:
-    db = tmp_path / "state.sqlite"
-    write_codex_db(db, task_id=9, title="clean", cwd="/a", archived=False, archived_at=None)
-    with pytest.raises(codex_state.CodexStateContextError):
-        codex_state.reconcile_task_thread(
-            task_id=9,
-            action="archive",
-            expected_title="clean",
-            expected_cwd="/b",
-            expected_host="runner-host",
-            db_path=db,
-        )
-
-    with pytest.raises(codex_state.CodexStateContextError):
-        codex_state.reconcile_task_thread(
-            task_id=9,
-            action="archive",
-            expected_title="clean",
-            expected_cwd="/a",
-            expected_host="different-host",
-            db_path=db,
-        )
-
-
-def test_verify_frozen_preconditions_blocks_active_jobs(tmp_path: Path) -> None:
-    repo, _ = init_repo(tmp_path)
-    state_root = git_safety.resolve_state_root(repo)
-    active = state_root / "jobs" / "job-lineage-5140.json"
-    active.parent.mkdir(parents=True, exist_ok=True)
-    active.write_text(json.dumps({"lineage": "lineage-5140"}), encoding="utf-8")
-    with (
-        git_safety.operation_lock(repo),
-        git_safety.lineage_lock(repo, "lineage-5140"),
-        git_safety.family_lock(repo, "cleanup"),
-        git_safety.worktree_lock(repo, repo),
-    ):
-        with pytest.raises(git_safety.GitSafetyError, match="active jobs/leases"):
-            git_safety.verify_frozen_preconditions(
-                repo, lineage_id="lineage-5140", family="cleanup", worktree=repo
-            )
-
-
-def test_verify_worktree_candidate_blocks_dirty_worktree(tmp_path: Path) -> None:
-    repo, _ = init_repo(tmp_path)
-    worktree = add_worktree_branch(repo, "cleanup/dirty")
-    (worktree / "dirty.txt").write_text("dirty\n", encoding="utf-8")
-    with pytest.raises(git_safety.GitSafetyError, match="dirty"):
-        git_safety.verify_worktree_candidate(
-            repo,
-            worktree=worktree,
-            branch=worktree.name,
-        )
-
-
-def test_verify_worktree_candidate_blocks_shared_worktree(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    repo, _ = init_repo(tmp_path)
-    worktree = add_worktree_branch(repo, "cleanup/shared")
-    info = git_safety.worktree_list(repo)
-    shared = git_safety.WorktreeInfo(worktree, worktree.name)
-    fake_list = [*info, git_safety.WorktreeInfo(repo / ".tmp-fake", worktree.name)]
-    monkeypatch.setattr(git_safety, "worktree_list", lambda *_args, **_kwargs: fake_list)
-    with pytest.raises(git_safety.GitSafetyError, match="shared"):
-        git_safety.verify_worktree_candidate(
-            repo,
-            worktree=worktree,
-            branch=worktree.name,
-        )
-
-
-def test_protected_branch_lookup_failure_blocks_decision(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    repo, _ = init_repo(tmp_path)
-
-    def fake_run_gh(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(args, 1, "", "network unavailable")
-
-    monkeypatch.setattr(git_safety, "run_gh", fake_run_gh)
-    with pytest.raises(git_safety.GitHubQueryError):
-        git_safety.protected_branches(repo)
-
-
-def test_build_and_verify_bundle_receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    repo, _ = init_repo(tmp_path)
-    monkeypatch.setattr(git_safety, "assert_no_unknown_branch_mutation", lambda *args, **kwargs: None)
-    receipt = git_safety.build_bundle(
-        repo,
-        branch="main",
-        bundle_dir=tmp_path / "bundles",
-    )
-    git_safety.verify_bundle(receipt.path, branch="main", repo_root=repo)
-
-    with receipt.path.open("a", encoding="utf-8") as handle:
-        handle.write("tamper\n")
-    with pytest.raises(git_safety.GitSafetyError):
-        git_safety.assert_bundle_matches_receipt(receipt, branch="main")
-
-
-def test_remote_present_blocks_branch_deletion_precondition(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    repo, _ = init_repo(tmp_path)
-    branch = "cleanup/locked"
-    worktree = add_worktree_branch(repo, branch, push_remote=False)
-    monkeypatch.setattr(git_safety, "is_protected_branch", lambda *args, **kwargs: False)
-
-    bundle = git_safety.build_bundle(
-        repo,
-        branch=branch,
-        bundle_dir=tmp_path / "bundles",
-    )
-    head = git(worktree, "rev-parse", "HEAD")
-    pr = {
-        "state": "MERGED",
-        "headRefOid": head,
-        "mergeCommit": "0" * 40,
-        "number": 99,
-        "baseRefName": "main",
-        "mergeStateStatus": "CLEAN",
-        "isCrossRepository": False,
-    }
-
-    # remote branch exists => should block.
-    git(worktree, "push", "-u", "origin", branch)
-    with pytest.raises(git_safety.GitSafetyError, match="remote branch"):
-        git_safety.assert_branch_deletion_preconditions(
-            repo_root=repo,
-            branch=branch,
-            pr_data=pr,
-            bundle=bundle,
-        )
-    git(repo, "push", "origin", f":{branch}")
-    assert git_safety.assert_branch_deletion_preconditions(
-        repo_root=repo,
-        branch=branch,
-        pr_data=pr,
-        bundle=bundle,
-    )
-
-
-def test_executor_partial_failure_resume(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    repo, _ = init_repo(tmp_path)
-    branch = "cleanup/resume"
-    worktree = add_worktree_branch(repo, branch)
-    db = tmp_path / "state.sqlite"
-    write_codex_db(db, task_id=1, title="Cleanup Task", cwd=str(worktree), archived=False)
-    plan = make_plan(
-        repo,
-        worktree,
-        db,
-        task_id=1,
-        lineage_id="lineage-resume",
-        branch=branch,
-    )
-
-    monkeypatch.setattr(git_safety, "assert_no_unknown_branch_mutation", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        git_safety,
-        "query_pr_by_head",
-        lambda *args, **kwargs: mk_pr_payload(worktree),
-    )
-
-    executor = CleanupExecutor(repo, plan, crash_after_stage="tasks_archived")
-    blocked = executor.run()
+    raw = json.loads(executor.plan_path(repo, approved).read_text(encoding="utf-8"))
+    raw["selected_task_ids"] = [other_id]
+    raw["digest"] = executor._canonical_plan_digest(raw)
+    git_safety.write_json_atomic(executor.plan_path(repo, approved), raw)
+    blocked = executor.CleanupExecutor(repo, approved).run()
     assert blocked["state"] == "blocked"
-    assert blocked["resume_stage"] == "tasks_archived"
-
-    resumed = CleanupExecutor(repo, plan).run()
-    assert resumed["state"] == "completed"
-    assert resumed["stages"]["runtime_retired"]["retained"] is True
-    assert resumed["history"] == [
-        "planned",
-        "frozen",
-        "verified",
-        "snapshotted",
-        "tasks_archived",
-        "worktrees_removed",
-        "branches_deleted",
-        "runtime_retired",
-        "completed",
-    ]
-
-    payload = load_state(repo, plan)
-    assert payload["stages"]["snapshotted"]["bundle"]["sha256"]
-    assert not worktree.exists()
-
-    with pytest.raises(subprocess.CalledProcessError):
-        subprocess.run(
-            ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{worktree.name}"],
-            cwd=repo,
-            check=True,
-            capture_output=True,
-            text=True,
-            env=_git_env(),
-        )
-
-    conn = sqlite3.connect(db)
-    row = conn.execute("SELECT archived FROM threads WHERE id = 1").fetchone()
-    conn.close()
-    assert row == (1,)
+    assert "caller digest" in blocked["blocked"]["reason"]
 
 
-def test_executor_remote_block_then_remote_gone_cleanup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    repo, _ = init_repo(tmp_path)
-    branch = "cleanup/remote"
-    worktree = add_worktree_branch(repo, branch)
-    db = tmp_path / "state.sqlite"
-    write_codex_db(db, task_id=2, title="Cleanup Task", cwd=str(worktree), archived=False)
-    plan = make_plan(
-        repo,
-        worktree,
-        db,
-        task_id=2,
-        lineage_id="lineage-remote",
-        branch=branch,
-    )
+def test_archive_only_observes_native_archive_and_stops_at_tasks_archived(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = init_repo(tmp_path)
+    task_id = str(uuid4())
+    db = tmp_path / "state_5.sqlite"
+    write_threads(db, [{"id": task_id, "title": "A", "cwd": str(repo), "archived": 1, "archived_at": "2026-01-01Z", "host": "host-a"}])
+    approved = plan(repo, family="archive", mode="archive_only", task_targets=(task(task_id, title="A", cwd=repo, db_path=db),))
+    monkeypatch.setattr(git_safety, "run_git", lambda *_args, **_kwargs: pytest.fail("archive-only called git"))
 
-    monkeypatch.setattr(git_safety, "assert_no_unknown_branch_mutation", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        git_safety,
-        "query_pr_by_head",
-        lambda *args, **kwargs: mk_pr_payload(worktree),
-    )
-    git(worktree, "push", "-u", "origin", branch)
-    first = CleanupExecutor(repo, plan, crash_after_stage="worktrees_removed")
-    stopped = first.run()
-    assert stopped["state"] == "blocked"
-    assert stopped["resume_stage"] == "worktrees_removed"
-
-    second = CleanupExecutor(repo, plan)
-    still_blocked = second.run()
-    assert still_blocked["state"] == "blocked"
-    assert still_blocked["resume_stage"] == "worktrees_removed"
-    assert "remote branch still present" in still_blocked["blocked"]["reason"]
-
-    git(repo, "push", "origin", f":{branch}")
-    completed = CleanupExecutor(repo, plan).run()
-    assert completed["state"] == "completed"
+    result = executor.CleanupExecutor(repo, approved).run()
+    assert result["state"] == "tasks_archived"
+    assert result["resources"]["task"].keys() == {task_id}
+    receipt = json.loads(executor.receipt_path(repo, approved).read_text(encoding="utf-8"))
+    assert receipt["state"] == "tasks_archived"
+    assert receipt["resources"]["task"][task_id]["status"] == "actual"
 
 
-def test_executor_unmerged_pr_blocks_verification(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    repo, _ = init_repo(tmp_path)
-    branch = "cleanup/reject"
-    worktree = add_worktree_branch(repo, branch)
-    db = tmp_path / "state.sqlite"
-    write_codex_db(db, task_id=3, title="Cleanup Task", cwd=str(worktree), archived=False)
-    plan = make_plan(
-        repo,
-        worktree,
-        db,
-        task_id=3,
-        lineage_id="lineage-reject",
-        branch=branch,
-    )
+def test_advisory_lock_path_is_not_git_lock_but_git_worktree_lock_blocks(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    worktree = add_worktree(repo, "cleanup/locked")
+    git_safety._worktree_lock_path(repo, worktree).parent.mkdir(parents=True, exist_ok=True)
+    git_safety._worktree_lock_path(repo, worktree).touch()
+    assert git_safety.is_worktree_locked(repo, worktree) is False
 
-    pr_open = mk_pr_payload(worktree)
-    pr_open["state"] = "OPEN"
-    monkeypatch.setattr(git_safety, "assert_no_unknown_branch_mutation", lambda *args, **kwargs: None)
-    monkeypatch.setattr(git_safety, "query_pr_by_head", lambda *args, **kwargs: pr_open)
-
-    blocked = CleanupExecutor(repo, plan).run()
-    assert blocked["state"] == "blocked"
-    assert blocked["resume_stage"] == "frozen"
+    git(repo, "worktree", "lock", "--reason", "operator-held", str(worktree))
+    assert git_safety.is_worktree_locked(repo, worktree) is True
+    with pytest.raises(git_safety.GitSafetyError, match="locked"):
+        git_safety.verify_worktree_candidate(repo, worktree=worktree, branch="cleanup/locked")
 
 
-def test_executor_restore_archive_is_supported_before_cleanup_stages(tmp_path: Path) -> None:
-    repo, _ = init_repo(tmp_path)
-    branch = "cleanup/restore"
-    worktree = add_worktree_branch(repo, branch)
-    db = tmp_path / "state.sqlite"
-    write_codex_db(
-        db,
-        task_id=4,
-        title="Cleanup Task",
-        cwd=str(worktree),
-        archived=True,
-        archived_at="2026-07-13T00:00:00Z",
-    )
-    plan = make_plan(
-        repo,
-        worktree,
-        db,
-        task_id=4,
-        lineage_id="lineage-restore",
-        branch=branch,
-    )
-    restored = CleanupExecutor(repo, plan).restore_archive()
-    assert restored["state"] == "verified"
+def test_github_queries_use_valid_commands_and_normalize_merge_commit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = init_repo(tmp_path)
+    calls: list[list[str]] = []
 
-    conn = sqlite3.connect(db)
-    row = conn.execute("SELECT archived, archived_at FROM threads WHERE id = 4").fetchone()
-    conn.close()
-    assert row == (0, None)
+    def fake_gh(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        if args[:3] == ["repo", "view", "--json"]:
+            return subprocess.CompletedProcess(args, 0, '{"owner":{"login":"o"},"name":"r"}', "")
+        if args[:2] == ["api", "--paginate"]:
+            return subprocess.CompletedProcess(args, 0, '[{"name":"main","protected":true}]', "")
+        return subprocess.CompletedProcess(args, 1, "", "unexpected")
+
+    monkeypatch.setattr(git_safety, "run_gh", fake_gh)
+    assert git_safety.remote_protected_branches(repo) == {"main"}
+    assert all("--json" not in call for call in calls if call and call[0] == "api")
+    assert git_safety._normalize_merge_commit({"oid": "a" * 40}) == "a" * 40
+    assert git_safety._normalize_merge_commit("b" * 40) == "b" * 40
 
 
-def test_executor_preserves_unrelated_files_and_receipts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    repo, _ = init_repo(tmp_path)
-    branch = "cleanup/unrelated"
-    worktree = add_worktree_branch(repo, branch)
-    db = tmp_path / "state.sqlite"
-    write_codex_db(db, task_id=5, title="Cleanup Task", cwd=str(worktree), archived=False)
-    marker = git_safety.resolve_state_root(repo) / "states" / "external.txt"
-    marker.parent.mkdir(parents=True, exist_ok=True)
-    marker.write_text("preserve\n", encoding="utf-8")
+def test_finish_cleanup_preserves_unrelated_worktree_and_rechecks_pr_before_mutation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = init_repo(tmp_path)
+    target_branch, unrelated_branch = "cleanup/remove", "cleanup/keep"
+    remove_worktree, keep_worktree = add_worktree(repo, target_branch), add_worktree(repo, unrelated_branch)
+    task_id = str(uuid4())
+    db = tmp_path / "state_5.sqlite"
+    write_threads(db, [{"id": task_id, "title": "A", "cwd": str(remove_worktree), "archived": 1, "archived_at": "2026-01-01Z", "host": "host-a"}])
+    target = worktree_target(remove_worktree, target_branch, "scope", number=9)
+    approved = plan(repo, family="scope", mode="finish_and_clean", task_targets=(task(task_id, title="A", cwd=remove_worktree, db_path=db),), worktree_targets=(target,))
+    stub_remote(monkeypatch)
+    calls = {"count": 0}
+    head = git(remove_worktree, "rev-parse", "HEAD")
 
-    plan = make_plan(
-        repo,
-        worktree,
-        db,
-        task_id=5,
-        lineage_id="lineage-unrelated",
-        branch=branch,
-    )
-    monkeypatch.setattr(git_safety, "assert_no_unknown_branch_mutation", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        git_safety,
-        "query_pr_by_head",
-        lambda *args, **kwargs: mk_pr_payload(worktree),
-    )
+    def query(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        calls["count"] += 1
+        return pr(target_branch, head, 9)
 
-    result = CleanupExecutor(repo, plan).run()
+    monkeypatch.setattr(git_safety, "query_pr_by_head", query)
+    result = executor.CleanupExecutor(repo, approved).run()
     assert result["state"] == "completed"
-    assert marker.exists()
-    assert "snapshotted" in result["stages"]
-    assert "bundle" in result["stages"]["snapshotted"]
+    assert calls["count"] >= 3
+    assert not remove_worktree.exists()
+    assert keep_worktree.exists()
+    git(repo, "show-ref", "--verify", "--quiet", f"refs/heads/{unrelated_branch}")
+    assert not git_safety.local_branch_exists(repo, target_branch)
+
+
+def test_remote_lookup_failure_blocks_branch_delete(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = init_repo(tmp_path)
+    monkeypatch.setattr(git_safety, "run_git", lambda *_args, **_kwargs: subprocess.CompletedProcess([], 128, "", "network down"))
+    with pytest.raises(git_safety.GitSafetyError, match="remote branch lookup failed"):
+        git_safety.remote_branch_present(repo, "cleanup/x")
+
+
+def test_runtime_without_eligibility_or_proof_is_preserved_and_blocks(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = init_repo(tmp_path)
+    branch, worktree = "cleanup/runtime", add_worktree(repo, "cleanup/runtime")
+    task_id = str(uuid4())
+    db = tmp_path / "state_5.sqlite"
+    write_threads(db, [{"id": task_id, "title": "A", "cwd": str(worktree), "archived": 1, "archived_at": "2026-01-01Z", "host": "host-a"}])
+    target = worktree_target(worktree, branch, "runtime", number=11)
+    runtime = executor.RuntimeTarget(id=str(uuid4()), kind="handoff", eligible=False, proof=None)
+    approved = plan(repo, family="runtime", mode="finish_and_clean", task_targets=(task(task_id, title="A", cwd=worktree, db_path=db),), worktree_targets=(target,), runtime_targets=(runtime,))
+    stub_remote(monkeypatch)
+    head = git(worktree, "rev-parse", "HEAD")
+    monkeypatch.setattr(git_safety, "query_pr_by_head", lambda *_args, **_kwargs: pr(branch, head, 11))
+
+    result = executor.CleanupExecutor(repo, approved).run()
+    assert result["state"] == "blocked"
+    assert result["resume_stage"] == "runtime_retired"
+    saved = result["resources"]["runtime"][runtime.id]
+    assert saved["status"] == "failed"
+    assert "preserved" in saved["reason"]

--- a/tests/orchestration/task_family/test_executor.py
+++ b/tests/orchestration/task_family/test_executor.py
@@ -14,6 +14,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from scripts.orchestration.task_family import codex_state, executor, git_safety
+from scripts.orchestration.task_family.storage import TaskFamilyStorage
 
 
 def _git_env() -> dict[str, str]:
@@ -164,6 +165,28 @@ def test_discovers_state_5_and_uses_read_only_production_threads_schema(tmp_path
     record = codex_state.read_thread_record(production_db, task_id=task_id)
     assert record.thread_id == task_id
     assert record.archived is False
+
+
+def test_executor_paths_match_task_family_storage(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path)
+    cleanup_plan = executor.CleanupPlan(
+        operation_id=str(uuid4()),
+        family_id="path-contract",
+        lineage_id=str(uuid4()),
+        mode="archive_only",
+        task_targets=(),
+        worktree_targets=(),
+        runtime_targets=(),
+        selected_task_ids=frozenset(),
+        pin_unknown_confirmed=True,
+        persisted_plan_digest="0" * 64,
+    )
+    storage = TaskFamilyStorage(repo, cleanup_plan.family_id, cleanup_plan.operation_id)
+
+    assert executor.state_path(repo, cleanup_plan) == storage.state_path
+    assert executor.plan_path(repo, cleanup_plan) == storage.plan_path
+    assert executor.manifest_path(repo, cleanup_plan) == storage.manifest_path
+    assert executor.receipt_path(repo, cleanup_plan) == storage.receipt_path
 
 
 def test_apply_requires_caller_digest_and_exact_persisted_selection(tmp_path: Path) -> None:

--- a/tests/orchestration/task_family/test_executor.py
+++ b/tests/orchestration/task_family/test_executor.py
@@ -222,8 +222,18 @@ def test_archive_only_observes_native_archive_and_stops_at_tasks_archived(tmp_pa
     assert result["state"] == "tasks_archived"
     assert result["resources"]["task"].keys() == {task_id}
     receipt = json.loads(executor.receipt_path(repo, approved).read_text(encoding="utf-8"))
-    assert receipt["state"] == "tasks_archived"
-    assert receipt["resources"]["task"][task_id]["status"] == "actual"
+    assert receipt["final_state"] == "tasks_archived"
+    assert receipt["actual"][-1]["action"] == "archive"
+    assert receipt["final_resources"] == [{
+        "resource_type": "task",
+        "resource_id": task_id,
+        "task_ids": [task_id],
+        "action": "archived",
+        "reason": "final executor resource status: actual",
+        "error": "",
+        "recovery": "",
+    }]
+    assert "Final resources: task:" in executor.receipt_path(repo, approved).with_name("receipt.txt").read_text(encoding="utf-8")
 
 
 def test_advisory_lock_path_is_not_git_lock_but_git_worktree_lock_blocks(tmp_path: Path) -> None:
@@ -283,6 +293,37 @@ def test_finish_cleanup_preserves_unrelated_worktree_and_rechecks_pr_before_muta
     assert keep_worktree.exists()
     git(repo, "show-ref", "--verify", "--quiet", f"refs/heads/{unrelated_branch}")
     assert not git_safety.local_branch_exists(repo, target_branch)
+
+
+def test_branch_delete_crash_resumes_from_verified_bundle_when_branch_is_already_absent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = init_repo(tmp_path)
+    branch, worktree = "cleanup/resume", add_worktree(repo, "cleanup/resume")
+    task_id = str(uuid4())
+    db = tmp_path / "state_5.sqlite"
+    write_threads(db, [{"id": task_id, "title": "A", "cwd": str(worktree), "archived": 1, "archived_at": "2026-01-01Z", "host": "host-a"}])
+    target = worktree_target(worktree, branch, "resume", number=10)
+    approved = plan(repo, family="resume", mode="finish_and_clean", task_targets=(task(task_id, title="A", cwd=worktree, db_path=db),), worktree_targets=(target,))
+    stub_remote(monkeypatch)
+    head = git(worktree, "rev-parse", "HEAD")
+    monkeypatch.setattr(git_safety, "query_pr_by_head", lambda *_args, **_kwargs: pr(branch, head, 10))
+    original_delete = git_safety.delete_branch
+
+    def delete_then_crash(*args: Any, **kwargs: Any) -> None:
+        original_delete(*args, **kwargs)
+        raise RuntimeError("simulated process crash immediately after branch deletion")
+
+    monkeypatch.setattr(git_safety, "delete_branch", delete_then_crash)
+
+    interrupted = executor.CleanupExecutor(repo, approved).run()
+    assert interrupted["state"] == "blocked"
+    assert not git_safety.local_branch_exists(repo, branch)
+
+    monkeypatch.setattr(git_safety, "delete_branch", original_delete)
+    resumed = executor.CleanupExecutor(repo, approved).run()
+    assert resumed["state"] == "completed"
+    assert resumed["stages"]["branches_deleted"]["results"][target.id]["status"] == "already_absent"
+    receipt = json.loads(executor.receipt_path(repo, approved).read_text(encoding="utf-8"))
+    assert any(item["action"] == "retired_before_resume" for item in receipt["final_resources"])
 
 
 def test_remote_lookup_failure_blocks_branch_delete(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/orchestration/task_family/test_executor.py
+++ b/tests/orchestration/task_family/test_executor.py
@@ -6,6 +6,7 @@ import json
 import os
 import sqlite3
 import subprocess
+from contextlib import nullcontext
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -251,6 +252,34 @@ def test_advisory_lock_path_is_not_git_lock_but_git_worktree_lock_blocks(tmp_pat
     assert git_safety.is_worktree_locked(repo, worktree) is True
     with pytest.raises(git_safety.GitSafetyError, match="locked"):
         git_safety.verify_worktree_candidate(repo, worktree=worktree, branch="cleanup/locked")
+
+
+def test_executor_locks_each_resolved_worktree_path_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = init_repo(tmp_path)
+    shared_worktree = tmp_path / "shared-worktree"
+    approved = plan(
+        repo,
+        family="shared-worktree-lock",
+        mode="finish_and_clean",
+        task_targets=(),
+        worktree_targets=(
+            worktree_target(shared_worktree, "cleanup/shared-a", "shared-worktree-lock", number=31),
+            worktree_target(shared_worktree, "cleanup/shared-b", "shared-worktree-lock", number=32),
+        ),
+    )
+    locked_paths: list[Path] = []
+
+    def record_lock(_repo: Path, worktree: Path):
+        locked_paths.append(worktree.resolve())
+        return nullcontext()
+
+    monkeypatch.setattr(git_safety, "worktree_lock", record_lock)
+    monkeypatch.setattr(executor.CleanupExecutor, "_run_locked", lambda _self: {"state": "locks-acquired"})
+
+    assert executor.CleanupExecutor(repo, approved).run() == {"state": "locks-acquired"}
+    assert locked_paths == [shared_worktree.resolve()]
 
 
 def test_github_queries_use_valid_commands_and_normalize_merge_commit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/orchestration/task_family/test_executor.py
+++ b/tests/orchestration/task_family/test_executor.py
@@ -1,0 +1,564 @@
+"""Tests for cleanup state-machine and Codex-state bridge primitives."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from scripts.orchestration.task_family import codex_state, git_safety
+from scripts.orchestration.task_family.executor import CleanupExecutor, CleanupPlan, load_state
+
+
+def _git_env() -> dict[str, str]:
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_")
+    }
+
+
+def git(tmp_path: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=_git_env(),
+    )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    return (completed.stdout or "").strip()
+
+
+def init_repo(tmp_path: Path) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    remote = tmp_path / "origin.git"
+    git(tmp_path, "init", "--initial-branch=main", str(repo))
+    git(tmp_path, "init", "--bare", str(remote))
+    git(repo, "config", "user.email", "cleanup-tester@example.com")
+    git(repo, "config", "user.name", "Cleanup Executor")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    git(repo, "add", "README.md")
+    git(repo, "commit", "-m", "seed")
+    git(repo, "remote", "add", "origin", str(remote))
+    git(repo, "push", "-u", "origin", "main")
+    return repo, remote
+
+
+def add_worktree_branch(repo: Path, branch: str, *, push_remote: bool = False) -> Path:
+    worktree = repo.parent / f"wt-{branch.replace('/', '-')}-{uuid4().hex[:6]}"
+    git(repo, "worktree", "add", "-b", branch, str(worktree), "main")
+    (worktree / "payload.txt").write_text(f"{branch}\n", encoding="utf-8")
+    git(worktree, "add", "payload.txt")
+    git(worktree, "commit", "-m", f"worktree {branch}")
+    if push_remote:
+        git(worktree, "push", "-u", "origin", branch)
+    return worktree
+
+
+def write_codex_db(
+    path: Path,
+    *,
+    task_id: int,
+    title: str,
+    cwd: str,
+    archived: bool = False,
+    archived_at: str | None = None,
+    host: str = "runner-host",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE threads(id INTEGER PRIMARY KEY, title TEXT, cwd TEXT, archived INTEGER, archived_at TEXT, host TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO threads(id,title,cwd,archived,archived_at,host) VALUES (?,?,?,?,?,?)",
+        (task_id, title, cwd, int(archived), archived_at, host),
+    )
+    conn.commit()
+    conn.close()
+
+
+def make_plan(
+    repo: Path,
+    worktree: Path,
+    db_path: Path,
+    *,
+    lineage_id: str = "lineage-5140",
+    task_id: int = 1,
+    branch: str,
+) -> CleanupPlan:
+    return CleanupPlan(
+        task_id=task_id,
+        family="cleanup",
+        lineage_id=lineage_id,
+        title="Cleanup Task",
+        cwd=str(worktree),
+        branch=branch,
+        worktree=worktree,
+        thread_id=task_id,
+        db_path=db_path,
+        host="runner-host",
+        explicit_protected=frozenset({"forbidden/branch"}),
+    )
+
+
+def mk_pr_payload(worktree: Path) -> dict[str, Any]:
+    head = git(worktree, "rev-parse", "HEAD")
+    return {
+        "number": 42,
+        "state": "MERGED",
+        "headRefOid": head,
+        "headRefName": worktree.name,
+        "baseRefName": "main",
+        "mergeStateStatus": "CLEAN",
+        "mergeCommit": "0" * 40,
+        "isCrossRepository": False,
+    }
+
+
+def test_codex_state_discovery_and_archive_restore(tmp_path: Path) -> None:
+    home = tmp_path / ".codex"
+    home.mkdir()
+    first = home / "state_old.sqlite"
+    second = home / "state_new.sqlite"
+    third = home / "state_invalid.sqlite"
+    write_codex_db(first, task_id=1, title="a", cwd="/x", archived=False)
+    write_codex_db(second, task_id=1, title="a", cwd="/x", archived=False)
+    third.write_text("", encoding="utf-8")
+    now = time.time()
+    os.utime(first, (now - 10, now - 10))
+    os.utime(second, (now, now))
+    os.utime(third, (now - 20, now - 20))
+
+    discovered = codex_state.discover_state_database(codex_home=home)
+    assert discovered == second
+
+    with pytest.raises(codex_state.CodexStateDiscoveryError):
+        os.utime(first, (now, now))
+        codex_state.discover_state_database(codex_home=home)
+
+    with pytest.raises(codex_state.CodexStateSchemaError):
+        conn = sqlite3.connect(third)
+        conn.execute("CREATE TABLE missing_threads(value INTEGER)")
+        conn.commit()
+        conn.close()
+        codex_state.discover_state_database(codex_home=home)
+
+
+def test_codex_state_reconcile_archive_roundtrip(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.sqlite"
+    write_codex_db(
+        db_path,
+        task_id=11,
+        title="task",
+        cwd="/repo/main",
+        archived=False,
+        archived_at=None,
+    )
+
+    before, after, changed = codex_state.reconcile_task_thread(
+        task_id=11,
+        action="archive",
+        expected_title="task",
+        expected_cwd="/repo/main",
+        expected_host="runner-host",
+        db_path=db_path,
+    )
+    assert changed
+    assert not before.archived and after.archived
+    assert after.archived_at is not None
+
+    unchanged = codex_state.reconcile_task_thread(
+        task_id=11,
+        action="archive",
+        expected_title="task",
+        expected_cwd="/repo/main",
+        expected_host="runner-host",
+        db_path=db_path,
+    )
+    assert unchanged[2] is False
+
+    before_restore, after_restore, restored = codex_state.reconcile_task_thread(
+        task_id=11,
+        action="restore",
+        expected_title="task",
+        expected_cwd="/repo/main",
+        expected_host="runner-host",
+        db_path=db_path,
+    )
+    assert restored
+    assert before_restore.archived and not after_restore.archived
+
+    _again, final, unchanged_restore = codex_state.reconcile_task_thread(
+        task_id=11,
+        action="restore",
+        expected_title="task",
+        expected_cwd="/repo/main",
+        expected_host="runner-host",
+        db_path=db_path,
+    )
+    assert unchanged_restore is False
+    assert not final.archived and final.archived_at is None
+
+
+def test_codex_state_read_thread_record_stable_and_conflict(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db_path = tmp_path / "state.sqlite"
+    db_path.write_text("", encoding="utf-8")
+    record_one = codex_state.ThreadRecord(1, "task", "/repo", False, None, "host")
+    record_two = codex_state.ThreadRecord(1, "task", "/repo", False, None, "host")
+    record_three = codex_state.ThreadRecord(1, "task", "/repo", False, None, "host")
+
+    calls = {"n": 0}
+
+    def unstable_read(*args: Any, **kwargs: Any) -> codex_state.ThreadRecord:
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            return record_one
+        if calls["n"] <= 4:
+            return record_two
+        return record_three
+
+    monkeypatch.setattr(codex_state, "_read_thread_once", unstable_read)
+    assert codex_state.read_thread_record(1, db_path, read_window_seconds=1.2) == record_three
+
+    calls["n"] = 0
+
+    def never_stable(*args: Any, **kwargs: Any) -> codex_state.ThreadRecord:
+        calls["n"] += 1
+        return record_one if calls["n"] % 2 else record_two
+
+    monkeypatch.setattr(codex_state, "_read_thread_once", never_stable)
+    with pytest.raises(codex_state.CodexStateConflictError):
+        codex_state.read_thread_record(1, db_path, read_window_seconds=0.01)
+
+
+def test_codex_state_context_and_host_mismatch(tmp_path: Path) -> None:
+    db = tmp_path / "state.sqlite"
+    write_codex_db(db, task_id=9, title="clean", cwd="/a", archived=False, archived_at=None)
+    with pytest.raises(codex_state.CodexStateContextError):
+        codex_state.reconcile_task_thread(
+            task_id=9,
+            action="archive",
+            expected_title="clean",
+            expected_cwd="/b",
+            expected_host="runner-host",
+            db_path=db,
+        )
+
+    with pytest.raises(codex_state.CodexStateContextError):
+        codex_state.reconcile_task_thread(
+            task_id=9,
+            action="archive",
+            expected_title="clean",
+            expected_cwd="/a",
+            expected_host="different-host",
+            db_path=db,
+        )
+
+
+def test_verify_frozen_preconditions_blocks_active_jobs(tmp_path: Path) -> None:
+    repo, _ = init_repo(tmp_path)
+    state_root = git_safety.resolve_state_root(repo)
+    active = state_root / "jobs" / "job-lineage-5140.json"
+    active.parent.mkdir(parents=True, exist_ok=True)
+    active.write_text(json.dumps({"lineage": "lineage-5140"}), encoding="utf-8")
+    with (
+        git_safety.operation_lock(repo),
+        git_safety.lineage_lock(repo, "lineage-5140"),
+        git_safety.family_lock(repo, "cleanup"),
+        git_safety.worktree_lock(repo, repo),
+    ):
+        with pytest.raises(git_safety.GitSafetyError, match="active jobs/leases"):
+            git_safety.verify_frozen_preconditions(
+                repo, lineage_id="lineage-5140", family="cleanup", worktree=repo
+            )
+
+
+def test_verify_worktree_candidate_blocks_dirty_worktree(tmp_path: Path) -> None:
+    repo, _ = init_repo(tmp_path)
+    worktree = add_worktree_branch(repo, "cleanup/dirty")
+    (worktree / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+    with pytest.raises(git_safety.GitSafetyError, match="dirty"):
+        git_safety.verify_worktree_candidate(
+            repo,
+            worktree=worktree,
+            branch=worktree.name,
+        )
+
+
+def test_verify_worktree_candidate_blocks_shared_worktree(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    repo, _ = init_repo(tmp_path)
+    worktree = add_worktree_branch(repo, "cleanup/shared")
+    info = git_safety.worktree_list(repo)
+    shared = git_safety.WorktreeInfo(worktree, worktree.name)
+    fake_list = [*info, git_safety.WorktreeInfo(repo / ".tmp-fake", worktree.name)]
+    monkeypatch.setattr(git_safety, "worktree_list", lambda *_args, **_kwargs: fake_list)
+    with pytest.raises(git_safety.GitSafetyError, match="shared"):
+        git_safety.verify_worktree_candidate(
+            repo,
+            worktree=worktree,
+            branch=worktree.name,
+        )
+
+
+def test_protected_branch_lookup_failure_blocks_decision(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo, _ = init_repo(tmp_path)
+
+    def fake_run_gh(args: list[str], **_kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args, 1, "", "network unavailable")
+
+    monkeypatch.setattr(git_safety, "run_gh", fake_run_gh)
+    with pytest.raises(git_safety.GitHubQueryError):
+        git_safety.protected_branches(repo)
+
+
+def test_build_and_verify_bundle_receipt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo, _ = init_repo(tmp_path)
+    monkeypatch.setattr(git_safety, "assert_no_unknown_branch_mutation", lambda *args, **kwargs: None)
+    receipt = git_safety.build_bundle(
+        repo,
+        branch="main",
+        bundle_dir=tmp_path / "bundles",
+    )
+    git_safety.verify_bundle(receipt.path, branch="main", repo_root=repo)
+
+    with receipt.path.open("a", encoding="utf-8") as handle:
+        handle.write("tamper\n")
+    with pytest.raises(git_safety.GitSafetyError):
+        git_safety.assert_bundle_matches_receipt(receipt, branch="main")
+
+
+def test_remote_present_blocks_branch_deletion_precondition(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo, _ = init_repo(tmp_path)
+    branch = "cleanup/locked"
+    worktree = add_worktree_branch(repo, branch, push_remote=False)
+    monkeypatch.setattr(git_safety, "is_protected_branch", lambda *args, **kwargs: False)
+
+    bundle = git_safety.build_bundle(
+        repo,
+        branch=branch,
+        bundle_dir=tmp_path / "bundles",
+    )
+    head = git(worktree, "rev-parse", "HEAD")
+    pr = {
+        "state": "MERGED",
+        "headRefOid": head,
+        "mergeCommit": "0" * 40,
+        "number": 99,
+        "baseRefName": "main",
+        "mergeStateStatus": "CLEAN",
+        "isCrossRepository": False,
+    }
+
+    # remote branch exists => should block.
+    git(worktree, "push", "-u", "origin", branch)
+    with pytest.raises(git_safety.GitSafetyError, match="remote branch"):
+        git_safety.assert_branch_deletion_preconditions(
+            repo_root=repo,
+            branch=branch,
+            pr_data=pr,
+            bundle=bundle,
+        )
+    git(repo, "push", "origin", f":{branch}")
+    assert git_safety.assert_branch_deletion_preconditions(
+        repo_root=repo,
+        branch=branch,
+        pr_data=pr,
+        bundle=bundle,
+    )
+
+
+def test_executor_partial_failure_resume(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo, _ = init_repo(tmp_path)
+    branch = "cleanup/resume"
+    worktree = add_worktree_branch(repo, branch)
+    db = tmp_path / "state.sqlite"
+    write_codex_db(db, task_id=1, title="Cleanup Task", cwd=str(worktree), archived=False)
+    plan = make_plan(
+        repo,
+        worktree,
+        db,
+        task_id=1,
+        lineage_id="lineage-resume",
+        branch=branch,
+    )
+
+    monkeypatch.setattr(git_safety, "assert_no_unknown_branch_mutation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        git_safety,
+        "query_pr_by_head",
+        lambda *args, **kwargs: mk_pr_payload(worktree),
+    )
+
+    executor = CleanupExecutor(repo, plan, crash_after_stage="tasks_archived")
+    blocked = executor.run()
+    assert blocked["state"] == "blocked"
+    assert blocked["resume_stage"] == "tasks_archived"
+
+    resumed = CleanupExecutor(repo, plan).run()
+    assert resumed["state"] == "completed"
+    assert resumed["stages"]["runtime_retired"]["retained"] is True
+    assert resumed["history"] == [
+        "planned",
+        "frozen",
+        "verified",
+        "snapshotted",
+        "tasks_archived",
+        "worktrees_removed",
+        "branches_deleted",
+        "runtime_retired",
+        "completed",
+    ]
+
+    payload = load_state(repo, plan)
+    assert payload["stages"]["snapshotted"]["bundle"]["sha256"]
+    assert not worktree.exists()
+
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.run(
+            ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{worktree.name}"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+            env=_git_env(),
+        )
+
+    conn = sqlite3.connect(db)
+    row = conn.execute("SELECT archived FROM threads WHERE id = 1").fetchone()
+    conn.close()
+    assert row == (1,)
+
+
+def test_executor_remote_block_then_remote_gone_cleanup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo, _ = init_repo(tmp_path)
+    branch = "cleanup/remote"
+    worktree = add_worktree_branch(repo, branch)
+    db = tmp_path / "state.sqlite"
+    write_codex_db(db, task_id=2, title="Cleanup Task", cwd=str(worktree), archived=False)
+    plan = make_plan(
+        repo,
+        worktree,
+        db,
+        task_id=2,
+        lineage_id="lineage-remote",
+        branch=branch,
+    )
+
+    monkeypatch.setattr(git_safety, "assert_no_unknown_branch_mutation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        git_safety,
+        "query_pr_by_head",
+        lambda *args, **kwargs: mk_pr_payload(worktree),
+    )
+    git(worktree, "push", "-u", "origin", branch)
+    first = CleanupExecutor(repo, plan, crash_after_stage="worktrees_removed")
+    stopped = first.run()
+    assert stopped["state"] == "blocked"
+    assert stopped["resume_stage"] == "worktrees_removed"
+
+    second = CleanupExecutor(repo, plan)
+    still_blocked = second.run()
+    assert still_blocked["state"] == "blocked"
+    assert still_blocked["resume_stage"] == "worktrees_removed"
+    assert "remote branch still present" in still_blocked["blocked"]["reason"]
+
+    git(repo, "push", "origin", f":{branch}")
+    completed = CleanupExecutor(repo, plan).run()
+    assert completed["state"] == "completed"
+
+
+def test_executor_unmerged_pr_blocks_verification(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo, _ = init_repo(tmp_path)
+    branch = "cleanup/reject"
+    worktree = add_worktree_branch(repo, branch)
+    db = tmp_path / "state.sqlite"
+    write_codex_db(db, task_id=3, title="Cleanup Task", cwd=str(worktree), archived=False)
+    plan = make_plan(
+        repo,
+        worktree,
+        db,
+        task_id=3,
+        lineage_id="lineage-reject",
+        branch=branch,
+    )
+
+    pr_open = mk_pr_payload(worktree)
+    pr_open["state"] = "OPEN"
+    monkeypatch.setattr(git_safety, "assert_no_unknown_branch_mutation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(git_safety, "query_pr_by_head", lambda *args, **kwargs: pr_open)
+
+    blocked = CleanupExecutor(repo, plan).run()
+    assert blocked["state"] == "blocked"
+    assert blocked["resume_stage"] == "frozen"
+
+
+def test_executor_restore_archive_is_supported_before_cleanup_stages(tmp_path: Path) -> None:
+    repo, _ = init_repo(tmp_path)
+    branch = "cleanup/restore"
+    worktree = add_worktree_branch(repo, branch)
+    db = tmp_path / "state.sqlite"
+    write_codex_db(
+        db,
+        task_id=4,
+        title="Cleanup Task",
+        cwd=str(worktree),
+        archived=True,
+        archived_at="2026-07-13T00:00:00Z",
+    )
+    plan = make_plan(
+        repo,
+        worktree,
+        db,
+        task_id=4,
+        lineage_id="lineage-restore",
+        branch=branch,
+    )
+    restored = CleanupExecutor(repo, plan).restore_archive()
+    assert restored["state"] == "verified"
+
+    conn = sqlite3.connect(db)
+    row = conn.execute("SELECT archived, archived_at FROM threads WHERE id = 4").fetchone()
+    conn.close()
+    assert row == (0, None)
+
+
+def test_executor_preserves_unrelated_files_and_receipts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo, _ = init_repo(tmp_path)
+    branch = "cleanup/unrelated"
+    worktree = add_worktree_branch(repo, branch)
+    db = tmp_path / "state.sqlite"
+    write_codex_db(db, task_id=5, title="Cleanup Task", cwd=str(worktree), archived=False)
+    marker = git_safety.resolve_state_root(repo) / "states" / "external.txt"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text("preserve\n", encoding="utf-8")
+
+    plan = make_plan(
+        repo,
+        worktree,
+        db,
+        task_id=5,
+        lineage_id="lineage-unrelated",
+        branch=branch,
+    )
+    monkeypatch.setattr(git_safety, "assert_no_unknown_branch_mutation", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        git_safety,
+        "query_pr_by_head",
+        lambda *args, **kwargs: mk_pr_payload(worktree),
+    )
+
+    result = CleanupExecutor(repo, plan).run()
+    assert result["state"] == "completed"
+    assert marker.exists()
+    assert "snapshotted" in result["stages"]
+    assert "bundle" in result["stages"]["snapshotted"]

--- a/tests/orchestration/task_family/test_executor.py
+++ b/tests/orchestration/task_family/test_executor.py
@@ -18,7 +18,11 @@ from scripts.orchestration.task_family.storage import TaskFamilyStorage
 
 
 def _git_env() -> dict[str, str]:
-    return {key: value for key, value in os.environ.items() if not key.startswith("GIT_")}
+    return {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith("GIT_") and key != "AGENT_NO_MERGE"
+    }
 
 
 def git(cwd: Path, *args: str) -> str:
@@ -266,6 +270,11 @@ def test_github_queries_use_valid_commands_and_normalize_merge_commit(tmp_path: 
     assert all("--json" not in call for call in calls if call and call[0] == "api")
     assert git_safety._normalize_merge_commit({"oid": "a" * 40}) == "a" * 40
     assert git_safety._normalize_merge_commit("b" * 40) == "b" * 40
+    incomplete_pr = pr("cleanup/missing-number", "a" * 40, 0)
+    with pytest.raises(git_safety.GitSafetyError, match="PR number mismatch"):
+        git_safety.assert_pr_is_merged(incomplete_pr, expected_number=9)
+    with pytest.raises(git_safety.GitSafetyError, match="invalid branch token"):
+        git_safety.assert_no_unknown_branch_mutation(repo, "--all")
 
 
 def test_finish_cleanup_preserves_unrelated_worktree_and_rechecks_pr_before_mutation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -352,3 +361,24 @@ def test_runtime_without_eligibility_or_proof_is_preserved_and_blocks(tmp_path: 
     saved = result["resources"]["runtime"][runtime.id]
     assert saved["status"] == "failed"
     assert "preserved" in saved["reason"]
+
+
+def test_eligible_runtime_is_truthfully_preserved_when_native_retirement_is_unavailable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo = init_repo(tmp_path)
+    branch, worktree = "cleanup/runtime-deferred", add_worktree(repo, "cleanup/runtime-deferred")
+    task_id = str(uuid4())
+    db = tmp_path / "state_5.sqlite"
+    write_threads(db, [{"id": task_id, "title": "A", "cwd": str(worktree), "archived": 1, "archived_at": "2026-01-01Z", "host": "host-a"}])
+    target = worktree_target(worktree, branch, "runtime-deferred", number=12)
+    runtime = executor.RuntimeTarget(id=str(uuid4()), kind="handoff", eligible=True, proof="replacement confirmed")
+    approved = plan(repo, family="runtime-deferred", mode="finish_and_clean", task_targets=(task(task_id, title="A", cwd=worktree, db_path=db),), worktree_targets=(target,), runtime_targets=(runtime,))
+    stub_remote(monkeypatch)
+    head = git(worktree, "rev-parse", "HEAD")
+    monkeypatch.setattr(git_safety, "query_pr_by_head", lambda *_args, **_kwargs: pr(branch, head, 12))
+
+    result = executor.CleanupExecutor(repo, approved).run()
+    assert result["state"] == "completed"
+    saved = result["resources"]["runtime"][runtime.id]
+    assert saved["status"] == "skipped"
+    assert saved["actual"]["retired"] is False
+    assert saved["actual"]["preserved"] is True

--- a/tests/orchestration/task_family/test_graph_planner.py
+++ b/tests/orchestration/task_family/test_graph_planner.py
@@ -103,8 +103,18 @@ def test_rename_mapping_uses_one_caller_supplied_base_and_stable_separator() -> 
     mapping = {item.task_id: item for item in rename_mapping(_graph(), "Lifecycle repair")}
 
     assert mapping["root"].new_title == "Lifecycle repair [Lead]"
-    assert mapping["replacement"].new_title == "Lifecycle repair [Replacement · Generation 1]"
+    assert mapping["replacement"].new_title == "Lifecycle repair [Repl. · Gen. 1]"
     assert mapping["replacement"].old_title == "Continuation"
+
+
+def test_rename_mapping_respects_native_codex_title_limit_without_losing_roles() -> None:
+    mapping = {item.task_id: item for item in rename_mapping(_graph(), "A deliberately oversized lifecycle repair title")}
+
+    replacement = mapping["replacement"]
+    assert len(replacement.new_title) <= 60
+    assert "… [" in replacement.new_title
+    assert replacement.new_title.endswith("[Repl. · Gen. 1]")
+    assert replacement.roles == ("Replacement", "Generation 1")
 
 
 def test_generation_is_transitive_and_relation_order_independent() -> None:

--- a/tests/orchestration/task_family/test_graph_planner.py
+++ b/tests/orchestration/task_family/test_graph_planner.py
@@ -99,6 +99,19 @@ def test_exact_id_component_excludes_similar_title_and_display_only_members() ->
     assert plan.excluded_task_ids == ("display", "unrelated")
 
 
+def test_unknown_relation_endpoint_blocks_without_entering_component() -> None:
+    graph = discover_task_family(
+        _manifest(
+            nodes=(_node("root", "Root"),),
+            relations=(TaskRelation("unknown-worker", "root", RelationType.SUBAGENT_OF, "invalid endpoint"),),
+        )
+    )
+
+    assert graph.included_task_ids == ("root",)
+    assert graph.roles_by_task == {"root": ("Lead",)}
+    assert any(blocker.code == "unknown_endpoint" for blocker in graph.blockers)
+
+
 def test_rename_mapping_uses_one_caller_supplied_base_and_stable_separator() -> None:
     mapping = {item.task_id: item for item in rename_mapping(_graph(), "Lifecycle repair")}
 

--- a/tests/orchestration/task_family/test_graph_planner.py
+++ b/tests/orchestration/task_family/test_graph_planner.py
@@ -7,14 +7,17 @@ import pytest
 from scripts.orchestration.task_family.graph import discover_task_family, rename_mapping
 from scripts.orchestration.task_family.model import (
     ArchiveSelection,
+    LifecycleEvent,
     LifecycleState,
     OperationKind,
+    OperationReceipt,
+    ReceiptAction,
     RelationType,
     TaskFamilyManifest,
     TaskNode,
     TaskRelation,
 )
-from scripts.orchestration.task_family.planner import build_plan
+from scripts.orchestration.task_family.planner import TaskFamilyPlan, build_plan
 from scripts.orchestration.task_family.storage import TaskFamilyStorage, atomic_write_json
 
 
@@ -22,9 +25,15 @@ def _node(task_id: str, title: str, **resources: str) -> TaskNode:
     return TaskNode(task_id, title, "/repo", **resources)
 
 
-def _manifest(*, relations: tuple[TaskRelation, ...], nodes: tuple[TaskNode, ...] | None = None) -> TaskFamilyManifest:
+def _manifest(
+    *,
+    relations: tuple[TaskRelation, ...],
+    nodes: tuple[TaskNode, ...] | None = None,
+    seed_task_id: str = "root",
+) -> TaskFamilyManifest:
     return TaskFamilyManifest(
         "family-5140",
+        seed_task_id,
         nodes
         or (
             _node("root", "Planner", worktree="/repo/root", branch="codex/root", pr_id="1"),
@@ -51,6 +60,10 @@ def _graph():
     )
 
 
+def _selection(task_id: str) -> ArchiveSelection:
+    return ArchiveSelection(task_id, "operator", selected_at="2026-07-14T00:00:00Z", pin_state_unknown_confirmed=True)
+
+
 def test_discovers_synthetic_root_worker_reviewer_handoff_and_replacement() -> None:
     graph = _graph()
 
@@ -63,44 +76,79 @@ def test_discovers_synthetic_root_worker_reviewer_handoff_and_replacement() -> N
     assert graph.roles_by_task["replacement"] == ("Replacement", "Generation 1")
 
 
-def test_similar_titles_do_not_establish_membership() -> None:
+def test_exact_id_component_excludes_similar_title_and_display_only_members() -> None:
     manifest = _manifest(
-        nodes=(_node("a", "Same title"), _node("b", "Same title")),
-        relations=(),
+        nodes=(
+            _node("root", "Same title"),
+            _node("worker", "Worker"),
+            _node("unrelated", "Same title"),
+            _node("display", "Same title"),
+        ),
+        relations=(
+            TaskRelation("worker", "root", RelationType.SUBAGENT_OF, "spawn"),
+            TaskRelation("display", "root", RelationType.ISSUE_OR_PR_MEMBER, "issue annotation", family_defining=False),
+        ),
     )
 
     graph = discover_task_family(manifest)
 
-    assert not graph.is_valid
-    assert any(blocker.code == "multiple_or_missing_roots" for blocker in graph.blockers)
+    assert graph.is_valid
+    assert graph.included_task_ids == ("root", "worker")
+    assert graph.excluded_task_ids == ("display", "unrelated")
+    plan = build_plan(graph, operation_id="component-preview", operation=OperationKind.ARCHIVE_ONLY, selections=(_selection("root"), _selection("worker")), base_title="Lifecycle repair")
+    assert plan.excluded_task_ids == ("display", "unrelated")
 
 
-def test_rename_mapping_preserves_multiple_roles_in_stable_order() -> None:
-    mapping = {item.task_id: item for item in rename_mapping(_graph())}
+def test_rename_mapping_uses_one_caller_supplied_base_and_stable_separator() -> None:
+    mapping = {item.task_id: item for item in rename_mapping(_graph(), "Lifecycle repair")}
 
-    assert mapping["replacement"].new_title == "Continuation [Replacement, Generation 1]"
+    assert mapping["root"].new_title == "Lifecycle repair [Lead]"
+    assert mapping["replacement"].new_title == "Lifecycle repair [Replacement · Generation 1]"
     assert mapping["replacement"].old_title == "Continuation"
 
 
-def test_conflicting_membership_fails_closed() -> None:
-    graph = discover_task_family(
+def test_generation_is_transitive_and_relation_order_independent() -> None:
+    nodes = (_node("root", "Root"), _node("generation-1", "One"), _node("generation-2", "Two"))
+    relations = (
+        TaskRelation("generation-1", "root", RelationType.ROLLOVER_GENERATION_OF, "first rollover"),
+        TaskRelation("generation-2", "generation-1", RelationType.ROLLOVER_GENERATION_OF, "second rollover"),
+    )
+    first = discover_task_family(_manifest(nodes=nodes, relations=relations))
+    second = discover_task_family(_manifest(nodes=nodes, relations=tuple(reversed(relations))))
+
+    assert first.roles_by_task == second.roles_by_task
+    assert first.roles_by_task["generation-2"] == ("Generation 2",)
+
+
+def test_rollover_cycle_and_conflict_fail_closed() -> None:
+    cycle = discover_task_family(
         _manifest(
-            nodes=(_node("root", "Root"), _node("other", "Other"), _node("worker", "Worker")),
+            nodes=(_node("root", "Root"), _node("next", "Next")),
             relations=(
-                TaskRelation("worker", "root", RelationType.SUBAGENT_OF, "first"),
-                TaskRelation("worker", "other", RelationType.SUBAGENT_OF, "conflict"),
+                TaskRelation("root", "next", RelationType.ROLLOVER_GENERATION_OF, "a"),
+                TaskRelation("next", "root", RelationType.ROLLOVER_GENERATION_OF, "b"),
+            ),
+        )
+    )
+    conflict = discover_task_family(
+        _manifest(
+            nodes=(_node("root", "Root"), _node("one", "One"), _node("two", "Two")),
+            relations=(
+                TaskRelation("root", "one", RelationType.ROLLOVER_GENERATION_OF, "a"),
+                TaskRelation("root", "two", RelationType.ROLLOVER_GENERATION_OF, "b"),
             ),
         )
     )
 
-    assert any(blocker.code == "conflicting_membership" for blocker in graph.blockers)
+    assert any(blocker.code == "parent_relation_cycle" for blocker in cycle.blockers)
+    assert any(blocker.code == "conflicting_membership" for blocker in conflict.blockers)
 
 
 def test_selection_requires_explicit_source_and_pin_confirmation() -> None:
     graph = _graph()
     selection = ArchiveSelection("root", "operator", selected_at="2026-07-14T00:00:00Z")
 
-    plan = build_plan(graph, operation_id="op-1", operation=OperationKind.ARCHIVE_ONLY, selections=(selection,))
+    plan = build_plan(graph, operation_id="op-1", operation=OperationKind.ARCHIVE_ONLY, selections=(selection,), base_title="Lifecycle repair")
 
     assert any(blocker.code == "pin_state_unconfirmed" for blocker in plan.blockers)
     assert plan.selections[0].selection_source == "explicit"
@@ -113,47 +161,46 @@ def test_unselected_shared_resource_blocks_planning() -> None:
         nodes=(_node("root", "Root", branch="codex/shared"), _node("worker", "Worker", branch="codex/shared")),
         relations=(TaskRelation("worker", "root", RelationType.SUBAGENT_OF, "spawn"),),
     )
-    plan = build_plan(
-        discover_task_family(manifest),
-        operation_id="op-2",
-        operation=OperationKind.ARCHIVE_ONLY,
-        selections=(ArchiveSelection("root", "operator", selected_at="2026-07-14T00:00:00Z", pin_state_unknown_confirmed=True),),
-    )
+    plan = build_plan(discover_task_family(manifest), operation_id="op-2", operation=OperationKind.ARCHIVE_ONLY, selections=(_selection("root"),), base_title="Lifecycle repair")
 
     assert any(blocker.code == "unselected_shared_resource" for blocker in plan.blockers)
     assert any(blocker.code == "unselected_lineage_endpoint" for blocker in plan.blockers)
 
 
-def test_plan_digest_is_deterministic() -> None:
-    selection = ArchiveSelection("root", "operator", selected_at="2026-07-14T00:00:00Z", pin_state_unknown_confirmed=True)
-
-    first = build_plan(_graph(), operation_id="op-digest", operation=OperationKind.ARCHIVE_ONLY, selections=(selection,))
-    second = build_plan(_graph(), operation_id="op-digest", operation=OperationKind.ARCHIVE_ONLY, selections=(selection,))
+def test_plan_digest_is_stable_across_relation_order_and_changes_on_mutation() -> None:
+    selection = _selection("root")
+    first = build_plan(_graph(), operation_id="op-digest", operation=OperationKind.ARCHIVE_ONLY, selections=(selection,), base_title="Lifecycle repair")
+    reordered = discover_task_family(_manifest(relations=tuple(reversed(_graph().manifest.relations))))
+    second = build_plan(reordered, operation_id="op-digest", operation=OperationKind.ARCHIVE_ONLY, selections=(selection,), base_title="Lifecycle repair")
+    mutated = build_plan(_graph(), operation_id="op-digest", operation=OperationKind.ARCHIVE_ONLY, selections=(selection,), base_title="Different lifecycle")
 
     assert first.digest == second.digest
-    assert first.digest == "0d96804ef4062004a5d4a414285732665c0e5e9c4720b887e962bff523b2456c"
+    assert first.digest != mutated.digest
 
 
-def test_atomic_persistence_and_immutable_digest(tmp_path) -> None:
-    path = tmp_path / "record.json"
-    atomic_write_json(path, {"b": 2, "a": 1})
-    assert json.loads(path.read_text(encoding="utf-8")) == {"a": 1, "b": 2}
-
-    selection = ArchiveSelection("root", "operator", selected_at="2026-07-14T00:00:00Z", pin_state_unknown_confirmed=True)
-    plan = build_plan(_graph(), operation_id="op-store", operation=OperationKind.ARCHIVE_ONLY, selections=(selection,))
-    storage = TaskFamilyStorage(tmp_path, plan.family_id, plan.operation_id)
-    storage.write_plan(plan)
-    assert storage.assert_plan_digest(plan.digest)["digest"] == plan.digest
-    storage.write_plan(plan)
-
-
-def test_completed_cleanup_is_a_model_level_noop() -> None:
-    selections = tuple(
-        ArchiveSelection(task_id, "operator", selected_at="2026-07-14T00:00:00Z", pin_state_unknown_confirmed=True)
-        for task_id in ("root", "worker", "review", "handoff", "replacement")
+def test_archive_only_stops_at_independently_reconciled_tasks_archived() -> None:
+    selections = tuple(_selection(task_id) for task_id in ("root", "worker", "review", "handoff", "replacement"))
+    plan = build_plan(_graph(), operation_id="op-archive", operation=OperationKind.ARCHIVE_ONLY, selections=selections, base_title="Lifecycle repair")
+    assert tuple(stage.state for stage in plan.stages) == (
+        LifecycleState.PLANNED,
+        LifecycleState.FROZEN,
+        LifecycleState.VERIFIED,
+        LifecycleState.TASKS_ARCHIVED,
     )
-    plan = build_plan(_graph(), operation_id="op-done", operation=OperationKind.ARCHIVE_ONLY, selections=selections)
-    for state in (
+    for state in (LifecycleState.FROZEN, LifecycleState.VERIFIED, LifecycleState.TASKS_ARCHIVED):
+        plan = plan.with_state(state)
+
+    assert plan.is_completed_cleanup_noop
+    assert plan.with_state(LifecycleState.TASKS_ARCHIVED) is plan
+    with pytest.raises(ValueError, match="terminal state"):
+        plan.with_state(LifecycleState.COMPLETED)
+
+
+def test_finish_and_clean_retains_full_ordered_path() -> None:
+    plan = build_plan(_graph(), operation_id="op-clean", operation=OperationKind.FINISH_AND_CLEAN, selections=tuple(_selection(task_id) for task_id in ("root", "worker", "review", "handoff", "replacement")), base_title="Lifecycle repair")
+
+    assert tuple(stage.state for stage in plan.stages) == (
+        LifecycleState.PLANNED,
         LifecycleState.FROZEN,
         LifecycleState.VERIFIED,
         LifecycleState.SNAPSHOTTED,
@@ -162,8 +209,51 @@ def test_completed_cleanup_is_a_model_level_noop() -> None:
         LifecycleState.BRANCHES_DELETED,
         LifecycleState.RUNTIME_RETIRED,
         LifecycleState.COMPLETED,
-    ):
-        plan = plan.with_state(state)
+    )
 
-    assert plan.is_completed_cleanup_noop
-    assert plan.with_state(LifecycleState.COMPLETED) is plan
+
+def test_storage_exposes_all_runtime_evidence_and_validated_loaders(tmp_path) -> None:
+    selection = _selection("root")
+    plan = build_plan(_graph(), operation_id="op-store", operation=OperationKind.ARCHIVE_ONLY, selections=(selection,), base_title="Lifecycle repair")
+    storage = TaskFamilyStorage(tmp_path, plan.family_id, plan.operation_id)
+    storage.write_manifest(_graph().manifest)
+    storage.write_plan(plan)
+    storage.write_state(LifecycleState.FROZEN, details={"lock": "held"})
+    storage.write_snapshot("before-archive.json", {"task_ids": ["root"]})
+    event = LifecycleEvent("event-1", "2026-07-14T00:00:00Z", LifecycleState.FROZEN, "verified", {"task_id": "root"})
+    storage.append_event(event)
+    action = ReceiptAction("task", "root", ("root",), "archive", "selected explicitly")
+    final = ReceiptAction("runtime", plan.operation_id, ("root",), "retained", "archive-only target reached")
+    receipt = OperationReceipt(plan.operation_id, plan.family_id, plan.digest, LifecycleState.TASKS_ARCHIVED, planned=(action,), actual=(action,), skipped=(ReceiptAction("worktree", "/repo/root", ("root",), "not-run", "archive-only"),), restoration=(ReceiptAction("task", "root", ("root",), "restore", "unarchive via task system"),), final_resources=(final,), events=(event,))
+    storage.write_receipt(receipt)
+
+    assert storage.manifest_path.is_file()
+    assert storage.plan_path.is_file()
+    assert storage.state_path.is_file()
+    assert storage.receipt_path.is_file() and storage.receipt_text_path.is_file()
+    assert (storage.snapshots_dir / "before-archive.json").is_file()
+    assert storage.load_manifest() == _graph().manifest
+    assert storage.load_plan() == plan
+    assert storage.load_state()["state"] == "frozen"
+    assert storage.load_events() == (event,)
+    assert storage.load_receipt() == receipt
+    assert "task:root archive" in storage.receipt_text_path.read_text(encoding="utf-8")
+
+
+def test_atomic_persistence_and_schema_validation_reject_drift_and_unknown_enums(tmp_path) -> None:
+    path = tmp_path / "record.json"
+    atomic_write_json(path, {"b": 2, "a": 1})
+    assert json.loads(path.read_text(encoding="utf-8")) == {"a": 1, "b": 2}
+    manifest_data = _graph().manifest.to_dict()
+    manifest_data["schema_version"] = 99
+    with pytest.raises(ValueError, match="schema_version"):
+        TaskFamilyManifest.from_dict(manifest_data)
+    manifest_data = _graph().manifest.to_dict()
+    manifest_data["relations"][0]["relation_type"] = "unknown"
+    with pytest.raises(ValueError, match="unknown task relation type"):
+        TaskFamilyManifest.from_dict(manifest_data)
+    plan = build_plan(_graph(), operation_id="op-parse", operation=OperationKind.ARCHIVE_ONLY, selections=(_selection("root"),), base_title="Lifecycle repair")
+    payload = plan.to_dict()
+    payload["state"] = "unknown"
+    with pytest.raises(ValueError, match="unknown operation or lifecycle state"):
+        TaskFamilyPlan.from_dict(payload)

--- a/tests/orchestration/task_family/test_graph_planner.py
+++ b/tests/orchestration/task_family/test_graph_planner.py
@@ -116,6 +116,10 @@ def test_rename_mapping_respects_native_codex_title_limit_without_losing_roles()
     assert replacement.new_title.endswith("[Repl. · Gen. 1]")
     assert replacement.roles == ("Replacement", "Generation 1")
 
+    ukrainian = {item.task_id: item for item in rename_mapping(_graph(), "Завершення надзвичайно довгого життєвого циклу завдання")}
+    assert len(ukrainian["replacement"].new_title) <= 60
+    assert ukrainian["replacement"].new_title.endswith("[Repl. · Gen. 1]")
+
 
 def test_generation_is_transitive_and_relation_order_independent() -> None:
     nodes = (_node("root", "Root"), _node("generation-1", "One"), _node("generation-2", "Two"))

--- a/tests/orchestration/task_family/test_graph_planner.py
+++ b/tests/orchestration/task_family/test_graph_planner.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.orchestration.task_family.graph import discover_task_family, rename_mapping
+from scripts.orchestration.task_family.model import (
+    ArchiveSelection,
+    LifecycleState,
+    OperationKind,
+    RelationType,
+    TaskFamilyManifest,
+    TaskNode,
+    TaskRelation,
+)
+from scripts.orchestration.task_family.planner import build_plan
+from scripts.orchestration.task_family.storage import TaskFamilyStorage, atomic_write_json
+
+
+def _node(task_id: str, title: str, **resources: str) -> TaskNode:
+    return TaskNode(task_id, title, "/repo", **resources)
+
+
+def _manifest(*, relations: tuple[TaskRelation, ...], nodes: tuple[TaskNode, ...] | None = None) -> TaskFamilyManifest:
+    return TaskFamilyManifest(
+        "family-5140",
+        nodes
+        or (
+            _node("root", "Planner", worktree="/repo/root", branch="codex/root", pr_id="1"),
+            _node("worker", "Implementation", worktree="/repo/worker", branch="codex/worker", pr_id="2"),
+            _node("review", "Review"),
+            _node("handoff", "Continuation"),
+            _node("replacement", "Continuation"),
+        ),
+        relations,
+    )
+
+
+def _graph():
+    return discover_task_family(
+        _manifest(
+            relations=(
+                TaskRelation("worker", "root", RelationType.SUBAGENT_OF, "spawn edge"),
+                TaskRelation("review", "worker", RelationType.REVIEWER_FOR, "review assignment"),
+                TaskRelation("handoff", "worker", RelationType.HANDOFF_OF, "handoff record"),
+                TaskRelation("replacement", "handoff", RelationType.REPLACEMENT_OF, "replacement record"),
+                TaskRelation("replacement", "handoff", RelationType.ROLLOVER_GENERATION_OF, "generation record"),
+            )
+        )
+    )
+
+
+def test_discovers_synthetic_root_worker_reviewer_handoff_and_replacement() -> None:
+    graph = _graph()
+
+    assert graph.is_valid
+    assert graph.roots == ("root",)
+    assert graph.roles_by_task["root"] == ("Lead",)
+    assert graph.roles_by_task["worker"] == ("Worker",)
+    assert graph.roles_by_task["review"] == ("Reviewer",)
+    assert graph.roles_by_task["handoff"] == ("Handoff",)
+    assert graph.roles_by_task["replacement"] == ("Replacement", "Generation 1")
+
+
+def test_similar_titles_do_not_establish_membership() -> None:
+    manifest = _manifest(
+        nodes=(_node("a", "Same title"), _node("b", "Same title")),
+        relations=(),
+    )
+
+    graph = discover_task_family(manifest)
+
+    assert not graph.is_valid
+    assert any(blocker.code == "multiple_or_missing_roots" for blocker in graph.blockers)
+
+
+def test_rename_mapping_preserves_multiple_roles_in_stable_order() -> None:
+    mapping = {item.task_id: item for item in rename_mapping(_graph())}
+
+    assert mapping["replacement"].new_title == "Continuation [Replacement, Generation 1]"
+    assert mapping["replacement"].old_title == "Continuation"
+
+
+def test_conflicting_membership_fails_closed() -> None:
+    graph = discover_task_family(
+        _manifest(
+            nodes=(_node("root", "Root"), _node("other", "Other"), _node("worker", "Worker")),
+            relations=(
+                TaskRelation("worker", "root", RelationType.SUBAGENT_OF, "first"),
+                TaskRelation("worker", "other", RelationType.SUBAGENT_OF, "conflict"),
+            ),
+        )
+    )
+
+    assert any(blocker.code == "conflicting_membership" for blocker in graph.blockers)
+
+
+def test_selection_requires_explicit_source_and_pin_confirmation() -> None:
+    graph = _graph()
+    selection = ArchiveSelection("root", "operator", selected_at="2026-07-14T00:00:00Z")
+
+    plan = build_plan(graph, operation_id="op-1", operation=OperationKind.ARCHIVE_ONLY, selections=(selection,))
+
+    assert any(blocker.code == "pin_state_unconfirmed" for blocker in plan.blockers)
+    assert plan.selections[0].selection_source == "explicit"
+    with pytest.raises(ValueError, match="selection_source"):
+        ArchiveSelection("root", "operator", selection_source="inferred", pin_state_unknown_confirmed=True)
+
+
+def test_unselected_shared_resource_blocks_planning() -> None:
+    manifest = _manifest(
+        nodes=(_node("root", "Root", branch="codex/shared"), _node("worker", "Worker", branch="codex/shared")),
+        relations=(TaskRelation("worker", "root", RelationType.SUBAGENT_OF, "spawn"),),
+    )
+    plan = build_plan(
+        discover_task_family(manifest),
+        operation_id="op-2",
+        operation=OperationKind.ARCHIVE_ONLY,
+        selections=(ArchiveSelection("root", "operator", selected_at="2026-07-14T00:00:00Z", pin_state_unknown_confirmed=True),),
+    )
+
+    assert any(blocker.code == "unselected_shared_resource" for blocker in plan.blockers)
+    assert any(blocker.code == "unselected_lineage_endpoint" for blocker in plan.blockers)
+
+
+def test_plan_digest_is_deterministic() -> None:
+    selection = ArchiveSelection("root", "operator", selected_at="2026-07-14T00:00:00Z", pin_state_unknown_confirmed=True)
+
+    first = build_plan(_graph(), operation_id="op-digest", operation=OperationKind.ARCHIVE_ONLY, selections=(selection,))
+    second = build_plan(_graph(), operation_id="op-digest", operation=OperationKind.ARCHIVE_ONLY, selections=(selection,))
+
+    assert first.digest == second.digest
+    assert first.digest == "0d96804ef4062004a5d4a414285732665c0e5e9c4720b887e962bff523b2456c"
+
+
+def test_atomic_persistence_and_immutable_digest(tmp_path) -> None:
+    path = tmp_path / "record.json"
+    atomic_write_json(path, {"b": 2, "a": 1})
+    assert json.loads(path.read_text(encoding="utf-8")) == {"a": 1, "b": 2}
+
+    selection = ArchiveSelection("root", "operator", selected_at="2026-07-14T00:00:00Z", pin_state_unknown_confirmed=True)
+    plan = build_plan(_graph(), operation_id="op-store", operation=OperationKind.ARCHIVE_ONLY, selections=(selection,))
+    storage = TaskFamilyStorage(tmp_path, plan.family_id, plan.operation_id)
+    storage.write_plan(plan)
+    assert storage.assert_plan_digest(plan.digest)["digest"] == plan.digest
+    storage.write_plan(plan)
+
+
+def test_completed_cleanup_is_a_model_level_noop() -> None:
+    selections = tuple(
+        ArchiveSelection(task_id, "operator", selected_at="2026-07-14T00:00:00Z", pin_state_unknown_confirmed=True)
+        for task_id in ("root", "worker", "review", "handoff", "replacement")
+    )
+    plan = build_plan(_graph(), operation_id="op-done", operation=OperationKind.ARCHIVE_ONLY, selections=selections)
+    for state in (
+        LifecycleState.FROZEN,
+        LifecycleState.VERIFIED,
+        LifecycleState.SNAPSHOTTED,
+        LifecycleState.TASKS_ARCHIVED,
+        LifecycleState.WORKTREES_REMOVED,
+        LifecycleState.BRANCHES_DELETED,
+        LifecycleState.RUNTIME_RETIRED,
+        LifecycleState.COMPLETED,
+    ):
+        plan = plan.with_state(state)
+
+    assert plan.is_completed_cleanup_noop
+    assert plan.with_state(LifecycleState.COMPLETED) is plan


### PR DESCRIPTION
## Summary

- add an exact-ID, typed-relation task-family graph, deterministic planner, durable operation storage, and noninteractive CLI
- add native Codex state inspection/reconciliation plus fail-closed, resumable cleanup with recovery bundles and append-only receipts
- add the promoted `task-family-manager` skill and native UI integration specification
- cover archive-only, finish-and-clean, crash/resume, digest binding, malformed identity input, shared resources, and shared-worktree locks

## Safety model

- no family inference from titles, cwd, project roots, issue/PR membership, chronology, or model/provider
- archive selection remains explicit per exact task ID; pin uncertainty requires affirmative confirmation
- destructive cleanup requires terminal task evidence, exact merged-PR/head/base evidence, clean/current base, worktree exclusivity, remote-branch absence, and a verified recovery bundle
- local branches are deleted only by exact validated name after the complete fence; runtime and automation records are preserved and truthfully marked deferred when no native retirement API exists
- locks are ordered and keyed by operation, lineage, family, and unique resolved worktree path

## Verification

- `AGENT_NO_MERGE=1 .venv/bin/python -m pytest tests/orchestration/task_family -q` — **40 passed**
- Ruff and Python compileall — pass
- skill quick validation and Markdown lint — pass
- `npm run agents:deploy` — pass
- protected config, artifact, diff, and 13-commit `X-Agent` trailer gates — pass
- real Codex-app smoke across lead/worker/reviewer/handoff/replacement: rename, archive, restore, re-archive — pass; unrelated task preserved

## Independent review

- architecture: Claude Opus/xhigh R3 APPROVE
- independent implementation: DeepSeek APPROVE
- cross-family release gates: Claude Opus/xhigh R2, exact-SHA R3, and final-delta R4 all APPROVE
- evidence and smoke receipt: https://github.com/learn-ukrainian/learn-ukrainian.github.io/issues/5140#issuecomment-4970921760

Fixes #5140