### PR TITLE
feat(orchestration): add deterministic prompt contracts

### DIFF
--- a/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-common.md
+++ b/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-common.md
@@ -1,0 +1,10 @@
+# Curriculum lifecycle module contract
+
+Operate on the manifest target `{{track}}/{{slug}}` in phase `{{phase}}` from
+derived state `{{module_state}}`. Treat evidence identity
+`{{evidence_identity}}` as immutable input, and stop if any consumed dependency
+does not match it.
+
+Return only JSON conforming to the registered
+`curriculum-lifecycle-output.v1` schema. Findings must name the owning phase;
+never repair content from inside a read-only gate.

--- a/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-core.md
+++ b/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-core.md
@@ -1,0 +1,6 @@
+# CORE family policy
+
+Apply the registered CORE profile for family `{{family}}`. Preserve the active
+level's progression and immersion policy: A1 English scaffolding is intentional,
+while A2 and later levels must not gain English. Do not borrow a seminar-specific
+source or framing rule unless the profile registers it.

--- a/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar.md
+++ b/agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar.md
@@ -1,0 +1,6 @@
+# Seminar family policy
+
+Apply the registered seminar profile for family `{{family}}`. Keep source,
+quotation, rights, historical-language, and decolonization requirements bound to
+the selected track profile. Do not infer that two seminar tracks share identical
+preparation or certification requirements.

--- a/agents_extensions/shared/prompt-contracts/manifests/curriculum-lifecycle.module.v1.yaml
+++ b/agents_extensions/shared/prompt-contracts/manifests/curriculum-lifecycle.module.v1.yaml
@@ -1,0 +1,32 @@
+manifest_version: prompt-manifest.v1
+prompt_id: curriculum-lifecycle.module
+version: 1.0.0
+input_schema: agents_extensions/shared/prompt-contracts/schema/curriculum-lifecycle-input.v1.schema.json
+output_schema: agents_extensions/shared/prompt-contracts/schema/curriculum-lifecycle-output.v1.schema.json
+policy_ids:
+  operator-contract: agents_extensions/shared/rules/operator-expectations.md
+  workflow: agents_extensions/shared/rules/workflow.md
+compatible:
+  families: [core, seminar]
+  routes: [tool-capable]
+fragments:
+  contract.base:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-common.md
+    section: contract-base
+    includes: []
+  family.core:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-core.md
+    section: family-policy
+    includes: [contract.base]
+  family.seminar:
+    path: agents_extensions/shared/prompt-contracts/fragments/curriculum-lifecycle-seminar.md
+    section: family-policy
+    includes: [contract.base]
+variants:
+  core:
+    family: core
+    roots: [family.core]
+  seminar:
+    family: seminar
+    roots: [family.seminar]
+deprecation: null

--- a/agents_extensions/shared/prompt-contracts/profiles/curriculum-lifecycle.v1.yaml
+++ b/agents_extensions/shared/prompt-contracts/profiles/curriculum-lifecycle.v1.yaml
@@ -1,0 +1,10 @@
+profile_schema_version: prompt-profile.v1
+profiles:
+  core:
+    prompt_id: curriculum-lifecycle.module
+    prompt_version: 1.0.0
+    variant: core
+  seminar:
+    prompt_id: curriculum-lifecycle.module
+    prompt_version: 1.0.0
+    variant: seminar

--- a/agents_extensions/shared/prompt-contracts/registry.v1.yaml
+++ b/agents_extensions/shared/prompt-contracts/registry.v1.yaml
@@ -1,0 +1,6 @@
+registry_version: prompt-registry.v1
+prompts:
+  curriculum-lifecycle.module:
+    current: 1.0.0
+    versions:
+      1.0.0: agents_extensions/shared/prompt-contracts/manifests/curriculum-lifecycle.module.v1.yaml

--- a/agents_extensions/shared/prompt-contracts/schema/curriculum-lifecycle-input.v1.schema.json
+++ b/agents_extensions/shared/prompt-contracts/schema/curriculum-lifecycle-input.v1.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "curriculum-lifecycle-input.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["track", "slug", "family", "phase", "module_state", "evidence_identity"],
+  "properties": {
+    "track": {"type": "string", "pattern": "^[a-z][a-z0-9-]+$"},
+    "slug": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$"},
+    "family": {"enum": ["core", "seminar"]},
+    "phase": {"enum": ["prepare", "plan", "build", "certify"]},
+    "module_state": {"enum": ["built", "unbuilt", "partial", "stale", "current"]},
+    "evidence_identity": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+  }
+}

--- a/agents_extensions/shared/prompt-contracts/schema/curriculum-lifecycle-output.v1.schema.json
+++ b/agents_extensions/shared/prompt-contracts/schema/curriculum-lifecycle-output.v1.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "curriculum-lifecycle-output.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["status", "findings", "next_action", "evidence_identity"],
+  "properties": {
+    "status": {"enum": ["ready", "repair_required", "blocked"]},
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "category", "severity", "summary", "owner"],
+        "properties": {
+          "id": {"type": "string", "minLength": 1},
+          "category": {"type": "string", "minLength": 1},
+          "severity": {"enum": ["blocker", "high", "medium", "low"]},
+          "summary": {"type": "string", "minLength": 1},
+          "owner": {"enum": ["preparation", "plan", "built_artifact", "audit_tooling", "authority"]}
+        }
+      }
+    },
+    "next_action": {"enum": ["prepare", "plan", "build", "certify", "stop"]},
+    "evidence_identity": {"type": "string", "pattern": "^[0-9a-f]{64}$"}
+  }
+}

