### PR TITLE
fix(bridge): anchor dispatch state to the primary checkout

### DIFF
--- a/scripts/ai_agent_bridge/_config.py
+++ b/scripts/ai_agent_bridge/_config.py
@@ -2,26 +2,36 @@
 
 import os
 import shutil
+import sys
 from pathlib import Path
 
 from ._env import build_agent_env
+
+# Bootstrap import path for scripts.* from any cwd
+_local_repo_root = Path(__file__).resolve().parents[2]
+if str(_local_repo_root) not in sys.path:
+    sys.path.insert(0, str(_local_repo_root))
+
+from scripts.common.repo_root import resolve_repo_root
 
 # Repo root for path resolution
 REPO_ROOT = Path(
     os.environ.get("AB_REPO_ROOT", str(Path(__file__).parent.parent.parent))
 )
 
+PRIMARY_REPO_ROOT = resolve_repo_root(Path(__file__), 2)
+
 # Database path (same as MCP server uses)
 DB_PATH = Path(
     os.environ.get(
         "AB_DB_PATH",
-        str(REPO_ROOT / ".mcp" / "servers" / "message-broker" / "messages.db"),
+        str(PRIMARY_REPO_ROOT / ".mcp" / "servers" / "message-broker" / "messages.db"),
     )
 )
 PID_DIR = Path(
     os.environ.get(
         "AB_PID_DIR",
-        str(REPO_ROOT / ".mcp" / "servers" / "message-broker" / "pids"),
+        str(PRIMARY_REPO_ROOT / ".mcp" / "servers" / "message-broker" / "pids"),
     )
 )
 

--- a/scripts/ai_agent_bridge/_dispatch_wrappers.py
+++ b/scripts/ai_agent_bridge/_dispatch_wrappers.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -13,7 +14,14 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+# Bootstrap import path for scripts.* from any cwd
+_local_repo_root = Path(__file__).resolve().parents[2]
+if str(_local_repo_root) not in sys.path:
+    sys.path.insert(0, str(_local_repo_root))
+
+from scripts.common.repo_root import resolve_repo_root
+
+REPO_ROOT = resolve_repo_root(Path(__file__), 2)
 PYTHON = ".venv/bin/python"
 
 MANDATORY_COMMIT_PUSH_PR_CHECKLIST = """## MANDATORY checklist — do NOT skip these (the dispatch will be marked failed if you do)

--- a/scripts/ai_agent_bridge/_monitor_cache.py
+++ b/scripts/ai_agent_bridge/_monitor_cache.py
@@ -28,12 +28,20 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import sys
 import tempfile
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+# Bootstrap import path for scripts.* from any cwd
+_local_repo_root = Path(__file__).resolve().parents[2]
+if str(_local_repo_root) not in sys.path:
+    sys.path.insert(0, str(_local_repo_root))
+
+from scripts.common.repo_root import resolve_repo_root
+
+_PROJECT_ROOT = resolve_repo_root(Path(__file__), 2)
 DEFAULT_CACHE_DIR = _PROJECT_ROOT / ".agent" / "cache" / "monitor"
 
 # Allow environment override for tests / alternate checkouts. Respects

--- a/scripts/common/repo_root.py
+++ b/scripts/common/repo_root.py
@@ -1,0 +1,50 @@
+"""Repository root resolver helpers for primary/worktree anchoring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main_checkout_root(repo_root: Path) -> Path:
+    """Return the primary checkout root that owns the shared .git dir."""
+    git_path = repo_root / ".git"
+    if git_path.is_dir():
+        return repo_root
+    if not git_path.is_file():
+        return repo_root
+
+    try:
+        first_line = git_path.read_text().splitlines()[0]
+    except (IndexError, OSError):
+        return repo_root
+    prefix = "gitdir:"
+    if not first_line.startswith(prefix):
+        return repo_root
+
+    git_dir = Path(first_line[len(prefix) :].strip())
+    if not git_dir.is_absolute():
+        git_dir = repo_root / git_dir
+    git_dir = git_dir.resolve()
+    if git_dir.parent.name != "worktrees":
+        return repo_root
+    common_git_dir = git_dir.parent.parent
+    if common_git_dir.name != ".git":
+        return repo_root
+    return common_git_dir.parent
+
+
+def resolve_repo_root(script_path: Path, parents: int) -> Path:
+    """Anchor all dispatch state to the PRIMARY checkout, never a worktree copy.
+
+    Every dispatch worktree carries its own copy of this script; running that
+    copy used to anchor batch_state/ and .worktrees/ to the WORKTREE root,
+    nesting worktrees and hiding tasks from the Monitor API (#5171).
+
+    Consequence: sys.path inserts and relative-path resolution (e.g. a
+    relative --cwd) also anchor to the primary checkout — a worktree copy
+    of this script lazy-imports the PRIMARY's scripts/* modules, not the
+    worktree branch's. Intentional: dispatch infrastructure is ground truth
+    in the primary; cross-cutting changes to delegate.py plus its lazy deps
+    must land on main before they steer live dispatches.
+    """
+    return main_checkout_root(script_path.resolve().parents[parents])

