### PR TITLE
fix(orchestration): accept clean fast-forward descent in rollover checkout-continuity gate

### DIFF
--- a/scripts/orchestration/thread_handoff.py
+++ b/scripts/orchestration/thread_handoff.py
@@ -21,7 +21,7 @@ import sys
 import urllib.error
 import urllib.request
 import uuid
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from contextlib import closing
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -433,26 +433,34 @@ def source_checkout_binding_error(replacement: Mapping[str, Any]) -> str | None:
     binding = replacement.get("source_checkout")
     if not isinstance(binding, dict):
         return "live rollover is missing its source checkout binding"
-    if set(binding) != {"full_head", "clean"}:
+    if set(binding) not in ({"full_head", "clean"}, {"full_head", "clean", "head_advanced_to"}):
         return "live rollover source checkout binding is malformed"
     if binding.get("clean") is not True:
         return "live rollover source checkout binding is not clean"
     full_head = binding.get("full_head")
     if not isinstance(full_head, str) or not full_head.strip():
         return "live rollover source checkout HEAD is malformed"
+    if "head_advanced_to" in binding:
+        head_advanced = binding.get("head_advanced_to")
+        if not isinstance(head_advanced, str) or not head_advanced.strip():
+            return "live rollover source checkout HEAD is malformed"
     return None
 
 
-def checkout_continuity_error(replacement: Mapping[str, Any], current_git_state: Mapping[str, Any]) -> str | None:
+def checkout_continuity_error(
+    replacement: Mapping[str, Any],
+    current_git_state: Mapping[str, Any],
+    *,
+    is_ancestor: Callable[[str, str], bool | None] | None = None,
+) -> str | None:
     binding_error = source_checkout_binding_error(replacement)
     if binding_error:
         return binding_error
+
     current_head = current_git_state.get("full_head")
     if not isinstance(current_head, str) or not current_head.strip():
         return "invoking checkout HEAD could not be determined"
-    expected_head = replacement["source_checkout"]["full_head"]
-    if current_head != expected_head:
-        return f"invoking checkout HEAD {current_head} does not match prepared HEAD {expected_head}"
+
     modified_files = current_git_state.get("modified_files")
     if not isinstance(modified_files, list):
         return "invoking checkout status could not be determined"
@@ -461,13 +469,54 @@ def checkout_continuity_error(replacement: Mapping[str, Any], current_git_state:
             str(item.get("path") or "unknown") if isinstance(item, dict) else "unknown" for item in modified_files[:5]
         )
         return f"invoking checkout must be clean; dirty paths: {paths}"
-    return None
+
+    expected_head = replacement["source_checkout"]["full_head"]
+    if current_head == expected_head:
+        return None
+
+    if is_ancestor is None:
+        return f"invoking checkout HEAD {current_head} does not match prepared HEAD {expected_head} (ancestry undeterminable)"
+
+    expected_is_ancestor = is_ancestor(expected_head, current_head)
+    if expected_is_ancestor is None:
+        return f"invoking checkout HEAD {current_head} does not match prepared HEAD {expected_head} (ancestry undeterminable)"
+    elif expected_is_ancestor is True:
+        return None
+
+    current_is_ancestor = is_ancestor(current_head, expected_head)
+    if current_is_ancestor is True:
+        return f"invoking checkout HEAD {current_head} is a rewind (strict ancestor of prepared HEAD {expected_head})"
+    elif current_is_ancestor is False:
+        return f"invoking checkout HEAD {current_head} has diverged from prepared HEAD {expected_head}"
+    else:
+        return f"invoking checkout HEAD {current_head} does not match prepared HEAD {expected_head} (ancestry undeterminable)"
 
 
 def require_checkout_continuity(replacement: Mapping[str, Any], repo_root: Path) -> None:
-    error = checkout_continuity_error(replacement, gather_git_state(repo_root))
+    def is_ancestor(expected_head: str, current_head: str) -> bool | None:
+        res = run_command(
+            ["git", "merge-base", "--is-ancestor", expected_head, current_head],
+            cwd=repo_root,
+            env=git_environment(),
+        )
+        if res.returncode == 0:
+            return True
+        elif res.returncode == 1:
+            return False
+        else:
+            return None
+
+    current_git_state = gather_git_state(repo_root)
+    error = checkout_continuity_error(replacement, current_git_state, is_ancestor=is_ancestor)
     if error:
         raise ValueError(f"checkout continuity failed: {error}")
