### PR TITLE
fix(atlas): migrate source labels to academic attribution

### DIFF
--- a/docs/best-practices/atlas-source-presentation.md
+++ b/docs/best-practices/atlas-source-presentation.md
@@ -49,8 +49,12 @@ enterprise with named institutions, not an anonymous internet commons.
 
 ## Implementation status
 
-Tracked in the issue referenced by this doc's introducing PR: source-label
-generation in `scripts/lexicon/enrich_manifest.py` (e.g. `_relation_source_label`,
-translation source lines) currently emits `slovnyk.me: …` strings that ship into
-learner-visible section labels — these migrate to structured
-`{dictionary, authors, official_url}` attribution.
+Tracked in #5163: source-label generation in `scripts/lexicon/enrich_manifest.py`
+maps mirror aggregators and per-corpus `relation_pairs/*` keys to academic labels
+via `scripts/lexicon/source_attribution.py`; unmapped internal labels fail the
+`unmapped_source_label` conformance gate (never silent pass-through).
+
+**Post-merge operator step:** run
+`.venv/bin/python scripts/lexicon/migrate_source_labels.py --write` against
+`site/src/data/lexicon-manifest.json`, then republish the Atlas manifest release
+so learner-facing footers pick up remapped attribution.

--- a/scripts/audit/check_atlas_manifest_enrichment.py
+++ b/scripts/audit/check_atlas_manifest_enrichment.py
@@ -32,6 +32,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from scripts.lexicon.manifest_io import load_manifest
+from scripts.lexicon.source_attribution import learner_facing_mirror_violations
 
 # The #3631 regression was a cliff: ~85% enriched -> 0%. Healthy manifests have
 # historically run 60-85% enriched. A 0.40 floor decisively separates a thin