--- a/scripts/delegate.py
+++ b/scripts/delegate.py
@@ -110,55 +110,16 @@ from typing import Any
 import yaml
 from agent_runtime.routes import RUNTIME_ROUTE_TOOL_CONFIG_KEY
 
-
-def _main_checkout_root(repo_root: Path) -> Path:
-    """Return the primary checkout root that owns the shared .git dir."""
-    git_path = repo_root / ".git"
-    if git_path.is_dir():
-        return repo_root
-    if not git_path.is_file():
-        return repo_root
-
-    try:
-        first_line = git_path.read_text().splitlines()[0]
-    except (IndexError, OSError):
-        return repo_root
-    prefix = "gitdir:"
-    if not first_line.startswith(prefix):
-        return repo_root
-
-    git_dir = Path(first_line[len(prefix) :].strip())
-    if not git_dir.is_absolute():
-        git_dir = repo_root / git_dir
-    git_dir = git_dir.resolve()
-    if git_dir.parent.name != "worktrees":
-        return repo_root
-    common_git_dir = git_dir.parent.parent
-    if common_git_dir.name != ".git":
-        return repo_root
-    return common_git_dir.parent
-
-
-def _resolve_repo_root(script_path: Path) -> Path:
-    """Anchor all dispatch state to the PRIMARY checkout, never a worktree copy.
-
-    Every dispatch worktree carries its own copy of this script; running that
-    copy used to anchor batch_state/ and .worktrees/ to the WORKTREE root,
-    nesting worktrees and hiding tasks from the Monitor API (#5171).
-
-    Consequence: sys.path inserts and relative-path resolution (e.g. a
-    relative --cwd) also anchor to the primary checkout — a worktree copy
-    of this script lazy-imports the PRIMARY's scripts/* modules, not the
-    worktree branch's. Intentional: dispatch infrastructure is ground truth
-    in the primary; cross-cutting changes to delegate.py plus its lazy deps
-    must land on main before they steer live dispatches.
-    """
-    return _main_checkout_root(script_path.resolve().parents[1])
-
-
 # Resolve repo root from this file's location so we work from any cwd —
 # then hop to the primary checkout so worktree copies behave identically.
-_REPO_ROOT = _resolve_repo_root(Path(__file__))
+_local_repo_root = Path(__file__).resolve().parents[1]
+if str(_local_repo_root) not in sys.path:
+    sys.path.insert(0, str(_local_repo_root))
+
+from scripts.common.repo_root import main_checkout_root as _main_checkout_root
+from scripts.common.repo_root import resolve_repo_root
+
+_REPO_ROOT = resolve_repo_root(Path(__file__), 1)
 _TASKS_DIR = _REPO_ROOT / "batch_state" / "tasks"
 _BASH_SECRETS_PATH = Path.home() / ".bash_secrets"
 _GH_TOKEN_AGENTS = {"codex", "claude", "bridge"}

--- a/tests/test_ab_dispatch_wrappers.py
+++ b/tests/test_ab_dispatch_wrappers.py
@@ -29,6 +29,7 @@ def _patch_state_dir(monkeypatch, tmp_path: Path) -> Path:
 
 
 def test_dispatch_fix_with_explicit_brief_file_appends_checklist_and_dispatches(monkeypatch, tmp_path):