--- a/agents_extensions/shared/prompt-contracts/schema/prompt-manifest.v1.schema.json
+++ b/agents_extensions/shared/prompt-contracts/schema/prompt-manifest.v1.schema.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "prompt-manifest.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "manifest_version",
+    "prompt_id",
+    "version",
+    "input_schema",
+    "output_schema",
+    "policy_ids",
+    "compatible",
+    "fragments",
+    "variants",
+    "deprecation"
+  ],
+  "properties": {
+    "manifest_version": {"const": "prompt-manifest.v1"},
+    "prompt_id": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+$"},
+    "version": {"$ref": "#/$defs/semver"},
+    "input_schema": {"$ref": "#/$defs/path"},
+    "output_schema": {"$ref": "#/$defs/path"},
+    "policy_ids": {
+      "type": "object",
+      "minProperties": 1,
+      "patternProperties": {
+        "^[a-z][a-z0-9.-]+$": {"$ref": "#/$defs/path"}
+      },
+      "additionalProperties": false
+    },
+    "compatible": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["families", "routes"],
+      "properties": {
+        "families": {"$ref": "#/$defs/stringArray"},
+        "routes": {"$ref": "#/$defs/stringArray"}
+      }
+    },
+    "fragments": {
+      "type": "object",
+      "minProperties": 1,
+      "patternProperties": {
+        "^[a-z][a-z0-9.-]+$": {"$ref": "#/$defs/fragment"}
+      },
+      "additionalProperties": false
+    },
+    "variants": {
+      "type": "object",
+      "minProperties": 1,
+      "patternProperties": {
+        "^[a-z][a-z0-9.-]+$": {"$ref": "#/$defs/variant"}
+      },
+      "additionalProperties": false
+    },
+    "deprecation": {
+      "oneOf": [
+        {"type": "null"},
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["replacement", "message"],
+          "properties": {
+            "replacement": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+$"},
+            "message": {"type": "string", "minLength": 1}
+          }
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "semver": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "path": {
+      "type": "string",
+      "minLength": 1,
+      "not": {"pattern": "(^/|^~|(^|/)\\.\\.(/|$))"}
+    },
+    "stringArray": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "fragment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "section", "includes"],
+      "properties": {
+        "path": {"$ref": "#/$defs/path"},
+        "section": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+$"},
+        "includes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+$"}
+        }
+      }
+    },
+    "variant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["family", "roots"],
+      "properties": {
+        "family": {"type": "string", "minLength": 1},
+        "roots": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+$"}
+        }
+      }
+    }
+  }
+}

--- a/agents_extensions/shared/prompt-contracts/schema/prompt-profile.v1.schema.json
+++ b/agents_extensions/shared/prompt-contracts/schema/prompt-profile.v1.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "prompt-profile.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["profile_schema_version", "profiles"],
+  "properties": {
+    "profile_schema_version": {"const": "prompt-profile.v1"},
+    "profiles": {
+      "type": "object",
+      "minProperties": 1,
+      "patternProperties": {
+        "^[a-z][a-z0-9.-]+$": {"$ref": "#/$defs/profile"}
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "semver": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["prompt_id", "prompt_version", "variant"],
+      "properties": {
+        "prompt_id": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+$"},
+        "prompt_version": {"$ref": "#/$defs/semver"},
+        "variant": {"type": "string", "pattern": "^[a-z][a-z0-9.-]+$"}
+      }
+    }
+  }
+}