+
+    current_head = current_git_state.get("full_head")
+    expected_head = replacement["source_checkout"]["full_head"]
+    if current_head != expected_head and isinstance(replacement, dict):
+        source_checkout = replacement.get("source_checkout")
+        if isinstance(source_checkout, dict):
+            source_checkout["head_advanced_to"] = current_head
 
 
 def gather_monitor_state(base_url: str) -> dict[str, Any]:
@@ -1085,7 +1134,7 @@ def render_bootstrap_prompt(
                 "",
                 "Rules:",
                 "- Continue from the durable packet exactly; do not fork, continue, or resume provider conversation history.",
-                f"- Keep the invoking checkout clean at prepared HEAD {replacement.get('source_checkout', {}).get('full_head', 'unknown')} through resume and confirmation.",
+                f"- Keep the invoking checkout clean at prepared HEAD {replacement.get('source_checkout', {}).get('full_head', 'unknown')} through resume and confirmation (clean fast-forward advances are tolerated).",
                 "- Keep the main checkout read-only; thread rollover state belongs in gitignored .agent/ files.",
                 "- Use dispatch worktrees for implementation work: .worktrees/dispatch/<agent>/<task>/.",
                 "- Do not edit generated status/audit/review artifacts, linter configs, or .python-version.",

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -237,7 +237,7 @@ def test_render_bootstrap_prompt_contains_guardrails(tmp_path: Path):
     assert "git worktree list" in prompt
     assert "confirm-started --agent orchestrator --lineage-id" in prompt
     assert "Only after that command reports old_automation_ready_to_delete=true" in prompt
-    assert "Keep the invoking checkout clean at prepared HEAD abc123def0456789" in prompt
+    assert "Keep the invoking checkout clean at prepared HEAD abc123def0456789 through resume and confirmation (clean fast-forward advances are tolerated)." in prompt
     assert "Context estimate: 86.0% (ROLL OVER NOW; threshold 82.0%)." in prompt
     assert "orchestrator_control.py inbox --recent 20 --include-results" in prompt
 
@@ -340,6 +340,85 @@ def test_checkout_continuity_requires_clean_source_binding_and_same_clean_head()
     assert "invoking checkout must be clean" in th.checkout_continuity_error(replacement, dirty)
     with pytest.raises(ValueError, match="source checkout must be clean before prepare"):
         th.source_checkout_binding(dirty)
+
+
+def test_checkout_continuity_ff_descent_and_failure_modes():
+    clean = sample_snapshot(Path("."))["git"]
+    binding = th.source_checkout_binding(clean)
+    replacement = {"source_checkout": binding}
+
+    prepared_head = binding["full_head"]
+    current_head = "current-head"
+    git_state = {**clean, "full_head": current_head}
+
+    def make_is_ancestor(ancestry_map):
+        def is_ancestor(expected, current):
+            return ancestry_map.get((expected, current))
+        return is_ancestor
+
+    # 1. Descent accepted: prepared is ancestor of current
+    is_ancestor_ok = make_is_ancestor({(prepared_head, current_head): True})
+    assert th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_ok) is None
+
+    # 2. Divergence rejected: neither is ancestor
+    is_ancestor_diverged = make_is_ancestor({
+        (prepared_head, current_head): False,
+        (current_head, prepared_head): False,
+    })
+    err = th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_diverged)
+    assert f"invoking checkout HEAD {current_head} has diverged from prepared HEAD {prepared_head}" in err
+
+    # 3. Rewind rejected: current is strict ancestor of prepared
+    is_ancestor_rewind = make_is_ancestor({
+        (prepared_head, current_head): False,
+        (current_head, prepared_head): True,
+    })
+    err = th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_rewind)
+    assert f"invoking checkout HEAD {current_head} is a rewind (strict ancestor of prepared HEAD {prepared_head})" in err
+
+    # 4. Dirty-at-descent rejected: prepared is ancestor, but tree is dirty
+    dirty_state = {
+        **clean,
+        "full_head": current_head,
+        "modified_files": [{"status": "M", "path": "tracked.txt"}]
+    }
+    err = th.checkout_continuity_error(replacement, dirty_state, is_ancestor=is_ancestor_ok)
+    assert "invoking checkout must be clean" in err
+
+    # 5. Ancestry undeterminable rejected: is_ancestor is None or returns None
+    err = th.checkout_continuity_error(replacement, git_state, is_ancestor=None)
+    assert "does not match prepared HEAD" in err
+    assert "ancestry undeterminable" in err
+
+    is_ancestor_none = make_is_ancestor({(prepared_head, current_head): None})
+    err = th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_none)
+    assert "does not match prepared HEAD" in err
+    assert "ancestry undeterminable" in err
+
+    is_ancestor_partial_none = make_is_ancestor({
+        (prepared_head, current_head): False,
+        (current_head, prepared_head): None,
+    })
+    err = th.checkout_continuity_error(replacement, git_state, is_ancestor=is_ancestor_partial_none)
+    assert "does not match prepared HEAD" in err
+    assert "ancestry undeterminable" in err
+
+
+def test_resume_after_descent_state_roundtrips(tmp_path: Path):
+    state = prepared()
+    replacement = state["replacement"]
+    replacement["source_checkout"]["head_advanced_to"] = "some-advanced-sha"
+
+    assert th.source_checkout_binding_error(replacement) is None
+
+    state_path = th.default_state_path("orchestrator", state["lineage_id"])
+    th.write_json_atomic(state_path, state)
+
+    loaded_state = th.load_state(state_path)
+    res_replacement, err = th.validate_live_lease(loaded_state, agent="orchestrator", state_path=state_path)
+    assert err is None
+    assert res_replacement is not None
+    assert res_replacement["source_checkout"]["head_advanced_to"] == "some-advanced-sha"
 
 
 def test_live_lease_requires_binding_but_started_history_remains_compatible():