+    monkeypatch.delenv("LU_RUNTIME_TMP_ROOT", raising=False)
     brief = tmp_path / "brief.md"
     brief.write_text("# Fix this\n\nExisting acceptance criteria.\n", encoding="utf-8")
     calls = []
@@ -140,6 +141,7 @@ def test_review_deep_for_pr_target_generates_prompt_and_dry_run_state(monkeypatc
 
 
 def test_review_deep_for_path_target_generates_prompt_and_dispatches(monkeypatch, tmp_path):
+    monkeypatch.delenv("LU_RUNTIME_TMP_ROOT", raising=False)
     target = tmp_path / "target.py"
     target.write_text("def broken():\n    return missing_name\n", encoding="utf-8")
     calls = []

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -43,6 +43,7 @@ def _sanitize_git_env_for_test(monkeypatch) -> None:
     for key in tuple(os.environ):
         if key.startswith(("GIT_", "PRE_COMMIT")):
             monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("AGENT_NO_MERGE", raising=False)
 
 
 def test_sanitized_git_env_keeps_benign_git_transport_env(monkeypatch):

--- a/tests/test_delegate_data_symlinks.py
+++ b/tests/test_delegate_data_symlinks.py
@@ -111,14 +111,14 @@ def test_resolve_repo_root_hops_to_primary_from_worktree_script_copy(tmp_path):
     (worktree / "scripts").mkdir(parents=True)
     (worktree / ".git").write_text(f"gitdir: {git_dir}\n")
 
-    assert delegate._resolve_repo_root(worktree / "scripts" / "delegate.py") == main_repo
+    assert delegate.resolve_repo_root(worktree / "scripts" / "delegate.py", 1) == main_repo
 
 
 def test_resolve_repo_root_is_identity_in_primary_checkout(tmp_path):
     main_repo = tmp_path / "main"
     (main_repo / ".git").mkdir(parents=True)
     (main_repo / "scripts").mkdir()
-    assert delegate._resolve_repo_root(main_repo / "scripts" / "delegate.py") == main_repo
+    assert delegate.resolve_repo_root(main_repo / "scripts" / "delegate.py", 1) == main_repo
 
 
 def test_repo_root_constant_is_wired_through_the_resolver():
@@ -127,4 +127,4 @@ def test_repo_root_constant_is_wired_through_the_resolver():
     from pathlib import Path as _P
 
     source = _P(delegate.__file__).read_text(encoding="utf-8")
-    assert "_REPO_ROOT = _resolve_repo_root(Path(__file__))" in source
+    assert "_REPO_ROOT = resolve_repo_root(Path(__file__), 1)" in source

--- a/tests/test_repo_root.py
+++ b/tests/test_repo_root.py
@@ -1,0 +1,146 @@
+"""Unit and integration tests for repository root resolver and primary checkout anchoring."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.common.repo_root import main_checkout_root, resolve_repo_root
+
+
+def test_main_checkout_root_resolves_primary_checkout_from_worktree(tmp_path):
+    """Verify that main_checkout_root correctly identifies primary repo root from a worktree."""
+    main_repo = tmp_path / "main"
+    worktree = main_repo / ".worktrees" / "dispatch" / "agy" / "task-123"
+    git_dir = main_repo / ".git" / "worktrees" / "task-123"
+
+    git_dir.mkdir(parents=True)
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text(f"gitdir: {git_dir}\n")
+
+    assert main_checkout_root(worktree) == main_repo
+
+
+def test_main_checkout_root_is_identity_in_primary_checkout(tmp_path):
+    """Verify that main_checkout_root is an identity function in a primary checkout."""
+    main_repo = tmp_path / "main"
+    (main_repo / ".git").mkdir(parents=True)
+
+    assert main_checkout_root(main_repo) == main_repo
+
+
+def test_resolve_repo_root_generalized_depths(tmp_path):
+    """Verify resolve_repo_root with different parents/depth levels."""
+    main_repo = tmp_path / "main"
+    worktree = main_repo / ".worktrees" / "dispatch" / "agy" / "task-123"
+    git_dir = main_repo / ".git" / "worktrees" / "task-123"
+
+    git_dir.mkdir(parents=True)
+    (worktree / "scripts" / "ai_agent_bridge").mkdir(parents=True)
+    (worktree / ".git").write_text(f"gitdir: {git_dir}\n")
+
+    # depth = 1 (scripts/delegate.py)
+    dummy_delegate = worktree / "scripts" / "delegate.py"
+    assert resolve_repo_root(dummy_delegate, 1) == main_repo
+
+    # depth = 2 (scripts/ai_agent_bridge/_config.py)
+    dummy_config = worktree / "scripts" / "ai_agent_bridge" / "_config.py"
+    assert resolve_repo_root(dummy_config, 2) == main_repo
+
+
+@pytest.fixture
+def wt_layout(tmp_path) -> tuple[Path, Path]:
+    """Sets up a mock primary repo and a mock worktree layout.
+
+    Returns a tuple of (mock_primary_root, mock_worktree_root).
+    """
+    main_repo = tmp_path / "main"
+    worktree = main_repo / ".worktrees" / "dispatch" / "agy" / "task-123"
+    git_dir = main_repo / ".git" / "worktrees" / "task-123"
+
+    git_dir.mkdir(parents=True)
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text(f"gitdir: {git_dir}\n")
+
+    # Copy the bridge and common module code files to the mock worktree
+    src_root = Path(__file__).resolve().parents[1]
+
+    # Create empty init for the bridge package to avoid loading other bridge modules
+    bridge_init = worktree / "scripts" / "ai_agent_bridge" / "__init__.py"
+    bridge_init.parent.mkdir(parents=True, exist_ok=True)
+    bridge_init.write_text("", encoding="utf-8")
+
+    files_to_copy = [
+        "scripts/common/__init__.py",
+        "scripts/common/repo_root.py",
+        "scripts/ai_agent_bridge/_config.py",
+        "scripts/ai_agent_bridge/_env.py",
+        "scripts/ai_agent_bridge/_dispatch_wrappers.py",
+        "scripts/ai_agent_bridge/_monitor_cache.py",
+    ]
+    for f in files_to_copy:
+        dest = worktree / f
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text((src_root / f).read_text(encoding="utf-8"), encoding="utf-8")
+
+    return main_repo, worktree
+
+
+def test_bridge_config_state_paths_resolve_to_primary_in_worktree(wt_layout):
+    """Verify that importing _config.py from a worktree layout resolves state paths to the primary root."""
+    main_repo, worktree = wt_layout
+
+    # Run subprocess to check DB_PATH and PID_DIR
+    script = (
+        "from scripts.ai_agent_bridge._config import DB_PATH, PID_DIR; "
+        "print(f'{DB_PATH};{PID_DIR}')"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(worktree),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    db_path_str, pid_dir_str = proc.stdout.strip().split(";")
+
+    expected_db_path = main_repo / ".mcp" / "servers" / "message-broker" / "messages.db"
+    expected_pid_dir = main_repo / ".mcp" / "servers" / "message-broker" / "pids"
+
+    assert Path(db_path_str).resolve() == expected_db_path.resolve()
+    assert Path(pid_dir_str).resolve() == expected_pid_dir.resolve()
+
+
+def test_bridge_dispatch_wrappers_repo_root_resolves_to_primary_in_worktree(wt_layout):
+    """Verify that importing _dispatch_wrappers.py from a worktree layout resolves REPO_ROOT to primary."""
+    main_repo, worktree = wt_layout
+
+    script = "from scripts.ai_agent_bridge._dispatch_wrappers import REPO_ROOT; print(REPO_ROOT)"
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(worktree),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    resolved_repo_root = Path(proc.stdout.strip())
+    assert resolved_repo_root.resolve() == main_repo.resolve()
+
+
+def test_bridge_monitor_cache_project_root_resolves_to_primary_in_worktree(wt_layout):
+    """Verify that importing _monitor_cache.py from a worktree layout resolves _PROJECT_ROOT to primary."""
+    main_repo, worktree = wt_layout
+
+    script = "from scripts.ai_agent_bridge._monitor_cache import _PROJECT_ROOT; print(_PROJECT_ROOT)"
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(worktree),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    resolved_project_root = Path(proc.stdout.strip())
+    assert resolved_project_root.resolve() == main_repo.resolve()


### PR DESCRIPTION
## Root Cause
When the bridge was executed from inside a dispatch worktree, `Path(__file__).resolve().parents[N]` resolved paths relative to the worktree checkout root instead of the primary repository checkout root. Consequently:
- State files (such as `messages.db` and the `.agent/cache/monitor` cache) were written inside the transient worktree directory, rendering them invisible/lost once the worktree was deleted and causing synchronization issues with the Monitor API.
- Task status files (`batch_state/tasks/`) and subprocess command execution directory roots resolved inside the worktree instead of the primary repository.

To resolve this bug class, we extracted the primary checkout root resolution helpers into a single shared module `scripts/common/repo_root.py` and refactored the bridge modules to resolve state paths to the primary checkout.

## Per-File Disposition Table

| File | Before Refactoring | After Refactoring | Disposition | Rationale |
| :--- | :--- | :--- | :--- | :--- |
| `scripts/ai_agent_bridge/_config.py` | `Path(__file__).parent.parent.parent` | `resolve_repo_root(Path(__file__), 2)` | **CONVERTED** | Shared state paths (`DB_PATH` for messages database, `PID_DIR` for lockfiles) must be anchored to the primary repository checkout. |
| `scripts/ai_agent_bridge/_dispatch_wrappers.py` | `Path(__file__).resolve().parents[2]` | `resolve_repo_root(Path(__file__), 2)` | **CONVERTED** | Task state file paths (`tasks_dir = REPO_ROOT / "batch_state" / "tasks"`) must resolve inside the primary repository checkout. |
| `scripts/ai_agent_bridge/_monitor_cache.py` | `Path(__file__).resolve().parents[2]` | `resolve_repo_root(Path(__file__), 2)` | **CONVERTED** | Persistent manifest cache (`DEFAULT_CACHE_DIR = _PROJECT_ROOT / ".agent" / "cache" / "monitor"`) is shared state across worktrees and must reside in the primary checkout. |
| `scripts/ai_agent_bridge/_db.py` | `Path(__file__).resolve().parents[1]` | `Path(__file__).resolve().parents[1]` | **KEPT (Local)** | The constant `migration_path` resolves python migration source files. If running or testing code inside a worktree branch, we must load the current checkout's migration code, not the primary checkout's code. |
| `scripts/ai_agent_bridge/_gemini.py` | `Path(__file__).parents[2]` | `Path(__file__).parents[2]` | **KEPT (Local)** | Resolves the local python interpreter (`.venv/bin/python`) of the current checkout/worktree to launch task processing. This must use the worktree's virtual environment. |
| `scripts/ai_agent_bridge/measure_cold_start.py` | `Path(__file__).resolve().parents[2]` | `Path(__file__).resolve().parents[2]` | **KEPT (Local)** | Appends to performance baseline documentation (`docs/monitor-api/cold-start-baseline.md`) inside the local checkout for version-controlled commits. |

## Test Evidence
We implemented:
1. Comprehensive unit tests for `main_checkout_root` and `resolve_repo_root` with mock worktree/checkout directory hierarchies.
2. Direct integration tests checking that importing the converted bridge modules (`_config.py`, `_dispatch_wrappers.py`, `_monitor_cache.py`) inside a worktree layout resolves their state-related path constants (`DB_PATH`, `PID_DIR`, `REPO_ROOT`, `_PROJECT_ROOT`) to the mock primary repository instead of the worktree.

### pytest Output:
```text
tests/test_ab_dispatch_wrappers.py ....                                  [  2%]
tests/test_delegate_data_symlinks.py .......                             [  7%]
tests/test_delegate.py ................................................. [ 42%]
....................................................................     [ 90%]
tests/test_monitor_cache.py ........                                     [ 95%]
tests/test_repo_root.py ......                                           [100%]

============================= 142 passed in 9.34s ==============================
```

Refs #5174
