### PR TITLE
feat(curriculum): add versioned preparation readiness

### DIFF
--- a/agents_extensions/shared/curriculum-lifecycle/config/readiness-profiles.v1.yaml
+++ b/agents_extensions/shared/curriculum-lifecycle/config/readiness-profiles.v1.yaml
@@ -1,0 +1,91 @@
+---
+config_version: curriculum-readiness.v1
+selectors:
+  tracks:
+    bio: bio
+  manifest_types:
+    core: core
+    track: seminar
+profiles:
+  core:
+    version: 1.0.0
+    family: core
+    prompt_profile: core
+    requirements:
+      - id: plan
+        owner: plan
+        options:
+          - artifact: plan
+            validators: [exists, plan-check]
+  seminar:
+    version: 1.0.0
+    family: seminar
+    prompt_profile: seminar
+    requirements:
+      - id: plan
+        owner: plan
+        options:
+          - artifact: plan
+            validators: [exists, plan-check, seminar-plan-language]
+  bio:
+    version: 1.0.0
+    family: seminar
+    prompt_profile: seminar
+    requirements:
+      - id: dossier
+        owner: preparation
+        options:
+          - artifact: dossier
+            validators: [exists, bio-dossier-xref]
+      - id: dossier-grounding
+        owner: preparation
+        options:
+          - artifact: manual-registry
+            validators: [exists, manual-gate]
+            manual_gate: dossier_grounding
+      - id: plan
+        owner: plan
+        options:
+          - artifact: plan
+            validators: [exists, plan-check, seminar-plan-language]
+      - id: reading-or-rights
+        owner: preparation
+        options:
+          - artifact: plan
+            validators: [exists, readings-present]
+          - artifact: manual-registry
+            validators: [exists, manual-gate]
+            manual_gate: reading_rights
+      - id: wiki-document
+        owner: preparation
+        options:
+          - artifact: wiki-document
+            validators: [exists, wiki-completeness, bio-wiki-subject, seminar-wiki-language]
+      - id: wiki-sources
+        owner: preparation
+        options:
+          - artifact: wiki-sources
+            validators: [exists, yaml-mapping]
+      - id: wiki-grounding
+        owner: preparation
+        options:
+          - artifact: manual-registry
+            validators: [exists, manual-gate]
+            manual_gate: wiki_grounding
+      - id: wiki-quote-verification
+        owner: preparation
+        options:
+          - artifact: manual-registry
+            validators: [exists, manual-gate]
+            manual_gate: wiki_quote_verification
+      - id: image-rights
+        owner: preparation
+        options:
+          - artifact: manual-registry
+            validators: [exists, manual-gate]
+            manual_gate: image_rights
+      - id: discovery
+        owner: preparation
+        options:
+          - artifact: discovery
+            validators: [exists, bio-discovery-integrity]

--- a/agents_extensions/shared/curriculum-lifecycle/schema/preparation-result.v1.schema.json
+++ b/agents_extensions/shared/curriculum-lifecycle/schema/preparation-result.v1.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "curriculum-preparation-result.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_version",
+    "track",
+    "slug",
+    "profile_id",
+    "profile_version",
+    "family",
+    "manifest",
+    "module_state",
+    "preparation_state",
+    "state",
+    "next_action",
+    "requirements",
+    "findings",
+    "sources",
+    "preparation_identity",
+    "consumed_preparation_identity"
+  ],
+  "properties": {
+    "contract_version": {"const": "curriculum-preparation-result.v1"},
+    "track": {"type": "string", "minLength": 1},
+    "slug": {"type": "string", "minLength": 1},
+    "profile_id": {"type": "string", "minLength": 1},
+    "profile_version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "family": {"enum": ["core", "seminar"]},
+    "manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256", "index"],
+      "properties": {
+        "path": {"type": "string", "minLength": 1},
+        "sha256": {"$ref": "#/$defs/hash"},
+        "index": {"type": ["integer", "null"], "minimum": 0}
+      }
+    },
+    "module_state": {"enum": ["off-manifest", "unbuilt", "partial", "built"]},
+    "preparation_state": {"enum": ["not-applicable", "missing", "stale", "current"]},
+    "state": {
+      "enum": [
+        "off-manifest",
+        "missing-plan",
+        "preparation-required",
+        "prepared-plan",
+        "partial-bundle",
+        "built-preparation-drift",
+        "built-current"
+      ]
+    },
+    "next_action": {"enum": ["stop", "prepare", "plan", "build", "certify"]},
+    "requirements": {"type": "array", "items": {"$ref": "#/$defs/requirement"}},
+    "findings": {"type": "array", "items": {"$ref": "#/$defs/finding"}},
+    "sources": {"type": "array", "items": {"$ref": "#/$defs/source"}},
+    "preparation_identity": {"anyOf": [{"$ref": "#/$defs/hash"}, {"type": "null"}]},
+    "consumed_preparation_identity": {"anyOf": [{"$ref": "#/$defs/hash"}, {"type": "null"}]}
+  },
+  "$defs": {
+    "hash": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "path", "sha256", "exists"],
+      "properties": {
+        "role": {"type": "string", "minLength": 1},
+        "path": {"type": "string", "minLength": 1},
+        "sha256": {"anyOf": [{"$ref": "#/$defs/hash"}, {"type": "null"}]},
+        "exists": {"type": "boolean"}
+      }
+    },
+    "validator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "passed", "detail"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "passed": {"type": "boolean"},
+        "detail": {"type": "string"}
+      }
+    },
+    "option": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact", "path", "sha256", "passed", "validators"],
+      "properties": {
+        "artifact": {"type": "string", "minLength": 1},
+        "path": {"type": "string", "minLength": 1},
+        "sha256": {"anyOf": [{"$ref": "#/$defs/hash"}, {"type": "null"}]},
+        "passed": {"type": "boolean"},
+        "validators": {"type": "array", "items": {"$ref": "#/$defs/validator"}}
+      }
+    },
+    "requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "owner", "passed", "options"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "owner": {"enum": ["preparation", "plan", "built_artifact", "audit_tooling", "authority"]},
+        "passed": {"type": "boolean"},
+        "options": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/option"}}
+      }
+    },
+    "finding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "category", "severity", "summary", "owner"],
+      "properties": {
+        "id": {"type": "string", "minLength": 1},
+        "category": {"type": "string", "minLength": 1},
+        "severity": {"enum": ["blocker", "high", "medium", "low"]},
+        "summary": {"type": "string", "minLength": 1},
+        "owner": {"enum": ["preparation", "plan", "built_artifact", "audit_tooling", "authority"]}
+      }
+    }
+  }
+}

--- a/agents_extensions/shared/curriculum-lifecycle/schema/readiness-profiles.v1.schema.json
+++ b/agents_extensions/shared/curriculum-lifecycle/schema/readiness-profiles.v1.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "curriculum-readiness-profiles.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["config_version", "selectors", "profiles"],
+  "properties": {
+    "config_version": {"const": "curriculum-readiness.v1"},
+    "selectors": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tracks", "manifest_types"],
+      "properties": {
+        "tracks": {"$ref": "#/$defs/selectorMap"},
+        "manifest_types": {"$ref": "#/$defs/selectorMap"}
+      }
+    },
+    "profiles": {
+      "type": "object",
+      "minProperties": 1,
+      "patternProperties": {
+        "^[a-z][a-z0-9-]+$": {"$ref": "#/$defs/profile"}
+      },
+      "additionalProperties": false
+    }
+  },
+  "$defs": {
+    "selectorMap": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z][a-z0-9-]+$": {"type": "string", "pattern": "^[a-z][a-z0-9-]+$"}
+      },
+      "additionalProperties": false
+    },
+    "profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "family", "prompt_profile", "requirements"],
+      "properties": {
+        "version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+        "family": {"enum": ["core", "seminar"]},
+        "prompt_profile": {"enum": ["core", "seminar"]},
+        "requirements": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/requirement"}
+        }
+      }
+    },
+    "requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "owner", "options"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^[a-z][a-z0-9-]+$"},
+        "owner": {"enum": ["preparation", "plan", "built_artifact", "audit_tooling", "authority"]},
+        "options": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/option"}
+        }
+      }
+    },
+    "option": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact", "validators"],
+      "properties": {
+        "artifact": {
+          "enum": ["dossier", "plan", "manual-registry", "wiki-document", "wiki-sources", "discovery"]
+        },
+        "validators": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "exists",
+              "yaml-mapping",
+              "plan-check",
+              "seminar-plan-language",
+              "readings-present",
+              "bio-dossier-xref",
+              "manual-gate",
+              "wiki-completeness",
+              "bio-wiki-subject",
+              "seminar-wiki-language",
+              "bio-discovery-integrity"
+            ]
+          }
+        },
+        "manual_gate": {
+          "enum": [
+            "dossier_grounding",
+            "reading_rights",
+            "wiki_grounding",
+            "wiki_quote_verification",
+            "image_rights"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {"properties": {"validators": {"contains": {"const": "manual-gate"}}}},
+          "then": {"required": ["manual_gate"]},
+          "else": {"not": {"required": ["manual_gate"]}}
+        },
+        {
+          "if": {"required": ["manual_gate"]},
+          "then": {"properties": {"artifact": {"const": "manual-registry"}}}
+        }
+      ]
+    }
+  }
+}

