### PR TITLE
Refs #4222 — bulk-reject rules batch R1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -414,6 +414,7 @@ data/lexicon/grow_needs_review.json
 # data/lexicon/source-inventory-review-decisions/2026-07-14-ohoiko-corpus-intake-batch-*.yaml
 # plus the committed SUMMARY (counts + content hash) beside this path.
 data/lexicon/source-inventory/ohoiko-corpus-intake.json
+data/lexicon/source-inventory/curriculum-full-text-intake.json
 data/eval-archive/
 
 # clawpatch tool output (config + findings + locks + patches — regenerable)

--- a/data/lexicon/source-inventory-review-decisions/2026-07-14-curriculum-intake-bulk-reject-R1.yaml
+++ b/data/lexicon/source-inventory-review-decisions/2026-07-14-curriculum-intake-bulk-reject-R1.yaml
@@ -1,0 +1,234 @@
+version: 1
+kind: atlas_source_inventory_review_decisions
+batch_id: curriculum-intake-2026-07-14-bulk-reject-R1
+batch_label: 'Refs #4222 — bulk-reject rules batch R1'
+reviewer: curriculum-intake-automation
+reviewed_at: '2026-07-14'
+source_queue:
+  workflow: source_inventory_publish_review_queue.v1
+  total_queue_rows: 25502
+  approved_in_queue: 0
+  promotion_batch_size: 1
+production_outputs_updated: []
+decisions:
+- lemma: д
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: c0e489255c53cbc2
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/reading-ukrainian/activities.yaml::inline[3].items[1].error
+    source_id: curriculum-b39cf20d79ca2721
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: и
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: 71e533f85767363b
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md::module_body
+    source_id: curriculum-6ce2915bf2ed755d
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: к
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: 85cb00d25c2a1582
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/many-things/activities.yaml::inline[0].items[5].explanation
+    source_id: curriculum-cb80bbcd13af0089
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: н
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: efcf4f18b7c42767
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/reading-ukrainian/activities.yaml::inline[3].items[3].correction
+    source_id: curriculum-b39cf20d79ca2721
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: п
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: 2d4ca738cfb5fd35
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md::module_body
+    source_id: curriculum-6ce2915bf2ed755d
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: п-п-п-п
+  decision: reject
+  sense_note: 'Bulk-reject noise: interjection_onomatopoeia'
+  source_inventory:
+    key: 75dcc1fbd2753e5c
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/b1/aspect-in-narration/module.md::module_body
+    source_id: curriculum-c4330011cdd0f739
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: р
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: 1516209dc8057242
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml::[2].items[20].letter
+    source_id: curriculum-c5a78b5f0b44229b
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: ф
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: 1a042897e69b30eb
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml::[2].items[24].letter
+    source_id: curriculum-c5a78b5f0b44229b
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: х
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: 2ce77e2a06e205ca
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml::[2].items[25].letter
+    source_id: curriculum-c5a78b5f0b44229b
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: ч
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: 8028c63ae0ea4511
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml::[2].items[27].letter
+    source_id: curriculum-c5a78b5f0b44229b
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: ш
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: faf330aa5bce1371
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/checkpoint-actions/module.md::module_body
+    source_id: curriculum-c6d053649508e126
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: щ
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: 3149a91058fec8de
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml::[2].items[29].letter
+    source_id: curriculum-c5a78b5f0b44229b
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: ь
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: 45badc6a2e42e308
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/checkpoint-first-contact/activities.yaml::inline[0].items[7].explanation
+    source_id: curriculum-634571f8cf51a5ab
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: ю
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: c5481966872580ab
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/checkpoint-actions/module.md::module_body
+    source_id: curriculum-c6d053649508e126
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: і-і-і
+  decision: reject
+  sense_note: 'Bulk-reject noise: interjection_onomatopoeia'
+  source_inventory:
+    key: 59fbf0210651d074
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md::module_body
+    source_id: curriculum-749bfd30f83ef9a1
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: ї
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: 0353a5669bf83cb0
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md::module_body
+    source_id: curriculum-6ce2915bf2ed755d
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized
+- lemma: ґ
+  decision: reject
+  sense_note: 'Bulk-reject noise: single_letter'
+  source_inventory:
+    key: 0078c2e794ba4b6e
+    path: data/lexicon/source-inventory/curriculum-full-text-intake.json
+    locator: curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md::module_body
+    source_id: curriculum-6ce2915bf2ed755d
+    source_family: curriculum
+  evidence_refs:
+  - vesum_unrecognized
+  original_flags:
+  - vesum_unrecognized