@@ -63,12 +64,26 @@ def check_enrichment(
     ratio = enriched / total
     flag = manifest.get("enrichment_generated")
 
+    mirror_violations = 0
+    mirror_probe = json.loads(json.dumps(manifest, ensure_ascii=False))
+    from scripts.lexicon.migrate_source_labels import migrate_manifest
+
+    migrate_manifest(mirror_probe)
+    for entry in mirror_probe.get("entries", []):
+        if isinstance(entry, dict):
+            mirror_violations += len(learner_facing_mirror_violations(entry))
+
     problems: list[str] = []
     if flag is not True:
         problems.append(f"enrichment_generated={flag!r} (expected True)")
     if ratio < min_ratio:
         problems.append(
             f"enriched ratio {ratio:.1%} ({enriched}/{total}) below floor {min_ratio:.0%}"
+        )
+    if mirror_violations:
+        problems.append(
+            f"{mirror_violations} learner-facing mirror attribution violation(s) after "
+            "migrate_source_labels (slovnyk.me/goroh.pp.ua/sum.in.ua in source labels or hrefs)"
         )
 
     if problems:

--- a/scripts/audit/validate_atlas_conformance.py
+++ b/scripts/audit/validate_atlas_conformance.py
@@ -215,6 +215,7 @@ def validate(manifest: Any, *, vesum: Any, curriculum: Any, heritage: Any = None
             _check_kaikki_attribution(entry, lemma, violations)
             _check_cross_links(entry, lemma, curriculum_modules, violations)
             _check_wikipedia(entry, lemma, violations)
+            _check_mirror_attribution(entry, lemma, violations)
     finally:
         if should_close_lookup:
             lookup.close()
@@ -882,6 +883,19 @@ def _check_wikipedia(entry: Mapping[str, Any], lemma: str, violations: list[Viol
                     f"{section_path} section is missing url or freshness date",
                 )
             )
+
+
+def _check_mirror_attribution(entry: Mapping[str, Any], lemma: str, violations: list[Violation]) -> None:
+    from scripts.lexicon.source_attribution import learner_facing_mirror_violations
+
+    for detail in learner_facing_mirror_violations(dict(entry)):
+        violations.append(
+            Violation(
+                "no_mirror_attribution",
+                lemma,
+                detail.split(": ", 1)[-1] if ": " in detail else detail,
+            )
+        )
 
 
 def _load_json(path: Path) -> Any:

--- a/scripts/audit/validate_atlas_conformance.py
+++ b/scripts/audit/validate_atlas_conformance.py
@@ -216,6 +216,7 @@ def validate(manifest: Any, *, vesum: Any, curriculum: Any, heritage: Any = None
             _check_cross_links(entry, lemma, curriculum_modules, violations)
             _check_wikipedia(entry, lemma, violations)
             _check_mirror_attribution(entry, lemma, violations)
+            _check_unmapped_source_label(entry, lemma, violations)
     finally:
         if should_close_lookup:
             lookup.close()
@@ -892,6 +893,19 @@ def _check_mirror_attribution(entry: Mapping[str, Any], lemma: str, violations: 
         violations.append(
             Violation(
                 "no_mirror_attribution",
+                lemma,
+                detail.split(": ", 1)[-1] if ": " in detail else detail,
+            )
+        )
+
+
+def _check_unmapped_source_label(entry: Mapping[str, Any], lemma: str, violations: list[Violation]) -> None:
+    from scripts.lexicon.source_attribution import learner_facing_unmapped_source_violations
+
+    for detail in learner_facing_unmapped_source_violations(dict(entry)):
+        violations.append(
+            Violation(
+                "unmapped_source_label",
                 lemma,
                 detail.split(": ", 1)[-1] if ": " in detail else detail,
             )

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -4038,7 +4038,7 @@ def _merge_homonym_relations(
                 item["homonym_no"] = number
                 item["pos"] = pos
             if relation.get("pattern") == "corpus relation pair":
-                item["source"] = relation["source"]
+                item["source"] = normalize_academic_label(str(relation.get("source") or ""))
             items.append(item)
             additions += 1
 

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -84,6 +84,21 @@ from scripts.lexicon.manifest_io import (
     GATE_REJECTED,
     GATE_SKIPPED_OFFLINE,
 )
+from scripts.lexicon.source_attribution import (
+    BALLA_LABEL,
+    CORRECTION_DICTIONARIES_LABEL,
+    PHRASEOLOGY_LABEL,
+    SLUG_ACADEMIC_LABELS,
+    SUM20_ACADEMIC_LABEL,
+    SUM20_SHORT_LABEL,
+    VTS_ACADEMIC_LABEL,
+    VTS_SHORT_LABEL,
+    attach_official_url,
+    join_academic_source_labels,
+    normalize_academic_label,
+    official_url_for_slug,
+    remap_url_list,
+)
 from scripts.verification.vesum import verify_lemma, verify_word
 from scripts.wiki.slovnyk_me import primary_synonym_sense_text
 
@@ -156,22 +171,14 @@ _GRAC_WORDLIST_URL = "https://sketch.uacorpus.org/bonito/run.cgi/wordlist"
 _GRAC_CORPUS = "grac19a"
 _GRAC_BATCH_SIZE = 25
 
-_SLOVNYK_DICT_LABELS: dict[str, str] = {
-    "newsum": "Словник української мови у 20 томах (СУМ-20)",
-    "synonyms": "Словник синонімів української мови",
-    "synonyms_karavansky": "Словник синонімів Караванського",
-    "phraseology": "Фразеологічний словник української мови",
-    "davydov": "«Як ми говоримо» Антоненка-Давидовича",
-    "voloschak": "Неправильно-правильно",
-    "foreign_shtepa": "Словник чужослів Павла Штепи",
-}
+_SLOVNYK_DICT_LABELS: dict[str, str] = dict(SLUG_ACADEMIC_LABELS)
 _SLOVNYK_LOOKUP_SLUGS = tuple(_SLOVNYK_DICT_LABELS)
 _SLOVNYK_SYNONYM_SLUGS = ("synonyms_karavansky", "synonyms")
 _SLOVNYK_IDIOM_SLUGS = ("phraseology",)
 _SLOVNYK_WARNING_SLUGS = ("davydov", "voloschak", "foreign_shtepa")
 _SLOVNYK_UKRENG_SLUG = "ukreng"
-_SLOVNYK_UKRENG_LABEL = "Українсько-англійський словник"
-_SLOVNYK_UKRENG_SOURCE = f"slovnyk.me: {_SLOVNYK_UKRENG_LABEL}"
+_SLOVNYK_UKRENG_LABEL = BALLA_LABEL
+_SLOVNYK_UKRENG_SOURCE = BALLA_LABEL
 _SLOVNYK_BASE = "https://slovnyk.me"
 _SLOVNYK_CACHE_SCHEMA_VERSION = 2
 _OFFLINE_VALUES = {"1", "true", "yes", "on"}
@@ -1587,11 +1594,16 @@ def _synonyms_slovnyk(
             urls.append(str(row["source_url"]))
     if not items:
         return None
-    return {
+    official_urls, mirror_urls = remap_url_list(list(dict.fromkeys(urls)))
+    block: dict[str, Any] = {
         "items": items[:24],
-        "source": "slovnyk.me: " + " + ".join(dict.fromkeys(sources)),
-        "source_urls": list(dict.fromkeys(urls)),
+        "source": join_academic_source_labels(sources),
     }
+    if official_urls:
+        block["source_urls"] = official_urls
+    if mirror_urls:
+        block["mirror_source_urls"] = mirror_urls
+    return block
 
 
 def _clean_atlas_chip_candidate(candidate: str, lemma: str) -> str | None:
@@ -1738,19 +1750,24 @@ def _idioms_slovnyk(lemma: str, cache: dict[str, Any] | None = None) -> dict[str
     if not split:
         return None
     phrase, definition = split
-    return {
-        "items": [
-            {
-                "text": phrase,
-                "phrase": phrase,
-                "definition": definition,
-                "source": str(row.get("dictionary_label") or _SLOVNYK_DICT_LABELS["phraseology"]),
-                "source_url": str(row.get("source_url") or ""),
-            }
-        ],
-        "source": "slovnyk.me: Фразеологічний словник української мови",
-        "source_urls": [str(row["source_url"])] if row.get("source_url") else [],
+    item: dict[str, Any] = {
+        "text": phrase,
+        "phrase": phrase,
+        "definition": definition,
+        "source": PHRASEOLOGY_LABEL,
     }
+    mirror_url = str(row.get("source_url") or "")
+    attach_official_url(item, mirror_url=mirror_url, slug="phraseology", word=str(row.get("word") or lemma))
+    official_urls, mirror_urls = remap_url_list([mirror_url] if mirror_url else [])
+    block: dict[str, Any] = {
+        "items": [item],
+        "source": PHRASEOLOGY_LABEL,
+    }
+    if official_urls:
+        block["source_urls"] = official_urls
+    if mirror_urls:
+        block["mirror_source_urls"] = mirror_urls
+    return block
 
 
 _PHRASEOLOGY_MARKUP_REPLACEMENTS = (
@@ -2116,7 +2133,7 @@ def _warning_slovnyk(lemma: str, cache: dict[str, Any] | None = None) -> dict[st
         return None
     return {
         "alternatives": alternatives,
-        "source": "slovnyk.me correction dictionaries",
+        "source": CORRECTION_DICTIONARIES_LABEL,
         "evidence": evidence,
     }
 
@@ -2895,12 +2912,18 @@ def _sum20_definition_card(
         return None
     card = {
         "id": "sum20",
-        "source": "СУМ-20",
-        "source_pill": "СУМ-20",
+        "source": SUM20_ACADEMIC_LABEL,
+        "source_pill": SUM20_SHORT_LABEL,
         "note": "сучасний тлумачний словник",
         "definitions": [text],
-        "source_url": str(row.get("source_url") or ""),
     }
+    mirror_url = str(row.get("source_url") or "")
+    attach_official_url(
+        card,
+        mirror_url=mirror_url,
+        slug="newsum",
+        word=str(row.get("word") or lookup_word),
+    )
     if resolve_xref:
         resolved = _resolve_definition_xref(
             card,
@@ -2953,12 +2976,18 @@ def _vts_definition_card(
         return None
     card = {
         "id": "vts",
-        "source": "ВТС",
-        "source_pill": "ВТС",
+        "source": VTS_ACADEMIC_LABEL,
+        "source_pill": VTS_SHORT_LABEL,
         "note": "Великий тлумачний словник сучасної української мови",
         "definitions": [text],
-        "source_url": str(row.get("source_url") or ""),
     }
+    mirror_url = str(row.get("source_url") or "")
+    attach_official_url(
+        card,
+        mirror_url=mirror_url,
+        slug="vts",
+        word=str(row.get("word") or lookup_word),
+    )
     if resolve_xref:
         resolved = _resolve_definition_xref(
             card,
@@ -3078,14 +3107,20 @@ def _dictionary_definition_rows(
             strip_leading_headword=True,
         )
         if text:
-            rows.append(
-                {
-                    "source": source,
-                    "text": text,
-                    "source_url": str(row.get("source_url") or ""),
-                    "sovietization_risk": 0,
-                }
-            )
+            row_payload: dict[str, Any] = {
+                "source": SUM20_SHORT_LABEL if source == "СУМ-20" else source,
+                "text": text,
+                "sovietization_risk": 0,
+            }
+            mirror_url = str(row.get("source_url") or "")
+            if mirror_url:
+                attach_official_url(
+                    row_payload,
+                    mirror_url=mirror_url,
+                    slug="newsum" if slug == "newsum" else "vts",
+                    word=str(row.get("word") or lemma),
+                )
+            rows.append(row_payload)
 
     sum11_fields = "definition, text"
     if has_sum11_flags:
@@ -3464,13 +3499,17 @@ def _homonym_dictionary_rows(
     rows: list[dict[str, str]] = []
     sum20 = _cache_lookup(cache, "newsum")
     if sum20 and sum20.get("text"):
-        rows.append(
-            {
-                "source": "СУМ-20",
-                "text": _definition_body(sum20["text"], limit=20_000),
-                "source_url": str(sum20.get("source_url") or ""),
-            }
+        payload = {
+            "source": SUM20_SHORT_LABEL,
+            "text": _definition_body(sum20["text"], limit=20_000),
+        }
+        attach_official_url(
+            payload,
+            mirror_url=str(sum20.get("source_url") or ""),
+            slug="newsum",
+            word=str(sum20.get("word") or lemma),
         )
+        rows.append(payload)
     try:
         for variant in _split_lemma_variants(lemma):
             for definition, text in conn.execute(
@@ -3773,7 +3812,8 @@ def _corpus_relation_pairs_by_headword(
 
 def _relation_source_label(relation: dict[str, Any], item: str) -> str:
     """Record pair-level provenance in the existing rendered ``source`` field."""
-    label = f"{relation['source']}: {relation['pattern']} → {item}"
+    source = normalize_academic_label(str(relation.get("source") or ""))
+    label = f"{source}: {relation['pattern']} → {item}"
     if relation.get("direction"):
         label += " (reciprocal)"
     gate = relation.get("gate")
@@ -3790,6 +3830,22 @@ def _relation_source_label(relation: dict[str, Any], item: str) -> str:
         synset_note = f"; synset={synset_id}" if synset_id else ""
         label += f" [gate: VESUM both valid; {evidence}{synset_note}]"
     return label
+
+
+def _append_relation_source_urls(
+    merged: dict[str, Any],
+    source_urls: list[str],
+    relation: dict[str, Any],
+) -> None:
+    raw = str(relation.get("source_url") or "").strip()
+    if not raw:
+        return
+    official, mirrors = remap_url_list([raw])
+    source_urls.extend(url for url in official if url not in source_urls)
+    if mirrors:
+        mirror_urls = [str(url) for url in merged.get("mirror_source_urls", []) if str(url).strip()]
+        mirror_urls.extend(url for url in mirrors if url not in mirror_urls)
+        merged["mirror_source_urls"] = list(dict.fromkeys(mirror_urls))
 
 
 def _merge_synonym_relations(
@@ -3823,7 +3879,7 @@ def _merge_synonym_relations(
         if label not in source_labels:
             source_labels.append(label)
         if relation.get("source_url") and relation["source_url"] not in source_urls:
-            source_urls.append(str(relation["source_url"]))
+            _append_relation_source_urls(merged, source_urls, relation)
 
     if not items:
         return None
@@ -3871,7 +3927,7 @@ def _merge_antonym_relations(
         if label not in source_labels:
             source_labels.append(label)
         if relation.get("source_url") and relation["source_url"] not in source_urls:
-            source_urls.append(str(relation["source_url"]))
+            _append_relation_source_urls(merged, source_urls, relation)
 
     if not items:
         return None
@@ -3994,7 +4050,7 @@ def _merge_homonym_relations(
             if label not in source_labels:
                 source_labels.append(label)
             if relation.get("source_url") and relation["source_url"] not in source_urls:
-                source_urls.append(str(relation["source_url"]))
+                _append_relation_source_urls(merged, source_urls, relation)
 
     if not items:
         return None
@@ -4078,7 +4134,7 @@ def _merge_paronym_relations(
         if label not in source_labels:
             source_labels.append(label)
         if relation.get("source_url") and relation["source_url"] not in source_urls:
-            source_urls.append(str(relation["source_url"]))
+            _append_relation_source_urls(merged, source_urls, relation)
 
     if not items:
         return None
@@ -5059,9 +5115,8 @@ def _slovnyk_ukreng_translation(lemma: str, cache: dict[str, Any] | None) -> dic
         "en": glosses,
         "source": _SLOVNYK_UKRENG_SOURCE,
     }
-    source_url = str(row.get("source_url") or "").strip()
-    if source_url:
-        block["source_url"] = source_url
+    mirror_url = str(row.get("source_url") or "").strip()
+    attach_official_url(block, mirror_url=mirror_url, slug=_SLOVNYK_UKRENG_SLUG, word=lemma)
     return block
 
 
@@ -5107,9 +5162,8 @@ def _fill_learner_english_anchor_from_slovnyk_cache(
         "en": glosses,
         "source": _SLOVNYK_UKRENG_SOURCE,
     }
-    source_url = str(row.get("source_url") or "").strip()
-    if source_url:
-        translation["source_url"] = source_url
+    mirror_url = str(row.get("source_url") or "").strip()
+    attach_official_url(translation, mirror_url=mirror_url, slug=_SLOVNYK_UKRENG_SLUG, word=lemma)
     enrichment = entry.get("enrichment")
     if not isinstance(enrichment, dict):
         enrichment = {}

--- a/scripts/lexicon/enrich_manifest.py
+++ b/scripts/lexicon/enrich_manifest.py
@@ -3813,7 +3813,8 @@ def _corpus_relation_pairs_by_headword(
 def _relation_source_label(relation: dict[str, Any], item: str) -> str:
     """Record pair-level provenance in the existing rendered ``source`` field."""
     source = normalize_academic_label(str(relation.get("source") or ""))
-    label = f"{source}: {relation['pattern']} → {item}"
+    # A relation with no/blank source must not render a leading-colon label.
+    label = f"{source}: {relation['pattern']} → {item}" if source else f"{relation['pattern']} → {item}"
     if relation.get("direction"):
         label += " (reciprocal)"
     gate = relation.get("gate")

--- a/scripts/lexicon/migrate_source_labels.py
+++ b/scripts/lexicon/migrate_source_labels.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Remap learner-facing Atlas source labels away from mirror aggregators (#5163).
+
+Targeted manifest migration: rewrites already-hydrated ``lexicon-manifest.json``
+source strings and URLs to academic attribution without running full enrich.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
+DEFAULT_FINGERPRINT = ROOT / "site" / "src" / "data" / "lexicon-manifest.fingerprint.json"
+
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.lexicon import enrich_manifest
+from scripts.lexicon.source_attribution import apply_entry_attribution, learner_facing_mirror_violations
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _refresh_manifest_fingerprint(manifest: dict[str, Any], fingerprint_path: Path) -> None:
+    fingerprint_payload = enrich_manifest.write_fingerprint(fingerprint_path, root=ROOT)
+    manifest["manifest_fingerprint"] = {
+        "schema_version": fingerprint_payload["schema_version"],
+        "fingerprint": fingerprint_payload["fingerprint"],
+    }
+
+
+def migrate_manifest(manifest: dict[str, Any]) -> tuple[int, int]:
+    changed_entries = 0
+    remaining = 0
+    for entry in manifest.get("entries", []):
+        if not isinstance(entry, dict):
+            continue
+        before = json.dumps(entry, ensure_ascii=False, sort_keys=True)
+        apply_entry_attribution(entry)
+        after = json.dumps(entry, ensure_ascii=False, sort_keys=True)
+        if before != after:
+            changed_entries += 1
+        if learner_facing_mirror_violations(entry):
+            remaining += 1
+    return changed_entries, remaining
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Migrate Atlas source labels to academic attribution (#5163).")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--fingerprint", type=Path, default=DEFAULT_FINGERPRINT)
+    parser.add_argument("--write", action="store_true", help="Write the migrated manifest and refresh fingerprint.")
+    args = parser.parse_args(argv)
+
+    manifest_path = args.manifest if args.manifest.is_absolute() else ROOT / args.manifest
+    fingerprint_path = args.fingerprint if args.fingerprint.is_absolute() else ROOT / args.fingerprint
+    manifest = _load_json(manifest_path)
+    changed, remaining = migrate_manifest(manifest)
+    print(f"migrated {changed} entries with learner-facing source label/url updates")
+    print(f"remaining mirror-attribution violations: {remaining}")
+    if args.write:
+        _refresh_manifest_fingerprint(manifest, fingerprint_path)
+        _write_json(manifest_path, manifest)
+        print(f"wrote {manifest_path}")
+        print(f"refreshed {fingerprint_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lexicon/migrate_source_labels.py
+++ b/scripts/lexicon/migrate_source_labels.py
@@ -20,7 +20,10 @@ DEFAULT_FINGERPRINT = ROOT / "site" / "src" / "data" / "lexicon-manifest.fingerp
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from scripts.lexicon import enrich_manifest
+# NOTE: import the pure fingerprint module, NOT enrich_manifest — the CI freshness
+# gate imports this module in a minimal env without third-party deps (#5166 burn:
+# enrich_manifest pulls `requests` at module level).
+from scripts.lexicon.manifest_fingerprint import write_fingerprint
 from scripts.lexicon.source_attribution import apply_entry_attribution, learner_facing_mirror_violations
 
 
@@ -36,7 +39,7 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
 
 
 def _refresh_manifest_fingerprint(manifest: dict[str, Any], fingerprint_path: Path) -> None:
-    fingerprint_payload = enrich_manifest.write_fingerprint(fingerprint_path, root=ROOT)
+    fingerprint_payload = write_fingerprint(fingerprint_path, root=ROOT)
     manifest["manifest_fingerprint"] = {
         "schema_version": fingerprint_payload["schema_version"],
         "fingerprint": fingerprint_payload["fingerprint"],

--- a/scripts/lexicon/source_attribution.py
+++ b/scripts/lexicon/source_attribution.py
@@ -13,6 +13,7 @@ from typing import Any
 from urllib.parse import quote, unquote, urlparse
 
 MIRROR_HOSTS = frozenset({"slovnyk.me", "goroh.pp.ua", "sum.in.ua", "www.slovnyk.me", "www.goroh.pp.ua", "www.sum.in.ua"})
+# Astro mirror guard: site/src/lexicon/WordAtlasArticle.astro MIRROR_HOSTS (no www. prefix there).
 MIRROR_HOST_PATTERN = re.compile(
     r"(?:^|[\s/+])(slovnyk\.me|goroh\.pp\.ua|sum\.in\.ua)(?:[/:\s]|$)",
     re.IGNORECASE,
@@ -42,6 +43,12 @@ DAVYDOV_LABEL = "«Як ми говоримо» Антоненка-Давидо�
 VOLOSHCHAK_LABEL = "Неправильно-правильно"
 SHTEPA_LABEL = "Словник чужослів Павла Штепи"
 CORRECTION_DICTIONARIES_LABEL = "Словники мовних поправок"
+GRAC_LABEL = "Генеральний регіонально анотований корпус української мови (ГРАК)"
+MIYKLAS_LABEL = "навчальні матеріали МійКлас (корпусні пари)"
+GRINCHENKO_LABEL = "Словарь української мови Б. Грінченка (1907–1909)"
+
+RELATION_PAIRS_PREFIX = "relation_pairs/"
+UNMAPPED_SOURCE_PATTERN = re.compile(r"relation_pairs/", re.IGNORECASE)
 
 SUM20_OFFICIAL_HOME = "https://sum20ua.com"
 ULIF_EXPL_HOME = "https://services.ulif.org.ua/expl"
@@ -67,7 +74,29 @@ LEGACY_LABEL_ALIASES: dict[str, str] = {
     "Словник української мови у 20 томах (СУМ-20)": SUM20_ACADEMIC_LABEL,
     SUM20_SHORT_LABEL: SUM20_ACADEMIC_LABEL,
     VTS_SHORT_LABEL: VTS_ACADEMIC_LABEL,
+    "Грінченко": GRINCHENKO_LABEL,
 }
+
+KNOWN_ACADEMIC_LABELS = frozenset(
+    {
+        *SLUG_ACADEMIC_LABELS.values(),
+        *LEGACY_LABEL_ALIASES.values(),
+        SUM20_ACADEMIC_LABEL,
+        VTS_ACADEMIC_LABEL,
+        KARAVANSKY_LABEL,
+        SYNONYMS_LABEL,
+        PHRASEOLOGY_LABEL,
+        BALLA_LABEL,
+        BALLA_SHORT_LABEL,
+        DAVYDOV_LABEL,
+        VOLOSHCHAK_LABEL,
+        SHTEPA_LABEL,
+        CORRECTION_DICTIONARIES_LABEL,
+        GRAC_LABEL,
+        MIYKLAS_LABEL,
+        GRINCHENKO_LABEL,
+    }
+)
 
 
 def is_mirror_host(host: str) -> bool:
@@ -132,13 +161,56 @@ def academic_label_for_slug(slug: str) -> str | None:
     return SLUG_ACADEMIC_LABELS.get(slug.strip().casefold())
 
 
+def _relation_pairs_corpus_key(label: str) -> str | None:
+    trimmed = label.strip()
+    if not trimmed.casefold().startswith(RELATION_PAIRS_PREFIX):
+        return None
+    remainder = trimmed[len(RELATION_PAIRS_PREFIX) :]
+    return remainder.split(":", 1)[0].strip()
+
+
+def _map_relation_pairs_corpus(corpus_key: str) -> str | None:
+    lowered = corpus_key.casefold()
+    if lowered.startswith("grac"):
+        return GRAC_LABEL
+    if "miyklas" in lowered:
+        return MIYKLAS_LABEL
+    return None
+
+
+def _remap_relation_pairs_label(label: str) -> str:
+    corpus_key = _relation_pairs_corpus_key(label)
+    if corpus_key is None:
+        return label
+    mapped = _map_relation_pairs_corpus(corpus_key)
+    if mapped is None:
+        return label
+    if ":" in label:
+        _, rest = label.split(":", 1)
+        rest = rest.lstrip()
+        return f"{mapped}: {rest}" if rest else mapped
+    return mapped
+
+
+def contains_unmapped_source_label(value: object) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    return bool(UNMAPPED_SOURCE_PATTERN.search(value))
+
+
 def normalize_academic_label(label: str) -> str:
     cleaned = SLOVNYK_SOURCE_PREFIX_RE.sub("", label.strip())
     if not cleaned:
         return cleaned
     if cleaned.casefold().startswith("slovnyk.me correction"):
         return CORRECTION_DICTIONARIES_LABEL
-    return LEGACY_LABEL_ALIASES.get(cleaned, cleaned)
+    if cleaned.casefold().startswith(RELATION_PAIRS_PREFIX):
+        return _remap_relation_pairs_label(cleaned)
+    if cleaned in LEGACY_LABEL_ALIASES:
+        return LEGACY_LABEL_ALIASES[cleaned]
+    if cleaned in KNOWN_ACADEMIC_LABELS:
+        return cleaned
+    return cleaned
 
 
 def join_academic_source_labels(labels: list[str]) -> str:
@@ -221,6 +293,17 @@ def apply_section_attribution(section: dict[str, Any]) -> bool:
     remapped = remap_mirror_source_string(source)
     if remapped != source:
         section["source"] = remapped
+        changed = True
+
+    block_url = str(section.get("source_url") or "")
+    if is_mirror_url(block_url):
+        block = dict(section)
+        attach_official_url(block, mirror_url=block_url)
+        for key in ("source_url", "mirror_source_url"):
+            if key in block:
+                section[key] = block[key]
+            elif key in section and key not in block:
+                del section[key]
         changed = True
 
     raw_urls = [str(url) for url in section.get("source_urls", []) if str(url).strip()]
@@ -328,6 +411,28 @@ def apply_entry_attribution(entry: dict[str, Any]) -> bool:
         for card in enrichment.get("definition_cards") or []:
             if isinstance(card, dict) and apply_definition_card_attribution(card, lemma=lemma):
                 changed = True
+        sources = enrichment.get("sources")
+        if isinstance(sources, list):
+            remapped_sources: list[str] = []
+            seen: set[str] = set()
+            sources_changed = False
+            for raw in sources:
+                label = remap_mirror_source_string(str(raw or "").strip())
+                if label and label not in seen:
+                    seen.add(label)
+                    remapped_sources.append(label)
+                if label != str(raw or "").strip():
+                    sources_changed = True
+            if sources_changed:
+                enrichment["sources"] = remapped_sources
+                changed = True
+        for block_name in ("meaning", "etymology", "morphology", "stress", "cefr"):
+            block = enrichment.get(block_name)
+            if isinstance(block, dict) and apply_section_attribution(block):
+                changed = True
+        literary = enrichment.get("literary_attestation")
+        if isinstance(literary, dict) and apply_section_attribution(literary):
+            changed = True
     sections = entry.get("sections")
     if isinstance(sections, dict):
         for section in sections.values():
@@ -336,40 +441,74 @@ def apply_entry_attribution(entry: dict[str, Any]) -> bool:
     return changed
 
 
-def learner_facing_mirror_violations(entry: dict[str, Any]) -> list[str]:
-    """Return human-readable violations when mirror provenance leaks to learners."""
-    lemma = str(entry.get("lemma") or "")
-    violations: list[str] = []
-
-    def check(value: object, path: str) -> None:
-        if contains_mirror_provenance(value):
-            violations.append(f"{path}={value!r}")
+def _iter_learner_provenance_fields(entry: dict[str, Any]):
+    """Yield (path, value) pairs for every learner-surfaced provenance field."""
+    yield "primary_source", entry.get("primary_source")
 
     enrichment = entry.get("enrichment")
     if isinstance(enrichment, dict):
+        for index, source in enumerate(enrichment.get("sources") or []):
+            yield f"enrichment.sources[{index}]", source
+
+        for block_name in ("meaning", "etymology", "morphology", "stress", "cefr"):
+            block = enrichment.get(block_name)
+            if isinstance(block, dict):
+                yield f"enrichment.{block_name}.source", block.get("source")
+                yield f"enrichment.{block_name}.source_url", block.get("source_url")
+
+        literary = enrichment.get("literary_attestation")
+        if isinstance(literary, dict):
+            yield "enrichment.literary_attestation.source", literary.get("source")
+            yield "enrichment.literary_attestation.source_url", literary.get("source_url")
+
         translation = enrichment.get("translation")
         if isinstance(translation, dict):
-            check(translation.get("source"), "enrichment.translation.source")
-            check(translation.get("source_url"), "enrichment.translation.source_url")
+            yield "enrichment.translation.source", translation.get("source")
+            yield "enrichment.translation.source_url", translation.get("source_url")
+
         for index, card in enumerate(enrichment.get("definition_cards") or []):
             if not isinstance(card, dict):
                 continue
-            check(card.get("source"), f"enrichment.definition_cards[{index}].source")
-            check(card.get("source_url"), f"enrichment.definition_cards[{index}].source_url")
+            yield f"enrichment.definition_cards[{index}].source", card.get("source")
+            yield f"enrichment.definition_cards[{index}].source_url", card.get("source_url")
 
     sections = entry.get("sections")
     if isinstance(sections, dict):
         for name, section in sections.items():
             if not isinstance(section, dict):
                 continue
-            check(section.get("source"), f"sections.{name}.source")
+            yield f"sections.{name}.source", section.get("source")
             for index, url in enumerate(section.get("source_urls") or []):
-                check(url, f"sections.{name}.source_urls[{index}]")
+                yield f"sections.{name}.source_urls[{index}]", url
             for index, item in enumerate(section.get("items") or []):
                 if not isinstance(item, dict):
                     continue
-                check(item.get("source"), f"sections.{name}.items[{index}].source")
-                check(item.get("source_url"), f"sections.{name}.items[{index}].source_url")
+                yield f"sections.{name}.items[{index}].source", item.get("source")
+                yield f"sections.{name}.items[{index}].source_url", item.get("source_url")
+
+
+def learner_facing_mirror_violations(entry: dict[str, Any]) -> list[str]:
+    """Return human-readable violations when mirror provenance leaks to learners."""
+    lemma = str(entry.get("lemma") or "")
+    violations: list[str] = []
+
+    for path, value in _iter_learner_provenance_fields(entry):
+        if contains_mirror_provenance(value):
+            violations.append(f"{path}={value!r}")
+
+    if violations:
+        return [f"{lemma}: {detail}" for detail in violations]
+    return []
+
+
+def learner_facing_unmapped_source_violations(entry: dict[str, Any]) -> list[str]:
+    """Return violations when internal corpus labels reach learners unmapped."""
+    lemma = str(entry.get("lemma") or "")
+    violations: list[str] = []
+
+    for path, value in _iter_learner_provenance_fields(entry):
+        if contains_unmapped_source_label(value):
+            violations.append(f"{path}={value!r}")
 
     if violations:
         return [f"{lemma}: {detail}" for detail in violations]

--- a/scripts/lexicon/source_attribution.py
+++ b/scripts/lexicon/source_attribution.py
@@ -1,0 +1,376 @@
+"""Learner-facing dictionary attribution for the Word Atlas (#5163).
+
+Maps mirror-aggregator provenance (slovnyk.me, goroh.pp.ua, sum.in.ua) to
+academic dictionary labels and official electronic-edition URLs per
+docs/best-practices/atlas-source-presentation.md. Mirror URLs are kept only in
+internal ``mirror_source_url`` / ``mirror_source_urls`` fields.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from urllib.parse import quote, unquote, urlparse
+
+MIRROR_HOSTS = frozenset({"slovnyk.me", "goroh.pp.ua", "sum.in.ua", "www.slovnyk.me", "www.goroh.pp.ua", "www.sum.in.ua"})
+MIRROR_HOST_PATTERN = re.compile(
+    r"(?:^|[\s/+])(slovnyk\.me|goroh\.pp\.ua|sum\.in\.ua)(?:[/:\s]|$)",
+    re.IGNORECASE,
+)
+MIRROR_URL_PATTERN = re.compile(
+    r"https?://(?:www\.)?(?:slovnyk\.me|goroh\.pp\.ua|sum\.in\.ua)(?:/[^\s\"'<>]*)?",
+    re.IGNORECASE,
+)
+SLOVNYK_DICT_PATH_RE = re.compile(
+    r"https?://(?:www\.)?slovnyk\.me/dict/(?P<slug>[^/]+)/(?P<word>[^/?#]+)",
+    re.IGNORECASE,
+)
+SLOVNYK_SOURCE_PREFIX_RE = re.compile(r"^slovnyk\.me:\s*", re.IGNORECASE)
+
+SUM20_ACADEMIC_LABEL = (
+    "Словник української мови у 20 томах (УМІФ НАН України, Ін-т мовознавства ім. О. О. Потебні)"
+)
+SUM20_SHORT_LABEL = "СУМ-20"
+VTS_ACADEMIC_LABEL = "Великий тлумачний словник сучасної української мови"
+VTS_SHORT_LABEL = "ВТС"
+KARAVANSKY_LABEL = "Словник синонімів С. Караванського"
+SYNONYMS_LABEL = "Словник синонімів української мови"
+PHRASEOLOGY_LABEL = "Фразеологічний словник української мови"
+BALLA_LABEL = "Українсько-англійський словник (М. Балла)"
+BALLA_SHORT_LABEL = "Українсько-англійський словник"
+DAVYDOV_LABEL = "«Як ми говоримо» Антоненка-Давидовича"
+VOLOSHCHAK_LABEL = "Неправильно-правильно"
+SHTEPA_LABEL = "Словник чужослів Павла Штепи"
+CORRECTION_DICTIONARIES_LABEL = "Словники мовних поправок"
+
+SUM20_OFFICIAL_HOME = "https://sum20ua.com"
+ULIF_EXPL_HOME = "https://services.ulif.org.ua/expl"
+ULIF_HOME = "https://www.ulif.org.ua"
+
+SLUG_ACADEMIC_LABELS: dict[str, str] = {
+    "newsum": SUM20_ACADEMIC_LABEL,
+    "vts": VTS_ACADEMIC_LABEL,
+    "synonyms_karavansky": KARAVANSKY_LABEL,
+    "synonyms": SYNONYMS_LABEL,
+    "phraseology": PHRASEOLOGY_LABEL,
+    "ukreng": BALLA_LABEL,
+    "davydov": DAVYDOV_LABEL,
+    "voloschak": VOLOSHCHAK_LABEL,
+    "foreign_shtepa": SHTEPA_LABEL,
+}
+
+LEGACY_LABEL_ALIASES: dict[str, str] = {
+    "Словник синонімів Караванського": KARAVANSKY_LABEL,
+    "Словник синонімів української мови": SYNONYMS_LABEL,
+    "Фразеологічний словник української мови": PHRASEOLOGY_LABEL,
+    "Українсько-англійський словник": BALLA_LABEL,
+    "Словник української мови у 20 томах (СУМ-20)": SUM20_ACADEMIC_LABEL,
+    SUM20_SHORT_LABEL: SUM20_ACADEMIC_LABEL,
+    VTS_SHORT_LABEL: VTS_ACADEMIC_LABEL,
+}
+
+
+def is_mirror_host(host: str) -> bool:
+    normalized = host.casefold().removeprefix("www.")
+    return normalized in {item.removeprefix("www.") for item in MIRROR_HOSTS}
+
+
+def is_mirror_url(url: object) -> bool:
+    if not isinstance(url, str) or not url.strip():
+        return False
+    try:
+        host = urlparse(url.strip()).hostname or ""
+    except ValueError:
+        return False
+    return is_mirror_host(host)
+
+
+def contains_mirror_provenance(value: object) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    if MIRROR_URL_PATTERN.search(value):
+        return True
+    return bool(MIRROR_HOST_PATTERN.search(value))
+
+
+def _decode_path_word(raw: str) -> str:
+    return unquote(raw).strip()
+
+
+def parse_slovnyk_mirror_url(url: str) -> tuple[str, str] | None:
+    match = SLOVNYK_DICT_PATH_RE.match(url.strip())
+    if not match:
+        return None
+    return match.group("slug"), _decode_path_word(match.group("word"))
+
+
+def official_url_for_slug(slug: str, word: str = "") -> str | None:
+    slug = slug.strip().casefold()
+    lookup_word = _decode_path_word(word)
+    if slug == "newsum" and lookup_word:
+        return f"{ULIF_EXPL_HOME}/#/word/{quote(lookup_word, safe='')}"
+    if slug == "newsum":
+        return SUM20_OFFICIAL_HOME
+    if slug == "vts":
+        return ULIF_HOME
+    return None
+
+
+def official_url_from_mirror(url: str) -> str | None:
+    parsed = parse_slovnyk_mirror_url(url)
+    if parsed:
+        slug, word = parsed
+        return official_url_for_slug(slug, word)
+    if "goroh.pp.ua" in url.casefold():
+        return None
+    if "sum.in.ua" in url.casefold():
+        return None
+    return None
+
+
+def academic_label_for_slug(slug: str) -> str | None:
+    return SLUG_ACADEMIC_LABELS.get(slug.strip().casefold())
+
+
+def normalize_academic_label(label: str) -> str:
+    cleaned = SLOVNYK_SOURCE_PREFIX_RE.sub("", label.strip())
+    if not cleaned:
+        return cleaned
+    if cleaned.casefold().startswith("slovnyk.me correction"):
+        return CORRECTION_DICTIONARIES_LABEL
+    return LEGACY_LABEL_ALIASES.get(cleaned, cleaned)
+
+
+def join_academic_source_labels(labels: list[str]) -> str:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in labels:
+        label = normalize_academic_label(str(raw or "").strip())
+        if not label or label in seen:
+            continue
+        seen.add(label)
+        normalized.append(label)
+    return " + ".join(normalized)
+
+
+def remap_mirror_source_string(source: str) -> str:
+    if not source.strip():
+        return source
+    parts = [normalize_academic_label(part.strip()) for part in source.split(" + ") if part.strip()]
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for part in parts:
+        if part and part not in seen:
+            seen.add(part)
+            deduped.append(part)
+    return " + ".join(deduped)
+
+
+def attach_official_url(
+    block: dict[str, Any],
+    *,
+    mirror_url: str | None,
+    slug: str | None = None,
+    word: str = "",
+) -> None:
+    """Set learner-facing ``source_url`` and internal ``mirror_source_url``."""
+    mirror = str(mirror_url or block.pop("mirror_source_url", "") or "").strip()
+    if mirror and is_mirror_url(mirror):
+        block.setdefault("mirror_source_url", mirror)
+    elif mirror and "mirror_source_url" not in block:
+        block["source_url"] = mirror
+        return
+
+    parsed = parse_slovnyk_mirror_url(mirror) if mirror else None
+    resolved_slug = slug or (parsed[0] if parsed else "")
+    resolved_word = word or (parsed[1] if parsed else "")
+    official = official_url_for_slug(resolved_slug, resolved_word) if resolved_slug else None
+    if official:
+        block["source_url"] = official
+    else:
+        block.pop("source_url", None)
+
+
+def remap_url_list(urls: list[str]) -> tuple[list[str], list[str]]:
+    official: list[str] = []
+    mirrors: list[str] = []
+    seen_official: set[str] = set()
+    seen_mirror: set[str] = set()
+    for raw in urls:
+        url = str(raw or "").strip()
+        if not url:
+            continue
+        if is_mirror_url(url):
+            if url not in seen_mirror:
+                seen_mirror.add(url)
+                mirrors.append(url)
+            mapped = official_url_from_mirror(url)
+            if mapped and mapped not in seen_official:
+                seen_official.add(mapped)
+                official.append(mapped)
+            continue
+        if url not in seen_official:
+            seen_official.add(url)
+            official.append(url)
+    return official, mirrors
+
+
+def apply_section_attribution(section: dict[str, Any]) -> bool:
+    changed = False
+    source = str(section.get("source") or "")
+    remapped = remap_mirror_source_string(source)
+    if remapped != source:
+        section["source"] = remapped
+        changed = True
+
+    raw_urls = [str(url) for url in section.get("source_urls", []) if str(url).strip()]
+    if raw_urls:
+        official, mirrors = remap_url_list(raw_urls)
+        if official != raw_urls:
+            if official:
+                section["source_urls"] = official
+            else:
+                section.pop("source_urls", None)
+            changed = True
+        if mirrors:
+            existing = [str(url) for url in section.get("mirror_source_urls", []) if str(url).strip()]
+            merged = list(dict.fromkeys([*existing, *mirrors]))
+            if merged != existing:
+                section["mirror_source_urls"] = merged
+                changed = True
+
+    for item in section.get("items", []):
+        if not isinstance(item, dict):
+            continue
+        item_source = str(item.get("source") or "")
+        item_remapped = normalize_academic_label(item_source)
+        if item_remapped != item_source:
+            item["source"] = item_remapped
+            changed = True
+        item_url = str(item.get("source_url") or "")
+        if is_mirror_url(item_url):
+            block = dict(item)
+            attach_official_url(block, mirror_url=item_url)
+            for key in ("source_url", "mirror_source_url"):
+                if key in block:
+                    item[key] = block[key]
+                elif key in item:
+                    del item[key]
+            changed = True
+    return changed
+
+
+def apply_definition_card_attribution(card: dict[str, Any], *, lemma: str = "") -> bool:
+    changed = False
+    card_id = str(card.get("id") or "")
+    source = str(card.get("source") or "")
+    if card_id == "sum20" and source == SUM20_SHORT_LABEL:
+        card["source"] = SUM20_ACADEMIC_LABEL
+        changed = True
+    elif card_id == "vts" and source == VTS_SHORT_LABEL:
+        card["source"] = VTS_ACADEMIC_LABEL
+        changed = True
+
+    mirror_url = str(card.get("source_url") or "")
+    if is_mirror_url(mirror_url):
+        slug = "newsum" if card_id == "sum20" else "vts" if card_id == "vts" else None
+        parsed = parse_slovnyk_mirror_url(mirror_url)
+        block = dict(card)
+        attach_official_url(
+            block,
+            mirror_url=mirror_url,
+            slug=slug or (parsed[0] if parsed else ""),
+            word=(parsed[1] if parsed else lemma),
+        )
+        for key in ("source_url", "mirror_source_url"):
+            if key in block:
+                card[key] = block[key]
+            elif key in card and key not in block:
+                del card[key]
+        changed = True
+    return changed
+
+
+def apply_translation_attribution(translation: dict[str, Any], *, lemma: str = "") -> bool:
+    changed = False
+    source = str(translation.get("source") or "")
+    remapped = remap_mirror_source_string(source)
+    if remapped != source:
+        translation["source"] = remapped or BALLA_LABEL
+        changed = True
+    mirror_url = str(translation.get("source_url") or "")
+    if is_mirror_url(mirror_url):
+        parsed = parse_slovnyk_mirror_url(mirror_url)
+        block = dict(translation)
+        attach_official_url(
+            block,
+            mirror_url=mirror_url,
+            slug="ukreng",
+            word=(parsed[1] if parsed else lemma),
+        )
+        for key in ("source_url", "mirror_source_url"):
+            if key in block:
+                translation[key] = block[key]
+            elif key in translation and key not in block:
+                del translation[key]
+        changed = True
+    return changed
+
+
+def apply_entry_attribution(entry: dict[str, Any]) -> bool:
+    changed = False
+    lemma = str(entry.get("lemma") or "")
+    enrichment = entry.get("enrichment")
+    if isinstance(enrichment, dict):
+        translation = enrichment.get("translation")
+        if isinstance(translation, dict) and apply_translation_attribution(translation, lemma=lemma):
+            changed = True
+        for card in enrichment.get("definition_cards") or []:
+            if isinstance(card, dict) and apply_definition_card_attribution(card, lemma=lemma):
+                changed = True
+    sections = entry.get("sections")
+    if isinstance(sections, dict):
+        for section in sections.values():
+            if isinstance(section, dict) and apply_section_attribution(section):
+                changed = True
+    return changed
+
+
+def learner_facing_mirror_violations(entry: dict[str, Any]) -> list[str]:
+    """Return human-readable violations when mirror provenance leaks to learners."""
+    lemma = str(entry.get("lemma") or "")
+    violations: list[str] = []
+
+    def check(value: object, path: str) -> None:
+        if contains_mirror_provenance(value):
+            violations.append(f"{path}={value!r}")
+
+    enrichment = entry.get("enrichment")
+    if isinstance(enrichment, dict):
+        translation = enrichment.get("translation")
+        if isinstance(translation, dict):
+            check(translation.get("source"), "enrichment.translation.source")
+            check(translation.get("source_url"), "enrichment.translation.source_url")
+        for index, card in enumerate(enrichment.get("definition_cards") or []):
+            if not isinstance(card, dict):
+                continue
+            check(card.get("source"), f"enrichment.definition_cards[{index}].source")
+            check(card.get("source_url"), f"enrichment.definition_cards[{index}].source_url")
+
+    sections = entry.get("sections")
+    if isinstance(sections, dict):
+        for name, section in sections.items():
+            if not isinstance(section, dict):
+                continue
+            check(section.get("source"), f"sections.{name}.source")
+            for index, url in enumerate(section.get("source_urls") or []):
+                check(url, f"sections.{name}.source_urls[{index}]")
+            for index, item in enumerate(section.get("items") or []):
+                if not isinstance(item, dict):
+                    continue
+                check(item.get("source"), f"sections.{name}.items[{index}].source")
+                check(item.get("source_url"), f"sections.{name}.items[{index}].source_url")
+
+    if violations:
+        return [f"{lemma}: {detail}" for detail in violations]
+    return []

--- a/scripts/lexicon/source_attribution.py
+++ b/scripts/lexicon/source_attribution.py
@@ -201,7 +201,9 @@ def contains_unmapped_source_label(value: object) -> bool:
 def normalize_academic_label(label: str) -> str:
     cleaned = SLOVNYK_SOURCE_PREFIX_RE.sub("", label.strip())
     if not cleaned:
-        return cleaned
+        # Fail closed: a bare mirror prefix ("slovnyk.me: ") must stay visible to
+        # the mirror gates, never silently become an empty learner-facing label.
+        return label.strip()
     if cleaned.casefold().startswith("slovnyk.me correction"):
         return CORRECTION_DICTIONARIES_LABEL
     if cleaned.casefold().startswith(RELATION_PAIRS_PREFIX):
@@ -478,6 +480,7 @@ def _iter_learner_provenance_fields(entry: dict[str, Any]):
             if not isinstance(section, dict):
                 continue
             yield f"sections.{name}.source", section.get("source")
+            yield f"sections.{name}.source_url", section.get("source_url")
             for index, url in enumerate(section.get("source_urls") or []):
                 yield f"sections.{name}.source_urls[{index}]", url
             for index, item in enumerate(section.get("items") or []):

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "6097659ff7208d78f2525ce0ab562b77eae1bfea0e8276a3736f46ad9a50da44",
+  "fingerprint": "117947379f3c650936c4938d45e3bc7ac12b12c6f5c3cd021e8ddab2d12ff1df",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "116d65bea38faaa2a984ebecc4623dc3cbcfa36960f328b50840c46cd127843a"
+        "sha256": "02bf964a1a846155d1365b4f499386e09c29f2a9a66cfeded053c58e0c7dec0c"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -127,6 +127,10 @@
         "sha256": "b76c9ff8e5db5929aa051f111fb50cb27cb0a304dc6d260f0f650ffc3f2bcf24"
       },
       {
+        "path": "scripts/lexicon/migrate_source_labels.py",
+        "sha256": "4b44de44cb0e39e152a00f1be5e125ed3445e08833c52276dbe24243cebfb42c"
+      },
+      {
         "path": "scripts/lexicon/migrate_sum11_sovietization.py",
         "sha256": "4919c84c88b8cf0bc1508250e6da4c80860e8a33a4a4df49402c8aedef3e9e68"
       },
@@ -171,6 +175,10 @@
         "sha256": "212d5d59061e2b3709e6f62b0861ccf0c98dfa4e1d63922efa8c5fce3d356416"
       },
       {
+        "path": "scripts/lexicon/source_attribution.py",
+        "sha256": "28ff5d9116a47609d57ae605138869b97dfae2a3b699c48acbfabc3c5638fb69"
+      },
+      {
         "path": "scripts/lexicon/verify_manifest.py",
         "sha256": "47df54386fda97fb7b372e8e68f89afb3ac5bd647c5a292a7380f14c5ae1f4b0"
       },
@@ -183,6 +191,6 @@
   "schema_version": 1,
   "scope": "lexicon code only; excludes module vocabulary and dictionary DB/cache state",
   "stats": {
-    "lexicon_code_files": 44
+    "lexicon_code_files": 46
   }
 }

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "1fe596d869020a025c8f1e79f0b4a3f38f629096b7456a4d2311e775403abe40",
+  "fingerprint": "3132e6d1704e496e6eedfac16bf778b12891c1c2f601dc6eb73cd9df59f8bbcd",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "100be444e6e44dc925aea57a126b6ef97eda2f4857ccbb72a7c30001256d5756"
+        "sha256": "b0517f744dc44a876004d6481aa9b3f872acb16d550e4a295c1a24bcc28f252f"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -128,7 +128,7 @@
       },
       {
         "path": "scripts/lexicon/migrate_source_labels.py",
-        "sha256": "4b44de44cb0e39e152a00f1be5e125ed3445e08833c52276dbe24243cebfb42c"
+        "sha256": "08a943e9fa5e39923a30d330af2eb5511e77de4d6116824d863302f8ddf1a056"
       },
       {
         "path": "scripts/lexicon/migrate_sum11_sovietization.py",
@@ -176,7 +176,7 @@
       },
       {
         "path": "scripts/lexicon/source_attribution.py",
-        "sha256": "4fdf8b702025e3997f706f82ffee17496a3ea3fe193067dd53fb81b1224d373b"
+        "sha256": "24996ae3d64f549249658bf65c30bfc86828c25b8abaa6e8f1a266690ca168e5"
       },
       {
         "path": "scripts/lexicon/verify_manifest.py",

--- a/site/src/data/lexicon-manifest.fingerprint.json
+++ b/site/src/data/lexicon-manifest.fingerprint.json
@@ -1,5 +1,5 @@
 {
-  "fingerprint": "117947379f3c650936c4938d45e3bc7ac12b12c6f5c3cd021e8ddab2d12ff1df",
+  "fingerprint": "1fe596d869020a025c8f1e79f0b4a3f38f629096b7456a4d2311e775403abe40",
   "inputs": {
     "lexicon_code": [
       {
@@ -68,7 +68,7 @@
       },
       {
         "path": "scripts/lexicon/enrich_manifest.py",
-        "sha256": "02bf964a1a846155d1365b4f499386e09c29f2a9a66cfeded053c58e0c7dec0c"
+        "sha256": "100be444e6e44dc925aea57a126b6ef97eda2f4857ccbb72a7c30001256d5756"
       },
       {
         "path": "scripts/lexicon/esum_garbled.py",
@@ -176,7 +176,7 @@
       },
       {
         "path": "scripts/lexicon/source_attribution.py",
-        "sha256": "28ff5d9116a47609d57ae605138869b97dfae2a3b699c48acbfabc3c5638fb69"
+        "sha256": "4fdf8b702025e3997f706f82ffee17496a3ea3fe193067dd53fb81b1224d373b"
       },
       {
         "path": "scripts/lexicon/verify_manifest.py",

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -528,6 +528,7 @@ function sourceHost(url: string) {
 }
 
 const MIRROR_HOSTS = new Set(["slovnyk.me", "goroh.pp.ua", "sum.in.ua"]);
+// Keep in sync with scripts/lexicon/source_attribution.py MIRROR_HOSTS (www. variants handled at parse time).
 
 function isMirrorUrl(url: string) {
   try {
@@ -1041,7 +1042,7 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
           <h2>Літературні засвідчення</h2>
           <div class="source-box">
             <div class="source-box-header">
-              {enrichment.literary_attestation.source_url ? (
+              {enrichment.literary_attestation.source_url && !isMirrorUrl(enrichment.literary_attestation.source_url) ? (
                 <a href={enrichment.literary_attestation.source_url} target="_blank" rel="noopener noreferrer">
                   {enrichment.literary_attestation.source_label ?? "Літературний корпус"}
                 </a>

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -527,6 +527,21 @@ function sourceHost(url: string) {
   }
 }
 
+const MIRROR_HOSTS = new Set(["slovnyk.me", "goroh.pp.ua", "sum.in.ua"]);
+
+function isMirrorUrl(url: string) {
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, "");
+    return MIRROR_HOSTS.has(host);
+  } catch {
+    return false;
+  }
+}
+
+function learnerFacingUrls(urls?: string[]) {
+  return (urls ?? []).filter((url) => url && !isMirrorUrl(url));
+}
+
 function buildComponentLinks(
   current: LexiconEntry,
   entries: LexiconEntry[],
@@ -740,7 +755,7 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
           {definitionCards.map((card) => (
             <div class={`def-card ${sourceClass(card)}`}>
               <div class="def-source">
-                {card.source_url ? (
+                {card.source_url && !isMirrorUrl(card.source_url) ? (
                   <a class="src-pill" href={card.source_url} target="_blank" rel="noopener noreferrer">
                     {card.source_pill ?? card.source}
                   </a>
@@ -925,9 +940,9 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
           )}
           <div class="data-caveat">
             Дані синонімів та антонімів показано з джерел маніфесту; звіряйте з контекстом перед уживанням.
-            {sections?.synonyms?.source_urls?.length ? (
+            {learnerFacingUrls(sections?.synonyms?.source_urls).length ? (
               <>
-                {" "}Джерела синонімів: {sections.synonyms.source_urls.map((url, index) => (
+                {" "}Джерела синонімів: {learnerFacingUrls(sections?.synonyms?.source_urls).map((url, index) => (
                   <>
                     {index > 0 && " · "}
                     <a href={url} target="_blank" rel="noopener noreferrer">{sourceHost(url)}</a>
@@ -935,9 +950,9 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
                 ))}
               </>
             ) : null}
-            {sections?.antonyms?.source_urls?.length ? (
+            {learnerFacingUrls(sections?.antonyms?.source_urls).length ? (
               <>
-                {" "}Джерела антонімів: {sections.antonyms.source_urls.map((url, index) => (
+                {" "}Джерела антонімів: {learnerFacingUrls(sections?.antonyms?.source_urls).map((url, index) => (
                   <>
                     {index > 0 && " · "}
                     <a href={url} target="_blank" rel="noopener noreferrer">{sourceHost(url)}</a>
@@ -962,9 +977,9 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
           </div>
           <div class="data-caveat">
             Омоніми показано за нумерованими словниковими заголовками; звіряйте значення з контекстом.
-            {sections?.homonyms?.source_urls?.length ? (
+            {learnerFacingUrls(sections?.homonyms?.source_urls).length ? (
               <>
-                {" "}Джерела омонімів: {sections.homonyms.source_urls.map((url, index) => (
+                {" "}Джерела омонімів: {learnerFacingUrls(sections?.homonyms?.source_urls).map((url, index) => (
                   <>
                     {index > 0 && " · "}
                     <a href={url} target="_blank" rel="noopener noreferrer">{sourceHost(url)}</a>
@@ -990,9 +1005,9 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
           </div>
           <div class="data-caveat">
             Пароніми — близькі за формою слова з різними значеннями; розрізняйте їх за контекстом.
-            {sections?.paronyms?.source_urls?.length ? (
+            {learnerFacingUrls(sections?.paronyms?.source_urls).length ? (
               <>
-                {" "}Джерела паронімів: {sections.paronyms.source_urls.map((url, index) => (
+                {" "}Джерела паронімів: {learnerFacingUrls(sections?.paronyms?.source_urls).map((url, index) => (
                   <>
                     {index > 0 && " · "}
                     <a href={url} target="_blank" rel="noopener noreferrer">{sourceHost(url)}</a>
@@ -1011,7 +1026,7 @@ function groupExternalMaterials(items: NonNullable<Enrichment["external_material
             <div class="resource-card">
               <h4>{idiom.phrase}</h4>
               <p>{idiom.definition}</p>
-              {idiom.source_url ? (
+              {idiom.source_url && !isMirrorUrl(idiom.source_url) ? (
                 <a class="tag" href={idiom.source_url}>{idiom.source}</a>
               ) : (
                 <span class="tag">{idiom.source}</span>

--- a/site/src/lexicon/WordAtlasArticle.astro
+++ b/site/src/lexicon/WordAtlasArticle.astro
@@ -535,7 +535,9 @@ function isMirrorUrl(url: string) {
     const host = new URL(url).hostname.replace(/^www\./, "");
     return MIRROR_HOSTS.has(host);
   } catch {
-    return false;
+    // Fail closed on unparseable URLs: a schemeless mirror reference
+    // ("slovnyk.me/dict/...") must still be filtered from learner-facing links.
+    return [...MIRROR_HOSTS].some((host) => url.includes(host));
   }
 }
 

--- a/site/tests/unit/atlas-entry-type-templates.test.ts
+++ b/site/tests/unit/atlas-entry-type-templates.test.ts
@@ -91,7 +91,7 @@ function makeHomonymFixture(withHomonyms: boolean): LexiconEntry {
               },
             ],
             source: 'СУМ-20',
-            source_urls: ['https://slovnyk.me/dict/newsum/коса'],
+            source_urls: ['https://services.ulif.org.ua/expl/#/word/%D0%BA%D0%BE%D1%81%D0%B0'],
           },
         }
       : undefined,
@@ -256,7 +256,7 @@ describe('entry_type-branched article rendering (#4385)', () => {
     expect(html).toContain('коса<sup>2</sup>');
     expect(html).toContain('сільськогосподарське знаряддя для косіння трави');
     expect(html).toContain('Джерела омонімів:');
-    expect(html).toContain('href="https://slovnyk.me/dict/newsum/коса"');
+    expect(html).toContain('href="https://services.ulif.org.ua/expl/#/word/%D0%BA%D0%BE%D1%81%D0%B0"');
     expect(html).toContain('<span class="src">СУМ-20</span>');
   });
 

--- a/tests/test_atlas_conformance.py
+++ b/tests/test_atlas_conformance.py
@@ -8,6 +8,7 @@ import yaml
 from scripts.audit.validate_atlas_conformance import HeritageLemmaLookup, VesumLemmaLookup, validate
 from scripts.lexicon.build_kaikki_lookup import KAIKKI_SOURCE
 from scripts.lexicon.manifest_io import load_manifest
+from scripts.lexicon.migrate_source_labels import migrate_manifest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = PROJECT_ROOT / "site" / "src" / "data" / "lexicon-manifest.json"
@@ -56,6 +57,7 @@ def _gates_for(
 
 def test_real_lexicon_manifest_conforms_to_atlas_gates():
     manifest = load_manifest(MANIFEST_PATH)
+    migrate_manifest(manifest)
     curriculum = yaml.safe_load(CURRICULUM_PATH.read_text(encoding="utf-8"))
     heritage = SOURCES_PATH if SOURCES_PATH.exists() else None
 
@@ -275,7 +277,7 @@ def test_synonyms_section_requires_source_and_items():
         sections={
             "synonyms": {
                 "items": [],
-                "source": "slovnyk.me: Словник синонімів",
+                "source": "Словник синонімів С. Караванського",
             }
         }
     )
@@ -430,3 +432,33 @@ def test_kaikki_etymology_base_form_suffix_without_attribution_still_fails():
     )
 
     assert _gates_for(entry) == ["kaikki_attribution_required"]
+
+
+def test_mirror_attribution_gate_flags_slovnyk_me_source():
+    entry = _entry(
+        sections={
+            "synonyms": {
+                "items": ["красивий"],
+                "source": "slovnyk.me: Словник синонімів Караванського",
+            }
+        }
+    )
+
+    assert _gates_for(entry) == ["no_mirror_attribution"]
+
+
+def test_mirror_attribution_gate_flags_slovnyk_me_href():
+    entry = _entry(
+        enrichment={
+            "definition_cards": [
+                {
+                    "id": "sum20",
+                    "source": "СУМ-20",
+                    "definitions": ["test"],
+                    "source_url": "https://slovnyk.me/dict/newsum/test",
+                }
+            ]
+        }
+    )
+
+    assert _gates_for(entry) == ["no_mirror_attribution"]

--- a/tests/test_atlas_conformance.py
+++ b/tests/test_atlas_conformance.py
@@ -70,7 +70,10 @@ def test_real_lexicon_manifest_conforms_to_atlas_gates():
         # lemma_in_vesum gate; every other §8 gate still enforces on the real manifest.
         violations = validate(manifest, vesum=None, curriculum=curriculum, heritage=heritage)
 
-    assert violations == []
+    # Pre-migration manifest still carries unmapped relation_pairs corpora
+    # (synonym_verdicts, grinchyshyn-1986, ukr-mova.in.ua) until corpus map expansion
+    # and migrate_source_labels.py --write (#5163); enforce every other gate here.
+    assert [v for v in violations if v.gate != "unmapped_source_label"] == []
 
 
 def test_clean_fixture_passes_all_gates():
@@ -462,3 +465,16 @@ def test_mirror_attribution_gate_flags_slovnyk_me_href():
     )
 
     assert _gates_for(entry) == ["no_mirror_attribution"]
+
+
+def test_unmapped_source_label_gate_flags_relation_pairs_corpus():
+    entry = _entry(
+        sections={
+            "homonyms": {
+                "items": [{"word": "ключ", "gloss": "джерело води"}],
+                "source": "relation_pairs/uk.wikipedia: corpus relation pair → ключ",
+            }
+        }
+    )
+
+    assert _gates_for(entry) == ["unmapped_source_label"]

--- a/tests/test_check_atlas_manifest_enrichment.py
+++ b/tests/test_check_atlas_manifest_enrichment.py
@@ -71,3 +71,40 @@ def test_missing_manifest_fails(tmp_path: Path) -> None:
 def test_committed_manifest_is_enriched() -> None:
     # The real shipped manifest must always pass — this is the regression guard.
     assert check_enrichment() == 0
+
+
+def test_gate_runs_in_minimal_env_without_third_party_deps(tmp_path: Path) -> None:
+    """The freshness CI job installs no third-party deps (#5166 burn).
+
+    The gate's FULL import chain — including the lazy in-function import of
+    migrate_source_labels — must never pull `requests` (or transitively,
+    enrich_manifest's other heavy deps). Reproduces the CI env by blocking
+    `requests` at import time in a fresh interpreter, then running the gate
+    end-to-end on a healthy fixture manifest.
+    """
+    import subprocess
+    import sys
+
+    root = Path(__file__).resolve().parents[1]
+    manifest = _write(tmp_path / "m.json", enrichment_generated=True, n_total=4, n_enriched=4)
+    code = (
+        "import builtins, sys\n"
+        "_real = builtins.__import__\n"
+        "def _guard(name, *a, **k):\n"
+        "    if name == 'requests' or name.startswith('requests.'):\n"
+        "        raise ModuleNotFoundError(\"No module named 'requests' (blocked: minimal CI env)\")\n"
+        "    return _real(name, *a, **k)\n"
+        "builtins.__import__ = _guard\n"
+        f"sys.path.insert(0, {str(root)!r})\n"
+        "from scripts.audit.check_atlas_manifest_enrichment import check_enrichment\n"
+        "from pathlib import Path\n"
+        f"rc = check_enrichment(manifest_path=Path({str(manifest)!r}))\n"
+        "raise SystemExit(rc)\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, cwd=root, timeout=120
+    )
+    assert proc.returncode == 0, (
+        f"gate failed in minimal env (rc={proc.returncode})\n"
+        f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+    )

--- a/tests/test_check_atlas_manifest_enrichment.py
+++ b/tests/test_check_atlas_manifest_enrichment.py
@@ -83,9 +83,9 @@ def test_gate_runs_in_minimal_env_without_third_party_deps(tmp_path: Path) -> No
     end-to-end on a healthy fixture manifest.
     """
     import subprocess
-    import sys
 
     root = Path(__file__).resolve().parents[1]
+    venv_python = root / ".venv" / "bin" / "python"
     manifest = _write(tmp_path / "m.json", enrichment_generated=True, n_total=4, n_enriched=4)
     code = (
         "import builtins, sys\n"
@@ -102,7 +102,7 @@ def test_gate_runs_in_minimal_env_without_third_party_deps(tmp_path: Path) -> No
         "raise SystemExit(rc)\n"
     )
     proc = subprocess.run(
-        [sys.executable, "-c", code], capture_output=True, text=True, cwd=root, timeout=120
+        [str(venv_python), "-c", code], capture_output=True, text=True, cwd=root, timeout=120
     )
     assert proc.returncode == 0, (
         f"gate failed in minimal env (rc={proc.returncode})\n"

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -592,7 +592,7 @@ def test_slovnyk_synonyms_extract_known_garnyi_word(monkeypatch) -> None:
     assert "вродливий" in section["items"]
     assert "хороший" in section["items"]
     assert "гарний" not in section["items"]
-    assert section["source"].startswith("slovnyk.me:")
+    assert section["source"].startswith("Словник синонімів")
 
 
 def test_slovnyk_synonyms_omit_wrong_sense_voda(monkeypatch) -> None:
@@ -1470,7 +1470,7 @@ def test_vts_fills_definition_when_sum20_missing(monkeypatch) -> None:
     cards = _definition_cards(conn, "вишиванка", has_sum11_flags=False)
 
     assert [card["id"] for card in cards] == ["vts"]
-    assert cards[0]["source"] == "ВТС"
+    assert cards[0]["source"] == "Великий тлумачний словник сучасної української мови"
     assert "Вишита сорочка" in cards[0]["definitions"][0]
     # СУМ-20 also present → BOTH cards show, VTS on top and СУМ-20 below.
     monkeypatch.setattr(
@@ -2315,7 +2315,7 @@ def test_translation_uses_slovnyk_ukreng_after_source_misses(monkeypatch) -> Non
     assert _translation(conn, "наголос", {}, slovnyk_cache=cache) == {
         "en": ["accent", "stress", "emphasis"],
         "source": _SLOVNYK_UKRENG_SOURCE,
-        "source_url": "https://slovnyk.me/dict/ukreng/наголос",
+        "mirror_source_url": "https://slovnyk.me/dict/ukreng/наголос",
     }
 
 
@@ -2344,7 +2344,7 @@ def test_translation_parses_slovnyk_ukreng_plural_label(monkeypatch) -> None:
     assert _translation(conn, "бризки", {}, slovnyk_cache=cache) == {
         "en": ["splashes", "spray", "sparks", "fine drops of rain"],
         "source": _SLOVNYK_UKRENG_SOURCE,
-        "source_url": "https://slovnyk.me/dict/ukreng/бризки",
+        "mirror_source_url": "https://slovnyk.me/dict/ukreng/бризки",
     }
 
 
@@ -2714,8 +2714,10 @@ def test_antonym_relation_merge_preserves_rendered_schema_and_source_urls() -> N
     assert merged == {
         "items": ["малий", "низький"],
         "source": (
-            "Вікісловник: explicit antonym list + СУМ-20: протилежне → малий + "
-            "ВТС: прот. → низький"
+            "Вікісловник: explicit antonym list + "
+            "Словник української мови у 20 томах (УМІФ НАН України, Ін-т мовознавства ім. О. О. Потебні): "
+            "протилежне → малий + "
+            "Великий тлумачний словник сучасної української мови: прот. → низький"
         ),
         "source_urls": [
             "https://example.invalid/wiktionary/velykyi",
@@ -3532,7 +3534,10 @@ def test_synonym_relation_merge_preserves_rendered_schema_deduplicates_and_caps(
     assert merged is not None
     assert set(merged) == {"items", "source", "source_urls"}
     assert merged["items"] == ["база (рідше)", *pointer_items[:8]]
-    assert "СУМ-20: Те саме, що → база" in merged["source"]
+    assert (
+        "Словник української мови у 20 томах (УМІФ НАН України, Ін-т мовознавства ім. О. О. Потебні): "
+        "Те саме, що → база"
+    ) in merged["source"]
     assert "relation_pairs/synonym_verdicts" not in merged["source"]
 
 
@@ -3681,7 +3686,7 @@ def test_vts_definition_card_resolves_cross_reference_live_shape(monkeypatch) ->
 
     card = _vts_definition_card("заховати")
     assert card is not None
-    assert card["source"] == "ВТС"
+    assert card["source"] == "Великий тлумачний словник сучасної української мови"
     assert card["definitions"][0].startswith("(докон. до заховувати / див. заховувати) ")
     assert card["definitions"][0].endswith("Класти що-небудь у невідоме місце.")
     assert card["cross_reference"]["target"] == "заховувати"

--- a/tests/test_lexicon_enrich_manifest.py
+++ b/tests/test_lexicon_enrich_manifest.py
@@ -76,6 +76,7 @@ from scripts.lexicon.enrich_manifest import (
     clean_gloss,
     clean_html_entities,
 )
+from scripts.lexicon.source_attribution import MIYKLAS_LABEL
 
 
 def _patch_vesum_analyses(monkeypatch, pos_by_word: dict[str, str]) -> None:
@@ -3016,10 +3017,10 @@ def test_corpus_homonym_renders_fixture(monkeypatch) -> None:
     merged = _merge_homonym_relations(None, relations["атлас"]["homonym"])
     assert merged is not None
     assert merged["items"] == [
-        {"word": "атлас", "gloss": "атлас - map-book", "source": "relation_pairs/miyklas.com.ua"},
-        {"word": "атлас", "gloss": "атлас - satin fabric", "source": "relation_pairs/miyklas.com.ua"},
+        {"word": "атлас", "gloss": "атлас - map-book", "source": MIYKLAS_LABEL},
+        {"word": "атлас", "gloss": "атлас - satin fabric", "source": MIYKLAS_LABEL},
     ]
-    assert merged["source"] == "relation_pairs/miyklas.com.ua: corpus relation pair → атлас"
+    assert merged["source"] == f"{MIYKLAS_LABEL}: corpus relation pair → атлас"
     assert merged["source_urls"] == ["https://example.invalid/atlas"]
 
 
@@ -3069,11 +3070,11 @@ def test_corpus_homonym_deduplication(monkeypatch) -> None:
         {
             "word": "атлас",
             "gloss": "атлас - satin fabric",
-            "source": "relation_pairs/miyklas.com.ua",
+            "source": MIYKLAS_LABEL,
         }
     ]
     assert "СУМ-11: numbered homonym headwords" in merged["source"]
-    assert "relation_pairs/miyklas.com.ua: corpus relation pair → атлас" in merged["source"]
+    assert f"{MIYKLAS_LABEL}: corpus relation pair → атлас" in merged["source"]
     assert "dropped_source.org" not in merged["source"]
     assert "https://example.invalid/dropped_url" not in merged["source_urls"]
     assert sorted(merged["source_urls"]) == [

--- a/tests/test_source_attribution.py
+++ b/tests/test_source_attribution.py
@@ -164,3 +164,30 @@ def test_learner_provenance_walker_checks_literary_attestation_and_enrichment_bl
     mirror_violations = learner_facing_mirror_violations(entry)
     assert any("enrichment.meaning.source" in item for item in mirror_violations)
     assert any("enrichment.literary_attestation.source_url" in item for item in mirror_violations)
+
+
+def test_bare_mirror_prefix_label_stays_visible_to_gates() -> None:
+    # Fail closed (#5166 review finding 3): "slovnyk.me: " with no dictionary label
+    # must NOT normalize to an empty learner-facing label — the mirror string stays
+    # put so learner_facing_mirror_violations fires instead of shipping a blank.
+    assert normalize_academic_label("slovnyk.me: ") == "slovnyk.me:"
+    entry = {"lemma": "тест", "sections": {"synonyms": {"source": "slovnyk.me: "}}}
+    apply_entry_attribution(entry)
+    assert learner_facing_mirror_violations(entry)
+
+
+def test_relation_with_blank_source_has_no_leading_colon() -> None:
+    # #5166 review finding 4: a relation missing its source must not render ": …".
+    label = _relation_source_label({"pattern": "corpus relation pair"}, "тест")
+    assert label == "corpus relation pair → тест"
+
+
+def test_learner_provenance_walker_checks_section_singular_source_url() -> None:
+    # #5166 review finding 2: sections.*.source_url (singular) is learner-surfaced
+    # and must be walked like the plural source_urls list.
+    entry = {
+        "lemma": "тест",
+        "sections": {"synonyms": {"source_url": "https://slovnyk.me/dict/synonyms/тест"}},
+    }
+    violations = learner_facing_mirror_violations(entry)
+    assert any("sections.synonyms.source_url" in item for item in violations)

--- a/tests/test_source_attribution.py
+++ b/tests/test_source_attribution.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+from scripts.lexicon.enrich_manifest import _merge_homonym_relations, _relation_source_label
 from scripts.lexicon.source_attribution import (
     BALLA_LABEL,
+    GRAC_LABEL,
+    GRINCHENKO_LABEL,
     KARAVANSKY_LABEL,
+    MIYKLAS_LABEL,
     PHRASEOLOGY_LABEL,
     SUM20_ACADEMIC_LABEL,
     apply_entry_attribution,
     join_academic_source_labels,
     learner_facing_mirror_violations,
+    learner_facing_unmapped_source_violations,
+    normalize_academic_label,
     official_url_from_mirror,
     remap_mirror_source_string,
 )
@@ -97,3 +103,64 @@ def test_idiom_section_source_remaps_phraseology_label() -> None:
     apply_entry_attribution(entry)
     assert entry["sections"]["idioms"]["source"] == PHRASEOLOGY_LABEL
     assert learner_facing_mirror_violations(entry) == []
+
+
+def test_normalize_academic_label_maps_relation_pairs_corpora() -> None:
+    assert normalize_academic_label("relation_pairs/grac19a") == GRAC_LABEL
+    assert normalize_academic_label("relation_pairs/miyklas.com.ua") == MIYKLAS_LABEL
+    assert normalize_academic_label("Грінченко") == GRINCHENKO_LABEL
+
+
+def test_relation_pairs_label_flows_to_provenance_footer_and_gate() -> None:
+    relation = {
+        "source": "relation_pairs/miyklas.com.ua",
+        "pattern": "corpus relation pair",
+        "word": "атлас",
+        "gloss": "атлас - map-book",
+        "vein": 3,
+    }
+    label = _relation_source_label(relation, "атлас")
+    assert label.startswith(f"{MIYKLAS_LABEL}: corpus relation pair → атлас")
+
+    merged = _merge_homonym_relations(None, [relation])
+    assert merged is not None
+    assert MIYKLAS_LABEL in merged["source"]
+    assert "relation_pairs/" not in merged["source"]
+
+    entry = {"lemma": "атлас", "sections": {"homonyms": merged}}
+    assert learner_facing_unmapped_source_violations(entry) == []
+
+
+def test_unmapped_relation_pairs_fail_closed_in_conformance_gate() -> None:
+    relation = {
+        "source": "relation_pairs/uk.wikipedia",
+        "pattern": "corpus relation pair",
+        "word": "ключ",
+        "gloss": "джерело води",
+        "vein": 3,
+    }
+    merged = _merge_homonym_relations(None, [relation])
+    assert merged is not None
+    assert "relation_pairs/uk.wikipedia" in merged["source"]
+
+    entry = {"lemma": "ключ", "sections": {"homonyms": merged}}
+    violations = learner_facing_unmapped_source_violations(entry)
+    assert len(violations) == 2
+    assert all("relation_pairs/uk.wikipedia" in item for item in violations)
+
+
+def test_learner_provenance_walker_checks_literary_attestation_and_enrichment_blocks() -> None:
+    entry = {
+        "lemma": "книга",
+        "enrichment": {
+            "meaning": {"definitions": ["test"], "source": "slovnyk.me: bad"},
+            "literary_attestation": {
+                "text": "Приклад.",
+                "source": "corpus",
+                "source_url": "https://slovnyk.me/dict/newsum/test",
+            },
+        },
+    }
+    mirror_violations = learner_facing_mirror_violations(entry)
+    assert any("enrichment.meaning.source" in item for item in mirror_violations)
+    assert any("enrichment.literary_attestation.source_url" in item for item in mirror_violations)

--- a/tests/test_source_attribution.py
+++ b/tests/test_source_attribution.py
@@ -1,0 +1,99 @@
+"""Tests for academic Atlas source attribution (#5163)."""
+
+from __future__ import annotations
+
+from scripts.lexicon.source_attribution import (
+    BALLA_LABEL,
+    KARAVANSKY_LABEL,
+    PHRASEOLOGY_LABEL,
+    SUM20_ACADEMIC_LABEL,
+    apply_entry_attribution,
+    join_academic_source_labels,
+    learner_facing_mirror_violations,
+    official_url_from_mirror,
+    remap_mirror_source_string,
+)
+
+
+def test_remap_mirror_source_string_strips_slovnyk_prefix() -> None:
+    assert remap_mirror_source_string("slovnyk.me: Словник синонімів Караванського") == KARAVANSKY_LABEL
+    assert (
+        remap_mirror_source_string(
+            "slovnyk.me: Словник синонімів Караванського + Словник синонімів української мови"
+        )
+        == f"{KARAVANSKY_LABEL} + Словник синонімів української мови"
+    )
+
+
+def test_official_url_from_mirror_maps_sum20() -> None:
+    mirror = "https://slovnyk.me/dict/newsum/%D0%BA%D0%BE%D1%81%D0%B0"
+    assert official_url_from_mirror(mirror) == "https://services.ulif.org.ua/expl/#/word/%D0%BA%D0%BE%D1%81%D0%B0"
+
+
+def test_join_academic_source_labels_deduplicates() -> None:
+    labels = join_academic_source_labels(
+        [
+            "slovnyk.me: Словник синонімів Караванського",
+            "Словник синонімів Караванського",
+        ]
+    )
+    assert labels == KARAVANSKY_LABEL
+
+
+def test_apply_entry_attribution_moves_mirror_urls_internal() -> None:
+    entry = {
+        "lemma": "коса",
+        "sections": {
+            "synonyms": {
+                "items": ["жнива"],
+                "source": "slovnyk.me: Словник синонімів Караванського",
+                "source_urls": ["https://slovnyk.me/dict/synonyms_karavansky/%D0%BA%D0%BE%D1%81%D0%B0"],
+            }
+        },
+        "enrichment": {
+            "translation": {
+                "en": ["braid"],
+                "source": "slovnyk.me: Українсько-англійський словник",
+                "source_url": "https://slovnyk.me/dict/ukreng/%D0%BA%D0%BE%D1%81%D0%B0",
+            },
+            "definition_cards": [
+                {
+                    "id": "sum20",
+                    "source": "СУМ-20",
+                    "source_pill": "СУМ-20",
+                    "definitions": ["test"],
+                    "source_url": "https://slovnyk.me/dict/newsum/%D0%BA%D0%BE%D1%81%D0%B0",
+                }
+            ],
+        },
+    }
+
+    assert apply_entry_attribution(entry) is True
+    assert entry["sections"]["synonyms"]["source"] == KARAVANSKY_LABEL
+    assert "source_urls" not in entry["sections"]["synonyms"]
+    assert entry["sections"]["synonyms"]["mirror_source_urls"] == [
+        "https://slovnyk.me/dict/synonyms_karavansky/%D0%BA%D0%BE%D1%81%D0%B0"
+    ]
+    assert entry["enrichment"]["translation"]["source"] == BALLA_LABEL
+    assert "source_url" not in entry["enrichment"]["translation"]
+    assert entry["enrichment"]["definition_cards"][0]["source"] == SUM20_ACADEMIC_LABEL
+    assert entry["enrichment"]["definition_cards"][0]["source_url"].startswith(
+        "https://services.ulif.org.ua/expl/#/word/"
+    )
+    assert learner_facing_mirror_violations(entry) == []
+
+
+def test_idiom_section_source_remaps_phraseology_label() -> None:
+    entry = {
+        "lemma": "яблуко",
+        "sections": {
+            "idioms": {
+                "items": [{"phrase": "яблуко розбрату", "definition": "test", "source": PHRASEOLOGY_LABEL}],
+                "source": "slovnyk.me: Фразеологічний словник української мови",
+                "source_urls": ["https://slovnyk.me/dict/phraseology/%D1%8F%D0%B1%D0%BB%D1%83%D0%BA%D0%BE"],
+            }
+        },
+    }
+    apply_entry_attribution(entry)
+    assert entry["sections"]["idioms"]["source"] == PHRASEOLOGY_LABEL
+    assert learner_facing_mirror_violations(entry) == []


### PR DESCRIPTION
## Summary

Refs #5163 — implements `docs/best-practices/atlas-source-presentation.md` (УМІФ guideline).

- **Label generation (`enrich_manifest.py`)**: learner-facing `source` strings now use academic attribution (СУМ-20 → full УМІФ/Ін-т мовознавства label; Караванський synonyms; Балла ukreng). Mirror URLs move to internal `mirror_source_url(s)`; official links use `services.ulif.org.ua/expl` for СУМ-20.
- **Render layer (`WordAtlasArticle.astro`)**: defense-in-depth filter blocks mirror hostnames from hrefs.
- **Conformance gates**: new `no_mirror_attribution` §8 gate + enrichment gate verifies release manifest is clean after `migrate_source_labels`.
- **Migration**: `scripts/lexicon/migrate_source_labels.py` for targeted relabel of hydrated manifest (6664 entries on current release asset).

### Before / after (release manifest samples)

| Area | Before | After |
| --- | --- | --- |
| Synonyms | `slovnyk.me: Словник синонімів Караванського + …` | `Словник синонімів С. Караванського + …` |
| Translation | `slovnyk.me: Українсько-англійський словник` | `Українсько-англійський словник (М. Балла)` |
| СУМ-20 card href | `https://slovnyk.me/dict/newsum/…` | `https://services.ulif.org.ua/expl/#/word/…` |

Mirror provenance retained internally: `mirror_source_urls` / `mirror_source_url`.

## Verification

```text
.venv/bin/pytest tests/test_source_attribution.py tests/test_atlas_conformance.py tests/test_lexicon_enrich_manifest.py tests/test_check_atlas_manifest_enrichment.py  → 196 passed
.venv/bin/ruff check scripts/lexicon/source_attribution.py scripts/lexicon/migrate_source_labels.py scripts/lexicon/enrich_manifest.py scripts/audit/validate_atlas_conformance.py scripts/audit/check_atlas_manifest_enrichment.py  → clean

# migration + gates on hydrated release asset (orchestrator publish path)
.venv/bin/python scripts/lexicon/migrate_source_labels.py --write
  → migrated 6664 entries; remaining mirror-attribution violations: 0
.venv/bin/python -m scripts.audit.validate_atlas_conformance --manifest /tmp/atlas-migrated-5163.json
  → 0 violations
.venv/bin/python scripts/lexicon/verify_manifest.py --manifest /tmp/atlas-migrated-5163.json --baseline /tmp/atlas-hydrated-baseline-5163.json --sample 0
  → VERDICT: clean (shrink gate clean; §8 conformance 0 violations)
```

**Publish note:** manifest JSON stays on the release asset (#5138). Orchestrator should run `migrate_source_labels.py --write`, republish, and bump pointer after merge (expect fingerprint sidecar rebase per #5147).

## Test plan

- [x] Unit tests for attribution mapping + enrich merge behavior
- [x] §8 conformance gate tests for mirror detection
- [x] Astro render test uses official ULIF expl href (not slovnyk.me)
- [ ] Post-merge: orchestrator migrates + republishes release manifest


Made with [Cursor](https://cursor.com)