--- a/tests/orchestration/test_thread_handoff.py
+++ b/tests/orchestration/test_thread_handoff.py
@@ -404,7 +404,11 @@ def test_checkout_continuity_ff_descent_and_failure_modes():
     assert "ancestry undeterminable" in err
 
 
-def test_resume_after_descent_state_roundtrips(tmp_path: Path):
+def test_resume_after_descent_state_roundtrips(tmp_path: Path, monkeypatch):
+    # default_state_path is CWD-relative; without chdir this test would plant a
+    # phantom orchestrator lease in the invoking checkout's real .agent/ tree,
+    # which detect scans.
+    monkeypatch.chdir(tmp_path)
     state = prepared()
     replacement = state["replacement"]
     replacement["source_checkout"]["head_advanced_to"] = "some-advanced-sha"


### PR DESCRIPTION
## Root Cause
The rollover checkout-continuity gate originally required the invoking checkout's HEAD to exactly match the prepared HEAD. However, because the primary checkout is shared across multiple agent lanes and receives fast-forward git pulls periodically, any rollover pending across a git pull was permanently bricked and unclaimable because there was no way to bypass this strict equality check.

## Contract Summary
1. Clean fast-forward descent is now accepted: if current HEAD is not equal to prepared HEAD, but prepared HEAD is an ancestor of the current HEAD (and the working directory is clean), it is accepted.
2. In `checkout_continuity_error`, the ancestry checks are performed via the optional `is_ancestor` predicate parameter to keep the function pure and hermetically testable.
3. In `require_checkout_continuity`, the predicate is implemented using `git merge-base --is-ancestor`.
4. When a clean descent is accepted, `head_advanced_to` is recorded under `source_checkout` in the state file. `source_checkout_binding_error` was updated to allow this key.
5. Human guidance was updated to reflect fast-forward tolerance.
6. Added tests for fast-forward descent, rewind, divergence, dirty-at-descent, and ancestry-undeterminable scenarios. Added a state round-trip test for the advanced head.

## New Error Messages (Unit-Test Verified)
- **Divergence**: `invoking checkout HEAD <current_head> has diverged from prepared HEAD <prepared_head>`
- **Rewind**: `invoking checkout HEAD <current_head> is a rewind (strict ancestor of prepared HEAD <prepared_head>)`
- **Undeterminable**: `invoking checkout HEAD <current_head> does not match prepared HEAD <prepared_head> (ancestry undeterminable)`

## Raw Tool Evidence
### Pytest Run:
```
tests/orchestration/test_thread_handoff.py::test_checkout_continuity_ff_descent_and_failure_modes PASSED [ 17%]
tests/orchestration/test_thread_handoff.py::test_resume_after_descent_state_roundtrips PASSED [ 19%]
...
============================= 62 passed in 11.39s ==============================
```

### Ruff Check:
```
$ .venv/bin/ruff check scripts/orchestration/thread_handoff.py tests/
All checks passed!
```

Refs #5189