--- a/scripts/lexicon/obvious_noise_classifier.py
+++ b/scripts/lexicon/obvious_noise_classifier.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Deterministic classifier for obvious non-lemma noise in the Word Atlas intake review-queue (#4222)."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.lexicon.content_lexicon_reconciler import PROJECT_ROOT
+
+# Closed list of interjections and onomatopoeia as required by triage plan.
+CLOSED_INTERJECTIONS = {
+    "ааа",
+    "а-а-а",
+    "ау",
+    "ах",
+    "ало",
+    "алло",
+    "апчхи",
+    "бах",
+    "бабах",
+    "бе",
+    "бом",
+    "бум",
+    "вау",
+    "гав",
+    "гей",
+    "гоп",
+    "гуп",
+    "еге",
+    "е-е-е",
+    "ех",
+    "и-и-и",
+    "і-і-і",
+    "кап",
+    "ква",
+    "ко-ко-ко",
+    "ку-ку",
+    "кукуріку",
+    "ме",
+    "му",
+    "няв",
+    "о",
+    "ой",
+    "ох",
+    "ого",
+    "ооо",
+    "о-о-о",
+    "охохо",
+    "плиг",
+    "п-п-п-п",
+    "тиць",
+    "тьху",
+    "уа",
+    "ура",
+    "ур-ра",
+    "ух",
+    "у-у-у",
+    "хрю",
+    "ціп-ціп",
+    "хе-хе",
+    "ха-ха",
+    "хі-хі",
+    "хо-хо",
+    "цок",
+    "чирик",
+    "чух",
+    "ша",
+    "шух",
+}
+
+
+def is_interjection_onomatopoeia(lemma: str) -> bool:
+    """Identify interjections and onomatopoeia from a closed list."""
+    return lemma.lower() in CLOSED_INTERJECTIONS
+
+
+def is_bare_number(lemma: str) -> bool:
+    """Identify bare numbers/numerals-as-digits."""
+    return bool(re.match(r"^[0-9\s.,-]+$", lemma) and any(c.isdigit() for c in lemma))
+
+
+def is_single_letter(lemma: str) -> bool:
+    """Identify single letters."""
+    return len(lemma) == 1 and lemma.isalpha()
+
+
+def is_markup_debris(lemma: str) -> bool:
+    """Identify markup/template debris (e.g. braces, brackets, percent formatting)."""
+    return any(c in lemma for c in "[]{}<>`*%\\")
+
+
+def is_latin_script(lemma: str) -> bool:
+    """Identify Latin-script tokens containing no Cyrillic characters."""
+    contains_latin = any("a" <= c.lower() <= "z" for c in lemma)
+    contains_cyrillic = any("\u0400" <= c <= "\u04ff" or "\u0500" <= c <= "\u052f" for c in lemma)
+    has_valid_chars = bool(re.match(r"^[A-Za-z0-9\s.,\-\x27\u2019]+$", lemma))
+    return contains_latin and not contains_cyrillic and has_valid_chars
+
+
+def is_punctuation_debris(lemma: str) -> bool:
+    """Identify punctuation remnants/debris."""
+    return all(not c.isalnum() for c in lemma)
+
+
+def classify_lemma(lemma: str) -> str | None:
+    """Classify a lemma using noise rules, ensuring a clean intersection.
+
+    If multiple rules match a lemma, it is considered ambiguous and returned as None
+    so it remains in the queue untouched.
+    """
+    matches = []
+    if is_interjection_onomatopoeia(lemma):
+        matches.append("interjection_onomatopoeia")
+    if is_bare_number(lemma):
+        matches.append("bare_number")
+    if is_single_letter(lemma):
+        matches.append("single_letter")
+    if is_markup_debris(lemma):
+        matches.append("markup_debris")
+    if is_latin_script(lemma):
+        matches.append("latin_script")
+    if is_punctuation_debris(lemma):
+        matches.append("punctuation_debris")
+
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Deterministic classifier for obvious non-lemma noise.")
+    parser.add_argument("--ledger-in", type=Path, default=Path("/tmp/curriculum-ledger.yaml"))
+    parser.add_argument("--write", action="store_true", help="Write reject batch YAML to the decisions directory")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.ledger_in.exists():
+        print(f"error: input ledger {args.ledger_in} not found. Run curriculum intake first.", file=sys.stderr)
+        return 1
+
+    with args.ledger_in.open("r", encoding="utf-8") as fh:
+        payload = yaml.safe_load(fh)
+
+    decisions = payload.get("decisions", [])
+    unrecognized = [
+        d
+        for d in decisions
+        if d.get("decision") == "needs_more_evidence" and "vesum_unrecognized" in d.get("review_queue_reasons", [])
+    ]
+
+    matches: dict[str, list[dict[str, Any]]] = {
+        "interjection_onomatopoeia": [],
+        "bare_number": [],
+        "single_letter": [],
+        "markup_debris": [],
+        "latin_script": [],
+        "punctuation_debris": [],
+    }
+
+    for row in unrecognized:
+        lemma = row.get("lemma", "")
+        cls = classify_lemma(lemma)
+        if cls:
+            matches[cls].append(row)
+
+    print(f"Total vesum_unrecognized rows: {len(unrecognized)}")
+    for rule_name, rows in matches.items():
+        print(f"Rule '{rule_name}': matches={len(rows)}")
+
+    if args.write:
+        # Build reject batch decisions list
+        reject_decisions = []
+        for rule_name, rows in matches.items():
+            for row in rows:
+                reject_row = {
+                    "lemma": row["lemma"],
+                    "decision": "reject",
+                    "sense_note": f"Bulk-reject noise: {rule_name}",
+                    "source_inventory": row["source_inventory"],
+                    "evidence_refs": row.get("evidence_refs", ["vesum_unrecognized"]),
+                    "original_flags": row.get("review_queue_reasons", ["vesum_unrecognized"]),
+                }
+                reject_decisions.append(reject_row)
+
+        # Sort decisions deterministically
+        reject_decisions.sort(key=lambda d: (d["lemma"].casefold(), d["lemma"]))
+
+        batch_id = "curriculum-intake-2026-07-14-bulk-reject-R1"
+        batch_label = "Refs #4222 — bulk-reject rules batch R1"
+
+        reject_payload = {
+            "version": 1,
+            "kind": "atlas_source_inventory_review_decisions",
+            "batch_id": batch_id,
+            "batch_label": batch_label,
+            "reviewer": "curriculum-intake-automation",
+            "reviewed_at": "2026-07-14",
+            "source_queue": {
+                "workflow": "source_inventory_publish_review_queue.v1",
+                "total_queue_rows": len(decisions),
+                "approved_in_queue": 0,
+                "promotion_batch_size": 1,
+            },
+            "production_outputs_updated": [],
+            "decisions": reject_decisions,
+        }
+
+        out_path = (
+            PROJECT_ROOT
+            / "data/lexicon/source-inventory-review-decisions/2026-07-14-curriculum-intake-bulk-reject-R1.yaml"
+        )
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w", encoding="utf-8") as fh:
+            yaml.safe_dump(reject_payload, fh, allow_unicode=True, sort_keys=False)
+
+        print(f"Wrote {len(reject_decisions)} rejects to {out_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_obvious_noise_classifier.py
+++ b/tests/test_obvious_noise_classifier.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.lexicon.obvious_noise_classifier import (
+    classify_lemma,
+    is_bare_number,
+    is_interjection_onomatopoeia,
+    is_latin_script,
+    is_markup_debris,
+    is_punctuation_debris,
+    is_single_letter,
+)
+
+
+@pytest.mark.parametrize(
+    "lemma, expected",
+    [
+        ("ааа", True),
+        ("бах", True),
+        ("ку-ку", True),
+        ("п-п-п-п", True),
+        ("і-і-і", True),
+        ("кіт", False),
+        ("аби-як", False),
+        ("аа", False),
+    ],
+)
+def test_is_interjection_onomatopoeia(lemma: str, expected: bool) -> None:
+    assert is_interjection_onomatopoeia(lemma) == expected
+
+
+@pytest.mark.parametrize(
+    "lemma, expected",
+    [
+        ("123", True),
+        ("2026", True),
+        ("1,000", True),
+        ("1-2", True),
+        ("123a", False),
+        ("перший", False),
+        ("1. урок", False),
+    ],
+)
+def test_is_bare_number(lemma: str, expected: bool) -> None:
+    assert is_bare_number(lemma) == expected
+
+
+@pytest.mark.parametrize(
+    "lemma, expected",
+    [
+        ("д", True),
+        ("и", True),
+        ("к", True),
+        ("a", True),
+        ("кіт", False),
+        ("1", False),
+        ("-", False),
+    ],
+)
+def test_is_single_letter(lemma: str, expected: bool) -> None:
+    assert is_single_letter(lemma) == expected
+
+
+@pytest.mark.parametrize(
+    "lemma, expected",
+    [
+        ("{{word}}", True),
+        ("<br>", True),
+        ("[link]", True),
+        ("*bold*", True),
+        ("%s", True),
+        ("кіт", False),
+        ("аби-як", False),
+    ],
+)
+def test_is_markup_debris(lemma: str, expected: bool) -> None:
+    assert is_markup_debris(lemma) == expected
+
+
+@pytest.mark.parametrize(
+    "lemma, expected",
+    [
+        ("Present", True),
+        ("hello", True),
+        ("word", True),
+        ("cat-dog", True),
+        ("кіт", False),
+        ("Presentкіт", False),
+        ("123", False),
+    ],
+)
+def test_is_latin_script(lemma: str, expected: bool) -> None:
+    assert is_latin_script(lemma) == expected
+
+
+@pytest.mark.parametrize(
+    "lemma, expected",
+    [
+        ("...", True),
+        ("!!!", True),
+        ("---", True),
+        ("?", True),
+        ("_", True),
+        ("аби-як", False),
+        ("123", False),
+        ("кіт", False),
+    ],
+)
+def test_is_punctuation_debris(lemma: str, expected: bool) -> None:
+    assert is_punctuation_debris(lemma) == expected
+
+
+@pytest.mark.parametrize(
+    "lemma, expected",
+    [
+        ("ааа", "interjection_onomatopoeia"),
+        ("123", "bare_number"),
+        ("д", "single_letter"),
+        ("<br>", "markup_debris"),
+        ("Present", "latin_script"),
+        ("...", "punctuation_debris"),
+        ("кіт", None),
+    ],
+)
+def test_classify_lemma(lemma: str, expected: str | None) -> None:
+    assert classify_lemma(lemma) == expected


### PR DESCRIPTION
# Description

PR stages the R1 bulk-reject batch for the #4222 curriculum intake review-queue, using a small deterministic classifier to screen out obvious non-lemma noise from the unrecognized bucket.

## Deterministic Preamble

Each noise classification rule, its definition, and its match count over the real queue:

1. **interjection_onomatopoeia**
   - *Definition*: Lemma matches a closed list of known interjections and onomatopoeia.
   - *Count*: 2
2. **bare_number**
   - *Definition*: Lemma composed entirely of digits and optional formatting marks (commas, periods, hyphens, spaces), containing at least one digit.
   - *Count*: 0
3. **single_letter**
   - *Definition*: Lemma is a single Cyrillic or Latin letter.
   - *Count*: 15
4. **markup_debris**
   - *Definition*: Lemma contains brackets, markup characters, percent formatting, XML/HTML tags, or backticks.
   - *Count*: 0
5. **latin_script**
   - *Definition*: Lemma composed entirely of Latin script characters and digits/spaces/punctuation, containing at least one alphabetical letter and no Cyrillic letters at all.
   - *Count*: 0
6. **punctuation_debris**
   - *Definition*: Lemma composed entirely of punctuation remnants or symbols (no letters or numbers).
   - *Count*: 0

Total rejected candidates: 17

## Random Sample Table (all matched rows)

| Lemma | Rule | Source Locator | Source ID |
|---|---|---|---|
| д | single_letter | curriculum/l2-uk-en/a1/reading-ukrainian/activities.yaml::inline[3].items[1].error | curriculum-b39cf20d79ca2721 |
| и | single_letter | curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md::module_body | curriculum-6ce2915bf2ed755d |
| к | single_letter | curriculum/l2-uk-en/a1/many-things/activities.yaml::inline[0].items[5].explanation | curriculum-cb80bbcd13af0089 |
| н | single_letter | curriculum/l2-uk-en/a1/reading-ukrainian/activities.yaml::inline[3].items[3].correction | curriculum-b39cf20d79ca2721 |
| п | single_letter | curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md::module_body | curriculum-6ce2915bf2ed755d |
| п-п-п-п | interjection_onomatopoeia | curriculum/l2-uk-en/b1/aspect-in-narration/module.md::module_body | curriculum-c4330011cdd0f739 |
| р | single_letter | curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml::[2].items[20].letter | curriculum-c5a78b5f0b44229b |
| ф | single_letter | curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml::[2].items[24].letter | curriculum-c5a78b5f0b44229b |
| х | single_letter | curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml::[2].items[25].letter | curriculum-c5a78b5f0b44229b |
| ч | single_letter | curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml::[2].items[27].letter | curriculum-c5a78b5f0b44229b |
| ш | single_letter | curriculum/l2-uk-en/a1/checkpoint-actions/module.md::module_body | curriculum-c6d053649508e126 |
| щ | single_letter | curriculum/l2-uk-en/a1/sounds-letters-and-hello/activities.yaml::[2].items[29].letter | curriculum-c5a78b5f0b44229b |
| ь | single_letter | curriculum/l2-uk-en/a1/checkpoint-first-contact/activities.yaml::inline[0].items[7].explanation | curriculum-634571f8cf51a5ab |
| ю | single_letter | curriculum/l2-uk-en/a1/checkpoint-actions/module.md::module_body | curriculum-c6d053649508e126 |
| і-і-і | interjection_onomatopoeia | curriculum/l2-uk-en/a1/sounds-letters-and-hello/module.md::module_body | curriculum-749bfd30f83ef9a1 |
| ї | single_letter | curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md::module_body | curriculum-6ce2915bf2ed755d |
| ґ | single_letter | curriculum/l2-uk-en/a1/checkpoint-first-contact/module.md::module_body | curriculum-6ce2915bf2ed755d |

## Validation

- Validated via `scripts/audit/source_inventory_review_decisions.py` (passes with 44 files, 21,594 decisions total).
- Unit tests written for the classifier (`tests/test_obvious_noise_classifier.py` checking positive and negative cases for all 6 rules - 51 tests pass successfully).
- Formatting verified with ruff check/format.

X-Agent: agy (dispatch 4222-batchR1-reject-rules)