### PR TITLE
fix(delegate): anchor dispatch state to the primary checkout from worktree script copies

### DIFF
--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -145,6 +145,13 @@ def _resolve_repo_root(script_path: Path) -> Path:
     Every dispatch worktree carries its own copy of this script; running that
     copy used to anchor batch_state/ and .worktrees/ to the WORKTREE root,
     nesting worktrees and hiding tasks from the Monitor API (#5171).
+
+    Consequence: sys.path inserts and relative-path resolution (e.g. a
+    relative --cwd) also anchor to the primary checkout — a worktree copy
+    of this script lazy-imports the PRIMARY's scripts/* modules, not the
+    worktree branch's. Intentional: dispatch infrastructure is ground truth
+    in the primary; cross-cutting changes to delegate.py plus its lazy deps
+    must land on main before they steer live dispatches.
     """
     return _main_checkout_root(script_path.resolve().parents[1])
 

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -110,8 +110,48 @@ from typing import Any
 import yaml
 from agent_runtime.routes import RUNTIME_ROUTE_TOOL_CONFIG_KEY
 
-# Resolve repo root from this file's location so we work from any cwd.
-_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+def _main_checkout_root(repo_root: Path) -> Path:
+    """Return the primary checkout root that owns the shared .git dir."""
+    git_path = repo_root / ".git"
+    if git_path.is_dir():
+        return repo_root
+    if not git_path.is_file():
+        return repo_root
+
+    try:
+        first_line = git_path.read_text().splitlines()[0]
+    except (IndexError, OSError):
+        return repo_root
+    prefix = "gitdir:"
+    if not first_line.startswith(prefix):
+        return repo_root
+
+    git_dir = Path(first_line[len(prefix) :].strip())
+    if not git_dir.is_absolute():
+        git_dir = repo_root / git_dir
+    git_dir = git_dir.resolve()
+    if git_dir.parent.name != "worktrees":
+        return repo_root
+    common_git_dir = git_dir.parent.parent
+    if common_git_dir.name != ".git":
+        return repo_root
+    return common_git_dir.parent
+
+
+def _resolve_repo_root(script_path: Path) -> Path:
+    """Anchor all dispatch state to the PRIMARY checkout, never a worktree copy.
+
+    Every dispatch worktree carries its own copy of this script; running that
+    copy used to anchor batch_state/ and .worktrees/ to the WORKTREE root,
+    nesting worktrees and hiding tasks from the Monitor API (#5171).
+    """
+    return _main_checkout_root(script_path.resolve().parents[1])
+
+
+# Resolve repo root from this file's location so we work from any cwd —
+# then hop to the primary checkout so worktree copies behave identically.
+_REPO_ROOT = _resolve_repo_root(Path(__file__))
 _TASKS_DIR = _REPO_ROOT / "batch_state" / "tasks"
 _BASH_SECRETS_PATH = Path.home() / ".bash_secrets"
 _GH_TOKEN_AGENTS = {"codex", "claude", "bridge"}
@@ -183,34 +223,6 @@ DEFAULT_SILENCE_TIMEOUT_S = 3600
 # Fail fast when Codex (or any agent) never produces stdout/stderr/liveness
 # activity at startup — distinct from the long silence window above (#2071).
 DEFAULT_INITIAL_RESPONSE_TIMEOUT_S = 180
-
-
-def _main_checkout_root(repo_root: Path = _REPO_ROOT) -> Path:
-    """Return the primary checkout root that owns the shared .git dir."""
-    git_path = repo_root / ".git"
-    if git_path.is_dir():
-        return repo_root
-    if not git_path.is_file():
-        return repo_root
-
-    try:
-        first_line = git_path.read_text().splitlines()[0]
-    except (IndexError, OSError):
-        return repo_root
-    prefix = "gitdir:"
-    if not first_line.startswith(prefix):
-        return repo_root
-
-    git_dir = Path(first_line[len(prefix) :].strip())
-    if not git_dir.is_absolute():
-        git_dir = repo_root / git_dir
-    git_dir = git_dir.resolve()
-    if git_dir.parent.name != "worktrees":
-        return repo_root
-    common_git_dir = git_dir.parent.parent
-    if common_git_dir.name != ".git":
-        return repo_root
-    return common_git_dir.parent
 
 
 # ---------------------------------------------------------------------------
@@ -1436,7 +1448,7 @@ def _ensure_worktree(
             return worktree_path, worktree_branch, telemetry
         # Reused worktrees may predate this provisioning hook; the helper is
         # idempotent and never clobbers existing files.
-        _provision_data_symlinks(worktree_path, _main_checkout_root())
+        _provision_data_symlinks(worktree_path, _REPO_ROOT)
         return worktree_path, worktree_branch, telemetry
 
     if dry_run:
@@ -1491,7 +1503,7 @@ def _ensure_worktree(
     if proc.returncode != 0:
         stderr = (proc.stderr or proc.stdout or "git worktree add failed").strip()
         raise RuntimeError(stderr)
-    _provision_data_symlinks(worktree_path, _main_checkout_root())
+    _provision_data_symlinks(worktree_path, _REPO_ROOT)
     telemetry["base_sha"] = _resolve_sha(worktree_path)
     return worktree_path, worktree_branch, telemetry
 

--- a/tests/test_delegate_data_symlinks.py
+++ b/tests/test_delegate_data_symlinks.py
@@ -1,4 +1,5 @@
 """Tests for delegate.py worktree local-file provisioning."""
+
 from __future__ import annotations
 
 import sys
@@ -98,3 +99,32 @@ def test_provision_data_symlinks_refuses_when_worktree_is_main(tmp_path, capsys)
     # node_modules stays a real directory — no self-referential symlink created.
     assert (main_repo / "node_modules").is_dir()
     assert not (main_repo / "node_modules").is_symlink()
+
+
+def test_resolve_repo_root_hops_to_primary_from_worktree_script_copy(tmp_path):
+    # #5171: every dispatch worktree carries its own scripts/delegate.py copy;
+    # running that copy must still anchor state to the PRIMARY checkout.
+    main_repo = tmp_path / "main"
+    worktree = main_repo / ".worktrees" / "dispatch" / "cursor" / "fix-123"
+    git_dir = main_repo / ".git" / "worktrees" / "fix-123"
+    git_dir.mkdir(parents=True)
+    (worktree / "scripts").mkdir(parents=True)
+    (worktree / ".git").write_text(f"gitdir: {git_dir}\n")
+
+    assert delegate._resolve_repo_root(worktree / "scripts" / "delegate.py") == main_repo
+
+
+def test_resolve_repo_root_is_identity_in_primary_checkout(tmp_path):
+    main_repo = tmp_path / "main"
+    (main_repo / ".git").mkdir(parents=True)
+    (main_repo / "scripts").mkdir()
+    assert delegate._resolve_repo_root(main_repo / "scripts" / "delegate.py") == main_repo
+
+
+def test_repo_root_constant_is_wired_through_the_resolver():
+    # Revert guard for #5171: in the primary checkout raw parents[1] and the
+    # resolver agree, so behavior alone can't detect a revert — pin the wiring.
+    from pathlib import Path as _P
+
+    source = _P(delegate.__file__).read_text(encoding="utf-8")
+    assert "_REPO_ROOT = _resolve_repo_root(Path(__file__))" in source


### PR DESCRIPTION
## Root cause
`_REPO_ROOT = Path(__file__).resolve().parents[1]` anchors to whichever COPY of delegate.py runs. Each dispatch worktree carries its own copy, so invoking it (stale cwd, or an agent inside its worktree) anchored `batch_state/` + the `.worktrees/dispatch/` base to the worktree: nested worktrees, and tasks invisible to `/api/delegate/active` (Monitor API reads the primary root's batch_state). Struck live twice (2026-07-14, 2026-07-10 — see #5171).

## Fix
Hoist the existing `_main_checkout_root()` gitdir-pointer resolver above the constants and route `_REPO_ROOT` through it (`_resolve_repo_root(Path(__file__))`). All consumers (tasks dir, worktree base, git cwds, sys.path, fallback-subs config) now anchor to the primary checkout regardless of invocation cwd or script copy. The two `_provision_data_symlinks` call sites pass `_REPO_ROOT` directly.

## Verification (all tool-backed)
- 141 delegate tests pass (`tests/test_delegate*.py`), incl. 3 new: worktree-layout resolution, primary identity, source-level revert guard.
- ruff clean.
- E2E: importing the WORKTREE copy resolves `_REPO_ROOT`/`_TASKS_DIR` to the primary checkout (asserted in a fresh interpreter).

## Follow-up (tracked on #5171)
Sibling sweep found the same pattern in `ai_agent_bridge/_db.py`, `_dispatch_wrappers.py`, `_monitor_cache.py` — the orphaned `messages.db` found inside a stale dispatch worktree is live evidence the bridge class needs the same treatment.

Closes #5171

🤖 Generated with [Claude Code](https://claude.com/claude-code)