### PR TITLE
Refs #4385 — phase 1: Word-of-the-Day daily pool from atlas.db (entry-model SSOT)

### DIFF
--- a/docs/decisions/2026-06-25-lexicon-update-mechanics.md
+++ b/docs/decisions/2026-06-25-lexicon-update-mechanics.md
@@ -72,6 +72,14 @@ generate_daily_pool → verify_manifest`. The manifest is published as a **GitHu
 with a committed pointer; the build hydrates it (`hydrate-manifest.mjs`). The "Atlas Manifest Freshness"
 CI gate + `check_atlas_manifest_enrichment` guard staleness/thin-manifest.
 
+At **site build time** (`npm run hydrate`) the derived artifacts are regenerated from the entry-model
+SSOT rather than the flat manifest: `atlas:build-db` materializes `data/atlas.db`, then
+`atlas:build-search` (`generate_search_index.py --db`) and `atlas:build-daily`
+(`generate_daily_pool --db`) rebuild the search/browse and Word-of-the-Day artifacts straight from that
+database (GH #4385). Both generators keep their legacy `--manifest` mode for the local `make atlas`
+pass, which runs before the DB exists; the `--db` mode is admission-identical (same selection logic,
+SSOT-sourced), so the two paths agree.
+
 ## The two gaps
 
 ### Gap 1 — the auto-grow cron is dormant (no-op on GitHub-hosted runners)

--- a/scripts/audit/generate_daily_pool.py
+++ b/scripts/audit/generate_daily_pool.py
@@ -1,13 +1,30 @@
-"""Generate the small daily-curated Word Atlas pool from the manifest."""
+"""Generate the small daily-curated Word Atlas pool.
+
+Two source modes, mirroring ``generate_search_index``:
+
+* ``--db data/atlas.db`` — read the daily-pool candidates from the entry-model
+  SSOT (``atlas.db``). This is the site-build path (``npm run hydrate``): every
+  learner-facing Atlas surface then reads from the one database. Candidate
+  selection is structurally constrained to approved, public *article* rows, so
+  ``form_of`` alias routes can never surface as Word-of-the-Day.
+* ``--manifest`` (default) — the legacy flat-manifest path used by ``make atlas``
+  before the DB is materialized.
+
+Both modes feed the identical ``build_pool`` admission logic, so flipping the
+source does not change which words are admitted (GH #4385, "no admission
+changes"): the migration only moves the read to the SSOT.
+"""
 
 from __future__ import annotations
 
 import argparse
 import hashlib
 import json
+import sqlite3
 from pathlib import Path
 from typing import Any
 
+from scripts.audit.generate_search_index import _site_build_entry_model_gates
 from scripts.audit.lexeme_filter import (
     DERIVED_FORM_SOURCES,
     SURFACE_DAILY,
@@ -146,17 +163,53 @@ def write_pool(pool: list[dict[str, Any]], out_path: Path) -> None:
     )
 
 
+def load_db_entries(db_path: Path) -> list[dict[str, Any]]:
+    """Load daily-pool candidate entries from the entry-model SSOT (``atlas.db``).
+
+    Only approved, public *article* payloads are returned — the same rows the
+    entry-model gates count as reviewed entries. ``form_of`` alias routes have no
+    ``articles`` row, so the join structurally excludes them (they are search
+    resolvers, never Word-of-the-Day candidates). Each ``article_payloads`` row
+    stores the manifest-shaped public payload, so ``build_pool`` runs unchanged.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        # Fail loudly on a stale/hand-edited DB before selecting candidates —
+        # the same count/target gates the search-artifact builder runs (#4385 §CI).
+        _site_build_entry_model_gates(conn)
+        rows = conn.execute(
+            """SELECT payload.payload_json
+               FROM article_payloads AS payload
+               JOIN articles AS article ON article.slug = payload.slug
+               WHERE payload.is_public_route = 1
+                 AND article.review_state = 'approved'
+                 AND article.visibility = 'public'
+               ORDER BY payload.route_order"""
+        ).fetchall()
+    finally:
+        conn.close()
+    return [json.loads(row[0]) for row in rows]
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument(
+        "--db",
+        type=Path,
+        help="Build the daily pool from atlas.db (entry-model SSOT) instead of the legacy manifest.",
+    )
     parser.add_argument("--out", type=Path, default=DEFAULT_OUT)
     parser.add_argument("--size", type=int, default=300)
     args = parser.parse_args(argv)
 
-    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
-    entries = manifest.get("entries", [])
-    if not isinstance(entries, list):
-        raise ValueError("manifest entries must be a list")
+    if args.db is not None:
+        entries = load_db_entries(args.db)
+    else:
+        manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+        entries = manifest.get("entries", [])
+        if not isinstance(entries, list):
+            raise ValueError("manifest entries must be a list")
     pool = build_pool(entries, args.size)
     write_pool(pool, args.out)
     return 0

--- a/site/package.json
+++ b/site/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "atlas:build-db": "cd .. && .venv/bin/python -m scripts.atlas.atlas_db --db data/atlas.db",
     "atlas:build-search": "cd .. && python3 scripts/audit/generate_search_index.py --db data/atlas.db",
+    "atlas:build-daily": "cd .. && .venv/bin/python -m scripts.audit.generate_daily_pool --db data/atlas.db",
     "atlas:perf": "node ./scripts/benchmark-atlas-db.mjs",
     "atlas:validate-aliases": "cd .. && .venv/bin/python -m scripts.atlas.atlas_db --db data/atlas.db --validate-aliases-only",
-    "hydrate": "node ./scripts/hydrate-manifest.mjs && npm run atlas:build-db && npm run atlas:build-search && node ./scripts/hydrate-practice-deck.mjs && node --experimental-strip-types ./scripts/hydrate-lexicon-api-shards.ts",
+    "hydrate": "node ./scripts/hydrate-manifest.mjs && npm run atlas:build-db && npm run atlas:build-search && npm run atlas:build-daily && node ./scripts/hydrate-practice-deck.mjs && node --experimental-strip-types ./scripts/hydrate-lexicon-api-shards.ts",
     "hydrate:manifest": "node ./scripts/hydrate-manifest.mjs && npm run atlas:build-db",
     "hydrate:practice": "node ./scripts/hydrate-practice-deck.mjs",
     "dev": "npm run hydrate && astro dev",

--- a/tests/test_generate_daily_pool.py
+++ b/tests/test_generate_daily_pool.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
-from scripts.audit.generate_daily_pool import build_pool, compute_weight, main
+from scripts.atlas import atlas_db
+from scripts.audit.generate_daily_pool import (
+    build_pool,
+    compute_weight,
+    load_db_entries,
+    main,
+)
 
 
 def fixture_entries() -> list[dict[str, object]]:
@@ -147,6 +154,104 @@ def test_main_writes_deterministic_json_bytes(tmp_path) -> None:
     assert out_one.read_bytes() == out_two.read_bytes()
     assert out_one.read_text(encoding="utf-8").endswith("\n")
 
+
+
+def _daily_atlas_db(tmp_path: Path) -> Path:
+    """Materialize a fixture atlas.db from a small manifest via the real migrator.
+
+    Two eligible public lemma articles, one gloss-less lemma (admission-excluded),
+    and one ``form_of`` alias route (payload-only, no ``articles`` row) that the
+    entry-model SSOT must keep out of Word-of-the-Day.
+    """
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "entries": [
+                    {
+                        "lemma": "баба",
+                        "url_slug": "baba",
+                        "gloss": "grandmother",
+                        "primary_source": "course",
+                        "course_usage": [
+                            {"track": "a1", "module_num": 1, "slug": "family", "context": "x"}
+                        ],
+                        "enrichment": {"cefr": {"level": "A1", "source": "est", "text": "A1"}},
+                    },
+                    {
+                        "lemma": "дім",
+                        "url_slug": "dim",
+                        "gloss": "house",
+                        "primary_source": "course",
+                        "course_usage": [],
+                        "enrichment": {"cefr": {"level": "A1", "source": "est", "text": "A1"}},
+                    },
+                    # No gloss → admission-excluded by build_pool, but still an article row.
+                    {"lemma": "жмур", "url_slug": "zhmur", "primary_source": "remainder"},
+                    # form_of alias route: public payload, NO articles row → structurally excluded.
+                    {"lemma": "бабу", "url_slug": "babu", "form_of": {"url_slug": "baba"}},
+                ]
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    db = tmp_path / "atlas.db"
+    atlas_db.migrate_manifest(manifest, db)
+    return db
+
+
+def test_load_db_entries_returns_only_approved_public_articles(tmp_path) -> None:
+    entries = load_db_entries(_daily_atlas_db(tmp_path))
+
+    slugs = {entry["url_slug"] for entry in entries}
+    # form_of alias route (babu) has no articles row → never a candidate.
+    assert slugs == {"baba", "dim", "zhmur"}
+    assert "babu" not in slugs
+
+
+def test_db_mode_matches_manifest_admission_and_excludes_form_of(tmp_path) -> None:
+    db = _daily_atlas_db(tmp_path)
+
+    # payload_json stores the exact public manifest entry, so DB-sourced admission
+    # is identical to manifest-sourced admission over the same article rows.
+    article_entries = [
+        {
+            "lemma": "баба",
+            "url_slug": "baba",
+            "gloss": "grandmother",
+            "primary_source": "course",
+            "course_usage": [{"track": "a1", "module_num": 1, "slug": "family", "context": "x"}],
+            "enrichment": {"cefr": {"level": "A1", "source": "est", "text": "A1"}},
+        },
+        {
+            "lemma": "дім",
+            "url_slug": "dim",
+            "gloss": "house",
+            "primary_source": "course",
+            "course_usage": [],
+            "enrichment": {"cefr": {"level": "A1", "source": "est", "text": "A1"}},
+        },
+        {"lemma": "жмур", "url_slug": "zhmur", "primary_source": "remainder"},
+    ]
+    assert build_pool(load_db_entries(db), 300) == build_pool(article_entries, 300)
+
+    out = tmp_path / "pool.json"
+    assert main(["--db", str(db), "--out", str(out), "--size", "300"]) == 0
+    pool = json.loads(out.read_text(encoding="utf-8"))
+    assert [item["lemma"] for item in pool] == ["баба", "дім"]  # жмур dropped (no gloss)
+    assert "babu" not in {item["slug"] for item in pool}
+
+
+def test_db_mode_writes_deterministic_json_bytes(tmp_path) -> None:
+    db = _daily_atlas_db(tmp_path)
+    out_one = tmp_path / "one.json"
+    out_two = tmp_path / "two.json"
+
+    assert main(["--db", str(db), "--out", str(out_one), "--size", "300"]) == 0
+    assert main(["--db", str(db), "--out", str(out_two), "--size", "300"]) == 0
+    assert out_one.read_bytes() == out_two.read_bytes()
+    assert out_one.read_text(encoding="utf-8").endswith("\n")
 
 
 def test_build_pool_keeps_source_inventory_browse_only_by_default() -> None:


### PR DESCRIPTION
Refs #4385 — phase 1: Word-of-the-Day daily pool now generated from `atlas.db` (entry-model SSOT), closing the last flat-manifest–derived Atlas site artifact.

## Investigation — true state of #4385 (verified against `data/atlas.db`, immutable read)

Contrary to the epic's original premise ("the site still renders the old per-lemma model"), **most of #4385 already landed** — PR-2 #4759 (route semantics + entry_type templates), PR-3 #4906 (article-vs-alias search split, honest counts, alias CI gates), PR-4 #4925 (expression detail + component backlinks). This PR closes the remaining SSG-from-DB tail.

**DB shape (tool-backed, `data/atlas.db`):**
- `articles`: **8216** — `lemma` 6931, `multiword_term` 1285. No `expression`/`phraseologism`/`proverb`/`proper_name` rows yet (the fill hasn't produced them). `visibility`: 8206 public / 10 private. `review_state`: all approved.
- `article_payloads`: **8542** public routes = 8206 article routes + **336 `form_of` stub routes** (no `articles` row).
- `aliases`: 9987 (9969 public) — transliteration 8214, canonical 1437, inflected_form 336.
- `enrichment`: 14 sections (heritage_status 8216, cefr 7008, stress 6870, …); `related_entries`: 1022 synonym.

**What the current site renders vs. what the model supports:**

| Surface | Source today | Entry-model-correct? |
|---|---|---|
| Article detail `/lexicon/{slug}` | **atlas.db** (`getAtlasPayloadCache`, better-sqlite3; entry-model gates run at build) | ✅ entry_type-branched (lemma vs multiword_term: morphology suppressed, «термін» label, component backlinks) |
| Search index + aliases + browse | **atlas.db** (`generate_search_index.py --db`) | ✅ article/alias split, honest counts |
| Static status counts | **atlas.db** (`getAtlasEntryModelCounts` + `runEntryModelGates`) | ✅ counts by entry_type; `article_vs_alias_count`, `alias_target_integrity` |
| **Word-of-the-Day daily pool** | **flat manifest** (`generate_daily_pool.py --manifest`) | ❌ pre-entry-model manifest; heuristic source-tag filtering — **this PR** |

**Acceptance gates:** `entry_type_enum`/`entry_type_shape` enforced by `atlas_db` CHECK constraints (#4391); `article_vs_alias_count` + `alias_target_integrity` live as site-build assertions (`atlasDb.ts` / `generate_search_index.py`).

## This PR (phase 1) — daily pool from the SSOT

`generate_daily_pool.py` gains a `--db` mode that reads Word-of-the-Day candidates from `atlas.db` and feeds the **identical `build_pool` admission logic**. Wired into `npm run hydrate` (`atlas:build-daily`, after `atlas:build-search`), mirroring the already-reviewed `generate_search_index.py --db` dual-mode. The legacy `--manifest` mode stays for the local `make atlas` pass (which runs before the DB exists).

**Why this slice (highest-value, in-scope, invariant-safe):**
- It is the **last learner-facing Atlas site-build artifact still derived from the pre-entry-model flat manifest**. After it, *every* learner-visible Atlas surface reads from the one SSOT.
- **Entry-model-correct:** candidates are structurally constrained to approved+public *article* rows (`JOIN articles WHERE review_state='approved' AND visibility='public'`), so `form_of` alias routes and non-public/unreviewed records can never surface as Word-of-the-Day — a guarantee the manifest's heuristic source-tag filter can't give.
- **Respects "no Daily/Practice admission changes":** the DB-mode generator reuses `build_pool` unchanged. Verified **byte-identical** output (300 items, same order & fields) against the shipped pool, from both the real `data/atlas.db` and a freshly-migrated matched DB. Zero learner-visible change.
- **Low-risk:** additive `--db` flag; proven pattern; no Astro/TS runtime surface (the `/lexicon/daily-pool.json` endpoint consumes the byte-identical artifact).

**Changes:**
- `scripts/audit/generate_daily_pool.py` — `--db` mode (`load_db_entries` reads approved+public article payloads, runs the shared entry-model gate, feeds `build_pool`).
- `site/package.json` — `atlas:build-daily`; added to the `hydrate` chain.
- `tests/test_generate_daily_pool.py` — DB-mode tests (fixture `atlas.db` via `migrate_manifest`; `form_of` + gloss-less exclusion; parity with manifest mode; deterministic bytes).
- `docs/decisions/2026-06-25-lexicon-update-mechanics.md` — documents the site-build DB-sourced derived artifacts.

## Verification (tool-backed)

- **Python:** `pytest tests/test_generate_daily_pool.py` → **9/9**; with `test_generate_search_index.py` + `test_check_static_practice_assets.py` → **37/37**. `ruff` clean.
- **Admission-preserving:** `generate_daily_pool --db <real atlas.db>` and `npm run atlas:build-daily` → **byte-identical** to the committed pool.
- **Site vitest:** green against a matched manifest+DB pair (incl. `atlas-db-read` render-parity **4/4**). The 2 `atlas-db-read` parity failures seen in the offline worktree with a *stale* symlinked DB **fail identically without this diff** (environmental: the offline DB predates the locally-hydrated manifest; CI's `npm test` hydrates a matched pair).
- **Astro build:** green — `astro build` Complete, **8973 pages built in 59s** (incl. the 8542 lexicon SSG pages from `atlas.db`); `dist/lexicon/daily-pool.json` emitted with 300 valid entries.

## Invariants
- Static-only runtime (#3936): build-time generation only. UA-immersion copy: untouched. Source attribution: no source strings touched (pool carries slug/gloss/kind/weight; attribution lives on article pages). No Daily/Practice admission changes: verified byte-identical.

## Phased plan for the remaining #4385 tail

| Phase | Scope | Notes |
|---|---|---|
| **2 — form-stub retirement** | Retire the 336 `form_of` standalone routes in favor of alias records: filter them out of `getStaticPaths`, emit static redirects (slug → target lemma; `astro.config` redirect infra exists), exclude from sitemap, add URL-parity test (every pre-retirement route → 200-or-redirect). | The explicitly-named remaining SSG work (#4928 `form_stub` class). **Outward-facing:** retires 336 indexed URLs — recommend the epic owner confirm the auto-redirect-vs-informational-stub UX first. |
| **3 — `[lemma].astro` → `[slug].astro` rename (OD-4)** | Route semantics already correct; the rename is the cosmetic finish. | Trivial, internal, no learner-visible change. |
| **4 — first-class expression/proverb/proper_name pages** (data-gated) | `ExpressionArticle` + expression-detail already exist, but the DB has **0** rows of these types today. Wire nothing until the corpus fill materializes them, then verify the template renders real data. | Blocked on the two-phase fill (#4378). |
| **5 — Phase B (at scale, separate epic step)** | Publish `atlas.db` as the content-addressed release asset; drop the JSON manifest; make the derived-artifact generators DB-only (drop the legacy `--manifest` paths). | Out of scope here; named so nobody designs against the wrong horizon. |

Follow-up nit: `--db` mode reuses `_site_build_entry_model_gates` from `generate_search_index`; promoting that shared gate to a public helper in a small module would remove the cross-module private import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