--- a/agents_extensions/shared/prompt-contracts/schema/prompt-registry.v1.schema.json
+++ b/agents_extensions/shared/prompt-contracts/schema/prompt-registry.v1.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "prompt-registry.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["registry_version", "prompts"],
+  "properties": {
+    "registry_version": {"const": "prompt-registry.v1"},
+    "prompts": {
+      "type": "object",
+      "minProperties": 1,
+      "patternProperties": {
+        "^[a-z][a-z0-9.-]+$": {"$ref": "#/$defs/prompt"}
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "semver": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "path": {
+      "type": "string",
+      "minLength": 1,
+      "not": {"pattern": "(^/|^~|(^|/)\\.\\.(/|$))"}
+    },
+    "prompt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["current", "versions"],
+      "properties": {
+        "current": {"$ref": "#/$defs/semver"},
+        "versions": {
+          "type": "object",
+          "minProperties": 1,
+          "patternProperties": {
+            "^[0-9]+\\.[0-9]+\\.[0-9]+$": {"$ref": "#/$defs/path"}
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  }
+}

--- a/scripts/orchestration/prompt_contracts.py
+++ b/scripts/orchestration/prompt_contracts.py
@@ -1,0 +1,545 @@
+#!/usr/bin/env python3
+"""Deterministic, versioned prompt contracts for curriculum lifecycle phases."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_ROOT = Path("agents_extensions/shared/prompt-contracts")
+REGISTRY_PATH = CONTRACT_ROOT / "registry.v1.yaml"
+REGISTRY_SCHEMA_PATH = CONTRACT_ROOT / "schema/prompt-registry.v1.schema.json"
+MANIFEST_SCHEMA_PATH = CONTRACT_ROOT / "schema/prompt-manifest.v1.schema.json"
+PROFILE_SCHEMA_PATH = CONTRACT_ROOT / "schema/prompt-profile.v1.schema.json"
+PROFILE_PATH = CONTRACT_ROOT / "profiles/curriculum-lifecycle.v1.yaml"
+PARITY_PATH = Path("docs/architecture/curriculum-lifecycle-prompt-responsibility-parity.md")
+LEGACY_PROMPT_ROOT = Path("docs/prompts/orchestrators")
+
+_PLACEHOLDER_RE = re.compile(r"\{\{([a-z][a-z0-9_]*)\}\}")
+_PARITY_ROW_RE = re.compile(r"^\| `([^`]+\.md)` \|", re.MULTILINE)
+
+
+class PromptContractError(ValueError):
+    """Raised when prompt contract source or resolved evidence is invalid."""
+
+
+class _StrictLoader(yaml.SafeLoader):
+    """YAML loader that fails instead of silently overwriting duplicate keys."""
+
+
+def _construct_mapping(loader: _StrictLoader, node: yaml.MappingNode, deep: bool = False) -> dict[Any, Any]:
+    loader.flatten_mapping(node)
+    result: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in result:
+            raise PromptContractError(f"duplicate YAML key: {key!r}")
+        result[key] = loader.construct_object(value_node, deep=deep)
+    return result
+
+
+_StrictLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_mapping)
+
+
+@dataclass(frozen=True)
+class SourceIdentity:
+    kind: str
+    id: str
+    path: str
+    sha256: str
+
+
+@dataclass(frozen=True)
+class ResolvedPrompt:
+    prompt_id: str
+    version: str
+    variant: str
+    route: str
+    profile_id: str | None
+    context: dict[str, Any]
+    context_sha256: str
+    input_schema_id: str
+    output_schema_id: str
+    fragment_ids: tuple[str, ...]
+    sources: tuple[SourceIdentity, ...]
+    rendered_prompt: str
+    prompt_sha256: str
+    identity_sha256: str
+
+    def to_record(self) -> dict[str, Any]:
+        record = asdict(self)
+        record["fragment_ids"] = list(self.fragment_ids)
+        record["sources"] = [asdict(source) for source in self.sources]
+        return record
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise PromptContractError(f"duplicate JSON key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_json_constant(value: str) -> None:
+    raise PromptContractError(f"non-standard JSON constant: {value}")
+
+
+def _repo_file(repo_root: Path, relative: str | Path) -> Path:
+    raw = str(relative)
+    path = Path(raw)
+    if not raw or "\\" in raw or path.is_absolute() or ".." in path.parts or raw.startswith("~"):
+        raise PromptContractError(f"path must be a safe repository-relative path: {raw!r}")
+    root = repo_root.resolve()
+    candidate = (root / path).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise PromptContractError(f"path escapes repository root: {raw!r}") from exc
+    if not candidate.is_file():
+        raise PromptContractError(f"required prompt contract file is missing: {raw}")
+    return candidate
+
+
+def _relative(path: Path, repo_root: Path) -> str:
+    return path.resolve().relative_to(repo_root.resolve()).as_posix()
+
+
+def _shared_file(repo_root: Path, relative: str | Path, label: str) -> Path:
+    path = _repo_file(repo_root, relative)
+    source = _relative(path, repo_root)
+    if not source.startswith("agents_extensions/shared/"):
+        raise PromptContractError(f"{label} must live under agents_extensions/shared: {source}")
+    return path
+
+
+def _read_bytes(path: Path) -> bytes:
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        raise PromptContractError(f"cannot read {path}: {exc}") from exc
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    raw = _read_bytes(path)
+    try:
+        value = yaml.load(raw.decode("utf-8", errors="strict"), Loader=_StrictLoader)
+    except (UnicodeDecodeError, yaml.YAMLError) as exc:
+        raise PromptContractError(f"invalid UTF-8/YAML in {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise PromptContractError(f"YAML document must be an object: {path}")
+    return value
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    raw = _read_bytes(path)
+    try:
+        value = json.loads(
+            raw.decode("utf-8", errors="strict"),
+            object_pairs_hook=_reject_duplicate_json_keys,
+            parse_constant=_reject_json_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PromptContractError(f"invalid UTF-8/JSON in {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise PromptContractError(f"JSON document must be an object: {path}")
+    return value
+
+
+def _check_schema(schema: Mapping[str, Any], label: str) -> None:
+    try:
+        Draft202012Validator.check_schema(schema)
+    except Exception as exc:  # jsonschema exposes several schema error subclasses
+        raise PromptContractError(f"invalid JSON schema for {label}: {exc}") from exc
+
+
+def _schema_id(schema: Mapping[str, Any], label: str) -> str:
+    schema_id = schema.get("$id")
+    if not isinstance(schema_id, str) or not schema_id:
+        raise PromptContractError(f"{label} must declare a non-empty $id")
+    return schema_id
+
+
+def _validate(document: Mapping[str, Any], schema: Mapping[str, Any], label: str) -> None:
+    _check_schema(schema, label)
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(document),
+        key=lambda item: tuple(str(part) for part in item.path),
+    )
+    if errors:
+        error = errors[0]
+        location = ".".join(str(part) for part in error.absolute_path) or "<root>"
+        raise PromptContractError(f"{label} failed schema validation at {location}: {error.message}")
+
+
+def _source_identity(kind: str, source_id: str, path: Path, repo_root: Path) -> SourceIdentity:
+    return SourceIdentity(
+        kind=kind,
+        id=source_id,
+        path=_relative(path, repo_root),
+        sha256=_sha256_bytes(_read_bytes(path)),
+    )
+
+
+def load_registry(*, repo_root: Path = PROJECT_ROOT) -> dict[str, Any]:
+    registry_path = _repo_file(repo_root, REGISTRY_PATH)
+    schema = _load_json(_repo_file(repo_root, REGISTRY_SCHEMA_PATH))
+    registry = _load_yaml(registry_path)
+    _validate(registry, schema, "prompt registry")
+    for prompt_id, record in registry["prompts"].items():
+        if record["current"] not in record["versions"]:
+            raise PromptContractError(f"registry current version is not registered: {prompt_id}@{record['current']}")
+    return registry
+
+
+def load_profiles(*, repo_root: Path = PROJECT_ROOT) -> dict[str, Any]:
+    schema = _load_json(_repo_file(repo_root, PROFILE_SCHEMA_PATH))
+    profiles = _load_yaml(_repo_file(repo_root, PROFILE_PATH))
+    _validate(profiles, schema, "prompt profiles")
+    return profiles
+
+
+def _load_manifest(
+    prompt_id: str,
+    version: str | None,
+    *,
+    repo_root: Path,
+) -> tuple[dict[str, Any], Path, str]:
+    registry = load_registry(repo_root=repo_root)
+    prompt_record = registry["prompts"].get(prompt_id)
+    if not isinstance(prompt_record, Mapping):
+        raise PromptContractError(f"prompt id is not registered: {prompt_id}")
+    resolved_version = version or str(prompt_record["current"])
+    manifest_ref = prompt_record["versions"].get(resolved_version)
+    if not isinstance(manifest_ref, str):
+        raise PromptContractError(f"prompt version is not registered: {prompt_id}@{resolved_version}")
+    manifest_path = _shared_file(repo_root, manifest_ref, "executable prompt manifest")
+    manifest = _load_yaml(manifest_path)
+    schema = _load_json(_repo_file(repo_root, MANIFEST_SCHEMA_PATH))
+    _validate(manifest, schema, f"prompt manifest {prompt_id}@{resolved_version}")
+    if manifest["prompt_id"] != prompt_id or manifest["version"] != resolved_version:
+        raise PromptContractError("registry identity does not match manifest prompt_id/version")
+    return manifest, manifest_path, resolved_version
+
+
+def _ordered_fragment_ids(manifest: Mapping[str, Any], variant: str) -> tuple[str, ...]:
+    variants = manifest["variants"]
+    variant_record = variants.get(variant)
+    if not isinstance(variant_record, Mapping):
+        raise PromptContractError(f"prompt variant is not registered: {variant}")
+    fragments = manifest["fragments"]
+    emitted: set[str] = set()
+    active: list[str] = []
+    sections: dict[str, str] = {}
+    ordered: list[str] = []
+
+    def visit(fragment_id: str) -> None:
+        fragment = fragments.get(fragment_id)
+        if not isinstance(fragment, Mapping):
+            raise PromptContractError(f"missing registered fragment: {fragment_id}")
+        if fragment_id in active:
+            cycle = " -> ".join([*active, fragment_id])
+            raise PromptContractError(f"prompt include cycle: {cycle}")
+        if fragment_id in emitted:
+            raise PromptContractError(f"duplicate fragment inclusion: {fragment_id}")
+        active.append(fragment_id)
+        for included in fragment["includes"]:
+            visit(str(included))
+        active.pop()
+        section = str(fragment["section"])
+        owner = sections.get(section)
+        if owner is not None:
+            raise PromptContractError(f"conflicting prompt section {section!r}: {owner} and {fragment_id}")
+        sections[section] = fragment_id
+        emitted.add(fragment_id)
+        ordered.append(fragment_id)
+
+    for root in variant_record["roots"]:
+        visit(str(root))
+    return tuple(ordered)
+
+
+def _fragment_text(path: Path) -> str:
+    raw = _read_bytes(path)
+    try:
+        text = raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise PromptContractError(f"prompt fragment is not strict UTF-8: {path}") from exc
+    if "\r" in text or not text.endswith("\n") or text.endswith("\n\n"):
+        raise PromptContractError(f"prompt fragment must use LF and end with exactly one newline: {path}")
+    return text[:-1]
+
+
+def _render_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return _canonical_json(value)
+
+
+def _render_fragment(text: str, context: Mapping[str, Any], declared_inputs: set[str]) -> str:
+    placeholders = set(_PLACEHOLDER_RE.findall(text))
+    undeclared = sorted(placeholders - declared_inputs)
+    if undeclared:
+        raise PromptContractError(f"fragment uses undeclared input placeholders: {', '.join(undeclared)}")
+    missing = sorted(placeholders - set(context))
+    if missing:
+        raise PromptContractError(f"fragment inputs are missing: {', '.join(missing)}")
+    rendered = _PLACEHOLDER_RE.sub(lambda match: _render_value(context[match.group(1)]), text)
+    if "{{" in rendered or "}}" in rendered:
+        raise PromptContractError("rendered prompt contains an unresolved or malformed placeholder")
+    return rendered
+
+
+def resolve_prompt(
+    prompt_id: str,
+    *,
+    variant: str,
+    context: Mapping[str, Any],
+    version: str | None = None,
+    route: str = "tool-capable",
+    profile_id: str | None = None,
+    repo_root: Path = PROJECT_ROOT,
+) -> ResolvedPrompt:
+    manifest, manifest_path, resolved_version = _load_manifest(
+        prompt_id,
+        version,
+        repo_root=repo_root,
+    )
+    if route not in manifest["compatible"]["routes"]:
+        raise PromptContractError(f"route is not compatible with prompt contract: {route}")
+    variant_record = manifest["variants"].get(variant)
+    if not isinstance(variant_record, Mapping):
+        raise PromptContractError(f"prompt variant is not registered: {variant}")
+    if variant_record["family"] not in manifest["compatible"]["families"]:
+        raise PromptContractError(f"variant family is not compatible with prompt contract: {variant}")
+
+    input_schema_path = _shared_file(repo_root, manifest["input_schema"], "prompt input schema")
+    output_schema_path = _shared_file(repo_root, manifest["output_schema"], "prompt output schema")
+    input_schema = _load_json(input_schema_path)
+    output_schema = _load_json(output_schema_path)
+    _validate(dict(context), input_schema, "prompt input")
+    _check_schema(output_schema, "prompt output")
+    input_schema_id = _schema_id(input_schema, "prompt input schema")
+    output_schema_id = _schema_id(output_schema, "prompt output schema")
+    if context.get("family") != variant_record["family"]:
+        raise PromptContractError("prompt context family does not match selected variant family")
+
+    ordered_ids = _ordered_fragment_ids(manifest, variant)
+    declared_inputs = set((input_schema.get("properties") or {}).keys())
+    sources: list[SourceIdentity] = [
+        _source_identity("registry", "prompt-registry.v1", _repo_file(repo_root, REGISTRY_PATH), repo_root),
+        _source_identity("manifest", f"{prompt_id}@{resolved_version}", manifest_path, repo_root),
+        _source_identity("input-schema", input_schema_id, input_schema_path, repo_root),
+        _source_identity("output-schema", output_schema_id, output_schema_path, repo_root),
+    ]
+    if profile_id is not None:
+        sources.append(_source_identity("profile", profile_id, _repo_file(repo_root, PROFILE_PATH), repo_root))
+    for policy_id in sorted(manifest["policy_ids"]):
+        policy_path = _shared_file(
+            repo_root,
+            manifest["policy_ids"][policy_id],
+            f"prompt policy {policy_id}",
+        )
+        sources.append(_source_identity("policy", policy_id, policy_path, repo_root))
+
+    rendered_fragments: list[str] = []
+    for fragment_id in ordered_ids:
+        fragment = manifest["fragments"][fragment_id]
+        fragment_path = _shared_file(repo_root, fragment["path"], f"prompt fragment {fragment_id}")
+        sources.append(_source_identity("fragment", fragment_id, fragment_path, repo_root))
+        rendered_fragments.append(_render_fragment(_fragment_text(fragment_path), context, declared_inputs))
+
+    rendered_prompt = "\n\n---\n\n".join(rendered_fragments) + "\n"
+    prompt_sha256 = _sha256_bytes(rendered_prompt.encode("utf-8"))
+    context_record = dict(context)
+    context_sha256 = _sha256_bytes(_canonical_json(context_record).encode("utf-8"))
+    identity_payload = {
+        "prompt_id": prompt_id,
+        "version": resolved_version,
+        "variant": variant,
+        "route": route,
+        "profile_id": profile_id,
+        "context_sha256": context_sha256,
+        "prompt_sha256": prompt_sha256,
+        "sources": [asdict(source) for source in sources],
+    }
+    identity_sha256 = _sha256_bytes(_canonical_json(identity_payload).encode("utf-8"))
+    return ResolvedPrompt(
+        prompt_id=prompt_id,
+        version=resolved_version,
+        variant=variant,
+        route=route,
+        profile_id=profile_id,
+        context=context_record,
+        context_sha256=context_sha256,
+        input_schema_id=input_schema_id,
+        output_schema_id=output_schema_id,
+        fragment_ids=ordered_ids,
+        sources=tuple(sources),
+        rendered_prompt=rendered_prompt,
+        prompt_sha256=prompt_sha256,
+        identity_sha256=identity_sha256,
+    )
+
+
+def resolve_profile(
+    profile_id: str,
+    *,
+    context: Mapping[str, Any],
+    route: str = "tool-capable",
+    repo_root: Path = PROJECT_ROOT,
+) -> ResolvedPrompt:
+    profile = load_profiles(repo_root=repo_root)["profiles"].get(profile_id)
+    if not isinstance(profile, Mapping):
+        raise PromptContractError(f"prompt profile is not registered: {profile_id}")
+    return resolve_prompt(
+        str(profile["prompt_id"]),
+        version=str(profile["prompt_version"]),
+        variant=str(profile["variant"]),
+        context=context,
+        route=route,
+        profile_id=profile_id,
+        repo_root=repo_root,
+    )
+
+
+def validate_output(resolved: ResolvedPrompt, payload: Mapping[str, Any], *, repo_root: Path = PROJECT_ROOT) -> None:
+    manifest, _, _ = _load_manifest(resolved.prompt_id, resolved.version, repo_root=repo_root)
+    output_schema = _load_json(_repo_file(repo_root, manifest["output_schema"]))
+    _validate(dict(payload), output_schema, "prompt output")
+
+
+def verify_record(record: Mapping[str, Any], *, repo_root: Path = PROJECT_ROOT) -> ResolvedPrompt:
+    required = set(ResolvedPrompt.__dataclass_fields__)
+    if set(record) != required:
+        raise PromptContractError("resolved prompt record has missing or extra fields")
+    context = record.get("context")
+    if not isinstance(context, Mapping):
+        raise PromptContractError("resolved prompt record context must be an object")
+    profile_id = record.get("profile_id")
+    if profile_id is None:
+        resolved = resolve_prompt(
+            str(record["prompt_id"]),
+            version=str(record["version"]),
+            variant=str(record["variant"]),
+            context=context,
+            route=str(record["route"]),
+            repo_root=repo_root,
+        )
+    else:
+        resolved = resolve_profile(
+            str(profile_id),
+            context=context,
+            route=str(record["route"]),
+            repo_root=repo_root,
+        )
+    if resolved.to_record() != dict(record):
+        raise PromptContractError("resolved prompt record does not match current exact contract bytes and identities")
+    return resolved
+
+
+def audit_contracts(*, repo_root: Path = PROJECT_ROOT) -> dict[str, Any]:
+    registry = load_registry(repo_root=repo_root)
+    prompt_versions: list[str] = []
+    variants: list[str] = []
+    for prompt_id in sorted(registry["prompts"]):
+        for version in sorted(registry["prompts"][prompt_id]["versions"]):
+            manifest, _, _ = _load_manifest(prompt_id, version, repo_root=repo_root)
+            for variant in sorted(manifest["variants"]):
+                _ordered_fragment_ids(manifest, variant)
+                variants.append(f"{prompt_id}@{version}:{variant}")
+            prompt_versions.append(f"{prompt_id}@{version}")
+
+    profiles = load_profiles(repo_root=repo_root)["profiles"]
+    for profile_id, profile in profiles.items():
+        manifest, _, _ = _load_manifest(
+            str(profile["prompt_id"]),
+            str(profile["prompt_version"]),
+            repo_root=repo_root,
+        )
+        variant = manifest["variants"].get(profile["variant"])
+        if not isinstance(variant, Mapping):
+            raise PromptContractError(f"profile {profile_id} selects an unregistered variant")
+
+    legacy_root = repo_root / LEGACY_PROMPT_ROOT
+    inventory = sorted(path.relative_to(legacy_root).as_posix() for path in legacy_root.rglob("*") if path.is_file())
+    parity_text = _repo_file(repo_root, PARITY_PATH).read_text(encoding="utf-8")
+    classified = _PARITY_ROW_RE.findall(parity_text)
+    duplicate_classifications = sorted({item for item in classified if classified.count(item) > 1})
+    missing = sorted(set(inventory) - set(classified))
+    extra = sorted(set(classified) - set(inventory))
+    if duplicate_classifications or missing or extra:
+        raise PromptContractError(
+            "responsibility parity is incomplete: "
+            f"duplicates={duplicate_classifications} missing={missing} extra={extra}"
+        )
+    return {
+        "registry_version": registry["registry_version"],
+        "canonical_source_root": CONTRACT_ROOT.as_posix(),
+        "docs_prompts_executable_authority": False,
+        "registered_prompt_versions": prompt_versions,
+        "registered_variants": variants,
+        "registered_profiles": sorted(profiles),
+        "legacy_inventory_count": len(inventory),
+        "classified_inventory_count": len(classified),
+        "unclassified_inventory": missing,
+        "legacy_entry_points_removed": 0,
+    }
+
+
+def _context_from_file(value: str, repo_root: Path) -> dict[str, Any]:
+    path = _repo_file(repo_root, value)
+    return _load_json(path)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    resolve_parser = subparsers.add_parser("resolve", help="Resolve one registered profile to exact prompt bytes")
+    resolve_parser.add_argument("--profile", required=True)
+    resolve_parser.add_argument("--context", required=True, help="Repository-relative JSON context path")
+    resolve_parser.add_argument("--route", default="tool-capable")
+    subparsers.add_parser("audit", help="Validate contracts and report P0 responsibility parity")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "resolve":
+            payload = resolve_profile(
+                args.profile,
+                context=_context_from_file(args.context, PROJECT_ROOT),
+                route=args.route,
+            ).to_record()
+        else:
+            payload = audit_contracts()
+    except PromptContractError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/prompt_contracts/core.golden.md
+++ b/tests/fixtures/prompt_contracts/core.golden.md
@@ -1,0 +1,19 @@
+# Curriculum lifecycle module contract
+
+Operate on the manifest target `a1/introductions` in phase `build` from
+derived state `unbuilt`. Treat evidence identity
+`aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` as immutable input, and stop if any consumed dependency
+does not match it.
+
+Return only JSON conforming to the registered
+`curriculum-lifecycle-output.v1` schema. Findings must name the owning phase;
+never repair content from inside a read-only gate.
+
+---
+
+# CORE family policy
+
+Apply the registered CORE profile for family `core`. Preserve the active
+level's progression and immersion policy: A1 English scaffolding is intentional,
+while A2 and later levels must not gain English. Do not borrow a seminar-specific
+source or framing rule unless the profile registers it.

--- a/tests/fixtures/prompt_contracts/seminar.golden.md
+++ b/tests/fixtures/prompt_contracts/seminar.golden.md
@@ -1,0 +1,19 @@
+# Curriculum lifecycle module contract
+
+Operate on the manifest target `bio/lesia-ukrainka` in phase `certify` from
+derived state `built`. Treat evidence identity
+`bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb` as immutable input, and stop if any consumed dependency
+does not match it.
+
+Return only JSON conforming to the registered
+`curriculum-lifecycle-output.v1` schema. Findings must name the owning phase;
+never repair content from inside a read-only gate.
+
+---
+
+# Seminar family policy
+
+Apply the registered seminar profile for family `seminar`. Keep source,
+quotation, rights, historical-language, and decolonization requirements bound to
+the selected track profile. Do not infer that two seminar tracks share identical
+preparation or certification requirements.

--- a/tests/orchestration/test_prompt_contracts.py
+++ b/tests/orchestration/test_prompt_contracts.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import hashlib
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.orchestration import prompt_contracts as contracts
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = Path(
+    "agents_extensions/shared/prompt-contracts/manifests/"
+    "curriculum-lifecycle.module.v1.yaml"
+)
+PROFILES = Path(
+    "agents_extensions/shared/prompt-contracts/profiles/"
+    "curriculum-lifecycle.v1.yaml"
+)
+REGISTRY = Path("agents_extensions/shared/prompt-contracts/registry.v1.yaml")
+INPUT_SCHEMA = Path(
+    "agents_extensions/shared/prompt-contracts/schema/"
+    "curriculum-lifecycle-input.v1.schema.json"
+)
+COMMON_FRAGMENT = Path(
+    "agents_extensions/shared/prompt-contracts/fragments/"
+    "curriculum-lifecycle-common.md"
+)
+GOLDEN_ROOT = REPO_ROOT / "tests/fixtures/prompt_contracts"
+
+CORE_CONTEXT = {
+    "track": "a1",
+    "slug": "introductions",
+    "family": "core",
+    "phase": "build",
+    "module_state": "unbuilt",
+    "evidence_identity": "a" * 64,
+}
+SEMINAR_CONTEXT = {
+    "track": "bio",
+    "slug": "lesia-ukrainka",
+    "family": "seminar",
+    "phase": "certify",
+    "module_state": "built",
+    "evidence_identity": "b" * 64,
+}
+
+
+def _copy_contract_repo(destination: Path) -> Path:
+    for relative in (
+        Path("agents_extensions/shared/prompt-contracts"),
+        Path("agents_extensions/shared/rules/operator-expectations.md"),
+        Path("agents_extensions/shared/rules/workflow.md"),
+    ):
+        source = REPO_ROOT / relative
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if source.is_dir():
+            shutil.copytree(source, target)
+        else:
+            shutil.copyfile(source, target)
+    return destination
+
+
+def _load_yaml(repo_root: Path, relative: Path) -> dict:
+    value = yaml.safe_load((repo_root / relative).read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value
+
+
+def _write_yaml(repo_root: Path, relative: Path, value: dict) -> None:
+    (repo_root / relative).write_text(
+        yaml.safe_dump(value, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def _resolve_core(repo_root: Path = REPO_ROOT) -> contracts.ResolvedPrompt:
+    return contracts.resolve_profile("core", context=CORE_CONTEXT, repo_root=repo_root)
+
+
+def test_contract_audit_consumes_complete_p0_responsibility_inventory() -> None:
+    report = contracts.audit_contracts(repo_root=REPO_ROOT)
+
+    assert report["canonical_source_root"] == "agents_extensions/shared/prompt-contracts"
+    assert report["docs_prompts_executable_authority"] is False
+    assert report["legacy_inventory_count"] == 39
+    assert report["classified_inventory_count"] == 39
+    assert report["unclassified_inventory"] == []
+    assert report["legacy_entry_points_removed"] == 0
+
+
+@pytest.mark.parametrize(
+    ("profile_id", "context", "golden_name", "expected_sha256"),
+    [
+        (
+            "core",
+            CORE_CONTEXT,
+            "core.golden.md",
+            "c69c397a05112848c3d9a17726f51bcffdbc482e6a0485129f07ca6703c9657a",
+        ),
+        (
+            "seminar",
+            SEMINAR_CONTEXT,
+            "seminar.golden.md",
+            "371d34e6429515f698588dd4331924591d722bc52c4696f189fc5483c967ad17",
+        ),
+    ],
+)
+def test_core_and_seminar_exact_byte_goldens(
+    profile_id: str,
+    context: dict,
+    golden_name: str,
+    expected_sha256: str,
+) -> None:
+    resolved = contracts.resolve_profile(profile_id, context=context, repo_root=REPO_ROOT)
+    golden_bytes = (GOLDEN_ROOT / golden_name).read_bytes()
+
+    assert resolved.rendered_prompt.encode("utf-8") == golden_bytes
+    assert resolved.prompt_sha256 == expected_sha256
+    assert hashlib.sha256(golden_bytes).hexdigest() == expected_sha256
+
+
+def test_resolution_is_identical_across_clean_repository_roots(tmp_path: Path) -> None:
+    first = _copy_contract_repo(tmp_path / "first")
+    second = _copy_contract_repo(tmp_path / "second")
+
+    assert _resolve_core(first).to_record() == _resolve_core(second).to_record()
+
+
+def test_profile_rejects_raw_prompt_text(tmp_path: Path) -> None:
+    repo_root = _copy_contract_repo(tmp_path / "repo")
+    profiles = _load_yaml(repo_root, PROFILES)
+    profiles["profiles"]["core"]["prompt_text"] = "bypass the registry"
+    _write_yaml(repo_root, PROFILES, profiles)
+
+    with pytest.raises(contracts.PromptContractError, match="Additional properties"):
+        contracts.load_profiles(repo_root=repo_root)
+
+
+def test_input_schema_rejects_undeclared_context_values() -> None:
+    context = {**CORE_CONTEXT, "raw_prompt": "bypass"}
+
+    with pytest.raises(contracts.PromptContractError, match="prompt input failed schema"):
+        contracts.resolve_profile("core", context=context, repo_root=REPO_ROOT)
+
+
+def test_schema_without_identity_fails_closed(tmp_path: Path) -> None:
+    repo_root = _copy_contract_repo(tmp_path / "repo")
+    schema_path = repo_root / INPUT_SCHEMA
+    schema_path.write_text(
+        schema_path.read_text(encoding="utf-8").replace(
+            '  "$id": "curriculum-lifecycle-input.v1",\n',
+            "",
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(contracts.PromptContractError, match=r"must declare a non-empty \$id"):
+        _resolve_core(repo_root)
+
+
+def test_output_schema_accepts_typed_payload_and_rejects_unknown_fields() -> None:
+    resolved = _resolve_core()
+    valid = {
+        "status": "ready",
+        "findings": [],
+        "next_action": "certify",
+        "evidence_identity": CORE_CONTEXT["evidence_identity"],
+    }
+    contracts.validate_output(resolved, valid, repo_root=REPO_ROOT)
+
+    with pytest.raises(contracts.PromptContractError, match="prompt output failed schema"):
+        contracts.validate_output(resolved, {**valid, "commentary": "not declared"}, repo_root=REPO_ROOT)
+
+
+def test_missing_fragment_fails_closed(tmp_path: Path) -> None:
+    repo_root = _copy_contract_repo(tmp_path / "repo")
+    manifest = _load_yaml(repo_root, MANIFEST)
+    manifest["fragments"]["contract.base"]["path"] = "agents_extensions/shared/missing.md"
+    _write_yaml(repo_root, MANIFEST, manifest)
+
+    with pytest.raises(contracts.PromptContractError, match="required prompt contract file is missing"):
+        _resolve_core(repo_root)
+
+
+def test_prompt_fragment_outside_canonical_source_fails_closed(tmp_path: Path) -> None:
+    repo_root = _copy_contract_repo(tmp_path / "repo")
+    bypass = repo_root / "docs/prompts/bypass.md"
+    bypass.parent.mkdir(parents=True)
+    bypass.write_text("# Unregistered authority\n", encoding="utf-8")
+    manifest = _load_yaml(repo_root, MANIFEST)
+    manifest["fragments"]["contract.base"]["path"] = "docs/prompts/bypass.md"
+    _write_yaml(repo_root, MANIFEST, manifest)
+
+    with pytest.raises(contracts.PromptContractError, match="must live under agents_extensions/shared"):
+        _resolve_core(repo_root)
+
+
+def test_include_cycle_fails_closed(tmp_path: Path) -> None:
+    repo_root = _copy_contract_repo(tmp_path / "repo")
+    manifest = _load_yaml(repo_root, MANIFEST)
+    manifest["fragments"]["contract.base"]["includes"] = ["family.core"]
+    _write_yaml(repo_root, MANIFEST, manifest)
+
+    with pytest.raises(contracts.PromptContractError, match="prompt include cycle"):
+        _resolve_core(repo_root)
+
+
+def test_duplicate_inclusion_fails_closed(tmp_path: Path) -> None:
+    repo_root = _copy_contract_repo(tmp_path / "repo")
+    manifest = _load_yaml(repo_root, MANIFEST)
+    manifest["variants"]["core"]["roots"] = ["family.core", "contract.base"]
+    _write_yaml(repo_root, MANIFEST, manifest)
+
+    with pytest.raises(contracts.PromptContractError, match="duplicate fragment inclusion"):
+        _resolve_core(repo_root)
+
+
+def test_conflicting_sections_fail_closed(tmp_path: Path) -> None:
+    repo_root = _copy_contract_repo(tmp_path / "repo")
+    manifest = _load_yaml(repo_root, MANIFEST)
+    manifest["fragments"]["contract.base"]["section"] = "family-policy"
+    _write_yaml(repo_root, MANIFEST, manifest)
+
+    with pytest.raises(contracts.PromptContractError, match="conflicting prompt section"):
+        _resolve_core(repo_root)
+
+
+@pytest.mark.parametrize("extra_text", ["\n{{secret}}\n", "\n{{broken-name}}\n"])
+def test_undeclared_or_malformed_placeholders_fail_closed(tmp_path: Path, extra_text: str) -> None:
+    repo_root = _copy_contract_repo(tmp_path / "repo")
+    fragment = repo_root / COMMON_FRAGMENT
+    fragment.write_text(fragment.read_text(encoding="utf-8").rstrip("\n") + extra_text, encoding="utf-8")
+
+    with pytest.raises(
+        contracts.PromptContractError,
+        match=r"undeclared input placeholders|unresolved or malformed placeholder",
+    ):
+        _resolve_core(repo_root)
+
+
+def test_resolved_record_detects_rendered_prompt_tampering() -> None:
+    record = _resolve_core().to_record()
+    record["rendered_prompt"] += "tampered\n"
+
+    with pytest.raises(contracts.PromptContractError, match="does not match current exact contract bytes"):
+        contracts.verify_record(record, repo_root=REPO_ROOT)
+
+
+def test_policy_bytes_change_identity_without_changing_rendered_prompt(tmp_path: Path) -> None:
+    repo_root = _copy_contract_repo(tmp_path / "repo")
+    before = _resolve_core(repo_root)
+    policy = repo_root / "agents_extensions/shared/rules/workflow.md"
+    policy.write_text(policy.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+    after = _resolve_core(repo_root)
+
+    assert after.rendered_prompt == before.rendered_prompt
+    assert after.prompt_sha256 == before.prompt_sha256
+    assert after.identity_sha256 != before.identity_sha256
+
+
+def test_explicit_historical_version_survives_current_version_change(tmp_path: Path) -> None:
+    repo_root = _copy_contract_repo(tmp_path / "repo")
+    baseline = contracts.resolve_prompt(
+        "curriculum-lifecycle.module",
+        version="1.0.0",
+        variant="core",
+        context=CORE_CONTEXT,
+        repo_root=repo_root,
+    )
+    v2_path = MANIFEST.with_name("curriculum-lifecycle.module.v2.yaml")
+    v2 = _load_yaml(repo_root, MANIFEST)
+    v2["version"] = "1.1.0"
+    _write_yaml(repo_root, v2_path, v2)
+    registry = _load_yaml(repo_root, REGISTRY)
+    prompt = registry["prompts"]["curriculum-lifecycle.module"]
+    prompt["current"] = "1.1.0"
+    prompt["versions"]["1.1.0"] = v2_path.as_posix()
+    _write_yaml(repo_root, REGISTRY, registry)
+
+    historical = contracts.resolve_prompt(
+        "curriculum-lifecycle.module",
+        version="1.0.0",
+        variant="core",
+        context=CORE_CONTEXT,
+        repo_root=repo_root,
+    )
+    current = contracts.resolve_prompt(
+        "curriculum-lifecycle.module",
+        variant="core",
+        context=CORE_CONTEXT,
+        repo_root=repo_root,
+    )
+
+    assert historical.rendered_prompt == baseline.rendered_prompt
+    assert historical.prompt_sha256 == baseline.prompt_sha256
+    assert historical.version == "1.0.0"
+    assert current.version == "1.1.0"
+    assert current.identity_sha256 != historical.identity_sha256

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -22,6 +22,7 @@ ORPHAN_PATH_VARS = (
 DRIFT_TARGET = Path(".claude/rules/pipeline.md")
 CODEX_HOOK_TARGET = Path(".codex/hooks/session-setup.sh")
 CODEX_HOOKS_CONFIG = Path(".codex/hooks.json")
+PROMPT_CONTRACT_MANIFEST = Path("prompt-contracts/manifests/curriculum-lifecycle.module.v1.yaml")
 UNSCOPED_RULE_FILES = (
     "operator-expectations.md",
     "critical-rules.md",
@@ -124,6 +125,9 @@ def test_fresh_deploy_produces_synced_output(tmp_path: Path) -> None:
         assert (repo / ".agent" / "rules" / filename).exists()
         assert (repo / ".gemini" / "rules" / filename).exists()
         assert (repo / ".codex" / "rules" / filename).exists()
+    canonical_manifest = repo / "agents_extensions/shared" / PROMPT_CONTRACT_MANIFEST
+    for mirror_root in (".claude", ".agent", ".codex"):
+        assert (repo / mirror_root / PROMPT_CONTRACT_MANIFEST).read_bytes() == canonical_manifest.read_bytes()
 
     codex_hooks_diff = _run_command(
         repo,


### PR DESCRIPTION
## Summary

- add versioned, schema-validated prompt registry, manifests, profiles, fragments, and typed lifecycle contracts
- add a deterministic resolver with exact-byte and source-identity hashes, strict include graph validation, historical lookup, and tamper verification
- add CORE and seminar goldens, P0 responsibility-parity audit, and explicit deploy-mirror coverage

## Verification

- 90 targeted tests passed: prompt contracts, post-build-review preservation, and deploy idempotency
- ruff clean; git diff check clean; agent trailer gate clean
- prompt contract audit: 39 legacy prompt files / 39 classifications / 0 removals
- npm run agents:deploy and scripts/check_rules_deployment.sh produced clean managed mirrors
- Markdown and JSON validation clean; YAML has only existing document-start warnings
- protected/config/generated-artifact checklist clean; 16 scoped files

## Independent cross-family review

Claude Opus 4.8 task review-5155-prompt-contracts returned APPROVE with no blocker, high, or medium findings and explicitly passed the independent cross-family merge gate. It reviewed commit 02319fb92f. Final rebased commit 041a5f1592 has the identical stable patch ID a8190e844caeb5e4618c3c71fc445de0207863c2.

Closes #5155
Refs #5152
Refs #4707