### PR TITLE
fix(bridge): review asks resolve the PR branch, not the primary checkout

### DIFF
--- a/scripts/ai_agent_bridge/_agy.py
+++ b/scripts/ai_agent_bridge/_agy.py
@@ -26,6 +26,12 @@ from ._config import REPO_ROOT
 from ._db import get_db, set_session
 from ._messaging import acknowledge, send_message
 from ._prompts import build_agy_prompt
+from ._review_worktree import (
+    ReviewWorktreeError,
+    provision_review_worktree,
+    review_target_from_message,
+    review_target_payload,
+)
 
 _DEFAULT_AGY_BRIDGE_TIMEOUT_SECONDS = 900
 _NO_TIMEOUT_AGY_BRIDGE_TIMEOUT_SECONDS = 24 * 60 * 60
@@ -87,6 +93,8 @@ def ask_agy(
     stdout_only: bool = False,
     output_path: str | None = None,
     background: bool = False,
+    review_branch: str | None = None,
+    review_pr_number: int | None = None,
 ):
     """Send message to Agy AND invoke Agy to process it (one-shot)."""
     if background and (stdout_only or output_path):
@@ -100,6 +108,7 @@ def ask_agy(
         to_llm="agy",
         from_model=from_model,
         to_model=to_model,
+        review_target=review_target_payload(review_branch, review_pr_number),
     )
     register_ask(msg_id)
     if background:
@@ -148,7 +157,7 @@ def process_for_agy(
     timeout_val = _resolve_agy_bridge_timeout(no_timeout)
     model = _extract_target_model(msg) or _DEFAULT_AGY_MODEL
 
-    prompt = build_agy_prompt(msg, review)
+    review_target = review_target_from_message(msg) if review else None
 
     if not stdout_only:
         print(f"📨 Message #{msg['id']}")
@@ -162,32 +171,39 @@ def process_for_agy(
             print(f"   Hard timeout: {timeout_val}s")
 
     try:
-        result = agent_runner.invoke(
-            "agy",
-            prompt,
-            # AGY's only sandbox switch is the opt-in ``--sandbox`` flag;
-            # there is no ``--no-sandbox`` counterpart.  Bridge Q&A must run
-            # without that sandbox so it can read the repository named by the
-            # caller.  The prompt remains explicitly read-only because AGY's
-            # headless permission bypass is otherwise full-trust.
-            mode="danger",
-            # Spawn from an out-of-tree scratch cwd: the runner's worktree
-            # containment guard (#4444) correctly refuses write-capable
-            # spawns whose cwd IS the protected primary checkout, which
-            # broke every `ask-agy` run from repo root after #4841 shipped
-            # cwd=REPO_ROOT (its live verify ran inside a dispatch worktree,
-            # masking this).  Repo READ access is granted separately via
-            # ``repo_read_root`` → ``--add-dir`` in the adapter, so the
-            # guard stays fully intact — no exemptions.
-            cwd=_agy_ask_scratch_cwd(),
-            model=model,
-            task_id=msg["task_id"],
-            session_id=None,
-            tool_config={"bridge_repo_read": True, "repo_read_root": str(REPO_ROOT)},
-            entrypoint="bridge",
-            hard_timeout=timeout_val,
-            stall_timeout=min(600, timeout_val),
-        )
+        with provision_review_worktree(review_target, repo_root=REPO_ROOT) as checkout:
+            prompt = build_agy_prompt(
+                msg,
+                review,
+                review_branch=checkout.branch if checkout else None,
+                review_pr_number=checkout.pr_number if checkout else None,
+                review_worktree_provisioned=checkout is not None,
+            )
+            result = agent_runner.invoke(
+                "agy",
+                prompt,
+                # AGY's only sandbox switch is the opt-in ``--sandbox`` flag;
+                # there is no ``--no-sandbox`` counterpart. Bridge Q&A must run
+                # without that sandbox so it can read the named review checkout.
+                mode="danger",
+                # Keep AGY in its out-of-tree scratch cwd. The runner rejects a
+                # danger-mode spawn inside the protected primary checkout; the
+                # branch-pinned worktree is granted only through ``--add-dir``.
+                cwd=_agy_ask_scratch_cwd(),
+                model=model,
+                task_id=msg["task_id"],
+                session_id=None,
+                tool_config={
+                    "bridge_repo_read": True,
+                    "repo_read_root": str(checkout.path if checkout else REPO_ROOT),
+                },
+                entrypoint="bridge",
+                hard_timeout=timeout_val,
+                stall_timeout=min(600, timeout_val),
+            )
+    except ReviewWorktreeError as exc:
+        _handle_agy_error(msg, message_id, f"Agy review checkout failed: {exc}")
+        return None
     except RateLimitedError as exc:
         _handle_agy_error(msg, message_id, f"Agy rate limited: {exc}")
         return None

--- a/scripts/ai_agent_bridge/_claude.py
+++ b/scripts/ai_agent_bridge/_claude.py
@@ -35,6 +35,12 @@ from ._config import _PARENT_ENV, CLAUDE_CMD, REPO_ROOT
 from ._db import get_db, get_session, set_session
 from ._messaging import acknowledge, send_message
 from ._prompts import build_claude_prompt
+from ._review_worktree import (
+    ReviewWorktreeError,
+    provision_review_worktree,
+    review_target_from_message,
+    review_target_payload,
+)
 
 VENV_PYTHON = REPO_ROOT / ".venv" / "bin" / "python"
 
@@ -43,10 +49,20 @@ def ask_claude(content: str, task_id: str | None = None, msg_type: str = "query"
                data: str | None = None, new_session: bool = False,
                from_llm: str = "gemini", from_model: str | None = None,
                to_model: str | None = None, review: bool = False,
-               background: bool = False):
+               background: bool = False, review_branch: str | None = None,
+               review_pr_number: int | None = None):
     """Send message to Claude AND invoke Claude to process it."""
-    msg_id = send_message(content, task_id, msg_type, data, from_llm=from_llm,
-                          to_llm="claude", from_model=from_model, to_model=to_model)
+    msg_id = send_message(
+        content,
+        task_id,
+        msg_type,
+        data,
+        from_llm=from_llm,
+        to_llm="claude",
+        from_model=from_model,
+        to_model=to_model,
+        review_target=review_target_payload(review_branch, review_pr_number),
+    )
     register_ask(msg_id)
     if background:
         launch_background_ask(
@@ -144,25 +160,33 @@ def _run_claude_sync_via_runtime(
     _response_sent = False
     try:
         target_model = _extract_target_model(msg)
-        result = runtime_invoke(
-            "claude",
-            build_claude_prompt(msg, review),
-            mode="read-only",
-            cwd=REPO_ROOT,
-            model=target_model,
-            task_id=msg.get('task_id'),
-            session_id=session_id_to_pass,
-            tool_config=tool_config,
-            entrypoint="bridge",
-            hard_timeout=timeout_val,
-            # 600s matches dispatch.py. Claude CLI can go quiet for
-            # several minutes during long reasoning; the project-scoped
-            # session JSONL dir under ~/.claude/projects/<slug>/ gives
-            # the mtime poller a reliable liveness signal. Raised from
-            # 300s on 2026-04-10 for consistency across the codebase
-            # after the dispatch.py bump. (#1184)
-            stall_timeout=min(600, timeout_val),
-        )
+        review_target = review_target_from_message(msg) if review else None
+        with provision_review_worktree(review_target, repo_root=REPO_ROOT) as checkout:
+            result = runtime_invoke(
+                "claude",
+                build_claude_prompt(
+                    msg,
+                    review,
+                    review_branch=checkout.branch if checkout else None,
+                    review_pr_number=checkout.pr_number if checkout else None,
+                    review_worktree_provisioned=checkout is not None,
+                ),
+                mode="read-only",
+                cwd=checkout.path if checkout else REPO_ROOT,
+                model=target_model,
+                task_id=msg.get('task_id'),
+                session_id=session_id_to_pass,
+                tool_config=tool_config,
+                entrypoint="bridge",
+                hard_timeout=timeout_val,
+                # 600s matches dispatch.py. Claude CLI can go quiet for
+                # several minutes during long reasoning; the project-scoped
+                # session JSONL dir under ~/.claude/projects/<slug>/ gives
+                # the mtime poller a reliable liveness signal. Raised from
+                # 300s on 2026-04-10 for consistency across the codebase
+                # after the dispatch.py bump. (#1184)
+                stall_timeout=min(600, timeout_val),
+            )
 
         if not result.ok:
             _response_sent = _handle_claude_error(
@@ -227,6 +251,17 @@ def _run_claude_sync_via_runtime(
         acknowledge(message_id)  # Must ack incoming msg to prevent stuck queue
         acknowledge(err_id)
         record_ask_failure(message_id, "Claude CLI not found")
+    except ReviewWorktreeError as exc:
+        err_id = send_message(
+            content=f"[Bridge Error] Claude review checkout failed: {exc}",
+            task_id=msg['task_id'], msg_type="error",
+            from_llm="claude", to_llm=msg['from'],
+            from_model="claude-bridge-review-checkout",
+        )
+        _response_sent = True
+        acknowledge(message_id)
+        acknowledge(err_id)
+        record_ask_failure(message_id, str(exc))
     finally:
         if not _response_sent:
             _send_claude_fallback_error(msg, message_id)

--- a/scripts/ai_agent_bridge/_cli.py
+++ b/scripts/ai_agent_bridge/_cli.py
@@ -811,6 +811,24 @@ def _build_parser() -> argparse.ArgumentParser:
     ask_grok_build_parser.add_argument("--no-timeout", dest="no_timeout", action="store_true")
     ask_grok_build_parser.add_argument("--review", action="store_true", help="Prepend docs/review-protocol.md")
 
+    for review_parser in (
+        ask_claude_parser,
+        ask_codex_parser,
+        ask_gemini_parser,
+        ask_agy_parser,
+        ask_grok_build_parser,
+    ):
+        review_target = review_parser.add_mutually_exclusive_group()
+        review_target.add_argument(
+            "--branch",
+            help="Remote branch to review; fetched and resolved only as origin/<branch>",
+        )
+        review_target.add_argument(
+            "--pr",
+            type=int,
+            help="PR whose head branch to fetch and review",
+        )
+
     for ask_parser in (
         ask_claude_parser,
         ask_codex_parser,
@@ -1256,12 +1274,24 @@ def _background_kwargs(args) -> dict[str, bool]:
     return {"background": True} if getattr(args, "background", False) else {}
 
 
+def _review_target_kwargs(args) -> dict[str, str | int | None]:
+    """Pass an explicit branch target only to a review ask."""
+    branch = getattr(args, "branch", None)
+    pr_number = getattr(args, "pr", None)
+    if branch is None and pr_number is None:
+        return {}
+    if not getattr(args, "review", False):
+        raise SystemExit("--branch/--pr require --review")
+    return {"review_branch": branch, "review_pr_number": pr_number}
+
+
 def _handle_ask_claude(args):
     """Handle ask-claude subcommand."""
     data = None
     if args.data:
         data = Path(args.data).read_text()
     kwargs = {"review": True} if getattr(args, "review", False) else {}
+    kwargs.update(_review_target_kwargs(args))
     from_llm = _resolve_from_llm(args)
     ask_claude(
         args.content,
@@ -1288,6 +1318,7 @@ def _handle_ask_codex(args):
             raise SystemExit("ask-codex --chain derives issue task IDs automatically; omit --task-id")
         try:
             kwargs = {"review": True} if getattr(args, "review", False) else {}
+            kwargs.update(_review_target_kwargs(args))
             from_llm = _resolve_from_llm(args)
             ask_codex_chain(
                 content,
@@ -1308,6 +1339,7 @@ def _handle_ask_codex(args):
     if not args.task_id:
         raise SystemExit("ask-codex requires --task-id unless --chain is used")
     kwargs = {"review": True} if getattr(args, "review", False) else {}
+    kwargs.update(_review_target_kwargs(args))
     from_llm = _resolve_from_llm(args)
     ask_codex(
         content,
@@ -1331,6 +1363,7 @@ def _handle_ask_agy(args):
         data = Path(args.data).read_text()
     content = sys.stdin.read() if args.content == "-" else args.content
     kwargs = {"review": True} if getattr(args, "review", False) else {}
+    kwargs.update(_review_target_kwargs(args))
     from_llm = _resolve_from_llm(args)
     ask_agy(
         content,
@@ -1474,6 +1507,7 @@ def _handle_ask_grok_build(args):
         no_timeout=args.no_timeout,
         review=args.review,
         model=args.model,
+        **_review_target_kwargs(args),
         **_background_kwargs(args),
     )
 
@@ -1485,6 +1519,7 @@ def _handle_ask_gemini(args):
         data = Path(args.data).read_text()
     content = sys.stdin.read() if args.content == "-" else args.content
     kwargs = {"review": True} if getattr(args, "review", False) else {}
+    kwargs.update(_review_target_kwargs(args))
     from_llm = _resolve_from_llm(args)
     if not getattr(args, "stdout_only", False):
         print("⚠️ ask-gemini is retired; routing through ask-agy.", file=sys.stderr)

--- a/scripts/ai_agent_bridge/_codex.py
+++ b/scripts/ai_agent_bridge/_codex.py
@@ -22,6 +22,12 @@ from ._config import REPO_ROOT
 from ._db import get_db, set_session
 from ._messaging import acknowledge, send_message
 from ._prompts import build_codex_prompt
+from ._review_worktree import (
+    ReviewWorktreeError,
+    provision_review_worktree,
+    review_target_from_message,
+    review_target_payload,
+)
 
 _CODEX_MODES = {"safe", "workspace-write", "full-auto", "danger"}
 _CHAIN_ISSUE_REF_RE = re.compile(r"^(?:#|issue-|gh-)?(?P<num>\d+)$")
@@ -103,11 +109,21 @@ def ask_codex(
     no_timeout: bool = False,
     review: bool = False,
     background: bool = False,
+    review_branch: str | None = None,
+    review_pr_number: int | None = None,
 ):
     """Send message to Codex AND invoke Codex to process it."""
     from_llm = _resolve_codex_from_llm(from_llm)
     msg_id = send_message(
-        content, task_id, msg_type, data, from_llm=from_llm, to_llm="codex", from_model=from_model, to_model=to_model
+        content,
+        task_id,
+        msg_type,
+        data,
+        from_llm=from_llm,
+        to_llm="codex",
+        from_model=from_model,
+        to_model=to_model,
+        review_target=review_target_payload(review_branch, review_pr_number),
     )
     register_ask(msg_id)
     if background:
@@ -134,6 +150,8 @@ def ask_codex_chain(
     no_timeout: bool = False,
     review: bool = False,
     background: bool = False,
+    review_branch: str | None = None,
+    review_pr_number: int | None = None,
 ) -> list[int]:
     """Dispatch a sequence of issue-targeted Codex tasks one at a time."""
     from_llm = _resolve_codex_from_llm(from_llm)
@@ -158,6 +176,8 @@ def ask_codex_chain(
             no_timeout,
             review=review,
             background=background,
+            review_branch=review_branch,
+            review_pr_number=review_pr_number,
         )
         message_ids.append(msg_id)
 
@@ -233,8 +253,6 @@ def process_for_codex(message_id: int, new_session: bool = False, no_timeout: bo
         _handle_codex_rate_limited(msg, message_id, reason)
         return
 
-    prompt = build_codex_prompt(msg, review)
-
     print(f"📨 Message #{msg['id']}")
     print(f"   From: {msg['from']} → To: {msg['to']}")
     print(f"   Type: {msg['type']}")
@@ -246,25 +264,33 @@ def process_for_codex(message_id: int, new_session: bool = False, no_timeout: bo
         print(f"   Hard timeout: {timeout_val}s")
 
     try:
-        result = agent_runner.invoke(
-            "codex",
-            prompt,
-            mode=_codex_bridge_runtime_mode(),
-            cwd=REPO_ROOT,
-            model=model,
-            task_id=msg["task_id"],
-            session_id=None,  # Codex resume_policy="never"
-            tool_config=None,
-            entrypoint="bridge",
-            hard_timeout=timeout_val,
-            # 600s matches dispatch.py — with the mtime-poller liveness
-            # fallback in place (state_5.sqlite, sessions/YYYY/MM/DD/,
-            # history.jsonl, output file), the stall ceiling only applies
-            # to genuinely dead processes. Raised from 180s 2026-04-10
-            # after a real delegated task stalled at 181s on a
-            # successfully-running invocation. (#1184)
-            stall_timeout=min(600, timeout_val),
-        )
+        review_target = review_target_from_message(msg) if review else None
+        with provision_review_worktree(review_target, repo_root=REPO_ROOT) as checkout:
+            result = agent_runner.invoke(
+                "codex",
+                build_codex_prompt(
+                    msg,
+                    review,
+                    review_branch=checkout.branch if checkout else None,
+                    review_pr_number=checkout.pr_number if checkout else None,
+                    review_worktree_provisioned=checkout is not None,
+                ),
+                mode=_codex_bridge_runtime_mode(),
+                cwd=checkout.path if checkout else REPO_ROOT,
+                model=model,
+                task_id=msg["task_id"],
+                session_id=None,  # Codex resume_policy="never"
+                tool_config=None,
+                entrypoint="bridge",
+                hard_timeout=timeout_val,
+                # 600s matches dispatch.py — with the mtime-poller liveness
+                # fallback in place (state_5.sqlite, sessions/YYYY/MM/DD/,
+                # history.jsonl, output file), the stall ceiling only applies
+                # to genuinely dead processes. Raised from 180s 2026-04-10
+                # after a real delegated task stalled at 181s on a
+                # successfully-running invocation. (#1184)
+                stall_timeout=min(600, timeout_val),
+            )
     except RateLimitedError as exc:
         _handle_codex_rate_limited(msg, message_id, f"Rate limited: {exc}")
         return
@@ -276,6 +302,9 @@ def process_for_codex(message_id: int, new_session: bool = False, no_timeout: bo
         return
     except AgentUnavailableError as exc:
         _handle_codex_error(msg, message_id, f"Codex unavailable: {exc}")
+        return
+    except ReviewWorktreeError as exc:
+        _handle_codex_error(msg, message_id, f"Codex review checkout failed: {exc}")
         return
 
     if not result.ok:

--- a/scripts/ai_agent_bridge/_grok_build.py
+++ b/scripts/ai_agent_bridge/_grok_build.py
@@ -27,6 +27,12 @@ from ._config import REPO_ROOT
 from ._db import get_db, set_session
 from ._messaging import acknowledge, send_message
 from ._prompts import _prepend_review_protocol
+from ._review_worktree import (
+    ReviewWorktreeError,
+    provision_review_worktree,
+    review_target_from_message,
+    review_target_payload,
+)
 
 _DEFAULT_GROK_BUILD_BRIDGE_TIMEOUT_SECONDS = 900
 _NO_TIMEOUT_GROK_BUILD_BRIDGE_TIMEOUT_SECONDS = 24 * 60 * 60
@@ -72,6 +78,8 @@ def ask_grok_build(
     review: bool = False,
     model: str | None = None,
     background: bool = False,
+    review_branch: str | None = None,
+    review_pr_number: int | None = None,
 ) -> int:
     """Send message to native Grok Build and invoke it to process the message."""
     effective_model = to_model or model or GROK_BUILD_DEFAULT_MODEL
@@ -84,6 +92,7 @@ def ask_grok_build(
         to_llm="grok-build",
         from_model=from_model,
         to_model=effective_model,
+        review_target=review_target_payload(review_branch, review_pr_number),
     )
     register_ask(msg_id)
     if background:
@@ -117,7 +126,6 @@ def process_for_grok_build(
     _ = new_session  # grok-build resume_policy="never"; bridge calls are fresh.
     timeout_val = _resolve_grok_build_bridge_timeout(no_timeout)
     model = _extract_target_model(msg) or GROK_BUILD_DEFAULT_MODEL
-    prompt = _build_grok_build_prompt(msg, review)
 
     print(f"Message #{msg['id']}")
     print(f"   From: {msg['from']} -> To: {msg['to']}")
@@ -132,20 +140,28 @@ def process_for_grok_build(
         print(f"   Hard timeout: {timeout_val}s")
 
     try:
-        result = agent_runner.invoke(
-            "grok-build",
-            prompt,
-            mode="read-only",
-            cwd=REPO_ROOT,
-            model=model,
-            task_id=msg["task_id"],
-            session_id=None,
-            tool_config=None,
-            entrypoint="bridge",
-            hard_timeout=timeout_val,
-            stall_timeout=min(600, timeout_val),
-            effort=GROK_BUILD_DEFAULT_EFFORT,
-        )
+        review_target = review_target_from_message(msg) if review else None
+        with provision_review_worktree(review_target, repo_root=REPO_ROOT) as checkout:
+            result = agent_runner.invoke(
+                "grok-build",
+                _build_grok_build_prompt(
+                    msg,
+                    review,
+                    review_branch=checkout.branch if checkout else None,
+                    review_pr_number=checkout.pr_number if checkout else None,
+                    review_worktree_provisioned=checkout is not None,
+                ),
+                mode="read-only",
+                cwd=checkout.path if checkout else REPO_ROOT,
+                model=model,
+                task_id=msg["task_id"],
+                session_id=None,
+                tool_config=None,
+                entrypoint="bridge",
+                hard_timeout=timeout_val,
+                stall_timeout=min(600, timeout_val),
+                effort=GROK_BUILD_DEFAULT_EFFORT,
+            )
     except RateLimitedError as exc:
         _handle_grok_build_error(msg, message_id, f"Grok Build rate limited: {exc}")
         return
@@ -157,6 +173,9 @@ def process_for_grok_build(
         return
     except AgentUnavailableError as exc:
         _handle_grok_build_error(msg, message_id, f"Grok Build unavailable: {exc}")
+        return
+    except ReviewWorktreeError as exc:
+        _handle_grok_build_error(msg, message_id, f"Grok Build review checkout failed: {exc}")
         return
 
     if not result.ok:
@@ -235,7 +254,13 @@ def _extract_target_model(msg: dict) -> str | None:
     return str(model) if model else None
 
 
-def _build_grok_build_prompt(msg: dict, review: bool = False) -> str:
+def _build_grok_build_prompt(
+    msg: dict,
+    review: bool = False,
+    review_branch: str | None = None,
+    review_pr_number: int | None = None,
+    review_worktree_provisioned: bool = False,
+) -> str:
     """Build the native Grok Build bridge prompt."""
     prompt = f"""You are Grok Build (native grok CLI), receiving a message from {msg['from'].title()} via the message broker.
 
@@ -261,7 +286,13 @@ Standing rules for bridge Q&A:
 - Do NOT use broker or MCP messaging tools to send your response; output it directly.
 - This is the native grok-build lane. Do not route through Hermes/OpenRouter.
 """
-    return _prepend_review_protocol(prompt, review)
+    return _prepend_review_protocol(
+        prompt,
+        review,
+        review_branch=review_branch,
+        review_pr_number=review_pr_number,
+        review_worktree_provisioned=review_worktree_provisioned,
+    )
 
 
 def _handle_grok_build_error(msg: dict, message_id: int, reason: str) -> None:

--- a/scripts/ai_agent_bridge/_messaging.py
+++ b/scripts/ai_agent_bridge/_messaging.py
@@ -91,6 +91,7 @@ def read_message(message_id: int, quiet: bool = False):
 def send_message(content: str, task_id: str | None = None, msg_type: str = "response",
                  data: str | None = None, from_llm: str = "gemini", to_llm: str = "claude",
                  from_model: str | None = None, to_model: str | None = None,
+                 review_target: dict | None = None,
                  quiet: bool = False):
     """Send a message between agents."""
     content = redact_text(content) or ""
@@ -111,6 +112,8 @@ def send_message(content: str, task_id: str | None = None, msg_type: str = "resp
         metadata["from_model"] = from_model
     if to_model:
         metadata["to_model"] = to_model
+    if review_target is not None:
+        metadata["review_target"] = review_target
 
     metadata = redact_value(metadata)
     data_json = json.dumps(metadata) if metadata else None

--- a/scripts/ai_agent_bridge/_prompts.py
+++ b/scripts/ai_agent_bridge/_prompts.py
@@ -3,13 +3,60 @@
 from ._config import REPO_ROOT
 
 
-def review_protocol_prefix() -> str:
-    """Load the canonical review protocol at call time."""
-    return (REPO_ROOT / "docs" / "review-protocol.md").read_text("utf-8").rstrip() + "\n\n"
+def review_protocol_prefix(
+    *,
+    branch: str | None = None,
+    pr_number: int | None = None,
+    worktree_provisioned: bool = False,
+) -> str:
+    """Load the canonical review protocol and optional branch-target guard."""
+    protocol = (REPO_ROOT / "docs" / "review-protocol.md").read_text("utf-8").rstrip()
+    if branch is None:
+        return protocol + "\n\n"
+
+    pr_evidence = f" `gh pr diff {pr_number}` or" if pr_number is not None else ""
+    fallback = (
+        "BRANCH-TARGETED REVIEW — EVIDENCE BOUNDARY\n"
+        f"The target is `origin/{branch}`. Your checkout may NOT be that branch; "
+        "never infer branch contents from the primary checkout.\n"
+    )
+    if worktree_provisioned:
+        fallback += (
+            "A read-only detached worktree at that fetched branch head was provisioned "
+            "for this invocation. Use it for branch file evidence. If it is unavailable, "
+            "do not fall back to ordinary local file reads; use the no-worktree evidence "
+            "forms below.\n"
+        )
+    else:
+        fallback += "No branch worktree is provisioned for this invocation.\n"
+    fallback += (
+        "Without a provisioned worktree, the ONLY permitted file-evidence forms are"
+        f"{pr_evidence} `git show origin/{branch}:<path>`. "
+        "Do not read files from the current checkout.\n"
+    )
+    return f"{protocol}\n\n{fallback}\n"
 
 
-def _prepend_review_protocol(prompt: str, review: bool) -> str:
-    return f"{review_protocol_prefix()}{prompt}" if review else prompt
+def _prepend_review_protocol(
+    prompt: str,
+    review: bool,
+    *,
+    review_branch: str | None = None,
+    review_pr_number: int | None = None,
+    review_worktree_provisioned: bool = False,
+) -> str:
+    if not review:
+        return prompt
+    if review_branch is None and review_pr_number is None and not review_worktree_provisioned:
+        return f"{review_protocol_prefix()}{prompt}"
+    return (
+        review_protocol_prefix(
+            branch=review_branch,
+            pr_number=review_pr_number,
+            worktree_provisioned=review_worktree_provisioned,
+        )
+        + prompt
+    )
 
 
 def _load_gemini_context() -> str:
@@ -173,7 +220,13 @@ Format your response clearly.
     return prompt
 
 
-def build_claude_prompt(msg: dict, review: bool = False) -> str:
+def build_claude_prompt(
+    msg: dict,
+    review: bool = False,
+    review_branch: str | None = None,
+    review_pr_number: int | None = None,
+    review_worktree_provisioned: bool = False,
+) -> str:
     """Build prompt for Claude invocation."""
     prompt = f"""You are Claude, receiving a message from {msg['from'].title()} via the message broker.
 
@@ -197,7 +250,13 @@ Respond directly to this message. Be concise and helpful.
 Your response will be automatically sent back to the sender via the message broker.
 Do NOT use MCP tools to send your response - just output your response directly.
 """
-    return _prepend_review_protocol(prompt, review)
+    return _prepend_review_protocol(
+        prompt,
+        review,
+        review_branch=review_branch,
+        review_pr_number=review_pr_number,
+        review_worktree_provisioned=review_worktree_provisioned,
+    )
 
 
 _CODEX_STANDING_RULES = """\
@@ -243,7 +302,13 @@ English scaffolding is by design; from A2 never raise English) - reviews need an
 cross-family reviewer (discussion does not satisfy the gate) - note any lane substitution."""
 
 
-def build_agy_prompt(msg: dict, review: bool = False) -> str:
+def build_agy_prompt(
+    msg: dict,
+    review: bool = False,
+    review_branch: str | None = None,
+    review_pr_number: int | None = None,
+    review_worktree_provisioned: bool = False,
+) -> str:
     """Build prompt for Agy (Antigravity CLI) invocation.
 
     Mirrors the codex prompt shape — minimal context, directive framing,
@@ -289,10 +354,22 @@ Standing rules for bridge Q&A:
   them via your native plugin surface; only fall back to run_command +
   curl if the plugin isn't loaded.
 """
-    return _prepend_review_protocol(prompt, review)
+    return _prepend_review_protocol(
+        prompt,
+        review,
+        review_branch=review_branch,
+        review_pr_number=review_pr_number,
+        review_worktree_provisioned=review_worktree_provisioned,
+    )
 
 
-def build_codex_prompt(msg: dict, review: bool = False) -> str:
+def build_codex_prompt(
+    msg: dict,
+    review: bool = False,
+    review_branch: str | None = None,
+    review_pr_number: int | None = None,
+    review_worktree_provisioned: bool = False,
+) -> str:
     """Build prompt for Codex invocation."""
     prompt = f"""You are Codex, receiving a message from {msg['from'].title()} via the message broker.
 
@@ -318,4 +395,10 @@ Respond directly to this message. Be concise and helpful.
 This bridge is for quick questioning and short coordination, not long-running task execution.
 Do NOT use broker or MCP messaging tools to send your response - just output your response directly.
 """
-    return _prepend_review_protocol(prompt, review)
+    return _prepend_review_protocol(
+        prompt,
+        review,
+        review_branch=review_branch,
+        review_pr_number=review_pr_number,
+        review_worktree_provisioned=review_worktree_provisioned,
+    )

--- a/scripts/ai_agent_bridge/_review_worktree.py
+++ b/scripts/ai_agent_bridge/_review_worktree.py
@@ -1,0 +1,210 @@
+"""Ephemeral, branch-pinned worktrees for bridge review asks.
+
+Bridge asks normally run from the primary checkout (or, for Agy, grant that
+checkout through ``--add-dir``).  A review that names a branch must instead
+read a freshly fetched ``origin/<branch>`` snapshot.  This module owns that
+short-lived checkout so every review adapter uses the same stale-head and
+cleanup rules.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class ReviewWorktreeError(RuntimeError):
+    """A branch-pinned review checkout could not be safely prepared."""
+
+
+@dataclass(frozen=True)
+class ReviewTarget:
+    """A review target supplied as either a branch name or a pull request."""
+
+    branch: str | None = None
+    pr_number: int | None = None
+
+    def __post_init__(self) -> None:
+        if (self.branch is None) == (self.pr_number is None):
+            raise ValueError("review target must specify exactly one of branch or pr_number")
+        if self.branch is not None and (
+            not isinstance(self.branch, str) or not self.branch.strip()
+        ):
+            raise ValueError("review branch must be a non-empty string")
+        if self.pr_number is not None:
+            if isinstance(self.pr_number, bool) or not isinstance(self.pr_number, int):
+                raise ValueError("review PR number must be an integer")
+            if self.pr_number <= 0:
+                raise ValueError("review PR number must be positive")
+
+
+@dataclass(frozen=True)
+class ProvisionedReviewWorktree:
+    """The immutable branch snapshot made available to one review ask."""
+
+    path: Path
+    branch: str
+    sha: str
+    pr_number: int | None = None
+
+
+def review_target_payload(
+    branch: str | None = None, pr_number: int | None = None
+) -> dict[str, Any] | None:
+    """Return serializable review-target metadata for a bridge message."""
+    if branch is None and pr_number is None:
+        return None
+    target = ReviewTarget(branch=branch, pr_number=pr_number)
+    if target.branch is not None:
+        return {"branch": target.branch}
+    return {"pr": target.pr_number}
+
+
+def review_target_from_message(message: dict[str, Any]) -> ReviewTarget | None:
+    """Recover optional branch-review metadata stored by ``send_message``."""
+    raw_data = message.get("data")
+    if not raw_data:
+        return None
+    try:
+        metadata = json.loads(raw_data)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(metadata, dict):
+        return None
+    raw_target = metadata.get("review_target")
+    if not isinstance(raw_target, dict):
+        return None
+
+    branch = raw_target.get("branch")
+    pr_number = raw_target.get("pr")
+    if branch is not None and not isinstance(branch, str):
+        raise ReviewWorktreeError("review target branch metadata must be a string")
+    if pr_number is not None and (isinstance(pr_number, bool) or not isinstance(pr_number, int)):
+        raise ReviewWorktreeError("review target PR metadata must be an integer")
+    try:
+        return ReviewTarget(branch=branch, pr_number=pr_number)
+    except ValueError as exc:
+        raise ReviewWorktreeError(f"invalid review target metadata: {exc}") from exc
+
+
+def _run_command(command: list[str], *, cwd: Path) -> str:
+    """Run one deterministic checkout command and surface useful failures."""
+    completed = subprocess.run(command, cwd=cwd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout or "unknown command failure").strip()
+        raise ReviewWorktreeError(f"{' '.join(command)} failed: {detail}")
+    return completed.stdout.strip()
+
+
+def _validate_branch_name(branch: str, *, repo_root: Path) -> str:
+    """Reject ambiguous revision syntax before building ``origin/<branch>``."""
+    normalized = branch.strip()
+    if not normalized or normalized.startswith(("-", "origin/", "refs/")):
+        raise ReviewWorktreeError(
+            "--branch must be a non-empty branch name without origin/ or refs/ prefixes"
+        )
+    _run_command(["git", "check-ref-format", "--branch", normalized], cwd=repo_root)
+    return normalized
+
+
+def _resolve_pr_branch(pr_number: int, *, repo_root: Path) -> str:
+    """Resolve a PR head name without consulting local branch state."""
+    raw = _run_command(
+        ["gh", "pr", "view", str(pr_number), "--json", "headRefName"], cwd=repo_root
+    )
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ReviewWorktreeError(f"PR #{pr_number} returned invalid JSON") from exc
+    branch = payload.get("headRefName") if isinstance(payload, dict) else None
+    if not isinstance(branch, str) or not branch.strip():
+        raise ReviewWorktreeError(f"PR #{pr_number} did not provide a head branch")
+    return _validate_branch_name(branch, repo_root=repo_root)
+
+
+def _resolve_branch(target: ReviewTarget, *, repo_root: Path) -> tuple[str, int | None]:
+    if target.branch is not None:
+        return _validate_branch_name(target.branch, repo_root=repo_root), None
+    assert target.pr_number is not None
+    return _resolve_pr_branch(target.pr_number, repo_root=repo_root), target.pr_number
+
+
+def _set_owner_writable(path: Path, *, writable: bool) -> None:
+    """Toggle owner write permission without following repository symlinks."""
+    if not path.exists():
+        return
+    paths: list[Path] = [path]
+    for root, directories, files in os.walk(path, followlinks=False):
+        root_path = Path(root)
+        paths.extend(root_path / name for name in [*directories, *files])
+    for candidate in reversed(paths) if writable else paths:
+        try:
+            mode = candidate.lstat().st_mode
+        except FileNotFoundError:
+            continue
+        if stat.S_ISLNK(mode):
+            continue
+        updated = mode | stat.S_IWUSR if writable else mode & ~stat.S_IWUSR
+        if updated != mode:
+            candidate.chmod(updated)
+
+
+def _remove_unregistered_path(path: Path) -> None:
+    """Remove a temporary directory when ``git worktree add`` never registered it."""
+    if not path.exists():
+        return
+    _set_owner_writable(path, writable=True)
+    shutil.rmtree(path)
+
+
+@contextlib.contextmanager
+def provision_review_worktree(
+    target: ReviewTarget | None, *, repo_root: Path
+) -> Iterator[ProvisionedReviewWorktree | None]:
+    """Yield a read-only detached worktree for a branch-targeted review.
+
+    The remote fetch and ``origin/<branch>`` resolution happen before any
+    worktree is created.  This deliberately refuses stale local branch heads.
+    The teardown is in ``finally`` so reviewer failures cannot strand a
+    temporary checkout.
+    """
+    if target is None:
+        yield None
+        return
+
+    root = repo_root.resolve()
+    branch, pr_number = _resolve_branch(target, repo_root=root)
+    origin_ref = f"origin/{branch}"
+    _run_command(["git", "fetch", "origin", branch], cwd=root)
+    sha = _run_command(["git", "rev-parse", "--verify", origin_ref], cwd=root)
+
+    path = Path(tempfile.mkdtemp(prefix="learn-ukrainian-review-"))
+    path.rmdir()
+    registered = False
+    try:
+        _run_command(
+            ["git", "worktree", "add", "--detach", str(path), sha], cwd=root
+        )
+        registered = True
+        actual_sha = _run_command(["git", "rev-parse", "HEAD"], cwd=path)
+        if actual_sha != sha:
+            raise ReviewWorktreeError(
+                f"review worktree HEAD {actual_sha} did not match {origin_ref} {sha}"
+            )
+        _set_owner_writable(path, writable=False)
+        yield ProvisionedReviewWorktree(path, branch, sha, pr_number)
+    finally:
+        _set_owner_writable(path, writable=True)
+        if registered:
+            _run_command(["git", "worktree", "remove", "--force", str(path)], cwd=root)
+        else:
+            _remove_unregistered_path(path)

--- a/scripts/ai_agent_bridge/_review_worktree.py
+++ b/scripts/ai_agent_bridge/_review_worktree.py
@@ -80,9 +80,14 @@ def review_target_from_message(message: dict[str, Any]) -> ReviewTarget | None:
         return None
     if not isinstance(metadata, dict):
         return None
+    if "review_target" not in metadata:
+        return None
     raw_target = metadata.get("review_target")
     if not isinstance(raw_target, dict):
-        return None
+        # Fail closed (#5175 review BLOCKER): a present-but-malformed target must
+        # never silently degrade to a primary-checkout review — that IS the bug
+        # this module exists to fix.
+        raise ReviewWorktreeError("review_target metadata must be an object when present")
 
     branch = raw_target.get("branch")
     pr_number = raw_target.get("pr")
@@ -182,6 +187,10 @@ def provision_review_worktree(
         return
 
     root = repo_root.resolve()
+    # Self-heal SIGKILL-stranded registrations from prior review asks: the
+    # finally-teardown below cannot run under SIGKILL, and a stale
+    # .git/worktrees/<id> entry otherwise persists forever (#5175 review).
+    _run_command(["git", "worktree", "prune"], cwd=root)
     branch, pr_number = _resolve_branch(target, repo_root=root)
     origin_ref = f"origin/{branch}"
     _run_command(["git", "fetch", "origin", branch], cwd=root)

--- a/scripts/verify_review.py
+++ b/scripts/verify_review.py
@@ -61,8 +61,18 @@ def _parse_finding(body: str, finding_id: int) -> dict[str, object]:
     }
 
 
+def _origin_branch_ref(branch: str) -> str:
+    """Return the remote-tracking ref used for branch quote verification."""
+    normalized = branch.strip()
+    if not normalized or normalized.startswith(("origin/", "refs/", "-")):
+        raise ValueError("--branch must be a branch name without origin/ or refs/ prefixes")
+    return f"origin/{normalized}"
+
+
 def _load_file(path: str, branch: str | None) -> str:
-    return _run(["git", "show", f"{branch}:{path}"]) if branch else Path(path).read_text("utf-8")
+    if branch is None:
+        return Path(path).read_text("utf-8")
+    return _run(["git", "show", f"{_origin_branch_ref(branch)}:{path}"])
 
 
 def _verify_finding(finding: dict[str, object], branch: str | None) -> dict[str, object]:

--- a/tests/ai_agent_bridge/test_agy_model_selection.py
+++ b/tests/ai_agent_bridge/test_agy_model_selection.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
@@ -17,6 +18,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 from agent_runtime.result import Result
 from ai_agent_bridge._agy import _extract_target_model, process_for_agy
 from ai_agent_bridge._config import REPO_ROOT
+from ai_agent_bridge._review_worktree import ProvisionedReviewWorktree
 
 
 def test_pro_slug_round_trips_from_data_blob():
@@ -102,3 +104,57 @@ def test_agy_bridge_records_unsandboxed_repo_read_mode(monkeypatch):
     assert spawn_cwd != repo_root
     assert not spawn_cwd.is_relative_to(repo_root)
     assert spawn_cwd.is_dir()
+
+
+def test_agy_branch_review_grants_only_the_provisioned_worktree(monkeypatch, tmp_path):
+    checkout = ProvisionedReviewWorktree(
+        path=tmp_path / "review-checkout",
+        branch="feature/review",
+        sha="a" * 40,
+    )
+    checkout.path.mkdir()
+    msg = {
+        "id": 9,
+        "task_id": "branch-review",
+        "from": "codex",
+        "to": "agy",
+        "type": "query",
+        "content": "Review the branch.",
+        "data": json.dumps({"review_target": {"branch": "feature/review"}}),
+    }
+    captured: dict[str, object] = {}
+
+    @contextmanager
+    def fake_checkout(*_args, **_kwargs):
+        yield checkout
+
+    monkeypatch.setattr("ai_agent_bridge._agy._fetch_agy_message", lambda _id: msg)
+    monkeypatch.setattr("ai_agent_bridge._agy.provision_review_worktree", fake_checkout)
+    monkeypatch.setattr("ai_agent_bridge._agy.acknowledge", lambda _id: None)
+    monkeypatch.setattr("ai_agent_bridge._agy.send_message", lambda **_kwargs: 10)
+    monkeypatch.setattr("ai_agent_bridge._agy.record_ask_reply", lambda *_args: None)
+    monkeypatch.setattr(
+        "ai_agent_bridge._agy.agent_runner.invoke",
+        lambda *_args, **kwargs: captured.update(kwargs)
+        or Result(
+            ok=True,
+            agent="agy",
+            model="gemini-3.5-flash-high",
+            mode="danger",
+            response="reply",
+            stderr_excerpt=None,
+            duration_s=0.1,
+            session_id=None,
+            rate_limited=False,
+            stalled=False,
+            returncode=0,
+            usage_record={},
+        ),
+    )
+
+    assert process_for_agy(9, review=True, stdout_only=True) == "reply"
+    assert captured["cwd"] != checkout.path
+    assert captured["tool_config"] == {
+        "bridge_repo_read": True,
+        "repo_read_root": str(checkout.path),
+    }

--- a/tests/ai_agent_bridge/test_ask_lifecycle.py
+++ b/tests/ai_agent_bridge/test_ask_lifecycle.py
@@ -67,6 +67,26 @@ def test_background_ask_sends_immediately_and_mocks_detached_spawn(bridge_db, mo
     )
 
 
+def test_background_branch_review_persists_target_in_message_metadata(bridge_db, monkeypatch):
+    monkeypatch.setattr("ai_agent_bridge._agy.launch_background_ask", Mock(return_value=4321))
+
+    message_id = ask_agy(
+        "Review the branch.",
+        task_id="review-5150",
+        review=True,
+        review_branch="feature/review",
+        background=True,
+    )
+
+    conn = get_db()
+    try:
+        row = conn.execute("SELECT data FROM messages WHERE id = ?", (message_id,)).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    assert json.loads(row[0])["review_target"] == {"branch": "feature/review"}
+
+
 def test_launch_background_ask_writes_state_and_uses_detached_popen(bridge_db, monkeypatch, tmp_path):
     message_id = _send_ask()
     monkeypatch.setattr(lifecycle, "REPO_ROOT", tmp_path)

--- a/tests/ai_agent_bridge/test_claude_review_worktree.py
+++ b/tests/ai_agent_bridge/test_claude_review_worktree.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from agent_runtime.result import Result
+from ai_agent_bridge import _claude
+from ai_agent_bridge._review_worktree import ProvisionedReviewWorktree
+
+
+def test_claude_branch_review_invokes_from_provisioned_checkout(monkeypatch, tmp_path):
+    checkout = ProvisionedReviewWorktree(
+        path=tmp_path / "review-checkout",
+        branch="feature/review",
+        sha="a" * 40,
+    )
+    checkout.path.mkdir()
+    captured: dict[str, object] = {}
+    msg = {
+        "id": 9,
+        "task_id": "branch-review",
+        "from": "codex",
+        "to": "claude",
+        "type": "query",
+        "content": "Review the branch.",
+        "data": json.dumps({"review_target": {"branch": "feature/review"}}),
+    }
+
+    @contextmanager
+    def fake_checkout(*_args, **_kwargs):
+        yield checkout
+
+    monkeypatch.setattr(_claude, "_is_task_locked", lambda *_args: False)
+    monkeypatch.setattr(_claude, "_write_pid_file", lambda *_args: None)
+    monkeypatch.setattr(_claude, "_remove_pid_file", lambda *_args: None)
+    monkeypatch.setattr(_claude.atexit, "register", lambda *_args: None)
+    monkeypatch.setattr(_claude, "set_session", lambda *_args: None)
+    monkeypatch.setattr(_claude, "provision_review_worktree", fake_checkout)
+    monkeypatch.setattr(_claude, "send_message", lambda **_kwargs: 10)
+    monkeypatch.setattr(_claude, "acknowledge", lambda *_args: None)
+    monkeypatch.setattr(_claude, "record_ask_reply", lambda *_args: None)
+    monkeypatch.setattr(
+        _claude,
+        "runtime_invoke",
+        lambda *_args, **kwargs: captured.update(kwargs)
+        or Result(
+            ok=True,
+            agent="claude",
+            model="claude-opus-4-8",
+            mode="read-only",
+            response="reply",
+            stderr_excerpt=None,
+            duration_s=0.1,
+            session_id=None,
+            rate_limited=False,
+            stalled=False,
+            returncode=0,
+            usage_record={},
+        ),
+    )
+
+    _claude._run_claude_sync_via_runtime(msg, 9, None, no_timeout=False, review=True)
+
+    assert captured["cwd"] == checkout.path

--- a/tests/ai_agent_bridge/test_review_worktree.py
+++ b/tests/ai_agent_bridge/test_review_worktree.py
@@ -131,3 +131,39 @@ def test_review_cli_accepts_explicit_branch_only_with_review() -> None:
     args.review = False
     with pytest.raises(SystemExit, match="require --review"):
         _cli._review_target_kwargs(args)
+
+
+def test_review_target_present_but_non_dict_fails_closed() -> None:
+    # #5175 review BLOCKER: a present-but-malformed review_target must raise,
+    # never silently degrade to a primary-checkout review (the original #5150 bug).
+    for bad in (None, "garbage", ["branch"], 7):
+        with pytest.raises(review_worktree.ReviewWorktreeError, match="must be an object"):
+            review_worktree.review_target_from_message(
+                {"data": json.dumps({"review_target": bad})}
+            )
+    # Absent key is a normal non-branch review — still None, no error.
+    assert review_worktree.review_target_from_message({"data": json.dumps({"x": 1})}) is None
+
+
+def test_provision_prunes_stale_worktree_registrations(tmp_path, monkeypatch) -> None:
+    # #5175 review MAJOR: SIGKILL between add and remove strands a
+    # .git/worktrees/<id> registration; provisioning must self-heal via prune.
+    commands: list[list[str]] = []
+
+    def fake_run(command, *, cwd):
+        commands.append(command)
+        if command[:2] == ["git", "fetch"]:
+            return ""
+        if command[:2] == ["git", "rev-parse"] and "--verify" in command:
+            return "deadbeef"
+        if command[:3] == ["git", "worktree", "add"]:
+            raise review_worktree.ReviewWorktreeError("stop before real checkout")
+        return ""
+
+    monkeypatch.setattr(review_worktree, "_run_command", fake_run)
+    target = review_worktree.ReviewTarget(branch="feature/x")
+    with pytest.raises(review_worktree.ReviewWorktreeError, match="stop before real checkout"):
+        with review_worktree.provision_review_worktree(target, repo_root=tmp_path):
+            pass
+    assert ["git", "worktree", "prune"] in commands
+    assert commands.index(["git", "worktree", "prune"]) == 0

--- a/tests/ai_agent_bridge/test_review_worktree.py
+++ b/tests/ai_agent_bridge/test_review_worktree.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+from ai_agent_bridge import _cli
+from ai_agent_bridge import _review_worktree as review_worktree
+
+
+def test_provision_review_worktree_fetches_origin_head_and_reaps_on_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failing reviewer cannot strand the fetched detached checkout."""
+    checkout_path = tmp_path / "review-checkout"
+    checkout_path.mkdir()
+    calls: list[tuple[list[str], Path]] = []
+    sha = "a" * 40
+
+    monkeypatch.setattr(review_worktree.tempfile, "mkdtemp", lambda **_kwargs: str(checkout_path))
+
+    def fake_run(command: list[str], *, cwd: Path) -> str:
+        calls.append((command, cwd))
+        if command[:4] == ["git", "worktree", "add", "--detach"]:
+            path = Path(command[4])
+            path.mkdir()
+            (path / "tracked.py").write_text("value = 1\n", encoding="utf-8")
+        if command == ["git", "rev-parse", "--verify", "origin/feature/review"]:
+            return sha
+        if command == ["git", "rev-parse", "HEAD"]:
+            return sha
+        return ""
+
+    monkeypatch.setattr(review_worktree, "_run_command", fake_run)
+
+    with pytest.raises(RuntimeError, match="reviewer failed"):
+        with review_worktree.provision_review_worktree(
+            review_worktree.ReviewTarget(branch="feature/review"), repo_root=tmp_path
+        ) as checkout:
+            assert checkout is not None
+            assert checkout.branch == "feature/review"
+            assert checkout.sha == sha
+            assert not (checkout.path / "tracked.py").stat().st_mode & stat.S_IWUSR
+            raise RuntimeError("reviewer failed")
+
+    commands = [command for command, _cwd in calls]
+    assert ["git", "fetch", "origin", "feature/review"] in commands
+    assert ["git", "rev-parse", "--verify", "origin/feature/review"] in commands
+    assert ["git", "worktree", "add", "--detach", str(checkout_path), sha] in commands
+    assert ["git", "worktree", "remove", "--force", str(checkout_path)] in commands
+    assert not any(command == ["git", "rev-parse", "feature/review"] for command in commands)
+
+
+def test_pr_review_target_resolves_head_then_fetches_origin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    checkout_path = tmp_path / "review-checkout"
+    checkout_path.mkdir()
+    calls: list[list[str]] = []
+    sha = "b" * 40
+
+    monkeypatch.setattr(review_worktree.tempfile, "mkdtemp", lambda **_kwargs: str(checkout_path))
+
+    def fake_run(command: list[str], *, cwd: Path) -> str:
+        calls.append(command)
+        if command[:4] == ["git", "worktree", "add", "--detach"]:
+            Path(command[4]).mkdir()
+        if command == ["gh", "pr", "view", "5150", "--json", "headRefName"]:
+            return json.dumps({"headRefName": "codex/5150-review"})
+        if command == ["git", "rev-parse", "--verify", "origin/codex/5150-review"]:
+            return sha
+        if command == ["git", "rev-parse", "HEAD"]:
+            return sha
+        return ""
+
+    monkeypatch.setattr(review_worktree, "_run_command", fake_run)
+
+    with review_worktree.provision_review_worktree(
+        review_worktree.ReviewTarget(pr_number=5150), repo_root=tmp_path
+    ) as checkout:
+        assert checkout is not None
+        assert checkout.branch == "codex/5150-review"
+        assert checkout.pr_number == 5150
+
+    assert calls.index(["git", "fetch", "origin", "codex/5150-review"]) > calls.index(
+        ["gh", "pr", "view", "5150", "--json", "headRefName"]
+    )
+
+
+def test_review_target_metadata_rejects_ambiguous_or_malformed_values() -> None:
+    assert review_worktree.review_target_payload(branch="feature/review") == {
+        "branch": "feature/review"
+    }
+    assert review_worktree.review_target_from_message(
+        {"data": json.dumps({"review_target": {"pr": 123}})}
+    ) == review_worktree.ReviewTarget(pr_number=123)
+    with pytest.raises(ValueError, match="exactly one"):
+        review_worktree.review_target_payload(branch="feature/review", pr_number=123)
+    with pytest.raises(ValueError, match="non-empty"):
+        review_worktree.review_target_payload(branch="")
+    with pytest.raises(review_worktree.ReviewWorktreeError, match="must be an integer"):
+        review_worktree.review_target_from_message(
+            {"data": json.dumps({"review_target": {"pr": "123"}})}
+        )
+
+
+def test_review_cli_accepts_explicit_branch_only_with_review() -> None:
+    parser = _cli._build_parser()
+    args = parser.parse_args(
+        [
+            "ask-agy",
+            "Review the branch.",
+            "--task-id",
+            "review-5150",
+            "--review",
+            "--branch",
+            "feature/review",
+        ]
+    )
+
+    assert _cli._review_target_kwargs(args) == {
+        "review_branch": "feature/review",
+        "review_pr_number": None,
+    }
+
+    args.review = False
+    with pytest.raises(SystemExit, match="require --review"):
+        _cli._review_target_kwargs(args)

--- a/tests/ai_agent_bridge/test_verify_review.py
+++ b/tests/ai_agent_bridge/test_verify_review.py
@@ -4,6 +4,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 import verify_review
@@ -30,9 +32,9 @@ def _finding(path: str, line: int, quote: str, *, include_fix: bool = True) -> s
 
 def test_verify_review_outcomes(monkeypatch):
     files = {
-        "main:ok.py": "a = 1\nb = 2\n",
-        "main:mismatch.py": "x = 0\nvalue = 2\n",
-        "main:missing.py": "z = 9\n",
+        "origin/main:ok.py": "a = 1\nb = 2\n",
+        "origin/main:mismatch.py": "x = 0\nvalue = 2\n",
+        "origin/main:missing.py": "z = 9\n",
     }
     monkeypatch.setattr(verify_review, "_run", lambda cmd, input_text=None: files[cmd[-1]])
     review = "\n\n".join(
@@ -98,6 +100,22 @@ def test_issue_mode_reads_latest_comment_and_posts_summary(
     assert calls[-1][:3] == ["gh", "issue", "comment"]
 
 
+def test_verify_review_branch_mode_never_uses_a_local_branch_or_worktree(monkeypatch):
+    commands: list[list[str]] = []
+
+    def fake_run(command, input_text=None):
+        commands.append(command)
+        assert input_text is None
+        return "value = 1\n"
+
+    monkeypatch.setattr(verify_review, "_run", fake_run)
+
+    assert verify_review._load_file("path/to/file.py", "feature/review") == "value = 1\n"
+    assert commands == [["git", "show", "origin/feature/review:path/to/file.py"]]
+    with pytest.raises(ValueError, match="without origin"):
+        verify_review._load_file("path/to/file.py", "origin/feature/review")
+
+
 def test_review_protocol_is_loaded_at_call_time(tmp_path, monkeypatch):
     docs = tmp_path / "docs"
     docs.mkdir()
@@ -118,6 +136,22 @@ def test_review_protocol_is_loaded_at_call_time(tmp_path, monkeypatch):
 
     assert "PROTO v1" in first
     assert "PROTO v2" in second
+
+
+def test_branch_targeted_review_prompt_forbids_primary_checkout_evidence(tmp_path, monkeypatch):
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "review-protocol.md").write_text("PROTO", encoding="utf-8")
+    monkeypatch.setattr(_prompts, "REPO_ROOT", tmp_path)
+
+    prompt = _prompts.review_protocol_prefix(
+        branch="feature/review", pr_number=5150, worktree_provisioned=False
+    )
+
+    assert "checkout may NOT be that branch" in prompt
+    assert "gh pr diff 5150" in prompt
+    assert "git show origin/feature/review:<path>" in prompt
+    assert "Do not read files from the current checkout" in prompt
 
 
 def test_build_agent_prompt_review_prefix_precedes_channel_context(monkeypatch):

--- a/tests/test_codex_bridge.py
+++ b/tests/test_codex_bridge.py
@@ -9,6 +9,7 @@ import os
 import re
 import sqlite3
 import sys
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
@@ -29,6 +30,7 @@ from ai_agent_bridge._codex import (
 )
 from ai_agent_bridge._db import get_db, init_db
 from ai_agent_bridge._messaging import detect_sender, send_message
+from ai_agent_bridge._review_worktree import ProvisionedReviewWorktree
 
 
 @pytest.fixture(autouse=True)
@@ -381,6 +383,61 @@ def test_process_for_codex_uses_workspace_write_mode_and_never_resumes(
     )
     assert mock_acknowledge.call_args_list[0].args == (8,)
     assert mock_acknowledge.call_args_list[1].args == (100,)
+
+
+def test_codex_branch_review_invokes_from_provisioned_checkout(monkeypatch, tmp_path):
+    checkout = ProvisionedReviewWorktree(
+        path=tmp_path / "review-checkout",
+        branch="feature/review",
+        sha="a" * 40,
+    )
+    checkout.path.mkdir()
+    captured: dict[str, object] = {}
+
+    @contextmanager
+    def fake_checkout(*_args, **_kwargs):
+        yield checkout
+
+    monkeypatch.setattr(
+        "ai_agent_bridge._codex._fetch_codex_message",
+        lambda _id: {
+            "id": 9,
+            "task_id": "branch-review",
+            "from": "gemini",
+            "to": "codex",
+            "type": "query",
+            "content": "Review the branch.",
+            "data": json.dumps({"review_target": {"branch": "feature/review"}}),
+        },
+    )
+    monkeypatch.setattr("ai_agent_bridge._codex.has_codex_headroom", lambda _model: (True, ""))
+    monkeypatch.setattr("ai_agent_bridge._codex.provision_review_worktree", fake_checkout)
+    monkeypatch.setattr("ai_agent_bridge._codex.acknowledge", lambda *_args: None)
+    monkeypatch.setattr("ai_agent_bridge._codex.send_message", lambda **_kwargs: 10)
+    monkeypatch.setattr("ai_agent_bridge._codex.record_ask_reply", lambda *_args: None)
+    monkeypatch.setattr("ai_agent_bridge._codex.set_session", lambda *_args: None)
+    monkeypatch.setattr(
+        "ai_agent_bridge._codex.agent_runner.invoke",
+        lambda *_args, **kwargs: captured.update(kwargs)
+        or Result(
+            ok=True,
+            agent="codex",
+            model="gpt-5.6-terra",
+            mode="read-only",
+            response="reply",
+            stderr_excerpt=None,
+            duration_s=0.1,
+            session_id=None,
+            rate_limited=False,
+            stalled=False,
+            returncode=0,
+            usage_record={},
+        ),
+    )
+
+    process_for_codex(9, review=True)
+
+    assert captured["cwd"] == checkout.path
 
 
 def test_process_for_codex_short_circuits_when_no_headroom(bridge_db):

--- a/tests/test_grok_build_bridge.py
+++ b/tests/test_grok_build_bridge.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import json
 from argparse import Namespace
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import patch
 
 from scripts.agent_runtime.registry import get_agent_entry
 from scripts.ai_agent_bridge import _cli, _grok_build
+from scripts.ai_agent_bridge._review_worktree import ProvisionedReviewWorktree
 
 
 def test_ask_grok_build_parser_accepts_first_class_args():
@@ -117,6 +120,49 @@ def test_process_grok_build_invokes_native_registry_key(monkeypatch):
     assert kwargs["model"] == "grok-build"
     assert kwargs["effort"] == _grok_build.GROK_BUILD_DEFAULT_EFFORT
     assert kwargs["entrypoint"] == "bridge"
+
+
+def test_grok_build_branch_review_uses_provisioned_checkout(monkeypatch, tmp_path):
+    checkout = ProvisionedReviewWorktree(
+        path=tmp_path / "review-checkout",
+        branch="feature/review",
+        sha="a" * 40,
+    )
+    checkout.path.mkdir()
+    captured: dict[str, object] = {}
+
+    @contextmanager
+    def fake_checkout(*_args, **_kwargs):
+        yield checkout
+
+    monkeypatch.setattr(
+        _grok_build,
+        "_fetch_grok_build_message",
+        lambda _message_id: {
+            "id": 9,
+            "task_id": "branch-review",
+            "from": "codex",
+            "to": "grok-build",
+            "type": "query",
+            "content": "Review the branch.",
+            "data": json.dumps({"review_target": {"branch": "feature/review"}}),
+        },
+    )
+    monkeypatch.setattr(_grok_build, "provision_review_worktree", fake_checkout)
+    monkeypatch.setattr(_grok_build, "send_message", lambda **_kwargs: 10)
+    monkeypatch.setattr(_grok_build, "acknowledge", lambda *_args: None)
+    monkeypatch.setattr(_grok_build, "record_ask_reply", lambda *_args: None)
+    monkeypatch.setattr(_grok_build, "set_session", lambda *_args: None)
+    monkeypatch.setattr(
+        _grok_build.agent_runner,
+        "invoke",
+        lambda *_args, **kwargs: captured.update(kwargs)
+        or SimpleNamespace(ok=True, response="reply", session_id=None, model="grok-build"),
+    )
+
+    _grok_build.process_for_grok_build(9, review=True)
+
+    assert captured["cwd"] == checkout.path
 
 
 def test_grok_build_registry_key_resolves_native_adapter():


### PR DESCRIPTION
## Root cause

Branch reviews had no structured target. Claude, Codex, and Grok Build invoked from `REPO_ROOT`; Agy granted `REPO_ROOT` through `--add-dir`, so reviewers could quote primary-checkout code instead of the PR branch.

## Fix

1. Adds `--branch` / `--pr` for `--review` asks and persists the target through detached asks.
2. Fetches the target, resolves only `origin/<branch>`, creates a detached read-only temporary worktree at that SHA, passes it to the adapter, and reaps it in `finally`.
3. Adds branch-targeted protocol evidence rules and makes `verify_review.py --branch` read `origin/<branch>:<path>`.

## Evidence

- Focused pytest: 64 passed.
- Ruff: clean.
- Live lifecycle probe: detached worktree HEAD equaled `origin/main`; its files were read-only and it was absent from `git worktree list` after teardown.
- Covers failure cleanup, PR-head resolution, background metadata persistence, adapter cwd/add-dir handoff, prompt hardening, and branch quote verification.

Refs #5150