--- a/scripts/audit/bio_readiness_ledger.py
+++ b/scripts/audit/bio_readiness_ledger.py
@@ -13,9 +13,7 @@ import sqlite3
 import sys
 from collections import Counter
 from collections.abc import Mapping
-from datetime import date
 from pathlib import Path
-from urllib.parse import urlparse
 
 import yaml
 
@@ -34,27 +32,10 @@ from scripts.audit.llm_qg_store import db_path as configured_qg_db_path
 from scripts.audit.module_quality_audit import PlannedModule, audit_one_module
 from scripts.audit.wiki_completeness_gate import check_wiki_completeness
 from scripts.build import linear_pipeline
+from scripts.orchestration.preparation_evidence import RegistryValidationError, load_manual_evidence
 from scripts.validate import check_discovery_integrity, check_wiki_subject, lint_seminar_quality
 from scripts.wiki.domains import resolve_write_domain
 
-MANUAL_GATES = frozenset(
-    {
-        "dossier_grounding",
-        "reading_rights",
-        "wiki_grounding",
-        "wiki_quote_verification",
-        "image_rights",
-        "corpus_hammer",
-        "independent_content_review",
-        "cohort_promotion",
-        "hold",
-        "merged_publication",
-    }
-)
-MANUAL_STATUSES = frozenset({"pass", "fail"})
-REVIEWER_FAMILIES = frozenset({"agy", "claude", "codex", "deepseek", "gemini", "grok", "human", "mixed"})
-RIGHTS_DISPOSITIONS = frozenset({"approved", "exception-approved", "link-only-approved", "not-approved"})
-APPROVED_RIGHTS_DISPOSITIONS = RIGHTS_DISPOSITIONS - {"not-approved"}
 MILESTONES = (
     "inventory",
     "source-ready",
@@ -64,30 +45,6 @@ MILESTONES = (
     "module-built",
     "qg-current",
     "shipped",
-)
-
-
-class RegistryValidationError(ValueError):
-    """Raised when the manual promotion registry is malformed."""
-
-
-class _UniqueKeyLoader(yaml.SafeLoader):
-    pass
-
-
-def _construct_unique_mapping(loader: yaml.SafeLoader, node: yaml.nodes.MappingNode, deep: bool = False):
-    mapping: dict[object, object] = {}
-    for key_node, value_node in node.value:
-        key = loader.construct_object(key_node, deep=deep)
-        if key in mapping:
-            raise RegistryValidationError(f"duplicate YAML key: {key!r}")
-        mapping[key] = loader.construct_object(value_node, deep=deep)
-    return mapping
-
-
-_UniqueKeyLoader.add_constructor(
-    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-    _construct_unique_mapping,
 )
 
 
@@ -119,81 +76,6 @@ def _manual_gate(record: Mapping[str, object] | None, registry_path: Path, slug:
     if "reason" in record:
         result["reason"] = record["reason"]
     return result
-
-
-def _http_url(value: object) -> bool:
-    if not isinstance(value, str):
-        return False
-    parsed = urlparse(value)
-    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
-
-
-def load_manual_evidence(path: Path, manifest_slugs: set[str]) -> dict[str, dict[str, dict]]:
-    """Load and strictly validate sparse source-controlled manual evidence."""
-    if not path.exists():
-        return {}
-    try:
-        raw = yaml.load(path.read_text(encoding="utf-8"), Loader=_UniqueKeyLoader)
-    except (OSError, yaml.YAMLError, RegistryValidationError) as exc:
-        raise RegistryValidationError(f"invalid promotion evidence registry {path}: {exc}") from exc
-    if not isinstance(raw, Mapping) or raw.get("version") != 1:
-        raise RegistryValidationError("registry must be a mapping with version: 1")
-    entries = raw.get("entries", {})
-    if not isinstance(entries, Mapping):
-        raise RegistryValidationError("registry entries must be a mapping")
-
-    validated: dict[str, dict[str, dict]] = {}
-    for slug, gates in entries.items():
-        if not isinstance(slug, str) or slug not in manifest_slugs:
-            raise RegistryValidationError(f"off-manifest registry slug: {slug!r}")
-        if not isinstance(gates, Mapping) or not gates:
-            raise RegistryValidationError(f"registry entry for {slug!r} must be a non-empty mapping")
-        validated[slug] = {}
-        for name, record in gates.items():
-            if name not in MANUAL_GATES:
-                raise RegistryValidationError(f"unsupported manual evidence gate {name!r} for {slug!r}")
-            if not isinstance(record, Mapping):
-                raise RegistryValidationError(f"manual evidence {slug}.{name} must be a mapping")
-            status = record.get("status")
-            if status not in MANUAL_STATUSES:
-                raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid status {status!r}")
-            family = record.get("reviewer_family")
-            if family not in REVIEWER_FAMILIES:
-                raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid reviewer_family {family!r}")
-            raw_date = record.get("date")
-            if isinstance(raw_date, str):
-                try:
-                    parsed_date = date.fromisoformat(raw_date)
-                except ValueError as exc:
-                    raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid date") from exc
-            elif isinstance(raw_date, date):
-                parsed_date = raw_date
-            else:
-                raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid date")
-            if not _http_url(record.get("evidence_url")):
-                raise RegistryValidationError(f"manual evidence {slug}.{name} needs an HTTP(S) evidence_url")
-            clean = dict(record)
-            clean["date"] = parsed_date
-            if name in {"reading_rights", "image_rights"}:
-                disposition = clean.get("disposition")
-                if disposition not in RIGHTS_DISPOSITIONS:
-                    raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid disposition")
-                approved = disposition in APPROVED_RIGHTS_DISPOSITIONS
-                if (status == "pass") != approved:
-                    raise RegistryValidationError(
-                        f"manual evidence {slug}.{name} status conflicts with disposition {disposition!r}"
-                    )
-            if name == "hold":
-                if status != "pass":
-                    raise RegistryValidationError(f"manual evidence {slug}.hold must record a reviewed pass")
-                if (
-                    not isinstance(clean.get("active"), bool)
-                    or not isinstance(clean.get("reason"), str)
-                    or not clean["reason"].strip()
-                ):
-                    raise RegistryValidationError(f"manual evidence {slug}.hold needs active boolean and reason")
-            validated[slug][str(name)] = clean
-    return validated
 
 
 def manifest_inventory(root: Path, track: str) -> tuple[list[str], Counter[str]]:

--- a/scripts/orchestration/curriculum_readiness.py
+++ b/scripts/orchestration/curriculum_readiness.py
@@ -1,0 +1,813 @@
+#!/usr/bin/env python3
+"""Profile-driven, hash-bound PREPARE contract for curriculum modules."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.audit import lint_bio_dossier_xref
+from scripts.audit.wiki_completeness_gate import check_wiki_completeness
+from scripts.build import linear_pipeline
+from scripts.orchestration import prompt_contracts
+from scripts.orchestration.preparation_evidence import (
+    RegistryValidationError,
+    load_manual_evidence,
+    load_yaml_mapping,
+)
+from scripts.validate import check_discovery_integrity, check_wiki_subject, lint_seminar_quality
+from scripts.wiki.domains import resolve_write_domain
+
+CONFIG_PATH = Path("agents_extensions/shared/curriculum-lifecycle/config/readiness-profiles.v1.yaml")
+CONFIG_SCHEMA_PATH = Path(
+    "agents_extensions/shared/curriculum-lifecycle/schema/readiness-profiles.v1.schema.json"
+)
+RESULT_SCHEMA_PATH = Path(
+    "agents_extensions/shared/curriculum-lifecycle/schema/preparation-result.v1.schema.json"
+)
+MANIFEST_PATH = Path("curriculum/l2-uk-en/curriculum.yaml")
+MODULE_BUNDLE_FILES = ("module.md", "activities.yaml", "vocabulary.yaml", "resources.yaml")
+DEPENDENT_EVIDENCE_CLASSES = frozenset({"build", "post-build", "production-qg"})
+_TARGET_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ReadinessError(ValueError):
+    """Raised when a preparation contract cannot be evaluated safely."""
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    passed: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class ContractFiles:
+    manifest: Path
+    readiness_config: Path
+    readiness_config_schema: Path
+    preparation_result_schema: Path
+    prompt_profiles: Path
+    prompt_profile_schema: Path
+
+
+@dataclass(frozen=True)
+class LifecycleDecision:
+    preparation_state: str
+    state: str
+    next_action: str
+
+
+@dataclass
+class ValidationContext:
+    repo_root: Path
+    track: str
+    slug: str
+    manifest_slugs: tuple[str, ...]
+    cache: dict[str, Any] = field(default_factory=dict)
+
+    def plan(self) -> Mapping[str, Any] | None:
+        if "plan" not in self.cache:
+            path = artifact_path("plan", self.repo_root, self.track, self.slug)
+            try:
+                self.cache["plan"] = load_yaml_mapping(path) if path.is_file() else None
+            except RegistryValidationError:
+                self.cache["plan"] = None
+        value = self.cache["plan"]
+        return value if isinstance(value, Mapping) else None
+
+    def manual_evidence(self, path: Path) -> Mapping[str, Mapping[str, Any]]:
+        key = f"manual:{path}"
+        if key not in self.cache:
+            self.cache[key] = load_manual_evidence(path, set(self.manifest_slugs))
+        value = self.cache[key]
+        return value if isinstance(value, Mapping) else {}
+
+
+Validator = Callable[[Path, Mapping[str, Any], ValidationContext], ValidationResult]
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _repo_file(repo_root: Path, relative: str | Path) -> Path:
+    raw = str(relative)
+    path = Path(raw)
+    if not raw or "\\" in raw or path.is_absolute() or ".." in path.parts or raw.startswith("~"):
+        raise ReadinessError(f"path must be a safe repository-relative path: {raw!r}")
+    root = repo_root.resolve()
+    candidate = (root / path).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise ReadinessError(f"path escapes repository root: {raw!r}") from exc
+    if not candidate.is_file():
+        raise ReadinessError(f"required preparation contract file is missing: {raw}")
+    return candidate
+
+
+def _relative(path: Path, repo_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError as exc:
+        raise ReadinessError(f"preparation evidence path escapes repository root: {path}") from exc
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8", errors="strict"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ReadinessError(f"invalid JSON contract {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ReadinessError(f"JSON contract must be an object: {path}")
+    return value
+
+
+def _validate(document: Mapping[str, Any], schema: Mapping[str, Any], label: str) -> None:
+    try:
+        Draft202012Validator.check_schema(schema)
+    except Exception as exc:  # jsonschema exposes multiple schema exception subclasses
+        raise ReadinessError(f"invalid JSON schema for {label}: {exc}") from exc
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(document),
+        key=lambda error: tuple(str(part) for part in error.path),
+    )
+    if errors:
+        error = errors[0]
+        location = ".".join(str(part) for part in error.absolute_path) or "<root>"
+        raise ReadinessError(f"{label} failed schema validation at {location}: {error.message}")
+
+
+def _source(role: str, path: Path, repo_root: Path) -> dict[str, Any]:
+    exists = path.is_file()
+    return {
+        "role": role,
+        "path": _relative(path, repo_root),
+        "sha256": _sha256_bytes(path.read_bytes()) if exists else None,
+        "exists": exists,
+    }
+
+
+def artifact_path(artifact: str, repo_root: Path, track: str, slug: str) -> Path:
+    """Resolve a registered artifact ID without track-name branches."""
+    curriculum = repo_root / "curriculum" / "l2-uk-en"
+    resolvers: dict[str, Callable[[], Path]] = {
+        "dossier": lambda: repo_root / "docs" / "research" / track / f"{slug}.md",
+        "plan": lambda: curriculum / "plans" / track / f"{slug}.yaml",
+        "manual-registry": lambda: curriculum / track / "promotion-evidence.yaml",
+        "wiki-document": lambda: repo_root / "wiki" / resolve_write_domain(track, slug) / f"{slug}.md",
+        "wiki-sources": lambda: repo_root
+        / "wiki"
+        / resolve_write_domain(track, slug)
+        / f"{slug}.sources.yaml",
+        "discovery": lambda: curriculum / track / "discovery" / f"{slug}.yaml",
+    }
+    resolver = resolvers.get(artifact)
+    if resolver is None:
+        raise ReadinessError(f"unregistered preparation artifact: {artifact}")
+    path = resolver().resolve()
+    _relative(path, repo_root)
+    return path
+
+
+def _exists(path: Path, _option: Mapping[str, Any], _context: ValidationContext) -> ValidationResult:
+    return ValidationResult(path.is_file(), "file exists" if path.is_file() else "file is missing")
+
+
+def _yaml_mapping(path: Path, _option: Mapping[str, Any], _context: ValidationContext) -> ValidationResult:
+    try:
+        load_yaml_mapping(path)
+    except RegistryValidationError as exc:
+        return ValidationResult(False, str(exc))
+    return ValidationResult(True, "strict YAML mapping")
+
+
+def _plan_check(path: Path, _option: Mapping[str, Any], _context: ValidationContext) -> ValidationResult:
+    try:
+        linear_pipeline.plan_check(path)
+    except Exception as exc:  # authoritative plan validator has several error types
+        return ValidationResult(False, f"{type(exc).__name__}: {exc}")
+    return ValidationResult(True, "authoritative plan check passed")
+
+
+def _seminar_plan_language(
+    path: Path,
+    _option: Mapping[str, Any],
+    _context: ValidationContext,
+) -> ValidationResult:
+    findings = [finding for finding in lint_seminar_quality.lint_plan(path) if finding.severity == "high"]
+    return ValidationResult(not findings, f"{len(findings)} high seminar-language finding(s)")
+
+
+def _readings_present(path: Path, _option: Mapping[str, Any], _context: ValidationContext) -> ValidationResult:
+    try:
+        plan = load_yaml_mapping(path)
+    except RegistryValidationError as exc:
+        return ValidationResult(False, str(exc))
+    readings = plan.get("readings")
+    passed = isinstance(readings, list) and bool(readings)
+    return ValidationResult(passed, "plan reading packet is present" if passed else "plan has no reading packet")
+
+
+def _bio_dossier_xref(
+    path: Path,
+    _option: Mapping[str, Any],
+    _context: ValidationContext,
+) -> ValidationResult:
+    findings = lint_bio_dossier_xref.lint_dossier(path)
+    return ValidationResult(not findings, f"{len(findings)} dossier cross-reference finding(s)")
+
+
+def _manual_gate(path: Path, option: Mapping[str, Any], context: ValidationContext) -> ValidationResult:
+    gate = str(option["manual_gate"])
+    try:
+        record = context.manual_evidence(path).get(context.slug, {}).get(gate)
+    except RegistryValidationError as exc:
+        return ValidationResult(False, str(exc))
+    passed = isinstance(record, Mapping) and record.get("status") == "pass"
+    return ValidationResult(passed, f"manual gate {gate}: {'pass' if passed else 'missing-or-fail'}")
+
+
+def _wiki_completeness(
+    path: Path,
+    _option: Mapping[str, Any],
+    context: ValidationContext,
+) -> ValidationResult:
+    report = check_wiki_completeness(path, level=context.track, slug=context.slug)
+    return ValidationResult(report["verdict"] == "PASS", str(report["diagnostic"]))
+
+
+def _bio_wiki_subject(
+    path: Path,
+    _option: Mapping[str, Any],
+    context: ValidationContext,
+) -> ValidationResult:
+    plan = context.plan()
+    if plan is None:
+        return ValidationResult(False, "plan title unavailable for wiki subject check")
+    finding = check_wiki_subject.check_wiki_file(path, plan_title=str(plan.get("title", "")))
+    return ValidationResult(finding is None, "wiki subject matches plan" if finding is None else str(finding))
+
+
+def _seminar_wiki_language(
+    path: Path,
+    _option: Mapping[str, Any],
+    _context: ValidationContext,
+) -> ValidationResult:
+    findings = [finding for finding in lint_seminar_quality.lint_text(path) if finding.severity == "high"]
+    return ValidationResult(not findings, f"{len(findings)} high seminar-language finding(s)")
+
+
+def _bio_discovery_integrity(
+    path: Path,
+    _option: Mapping[str, Any],
+    context: ValidationContext,
+) -> ValidationResult:
+    plan = context.plan()
+    if plan is None:
+        return ValidationResult(False, "plan title unavailable for discovery integrity check")
+    finding = check_discovery_integrity.check_discovery_file(path, plan_title=str(plan.get("title", "")))
+    return ValidationResult(finding is None, "discovery subject matches plan" if finding is None else str(finding))
+
+
+VALIDATORS: dict[str, Validator] = {
+    "exists": _exists,
+    "yaml-mapping": _yaml_mapping,
+    "plan-check": _plan_check,
+    "seminar-plan-language": _seminar_plan_language,
+    "readings-present": _readings_present,
+    "bio-dossier-xref": _bio_dossier_xref,
+    "manual-gate": _manual_gate,
+    "wiki-completeness": _wiki_completeness,
+    "bio-wiki-subject": _bio_wiki_subject,
+    "seminar-wiki-language": _seminar_wiki_language,
+    "bio-discovery-integrity": _bio_discovery_integrity,
+}
+
+
+def load_config(*, repo_root: Path = PROJECT_ROOT) -> dict[str, Any]:
+    config_path = _repo_file(repo_root, CONFIG_PATH)
+    schema = _load_json(_repo_file(repo_root, CONFIG_SCHEMA_PATH))
+    try:
+        config = load_yaml_mapping(config_path)
+    except RegistryValidationError as exc:
+        raise ReadinessError(str(exc)) from exc
+    _validate(config, schema, "readiness profiles")
+    profiles = config["profiles"]
+    try:
+        registered_prompt_profiles = prompt_contracts.load_profiles(repo_root=repo_root)["profiles"]
+    except prompt_contracts.PromptContractError as exc:
+        raise ReadinessError(f"invalid registered prompt profiles: {exc}") from exc
+    for selector_group in config["selectors"].values():
+        for profile_id in selector_group.values():
+            if profile_id not in profiles:
+                raise ReadinessError(f"readiness selector references unknown profile: {profile_id}")
+    for profile_id, profile in profiles.items():
+        if profile["prompt_profile"] not in registered_prompt_profiles:
+            raise ReadinessError(
+                f"readiness profile {profile_id} selects unknown prompt profile: {profile['prompt_profile']}"
+            )
+        ids = [requirement["id"] for requirement in profile["requirements"]]
+        duplicates = sorted({item for item in ids if ids.count(item) > 1})
+        if duplicates:
+            raise ReadinessError(f"readiness profile {profile_id} has duplicate requirements: {duplicates}")
+        for requirement in profile["requirements"]:
+            for option in requirement["options"]:
+                unknown = sorted(set(option["validators"]) - set(VALIDATORS))
+                if unknown:
+                    raise ReadinessError(f"readiness profile {profile_id} uses unknown validators: {unknown}")
+    return config
+
+
+def _manifest_record(repo_root: Path, track: str) -> tuple[dict[str, Any], tuple[str, ...]]:
+    manifest_path = _repo_file(repo_root, MANIFEST_PATH)
+    try:
+        manifest = load_yaml_mapping(manifest_path)
+    except RegistryValidationError as exc:
+        raise ReadinessError(str(exc)) from exc
+    levels = manifest.get("levels")
+    level = levels.get(track) if isinstance(levels, Mapping) else None
+    if not isinstance(level, Mapping):
+        raise ReadinessError(f"curriculum manifest has no active track: {track}")
+    modules = level.get("modules")
+    if not isinstance(modules, list) or not all(isinstance(item, str) and item for item in modules):
+        raise ReadinessError(f"manifest levels.{track}.modules must be a list of non-empty slugs")
+    duplicates = sorted({item for item in modules if modules.count(item) > 1})
+    if duplicates:
+        raise ReadinessError(f"manifest levels.{track}.modules contains duplicate slugs: {duplicates}")
+    manifest_type = level.get("type")
+    if not isinstance(manifest_type, str) or not manifest_type:
+        raise ReadinessError(f"manifest levels.{track}.type must be a non-empty string")
+    return {"type": manifest_type, "path": manifest_path}, tuple(modules)
+
+
+def _select_profile(config: Mapping[str, Any], track: str, manifest_type: str) -> tuple[str, Mapping[str, Any]]:
+    selectors = config["selectors"]
+    profile_id = selectors["tracks"].get(track) or selectors["manifest_types"].get(manifest_type)
+    if not isinstance(profile_id, str):
+        raise ReadinessError(f"no readiness profile for track={track} manifest_type={manifest_type}")
+    profile = config["profiles"].get(profile_id)
+    if not isinstance(profile, Mapping):
+        raise ReadinessError(f"selected readiness profile is missing: {profile_id}")
+    return profile_id, profile
+
+
+def _module_state(repo_root: Path, track: str, slug: str) -> str:
+    module_dir = repo_root / "curriculum" / "l2-uk-en" / track / slug
+    count = sum((module_dir / filename).is_file() for filename in MODULE_BUNDLE_FILES)
+    if count == 0:
+        return "unbuilt"
+    if count == len(MODULE_BUNDLE_FILES):
+        return "built"
+    return "partial"
+
+
+def _run_validator(
+    validator_id: str,
+    path: Path,
+    option: Mapping[str, Any],
+    context: ValidationContext,
+    validators: Mapping[str, Validator],
+) -> ValidationResult:
+    validator = validators.get(validator_id)
+    if validator is None:
+        raise ReadinessError(f"validator implementation is unavailable: {validator_id}")
+    try:
+        return validator(path, option, context)
+    except Exception as exc:  # external validators fail closed at the adapter boundary
+        return ValidationResult(False, f"{type(exc).__name__}: {exc}")
+
+
+def _evaluate_requirements(
+    profile: Mapping[str, Any],
+    context: ValidationContext,
+    validators: Mapping[str, Validator],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    requirements: list[dict[str, Any]] = []
+    findings: list[dict[str, Any]] = []
+    sources: dict[str, dict[str, Any]] = {}
+    for requirement in profile["requirements"]:
+        options: list[dict[str, Any]] = []
+        for option in requirement["options"]:
+            path = artifact_path(str(option["artifact"]), context.repo_root, context.track, context.slug)
+            source = _source(f"artifact:{option['artifact']}", path, context.repo_root)
+            sources.setdefault(source["path"], source)
+            results: list[dict[str, Any]] = []
+            for validator_id in option["validators"]:
+                result = _run_validator(str(validator_id), path, option, context, validators)
+                results.append({"id": str(validator_id), "passed": result.passed, "detail": result.detail})
+                if not result.passed:
+                    break
+            options.append(
+                {
+                    "artifact": str(option["artifact"]),
+                    "path": source["path"],
+                    "sha256": source["sha256"],
+                    "passed": bool(results) and all(result["passed"] for result in results),
+                    "validators": results,
+                }
+            )
+        passed = any(option["passed"] for option in options)
+        record = {
+            "id": str(requirement["id"]),
+            "owner": str(requirement["owner"]),
+            "passed": passed,
+            "options": options,
+        }
+        requirements.append(record)
+        if not passed:
+            findings.append(
+                {
+                    "id": f"PREPARATION_{str(requirement['id']).upper().replace('-', '_')}",
+                    "category": "plan" if requirement["owner"] == "plan" else "preparation",
+                    "severity": "high",
+                    "summary": f"Required evidence did not pass: {requirement['id']}",
+                    "owner": str(requirement["owner"]),
+                }
+            )
+    return requirements, findings, list(sources.values())
+
+
+def _identity_requirements(requirements: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Remove diagnostic prose so identities remain repository-root independent."""
+    return [
+        {
+            "id": requirement["id"],
+            "owner": requirement["owner"],
+            "passed": requirement["passed"],
+            "options": [
+                {
+                    "artifact": option["artifact"],
+                    "path": option["path"],
+                    "sha256": option["sha256"],
+                    "passed": option["passed"],
+                    "validators": [
+                        {"id": result["id"], "passed": result["passed"]}
+                        for result in option["validators"]
+                    ],
+                }
+                for option in requirement["options"]
+            ],
+        }
+        for requirement in requirements
+    ]
+
+
+def _contract_files(repo_root: Path, manifest_path: Path) -> ContractFiles:
+    return ContractFiles(
+        manifest=manifest_path,
+        readiness_config=_repo_file(repo_root, CONFIG_PATH),
+        readiness_config_schema=_repo_file(repo_root, CONFIG_SCHEMA_PATH),
+        preparation_result_schema=_repo_file(repo_root, RESULT_SCHEMA_PATH),
+        prompt_profiles=_repo_file(repo_root, prompt_contracts.PROFILE_PATH),
+        prompt_profile_schema=_repo_file(repo_root, prompt_contracts.PROFILE_SCHEMA_PATH),
+    )
+
+
+def _contract_sources(files: ContractFiles, repo_root: Path) -> list[dict[str, Any]]:
+    return [
+        _source("manifest", files.manifest, repo_root),
+        _source("readiness-config", files.readiness_config, repo_root),
+        _source("readiness-config-schema", files.readiness_config_schema, repo_root),
+        _source("preparation-result-schema", files.preparation_result_schema, repo_root),
+        _source("prompt-profiles", files.prompt_profiles, repo_root),
+        _source("prompt-profile-schema", files.prompt_profile_schema, repo_root),
+    ]
+
+
+def _manifest_evidence(
+    files: ContractFiles,
+    sources: Sequence[Mapping[str, Any]],
+    repo_root: Path,
+    index: int | None,
+) -> dict[str, Any]:
+    return {"path": _relative(files.manifest, repo_root), "sha256": sources[0]["sha256"], "index": index}
+
+
+def _result_document(
+    *,
+    track: str,
+    slug: str,
+    profile_id: str,
+    profile: Mapping[str, Any],
+    manifest: Mapping[str, Any],
+    module_state: str,
+    decision: LifecycleDecision,
+    requirements: list[dict[str, Any]],
+    findings: list[dict[str, Any]],
+    sources: list[dict[str, Any]],
+    preparation_identity: str | None,
+    consumed_preparation_identity: str | None,
+) -> dict[str, Any]:
+    return {
+        "contract_version": "curriculum-preparation-result.v1",
+        "track": track,
+        "slug": slug,
+        "profile_id": profile_id,
+        "profile_version": str(profile["version"]),
+        "family": str(profile["family"]),
+        "manifest": dict(manifest),
+        "module_state": module_state,
+        "preparation_state": decision.preparation_state,
+        "state": decision.state,
+        "next_action": decision.next_action,
+        "requirements": requirements,
+        "findings": findings,
+        "sources": sources,
+        "preparation_identity": preparation_identity,
+        "consumed_preparation_identity": consumed_preparation_identity,
+    }
+
+
+def _off_manifest_result(
+    *,
+    repo_root: Path,
+    track: str,
+    slug: str,
+    profile_id: str,
+    profile: Mapping[str, Any],
+    files: ContractFiles,
+) -> dict[str, Any]:
+    sources = _contract_sources(files, repo_root)
+    return _result_document(
+        track=track,
+        slug=slug,
+        profile_id=profile_id,
+        profile=profile,
+        manifest=_manifest_evidence(files, sources, repo_root, None),
+        module_state="off-manifest",
+        decision=LifecycleDecision("not-applicable", "off-manifest", "stop"),
+        requirements=[],
+        findings=[
+            {
+                "id": "OFF_MANIFEST_TARGET",
+                "category": "authority",
+                "severity": "blocker",
+                "summary": "Target is not an active curriculum manifest member",
+                "owner": "authority",
+            }
+        ],
+        sources=sources,
+        preparation_identity=None,
+        consumed_preparation_identity=None,
+    )
+
+
+def _preparation_identity(
+    *,
+    track: str,
+    slug: str,
+    profile_id: str,
+    profile: Mapping[str, Any],
+    manifest_index: int,
+    requirements: Sequence[Mapping[str, Any]],
+    sources: Sequence[Mapping[str, Any]],
+) -> str:
+    payload = {
+        "contract_version": "curriculum-preparation-result.v1",
+        "track": track,
+        "slug": slug,
+        "profile_id": profile_id,
+        "profile": profile,
+        "manifest_index": manifest_index,
+        "requirements": _identity_requirements(requirements),
+        "sources": sources,
+    }
+    return _sha256_bytes(_canonical_json(payload).encode("utf-8"))
+
+
+def _plan_is_missing(requirements: Sequence[Mapping[str, Any]]) -> bool:
+    return any(
+        requirement["id"] == "plan"
+        and not requirement["passed"]
+        and any(option["artifact"] == "plan" and option["sha256"] is None for option in requirement["options"])
+        for requirement in requirements
+    )
+
+
+def _built_decision(
+    requirements_pass: bool,
+    preparation_identity: str,
+    consumed_preparation_identity: str | None,
+) -> tuple[LifecycleDecision, list[dict[str, Any]]]:
+    if requirements_pass and consumed_preparation_identity == preparation_identity:
+        return LifecycleDecision("current", "built-current", "certify"), []
+    findings: list[dict[str, Any]] = []
+    if consumed_preparation_identity is None:
+        findings.append(
+            {
+                "id": "PREPARATION_IDENTITY_MISSING",
+                "category": "audit_tooling",
+                "severity": "high",
+                "summary": "Built bundle does not record the preparation identity it consumed",
+                "owner": "audit_tooling",
+            }
+        )
+    elif consumed_preparation_identity != preparation_identity:
+        findings.append(
+            {
+            "id": "PREPARATION_IDENTITY_DRIFT",
+            "category": "preparation",
+            "severity": "high",
+            "summary": "Current preparation identity differs from the identity consumed by the build",
+            "owner": "preparation",
+            }
+        )
+    return LifecycleDecision("stale", "built-preparation-drift", "prepare"), findings
+
+
+def _lifecycle_decision(
+    *,
+    module_state: str,
+    requirements_pass: bool,
+    plan_missing: bool,
+    plan_owner_only: bool,
+    preparation_identity: str,
+    consumed_preparation_identity: str | None,
+) -> tuple[LifecycleDecision, list[dict[str, Any]]]:
+    if module_state == "partial":
+        finding = {
+            "id": "PARTIAL_LEARNER_BUNDLE",
+            "category": "built_artifact",
+            "severity": "blocker",
+            "summary": "Learner bundle is partial and requires non-destructive recovery",
+            "owner": "built_artifact",
+        }
+        preparation_state = "current" if requirements_pass else "missing"
+        return LifecycleDecision(preparation_state, "partial-bundle", "stop"), [finding]
+    if module_state == "built":
+        return _built_decision(requirements_pass, preparation_identity, consumed_preparation_identity)
+    if requirements_pass:
+        return LifecycleDecision("current", "prepared-plan", "build"), []
+    if plan_missing:
+        return LifecycleDecision("missing", "missing-plan", "plan"), []
+    next_action = "plan" if plan_owner_only else "prepare"
+    return LifecycleDecision("missing", "preparation-required", next_action), []
+
+
+def _evaluate_manifest_target(
+    *,
+    repo_root: Path,
+    track: str,
+    slug: str,
+    profile_id: str,
+    profile: Mapping[str, Any],
+    manifest_slugs: tuple[str, ...],
+    files: ContractFiles,
+    validators: Mapping[str, Validator],
+    consumed_preparation_identity: str | None,
+) -> dict[str, Any]:
+    context = ValidationContext(repo_root, track, slug, manifest_slugs)
+    requirements, findings, artifact_sources = _evaluate_requirements(profile, context, validators)
+    sources = [*_contract_sources(files, repo_root), *artifact_sources]
+    manifest_index = manifest_slugs.index(slug)
+    preparation_identity = _preparation_identity(
+        track=track,
+        slug=slug,
+        profile_id=profile_id,
+        profile=profile,
+        manifest_index=manifest_index,
+        requirements=requirements,
+        sources=sources,
+    )
+    module_state = _module_state(repo_root, track, slug)
+    decision, state_findings = _lifecycle_decision(
+        module_state=module_state,
+        requirements_pass=all(requirement["passed"] for requirement in requirements),
+        plan_missing=_plan_is_missing(requirements),
+        plan_owner_only=bool(findings) and all(item["owner"] == "plan" for item in findings),
+        preparation_identity=preparation_identity,
+        consumed_preparation_identity=consumed_preparation_identity,
+    )
+    result = _result_document(
+        track=track,
+        slug=slug,
+        profile_id=profile_id,
+        profile=profile,
+        manifest=_manifest_evidence(files, sources, repo_root, manifest_index),
+        module_state=module_state,
+        decision=decision,
+        requirements=requirements,
+        findings=[*findings, *state_findings],
+        sources=sources,
+        preparation_identity=preparation_identity,
+        consumed_preparation_identity=consumed_preparation_identity,
+    )
+    validate_result(result, repo_root=repo_root)
+    return result
+
+
+def evaluate_preparation(
+    track: str,
+    slug: str,
+    *,
+    consumed_preparation_identity: str | None = None,
+    repo_root: Path = PROJECT_ROOT,
+    validators: Mapping[str, Validator] = VALIDATORS,
+) -> dict[str, Any]:
+    """Evaluate one manifest target without reading legacy QG state."""
+    track = track.lower()
+    slug = slug.lower()
+    if not _TARGET_RE.fullmatch(track) or not _TARGET_RE.fullmatch(slug):
+        raise ReadinessError("track and slug must be lowercase repository identifiers")
+    if consumed_preparation_identity is not None and not _HASH_RE.fullmatch(consumed_preparation_identity):
+        raise ReadinessError("consumed preparation identity must be a SHA-256 hex digest")
+
+    config = load_config(repo_root=repo_root)
+    manifest_record, manifest_slugs = _manifest_record(repo_root, track)
+    profile_id, profile = _select_profile(config, track, str(manifest_record["type"]))
+    files = _contract_files(repo_root, manifest_record["path"])
+
+    if slug not in manifest_slugs:
+        result = _off_manifest_result(
+            repo_root=repo_root,
+            track=track,
+            slug=slug,
+            profile_id=profile_id,
+            profile=profile,
+            files=files,
+        )
+        validate_result(result, repo_root=repo_root)
+        return result
+    return _evaluate_manifest_target(
+        repo_root=repo_root,
+        track=track,
+        slug=slug,
+        profile_id=profile_id,
+        profile=profile,
+        manifest_slugs=manifest_slugs,
+        files=files,
+        validators=validators,
+        consumed_preparation_identity=consumed_preparation_identity,
+    )
+
+
+def validate_result(result: Mapping[str, Any], *, repo_root: Path = PROJECT_ROOT) -> None:
+    schema = _load_json(_repo_file(repo_root, RESULT_SCHEMA_PATH))
+    _validate(result, schema, "preparation result")
+
+
+def dependent_evidence_identity(
+    evidence_class: str,
+    preparation_identity: str,
+    dependencies: Mapping[str, str],
+) -> str:
+    """Bind build, PBR, or production-QG evidence to preparation identity."""
+    if evidence_class not in DEPENDENT_EVIDENCE_CLASSES:
+        raise ReadinessError(f"unsupported dependent evidence class: {evidence_class}")
+    if not _HASH_RE.fullmatch(preparation_identity):
+        raise ReadinessError("preparation identity must be a SHA-256 hex digest")
+    if not all(isinstance(key, str) and key and isinstance(value, str) and value for key, value in dependencies.items()):
+        raise ReadinessError("dependent evidence identities require non-empty string keys and values")
+    payload = {
+        "evidence_class": evidence_class,
+        "preparation_identity": preparation_identity,
+        "dependencies": dict(sorted(dependencies.items())),
+    }
+    return _sha256_bytes(_canonical_json(payload).encode("utf-8"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--track", required=True)
+    parser.add_argument("--slug", required=True)
+    parser.add_argument("--consumed-preparation-identity")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        result = evaluate_preparation(
+            args.track,
+            args.slug,
+            consumed_preparation_identity=args.consumed_preparation_identity,
+        )
+    except (ReadinessError, RegistryValidationError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/orchestration/preparation_evidence.py
+++ b/scripts/orchestration/preparation_evidence.py
@@ -1,0 +1,145 @@
+"""Strict source-controlled manual evidence shared by preparation adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date
+from pathlib import Path
+from urllib.parse import urlparse
+
+import yaml
+
+MANUAL_GATES = frozenset(
+    {
+        "dossier_grounding",
+        "reading_rights",
+        "wiki_grounding",
+        "wiki_quote_verification",
+        "image_rights",
+        "corpus_hammer",
+        "independent_content_review",
+        "cohort_promotion",
+        "hold",
+        "merged_publication",
+    }
+)
+MANUAL_STATUSES = frozenset({"pass", "fail"})
+REVIEWER_FAMILIES = frozenset({"agy", "claude", "codex", "deepseek", "gemini", "grok", "human", "mixed"})
+RIGHTS_DISPOSITIONS = frozenset({"approved", "exception-approved", "link-only-approved", "not-approved"})
+APPROVED_RIGHTS_DISPOSITIONS = RIGHTS_DISPOSITIONS - {"not-approved"}
+
+
+class RegistryValidationError(ValueError):
+    """Raised when source-controlled manual evidence is malformed."""
+
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects duplicate mapping keys."""
+
+
+def _construct_unique_mapping(
+    loader: yaml.SafeLoader,
+    node: yaml.nodes.MappingNode,
+    deep: bool = False,
+) -> dict[object, object]:
+    loader.flatten_mapping(node)
+    mapping: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise RegistryValidationError(f"duplicate YAML key: {key!r}")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+def load_yaml_mapping(path: Path) -> dict:
+    """Load one strict UTF-8 YAML mapping."""
+    try:
+        value = yaml.load(path.read_text(encoding="utf-8", errors="strict"), Loader=UniqueKeyLoader)
+    except (OSError, UnicodeDecodeError, yaml.YAMLError, RegistryValidationError) as exc:
+        raise RegistryValidationError(f"invalid YAML mapping {path}: {exc}") from exc
+    if not isinstance(value, Mapping):
+        raise RegistryValidationError(f"YAML document must be a mapping: {path}")
+    return dict(value)
+
+
+def _http_url(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _evidence_date(slug: str, name: object, raw_date: object) -> date:
+    if isinstance(raw_date, str):
+        try:
+            return date.fromisoformat(raw_date)
+        except ValueError as exc:
+            raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid date") from exc
+    if isinstance(raw_date, date):
+        return raw_date
+    raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid date")
+
+
+def _validated_manual_record(slug: str, name: object, record: object) -> dict:
+    if name not in MANUAL_GATES:
+        raise RegistryValidationError(f"unsupported manual evidence gate {name!r} for {slug!r}")
+    if not isinstance(record, Mapping):
+        raise RegistryValidationError(f"manual evidence {slug}.{name} must be a mapping")
+    status = record.get("status")
+    if status not in MANUAL_STATUSES:
+        raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid status {status!r}")
+    family = record.get("reviewer_family")
+    if family not in REVIEWER_FAMILIES:
+        raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid reviewer_family {family!r}")
+    if not _http_url(record.get("evidence_url")):
+        raise RegistryValidationError(f"manual evidence {slug}.{name} needs an HTTP(S) evidence_url")
+    clean = dict(record)
+    clean["date"] = _evidence_date(slug, name, record.get("date"))
+    if name in {"reading_rights", "image_rights"}:
+        disposition = clean.get("disposition")
+        if disposition not in RIGHTS_DISPOSITIONS:
+            raise RegistryValidationError(f"manual evidence {slug}.{name} has invalid disposition")
+        if (status == "pass") != (disposition in APPROVED_RIGHTS_DISPOSITIONS):
+            raise RegistryValidationError(
+                f"manual evidence {slug}.{name} status conflicts with disposition {disposition!r}"
+            )
+    if name == "hold":
+        if status != "pass":
+            raise RegistryValidationError(f"manual evidence {slug}.hold must record a reviewed pass")
+        if (
+            not isinstance(clean.get("active"), bool)
+            or not isinstance(clean.get("reason"), str)
+            or not clean["reason"].strip()
+        ):
+            raise RegistryValidationError(f"manual evidence {slug}.hold needs active boolean and reason")
+    return clean
+
+
+def load_manual_evidence(path: Path, manifest_slugs: set[str]) -> dict[str, dict[str, dict]]:
+    """Load and strictly validate sparse source-controlled manual evidence."""
+    if not path.exists():
+        return {}
+    raw = load_yaml_mapping(path)
+    if raw.get("version") != 1:
+        raise RegistryValidationError("registry must be a mapping with version: 1")
+    entries = raw.get("entries", {})
+    if not isinstance(entries, Mapping):
+        raise RegistryValidationError("registry entries must be a mapping")
+
+    validated: dict[str, dict[str, dict]] = {}
+    for slug, gates in entries.items():
+        if not isinstance(slug, str) or slug not in manifest_slugs:
+            raise RegistryValidationError(f"off-manifest registry slug: {slug!r}")
+        if not isinstance(gates, Mapping) or not gates:
+            raise RegistryValidationError(f"registry entry for {slug!r} must be a non-empty mapping")
+        validated[slug] = {}
+        for name, record in gates.items():
+            validated[slug][str(name)] = _validated_manual_record(slug, name, record)
+    return validated

--- a/tests/orchestration/test_curriculum_readiness.py
+++ b/tests/orchestration/test_curriculum_readiness.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.orchestration import curriculum_readiness as readiness
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BIO_SLUG = "borys-hrinchenko"
+
+
+def _copy(repo_root: Path, relative: str | Path) -> None:
+    relative = Path(relative)
+    source = REPO_ROOT / relative
+    target = repo_root / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if source.is_dir():
+        shutil.copytree(source, target)
+    else:
+        shutil.copy2(source, target)
+
+
+def _copy_contracts(repo_root: Path) -> None:
+    _copy(repo_root, "agents_extensions/shared/curriculum-lifecycle")
+    _copy(repo_root, "agents_extensions/shared/prompt-contracts")
+
+
+def _bio_fixture(tmp_path: Path) -> Path:
+    repo_root = tmp_path / "repo"
+    _copy_contracts(repo_root)
+    for relative in (
+        "curriculum/l2-uk-en/curriculum.yaml",
+        "curriculum/l2-uk-en/bio/promotion-evidence.yaml",
+        f"curriculum/l2-uk-en/plans/bio/{BIO_SLUG}.yaml",
+        f"curriculum/l2-uk-en/bio/discovery/{BIO_SLUG}.yaml",
+        f"docs/research/bio/{BIO_SLUG}.md",
+        f"wiki/figures/{BIO_SLUG}.md",
+        f"wiki/figures/{BIO_SLUG}.sources.yaml",
+    ):
+        _copy(repo_root, relative)
+    return repo_root
+
+
+def _write_manifest(repo_root: Path, track: str, manifest_type: str, slug: str) -> None:
+    path = repo_root / readiness.MANIFEST_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "version": "1.0",
+                "levels": {track: {"type": manifest_type, "modules": [slug]}},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _create_bundle(repo_root: Path, track: str, slug: str) -> None:
+    directory = repo_root / "curriculum" / "l2-uk-en" / track / slug
+    directory.mkdir(parents=True, exist_ok=True)
+    for filename in readiness.MODULE_BUNDLE_FILES:
+        (directory / filename).write_text(f"fixture: {filename}\n", encoding="utf-8")
+
+
+def test_bio_profile_expresses_complete_preparation_without_track_branches() -> None:
+    config = readiness.load_config(repo_root=REPO_ROOT)
+    bio = config["profiles"]["bio"]
+    requirement_ids = {item["id"] for item in bio["requirements"]}
+    validators = {
+        validator
+        for requirement in bio["requirements"]
+        for option in requirement["options"]
+        for validator in option["validators"]
+    }
+
+    assert requirement_ids == {
+        "dossier",
+        "dossier-grounding",
+        "plan",
+        "reading-or-rights",
+        "wiki-document",
+        "wiki-sources",
+        "wiki-grounding",
+        "wiki-quote-verification",
+        "image-rights",
+        "discovery",
+    }
+    assert {
+        "bio-dossier-xref",
+        "plan-check",
+        "readings-present",
+        "manual-gate",
+        "wiki-completeness",
+        "bio-wiki-subject",
+        "bio-discovery-integrity",
+    } <= validators
+    assert config["profiles"]["core"]["prompt_profile"] == "core"
+    assert config["profiles"]["seminar"]["prompt_profile"] == "seminar"
+    assert bio["prompt_profile"] == "seminar"
+    engine_source = (REPO_ROOT / "scripts/orchestration/curriculum_readiness.py").read_text(encoding="utf-8")
+    assert 'track == "bio"' not in engine_source
+    assert "llm_qg" not in engine_source
+    assert "sqlite" not in engine_source
+
+
+def test_prepared_unbuilt_bio_uses_real_validators_and_exact_sources(tmp_path: Path) -> None:
+    repo_root = _bio_fixture(tmp_path)
+
+    result = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=repo_root)
+
+    assert result["profile_id"] == "bio"
+    assert result["module_state"] == "unbuilt"
+    assert result["preparation_state"] == "current"
+    assert result["state"] == "prepared-plan"
+    assert result["next_action"] == "build"
+    assert result["findings"] == []
+    assert all(requirement["passed"] for requirement in result["requirements"])
+    assert len(result["preparation_identity"]) == 64
+    readiness.validate_result(result, repo_root=repo_root)
+
+
+def test_preparation_identity_is_stable_across_clean_repository_roots(tmp_path: Path) -> None:
+    first_root = _bio_fixture(tmp_path / "first")
+    second_root = _bio_fixture(tmp_path / "second")
+
+    first = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=first_root)
+    second = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=second_root)
+
+    assert first["preparation_identity"] == second["preparation_identity"]
+    assert first["sources"] == second["sources"]
+
+
+def test_registered_prompt_profile_bytes_are_preparation_identity_inputs(tmp_path: Path) -> None:
+    repo_root = _bio_fixture(tmp_path)
+    before = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=repo_root)
+    prompt_profiles = repo_root / "agents_extensions/shared/prompt-contracts/profiles/curriculum-lifecycle.v1.yaml"
+    prompt_profiles.write_text(prompt_profiles.read_text(encoding="utf-8") + "# identity change\n", encoding="utf-8")
+
+    after = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=repo_root)
+
+    assert after["state"] == before["state"]
+    assert after["preparation_identity"] != before["preparation_identity"]
+
+
+def test_missing_bio_evidence_fails_closed_with_preparation_owner(tmp_path: Path) -> None:
+    repo_root = _bio_fixture(tmp_path)
+    (repo_root / f"docs/research/bio/{BIO_SLUG}.md").unlink()
+
+    result = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=repo_root)
+
+    assert result["state"] == "preparation-required"
+    assert result["next_action"] == "prepare"
+    finding = next(item for item in result["findings"] if item["id"] == "PREPARATION_DOSSIER")
+    assert finding["owner"] == "preparation"
+
+
+def test_missing_plan_routes_to_plan_owner(tmp_path: Path) -> None:
+    repo_root = _bio_fixture(tmp_path)
+    (repo_root / f"curriculum/l2-uk-en/plans/bio/{BIO_SLUG}.yaml").unlink()
+
+    result = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=repo_root)
+
+    assert result["state"] == "missing-plan"
+    assert result["next_action"] == "plan"
+    finding = next(item for item in result["findings"] if item["id"] == "PREPARATION_PLAN")
+    assert finding["owner"] == "plan"
+
+
+def test_built_module_is_current_only_with_consumed_preparation_identity(tmp_path: Path) -> None:
+    repo_root = _bio_fixture(tmp_path)
+    prepared = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=repo_root)
+    _create_bundle(repo_root, "bio", BIO_SLUG)
+
+    missing_link = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=repo_root)
+    current = readiness.evaluate_preparation(
+        "bio",
+        BIO_SLUG,
+        consumed_preparation_identity=prepared["preparation_identity"],
+        repo_root=repo_root,
+    )
+
+    assert missing_link["state"] == "built-preparation-drift"
+    assert "PREPARATION_IDENTITY_MISSING" in {item["id"] for item in missing_link["findings"]}
+    assert current["state"] == "built-current"
+    assert current["preparation_state"] == "current"
+    assert current["next_action"] == "certify"
+
+
+def test_preparation_change_invalidates_build_pbr_and_qg_identities(tmp_path: Path) -> None:
+    repo_root = _bio_fixture(tmp_path)
+    prepared = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=repo_root)
+    consumed = prepared["preparation_identity"]
+    before = {
+        evidence_class: readiness.dependent_evidence_identity(
+            evidence_class,
+            consumed,
+            {"artifact": "fixture-v1"},
+        )
+        for evidence_class in readiness.DEPENDENT_EVIDENCE_CLASSES
+    }
+    _create_bundle(repo_root, "bio", BIO_SLUG)
+    dossier = repo_root / f"docs/research/bio/{BIO_SLUG}.md"
+    dossier.write_text(dossier.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+    drifted = readiness.evaluate_preparation(
+        "bio",
+        BIO_SLUG,
+        consumed_preparation_identity=consumed,
+        repo_root=repo_root,
+    )
+    after = {
+        evidence_class: readiness.dependent_evidence_identity(
+            evidence_class,
+            drifted["preparation_identity"],
+            {"artifact": "fixture-v1"},
+        )
+        for evidence_class in readiness.DEPENDENT_EVIDENCE_CLASSES
+    }
+
+    assert drifted["state"] == "built-preparation-drift"
+    assert drifted["preparation_identity"] != consumed
+    assert before.keys() == after.keys()
+    assert all(before[key] != after[key] for key in before)
+
+
+@pytest.mark.parametrize(
+    ("track", "manifest_type", "slug", "plan_source", "expected_profile"),
+    [
+        ("a1", "core", "sounds-letters-and-hello", "plans/a1/sounds-letters-and-hello.yaml", "core"),
+        ("hist", "track", "trypillian-civilization", "plans/hist/trypillian-civilization.yaml", "seminar"),
+    ],
+)
+def test_unbuilt_core_and_generic_seminar_profile_seams(
+    tmp_path: Path,
+    track: str,
+    manifest_type: str,
+    slug: str,
+    plan_source: str,
+    expected_profile: str,
+) -> None:
+    repo_root = tmp_path / track
+    _copy_contracts(repo_root)
+    _write_manifest(repo_root, track, manifest_type, slug)
+    _copy(repo_root, f"curriculum/l2-uk-en/{plan_source}")
+
+    result = readiness.evaluate_preparation(track, slug, repo_root=repo_root)
+
+    assert result["profile_id"] == expected_profile
+    assert result["module_state"] == "unbuilt"
+    assert result["state"] == "prepared-plan"
+    assert result["next_action"] == "build"
+
+
+def test_off_manifest_target_fails_with_authority_owner(tmp_path: Path) -> None:
+    repo_root = _bio_fixture(tmp_path)
+
+    result = readiness.evaluate_preparation("bio", "not-in-curriculum", repo_root=repo_root)
+
+    assert result["state"] == "off-manifest"
+    assert result["next_action"] == "stop"
+    assert result["preparation_identity"] is None
+    assert result["findings"] == [
+        {
+            "id": "OFF_MANIFEST_TARGET",
+            "category": "authority",
+            "severity": "blocker",
+            "summary": "Target is not an active curriculum manifest member",
+            "owner": "authority",
+        }
+    ]
+
+
+def test_legacy_qg_files_and_mtimes_are_not_readiness_inputs(tmp_path: Path) -> None:
+    repo_root = _bio_fixture(tmp_path)
+    before = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=repo_root)
+    module_dir = repo_root / "curriculum/l2-uk-en/bio" / BIO_SLUG
+    module_dir.mkdir(parents=True)
+    (module_dir / "llm_qg.json").write_text('{"terminal_verdict":"PASS"}\n', encoding="utf-8")
+    (module_dir / "qg_evidence.json").write_text('{"passed":true}\n', encoding="utf-8")
+    (module_dir / "legacy-qg.sqlite3").write_bytes(b"not a database")
+    after = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=repo_root)
+
+    assert after["state"] == before["state"]
+    assert after["preparation_identity"] == before["preparation_identity"]
+    assert not any("qg" in source["path"].lower() or "sqlite" in source["path"].lower() for source in after["sources"])
+
+
+def test_partial_bundle_stops_for_built_artifact_recovery(tmp_path: Path) -> None:
+    repo_root = _bio_fixture(tmp_path)
+    module_dir = repo_root / "curriculum/l2-uk-en/bio" / BIO_SLUG
+    module_dir.mkdir(parents=True)
+    (module_dir / "module.md").write_text("# Partial\n", encoding="utf-8")
+
+    result = readiness.evaluate_preparation("bio", BIO_SLUG, repo_root=repo_root)
+
+    assert result["state"] == "partial-bundle"
+    assert result["next_action"] == "stop"
+    assert "PARTIAL_LEARNER_BUNDLE" in {item["id"] for item in result["findings"]}
+
+
+def test_config_rejects_raw_prose_and_unknown_selector(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    _copy_contracts(repo_root)
+    config_path = repo_root / readiness.CONFIG_PATH
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["profiles"]["core"]["prompt_text"] = "free-form bypass"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(readiness.ReadinessError, match="Additional properties"):
+        readiness.load_config(repo_root=repo_root)
+
+    _copy_contracts(repo_root := tmp_path / "selector")
+    config_path = repo_root / readiness.CONFIG_PATH
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    config["selectors"]["tracks"]["bio"] = "missing-profile"
+    config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(readiness.ReadinessError, match="unknown profile"):
+        readiness.load_config(repo_root=repo_root)
+
+
+def test_dependent_identity_rejects_unknown_evidence_class() -> None:
+    with pytest.raises(readiness.ReadinessError, match="unsupported dependent evidence class"):
+        readiness.dependent_evidence_identity("legacy-qg", "a" * 64, {"artifact": "v1"})

--- a/tests/test_deploy_script_idempotency.py
+++ b/tests/test_deploy_script_idempotency.py
@@ -23,6 +23,7 @@ DRIFT_TARGET = Path(".claude/rules/pipeline.md")
 CODEX_HOOK_TARGET = Path(".codex/hooks/session-setup.sh")
 CODEX_HOOKS_CONFIG = Path(".codex/hooks.json")
 PROMPT_CONTRACT_MANIFEST = Path("prompt-contracts/manifests/curriculum-lifecycle.module.v1.yaml")
+READINESS_PROFILE_CONFIG = Path("curriculum-lifecycle/config/readiness-profiles.v1.yaml")
 UNSCOPED_RULE_FILES = (
     "operator-expectations.md",
     "critical-rules.md",
@@ -125,9 +126,10 @@ def test_fresh_deploy_produces_synced_output(tmp_path: Path) -> None:
         assert (repo / ".agent" / "rules" / filename).exists()
         assert (repo / ".gemini" / "rules" / filename).exists()
         assert (repo / ".codex" / "rules" / filename).exists()
-    canonical_manifest = repo / "agents_extensions/shared" / PROMPT_CONTRACT_MANIFEST
-    for mirror_root in (".claude", ".agent", ".codex"):
-        assert (repo / mirror_root / PROMPT_CONTRACT_MANIFEST).read_bytes() == canonical_manifest.read_bytes()
+    for shared_file in (PROMPT_CONTRACT_MANIFEST, READINESS_PROFILE_CONFIG):
+        canonical = repo / "agents_extensions/shared" / shared_file
+        for mirror_root in (".claude", ".agent", ".codex"):
+            assert (repo / mirror_root / shared_file).read_bytes() == canonical.read_bytes()
 
     codex_hooks_diff = _run_command(
         repo,


### PR DESCRIPTION
Closes #5154.

Coordination: #5152. Stream epic: #4707.

## Summary

- add strict versioned readiness-profile and preparation-result schemas
- add a manifest-authoritative, profile-driven PREPARE evaluator for CORE, generic seminars, and the complete BIO evidence surface
- bind declared preparation artifacts plus config/schema/prompt-profile bytes into root-independent identities and downstream build/PBR/production-QG invalidation identities
- require exact consumed preparation identity for built-current; fail closed with separate preparation, plan, built-artifact, audit-tooling, and authority ownership
- extract strict manual evidence parsing for reuse while preserving the legacy BIO ledger reporting surface
- explicitly exclude legacy QG DB/file/mtime state from PREPARE authority

## Verification

- `.venv/bin/ruff check` on all changed Python/test files
- `.venv/bin/python -m compileall -q` on changed runtime files
- `82 passed`: readiness, BIO ledger, prompt-contract, and deployment regression suites
- Claude Opus 4.8 xhigh independent cross-family review: APPROVE, no material findings; reviewer also ran 199 orchestration/audit tests and adversarial duplicate-key, symlink-escape, and malformed-evidence probes
- exact reviewed commit `7506af03b40e281e777347118535bb8fa99a7357`; final rebased commit `de6909c2106771776dd229a5bfefb91624e56c7c` has identical stable patch id `201714ad1a9de85b58c9b9ab91d7fc9e5ffdb379` (intervening main change was disjoint bridge runtime work)
- `.venv/bin/python -m yamllint agents_extensions/shared/curriculum-lifecycle`
- `jq empty agents_extensions/shared/curriculum-lifecycle/schema/*.json`
- real BIO, CORE, and generic seminar CLI probes
- `npm run agents:deploy` and `bash scripts/check_rules_deployment.sh`
- protected-file, artifact, file-count, diff, and X-Agent trailer checks

## Fleet note

A bounded read-only readiness reconnaissance used the Spark quota lane because the regular Codex lane was comparatively constrained at dispatch time; the first brief omitted the explicit coordination-epic line and was correctly stopped by the intake guard, then the corrected #5152/#4707-classified retry completed. Sol retained all design, implementation, integration, and merge decisions. The merge gate used the independent Claude family.
